### PR TITLE
Using alpha_vapor instead of alpha_liquid

### DIFF
--- a/modules/fluid_properties/include/userobjects/HEMFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HEMFluidProperties.h
@@ -114,12 +114,12 @@ public:
   virtual Real k(Real v, Real e) const = 0;
 
   /**
-   * Liquid Void Fraction as a function of specific volume and specific
+   * Vapor void fraction as a function of specific volume and specific
    * internal energy
    * @param v Specific volume
    * @param e Specific internal energy
    */
-  virtual Real alpha_liquid(Real v, Real e) const = 0;
+  virtual Real alpha_vapor(Real v, Real e) const = 0;
 
   /**
    * dT/dp along the saturation line


### PR DESCRIPTION
Void fraction of vapor is commonly used by the community, so it should
be included in the interface.

Closes #11130

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
