### PR TITLE
PorousFlow doco gives example of scaling variables.

### DIFF
--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/convergence.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/convergence.md
@@ -112,3 +112,6 @@ $10^9$ on the porepressure variable (or whatever MOOSE variable is associated to
 the fluid equation) would be appropriate.  Similarly, a scaling of around $10^3$
 on the temperature variable would be appropriate.
 
+Scaling the variables is implemented in the input file using the `scaling` parameter, for instance:
+
+!listing modules/porous_flow/examples/tutorial/03.i start=[Variables] end=[PorousFlowBasicTHM]


### PR DESCRIPTION
Refs #11001

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
