### PR TITLE
Convert test spec parameter values to proper types

### DIFF
--- a/modules/heat_conduction/test/tests/parallel_element_pps_test/tests
+++ b/modules/heat_conduction/test/tests/parallel_element_pps_test/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'parallel_element_pps_test.i'
     exodiff = 'out.e'
-    min_parallel = '2'
+    min_parallel = 2
     platform = 'DARWIN'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/cp_user_object/tests
+++ b/modules/tensor_mechanics/test/tests/cp_user_object/tests
@@ -8,7 +8,7 @@
     type = 'Exodiff'
     input = 'crysp_exception.i'
     exodiff = 'crysp_exception_out.e'
-    allow_warnings = 'true'
+    allow_warnings = true
   [../]
   [./test_fileread]
     type = 'Exodiff'

--- a/modules/tensor_mechanics/test/tests/elastic_patch/tests
+++ b/modules/tensor_mechanics/test/tests/elastic_patch/tests
@@ -16,14 +16,14 @@
     type = Exodiff
     input = 'elastic_patch.i'
     exodiff = 'elastic_patch_out.e'
-    min_parallel = '2'
+    min_parallel = 2
     prereq = 'elastic_patch_Bbar'
   [../]
   [./elastic_patch_2Procs_Bbar]
     type = Exodiff
     input = 'elastic_patch.i'
     exodiff = 'elastic_patch_out.e'
-    min_parallel = '2'
+    min_parallel = 2
     prereq = 'elastic_patch_2Procs'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
   [../]

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -118,11 +118,9 @@ class Parser:
                             elif strict_type != type(value):
                                 self.error("wrong data type for parameter value: '{}=\"{}\"'".format(child.fullpath(), value), node=child)
                                 have_err = True
-                        elif child.kind() == hit.FieldKind.Bool:
+                        else:
                             # Otherwise, just do normal assignment
                             params[key] = child.param()
-                        else:
-                            params[key] = value
             else:
                 self.error('unused parameter "{}"'.format(child.fullpath()), node=child)
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -156,7 +156,7 @@ class Tester(MooseObject):
 
     def getMaxTime(self):
         """ return maximum time elapse before reporting a 'timeout' status """
-        return self.specs['max_time']
+        return float(self.specs['max_time'])
 
     def getRunnable(self, options):
         """ return bool and cache results, if this test can run """
@@ -294,9 +294,9 @@ class Tester(MooseObject):
     def setValgrindMode(self, mode):
         """ Increase the alloted time for tests when running with the valgrind option """
         if mode == 'NORMAL':
-            self.specs['max_time'] = self.specs['max_time'] * 2
+            self.specs['max_time'] = float(self.specs['max_time']) * 2
         elif mode == 'HEAVY':
-            self.specs['max_time'] = self.specs['max_time'] * 6
+            self.specs['max_time'] = float(self.specs['max_time']) * 6
 
     def checkRunnable(self, options):
         """

--- a/test/tests/controls/error/tests
+++ b/test/tests/controls/error/tests
@@ -12,7 +12,7 @@
     type = RunApp
     input = 'multiple_parameters_found.i'
     expect_out = "parameters have differing values"
-    allow_warnings = 1
+    allow_warnings = true
   [../]
 
   [./no_param_found]

--- a/test/tests/geomsearch/penetration_locator/tests
+++ b/test/tests/geomsearch/penetration_locator/tests
@@ -11,7 +11,7 @@
     input = 'penetration_locator_test.i'
     exodiff = 'out.e'
     group = 'requirements geometric'
-    max_parallel = '3'
+    max_parallel = 3
     prereq = 'test'
   [../]
 []

--- a/test/tests/nodalkernels/constant_rate/tests
+++ b/test/tests/nodalkernels/constant_rate/tests
@@ -12,7 +12,7 @@
     type = 'Exodiff'
     input = 'constant_rate.i'
     exodiff = 'constant_rate_out.e'
-    min_threads = '3'
+    min_threads = 3
     prereq = 'test' # Force ordering since they output the same files
     rel_err = 1e-05
     use_old_floor = True

--- a/test/tests/transfers/multiapp_projection_transfer/tests
+++ b/test/tests/transfers/multiapp_projection_transfer/tests
@@ -17,7 +17,7 @@
     type = 'Exodiff'
     input = 'high_order_master.i'
     exodiff = 'high_order_master_out.e high_order_master_out_sub0.e'
-    recover = 'false' # This is because the sub-app is Steady
+    recover = false # This is because the sub-app is Steady
   [../]
 
   [./fixed_meshes]


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
This changes `python/FactorySystem/Parser.py` to convert the parameter value to the type that the hit parser thinks it is.
This is still not very robust. For example, the hit parser doesn't recognize `nan` as a float and leaves it as a string. Also, if you have something like `max_time = '60'` it doesn't convert it to an int, even though the InputParameter is expecting an int.

I fixed up some test spec files to not use strings on ints and bools. I don't think the integer changes actually change anything since there was an explicit conversion to int for those parameter values.

closes #11185