### PR TITLE
Avoid printing confusing error messages.

### DIFF
--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -110,12 +110,11 @@ public:
 
   // Variables /////
   virtual bool hasVariable(const std::string & var_name) const override;
-  virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) override;
-  virtual MooseVariableFEBase &
-  getVariableWithChecks(THREAD_ID tid,
-                        const std::string & var_name,
-                        Moose::VarKindType expected_var_type,
-                        Moose::VarFieldType expected_var_field_type) override;
+  virtual MooseVariableFEBase & getVariable(
+      THREAD_ID tid,
+      const std::string & var_name,
+      Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
+      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_ANY) override;
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) override;
   virtual VectorMooseVariable & getVectorVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;

--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -111,6 +111,11 @@ public:
   // Variables /////
   virtual bool hasVariable(const std::string & var_name) const override;
   virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) override;
+  virtual MooseVariableFEBase &
+  getVariableWithChecks(THREAD_ID tid,
+                        const std::string & var_name,
+                        Moose::VarKindType expected_var_type,
+                        Moose::VarFieldType expected_var_field_type) override;
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) override;
   virtual VectorMooseVariable & getVectorVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -220,12 +220,11 @@ public:
                                                               const PetscInt maxits);
 
   virtual bool hasVariable(const std::string & var_name) const override;
-  virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) override;
-  virtual MooseVariableFEBase &
-  getVariableWithChecks(THREAD_ID tid,
-                        const std::string & var_name,
-                        Moose::VarKindType expected_var_type,
-                        Moose::VarFieldType expected_var_field_type) override;
+  virtual MooseVariableFEBase & getVariable(
+      THREAD_ID tid,
+      const std::string & var_name,
+      Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
+      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_ANY) override;
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) override;
   virtual VectorMooseVariable & getVectorVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -221,6 +221,11 @@ public:
 
   virtual bool hasVariable(const std::string & var_name) const override;
   virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) override;
+  virtual MooseVariableFEBase &
+  getVariableWithChecks(THREAD_ID tid,
+                        const std::string & var_name,
+                        Moose::VarKindType expected_var_type,
+                        Moose::VarFieldType expected_var_field_type) override;
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) override;
   virtual VectorMooseVariable & getVectorVariable(THREAD_ID tid,
                                                   const std::string & var_name) override;

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -507,13 +507,12 @@ protected:
    * Helper function called by getVariable that handles the logic for
    * checking whether Variables of the requested type are available.
    */
-  MooseVariableFEBase &
-  getVariableHelper(THREAD_ID tid,
-                    const std::string & var_name,
-                    Moose::VarKindType expected_var_type,
-                    Moose::VarFieldType expected_var_field_type,
-                    SystemBase & nl,
-                    SystemBase & aux);
+  MooseVariableFEBase & getVariableHelper(THREAD_ID tid,
+                                          const std::string & var_name,
+                                          Moose::VarKindType expected_var_type,
+                                          Moose::VarFieldType expected_var_field_type,
+                                          SystemBase & nl,
+                                          SystemBase & aux);
 
   /// The currently declared tags
   std::map<TagName, TagID> _vector_tag_name_to_tag_id;

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -28,6 +28,7 @@ class MooseVariableFE;
 typedef MooseVariableFE<Real> MooseVariable;
 typedef MooseVariableFE<RealVectorValue> VectorMooseVariable;
 class RestartableDataValue;
+class SystemBase;
 
 // libMesh forward declarations
 namespace libMesh
@@ -502,6 +503,18 @@ public:
   bool & computingNonlinearResid() { return _computing_nonlinear_residual; }
 
 protected:
+  /**
+   * Helper function called by getVariable that handles the logic for
+   * checking whether Variables of the requested type are available.
+   */
+  MooseVariableFEBase &
+  getVariableHelper(THREAD_ID tid,
+                    const std::string & var_name,
+                    Moose::VarKindType expected_var_type,
+                    Moose::VarFieldType expected_var_field_type,
+                    SystemBase & nl,
+                    SystemBase & aux);
+
   /// The currently declared tags
   std::map<TagName, TagID> _vector_tag_name_to_tag_id;
 

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -160,7 +160,7 @@ public:
    * in question is not in the expected System or of the expected
    * type.
    */
-  virtual MooseVariableFE &
+  virtual MooseVariableFEBase &
   getVariable(THREAD_ID tid,
               const std::string & var_name,
               Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -154,6 +154,15 @@ public:
   /// Returns the variable reference for requested variable which may be in any system
   virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) = 0;
 
+  /**
+   * Similar to getVariable, but throws an error if the variable in
+   * question is not in the correct System.
+   */
+  virtual MooseVariableFE & getVariableWithChecks(THREAD_ID tid,
+                                                  const std::string & var_name,
+                                                  Moose::VarKindType expected_var_type,
+                                                  Moose::VarFieldType expected_var_field_type) = 0;
+
   /// Returns the variable reference for requested MooseVariable which may be in any system
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) = 0;
 

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -151,17 +151,20 @@ public:
   // Variables /////
   virtual bool hasVariable(const std::string & var_name) const = 0;
 
-  /// Returns the variable reference for requested variable which may be in any system
-  virtual MooseVariableFEBase & getVariable(THREAD_ID tid, const std::string & var_name) = 0;
-
   /**
-   * Similar to getVariable, but throws an error if the variable in
-   * question is not in the correct System.
+   * Returns the variable reference for requested variable which must
+   * be of the expected_var_type (Nonlinear vs. Auxiliary) and
+   * expected_var_field_type (standard, scalar, vector). The default
+   * values of VAR_ANY and VAR_FIELD_ANY should be used when "any"
+   * type of variable is acceptable.  Throws an error if the variable
+   * in question is not in the expected System or of the expected
+   * type.
    */
-  virtual MooseVariableFE & getVariableWithChecks(THREAD_ID tid,
-                                                  const std::string & var_name,
-                                                  Moose::VarKindType expected_var_type,
-                                                  Moose::VarFieldType expected_var_field_type) = 0;
+  virtual MooseVariableFE &
+  getVariable(THREAD_ID tid,
+              const std::string & var_name,
+              Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
+              Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_ANY) = 0;
 
   /// Returns the variable reference for requested MooseVariable which may be in any system
   virtual MooseVariable & getStandardVariable(THREAD_ID tid, const std::string & var_name) = 0;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -187,7 +187,16 @@ enum AuxGroup
 enum VarKindType
 {
   VAR_NONLINEAR,
-  VAR_AUXILIARY
+  VAR_AUXILIARY,
+  VAR_ANY
+};
+
+enum VarFieldType
+{
+  VAR_FIELD_STANDARD,
+  VAR_FIELD_SCALAR,
+  VAR_FIELD_VECTOR,
+  VAR_FIELD_ANY
 };
 
 enum CouplingType

--- a/framework/include/variables/MooseVariableBase.h
+++ b/framework/include/variables/MooseVariableBase.h
@@ -102,6 +102,11 @@ public:
    */
   virtual bool isNodal() const = 0;
 
+  /**
+   * @returns true if this is a vector-valued element, false otherwise.
+   */
+  bool isVector() const;
+
 protected:
   /// variable number (from libMesh)
   unsigned int _var_num;

--- a/framework/include/variables/MooseVariableBase.h
+++ b/framework/include/variables/MooseVariableBase.h
@@ -105,7 +105,7 @@ public:
   /**
    * @returns true if this is a vector-valued element, false otherwise.
    */
-  bool isVector() const;
+  virtual bool isVector() const = 0;
 
 protected:
   /// variable number (from libMesh)

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -131,6 +131,7 @@ public:
   bool activeOnSubdomain(SubdomainID subdomain) const override;
 
   bool isNodal() const override { return _is_nodal; }
+  bool isVector() const override;
   const Node *& node() const { return _node; }
   virtual dof_id_type & nodalDofIndex() override { return _nodal_dof_index; }
   bool isNodalDefined() const { return _has_dofs; }

--- a/framework/include/variables/MooseVariableInterface.h
+++ b/framework/include/variables/MooseVariableInterface.h
@@ -34,9 +34,9 @@ public:
   MooseVariableInterface(
       const MooseObject * moose_object,
       bool nodal,
+      std::string var_param_name = "variable",
       Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
-      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_STANDARD,
-      std::string var_param_name = "variable");
+      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_ANY);
 
   /**
    * Get the variable that this object is using.

--- a/framework/include/variables/MooseVariableInterface.h
+++ b/framework/include/variables/MooseVariableInterface.h
@@ -169,15 +169,6 @@ protected:
   /// The variable this object is acting on
   MooseVariableFE<T> * _variable;
 
-  /// The _expected_ type for this variable. For example, if we are a
-  /// base class of Kernel, this will be VAR_NONLINEAR, etc.
-  const Moose::VarKindType _expected_var_type;
-
-  /// The _expected_ "field" type for this variable. For example,
-  /// LAGRANGE variables are of type VAR_FIELD_STANDARD, LAGRANGE_VEC
-  /// variables are of type VAR_FIELD_VECTOR, etc.
-  const Moose::VarFieldType _expected_var_field_type;
-
 protected:
   Assembly * _mvi_assembly;
 };

--- a/framework/include/variables/MooseVariableInterface.h
+++ b/framework/include/variables/MooseVariableInterface.h
@@ -31,9 +31,12 @@ public:
    * @param nodal true if the variable is nodal
    * @param var_param_name the parameter name where we will find the coupled variable name
    */
-  MooseVariableInterface(const MooseObject * moose_object,
-                         bool nodal,
-                         std::string var_param_name = "variable");
+  MooseVariableInterface(
+      const MooseObject * moose_object,
+      bool nodal,
+      Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
+      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_STANDARD,
+      std::string var_param_name = "variable");
 
   /**
    * Get the variable that this object is using.
@@ -165,6 +168,15 @@ protected:
 
   /// The variable this object is acting on
   MooseVariableFE<T> * _variable;
+
+  /// The _expected_ type for this variable. For example, if we are a
+  /// base class of Kernel, this will be VAR_NONLINEAR, etc.
+  const Moose::VarKindType _expected_var_type;
+
+  /// The _expected_ "field" type for this variable. For example,
+  /// LAGRANGE variables are of type VAR_FIELD_STANDARD, LAGRANGE_VEC
+  /// variables are of type VAR_FIELD_VECTOR, etc.
+  const Moose::VarFieldType _expected_var_field_type;
 
 protected:
   Assembly * _mvi_assembly;

--- a/framework/include/variables/MooseVariableScalar.h
+++ b/framework/include/variables/MooseVariableScalar.h
@@ -37,6 +37,7 @@ public:
   void reinit();
 
   virtual bool isNodal() const override;
+  virtual bool isVector() const override;
 
   //
   VariableValue & sln() { return _u; }

--- a/framework/include/variables/NeighborMooseVariableInterface.h
+++ b/framework/include/variables/NeighborMooseVariableInterface.h
@@ -26,7 +26,11 @@ public:
    * @param parameters Parameters that come from constructing the object
    * @param nodal true if the variable is nodal
    */
-  NeighborMooseVariableInterface(const MooseObject * moose_object, bool nodal);
+  NeighborMooseVariableInterface(
+      const MooseObject * moose_object,
+      bool nodal,
+      Moose::VarKindType expected_var_type = Moose::VarKindType::VAR_ANY,
+      Moose::VarFieldType expected_var_field_type = Moose::VarFieldType::VAR_FIELD_STANDARD);
 
   virtual ~NeighborMooseVariableInterface();
 

--- a/framework/include/warehouses/MooseObjectWarehouseBase.h
+++ b/framework/include/warehouses/MooseObjectWarehouseBase.h
@@ -302,7 +302,8 @@ MooseObjectWarehouseBase<T>::addObject(std::shared_ptr<T> object,
         // interface level...
         variable_name = parameters.getVecMooseType("variable")[0];
 
-      blk->checkVariable(problem.getVariable(tid, variable_name));
+      blk->checkVariable(problem.getVariable(
+          tid, variable_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY));
     }
   }
 }

--- a/framework/src/actions/SetupResidualDebugAction.C
+++ b/framework/src/actions/SetupResidualDebugAction.C
@@ -47,7 +47,8 @@ SetupResidualDebugAction::act()
   for (const auto & var_name : _show_var_residual)
   {
     // add aux-variable
-    MooseVariableFEBase & var = _problem->getVariable(0, var_name);
+    MooseVariableFEBase & var = _problem->getVariable(
+        0, var_name, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD);
     InputParameters params = _factory.getValidParams("DebugResidualAux");
     const std::set<SubdomainID> & subdomains = var.activeSubdomains();
 

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -61,7 +61,9 @@ AuxKernel::AuxKernel(const InputParameters & parameters)
                                  parameters.getCheckedPointerParam<AuxiliarySystem *>("_aux_sys")
                                      ->getVariable(parameters.get<THREAD_ID>("_tid"),
                                                    parameters.get<AuxVariableName>("variable"))
-                                     .isNodal()),
+                                     .isNodal(),
+                                 Moose::VarKindType::VAR_AUXILIARY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     BlockRestrictable(this),
     BoundaryRestrictable(this, mooseVariable()->isNodal()),
     SetupInterface(this),

--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -62,6 +62,7 @@ AuxKernel::AuxKernel(const InputParameters & parameters)
                                      ->getVariable(parameters.get<THREAD_ID>("_tid"),
                                                    parameters.get<AuxVariableName>("variable"))
                                      .isNodal(),
+                                 "variable",
                                  Moose::VarKindType::VAR_AUXILIARY,
                                  Moose::VarFieldType::VAR_FIELD_STANDARD),
     BlockRestrictable(this),

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -28,7 +28,8 @@ validParams<IntegratedBC>()
 
 IntegratedBC::IntegratedBC(const InputParameters & parameters)
   : IntegratedBCBase(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _normals(_var.normals()),
     _phi(_assembly.phiFace(_var)),

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -28,8 +28,11 @@ validParams<IntegratedBC>()
 
 IntegratedBC::IntegratedBC(const InputParameters & parameters)
   : IntegratedBCBase(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _normals(_var.normals()),
     _phi(_assembly.phiFace(_var)),

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -26,7 +26,8 @@ validParams<NodalBC>()
 
 NodalBC::NodalBC(const InputParameters & parameters)
   : NodalBCBase(parameters),
-    MooseVariableInterface<Real>(this, true),
+    MooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _current_node(_var.node()),
     _u(_var.dofValues())

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -26,8 +26,11 @@ validParams<NodalBC>()
 
 NodalBC::NodalBC(const InputParameters & parameters)
   : NodalBCBase(parameters),
-    MooseVariableInterface<Real>(
-        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 true,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _current_node(_var.node()),
     _u(_var.dofValues())

--- a/framework/src/bcs/VectorIntegratedBC.C
+++ b/framework/src/bcs/VectorIntegratedBC.C
@@ -33,8 +33,11 @@ validParams<VectorIntegratedBC>()
 
 VectorIntegratedBC::VectorIntegratedBC(const InputParameters & parameters)
   : IntegratedBCBase(parameters),
-    MooseVariableInterface<RealVectorValue>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
+    MooseVariableInterface<RealVectorValue>(this,
+                                            false,
+                                            "variable",
+                                            Moose::VarKindType::VAR_NONLINEAR,
+                                            Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _normals(_var.normals()),
     _phi(_assembly.phiFace(_var)),

--- a/framework/src/bcs/VectorIntegratedBC.C
+++ b/framework/src/bcs/VectorIntegratedBC.C
@@ -33,7 +33,8 @@ validParams<VectorIntegratedBC>()
 
 VectorIntegratedBC::VectorIntegratedBC(const InputParameters & parameters)
   : IntegratedBCBase(parameters),
-    MooseVariableInterface<RealVectorValue>(this, false),
+    MooseVariableInterface<RealVectorValue>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _normals(_var.normals()),
     _phi(_assembly.phiFace(_var)),

--- a/framework/src/bcs/VectorNodalBC.C
+++ b/framework/src/bcs/VectorNodalBC.C
@@ -23,7 +23,8 @@ validParams<VectorNodalBC>()
 
 VectorNodalBC::VectorNodalBC(const InputParameters & parameters)
   : NodalBCBase(parameters),
-    MooseVariableInterface<RealVectorValue>(this, true),
+    MooseVariableInterface<RealVectorValue>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _current_node(_var.node()),
     _u(_var.nodalValue())

--- a/framework/src/bcs/VectorNodalBC.C
+++ b/framework/src/bcs/VectorNodalBC.C
@@ -23,8 +23,11 @@ validParams<VectorNodalBC>()
 
 VectorNodalBC::VectorNodalBC(const InputParameters & parameters)
   : NodalBCBase(parameters),
-    MooseVariableInterface<RealVectorValue>(
-        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
+    MooseVariableInterface<RealVectorValue>(this,
+                                            true,
+                                            "variable",
+                                            Moose::VarKindType::VAR_NONLINEAR,
+                                            Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _current_node(_var.node()),
     _u(_var.nodalValue())

--- a/framework/src/constraints/ElemElemConstraint.C
+++ b/framework/src/constraints/ElemElemConstraint.C
@@ -30,7 +30,8 @@ validParams<ElemElemConstraint>()
 ElemElemConstraint::ElemElemConstraint(const InputParameters & parameters)
   : Constraint(parameters),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
-    NeighborMooseVariableInterface<Real>(this, false),
+    NeighborMooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _dim(_mesh.dimension()),
     _interface_id(getParam<unsigned int>("interface_id")),

--- a/framework/src/constraints/MortarConstraint.C
+++ b/framework/src/constraints/MortarConstraint.C
@@ -32,8 +32,11 @@ validParams<MortarConstraint>()
 MortarConstraint::MortarConstraint(const InputParameters & parameters)
   : Constraint(parameters),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
-    MooseVariableInterface<Real>(
-        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 true,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _dim(_mesh.dimension()),
 

--- a/framework/src/constraints/MortarConstraint.C
+++ b/framework/src/constraints/MortarConstraint.C
@@ -32,7 +32,8 @@ validParams<MortarConstraint>()
 MortarConstraint::MortarConstraint(const InputParameters & parameters)
   : Constraint(parameters),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
-    MooseVariableInterface<Real>(this, true),
+    MooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _dim(_mesh.dimension()),
 

--- a/framework/src/constraints/NodalConstraint.C
+++ b/framework/src/constraints/NodalConstraint.C
@@ -31,7 +31,8 @@ validParams<NodalConstraint>()
 NodalConstraint::NodalConstraint(const InputParameters & parameters)
   : Constraint(parameters),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, true, true),
-    NeighborMooseVariableInterface<Real>(this, true),
+    NeighborMooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u_slave(_var.dofValuesNeighbor()),
     _u_master(_var.dofValues())
 {

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -47,7 +47,8 @@ NodeFaceConstraint::NodeFaceConstraint(const InputParameters & parameters)
     // The slave side is at nodes (hence passing 'true').  The neighbor side is the master side and
     // it is not at nodes (so passing false)
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, true, false),
-    NeighborMooseVariableInterface<Real>(this, true),
+    NeighborMooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _slave(_mesh.getBoundaryID(getParam<BoundaryName>("slave"))),
     _master(_mesh.getBoundaryID(getParam<BoundaryName>("master"))),
 

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -130,7 +130,10 @@ DGKernel::DGKernel(const InputParameters & parameters)
 
   for (unsigned int i = 0; i < _save_in_strings.size(); i++)
   {
-    MooseVariableFEBase * var = &_subproblem.getVariable(_tid, _save_in_strings[i]);
+    MooseVariableFEBase * var = &_subproblem.getVariable(_tid,
+                                                         _save_in_strings[i],
+                                                         Moose::VarKindType::VAR_AUXILIARY,
+                                                         Moose::VarFieldType::VAR_FIELD_STANDARD);
 
     if (_sys.hasVariable(_save_in_strings[i]))
       mooseError("Trying to use solution variable " + _save_in_strings[i] +
@@ -151,7 +154,10 @@ DGKernel::DGKernel(const InputParameters & parameters)
 
   for (unsigned int i = 0; i < _diag_save_in_strings.size(); i++)
   {
-    MooseVariableFEBase * var = &_subproblem.getVariable(_tid, _diag_save_in_strings[i]);
+    MooseVariableFEBase * var = &_subproblem.getVariable(_tid,
+                                                         _diag_save_in_strings[i],
+                                                         Moose::VarKindType::VAR_NONLINEAR,
+                                                         Moose::VarFieldType::VAR_FIELD_STANDARD);
 
     if (_sys.hasVariable(_diag_save_in_strings[i]))
       mooseError("Trying to use solution variable " + _diag_save_in_strings[i] +

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -73,7 +73,8 @@ DGKernel::DGKernel(const InputParameters & parameters)
     FunctionInterface(this),
     UserObjectInterface(this),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
-    NeighborMooseVariableInterface(this, false),
+    NeighborMooseVariableInterface(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     TwoMaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
     Restartable(this, "DGKernels"),
     MeshChangedInterface(parameters),

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -50,8 +50,11 @@ DiracKernel::DiracKernel(const InputParameters & parameters)
   : MooseObject(parameters),
     SetupInterface(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     FunctionInterface(this),
     UserObjectInterface(this),
     TransientInterface(this),

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -50,7 +50,8 @@ DiracKernel::DiracKernel(const InputParameters & parameters)
   : MooseObject(parameters),
     SetupInterface(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     FunctionInterface(this),
     UserObjectInterface(this),
     TransientInterface(this),

--- a/framework/src/indicators/ElementIndicator.C
+++ b/framework/src/indicators/ElementIndicator.C
@@ -38,8 +38,8 @@ ElementIndicator::ElementIndicator(const InputParameters & parameters)
     PostprocessorInterface(this),
     Coupleable(this, false),
     ScalarCoupleable(this),
-    MooseVariableInterface<Real>(this, false),
-
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _field_var(_subproblem.getStandardVariable(_tid, name())),
 
     _current_elem(_field_var.currentElem()),

--- a/framework/src/indicators/ElementIndicator.C
+++ b/framework/src/indicators/ElementIndicator.C
@@ -38,8 +38,11 @@ ElementIndicator::ElementIndicator(const InputParameters & parameters)
     PostprocessorInterface(this),
     Coupleable(this, false),
     ScalarCoupleable(this),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _field_var(_subproblem.getStandardVariable(_tid, name())),
 
     _current_elem(_field_var.currentElem()),

--- a/framework/src/indicators/InternalSideIndicator.C
+++ b/framework/src/indicators/InternalSideIndicator.C
@@ -48,7 +48,8 @@ InternalSideIndicator::InternalSideIndicator(const InputParameters & parameters)
   : Indicator(parameters),
     NeighborCoupleable(this, false, false),
     ScalarCoupleable(this),
-    NeighborMooseVariableInterface(this, false),
+    NeighborMooseVariableInterface(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _field_var(_sys.getVariable(_tid, name())),
 
     _current_elem(_assembly.elem()),

--- a/framework/src/interfacekernels/InterfaceKernel.C
+++ b/framework/src/interfacekernels/InterfaceKernel.C
@@ -78,7 +78,8 @@ InterfaceKernel::InterfaceKernel(const InputParameters & parameters)
     FunctionInterface(this),
     UserObjectInterface(this),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
-    NeighborMooseVariableInterface<Real>(this, false),
+    NeighborMooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     Restartable(this, "InterfaceKernels"),
     MeshChangedInterface(parameters),
     TwoMaterialPropertyInterface(this, boundaryIDs()),

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -105,7 +105,12 @@ BlockRestrictable::initializeBlockRestrictable(const MooseObject * moose_object)
   {
     std::string variable_name = moose_object->parameters().getMooseType("variable");
     if (!variable_name.empty())
-      _blk_ids = _blk_feproblem->getVariable(_blk_tid, variable_name).activeSubdomains();
+      _blk_ids = _blk_feproblem
+                     ->getVariable(_blk_tid,
+                                   variable_name,
+                                   Moose::VarKindType::VAR_ANY,
+                                   Moose::VarFieldType::VAR_FIELD_ANY)
+                     .activeSubdomains();
   }
 
   // Produce error if the object is not allowed to be both block and boundary restricted

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -51,7 +51,11 @@ Coupleable::Coupleable(const MooseObject * moose_object, bool nodal)
       {
         if (problem.hasVariable(coupled_var_name))
         {
-          MooseVariableFEBase * moose_var = &problem.getVariable(_c_tid, coupled_var_name);
+          MooseVariableFEBase * moose_var =
+              &problem.getVariable(_c_tid,
+                                   coupled_var_name,
+                                   Moose::VarKindType::VAR_ANY,
+                                   Moose::VarFieldType::VAR_FIELD_ANY);
           _coupled_vars[name].push_back(moose_var);
           _coupled_moose_vars.push_back(moose_var);
           if (auto * tmp_var = dynamic_cast<MooseVariable *>(moose_var))

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -214,8 +214,9 @@ Coupleable::coupled(const std::string & var_name, unsigned int comp)
       return var->number();
     case Moose::VAR_AUXILIARY:
       return std::numeric_limits<unsigned int>::max() - var->number();
+    default:
+      mooseError(_c_name, ": Unknown variable kind. Corrupted binary?");
   }
-  mooseError(_c_name, ": Unknown variable kind. Corrupted binary?");
 }
 
 VariableValue *

--- a/framework/src/interfaces/LazyCoupleable.C
+++ b/framework/src/interfaces/LazyCoupleable.C
@@ -43,7 +43,8 @@ LazyCoupleable::init()
     if (!_l_fe_problem->hasVariable(var_pair.first))
       mooseError("Unable to find variable ", var_pair.first);
 
-    auto & moose_var = _l_fe_problem->getVariable(0, var_pair.first);
+    auto & moose_var = _l_fe_problem->getVariable(
+        0, var_pair.first, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY);
     if (moose_var.kind() == Moose::VAR_NONLINEAR)
       *(var_pair.second) = moose_var.number();
     else

--- a/framework/src/interfaces/ScalarCoupleable.C
+++ b/framework/src/interfaces/ScalarCoupleable.C
@@ -50,7 +50,11 @@ ScalarCoupleable::ScalarCoupleable(const MooseObject * moose_object)
         }
         else if (problem.hasVariable(coupled_var_name))
         {
-          MooseVariableFEBase * moose_var = &problem.getVariable(_sc_tid, coupled_var_name);
+          MooseVariableFEBase * moose_var =
+              &problem.getVariable(_sc_tid,
+                                   coupled_var_name,
+                                   Moose::VarKindType::VAR_ANY,
+                                   Moose::VarFieldType::VAR_FIELD_ANY);
           _sc_coupled_vars[name].push_back(moose_var);
         }
         else

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -30,7 +30,8 @@ validParams<Kernel>()
 
 Kernel::Kernel(const InputParameters & parameters)
   : KernelBase(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _test(_var.phi()),
     _grad_test(_var.gradPhi()),

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -30,8 +30,11 @@ validParams<Kernel>()
 
 Kernel::Kernel(const InputParameters & parameters)
   : KernelBase(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(*mooseVariable()),
     _test(_var.phi()),
     _grad_test(_var.gradPhi()),

--- a/framework/src/kernels/VectorKernel.C
+++ b/framework/src/kernels/VectorKernel.C
@@ -33,7 +33,8 @@ validParams<VectorKernel>()
 
 VectorKernel::VectorKernel(const InputParameters & parameters)
   : KernelBase(parameters),
-    MooseVariableInterface<RealVectorValue>(this, false),
+    MooseVariableInterface<RealVectorValue>(
+        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _test(_var.phi()),
     _grad_test(_var.gradPhi()),

--- a/framework/src/kernels/VectorKernel.C
+++ b/framework/src/kernels/VectorKernel.C
@@ -33,8 +33,11 @@ validParams<VectorKernel>()
 
 VectorKernel::VectorKernel(const InputParameters & parameters)
   : KernelBase(parameters),
-    MooseVariableInterface<RealVectorValue>(
-        this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_VECTOR),
+    MooseVariableInterface<RealVectorValue>(this,
+                                            false,
+                                            "variable",
+                                            Moose::VarKindType::VAR_NONLINEAR,
+                                            Moose::VarFieldType::VAR_FIELD_VECTOR),
     _var(*mooseVariable()),
     _test(_var.phi()),
     _grad_test(_var.gradPhi()),

--- a/framework/src/loops/FlagElementsThread.C
+++ b/framework/src/loops/FlagElementsThread.C
@@ -32,7 +32,8 @@ FlagElementsThread::FlagElementsThread(FEProblemBase & fe_problem,
     _aux_sys(fe_problem.getAuxiliarySystem()),
     _system_number(_aux_sys.number()),
     _adaptivity(_fe_problem.adaptivity()),
-    _field_var(_fe_problem.getVariable(0, marker_name)),
+    _field_var(_fe_problem.getVariable(
+        0, marker_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY)),
     _field_var_number(_field_var.number()),
     _serialized_solution(serialized_solution),
     _max_h_level(max_h_level)

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -73,7 +73,8 @@ NodalKernel::NodalKernel(const InputParameters & parameters)
                     parameters.get<THREAD_ID>("_tid"),
                     true),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
-    MooseVariableInterface<Real>(this, true),
+    MooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     TaggingInterface(this),
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -73,8 +73,11 @@ NodalKernel::NodalKernel(const InputParameters & parameters)
                     parameters.get<THREAD_ID>("_tid"),
                     true),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
-    MooseVariableInterface<Real>(
-        this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 true,
+                                 "variable",
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     TaggingInterface(this),
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -382,7 +382,8 @@ AdvancedOutput::initAvailableLists()
   {
     if (_problem_ptr->hasVariable(var_name))
     {
-      MooseVariableFEBase & var = _problem_ptr->getVariable(0, var_name);
+      MooseVariableFEBase & var = _problem_ptr->getVariable(
+          0, var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
         _execute_data["elemental"].available.insert(var_name);
@@ -452,7 +453,8 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
   {
     if (_problem_ptr->hasVariable(var_name))
     {
-      MooseVariableFEBase & var = _problem_ptr->getVariable(0, var_name);
+      MooseVariableFEBase & var = _problem_ptr->getVariable(
+          0, var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
         _execute_data["elemental"].show.insert(var_name);
@@ -493,7 +495,8 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
   {
     if (_problem_ptr->hasVariable(var_name))
     {
-      MooseVariableFEBase & var = _problem_ptr->getVariable(0, var_name);
+      MooseVariableFEBase & var = _problem_ptr->getVariable(
+          0, var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY);
       const FEType type = var.feType();
       if (type.order == CONSTANT)
         _execute_data["elemental"].hide.insert(var_name);

--- a/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
@@ -23,8 +23,11 @@ validParams<ElementIntegralVariablePostprocessor>()
 ElementIntegralVariablePostprocessor::ElementIntegralVariablePostprocessor(
     const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
     _u_dot(_is_transient ? coupledDot("variable") : _zero)

--- a/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementIntegralVariablePostprocessor.C
@@ -23,7 +23,8 @@ validParams<ElementIntegralVariablePostprocessor>()
 ElementIntegralVariablePostprocessor::ElementIntegralVariablePostprocessor(
     const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
     _u_dot(_is_transient ? coupledDot("variable") : _zero)

--- a/framework/src/postprocessors/ElementVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementVariablePostprocessor.C
@@ -26,8 +26,11 @@ validParams<ElementVariablePostprocessor>()
 
 ElementVariablePostprocessor::ElementVariablePostprocessor(const InputParameters & parameters)
   : ElementPostprocessor(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
     _u_dot(_is_transient ? coupledDot("variable") : _zero),

--- a/framework/src/postprocessors/ElementVariablePostprocessor.C
+++ b/framework/src/postprocessors/ElementVariablePostprocessor.C
@@ -26,7 +26,8 @@ validParams<ElementVariablePostprocessor>()
 
 ElementVariablePostprocessor::ElementVariablePostprocessor(const InputParameters & parameters)
   : ElementPostprocessor(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
     _u_dot(_is_transient ? coupledDot("variable") : _zero),

--- a/framework/src/postprocessors/NodalVariablePostprocessor.C
+++ b/framework/src/postprocessors/NodalVariablePostprocessor.C
@@ -24,7 +24,8 @@ validParams<NodalVariablePostprocessor>()
 
 NodalVariablePostprocessor::NodalVariablePostprocessor(const InputParameters & parameters)
   : NodalPostprocessor(parameters),
-    MooseVariableInterface<Real>(this, true),
+    MooseVariableInterface<Real>(
+        this, true, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable"))
 {
 }

--- a/framework/src/postprocessors/NodalVariablePostprocessor.C
+++ b/framework/src/postprocessors/NodalVariablePostprocessor.C
@@ -24,8 +24,11 @@ validParams<NodalVariablePostprocessor>()
 
 NodalVariablePostprocessor::NodalVariablePostprocessor(const InputParameters & parameters)
   : NodalPostprocessor(parameters),
-    MooseVariableInterface<Real>(
-        this, true, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 true,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable"))
 {
 }

--- a/framework/src/postprocessors/NodalVariableValue.C
+++ b/framework/src/postprocessors/NodalVariableValue.C
@@ -60,7 +60,12 @@ NodalVariableValue::getValue()
   Real value = 0;
 
   if (_node_ptr && _node_ptr->processor_id() == processor_id())
-    value = _subproblem.getVariable(_tid, _var_name).getNodalValue(*_node_ptr);
+    value = _subproblem
+                .getVariable(_tid,
+                             _var_name,
+                             Moose::VarKindType::VAR_ANY,
+                             Moose::VarFieldType::VAR_FIELD_STANDARD)
+                .getNodalValue(*_node_ptr);
 
   gatherSum(value);
 

--- a/framework/src/postprocessors/PointValue.C
+++ b/framework/src/postprocessors/PointValue.C
@@ -33,7 +33,12 @@ validParams<PointValue>()
 
 PointValue::PointValue(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
-    _var_number(_subproblem.getVariable(_tid, parameters.get<VariableName>("variable")).number()),
+    _var_number(_subproblem
+                    .getVariable(_tid,
+                                 parameters.get<VariableName>("variable"),
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD)
+                    .number()),
     _system(_subproblem.getSystem(getParam<VariableName>("variable"))),
     _point(getParam<Point>("point")),
     _value(0)

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -24,8 +24,11 @@ validParams<SideIntegralVariablePostprocessor>()
 SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(
     const InputParameters & parameters)
   : SideIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -24,7 +24,8 @@ validParams<SideIntegralVariablePostprocessor>()
 SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(
     const InputParameters & parameters)
   : SideIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/postprocessors/VariableResidual.C
+++ b/framework/src/postprocessors/VariableResidual.C
@@ -27,10 +27,11 @@ validParams<VariableResidual>()
 
 VariableResidual::VariableResidual(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
-    _var(_fe_problem.getVariable(_tid, getParam<VariableName>("variable")))
+    _var(_fe_problem.getVariable(_tid,
+                                 getParam<VariableName>("variable"),
+                                 Moose::VarKindType::VAR_NONLINEAR,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD))
 {
-  if (_var.kind() != Moose::VAR_NONLINEAR)
-    mooseError(name(), ": Residual can be computed only for nonlinear variables.");
 }
 
 void

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -307,58 +307,12 @@ DisplacedProblem::getVariable(THREAD_ID tid,
                               Moose::VarKindType expected_var_type,
                               Moose::VarFieldType expected_var_field_type)
 {
-  // Eventual return value
-  MooseVariableFEBase * var = nullptr;
-
-  // First check that the variable is found on the expected system.
-  if (expected_var_type == Moose::VarKindType::VAR_ANY)
-  {
-    if (_displaced_nl.hasVariable(var_name))
-      var = &(_displaced_nl.getVariable(tid, var_name));
-    else if (_displaced_aux.hasVariable(var_name))
-      var = &(_displaced_aux.getVariable(tid, var_name));
-    else
-      mooseError("No variable with name '" + var_name + "'");
-  }
-  else if (expected_var_type == Moose::VarKindType::VAR_NONLINEAR &&
-           _displaced_nl.hasVariable(var_name))
-    var = &(_displaced_nl.getVariable(tid, var_name));
-  else if (expected_var_type == Moose::VarKindType::VAR_AUXILIARY &&
-           _displaced_aux.hasVariable(var_name))
-    var = &(_displaced_aux.getVariable(tid, var_name));
-  else
-  {
-    std::string expected_var_type_string =
-        (expected_var_type == Moose::VarKindType::VAR_NONLINEAR ? "nonlinear" : "auxiliary");
-    mooseError("No ",
-               expected_var_type_string,
-               " variable named ",
-               var_name,
-               " found. "
-               "Did you specify an auxiliary variable when you meant to specify a nonlinear "
-               "variable (or vice-versa)?");
-  }
-
-  // Now make sure the var found has the expected field type.
-  bool var_is_vector = var->isVector();
-  if ((expected_var_field_type == Moose::VarFieldType::VAR_FIELD_ANY) ||
-      (var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_VECTOR) ||
-      (!var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD))
-    return *var;
-  else
-  {
-    std::string expected_var_field_type_string =
-        (expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD ? "standard"
-                                                                            : "vector");
-    ;
-    mooseError("No ",
-               expected_var_field_type_string,
-               " variable named ",
-               var_name,
-               " found. "
-               "Did you specify a vector variable when you meant to specify a standard variable "
-               "(or vice-versa)?");
-  }
+  return getVariableHelper(tid,
+                           var_name,
+                           expected_var_type,
+                           expected_var_field_type,
+                           _displaced_nl,
+                           _displaced_aux);
 }
 
 MooseVariable &

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -307,12 +307,8 @@ DisplacedProblem::getVariable(THREAD_ID tid,
                               Moose::VarKindType expected_var_type,
                               Moose::VarFieldType expected_var_field_type)
 {
-  return getVariableHelper(tid,
-                           var_name,
-                           expected_var_type,
-                           expected_var_field_type,
-                           _displaced_nl,
-                           _displaced_aux);
+  return getVariableHelper(
+      tid, var_name, expected_var_type, expected_var_field_type, _displaced_nl, _displaced_aux);
 }
 
 MooseVariable &

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -301,14 +301,14 @@ DisplacedProblem::hasVariable(const std::string & var_name) const
     return false;
 }
 
-MooseVariableFE &
+MooseVariableFEBase &
 DisplacedProblem::getVariable(THREAD_ID tid,
                               const std::string & var_name,
                               Moose::VarKindType expected_var_type,
                               Moose::VarFieldType expected_var_field_type)
 {
   // Eventual return value
-  MooseVariableFE * var = nullptr;
+  MooseVariableFEBase * var = nullptr;
 
   // First check that the variable is found on the expected system.
   if (expected_var_type == Moose::VarKindType::VAR_ANY)

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -312,6 +312,58 @@ DisplacedProblem::getVariable(THREAD_ID tid, const std::string & var_name)
   return _displaced_aux.getVariable(tid, var_name);
 }
 
+MooseVariableFE &
+DisplacedProblem::getVariableWithChecks(THREAD_ID tid,
+                                        const std::string & var_name,
+                                        Moose::VarKindType expected_var_type,
+                                        Moose::VarFieldType expected_var_field_type)
+{
+  // Eventual return value
+  MooseVariableFE * var = nullptr;
+
+  // First check that the variable is found on the expected system.
+  if (expected_var_type == Moose::VarKindType::VAR_ANY)
+    var = &(getVariable(tid, var_name));
+  else if (expected_var_type == Moose::VarKindType::VAR_NONLINEAR &&
+           _displaced_nl.hasVariable(var_name))
+    var = &(_displaced_nl.getVariable(tid, var_name));
+  else if (expected_var_type == Moose::VarKindType::VAR_AUXILIARY &&
+           _displaced_aux.hasVariable(var_name))
+    var = &(_displaced_aux.getVariable(tid, var_name));
+  else
+  {
+    std::string expected_var_type_string =
+        (expected_var_type == Moose::VarKindType::VAR_NONLINEAR ? "nonlinear" : "auxiliary");
+    mooseError("No ",
+               expected_var_type_string,
+               " variable named ",
+               var_name,
+               " found. "
+               "Did you specify an auxiliary variable when you meant to specify a nonlinear "
+               "variable (or vice-versa)?");
+  }
+
+  // Now make sure the var found has the expected field type.
+  bool var_is_vector = var->isVector();
+  if ((var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_VECTOR) ||
+      (!var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD))
+    return *var;
+  else
+  {
+    std::string expected_var_field_type_string =
+        (expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD ? "standard"
+                                                                            : "vector");
+    ;
+    mooseError("No ",
+               expected_var_field_type_string,
+               " variable named ",
+               var_name,
+               " found. "
+               "Did you specify a vector variable when you meant to specify a standard variable "
+               "(or vice-versa)?");
+  }
+}
+
 MooseVariable &
 DisplacedProblem::getStandardVariable(THREAD_ID tid, const std::string & var_name)
 {

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3434,14 +3434,14 @@ FEProblemBase::hasVariable(const std::string & var_name) const
     return false;
 }
 
-MooseVariableFE &
+MooseVariableFEBase &
 FEProblemBase::getVariable(THREAD_ID tid,
                            const std::string & var_name,
                            Moose::VarKindType expected_var_type,
                            Moose::VarFieldType expected_var_field_type)
 {
   // Eventual return value
-  MooseVariableFE * var = nullptr;
+  MooseVariableFEBase * var = nullptr;
 
   // First check that the variable is found on the expected system.
   if (expected_var_type == Moose::VarKindType::VAR_ANY)

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3440,56 +3440,12 @@ FEProblemBase::getVariable(THREAD_ID tid,
                            Moose::VarKindType expected_var_type,
                            Moose::VarFieldType expected_var_field_type)
 {
-  // Eventual return value
-  MooseVariableFEBase * var = nullptr;
-
-  // First check that the variable is found on the expected system.
-  if (expected_var_type == Moose::VarKindType::VAR_ANY)
-  {
-    if (_nl->hasVariable(var_name))
-      var = &(_nl->getVariable(tid, var_name));
-    else if (_aux->hasVariable(var_name))
-      var = &(_aux->getVariable(tid, var_name));
-    else
-      mooseError("Unknown variable " + var_name);
-  }
-  else if (expected_var_type == Moose::VarKindType::VAR_NONLINEAR && _nl->hasVariable(var_name))
-    var = &(_nl->getVariable(tid, var_name));
-  else if (expected_var_type == Moose::VarKindType::VAR_AUXILIARY && _aux->hasVariable(var_name))
-    var = &(_aux->getVariable(tid, var_name));
-  else
-  {
-    std::string expected_var_type_string =
-        (expected_var_type == Moose::VarKindType::VAR_NONLINEAR ? "nonlinear" : "auxiliary");
-    mooseError("No ",
-               expected_var_type_string,
-               " variable named ",
-               var_name,
-               " found. "
-               "Did you specify an auxiliary variable when you meant to specify a nonlinear "
-               "variable (or vice-versa)?");
-  }
-
-  // Now make sure the var found has the expected field type.
-  bool var_is_vector = var->isVector();
-  if ((expected_var_field_type == Moose::VarFieldType::VAR_FIELD_ANY) ||
-      (var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_VECTOR) ||
-      (!var_is_vector && expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD))
-    return *var;
-  else
-  {
-    std::string expected_var_field_type_string =
-        (expected_var_field_type == Moose::VarFieldType::VAR_FIELD_STANDARD ? "standard"
-                                                                            : "vector");
-
-    mooseError("No ",
-               expected_var_field_type_string,
-               " variable named ",
-               var_name,
-               " found. "
-               "Did you specify a vector variable when you meant to specify a standard variable "
-               "(or vice-versa)?");
-  }
+  return getVariableHelper(tid,
+                           var_name,
+                           expected_var_type,
+                           expected_var_field_type,
+                           *_nl,
+                           *_aux);
 }
 
 MooseVariable &

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3440,12 +3440,7 @@ FEProblemBase::getVariable(THREAD_ID tid,
                            Moose::VarKindType expected_var_type,
                            Moose::VarFieldType expected_var_field_type)
 {
-  return getVariableHelper(tid,
-                           var_name,
-                           expected_var_type,
-                           expected_var_field_type,
-                           *_nl,
-                           *_aux);
+  return getVariableHelper(tid, var_name, expected_var_type, expected_var_field_type, *_nl, *_aux);
 }
 
 MooseVariable &

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1743,10 +1743,10 @@ FEProblemBase::addKernel(const std::string & kernel_name,
 
   // Check that "variable" is in the NonlinearSystem.
   if (!_nl->hasVariable(parameters.get<NonlinearVariableName>("variable")))
-    mooseError(name,
-               ": Cannot add Kernel for variable ",
-               parameters.get<NonlinearVariableName>("variable"),
-               ", it is not a nonlinear variable!");
+    mooseError(
+        "Error adding Kernel ",
+        name,
+        ", \"variable\" parameter either missing or does not specify a valid nonlinear variable!");
 
   _nl->addKernel(kernel_name, name, parameters);
 }

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -73,10 +73,12 @@ void
 MultiAppCopyTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_problem)
 {
   // Populate the to/from variables needed to perform the transfer
-  MooseVariableFEBase & to_var = to_problem.getVariable(0, _to_var_name);
+  MooseVariableFEBase & to_var = to_problem.getVariable(
+      0, _to_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
   MeshBase & to_mesh = to_problem.mesh().getMesh();
 
-  MooseVariableFEBase & from_var = from_problem.getVariable(0, _from_var_name);
+  MooseVariableFEBase & from_var = from_problem.getVariable(
+      0, _from_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
   MeshBase & from_mesh = from_problem.mesh().getMesh();
 
   // Check integrity

--- a/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppDTKUserObjectTransfer.C
@@ -38,7 +38,11 @@ validParams<MultiAppDTKUserObjectTransfer>()
 
 MultiAppDTKUserObjectTransfer::MultiAppDTKUserObjectTransfer(const InputParameters & parameters)
   : MultiAppTransfer(parameters),
-    MooseVariableInterface<Real>(this, true),
+    MooseVariableInterface<Real>(this,
+                                 true,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _user_object_name(getParam<UserObjectName>("user_object")),
     _setup(false)
 {

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -83,7 +83,8 @@ MultiAppInterpolationTransfer::execute()
     case TO_MULTIAPP:
     {
       FEProblemBase & from_problem = _multi_app->problemBase();
-      MooseVariableFEBase & from_var = from_problem.getVariable(0, _from_var_name);
+      MooseVariableFEBase & from_var = from_problem.getVariable(
+          0, _from_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
 
       MeshBase * from_mesh = NULL;
 
@@ -259,7 +260,8 @@ MultiAppInterpolationTransfer::execute()
     case FROM_MULTIAPP:
     {
       FEProblemBase & to_problem = _multi_app->problemBase();
-      MooseVariableFEBase & to_var = to_problem.getVariable(0, _to_var_name);
+      MooseVariableFEBase & to_var = to_problem.getVariable(
+          0, _to_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
       SystemBase & to_system_base = to_var.sys();
 
       System & to_sys = to_system_base.system();
@@ -317,7 +319,11 @@ MultiAppInterpolationTransfer::execute()
         Moose::ScopedCommSwapper swapper(_multi_app->comm());
 
         FEProblemBase & from_problem = _multi_app->appProblemBase(i);
-        MooseVariableFEBase & from_var = from_problem.getVariable(0, _from_var_name);
+        MooseVariableFEBase & from_var =
+            from_problem.getVariable(0,
+                                     _from_var_name,
+                                     Moose::VarKindType::VAR_ANY,
+                                     Moose::VarFieldType::VAR_FIELD_STANDARD);
         SystemBase & from_system_base = from_var.sys();
 
         System & from_sys = from_system_base.system();

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -226,7 +226,8 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
   for (unsigned int i_from = 0; i_from < _from_problems.size(); ++i_from)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];
-    MooseVariableFEBase & from_var = from_problem.getVariable(0, _from_var_name[i]);
+    MooseVariableFEBase & from_var = from_problem.getVariable(
+        0, _from_var_name[i], Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -292,7 +292,10 @@ MultiAppNearestNodeTransfer::execute()
              i_local_from++)
         {
           MooseVariableFEBase & from_var =
-              _from_problems[i_local_from]->getVariable(0, _from_var_name);
+              _from_problems[i_local_from]->getVariable(0,
+                                                        _from_var_name,
+                                                        Moose::VarKindType::VAR_ANY,
+                                                        Moose::VarFieldType::VAR_FIELD_STANDARD);
           System & from_sys = from_var.sys().system();
           unsigned int from_sys_num = from_sys.number();
           unsigned int from_var_num = from_sys.variable_number(from_var.name());
@@ -340,8 +343,11 @@ MultiAppNearestNodeTransfer::execute()
 
       for (unsigned int qp = 0; qp < outgoing_evals.size(); qp++)
       {
-        MooseVariableFEBase & from_var =
-            _from_problems[_cached_froms[i_proc][qp]]->getVariable(0, _from_var_name);
+        MooseVariableFEBase & from_var = _from_problems[_cached_froms[i_proc][qp]]->getVariable(
+            0,
+            _from_var_name,
+            Moose::VarKindType::VAR_ANY,
+            Moose::VarFieldType::VAR_FIELD_STANDARD);
         System & from_sys = from_var.sys().system();
         dof_id_type from_dof = _cached_dof_ids[i_proc][qp];
         // outgoing_evals[qp] = (*from_sys.solution)(_cached_dof_ids[i_proc][qp]);

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -81,7 +81,12 @@ MultiAppProjectionTransfer::initialSetup()
     EquationSystems & to_es = to_problem.es();
 
     // Add the projection system.
-    FEType fe_type = to_problem.getVariable(0, _to_var_name).feType();
+    FEType fe_type = to_problem
+                         .getVariable(0,
+                                      _to_var_name,
+                                      Moose::VarKindType::VAR_ANY,
+                                      Moose::VarFieldType::VAR_FIELD_STANDARD)
+                         .feType();
     LinearImplicitSystem & proj_sys = to_es.add_system<LinearImplicitSystem>("proj-sys-" + name());
     _proj_var_num = proj_sys.add_variable("var", fe_type);
     proj_sys.attach_assemble_function(assemble_l2);
@@ -316,7 +321,8 @@ MultiAppProjectionTransfer::execute()
   for (unsigned int i_from = 0; i_from < _from_problems.size(); i_from++)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];
-    MooseVariableFEBase & from_var = from_problem.getVariable(0, _from_var_name);
+    MooseVariableFEBase & from_var = from_problem.getVariable(
+        0, _from_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
@@ -522,7 +528,8 @@ MultiAppProjectionTransfer::projectSolution(unsigned int i_to)
   // copy projected solution into target es
   MeshBase & to_mesh = proj_es.get_mesh();
 
-  MooseVariableFEBase & to_var = to_problem.getVariable(0, _to_var_name);
+  MooseVariableFEBase & to_var = to_problem.getVariable(
+      0, _to_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
   System & to_sys = to_var.sys().system();
   NumericVector<Number> * to_solution = to_sys.solution.get();
 

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -151,7 +151,8 @@ MultiAppUserObjectTransfer::execute()
     case FROM_MULTIAPP:
     {
       FEProblemBase & to_problem = _multi_app->problemBase();
-      MooseVariableFEBase & to_var = to_problem.getVariable(0, _to_var_name);
+      MooseVariableFEBase & to_var = to_problem.getVariable(
+          0, _to_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
       SystemBase & to_system_base = to_var.sys();
 
       System & to_sys = to_system_base.system();

--- a/framework/src/userobject/ElementIntegralVariableUserObject.C
+++ b/framework/src/userobject/ElementIntegralVariableUserObject.C
@@ -23,8 +23,11 @@ validParams<ElementIntegralVariableUserObject>()
 ElementIntegralVariableUserObject::ElementIntegralVariableUserObject(
     const InputParameters & parameters)
   : ElementIntegralUserObject(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/userobject/ElementIntegralVariableUserObject.C
+++ b/framework/src/userobject/ElementIntegralVariableUserObject.C
@@ -23,7 +23,8 @@ validParams<ElementIntegralVariableUserObject>()
 ElementIntegralVariableUserObject::ElementIntegralVariableUserObject(
     const InputParameters & parameters)
   : ElementIntegralUserObject(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/userobject/NodalNormalsCorner.C
+++ b/framework/src/userobject/NodalNormalsCorner.C
@@ -50,14 +50,38 @@ NodalNormalsCorner::execute()
   {
     const Node * node = _current_side_elem->node_ptr(nd);
     if (boundary_info.has_boundary_id(node, _corner_boundary_id) &&
-        node->n_dofs(_aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number()) > 0)
+        node->n_dofs(_aux.number(),
+                     _fe_problem
+                         .getVariable(_tid,
+                                      "nodal_normal_x",
+                                      Moose::VarKindType::VAR_AUXILIARY,
+                                      Moose::VarFieldType::VAR_FIELD_STANDARD)
+                         .number()) > 0)
     {
-      dof_id_type dof_x = node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number(), 0);
-      dof_id_type dof_y = node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_y").number(), 0);
-      dof_id_type dof_z = node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_z").number(), 0);
+      dof_id_type dof_x = node->dof_number(_aux.number(),
+                                           _fe_problem
+                                               .getVariable(_tid,
+                                                            "nodal_normal_x",
+                                                            Moose::VarKindType::VAR_AUXILIARY,
+                                                            Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                               .number(),
+                                           0);
+      dof_id_type dof_y = node->dof_number(_aux.number(),
+                                           _fe_problem
+                                               .getVariable(_tid,
+                                                            "nodal_normal_y",
+                                                            Moose::VarKindType::VAR_AUXILIARY,
+                                                            Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                               .number(),
+                                           0);
+      dof_id_type dof_z = node->dof_number(_aux.number(),
+                                           _fe_problem
+                                               .getVariable(_tid,
+                                                            "nodal_normal_z",
+                                                            Moose::VarKindType::VAR_AUXILIARY,
+                                                            Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                               .number(),
+                                           0);
 
       // substitute the normal form the face, we are going to have at least one normal every time
       sln.add(dof_x, _normals[0](0));

--- a/framework/src/userobject/NodalNormalsEvaluator.C
+++ b/framework/src/userobject/NodalNormalsEvaluator.C
@@ -39,16 +39,42 @@ NodalNormalsEvaluator::execute()
   if (_current_node->processor_id() == processor_id())
   {
     if (_current_node->n_dofs(_aux.number(),
-                              _fe_problem.getVariable(_tid, "nodal_normal_x").number()) > 0)
+                              _fe_problem
+                                  .getVariable(_tid,
+                                               "nodal_normal_x",
+                                               Moose::VarKindType::VAR_AUXILIARY,
+                                               Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                  .number()) > 0)
     {
       Threads::spin_mutex::scoped_lock lock(nodal_normals_evaluator_mutex);
 
-      dof_id_type dof_x = _current_node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number(), 0);
-      dof_id_type dof_y = _current_node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_y").number(), 0);
-      dof_id_type dof_z = _current_node->dof_number(
-          _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_z").number(), 0);
+      dof_id_type dof_x =
+          _current_node->dof_number(_aux.number(),
+                                    _fe_problem
+                                        .getVariable(_tid,
+                                                     "nodal_normal_x",
+                                                     Moose::VarKindType::VAR_AUXILIARY,
+                                                     Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                        .number(),
+                                    0);
+      dof_id_type dof_y =
+          _current_node->dof_number(_aux.number(),
+                                    _fe_problem
+                                        .getVariable(_tid,
+                                                     "nodal_normal_y",
+                                                     Moose::VarKindType::VAR_AUXILIARY,
+                                                     Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                        .number(),
+                                    0);
+      dof_id_type dof_z =
+          _current_node->dof_number(_aux.number(),
+                                    _fe_problem
+                                        .getVariable(_tid,
+                                                     "nodal_normal_z",
+                                                     Moose::VarKindType::VAR_AUXILIARY,
+                                                     Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                        .number(),
+                                    0);
 
       NumericVector<Number> & sln = _aux.solution();
       Real nx = sln(dof_x);

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -112,16 +112,42 @@ NodalNormalsPreprocessor::execute()
           (!_has_corners || !boundary_info.has_boundary_id(node, _corner_boundary_id)))
       {
         // Perform the caluation of the normal
-        if (node->n_dofs(_aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number()) >
-            0)
+        if (node->n_dofs(_aux.number(),
+                         _fe_problem
+                             .getVariable(_tid,
+                                          "nodal_normal_x",
+                                          Moose::VarKindType::VAR_AUXILIARY,
+                                          Moose::VarFieldType::VAR_FIELD_STANDARD)
+                             .number()) > 0)
         {
           // but it is not a corner node, they will be treated differently later on
-          dof_id_type dof_x = node->dof_number(
-              _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_x").number(), 0);
-          dof_id_type dof_y = node->dof_number(
-              _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_y").number(), 0);
-          dof_id_type dof_z = node->dof_number(
-              _aux.number(), _fe_problem.getVariable(_tid, "nodal_normal_z").number(), 0);
+          dof_id_type dof_x =
+              node->dof_number(_aux.number(),
+                               _fe_problem
+                                   .getVariable(_tid,
+                                                "nodal_normal_x",
+                                                Moose::VarKindType::VAR_AUXILIARY,
+                                                Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                   .number(),
+                               0);
+          dof_id_type dof_y =
+              node->dof_number(_aux.number(),
+                               _fe_problem
+                                   .getVariable(_tid,
+                                                "nodal_normal_y",
+                                                Moose::VarKindType::VAR_AUXILIARY,
+                                                Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                   .number(),
+                               0);
+          dof_id_type dof_z =
+              node->dof_number(_aux.number(),
+                               _fe_problem
+                                   .getVariable(_tid,
+                                                "nodal_normal_z",
+                                                Moose::VarKindType::VAR_AUXILIARY,
+                                                Moose::VarFieldType::VAR_FIELD_STANDARD)
+                                   .number(),
+                               0);
 
           for (unsigned int qp = 0; qp < _qrule->n_points(); qp++)
           {

--- a/framework/src/userobject/SideIntegralVariableUserObject.C
+++ b/framework/src/userobject/SideIntegralVariableUserObject.C
@@ -21,8 +21,11 @@ validParams<SideIntegralVariableUserObject>()
 
 SideIntegralVariableUserObject::SideIntegralVariableUserObject(const InputParameters & parameters)
   : SideIntegralUserObject(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/userobject/SideIntegralVariableUserObject.C
+++ b/framework/src/userobject/SideIntegralVariableUserObject.C
@@ -21,7 +21,8 @@ validParams<SideIntegralVariableUserObject>()
 
 SideIntegralVariableUserObject::SideIntegralVariableUserObject(const InputParameters & parameters)
   : SideIntegralUserObject(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable"))
 {

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -627,10 +627,15 @@ SolutionUserObject::pointValueWrapper(Real t,
   // first check if the FE type is continuous because in that case the value is
   // unique and we can take a short cut, the default weighting_type found_first also
   // shortcuts out
+  auto family =
+      _fe_problem
+          .getVariable(
+              _tid, var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD)
+          .feType()
+          .family;
+
   if (weighting_type == 1 ||
-      (_fe_problem.getVariable(_tid, var_name).feType().family != L2_LAGRANGE &&
-       _fe_problem.getVariable(_tid, var_name).feType().family != MONOMIAL &&
-       _fe_problem.getVariable(_tid, var_name).feType().family != L2_HIERARCHIC))
+      (family != L2_LAGRANGE && family != MONOMIAL && family != L2_HIERARCHIC))
     return pointValue(t, p, var_name);
 
   // the shape function is discontinuous so we need to compute a suitable unique value

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -56,3 +56,9 @@ MooseVariableBase::order() const
 {
   return _fe_type.order;
 }
+
+bool
+MooseVariableBase::isVector() const
+{
+  return (_fe_type.family == LAGRANGE_VEC || _fe_type.family == NEDELEC_ONE);
+}

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -56,9 +56,3 @@ MooseVariableBase::order() const
 {
   return _fe_type.order;
 }
-
-bool
-MooseVariableBase::isVector() const
-{
-  return (_fe_type.family == LAGRANGE_VEC || _fe_type.family == NEDELEC_ONE);
-}

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -1512,5 +1512,12 @@ MooseVariableFE<OutputType>::computeNodalNeighborValues()
   }
 }
 
+template <typename OutputType>
+bool
+MooseVariableFE<OutputType>::isVector() const
+{
+  return std::is_same<OutputType, RealVectorValue>::value;
+}
+
 template class MooseVariableFE<Real>;
 template class MooseVariableFE<RealVectorValue>;

--- a/framework/src/variables/MooseVariableInterface.C
+++ b/framework/src/variables/MooseVariableInterface.C
@@ -41,7 +41,13 @@ MooseVariableInterface<T>::MooseVariableInterface(const MooseObject * moose_obje
     // in their input file. This could happen if e.g. something goes
     // wrong with dollar bracket expression expansion.
     if (vec.empty())
-      mooseError("Error constructing object '", moose_object->name(), "' while retrieving value for '", var_param_name, "' parameter! Did you set ", var_param_name, " = '' (empty string) by accident?");
+      mooseError("Error constructing object '",
+                 moose_object->name(),
+                 "' while retrieving value for '",
+                 var_param_name,
+                 "' parameter! Did you set ",
+                 var_param_name,
+                 " = '' (empty string) by accident?");
 
     // When using vector variables, we are only going to use the first one in the list at the
     // interface level...

--- a/framework/src/variables/MooseVariableInterface.C
+++ b/framework/src/variables/MooseVariableInterface.C
@@ -36,11 +36,12 @@ MooseVariableInterface<T>::MooseVariableInterface(const MooseObject * moose_obje
   {
     auto vec = parameters.getVecMooseType(var_param_name);
 
-    // Catch the (unlikely) case where a user specifies variable = ''
+    // Catch the (very unlikely) case where a user specifies
+    // variable = '' (the empty string)
     // in their input file. This could happen if e.g. something goes
     // wrong with dollar bracket expression expansion.
     if (vec.empty())
-      mooseError("Error retrieving variable name! Did you set variable = '' by accident?");
+      mooseError("Error constructing object '", moose_object->name(), "' while retrieving value for '", var_param_name, "' parameter! Did you set ", var_param_name, " = '' (empty string) by accident?");
 
     // When using vector variables, we are only going to use the first one in the list at the
     // interface level...

--- a/framework/src/variables/MooseVariableInterface.C
+++ b/framework/src/variables/MooseVariableInterface.C
@@ -22,9 +22,7 @@ MooseVariableInterface<T>::MooseVariableInterface(const MooseObject * moose_obje
                                                   Moose::VarKindType expected_var_type,
                                                   Moose::VarFieldType expected_var_field_type,
                                                   std::string var_param_name)
-  : _nodal(nodal),
-    _expected_var_type(expected_var_type),
-    _expected_var_field_type(expected_var_field_type)
+  : _nodal(nodal)
 {
   const InputParameters & parameters = moose_object->parameters();
 
@@ -49,8 +47,8 @@ MooseVariableInterface<T>::MooseVariableInterface(const MooseObject * moose_obje
     variable_name = vec[0];
   }
 
-  _variable = &dynamic_cast<MooseVariableFE<T> &>(problem.getVariableWithChecks(
-      tid, variable_name, expected_var_type, expected_var_field_type));
+  _variable = &dynamic_cast<MooseVariableFE<T> &>(
+      problem.getVariable(tid, variable_name, expected_var_type, expected_var_field_type));
 
   _mvi_assembly = &problem.assembly(tid);
 }

--- a/framework/src/variables/MooseVariableInterface.C
+++ b/framework/src/variables/MooseVariableInterface.C
@@ -19,9 +19,9 @@
 template <typename T>
 MooseVariableInterface<T>::MooseVariableInterface(const MooseObject * moose_object,
                                                   bool nodal,
+                                                  std::string var_param_name,
                                                   Moose::VarKindType expected_var_type,
-                                                  Moose::VarFieldType expected_var_field_type,
-                                                  std::string var_param_name)
+                                                  Moose::VarFieldType expected_var_field_type)
   : _nodal(nodal)
 {
   const InputParameters & parameters = moose_object->parameters();

--- a/framework/src/variables/MooseVariableScalar.C
+++ b/framework/src/variables/MooseVariableScalar.C
@@ -115,6 +115,12 @@ MooseVariableScalar::isNodal() const
   return false;
 }
 
+bool
+MooseVariableScalar::isVector() const
+{
+  return false;
+}
+
 void
 MooseVariableScalar::setValue(unsigned int i, Number value)
 {

--- a/framework/src/variables/NeighborMooseVariableInterface.C
+++ b/framework/src/variables/NeighborMooseVariableInterface.C
@@ -17,9 +17,12 @@
 #include "SubProblem.h"
 
 template <typename T>
-NeighborMooseVariableInterface<T>::NeighborMooseVariableInterface(const MooseObject * moose_object,
-                                                                  bool nodal)
-  : MooseVariableInterface<T>(moose_object, nodal)
+NeighborMooseVariableInterface<T>::NeighborMooseVariableInterface(
+    const MooseObject * moose_object,
+    bool nodal,
+    Moose::VarKindType expected_var_type,
+    Moose::VarFieldType expected_var_field_type)
+  : MooseVariableInterface<T>(moose_object, nodal, expected_var_type, expected_var_field_type)
 {
 }
 

--- a/framework/src/variables/NeighborMooseVariableInterface.C
+++ b/framework/src/variables/NeighborMooseVariableInterface.C
@@ -22,7 +22,8 @@ NeighborMooseVariableInterface<T>::NeighborMooseVariableInterface(
     bool nodal,
     Moose::VarKindType expected_var_type,
     Moose::VarFieldType expected_var_field_type)
-  : MooseVariableInterface<T>(moose_object, nodal, expected_var_type, expected_var_field_type)
+  : MooseVariableInterface<T>(
+        moose_object, nodal, "variable", expected_var_type, expected_var_field_type)
 {
 }
 

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -32,7 +32,8 @@ validParams<PointSamplerBase>()
 PointSamplerBase::PointSamplerBase(const InputParameters & parameters)
   : GeneralVectorPostprocessor(parameters),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     SamplerBase(parameters, this, _communicator),
     _mesh(_subproblem.mesh())
 {

--- a/framework/src/vectorpostprocessors/PointSamplerBase.C
+++ b/framework/src/vectorpostprocessors/PointSamplerBase.C
@@ -32,8 +32,11 @@ validParams<PointSamplerBase>()
 PointSamplerBase::PointSamplerBase(const InputParameters & parameters)
   : GeneralVectorPostprocessor(parameters),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     SamplerBase(parameters, this, _communicator),
     _mesh(_subproblem.mesh())
 {

--- a/modules/phase_field/src/postprocessors/PFCElementEnergyIntegral.C
+++ b/modules/phase_field/src/postprocessors/PFCElementEnergyIntegral.C
@@ -27,8 +27,11 @@ validParams<PFCElementEnergyIntegral>()
 
 PFCElementEnergyIntegral::PFCElementEnergyIntegral(const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(
-        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(_subproblem.getStandardVariable(_tid, parameters.get<VariableName>("variable"))),
     _u(_var.sln()),
     _grad_u(_var.gradSln()),

--- a/modules/phase_field/src/postprocessors/PFCElementEnergyIntegral.C
+++ b/modules/phase_field/src/postprocessors/PFCElementEnergyIntegral.C
@@ -27,7 +27,8 @@ validParams<PFCElementEnergyIntegral>()
 
 PFCElementEnergyIntegral::PFCElementEnergyIntegral(const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(
+        this, false, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD),
     _var(_subproblem.getStandardVariable(_tid, parameters.get<VariableName>("variable"))),
     _u(_var.sln()),
     _grad_u(_var.gradSln()),

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -49,8 +49,14 @@ RichardsMultiphaseProblem::initialSetup()
 {
   // the first argument to getVariable is threadID - i hope the following always works
   unsigned int tid = 0;
-  MooseVariableFEBase & bounded = getVariable(tid, _bounded_var_name);
-  MooseVariableFEBase & lower = getVariable(tid, _lower_var_name);
+
+  // We are going to do more specific checks below, hence allowing
+  // more specific error messages to be printed in case something goes
+  // wrong. Therefore we just pass VAR_ANY here.
+  MooseVariableFEBase & bounded = getVariable(
+      tid, _bounded_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
+  MooseVariableFEBase & lower = getVariable(
+      tid, _lower_var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_STANDARD);
 
   // some checks
   if (!bounded.isNodal() || !lower.isNodal())

--- a/modules/tensor_mechanics/include/postprocessors/CrackFrontData.h
+++ b/modules/tensor_mechanics/include/postprocessors/CrackFrontData.h
@@ -43,6 +43,7 @@ protected:
   MooseMesh & _mesh;
   std::string _var_name;
   const Real _scale_factor;
+  MooseVariableFEBase & _field_var;
 };
 
 #endif // CRACKFRONTDATA_H

--- a/modules/tensor_mechanics/src/postprocessors/CrackFrontData.C
+++ b/modules/tensor_mechanics/src/postprocessors/CrackFrontData.C
@@ -43,9 +43,11 @@ CrackFrontData::CrackFrontData(const InputParameters & parameters)
     _crack_front_node(NULL),
     _mesh(_subproblem.mesh()),
     _var_name(parameters.get<VariableName>("variable")),
-    _scale_factor(getParam<Real>("scale_factor"))
+    _scale_factor(getParam<Real>("scale_factor")),
+    _field_var(_subproblem.getVariable(
+        _tid, _var_name, Moose::VarKindType::VAR_ANY, Moose::VarFieldType::VAR_FIELD_ANY))
 {
-  if (!_subproblem.getVariable(_tid, _var_name).isNodal())
+  if (!_field_var.isNodal())
     mooseError("CrackFrontData can be output only for nodal variables, variable '",
                _var_name,
                "' is not nodal");
@@ -69,7 +71,7 @@ CrackFrontData::getValue()
   Real value = 0;
 
   if (_crack_front_node->processor_id() == processor_id())
-    value = _subproblem.getVariable(_tid, _var_name).getNodalValue(*_crack_front_node);
+    value = _field_var.getNodalValue(*_crack_front_node);
 
   gatherSum(value);
 

--- a/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -1346,20 +1346,34 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
   for (unsigned int i = 0; i < num_crack_front_nodes; ++i)
     _strain_along_front[i] = -std::numeric_limits<Real>::max();
 
+  MooseVariableFEBase & disp_x_var =
+      _subproblem.getVariable(_tid,
+                              _disp_x_var_name,
+                              Moose::VarKindType::VAR_NONLINEAR,
+                              Moose::VarFieldType::VAR_FIELD_STANDARD);
+  MooseVariableFEBase & disp_y_var =
+      _subproblem.getVariable(_tid,
+                              _disp_y_var_name,
+                              Moose::VarKindType::VAR_NONLINEAR,
+                              Moose::VarFieldType::VAR_FIELD_STANDARD);
+
+  MooseVariableFEBase & disp_z_var =
+      _subproblem.getVariable(_tid,
+                              _disp_z_var_name,
+                              Moose::VarKindType::VAR_NONLINEAR,
+                              Moose::VarFieldType::VAR_FIELD_STANDARD);
+
   current_node = getCrackFrontNodePtr(0);
   if (current_node->processor_id() == processor_id())
   {
-    disp_current_node(0) =
-        _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*current_node);
-    disp_current_node(1) =
-        _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*current_node);
-    disp_current_node(2) =
-        _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*current_node);
+    disp_current_node(0) = disp_x_var.getNodalValue(*current_node);
+    disp_current_node(1) = disp_y_var.getNodalValue(*current_node);
+    disp_current_node(2) = disp_z_var.getNodalValue(*current_node);
 
     next_node = getCrackFrontNodePtr(1);
-    disp_next_node(0) = _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*next_node);
-    disp_next_node(1) = _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*next_node);
-    disp_next_node(2) = _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*next_node);
+    disp_next_node(0) = disp_x_var.getNodalValue(*next_node);
+    disp_next_node(1) = disp_y_var.getNodalValue(*next_node);
+    disp_next_node(2) = disp_z_var.getNodalValue(*next_node);
 
     forward_segment0 = *next_node - *current_node;
     forward_segment0 = (forward_segment0 * _tangent_directions[0]) * _tangent_directions[0];
@@ -1377,25 +1391,19 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
     current_node = getCrackFrontNodePtr(i);
     if (current_node->processor_id() == processor_id())
     {
-      disp_current_node(0) =
-          _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*current_node);
-      disp_current_node(1) =
-          _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*current_node);
-      disp_current_node(2) =
-          _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*current_node);
+      disp_current_node(0) = disp_x_var.getNodalValue(*current_node);
+      disp_current_node(1) = disp_y_var.getNodalValue(*current_node);
+      disp_current_node(2) = disp_z_var.getNodalValue(*current_node);
 
       previous_node = getCrackFrontNodePtr(i - 1);
-      disp_previous_node(0) =
-          _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*previous_node);
-      disp_previous_node(1) =
-          _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*previous_node);
-      disp_previous_node(2) =
-          _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*previous_node);
+      disp_previous_node(0) = disp_x_var.getNodalValue(*previous_node);
+      disp_previous_node(1) = disp_y_var.getNodalValue(*previous_node);
+      disp_previous_node(2) = disp_z_var.getNodalValue(*previous_node);
 
       next_node = getCrackFrontNodePtr(i + 1);
-      disp_next_node(0) = _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*next_node);
-      disp_next_node(1) = _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*next_node);
-      disp_next_node(2) = _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*next_node);
+      disp_next_node(0) = disp_x_var.getNodalValue(*next_node);
+      disp_next_node(1) = disp_y_var.getNodalValue(*next_node);
+      disp_next_node(2) = disp_z_var.getNodalValue(*next_node);
 
       back_segment0 = *current_node - *previous_node;
       back_segment0 = (back_segment0 * _tangent_directions[i]) * _tangent_directions[i];
@@ -1422,20 +1430,14 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
   current_node = getCrackFrontNodePtr(num_crack_front_nodes - 1);
   if (current_node->processor_id() == processor_id())
   {
-    disp_current_node(0) =
-        _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*current_node);
-    disp_current_node(1) =
-        _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*current_node);
-    disp_current_node(2) =
-        _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*current_node);
+    disp_current_node(0) = disp_x_var.getNodalValue(*current_node);
+    disp_current_node(1) = disp_y_var.getNodalValue(*current_node);
+    disp_current_node(2) = disp_z_var.getNodalValue(*current_node);
 
     previous_node = getCrackFrontNodePtr(num_crack_front_nodes - 2);
-    disp_previous_node(0) =
-        _subproblem.getVariable(_tid, _disp_x_var_name).getNodalValue(*previous_node);
-    disp_previous_node(1) =
-        _subproblem.getVariable(_tid, _disp_y_var_name).getNodalValue(*previous_node);
-    disp_previous_node(2) =
-        _subproblem.getVariable(_tid, _disp_z_var_name).getNodalValue(*previous_node);
+    disp_previous_node(0) = disp_x_var.getNodalValue(*previous_node);
+    disp_previous_node(1) = disp_y_var.getNodalValue(*previous_node);
+    disp_previous_node(2) = disp_z_var.getNodalValue(*previous_node);
 
     back_segment0 = *current_node - *previous_node;
     back_segment0 = (back_segment0 * _tangent_directions[num_crack_front_nodes - 1]) *

--- a/modules/xfem/src/materials/LevelSetBiMaterialBase.C
+++ b/modules/xfem/src/materials/LevelSetBiMaterialBase.C
@@ -30,8 +30,12 @@ validParams<LevelSetBiMaterialBase>()
 LevelSetBiMaterialBase::LevelSetBiMaterialBase(const InputParameters & parameters)
   : Material(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
-    _level_set_var_number(
-        _subproblem.getVariable(_tid, parameters.get<VariableName>("level_set_var")).number()),
+    _level_set_var_number(_subproblem
+                              .getVariable(_tid,
+                                           parameters.get<VariableName>("level_set_var"),
+                                           Moose::VarKindType::VAR_ANY,
+                                           Moose::VarFieldType::VAR_FIELD_STANDARD)
+                              .number()),
     _system(_subproblem.getSystem(getParam<VariableName>("level_set_var"))),
     _solution(_system.current_local_solution.get()),
     _use_positive_property(false)

--- a/modules/xfem/src/userobjects/LevelSetCutUserObject.C
+++ b/modules/xfem/src/userobjects/LevelSetCutUserObject.C
@@ -22,8 +22,12 @@ validParams<LevelSetCutUserObject>()
 
 LevelSetCutUserObject::LevelSetCutUserObject(const InputParameters & parameters)
   : GeometricCutUserObject(parameters),
-    _level_set_var_number(
-        _subproblem.getVariable(_tid, parameters.get<VariableName>("level_set_var")).number()),
+    _level_set_var_number(_subproblem
+                              .getVariable(_tid,
+                                           parameters.get<VariableName>("level_set_var"),
+                                           Moose::VarKindType::VAR_ANY,
+                                           Moose::VarFieldType::VAR_FIELD_STANDARD)
+                              .number()),
     _system(_subproblem.getSystem(getParam<VariableName>("level_set_var"))),
     _solution(_system.current_local_solution.get())
 {

--- a/test/tests/misc/check_error/kernel_with_empty_var.i
+++ b/test/tests/misc/check_error/kernel_with_empty_var.i
@@ -12,11 +12,6 @@
   [../]
 []
 
-[AuxVariables]
-  [./v]
-  [../]
-[]
-
 [Kernels]
   [./diff]
     type = Diffusion
@@ -24,18 +19,7 @@
   [../]
   [./rea]
     type = Reaction
-    variable = u
-  [../]
-[]
-
-[InterfaceKernels]
-  [./nope]
-    type = InterfaceDiffusion
-    variable = v
-    neighbor_var = u
-    boundary = 'left'
-    D = 4
-    D_neighbor = 2
+    variable = ''
   [../]
 []
 

--- a/test/tests/misc/check_error/kernel_with_vector_var.i
+++ b/test/tests/misc/check_error/kernel_with_vector_var.i
@@ -8,12 +8,7 @@
 [Variables]
   [./u]
     order = FIRST
-    family = LAGRANGE
-  [../]
-[]
-
-[AuxVariables]
-  [./v]
+    family = LAGRANGE_VEC
   [../]
 []
 
@@ -21,21 +16,6 @@
   [./diff]
     type = Diffusion
     variable = u
-  [../]
-  [./rea]
-    type = Reaction
-    variable = u
-  [../]
-[]
-
-[InterfaceKernels]
-  [./nope]
-    type = InterfaceDiffusion
-    variable = v
-    neighbor_var = u
-    boundary = 'left'
-    D = 4
-    D_neighbor = 2
   [../]
 []
 

--- a/test/tests/misc/check_error/missing_var_in_kernel_test.i
+++ b/test/tests/misc/check_error/missing_var_in_kernel_test.i
@@ -1,0 +1,43 @@
+[Mesh]
+  file = square.e
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  # Test error message for missing variable param.
+  [./diff]
+    type = Diffusion
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/misc/check_error/scalar_kernel_with_var.i
+++ b/test/tests/misc/check_error/scalar_kernel_with_var.i
@@ -52,7 +52,7 @@
 []
 
 [Executioner]
-  type = Steady
+  type = Transient
   solve_type = 'NEWTON'
 []
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -39,7 +39,7 @@
   [./bad_bc_var_test]
     type = 'RunException'
     input = 'bad_bc_var_test.i'
-    expect_err = "Cannot add BoundaryCondition for variable foo, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named foo found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
 
   [./bad_enum_test]
@@ -63,7 +63,7 @@
   [./bad_kernel_var_test]
     type = 'RunException'
     input = 'bad_kernel_var_test.i'
-    expect_err = "Error adding Kernel diff, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
+    expect_err = "Unknown variable foo"
   [../]
 
   [./Badd_material_test]
@@ -351,7 +351,7 @@
   [./missing_var_in_kernel_test]
     type = 'RunException'
     input = 'missing_var_in_kernel_test.i'
-    expect_err = "Error adding Kernel diff, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
+    expect_err = "missing required parameter 'Kernels/diff/variable'"
   [../]
 
   [./missing_required_coupled_test]
@@ -628,27 +628,27 @@
   [./kernel_with_aux_var]
     type = 'RunException'
     input = 'kernel_with_aux_var.i'
-    expect_err = "Error adding Kernel rea, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
   [./bc_with_aux_var]
     type = 'RunException'
     input = 'bc_with_aux_var.i'
-    expect_err = "Cannot add BoundaryCondition for variable v, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
   [./aux_kernel_with_var]
     type = 'RunException'
     input = 'aux_kernel_with_var.i'
-    expect_err = "Cannot add AuxKernel for variable u, it is not an auxiliary variable"
+    expect_err = "Variable 'u' does not exist in this system"
   [../]
   [./scalar_kernel_with_var]
     type = 'RunException'
     input = 'scalar_kernel_with_var.i'
-    expect_err = "Cannot add ScalarKernel for variable u, it is not a SCALAR variable"
+    expect_err = "Scalar variable 'u' does not exist in this system"
   [../]
   [./nodal_kernel_with_aux_var]
     type = 'RunException'
     input = 'nodal_kernel_with_aux_var.i'
-    expect_err = "Cannot add NodalKernel for variable v, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
   [./constraint_with_aux_var]
     type = 'RunException'
@@ -658,21 +658,36 @@
   [./scalar_aux_kernel_with_var]
     type = 'RunException'
     input = 'scalar_aux_kernel_with_var.i'
-    expect_err = "Cannot add AuxScalarKernel for variable u, it is not a SCALAR auxiliary variable"
+    expect_err = "Scalar variable 'u' does not exist in this system"
   [../]
   [./dirac_kernel_with_aux_var]
     type = 'RunException'
     input = 'dirac_kernel_with_aux_var.i'
-    expect_err = "Cannot add DiracKernel for variable v, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
   [./dg_kernel_with_aux_var]
     type = 'RunException'
     input = 'dg_kernel_with_aux_var.i'
-    expect_err = "Cannot add DGKernel for variable v, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
   [../]
   [./interface_kernel_with_aux_var]
     type = 'RunException'
     input = 'interface_kernel_with_aux_var.i'
-    expect_err = "Cannot add InterfaceKernel for variable v, it is not a nonlinear variable"
+    expect_err = "No nonlinear variable named v found. Did you specify an auxiliary variable when you meant to specify a nonlinear variable"
+  [../]
+  [./kernel_with_empty_var]
+    type = 'RunException'
+    input = 'kernel_with_empty_var.i'
+    expect_err = 'Error retrieving variable name'
+  [../]
+  [./vector_kernel_with_standard_var]
+    type = 'RunException'
+    input = 'vector_kernel_with_standard_var.i'
+    expect_err = 'No vector variable named u found. Did you specify a vector variable when you meant to specify a standard variable'
+  [../]
+  [./kernel_with_vector_var]
+    type = 'RunException'
+    input = 'kernel_with_vector_var.i'
+    expect_err = 'No standard variable named u found. Did you specify a vector variable when you meant to specify a standard variable'
   [../]
 []

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -63,7 +63,7 @@
   [./bad_kernel_var_test]
     type = 'RunException'
     input = 'bad_kernel_var_test.i'
-    expect_err = "Cannot add Kernel for variable foo, it is not a nonlinear variable"
+    expect_err = "Error adding Kernel diff, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
   [../]
 
   [./Badd_material_test]
@@ -348,6 +348,12 @@
     expect_err = "missing required parameter 'Kernels/diff/type'"
   [../]
 
+  [./missing_var_in_kernel_test]
+    type = 'RunException'
+    input = 'missing_var_in_kernel_test.i'
+    expect_err = "Error adding Kernel diff, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
+  [../]
+
   [./missing_required_coupled_test]
     type = 'RunException'
     input = 'missing_required_coupled.i'
@@ -622,7 +628,7 @@
   [./kernel_with_aux_var]
     type = 'RunException'
     input = 'kernel_with_aux_var.i'
-    expect_err = "Cannot add Kernel for variable v, it is not a nonlinear variable"
+    expect_err = "Error adding Kernel rea, \"variable\" parameter either missing or does not specify a valid nonlinear variable"
   [../]
   [./bc_with_aux_var]
     type = 'RunException'

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -678,7 +678,7 @@
   [./kernel_with_empty_var]
     type = 'RunException'
     input = 'kernel_with_empty_var.i'
-    expect_err = 'Error retrieving variable name'
+    expect_err = 'Error constructing object \'rea\' while retrieving value for \'variable\' parameter! Did you set variable = \'\' \(empty string\) by accident'
   [../]
   [./vector_kernel_with_standard_var]
     type = 'RunException'

--- a/test/tests/misc/check_error/vector_kernel_with_standard_var.i
+++ b/test/tests/misc/check_error/vector_kernel_with_standard_var.i
@@ -12,30 +12,10 @@
   [../]
 []
 
-[AuxVariables]
-  [./v]
-  [../]
-[]
-
 [Kernels]
   [./diff]
-    type = Diffusion
+    type = VectorDiffusion
     variable = u
-  [../]
-  [./rea]
-    type = Reaction
-    variable = u
-  [../]
-[]
-
-[InterfaceKernels]
-  [./nope]
-    type = InterfaceDiffusion
-    variable = v
-    neighbor_var = u
-    boundary = 'left'
-    D = 4
-    D_neighbor = 2
   [../]
 []
 


### PR DESCRIPTION
Instead of trying to handle every possible case, e.g. forgetting to specify a variable, or setting `variable = ''`, or `variable = ' '`, we can just alert the user that the variable parameter is either missing or not a valid nonlinear variable.

Add new test which attempts to add a Kernel with no variable parameter. The error message is now:
```
*** ERROR ***
Error adding Kernel diff, "variable" parameter either missing or does not specify a valid nonlinear variable!
```
Also update the expect_err message for related check_error tests.

Refs #11192.


