### PR TITLE
mu_from_rho_T and mu_drhoT_from_rho_T are no longer pure virtual

### DIFF
--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -153,7 +153,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return viscosity (Pa.s)
    */
-  virtual Real mu_from_rho_T(Real density, Real temperature) const = 0;
+  virtual Real mu_from_rho_T(Real density, Real temperature) const;
 
   /**
    * Dynamic viscosity and its derivatives wrt density and temperature
@@ -169,7 +169,7 @@ public:
                                    Real ddensity_dT,
                                    Real & mu,
                                    Real & dmu_drho,
-                                   Real & dmu_dT) const = 0;
+                                   Real & dmu_dT) const;
 
   /**
    * Density and viscosity

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -224,7 +224,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return thermal conductivity  (W/m/K)
    */
-  virtual Real k_from_rho_T(Real density, Real temperature) const = 0;
+  virtual Real k_from_rho_T(Real density, Real temperature) const;
 
   /**
    * Specific entropy

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
@@ -85,3 +85,14 @@ SinglePhaseFluidPropertiesPT::henryConstantIAPWS_dT(
   Kh = p * std::exp(lnkh);
   dKh_dT = (p * dlnkh_dT + dp_dT) * std::exp(lnkh);
 }
+
+Real SinglePhaseFluidPropertiesPT::mu_from_rho_T(Real, Real) const
+{
+  mooseError(name(), ": mu_from_rho_T is not implemented.");
+}
+
+void
+SinglePhaseFluidPropertiesPT::mu_drhoT_from_rho_T(Real, Real, Real, Real &, Real &, Real &) const
+{
+  mooseError(name(), ": mu_drhoT_from_rho_T is not implemented.");
+}

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
@@ -96,3 +96,8 @@ SinglePhaseFluidPropertiesPT::mu_drhoT_from_rho_T(Real, Real, Real, Real &, Real
 {
   mooseError(name(), ": mu_drhoT_from_rho_T is not implemented.");
 }
+
+Real SinglePhaseFluidPropertiesPT::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
+{
+  mooseError(name(), ": k_from_rho_T is not implemented.");
+}


### PR DESCRIPTION
This prepares the API change for removing the methods fromt he interface

Refs #11031

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
