### PR TITLE
Restrict tests to not run with old/differently configured PETSc

### DIFF
--- a/test/tests/functions/vector_postprocessor_function/tests
+++ b/test/tests/functions/vector_postprocessor_function/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'vector_postprocessor_function.i'
     exodiff = 'out.e'
+    superlu = true
   [../]
 []

--- a/test/tests/kernels/vector_fe/tests
+++ b/test/tests/kernels/vector_fe/tests
@@ -22,7 +22,6 @@
     type = PetscJacobianTester
     input = 'coupled_scalar_vector_jacobian.i'
     recover = false
-    state = const_positive
     ratio_tol = 1e-7
     difference_tol = 5e-6
   [../]

--- a/test/tests/materials/material_dependency/tests
+++ b/test/tests/materials/material_dependency/tests
@@ -4,5 +4,10 @@
     input = 'diff_kernel_aux_mat_dep.i'
     exodiff = 'diff_kernel_aux_mat_dep_out.e'
     max_threads = 1
+    # The Material in this test effectively counts the number of residual
+    # evaluations performed by the code, and that varies between older and
+    # newer versions of PETSc due to the changes in 3061bbd5d. This test is
+    # therefore only valid with newer versions of PETSc.
+    petsc_version = '>=3.5.0'
   [../]
 []

--- a/test/tests/outputs/iterative/tests
+++ b/test/tests/outputs/iterative/tests
@@ -63,7 +63,11 @@
     # This test relies on number of residuals being the same, so run it serially
     max_parallel = 1
     max_threads = 1
-    recover = false #no. of iterations is not recoverable
+    # no. of iterations is not recoverable
+    recover = false
+    # This test requires a different number of residual evaluations in older PETScs
+    # due to the changes in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
   [./exodus_inline]
     # Test the output of linear and nonlinear iterations to Exodus with inline start times

--- a/test/tests/postprocessors/all_print_pps/tests
+++ b/test/tests/postprocessors/all_print_pps/tests
@@ -10,5 +10,8 @@
     # of iterations.  And then the number of residuals is reduced by 1,
     # and this causes CSV diff. 
     petsc_version_release = true
+    # This test requires a different number of residual evaluations in older PETScs
+    # due to the changes in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 []


### PR DESCRIPTION
Only four framework tests diff for me when trying to run with PETSc 3.4.5. Only three of those were actual differences, and they were all related to the same thing: MOOSE does a slightly different number of residual evaluations in PETSc >= 3.5.0 (due to 3061bbd5d) and all these tests are basically counting residual evaluations.

I could not reproduce all the failures that @kevindugan reported with 3.4.5 (there may be something else funny going on with his build?) so I don't think we should restrict any other tests at the current time.

Refs #10906.


