### PR TITLE
Add better error message when an error is enouncter in get_repo_revision

### DIFF
--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -25,7 +25,7 @@ def shellCommand(command, cwd=None):
         p.wait()
         retcode = p.returncode
         if retcode != 0:
-            raise Exception()
+            raise Exception("Exception raised while running the command: " + command + " in directory: " + cwd)
 
         return p.communicate()[0]
 


### PR DESCRIPTION
The better error will help us track down issues that we occasionally see
on the build boxes.

refs #10970

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
