### PR TITLE
FX custom normalizations

### DIFF
--- a/modules/functional_expansion_tools/doc/content/documentation/systems/Functions/FunctionSeries.md
+++ b/modules/functional_expansion_tools/doc/content/documentation/systems/Functions/FunctionSeries.md
@@ -4,11 +4,36 @@
 
 ## Description
 
-This `Function` is the workhorse of the Functional Expansion Tools module. It bridges the gap between the functional series and the associated coefficients. For example, it provides access to the orthonormalized function series that the `UserObject` classes need to evaluate a functional expansion. It also provides the standard function series that are required to couple FXs to the solvers (`AuxKernels`, `BCs`, etc...).
-
-As such, it is configured with correlation parameters. These includes physical boundaries, series types, and series' orders.
+This `Function` is the workhorse of the Functional Expansion Tools module. It
+bridges the gap between the functional series and the associated
+coefficients. For example, it provides access to the orthonormalized function
+series that the `UserObject` classes need to evaluate a functional expansion. It
+also provides the standard function series that are required to couple FXs to
+the solvers (`AuxKernels`, `BCs`, etc...). As such, it is configured with
+correlation parameters. These includes physical boundaries, series types, and
+series' orders.
 
 The coefficients are provided through implementing `MutableCoefficientsFunctionInterface`, and the function series are provided by composition (member variable) via `CompositeSeriesBasisInterface`.
+
+!alert note title=Series normalization
+There are `generation_type` and `expansion_type` parameters provided by `FunctionSeries`
+that are passed on to the single series (`Zernike`, `Legendre`, ...). The
+aforementioned parameters are `MooseEnum`s with (at the time of writing)
+possible values of `orthonormal`, `standard`, and `sqrt_mu`. If the user does
+not make any specification in the input file, then `generation_type` defaults to
+`orthonormal` and `expansion_type` defaults to `standard`. Note that the
+combination of generation and expansion must together apply the square of the
+orthonormalization coefficient (see the work of David Griesheimer for more
+detail).   `sqrt_mu` series generation/expansion
+applies the orthonormalization constant. `orthonormal` series
+generation/expansion applies the square of the
+orthonormalization constant.  `standard` series generation/expansion
+does not apply any factor. Consequently, valid combinations include: 1)
+`orthonormal` for generation and `standard` for expansion (the default), 2)
+`sqrt_mu` for both generation and expansion, and 3) `standard` for generation
+and `orthonormal` for expansion. We suggest that users stick with the defaults
+unless coupling with external codes that require different normalizations.
+
 
 ## Example Input File Syntax
 
@@ -17,6 +42,8 @@ The coefficients are provided through implementing `MutableCoefficientsFunctionI
 !listing modules/functional_expansion_tools/examples/3D_volumetric_Cartesian/main.i block=Functions id=3DCart caption=Example use of 3D Cartesian FunctionSeries
 
 !listing modules/functional_expansion_tools/examples/3D_volumetric_cylindrical/main.i block=Functions id=3DCyl caption=Example use of 3D cylindrical FunctionSeries
+
+!listing modules/functional_expansion_tools/test/tests/standard_use/volume_coupling_custom_norm.i block=Functions id=CustomNorm caption=Example of specifying custom normalization
 
 !syntax parameters /Functions/FunctionSeries
 

--- a/modules/functional_expansion_tools/include/coefficients/MutableCoefficientsInterface.h
+++ b/modules/functional_expansion_tools/include/coefficients/MutableCoefficientsInterface.h
@@ -17,6 +17,7 @@
 #include "Restartable.h"
 
 class MutableCoefficientsInterface;
+class ConsoleStream;
 
 template <>
 InputParameters validParams<MutableCoefficientsInterface>();
@@ -43,9 +44,13 @@ public:
    */
   const std::vector<std::size_t> & getCharacteristics() const;
   /**
-   * Get a reference to the vector of coefficients
+   * Get a read-only reference to the vector of coefficients
    */
   const std::vector<Real> & getCoefficients() const;
+  /**
+   * Get a writeable reference to the vector of coefficients
+   */
+  std::vector<Real> & getCoefficients();
   /**
    * Get a formatted string of the coefficients
    */

--- a/modules/functional_expansion_tools/include/functions/FunctionSeries.h
+++ b/modules/functional_expansion_tools/include/functions/FunctionSeries.h
@@ -64,14 +64,14 @@ public:
   const std::vector<std::size_t> & getOrders() const;
 
   /**
-   * Returns a vector of the orthogonally-evaluated functional series at the current location
+   * Returns a vector of the generation-evaluated functional series at the current location
    */
-  const std::vector<Real> & getOrthonormal();
+  const std::vector<Real> & getGeneration();
 
   /**
-   * Returns a vector of the standardly-evaluated functional series at the current location
+   * Returns a vector of the expansion-evaluated functional series at the current location
    */
-  const std::vector<Real> & getStandard();
+  const std::vector<Real> & getExpansion();
 
   /**
    * Returns true if the provided point is within the set physical boundaries
@@ -113,6 +113,10 @@ protected:
   const MooseEnum & _z;
   /// Stores the name of the single function series to use for a unit disc
   const MooseEnum & _disc;
+  /// The normalization type for expansion
+  const MooseEnum & _expansion_type;
+  /// The normalization type for generation
+  const MooseEnum & _generation_type;
 
 private:
   /**

--- a/modules/functional_expansion_tools/include/series/Cartesian.h
+++ b/modules/functional_expansion_tools/include/series/Cartesian.h
@@ -23,7 +23,9 @@ public:
   Cartesian(const std::vector<MooseEnum> & domain,
             const std::vector<std::size_t> & order,
             const std::vector<MooseEnum> & series_types,
-            const std::string & who_is_using_me);
+            const std::string & who_is_using_me,
+            MooseEnum expansion_type,
+            MooseEnum generation_type);
 
   // Overrides from FunctionalBasisInterface
   virtual void setPhysicalBounds(const std::vector<Real> & bounds) final;

--- a/modules/functional_expansion_tools/include/series/CompositeSeriesBasisInterface.h
+++ b/modules/functional_expansion_tools/include/series/CompositeSeriesBasisInterface.h
@@ -62,12 +62,12 @@ public:
 
 protected:
   // Overrides from FunctionalBasisInterface
-  virtual void evaluateOrthonormal() final;
-  virtual void evaluateStandard() final;
+  virtual void evaluateGeneration() final;
+  virtual void evaluateExpansion() final;
 
   /**
-   * Evaluates the values of _basis_evaluation for either evaluateOrthonormal() or
-   * evaluateStandard()
+   * Evaluates the values of _basis_evaluation for either evaluateGeneration() or
+   * evaluateExpansion()
    */
   void evaluateSeries(const std::vector<std::vector<Real>> & single_series_basis_evaluations);
 

--- a/modules/functional_expansion_tools/include/series/CylindricalDuo.h
+++ b/modules/functional_expansion_tools/include/series/CylindricalDuo.h
@@ -23,7 +23,9 @@ public:
   CylindricalDuo(const std::vector<MooseEnum> & domain,
                  const std::vector<std::size_t> & order,
                  const std::vector<MooseEnum> & series_types,
-                 const std::string & who_is_using_me);
+                 const std::string & who_is_using_me,
+                 MooseEnum expansion_type,
+                 MooseEnum generation_type);
 
   // Virtual overrides
   virtual void setPhysicalBounds(const std::vector<Real> & bounds) final;

--- a/modules/functional_expansion_tools/include/series/FunctionalBasisInterface.h
+++ b/modules/functional_expansion_tools/include/series/FunctionalBasisInterface.h
@@ -33,14 +33,14 @@ public:
   Real operator[](std::size_t index) const;
 
   /**
-   * Returns an array reference containing the value of each orthonormalized term
+   * Returns an array reference containing the value of each generation term
    */
-  const std::vector<Real> & getAllOrthonormal();
+  const std::vector<Real> & getAllGeneration();
 
   /**
-   * Returns an array reference containing the value of each standardized term
+   * Returns an array reference containing the value of each expansion term
    */
-  const std::vector<Real> & getAllStandard();
+  const std::vector<Real> & getAllExpansion();
 
   /**
    * Returns the number of terms in the series
@@ -48,27 +48,27 @@ public:
   std::size_t getNumberOfTerms() const;
 
   /**
-   * Gets the last term of the orthonormalized functional basis
+   * Gets the last term of the generation functional basis
    */
-  Real getOrthonormal();
+  Real getGeneration();
 
   /**
-   * Gets the sum of all terms in the orthonormalized functional basis
+   * Gets the sum of all terms in the generation functional basis
    */
-  Real getOrthonormalSeriesSum();
+  Real getGenerationSeriesSum();
 
   /**
-   * Gets the #_order-th term of the standardized functional basis
+   * Gets the #_order-th term of the expansion functional basis
    */
-  Real getStandard();
+  Real getExpansion();
 
   /**
-   * Evaluates the sum of all terms in the standardized functional basis up to #_order
+   * Evaluates the sum of all terms in the expansion functional basis up to #_order
    */
-  Real getStandardSeriesSum();
+  Real getExpansionSeriesSum();
 
   /**
-   * Returns a vector of the lower and upper bounds of the standardized functional space
+   * Returns a vector of the lower and upper bounds of the standard functional space
    */
   virtual const std::vector<Real> & getStandardizedFunctionLimits() const = 0;
 
@@ -78,14 +78,14 @@ public:
   virtual Real getStandardizedFunctionVolume() const = 0;
 
   /**
-   * Returns true if the current evaluation is orthonormalized
+   * Returns true if the current evaluation is generation
    */
-  bool isOrthonormal() const;
+  bool isGeneration() const;
 
   /**
-   * Returns true if the current evaluation is standardized
+   * Returns true if the current evaluation is expansion
    */
-  bool isStandard() const;
+  bool isExpansion() const;
 
   /**
    * Whether the cached values correspond to the current point
@@ -122,14 +122,14 @@ protected:
   virtual void clearBasisEvaluation(const unsigned int & number_of_terms);
 
   /**
-   * Evaluate the orthonormal form of the functional basis
+   * Evaluate the generation form of the functional basis
    */
-  virtual void evaluateOrthonormal() = 0;
+  virtual void evaluateGeneration() = 0;
 
   /**
-   * Evaluate the standardized form of the functional basis
+   * Evaluate the expansion form of the functional basis
    */
-  virtual void evaluateStandard() = 0;
+  virtual void evaluateExpansion() = 0;
 
   /**
    * Helper function to load a value from #_series
@@ -151,8 +151,8 @@ private:
   /// Stores the values of the basis evaluation
   std::vector<Real> _basis_evaluation;
 
-  /// Indicates whether the current evaluation is standardized or orthonormalized
-  bool _is_orthonormal;
+  /// Indicates whether the current evaluation is expansion or generation
+  bool _is_generation;
 };
 
 #endif // FUNCTIONALBASISINTERFACE_H

--- a/modules/functional_expansion_tools/include/series/Legendre.h
+++ b/modules/functional_expansion_tools/include/series/Legendre.h
@@ -19,7 +19,10 @@ class Legendre final : public SingleSeriesBasisInterface
 {
 public:
   Legendre();
-  Legendre(const std::vector<MooseEnum> & domain, const std::vector<std::size_t> & order);
+  Legendre(const std::vector<MooseEnum> & domain,
+           const std::vector<std::size_t> & order,
+           MooseEnum expansion_type,
+           MooseEnum generation_type);
 
   // Overrides from FunctionalBasisInterface
   virtual Real getStandardizedFunctionVolume() const override;
@@ -31,9 +34,18 @@ public:
   virtual const std::vector<Real> & getStandardizedFunctionLimits() const override;
 
 protected:
-  // Overrides from FunctionalBasisInterface
-  virtual void evaluateOrthonormal() override;
-  virtual void evaluateStandard() override;
+  /**
+   * Evaluates the orthonormal form of the basis functions
+   */
+  virtual void evaluateOrthonormal();
+  /**
+   * Evaluates the standard form of the basis functions
+   */
+  virtual void evaluateStandard();
+  /**
+   * Evaluates the 1/sqrt(mu) normalized form of the basis functions
+   */
+  virtual void evaluateSqrtMu();
 
   // Overrides from SingleSeriesBasisInterface
   virtual void checkPhysicalBounds(const std::vector<Real> & bounds) const override;

--- a/modules/functional_expansion_tools/include/series/SingleSeriesBasisInterface.h
+++ b/modules/functional_expansion_tools/include/series/SingleSeriesBasisInterface.h
@@ -11,6 +11,7 @@
 #define SINGLESERIESBASISINTERFACE_H
 
 #include "FunctionalBasisInterface.h"
+#include <functional>
 
 /**
  * This class is a simple wrapper around FunctionalBasisInterface, and intended for use by any
@@ -60,6 +61,10 @@ public:
   const std::vector<MooseEnum> _domains;
 
 protected:
+  // Overrides from FunctionalBasisInterface
+  virtual void evaluateGeneration() override;
+  virtual void evaluateExpansion() override;
+
   /**
    * Checks the physical bounds according to the actual implementation
    */
@@ -79,6 +84,12 @@ protected:
 
   /// The standardized location of evaluation
   std::vector<Real> _standardized_location;
+
+  /// The expansion evaluation wrapper
+  std::function<void()> _evaluateExpansionWrapper;
+
+  /// The generation evaluation wrapper
+  std::function<void()> _evaluateGenerationWrapper;
 
 private:
   /// Flag for if the physical bounds are specified for this series

--- a/modules/functional_expansion_tools/include/series/Zernike.h
+++ b/modules/functional_expansion_tools/include/series/Zernike.h
@@ -20,7 +20,10 @@ class Zernike : public SingleSeriesBasisInterface
 public:
   Zernike();
 
-  Zernike(const std::vector<MooseEnum> & domain, const std::vector<std::size_t> & order);
+  Zernike(const std::vector<MooseEnum> & domain,
+          const std::vector<std::size_t> & order,
+          MooseEnum expansion_type,
+          MooseEnum generation_type);
 
   // Overrides from FunctionalBasisInterface
   virtual Real getStandardizedFunctionVolume() const override;
@@ -32,9 +35,18 @@ public:
   virtual const std::vector<Real> & getStandardizedFunctionLimits() const override;
 
 protected:
-  // Overrides from FunctionalBasisInterface
-  virtual void evaluateOrthonormal() override;
-  virtual void evaluateStandard() override;
+  /**
+   * Evaluates the orthonormal form of the basis functions
+   */
+  virtual void evaluateOrthonormal();
+  /**
+   * Evaluates the standard form of the basis functions
+   */
+  virtual void evaluateStandard();
+  /**
+   * Evaluates the 1/sqrt(mu) normalized form of the basis functions
+   */
+  virtual void evaluateSqrtMu();
 
   // Overrides from SingleSeriesBasisInterface
   virtual void checkPhysicalBounds(const std::vector<Real> & bounds) const override;
@@ -42,7 +54,7 @@ protected:
   getStandardizedLocation(const std::vector<Real> & location) const override;
 
   /**
-   * Helper function used by evaluateOrthonormal() and evaluateStandard(). It
+   * Helper function used by evaluateGeneration() and evaluateExpansion(). It
    * uses the evaluated value array of the zero and positive rank terms to:
    *  1) fill out the negative rank terms
    *  2) apply the azimuthal components to all terms

--- a/modules/functional_expansion_tools/include/transfers/MultiAppFXTransfer.h
+++ b/modules/functional_expansion_tools/include/transfers/MultiAppFXTransfer.h
@@ -60,6 +60,7 @@ private:
   typedef MutableCoefficientsInterface & (MultiAppFXTransfer::*GetProblemObject)(
       FEProblemBase & base, const std::string & object_name, THREAD_ID thread);
 
+protected:
   /**
    * Searches an FEProblemBase for a MutableCoefficientsInterface-based object and returns a
    * function pointer to the matched function type.

--- a/modules/functional_expansion_tools/include/userobject/FXIntegralBaseUserObject.h
+++ b/modules/functional_expansion_tools/include/userobject/FXIntegralBaseUserObject.h
@@ -147,7 +147,7 @@ FXIntegralBaseUserObject<IntegralBaseVariableUserObject>::computeIntegral()
   {
     // Get the functional terms for a vectorized approach
     _function_series.setLocation(_q_point[_qp]);
-    const std::vector<Real> & term_evaluations = _function_series.getOrthonormal();
+    const std::vector<Real> & term_evaluations = _function_series.getGeneration();
 
     // Evaluate the functional expansion coefficients at each quadrature point
     const Real local_contribution = computeQpIntegral();

--- a/modules/functional_expansion_tools/src/coefficients/MutableCoefficientsInterface.C
+++ b/modules/functional_expansion_tools/src/coefficients/MutableCoefficientsInterface.C
@@ -58,6 +58,12 @@ MutableCoefficientsInterface::getCoefficients() const
   return _coefficients;
 }
 
+std::vector<Real> &
+MutableCoefficientsInterface::getCoefficients()
+{
+  return _coefficients;
+}
+
 std::string
 MutableCoefficientsInterface::getCoefficientsTable() const
 {

--- a/modules/functional_expansion_tools/src/series/Cartesian.C
+++ b/modules/functional_expansion_tools/src/series/Cartesian.C
@@ -18,7 +18,9 @@ Cartesian::Cartesian(const std::string & who_is_using_me)
 Cartesian::Cartesian(const std::vector<MooseEnum> & domains,
                      const std::vector<std::size_t> & orders,
                      const std::vector<MooseEnum> & series_types,
-                     const std::string & who_is_using_me)
+                     const std::string & who_is_using_me,
+                     MooseEnum expansion_type,
+                     MooseEnum generation_type)
   : CompositeSeriesBasisInterface(orders, series_types, who_is_using_me)
 {
   // Initialize the pointers to each of the single series
@@ -27,7 +29,8 @@ Cartesian::Cartesian(const std::vector<MooseEnum> & domains,
     {
       std::vector<MooseEnum> local_domain = {domains[i]};
       std::vector<std::size_t> local_order = {orders[i]};
-      _series.push_back(libmesh_make_unique<Legendre>(local_domain, local_order));
+      _series.push_back(libmesh_make_unique<Legendre>(
+          local_domain, local_order, expansion_type, generation_type));
     }
     else
       mooseError("Cartesian: No other linear series implemented except Legendre!");

--- a/modules/functional_expansion_tools/src/series/CompositeSeriesBasisInterface.C
+++ b/modules/functional_expansion_tools/src/series/CompositeSeriesBasisInterface.C
@@ -39,16 +39,16 @@ CompositeSeriesBasisInterface::CompositeSeriesBasisInterface(
 }
 
 void
-CompositeSeriesBasisInterface::evaluateOrthonormal()
+CompositeSeriesBasisInterface::evaluateGeneration()
 {
   /*
-   * Evaluate the orthonormal versions of each of the single series, and collect the results before
+   * Evaluate the generation versions of each of the single series, and collect the results before
    * passing them to evaluateSeries, where they will be multiplied together correctly and stored in
    * the composite series basis evaluation.
    */
   std::vector<std::vector<Real>> single_series_basis_evaluation;
   for (auto & series : _series)
-    single_series_basis_evaluation.push_back(series->getAllOrthonormal());
+    single_series_basis_evaluation.push_back(series->getAllGeneration());
 
   evaluateSeries(single_series_basis_evaluation);
 }
@@ -96,16 +96,16 @@ CompositeSeriesBasisInterface::evaluateSeries(
 }
 
 void
-CompositeSeriesBasisInterface::evaluateStandard()
+CompositeSeriesBasisInterface::evaluateExpansion()
 {
   /*
-   * Evaluate the standard versions of each of the single series, and collect the results before
+   * Evaluate the expansion versions of each of the single series, and collect the results before
    * passing them to evaluateSeries, where they will be multiplied together correctly and stored in
    * the composite series basis evaluation.
    */
   std::vector<std::vector<Real>> single_series_basis_evaluation;
   for (auto & series : _series)
-    single_series_basis_evaluation.push_back(series->getAllStandard());
+    single_series_basis_evaluation.push_back(series->getAllExpansion());
 
   evaluateSeries(single_series_basis_evaluation);
 }

--- a/modules/functional_expansion_tools/src/series/CylindricalDuo.C
+++ b/modules/functional_expansion_tools/src/series/CylindricalDuo.C
@@ -19,7 +19,9 @@ CylindricalDuo::CylindricalDuo(const std::string & who_is_using_me)
 CylindricalDuo::CylindricalDuo(const std::vector<MooseEnum> & domains,
                                const std::vector<std::size_t> & orders,
                                const std::vector<MooseEnum> & series_types,
-                               const std::string & who_is_using_me)
+                               const std::string & who_is_using_me,
+                               MooseEnum expansion_type,
+                               MooseEnum generation_type)
   : CompositeSeriesBasisInterface(orders, series_types, who_is_using_me)
 {
   // Initialize the pointer to the axial series
@@ -27,7 +29,8 @@ CylindricalDuo::CylindricalDuo(const std::vector<MooseEnum> & domains,
   {
     std::vector<MooseEnum> local_domain = {domains[0]};
     std::vector<std::size_t> local_order = {orders[0]};
-    _series.push_back(libmesh_make_unique<Legendre>(local_domain, local_order));
+    _series.push_back(
+        libmesh_make_unique<Legendre>(local_domain, local_order, expansion_type, generation_type));
   }
   else
     mooseError("CylindricalDuo: No other linear series implemented except Legendre!");
@@ -37,7 +40,8 @@ CylindricalDuo::CylindricalDuo(const std::vector<MooseEnum> & domains,
   {
     std::vector<MooseEnum> local_domain = {domains[1], domains[2]};
     std::vector<std::size_t> local_order = {orders[1]};
-    _series.push_back(libmesh_make_unique<Zernike>(local_domain, local_order));
+    _series.push_back(
+        libmesh_make_unique<Zernike>(local_domain, local_order, expansion_type, generation_type));
   }
   else
     mooseError("CylindricalDuo: No other disc series implemented except Zernike!");

--- a/modules/functional_expansion_tools/src/series/FunctionalBasisInterface.C
+++ b/modules/functional_expansion_tools/src/series/FunctionalBasisInterface.C
@@ -18,7 +18,7 @@ MooseEnum FunctionalBasisInterface::_domain_options("x=0 y=1 z=2");
  * non-default constructor.
  */
 FunctionalBasisInterface::FunctionalBasisInterface()
-  : _is_cache_invalid(true), _is_orthonormal(false)
+  : _is_cache_invalid(true), _is_generation(false)
 {
 }
 
@@ -30,7 +30,7 @@ FunctionalBasisInterface::FunctionalBasisInterface(const unsigned int number_of_
   : _number_of_terms(number_of_terms),
     _is_cache_invalid(true),
     _basis_evaluation(_number_of_terms, 0.0),
-    _is_orthonormal(false)
+    _is_generation(false)
 {
   _basis_evaluation.shrink_to_fit();
 }
@@ -41,27 +41,27 @@ Real FunctionalBasisInterface::operator[](std::size_t index) const
 }
 
 bool
-FunctionalBasisInterface::isOrthonormal() const
+FunctionalBasisInterface::isGeneration() const
 {
-  return _is_orthonormal;
+  return _is_generation;
 }
 
 bool
-FunctionalBasisInterface::isStandard() const
+FunctionalBasisInterface::isExpansion() const
 {
-  return !_is_orthonormal;
+  return !_is_generation;
 }
 
 const std::vector<Real> &
-FunctionalBasisInterface::getAllOrthonormal()
+FunctionalBasisInterface::getAllGeneration()
 {
-  if (isStandard() || isCacheInvalid())
+  if (isExpansion() || isCacheInvalid())
   {
     clearBasisEvaluation(_number_of_terms);
 
-    evaluateOrthonormal();
+    evaluateGeneration();
 
-    _is_orthonormal = true;
+    _is_generation = true;
     _is_cache_invalid = false;
   }
 
@@ -69,15 +69,15 @@ FunctionalBasisInterface::getAllOrthonormal()
 }
 
 const std::vector<Real> &
-FunctionalBasisInterface::getAllStandard()
+FunctionalBasisInterface::getAllExpansion()
 {
-  if (isOrthonormal() || isCacheInvalid())
+  if (isGeneration() || isCacheInvalid())
   {
     clearBasisEvaluation(_number_of_terms);
 
-    evaluateStandard();
+    evaluateExpansion();
 
-    _is_orthonormal = false;
+    _is_generation = false;
     _is_cache_invalid = false;
   }
 
@@ -91,38 +91,38 @@ FunctionalBasisInterface::getNumberOfTerms() const
 }
 
 Real
-FunctionalBasisInterface::getOrthonormal()
+FunctionalBasisInterface::getGeneration()
 {
-  // Use getAllOrthonormal() which will lazily evaluate the series as needed
-  return getAllOrthonormal().back();
+  // Use getAllGeneration() which will lazily evaluate the series as needed
+  return getAllGeneration().back();
 }
 
 Real
-FunctionalBasisInterface::getOrthonormalSeriesSum()
+FunctionalBasisInterface::getGenerationSeriesSum()
 {
   Real sum = 0.0;
 
-  // Use getAllOrthonormal() which will lazily evaluate the series as needed
-  for (auto term : getAllOrthonormal())
+  // Use getAllGeneration() which will lazily evaluate the series as needed
+  for (auto term : getAllGeneration())
     sum += term;
 
   return sum;
 }
 
 Real
-FunctionalBasisInterface::getStandard()
+FunctionalBasisInterface::getExpansion()
 {
-  // Use getAllStandard() which will lazily evaluate the series as needed
-  return getAllStandard().back();
+  // Use getAllExpansion() which will lazily evaluate the series as needed
+  return getAllExpansion().back();
 }
 
 Real
-FunctionalBasisInterface::getStandardSeriesSum()
+FunctionalBasisInterface::getExpansionSeriesSum()
 {
   Real sum = 0.0;
 
-  // Use getAllStandard() which will lazily evaluate the series as needed
-  for (auto term : getAllStandard())
+  // Use getAllExpansion() which will lazily evaluate the series as needed
+  for (auto term : getAllExpansion())
     sum += term;
 
   return sum;

--- a/modules/functional_expansion_tools/src/series/Legendre.C
+++ b/modules/functional_expansion_tools/src/series/Legendre.C
@@ -260,7 +260,7 @@ Legendre::evaluateSqrtMu()
 {
   evaluateStandard();
   for (size_t i = 0; i < getNumberOfTerms(); ++i)
-    save(i, load(i) / std::sqrt(2));
+    save(i, load(i) * std::sqrt(i + 0.5));
 }
 
 const std::vector<Real> &

--- a/modules/functional_expansion_tools/src/series/Legendre.C
+++ b/modules/functional_expansion_tools/src/series/Legendre.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "Legendre.h"
+#include <functional>
 
 /**
  * The highest order of Legendre polynomials calculated directly instead of via the recurrence
@@ -17,9 +18,29 @@
 
 Legendre::Legendre() : SingleSeriesBasisInterface() {}
 
-Legendre::Legendre(const std::vector<MooseEnum> & domain, const std::vector<std::size_t> & order)
+Legendre::Legendre(const std::vector<MooseEnum> & domain,
+                   const std::vector<std::size_t> & order,
+                   MooseEnum expansion_type,
+                   MooseEnum generation_type)
   : SingleSeriesBasisInterface(domain, order, calculatedNumberOfTermsBasedOnOrder(order))
 {
+  if (expansion_type == "orthonormal")
+    _evaluateExpansionWrapper = [this]() { this->evaluateOrthonormal(); };
+  else if (expansion_type == "sqrt_mu")
+    _evaluateExpansionWrapper = [this]() { this->evaluateSqrtMu(); };
+  else if (expansion_type == "standard")
+    _evaluateExpansionWrapper = [this]() { this->evaluateStandard(); };
+  else
+    mooseError("The specified type of normalization for expansion does not exist");
+
+  if (generation_type == "orthonormal")
+    _evaluateGenerationWrapper = [this]() { this->evaluateOrthonormal(); };
+  else if (generation_type == "sqrt_mu")
+    _evaluateGenerationWrapper = [this]() { this->evaluateSqrtMu(); };
+  else if (generation_type == "standard")
+    _evaluateGenerationWrapper = [this]() { this->evaluateStandard(); };
+  else
+    mooseError("The specified type of normalization for generation does not exist");
 }
 
 std::size_t
@@ -232,6 +253,14 @@ Legendre::evaluateStandard()
    */
   for (k = MAX_DIRECT_CALCULATION_LEGENDRE + 1; k <= _orders[0]; ++k)
     save(k, (((2 * k - 1) * x * load(k - 1)) - ((k - 1) * load(k - 2))) / Real(k));
+}
+
+void
+Legendre::evaluateSqrtMu()
+{
+  evaluateStandard();
+  for (size_t i = 0; i < getNumberOfTerms(); ++i)
+    save(i, load(i) / std::sqrt(2));
 }
 
 const std::vector<Real> &

--- a/modules/functional_expansion_tools/src/series/SingleSeriesBasisInterface.C
+++ b/modules/functional_expansion_tools/src/series/SingleSeriesBasisInterface.C
@@ -46,6 +46,18 @@ SingleSeriesBasisInterface::isCacheInvalid() const
 }
 
 void
+SingleSeriesBasisInterface::evaluateGeneration()
+{
+  _evaluateGenerationWrapper();
+}
+
+void
+SingleSeriesBasisInterface::evaluateExpansion()
+{
+  _evaluateExpansionWrapper();
+}
+
+void
 SingleSeriesBasisInterface::setOrder(const std::vector<std::size_t> & orders)
 {
   if (orders.size() != _orders.size())

--- a/modules/functional_expansion_tools/src/series/Zernike.C
+++ b/modules/functional_expansion_tools/src/series/Zernike.C
@@ -8,8 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "MooseUtils.h"
-
 #include "Zernike.h"
+#include <functional>
 
 /**
  * The higherst order of Zernike polynomials calculated directly instead of via the recurrence
@@ -19,9 +19,29 @@
 
 Zernike::Zernike() : SingleSeriesBasisInterface() {}
 
-Zernike::Zernike(const std::vector<MooseEnum> & domain, const std::vector<std::size_t> & order)
+Zernike::Zernike(const std::vector<MooseEnum> & domain,
+                 const std::vector<std::size_t> & order,
+                 MooseEnum expansion_type,
+                 MooseEnum generation_type)
   : SingleSeriesBasisInterface(domain, order, calculatedNumberOfTermsBasedOnOrder(order))
 {
+  if (expansion_type == "orthonormal")
+    _evaluateExpansionWrapper = [this]() { this->evaluateOrthonormal(); };
+  else if (expansion_type == "sqrt_mu")
+    _evaluateExpansionWrapper = [this]() { this->evaluateSqrtMu(); };
+  else if (expansion_type == "standard")
+    _evaluateExpansionWrapper = [this]() { this->evaluateStandard(); };
+  else
+    mooseError("The specified type of normalization for expansion does not exist");
+
+  if (generation_type == "orthonormal")
+    _evaluateGenerationWrapper = [this]() { this->evaluateOrthonormal(); };
+  else if (generation_type == "sqrt_mu")
+    _evaluateGenerationWrapper = [this]() { this->evaluateSqrtMu(); };
+  else if (generation_type == "standard")
+    _evaluateGenerationWrapper = [this]() { this->evaluateStandard(); };
+  else
+    mooseError("The specified type of normalization for generation does not exist");
 }
 
 std::size_t
@@ -201,6 +221,25 @@ Zernike::evaluateOrthonormal()
   fillOutNegativeRankAndApplyAzimuthalComponent();
 }
 // clang-format on
+
+void
+Zernike::evaluateSqrtMu()
+{
+  evaluateStandard();
+  save(0, load(0) / std::sqrt(M_PI));
+  size_t j = 1;
+  for (size_t n = 1; n < _orders[0] + 1; ++n)
+  {
+    for (size_t m = 0; m < n + 1; ++m)
+    {
+      if (m != 0 && n / m == 2 && n % m == 0)
+        save(j, load(j) * std::sqrt((2 * n + 2) / (2 * M_PI)));
+      else
+        save(j, load(j) * std::sqrt((2 * n + 2) / M_PI));
+      ++j;
+    }
+  }
+}
 
 void
 Zernike::evaluateStandard()

--- a/modules/functional_expansion_tools/src/series/Zernike.C
+++ b/modules/functional_expansion_tools/src/series/Zernike.C
@@ -233,7 +233,7 @@ Zernike::evaluateSqrtMu()
     for (size_t m = 0; m < n + 1; ++m)
     {
       if (m != 0 && n / m == 2 && n % m == 0)
-        save(j, load(j) * std::sqrt((2 * n + 2) / (2 * M_PI)));
+        save(j, load(j) * std::sqrt((n + 1) / M_PI));
       else
         save(j, load(j) * std::sqrt((2 * n + 2) / M_PI));
       ++j;

--- a/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
+++ b/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
@@ -54,7 +54,7 @@ MultiAppFXTransfer::initialSetup()
       scanProblemBaseForObject(_multi_app->problemBase(), _this_app_object_name, "MultiApp");
   if (getMultiAppObject == NULL)
     mooseError(
-        "Transfer '", name(), "': Cannot find object '", _multi_app_object_name, "' in MultiApp");
+        "Transfer '", name(), "': Cannot find object '", _this_app_object_name, "' in MultiApp");
 
   // Search for the _multi_app_object_name in each of the MultiApps
   for (std::size_t i = 0; i < _multi_app->numGlobalApps(); ++i)

--- a/modules/functional_expansion_tools/test/tests/standard_use/tests
+++ b/modules/functional_expansion_tools/test/tests/standard_use/tests
@@ -17,6 +17,15 @@
     group = functional_expansion_tools
   [../]
 
+  [./volume_coupling_custom_norm]
+    # This test couples a master and sub app in 1D for a light but fully-functional volumetric test
+    type = Exodiff
+    input = volume_coupling_custom_norm.i
+    exodiff = volume_coupled_out.e
+    group = functional_expansion_tools
+    prereq = 'volume_coupling'
+  [../]
+
 
   [./print_coefficients]
     # If an extraneous field is provided, then so long as the 'physical_bounds' and 'orders' fields

--- a/modules/functional_expansion_tools/test/tests/standard_use/volume_coupling_custom_norm.i
+++ b/modules/functional_expansion_tools/test/tests/standard_use/volume_coupling_custom_norm.i
@@ -1,0 +1,141 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+
+  xmin = 0.0
+  xmax = 10.0
+  nx = 15
+[]
+
+[Variables]
+  [./m]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./s_in]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff_m]
+    type = Diffusion
+    variable = m
+  [../]
+  [./time_diff_m]
+    type = TimeDerivative
+    variable = m
+  [../]
+  [./s_in]
+    type = CoupledForce
+    variable = m
+    v = s_in
+  [../]
+[]
+
+[AuxKernels]
+  [./reconstruct_s_in]
+    type = FunctionSeriesToAux
+    variable = s_in
+    function = FX_Basis_Value_Main
+  [../]
+[]
+
+[ICs]
+  [./start_m]
+    type = ConstantIC
+    variable = m
+    value = 1
+  [../]
+[]
+
+[BCs]
+  [./surround]
+    type = DirichletBC
+    variable = m
+    value = 1
+    boundary = 'left right'
+  [../]
+[]
+
+[Functions]
+  [./FX_Basis_Value_Main]
+    type = FunctionSeries
+    series_type = Cartesian
+    orders = '3'
+    physical_bounds = '0.0  10.0'
+    x = Legendre
+    generation_type = 'sqrt_mu'
+    expansion_type = 'sqrt_mu'
+  [../]
+[]
+
+[UserObjects]
+  [./FX_Value_UserObject_Main]
+    type = FXVolumeUserObject
+    function = FX_Basis_Value_Main
+    variable = m
+  [../]
+[]
+
+[Postprocessors]
+  [./average_value]
+    type = ElementAverageValue
+    variable = m
+  [../]
+  [./peak_value]
+    type = ElementExtremeValue
+    value_type = max
+    variable = m
+  [../]
+  [./picard_iterations]
+    type = NumPicardIterations
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 10
+  dt = 0.5
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+  picard_max_its = 30
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-9
+  picard_rel_tol = 1e-8
+  picard_abs_tol = 1e-9
+[]
+
+[Outputs]
+  exodus = true
+  file_base = 'volume_coupled_out'
+[]
+
+[MultiApps]
+  [./FXTransferApp]
+    type = TransientMultiApp
+    input_files = volume_coupling_custom_norm_sub.i
+  [../]
+[]
+
+[Transfers]
+  [./ValueToSub]
+    type = MultiAppFXTransfer
+    direction = to_multiapp
+    multi_app = FXTransferApp
+    this_app_object_name = FX_Value_UserObject_Main
+    multi_app_object_name = FX_Basis_Value_Sub
+  [../]
+  [./ValueToMe]
+    type = MultiAppFXTransfer
+    direction = from_multiapp
+    multi_app = FXTransferApp
+    this_app_object_name = FX_Basis_Value_Main
+    multi_app_object_name = FX_Value_UserObject_Sub
+  [../]
+[]

--- a/modules/functional_expansion_tools/test/tests/standard_use/volume_coupling_custom_norm_sub.i
+++ b/modules/functional_expansion_tools/test/tests/standard_use/volume_coupling_custom_norm_sub.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+
+  xmin = 0.0
+  xmax = 10.0
+  nx = 15
+[]
+
+[Variables]
+  [./empty]
+  [../]
+[]
+
+[AuxVariables]
+  [./s]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./m_in]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./null_kernel]
+    type = NullKernel
+    variable = empty
+  [../]
+[]
+
+[AuxKernels]
+  [./reconstruct_m_in]
+    type = FunctionSeriesToAux
+    function = FX_Basis_Value_Sub
+    variable = m_in
+  [../]
+  [./calculate_s]
+    type = ParsedAux
+    variable = s
+    args = m_in
+    function = '2*exp(-m_in/0.8)'
+  [../]
+[]
+
+[Functions]
+  [./FX_Basis_Value_Sub]
+    type = FunctionSeries
+    series_type = Cartesian
+    orders = '3'
+    physical_bounds = '0.0  10.0'
+    x = Legendre
+    generation_type = 'sqrt_mu'
+    expansion_type = 'sqrt_mu'
+  [../]
+[]
+
+[UserObjects]
+  [./FX_Value_UserObject_Sub]
+    type = FXVolumeUserObject
+    function = FX_Basis_Value_Sub
+    variable = s
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 10
+  dt = 0.5
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]

--- a/modules/functional_expansion_tools/unit/include/Setup.h
+++ b/modules/functional_expansion_tools/unit/include/Setup.h
@@ -24,5 +24,7 @@ const std::string name = "UnitTesting";
 // Recreate the MooseEnum types used in validParams<FunctionSeries>()
 extern MooseEnum single_series_types_1D;
 extern MooseEnum single_series_types_2D;
+extern MooseEnum expansion_type;
+extern MooseEnum generation_type;
 
 #endif // SETUP_H

--- a/modules/functional_expansion_tools/unit/src/Cartesian.C
+++ b/modules/functional_expansion_tools/unit/src/Cartesian.C
@@ -16,35 +16,105 @@
 TEST(FunctionalExpansionsTest, legendreConstructor)
 {
   const unsigned int order = 5;
-  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"}, {order});
+
+  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"},
+                    {order},
+                    expansion_type = "orthonormal",
+                    generation_type = "standard");
   EXPECT_EQ(legendre.getOrder(0), order);
 }
 
-TEST(FunctionalExpansionsTest, legendreSeriesEvaluation)
+TEST(FunctionalExpansionsTest, legendreSeriesOrthonormalEvaluation)
 {
   const unsigned int order = 15;
   Real location = -0.90922108754014;
-  std::array<Real, order> truth = {{0.50000000000000,
-                                    -1.36383163131021,
-                                    1.85006119760378,
-                                    -1.80341832197563,
-                                    1.19175581122701,
-                                    -0.11669847057321,
-                                    -1.20462734483853,
-                                    2.48341349094950,
-                                    -3.41981864606651,
-                                    3.76808851494207,
-                                    -3.39261995754146,
-                                    2.30300489952095,
-                                    -0.66011244776270,
-                                    -1.24901920248131,
-                                    3.06342136027001}};
-  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"}, {order});
+  const std::array<Real, order> truth = {{0.50000000000000,
+                                          -1.36383163131021,
+                                          1.85006119760378,
+                                          -1.80341832197563,
+                                          1.19175581122701,
+                                          -0.11669847057321,
+                                          -1.20462734483853,
+                                          2.48341349094950,
+                                          -3.41981864606651,
+                                          3.76808851494207,
+                                          -3.39261995754146,
+                                          2.30300489952095,
+                                          -0.66011244776270,
+                                          -1.24901920248131,
+                                          3.06342136027001}};
+
+  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"},
+                    {order},
+                    expansion_type = "standard",
+                    generation_type = "orthonormal");
 
   legendre.setLocation(Point(location));
-  auto & answer = legendre.getAllOrthonormal();
+  auto & answer = legendre.getAllGeneration();
   for (std::size_t i = 0; i < order; ++i)
     EXPECT_NEAR(answer[i], truth[i], tol);
+}
+
+TEST(FunctionalExpansionsTest, legendreSeriesSqrtMuEvaluation)
+{
+  const unsigned int order = 15;
+  Real location = -0.90922108754014;
+  const std::array<Real, order> truth = {{0.50000000000000,
+                                          -1.36383163131021,
+                                          1.85006119760378,
+                                          -1.80341832197563,
+                                          1.19175581122701,
+                                          -0.11669847057321,
+                                          -1.20462734483853,
+                                          2.48341349094950,
+                                          -3.41981864606651,
+                                          3.76808851494207,
+                                          -3.39261995754146,
+                                          2.30300489952095,
+                                          -0.66011244776270,
+                                          -1.24901920248131,
+                                          3.06342136027001}};
+
+  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"},
+                    {order},
+                    expansion_type = "standard",
+                    generation_type = "sqrt_mu");
+
+  legendre.setLocation(Point(location));
+  auto & answer = legendre.getAllGeneration();
+  for (std::size_t i = 0; i < order; ++i)
+    EXPECT_NEAR(answer[i], truth[i] / std::sqrt(i + 0.5), tol);
+}
+
+TEST(FunctionalExpansionsTest, legendreSeriesStandardEvaluation)
+{
+  const unsigned int order = 15;
+  Real location = -0.90922108754014;
+  const std::array<Real, order> truth = {{0.50000000000000,
+                                          -1.36383163131021,
+                                          1.85006119760378,
+                                          -1.80341832197563,
+                                          1.19175581122701,
+                                          -0.11669847057321,
+                                          -1.20462734483853,
+                                          2.48341349094950,
+                                          -3.41981864606651,
+                                          3.76808851494207,
+                                          -3.39261995754146,
+                                          2.30300489952095,
+                                          -0.66011244776270,
+                                          -1.24901920248131,
+                                          3.06342136027001}};
+
+  Legendre legendre({FunctionalBasisInterface::_domain_options = "x"},
+                    {order},
+                    expansion_type = "standard",
+                    generation_type = "standard");
+
+  legendre.setLocation(Point(location));
+  auto & answer = legendre.getAllGeneration();
+  for (std::size_t i = 0; i < order; ++i)
+    EXPECT_NEAR(answer[i], truth[i] / (i + 0.5), tol);
 }
 
 TEST(FunctionalExpansionsTest, CartesianConstructor)
@@ -52,23 +122,25 @@ TEST(FunctionalExpansionsTest, CartesianConstructor)
   std::vector<MooseEnum> domains;
   std::vector<std::size_t> orders;
   std::vector<MooseEnum> series;
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
   domains.push_back(FunctionalBasisInterface::_domain_options = "x");
   orders = {19};
   series.push_back(single_series_types_1D = "Legendre");
-  Cartesian legendreOne(domains, orders, series, name);
+  Cartesian legendreOne(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(legendreOne.getNumberOfTerms(), orders[0] + 1);
 
   domains.push_back(FunctionalBasisInterface::_domain_options = "y");
   orders = {{13, 15}};
   series.push_back(single_series_types_1D = "Legendre");
-  Cartesian legendreTwo(domains, orders, series, name);
+  Cartesian legendreTwo(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(legendreTwo.getNumberOfTerms(), (orders[0] + 1) * (orders[1] + 1));
 
   domains.push_back(FunctionalBasisInterface::_domain_options = "z");
   orders = {{14, 21, 22}};
   series.push_back(single_series_types_1D = "Legendre");
-  Cartesian legendreThree(domains, orders, series, name);
+  Cartesian legendreThree(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(legendreThree.getNumberOfTerms(), (orders[0] + 1) * (orders[1] + 1) * (orders[2] + 1));
 }
 
@@ -82,7 +154,8 @@ TEST(FunctionalExpansionsTest, Cartesian3D)
                                          single_series_types_1D = "Legendre",
                                          single_series_types_1D = "Legendre"};
 
-  Cartesian legendre3D(domains, orders, series, name);
+  Cartesian legendre3D(
+      domains, orders, series, name, expansion_type = "standard", generation_type = "orthonormal");
 
   const std::vector<Point> locations = {
       Point(-0.14854612627465, 0.60364074055275, 0.76978431165674),
@@ -95,8 +168,8 @@ TEST(FunctionalExpansionsTest, Cartesian3D)
   for (std::size_t i = 0; i < locations.size(); ++i)
   {
     legendre3D.setLocation(locations[i]);
-    EXPECT_NEAR(legendre3D.getStandardSeriesSum(), standard_truth[i], tol);
-    EXPECT_NEAR(legendre3D.getOrthonormalSeriesSum(), orthogonal_truth[i], tol);
+    EXPECT_NEAR(legendre3D.getExpansionSeriesSum(), standard_truth[i], tol);
+    EXPECT_NEAR(legendre3D.getGenerationSeriesSum(), orthogonal_truth[i], tol);
   }
 }
 
@@ -110,12 +183,13 @@ TEST(FunctionalExpansionsTest, functionalBasisInterfaceCartesian)
                                          single_series_types_1D = "Legendre",
                                          single_series_types_1D = "Legendre"};
 
-  Cartesian legendre3D(domains, orders, series, name);
+  Cartesian legendre3D(
+      domains, orders, series, name, expansion_type = "standard", generation_type = "orthonormal");
 
   const Point location(-0.38541903411291, 0.61369802505416, -0.04539307255549);
   const Real truth = 0.26458908225718;
   FunctionalBasisInterface & interface = (FunctionalBasisInterface &)legendre3D;
 
   interface.setLocation(location);
-  EXPECT_NEAR(interface.getStandardSeriesSum(), truth, tol);
+  EXPECT_NEAR(interface.getExpansionSeriesSum(), truth, tol);
 }

--- a/modules/functional_expansion_tools/unit/src/CylindricalDuo.C
+++ b/modules/functional_expansion_tools/unit/src/CylindricalDuo.C
@@ -9,14 +9,20 @@
 
 #include "gtest/gtest.h"
 
+#include <array>
+
 #include "Setup.h"
 
 TEST(FunctionalExpansionsTest, zernikeConstructor)
 {
   const unsigned int order = 5;
+  expansion_type = "orthonormal";
+  generation_type = "standard";
   Zernike zernike({FunctionalBasisInterface::_domain_options = "x",
                    FunctionalBasisInterface::_domain_options = "y"},
-                  {order});
+                  {order},
+                  expansion_type,
+                  generation_type);
   EXPECT_EQ(zernike.getOrder(0), order);
 }
 
@@ -24,28 +30,32 @@ TEST(FunctionalExpansionsTest, zernikeSeriesEvaluationXY)
 {
   const unsigned int order = 4;
   const Point location(-0.90922108754014, 0.262698547343, 0.156796889218);
-  std::vector<Real> truth;
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
   Zernike zernike({FunctionalBasisInterface::_domain_options = "x",
                    FunctionalBasisInterface::_domain_options = "y"},
-                  {order});
+                  {order},
+                  expansion_type,
+                  generation_type);
   zernike.setLocation(location);
-  truth = {{0.318309886183791,
-            -0.300628811510287,
-            -1.117940202314423,
-            0.791881706198328,
-            0.623918544603900,
-            1.365900806059890,
-            -1.357069098439213,
-            -0.288633095470502,
-            -1.073332058640328,
-            -1.349767446988918,
-            1.887803726543957,
-            0.404825692079851,
-            0.223343150486739,
-            0.698275682841869,
-            1.080889714660983}};
-  auto & answer = zernike.getAllOrthonormal();
+  const std::array<Real, 15> truth = {{0.318309886183791,
+                                       -0.300628811510287,
+                                       -1.117940202314423,
+                                       0.791881706198328,
+                                       0.623918544603900,
+                                       1.365900806059890,
+                                       -1.357069098439213,
+                                       -0.288633095470502,
+                                       -1.073332058640328,
+                                       -1.349767446988918,
+                                       1.887803726543957,
+                                       0.404825692079851,
+                                       0.223343150486739,
+                                       0.698275682841869,
+                                       1.080889714660983}};
+
+  auto & answer = zernike.getAllGeneration();
   for (std::size_t i = 0; i < zernike.getNumberOfTerms(); ++i)
     EXPECT_NEAR(answer[i], truth[i], tol);
 }
@@ -54,28 +64,32 @@ TEST(FunctionalExpansionsTest, zernikeSeriesEvaluationXZ)
 {
   const unsigned int order = 4;
   const Point location(-0.90922108754014, 0.262698547343, 0.156796889218);
-  std::vector<Real> truth;
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
   Zernike zernike({FunctionalBasisInterface::_domain_options = "x",
                    FunctionalBasisInterface::_domain_options = "z"},
-                  {order});
+                  {order},
+                  expansion_type,
+                  generation_type);
   zernike.setLocation(location);
-  truth = {{0.318309886183791,
-            -0.180774038043348,
-            -1.143454732567233,
-            0.487041727962393,
-            0.623918544603900,
-            1.501849527692451,
-            -0.867504286868072,
-            -0.173560777222340,
-            -1.097828505968007,
-            -1.706149176114187,
-            1.276644449771070,
-            0.248985426801565,
-            0.223343150486739,
-            0.767775375651402,
-            1.761335979897610}};
-  auto & answer = zernike.getAllOrthonormal();
+  const std::array<Real, 15> truth = {{0.318309886183791,
+                                       -0.180774038043348,
+                                       -1.143454732567233,
+                                       0.487041727962393,
+                                       0.623918544603900,
+                                       1.501849527692451,
+                                       -0.867504286868072,
+                                       -0.173560777222340,
+                                       -1.097828505968007,
+                                       -1.706149176114187,
+                                       1.276644449771070,
+                                       0.248985426801565,
+                                       0.223343150486739,
+                                       0.767775375651402,
+                                       1.761335979897610}};
+
+  auto & answer = zernike.getAllGeneration();
   for (std::size_t i = 0; i < zernike.getNumberOfTerms(); ++i)
     EXPECT_NEAR(answer[i], truth[i], tol);
 }
@@ -84,30 +98,124 @@ TEST(FunctionalExpansionsTest, zernikeSeriesEvaluationYZ)
 {
   const unsigned int order = 4;
   const Point location(-0.90922108754014, 0.262698547343, 0.156796889218);
-  std::vector<Real> truth;
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
   Zernike zernike({FunctionalBasisInterface::_domain_options = "y",
                    FunctionalBasisInterface::_domain_options = "z"},
-                  {order});
+                  {order},
+                  expansion_type,
+                  generation_type);
   zernike.setLocation(location);
-  truth = {{0.318309886183791,
-            0.052230505695590,
-            0.330374978445085,
-            0.040657672622662,
-            -0.823129261009826,
-            0.125372638358686,
-            0.020923587239414,
-            -0.187295294511344,
-            -1.184703806003468,
-            0.041151106306071,
-            0.008896570968308,
-            -0.184582980412102,
-            0.978025517529447,
-            -0.569182979683797,
-            0.012274247968574}};
-  auto & answer = zernike.getAllOrthonormal();
+  const std::array<Real, 15> truth = {{0.318309886183791,
+                                       0.052230505695590,
+                                       0.330374978445085,
+                                       0.040657672622662,
+                                       -0.823129261009826,
+                                       0.125372638358686,
+                                       0.020923587239414,
+                                       -0.187295294511344,
+                                       -1.184703806003468,
+                                       0.041151106306071,
+                                       0.008896570968308,
+                                       -0.184582980412102,
+                                       0.978025517529447,
+                                       -0.569182979683797,
+                                       0.012274247968574}};
+
+  auto & answer = zernike.getAllGeneration();
   for (std::size_t i = 0; i < zernike.getNumberOfTerms(); ++i)
     EXPECT_NEAR(answer[i], truth[i], tol);
+}
+
+TEST(FunctionalExpansionsTest, zernikeSeriesSqrtMuEvaluation)
+{
+  const unsigned int order = 4;
+  const Point location(-0.90922108754014, 0.262698547343, 0.156796889218);
+  expansion_type = "standard";
+  generation_type = "sqrt_mu";
+
+  Zernike zernike({FunctionalBasisInterface::_domain_options = "y",
+                   FunctionalBasisInterface::_domain_options = "z"},
+                  {order},
+                  expansion_type,
+                  generation_type);
+  zernike.setLocation(location);
+  const std::array<Real, 15> truth = {{0.318309886183791,
+                                       0.052230505695590,
+                                       0.330374978445085,
+                                       0.040657672622662,
+                                       -0.823129261009826,
+                                       0.125372638358686,
+                                       0.020923587239414,
+                                       -0.187295294511344,
+                                       -1.184703806003468,
+                                       0.041151106306071,
+                                       0.008896570968308,
+                                       -0.184582980412102,
+                                       0.978025517529447,
+                                       -0.569182979683797,
+                                       0.012274247968574}};
+
+  auto & answer = zernike.getAllGeneration();
+  EXPECT_NEAR(answer[0], truth[0] * std::sqrt(M_PI), tol);
+  size_t i = 1;
+  for (size_t n = 1; n < order + 1; ++n)
+  {
+    for (size_t m = 0; m < n + 1; ++m)
+    {
+      if (m != 0 && n / m == 2 && n % m == 0)
+        EXPECT_NEAR(answer[i], truth[i] * std::sqrt(M_PI / (n + 1)), tol);
+      else
+        EXPECT_NEAR(answer[i], truth[i] * std::sqrt(M_PI / (2 * n + 2)), tol);
+      ++i;
+    }
+  }
+}
+
+TEST(FunctionalExpansionsTest, zernikeSeriesStandardEvaluation)
+{
+  const unsigned int order = 4;
+  const Point location(-0.90922108754014, 0.262698547343, 0.156796889218);
+  expansion_type = "standard";
+  generation_type = "standard";
+
+  Zernike zernike({FunctionalBasisInterface::_domain_options = "y",
+                   FunctionalBasisInterface::_domain_options = "z"},
+                  {order},
+                  expansion_type,
+                  generation_type);
+  zernike.setLocation(location);
+  const std::array<Real, 15> truth = {{0.318309886183791,
+                                       0.052230505695590,
+                                       0.330374978445085,
+                                       0.040657672622662,
+                                       -0.823129261009826,
+                                       0.125372638358686,
+                                       0.020923587239414,
+                                       -0.187295294511344,
+                                       -1.184703806003468,
+                                       0.041151106306071,
+                                       0.008896570968308,
+                                       -0.184582980412102,
+                                       0.978025517529447,
+                                       -0.569182979683797,
+                                       0.012274247968574}};
+
+  auto & answer = zernike.getAllGeneration();
+  EXPECT_NEAR(answer[0], truth[0] * M_PI, tol);
+  size_t i = 1;
+  for (size_t n = 1; n < order + 1; ++n)
+  {
+    for (size_t m = 0; m < n + 1; ++m)
+    {
+      if (m != 0 && n / m == 2 && n % m == 0)
+        EXPECT_NEAR(answer[i], truth[i] * M_PI / (n + 1), tol);
+      else
+        EXPECT_NEAR(answer[i], truth[i] * M_PI / (2 * n + 2), tol);
+      ++i;
+    }
+  }
 }
 
 TEST(FunctionalExpansionsTest, cylindricalDuoConstructorAxialX)
@@ -118,8 +226,10 @@ TEST(FunctionalExpansionsTest, cylindricalDuoConstructorAxialX)
   const std::vector<std::size_t> orders = {5, 18};
   const std::vector<MooseEnum> series = {single_series_types_1D = "Legendre",
                                          single_series_types_2D = "Zernike"};
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
-  CylindricalDuo cylindrical(domains, orders, series, name);
+  CylindricalDuo cylindrical(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(cylindrical.getNumberOfTerms(),
             (orders[0] + 1) * ((orders[1] + 1) * (orders[1] + 2)) / 2);
 }
@@ -132,8 +242,10 @@ TEST(FunctionalExpansionsTest, cylindricalDuoConstructorAxialY)
   const std::vector<std::size_t> orders = {23, 8};
   const std::vector<MooseEnum> series = {single_series_types_1D = "Legendre",
                                          single_series_types_2D = "Zernike"};
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
-  CylindricalDuo cylindrical(domains, orders, series, name);
+  CylindricalDuo cylindrical(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(cylindrical.getNumberOfTerms(),
             (orders[0] + 1) * ((orders[1] + 1) * (orders[1] + 2)) / 2);
 }
@@ -146,8 +258,10 @@ TEST(FunctionalExpansionsTest, cylindricalDuoConstructorAxialZ)
   const std::vector<std::size_t> orders = {21, 23};
   const std::vector<MooseEnum> series = {single_series_types_1D = "Legendre",
                                          single_series_types_2D = "Zernike"};
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
-  CylindricalDuo cylindrical(domains, orders, series, name);
+  CylindricalDuo cylindrical(domains, orders, series, name, expansion_type, generation_type);
   EXPECT_EQ(cylindrical.getNumberOfTerms(),
             (orders[0] + 1) * ((orders[1] + 1) * (orders[1] + 2)) / 2);
 }
@@ -160,8 +274,10 @@ TEST(FunctionalExpansionsTest, cylindricalDuoEvaluator)
   const std::vector<std::size_t> orders = {15, 17};
   const std::vector<MooseEnum> series = {single_series_types_1D = "Legendre",
                                          single_series_types_2D = "Zernike"};
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
-  CylindricalDuo cylindrical(domains, orders, series, name);
+  CylindricalDuo cylindrical(domains, orders, series, name, expansion_type, generation_type);
 
   const std::vector<Point> locations = {
       Point(-0.14854612627465, 0.60364074055275, 0.76978431165674),
@@ -175,8 +291,8 @@ TEST(FunctionalExpansionsTest, cylindricalDuoEvaluator)
   for (std::size_t i = 0; i < locations.size(); ++i)
   {
     cylindrical.setLocation(locations[i]);
-    EXPECT_NEAR(cylindrical.getStandardSeriesSum(), standard_truth[i], tol);
-    EXPECT_NEAR(cylindrical.getOrthonormalSeriesSum(), orthogonal_truth[i], tol);
+    EXPECT_NEAR(cylindrical.getExpansionSeriesSum(), standard_truth[i], tol);
+    EXPECT_NEAR(cylindrical.getGenerationSeriesSum(), orthogonal_truth[i], tol);
   }
 }
 
@@ -188,13 +304,15 @@ TEST(FunctionalExpansionsTest, functionalBasisInterfaceCylindrical)
   const std::vector<std::size_t> orders = {4, 5};
   const std::vector<MooseEnum> series = {single_series_types_1D = "Legendre",
                                          single_series_types_2D = "Zernike"};
+  expansion_type = "standard";
+  generation_type = "orthonormal";
 
-  CylindricalDuo cylindrical(domains, orders, series, name);
+  CylindricalDuo cylindrical(domains, orders, series, name, expansion_type, generation_type);
 
   const Point location(-0.38541903411291, 0.61369802505416, -0.04539307255549);
   const Real truth = 0.10414963426362565;
   FunctionalBasisInterface & interface = (FunctionalBasisInterface &)cylindrical;
 
   interface.setLocation(location);
-  EXPECT_NEAR(interface.getStandardSeriesSum(), truth, tol);
+  EXPECT_NEAR(interface.getExpansionSeriesSum(), truth, tol);
 }

--- a/modules/functional_expansion_tools/unit/src/main.C
+++ b/modules/functional_expansion_tools/unit/src/main.C
@@ -22,6 +22,8 @@ PerfLog Moose::perf_log("gtest");
 
 MooseEnum single_series_types_1D("Legendre");
 MooseEnum single_series_types_2D("Zernike");
+MooseEnum expansion_type("orthonormal sqrt_mu standard");
+MooseEnum generation_type("orthonormal sqrt_mu standard");
 
 GTEST_API_ int
 main(int argc, char ** argv)


### PR DESCRIPTION
- By and large renames `orthonormal` with `generation` and `standard` with `expansion` in interfaces
    - `evaluateOrthonormal` and `evaluateStandard` methods still exist on base series `Legendre` and `Zernike` as they define normalization types
    - also adds `evaluateSqrtMu` normalization evaulation for both `Legendre` and `Zernike`
- Based on input parameter in function series, the evaluation methods call std::function
  wrappers
- Change some methods from private to protected

Closes #11190
