### PR TITLE
Non-spline Bicubic interpolation added

### DIFF
--- a/framework/include/utils/BicubicInterpolation.h
+++ b/framework/include/utils/BicubicInterpolation.h
@@ -1,0 +1,121 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef BICUBICINTERPOLATION_H
+#define BICUBICINTERPOLATION_H
+
+#include "MooseTypes.h"
+
+/**
+ * This class interpolates tabulated data with a bicubic function. In order to
+ * minimize the computational expense of each sample, the coefficients at each
+ * point in the tabulated data are computed once in advance, and then accessed
+ * during the interpolation.
+ *
+ * As a result, this bicubic interpolation can be much faster than the bicubic
+ * spline interpolation method in BicubicSplineInterpolation.
+ *
+ * Adapted from Numerical Recipes in C (section 3.6). The terminology used is
+ * consistent with that used in Numerical Recipes, where moving over a column
+ * corresponds to moving over the x1 coord. Likewise, moving over a row means
+ * moving over the x2 coord.
+ */
+class BicubicInterpolation
+{
+public:
+  BicubicInterpolation(const std::vector<Real> & x1,
+                       const std::vector<Real> & x2,
+                       const std::vector<std::vector<Real>> & y);
+
+  virtual ~BicubicInterpolation() = default;
+
+  /**
+   * Sanity checks on input data
+   */
+  void errorCheck();
+
+  /**
+   * Samples value at point (x1, x2)
+   */
+  Real sample(Real x1, Real x2);
+
+  /**
+   * Samples value and first derivatives at point (x1, x2)
+   * Use this function for speed when computing both value and derivatives,
+   * as it minimizes the amount of time spent locating the point in the
+   * tabulated data
+   */
+  void sampleValueAndDerivatives(Real x1, Real x2, Real & y, Real & dy1, Real & dy2);
+
+  /**
+   * Samples first derivative at point (x1, x2)
+   */
+  Real sampleDerivative(Real x1, Real x2, unsigned int deriv_var);
+
+  /**
+   * Samples second derivative at point (x1, x2)
+   */
+  Real sample2ndDerivative(Real x1, Real x2, unsigned int deriv_var);
+
+  /**
+   * Precompute all of the coefficients for the bicubic interpolation to avoid
+   * calculating them repeatedly
+   */
+  void precomputeCoefficients();
+
+protected:
+  /**
+   * Find the indices of the dependent values axis which bracket the point xi
+   */
+  void findInterval(
+      const std::vector<Real> & x, Real xi, unsigned int & klo, unsigned int & khi, Real & xs);
+
+  /**
+   * Provides the values of the first derivatives in each direction at all
+   * points in the table of data, as well as the mixed second derivative.
+   * This is implemented using finite differencing, but could be supplied through
+   * other means (such as by sampling with cubic splines)
+   */
+  void tableDerivatives(std::vector<std::vector<Real>> & dy_dx1,
+                        std::vector<std::vector<Real>> & dy_dx2,
+                        std::vector<std::vector<Real>> & d2y_dx1x2);
+
+  /// Independent values in the x1 direction
+  std::vector<Real> _x1;
+  /// Independent values in the x2 direction
+  std::vector<Real> _x2;
+  /// The dependent values at (x1, x2) points
+  std::vector<std::vector<Real>> _y;
+
+  /// Matrix of precomputed coefficients
+  /// There are four coefficients in each direction at each dependent value
+  std::vector<std::vector<std::vector<std::vector<Real>>>> _bicubic_coeffs;
+
+  /// Matrix used to calculate bicubic interpolation coefficients
+  /// (from Numerical Recipes)
+  const std::vector<std::vector<int>> _wt{
+      {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+      {-3, 0, 0, 3, 0, 0, 0, 0, -2, 0, 0, -1, 0, 0, 0, 0},
+      {2, 0, 0, -2, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0},
+      {0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+      {0, 0, 0, 0, -3, 0, 0, 3, 0, 0, 0, 0, -2, 0, 0, -1},
+      {0, 0, 0, 0, 2, 0, 0, -2, 0, 0, 0, 0, 1, 0, 0, 1},
+      {-3, 3, 0, 0, -2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, -3, 3, 0, 0, -2, -1, 0, 0},
+      {9, -9, 9, -9, 6, 3, -3, -6, 6, -6, -3, 3, 4, 2, 1, 2},
+      {-6, 6, -6, 6, -4, -2, 2, 4, -3, 3, 3, -3, -2, -1, -1, -2},
+      {2, -2, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 2, -2, 0, 0, 1, 1, 0, 0},
+      {-6, 6, -6, 6, -3, -3, 3, 3, -4, 4, 2, -2, -2, -2, -1, -1},
+      {4, -4, 4, -4, 2, 2, -2, -2, 2, -2, -2, 2, 1, 1, 1, 1}};
+};
+
+#endif

--- a/framework/src/utils/BicubicInterpolation.C
+++ b/framework/src/utils/BicubicInterpolation.C
@@ -1,0 +1,347 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "BicubicInterpolation.h"
+#include "MooseError.h"
+#include "MathUtils.h"
+#include "MooseUtils.h"
+
+BicubicInterpolation::BicubicInterpolation(const std::vector<Real> & x1,
+                                           const std::vector<Real> & x2,
+                                           const std::vector<std::vector<Real>> & y)
+  : _x1(x1), _x2(x2), _y(y)
+{
+  errorCheck();
+
+  // Resize the vector of coefficients
+  auto m = _x1.size();
+  auto n = _x2.size();
+
+  _bicubic_coeffs.resize(m - 1);
+  for (auto i = beginIndex(_bicubic_coeffs); i < _bicubic_coeffs.size(); ++i)
+  {
+    _bicubic_coeffs[i].resize(n - 1);
+    for (auto j = beginIndex(_bicubic_coeffs[i]); j < _bicubic_coeffs[i].size(); ++j)
+    {
+      _bicubic_coeffs[i][j].resize(4);
+      for (unsigned int k = 0; k < 4; ++k)
+        _bicubic_coeffs[i][j][k].resize(4);
+    }
+  }
+
+  // Precompute the coefficients
+  precomputeCoefficients();
+}
+
+Real
+BicubicInterpolation::sample(Real x1, Real x2)
+{
+  unsigned int x1l, x1u, x2l, x2u;
+  Real t, u;
+  findInterval(_x1, x1, x1l, x1u, t);
+  findInterval(_x2, x2, x2l, x2u, u);
+
+  Real sample = 0.0;
+  for (unsigned int i = 0; i < 4; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+      sample += _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i) * MathUtils::pow(u, j);
+
+  return sample;
+}
+
+Real
+BicubicInterpolation::sampleDerivative(Real x1, Real x2, unsigned int deriv_var)
+{
+  unsigned int x1l, x1u, x2l, x2u;
+  Real t, u;
+  findInterval(_x1, x1, x1l, x1u, t);
+  findInterval(_x2, x2, x2l, x2u, u);
+
+  // Take derivative along x1 axis
+  if (deriv_var == 1)
+  {
+    Real sample_deriv = 0.0;
+    for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int j = 0; j < 4; ++j)
+        sample_deriv +=
+            i * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i - 1) * MathUtils::pow(u, j);
+
+    Real d = _x1[x1u] - _x1[x1l];
+
+    if (!MooseUtils::absoluteFuzzyEqual(d, 0.0))
+      sample_deriv /= d;
+
+    return sample_deriv;
+  }
+
+  // Take derivative along x1 axis
+  else if (deriv_var == 2)
+  {
+    Real sample_deriv = 0.0;
+    for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int j = 0; j < 4; ++j)
+        sample_deriv +=
+            j * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i) * MathUtils::pow(u, j - 1);
+
+    Real d = _x2[x2u] - _x2[x2l];
+
+    if (!MooseUtils::absoluteFuzzyEqual(d, 0.0))
+      sample_deriv /= d;
+
+    return sample_deriv;
+  }
+
+  else
+    mooseError("deriv_var must be either 1 or 2 in BicubicInterpolation");
+}
+
+Real
+BicubicInterpolation::sample2ndDerivative(Real x1, Real x2, unsigned int deriv_var)
+{
+  unsigned int x1l, x1u, x2l, x2u;
+  Real t, u;
+  findInterval(_x1, x1, x1l, x1u, t);
+  findInterval(_x2, x2, x2l, x2u, u);
+
+  // Take derivative along x1 axis
+  if (deriv_var == 1)
+  {
+    Real sample_deriv = 0.0;
+    for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int j = 0; j < 4; ++j)
+        sample_deriv += i * (i - 1) * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i - 2) *
+                        MathUtils::pow(u, j);
+
+    Real d = _x1[x1u] - _x1[x1l];
+
+    if (!MooseUtils::absoluteFuzzyEqual(d, 0.0))
+      sample_deriv /= (d * d);
+
+    return sample_deriv;
+  }
+
+  // Take derivative along x1 axis
+  else if (deriv_var == 2)
+  {
+    Real sample_deriv = 0.0;
+    for (unsigned int i = 0; i < 4; ++i)
+      for (unsigned int j = 0; j < 4; ++j)
+        sample_deriv += j * (j - 1) * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i) *
+                        MathUtils::pow(u, j - 2);
+
+    Real d = _x2[x2u] - _x2[x2l];
+
+    if (!MooseUtils::absoluteFuzzyEqual(d, 0.0))
+      sample_deriv /= (d * d);
+
+    return sample_deriv;
+  }
+
+  else
+    mooseError("deriv_var must be either 1 or 2 in BicubicInterpolation");
+}
+
+void
+BicubicInterpolation::sampleValueAndDerivatives(Real x1, Real x2, Real & y, Real & dy1, Real & dy2)
+{
+  unsigned int x1l, x1u, x2l, x2u;
+  Real t, u;
+  findInterval(_x1, x1, x1l, x1u, t);
+  findInterval(_x2, x2, x2l, x2u, u);
+
+  y = 0.0;
+  dy1 = 0.0;
+  dy2 = 0.0;
+  for (unsigned int i = 0; i < 4; ++i)
+    for (unsigned int j = 0; j < 4; ++j)
+    {
+      y += _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i) * MathUtils::pow(u, j);
+      dy1 += i * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i - 1) * MathUtils::pow(u, j);
+      dy2 += j * _bicubic_coeffs[x1l][x2l][i][j] * MathUtils::pow(t, i) * MathUtils::pow(u, j - 1);
+    }
+
+  Real d1 = _x1[x1u] - _x1[x1l];
+
+  if (!MooseUtils::absoluteFuzzyEqual(d1, 0.0))
+    dy1 /= d1;
+
+  Real d2 = _x2[x2u] - _x2[x2l];
+
+  if (!MooseUtils::absoluteFuzzyEqual(d2, 0.0))
+    dy2 /= d2;
+}
+
+void
+BicubicInterpolation::precomputeCoefficients()
+{
+  // Calculate the first derivatives in each direction at each point, and the
+  // mixed second derivative
+  std::vector<std::vector<Real>> dy_dx1, dy_dx2, d2y_dx1x2;
+  tableDerivatives(dy_dx1, dy_dx2, d2y_dx1x2);
+
+  // Now solve for the coefficients at each point in the grid
+  for (auto i = beginIndex(_bicubic_coeffs); i < _bicubic_coeffs.size(); ++i)
+    for (auto j = beginIndex(_bicubic_coeffs); j < _bicubic_coeffs[i].size(); ++j)
+    {
+      // Distance between corner points in each direction
+      const Real d1 = _x1[i + 1] - _x1[i];
+      const Real d2 = _x2[j + 1] - _x2[j];
+
+      // Values of function and derivatives of the four corner points
+      std::vector<Real> y = {_y[i][j], _y[i + 1][j], _y[i + 1][j + 1], _y[i][j + 1]};
+      std::vector<Real> y1 = {
+          dy_dx1[i][j], dy_dx1[i + 1][j], dy_dx1[i + 1][j + 1], dy_dx1[i][j + 1]};
+      std::vector<Real> y2 = {
+          dy_dx2[i][j], dy_dx2[i + 1][j], dy_dx2[i + 1][j + 1], dy_dx2[i][j + 1]};
+      std::vector<Real> y12 = {
+          d2y_dx1x2[i][j], d2y_dx1x2[i + 1][j], d2y_dx1x2[i + 1][j + 1], d2y_dx1x2[i][j + 1]};
+
+      std::vector<Real> cl(16), x(16);
+      Real xx;
+      unsigned int count = 0;
+
+      // Temporary vector used in the matrix multiplication
+      for (unsigned int k = 0; k < 4; ++k)
+      {
+        x[k] = y[k];
+        x[k + 4] = y1[k] * d1;
+        x[k + 8] = y2[k] * d2;
+        x[k + 12] = y12[k] * d1 * d2;
+      }
+
+      // Multiply by the matrix of constants
+      for (unsigned int k = 0; k < 16; ++k)
+      {
+        xx = 0.0;
+        for (unsigned int q = 0; q < 16; ++q)
+          xx += _wt[k][q] * x[q];
+
+        cl[k] = xx;
+      }
+
+      // Unpack results into coefficient table
+      for (unsigned int k = 0; k < 4; ++k)
+        for (unsigned int q = 0; q < 4; ++q)
+        {
+          _bicubic_coeffs[i][j][k][q] = cl[count];
+          count++;
+        }
+    }
+}
+
+void
+BicubicInterpolation::tableDerivatives(std::vector<std::vector<Real>> & dy_dx1,
+                                       std::vector<std::vector<Real>> & dy_dx2,
+                                       std::vector<std::vector<Real>> & d2y_dx1x2)
+{
+  auto m = _x1.size(), n = _x2.size();
+  dy_dx1.resize(m);
+  dy_dx2.resize(m);
+  d2y_dx1x2.resize(m);
+
+  for (auto i = beginIndex(_x1); i < m; ++i)
+  {
+    dy_dx1[i].resize(n);
+    dy_dx2[i].resize(n);
+    d2y_dx1x2[i].resize(n);
+  }
+
+  // Central difference calculations of derivatives
+  for (auto i = beginIndex(_y); i < m; ++i)
+    for (auto j = beginIndex(_y[i]); j < n; ++j)
+    {
+      // Derivative wrt x1
+      if (i == 0)
+      {
+        dy_dx1[i][j] = (_y[i + 1][j] - _y[i][j]) / (_x1[i + 1] - _x1[i]);
+      }
+      else if (i == m - 1)
+        dy_dx1[i][j] = (_y[i][j] - _y[i - 1][j]) / (_x1[i] - _x1[i - 1]);
+      else
+        dy_dx1[i][j] = (_y[i + 1][j] - _y[i - 1][j]) / (_x1[i + 1] - _x1[i - 1]);
+
+      // Derivative wrt x2
+      if (j == 0)
+        dy_dx2[i][j] = (_y[i][j + 1] - _y[i][j]) / (_x2[j + 1] - _x2[j]);
+      else if (j == n - 1)
+        dy_dx2[i][j] = (_y[i][j] - _y[i][j - 1]) / (_x2[j] - _x2[j - 1]);
+      else
+        dy_dx2[i][j] = (_y[i][j + 1] - _y[i][j - 1]) / (_x2[j + 1] - _x2[j - 1]);
+
+      // Mixed derivative d2y/dx1x2
+      if (i == 0 && j == 0)
+        d2y_dx1x2[i][j] = (_y[i + 1][j + 1] - _y[i + 1][j] - _y[i][j + 1] + _y[i][j]) /
+                          (_x1[i + 1] - _x1[i]) / (_x2[j + 1] - _x2[j]);
+      else if (i == 0 && j == n - 1)
+        d2y_dx1x2[i][j] = (_y[i + 1][j] - _y[i + 1][j - 1] - _y[i][j] + _y[i][j - 1]) /
+                          (_x1[i + 1] - _x1[i]) / (_x2[j] - _x2[j - 1]);
+      else if (i == m - 1 && j == 0)
+        d2y_dx1x2[i][j] = (_y[i][j + 1] - _y[i][j] - _y[i - 1][j + 1] + _y[i - 1][j]) /
+                          (_x1[i] - _x1[i - 1]) / (_x2[j + 1] - _x2[j]);
+      else if (i == m - 1 && j == n - 1)
+        d2y_dx1x2[i][j] = (_y[i][j] - _y[i][j - 1] - _y[i - 1][j] + _y[i - 1][j - 1]) /
+                          (_x1[i] - _x1[i - 1]) / (_x2[j] - _x2[j - 1]);
+      else if (i == 0)
+        d2y_dx1x2[i][j] = (_y[i + 1][j + 1] - _y[i + 1][j - 1] - _y[i][j + 1] + _y[i][j - 1]) /
+                          (_x1[i + 1] - _x1[i]) / (_x2[j + 1] - _x2[j - 1]);
+      else if (i == m - 1)
+        d2y_dx1x2[i][j] = (_y[i][j + 1] - _y[i][j - 1] - _y[i - 1][j + 1] + _y[i - 1][j - 1]) /
+                          (_x1[i] - _x1[i - 1]) / (_x2[j + 1] - _x2[j - 1]);
+      else if (j == 0)
+        d2y_dx1x2[i][j] = (_y[i + 1][j + 1] - _y[i + 1][j] - _y[i - 1][j + 1] + _y[i - 1][j]) /
+                          (_x1[i + 1] - _x1[i - 1]) / (_x2[j + 1] - _x2[j]);
+      else if (j == n - 1)
+        d2y_dx1x2[i][j] = (_y[i + 1][j] - _y[i + 1][j - 1] - _y[i - 1][j] + _y[i - 1][j - 1]) /
+                          (_x1[i + 1] - _x1[i - 1]) / (_x2[j] - _x2[j - 1]);
+      else
+        d2y_dx1x2[i][j] =
+            (_y[i + 1][j + 1] - _y[i + 1][j - 1] - _y[i - 1][j + 1] + _y[i - 1][j - 1]) /
+            (_x1[i + 1] - _x1[i - 1]) / (_x2[j + 1] - _x2[j - 1]);
+    }
+}
+
+void
+BicubicInterpolation::findInterval(
+    const std::vector<Real> & x, Real xi, unsigned int & klo, unsigned int & khi, Real & xs)
+{
+  // Find the indices that bracket the point xi
+  klo = 0;
+  mooseAssert(x.size() >= 2,
+              "There must be at least two points in the table in BicubicInterpolation");
+
+  khi = x.size() - 1;
+  while (khi - klo > 1)
+  {
+    unsigned int kmid = (khi + klo) / 2;
+    if (x[kmid] > xi)
+      khi = kmid;
+    else
+      klo = kmid;
+  }
+
+  // Now find the scaled position, normalized to [0,1]
+  Real d = x[khi] - x[klo];
+  xs = xi - x[klo];
+
+  if (!MooseUtils::absoluteFuzzyEqual(d, 0.0))
+    xs /= d;
+}
+
+void
+BicubicInterpolation::errorCheck()
+{
+  auto m = _x1.size(), n = _x2.size();
+
+  if (_y.size() != m)
+    mooseError("y row dimension does not match the size of x1 in BicubicInterpolation");
+  else
+    for (auto i = beginIndex(_y); i < _y.size(); ++i)
+      if (_y[i].size() != n)
+        mooseError("y column dimension does not match the size of x2 in BicubicInterpolation");
+}

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -14,7 +14,7 @@
 #include "DelimitedFileReader.h"
 
 class SinglePhaseFluidPropertiesPT;
-class BicubicSplineInterpolation;
+class BicubicInterpolation;
 class TabulatedFluidProperties;
 
 template <>
@@ -203,11 +203,11 @@ protected:
   /// Tabulated enthalpy
   std::vector<std::vector<Real>> _enthalpy;
   /// Interpoled density
-  std::unique_ptr<BicubicSplineInterpolation> _density_ipol;
+  std::unique_ptr<BicubicInterpolation> _density_ipol;
   /// Interpoled internal energy
-  std::unique_ptr<BicubicSplineInterpolation> _internal_energy_ipol;
+  std::unique_ptr<BicubicInterpolation> _internal_energy_ipol;
   /// Interpoled enthalpy
-  std::unique_ptr<BicubicSplineInterpolation> _enthalpy_ipol;
+  std::unique_ptr<BicubicInterpolation> _enthalpy_ipol;
   /// Derivatives along the boundary
   std::vector<Real> _drho_dp_0, _drho_dp_n, _drho_dT_0, _drho_dT_n;
   std::vector<Real> _de_dp_0, _de_dp_n, _de_dT_0, _de_dT_n;

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "TabulatedFluidProperties.h"
-#include "BicubicSplineInterpolation.h"
+#include "BicubicInterpolation.h"
 #include "MooseUtils.h"
 #include "Conversion.h"
 
@@ -185,18 +185,10 @@ TabulatedFluidProperties::initialSetup()
   }
 
   // Construct bicubic splines from tabulated data
-  _density_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
-  _internal_energy_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
-  _enthalpy_ipol = libmesh_make_unique<BicubicSplineInterpolation>();
-
-  _density_ipol->setData(
-      _pressure, _temperature, _density, _drho_dp_0, _drho_dp_n, _drho_dT_0, _drho_dT_n);
-
-  _internal_energy_ipol->setData(
-      _pressure, _temperature, _internal_energy, _de_dp_0, _de_dp_n, _de_dT_0, _de_dT_n);
-
-  _enthalpy_ipol->setData(
-      _pressure, _temperature, _enthalpy, _dh_dp_0, _dh_dp_n, _dh_dT_0, _dh_dT_n);
+  _density_ipol = libmesh_make_unique<BicubicInterpolation>(_pressure, _temperature, _density);
+  _internal_energy_ipol =
+      libmesh_make_unique<BicubicInterpolation>(_pressure, _temperature, _internal_energy);
+  _enthalpy_ipol = libmesh_make_unique<BicubicInterpolation>(_pressure, _temperature, _enthalpy);
 }
 
 std::string

--- a/unit/src/BiubicInterpolationTest.C
+++ b/unit/src/BiubicInterpolationTest.C
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "BicubicInterpolation.h"
+
+const double tol = 1e-8;
+
+TEST(BicubicInterpolationTest, sample)
+{
+  // Test BicubicInterpolation with a function y = x1^2 + 3 x2^2
+  const unsigned int n = 9;
+  std::vector<double> x1(n), x2(n);
+  std::vector<std::vector<double>> y(n);
+
+  for (unsigned int i = 0; i < n; ++i)
+  {
+    x1[i] = i;
+    x2[i] = i;
+    y[i].resize(n);
+  }
+
+  for (unsigned int i = 0; i < n; ++i)
+    for (unsigned int j = 0; j < n; ++j)
+      y[i][j] = x1[i] * x1[i] + 3.0 * x2[j] * x2[j];
+
+  BicubicInterpolation interp(x1, x2, y);
+
+  // Check sampled value and first and second derivatives
+  Real p1 = 4.5, p2 = 5.5;
+  EXPECT_NEAR(interp.sample(p1, p2), 111.0, tol);
+  EXPECT_NEAR(interp.sampleDerivative(p1, p2, 1), 9.0, tol);
+  EXPECT_NEAR(interp.sampleDerivative(p1, p2, 2), 33.0, tol);
+  EXPECT_NEAR(interp.sample2ndDerivative(p1, p2, 1), 2.0, tol);
+  EXPECT_NEAR(interp.sample2ndDerivative(p1, p2, 2), 6.0, tol);
+
+  // Check that sampleValueAndDerivatives() returns the same results as above
+  double y2, dy2_dx1, dy2_dx2;
+  interp.sampleValueAndDerivatives(p1, p2, y2, dy2_dx1, dy2_dx2);
+  EXPECT_NEAR(y2, 111.0, tol);
+  EXPECT_NEAR(dy2_dx1, 9.0, tol);
+  EXPECT_NEAR(dy2_dx2, 33.0, tol);
+}


### PR DESCRIPTION
This makes `TabulatedFluidProperties` much faster than before. 

Timing for 1 million samples (density and derivatives wrt pressure and temperature) for an n by n table of data:

| n | Before | After |
|---|---|---|
| 50 | 4.25 s | 0.35 s |
| 100 | 8.12 s | 0.37 s |

That is a really nice speed up!

Now, `TabulatedFluidProperties` is much faster than calculating water properties and CO2 properties using their UserObjects:

For 1 million samples of density and derivatives wrt pressure and temperature

| Fluid | FluidUserObject | TabulatedFluidProperties |
|---|---|---|
|water | 7.2 s | 0.36 s |
| CO2 | 52.2 s | 0.36 s |


Closes #11059 

