### PR TITLE
hit: Allow lex.cc to be compiled by MSVC.

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -356,7 +356,7 @@ lexString(Lexer * l)
     {
       prev = c;
       c = l->next();
-      if (c == quote[0] and prev != '\\')
+      if (c == quote[0] && prev != '\\')
         break;
       else if (c == '\0')
         return l->error("unterminated string");


### PR DESCRIPTION
Relates to issue #10863.

Apparently, Microsoft hates reasonable, modern syntax. This change also makes the file more internally consistent, as this is the only case of using 'and'.
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
