### PR TITLE
Fix transfer in step 10 of darcy tutorial

### DIFF
--- a/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
@@ -21,8 +21,7 @@
 
 [AuxVariables]
   [./k_eff]
-    order = CONSTANT
-    family = MONOMIAL
+    initial_condition = 14.362648
   [../]
   [./velocity_x]
     order = CONSTANT
@@ -68,12 +67,6 @@
 []
 
 [AuxKernels]
-  [./keff_initial]
-    type = MaterialRealAux
-    variable = k_eff
-    property = thermal_conductivity
-    execute_on = 'initial'
-  [../]
   [./velocity_x]
     type = DarcyVelocity
     variable = velocity_x

--- a/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10_micro.i
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10_micro.i
@@ -38,6 +38,10 @@
 [AuxVariables]
   [./phi]
   [../]
+  [./por_var]
+    family = MONOMIAL
+    order = CONSTANT
+  [../]
 []
 
 [AuxKernels]
@@ -47,6 +51,11 @@
     variable = phi
     reference_temperature = 300
     temperature = temperature_in
+  [../]
+  [./por_var]
+    type = MaterialRealAux
+    variable = por_var
+    property = porosity
   [../]
 []
 
@@ -93,6 +102,15 @@
     dx = 0.1
     boundary = right
     length_scale = 1
+  [../]
+  [./por_var]
+    type = ElementAverageValue
+    variable = por_var
+  [../]
+  [./t_right]
+    type = SideAverageValue
+    boundary = right
+    variable = temperature
   [../]
 []
 


### PR DESCRIPTION
Also adds `SideAverageValue` postprocessor and porosity auxiliary variable in sub-app to help visualize the physics better.

Closes #10882 

