### PR TITLE
Restrict/tweak modules tests for PETSc 3.4.5

### DIFF
--- a/modules/chemical_reactions/test/tests/jacobian/tests
+++ b/modules/chemical_reactions/test/tests/jacobian/tests
@@ -38,8 +38,8 @@
   [./coupled_equilsub2]
     type = PetscJacobianTester
     input = coupled_equilsub2.i
-    ratio_tol = 1e-7
-    difference_tol = 1e-6
+    ratio_tol = 1e-6
+    difference_tol = 1e-5
   [../]
   [./2species]
     type = PetscJacobianTester
@@ -51,12 +51,12 @@
     type = PetscJacobianTester
     input = 2species_equilibrium.i
     ratio_tol = 1e-7
-    difference_tol = 5e-7
+    difference_tol = 1e-6
   [../]
   [./2species_equilibrium_with_density]
     type = PetscJacobianTester
     input = 2species_equilibrium_with_density.i
     ratio_tol = 1e-7
-    difference_tol = 5e-7
+    difference_tol = 1e-6
   [../]
 []

--- a/modules/combined/test/tests/catch_release/tests
+++ b/modules/combined/test/tests/catch_release/tests
@@ -4,6 +4,10 @@
     input = 'catch_release.i'
     exodiff = 'catch_release_out.e'
     custom_cmp = 'catch_release.exodiff'
-    petsc_version = '>=3.1'
+    # This test fails with a negative Jacobian for older versions of
+    # PETSc, possibly due to the changes in 3061bbd5d. It had already
+    # been restricted for many years to PETSc >= 3.1, most likely due
+    # to numerical instability.
+    petsc_version = '>=3.5.0'
   [../]
 []

--- a/modules/combined/test/tests/contact/tests
+++ b/modules/combined/test/tests/contact/tests
@@ -30,6 +30,9 @@
     exodiff = 4ElemTensionRelease_out.e
     custom_cmp = '4ElemTensionRelease.exodiff'
     min_parallel = 4
+    # This test has substantial diffs in older versions of PETSc due to the changes
+    # in the way residuals are computed in contact problems in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./4ElemTensionRelease_constraint]
@@ -38,6 +41,9 @@
     exodiff = 4ElemTensionRelease_mechanical_constraint_out.e
     custom_cmp = '4ElemTensionRelease.exodiff'
     min_parallel = 4
+    # This test has substantial diffs in older versions of PETSc due to the changes
+    # in the way residuals are computed in contact problems in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./4ElemTensionRelease_no_new_nonzeros]
@@ -47,6 +53,9 @@
     custom_cmp = '4ElemTensionRelease.exodiff'
     cli_args = 'Problem/error_on_jacobian_nonzero_reallocation=true Outputs/file_base=4ElemTensionRelease_no_new_nonzeros_out'
     max_parallel = 1
+    # This test has substantial diffs in older versions of PETSc due to the changes
+    # in the way residuals are computed in contact problems in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./8ElemTensionRelease]
@@ -56,5 +65,8 @@
     custom_cmp = '8ElemTensionRelease.exodiff'
     min_parallel = 4
     max_parallel = 4
+    # This test has substantial diffs in older versions of PETSc due to the changes
+    # in the way residuals are computed in contact problems in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 []

--- a/modules/combined/test/tests/contact_verification/overclosure_removal/tests
+++ b/modules/combined/test/tests/contact_verification/overclosure_removal/tests
@@ -5,5 +5,6 @@
     exodiff = 'overclosure_exodus.e'
     rel_err = 1e-5
     abs_zero = 1e-6
+    superlu = true
   [../]
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/automatic_patch_update/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/automatic_patch_update/tests
@@ -4,6 +4,7 @@
     input = 'sliding_update.i'
     exodiff = 'sliding_update_out.e'
     abs_zero = 1e-7
+    superlu = true
   [../]
   [./error_test]
     type = RunException

--- a/modules/combined/test/tests/elastic_patch/elastic_patch_rz_nonlinear_sm.i
+++ b/modules/combined/test/tests/elastic_patch/elastic_patch_rz_nonlinear_sm.i
@@ -197,8 +197,10 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  start_time = 0.0
-  end_time = 1.0
+  dt = 1
+  dtmin = 1
+  num_steps = 1
+  nl_rel_tol = 1e-7
 []
 
 [Outputs]

--- a/modules/combined/test/tests/gravity/gravity_rz_quad8.cmp
+++ b/modules/combined/test/tests/gravity/gravity_rz_quad8.cmp
@@ -1,0 +1,22 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               1 @ t2
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	disp_x     absolute 1.e-9
+	disp_y     absolute 1.e-9
+	stress_xx  absolute 1.e-6
+	stress_xy  absolute 1.e-6
+	stress_yy  absolute 1.e-6
+
+ELEMENT VARIABLES absolute 1.e-6 floor 0.0
+	stress_xx
+	stress_yy
+	stress_xy
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES

--- a/modules/combined/test/tests/gravity/tests
+++ b/modules/combined/test/tests/gravity/tests
@@ -48,9 +48,8 @@
     type = 'Exodiff'
     input = 'gravity_rz_quad8.i'
     exodiff = 'gravity_rz_quad8_out.e'
-    abs_zero = 1e-07
-    use_old_floor = True
     prereq = 'rz_quad8_sm'
+    custom_cmp = gravity_rz_quad8.cmp
   [../]
   [./rz_quad4]
     type = 'Exodiff'

--- a/modules/combined/test/tests/nodal_area/tests
+++ b/modules/combined/test/tests/nodal_area/tests
@@ -42,6 +42,9 @@
     input = 'nodal_area_Hex20_3.i'
     exodiff = 'nodal_area_Hex20_3_out.e'
     custom_cmp = 'nodal_area_Hex20_3.exodiff'
+    # This test fails with a negative Jacobian for older versions of
+    # PETSc, possibly due to the changes in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
   [./Hex202Proc]
     type = 'Exodiff'

--- a/modules/combined/test/tests/normalized_penalty/tests
+++ b/modules/combined/test/tests/normalized_penalty/tests
@@ -21,6 +21,9 @@
     exodiff = 'normalized_penalty_kin_out.e'
     abs_zero = 1e-8
     max_parallel = 1                                    # -pc_type lu
+    # This test no longer works on older versions of PETSc due to the
+    # changes in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
   [./kin_Q8]
     type = Exodiff
@@ -28,6 +31,9 @@
     exodiff = 'normalized_penalty_kin_Q8_out.e'
     abs_zero = 1e-8
     max_parallel = 1                                    # -pc_type lu
+    # This test no longer works on older versions of PETSc due to the
+    # changes in 3061bbd5d.
+    petsc_version = '>=3.5.0'
   [../]
 
 []

--- a/modules/combined/test/tests/simple_contact/simple_contact_dirac_test.i
+++ b/modules/combined/test/tests/simple_contact/simple_contact_dirac_test.i
@@ -3,6 +3,10 @@
 
 [Mesh]
   file = contact.e
+  # PETSc < 3.5.0 requires the iteration patch_update_strategy to
+  # avoid PenetrationLocator warnings, which are currently treated as
+  # errors by the TestHarness.
+  patch_update_strategy = 'iteration'
 []
 
 [GlobalParams]

--- a/modules/combined/test/tests/simple_contact/simple_contact_rz_dirac_test.i
+++ b/modules/combined/test/tests/simple_contact/simple_contact_rz_dirac_test.i
@@ -9,6 +9,10 @@
 
 [Mesh]
   file = contact_rz.e
+  # PETSc < 3.5.0 requires the iteration patch_update_strategy to
+  # avoid PenetrationLocator warnings, which are currently treated as
+  # errors by the TestHarness.
+  patch_update_strategy = 'iteration'
 []
 
 [GlobalParams]

--- a/modules/combined/test/tests/simple_contact/simple_contact_rz_test.i
+++ b/modules/combined/test/tests/simple_contact/simple_contact_rz_test.i
@@ -9,6 +9,10 @@
 
 [Mesh]
   file = contact_rz.e
+  # PETSc < 3.5.0 requires the iteration patch_update_strategy to
+  # avoid PenetrationLocator warnings, which are currently treated as
+  # errors by the TestHarness.
+  patch_update_strategy = 'iteration'
 []
 
 [GlobalParams]

--- a/modules/combined/test/tests/simple_contact/simple_contact_test.i
+++ b/modules/combined/test/tests/simple_contact/simple_contact_test.i
@@ -2,6 +2,10 @@
 
 [Mesh]
   file = contact.e
+  # PETSc < 3.5.0 requires the iteration patch_update_strategy to
+  # avoid PenetrationLocator warnings, which are currently treated as
+  # errors by the TestHarness.
+  patch_update_strategy = 'iteration'
 []
 
 [GlobalParams]

--- a/modules/level_set/test/tests/kernels/advection/tests
+++ b/modules/level_set/test/tests/kernels/advection/tests
@@ -3,5 +3,7 @@
     type = CSVDiff
     input = advection_mms.i
     csvdiff = advection_mms_out.csv
+    # This problem uses SuperLU.
+    superlu = true
   [../]
 []

--- a/modules/navier_stokes/test/tests/ins/mms/supg/tests
+++ b/modules/navier_stokes/test/tests/ins/mms/supg/tests
@@ -97,5 +97,7 @@
     type = 'Exodiff'
     input = 'supg_pspg_adv_dominated_mms.i'
     exodiff = 'supg_pspg_adv_dominated_mms_exodus.e'
+    # This problem uses SuperLU.
+    superlu = true
   [../]
 []

--- a/modules/navier_stokes/test/tests/ins/pressure_channel/tests
+++ b/modules/navier_stokes/test/tests/ins/pressure_channel/tests
@@ -10,5 +10,8 @@
     input = 'open_bc_pressure_BC_fieldSplit.i'
     exodiff = 'open_bc_out_pressure_BC_fieldSplit.e'
     custom_cmp = open_bc_out_pressure_BC_fieldSplit.cmp
+    # This test uses the 'selfp' option for the fieldsplit
+    # preconditioner, which requires at least PETSc 3.5.0.
+    petsc_version = '>=3.5.0'
   [../]
 []

--- a/modules/navier_stokes/test/tests/scalar_adr/supg/tests
+++ b/modules/navier_stokes/test/tests/scalar_adr/supg/tests
@@ -23,5 +23,7 @@
     exodiff = '2d_advection_error_testing_exodus.e'
     input = '2d_advection_error_testing.i'
     allow_test_objects = true
+    # This problem uses SuperLU.
+    superlu = true
   [../]
 []

--- a/modules/phase_field/test/tests/grain_tracker_test/tests
+++ b/modules/phase_field/test/tests/grain_tracker_test/tests
@@ -42,6 +42,8 @@
     csvdiff = 'grain_tracker_remapping_test_out.csv'
     method = '!DBG' # slow test
     valgrind = 'HEAVY'
+    # This test uses a coloring algorithm that requires PETSc >= 3.5.0.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./remapping_with_reserve]
@@ -75,6 +77,8 @@
     max_time = 500
     method = '!DBG' # slow test
     valgrind ='HEAVY'
+    # This test uses a coloring algorithm that requires PETSc >= 3.5.0.
+    petsc_version = '>=3.5.0'
   [../]
 
   ###################################################

--- a/modules/phase_field/test/tests/initial_conditions/tests
+++ b/modules/phase_field/test/tests/initial_conditions/tests
@@ -175,12 +175,16 @@
     type = Exodiff
     input = 'polycrystalcircles_fromfile.i'
     exodiff = 'polycrystalcircles_fromfile_out.e'
+    # This test uses a coloring algorithm that requires PETSc >= 3.5.0.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./PolycrystalCircles_FromVector]
     type = Exodiff
     input = 'polycrystalcircles_fromvector.i'
     exodiff = 'polycrystalcircles_fromvector_out.e'
+    # This test uses a coloring algorithm that requires PETSc >= 3.5.0.
+    petsc_version = '>=3.5.0'
   [../]
 
   [./SmoothCirclesFromFile]

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/creep/tests
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/creep/tests
@@ -5,6 +5,7 @@
     exodiff = 'nafems_test5a_lim_out.e'
     rel_err = 1e-5
     abs_zero = 1e-8
+    superlu = true
   [../]
   [./test5a_lim_on_initial]
     type = 'CSVDiff'
@@ -12,6 +13,7 @@
     cli_args = 'Postprocessors/matl_ts_min/execute_on="initial timestep_end"
     Outputs/file_base=nafems_test5a_lim_on_initial_out'
     csvdiff = 'nafems_test5a_lim_on_initial_out.csv'
+    superlu = true
   [../]
   [./test5a_lim_no_comb]
     type = 'Exodiff'
@@ -21,5 +23,6 @@
     prereq = 'test5a_lim'
     rel_err = 1e-5
     abs_zero = 1e-8
+    superlu = true
   [../]
 []

--- a/modules/xfem/test/tests/crack_tip_enrichment/tests
+++ b/modules/xfem/test/tests/crack_tip_enrichment/tests
@@ -5,6 +5,7 @@
     exodiff = 'edge_crack_2d_out.e'
     map = false
     unique_id = true
+    superlu = true
   [../]
   [./crack_tip_enrichment_penny_crack_3d]
     type = Exodiff
@@ -13,5 +14,6 @@
     map = false
     unique_id = true
     heavy = true
+    superlu = true
   [../]
 []


### PR DESCRIPTION
Finishes the work in #10906 while I have this PETSc 3.4.5 build sitting around. 

After this PR, all the modules tests are either passing or skipped because they require the changes to residual evaluation during contact that was added in 3061bbd5d (that requires PETSc >= 3.5.0). Since I forgot to `--download-superlu_dist=1` in my PETSc 3.4.5 build, I also found a few test specs where `superlu=true` was missing and fixed those.
