### PR TITLE
Get_Repo_Revision.py: about twice as fast, more work to do

### DIFF
--- a/examples/ex01_inputfile/Makefile
+++ b/examples/ex01_inputfile/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex01
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex01
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex02_kernel/Makefile
+++ b/examples/ex02_kernel/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex02
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex02
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex03_coupling/Makefile
+++ b/examples/ex03_coupling/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex03
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex03
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 
@@ -36,5 +36,5 @@ ex_deps     := $(patsubst %.C, %.$(obj-suffix).d, $(ex_srcfiles))
 ###############################################################################
 # Additional special case targets should be added here
 
-test: all 
+test: all
 	$(call TEST_exodiff,ex03.i,ex03_out.e)

--- a/examples/ex04_bcs/Makefile
+++ b/examples/ex04_bcs/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex04
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex04
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex05_amr/Makefile
+++ b/examples/ex05_amr/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex05
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex05
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex06_transient/Makefile
+++ b/examples/ex06_transient/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex06
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex06
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex07_ics/Makefile
+++ b/examples/ex07_ics/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex07
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex07
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex08_materials/Makefile
+++ b/examples/ex08_materials/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex08
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex08
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex09_stateful_materials/Makefile
+++ b/examples/ex09_stateful_materials/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex09
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex09
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex10_aux/Makefile
+++ b/examples/ex10_aux/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex10
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex10
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex11_prec/Makefile
+++ b/examples/ex11_prec/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex11
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex11
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex12_pbp/Makefile
+++ b/examples/ex12_pbp/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex12
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex12
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex13_functions/Makefile
+++ b/examples/ex13_functions/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex13
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex13
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex14_pps/Makefile
+++ b/examples/ex14_pps/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex14
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex14
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex15_actions/Makefile
+++ b/examples/ex15_actions/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex15
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex15
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex16_timestepper/Makefile
+++ b/examples/ex16_timestepper/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex16
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex16
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex17_dirac/Makefile
+++ b/examples/ex17_dirac/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex17
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex17
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex18_scalar_kernel/Makefile
+++ b/examples/ex18_scalar_kernel/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex18
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex18
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex19_dampers/Makefile
+++ b/examples/ex19_dampers/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex19
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex19
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex20_user_objects/Makefile
+++ b/examples/ex20_user_objects/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex20
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex20
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/examples/ex21_debugging/Makefile
+++ b/examples/ex21_debugging/Makefile
@@ -24,7 +24,7 @@ APPLICATION_NAME := ex21
 APPLICATION_DIR    := $(shell pwd)
 APPLICATION_NAME   := ex21
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 include            ../test.mk
 

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -1,6 +1,7 @@
 # This file contains common MOOSE application settings
 # Note: MOOSE applications are assumed to reside in peer directories relative to MOOSE and its modules.
 #       This can be overridden by using the MOOSE_DIR environment variable
+GEN_REVISION ?= yes
 
 # list of application-wide excluded source files
 excluded_srcfiles :=
@@ -13,6 +14,7 @@ STACK := $(STACK).X
 $APPLICATION_DIR$(STACK) := $(APPLICATION_DIR)
 $APPLICATION_NAME$(STACK) := $(APPLICATION_NAME)
 $DEPEND_MODULES$(STACK) := $(DEPEND_MODULES)
+$GEN_REVISION$(STACK) := $(GEN_REVISION)
 $BUILD_EXEC$(STACK) := $(BUILD_EXEC)
 $DEP_APPS$(STACK) := $(DEP_APPS)
 
@@ -24,6 +26,7 @@ $DEP_APPS$(STACK) := $(DEP_APPS)
 APPLICATION_DIR := $($APPLICATION_DIR$(STACK))
 APPLICATION_NAME := $($APPLICATION_NAME$(STACK))
 DEPEND_MODULES := $($DEPEND_MODULES$(STACK))
+GEN_REVISION := $($GEN_REVISION$(STACK))
 BUILD_EXEC := $($BUILD_EXEC$(STACK))
 DEP_APPS := $($DEP_APPS$(STACK))
 STACK := $(basename $(STACK))
@@ -190,9 +193,12 @@ header_symlinks:: $(all_header_dir) $(link_names)
 app_EXEC    := $(APPLICATION_DIR)/$(APPLICATION_NAME)-$(METHOD)
 
 # revision header
-CAMEL_CASE_NAME := $(shell echo $(APPLICATION_NAME) | perl -pe 's/(?:^|_)([a-z])/\u$$1/g')
-app_BASE_DIR    ?= base/
-app_HEADER      ?= $(APPLICATION_DIR)/include/$(app_BASE_DIR)$(CAMEL_CASE_NAME)Revision.h
+ifeq ($(GEN_REVISION),yes)
+  CAMEL_CASE_NAME := $(shell echo $(APPLICATION_NAME) | perl -pe 's/(?:^|_)([a-z])/\u$$1/g')
+  app_BASE_DIR    ?= base/
+  app_HEADER      ?= $(APPLICATION_DIR)/include/$(app_BASE_DIR)$(CAMEL_CASE_NAME)Revision.h
+endif
+
 # depend modules
 depend_libs  := $(foreach i, $(DEPEND_MODULES), $(MOOSE_DIR)/modules/$(i)/lib/lib$(i)-$(METHOD).la)
 

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -1,6 +1,9 @@
 # This file contains common MOOSE application settings
 # Note: MOOSE applications are assumed to reside in peer directories relative to MOOSE and its modules.
-#       This can be overridden by using the MOOSE_DIR environment variable
+#       This can be overridden by using the MOOSE_DIR environment variable.
+
+# This variable is used to determine whether a C++ header revision file is generated for use
+# in your application. You can turn it on/off by changing it in your application Makefile.
 GEN_REVISION ?= yes
 
 # list of application-wide excluded source files

--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -116,11 +116,11 @@ def svnVersionString( cwd=None ):
 
 
 def repoVersionString( cwd=None ):
-    version = svnVersionString( cwd )
+    version = gitVersionString( cwd )
+    if version is None:
+        version = svnVersionString( cwd )
     if version is None:
         version = gitSvnVersionString( cwd )
-    if version is None:
-        version = gitVersionString( cwd )
     if version is None:
         version = "unknown"
     return version

--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -14,7 +14,7 @@
 import subprocess, os, sys, re
 from distutils.version import LooseVersion
 
-def shellCommand( command, cwd=None ):
+def shellCommand(command, cwd=None):
     """
     Run a command in the shell.
     We can ignore anything on stderr as that can potentially mess up the output
@@ -29,157 +29,183 @@ def shellCommand( command, cwd=None ):
 
         return p.communicate()[0]
 
-def hideSignature():
-    """
-    Conditionally returns the flag --no-show-signature if the version
-    of git is new enough to support that option.
-    """
-    try:
-        # Search for a version string in the git version output
-        m = re.search(r"(\d+\.\S+)", shellCommand( 'git --version' ))
-        if m:
-            gitVersion = m.group(1)
-            if LooseVersion(gitVersion) >= LooseVersion("2.9"):
-                return "--no-show-signature"
-    except:
-        pass
+class VersionInfo:
+    def __init__(self):
+        self.hide_signature_string = None
+        self.SHA1 = None
+        self.is_git_repo = False
 
-    return ""
+    def hideSignature(self):
+        """
+        Conditionally returns the flag --no-show-signature if the version
+        of git is new enough to support that option.
+        """
+        if self.hide_signature_string == None:
+            self.hide_signature_string = ""
+            try:
+                # Search for a version string in the git version output
+                m = re.search(r"(\d+\.\S+)", shellCommand('git --version'))
+                if m:
+                    gitVersion = m.group(1)
+                    if LooseVersion(gitVersion) >= LooseVersion("2.9"):
+                        self.hide_signature_string = "--no-show-signature"
+            except:
+                pass
 
+        return self.hide_signature_string
 
-def gitSHA1( cwd=None ):
-    try:
-        # The SHA1 should always be available if we have a git repo.
-        return shellCommand( 'git show ' + hideSignature() + ' -s --format=%h', cwd ).strip()
-    except: # subprocess.CalledProcessError:
-        return None
+    def gitSHA1(self, cwd=None):
+        if self.SHA1 == None:
+            try:
+                # The SHA1 should always be available if we have a git repo.
+                self.SHA1 = shellCommand('git show ' + self.hideSignature() + ' -s --format=%h', cwd).strip()
+                self.is_git_repo = True
+            except: # subprocess.CalledProcessError:
+                self.SHA1 = ""
 
+        return self.SHA1
 
-def gitTag( cwd=None ):
-    try:
-        # The tag should always be available if we have a git repo.
-        return shellCommand( 'git describe --tags', cwd).strip()
-    except: # subprocess.CalledProcessError:
-        return None
-
-
-def gitDate( cwd=None ):
-    try:
-        # The date should always be available if we have a git repo.
-        return shellCommand( 'git show ' + hideSignature() + ' -s --format=%ci', cwd ).split()[0]
-    except: # subprocess.CalledProcessError:
-        return None
-
-
-def gitVersionString( cwd=None ):
-    SHA1 = gitSHA1( cwd )
-    date = gitDate( cwd )
-
-    if not SHA1 or not date:
-        # Can happen if we aren't in a valid repo
-        return None
-
-    # The tag check will always succeed if the repo starts with a v0.0 tag. To find only tags that
-    # were part of the first parent, use --first-parent.
-    tag = ''
-    try:
-        description = shellCommand( 'git describe --tags --long --match "v[0-9]*"', cwd ).rsplit('-',2)
-        tag = description[0] + ', '
-        commitsSinceTag = description[1]
-        if commitsSinceTag != '0':
-            tag = 'derived from ' + tag
-    except: # subprocess.CalledProcessError:
-        pass
-    return tag + "git commit " + SHA1 + " on " + date
-
-
-def gitSvnVersionString( cwd=None ):
-    try:
-        date = shellCommand( 'git show -s --format=%ci', cwd ).split()[0]
-        revision = shellCommand( 'git svn find-rev $(git log --max-count 1 --pretty=format:%H)', cwd ).strip()
-        if len( revision ) > 0 and len( revision ) < 10:
-            return 'svn revision ' + revision + " on " + date
-    except: # subprocess.CalledProcessError:
-        pass
-    return None
-
-
-def svnVersionString( cwd=None ):
-    try:
-        revisionString = shellCommand( 'svnversion .', cwd )
-        matchingRevision = re.search( r'\d+', revisionString )
-        if matchingRevision is not None:
-            return 'svn revision ' + matchingRevision.group(0)
-    except: # subprocess.CalledProcessError:
-        pass
-    return None
-
-
-def repoVersionString( cwd=None ):
-    version = gitVersionString( cwd )
-    if version is None:
-        version = svnVersionString( cwd )
-    if version is None:
-        version = gitSvnVersionString( cwd )
-    if version is None:
-        version = "unknown"
-    return version
-
-
-def writeRevision( repo_location, app_name, revision_header ):
-    # Use all caps for app name (by convention).
-    app_def_name = app_name.upper()
-    app_def_name = re.sub( '[^a-zA-Z0-9]', '', app_def_name )
-    app_definition = app_def_name + '_REVISION'
-
-    app_revision = repoVersionString( repo_location )
-
-    # Version is the tag. If empty, we use the sha1 hash
-    app_version = gitTag(repo_location)
-    if app_version is None:
-        app_version = gitSHA1(repo_location)
-        if app_version is None:
-            app_version = "unknown"
-
-    # see if the revision is different
-    revision_changed = False
-    if os.path.exists(revision_header):
-        f = open(revision_header, "r")
-        buffer = f.read()
-
-        m =  re.search( re.escape( app_definition) + r' "([^"]*)"',buffer )
-        if m is not None and m.group(1) != app_revision:
-            revision_changed = True
-
-        if m is None:
-            # If the above RE doesn't match anything then we have
-            # a bad _REVISION define and we need to rewrite
-            # out a new file.
-            revision_changed = True
-
-        f.close()
-    else:
-        # Count it as changed if the header does not exist.
-        revision_changed = True
-
-    if revision_changed:
-        revision_dir = os.path.dirname(revision_header)
+    def gitTag(self, cwd=None):
         try:
-            os.stat(revision_dir)
-        except:
-            os.mkdir(revision_dir)
+            # The tag should always be available if we have a git repo.
+            return shellCommand('git describe --tags', cwd).strip()
+        except: # subprocess.CalledProcessError:
+            return None
 
-        f = open(revision_header, "w")
-        f.write( '/* THIS FILE IS AUTOGENERATED - DO NOT EDIT */\n' \
-                 '\n'
-                 '#ifndef ' + app_definition + '_H\n'
-                 '#define ' + app_definition + '_H\n'
-                 '\n'
-                 '#define ' + app_definition + ' "' + app_revision + '"\n'
-                 '#define ' + app_def_name + '_VERSION "' + app_version + '"\n'
-                 '\n'
-                 '#endif // ' + app_definition + '_H\n')
-        f.close()
+
+    def gitDate(self, cwd=None):
+        try:
+            # The date should always be available if we have a git repo.
+            return shellCommand('git show ' + self.hideSignature() + ' -s --format=%ci', cwd).split()[0]
+        except: # subprocess.CalledProcessError:
+            return None
+
+
+    def gitVersionString(self, cwd=None):
+        SHA1 = self.gitSHA1(cwd)
+        date = self.gitDate(cwd)
+
+        if not SHA1 or not date:
+            # Can happen if we aren't in a valid repo
+            return None
+
+        # The tag check will always succeed if the repo starts with a v0.0 tag. To find only tags that
+        # were part of the first parent, use --first-parent.
+        tag = ''
+        try:
+            description = shellCommand('git describe --tags --long --match "v[0-9]*"', cwd).rsplit('-',2)
+            tag = description[0] + ', '
+            commitsSinceTag = description[1]
+            if commitsSinceTag != '0':
+                tag = 'derived from ' + tag
+        except: # subprocess.CalledProcessError:
+            pass
+        return tag + "git commit " + SHA1 + " on " + date
+
+
+    def gitSvnVersionString(self, cwd=None):
+        try:
+            date = shellCommand('git show -s --format=%ci', cwd).split()[0]
+            revision = shellCommand('git svn find-rev $(git log --max-count 1 --pretty=format:%H)', cwd).strip()
+            if len(revision) > 0 and len(revision) < 10:
+                return 'svn revision ' + revision + " on " + date
+        except: # subprocess.CalledProcessError:
+            pass
+        return None
+
+
+    def svnVersionString(self, cwd=None):
+        try:
+            revisionString = shellCommand('svnversion .', cwd)
+            matchingRevision = re.search(r'\d+', revisionString)
+            if matchingRevision is not None:
+                return 'svn revision ' + matchingRevision.group(0)
+        except: # subprocess.CalledProcessError:
+            pass
+        return None
+
+
+    def repoVersionString(self, cwd=None):
+        version = self.gitVersionString(cwd)
+        if version is None:
+            version = self.svnVersionString(cwd)
+        if version is None:
+            version = self.gitSvnVersionString(cwd)
+        if version is None:
+            version = "unknown"
+        return version
+
+
+    def writeRevision(self, repo_location, app_name, revision_header):
+        # Use all caps for app name (by convention).
+        app_def_name = app_name.upper()
+        app_def_name = re.sub('[^a-zA-Z0-9]', '', app_def_name)
+        app_definition = app_def_name + '_REVISION'
+
+        app_revision = self.repoVersionString(repo_location)
+
+        # Version is the tag. If empty, we use the sha1 hash
+        app_version = self.gitTag(repo_location)
+        if app_version is None:
+            app_version = self.gitSHA1(repo_location)
+            if app_version is None:
+                app_version = "unknown"
+
+        # see if the revision is different
+        revision_changed = False
+        if os.path.exists(revision_header):
+            f = open(revision_header, "r")
+            buffer = f.read()
+
+            m =  re.search(re.escape(app_definition) + r' "([^"]*)"',buffer)
+            if m is not None and m.group(1) != app_revision:
+                revision_changed = True
+
+            if m is None:
+                # If the above RE doesn't match anything then we have
+                # a bad _REVISION define and we need to rewrite
+                # out a new file.
+                revision_changed = True
+
+            f.close()
+        else:
+            # Count it as changed if the header does not exist.
+            revision_changed = True
+
+        if revision_changed:
+            revision_dir = os.path.dirname(revision_header)
+            try:
+                os.stat(revision_dir)
+            except:
+                os.mkdir(revision_dir)
+
+            f = open(revision_header, "w")
+            f.write( '/* THIS FILE IS AUTOGENERATED - DO NOT EDIT */\n' \
+                     '\n'
+                     '#ifndef ' + app_definition + '_H\n'
+                     '#define ' + app_definition + '_H\n'
+                     '\n'
+                     '#define ' + app_definition + ' "' + app_revision + '"\n'
+                     '#define ' + app_def_name + '_VERSION "' + app_version + '"\n'
+                     '\n'
+                     '#endif // ' + app_definition + '_H\n')
+            f.close()
+        else:
+            # Nothing has changed, but if we don't do anything the revision file
+            # will still appear to be out of date every time we re-run make.
+            # We could touch the revision file, but that might spawn off another big
+            # build. Instead we will touch the repository files that triggered this
+            # script instead (e.g. .git/HEAD .git/index).
+            # Hopefully this doesn't cause the Universe to unravel.
+            cdup = shellCommand('git rev-parse --show-cdup', repo_location).strip()
+
+            timestamps_to_modify = []
+            timestamps_to_modify.append(os.path.join(cdup, '.git', 'HEAD'))
+            timestamps_to_modify.append(os.path.join(cdup, '.git', 'index'))
+
+            for touch_file in timestamps_to_modify:
+                shellCommand("touch -r " + revision_header + " " + touch_file)
+
 
 # Entry point
 if len(sys.argv) == 4:
@@ -187,4 +213,5 @@ if len(sys.argv) == 4:
     header_file = sys.argv[2]
     app_name = sys.argv[3]
 
-    writeRevision( repo_location, app_name, header_file )
+    version_info = VersionInfo()
+    version_info.writeRevision(repo_location, app_name, header_file)

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -26,9 +26,7 @@ include modules.mk
 APPLICATION_DIR    := $(MOOSE_DIR)/modules/combined
 APPLICATION_NAME   := combined
 BUILD_EXEC         := yes
-# Note: There are no applications that depend on moose_test so the test_up and up
-# targets are not very useful here.  Instead we will test up like this is MOOSE
-DEP_APPS           ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/chemical_reactions/Makefile
+++ b/modules/chemical_reactions/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/chemical_reactions
 APPLICATION_NAME   := chemical_reactions
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/combined/Makefile
+++ b/modules/combined/Makefile
@@ -29,9 +29,7 @@ include $(MODULE_DIR)/modules.mk
 APPLICATION_DIR    := $(MODULE_DIR)/combined
 APPLICATION_NAME   := combined
 BUILD_EXEC         := yes
-# Note: There are no applications that depend on moose_test so the test_up and up
-# targets are not very useful here.  Instead we will test up like this is MOOSE
-DEP_APPS           ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/contact/Makefile
+++ b/modules/contact/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/contact
 APPLICATION_NAME   := contact
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/fluid_properties/Makefile
+++ b/modules/fluid_properties/Makefile
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_NAME   := fluid_properties
 APPLICATION_DIR    := $(MODULE_DIR)/$(APPLICATION_NAME)
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/functional_expansion_tools/Makefile
+++ b/modules/functional_expansion_tools/Makefile
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_NAME   := functional_expansion_tools
 APPLICATION_DIR    := $(MODULE_DIR)/$(APPLICATION_NAME)
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/functional_expansion_tools/unit/Makefile
+++ b/modules/functional_expansion_tools/unit/Makefile
@@ -54,6 +54,7 @@ ADDITIONAL_LIBS   := $(FRAMEWORK_DIR)/contrib/gtest/libgtest.la
 CURRENT_DIR        := $(shell pwd)
 APPLICATION_DIR    := $(CURRENT_DIR)/..
 APPLICATION_NAME   := functional_expansion_tools
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 APPLICATION_DIR    := $(CURRENT_DIR)
@@ -61,6 +62,7 @@ APPLICATION_NAME   := functional_expansion_tools-unit
 BUILD_EXEC         := yes
 
 DEP_APPS    ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include $(FRAMEWORK_DIR)/app.mk
 
 # Find all the FunctionalExpansionTools unit test source files and include their dependencies.

--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/heat_conduction
 APPLICATION_NAME   := heat_conduction
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/level_set/Makefile
+++ b/modules/level_set/Makefile
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/level_set
 APPLICATION_NAME   := level_set
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/misc/Makefile
+++ b/modules/misc/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/misc
 APPLICATION_NAME   := misc
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/module_loader/Makefile
+++ b/modules/module_loader/Makefile
@@ -20,7 +20,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 # dep apps
 APPLICATION_DIR    := $(MODULE_DIR)/module_loader
 APPLICATION_NAME   := module_loader
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/modules.mk
+++ b/modules/modules.mk
@@ -51,6 +51,7 @@ MODULE_NAMES := "chemical_reactions contact fluid_properties functional_expansio
 ###############################################################################
 ########################## MODULE REGISTRATION ################################
 ###############################################################################
+GEN_REVISION  := no
 
 ifeq ($(CHEMICAL_REACTIONS),yes)
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/chemical_reactions
@@ -204,3 +205,6 @@ ifneq ($(SKIP_LOADER),yes)
   LIBRARY_SUFFIX     := yes
   include $(FRAMEWORK_DIR)/app.mk
 endif
+
+# Default to Generating revision for most applications
+GEN_REVISION := yes

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -26,7 +26,7 @@ include $(MODULE_DIR)/modules.mk
 APPLICATION_DIR    := $(MODULE_DIR)/navier_stokes
 APPLICATION_NAME   := navier_stokes
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -26,7 +26,7 @@ include $(MODULE_DIR)/modules.mk
 APPLICATION_DIR    := $(MODULE_DIR)/phase_field
 APPLICATION_NAME   := phase_field
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/porous_flow/Makefile
+++ b/modules/porous_flow/Makefile
@@ -28,7 +28,7 @@ include $(MODULE_DIR)/modules.mk
 APPLICATION_DIR    := $(MODULE_DIR)/porous_flow
 APPLICATION_NAME   := porous_flow
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/rdg/Makefile
+++ b/modules/rdg/Makefile
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/rdg
 APPLICATION_NAME   := rdg
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/richards/Makefile
+++ b/modules/richards/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/richards
 APPLICATION_NAME   := richards
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/solid_mechanics/Makefile
+++ b/modules/solid_mechanics/Makefile
@@ -26,7 +26,7 @@ include $(MODULE_DIR)/modules.mk
 APPLICATION_DIR    := $(MODULE_DIR)/solid_mechanics
 APPLICATION_NAME   := solid_mechanics
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/stochastic_tools/Makefile
+++ b/modules/stochastic_tools/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # HERD_TRUNK_DIR   - Location of the HERD repository
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/stochastic_tools
 APPLICATION_NAME   := stochastic_tools
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/tensor_mechanics/Makefile
+++ b/modules/tensor_mechanics/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/tensor_mechanics
 APPLICATION_NAME   := tensor_mechanics
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/water_steam_eos/Makefile
+++ b/modules/water_steam_eos/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # MODULE_DIR       - Location of the MOOSE modules directory
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/water_steam_eos
 APPLICATION_NAME   := water_steam_eos
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/modules/xfem/Makefile
+++ b/modules/xfem/Makefile
@@ -27,7 +27,7 @@ APPLICATION_DIR    := $(MODULE_DIR)/xfem
 APPLICATION_NAME   := xfem
 BUILD_EXEC         := yes
 DEPEND_MODULES     := solid_mechanics
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/stork/Makefile.app
+++ b/stork/Makefile.app
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 #
 ###############################################################################
 # Use the MOOSE submodule if it exists and MOOSE_DIR is not set
@@ -49,7 +49,7 @@ include $(MOOSE_DIR)/modules/modules.mk
 APPLICATION_DIR    := $(CURDIR)
 APPLICATION_NAME   := stork
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/stork/Makefile.module
+++ b/stork/Makefile.module
@@ -3,7 +3,7 @@
 ###############################################################################
 #
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project 
+# MOOSE_DIR        - Root directory of the MOOSE project
 # HERD_TRUNK_DIR   - Location of the HERD repository
 # FRAMEWORK_DIR    - Location of the MOOSE framework
 #
@@ -21,7 +21,7 @@ include $(FRAMEWORK_DIR)/moose.mk
 APPLICATION_DIR    := $(MODULE_DIR)/stork
 APPLICATION_NAME   := stork
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/test/Makefile
+++ b/test/Makefile
@@ -20,9 +20,7 @@ APPLICATION_DIR    := $(MOOSE_DIR)/test
 APPLICATION_NAME   := moose_test
 BUILD_EXEC         := yes
 BUILD_TEST_OBJECTS_LIB := no
-# Note: There are no applications that depend on moose_test so the test_up and up
-# targets are not very useful here.  Instead we will test up like this is MOOSE
-DEP_APPS           ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py moose)
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
@@ -46,7 +46,7 @@ include $(MOOSE_DIR)/modules/modules.mk
 APPLICATION_DIR    := $(CURDIR)
 APPLICATION_NAME   := darcy_thermo_mech
 BUILD_EXEC         := yes
-DEP_APPS           := $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
@@ -47,12 +47,13 @@ ADDITIONAL_LIBS 	:= $(FRAMEWORK_DIR)/contrib/gtest/libgtest.la
 # dep apps
 APPLICATION_DIR    := $(CURRENT_DIR)/..
 APPLICATION_NAME   := darcy_thermo_mech
+GEN_REVISION       := no
 include            $(FRAMEWORK_DIR)/app.mk
 
 APPLICATION_DIR    := $(CURRENT_DIR)
 APPLICATION_NAME   := darcy_thermo_mech-unit
 BUILD_EXEC         := yes
-DEP_APPS    ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
+GEN_REVISION       := no
 include $(FRAMEWORK_DIR)/app.mk
 
 # Find all the DARCY_THERMO_MECH unit test source files and include their dependencies.


### PR DESCRIPTION
The get_repo_revision.py script has been speed up by roughly 2x just by changing the order of repository discovery (e.g. we shouldn't be trying SVN first anymore, or at all for that matter). 

More importantly, the second commit in this PR makes it so we don't generate revision files for modules, examples, tutorials, or moose/test. This drastically increases compilation speed when there is little or nothing to do.
