### PR TITLE
Commandline enhancements

### DIFF
--- a/framework/doc/content/documentation/application_usage/command_line_usage.md
+++ b/framework/doc/content/documentation/application_usage/command_line_usage.md
@@ -1,0 +1,120 @@
+# Command-Line Usage
+
+## Command-Line Options
+
+All MOOSE-based applications come with quite a few command-line options.  These can be customized by each application by adding "Command Line Parameters" to their `MooseApp` derived object.
+
+Command-line options can be set using either short syntax such as `-i inputfile.i` or longer syntax with either `--long-option value` or `--long-option=value`.  If spaces are needed for the value then you need to quote them like `--long-option='value1 value2'`.  If using the `=` it's important not to put any space around it.
+
+To print out the available command-line options use `--help`.  An example from MooseTest looks like this:
+
+```
+> ./moose_test-opt --help
+
+Usage: ./moose_test-opt [<options>]
+
+Options:
+  --check-input                                     Check the input file (i.e. requires -i <filename>) and quit.
+  --color [auto,on,off]                             Whether to use color in console output (default 'on').
+  --definition                                      Shows a SON style input definition dump for input validation
+  --disallow-test-objects                           Don't register test objects and syntax
+  -v --version                                      Print application version
+  --distributed-mesh                                The libMesh Mesh underlying MooseMesh should always be a DistributedMesh
+  --dump [search_string]                            Shows a dump of available input file syntax.
+  --error                                           Turn all warnings into errors
+  --error-deprecated                                Turn deprecated code messages into Errors
+  -o --error-override                               Error when encountering overridden or parameters supplied multiple times
+  -e --error-unused                                 Error when encountering unused input file options
+  --half-transient                                  When true the simulation will only run half of its specified transient (ie half the timesteps).  This is useful for testing recovery and restart
+  -h --help                                         Displays CLI usage statement.
+  -i <input_file>                                   Specify an input file
+  --json                                            Dumps input file syntax in JSON format.
+  --keep-cout                                       Keep standard output from all processors when running in parallel
+  --list-constructed-objects                        List all moose object type names constructed by the master app factory.
+  --mesh-only [mesh_file_name]                      Setup and Output the input mesh only (Default: "<input_file_name>_in.e")
+  --minimal                                         Ignore input file and build a minimal application with Transient executioner.
+  --n-threads=<n>                                   Runs the specified number of threads per process
+  --no-color                                        Disable coloring of all Console outputs.
+  --no-timing                                       Disabled performance logging. Overrides -t or --timing if passed in conjunction with this flag
+  --no-trap-fpe                                     Disable Floating Point Exception handling in critical sections of code when using DEBUG mode.
+  --recover [file_base]                             Continue the calculation.  If file_base is omitted then the most recent recovery file will be utilized
+  --recoversuffix [suffix]                          Use a different file extension, other than cpr, for a recovery file
+  --redirect-stdout                                 Keep standard output from all processors when running in parallel
+  -r <n>                                            Specify additional initial uniform refinements for automatic scaling
+  --registry                                        Lists all known objects and actions.
+  --registry-hit                                    Lists all known objects and actions in hit format.
+  --show-controls                                   Shows the Control logic available and executed.
+  --show-input                                      Shows the parsed input file before running the simulation.
+  --show-outputs                                    Shows the output execution time information.
+  --split-file [filename]                           optional name of split mesh file(s) to write/read
+  --split-mesh [splits]                             comma-separated list of numbers of chunks to split the mesh into
+  --syntax                                          Dumps the associated Action syntax paths ONLY
+  -t --timing                                       Enable all performance logging for timing purposes. This will disable all screen output of performance logs for all Console objects.
+  --trap-fpe                                        Enable Floating Point Exception handling in critical sections of code.  This is enabled automatically in DEBUG mode
+  --use-split                                       use split distributed mesh files
+  -w --warn-unused                                  Warn about unused input file options
+  --yaml                                            Dumps input file syntax in YAML format.
+
+Solver Options:
+  See solver manual for details (Petsc or Trilinos)
+```
+
+## Important Options
+
+Below are a few important command-line options you should be aware of:
+
+### `-i`
+
+The most important option is `-i` this is how you specify an input file to read like so:
+
+```
+./yourapp-opt -i input.i
+```
+
+It's always important to `cd` to the directory where your input file is so that relative paths within the input file are treated properly.
+
+### `--dump`
+
+`--dump` will show you all of the available input file syntax for your application.  This can be quite overwhelming so `--dump` can optionally take an argument for a piece of syntax to search for like so:
+
+```
+./yourapp-opt --dump SomeKernel
+```
+
+Would show you documentation for objects matching `SomeKernel`.
+
+### `--recover`
+
+If you output checkpoint files (using `checkpoint = true` in your `Outputs` block in your input file) then `--recover` will allow you to continue a solve that died in the middle of the solve.  This can allow you to recover a job that was killed because the power went out or your job ran out of time on the cluster you were using.
+
+Again: you *MUST* turn on `checkpoint = true` in the `Outputs` block of your input file for this to work!  We now recommend that all input files contain `checkpoint = true`.
+
+### `--n-threads`
+
+`--n-threads` controls the number of threads per MPI process MOOSE will use for the computation.  This is how you turn on shared-memory parallelism.
+
+### Mesh Splitting Options
+
+For more information see [the Splitting documentation under the Mesh System](/splitting.md)
+
+## Command-Line Input File Overrides
+
+Any input file parameters can be overriden/set from the command-line.  This is incredibly handy for scripting and parameter studies.  The way it works is that you use a "directory" type of syntax.  Let's say that you have this `[Kernels]` block in your input file:
+
+```conf
+[Kernels]
+  [./akernel]
+    type = MyKernel
+    variable = somevar
+    coefficient = 0.2
+  [../]
+[]
+```
+
+To set the value of `coefficient` from the command-line you would run your application like so:
+
+```
+./yourapp-opt -i theinput.i Kernels/akernel/coefficient=0.7
+```
+
+It's important to remember not to use any spaces when doing command-line overrides like this.

--- a/framework/doc/content/documentation/application_usage/index.md
+++ b/framework/doc/content/documentation/application_usage/index.md
@@ -1,0 +1,1 @@
+[Command-line Options](command_line_usage.md)

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -102,6 +102,12 @@ public:
   }
 
 protected:
+  /**
+   * Used to set the argument value, allows specialization
+   */
+  template <typename T>
+  void setArgument(std::stringstream & stream, T & argument);
+
   /// Command line options
   std::map<std::string, Option> _cli_options;
 
@@ -112,6 +118,17 @@ private:
   char ** _argv = nullptr;
   std::vector<std::string> _args;
 };
+
+template <typename T>
+void
+CommandLine::setArgument(std::stringstream & stream, T & argument)
+{
+  stream >> argument;
+}
+
+// Specialization for std::string
+template <>
+void CommandLine::setArgument<std::string>(std::stringstream & stream, std::string & argument);
 
 template <typename T>
 bool
@@ -126,6 +143,7 @@ CommandLine::search(const std::string & option_name, T & argument)
       for (size_t j = 0; j < _args.size(); j++)
       {
         auto arg = _args[j];
+
         if (arg == pos->second.cli_switch[i])
         {
           // "Flag" CLI options are added as Boolean types, when we see them
@@ -136,7 +154,8 @@ CommandLine::search(const std::string & option_name, T & argument)
           {
             std::stringstream ss;
             ss << _args[j + 1];
-            ss >> argument;
+
+            setArgument(ss, argument);
           }
           return true;
         }

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -52,8 +52,6 @@ public:
   CommandLine(int argc, char * argv[]);
   virtual ~CommandLine();
 
-  void parseInputParams(const InputParameters & params);
-
   void addCommandLineOptionsFromParams(InputParameters & params);
 
   void populateInputParams(InputParameters & params);

--- a/modules/combined/doc/navigation.yml
+++ b/modules/combined/doc/navigation.yml
@@ -10,6 +10,7 @@ Getting Started:
     Manual Install: getting_started/installation/manual_installation.md
 Documentation:
     Systems: documentation/systems/index.md
+    Application Usage: documentation/application_usage/index.md
     Application Development: documentation/application_development/index.md
     Framework Development: documentation/framework_development/index.md
     Finite Element Concepts: documentation/finite_element_concepts/index.md

--- a/unit/src/CommandLine.C
+++ b/unit/src/CommandLine.C
@@ -1,0 +1,73 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest_include.h"
+
+#include "CommandLine.h"
+#include "InputParameters.h"
+
+TEST(CommandLine, parse)
+{
+  {
+    InputParameters params = emptyInputParameters();
+
+    params.addCommandLineParam<bool>(
+        "bool_param_with_default", "--bool_param_with_default", true, "Doc");
+    params.addCommandLineParam<int>(
+        "int_param_with_default", "--int_param_with_default", 42, "Doc");
+    params.addCommandLineParam<std::string>(
+        "string_param_with_default", "--string_param_with_default", "stuff", "Doc");
+
+    params.addCommandLineParam<bool>(
+        "bool_param_without_default", "--bool_param_without_default", "Doc");
+    params.addCommandLineParam<int>(
+        "int_param_without_default", "--int_param_without_default", "Doc");
+    params.addCommandLineParam<std::string>(
+        "string_param_without_default", "--string_param_without_default", "Doc");
+
+    params.addCommandLineParam<std::string>(
+        "compound_string_param", "--compound_string_param", "Doc");
+
+    params.addCommandLineParam<std::string>(
+        "compound_string_param_with_equals", "--compound_string_param_with_equals", "Doc");
+
+    int argc = 9;
+    const char * argv[9] = {"--bool_param_without_default",
+                            "true",
+                            "--int_param_without_default",
+                            "43",
+                            "--string_param_without_default",
+                            "astring",
+                            "--compound_string_param",
+                            "astring anotherstring",
+
+                            // Note that Bash will strip quotes automatically.
+                            // So this next one is really for
+                            // --compound_string_param_with_equals='astring anotherstring'
+                            "--compound_string_param_with_equals=astring anotherstring"};
+
+    CommandLine cl(argc, (char **)argv);
+
+    cl.addCommandLineOptionsFromParams(params);
+
+    cl.populateInputParams(params);
+
+    EXPECT_EQ(params.get<bool>("bool_param_with_default"), true);
+    EXPECT_EQ(params.get<int>("int_param_with_default"), 42);
+    EXPECT_EQ(params.get<std::string>("string_param_with_default"), "stuff");
+
+    EXPECT_EQ(params.get<bool>("bool_param_without_default"), true);
+    EXPECT_EQ(params.get<int>("int_param_without_default"), 43);
+    EXPECT_EQ(params.get<std::string>("string_param_without_default"), "astring");
+
+    EXPECT_EQ(params.get<std::string>("compound_string_param"), "astring anotherstring");
+    EXPECT_EQ(params.get<std::string>("compound_string_param_with_equals"),
+              "astring anotherstring");
+  }
+}


### PR DESCRIPTION
Two main enhancements: `std::string` params can now contain spaces and it's possible to use an `=` sign for assigning parameters like `--param=value`.

Also added some documentation on how to use the command-line and some unit tests for `CommandLine`.

Closes #11168