### PR TITLE
Explicity call python2 in run_tests

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -540,7 +540,7 @@ class TestHarness:
 
         # Alert the user to their session file
         if self.options.queueing:
-            print 'Your session file is %s' % self.options.session_file
+            print('Your session file is %s' % self.options.session_file)
 
         # Print a different footer when performing a dry run
         if self.options.dry_run:

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 MOOSE_DIR = os.environ.get('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')))


### PR DESCRIPTION
Also updated the print statement in `TestHarness.py`. This allows python3 to parse the file and the python version check at the top of `TestHarness.py` to activate. So, in case somebody runs `python3 ./run_tests` they will get the error that python 2.7 is required.

refs #11090

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
