### PR TITLE
Make TabulatedFluidProperties faster

### DIFF
--- a/framework/include/utils/BicubicSplineInterpolation.h
+++ b/framework/include/utils/BicubicSplineInterpolation.h
@@ -40,7 +40,7 @@ public:
   virtual ~BicubicSplineInterpolation() = default;
 
   /**
-   * Set the x1-, x2, y- values and first derivatives
+   * Set the x1, x2 and y values, and first derivatives at the edges
    */
   void setData(const std::vector<Real> & x1,
                const std::vector<Real> & x2,
@@ -50,17 +50,47 @@ public:
                const std::vector<Real> & yx21 = std::vector<Real>(),
                const std::vector<Real> & yx2n = std::vector<Real>());
 
+  /**
+   * Sanity checks on input data
+   */
   void errorCheck();
 
+  /**
+   * Samples value at point (x1, x2)
+   */
   Real sample(Real x1, Real x2, Real yx11 = _deriv_bound, Real yx1n = _deriv_bound);
+
+  /**
+   * Samples value and first derivatives at point (x1, x2)
+   */
+  void sampleValueAndDerivatives(Real x1,
+                                 Real x2,
+                                 Real & y,
+                                 Real & dy1,
+                                 Real & dy2,
+                                 Real yx11 = _deriv_bound,
+                                 Real yx1n = _deriv_bound,
+                                 Real yx21 = _deriv_bound,
+                                 Real yx2n = _deriv_bound);
+
+  /**
+   * Samples first derivative at point (x1, x2)
+   */
   Real sampleDerivative(
       Real x1, Real x2, unsigned int deriv_var, Real yp1 = _deriv_bound, Real ypn = _deriv_bound);
+
+  /**
+   * Samples second derivative at point (x1, x2)
+   */
   Real sample2ndDerivative(
       Real x1, Real x2, unsigned int deriv_var, Real yp1 = _deriv_bound, Real ypn = _deriv_bound);
 
 protected:
+  /// Independent values in the x1 direction
   std::vector<Real> _x1;
+  /// Independent values in the x2 direction
   std::vector<Real> _x2;
+  /// The dependent values at (x1, x2) points
   std::vector<std::vector<Real>> _y;
   /// Transpose of _y
   std::vector<std::vector<Real>> _y_trans;
@@ -80,10 +110,45 @@ protected:
   std::vector<std::vector<Real>> _y2_rows;
   std::vector<std::vector<Real>> _y2_columns;
 
+  /// Vectors used during sampling
+  std::vector<Real> _row_spline_second_derivs;
+  std::vector<Real> _row_spline_eval;
+  std::vector<Real> _column_spline_second_derivs;
+  std::vector<Real> _column_spline_eval;
+
+  /**
+   * Precompute tables of row (column) spline second derivatives
+   * and store them to reduce computational demands
+   */
   void constructRowSplineSecondDerivativeTable();
   void constructColumnSplineSecondDerivativeTable();
+
+  /**
+   * Calculates the tables of second derivatives
+   */
   void solve();
 
+  /**
+   * Helper functions to evaluate column splines and construct row spline
+   * for the given point
+   */
+  void constructRowSpline(Real x1,
+                          std::vector<Real> & spline_eval,
+                          std::vector<Real> & spline_second_derivs,
+                          Real yx11 = _deriv_bound,
+                          Real yx1n = _deriv_bound);
+
+  /**
+   * Helper functions to evaluate row splines and construct column spline
+   * for the given point
+   */
+  void constructColumnSpline(Real x2,
+                             std::vector<Real> & spline_eval,
+                             std::vector<Real> & spline_second_derivs,
+                             Real yx21 = _deriv_bound,
+                             Real yx2n = _deriv_bound);
+
+  /// File number for data dump
   static int _file_number;
 };
 

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -225,10 +225,6 @@ protected:
   unsigned int _num_T;
   /// Number of pressure points in the tabulated data
   unsigned int _num_p;
-  /// Index for derivatives wrt pressure
-  const unsigned int _wrt_p = 1;
-  /// Index for derivatives wrt temperature
-  const unsigned int _wrt_T = 2;
 
   /// SinglePhaseFluidPropertiesPT UserObject
   const SinglePhaseFluidPropertiesPT & _fp;

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -221,9 +221,7 @@ TabulatedFluidProperties::rho_dpT(
     Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
   checkInputVariables(pressure, temperature);
-  rho = _density_ipol->sample(pressure, temperature);
-  drho_dp = _density_ipol->sampleDerivative(pressure, temperature, _wrt_p);
-  drho_dT = _density_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+  _density_ipol->sampleValueAndDerivatives(pressure, temperature, rho, drho_dp, drho_dT);
 }
 
 Real
@@ -238,9 +236,7 @@ TabulatedFluidProperties::e_dpT(
     Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const
 {
   checkInputVariables(pressure, temperature);
-  e = _internal_energy_ipol->sample(pressure, temperature);
-  de_dp = _internal_energy_ipol->sampleDerivative(pressure, temperature, _wrt_p);
-  de_dT = _internal_energy_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+  _internal_energy_ipol->sampleValueAndDerivatives(pressure, temperature, e, de_dp, de_dT);
 }
 
 void
@@ -270,9 +266,7 @@ TabulatedFluidProperties::h_dpT(
     Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
 {
   checkInputVariables(pressure, temperature);
-  h = _enthalpy_ipol->sample(pressure, temperature);
-  dh_dp = _enthalpy_ipol->sampleDerivative(pressure, temperature, _wrt_p);
-  dh_dT = _enthalpy_ipol->sampleDerivative(pressure, temperature, _wrt_T);
+  _enthalpy_ipol->sampleValueAndDerivatives(pressure, temperature, h, dh_dp, dh_dT);
 }
 
 Real

--- a/unit/src/BiubicSplineInterpolationTest.C
+++ b/unit/src/BiubicSplineInterpolationTest.C
@@ -1,0 +1,52 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "BicubicSplineInterpolation.h"
+
+const double tol = 1e-8;
+
+TEST(BicubicSplineInterpolationTest, sample)
+{
+  // Test BicubicSplineInterpolation with a function y = x1^2 + x2^3
+  const unsigned int n = 5;
+  std::vector<double> x1(n), x2(n), yx11(n), yx1n(n), yx21(n), yx2n(n);
+  std::vector<std::vector<double>> y(n);
+
+  for (unsigned int i = 0; i < n; ++i)
+  {
+    x1[i] = i;
+    x2[i] = i;
+    yx1n[i] = 8.0;
+    yx2n[i] = 48.0;
+    y[i].resize(n);
+  }
+
+  for (unsigned int i = 0; i < n; ++i)
+    for (unsigned int j = 0; j < n; ++j)
+      y[i][j] = x1[i] * x1[i] + x2[j] * x2[j] * x2[j];
+
+  BicubicSplineInterpolation interp(x1, x2, y, yx11, yx1n, yx21, yx2n);
+
+  // Check sampled value and first and second derivatives
+  EXPECT_NEAR(interp.sample(2.0, 3.0), 31.0, tol);
+  EXPECT_NEAR(interp.sampleDerivative(2.0, 3.0, 1, yx11[0], yx1n[0]), 4.0, tol);
+  EXPECT_NEAR(interp.sampleDerivative(2.0, 3.0, 2, yx21[0], yx2n[0]), 27.0, tol);
+  EXPECT_NEAR(interp.sample2ndDerivative(2.0, 3.0, 1, yx11[0], yx1n[0]), 2.0, tol);
+  EXPECT_NEAR(interp.sample2ndDerivative(2.0, 3.0, 2, yx21[0], yx2n[0]), 18.0, tol);
+
+  // Check that sampleValueAndDerivatives() returns the same results as above
+  double y2, dy2_dx1, dy2_dx2;
+  interp.sampleValueAndDerivatives(
+      2.0, 3.0, y2, dy2_dx1, dy2_dx2, yx11[0], yx1n[0], yx21[0], yx2n[0]);
+  EXPECT_NEAR(y2, 31.0, tol);
+  EXPECT_NEAR(dy2_dx1, 4.0, tol);
+  EXPECT_NEAR(dy2_dx2, 27.0, tol);
+}


### PR DESCRIPTION
Add new method `sampleValueAndDerivatives` to `BicubicSplineInterpolation` to sample the value and derivatives together, reducing the number of spline evaluations from three to two. 

I also removed the temporary vectors from each method, replacing them with member vectors. This alone sped up each interpolation by between 5% and 10% (depending on number of points in vectors).

Some timing results for 1 million samples for the value and both first derivatives using this new method to calculate all at once, compared to the old method of evaluating each separately:

|              | Before | After | Speedup |
|--------|--------|------|----------|
| BicubicSplineInterpolation | 9.28251s | 5.77597s | 1.6 |
| TabulatedFluidProperties | 15.1424s | 9.29558s | 1.6 |

These results depend on the number of grid points etc, but I typically saw this degree of reduction in time +/- a few percent, which makes sense as it is basically reducing the calculation by a third.

Close #8936
Closes #10995 