### PR TITLE
Loosen tolerances to pass 64 bit dof tests

### DIFF
--- a/test/tests/kernels/vector_fe/tests
+++ b/test/tests/kernels/vector_fe/tests
@@ -9,8 +9,8 @@
     type = Exodiff
     input = 'coupled_scalar_vector.i'
     exodiff = 'coupled_scalar_vector_out.e'
-    abs_zero = 1e-8
-    rel_err = 1e-5
+    abs_zero = 3e-8
+    rel_err = 3e-5
   [../]
   [./lagrange_vec]
     type = Exodiff


### PR DESCRIPTION
The coupled vector-scalar FE test currently fails with 64 bit indices in parallel. Loosening the tolerances

Closes #10851