### PR TITLE
Refactor the writing of result files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ temp_print_trace.*
 *.processor.*
 .clang_complete
 .failed_tests
+.previous_test_results
 compile_commands.json
 build
 

--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,6 @@ temp_print_trace.*
 *.processor.*
 .clang_complete
 .failed_tests
-.previous_test_results
 compile_commands.json
 build
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -589,6 +589,7 @@ class TestHarness:
                                                                        'LONG_NAME' : tester.getTestName(),
                                                                        'TIMING'    : job.getTiming(),
                                                                        'STATUS'    : tester.getStatus().status,
+                                                                       'FAIL'      : tester.didFail(),
                                                                        'COLOR'     : tester.getStatus().color,
                                                                        'CAVEATS'   : list(tester.getCaveats()),
                                                                        'COMMAND'   : tester.getCommand(self.options)}

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -72,6 +72,10 @@ class Job(object):
         """ Wrapper method to return the testers test name """
         return self.__tester.getTestName()
 
+    def getTestNameShort(self):
+        """ Return the shorthand Test name """
+        return self.getTestName().split('.')[1]
+
     def getUniqueIdentifier(self):
         """ A unique identifier for this job object """
         return self.__unique_identifier

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -100,8 +100,7 @@ class Scheduler(MooseObject):
         # Jobs waiting to finish (includes actively running jobs)
         self.job_queue_count = 0
 
-        # Set containing our Job containers. We use this in the event of a KeyboardInterrupt to
-        # iterate over and kill any subprocesses
+        # Set containing all submitted jobs
         self.tester_datas = set([])
 
         # Allow threads to set an exception state
@@ -123,6 +122,10 @@ class Scheduler(MooseObject):
 
         with self.job_queue_lock:
             self.job_queue_count = 0
+
+    def retrieveJobs(self):
+        """ return all the jobs the scheduler was tasked to perform work for """
+        return self.tester_datas
 
     def schedulerError(self):
         """

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -467,8 +467,10 @@ class Tester(MooseObject):
             self.setStatus(self.success_message, self.bucket_success)
 
         # Check if we only want to run failed tests
-        if options.failed_tests:
-            if self.specs['test_name'] not in options._test_list:
+        if options.failed_tests and options.results_storage is not None:
+            result_key = options.results_storage.get(self.getTestDir(), {})
+            result_status = result_key.get(self.getTestName(), {}).get('STATUS', '')
+            if result_status not in ['FAILED', 'DIFF']:
                 self.setStatus('not failed', self.bucket_silent)
                 return False
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -469,8 +469,8 @@ class Tester(MooseObject):
         # Check if we only want to run failed tests
         if options.failed_tests and options.results_storage is not None:
             result_key = options.results_storage.get(self.getTestDir(), {})
-            result_status = result_key.get(self.getTestName(), {}).get('STATUS', '')
-            if result_status not in ['FAILED', 'DIFF']:
+            status = result_key.get(self.getTestName(), {}).get('FAIL', '')
+            if not status:
                 self.setStatus('not failed', self.bucket_silent)
                 return False
 

--- a/python/TestHarness/tests/test_WriteResults.py
+++ b/python/TestHarness/tests/test_WriteResults.py
@@ -1,0 +1,62 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import shutil, os, subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def setUp(self):
+        """
+        setUp occurs before every test. Clean up previous results file
+        """
+        self.output_dir = os.path.join(os.getenv('MOOSE_DIR'), 'test', 'WriteResults_OUTPUT')
+
+        try:
+            # remove previous results file
+            shutil.rmtree(self.output_dir)
+        except:
+            pass
+
+    def testWriteOK(self):
+        """ Test ability to write separate OK test --sep-files-ok """
+        self.runTests('--no-color', '-i', 'always_ok', '--sep-files-ok', '--output-dir', self.output_dir)
+        if not os.path.exists(os.path.join(self.output_dir, 'test_harness.always_ok.OK.txt')):
+           self.fail('Failed to create sep-files-ok')
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'diffs', '--sep-files-ok', '--output-dir', self.output_dir)
+
+        if (os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.DIFF.txt'))
+            or os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.OK.txt'))):
+           self.fail('Test results which failed were created when asked NOT to do so: --sep-files-ok')
+
+    def testWriteFail(self):
+        """ Test ability to write separate Fail test --sep-files-fail """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'diffs', '--sep-files-fail', '--output-dir', self.output_dir)
+
+        if not (os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.DIFF.txt'))
+            and os.path.exists(os.path.join(self.output_dir, 'test_harness.csvdiff.DIFF.txt'))):
+           self.fail('Failed to create sep-files-fail')
+
+        self.runTests('--no-color', '-i', 'always_ok', '--sep-files-fail', '--output-dir', self.output_dir)
+        if os.path.exists(os.path.join(self.output_dir, 'test_harness.always_ok.OK.txt')):
+           self.fail('Test results which passed were created when asked NOT to do so: --sep-files-fail')
+
+    def testWriteAll(self):
+        """ Test write all output files --sep-files """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'diffs', '--sep-files', '--output-dir', self.output_dir)
+
+        self.runTests('--no-color', '-i', 'always_ok', '--sep-files', '--output-dir', self.output_dir)
+
+        if not (os.path.exists(os.path.join(self.output_dir, 'test_harness.always_ok.OK.txt'))
+                and os.path.exists(os.path.join(self.output_dir, 'test_harness.csvdiff.DIFF.txt'))
+                and os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.DIFF.txt'))):
+           self.fail('Failed to create all output files --sep-files')

--- a/python/TestHarness/tests/test_WriteResults.py
+++ b/python/TestHarness/tests/test_WriteResults.py
@@ -29,7 +29,7 @@ class TestHarnessTester(TestHarnessTestCase):
         if not os.path.exists(os.path.join(self.output_dir, 'test_harness.always_ok.OK.txt')):
            self.fail('Failed to create sep-files-ok')
 
-        with self.assertRaises(subprocess.CalledProcessError) as cm:
+        with self.assertRaises(subprocess.CalledProcessError):
             self.runTests('--no-color', '-i', 'diffs', '--sep-files-ok', '--output-dir', self.output_dir)
 
         if (os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.DIFF.txt'))
@@ -38,7 +38,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testWriteFail(self):
         """ Test ability to write separate Fail test --sep-files-fail """
-        with self.assertRaises(subprocess.CalledProcessError) as cm:
+        with self.assertRaises(subprocess.CalledProcessError):
             self.runTests('--no-color', '-i', 'diffs', '--sep-files-fail', '--output-dir', self.output_dir)
 
         if not (os.path.exists(os.path.join(self.output_dir, 'test_harness.exodiff.DIFF.txt'))
@@ -51,7 +51,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
     def testWriteAll(self):
         """ Test write all output files --sep-files """
-        with self.assertRaises(subprocess.CalledProcessError) as cm:
+        with self.assertRaises(subprocess.CalledProcessError):
             self.runTests('--no-color', '-i', 'diffs', '--sep-files', '--output-dir', self.output_dir)
 
         self.runTests('--no-color', '-i', 'always_ok', '--sep-files', '--output-dir', self.output_dir)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -103,4 +103,8 @@
     type = PythonUnitTest
     input = test_ArbitrarySpecFile.py
   [../]
+  [./write_results]
+    type = PythonUnitTest
+    input = test_WriteResults.py
+  [../]
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -633,9 +633,10 @@ def readOutput(f, e, options, max_size=100000):
     f.seek(0)
     if e:
         e.seek(0)
-    if options.no_trimmed_output or options.sep_files == True:
+    if options.no_trimmed_output:
         output += f.read()
-        output += e.read()
+        if e:
+            output += e.read()
 
     else:
         output = f.read(first_part)     # Limit the output to 1MB


### PR DESCRIPTION
Concerning TestHarness features:
  --sep-files
  --sep-files-ok
  --sep-files-fail
  --output-dir

Consolidate the writing of anything 'resulty' which was
occurring at the end of a TestHarness run_tests run.

Store and work with a json file for failed tests (actually
all tests). This will allow anyone to easily parse the results
of their tests for what ever means they need it for.

The results json file is also a stepping stone towards doing
away with a PBS session file.

Closes #11116