### PR TITLE
henryConstant() and henryConstant_dT() don't need to be pure virtual

### DIFF
--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -121,10 +121,6 @@ public:
   virtual void
   h_dpT(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const override;
-
 protected:
   /// NaCl molar mass (kg/mol)
   const Real _Mnacl;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidPropertiesPT.h
@@ -270,7 +270,7 @@ public:
    * @param temperature fluid temperature (K)
    * @return Henry's constant
    */
-  virtual Real henryConstant(Real temperature) const = 0;
+  virtual Real henryConstant(Real temperature) const;
 
   /**
    * Henry's law constant for dissolution in water and derivative wrt temperature
@@ -278,7 +278,7 @@ public:
    * @param[out] Kh Henry's constant
    * @param[out] dKh_dT derivative of Kh wrt temperature
    */
-  virtual void henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const = 0;
+  virtual void henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const;
 
 protected:
   /**

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -266,10 +266,6 @@ public:
    */
   Real densityRegion3(Real pressure, Real temperature) const;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant_dT(Real temperature, Real & Kh, Real & dKh_dT) const override;
-
   /**
    * Backwards equation T(p, h)
    * From Revised Release on the IAPWS Industrial Formulation 1997 for the

--- a/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NaClFluidProperties.C
@@ -264,16 +264,3 @@ NaClFluidProperties::h_dpT(
   dh_dp = 44.14 * 1.0e-5;
   dh_dT = 8.7664e2 + 2.0 * 6.4139e-2 * Tc + 3.0 * 8.8101e-5 * Tc * Tc;
 }
-
-Real NaClFluidProperties::henryConstant(Real /*temperature*/) const
-{
-  mooseError(name(), ": henryConstant() is not defined");
-}
-
-void
-NaClFluidProperties::henryConstant_dT(Real /* temperature */,
-                                      Real & /* Kh */,
-                                      Real & /* dKh_dT */) const
-{
-  mooseError(name(), ": henryConstant_dT() is not defined");
-}

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidPropertiesPT.C
@@ -109,3 +109,16 @@ Real SinglePhaseFluidPropertiesPT::k_from_rho_T(Real /*density*/, Real /*tempera
 {
   mooseError(name(), ": k_from_rho_T is not implemented.");
 }
+
+Real SinglePhaseFluidPropertiesPT::henryConstant(Real /*temperature*/) const
+{
+  mooseError(name(), ": henryConstant() is not implemented");
+}
+
+void
+SinglePhaseFluidPropertiesPT::henryConstant_dT(Real /*temperature*/,
+                                               Real & /*Kh*/,
+                                               Real & /*dKh_dT*/) const
+{
+  mooseError(name(), ": henryConstant_dT() is not implemented");
+}

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -1672,19 +1672,6 @@ Water97FluidProperties::densityRegion3(Real pressure, Real temperature) const
   return 1.0 / volume;
 }
 
-Real Water97FluidProperties::henryConstant(Real /*temperature*/) const
-{
-  mooseError(name(), ": henryConstant() not defined");
-}
-
-void
-Water97FluidProperties::henryConstant_dT(Real /* temperature */,
-                                         Real & /* Kh */,
-                                         Real & /* dKh_dT */) const
-{
-  mooseError(name(), ": henryConstant_dT() not defined");
-}
-
 unsigned int
 Water97FluidProperties::inRegionPH(Real pressure, Real enthalpy) const
 {


### PR DESCRIPTION
As these methods are only appropriate for gases, they don't need to
be implemented in some fluid classes. Hence, we can supply a default "not implemented" error in the base class.

Follows on from API changes made in #11036, #11042 and #11068. I think this might be the last of these changes for a while.

Closes #11082
