### PR TITLE
Remove unused methods that are no longer pure virtual in FluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -84,17 +84,6 @@ public:
                        Real & dmu_dT,
                        Real & dmu_dx) const override;
 
-  virtual Real mu_from_rho_T(Real water_density, Real temperature, Real xnacl) const override;
-
-  virtual void mu_drhoTx(Real water_density,
-                         Real temperature,
-                         Real xnacl,
-                         Real dwater_density_dT,
-                         Real & mu,
-                         Real & dmu_drho,
-                         Real & dmu_dT,
-                         Real & dmu_dx) const override;
-
   virtual void
   rho_mu(Real pressure, Real temperature, Real xnacl, Real & rho, Real & mu) const override;
 
@@ -132,7 +121,7 @@ public:
                       Real & de_dT,
                       Real & de_dx) const override;
 
-  virtual Real k_from_rho_T(Real water_density, Real temperature, Real xnacl) const override;
+  virtual Real k(Real pressure, Real temperature, Real xnacl) const override;
 
   /**
    * Brine vapour pressure

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -44,8 +44,6 @@ public:
   virtual void
   k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  virtual Real k_from_rho_T(Real density, Real temperature) const override;
-
   virtual Real s(Real pressure, Real temperature) const override;
 
   virtual Real rho(Real pressure, Real temperature) const override;
@@ -71,15 +69,6 @@ public:
 
   virtual void
   mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
-
-  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
-
-  virtual void mu_drhoT_from_rho_T(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const override;
 
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
 

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -66,15 +66,6 @@ public:
   virtual void
   mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
-  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
-
-  virtual void mu_drhoT_from_rho_T(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const override;
-
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
 
   virtual void rho_mu_dpT(Real pressure,
@@ -90,8 +81,6 @@ public:
 
   virtual void
   k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   virtual Real s(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -88,35 +88,6 @@ public:
                        Real & dmu_dT,
                        Real & dmu_dx) const = 0;
 
-  /*
-   * Dynamic viscosity
-   * @param density fluid density (kg/m^3)
-   * @param temperature fluid temperature (K)
-   * @param xmass mass fraction (-)
-   * @return viscosity (Pa.s)
-   */
-  virtual Real mu_from_rho_T(Real density, Real temperature, Real xmass) const = 0;
-
-  /**
-   * Dynamic viscosity and its derivatives wrt density, temperature and mass fraction
-   * @param density fluid density (kg/m^3)
-   * @param temperature fluid temperature (K)
-   * @param xmass mass fraction (-)
-   * @param ddensity_dT derivative of density wrt temperature
-   * @param[out] mu viscosity (Pa.s)
-   * @param[out] dmu_drho derivative of viscosity wrt density
-   * @param[out] dmu_dT derivative of viscosity wrt temperature
-   * @param[out] dmu_dx derivative of viscosity wrt mass fraction
-   */
-  virtual void mu_drhoTx(Real density,
-                         Real temperature,
-                         Real xmass,
-                         Real ddensity_dT,
-                         Real & mu,
-                         Real & dmu_drho,
-                         Real & dmu_dT,
-                         Real & dmu_dx) const = 0;
-
   /**
    * Density and viscosity
    * @param pressure fluid pressure (Pa)
@@ -217,12 +188,12 @@ public:
 
   /**
    * Thermal conductivity
-   * @param water_density water density (kg/m^3)
+   * @param pressure fluid pressure (Pa)
    * @param temperature fluid temperature (K)
    * @param xmass mass fraction (-)
    * @return thermal conductivity (W/m/K)
    */
-  virtual Real k_from_rho_T(Real density, Real temperature, Real xmass) const = 0;
+  virtual Real k(Real pressure, Real temperature, Real xmass) const = 0;
 
   /**
    * Get UserObject for specified component

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -98,15 +98,6 @@ public:
   virtual void
   mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
-  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
-
-  virtual void mu_drhoT_from_rho_T(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const override;
-
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
 
   virtual void rho_mu_dpT(Real pressure,
@@ -122,8 +113,6 @@ public:
 
   virtual void
   k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   virtual Real s(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -57,12 +57,10 @@ public:
 
   /// Thermal conductivity (W/m/K)
   virtual Real k(Real pressure, Real temperature) const override;
+
   /// Thermal conductivity and its derivatives wrt pressure and temperature
   virtual void
   k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  /// Thermal conductivity (W/m/K)
-  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   /// Specific entropy (J/kg/K)
   virtual Real s(Real pressure, Real temperature) const override;
@@ -95,17 +93,6 @@ public:
 
   virtual void
   mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
-
-  /// Dynamic viscosity (Pa s)
-  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
-
-  /// Dynamic viscosity and its derivatives wrt density and temperature
-  virtual void mu_drhoT_from_rho_T(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const override;
 
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
 

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -136,6 +136,7 @@ public:
    * @return viscosity (Pa.s)
    */
   virtual Real mu(Real pressure, Real temperature) const = 0;
+
   /*
    * Dynamic viscosity and its derivatives wrt pressure and temperature
    * @param pressure fluid pressure (Pa)

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -127,15 +127,6 @@ public:
   virtual void
   mu_dpT(Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
-  virtual Real mu_from_rho_T(Real density, Real temperature) const override;
-
-  virtual void mu_drhoT_from_rho_T(Real density,
-                                   Real temperature,
-                                   Real ddensity_dT,
-                                   Real & mu,
-                                   Real & dmu_drho,
-                                   Real & dmu_dT) const override;
-
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;
 
   virtual void rho_mu_dpT(Real pressure,
@@ -157,8 +148,6 @@ public:
 
   virtual void
   k_dpT(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  virtual Real k_from_rho_T(Real density, Real temperature) const override;
 
   virtual Real s(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
+++ b/modules/fluid_properties/src/materials/FluidPropertiesMaterialPT.C
@@ -46,10 +46,10 @@ void
 FluidPropertiesMaterialPT::computeQpProperties()
 {
   _rho[_qp] = _fp.rho(_pressure[_qp], _temperature[_qp]);
-  _mu[_qp] = _fp.mu_from_rho_T(_rho[_qp], _temperature[_qp]);
+  _mu[_qp] = _fp.mu(_pressure[_qp], _temperature[_qp]);
   _cp[_qp] = _fp.cp(_pressure[_qp], _temperature[_qp]);
   _cv[_qp] = _fp.cv(_pressure[_qp], _temperature[_qp]);
-  _k[_qp] = _fp.k_from_rho_T(_rho[_qp], _temperature[_qp]);
+  _k[_qp] = _fp.k(_pressure[_qp], _temperature[_qp]);
   _h[_qp] = _fp.h(_pressure[_qp], _temperature[_qp]);
   _e[_qp] = _fp.e(_pressure[_qp], _temperature[_qp]);
   _s[_qp] = _fp.s(_pressure[_qp], _temperature[_qp]);

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -754,8 +754,9 @@ CO2FluidProperties::cv(Real pressure, Real temperature) const
 Real
 CO2FluidProperties::k(Real pressure, Real temperature) const
 {
-  Real rho = this->rho(pressure, temperature);
-  return this->k_from_rho_T(rho, temperature);
+  // Require density first
+  Real density = rho(pressure, temperature);
+  return this->k_from_rho_T(density, temperature);
 }
 
 void

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidPropertiesPT.C
@@ -85,11 +85,6 @@ IdealGasFluidPropertiesPT::k_dpT(
   dk_dT = 0;
 }
 
-Real IdealGasFluidPropertiesPT::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
-{
-  return _thermal_conductivity;
-}
-
 Real IdealGasFluidPropertiesPT::s(Real /*pressure*/, Real /*temperature*/) const
 {
   return _specific_entropy;
@@ -159,24 +154,6 @@ IdealGasFluidPropertiesPT::mu_dpT(
 {
   mu = this->mu(pressure, temperature);
   dmu_dp = 0.0;
-  dmu_dT = 0.0;
-}
-
-Real IdealGasFluidPropertiesPT::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
-{
-  return _viscosity;
-}
-
-void
-IdealGasFluidPropertiesPT::mu_drhoT_from_rho_T(Real density,
-                                               Real temperature,
-                                               Real /*ddensity_dT*/,
-                                               Real & mu,
-                                               Real & dmu_drho,
-                                               Real & dmu_dT) const
-{
-  mu = this->mu_from_rho_T(density, temperature);
-  dmu_drho = 0.0;
   dmu_dT = 0.0;
 }
 

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -177,22 +177,6 @@ NaClFluidProperties::mu_dpT(Real /*pressure*/,
   mooseError(name(), ": mu_dpT() is not implemented.");
 }
 
-Real NaClFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
-{
-  mooseError(name(), ": mu is not implemented");
-}
-
-void
-NaClFluidProperties::mu_drhoT_from_rho_T(Real /*density*/,
-                                         Real /*temperature*/,
-                                         Real /*ddensity_dT*/,
-                                         Real & /*mu*/,
-                                         Real & /*dmu_drho*/,
-                                         Real & /*dmu_dT*/) const
-{
-  mooseError(name(), ": mu_drhoT() is not implemented");
-}
-
 void
 NaClFluidProperties::rho_mu(Real /*pressure*/,
                             Real /*temperature*/,
@@ -215,25 +199,25 @@ NaClFluidProperties::rho_mu_dpT(Real /*pressure*/,
   mooseError(name(), ": rho_mu_dpT() is not implemented");
 }
 
-Real NaClFluidProperties::k(Real /*pressure*/, Real /*temperature*/) const
-{
-  mooseError(name(), ": k() is not implemented");
-}
-
-void
-NaClFluidProperties::k_dpT(
-    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
-{
-  mooseError(name(), ": k_dpT() is not implemented");
-}
-
 Real
-NaClFluidProperties::k_from_rho_T(Real /*density*/, Real temperature) const
+NaClFluidProperties::k(Real /*pressure*/, Real temperature) const
 {
   // Correlation requires temperature in Celcius
   Real Tc = temperature - _T_c2k;
 
   return 6.82793 - 3.16584e-2 * Tc + 1.03451e-4 * Tc * Tc - 1.48207e-7 * Tc * Tc * Tc;
+}
+
+void
+NaClFluidProperties::k_dpT(
+    Real /*pressure*/, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  // Correlation requires temperature in Celcius
+  Real Tc = temperature - _T_c2k;
+
+  k = 6.82793 - 3.16584e-2 * Tc + 1.03451e-4 * Tc * Tc - 1.48207e-7 * Tc * Tc * Tc;
+  dk_dp = 0.0;
+  dk_dT = -3.16584e-2 + 2.06902e-4 * Tc - 4.44621e-7 * Tc * Tc;
 }
 
 Real NaClFluidProperties::s(Real /*pressure*/, Real /*temperature*/) const

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -96,11 +96,6 @@ SimpleFluidProperties::k_dpT(
   dk_dT = 0;
 }
 
-Real SimpleFluidProperties::k_from_rho_T(Real /*density*/, Real /*temperature*/) const
-{
-  return _thermal_conductivity;
-}
-
 Real SimpleFluidProperties::s(Real /*pressure*/, Real /*temperature*/) const
 {
   return _specific_entropy;
@@ -167,24 +162,6 @@ SimpleFluidProperties::mu_dpT(
 {
   mu = this->mu(pressure, temperature);
   dmu_dp = 0.0;
-  dmu_dT = 0.0;
-}
-
-Real SimpleFluidProperties::mu_from_rho_T(Real /*density*/, Real /*temperature*/) const
-{
-  return _viscosity;
-}
-
-void
-SimpleFluidProperties::mu_drhoT_from_rho_T(Real density,
-                                           Real temperature,
-                                           Real /*ddensity_dT*/,
-                                           Real & mu,
-                                           Real & dmu_drho,
-                                           Real & dmu_dT) const
-{
-  mu = this->mu_from_rho_T(density, temperature);
-  dmu_drho = 0.0;
   dmu_dT = 0.0;
 }
 

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -272,36 +272,14 @@ TabulatedFluidProperties::h_dpT(
 Real
 TabulatedFluidProperties::mu(Real pressure, Real temperature) const
 {
-  Real rho = this->rho(pressure, temperature);
-  return this->mu_from_rho_T(rho, temperature);
+  return _fp.mu(pressure, temperature);
 }
 
 void
 TabulatedFluidProperties::mu_dpT(
     Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
 {
-  Real rho, drho_dp, drho_dT;
-  this->rho_dpT(pressure, temperature, rho, drho_dp, drho_dT);
-  Real dmu_drho;
-  this->mu_drhoT_from_rho_T(rho, temperature, drho_dT, mu, dmu_drho, dmu_dT);
-  dmu_dp = dmu_drho * drho_dp;
-}
-
-Real
-TabulatedFluidProperties::mu_from_rho_T(Real density, Real temperature) const
-{
-  return _fp.mu_from_rho_T(density, temperature);
-}
-
-void
-TabulatedFluidProperties::mu_drhoT_from_rho_T(Real density,
-                                              Real temperature,
-                                              Real ddensity_dT,
-                                              Real & mu,
-                                              Real & dmu_drho,
-                                              Real & dmu_dT) const
-{
-  _fp.mu_drhoT_from_rho_T(density, temperature, ddensity_dT, mu, dmu_drho, dmu_dT);
+  _fp.mu_dpT(pressure, temperature, mu, dmu_dp, dmu_dT);
 }
 
 void
@@ -344,21 +322,14 @@ TabulatedFluidProperties::cv(Real pressure, Real temperature) const
 Real
 TabulatedFluidProperties::k(Real pressure, Real temperature) const
 {
-  Real rho = this->rho(pressure, temperature);
-  return this->k_from_rho_T(rho, temperature);
+  return _fp.k(pressure, temperature);
 }
 
 void
 TabulatedFluidProperties::k_dpT(
-    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
 {
-  mooseError(name(), "k_dpT() is not implemented");
-}
-
-Real
-TabulatedFluidProperties::k_from_rho_T(Real density, Real temperature) const
-{
-  return _fp.k_from_rho_T(density, temperature);
+  _fp.k_dpT(pressure, temperature, k, dk_dp, dk_dT);
 }
 
 Real

--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -279,19 +279,14 @@ PorousFlowBrineCO2::liquidProperties(Real pressure,
       (dXco2_dz / brine_density - dXco2_dz / co2_partial_density) * liquid_density * liquid_density;
 
   // Assume that liquid viscosity is just the brine viscosity
-  // Note: brine viscosity (and derivatives) requires water density (and derivatives)
-  Real water_density, dwater_density_dp, dwater_density_dT;
-  _water_fp.rho_dpT(pressure, temperature, water_density, dwater_density_dp, dwater_density_dT);
-
-  Real liquid_viscosity, dliquid_viscosity_drho, dliquid_viscosity_dT, dliquid_viscosity_dx;
-  _brine_fp.mu_drhoTx(water_density,
-                      temperature,
-                      xnacl,
-                      dwater_density_dT,
-                      liquid_viscosity,
-                      dliquid_viscosity_drho,
-                      dliquid_viscosity_dT,
-                      dliquid_viscosity_dx);
+  Real liquid_viscosity, dliquid_viscosity_dp, dliquid_viscosity_dT, dliquid_viscosity_dx;
+  _brine_fp.mu_dpTx(pressure,
+                    temperature,
+                    xnacl,
+                    liquid_viscosity,
+                    dliquid_viscosity_dp,
+                    dliquid_viscosity_dT,
+                    dliquid_viscosity_dx);
 
   // Save the values to the FluidStateProperties object
   liquid.density = liquid_density;
@@ -300,7 +295,7 @@ PorousFlowBrineCO2::liquidProperties(Real pressure,
   liquid.ddensity_dz = dliquid_density_dz;
 
   liquid.viscosity = liquid_viscosity;
-  liquid.dviscosity_dp = dliquid_viscosity_drho * dwater_density_dp;
+  liquid.dviscosity_dp = dliquid_viscosity_dp;
   liquid.dviscosity_dT = dliquid_viscosity_dT;
   liquid.dviscosity_dz = 0.0;
 }

--- a/unit/src/IdealGasFluidPropertiesPTTest.C
+++ b/unit/src/IdealGasFluidPropertiesPTTest.C
@@ -35,12 +35,12 @@ TEST_F(IdealGasFluidPropertiesPTTest, properties)
   REL_TEST("cv", _fp->cv(p, T), cv, tol);
   REL_TEST("c", _fp->c(p, T), std::sqrt(cp * R * T / (cv * molar_mass)), tol);
   REL_TEST("k", _fp->k(p, T), thermal_conductivity, tol);
-  REL_TEST("k", _fp->k_from_rho_T(_fp->rho(p, T), T), thermal_conductivity, tol);
+  REL_TEST("k", _fp->k(p, T), thermal_conductivity, tol);
   REL_TEST("s", _fp->s(p, T), entropy, tol);
   REL_TEST("rho", _fp->rho(p, T), p * molar_mass / (R * T), tol);
   REL_TEST("e", _fp->e(p, T), cv * T, tol);
   REL_TEST("mu", _fp->mu(p, T), viscosity, tol);
-  REL_TEST("mu", _fp->mu_from_rho_T(_fp->rho(p, T), T), viscosity, tol);
+  REL_TEST("mu", _fp->mu(p, T), viscosity, tol);
   REL_TEST("h", _fp->h(p, T), cp * T, tol);
   ABS_TEST("henry", _fp->henryConstant(T), henry, tol);
 }

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -41,8 +41,8 @@ TEST_F(MethaneFluidPropertiesTest, properties)
   REL_TEST("cp", _fp->cp(p, T), 2.375e3, 1.0e-3);
   REL_TEST("cv", _fp->cv(p, T), 1.857e3, 1.0e-3);
   REL_TEST("c", _fp->c(p, T), 481.7, 1.0e-3);
-  REL_TEST("mu", _fp->mu_from_rho_T(0.0, T), 0.01276e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k_from_rho_T(0.0, T), 0.04113, 1.0e-3);
+  REL_TEST("mu", _fp->mu(p, T), 0.01276e-3, 1.0e-3);
+  REL_TEST("thermal conductivity", _fp->k(p, T), 0.04113, 1.0e-3);
 }
 
 /**
@@ -89,27 +89,24 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   REL_TEST("de_dT", de_dT, de_dT_fd, 1.0e-6);
 
   // Viscosity
-  rho = 1.0; // Not used in correlations
-  Real drho = 1.0e-4;
-
-  Real dmu_drho_fd =
-      (_fp->mu_from_rho_T(rho + drho, T) - _fp->mu_from_rho_T(rho - drho, T)) / (2.0 * drho);
-  Real dmu_dT_fd = (_fp->mu_from_rho_T(rho, T + dT) - _fp->mu_from_rho_T(rho, T - dT)) / (2.0 * dT);
-  Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
-  _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
-
-  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  ABS_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-15);
-  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
-
   Real dmu_dp_fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
-  dmu_dT_fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
-  Real dmu_dp = 0.0;
+  Real dmu_dT_fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
+  Real mu = 0.0, dmu_dp = 0.0, dmu_dT = 0.0;
   _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu(p, T), 1.0e-15);
   ABS_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-15);
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+
+  // Thermal conductivity
+  Real dk_dp_fd = (_fp->k(p + dp, T) - _fp->k(p - dp, T)) / (2.0 * dp);
+  Real dk_dT_fd = (_fp->k(p, T + dT) - _fp->k(p, T - dT)) / (2.0 * dT);
+  Real k = 0.0, dk_dp = 0.0, dk_dT = 0.0;
+  _fp->k_dpT(p, T, k, dk_dp, dk_dT);
+
+  ABS_TEST("k", k, _fp->k(p, T), 1.0e-15);
+  ABS_TEST("dk_dp", dk_dp, dk_dp_fd, 1.0e-15);
+  REL_TEST("dk_dT", dk_dT, dk_dT_fd, 1.0e-6);
 
   // Henry's constant
   T = 300.0;

--- a/unit/src/NaClFluidPropertiesTest.C
+++ b/unit/src/NaClFluidPropertiesTest.C
@@ -49,9 +49,9 @@ TEST_F(NaClFluidPropertiesTest, halite)
   REL_TEST("enthalpy", _fp->h(pt, 673.15), 366.55e3, 1.0e-3);
 
   // Thermal conductivity (function of T only)
-  REL_TEST("k", _fp->k_from_rho_T(p0, 323.15), 5.488, 1.0e-2);
-  REL_TEST("k", _fp->k_from_rho_T(p0, 423.15), 3.911, 1.0e-2);
-  REL_TEST("k", _fp->k_from_rho_T(p0, 523.15), 3.024, 2.0e-2);
+  REL_TEST("k", _fp->k(p0, 323.15), 5.488, 1.0e-2);
+  REL_TEST("k", _fp->k(p0, 423.15), 3.911, 1.0e-2);
+  REL_TEST("k", _fp->k(p0, 523.15), 3.024, 2.0e-2);
 }
 
 /**

--- a/unit/src/PorousFlowBrineCO2Test.C
+++ b/unit/src/PorousFlowBrineCO2Test.C
@@ -387,8 +387,7 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
 
   Real density = 1.0 / (z / co2_partial_density + (1.0 - z) / brine_density);
 
-  Real water_density = _water_fp->rho(p, T);
-  Real viscosity = _brine_fp->mu_from_rho_T(water_density, T, xnacl);
+  Real viscosity = _brine_fp->mu(p, T, xnacl);
 
   ABS_TEST("liquid density", liquid_density, density, 1.0e-12);
   ABS_TEST("liquid viscosity", liquid_viscosity, viscosity, 1.0e-12);

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -25,40 +25,38 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   const Real henry = 0.0;
   const Real pp_coef = 0.0;
 
-  Real P, T, rho;
+  Real P, T;
 
   P = 1E3;
   T = 200;
-  rho = _fp->rho(P, T);
   REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
   REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
+  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
   REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
+  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
 
   P = 1E7;
   T = 300;
-  rho = _fp->rho(P, T);
   REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
   REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
   REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
   REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
   REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("k", _fp->k_from_rho_T(rho, T), thermal_cond, 1.0E-8);
+  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
   REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
   REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
   REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
   REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(rho, T), visc, 1.0E-8);
+  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
   REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
   REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
   ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
@@ -72,10 +70,9 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
 {
   const Real dP = 1.0E1;
   const Real dT = 1.0E-4;
-  const Real ddens = 1.0E-3;
 
   Real fd;
-  Real P, T, dens;
+  Real P, T;
 
   Real rho, drho_dp, drho_dT;
   P = 1E7;
@@ -111,16 +108,9 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   fd = (_fp->e(P, T + dT) - _fp->e(P, T - dT)) / (2.0 * dT);
   REL_TEST("de_dT", de_dT, fd, 1.0E-8);
 
-  Real mu, dmu_drho, dmu_dT;
-  dens = 1000;
+  Real mu, dmu_dp, dmu_dT;
+  P = 1E6;
   T = 10;
-  _fp->mu_drhoT_from_rho_T(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
-  fd = (_fp->mu_from_rho_T(dens + ddens, T) - _fp->mu_from_rho_T(dens - ddens, T)) / (2.0 * ddens);
-  ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
-  fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
-  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
-
-  Real dmu_dp;
   _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
   fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
   ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);
@@ -134,14 +124,8 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   fd = (_fp->k(P, T + dT) - _fp->k(P, T - dT)) / (2.0 * dT);
   ABS_TEST("dk_dT", dk_dT, fd, 1.0E-8);
 
-  dens = 2000;
+  P = 2E6;
   T = 80;
-  _fp->mu_drhoT_from_rho_T(dens, T, drho_dT, mu, dmu_drho, dmu_dT);
-  fd = (_fp->mu_from_rho_T(dens + ddens, T) - _fp->mu_from_rho_T(dens - ddens, T)) / (2.0 * ddens);
-  ABS_TEST("dmu_ddens", dmu_drho, fd, 1.0E-8);
-  fd = (_fp->mu_from_rho_T(dens, T + dT) - _fp->mu_from_rho_T(dens, T - dT)) / (2.0 * dT);
-  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
-
   _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
   fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
   ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -422,11 +422,9 @@ TEST_F(Water97FluidPropertiesTest, properties)
   ABS_TEST("mu", _fp->mu(2e6, 1173.15), 4.42823959629e-5, 1e-12);
 
   // Thermal conductivity
-  // Note: data is given for pressure and temperature, but k requires density
-  // and temperature
-  REL_TEST("k", _fp->k_from_rho_T(_fp->rho(1.0e6, 323.15), 323.15), 0.641, 1.0e-4);
-  REL_TEST("k", _fp->k_from_rho_T(_fp->rho(20.0e6, 623.15), 623.15), 0.4541, 1.0e-4);
-  REL_TEST("k", _fp->k_from_rho_T(_fp->rho(50.0e6, 773.15), 773.15), 0.2055, 1.0e-4);
+  REL_TEST("k", _fp->k(1.0e6, 323.15), 0.641, 1.0e-4);
+  REL_TEST("k", _fp->k(20.0e6, 623.15), 0.4541, 1.0e-4);
+  REL_TEST("k", _fp->k(50.0e6, 773.15), 0.2055, 1.0e-4);
 
   ABS_TEST("k", _fp->k(1.0e6, 323.15), 0.640972, 5e-7);
   ABS_TEST("k", _fp->k(20.0e6, 623.15), 0.454131, 7e-7);
@@ -511,7 +509,7 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
   ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  REL_TEST("dmu_dp", dmu_drho, dmu_drho_fd, 1.0e-6);
+  REL_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-6);
 
   // To properly test derivative wrt temperature, use p and T and calculate density,
   // so that the change in density wrt temperature is included
@@ -524,4 +522,13 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
                    (2.0 * dT);
 
   REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+
+  // Check derivative of viscosity wrt pressure
+  Real dp = 1.0e-2;
+
+  Real dmu_dp_fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
+  Real dmu_dp = 0.0;
+  _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+
+  REL_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-3);
 }


### PR DESCRIPTION
Follows on from #11036 by removing these methods from fluids that don't implement them. Materials and unit tests updated to use methods that take pressure and temperature.

Closes #11031 