### PR TITLE
Disable timing that might be dangerous

### DIFF
--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -137,7 +137,7 @@ class RunApp(Tester):
             cli_args.append('--check-input')
 
         timing_string = ' '
-        if options.timing:
+        if options.timing and specs["timing"]:
             cli_args.append('--timing')
             cli_args.append('Outputs/print_perf_log=true')
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -72,6 +72,7 @@ class Tester(MooseObject):
         params.addParam('required_objects', [], "A list of required objects that are in the executable.")
         params.addParam('check_input',    False, "Check for correct input file syntax")
         params.addParam('display_required', False, "The test requires and active display for rendering (i.e., ImageDiff tests).")
+        params.addParam('timing',         True, "If True, the test will be allowed to run with the timing flag (i.e. Manually turning on performance logging).")
         params.addParam('boost',         ['ALL'], "A test that runs only if BOOT is detected ('ALL', 'TRUE', 'FALSE')")
 
         # Queueing specific

--- a/test/tests/materials/material/tests
+++ b/test/tests/materials/material/tests
@@ -71,6 +71,7 @@
     input = 'throw_material.i'
     exodiff = 'throw_material_out.e'
     recover = false
+    timing = false # See Ticket #10927
   [../]
 
   [./test_constant_on_elem]


### PR DESCRIPTION
refs #10927

This fix is better than restricting the test to '!DBG' because it turns of timing for all modes. It's equally dangerous to skip pops in optimized mode as it is debug mode.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
