### PR TITLE
Allow library name specification for dynamically loaded objects

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -386,12 +386,16 @@ public:
    */
   void dynamicObjectRegistration(const std::string & app_name,
                                  Factory * factory,
-                                 std::string library_path);
-  void dynamicAppRegistration(const std::string & app_name, std::string library_path);
+                                 std::string library_path,
+                                 const std::string & library_name);
+  void dynamicAppRegistration(const std::string & app_name,
+                              std::string library_path,
+                              const std::string & library_name);
   void dynamicSyntaxAssociation(const std::string & app_name,
                                 Syntax * syntax,
                                 ActionFactory * action_factory,
-                                std::string library_path);
+                                std::string library_path,
+                                const std::string & library_name);
   ///@}
 
   /**

--- a/framework/src/actions/DynamicObjectRegistrationAction.C
+++ b/framework/src/actions/DynamicObjectRegistrationAction.C
@@ -28,6 +28,10 @@ validParams<DynamicObjectRegistrationAction>()
                                "Path to search for dynamic libraries (please "
                                "avoid committing absolute paths in addition to "
                                "MOOSE_LIBRARY_PATH)");
+  params.addParam<std::string>(
+      "library_name",
+      "",
+      "The file name of the library (*.la file) that will be dynamically loaded.");
   return params;
 }
 
@@ -49,9 +53,15 @@ DynamicObjectRegistrationAction::DynamicObjectRegistrationAction(InputParameters
         getParam<std::vector<std::string>>("register_objects_from");
     for (const auto & app_name : application_names)
     {
-      _app.dynamicObjectRegistration(app_name, &_factory, getParam<std::string>("library_path"));
-      _app.dynamicSyntaxAssociation(
-          app_name, &_awh.syntax(), &_action_factory, getParam<std::string>("library_path"));
+      _app.dynamicObjectRegistration(app_name,
+                                     &_factory,
+                                     getParam<std::string>("library_path"),
+                                     getParam<std::string>("library_name"));
+      _app.dynamicSyntaxAssociation(app_name,
+                                    &_awh.syntax(),
+                                    &_action_factory,
+                                    getParam<std::string>("library_path"),
+                                    getParam<std::string>("library_name"));
     }
   }
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -844,13 +844,16 @@ MooseApp::registerRestartableData(std::string name,
 }
 
 void
-MooseApp::dynamicAppRegistration(const std::string & app_name, std::string library_path)
+MooseApp::dynamicAppRegistration(const std::string & app_name,
+                                 std::string library_path,
+                                 const std::string & library_name)
 {
   Parameters params;
   params.set<std::string>("app_name") = app_name;
   params.set<RegistrationType>("reg_type") = APPLICATION;
   params.set<std::string>("registration_method") = app_name + "__registerApps";
   params.set<std::string>("library_path") = library_path;
+  params.set<std::string>("library_name") = library_name;
 
   dynamicRegistration(params);
 
@@ -876,13 +879,15 @@ MooseApp::dynamicAppRegistration(const std::string & app_name, std::string libra
 void
 MooseApp::dynamicObjectRegistration(const std::string & app_name,
                                     Factory * factory,
-                                    std::string library_path)
+                                    std::string library_path,
+                                    const std::string & library_name)
 {
   Parameters params;
   params.set<std::string>("app_name") = app_name;
   params.set<RegistrationType>("reg_type") = OBJECT;
   params.set<std::string>("registration_method") = app_name + "__registerObjects";
   params.set<std::string>("library_path") = library_path;
+  params.set<std::string>("library_name") = library_name;
 
   params.set<Factory *>("factory") = factory;
 
@@ -893,13 +898,15 @@ void
 MooseApp::dynamicSyntaxAssociation(const std::string & app_name,
                                    Syntax * syntax,
                                    ActionFactory * action_factory,
-                                   std::string library_path)
+                                   std::string library_path,
+                                   const std::string & library_name)
 {
   Parameters params;
   params.set<std::string>("app_name") = app_name;
   params.set<RegistrationType>("reg_type") = SYNTAX;
   params.set<std::string>("registration_method") = app_name + "__associateSyntax";
   params.set<std::string>("library_path") = library_path;
+  params.set<std::string>("library_name") = library_name;
 
   params.set<Syntax *>("syntax") = syntax;
   params.set<ActionFactory *>("action_factory") = action_factory;
@@ -910,8 +917,12 @@ MooseApp::dynamicSyntaxAssociation(const std::string & app_name,
 void
 MooseApp::dynamicRegistration(const Parameters & params)
 {
-  // first convert the app name to a library name
-  std::string library_name = appNameToLibName(params.get<std::string>("app_name"));
+  std::string library_name;
+  // was library name provided by the user?
+  if (params.get<std::string>("library_name").empty())
+    library_name = appNameToLibName(params.get<std::string>("app_name"));
+  else
+    library_name = params.get<std::string>("library_name");
 
   // Create a vector of paths that we can search inside for libraries
   std::vector<std::string> paths;

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -68,6 +68,10 @@ validParams<MultiApp>()
                                "Path to search for dynamic libraries (please "
                                "avoid committing absolute paths in addition to "
                                "MOOSE_LIBRARY_PATH)");
+  params.addParam<std::string>(
+      "library_name",
+      "",
+      "The file name of the library (*.la file) that will be dynamically loaded.");
   params.addParam<std::vector<Point>>(
       "positions",
       "The positions of the App locations.  Each set of 3 values will represent a "
@@ -198,7 +202,8 @@ MultiApp::initialSetup()
 
   // If the user provided an unregistered app type, see if we can load it dynamically
   if (!AppFactory::instance().isRegistered(_app_type))
-    _app.dynamicAppRegistration(_app_type, getParam<std::string>("library_path"));
+    _app.dynamicAppRegistration(
+        _app_type, getParam<std::string>("library_path"), getParam<std::string>("library_name"));
 
   for (unsigned int i = 0; i < _my_num_apps; i++)
     createApp(i, _app.getGlobalTimeOffset());

--- a/modules/misc/test/tests/dynamic_loading/dynamic_load_multiapp/tests
+++ b/modules/misc/test/tests/dynamic_loading/dynamic_load_multiapp/tests
@@ -9,6 +9,19 @@
     queue_scheduler = false   # Relative paths do not work
   [../]
 
+  [./dynamic_load_w_name]
+    type = 'Exodiff'
+    input = 'misc_master.i'
+    exodiff = 'misc_master_out.e misc_master_out_sub_app0.e'
+    allow_warnings = true
+    library_mode = 'DYNAMIC'
+    cli_args = 'MultiApps/sub_app/library_name=libphase_field-opt.la'
+    method = OPT # because the library name is explicitly given
+    prereq = 'dynamic_load'
+    recover = false # See #5207
+    queue_scheduler = false   # Relative paths do not work
+  [../]
+
   [./dynamic_load_error_check]
     type = 'RunException'
     input = 'misc_master_bad.i'

--- a/modules/misc/test/tests/dynamic_loading/dynamic_obj_registration/tests
+++ b/modules/misc/test/tests/dynamic_loading/dynamic_obj_registration/tests
@@ -10,10 +10,38 @@
     allow_warnings = true
   [../]
 
+  [./dynamic_object_loading_w_name]
+    type = 'Exodiff'
+    input = 'dynamic_objects.i'
+    exodiff = 'dynamic_objects_out.e'
+    cli_args = 'Problem/library_name=libphase_field-opt.la'
+    method = OPT # because the library name is explicitly given
+    prereq = 'dynamic_object_restrict_bad'
+    library_mode = 'DYNAMIC'
+
+    # Test must be run with the misc app to test dynamic loading
+    executable_pattern = 'misc-\w+$'
+    allow_warnings = true
+  [../]
+
   [./dynamic_object_loading_syntax]
     type = 'Exodiff'
     input = 'dynamic_syntax.i'
     exodiff = 'dynamic_syntax_out.e'
+    library_mode = 'DYNAMIC'
+
+    # Test must be run with the misc app to test dynamic loading
+    executable_pattern = 'misc-\w+$'
+    allow_warnings = true
+  [../]
+
+  [./dynamic_object_loading_syntax_w_name]
+    type = 'Exodiff'
+    input = 'dynamic_syntax.i'
+    exodiff = 'dynamic_syntax_out.e'
+    cli_args = 'Problem/library_name=libphase_field-opt.la'
+    method = OPT # because the library name is explicitly given
+    prereq = 'dynamic_object_loading_syntax'
     library_mode = 'DYNAMIC'
 
     # Test must be run with the misc app to test dynamic loading

--- a/scripts/stork.sh
+++ b/scripts/stork.sh
@@ -8,7 +8,7 @@ function printusage {
     echo "    When --module is supplied after the <name> a MOOSE module will be created."
 }
 
-if [[ "$1" == "-h" || $# == 0 || $# > 2 ]]; then
+if [[ "$1" == "-h" || "$1" == "--help" || $# == 0 || $# > 2 ]]; then
     printusage
     exit 1
 fi

--- a/scripts/stork.sh
+++ b/scripts/stork.sh
@@ -4,7 +4,8 @@ function printusage {
     echo "Usage:    stork.sh <name>"
     echo ""
     echo "    Creates a new blank MOOSE app in the current working directory."
-    echo "    <name> should be given in CamelCase format."
+    echo "    <name> should be given in CamelCase format.  Allowed are letters and numbers "
+    echo "           (cannot start with a number). No special characters are allowed."
     echo "    When --module is supplied after the <name> a MOOSE module will be created."
 }
 
@@ -28,6 +29,17 @@ fi
 # set old/new app name variables
 srcname='Stork'
 dstname=$1
+
+# check that dstname does not contain a special character
+if [[ $dstname == *[\!\@\#\$\%\^\&\*\(\)\-\+]* ]] ; then
+  echo "error: provided name contains a special character."
+  exit 1
+fi
+# check that the name does not start with a number
+if [[ ${dstname:0:1} == *[0-9]* ]] ; then
+  echo "error: the first character of the name is a number."
+  exit 1
+fi
 
 regex='s/([A-Z][a-z])/_\1/g; s/([a-z])([A-Z])/\1_\2/g; s/^_//;'
 


### PR DESCRIPTION
1. Adding name checking in stork, so that we produce compilable code
2. Allow users to specify the name of the library that will be used to load the objects dynamically

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
