### PR TITLE
Allow parallel FDP execution

### DIFF
--- a/framework/src/preconditioners/FiniteDifferencePreconditioner.C
+++ b/framework/src/preconditioners/FiniteDifferencePreconditioner.C
@@ -57,7 +57,8 @@ FiniteDifferencePreconditioner::FiniteDifferencePreconditioner(const InputParame
     _finite_difference_type(getParam<MooseEnum>("finite_difference_type"))
 {
   if (n_processors() > 1)
-    mooseError("Can't use the Finite Difference Preconditioner in parallel yet!");
+    mooseWarning("Finite differencing to assemble the Jacobian is MUCH MUCH slower than forming "
+                 "the Jacobian by hand, so don't complain about performance if you use it!");
 
   NonlinearSystemBase & nl = _fe_problem.getNonlinearSystemBase();
   unsigned int n_vars = nl.nVariables();

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -14,4 +14,17 @@
     mesh_mode = REPLICATED
     prereq = test
   []
+
+  [./parallel_fdp_test]
+    type = 'Exodiff'
+    prereq = 'test'
+    exodiff = 'coupled_value_coupled_flux_out.e'
+    min_parallel = 2
+    input = 'coupled_value_coupled_flux.i'
+    cli_args = 'Preconditioning/smp/type=FDP'
+    design = 'Preconditioning/framework/FDP.md'
+    issues = '#10375'
+    requirement = 'The finite difference preconditioner shall work in parallel'
+    allow_warnings = true
+  [../]
 []


### PR DESCRIPTION
- Instead of generating an error, we throw out a huge warning that FDP will be much slower than a hand coded jacobian.
- runs a parallel FDP test on an existing interface kernel test

Closes #10375 

