### PR TITLE
Make test_PeacockMainWindow use input file in current directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,8 +202,10 @@ site
 
 # Peacock
 python/peacock/tests/exodus_tab/TestOutputPlugin_repr.py
+python/peacock/tests/exodus_tab/TestExodusPluginManager_repr.py
 python/peacock/tests/input_tab/InputFileEditor/fsp_test.i
 python/peacock/tests/postprocessor_tab/TestPostprocessorPluginManager_test_script.py
 !python/peacock/tests/**/gold/*.png
 !python/peacock/icons/**/*.*
 !python/peacock/tests/**/input/*.*
+peacock_tmp_diff.exo

--- a/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
+++ b/python/peacock/tests/peacock_app/PeacockMainWindow/test_PeacockMainWindow.py
@@ -40,14 +40,14 @@ class Tests(Testing.PeacockTester):
         runner = w.tab_plugin.ExecuteTabPlugin.ExecuteRunnerPlugin
         self.assertEqual(runner._total_steps, 0)
 
-        w.tab_plugin.InputFileEditorWithMesh.setInputFile("../../common/transient.i")
+        w.tab_plugin.InputFileEditorWithMesh.setInputFile("transient.i")
         w.setTab(w.tab_plugin.ExecuteTabPlugin.tabName())
-        w.tab_plugin.ExecuteTabPlugin.ExecuteOptionsPlugin.setWorkingDir(self.starting_directory)
         self.assertIn("transient.i", w.windowTitle())
 
         self.assertEqual(runner._total_steps, 8)
 
-        w.tab_plugin.ExecuteTabPlugin.ExecuteRunnerPlugin.runClicked()
+        runner.runClicked()
+        runner.runner.process.waitForFinished()
         Testing.process_events(t=2)
         self.assertTrue(os.path.exists("out_transient.e"))
 

--- a/python/peacock/tests/peacock_app/PeacockMainWindow/transient.i
+++ b/python/peacock/tests/peacock_app/PeacockMainWindow/transient.i
@@ -1,0 +1,1 @@
+../../common/transient.i


### PR DESCRIPTION
I have seen test_PeacockMainWindow fail a few times. There are usually a bunch of VTK errors looking for files in the common directory which really shouldn't happen.
This just forces reading in the input file in the current directory. Should prevent any race conditions happening when running tests in parallel.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
