### PR TITLE
Allow RunException to fail tests correctly

### DIFF
--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -67,7 +67,7 @@ class RunException(RunApp):
             output += "#"*80 + "\n\nUnable to match the following pattern against the program's output:\n\n" + specs['expect_err'] + "\n"
 
         if reason == '':
-            RunApp.testFileOutput(self, moose_dir, options, output)
+            reason = RunApp.testFileOutput(self, moose_dir, options, output)
 
         if reason != '':
             self.setStatus(reason, self.bucket_fail)

--- a/python/chigger/tests/line_sample/line_sample_error.py
+++ b/python/chigger/tests/line_sample/line_sample_error.py
@@ -18,3 +18,4 @@ sample = chigger.exodus.ExodusResultLineSampler(mug, point1=(0, 0.05, 0), point2
 sample.update()
 x = sample[0].getDistance()
 y = sample[0].getSample('invalid_name') # testing this error
+exit(1)

--- a/python/chigger/tests/line_sample/line_sample_error.py
+++ b/python/chigger/tests/line_sample/line_sample_error.py
@@ -18,4 +18,3 @@ sample = chigger.exodus.ExodusResultLineSampler(mug, point1=(0, 0.05, 0), point2
 sample.update()
 x = sample[0].getDistance()
 y = sample[0].getSample('invalid_name') # testing this error
-exit(1)

--- a/python/chigger/tests/line_sample/tests
+++ b/python/chigger/tests/line_sample/tests
@@ -22,8 +22,9 @@
   [../]
 
   [./line_sample_error]
-    type = RunException
+    type = RunApp
     command = line_sample_error.py
-    expect_err = "Unable to locate the variable, invalid_name, in the supplied source data."
+    expect_out = "Unable to locate the variable, invalid_name, in the supplied source data."
+    errors = "zzzzzzz" # Supress default error checking
   [../]
 []

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -92,16 +92,16 @@
   [../]
 
   [./deprecated_param_default]
-    type = 'RunException'
+    type = 'RunApp'
     input = 'deprecated_param_test.i'
-    expect_err = "The parameter \w+ is deprecated."
+    expect_out = "The parameter \w+ is deprecated."
     cli_args = 'Kernels/nan/deprecated_default=1'
   [../]
 
   [./deprecated_param_no_default]
-    type = 'RunException'
+    type = 'RunApp'
     input = 'deprecated_param_test.i'
-    expect_err = "The parameter \w+ is deprecated."
+    expect_out = "The parameter \w+ is deprecated."
     cli_args = 'Kernels/nan/deprecated_no_default=1'
   [../]
 
@@ -610,5 +610,10 @@
     type = 'RunException'
     input = 'coupling_itself.i'
     expect_err = "Coupled variable 'v' needs to be different from 'variable' with CoupledForce"
+  [../]
+  [./missing_input]
+    type = 'RunException'
+    input = 'missing_input_file.i'
+    expect_err = "Unable to open file"
   [../]
 []


### PR DESCRIPTION
A couple RunException tests were allowed to pass when they should
have been failing. However, we still want these tests to pass, so
use expect_out, instead of expect_error for the deprecated tests
located in misc/check_error.

Closes #10907