### PR TITLE
Have delete_trailing_whitespace.sh also fix DOS files.

### DIFF
--- a/scripts/delete_trailing_whitespace.sh
+++ b/scripts/delete_trailing_whitespace.sh
@@ -4,13 +4,13 @@
 # will be used (one up from the scripts directory where this script is located)
 REPO_DIR=${1:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../"}
 
-echo "if you have clang-format installed, please use it instead of this script"
+echo "If you have clang-format installed, please use it instead of this script for C++ files."
 
 if [ ! -d "$REPO_DIR" ]; then
   echo "$REPO_DIR directory does not exist";
 else
   while read -rd '' fname; do
-    if grep -q "[[:blank:]]$" "$fname"; then
+    if grep -q "[[:space:]]$" "$fname"; then
       echo "Removing trailing whitespace: $fname"
       perl -pli -e "s/\s+$//" "$fname" # this would also fix EOF issues
     elif [ "$(tail -c1 "$fname")" != "" ]; then


### PR DESCRIPTION
DOS files have newline characters "\r\n"
The pre check in Civet would flag this has having trailing whitespace (using perls `/\s+$/`)
However, the `delete_trailing_whitespace.sh` script needs to also detect this.
Changing the grep character class from `[[:blank:]]` to `[[:space:]]` detects the DOS files and they will automatically get converted to unix type files (newline character is only "\n")

refs #6372

@gardnerru 
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
