### PR TITLE
testing for failed eigenvalue and eigenvector computation

### DIFF
--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -15,6 +15,8 @@
 #include "MooseUtils.h"
 #include "ColumnMajorMatrix.h"
 
+#include "Conversion.h"
+
 #include "libmesh/libmesh.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/utility.h"
@@ -1122,9 +1124,8 @@ RankTwoTensor::syev(const char * calculation_type,
   LAPACKsyev_(calculation_type, "U", &nd, &a[0], &nd, &eigvals[0], &work[0], &lwork, &info);
 
   if (info != 0)
-    mooseError("In computing the eigenvalues and eigenvectors of a symmetric rank-2 tensor, the "
-               "PETSC LAPACK syev routine returned error code ",
-               info);
+    mooseError("In computing the eigenvalues and eigenvectors for the symmetric rank-2 tensor (",
+                Moose::stringify(a), "), the PETSC LAPACK syev routine returned error code ", info);
 }
 
 void

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1125,7 +1125,9 @@ RankTwoTensor::syev(const char * calculation_type,
 
   if (info != 0)
     mooseError("In computing the eigenvalues and eigenvectors for the symmetric rank-2 tensor (",
-                Moose::stringify(a), "), the PETSC LAPACK syev routine returned error code ", info);
+               Moose::stringify(a),
+               "), the PETSC LAPACK syev routine returned error code ",
+               info);
 }
 
 void

--- a/unit/src/RankTwoTensorTest.C
+++ b/unit/src/RankTwoTensorTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "RankTwoTensorTest.h"
+#include "RankTwoScalarTools.h"
 
 TEST_F(RankTwoTensorTest, L2norm)
 {
@@ -493,4 +494,27 @@ TEST_F(RankTwoTensorTest, initialContraction)
   const RankTwoTensor ic = _unsymmetric1.initialContraction(a);
   const RankTwoTensor ic1 = a.transposeMajor() * _unsymmetric1;
   EXPECT_NEAR(0.0, (ic - ic1).L2norm(), 0.0001);
+}
+
+TEST_F(RankTwoTensorTest, ErrorComputingEV)
+{
+  // generate tensor that does not allow computation of eigenvectors
+  // and fails because of nan entries
+
+  RankTwoTensor a;
+  a(0, 0) = a(0, 1) = a(0, 2) = std::numeric_limits<double>::quiet_NaN();
+  a(1, 0) = a(1, 1) = a(1, 2) = a(0, 0);
+  a(2, 0) = a(2, 1) = a(2, 2) = a(0, 0);
+
+  try
+  {
+    Point p(1, 0, 0);
+    RankTwoScalarTools::calcEigenValuesEigenVectors(a, 0, p);
+    FAIL();
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what()).find("In computing the eigenvalues and eigenvectors");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
 }


### PR DESCRIPTION
Added output for RankTwoTensor when eigenvalue or eigenvector computation returns error. 
Added test for failed RankTwoTensor eigenvalue computation. 
