### PR TITLE
Use -Wall -Wextra by default

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,6 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex01_inputfile/Makefile
+++ b/examples/ex01_inputfile/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex01_inputfile/Makefile
+++ b/examples/ex01_inputfile/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex02_kernel/Makefile
+++ b/examples/ex02_kernel/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex02_kernel/Makefile
+++ b/examples/ex02_kernel/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex03_coupling/Makefile
+++ b/examples/ex03_coupling/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex03_coupling/Makefile
+++ b/examples/ex03_coupling/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex04_bcs/Makefile
+++ b/examples/ex04_bcs/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex04_bcs/Makefile
+++ b/examples/ex04_bcs/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex05_amr/Makefile
+++ b/examples/ex05_amr/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex05_amr/Makefile
+++ b/examples/ex05_amr/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex06_transient/Makefile
+++ b/examples/ex06_transient/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex06_transient/Makefile
+++ b/examples/ex06_transient/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex07_ics/Makefile
+++ b/examples/ex07_ics/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex07_ics/Makefile
+++ b/examples/ex07_ics/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex08_materials/Makefile
+++ b/examples/ex08_materials/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex08_materials/Makefile
+++ b/examples/ex08_materials/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex09_stateful_materials/Makefile
+++ b/examples/ex09_stateful_materials/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex09_stateful_materials/Makefile
+++ b/examples/ex09_stateful_materials/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex10_aux/Makefile
+++ b/examples/ex10_aux/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex10_aux/Makefile
+++ b/examples/ex10_aux/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex11_prec/Makefile
+++ b/examples/ex11_prec/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex11_prec/Makefile
+++ b/examples/ex11_prec/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex12_pbp/Makefile
+++ b/examples/ex12_pbp/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex12_pbp/Makefile
+++ b/examples/ex12_pbp/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex13_functions/Makefile
+++ b/examples/ex13_functions/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex13_functions/Makefile
+++ b/examples/ex13_functions/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex14_pps/Makefile
+++ b/examples/ex14_pps/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex14_pps/Makefile
+++ b/examples/ex14_pps/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex15_actions/Makefile
+++ b/examples/ex15_actions/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex15_actions/Makefile
+++ b/examples/ex15_actions/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex16_timestepper/Makefile
+++ b/examples/ex16_timestepper/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex16_timestepper/Makefile
+++ b/examples/ex16_timestepper/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex17_dirac/Makefile
+++ b/examples/ex17_dirac/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex17_dirac/Makefile
+++ b/examples/ex17_dirac/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex18_scalar_kernel/Makefile
+++ b/examples/ex18_scalar_kernel/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex18_scalar_kernel/Makefile
+++ b/examples/ex18_scalar_kernel/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex19_dampers/Makefile
+++ b/examples/ex19_dampers/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex19_dampers/Makefile
+++ b/examples/ex19_dampers/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex20_user_objects/Makefile
+++ b/examples/ex20_user_objects/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex20_user_objects/Makefile
+++ b/examples/ex20_user_objects/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex21_debugging/Makefile
+++ b/examples/ex21_debugging/Makefile
@@ -10,7 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 TEST := test_ignore

--- a/examples/ex21_debugging/Makefile
+++ b/examples/ex21_debugging/Makefile
@@ -10,6 +10,7 @@
 EXAMPLE_DIR        ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(EXAMPLE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 TEST := test_ignore

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -9,6 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -9,6 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/chemical_reactions/Makefile
+++ b/modules/chemical_reactions/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/chemical_reactions/Makefile
+++ b/modules/chemical_reactions/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/combined/Makefile
+++ b/modules/combined/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/combined/Makefile
+++ b/modules/combined/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/contact/Makefile
+++ b/modules/contact/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/contact/Makefile
+++ b/modules/contact/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/fluid_properties/Makefile
+++ b/modules/fluid_properties/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/fluid_properties/Makefile
+++ b/modules/fluid_properties/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/functional_expansion_tools/Makefile
+++ b/modules/functional_expansion_tools/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/functional_expansion_tools/Makefile
+++ b/modules/functional_expansion_tools/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/level_set/Makefile
+++ b/modules/level_set/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/level_set/Makefile
+++ b/modules/level_set/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/misc/Makefile
+++ b/modules/misc/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/misc/Makefile
+++ b/modules/misc/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/module_loader/Makefile
+++ b/modules/module_loader/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/module_loader/Makefile
+++ b/modules/module_loader/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/porous_flow/Makefile
+++ b/modules/porous_flow/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/porous_flow/Makefile
+++ b/modules/porous_flow/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/rdg/Makefile
+++ b/modules/rdg/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/rdg/Makefile
+++ b/modules/rdg/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/richards/Makefile
+++ b/modules/richards/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/richards/Makefile
+++ b/modules/richards/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/solid_mechanics/Makefile
+++ b/modules/solid_mechanics/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/solid_mechanics/Makefile
+++ b/modules/solid_mechanics/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/stochastic_tools/Makefile
+++ b/modules/stochastic_tools/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/stochastic_tools/Makefile
+++ b/modules/stochastic_tools/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/tensor_mechanics/Makefile
+++ b/modules/tensor_mechanics/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/tensor_mechanics/Makefile
+++ b/modules/tensor_mechanics/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/water_steam_eos/Makefile
+++ b/modules/water_steam_eos/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/water_steam_eos/Makefile
+++ b/modules/water_steam_eos/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/modules/xfem/Makefile
+++ b/modules/xfem/Makefile
@@ -11,6 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/modules/xfem/Makefile
+++ b/modules/xfem/Makefile
@@ -11,7 +11,7 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,6 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # framework

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework

--- a/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
@@ -16,6 +16,7 @@ endif
 
 # framework
 FRAMEWORK_DIR      := $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 

--- a/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
@@ -16,7 +16,7 @@ endif
 
 # framework
 FRAMEWORK_DIR      := $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -12,6 +12,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
 ###############################################################################
 
 # Extra stuff for GTEST

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -12,7 +12,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # Extra stuff for GTEST


### PR DESCRIPTION
Just added the flags to all the Makefiles so they are used when doing moose development.

Note that the flags won't get set if someone builds moose within their app. If this is the desired behavior then I will have to figure out how to add the flags for just the moose objects.

refs #10733

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
