### PR TITLE
Make peacock use Hit to write input files

### DIFF
--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -19,7 +19,7 @@ def addInactive(hit_parent, parent, children):
         if entry and entry.checkInactive():
             inactive.append(entry.name)
     if inactive:
-        hit_parent.addChild(hit.NewField("inactive", "String", ' '.join(inactive)))
+        hit_parent.addChild(hit.NewField("inactive", "String", "'%s'" % ' '.join(inactive)))
 
 def inputTreeToString(root):
     """

--- a/python/peacock/Input/InputTreeWriter.py
+++ b/python/peacock/Input/InputTreeWriter.py
@@ -7,18 +7,21 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-import cStringIO
+import hit
 
-def writeInactive(output, parent, children, indent, sep):
+def addInactive(hit_parent, parent, children):
+    """
+    If there are any inactive blocks, add them
+    """
     inactive = []
     for child in children:
         entry = parent.children.get(child, None)
         if entry and entry.checkInactive():
             inactive.append(entry.name)
     if inactive:
-        output.write("%sinactive = '%s'\n" % (indent*sep, ' '.join(inactive)))
+        hit_parent.addChild(hit.NewField("inactive", "String", ' '.join(inactive)))
 
-def inputTreeToString(root, sep="  "):
+def inputTreeToString(root):
     """
     Main access point to write an InputTree to a string.
     Input:
@@ -26,71 +29,42 @@ def inputTreeToString(root, sep="  "):
     Return:
         str: The input file
     """
-    output = cStringIO.StringIO()
-    if root.comments:
-        commentString(output, root.comments, 0, sep)
     children = root.getChildNames()
+    hit_node = hit.NewSection("")
+    if root.comments:
+        commentNode(hit_node, root.comments, False)
+    addInactive(hit_node, root, children)
     last_child = children[-1]
-    writeInactive(output, root, children, 0, sep)
     for child in children:
         entry = root.children.get(child, None)
         if entry and entry.wantsToSave():
-            writeToString(output, entry, 0, sep, child == last_child)
-    return output.getvalue()
+            addNode(hit_node, entry)
+            if child != last_child:
+                hit_node.addChild(hit.NewBlank())
 
-def writeToString(output, entry, indent, sep="  ", is_last=False):
+    return hit_node.render()
+
+def addNode(parent_hit_node, entry):
     """
-    Write out this node and its children(recursively) to input file format.
+    Adds a node and its children to the HIT tree.
     Input:
-        curr_str[str]: Current input file
-        indent[int]: indent level
-    Return:
-        str: input file
+        parent_hit_node[hit.Node]: Parent to add children to
+        entry[BlockInfo]: The block to add
     """
-    nodeHeaderString(output, entry, indent, sep)
-    nodeParamsString(output, entry, indent+1, sep)
+    name = entry.name
+    hit_node = hit.NewSection(name)
+    parent_hit_node.addChild(hit_node)
+    if entry.comments:
+        commentNode(hit_node, entry.comments, False)
+    nodeParamsString(hit_node, entry)
     children = entry.getChildNames()
-    writeInactive(output, entry, children, indent+1, sep)
+    addInactive(hit_node, entry, children)
     for child in children:
         child_entry = entry.children.get(child, None)
         if child_entry and child_entry.wantsToSave():
-            writeToString(output, child_entry, indent+1, sep)
-    nodeCloseString(output, entry, indent, sep, is_last)
+            addNode(hit_node, child_entry)
 
-def nodeHeaderString(output, entry, indent, sep):
-    """
-    While writing the input file, start a new section.
-    Input:
-        curr_str[str]: Current input file
-        indent[int]: Current indent level
-    Return:
-        str: input file
-    """
-    str_indent = sep*indent
-    if entry.parent.path != '/':
-        output.write("%s[./%s]\n" % (str_indent, entry.name))
-    else:
-        output.write("[%s]\n" % entry.name)
-    if entry.comments:
-        commentString(output, entry.comments, indent+1, sep)
-
-def nodeCloseString(output, entry, indent, sep, is_last):
-    """
-    While writing the input file, close a section
-    Input:
-        curr_str[str]: Current input file
-        indent[int]: Current indent level
-    Return:
-        str: input file
-    """
-    if entry.parent.path != '/':
-        output.write("%s[../]\n" % (sep*indent))
-    elif is_last:
-        output.write("[]\n")
-    else:
-        output.write("[]\n\n")
-
-def nodeParamsString(output, entry, indent, sep, ignore_type=False):
+def nodeParamsString(hit_parent, entry, ignore_type=False):
     params = entry.getParamNames()
     for name in params:
         if ignore_type and name == "type":
@@ -101,31 +75,28 @@ def nodeParamsString(output, entry, indent, sep, ignore_type=False):
             continue
         comments = info.comments
         if info.hasChanged() or info.user_added or info.set_in_input_file:
-            paramToString(output, info.name, val, comments, indent, sep)
+            hit_param = hit.NewField(info.name, info.hitType(), val)
+            hit_parent.addChild(hit_param)
+            if comments:
+                commentNode(hit_param, comments, True)
 
     type_info = entry.parameters.get("type")
     if entry.types and type_info:
         type_name = type_info.value
         type_entry = entry.types.get(type_name)
         if type_entry:
-            nodeParamsString(output, type_entry, indent, sep, ignore_type=True)
+            nodeParamsString(hit_parent, type_entry, ignore_type=True)
 
-def commentString(output, comments, indent, sep):
+def commentNode(hit_parent, comments, is_inline):
     c_list = comments
     if isinstance(comments, str):
         c_list = [comments]
     for c in c_list:
         lines = c.split("\n")
         for line in lines:
-          if not line:
-            output.write("%s#\n" % (sep*indent))
-          else:
-            output.write("%s# %s\n" % (sep*indent, line))
-
-def paramToString(output, name, val, comments, indent, sep):
-    output.write("%s%s = %s" % (sep*indent, name, val))
-
-    if comments:
-        commentString(output, comments, indent, sep)
-    else:
-        output.write("\n")
+            if line:
+                line = "# %s" % line
+            else:
+                line = "#"
+            hit_comment = hit.NewComment(line, is_inline)
+            hit_parent.addChild(hit_comment)

--- a/python/peacock/Input/ParameterInfo.py
+++ b/python/peacock/Input/ParameterInfo.py
@@ -108,6 +108,13 @@ class ParameterInfo(object):
         else:
             return str(self.value)
 
+    def hitType(self):
+        """
+        Return the Hit Field type
+        """
+        hit_map = {"Boolean": "Bool", "Real": "Float", "Integer": "Int"}
+        return hit_map.get(self.basic_type, "String")
+
     def toolTip(self):
         return self.description + "\nDefault: %s" % self.default
 

--- a/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
@@ -6,58 +6,58 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
-  [../]
-  [./v]
+  []
+  [v]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [Kernels]
-  [./diff_u]
+  [diff_u]
     type = Diffusion
     variable = u
-  [../]
-  [./conv_v]
+  []
+  [conv_v]
     type = CoupledForce
     variable = v
     v = 'u'
-  [../]
-  [./diff_v]
+  []
+  [diff_v]
     type = Diffusion
     variable = v
-  [../]
+  []
 []
 
 [BCs]
-  inactive = 'right_v'
-  [./left_u]
+  inactive = right_v
+  [left_u]
     type = DirichletBC
     variable = u
     boundary = '1'
     value = 0
-  [../]
-  [./right_u]
+  []
+  [right_u]
     type = DirichletBC
     variable = u
     boundary = '2'
     value = 100
-  [../]
-  [./left_v]
+  []
+  [left_v]
     type = DirichletBC
     variable = v
     boundary = '1'
     value = 0
-  [../]
-  [./right_v]
+  []
+  [right_v]
     type = DirichletBC
     variable = v
     boundary = '2'
     value = 0
-  [../]
+  []
 []
 
 [Executioner]
@@ -69,11 +69,11 @@
 []
 
 [Preconditioning]
-  [./FSP]
+  [FSP]
     # It is the starting point of splitting
     type = FSP
-    topsplit = 'uv'    # uv should match the following block name
-    [./uv]
+    topsplit = 'uv' # uv should match the following block name
+    [uv]
       # Generally speaking, there are four types of splitting we could choose
       # <additive,multiplicative,symmetric_multiplicative,schur>
       # An approximate solution to the original system
@@ -85,27 +85,26 @@
       # control how schur works using PETSc options
       # petsc_options_iname = '-pc_fieldsplit_schur_fact_type -pc_fieldsplit_schur_precondition'
       # petsc_options_value = 'full selfp'
-      splitting = 'u v'      # u and v are the names of subsolvers
+      splitting = 'u v' # u and v are the names of subsolvers
       splitting_type = additive
-    [../]
-    [./u]
+    []
+    [u]
       # PETSc options for this subsolver
       # A prefix will be applied, so just put the options for this subsolver only
       vars = 'u'
       petsc_options_iname = '-pc_type -ksp_type'
       petsc_options_value = '     hypre preonly'
-    [../]
-    [./v]
+    []
+    [v]
       # PETSc options for this subsolver
       vars = 'v'
       petsc_options_iname = '-pc_type -ksp_type'
       petsc_options_value = '     hypre  preonly'
-    [../]
-  [../]
+    []
+  []
 []
 
 [Outputs]
   file_base = out
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputFileEditor/gold/fsp_test.i
@@ -33,7 +33,7 @@
 []
 
 [BCs]
-  inactive = right_v
+  inactive = 'right_v'
   [left_u]
     type = DirichletBC
     variable = u

--- a/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
+++ b/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
@@ -232,7 +232,7 @@ class Tests(BaseTests):
         mock_q.return_value = QMessageBox.Yes # The user wants to ignore changes
         self.assertEqual(w.canClose(), True)
 
-        new_block = "[AuxVariables]\n  [./New_0]\n  [../]\n[]\n\n"
+        new_block = "[AuxVariables]\n  [New_0]\n  []\n[]\n"
         s = tree.getInputFileString()
         self.assertEqual(new_block, s)
 

--- a/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
@@ -6,58 +6,58 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
-  [../]
-  [./v]
+  []
+  [v]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [Kernels]
-  [./diff_u]
+  [diff_u]
     type = Diffusion
     variable = u
-  [../]
-  [./conv_v]
+  []
+  [conv_v]
     type = CoupledForce
     variable = v
     v = 'u'
-  [../]
-  [./diff_v]
+  []
+  [diff_v]
     type = Diffusion
     variable = v
-  [../]
+  []
 []
 
 [BCs]
-  inactive = 'right_v'
-  [./left_u]
+  inactive = right_v
+  [left_u]
     type = DirichletBC
     variable = u
     boundary = '1'
     value = 0
-  [../]
-  [./right_u]
+  []
+  [right_u]
     type = DirichletBC
     variable = u
     boundary = '2'
     value = 100
-  [../]
-  [./left_v]
+  []
+  [left_v]
     type = DirichletBC
     variable = v
     boundary = '1'
     value = 0
-  [../]
-  [./right_v]
+  []
+  [right_v]
     type = DirichletBC
     variable = v
     boundary = '2'
     value = 0
-  [../]
+  []
 []
 
 [Executioner]
@@ -69,11 +69,11 @@
 []
 
 [Preconditioning]
-  [./FSP]
+  [FSP]
     # It is the starting point of splitting
     type = FSP
-    topsplit = 'uv'    # uv should match the following block name
-    [./uv]
+    topsplit = 'uv' # uv should match the following block name
+    [uv]
       # Generally speaking, there are four types of splitting we could choose
       # <additive,multiplicative,symmetric_multiplicative,schur>
       # An approximate solution to the original system
@@ -85,27 +85,26 @@
       # control how schur works using PETSc options
       # petsc_options_iname = '-pc_fieldsplit_schur_fact_type -pc_fieldsplit_schur_precondition'
       # petsc_options_value = 'full selfp'
-      splitting = 'u v'      # u and v are the names of subsolvers
+      splitting = 'u v' # u and v are the names of subsolvers
       splitting_type = additive
-    [../]
-    [./u]
+    []
+    [u]
       # PETSc options for this subsolver
       # A prefix will be applied, so just put the options for this subsolver only
       vars = 'u'
       petsc_options_iname = '-pc_type -ksp_type'
       petsc_options_value = '     hypre preonly'
-    [../]
-    [./v]
+    []
+    [v]
       # PETSc options for this subsolver
       vars = 'v'
       petsc_options_iname = '-pc_type -ksp_type'
       petsc_options_value = '     hypre  preonly'
-    [../]
-  [../]
+    []
+  []
 []
 
 [Outputs]
   file_base = out
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/fsp_test.i
@@ -33,7 +33,7 @@
 []
 
 [BCs]
-  inactive = right_v
+  inactive = 'right_v'
   [left_u]
     type = DirichletBC
     variable = u

--- a/python/peacock/tests/input_tab/InputTree/gold/lcf1.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/lcf1.i
@@ -9,64 +9,64 @@
 []
 
 [Variables]
-  [./dummy]
-  [../]
+  [dummy]
+  []
 []
 
 [Kernels]
-  [./dummy_u]
+  [dummy_u]
     type = TimeDerivative
     variable = dummy
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./the_linear_combo]
-  [../]
+  [the_linear_combo]
+  []
 []
 
 [AuxKernels]
-  [./the_linear_combo]
+  [the_linear_combo]
     type = FunctionAux
     variable = the_linear_combo
     function = the_linear_combo
-  [../]
+  []
 []
 
 [Functions]
-  [./xtimes]
+  [xtimes]
     type = ParsedFunction
     value = '1.1*x'
-  [../]
-  [./twoxplus1]
+  []
+  [twoxplus1]
     type = ParsedFunction
     value = '2*x+1'
-  [../]
-  [./xsquared]
+  []
+  [xsquared]
     type = ParsedFunction
     value = '(x-2)*x'
-  [../]
-  [./tover2]
+  []
+  [tover2]
     type = ParsedFunction
     value = '0.5*t'
-  [../]
-  [./the_linear_combo]
+  []
+  [the_linear_combo]
     type = LinearCombinationFunction
     functions = 'xtimes twoxplus1 xsquared tover2'
     w = '3 -1.2 0.4 3'
-  [../]
-  [./should_be_answer]
+  []
+  [should_be_answer]
     type = ParsedFunction
     value = '3*1.1*x-1.2*(2*x+1)+0.4*(x-2)*x+3*0.5*t'
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./should_be_zero]
+  [should_be_zero]
     type = NodalL2Error
     function = should_be_answer
     variable = 'the_linear_combo'
-  [../]
+  []
 []
 
 [Executioner]
@@ -82,4 +82,3 @@
   exodus = false
   csv = true
 []
-

--- a/python/peacock/tests/input_tab/InputTree/gold/simple_diffusion.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/simple_diffusion.i
@@ -6,30 +6,30 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 'left'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = 'right'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -43,4 +43,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTree/gold/simple_diffusion_vp.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/simple_diffusion_vp.i
@@ -6,30 +6,30 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 'left'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = 'right'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -45,11 +45,10 @@
 []
 
 [VectorPostprocessors]
-  [./foo]
+  [foo]
     type = LineValueSampler
     num_points = 10
     end_point = '1 0 0'
     start_point = '0 0 0'
-  [../]
+  []
 []
-

--- a/python/peacock/tests/input_tab/InputTree/gold/transient.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/transient.i
@@ -56,7 +56,7 @@
 []
 
 [BCs]
-  inactive = left right
+  inactive = 'left right'
   [all]
     type = FunctionDirichletBC
     variable = u

--- a/python/peacock/tests/input_tab/InputTree/gold/transient.i
+++ b/python/peacock/tests/input_tab/InputTree/gold/transient.i
@@ -17,75 +17,75 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
-    [./InitialCondition]
+    [InitialCondition]
       type = ConstantIC
       value = 0
-    [../]
-  [../]
+    []
+  []
 []
 
 [Functions]
-  [./forcing_fn]
+  [forcing_fn]
     # dudt = 3*t^2*(x^2 + y^2)
     type = ParsedFunction
     value = '3*t*t*((x*x)+(y*y))-(4*t*t*t)'
-  [../]
-  [./exact_fn]
+  []
+  [exact_fn]
     type = ParsedFunction
     value = 't*t*t*((x*x)+(y*y))'
-  [../]
+  []
 []
 
 [Kernels]
-  [./ie]
+  [ie]
     type = TimeDerivative
     variable = u
-  [../]
-  [./diff]
+  []
+  [diff]
     type = Diffusion
     variable = u
-  [../]
-  [./ffn]
+  []
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 []
 
 [BCs]
-  inactive = 'left right'
-  [./all]
+  inactive = left right
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = '0 1 2 3'
     function = exact_fn
-  [../]
-  [./left]
+  []
+  [left]
     type = DirichletBC
     variable = u
     boundary = '3'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = '1'
     value = 1
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./l2_err]
+  [l2_err]
     type = ElementL2Error
     variable = 'u'
     function = exact_fn
-  [../]
-  [./dt]
+  []
+  [dt]
     type = TimestepSize
-  [../]
+  []
 []
 
 [Executioner]
@@ -103,4 +103,3 @@
   file_base = out_transient
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTree/test_InputTree.py
+++ b/python/peacock/tests/input_tab/InputTree/test_InputTree.py
@@ -56,19 +56,19 @@ class Tests(Testing.PeacockTester):
 
     def testTransient(self):
         t = self.createTree(input_file=self.transient)
-        self.checkFile(t.getInputFileString(), self.transient_gold)
+        self.checkFile(t.getInputFileString(), self.transient_gold, True)
 
     def testLCF(self):
         t = self.createTree(input_file=self.lcf1)
-        self.checkFile(t.getInputFileString(), self.lcf1_gold)
+        self.checkFile(t.getInputFileString(), self.lcf1_gold, True)
 
     def testFSP(self):
         t = self.createTree(input_file=self.fsp)
-        self.checkFile(t.getInputFileString(), self.fsp_gold)
+        self.checkFile(t.getInputFileString(), self.fsp_gold, True)
 
     def testSimpleDiffusion(self):
         t = self.createTree(input_file=self.simple_diffusion)
-        self.checkFile(t.getInputFileString(), self.simple_diffusion_gold)
+        self.checkFile(t.getInputFileString(), self.simple_diffusion_gold, True)
 
     def testChangingInputFiles(self):
         t = self.createTree(input_file=self.simple_diffusion)

--- a/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion.i
+++ b/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion.i
@@ -6,30 +6,30 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 'left'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = 'right'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -43,4 +43,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_inactive.i
+++ b/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_inactive.i
@@ -7,31 +7,31 @@ inactive = 'Kernels BCs Executioner'
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
   inactive = 'diff'
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 'left'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = 'right'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -45,4 +45,3 @@ inactive = 'Kernels BCs Executioner'
 [Outputs]
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_no_diff.i
+++ b/python/peacock/tests/input_tab/InputTreeWriter/gold/simple_diffusion_no_diff.i
@@ -6,31 +6,31 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
   inactive = 'diff'
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 'left'
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = 'right'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]
@@ -44,4 +44,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
+++ b/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
@@ -31,14 +31,14 @@ class Tests(Testing.PeacockTester):
     def testWriter(self):
         t = self.createBasic()
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion.i")
+        self.checkFile(s, "gold/simple_diffusion.i", True)
 
     def testInactive(self):
         t = self.createBasic()
         d = t.getBlockInfo("/Kernels/diff")
         d.included = False
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion_no_diff.i")
+        self.checkFile(s, "gold/simple_diffusion_no_diff.i", True)
         k = t.getBlockInfo("/Kernels")
         k.included = False
         b = t.getBlockInfo("/BCs")
@@ -46,7 +46,7 @@ class Tests(Testing.PeacockTester):
         e = t.getBlockInfo("/Executioner")
         e.included = False
         s = InputTreeWriter.inputTreeToString(t.root)
-        self.checkFile(s, "gold/simple_diffusion_inactive.i")
+        self.checkFile(s, "gold/simple_diffusion_inactive.i", True)
 
         d.included = True
         k.included = True


### PR DESCRIPTION
The main difference in the written input files is that Hit doesn't support
writing out `[./block_name][../]` only `[block_name][]` when you construct the tree manually. It only remembers the path separators when they are in an existing input file.


This is in preparation for #10845 which will eventually take care of #10473
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
