### PR TITLE
hit: add consecutive string literal support

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -336,28 +336,34 @@ lexString(Lexer * l)
   l->ignore();
 
   if (!charIn(l->peek(), "'\""))
-    consumeUnquotedString(l);
-  else
   {
-    char quote = 0;
-    if (l->accept("\""))
-      quote = '"';
-    else if (l->accept("'"))
-      quote = '\'';
+    consumeUnquotedString(l);
+    l->emit(TokType::String);
+    return lexHit;
+  }
 
+  std::string quote = "";
+  if (l->peek() == '"')
+    quote = "\"";
+  else if (l->peek() == '\'')
+    quote = "'";
+
+  while (l->accept(quote))
+  {
     char c = l->input()[l->start()];
     char prev;
     while (true)
     {
       prev = c;
       c = l->next();
-      if (c == quote and prev != '\\')
+      if (c == quote[0] and prev != '\\')
         break;
       else if (c == '\0')
         return l->error("unterminated string");
     }
+    l->emit(TokType::String);
+    consumeWhitespace(l);
   }
-  l->emit(TokType::String);
   return lexHit;
 }
 

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -51,6 +51,7 @@ TEST(HitTests, FailCases)
       {"extra section close", "[]"},
       {"extra section close 2", "[../]"},
       {"empty  dotslash section name", "[./][]"},
+      {"mismatched consecutive string literal quotes", "foo='bar'\"baz\""},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(PassFailCase); i++)
@@ -74,6 +75,7 @@ TEST(HitTests, PassCases)
       {"no whitespace between headers/footers", "[hello][]"},
       {"no whitespace with sections and fields", "[hello][world]foo=bar[]baz=42[]"},
       {"no leading ./ in sub-block", "[hello] [world] [] []"},
+      {"consecutive string literals", "foo='bar''baz'"},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(PassFailCase); i++)
@@ -188,6 +190,12 @@ TEST(HitTests, ParseFields)
        "foo",
        "hello\\nworld",
        hit::Field::Kind::String},
+      {"cosecutive string literal 1", "foo='bar''baz'", "foo", "barbaz", hit::Field::Kind::String},
+      {"cosecutive string literal 2",
+       "foo='bar'\n\n'baz'",
+       "foo",
+       "barbaz",
+       hit::Field::Kind::String},
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(ValCase); i++)
@@ -199,13 +207,14 @@ TEST(HitTests, ParseFields)
     auto n = root->find(test.key);
     if (!n)
     {
-      FAIL() << "case " << i + 1 << " failed to find key '" << test.key << "'\n";
+      FAIL() << "case " << i + 1 << " (" << test.name << ") failed to find key '" << test.key
+             << "'\n";
       continue;
     }
     if (n->strVal() != test.val)
     {
-      FAIL() << "case " << i + 1 << " wrong value (key=" << test.key << "): got '" << n->strVal()
-             << "', want '" << test.val << "'\n";
+      FAIL() << "case " << i + 1 << " (" << test.name << ") wrong value (key=" << test.key
+             << "): got '" << n->strVal() << "', want '" << test.val << "'\n";
       continue;
     }
 


### PR DESCRIPTION
Allow:

```
foo = "hello" " my name is joe"
      " and I work in a button factory."
```

to be parsed as:

```
foo = "hello my name is joe and I work in a button factory"
````

Fixes #10844

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
