### PR TITLE
Update the moose package paths

### DIFF
--- a/framework/doc/content/getting_started/installation/centos_pre_req.md
+++ b/framework/doc/content/getting_started/installation/centos_pre_req.md
@@ -16,4 +16,4 @@ libX11-devel
 
 Download and install one our redistributable packages according to your version of CentOS
 
-  * CentOS 7: !package name arch=centos7!
+  * CentOS 7: !!package name arch=centos7!!

--- a/framework/doc/content/getting_started/installation/fedora_pre_req.md
+++ b/framework/doc/content/getting_started/installation/fedora_pre_req.md
@@ -21,4 +21,4 @@ git
 
 Download and install one our redistributable packages according to your version of Fedora.
 
-  * Fedora 25: !moosepackage arch=fedora25 return=link!
+  * Fedora 25: !!package name arch=fedora25!!

--- a/framework/doc/content/getting_started/installation/mint_pre_req.md
+++ b/framework/doc/content/getting_started/installation/mint_pre_req.md
@@ -16,4 +16,4 @@ m4
 
 Download and install one of our redistributable packages according to your version of Mint.
 
-  * Mint 18: !moosepackage arch=mint18 return=link!
+  * Mint 18: !!package name arch=mint18!!

--- a/framework/doc/content/getting_started/installation/opensuse_pre_req.md
+++ b/framework/doc/content/getting_started/installation/opensuse_pre_req.md
@@ -16,4 +16,4 @@ git
 
 Download and install one our redistributable packages according to your version of OpenSUSE.
 
-  * OpenSuSE Leap: !moosepackage arch=opensuseleap return=link!
+  * OpenSuSE Leap: !!package name arch=opensuseleap!!

--- a/framework/doc/content/getting_started/installation/ubuntu_pre_req.md
+++ b/framework/doc/content/getting_started/installation/ubuntu_pre_req.md
@@ -21,5 +21,5 @@ libhwloc-dev
 
 Download and install one of our redistributable packages according to your version of Ubuntu.
 
-  * Ubuntu 16.04: !moosepackage arch=ubuntu16.04 return=link!
-  * Ubuntu 14.04: !moosepackage arch=ubuntu14.04 return=link!
+- Ubuntu 16.04: !!package name arch=ubuntu16.04!!
+- Ubuntu 14.04: !!package name arch=ubuntu14.04!!

--- a/python/MooseDocs/extensions/package.py
+++ b/python/MooseDocs/extensions/package.py
@@ -24,7 +24,7 @@ class PackageExtension(command.CommandExtension):
 
         config = command.CommandExtension.defaultConfig()
         config['packages'] = (packages, "A dict of packages by name.")
-        config['link'] = (r'http://mooseframework.org/static/media/uploads/files',
+        config['link'] = (r'http://www.mooseframework.org/moose_packages',
                           "Location of packages.")
         return config
 


### PR DESCRIPTION
With the server migration we are changing the location of some of the files we store.
The apache alias  /moose_packages should be used for the location of where we store the packages internally.

refs #9638

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
