### PR TITLE
fix duplicate action registrations

### DIFF
--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -289,7 +289,7 @@ addActionTypes(Syntax & syntax)
 void
 registerActions(Syntax & syntax, ActionFactory & action_factory)
 {
-  registerActions(syntax, action_factory, {"MooseApp", action_factory.app().type()});
+  registerActions(syntax, action_factory, {"MooseApp"});
 }
 
 void


### PR DESCRIPTION
By convention, apps now call registerActionsTo in their associateSyntax
functions - adding all their app's custom actions to the apps action
factory.  But many apps also call Moose::associateSyntax which calls
Moose::registerActions which has an (usually omitted) arg that defaults
to including the current app's actions when registering.  This resulted
in some actions being registered/created twice.  Fix this by removing
that default (which had already been removed before #10991 went in for
the Moose::registerObjects case.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
