### PR TITLE
Loosen absolute exodiff tolerance for parallel sweeps

### DIFF
--- a/test/tests/kernels/vector_fe/tests
+++ b/test/tests/kernels/vector_fe/tests
@@ -9,7 +9,7 @@
     type = Exodiff
     input = 'coupled_scalar_vector.i'
     exodiff = 'coupled_scalar_vector_out.e'
-    abs_zero = 3e-8
+    abs_zero = 6e-8
     rel_err = 3e-5
   [../]
   [./lagrange_vec]


### PR DESCRIPTION
`nl_rel_tol` is such that it's unreasonable to expect better exodiff comparisons than what is now imposed.

Closes #10870 and #10871 
