### PR TITLE
Several Makefile improvements

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -250,6 +250,8 @@ $(eval $(call CXX_RULE_TEMPLATE,_with$(app_LIB_SUFFIX)))
 
 ifeq ($(BUILD_EXEC),yes)
   all:: $(app_EXEC)
+else
+  all:: $(app_LIB)
 endif
 
 BUILD_EXEC :=
@@ -262,7 +264,7 @@ $(app_HEADER): curr_dir    := $(APPLICATION_DIR)
 $(app_HEADER): curr_app    := $(APPLICATION_NAME)
 $(app_HEADER): all_header_dir := $(all_header_dir)
 $(app_HEADER): $(app_HEADER_deps)
-	@echo "MOOSE Checking if header needs updating: "$@"..."
+	@echo "Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(curr_dir) $@ $(curr_app))
 	@ln -sf $@ $(all_header_dir)
 

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -68,21 +68,21 @@ unity_files::
 # C++ rules
 #
 pcre%.$(obj-suffix) : pcre%.cc
-	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 %.$(obj-suffix) : %.cc
-	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
 %$(1).$(obj-suffix) : %.C
 ifeq ($(1),)
-	@echo "MOOSE Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
+	@echo "Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else
-	@echo "MOOSE Compiling C++ with suffix (in "$$(METHOD)" mode) "$$<"..."
+	@echo "Compiling C++ with suffix (in "$$(METHOD)" mode) "$$<"..."
 endif
 	@$$(libmesh_LIBTOOL) --tag=CXX $$(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $$(libmesh_CXX) $$(libmesh_CPPFLAGS) $$(ADDITIONAL_CPPFLAGS) $$(libmesh_CXXFLAGS) $$(app_INCLUDES) $$(libmesh_INCLUDE) -MMD -MP -MF $$@.d -MT $$@ -c $$< -o $$@
@@ -91,7 +91,7 @@ endef
 $(eval $(call CXX_RULE_TEMPLATE,))
 
 %.$(obj-suffix) : %.cpp
-	@echo "MOOSE Compiling C++ (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C++ (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
@@ -112,12 +112,12 @@ $(eval $(call CXX_RULE_TEMPLATE,))
 #
 
 pcre%.$(obj-suffix) : pcre%.c
-	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
           $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -w -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 %.$(obj-suffix) : %.c
-	@echo "MOOSE Compiling C (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=CC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
@@ -128,7 +128,7 @@ pcre%.$(obj-suffix) : pcre%.c
 #
 
 %.$(obj-suffix) : %.f
-	@echo "MOOSE Compiling Fortan (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling Fortan (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F77) $(libmesh_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< -o $@
 
@@ -139,7 +139,7 @@ pcre%.$(obj-suffix) : pcre%.c
 
 PreProcessed_FFLAGS := $(libmesh_FFLAGS)
 %.$(obj-suffix) : %.F
-	@echo "MOOSE Compiling Fortran (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling Fortran (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=F77 $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F90) $(PreProcessed_FFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -c $< $(module_dir_flag) -o $@
 
@@ -169,7 +169,7 @@ ifneq (,$(findstring gfortran,$(mpif90_command)))
 endif
 
 %.$(obj-suffix) : %.f90
-	@echo "MOOSE Compiling Fortran90 (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling Fortran90 (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_LIBTOOL) --tag=FC $(LIBTOOLFLAGS) --mode=compile --quiet \
 	  $(libmesh_F90) $(libmesh_FFLAGS) $(libmesh_INCLUDE) -c $< $(module_dir_flag) -o $@
 
@@ -254,16 +254,16 @@ endif
 # out to be more trouble than it was worth to get working.
 #
 %-$(METHOD).plugin : %.C
-	@echo "MOOSE Compiling C++ Plugin (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C++ Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CXXFLAGS) -shared -fPIC $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 %-$(METHOD).plugin : %.c
-	@echo "MOOSE Compiling C Plugin (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling C Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_CC) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(libmesh_CFLAGS) -shared -fPIC $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 %-$(METHOD).plugin : %.f
-	@echo "MOOSE Compiling Fortan Plugin (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling Fortan Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_F77) $(libmesh_FFLAGS) -shared -fPIC $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 %-$(METHOD).plugin : %.f90
-	@echo "MOOSE Compiling Fortan Plugin (in "$(METHOD)" mode) "$<"..."
+	@echo "Compiling Fortan Plugin (in "$(METHOD)" mode) "$<"..."
 	@$(libmesh_F90) $(libmesh_FFLAGS) -shared -fPIC $(app_INCLUDES) $(libmesh_INCLUDE) $< -o $@
 
 # Define the "test" target, we'll use a variable name so that we can override it without warnings if needed

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -186,12 +186,18 @@ moose_analyzer += $(patsubst %.cc, %.plist.$(obj-suffix), $(hit_srcfiles))
 app_INCLUDES := $(moose_INCLUDE) $(libmesh_INCLUDE)
 app_LIBS     := $(moose_LIBS)
 app_DIRS     := $(FRAMEWORK_DIR)
-all:: libmesh_submodule_status header_symlinks moose_revision moose
+
+moose_revision_header := $(FRAMEWORK_DIR)/include/base/MooseRevision.h
+
+all:: libmesh_submodule_status header_symlinks $(moose_revision_header) moose
 
 # revision header
-moose_revision_header = $(FRAMEWORK_DIR)/include/base/MooseRevision.h
-moose_revision:
-	@echo Regenerating MooseRevision
+moose_GIT_DIR := $(shell cd "$(FRAMEWORK_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
+# Use wildcard in case the files don't exist
+moose_HEADER_deps := $(wildcard $(moose_GIT_DIR)/.git/HEAD $(moose_GIT_DIR)/.git/index)
+
+$(moose_revision_header): $(moose_HEADER_deps)
+	@echo "Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(FRAMEWORK_DIR) \
 	  $(moose_revision_header) MOOSE)
 	@if [ ! -e "$(moose_all_header_dir)/MooseRevision.h" ]; then \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -42,7 +42,13 @@ ifneq ($(MOOSE_COLOR),true)
   COLOR_STRING = '--no-color'
 endif
 
-test_subs:
+.PHONY: builds $(MODULE_DIRS)
+builds: $(MODULE_DIRS)
+
+$(MODULE_DIRS): $(app_LIBS)
+	@$(MAKE) -C $@
+
+test_subs: all builds
 	@echo ======================================================
 	@echo Testing the following modules:
 	@for app in $(MODULE_DIRS); do echo \ $$app; done
@@ -52,6 +58,6 @@ test_subs:
 	for app in $(MODULE_DIRS); \
 	do \
 		echo ====== Testing in $${app} ====== ; \
-		cd $${app} && $(MAKE) && ./run_tests $(COLOR_STRING) -j $(MOOSE_JOBS) $(MOOSE_LOAD) -t || ret_val=1; \
+		cd $${app} && ./run_tests $(COLOR_STRING) -j $(MOOSE_JOBS) $(MOOSE_LOAD) -t || ret_val=1; \
 	done; \
 	exit $$ret_val;)

--- a/modules/module_loader/Makefile
+++ b/modules/module_loader/Makefile
@@ -18,7 +18,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/phase_field
+APPLICATION_DIR    := $(MODULE_DIR)/module_loader
 APPLICATION_NAME   := module_loader
 DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
 include            $(FRAMEWORK_DIR)/app.mk


### PR DESCRIPTION
- Adding an else condition to handle the case where we ONLY want to build a lib
- Making test_subs much faster (parallel compiles and links for all modules)
- Dropping MOOSE from all rule outputs (we don't need this)
- Proper dependencies for MOOSE's revision file

closes #10957

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
