### PR TITLE
Add variable type sanity checks in FEProblemBase::addXYZ() routines.

### DIFF
--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1851,7 +1851,7 @@ FEProblemBase::addScalarKernel(const std::string & kernel_name,
   if (!_nl->hasScalarVariable(parameters.get<NonlinearVariableName>("variable")))
     mooseError(name, ": Cannot add ScalarKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
-               ", it is not a Scalar variable!");
+               ", it is not a SCALAR variable!");
 
   _nl->addScalarKernel(kernel_name, name, parameters);
 }

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1777,7 +1777,7 @@ FEProblemBase::addKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add Kernel for variable ",
+    mooseError(name, ": Cannot add Kernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1815,7 +1815,7 @@ FEProblemBase::addNodalKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add NodalKernel for variable ",
+    mooseError(name, ": Cannot add NodalKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 }
@@ -1849,7 +1849,7 @@ FEProblemBase::addScalarKernel(const std::string & kernel_name,
 
   // Check that "variable" is a Scalar variable on the NonlinearSystem
   if (!_nl->hasScalarVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add ScalarKernel for variable ",
+    mooseError(name, ": Cannot add ScalarKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a Scalar variable!");
 
@@ -1886,7 +1886,7 @@ FEProblemBase::addBoundaryCondition(const std::string & bc_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add BoundaryCondition for variable ",
+    mooseError(name, ": Cannot add BoundaryCondition for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1919,7 +1919,7 @@ FEProblemBase::addConstraint(const std::string & c_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add Constraint for variable ",
+    mooseError(name, ": Cannot add Constraint for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1992,7 +1992,7 @@ FEProblemBase::addAuxKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the AuxiliarySystem.
   if (!_aux->hasVariable(parameters.get<AuxVariableName>("variable")))
-    mooseError("Cannot add AuxKernel for variable ",
+    mooseError(name, ": Cannot add AuxKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
                ", it is not an AuxVariable!");
 
@@ -2028,7 +2028,7 @@ FEProblemBase::addAuxScalarKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the AuxiliarySystem.
   if (!_aux->hasScalarVariable(parameters.get<AuxVariableName>("variable")))
-    mooseError("Cannot add AuxScalarKernel for variable ",
+    mooseError(name, ": Cannot add AuxScalarKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
                ", it is not a Scalar AuxVariable!");
 
@@ -2065,7 +2065,7 @@ FEProblemBase::addDiracKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add DiracKernel for variable ",
+    mooseError(name, ": Cannot add DiracKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -2104,7 +2104,7 @@ FEProblemBase::addDGKernel(const std::string & dg_kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add DGKernel for variable ",
+    mooseError(name, ": Cannot add DGKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -2145,7 +2145,7 @@ FEProblemBase::addInterfaceKernel(const std::string & interface_kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError("Cannot add InterfaceKernel for variable ",
+    mooseError(name, ": Cannot add InterfaceKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1994,7 +1994,7 @@ FEProblemBase::addAuxKernel(const std::string & kernel_name,
   if (!_aux->hasVariable(parameters.get<AuxVariableName>("variable")))
     mooseError(name, ": Cannot add AuxKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
-               ", it is not an AuxVariable!");
+               ", it is not an auxiliary variable!");
 
   _aux->addKernel(kernel_name, name, parameters);
 }

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -2030,7 +2030,7 @@ FEProblemBase::addAuxScalarKernel(const std::string & kernel_name,
   if (!_aux->hasScalarVariable(parameters.get<AuxVariableName>("variable")))
     mooseError(name, ": Cannot add AuxScalarKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
-               ", it is not a Scalar AuxVariable!");
+               ", it is not a SCALAR auxiliary variable!");
 
   _aux->addScalarKernel(kernel_name, name, parameters);
 }

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1777,7 +1777,8 @@ FEProblemBase::addKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add Kernel for variable ",
+    mooseError(name,
+               ": Cannot add Kernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1815,7 +1816,8 @@ FEProblemBase::addNodalKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add NodalKernel for variable ",
+    mooseError(name,
+               ": Cannot add NodalKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 }
@@ -1849,7 +1851,8 @@ FEProblemBase::addScalarKernel(const std::string & kernel_name,
 
   // Check that "variable" is a Scalar variable on the NonlinearSystem
   if (!_nl->hasScalarVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add ScalarKernel for variable ",
+    mooseError(name,
+               ": Cannot add ScalarKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a SCALAR variable!");
 
@@ -1886,7 +1889,8 @@ FEProblemBase::addBoundaryCondition(const std::string & bc_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add BoundaryCondition for variable ",
+    mooseError(name,
+               ": Cannot add BoundaryCondition for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1919,7 +1923,8 @@ FEProblemBase::addConstraint(const std::string & c_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add Constraint for variable ",
+    mooseError(name,
+               ": Cannot add Constraint for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -1992,7 +1997,8 @@ FEProblemBase::addAuxKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the AuxiliarySystem.
   if (!_aux->hasVariable(parameters.get<AuxVariableName>("variable")))
-    mooseError(name, ": Cannot add AuxKernel for variable ",
+    mooseError(name,
+               ": Cannot add AuxKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
                ", it is not an auxiliary variable!");
 
@@ -2028,7 +2034,8 @@ FEProblemBase::addAuxScalarKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the AuxiliarySystem.
   if (!_aux->hasScalarVariable(parameters.get<AuxVariableName>("variable")))
-    mooseError(name, ": Cannot add AuxScalarKernel for variable ",
+    mooseError(name,
+               ": Cannot add AuxScalarKernel for variable ",
                parameters.get<AuxVariableName>("variable"),
                ", it is not a SCALAR auxiliary variable!");
 
@@ -2065,7 +2072,8 @@ FEProblemBase::addDiracKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add DiracKernel for variable ",
+    mooseError(name,
+               ": Cannot add DiracKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -2104,7 +2112,8 @@ FEProblemBase::addDGKernel(const std::string & dg_kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add DGKernel for variable ",
+    mooseError(name,
+               ": Cannot add DGKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 
@@ -2145,7 +2154,8 @@ FEProblemBase::addInterfaceKernel(const std::string & interface_kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name, ": Cannot add InterfaceKernel for variable ",
+    mooseError(name,
+               ": Cannot add InterfaceKernel for variable ",
                parameters.get<NonlinearVariableName>("variable"),
                ", it is not a nonlinear variable!");
 

--- a/framework/src/base/FEProblemBase.C
+++ b/framework/src/base/FEProblemBase.C
@@ -1775,6 +1775,12 @@ FEProblemBase::addKernel(const std::string & kernel_name,
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
 
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add Kernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addKernel(kernel_name, name, parameters);
 }
 
@@ -1806,6 +1812,12 @@ FEProblemBase::addNodalKernel(const std::string & kernel_name,
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
   _nl->addNodalKernel(kernel_name, name, parameters);
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add NodalKernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
 }
 
 void
@@ -1834,6 +1846,13 @@ FEProblemBase::addScalarKernel(const std::string & kernel_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is a Scalar variable on the NonlinearSystem
+  if (!_nl->hasScalarVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add ScalarKernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a Scalar variable!");
+
   _nl->addScalarKernel(kernel_name, name, parameters);
 }
 
@@ -1864,6 +1883,13 @@ FEProblemBase::addBoundaryCondition(const std::string & bc_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add BoundaryCondition for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addBoundaryCondition(bc_name, name, parameters);
 }
 
@@ -1890,6 +1916,13 @@ FEProblemBase::addConstraint(const std::string & c_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add Constraint for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addConstraint(c_name, name, parameters);
 }
 
@@ -1956,6 +1989,13 @@ FEProblemBase::addAuxKernel(const std::string & kernel_name,
     parameters.set<SystemBase *>("_sys") = _aux.get();
     parameters.set<SystemBase *>("_nl_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the AuxiliarySystem.
+  if (!_aux->hasVariable(parameters.get<AuxVariableName>("variable")))
+    mooseError("Cannot add AuxKernel for variable ",
+               parameters.get<AuxVariableName>("variable"),
+               ", it is not an AuxVariable!");
+
   _aux->addKernel(kernel_name, name, parameters);
 }
 
@@ -1985,6 +2025,13 @@ FEProblemBase::addAuxScalarKernel(const std::string & kernel_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _aux.get();
   }
+
+  // Check that "variable" is in the AuxiliarySystem.
+  if (!_aux->hasScalarVariable(parameters.get<AuxVariableName>("variable")))
+    mooseError("Cannot add AuxScalarKernel for variable ",
+               parameters.get<AuxVariableName>("variable"),
+               ", it is not a Scalar AuxVariable!");
+
   _aux->addScalarKernel(kernel_name, name, parameters);
 }
 
@@ -2015,6 +2062,13 @@ FEProblemBase::addDiracKernel(const std::string & kernel_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add DiracKernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addDiracKernel(kernel_name, name, parameters);
 }
 
@@ -2047,6 +2101,13 @@ FEProblemBase::addDGKernel(const std::string & dg_kernel_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add DGKernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addDGKernel(dg_kernel_name, name, parameters);
 
   _has_internal_edge_residual_objects = true;
@@ -2081,6 +2142,13 @@ FEProblemBase::addInterfaceKernel(const std::string & interface_kernel_name,
     parameters.set<SubProblem *>("_subproblem") = this;
     parameters.set<SystemBase *>("_sys") = _nl.get();
   }
+
+  // Check that "variable" is in the NonlinearSystem.
+  if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
+    mooseError("Cannot add InterfaceKernel for variable ",
+               parameters.get<NonlinearVariableName>("variable"),
+               ", it is not a nonlinear variable!");
+
   _nl->addInterfaceKernel(interface_kernel_name, name, parameters);
 
   _has_internal_edge_residual_objects = true;

--- a/test/src/actions/BadAddKernelAction.C
+++ b/test/src/actions/BadAddKernelAction.C
@@ -24,6 +24,9 @@ BadAddKernelAction::BadAddKernelAction(InputParameters params) : MooseObjectActi
 void
 BadAddKernelAction::act()
 {
-  // Wrong method being called for adding *Kernel* object
-  _problem->addScalarKernel(_type, _name, _moose_object_pars);
+  // Wrong method being called for adding *Kernel* object.
+  // Note: we chose addIndicator() for this Action so that a specific
+  // Factory error is triggered (and not some other error check on
+  // e.g. variable types).
+  _problem->addIndicator(_type, _name, _moose_object_pars);
 }

--- a/test/tests/misc/check_error/aux_kernel_with_var.i
+++ b/test/tests/misc/check_error/aux_kernel_with_var.i
@@ -1,0 +1,62 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[AuxKernels]
+  [./nope]
+    type = SelfAux
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/bad_kernel_action.i
+++ b/test/tests/misc/check_error/bad_kernel_action.i
@@ -10,7 +10,9 @@
   [../]
 []
 
-# Custom block to add Kernels (incorrectly)
+# Note: the BadKernels syntax is set up to incorrectly call addIndicator()
+# when it should actually call addKernel() to test that we can detect when
+# people call the wrong FEProblem methods in their Actions.
 [BadKernels]
   [./diff]
     type = Diffusion

--- a/test/tests/misc/check_error/bc_with_aux_var.i
+++ b/test/tests/misc/check_error/bc_with_aux_var.i
@@ -1,0 +1,55 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = v
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/constraint_with_aux_var.i
+++ b/test/tests/misc/check_error/constraint_with_aux_var.i
@@ -1,0 +1,54 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Constraints]
+  [./nope]
+    type = CoupledTiedValueConstraint
+    variable = v
+    slave = 2
+    master = 3
+    master_variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/dg_kernel_with_aux_var.i
+++ b/test/tests/misc/check_error/dg_kernel_with_aux_var.i
@@ -1,0 +1,64 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[DGKernels]
+  [./nope]
+    type = DGDiffusion
+    variable = v
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/dirac_kernel_with_aux_var.i
+++ b/test/tests/misc/check_error/dirac_kernel_with_aux_var.i
@@ -1,0 +1,62 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[DiracKernels]
+  [./nope]
+    type = CachingPointSource
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/interface_kernel_with_aux_var.i
+++ b/test/tests/misc/check_error/interface_kernel_with_aux_var.i
@@ -1,0 +1,66 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[InterfaceKernels]
+  [./nope]
+    type = InterfaceDiffusion
+    variable = v
+    neighbor_var = u
+    boundary = master0_interface
+    D = 4
+    D_neighbor = 2
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/kernel_with_aux_var.i
+++ b/test/tests/misc/check_error/kernel_with_aux_var.i
@@ -1,0 +1,55 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/missing_req_par_moose_obj_test.i
+++ b/test/tests/misc/check_error/missing_req_par_moose_obj_test.i
@@ -14,9 +14,9 @@
 [Kernels]
   active = 'diff'
 
-  # Test missing required param (variable in this case)
+  # Test missing required param (type in this case)
   [./diff]
-    type = Diffusion
+    variable = u
   [../]
 []
 

--- a/test/tests/misc/check_error/nodal_kernel_with_aux_var.i
+++ b/test/tests/misc/check_error/nodal_kernel_with_aux_var.i
@@ -1,0 +1,51 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[NodalKernels]
+  [./nope]
+    type = TimeDerivativeNodalKernel
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/scalar_aux_kernel_with_var.i
+++ b/test/tests/misc/check_error/scalar_aux_kernel_with_var.i
@@ -1,0 +1,63 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[AuxScalarKernels]
+  [./nope]
+    type = ConstantScalarAux
+    variable = u
+    value = 11
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/scalar_kernel_with_var.i
+++ b/test/tests/misc/check_error/scalar_kernel_with_var.i
@@ -1,0 +1,62 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./rea]
+    type = Reaction
+    variable = u
+  [../]
+[]
+
+[ScalarKernels]
+  [./nope]
+    type = ODETimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -343,7 +343,7 @@
   [./missing_req_par_moose_obj_test]
     type = 'RunException'
     input = 'missing_req_par_moose_obj_test.i'
-    expect_err = "Cannot add Kernel for variable , it is not a nonlinear variable"
+    expect_err = "missing required parameter 'Kernels/diff/type'"
   [../]
 
   [./missing_required_coupled_test]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -635,7 +635,7 @@
   [./scalar_kernel_with_var]
     type = 'RunException'
     input = 'scalar_kernel_with_var.i'
-    expect_err = "Cannot add ScalarKernel for variable u, it is not a Scalar variable"
+    expect_err = "Cannot add ScalarKernel for variable u, it is not a SCALAR variable"
   [../]
   [./nodal_kernel_with_aux_var]
     type = 'RunException'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -650,7 +650,7 @@
   [./scalar_aux_kernel_with_var]
     type = 'RunException'
     input = 'scalar_aux_kernel_with_var.i'
-    expect_err = "Cannot add AuxScalarKernel for variable u, it is not a Scalar AuxVariable"
+    expect_err = "Cannot add AuxScalarKernel for variable u, it is not a SCALAR auxiliary variable"
   [../]
   [./dirac_kernel_with_aux_var]
     type = 'RunException'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -39,7 +39,7 @@
   [./bad_bc_var_test]
     type = 'RunException'
     input = 'bad_bc_var_test.i'
-    expect_err = "Unknown variable foo"
+    expect_err = "Cannot add BoundaryCondition for variable foo, it is not a nonlinear variable"
   [../]
 
   [./bad_enum_test]
@@ -63,7 +63,7 @@
   [./bad_kernel_var_test]
     type = 'RunException'
     input = 'bad_kernel_var_test.i'
-    expect_err = "Unknown variable"
+    expect_err = "Cannot add Kernel for variable foo, it is not a nonlinear variable"
   [../]
 
   [./Badd_material_test]
@@ -343,7 +343,7 @@
   [./missing_req_par_moose_obj_test]
     type = 'RunException'
     input = 'missing_req_par_moose_obj_test.i'
-    expect_err = "missing required parameter 'Kernels/diff/variable'"
+    expect_err = "Cannot add Kernel for variable , it is not a nonlinear variable"
   [../]
 
   [./missing_required_coupled_test]
@@ -615,5 +615,56 @@
     type = 'RunException'
     input = 'missing_input_file.i'
     expect_err = "Unable to open file"
+  [../]
+
+  [./kernel_with_aux_var]
+    type = 'RunException'
+    input = 'kernel_with_aux_var.i'
+    expect_err = "Cannot add Kernel for variable v, it is not a nonlinear variable"
+  [../]
+  [./bc_with_aux_var]
+    type = 'RunException'
+    input = 'bc_with_aux_var.i'
+    expect_err = "Cannot add BoundaryCondition for variable v, it is not a nonlinear variable"
+  [../]
+  [./aux_kernel_with_var]
+    type = 'RunException'
+    input = 'aux_kernel_with_var.i'
+    expect_err = "Cannot add AuxKernel for variable u, it is not an AuxVariable"
+  [../]
+  [./scalar_kernel_with_var]
+    type = 'RunException'
+    input = 'scalar_kernel_with_var.i'
+    expect_err = "Cannot add ScalarKernel for variable u, it is not a Scalar variable"
+  [../]
+  [./nodal_kernel_with_aux_var]
+    type = 'RunException'
+    input = 'nodal_kernel_with_aux_var.i'
+    expect_err = "Cannot add NodalKernel for variable v, it is not a nonlinear variable"
+  [../]
+  [./constraint_with_aux_var]
+    type = 'RunException'
+    input = 'constraint_with_aux_var.i'
+    expect_err = "Cannot add Constraint for variable v, it is not a nonlinear variable"
+  [../]
+  [./scalar_aux_kernel_with_var]
+    type = 'RunException'
+    input = 'scalar_aux_kernel_with_var.i'
+    expect_err = "Cannot add AuxScalarKernel for variable u, it is not a Scalar AuxVariable"
+  [../]
+  [./dirac_kernel_with_aux_var]
+    type = 'RunException'
+    input = 'dirac_kernel_with_aux_var.i'
+    expect_err = "Cannot add DiracKernel for variable v, it is not a nonlinear variable"
+  [../]
+  [./dg_kernel_with_aux_var]
+    type = 'RunException'
+    input = 'dg_kernel_with_aux_var.i'
+    expect_err = "Cannot add DGKernel for variable v, it is not a nonlinear variable"
+  [../]
+  [./interface_kernel_with_aux_var]
+    type = 'RunException'
+    input = 'interface_kernel_with_aux_var.i'
+    expect_err = "Cannot add InterfaceKernel for variable v, it is not a nonlinear variable"
   [../]
 []

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -630,7 +630,7 @@
   [./aux_kernel_with_var]
     type = 'RunException'
     input = 'aux_kernel_with_var.i'
-    expect_err = "Cannot add AuxKernel for variable u, it is not an AuxVariable"
+    expect_err = "Cannot add AuxKernel for variable u, it is not an auxiliary variable"
   [../]
   [./scalar_kernel_with_var]
     type = 'RunException'


### PR DESCRIPTION
This fixes the problem pointed out by @YaqiWang in #11021, and adds tests to make sure that we can keep detecting the error.
