### PR TITLE
Fix test_WriteResults collision with Diff test

### DIFF
--- a/python/TestHarness/tests/test_WriteResults.py
+++ b/python/TestHarness/tests/test_WriteResults.py
@@ -23,6 +23,12 @@ class TestHarnessTester(TestHarnessTestCase):
         except:
             pass
 
+    def tearDown(self):
+        """
+        tearDown occurs after every test.
+        """
+        self.setUp()
+
     def testWriteOK(self):
         """ Test ability to write separate OK test --sep-files-ok """
         self.runTests('--no-color', '-i', 'always_ok', '--sep-files-ok', '--output-dir', self.output_dir)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -106,5 +106,6 @@
   [./write_results]
     type = PythonUnitTest
     input = test_WriteResults.py
+    prereq = 'diff'
   [../]
 []


### PR DESCRIPTION
There is a collision occurring when both of these unit tests
launch in parallel. Adding a `prereq` parameter (very cool
and I didn't know that worked) to the write results unit
test.

Closes #11152
