### PR TITLE
Move viscosity derivative calculation from PorousFlow to FluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -74,6 +74,16 @@ public:
                         Real & drho_dT,
                         Real & drho_dx) const override;
 
+  virtual Real mu(Real pressure, Real temperature, Real xnacl) const override;
+
+  virtual void mu_dpTx(Real pressure,
+                       Real temperature,
+                       Real xnacl,
+                       Real & mu,
+                       Real & dmu_dp,
+                       Real & dmu_dT,
+                       Real & dmu_dx) const override;
+
   virtual Real mu_from_rho_T(Real water_density, Real temperature, Real xnacl) const override;
 
   virtual void mu_drhoTx(Real water_density,
@@ -84,6 +94,21 @@ public:
                          Real & dmu_drho,
                          Real & dmu_dT,
                          Real & dmu_dx) const override;
+
+  virtual void
+  rho_mu(Real pressure, Real temperature, Real xnacl, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real xnacl,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & drho_dx,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT,
+                          Real dmu_dx) const override;
 
   virtual Real h(Real pressure, Real temperature, Real xnacl) const override;
 

--- a/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
@@ -64,6 +64,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual std::string fluidName() const override;
 
   Real molarMass() const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -81,6 +81,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual Real h(Real p, Real T) const override;
 
   virtual void

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -75,6 +75,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual Real k(Real pressure, Real temperature) const override;
 
   virtual void

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -63,6 +63,33 @@ public:
 
   /*
    * Dynamic viscosity
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param xmass mass fraction (-)
+   * @return viscosity (Pa.s)
+   */
+  virtual Real mu(Real pressure, Real temperature, Real xmass) const = 0;
+
+  /*
+   * Dynamic viscosity and its derivatives wrt pressure and temperature
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param xmass mass fraction (-)
+   * @param[out] mu viscosity (Pa.s)
+   * @param[out] dmu_dp derivative of viscosity wrt pressure
+   * @param[out] dmu_dT derivative of viscosity wrt temperature
+   * @param[out] dmu_dx derivative of viscosity wrt mass fraction
+   */
+  virtual void mu_dpTx(Real pressure,
+                       Real temperature,
+                       Real xmass,
+                       Real & mu,
+                       Real & dmu_dp,
+                       Real & dmu_dT,
+                       Real & dmu_dx) const = 0;
+
+  /*
+   * Dynamic viscosity
    * @param density fluid density (kg/m^3)
    * @param temperature fluid temperature (K)
    * @param xmass mass fraction (-)
@@ -89,6 +116,41 @@ public:
                          Real & dmu_drho,
                          Real & dmu_dT,
                          Real & dmu_dx) const = 0;
+
+  /**
+   * Density and viscosity
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param xmass mass fraction (-)
+   * @param[out] rho density (kg/m^3)
+   */
+  virtual void rho_mu(Real pressure, Real temperature, Real xmass, Real & rho, Real & mu) const = 0;
+
+  /**
+   * Density and viscosity and their derivatives wrt pressure and temperature
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param xmass mass fraction (-)
+   * @param[out] rho density (kg/m^3)
+   * @param[out] drho_dp derivative of density wrt pressure
+   * @param[out] drho_dT derivative of density wrt temperature
+   * @param[out] drho_dx derivative of density wrt mass fraction
+   * @param[out] mu viscosity (Pa.s)
+   * @param[out] dmu_dp derivative of viscosity wrt pressure
+   * @param[out] dmu_dT derivative of viscosity wrt temperature
+   * @param[out] dmu_dx derivative of viscosity wrt mass fraction
+   */
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real xmass,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & drho_dx,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT,
+                          Real dmu_dx) const = 0;
 
   /**
    * Enthalpy

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -107,6 +107,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual Real k(Real pressure, Real temperature) const override;
 
   virtual void

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -107,6 +107,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   /// Specific enthalpy (J/kg)
   virtual Real h(Real p, Real T) const override;
 

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -170,6 +170,35 @@ public:
                                    Real & mu,
                                    Real & dmu_drho,
                                    Real & dmu_dT) const = 0;
+
+  /**
+   * Density and viscosity
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param[out] rho density (kg/m^3)
+   * @param[out] mu viscosity (Pa.s)
+   */
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const = 0;
+
+  /**
+   * Density and viscosity and their derivatives wrt pressure and temperature
+   * @param pressure fluid pressure (Pa)
+   * @param temperature fluid temperature (K)
+   * @param[out] rho density (kg/m^3)
+   * @param[out] drho_dp derivative of density wrt pressure
+   * @param[out] drho_dT derivative of density wrt temperature
+   * @param[out] mu viscosity (Pa.s)
+   * @param[out] dmu_dp derivative of viscosity wrt pressure
+   * @param[out] dmu_dT derivative of viscosity wrt temperature
+   */
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const = 0;
   /**
    * Thermal conductivity
    * @param pressure fluid pressure (Pa)

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -136,6 +136,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual Real cp(Real pressure, Real temperature) const override;
 
   virtual Real cv(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -123,6 +123,17 @@ public:
                                    Real & dmu_drho,
                                    Real & dmu_dT) const override;
 
+  virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
+
+  virtual void rho_mu_dpT(Real pressure,
+                          Real temperature,
+                          Real & rho,
+                          Real & drho_dp,
+                          Real & drho_dT,
+                          Real & mu,
+                          Real & dmu_dp,
+                          Real & dmu_dT) const override;
+
   virtual Real k(Real pressure, Real temperature) const override;
 
   virtual void

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -155,6 +155,32 @@ BrineFluidProperties::rho_dpTx(Real pressure,
 }
 
 Real
+BrineFluidProperties::mu(Real pressure, Real temperature, Real xnacl) const
+{
+  Real water_density = _water_fp->rho(pressure, temperature);
+  return this->mu_from_rho_T(water_density, temperature, xnacl);
+}
+
+void
+BrineFluidProperties::mu_dpTx(Real pressure,
+                              Real temperature,
+                              Real xnacl,
+                              Real & mu,
+                              Real & dmu_dp,
+                              Real & dmu_dT,
+                              Real & dmu_dx) const
+{
+  Real water_density, dwater_density_dp, dwater_density_dT;
+  _water_fp->rho_dpT(pressure, temperature, water_density, dwater_density_dp, dwater_density_dT);
+
+  Real dmu_drho;
+  this->mu_drhoTx(
+      water_density, temperature, xnacl, dwater_density_dT, mu, dmu_drho, dmu_dT, dmu_dx);
+
+  dmu_dp = dmu_drho * dwater_density_dp;
+}
+
+Real
 BrineFluidProperties::mu_from_rho_T(Real water_density, Real temperature, Real xnacl) const
 {
   // Correlation requires molal concentration (mol/kg)
@@ -205,6 +231,31 @@ BrineFluidProperties::mu_drhoTx(Real water_density,
   dmu_drho = a * dmuw_drhow;
   dmu_dx = da_dx * muw;
   dmu_dT = da_dT * muw + a * dmuw_dT;
+}
+
+void
+BrineFluidProperties::rho_mu(
+    Real pressure, Real temperature, Real xnacl, Real & rho, Real & mu) const
+{
+  rho = this->rho(pressure, temperature, xnacl);
+  mu = this->mu(pressure, temperature, xnacl);
+}
+
+void
+BrineFluidProperties::rho_mu_dpT(Real pressure,
+                                 Real temperature,
+                                 Real xnacl,
+                                 Real & rho,
+                                 Real & drho_dp,
+                                 Real & drho_dT,
+                                 Real & drho_dx,
+                                 Real & mu,
+                                 Real & dmu_dp,
+                                 Real & dmu_dT,
+                                 Real dmu_dx) const
+{
+  this->rho_dpTx(pressure, temperature, xnacl, rho, drho_dp, drho_dT, drho_dx);
+  this->mu_dpTx(pressure, temperature, xnacl, mu, dmu_dp, dmu_dT, dmu_dx);
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -180,6 +180,27 @@ IdealGasFluidPropertiesPT::mu_drhoT_from_rho_T(Real density,
   dmu_dT = 0.0;
 }
 
+void
+IdealGasFluidPropertiesPT::rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const
+{
+  rho = this->rho(pressure, temperature);
+  mu = this->mu(pressure, temperature);
+}
+
+void
+IdealGasFluidPropertiesPT::rho_mu_dpT(Real pressure,
+                                      Real temperature,
+                                      Real & rho,
+                                      Real & drho_dp,
+                                      Real & drho_dT,
+                                      Real & mu,
+                                      Real & dmu_dp,
+                                      Real & dmu_dT) const
+{
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  this->mu_dpT(pressure, temperature, mu, dmu_dp, dmu_dT);
+}
+
 Real
 IdealGasFluidPropertiesPT::h(Real /*pressure*/, Real temperature) const
 {

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -207,6 +207,27 @@ MethaneFluidProperties::mu_drhoT_from_rho_T(Real density,
   dmu_dT = dmudt * 1.e-6;
 }
 
+void
+MethaneFluidProperties::rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const
+{
+  rho = this->rho(pressure, temperature);
+  mu = this->mu_from_rho_T(rho, temperature);
+}
+
+void
+MethaneFluidProperties::rho_mu_dpT(Real pressure,
+                                   Real temperature,
+                                   Real & rho,
+                                   Real & drho_dp,
+                                   Real & drho_dT,
+                                   Real & mu,
+                                   Real & dmu_dp,
+                                   Real & dmu_dT) const
+{
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  this->mu_dpT(pressure, temperature, mu, dmu_dp, dmu_dT);
+}
+
 Real
 MethaneFluidProperties::k(Real pressure, Real temperature) const
 {

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -193,6 +193,28 @@ NaClFluidProperties::mu_drhoT_from_rho_T(Real /*density*/,
   mooseError(name(), ": mu_drhoT() is not implemented");
 }
 
+void
+NaClFluidProperties::rho_mu(Real /*pressure*/,
+                            Real /*temperature*/,
+                            Real & /*rho*/,
+                            Real & /*mu*/) const
+{
+  mooseError(name(), ": rho_mu() is not implemented");
+}
+
+void
+NaClFluidProperties::rho_mu_dpT(Real /*pressure*/,
+                                Real /*temperature*/,
+                                Real & /*rho*/,
+                                Real & /*drho_dp*/,
+                                Real & /*drho_dT*/,
+                                Real & /*mu*/,
+                                Real & /*dmu_dp*/,
+                                Real & /*dmu_dT*/) const
+{
+  mooseError(name(), ": rho_mu_dpT() is not implemented");
+}
+
 Real NaClFluidProperties::k(Real /*pressure*/, Real /*temperature*/) const
 {
   mooseError(name(), ": k() is not implemented");

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -188,6 +188,27 @@ SimpleFluidProperties::mu_drhoT_from_rho_T(Real density,
   dmu_dT = 0.0;
 }
 
+void
+SimpleFluidProperties::rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const
+{
+  rho = this->rho(pressure, temperature);
+  mu = this->mu(pressure, temperature);
+}
+
+void
+SimpleFluidProperties::rho_mu_dpT(Real pressure,
+                                  Real temperature,
+                                  Real & rho,
+                                  Real & drho_dp,
+                                  Real & drho_dT,
+                                  Real & mu,
+                                  Real & dmu_dp,
+                                  Real & dmu_dT) const
+{
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  this->mu_dpT(pressure, temperature, mu, dmu_dp, dmu_dT);
+}
+
 Real
 SimpleFluidProperties::h(Real pressure, Real temperature) const
 {

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -304,6 +304,25 @@ TabulatedFluidProperties::mu_drhoT_from_rho_T(Real density,
   _fp.mu_drhoT_from_rho_T(density, temperature, ddensity_dT, mu, dmu_drho, dmu_dT);
 }
 
+void
+TabulatedFluidProperties::rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const
+{
+  _fp.rho_mu(pressure, temperature, rho, mu);
+}
+
+void
+TabulatedFluidProperties::rho_mu_dpT(Real pressure,
+                                     Real temperature,
+                                     Real & rho,
+                                     Real & drho_dp,
+                                     Real & drho_dT,
+                                     Real & mu,
+                                     Real & dmu_dp,
+                                     Real & dmu_dT) const
+{
+  _fp.rho_mu_dpT(pressure, temperature, rho, drho_dp, drho_dT, mu, dmu_dp, dmu_dT);
+}
+
 Real
 TabulatedFluidProperties::c(Real pressure, Real temperature) const
 {

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -583,6 +583,29 @@ Water97FluidProperties::mu_drhoT_from_rho_T(Real density,
   dmu_dT = mu_star * (dmu0_dTbar * mu1 + mu0 * dmu1_dTbar) * dTbar_dT + dmu_drho * ddensity_dT;
 }
 
+void
+Water97FluidProperties::rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const
+{
+  rho = this->rho(pressure, temperature);
+  mu = this->mu_from_rho_T(rho, temperature);
+}
+
+void
+Water97FluidProperties::rho_mu_dpT(Real pressure,
+                                   Real temperature,
+                                   Real & rho,
+                                   Real & drho_dp,
+                                   Real & drho_dT,
+                                   Real & mu,
+                                   Real & dmu_dp,
+                                   Real & dmu_dT) const
+{
+  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
+  Real dmu_drho;
+  this->mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
+  dmu_dp = dmu_drho * drho_dp;
+}
+
 Real
 Water97FluidProperties::k(Real pressure, Real temperature) const
 {
@@ -856,9 +879,8 @@ Water97FluidProperties::vaporPressure_dT(Real temperature, Real & psat, Real & d
   Real dpsat = 4.0 * std::pow(2.0 * c / denominator, 3.0);
   dpsat *= (2.0 * dc_dtheta / denominator -
             2.0 * c / denominator / denominator *
-                (-db_dtheta +
-                 std::pow(b * b - 4.0 * a * c, -0.5) *
-                     (b * db_dtheta - 2.0 * da_dtheta * c - 2.0 * a * dc_dtheta)));
+                (-db_dtheta + std::pow(b * b - 4.0 * a * c, -0.5) *
+                                  (b * db_dtheta - 2.0 * da_dtheta * c - 2.0 * a * dc_dtheta)));
   dpsat_dT = dpsat * dtheta_dT * 1.0e6;
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
+++ b/modules/porous_flow/src/materials/PorousFlowSingleComponentFluid.C
@@ -42,15 +42,14 @@ PorousFlowSingleComponentFluid::PorousFlowSingleComponentFluid(const InputParame
                    : &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase,
                                                       _pressure_variable_name))
             : nullptr),
-    _ddensity_dT(
-        _compute_rho_mu
-            ? (_nodal_material
-                   ? &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_nodal" +
-                                                          _phase,
-                                                      _temperature_variable_name)
-                   : &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_density_qp" + _phase,
-                                                      _temperature_variable_name))
-            : nullptr),
+    _ddensity_dT(_compute_rho_mu
+                     ? (_nodal_material ? &declarePropertyDerivative<Real>(
+                                              "PorousFlow_fluid_phase_density_nodal" + _phase,
+                                              _temperature_variable_name)
+                                        : &declarePropertyDerivative<Real>(
+                                              "PorousFlow_fluid_phase_density_qp" + _phase,
+                                              _temperature_variable_name))
+                     : nullptr),
 
     _viscosity(_compute_rho_mu
                    ? (_nodal_material
@@ -111,15 +110,14 @@ PorousFlowSingleComponentFluid::PorousFlowSingleComponentFluid(const InputParame
                    : &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase,
                                                       _pressure_variable_name))
             : nullptr),
-    _denthalpy_dT(
-        _compute_enthalpy
-            ? (_nodal_material
-                   ? &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_nodal" +
-                                                          _phase,
-                                                      _temperature_variable_name)
-                   : &declarePropertyDerivative<Real>("PorousFlow_fluid_phase_enthalpy_qp" + _phase,
-                                                      _temperature_variable_name))
-            : nullptr),
+    _denthalpy_dT(_compute_enthalpy
+                      ? (_nodal_material ? &declarePropertyDerivative<Real>(
+                                               "PorousFlow_fluid_phase_enthalpy_nodal" + _phase,
+                                               _temperature_variable_name)
+                                         : &declarePropertyDerivative<Real>(
+                                               "PorousFlow_fluid_phase_enthalpy_qp" + _phase,
+                                               _temperature_variable_name))
+                      : nullptr),
 
     _fp(getUserObject<SinglePhaseFluidPropertiesPT>("fp"))
 {
@@ -143,19 +141,14 @@ PorousFlowSingleComponentFluid::computeQpProperties()
 
   if (_compute_rho_mu)
   {
-    // Density and derivatives wrt pressure and temperature at the qps
-    Real rho, drho_dp, drho_dT;
-    _fp.rho_dpT(_porepressure[_qp][_phase_num], Tk, rho, drho_dp, drho_dT);
+    // Density and viscosity, and derivatives wrt pressure and temperature
+    Real rho, drho_dp, drho_dT, mu, dmu_dp, dmu_dT;
+    _fp.rho_mu_dpT(_porepressure[_qp][_phase_num], Tk, rho, drho_dp, drho_dT, mu, dmu_dp, dmu_dT);
     (*_density)[_qp] = rho;
     (*_ddensity_dp)[_qp] = drho_dp;
     (*_ddensity_dT)[_qp] = drho_dT;
-
-    // Viscosity and derivatives wrt pressure and temperature at the nodes.
-    // Note that dmu_dp = dmu_drho * drho_dp
-    Real mu, dmu_drho, dmu_dT;
-    _fp.mu_drhoT_from_rho_T(rho, Tk, drho_dT, mu, dmu_drho, dmu_dT);
     (*_viscosity)[_qp] = mu;
-    (*_dviscosity_dp)[_qp] = dmu_drho * drho_dp;
+    (*_dviscosity_dp)[_qp] = dmu_dp;
     (*_dviscosity_dT)[_qp] = dmu_dT;
   }
 

--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -212,14 +212,15 @@ PorousFlowBrineCO2::gasProperties(Real pressure,
   // Gas density and viscosity are approximated with pure CO2 - no correction due
   // to the small amount of water vapor is made
   Real co2_density, dco2_density_dp, dco2_density_dT;
-  Real co2_viscosity, dco2_viscosity_drho, dco2_viscosity_dT;
-  _co2_fp.rho_dpT(pressure, temperature, co2_density, dco2_density_dp, dco2_density_dT);
-  _co2_fp.mu_drhoT_from_rho_T(co2_density,
-                              temperature,
-                              dco2_density_dT,
-                              co2_viscosity,
-                              dco2_viscosity_drho,
-                              dco2_viscosity_dT);
+  Real co2_viscosity, dco2_viscosity_dp, dco2_viscosity_dT;
+  _co2_fp.rho_mu_dpT(pressure,
+                     temperature,
+                     co2_density,
+                     dco2_density_dp,
+                     dco2_density_dT,
+                     co2_viscosity,
+                     dco2_viscosity_dp,
+                     dco2_viscosity_dT);
 
   // Save the values to the FluidStateProperties object. Note that derivatives wrt z are 0
   gas.density = co2_density;
@@ -228,7 +229,7 @@ PorousFlowBrineCO2::gasProperties(Real pressure,
   gas.ddensity_dz = 0.0;
 
   gas.viscosity = co2_viscosity;
-  gas.dviscosity_dp = dco2_viscosity_drho * dco2_density_dp;
+  gas.dviscosity_dp = dco2_viscosity_dp;
   gas.dviscosity_dT = dco2_viscosity_dT;
   gas.dviscosity_dz = 0.0;
 }


### PR DESCRIPTION
Add new methods to calculate density and viscosity (and derivatives wrt pressure and temperature) that can be used by PorousFlow. Viscosity derivative calculations are now handled by FluidProperties, rather than in PorousFlow.

The new methods enable each fluid to provide the most efficient calculation of both density and viscosity to PorousFlow.

Closes #11011