### PR TITLE
Remove duplicate entry of primary species in ReactionNetwork

### DIFF
--- a/docs/content/documentation/systems/ReactionNetwork/AqueousEquilibriumReactions/chemical_reactions/AddPrimarySpeciesAction.md
+++ b/docs/content/documentation/systems/ReactionNetwork/AqueousEquilibriumReactions/chemical_reactions/AddPrimarySpeciesAction.md
@@ -1,0 +1,6 @@
+<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+
+# AddPrimarySpeciesAction
+!syntax description /ReactionNetwork/AqueousEquilibriumReactions/AddPrimarySpeciesAction
+
+!syntax parameters /ReactionNetwork/AqueousEquilibriumReactions/AddPrimarySpeciesAction

--- a/docs/content/documentation/systems/ReactionNetwork/SolidKineticReactions/chemical_reactions/AddPrimarySpeciesAction.md
+++ b/docs/content/documentation/systems/ReactionNetwork/SolidKineticReactions/chemical_reactions/AddPrimarySpeciesAction.md
@@ -1,0 +1,6 @@
+<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+
+# AddPrimarySpeciesAction
+!syntax description /ReactionNetwork/SolidKineticReactions/AddPrimarySpeciesAction
+
+!syntax parameters /ReactionNetwork/SolidKineticReactions/AddPrimarySpeciesAction

--- a/docs/content/documentation/systems/ReactionNetwork/chemical_reactions/AddPrimarySpeciesAction.md
+++ b/docs/content/documentation/systems/ReactionNetwork/chemical_reactions/AddPrimarySpeciesAction.md
@@ -1,6 +1,0 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# AddPrimarySpeciesAction
-!syntax description /ReactionNetwork/AddPrimarySpeciesAction
-
-!syntax parameters /ReactionNetwork/AddPrimarySpeciesAction

--- a/docs/hidden.yml
+++ b/docs/hidden.yml
@@ -379,12 +379,13 @@ chemical_reactions:
     - /Materials/LangmuirMaterial
     - /Materials/MollifiedLangmuirMaterial
     - /ReactionNetwork
-    - /ReactionNetwork/AddPrimarySpeciesAction
     - /ReactionNetwork/AqueousEquilibriumReactions
     - /ReactionNetwork/AqueousEquilibriumReactions/AddCoupledEqSpeciesAction
+    - /ReactionNetwork/AqueousEquilibriumReactions/AddPrimarySpeciesAction
     - /ReactionNetwork/AqueousEquilibriumReactions/AddSecondarySpeciesAction
     - /ReactionNetwork/SolidKineticReactions
     - /ReactionNetwork/SolidKineticReactions/AddCoupledSolidKinSpeciesAction
+    - /ReactionNetwork/SolidKineticReactions/AddPrimarySpeciesAction
     - /ReactionNetwork/SolidKineticReactions/AddSecondarySpeciesAction
 contact:
     - /AuxKernels/ContactPressureAux

--- a/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
+++ b/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
@@ -99,7 +99,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'ca2+ hco3- h+'
   [./AqueousEquilibriumReactions]
     primary_species = 'ca2+ hco3- h+'
     secondary_species = 'co2_aq co32- caco3_aq cahco3+ caoh+ oh-'

--- a/modules/chemical_reactions/include/actions/AddPrimarySpeciesAction.h
+++ b/modules/chemical_reactions/include/actions/AddPrimarySpeciesAction.h
@@ -10,14 +10,14 @@
 #ifndef ADDPRIMARYSPECIESACTION_H
 #define ADDPRIMARYSPECIESACTION_H
 
-#include "Action.h"
+#include "AddVariableAction.h"
 
 class AddPrimarySpeciesAction;
 
 template <>
 InputParameters validParams<AddPrimarySpeciesAction>();
 
-class AddPrimarySpeciesAction : public Action
+class AddPrimarySpeciesAction : public AddVariableAction
 {
 public:
   AddPrimarySpeciesAction(const InputParameters & params);
@@ -25,7 +25,10 @@ public:
   virtual void act() override;
 
 private:
+  /// Primary species to add
   const std::vector<NonlinearVariableName> _vars;
+  /// Variable scaling
+  const Real _scaling;
 };
 
 #endif // ADDPRIMARYSPECIESACTION_H

--- a/modules/chemical_reactions/include/actions/AddSecondarySpeciesAction.h
+++ b/modules/chemical_reactions/include/actions/AddSecondarySpeciesAction.h
@@ -10,14 +10,14 @@
 #ifndef ADDSECONDARYSPECIESACTION_H
 #define ADDSECONDARYSPECIESACTION_H
 
-#include "Action.h"
+#include "AddAuxVariableAction.h"
 
 class AddSecondarySpeciesAction;
 
 template <>
 InputParameters validParams<AddSecondarySpeciesAction>();
 
-class AddSecondarySpeciesAction : public Action
+class AddSecondarySpeciesAction : public AddAuxVariableAction
 {
 public:
   AddSecondarySpeciesAction(const InputParameters & params);
@@ -25,6 +25,7 @@ public:
   virtual void act() override;
 
 private:
+  /// Secondary species to add
   const std::vector<AuxVariableName> _secondary_species;
 };
 

--- a/modules/chemical_reactions/src/actions/AddPrimarySpeciesAction.C
+++ b/modules/chemical_reactions/src/actions/AddPrimarySpeciesAction.C
@@ -8,48 +8,29 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "AddPrimarySpeciesAction.h"
-#include "AddVariableAction.h"
 #include "FEProblem.h"
-#include "Factory.h"
-
-#include "libmesh/string_to_enum.h"
 
 template <>
 InputParameters
 validParams<AddPrimarySpeciesAction>()
 {
-  InputParameters params = validParams<Action>();
+  InputParameters params = validParams<AddVariableAction>();
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
       "primary_species", "The list of primary variables to add");
-  // Get MooseEnums for the possible order/family options for this variable
-  MooseEnum families(AddVariableAction::getNonlinearVariableFamilies());
-  MooseEnum orders(AddVariableAction::getNonlinearVariableOrders());
-  params.addParam<MooseEnum>("family",
-                             families,
-                             "Specifies the family of FE "
-                             "shape function to use for the order parameters");
-  params.addParam<MooseEnum>("order",
-                             orders,
-                             "Specifies the order of the FE "
-                             "shape function to use for the order parameters");
-  params.addParam<Real>("scaling", 1.0, "Specifies a scaling factor to apply to this variable");
   params.addClassDescription("Adds Variables for all primary species");
   return params;
 }
 
 AddPrimarySpeciesAction::AddPrimarySpeciesAction(const InputParameters & params)
-  : Action(params), _vars(getParam<std::vector<NonlinearVariableName>>("primary_species"))
+  : AddVariableAction(params),
+    _vars(getParam<std::vector<NonlinearVariableName>>("primary_species")),
+    _scaling(getParam<Real>("scaling"))
 {
 }
 
 void
 AddPrimarySpeciesAction::act()
 {
-  for (unsigned int i = 0; i < _vars.size(); ++i)
-  {
-    FEType fe_type(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
-                   Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family")));
-
-    _problem->addVariable(_vars[i], fe_type, getParam<Real>("scaling"));
-  }
+  for (auto i = beginIndex(_vars); i < _vars.size(); ++i)
+    _problem->addVariable(_vars[i], _fe_type, _scaling);
 }

--- a/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
+++ b/modules/chemical_reactions/src/actions/AddSecondarySpeciesAction.C
@@ -8,53 +8,28 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "AddSecondarySpeciesAction.h"
-#include "AddAuxVariableAction.h"
-#include "MooseUtils.h"
 #include "FEProblem.h"
-#include "Factory.h"
-#include "MooseError.h"
-
-#include "libmesh/string_to_enum.h"
 
 template <>
 InputParameters
 validParams<AddSecondarySpeciesAction>()
 {
-  InputParameters params = validParams<Action>();
+  InputParameters params = validParams<AddAuxVariableAction>();
   params.addParam<std::vector<AuxVariableName>>("secondary_species",
                                                 "The list of secondary species to add");
-  // Get MooseEnums for the possible order/family options for this variable
-  MooseEnum families(AddAuxVariableAction::getAuxVariableFamilies());
-  MooseEnum orders(AddAuxVariableAction::getAuxVariableOrders());
-  params.addParam<MooseEnum>("family",
-                             families,
-                             "Specifies the family of FE "
-                             "shape function to use for the order parameters");
-  params.addParam<MooseEnum>("order",
-                             orders,
-                             "Specifies the order of the FE "
-                             "shape function to use for the order parameters");
   params.addClassDescription("Adds AuxVariables for all secondary species");
   return params;
 }
 
 AddSecondarySpeciesAction::AddSecondarySpeciesAction(const InputParameters & params)
-  : Action(params), _secondary_species(getParam<std::vector<AuxVariableName>>("secondary_species"))
+  : AddAuxVariableAction(params),
+    _secondary_species(getParam<std::vector<AuxVariableName>>("secondary_species"))
 {
 }
 
 void
 AddSecondarySpeciesAction::act()
 {
-  // Checking to see if there are secondary species to be added as AuxVariables
-  if (_pars.isParamValid("secondary_species"))
-  {
-    for (unsigned int i = 0; i < _secondary_species.size(); ++i)
-    {
-      FEType fe_type(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
-                     Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family")));
-
-      _problem->addAuxVariable(_secondary_species[i], fe_type);
-    }
-  }
+  for (auto i = beginIndex(_secondary_species); i < _secondary_species.size(); ++i)
+    _problem->addAuxVariable(_secondary_species[i], _fe_type);
 }

--- a/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
+++ b/modules/chemical_reactions/src/base/ChemicalReactionsApp.C
@@ -119,7 +119,8 @@ ChemicalReactionsApp__associateSyntax(Syntax & syntax, ActionFactory & action_fa
 void
 ChemicalReactionsApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  registerSyntax("AddPrimarySpeciesAction", "ReactionNetwork");
+  registerSyntax("AddPrimarySpeciesAction", "ReactionNetwork/AqueousEquilibriumReactions");
+  registerSyntax("AddPrimarySpeciesAction", "ReactionNetwork/SolidKineticReactions");
   registerSyntax("AddSecondarySpeciesAction", "ReactionNetwork/AqueousEquilibriumReactions");
   registerSyntax("AddSecondarySpeciesAction", "ReactionNetwork/SolidKineticReactions");
   registerSyntax("AddCoupledEqSpeciesAction", "ReactionNetwork/AqueousEquilibriumReactions");

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species.i
@@ -59,7 +59,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = a
   [./AqueousEquilibriumReactions]
     primary_species = a
     reactions = '2a = pa2 1'

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species.i
@@ -74,7 +74,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./AqueousEquilibriumReactions]
     primary_species = 'a b'
     reactions = '2a = pa2     2,

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_with_density.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_with_density.i
@@ -43,7 +43,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./AqueousEquilibriumReactions]
     primary_species = 'a b'
     reactions = '2a = pa2     2,

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/calcium_bicarbonate.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/calcium_bicarbonate.i
@@ -70,7 +70,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'ca++ hco3- h+'
   [./AqueousEquilibriumReactions]
     primary_species = 'ca++ hco3- h+'
     secondary_species = 'co2_aq co3-- caco3_aq cahco3+ caoh+ oh-'

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/co2_h2o.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/co2_h2o.i
@@ -54,7 +54,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'hco3- h+'
   [./AqueousEquilibriumReactions]
     primary_species = 'hco3- h+'
     secondary_species = 'co2_aq co3-- oh-'

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/water_dissociation.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/water_dissociation.i
@@ -38,7 +38,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = h+
   [./AqueousEquilibriumReactions]
     primary_species = h+
     secondary_species = oh-

--- a/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium.i
+++ b/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium.i
@@ -44,7 +44,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./AqueousEquilibriumReactions]
     primary_species = 'a b'
     reactions = '2a = pa2     2

--- a/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium_with_density.i
+++ b/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium_with_density.i
@@ -45,7 +45,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./AqueousEquilibriumReactions]
     primary_species = 'a b'
     reactions = '2a = pa2     2

--- a/modules/chemical_reactions/test/tests/parser/equilibrium_action.i
+++ b/modules/chemical_reactions/test/tests/parser/equilibrium_action.i
@@ -46,7 +46,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./AqueousEquilibriumReactions]
     primary_species = 'a b'
     reactions = '2a = pa2 2,

--- a/modules/chemical_reactions/test/tests/parser/kinetic_action.i
+++ b/modules/chemical_reactions/test/tests/parser/kinetic_action.i
@@ -21,7 +21,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b c d'
   [./SolidKineticReactions]
     primary_species = 'a b c d'
     secondary_species = 'm1 m2 m3'

--- a/modules/chemical_reactions/test/tests/solid_kinetics/2species.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/2species.i
@@ -40,7 +40,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'a b'
   [./SolidKineticReactions]
     primary_species = 'a b'
     secondary_species = mineral

--- a/modules/chemical_reactions/test/tests/solid_kinetics/calcite_dissolution.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/calcite_dissolution.i
@@ -50,7 +50,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'ca++ hco3- h+'
   [./AqueousEquilibriumReactions]
     primary_species = 'ca++ hco3- h+'
     secondary_species = 'co2_aq co3-- caco3_aq cahco3+ caoh+ oh-'

--- a/modules/chemical_reactions/test/tests/solid_kinetics/calcite_precipitation.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/calcite_precipitation.i
@@ -49,7 +49,6 @@
 []
 
 [ReactionNetwork]
-  primary_species = 'ca++ hco3- h+'
   [./AqueousEquilibriumReactions]
     primary_species = 'ca++ hco3- h+'
     secondary_species = 'co2_aq co3-- caco3_aq cahco3+ caoh+ oh-'


### PR DESCRIPTION
Duplicate code in AddPrimarySpeciesAction and
AddSecondarySpeciesAction is removed by changing their base class.

I couldn't think of a way to deprecate the `primary_species` parameter under the main `ReactionNetwork` block without duplicating the `AddPrimarySpeciesAction` and `AddSecondarySpeciesAction`. 

This will throw an unused parameter error for any input files that still have this additional `primary_species` parameter. I don't think many people are using this capability at the moment (perhaps only me while I add some more functionality to this module), so this might not be a big issue. 

Closes #10890