### PR TITLE
Use set for storing filenames to avoid duplicates

### DIFF
--- a/python/MooseDocs/tree/syntax.py
+++ b/python/MooseDocs/tree/syntax.py
@@ -153,7 +153,7 @@ class SyntaxNodeBase(NodeBase):
         for group in groups:
 
             # Locate all the possible locations for the markdown
-            filenames = []
+            filenames = set()
             for group in self.groups:
                 install = SyntaxNodeBase.DESTINATIONS.get(group,
                                                           'doc/content/documentation/systems')
@@ -162,7 +162,7 @@ class SyntaxNodeBase(NodeBase):
                     filename = os.path.join(MooseDocs.ROOT_DIR, install, self.markdown())
                 else:
                     filename = os.path.join(install, self.markdown())
-                filenames.append((filename, os.path.isfile(filename)))
+                filenames.add((filename, os.path.isfile(filename)))
 
             # Determine the number of files that exist
             count = sum([x[1] for x in filenames])


### PR DESCRIPTION
It is possible for an object and/or syntax to be associated with multiple groups so the group loop can reach the same file many times, so the filenames should be stored as a set
(refs #9638)

@jwpeterson This will fix the problem MASTODON is seeing with your PR.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
