### PR TITLE
explicitly call python2

### DIFF
--- a/examples/ex14_pps/plot.py
+++ b/examples/ex14_pps/plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/doc/doxygen/create_dox.py
+++ b/framework/doc/doxygen/create_dox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/LikelyOptimzer.py
+++ b/framework/scripts/LikelyOptimzer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/build_coverage.py
+++ b/framework/scripts/build_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/compile_commands.py
+++ b/framework/scripts/compile_commands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/ensight/ensightDR.py
+++ b/framework/scripts/ensight/ensightDR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/find_dep_apps.py
+++ b/framework/scripts/find_dep_apps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/find_hung_process.py
+++ b/framework/scripts/find_hung_process.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/fixup_headers.py
+++ b/framework/scripts/fixup_headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This script checks and can optionally update MOOSE source files.
 # You should always run this script without the "-u" option

--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/mooseExamplesLateX/gen_tex.py
+++ b/framework/scripts/mooseExamplesLateX/gen_tex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/rm_outdated_deps.py
+++ b/framework/scripts/rm_outdated_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/syntaxHTML/genInputFileSyntaxHTML.py
+++ b/framework/scripts/syntaxHTML/genInputFileSyntaxHTML.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/syntaxHTML/generate_input_syntax.py
+++ b/framework/scripts/syntaxHTML/generate_input_syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/framework/scripts/timingHTML/timing_utils.py
+++ b/framework/scripts/timingHTML/timing_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/combined/doc/moosedocs.py
+++ b/modules/combined/doc/moosedocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python222222222222222222
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/combined/doc/moosedocs.py
+++ b/modules/combined/doc/moosedocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python222222222222222222
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/doc/moosedocs.py
+++ b/modules/doc/moosedocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/examples/circle/viewer.py
+++ b/modules/level_set/examples/circle/viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/examples/rotating_circle/viewer.py
+++ b/modules/level_set/examples/rotating_circle/viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/examples/vortex/viewer.py
+++ b/modules/level_set/examples/vortex/viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/python/lsutils.py
+++ b/modules/level_set/python/lsutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/test/tests/kernels/advection/convergence.py
+++ b/modules/level_set/test/tests/kernels/advection/convergence.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/test/tests/kernels/olsson_reinitialization/olsson_1d.py
+++ b/modules/level_set/test/tests/kernels/olsson_reinitialization/olsson_1d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/test/tests/reinitialization/viewer.py
+++ b/modules/level_set/test/tests/reinitialization/viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 import vtk

--- a/modules/level_set/test/tests/verification/1d_level_set_mms/convergence.py
+++ b/modules/level_set/test/tests/verification/1d_level_set_mms/convergence.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/level_set/test/tests/verification/1d_level_set_supg_mms/convergence.py
+++ b/modules/level_set/test/tests/verification/1d_level_set_supg_mms/convergence.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/navier_stokes/test/tests/bump/SmoothBump.py
+++ b/modules/navier_stokes/test/tests/bump/SmoothBump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/navier_stokes/test/tests/ins/jeffery_hamel/jeffery_hamel.py
+++ b/modules/navier_stokes/test/tests/ins/jeffery_hamel/jeffery_hamel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/navier_stokes/test/tests/ins/jeffery_hamel/plot.py
+++ b/modules/navier_stokes/test/tests/ins/jeffery_hamel/plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/broadbridge_white.py
+++ b/modules/porous_flow/doc/tests/broadbridge_white.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/dirackernels.py
+++ b/modules/porous_flow/doc/tests/dirackernels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/dispersion.py
+++ b/modules/porous_flow/doc/tests/dispersion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/gravity.py
+++ b/modules/porous_flow/doc/tests/gravity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/heat_conduction.py
+++ b/modules/porous_flow/doc/tests/heat_conduction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/mandel.py
+++ b/modules/porous_flow/doc/tests/mandel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/newton_cooling.py
+++ b/modules/porous_flow/doc/tests/newton_cooling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/pressure_pulse.py
+++ b/modules/porous_flow/doc/tests/pressure_pulse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/radialinjection.py
+++ b/modules/porous_flow/doc/tests/radialinjection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/relperm.py
+++ b/modules/porous_flow/doc/tests/relperm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/rogers_stallybrass_clements.py
+++ b/modules/porous_flow/doc/tests/rogers_stallybrass_clements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/doc/tests/sinks.py
+++ b/modules/porous_flow/doc/tests/sinks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/examples/coal_mining/mesh/create_model.py
+++ b/modules/porous_flow/examples/coal_mining/mesh/create_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/porous_flow/test/tests/thm_rehbinder/thm_rehbinder.py
+++ b/modules/porous_flow/test/tests/thm_rehbinder/thm_rehbinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/stochastic_tools/python/stochastic/histogram.py
+++ b/modules/stochastic_tools/python/stochastic/histogram.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/doc/tests/beam_cosserat.py
+++ b/modules/tensor_mechanics/doc/tests/beam_cosserat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/doc/tests/cosserat_glide.py
+++ b/modules/tensor_mechanics/doc/tests/cosserat_glide.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/doc/tests/create_vtr.py
+++ b/modules/tensor_mechanics/doc/tests/create_vtr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/doc/tests/yf.py
+++ b/modules/tensor_mechanics/doc/tests/yf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/doc/theory/capped_weak_plane.py
+++ b/modules/tensor_mechanics/doc/theory/capped_weak_plane.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/examples/coal_mining/mesh/create_model.py
+++ b/modules/tensor_mechanics/examples/coal_mining/mesh/create_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_drucker_prager/small_deform2.py
+++ b/modules/tensor_mechanics/test/tests/capped_drucker_prager/small_deform2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_drucker_prager/small_deform3.py
+++ b/modules/tensor_mechanics/test/tests/capped_drucker_prager/small_deform3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_15_16_17.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_15_16_17.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_21.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_21.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_23_24.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_23_24.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_5_6_7.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_5_6_7.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_21.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_21.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_22.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_22.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_3_13.py
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/small_deform_hard_3_13.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/drucker_prager/small_deform2.py
+++ b/modules/tensor_mechanics/test/tests/drucker_prager/small_deform2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/drucker_prager/small_deform3.py
+++ b/modules/tensor_mechanics/test/tests/drucker_prager/small_deform3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/tensile/small_deform_5_6_update.py
+++ b/modules/tensor_mechanics/test/tests/tensile/small_deform_5_6_update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/modules/tensor_mechanics/test/tests/tensile/small_deform_hard3.py
+++ b/modules/tensor_mechanics/test/tests/tensile/small_deform_hard3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/GridVTKData/griddeddata_from_vtk.py
+++ b/python/GridVTKData/griddeddata_from_vtk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/GridVTKData/griddeddata_to_vtk.py
+++ b/python/GridVTKData/griddeddata_to_vtk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/MooseDocs/commands/devel.py
+++ b/python/MooseDocs/commands/devel.py
@@ -99,7 +99,7 @@ def main(options):
 RENDERERS = ['HTMLRenderer', 'MaterializeRenderer', 'LatexRenderer']
 
 HEAD = """
-#!/usr/bin/env python
+#!/usr/bin/env python2
 \"\"\"Testing for <MODULE> MooseDocs extension.\"\"\"
 import unittest
 

--- a/python/MooseDocs/test/base/test_components.py
+++ b/python/MooseDocs/test/base/test_components.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Tests for Component objects.
 """

--- a/python/MooseDocs/test/base/test_lexers.py
+++ b/python/MooseDocs/test/base/test_lexers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Tests for Lexer and related objects.
 """

--- a/python/MooseDocs/test/base/test_readers.py
+++ b/python/MooseDocs/test/base/test_readers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Test for the Reader objects.
 """

--- a/python/MooseDocs/test/base/test_renderers.py
+++ b/python/MooseDocs/test/base/test_renderers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Tests for the Renderer objects.
 """

--- a/python/MooseDocs/test/base/test_translators.py
+++ b/python/MooseDocs/test/base/test_translators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Testing for Translator object.
 """

--- a/python/MooseDocs/test/common/test_box.py
+++ b/python/MooseDocs/test/common/test_box.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unittest
 from MooseDocs import common

--- a/python/MooseDocs/test/common/test_check_type.py
+++ b/python/MooseDocs/test/common/test_check_type.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import types
 import unittest
 

--- a/python/MooseDocs/test/common/test_database.py
+++ b/python/MooseDocs/test/common/test_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/MooseDocs/test/common/test_exceptions.py
+++ b/python/MooseDocs/test/common/test_exceptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 from MooseDocs.common import exceptions
 

--- a/python/MooseDocs/test/common/test_load_config.py
+++ b/python/MooseDocs/test/common/test_load_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 import mock
 

--- a/python/MooseDocs/test/common/test_load_extensions.py
+++ b/python/MooseDocs/test/common/test_load_extensions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 
 import MooseDocs

--- a/python/MooseDocs/test/common/test_mixins.py
+++ b/python/MooseDocs/test/common/test_mixins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 
 import unittest

--- a/python/MooseDocs/test/common/test_parse_settings.py
+++ b/python/MooseDocs/test/common/test_parse_settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 from MooseDocs import common
 from MooseDocs.common import exceptions

--- a/python/MooseDocs/test/common/test_storage.py
+++ b/python/MooseDocs/test/common/test_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Testing for common.Storage class."""
 ####################################################################################################
 #                                    DO NOT MODIFY THIS HEADER                                     #

--- a/python/MooseDocs/test/extensions/test_alert.py
+++ b/python/MooseDocs/test/extensions/test_alert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Testing for MooseDocs.extensions.alert MooseDocs extension."""
 import unittest
 

--- a/python/MooseDocs/test/extensions/test_autolink.py
+++ b/python/MooseDocs/test/extensions/test_autolink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 import os
 import unittest

--- a/python/MooseDocs/test/extensions/test_command.py
+++ b/python/MooseDocs/test/extensions/test_command.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 import os
 import unittest

--- a/python/MooseDocs/test/extensions/test_core.py
+++ b/python/MooseDocs/test/extensions/test_core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 
 import unittest

--- a/python/MooseDocs/test/extensions/test_floats.py
+++ b/python/MooseDocs/test/extensions/test_floats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 
 import unittest

--- a/python/MooseDocs/test/extensions/test_include.py
+++ b/python/MooseDocs/test/extensions/test_include.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import unittest
 import tempfile

--- a/python/MooseDocs/test/extensions/test_katex.py
+++ b/python/MooseDocs/test/extensions/test_katex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Testing for MooseDocs.extensions.katex MooseDocs extension."""
 import unittest
 

--- a/python/MooseDocs/test/extensions/test_media.py
+++ b/python/MooseDocs/test/extensions/test_media.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 
 import unittest

--- a/python/MooseDocs/test/integrity/test_extensions.py
+++ b/python/MooseDocs/test/integrity/test_extensions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 
 import os

--- a/python/MooseDocs/test/integrity/test_pickle.py
+++ b/python/MooseDocs/test/integrity/test_pickle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import re
 import os
 import unittest

--- a/python/MooseDocs/test/integrity/test_spec_files.py
+++ b/python/MooseDocs/test/integrity/test_spec_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 import os
 import sys

--- a/python/MooseDocs/test/tree/test_base.py
+++ b/python/MooseDocs/test/tree/test_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 import unittest
 import mock

--- a/python/MooseDocs/test/tree/test_build_page_tree.py
+++ b/python/MooseDocs/test/tree/test_build_page_tree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import unittest
 import mock

--- a/python/MooseDocs/test/tree/test_html.py
+++ b/python/MooseDocs/test/tree/test_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 
 from MooseDocs.tree import html

--- a/python/MooseDocs/test/tree/test_latex.py
+++ b/python/MooseDocs/test/tree/test_latex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 
 from MooseDocs.tree import latex

--- a/python/MooseDocs/test/tree/test_page.py
+++ b/python/MooseDocs/test/tree/test_page.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 import os
 import logging

--- a/python/MooseDocs/test/tree/test_syntax_tree.py
+++ b/python/MooseDocs/test/tree/test_syntax_tree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import unittest
 

--- a/python/MooseDocs/test/tree/test_tokens.py
+++ b/python/MooseDocs/test/tree/test_tokens.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 import re
 import inspect

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/TestHarness/tests/test_QueuePBS.py
+++ b/python/TestHarness/tests/test_QueuePBS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/calphad/free_energy.py
+++ b/python/calphad/free_energy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/chigger/tests/adapt/adapt.py
+++ b/python/chigger/tests/adapt/adapt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/annotations/image_annotation.py
+++ b/python/chigger/tests/annotations/image_annotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/annotations/logo_annotation.py
+++ b/python/chigger/tests/annotations/logo_annotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/annotations/text_annotation.py
+++ b/python/chigger/tests/annotations/text_annotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/annotations/time_annotation.py
+++ b/python/chigger/tests/annotations/time_annotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/annotations/time_annotation_change.py
+++ b/python/chigger/tests/annotations/time_annotation_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/background/background.py
+++ b/python/chigger/tests/background/background.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/background/gradient.py
+++ b/python/chigger/tests/background/gradient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/chigger/test_chigger.py
+++ b/python/chigger/tests/chigger/test_chigger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/box_clip.py
+++ b/python/chigger/tests/clipping/box_clip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/clip.py
+++ b/python/chigger/tests/clipping/clip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/clip_change.py
+++ b/python/chigger/tests/clipping/clip_change.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/clip_elem.py
+++ b/python/chigger/tests/clipping/clip_elem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/clip_z.py
+++ b/python/chigger/tests/clipping/clip_z.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/dual.py
+++ b/python/chigger/tests/clipping/dual.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/clipping/multiple_clips.py
+++ b/python/chigger/tests/clipping/multiple_clips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/color/color.py
+++ b/python/chigger/tests/color/color.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar.py
+++ b/python/chigger/tests/colorbar/colorbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar_bottom.py
+++ b/python/chigger/tests/colorbar/colorbar_bottom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar_font.py
+++ b/python/chigger/tests/colorbar/colorbar_font.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar_horiz.py
+++ b/python/chigger/tests/colorbar/colorbar_horiz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar_left.py
+++ b/python/chigger/tests/colorbar/colorbar_left.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/colorbar_top.py
+++ b/python/chigger/tests/colorbar/colorbar_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/common_colorbar.py
+++ b/python/chigger/tests/colorbar/common_colorbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/common_colorbar_horiz.py
+++ b/python/chigger/tests/colorbar/common_colorbar_horiz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/dual_colorbar.py
+++ b/python/chigger/tests/colorbar/dual_colorbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/dual_colorbar_horiz.py
+++ b/python/chigger/tests/colorbar/dual_colorbar_horiz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colorbar/exodus_colorbar.py
+++ b/python/chigger/tests/colorbar/exodus_colorbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colormap/colormap.py
+++ b/python/chigger/tests/colormap/colormap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colormap/colormap_number.py
+++ b/python/chigger/tests/colormap/colormap_number.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colormap/reverse.py
+++ b/python/chigger/tests/colormap/reverse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colormap/reverse_default.py
+++ b/python/chigger/tests/colormap/reverse_default.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/colormap/reverse_xml.py
+++ b/python/chigger/tests/colormap/reverse_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/block.py
+++ b/python/chigger/tests/contours/block.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/block_elem.py
+++ b/python/chigger/tests/contours/block_elem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/combo.py
+++ b/python/chigger/tests/contours/combo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/default.py
+++ b/python/chigger/tests/contours/default.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/inline.py
+++ b/python/chigger/tests/contours/inline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/inline_clip.py
+++ b/python/chigger/tests/contours/inline_clip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/contours/levels.py
+++ b/python/chigger/tests/contours/levels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/displacement/displacement.py
+++ b/python/chigger/tests/displacement/displacement.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/displacement/displacement_mag.py
+++ b/python/chigger/tests/displacement/displacement_mag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/displacement/displacement_off.py
+++ b/python/chigger/tests/displacement/displacement_off.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/edge/edge.py
+++ b/python/chigger/tests/edge/edge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/error/result_given_file.py
+++ b/python/chigger/tests/error/result_given_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/error/time_timestep.py
+++ b/python/chigger/tests/error/time_timestep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/all_boundary.py
+++ b/python/chigger/tests/exodus/blocks/all_boundary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/all_nodesets.py
+++ b/python/chigger/tests/exodus/blocks/all_nodesets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/blocks.py
+++ b/python/chigger/tests/exodus/blocks/blocks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/boundary.py
+++ b/python/chigger/tests/exodus/blocks/boundary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/boundary_numeric.py
+++ b/python/chigger/tests/exodus/blocks/boundary_numeric.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/combo.py
+++ b/python/chigger/tests/exodus/blocks/combo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/default.py
+++ b/python/chigger/tests/exodus/blocks/default.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/nodesets.py
+++ b/python/chigger/tests/exodus/blocks/nodesets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/blocks/none.py
+++ b/python/chigger/tests/exodus/blocks/none.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/labels/cells.py
+++ b/python/chigger/tests/exodus/labels/cells.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/labels/points.py
+++ b/python/chigger/tests/exodus/labels/points.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/labels/variable.py
+++ b/python/chigger/tests/exodus/labels/variable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/test_ExodusReader.py
+++ b/python/chigger/tests/exodus/test_ExodusReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/exodus/test_ExodusSource.py
+++ b/python/chigger/tests/exodus/test_ExodusSource.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/field_data/current_field_data.py
+++ b/python/chigger/tests/field_data/current_field_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/field_data/field_data.py
+++ b/python/chigger/tests/field_data/field_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/field_data/plot_current_field_data.py
+++ b/python/chigger/tests/field_data/plot_current_field_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/field_data/plot_field_data.py
+++ b/python/chigger/tests/field_data/plot_field_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/base/orientation.py
+++ b/python/chigger/tests/geometric/base/orientation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/base/rotation.py
+++ b/python/chigger/tests/geometric/base/rotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/base/scale.py
+++ b/python/chigger/tests/geometric/base/scale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/cube_source/cube_source.py
+++ b/python/chigger/tests/geometric/cube_source/cube_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/cylinder_source/cylinder_source.py
+++ b/python/chigger/tests/geometric/cylinder_source/cylinder_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/line_source/line_source.py
+++ b/python/chigger/tests/geometric/line_source/line_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/geometric/plane_source/plane_source.py
+++ b/python/chigger/tests/geometric/plane_source/plane_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/graphs/dual.py
+++ b/python/chigger/tests/graphs/dual.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/graphs/dualx.py
+++ b/python/chigger/tests/graphs/dualx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/color.py
+++ b/python/chigger/tests/line/color.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/empty.py
+++ b/python/chigger/tests/line/empty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/legend.py
+++ b/python/chigger/tests/line/legend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/line.py
+++ b/python/chigger/tests/line/line.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/secondary.py
+++ b/python/chigger/tests/line/secondary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/single_point.py
+++ b/python/chigger/tests/line/single_point.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/tracer.py
+++ b/python/chigger/tests/line/tracer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line/update.py
+++ b/python/chigger/tests/line/update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line_sample/line_sample.py
+++ b/python/chigger/tests/line_sample/line_sample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line_sample/line_sample_default.py
+++ b/python/chigger/tests/line_sample/line_sample_default.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line_sample/line_sample_elem.py
+++ b/python/chigger/tests/line_sample/line_sample_elem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/line_sample/line_sample_error.py
+++ b/python/chigger/tests/line_sample/line_sample_error.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/mesh/mesh.py
+++ b/python/chigger/tests/mesh/mesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/mesh_only/mesh_only.py
+++ b/python/chigger/tests/mesh_only/mesh_only.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/multiapps/multiapp.py
+++ b/python/chigger/tests/multiapps/multiapp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/new_files/new_files.py
+++ b/python/chigger/tests/new_files/new_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/new_files/new_files_adapt.py
+++ b/python/chigger/tests/new_files/new_files_adapt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/new_files/old_files.py
+++ b/python/chigger/tests/new_files/old_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/observers/timer.py
+++ b/python/chigger/tests/observers/timer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/offscreen/offscreen.py
+++ b/python/chigger/tests/offscreen/offscreen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/options/options.py
+++ b/python/chigger/tests/options/options.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/auto.py
+++ b/python/chigger/tests/range/auto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/max.py
+++ b/python/chigger/tests/range/max.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/min.py
+++ b/python/chigger/tests/range/min.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/minmax.py
+++ b/python/chigger/tests/range/minmax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/none.py
+++ b/python/chigger/tests/range/none.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/range/range.py
+++ b/python/chigger/tests/range/range.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/result_group/result_group.py
+++ b/python/chigger/tests/result_group/result_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/simple/simple.py
+++ b/python/chigger/tests/simple/simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/simple/simple_camera.py
+++ b/python/chigger/tests/simple/simple_camera.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/speed/speed.py
+++ b/python/chigger/tests/speed/speed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/transform/rotate.py
+++ b/python/chigger/tests/transform/rotate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/transform/scale.py
+++ b/python/chigger/tests/transform/scale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/transform/scale_2d.py
+++ b/python/chigger/tests/transform/scale_2d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/transform/translate.py
+++ b/python/chigger/tests/transform/translate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/tube/tube.py
+++ b/python/chigger/tests/tube/tube.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/utils/test_get_active_filenames.py
+++ b/python/chigger/tests/utils/test_get_active_filenames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/vector/vector_magnitude.py
+++ b/python/chigger/tests/vector/vector_magnitude.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/vector/vector_x.py
+++ b/python/chigger/tests/vector/vector_x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/vector/vector_y.py
+++ b/python/chigger/tests/vector/vector_y.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/viewports/viewports.py
+++ b/python/chigger/tests/viewports/viewports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/volume_extents/extents.py
+++ b/python/chigger/tests/volume_extents/extents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/window/window_clear.py
+++ b/python/chigger/tests/window/window_clear.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/wireframe/points.py
+++ b/python/chigger/tests/wireframe/points.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/wireframe/wireframe.py
+++ b/python/chigger/tests/wireframe/wireframe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/tests/writers/writers.py
+++ b/python/chigger/tests/writers/writers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org

--- a/python/chigger/utils/Options.py
+++ b/python/chigger/utils/Options.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import textwrap
 from collections import OrderedDict

--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/ImageDiffer.py
+++ b/python/mooseutils/ImageDiffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_MooseDataFrame.py
+++ b/python/mooseutils/tests/test_MooseDataFrame.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_PostprocessorReader.py
+++ b/python/mooseutils/tests/test_PostprocessorReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_VectorPostprocessorReader.py
+++ b/python/mooseutils/tests/test_VectorPostprocessorReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_camel_to_space.py
+++ b/python/mooseutils/tests/test_camel_to_space.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_check_file_size.py
+++ b/python/mooseutils/tests/test_check_file_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_hit_load.py
+++ b/python/mooseutils/tests/test_hit_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import unittest
 import mooseutils

--- a/python/mooseutils/tests/test_mooseMessage.py
+++ b/python/mooseutils/tests/test_mooseMessage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_mooseMessageDialog.py
+++ b/python/mooseutils/tests/test_mooseMessageDialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/mooseutils/tests/test_yaml_load.py
+++ b/python/mooseutils/tests/test_yaml_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import unittest
 import mooseutils
 

--- a/python/peacock/BasePeacockMainWindow.py
+++ b/python/peacock/BasePeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/BasePeacockMainWindow.py
+++ b/python/peacock/BasePeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ConsoleOutputViewerPlugin.py
+++ b/python/peacock/Execute/ConsoleOutputViewerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ConsoleOutputViewerPlugin.py
+++ b/python/peacock/Execute/ConsoleOutputViewerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteOptionsPlugin.py
+++ b/python/peacock/Execute/ExecuteOptionsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteOptionsPlugin.py
+++ b/python/peacock/Execute/ExecuteOptionsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteRunnerPlugin.py
+++ b/python/peacock/Execute/ExecuteRunnerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteRunnerPlugin.py
+++ b/python/peacock/Execute/ExecuteRunnerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteTabPlugin.py
+++ b/python/peacock/Execute/ExecuteTabPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/ExecuteTabPlugin.py
+++ b/python/peacock/Execute/ExecuteTabPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/TerminalTextEdit.py
+++ b/python/peacock/Execute/TerminalTextEdit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Execute/TerminalTextEdit.py
+++ b/python/peacock/Execute/TerminalTextEdit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
+++ b/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
+++ b/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/ExecutableInfo.py
+++ b/python/peacock/Input/ExecutableInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/ExecutableInfo.py
+++ b/python/peacock/Input/ExecutableInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditorWithMesh.py
+++ b/python/peacock/Input/InputFileEditorWithMesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputFileEditorWithMesh.py
+++ b/python/peacock/Input/InputFileEditorWithMesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputTree.py
+++ b/python/peacock/Input/InputTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/InputTree.py
+++ b/python/peacock/Input/InputTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/JsonData.py
+++ b/python/peacock/Input/JsonData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/JsonData.py
+++ b/python/peacock/Input/JsonData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/TimeStepEstimate.py
+++ b/python/peacock/Input/TimeStepEstimate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/Input/TimeStepEstimate.py
+++ b/python/peacock/Input/TimeStepEstimate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/PeacockMainWindow.py
+++ b/python/peacock/PeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/PeacockMainWindow.py
+++ b/python/peacock/PeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/base/test_PeacockCollapsibleWidget.py
+++ b/python/peacock/tests/base/test_PeacockCollapsibleWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/base/test_PeacockCollapsibleWidget.py
+++ b/python/peacock/tests/base/test_PeacockCollapsibleWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/base/test_PluginManager.py
+++ b/python/peacock/tests/base/test_PluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/base/test_PluginManager.py
+++ b/python/peacock/tests/base/test_PluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/test_ConsoleOutputViewerPlugin.py
+++ b/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/test_ConsoleOutputViewerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/test_ConsoleOutputViewerPlugin.py
+++ b/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/test_ConsoleOutputViewerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/test_ExecuteOptionsPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/test_ExecuteOptionsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/test_ExecuteOptionsPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/test_ExecuteOptionsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/test_ExecuteRunnerPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/test_ExecuteRunnerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/test_ExecuteRunnerPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/test_ExecuteRunnerPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteTabPlugin/test_ExecuteTabPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteTabPlugin/test_ExecuteTabPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/ExecuteTabPlugin/test_ExecuteTabPlugin.py
+++ b/python/peacock/tests/execute_tab/ExecuteTabPlugin/test_ExecuteTabPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/JobRunner/test_JobRunner.py
+++ b/python/peacock/tests/execute_tab/JobRunner/test_JobRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/JobRunner/test_JobRunner.py
+++ b/python/peacock/tests/execute_tab/JobRunner/test_JobRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/TerminalTextEdit/test_TerminalTextEdit.py
+++ b/python/peacock/tests/execute_tab/TerminalTextEdit/test_TerminalTextEdit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/execute_tab/TerminalTextEdit/test_TerminalTextEdit.py
+++ b/python/peacock/tests/execute_tab/TerminalTextEdit/test_TerminalTextEdit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_BackgroundPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_BlockPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_BlockPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_BlockPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_BlockPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_CameraPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_CameraPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_CameraPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_CameraPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ClipPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_ClipPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ClipPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_ClipPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ContourPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_ContourPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ContourPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_ContourPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ExodusPluginManager.py
+++ b/python/peacock/tests/exodus_tab/test_ExodusPluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ExodusPluginManager.py
+++ b/python/peacock/tests/exodus_tab/test_ExodusPluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ExodusViewer.py
+++ b/python/peacock/tests/exodus_tab/test_ExodusViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_ExodusViewer.py
+++ b/python/peacock/tests/exodus_tab/test_ExodusViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_FilePlugin.py
+++ b/python/peacock/tests/exodus_tab/test_FilePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_FilePlugin.py
+++ b/python/peacock/tests/exodus_tab/test_FilePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_GoldDiffPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_GoldDiffPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_GoldDiffPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_GoldDiffPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_MediaControlPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_MediaControlPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_MeshPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_MeshPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_MeshPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_MeshPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_OutputPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_OutputPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_OutputPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_OutputPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_VTKWindowPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_VTKWindowPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_VTKWindowPlugin.py
+++ b/python/peacock/tests/exodus_tab/test_VTKWindowPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_VariablePlugin.py
+++ b/python/peacock/tests/exodus_tab/test_VariablePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/exodus_tab/test_VariablePlugin.py
+++ b/python/peacock/tests/exodus_tab/test_VariablePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
+++ b/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
+++ b/python/peacock/tests/input_tab/BlockEditor/test_BlockEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockInfo/test_BlockInfo.py
+++ b/python/peacock/tests/input_tab/BlockInfo/test_BlockInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockInfo/test_BlockInfo.py
+++ b/python/peacock/tests/input_tab/BlockInfo/test_BlockInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
+++ b/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
+++ b/python/peacock/tests/input_tab/BlockTree/test_BlockTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/CheckInputWidget/test_CheckInputWidget.py
+++ b/python/peacock/tests/input_tab/CheckInputWidget/test_CheckInputWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/CheckInputWidget/test_CheckInputWidget.py
+++ b/python/peacock/tests/input_tab/CheckInputWidget/test_CheckInputWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/CommentEditor/test_CommentEditor.py
+++ b/python/peacock/tests/input_tab/CommentEditor/test_CommentEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/CommentEditor/test_CommentEditor.py
+++ b/python/peacock/tests/input_tab/CommentEditor/test_CommentEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ExecutableInfo/test_ExecutableInfo.py
+++ b/python/peacock/tests/input_tab/ExecutableInfo/test_ExecutableInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ExecutableInfo/test_ExecutableInfo.py
+++ b/python/peacock/tests/input_tab/ExecutableInfo/test_ExecutableInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFile/test_InputFile.py
+++ b/python/peacock/tests/input_tab/InputFile/test_InputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFile/test_InputFile.py
+++ b/python/peacock/tests/input_tab/InputFile/test_InputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditor/test_InputFileEditor.py
+++ b/python/peacock/tests/input_tab/InputFileEditor/test_InputFileEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditor/test_InputFileEditor.py
+++ b/python/peacock/tests/input_tab/InputFileEditor/test_InputFileEditor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
+++ b/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
+++ b/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
+++ b/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
+++ b/python/peacock/tests/input_tab/InputFileEditorWithMesh/test_InputFileEditorWithMesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputTree/test_InputTree.py
+++ b/python/peacock/tests/input_tab/InputTree/test_InputTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputTree/test_InputTree.py
+++ b/python/peacock/tests/input_tab/InputTree/test_InputTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
+++ b/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
+++ b/python/peacock/tests/input_tab/InputTreeWriter/test_InputTreeWriter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/JsonData/test_JsonData.py
+++ b/python/peacock/tests/input_tab/JsonData/test_JsonData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/JsonData/test_JsonData.py
+++ b/python/peacock/tests/input_tab/JsonData/test_JsonData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
+++ b/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
+++ b/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
+++ b/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
+++ b/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsByGroup/test_ParamsByGroup.py
+++ b/python/peacock/tests/input_tab/ParamsByGroup/test_ParamsByGroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsByGroup/test_ParamsByGroup.py
+++ b/python/peacock/tests/input_tab/ParamsByGroup/test_ParamsByGroup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
+++ b/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
+++ b/python/peacock/tests/input_tab/ParamsByType/test_ParamsByType.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsTable/test_ParamsTable.py
+++ b/python/peacock/tests/input_tab/ParamsTable/test_ParamsTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/ParamsTable/test_ParamsTable.py
+++ b/python/peacock/tests/input_tab/ParamsTable/test_ParamsTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/TimeStepEstimate/test_TimeStepEstimate.py
+++ b/python/peacock/tests/input_tab/TimeStepEstimate/test_TimeStepEstimate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/input_tab/TimeStepEstimate/test_TimeStepEstimate.py
+++ b/python/peacock/tests/input_tab/TimeStepEstimate/test_TimeStepEstimate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/BasePeacockMainWindow/test_BasePeacockMainWindow.py
+++ b/python/peacock/tests/peacock_app/BasePeacockMainWindow/test_BasePeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/BasePeacockMainWindow/test_BasePeacockMainWindow.py
+++ b/python/peacock/tests/peacock_app/BasePeacockMainWindow/test_BasePeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/CheckRequirements/test_CheckRequirements.py
+++ b/python/peacock/tests/peacock_app/CheckRequirements/test_CheckRequirements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/CheckRequirements/test_CheckRequirements.py
+++ b/python/peacock/tests/peacock_app/CheckRequirements/test_CheckRequirements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
+++ b/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
+++ b/python/peacock/tests/peacock_app/LogWidget/test_LogWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
+++ b/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
+++ b/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PythonConsoleWidget/test_PythonConsoleWidget.py
+++ b/python/peacock/tests/peacock_app/PythonConsoleWidget/test_PythonConsoleWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/PythonConsoleWidget/test_PythonConsoleWidget.py
+++ b/python/peacock/tests/peacock_app/PythonConsoleWidget/test_PythonConsoleWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_add_variables_and_blocks/test_AddVariableAndBlock.py
+++ b/python/peacock/tests/peacock_app/check_add_variables_and_blocks/test_AddVariableAndBlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_add_variables_and_blocks/test_AddVariableAndBlock.py
+++ b/python/peacock/tests/peacock_app/check_add_variables_and_blocks/test_AddVariableAndBlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_change_input_file/test_ChangeInputFile.py
+++ b/python/peacock/tests/peacock_app/check_change_input_file/test_ChangeInputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_change_input_file/test_ChangeInputFile.py
+++ b/python/peacock/tests/peacock_app/check_change_input_file/test_ChangeInputFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
+++ b/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
+++ b/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_state.py
+++ b/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_state.py
+++ b/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_mesh/test_check_mesh.py
+++ b/python/peacock/tests/peacock_app/check_mesh/test_check_mesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_mesh/test_check_mesh.py
+++ b/python/peacock/tests/peacock_app/check_mesh/test_check_mesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_postprocessor/test_check_postprocessor.py
+++ b/python/peacock/tests/peacock_app/check_postprocessor/test_check_postprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_postprocessor/test_check_postprocessor.py
+++ b/python/peacock/tests/peacock_app/check_postprocessor/test_check_postprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
+++ b/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
+++ b/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_result/test_check_result.py
+++ b/python/peacock/tests/peacock_app/check_result/test_check_result.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_result/test_check_result.py
+++ b/python/peacock/tests/peacock_app/check_result/test_check_result.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_vectorpostprocessor/test_check_vectorpostprocessor.py
+++ b/python/peacock/tests/peacock_app/check_vectorpostprocessor/test_check_vectorpostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/check_vectorpostprocessor/test_check_vectorpostprocessor.py
+++ b/python/peacock/tests/peacock_app/check_vectorpostprocessor/test_check_vectorpostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/results_output/test_results_output.py
+++ b/python/peacock/tests/peacock_app/results_output/test_results_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/peacock_app/results_output/test_results_output.py
+++ b/python/peacock/tests/peacock_app/results_output/test_results_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_AxesSettingsPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_AxesSettingsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_AxesSettingsPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_AxesSettingsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_AxisTabsPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_AxisTabsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_AxisTabsPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_AxisTabsPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_FigurePlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_FigurePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_FigurePlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_FigurePlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetPostprocessor.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetPostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetPostprocessor.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetPostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetVectorPostprocessor.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetVectorPostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetVectorPostprocessor.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineGroupWidgetVectorPostprocessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineSettingsWidget.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineSettingsWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_LineSettingsWidget.py
+++ b/python/peacock/tests/postprocessor_tab/test_LineSettingsWidget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_MediaControlPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_MediaControlPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_MediaControlPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_OutputPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_OutputPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_OutputPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_OutputPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorSelectPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorSelectPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorSelectPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorSelectPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorSelectPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorSelectPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorSelectPlugin.py
+++ b/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorSelectPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_ExeFinder.py
+++ b/python/peacock/tests/utils/test_ExeFinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_ExeFinder.py
+++ b/python/peacock/tests/utils/test_ExeFinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_ExeLauncher.py
+++ b/python/peacock/tests/utils/test_ExeLauncher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_ExeLauncher.py
+++ b/python/peacock/tests/utils/test_ExeLauncher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_FileCache.py
+++ b/python/peacock/tests/utils/test_FileCache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_FileCache.py
+++ b/python/peacock/tests/utils/test_FileCache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_RecentlyUsedMenu.py
+++ b/python/peacock/tests/utils/test_RecentlyUsedMenu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_RecentlyUsedMenu.py
+++ b/python/peacock/tests/utils/test_RecentlyUsedMenu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_StoreLoadWidgetState.py
+++ b/python/peacock/tests/utils/test_StoreLoadWidgetState.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_StoreLoadWidgetState.py
+++ b/python/peacock/tests/utils/test_StoreLoadWidgetState.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_TerminalUtils.py
+++ b/python/peacock/tests/utils/test_TerminalUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_TerminalUtils.py
+++ b/python/peacock/tests/utils/test_TerminalUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_WidgetUtils.py
+++ b/python/peacock/tests/utils/test_WidgetUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/tests/utils/test_WidgetUtils.py
+++ b/python/peacock/tests/utils/test_WidgetUtils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/utils/build_cmaps.py
+++ b/python/peacock/utils/build_cmaps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python22
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/peacock/utils/build_cmaps.py
+++ b/python/peacock/utils/build_cmaps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python22
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/python/postprocessing/combine_csv.py
+++ b/python/postprocessing/combine_csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/add_exec_flag_registration.py
+++ b/scripts/add_exec_flag_registration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/are_queued_jobs_finished.py
+++ b/scripts/are_queued_jobs_finished.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/clobber.py
+++ b/scripts/clobber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/git_commit_history.py
+++ b/scripts/git_commit_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/github_traffic.py
+++ b/scripts/github_traffic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/memory_logger.py
+++ b/scripts/memory_logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/separate_unittests.py
+++ b/scripts/separate_unittests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/scripts/traceability_matrix.py
+++ b/scripts/traceability_matrix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/doc/moosedocs.py
+++ b/test/doc/moosedocs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/indicators/laplacian_jump_indicator/biharmonic.py
+++ b/test/tests/indicators/laplacian_jump_indicator/biharmonic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/indicators/laplacian_jump_indicator/plot.py
+++ b/test/tests/indicators/laplacian_jump_indicator/plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/multiapps/centroid_multiapp/view_subs.py
+++ b/test/tests/multiapps/centroid_multiapp/view_subs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #pylint: disable=missing-docstring
 #################################################################
 #                   DO NOT MODIFY THIS HEADER                   #

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/time_integrators/convergence/explicit_plot.py
+++ b/test/tests/time_integrators/convergence/explicit_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/time_integrators/convergence/implicit_plot.py
+++ b/test/tests/time_integrators/convergence/implicit_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/time_integrators/scalar/run.py
+++ b/test/tests/time_integrators/scalar/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/time_integrators/scalar/run_stiff.py
+++ b/test/tests/time_integrators/scalar/run_stiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tests/variables/fe_hermite_convergence/plot.py
+++ b/test/tests/variables/fe_hermite_convergence/plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tools/large_subdomain_gen/_output_cubit_commands.py
+++ b/test/tools/large_subdomain_gen/_output_cubit_commands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.5
+#!/usr/bin/env python2.52
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tools/large_subdomain_gen/_output_cubit_commands.py
+++ b/test/tools/large_subdomain_gen/_output_cubit_commands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.52
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tools/large_subdomain_gen/large_sub_gen.py
+++ b/test/tools/large_subdomain_gen/large_sub_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.5
+#!/usr/bin/env python2.52
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/test/tools/large_subdomain_gen/large_sub_gen.py
+++ b/test/tools/large_subdomain_gen/large_sub_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.52
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*

--- a/tutorials/darcy_thermo_mech/check.py
+++ b/tutorials/darcy_thermo_mech/check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #* This file is part of the MOOSE framework
 #* https://www.mooseframework.org
 #*


### PR DESCRIPTION
Newer Linux distributions have symlinked /usr/bin/python3 to /usr/bin/python,
such that "/usr/bin/env python" calls python3 instead of python2.

Changes:
- replace "/usr/bin/env python" with "/usr/bin/env python2" in all *.py files

- this change choses explicitly the python version (currently python2)

- this patch enables the gradual transition to python3, since python3 scripts
  can be marked with "/usr/bin/env python3"

- it is unlikely that this patch breaks anything on Linux or MacOS X, since
  /usr/bin/env should find the corresponding python version.
