### PR TITLE
NSMachAux only requires SinglePhaseFluidProperties.

### DIFF
--- a/modules/navier_stokes/include/auxkernels/NSMachAux.h
+++ b/modules/navier_stokes/include/auxkernels/NSMachAux.h
@@ -15,7 +15,7 @@
 
 // Forward Declarations
 class NSMachAux;
-class IdealGasFluidProperties;
+class SinglePhaseFluidProperties;
 
 template <>
 InputParameters validParams<NSMachAux>();
@@ -40,7 +40,7 @@ protected:
   const VariableValue & _internal_energy;
 
   // Fluid properties
-  const IdealGasFluidProperties & _fp;
+  const SinglePhaseFluidProperties & _fp;
 };
 
 #endif

--- a/modules/navier_stokes/src/auxkernels/NSMachAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSMachAux.C
@@ -12,7 +12,7 @@
 #include "NS.h"
 
 // FluidProperties includes
-#include "IdealGasFluidProperties.h"
+#include "SinglePhaseFluidProperties.h"
 
 // MOOSE includes
 #include "MooseMesh.h"
@@ -45,7 +45,7 @@ NSMachAux::NSMachAux(const InputParameters & parameters)
     _w_vel(_mesh.dimension() == 3 ? coupledValue(NS::velocity_z) : _zero),
     _specific_volume(coupledValue(NS::specific_volume)),
     _internal_energy(coupledValue(NS::internal_energy)),
-    _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
+    _fp(getUserObject<SinglePhaseFluidProperties>("fluid_properties"))
 {
 }
 


### PR DESCRIPTION
There's no reason for this class to require IdealGasFluidProperties as
it only requires the sound speed interface on the base class.

Refs #6972.


