### PR TITLE
Fixing potential uninitialized value

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrain.C
@@ -18,7 +18,7 @@ validParams<ComputeThermalExpansionEigenstrain>()
   InputParameters params = validParams<ComputeThermalExpansionEigenstrainBase>();
   params.addClassDescription("Computes eigenstrain due to thermal expansion "
                              "with a constant coefficient");
-  params.addParam<Real>("thermal_expansion_coeff", "Thermal expansion coefficient");
+  params.addRequiredParam<Real>("thermal_expansion_coeff", "Thermal expansion coefficient");
 
   return params;
 }


### PR DESCRIPTION
The the parameter was not set in the input file, uninitialized value
would be used in the computation.  Make it required, so users have to
provide it.

Closes #11074

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
