### PR TITLE
Fix warnings with coverage=true

### DIFF
--- a/framework/src/geomsearch/GeometricSearchData.C
+++ b/framework/src/geomsearch/GeometricSearchData.C
@@ -219,7 +219,8 @@ GeometricSearchData::getMortarPenetrationLocator(const BoundaryName & master,
 
   // Generate a new boundary id
   // TODO: Make this better!
-  unsigned int mortar_boundary_id, boundary_id;
+  unsigned int mortar_boundary_id = 0;
+  unsigned int boundary_id = 0;
   switch (side_type)
   {
     case Moose::Master:


### PR DESCRIPTION
This warning shows up with gcc and doing a `make coverage=true`
Unfortunately we don't have anything on PRs that test this configuration, only on the "Infrastructure" civet target that runs on master.

```
/opt/civet/build_0/moose/framework/src/geomsearch/GeometricSearchData.C: In member function 'PenetrationLocator& GeometricSearchData::getMortarPenetrationLocator(const BoundaryName&, const BoundaryName&, Moose::ConstraintType, libMesh::Order)':
/opt/civet/build_0/moose/framework/src/geomsearch/GeometricSearchData.C:248:92: warning: 'boundary_id' may be used uninitialized in this function [-Wmaybe-uninitialized]
                                 getMortarNearestNodeLocator(master_id, slave_id, side_type));
                                                                                            ^
/opt/civet/build_0/moose/framework/src/geomsearch/GeometricSearchData.C:248:92: warning: 'mortar_boundary_id' may be used uninitialized in this function [-Wmaybe-uninitialized]
```

I will add `-Werror` to the "Infrastructure" target when this goes through to catch this in the future.
Only caught this because iapws95 failed https://moosebuild.inl.gov/job/112427/
It has `-Werror` on by default.

refs #10733

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
