### PR TITLE
Enable patch tests that were disabled before 

### DIFF
--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/tests
@@ -100,7 +100,6 @@
     abs_zero = 1e-4
     max_parallel = 1
     superlu = true
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/tests
@@ -10,7 +10,6 @@
     superlu = true
     prereq = 'glued_kin_sm'
     petsc_version = '>=3.7.6'
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen]
     type = 'CSVDiff'
@@ -69,7 +68,6 @@
     max_parallel = 1
     superlu = true
     petsc_version = '>=3.7.6'
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
@@ -94,7 +92,6 @@
     abs_zero = 1e-8
     max_parallel = 1
     superlu = true
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/tests
@@ -64,7 +64,6 @@
     abs_zero = 1e-6
     max_parallel = 1
     superlu = true
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./glued_pen_sm]
     type = 'CSVDiff'
@@ -85,7 +84,6 @@
     abs_zero = 1e-6
     max_parallel = 1
     superlu = true
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
   [../]
   [./frictionless_pen_sm]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
@@ -200,8 +200,8 @@
   type = Transient
   solve_type = 'PJFNK'
 
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package'
-  petsc_options_value = 'lu    superlu_dist'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -mat_superlu_dist_iterrefine'
+  petsc_options_value = 'lu    superlu_dist 1'
 
   line_search = 'none'
 

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -11,7 +11,6 @@
     superlu = true
     prereq = 'glued_kin_sm'
     petsc_version = '>=3.7.6'
-    compiler = 'GCC CLANG' #superlu bug, see MOOSE issue #10084
     allow_warnings = true
   [../]
   [./glued_pen]


### PR DESCRIPTION
because of superlu_dist bugs

Closes #10084

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
