### PR TITLE
Debugging 

### DIFF
--- a/framework/doc/content/documentation/application_development/debugging.md
+++ b/framework/doc/content/documentation/application_development/debugging.md
@@ -1,0 +1,164 @@
+# Debugging
+
+At some point while developing a MOOSE-based application you will probably need to use a debugger.  A debugger will allow you to stop your program at certain points (or if things happen such as a memory segfault).  Once stopped you can then carefully step through the program, inspecting variable values as you go in order to find the source of the problem.
+
+In particular, if you ever see a "Segfault" or a "Signal 11" that means it's time to pull out the debugger.  Any debugger will automatically stop once a segfault is reached, showing you exactly where the invalid memory access occurred.
+
+For a good tutorial on debugging [see Example 21](/ex21_debugging.md)
+
+## Debug Executable
+
+The first step to debugging anything is to build a debug executable.  By default MOOSE-based applications are built in "optimized" (`opt`) mode.  That ensures the fastest solves.  However, an optimized executable is missing a lot of information that is useful to a debugger and the optimization process itself can cause code to get reordered (or even skipped!) making it difficult to step through a program.
+
+To build an executable suitable for debugging you need to set the `METHOD` environment variable to `dbg`.  You can `export` it in your environment but it's usually simpler to use a UNIX shortcut that allows you to define environment variables at the same time you run a command, like so:
+
+```bash
+METHOD=dbg make -j 8
+```
+
+Always remember that the `8` should be modified to reflect the number of processors you want to use for the build (usually the number of cores in your computer).
+
+Once the build is complete you should end up with a "debug executable" that look like: `yourapp-dbg`.  That executable is perfect for loading into a debugger.  However, that executable will run VERY slowly - so make sure that before you begin debugging you come up with a problem that is as small as possible but still shows the problem you're trying to fix.
+
+## Debuggers
+
+Many differen debuggers exist: `lldb`, `gdb`, `ddd`, Totalview and Intel Debugger are just a few.  While a command-line debugger (like `lldb` or `gdb`) might seem daunting at first, they are an invaluable tool for quick debugging and debugging in complicated scenarios such as when you're running on a cluster.  Learning one should be essential to any computational scientist.
+
+For debugging MOOSE-based applications we recommend `lldb` if you're using the clang compiler (default on Mac OSX) and `gdb` for the `gcc` compiler (default on Linux).
+
+### LLDB and GDB
+
+`lldb` and `gdb` are very similar.  They work on the "command-line" taking text input and moving through your program as it executes.
+
+With our MOOSE package on Mac OSX you actually need to run lldb using `sudo` so it has the elevated privileges it needs to attach to your program.  To invoke `lldb` with a MOOSE-based application on Mac OSX you would do:
+
+```bash
+sudo lldb -- ./yourapp-dbg -i inputfile.i
+```
+
+The `--` tells lldb that any command-line options after that point need to be passed to the executable you are running.  `sudo` will ask you for your password so that it can elevate the priveleges of `lldb`.  You can also look below to see how to allow `lldb` to run with sudo without using a password.
+
+`gdb` can be run with a similar command:
+
+```bash
+gdb --args ./yourapp-dbg -i inputfile.i
+```
+
+(On Linux this will generally work, without the need for `sudo`)
+
+Once this is done, your executable will be loaded but won't start running.  This is an opportune time to set breakpoints.  We usually recommmend setting a breakpoint on `MPI_Abort` using the `b` command:
+
+```
+b MPI_Abort
+```
+
+Then to start running your executable use the `r` command (type `r` then hit enter).
+
+If a breakpoint (or fault) is reached: I recommend first using the `bt` command to output a "back-trace" so you can see exactly what the current call-stack looks like to figure out where you are.
+
+To quit the debugger use `Ctrl+d` (by the way: that's a normal way to quit lots of command-line interpreters on Unix - including Python).
+
+Another useful command is `p` (for 'print') which allows you to print out the value of a variable.  Just do:
+
+```
+p variablename
+```
+
+You can learn about the full set of commands by using `help` or looking at any number of tutorials online.
+
+## Parallel Debugging
+
+Firstly, if you don't have to debug in parallel *DON'T*!  Only do parallel debugging when you have a problem that can only be reproduced when running in parallel.  If your problem will show up in serial, it is MUCH easier to debug in serial.  If it takes a long time for your problem to run so you are wanting to run it in parallel: don't do that... instead, try to make your problem smaller so that you can debug it in serial.
+
+With all of that said: if you actually do need to debug in parallel, MOOSE has a couple of command-line arguments to help.  However, before we get there, we need to do a bit of setup on Mac OSX:
+
+### Mac OSX Parallel Debugging Setup
+
+As noted above, when running `lldb` on Mac OSX we need to run with `sudo` to give it permission to attach to our running program.  `sudo` will ask for your password, but unfortunately when doing parallel debugging there is no way to enter that password.  Therefore, we need to make it so that you can run `lldb` with `sudo` without a password.
+
+First thing is to get the full path to where `lldb` is using the command-line:
+
+```bash
+which lldb
+```
+
+If you are using our package on OSX this should return something like `/opt/moose/llvm-5.0.1/bin/lldb`.  Make note of this location (copy it, or set that Terminal aside) because you'll need it in the next step.
+
+To set `lldb` to be able to run with `sudo` without a password we need to modify the `sudoers` file.  To do that issue this command in a terminal (preferably a new one so you can still see the path to `lldb` in the first one):
+
+```bash
+sudo visudo
+```
+
+Most-likely this is going to use `vi` (a text editor) to open the `sudoers` file (I say "most-likely" because it technically can open any editor based on the `EDITOR` environment variable).  If you are unfamiliar with `vi` don't worry.  Just press `i` to go into "insert" mode.  Navigate to the bottom of the file and add a line that looks like:
+
+```
+username ALL= NOPASSWD: /opt/moose/llvm-5.0.1/bin/lldb
+```
+
+Where `username` MUST be replaced with *your* username!  And the path to `lldb` needs to reflect what you got back from `which lldb` above.  Once that line is in place press `Esc` (to exit "insert mode") then type `:wq` (that's a `colon` then `w` then `q` - it's a command that says "write and quit") and press `Enter`.
+
+Once you've completed that you should be able to run `sudo lldb` on the command-line and not need to enter your password.  If you still need to enter your password, email `moose-users` so we can figure out what's wrong before you go further.
+
+### Actually Parallel Debugging
+
+With all of that setup we are ready to debug in parallel.  There are two options:
+
+#### 1. Launch a terminal for each MPI process
+
+What we're going to do is launch a terminal (using `xterm`) for each MPI process.  That terminal will run our debugger and attach to the running MPI process.  For this to work, you either need to be on your local box or have X-forwarding set up over SSH (which I'm not going to go into here).
+
+Let's assume that you're working on your local Mac workstation using our package.  In order to launch your program with 4 MPI processes and 4 terminals for debugging you would do:
+
+```bash
+mpiexec -n 4 ./yourapp-dbg -i inputfile.i --start-in-debugger='sudo lldb'
+```
+
+(If you are on Linux - most-likely you will want to put `gdb` where `sudo lldb` is)
+
+If everything is setup correctly you should see 4 XTerm windows show up with `lldb` command-line prompts.  Those debugger prompts are already attached to your running executable, but the executable is paused.  This is an opportune time to set breakpoints, but you have to do it in each terminal seperately.  For instance, you might want to go through each one and do:
+
+```
+b MPI_Abort
+```
+
+to be able to stop if MOOSE encounters an error.
+
+Once you are ready to *continue* - you do just that.  Use the `c` command (type `c` and hit `Enter`) in each terminal window to tell it to continue.  Once you go through all of the open terminal windows you should see your application start to run in your original terminal.  If a breakpoint (or any fault) is reached on any process that terminal window will show the command-prompt again, allowing you to inspect variables, etc.
+
+#### 2. Launch your application and tell it to wait so you can manually attach a debugger
+
+This is going to be used in cases where you need to debug using LOTS of MPI processes, but you don't want a terminal window for each one.  This is also handy if you're working on a cluster that doesn't have any way of doing X-forwarding for option #1 to work.  The idea is to launch your application and have it wait during the initialization phase so you have time to attach a debugger manually to one of the processes.
+
+To do this simply run your application like so:
+
+```bash
+mpiexec -n 4 ./yourapp-dbg -i inputfile.i --stop-for-debugger
+```
+
+This will cause your application to print something like the following and then wait 30 seconds (by default - if you need more time use `--stop-for-debugger=75` where `75` is the number of seconds you want it to wait):
+
+```
+> mpiexec -n 4 ../../../moose_test-opt -i simple_diffusion.i --stop-for-debugger=2
+
+Stopping for 2 seconds to allow attachment from a debugger.
+
+All of the processes you can connect to:
+rank - hostname - pid
+0 - dereksmacpro.local - 53403
+1 - dereksmacpro.local - 53404
+2 - dereksmacpro.local - 53405
+3 - dereksmacpro.local - 53406
+
+Waiting...
+```
+
+The message there is telling you where each process is running and what its "process ID" (`pid`) is.  That is the relevant information you need to be able to attach a debugger to that process.  In this case (on my local Mac) if I want to connect to "rank 2", in a separate Terminal I would do:
+
+```
+sudo lldb -p 53405
+```
+
+(`gdb` has a similar mechanism, see its docs)
+
+That will launch `lldb` and attach to my running program.  Attaching to the program "pauses" it - allowing me to set breakpoints and then use the `c` command to tell it to continue.

--- a/framework/doc/content/documentation/application_development/debugging.md
+++ b/framework/doc/content/documentation/application_development/debugging.md
@@ -22,7 +22,7 @@ Once the build is complete you should end up with a "debug executable" that look
 
 ## Debuggers
 
-Many differen debuggers exist: `lldb`, `gdb`, `ddd`, Totalview and Intel Debugger are just a few.  While a command-line debugger (like `lldb` or `gdb`) might seem daunting at first, they are an invaluable tool for quick debugging and debugging in complicated scenarios such as when you're running on a cluster.  Learning one should be essential to any computational scientist.
+Many different debuggers exist: `lldb`, `gdb`, `ddd`, Totalview and Intel Debugger are just a few.  While a command-line debugger (like `lldb` or `gdb`) might seem daunting at first, they are an invaluable tool for quick debugging and debugging in complicated scenarios such as when you're running on a cluster.  Learning one should be essential to any computational scientist.
 
 For debugging MOOSE-based applications we recommend `lldb` if you're using the clang compiler (default on Mac OSX) and `gdb` for the `gcc` compiler (default on Linux).
 

--- a/framework/doc/content/documentation/application_development/index.md
+++ b/framework/doc/content/documentation/application_development/index.md
@@ -11,3 +11,5 @@
 [Hypre/BoomerAMG Preconditioning](hypre.md)
 
 [Code Standards](code_standards.md)
+
+[Debugging](/debugging.md)

--- a/framework/doc/content/documentation/examples/ex21_debugging.md
+++ b/framework/doc/content/documentation/examples/ex21_debugging.md
@@ -1,0 +1,113 @@
+# Example 21: Debugging
+
+For a more in-depth discussion of debugging with MOOSE [see the Debugging Documentation](/debugging.md)
+
+- It's inevitable: at some point in your MOOSE application development career, you will create a bug.
+- Sometimes, print statements are sufficient to help you determine the cause of the error.
+- For more complex bugs, a debugger can be more effective than print statements in helping to pinpoint the problem.
+- Many debuggers exist: LLDB, GDB, Totalview, ddd, Intel Debugger, etc.
+- It's typically best to use a debugger that is associated with your compiler, if one is available.
+- Here we focus on LLDB/GDB since it is relatively simple to use and is included in the MOOSE binary redistributable package.
+- A "Segmentation fault," "Segfault," or "Signal 11" error denotes a memory bug (often array access out of bounds).
+- In your terminal you will see a message like:
+
+```text
+Segmentation fault: 11`
+```
+
+- A segfault is a "good" error to have, because a debugger can easily pinpoint the problem.
+
+[](---)
+
+# Debugging Example Problem
+
+- This example is similar to Example 3, except that a common error has been introduced.
+- In `ExampleDiffusion.h`, a `VariableValue` that should be declared as a reference is not: `const VariableValue _coupled_coef`
+- Not storing this as a reference will cause a **copy** of the `VariableValue` to be made.
+- That copy will never be resized, nor will it ever have values written to it.
+- Attempting to access that `VariableValue` results in a segfault when running in optimized mode:
+
+```text
+Time Step  0, time = 0
+                dt = 0
+
+Time Step  1, time = 0.1
+                dt = 0.1
+Segmentation fault: 11
+```
+
+- We can use a debugger to help us find the problem.
+
+[](---)
+
+# Debug Executable
+
+- To use a debugger with a MOOSE-based application, you must compile your application in something other than optimized mode (opt). We highly recommend debug (dbg) mode so that you'll get full line number information in your stack traces:
+
+```text
+cd ~/projects/moose/examples/ex21_debugging
+METHOD=dbg make -j8
+```
+
+- You will now have a "debug version" of your application called `ex21-dbg`.
+- Next, you need to run your application using either GDB (gcc) or LLDB (clang):
+
+```text
+gdb --args ./ex21-dbg -i ex21.i
+```
+
+```text
+lldb -- ./ex21-dbg -i ex21.i
+```
+
+- When using either of these tools, the command line arguments to the application appear after the `--` separator.
+- This will start debugger, load your executable, and leave you at the debugger command prompt.
+
+[](---)
+
+# Using GDB or LLDB
+
+- At any prompt in GDB or LLDB, you can type `h` and hit enter to get help.
+- We set a "breakpoint" in `MPI_Abort` so that the code pauses (maintaining the stack trace) before exiting.
+
+```text
+b MPI_Abort
+```
+
+- To run your application, type `r` and hit enter.
+- If your application hits the breakpoint in `MPI_Abort` you know it has crashed.
+- Type `where` (or `bt`) to see a backtrace.
+
+```text
+    frame #0: 0x0000000106b14a20 libmpi.12.dylib`MPI_Abort
+    frame #1: 0x00000001000d8e78 libex21-dbg.0.dylib`MooseArray<double>::operator[](this=0x0000000108852680, i=0) const + 2200 at MooseArray.h:267
+    frame #2: 0x00000001000d85ab libex21-dbg.0.dylib`ExampleDiffusion::computeQpResidual(this=0x0000000108852000) + 43 at ExampleDiffusion.C:40
+    frame #3: 0x0000000100c2affb libmoose-dbg.0.dylib`Kernel::computeResidual(this=0x0000000108852000) + 443 at Kernel.C:57
+.....
+```
+
+[](---)
+
+- This backtrace shows that, in `ExampleDiffusion::computeQpResidual()` we tried to access entry 0 of a `MooseArray` with 0 entries.
+- If we look at the relevant line of code, we'll see:
+
+```C++
+return _coupled_coef[_qp]*Diffusion::computeQpResidual();
+```
+
+- There is only one thing we're indexing into on that line: `_coupled_coef`.
+- Therefore, we can look at how `_coupled_coef` was declared, realize that we forgot an ampersand (`&`), and fix it!
+
+[](---)
+
+# Example 21 Source Code
+
+[ex21.i](https://github.com/idaholab/moose/blob/devel/examples/ex21_debugging/ex21.i)
+
+[](---)
+
+[ExampleDiffusion.h](https://github.com/idaholab/moose/blob/devel/examples/ex21_debugging/include/kernels/ExampleDiffusion.h)
+
+[](---)
+
+[ExampleDiffusion.C](https://github.com/idaholab/moose/blob/devel/examples/ex21_debugging/src/kernels/ExampleDiffusion.C)

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -92,14 +92,18 @@ void parallelBarrierNotify(const libMesh::Parallel::Communicator & comm, bool me
  * rank by rank. The section must be closed with a call to serialEnd.
  * These functions are intended for debugging use to obtain clean terminal output
  * from multiple ranks (use --keep-cout).
+ * @param comm The communicator to use
+ * @param warn Whether or not to warn that something is being serialized
  */
-void serialBegin(const libMesh::Parallel::Communicator & comm);
+void serialBegin(const libMesh::Parallel::Communicator & comm, bool warn = true);
 
 /**
  * Closes a section of code that is executed in serial rank by rank, and that was
  * opened with a call to serialBegin. No MPI communication can happen in this block.
+ * @param comm The communicator to use
+ * @param warn Whether or not to warn that something is being serialized
  */
-void serialEnd(const libMesh::Parallel::Communicator & comm);
+void serialEnd(const libMesh::Parallel::Communicator & comm, bool warn = true);
 
 /**
  * Function tests if the supplied filename as the desired extension
@@ -148,6 +152,11 @@ std::string shortName(const std::string & name);
  * Function for string the information before the final / in a parser block
  */
 std::string baseName(const std::string & name);
+
+/**
+ * Get the hostname the current process is running on
+ */
+std::string hostname();
 
 /**
  * This routine is a simple helper function for searching a map by values instead of keys

--- a/framework/include/utils/SerializerGuard.h
+++ b/framework/include/utils/SerializerGuard.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #ifndef SERIALIZERGUARD_H
 #define SERIALIZERGUARD_H
 

--- a/framework/include/utils/SerializerGuard.h
+++ b/framework/include/utils/SerializerGuard.h
@@ -1,0 +1,27 @@
+#ifndef SERIALIZERGUARD_H
+#define SERIALIZERGUARD_H
+
+namespace libMesh
+{
+namespace Parallel
+{
+class Communicator;
+}
+}
+
+/**
+ * A scope guard that guarantees that whatever happens between when it gets created and when it is
+ * destroyed is done "serially" (each MPI rank will run in turn starting from 0)
+ */
+class SerializerGuard
+{
+public:
+  SerializerGuard(const libMesh::Parallel::Communicator & comm, bool warn = true);
+  ~SerializerGuard();
+
+protected:
+  const libMesh::Parallel::Communicator & _comm;
+  bool _warn;
+};
+
+#endif

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -53,7 +53,7 @@
 #include <fstream>
 #include <sys/types.h>
 #include <unistd.h>
-#include <stdlib.h> // for system()
+#include <cstdlib> // for system()
 #include <chrono>
 #include <thread>
 
@@ -223,7 +223,7 @@ validParams<MooseApp>()
 
   // Options for debugging
   params.addCommandLineParam<std::string>("start_in_debugger",
-                                          "--start-in-debugger [debugger]",
+                                          "--start-in-debugger <debugger>",
                                           "Start the application and attach a debugger.  This will "
                                           "launch xterm windows using the command you specify for "
                                           "'debugger'");
@@ -329,7 +329,7 @@ MooseApp::MooseApp(InputParameters parameters)
     std::string command_string = command_stream.str();
     Moose::out << "Running: " << command_string << std::endl;
 
-    system(command_string.c_str());
+    std::system(command_string.c_str());
 
     // Sleep to allow time for the debugger to attach
     std::this_thread::sleep_for(std::chrono::seconds(10));

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -30,6 +30,7 @@
 // System includes
 #include <sys/stat.h>
 #include <numeric>
+#include <unistd.h>
 
 std::string getLatestCheckpointFileHelper(const std::list<std::string> & checkpoint_files,
                                           const std::vector<std::string> extensions,
@@ -201,7 +202,7 @@ parallelBarrierNotify(const Parallel::Communicator & comm, bool messaging)
 }
 
 void
-serialBegin(const libMesh::Parallel::Communicator & comm)
+serialBegin(const libMesh::Parallel::Communicator & comm, bool warn)
 {
   // unless we are the first processor...
   if (comm.rank() > 0)
@@ -210,12 +211,12 @@ serialBegin(const libMesh::Parallel::Communicator & comm)
     int dummy = 0;
     comm.receive(comm.rank() - 1, dummy);
   }
-  else
+  else if (warn)
     mooseWarning("Entering serial execution block (use only for debugging)");
 }
 
 void
-serialEnd(const libMesh::Parallel::Communicator & comm)
+serialEnd(const libMesh::Parallel::Communicator & comm, bool warn)
 {
   // unless we are the last processor...
   if (comm.rank() + 1 < comm.size())
@@ -226,7 +227,7 @@ serialEnd(const libMesh::Parallel::Communicator & comm)
   }
 
   comm.barrier();
-  if (comm.rank() == 0)
+  if (comm.rank() == 0 && warn)
     mooseWarning("Leaving serial execution block (use only for debugging)");
 }
 
@@ -347,6 +348,17 @@ std::string
 baseName(const std::string & name)
 {
   return name.substr(0, name.find_last_of('/') != std::string::npos ? name.find_last_of('/') : 0);
+}
+
+std::string
+hostname()
+{
+  // This is from: https://stackoverflow.com/a/505546
+  char hostname[1024];
+  hostname[1023] = '\0';
+  gethostname(hostname, 1023);
+
+  return hostname;
 }
 
 bool

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -356,7 +356,11 @@ hostname()
   // This is from: https://stackoverflow.com/a/505546
   char hostname[1024];
   hostname[1023] = '\0';
-  gethostname(hostname, 1023);
+
+  auto failure = gethostname(hostname, 1023);
+
+  if (failure)
+    mooseError("Failed to retrieve hostname!");
 
   return hostname;
 }

--- a/framework/src/utils/SerializerGuard.C
+++ b/framework/src/utils/SerializerGuard.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "SerializerGuard.h"
 
 #include "MooseUtils.h"

--- a/framework/src/utils/SerializerGuard.C
+++ b/framework/src/utils/SerializerGuard.C
@@ -1,0 +1,13 @@
+#include "SerializerGuard.h"
+
+#include "MooseUtils.h"
+
+#include "libmesh/parallel.h"
+
+SerializerGuard::SerializerGuard(const libMesh::Parallel::Communicator & comm, bool warn)
+  : _comm(comm), _warn(warn)
+{
+  MooseUtils::serialBegin(_comm, _warn);
+}
+
+SerializerGuard::~SerializerGuard() { MooseUtils::serialEnd(_comm, _warn); }

--- a/test/tests/misc/stop_for_debugger/stop_for_debugger.i
+++ b/test/tests/misc/stop_for_debugger/stop_for_debugger.i
@@ -1,0 +1,49 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/misc/stop_for_debugger/tests
+++ b/test/tests/misc/stop_for_debugger/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [./test]
+    type = 'RunApp'
+    input = 'stop_for_debugger.i'
+    exodiff = 'stop_for_debugger_out.e'
+    cli_args = '--stop-for-debugger=2'
+    expect_out = 'Stopping for 2 seconds to allow attachment from a debugger.'
+  [../]
+[]

--- a/test/tests/misc/stop_for_debugger/tests
+++ b/test/tests/misc/stop_for_debugger/tests
@@ -2,7 +2,6 @@
   [./test]
     type = 'RunApp'
     input = 'stop_for_debugger.i'
-    exodiff = 'stop_for_debugger_out.e'
     cli_args = '--stop-for-debugger=2'
     expect_out = 'Stopping for 2 seconds to allow attachment from a debugger.'
   [../]


### PR DESCRIPTION
It is time MOOSE had its own way to help people do parallel debugging.  This adds two new command-line options:

`--start-in-debugger` set this to the debug command you want to use and it will launch an XTerm for each MPI process that runs your debugger and attaches to each process.  Besides allowing you to run any command you want (vital for running `sudo lldb` on OSX) it also has a few other improvements over PETSc's `-start_in_debugger`.  Most notably, at the top of each XTerm it prints useful info like this:

```
Rank: 1  Hostname: dereksmacpro.local  PID: 53559

(lldb) process attach --pid 53559
Process 53559 stopped
```

`--stop-for-debugger` causes the executable to wait for a number of seconds (30 by default) to allow you to attach a debugger to one or more processes manually.  It also prints out a handy listing of all the processes you can attach to that looks like:

```
> mpiexec -n 4 ../../../moose_test-opt -i simple_diffusion.i --stop-for-debugger=200

Stopping for 200 seconds to allow attachment from a debugger.

All of the processes you can connect to:
rank - hostname - pid
0 - dereksmacpro.local - 53415
1 - dereksmacpro.local - 53416
2 - dereksmacpro.local - 53417
3 - dereksmacpro.local - 53418
Waiting...
```

I also added copious amounts of documentation about all of this, including moving over Example 21.

closes #11166