### PR TITLE
Allow skipping tests based on reigstered applications 

### DIFF
--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -16,6 +16,7 @@
 #include "Parser.h"
 #include "pcrecpp.h"
 #include "Action.h"
+#include "AppFactory.h"
 
 // C++ includes
 #include <algorithm>
@@ -134,6 +135,14 @@ JsonSyntaxTree::addGlobal()
     moosecontrib::Json::Value jparams;
     setParams(&params, true, jparams);
     _root["global"]["parameters"] = jparams;
+
+    // Just create a list of registered app names
+    moosecontrib::Json::Value apps;
+    auto factory = AppFactory::instance();
+    for (auto app = factory.registeredObjectsBegin(); app != factory.registeredObjectsEnd(); ++app)
+      apps.append(app->first);
+
+    _root["global"]["registered_apps"] = apps;
   }
 }
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -121,6 +121,7 @@ class TestHarness:
         checks['platform'] = util.getPlatforms()
         checks['submodules'] = util.getInitializedSubmodules(self.run_tests_dir)
         checks['exe_objects'] = None # This gets calculated on demand
+        checks['registered_apps'] = None # This gets extracted on demand
 
         # The TestHarness doesn't strictly require the existence of libMesh in order to run. Here we allow the user
         # to select whether they want to probe for libMesh configuration options.

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -70,6 +70,7 @@ class Tester(MooseObject):
         params.addParam('should_execute', True, 'Whether or not the executable needs to be run.  Use this to chain together multiple tests based off of one executeable invocation')
         params.addParam('required_submodule', [], "A list of initialized submodules for which this test requires.")
         params.addParam('required_objects', [], "A list of required objects that are in the executable.")
+        params.addParam('required_applications', [], "A list of required registered applications that are in the executable.")
         params.addParam('check_input',    False, "Check for correct input file syntax")
         params.addParam('display_required', False, "The test requires and active display for rendering (i.e., ImageDiff tests).")
         params.addParam('timing',         True, "If True, the test will be allowed to run with the timing flag (i.e. Manually turning on performance logging).")
@@ -600,6 +601,16 @@ class Tester(MooseObject):
         for var in self.specs['required_objects']:
             if var not in checks["exe_objects"]:
                 reasons['required_objects'] = '%s not found in executable' % var
+                break
+
+        # We extract the registered apps only if we need them
+        if self.specs["required_applications"] and checks["registered_apps"] is None:
+            checks["registered_apps"] = util.getExeRegisteredApps(self.specs["executable"])
+
+        # Check to see if we have the required application names
+        for var in self.specs['required_applications']:
+            if var not in checks["registered_apps"]:
+                reasons['required_applications'] = 'App %s not registered in executable' % var
                 break
 
         # Check to make sure required submodules are initialized

--- a/python/TestHarness/tests/test_RequiredApps.py
+++ b/python/TestHarness/tests/test_RequiredApps.py
@@ -1,0 +1,20 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testRequiredApps(self):
+        """
+        Test that the required_apps check works
+        """
+        output = self.runTests('--no-color', '-i', 'required_apps')
+        self.assertRegexpMatches(output, r'test_harness\.bad_app.*? \[APP DOESNOTEXIST NOT REGISTERED IN EXECUTABLE\] SKIP')
+        self.assertRegexpMatches(output, r'test_harness\.good_app.*? OK')
+        self.checkStatus(output, passed=1, skipped=1)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -63,7 +63,11 @@
     type = PythonUnitTest
     input = test_RequiredObjects.py
   [../]
-   [./should_execute]
+  [./required_apps]
+    type = PythonUnitTest
+    input = test_RequiredApps.py
+  [../]
+  [./should_execute]
     type = PythonUnitTest
     input = test_ShouldExecute.py
   [../]

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -524,17 +524,30 @@ def addObjectNames(objs, node):
     if star:
         addObjectNames(objs, star)
 
-def getExeObjects(exe):
+def getExeJSON(exe):
     """
-    Gets a set of object names that are in the executable JSON dump.
+    Extracts the JSON from the dump
     """
     output = runCommand("%s --json" % exe)
     output = output.split('**START JSON DATA**\n')[1]
     output = output.split('**END JSON DATA**\n')[0]
+    return json.loads(output)
+
+def getExeObjects(exe):
+    """
+    Gets a set of object names that are in the executable JSON dump.
+    """
+    data = getExeJSON(exe)
     obj_names = set()
-    data = json.loads(output)
     addObjectsFromBlock(obj_names, data, "blocks")
     return obj_names
+
+def getExeRegisteredApps(exe):
+    """
+    Gets a list of registered applications
+    """
+    data = getExeJSON(exe)
+    return data.get('global', {}).get('registered_apps', [])
 
 def checkOutputForPattern(output, re_pattern):
     """

--- a/test/tests/test_harness/required_apps
+++ b/test/tests/test_harness/required_apps
@@ -1,0 +1,12 @@
+[Tests]
+  [./bad_app]
+    type = RunApp
+    input = foo.i
+    required_applications = 'MooseTestApp DoesNotExist'
+  [../]
+  [./good_app]
+    type = RunApp
+    input = good.i
+    required_applications = 'MooseTestApp'
+  [../]
+[]


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Adds a `registered_apps` list in the `global` section of the JSON dump.
The TestHarness allows a `required_applications` parameter in the spec file that uses this list to optionally skip tests.

closes #11095 