### PR TITLE
Do a better job of cleaning up the FileCache

### DIFF
--- a/python/peacock/Input/InputFile.py
+++ b/python/peacock/Input/InputFile.py
@@ -54,17 +54,14 @@ class InputFile(object):
         # parser doesn't do any checks.
         if not os.path.exists(filename):
             msg = "Input file %s does not exist" % filename
-            mooseutils.mooseError(msg)
             raise PeacockException(msg)
 
         if not os.path.isfile(filename):
             msg = "Input file %s is not a file" % filename
-            mooseutils.mooseError(msg)
             raise PeacockException(msg)
 
         if not filename.endswith(".i"):
             msg = "Input file %s does not have the proper extension" % filename
-            mooseutils.mooseError(msg)
             raise PeacockException(msg)
 
         with open(filename, 'r') as f:

--- a/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
+++ b/python/peacock/tests/input_tab/InputFileEditorPlugin/test_InputFileEditorPlugin.py
@@ -26,6 +26,7 @@ class Tests(Testing.PeacockTester):
         self.input_file = os.path.abspath("../../common/transient.i")
 
     def tearDown(self):
+        super(Tests, self).tearDown()
         Testing.remove_file("delete_me.i")
         Testing.remove_file("delete_me2.i")
 

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -18,6 +18,7 @@ class Tests(Testing.PeacockTester):
     def tearDown(self):
         if self.input:
             self.input.MeshViewerPlugin.reset()
+        super(Tests, self).tearDown()
 
     def create_app(self, args):
         self.createPeacockApp(args)
@@ -149,7 +150,7 @@ class Tests(Testing.PeacockTester):
         self.assertEqual(tab.MeshPlugin.isEnabled(), False)
 
     def testBadInput(self):
-        self.create_app(["-i", "../../common/out_transient.e", Testing.find_moose_test_exe()])
+        self.create_app(["-i", "gold/out_transient.e", Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.input.tabName())
 

--- a/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
+++ b/python/peacock/tests/peacock_app/check_exodus_state/test_exodus_auto_range.py
@@ -23,7 +23,7 @@ class TestExodusState(Testing.PeacockImageTestCase):
         """
         Creates the peacock application.
         """
-
+        Testing.setupTestCache(self.__class__)
         args = ["-size", "1024", "768", "-i", "../../common/transient_big.i", "-e", Testing.find_moose_test_exe()]
         working_dir = os.getcwd()
         self._app = PeacockApp.PeacockApp(args, self.qapp)

--- a/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
+++ b/python/peacock/tests/peacock_app/check_postprocessor_state/test_postprocessor_state.py
@@ -23,7 +23,7 @@ class TestPostprocessorState(Testing.PeacockImageTestCase):
         """
         Creates the peacock application.
         """
-
+        Testing.setupTestCache(self.__class__)
         args = ["-size", "1024", "768", "-i", "../../common/time_data.i", "-e", Testing.find_moose_test_exe(), "-w", os.getcwd()]
         self._app = PeacockApp.PeacockApp(args, self.qapp)
         self._window = self._app.main_widget.tab_plugin.VectorPostprocessorViewer.currentWidget().FigurePlugin

--- a/python/peacock/tests/utils/test_RecentlyUsedMenu.py
+++ b/python/peacock/tests/utils/test_RecentlyUsedMenu.py
@@ -10,7 +10,6 @@
 
 from peacock.utils.RecentlyUsedMenu import RecentlyUsedMenu
 from peacock.utils import Testing
-from PyQt5.QtCore import QSettings
 from PyQt5 import QtWidgets
 
 class Tests(Testing.PeacockTester):
@@ -18,8 +17,6 @@ class Tests(Testing.PeacockTester):
 
     def setUp(self):
         super(Tests, self).setUp()
-        settings = QSettings()
-        settings.clear()
         self.main_win = QtWidgets.QMainWindow()
         self.menubar = self.main_win.menuBar()
         self.test_menu = self.menubar.addMenu("Test recently used")

--- a/python/peacock/utils/FileCache.py
+++ b/python/peacock/utils/FileCache.py
@@ -59,6 +59,7 @@ class FileCache(object):
                 or self.path_data.get("data_version") != self.data_version
                 or self.stat.st_ctime != self.path_data.get("ctime")
                 or self.stat.st_size != self.path_data.get("size")
+                or not os.path.exists(self.path_data.get("pickle_path"))
                 ):
             self.dirty = True
             return
@@ -81,7 +82,7 @@ class FileCache(object):
             return None
 
     @staticmethod
-    def removeCacheFile( path):
+    def removeCacheFile(path):
         try:
             os.remove(path)
         except:
@@ -141,3 +142,4 @@ class FileCache(object):
         for key, val in val.items():
             FileCache.removeCacheFile(val["pickle_path"])
         settings.remove(settings_key)
+        settings.sync()

--- a/python/peacock/utils/qtutils.py
+++ b/python/peacock/utils/qtutils.py
@@ -10,13 +10,17 @@
 from mooseutils import message
 from PyQt5 import QtCore
 
-def setAppInformation(app_name="peacock"):
+def setAppInformation(app_name="peacock", force=False):
     """
     Set the application depending on whether we are testing
     """
     QtCore.QCoreApplication.setOrganizationName("IdahoLab")
     QtCore.QCoreApplication.setOrganizationDomain("inl.gov")
     if message.MOOSE_TESTING_MODE:
-        QtCore.QCoreApplication.setApplicationName("test_%s" % app_name)
+        if force or not QtCore.QCoreApplication.applicationName():
+            # We don't want to override the application name if it is already
+            # set since PeacockApp will set it to "peacock_peacockapp" and
+            # we want the names to be more unique.
+            QtCore.QCoreApplication.setApplicationName("test_%s" % app_name)
     else:
         QtCore.QCoreApplication.setApplicationName(app_name)

--- a/scripts/separate_unittests.py
+++ b/scripts/separate_unittests.py
@@ -63,6 +63,6 @@ else:
             cmd.append("-b")
         ret = subprocess.call(cmd)
         if ret != 0:
-            print("%s exited %s" % (t, ret))
+            print("%s exited %s" % (name, ret))
             final_code = 1
     sys.exit(final_code)


### PR DESCRIPTION
This is an attempt to address the random peacock Mac failures, which I haven't been able to reproduce.

The basic assumption is that when the tests are run in parallel there is one or more tests messing with the same files, causing crashes/errors. Since tests run in their own directories, the main source of potential conflicts is the --json dump cache.

It does look like multiple tests were potentially writing to the same cache file since PeacockApp was overwriting the ApplicationName.

I also noticed that since we are clearing the QSettings at the start of a test, we were not properly cleaning up old cache files. There was ~300G of cache files on the mac test box and the partition was actually out of space. I suspect this also contributed to the random failures.

closes #11156

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
