### PR TITLE
Do what the help says it should do

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -847,6 +847,11 @@ class TestHarness:
         if opts.sep_files:
             opts.ok_files = True
             opts.fail_files = True
+            opts.quiet = True
+
+        # User wants only failed files, so unify the options involved
+        elif opts.fail_files:
+            opts.quiet = True
 
     def postRun(self, specs, timing):
         return


### PR DESCRIPTION
The --sep-files and -a / --sep-files-fail are allowing
failed tester application output to populate stdout when
the help message says it should not be doing that.

Closes #11175