### PR TITLE
Hit for windows

### DIFF
--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -1,5 +1,7 @@
 CXX ?= g++
 
+PYTHONCOMPILERFLAG ?= `if test "$$VS11COMNTOOLS"; then echo "--compiler=msvc"; fi`
+
 hit: main.cc parse.cc lex.cc lex.h parse.h
 	$(CXX) -std=c++11 -g $(CXXFLAGS) $< parse.cc lex.cc -o $@
 

--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -1,9 +1,5 @@
 CXX ?= g++
 
-PYTHONPREFIX ?= `python-config --prefix`
-PYTHONCFLAGS ?= `python-config --cflags`
-PYTHONLDFLAGS ?= `python-config --ldflags`
-
 hit: main.cc parse.cc lex.cc lex.h parse.h
 	$(CXX) -std=c++11 -g $(CXXFLAGS) $< parse.cc lex.cc -o $@
 
@@ -13,7 +9,7 @@ rewrite: rewrite.cc parse.cc lex.cc lex.h parse.h
 bindings: hit.so
 
 hit.so: parse.cc lex.cc hit.cpp
-	$(CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L$(PYTHONPREFIX)/lib $(PYTHONCFLAGS) $(PYTHONLDFLAGS)  $^ -o $@
+	python setup.py build_ext --inplace $(PYTHONCOMPILERFLAG)
 
 hit.cpp: hit.pyx chit.pxd
 	cython --cplus $<

--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -351,7 +351,7 @@ lexString(Lexer * l)
     {
       prev = c;
       c = l->next();
-      if (c == quote and prev != '\\')
+      if (c == quote && prev != '\\')
         break;
       else if (c == '\0')
         return l->error("unterminated string");

--- a/framework/contrib/hit/setup.py
+++ b/framework/contrib/hit/setup.py
@@ -10,6 +10,7 @@ setup(
         Extension(
             "hit",
             ["hit.cpp", "lex.cc", "parse.cc"],
+            extra_compile_args=['-std=c++11'],
         )
     ]
 )

--- a/framework/contrib/hit/setup.py
+++ b/framework/contrib/hit/setup.py
@@ -1,0 +1,15 @@
+try:
+    from setuptools import setup
+    from setuptools import Extension
+except ImportError:
+    from distutils.core import setup
+    from distutils.extension import Extension
+
+setup(
+    ext_modules=[
+        Extension(
+            "hit",
+            ["hit.cpp", "lex.cc", "parse.cc"],
+        )
+    ]
+)

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -39,7 +39,8 @@ pyhit_LIB       := $(FRAMEWORK_DIR)/../python/hit.so
 
 hit $(pyhit_LIB): $(pyhit_srcfiles)
 	@echo "Building and linking "$@"..."
-	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --includes` `python-config --ldflags` $^ -o $(pyhit_LIB))'
+	@bash -c 'cd "$(hit_DIR)" && python setup.py build_ext --inplace `if test "$$VS11COMNTOOLS"; then echo "--compiler=msvc"; fi`'
+	@bash -c 'mv $(hit_DIR)/hit.so $(pyhit_LIB) || mv $(hit_DIR)/hit.pyd $(FRAMEWORK_DIR)/../python/'
 
 #
 # gtest

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -37,6 +37,7 @@ hit_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(hit_srcfiles))
 pyhit_srcfiles  := $(hit_DIR)/hit.cpp $(hit_DIR)/lex.cc $(hit_DIR)/parse.cc
 pyhit_LIB       := $(FRAMEWORK_DIR)/../python/hit.so
 
+# on *nix, produces hit.so, on windows, produces hit.pyd
 hit $(pyhit_LIB): $(pyhit_srcfiles)
 	@echo "Building and linking "$@"..."
 	@bash -c 'cd "$(hit_DIR)" && python setup.py build_ext --inplace `if test "$$VS11COMNTOOLS"; then echo "--compiler=msvc"; fi`'


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Using setuptools allows hit to be compiled in windows. The change is only made for compiling the cython generated .cpp, which still allows the end user to not need to have cython installed.
Closes #10863. 

This is a resubmit of #10864 after fixing mangled history.