### PR TITLE
prevent mesh splitting test from running with other than 3 procs

### DIFF
--- a/test/tests/mesh/splitting/tests
+++ b/test/tests/mesh/splitting/tests
@@ -16,6 +16,7 @@
     cli_args = '--use-split --split-file foo UserObjects/splittester/type=SplitTester'
     prereq = 'make_split'
     min_parallel = 3
+    max_parallel = 3
     issues = '#10623'
     requirement = 'A mesh can be pre-split properly and used to generate equivalent results to running a simulation with the unsplit mesh.'
   [../]


### PR DESCRIPTION
The splitting tests only split the mesh into a 3 chunk configuration and
so running with other than 3 procs doesn't make sense. Fixes #10898 error.  The exodiff seems to just be an overly tight tolerance issue - should we just bump the tolerance?

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
