### PR TITLE
Allow the TestHarness to run without yaml in the python environment

### DIFF
--- a/python/MooseDocs/common/load_config.py
+++ b/python/MooseDocs/common/load_config.py
@@ -4,7 +4,7 @@ import types
 import importlib
 import logging
 
-import mooseutils
+from mooseutils.yaml_load import yaml_load
 import MooseDocs
 from MooseDocs.common import check_type, exceptions
 
@@ -39,7 +39,7 @@ def load_config(filename):
     """
     Read the config.yml file and create the Translator object.
     """
-    config = mooseutils.yaml_load(filename, root=MooseDocs.ROOT_DIR)
+    config = yaml_load(filename, root=MooseDocs.ROOT_DIR)
 
     content = _yaml_load_content(config)
     extensions = _yaml_load_extensions(config)

--- a/python/MooseDocs/extensions/package.py
+++ b/python/MooseDocs/extensions/package.py
@@ -19,8 +19,7 @@ class PackageExtension(command.CommandExtension):
 
     @staticmethod
     def defaultConfig():
-        packages = yaml_load(os.path.join(MooseDocs.MOOSE_DIR, 'framework', 'doc',
-                                                     'packages.yml'))
+        packages = yaml_load(os.path.join(MooseDocs.MOOSE_DIR, 'framework', 'doc', 'packages.yml'))
 
         config = command.CommandExtension.defaultConfig()
         config['packages'] = (packages, "A dict of packages by name.")

--- a/python/MooseDocs/extensions/package.py
+++ b/python/MooseDocs/extensions/package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import mooseutils
+from mooseutils.yaml_load import yaml_load
 
 import MooseDocs
 from MooseDocs.common import exceptions
@@ -19,7 +19,7 @@ class PackageExtension(command.CommandExtension):
 
     @staticmethod
     def defaultConfig():
-        packages = mooseutils.yaml_load(os.path.join(MooseDocs.MOOSE_DIR, 'framework', 'doc',
+        packages = yaml_load(os.path.join(MooseDocs.MOOSE_DIR, 'framework', 'doc',
                                                      'packages.yml'))
 
         config = command.CommandExtension.defaultConfig()

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -14,7 +14,6 @@ from message import mooseDebug, mooseWarning, mooseMessage, mooseError
 from hit_load import hit_load, HitNode, hit_parse
 from MooseException import MooseException
 from hit_load import hit_load
-from yaml_load import yaml_load
 from eval_path import eval_path
 
 try:

--- a/python/mooseutils/tests/test_check_file_size.py
+++ b/python/mooseutils/tests/test_check_file_size.py
@@ -17,8 +17,10 @@ class TestCheckFileSize(unittest.TestCase):
     """
 
     def testBasic(self):
-        results = check_file_size(size=1)
-        self.assertTrue(results)
+        results = check_file_size(size=1) # No files greater than 1Mb
+        self.assertEqual(results, [])
+        results = check_file_size(size=0)
+        self.assertNotEqual(results, [])
 
 if __name__ == '__main__':
     unittest.main(module=__name__, verbosity=2, buffer=True, exit=False)

--- a/python/mooseutils/tests/test_yaml_load.py
+++ b/python/mooseutils/tests/test_yaml_load.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python2
 import unittest
-import mooseutils
+from mooseutils.yaml_load import yaml_load
 
 class TestYamlLoad(unittest.TestCase):
     """
     Test that the size function returns something.
     """
     def testLoad(self):
-        data = mooseutils.yaml_load('bar.yml')
+        data = yaml_load('bar.yml')
         self.assertEqual(data[0], 3.6)
         self.assertEqual(data[1], [1,2,3])
         self.assertEqual(data[2], 'item')
         self.assertEqual(data[3], 'other')
 
     def testInclude(self):
-        data = mooseutils.yaml_load('foo.yml')
+        data = yaml_load('foo.yml')
         self.assertEqual(data['a'], 1)
         self.assertEqual(data['b'], [1.43, 543.55])
         self.assertEqual(data['c'][0], 3.6)
@@ -24,11 +24,11 @@ class TestYamlLoad(unittest.TestCase):
 
     def testError(self):
         with self.assertRaises(IOError) as e:
-            mooseutils.yaml_load('unkown.yml')
+            yaml_load('unkown.yml')
         self.assertIn("No such file or directory: 'unkown.yml'", str(e.exception))
 
         with self.assertRaises(IOError) as e:
-            mooseutils.yaml_load('foo_error.yml')
+            yaml_load('foo_error.yml')
         self.assertIn("Unknown include file 'unknown.yml' on line 5 of foo_error.yml",
                       str(e.exception))
 

--- a/python/mooseutils/tests/tests
+++ b/python/mooseutils/tests/tests
@@ -37,4 +37,12 @@
     type = PythonUnitTest
     input = test_hit_load.py
   []
+  [yaml_load]
+    type = PythonUnitTest
+    input = test_yaml_load.py
+  []
+  [check_file_size]
+    type = PythonUnitTest
+    input = test_check_file_size.py
+  []
 []


### PR DESCRIPTION
Only MooseDocs depends on `python/mooseutils/yaml_load.py` so don't load it
in `python/mooseutils/__init__.py`. MooseDocs then loads it explicitly.
This lets people run the TestHarness even if they don't have yaml in their python environment.

I also noticed that the test for `yaml_load.py` existed but was never run in the `tests` file.
Same for `test_check_file_size.py`.

closes #11186

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
