### PR TITLE
Increase speed of bicubic spline interpolation

### DIFF
--- a/framework/include/utils/BicubicSplineInterpolation.h
+++ b/framework/include/utils/BicubicSplineInterpolation.h
@@ -62,6 +62,8 @@ public:
 
   /**
    * Samples value and first derivatives at point (x1, x2)
+   * Use this function for speed when computing both value and derivatives,
+   * as it minimizes the amount of spline evaluation
    */
   void sampleValueAndDerivatives(Real x1,
                                  Real x2,

--- a/framework/include/utils/SplineInterpolationBase.h
+++ b/framework/include/utils/SplineInterpolationBase.h
@@ -25,10 +25,12 @@ public:
               const std::vector<Real> & y,
               const std::vector<Real> & y2,
               Real x_int) const;
+
   Real sampleDerivative(const std::vector<Real> & x,
                         const std::vector<Real> & y,
                         const std::vector<Real> & y2,
                         Real x_int) const;
+
   Real sample2ndDerivative(const std::vector<Real> & x,
                            const std::vector<Real> & y,
                            const std::vector<Real> & y2,
@@ -48,6 +50,7 @@ protected:
                     Real x_int,
                     unsigned int & klo,
                     unsigned int & khi) const;
+
   void computeCoeffs(const std::vector<Real> & x,
                      unsigned int klo,
                      unsigned int khi,
@@ -55,6 +58,19 @@ protected:
                      Real & h,
                      Real & a,
                      Real & b) const;
+
+  /**
+   * Sample value at point x_int given the indices of the vector of
+   * dependent values that bound the point. This method is useful
+   * in bicubic spline interpolation, where several spline evaluations
+   * are needed to sample from a 2D point.
+   */
+  Real sample(const std::vector<Real> & x,
+              const std::vector<Real> & y,
+              const std::vector<Real> & y2,
+              Real x_int,
+              unsigned int klo,
+              unsigned int khi) const;
 
   static const Real _deriv_bound;
 };

--- a/framework/src/utils/BicubicSplineInterpolation.C
+++ b/framework/src/utils/BicubicSplineInterpolation.C
@@ -259,9 +259,15 @@ BicubicSplineInterpolation::constructRowSpline(Real x1,
 {
   auto n = _x2.size();
 
-  // Evaluate n column-splines to get y-values for row spline construction
+  // Find the indices that bound the point x1
+  unsigned int klo, khi;
+  findInterval(_x1, x1, klo, khi);
+
+  // Evaluate n column-splines to get y-values for row spline construction using
+  // the indices above to avoid computing them for each j
   for (decltype(n) j = 0; j < n; ++j)
-    _column_spline_eval[j] = SplineInterpolationBase::sample(_x1, _y_trans[j], _y2_columns[j], x1);
+    _column_spline_eval[j] =
+        SplineInterpolationBase::sample(_x1, _y_trans[j], _y2_columns[j], x1, klo, khi);
 
   // Construct single row spline; get back the second derivatives wrt x2 coord
   // on the x2 grid points
@@ -277,9 +283,14 @@ BicubicSplineInterpolation::constructColumnSpline(Real x2,
 {
   auto m = _x1.size();
 
-  // Evaluate m row-splines to get y-values for column spline construction
+  // Find the indices that bound the point x2
+  unsigned int klo, khi;
+  findInterval(_x2, x2, klo, khi);
+
+  // Evaluate m row-splines to get y-values for column spline construction using
+  // the indices above to avoid computing them for each j
   for (decltype(m) j = 0; j < m; ++j)
-    _row_spline_eval[j] = SplineInterpolationBase::sample(_x2, _y[j], _y2_rows[j], x2);
+    _row_spline_eval[j] = SplineInterpolationBase::sample(_x2, _y[j], _y2_rows[j], x2, klo, khi);
 
   // Construct single column spline; get back the second derivatives wrt x1 coord
   // on the x1 grid points

--- a/framework/src/utils/SplineInterpolationBase.C
+++ b/framework/src/utils/SplineInterpolationBase.C
@@ -105,11 +105,7 @@ SplineInterpolationBase::sample(const std::vector<Real> & x,
   unsigned int klo, khi;
   findInterval(x, x_int, klo, khi);
 
-  Real h, a, b;
-  computeCoeffs(x, klo, khi, x_int, h, a, b);
-
-  return a * y[klo] + b * y[khi] +
-         ((a * a * a - a) * y2[klo] + (b * b * b - b) * y2[khi]) * (h * h) / 6.0;
+  return sample(x, y, y2, x_int, klo, khi);
 }
 
 Real
@@ -141,4 +137,19 @@ SplineInterpolationBase::sample2ndDerivative(const std::vector<Real> & x,
   computeCoeffs(x, klo, khi, x_int, h, a, b);
 
   return a * y2[klo] + b * y2[khi];
+}
+
+Real
+SplineInterpolationBase::sample(const std::vector<Real> & x,
+                                const std::vector<Real> & y,
+                                const std::vector<Real> & y2,
+                                Real x_int,
+                                unsigned int klo,
+                                unsigned int khi) const
+{
+  Real h, a, b;
+  computeCoeffs(x, klo, khi, x_int, h, a, b);
+
+  return a * y[klo] + b * y[khi] +
+         ((a * a * a - a) * y2[klo] + (b * b * b - b) * y2[khi]) * (h * h) / 6.0;
 }


### PR DESCRIPTION
By computing the interval that bounds the point in advance, the
repeated spline evaluation can be performed much faster.

Some timing for 1 million bicubic spline interpolations:

| Before | After | Speedup |
|--|--|--|
| 3.09155s | 1.8999s | ~1.6 |

I was looking at making `TabulatedFluidProperties` faster, and in combination with #10996, the time to sample a value and two first derivatives is now over twice as fast (numbers for 1 million samples):

| Before | After | Speedup |
|--|--|--|
| 15.1424s | 6.57069s | ~2.2 |

This change will also make objects that use bicubic spline interpolation faster, such as `BicubicSplineFunction`.

Closes #10999 