### PR TITLE
Add Registry label information to JSON dump

### DIFF
--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -89,8 +89,13 @@ protected:
   moosecontrib::Json::Value &
   getJson(const std::string & parent, const std::string & path, bool is_type);
   moosecontrib::Json::Value & getJson(const std::string & path);
+  std::string getObjectLabel(const std::string & obj) const;
+  std::string getActionLabel(const std::string & action) const;
+
   moosecontrib::Json::Value _root;
   std::string _search;
+  std::map<std::string, std::string> _action_label_map;
+  std::map<std::string, std::string> _object_label_map;
 };
 
 #endif // JSONSYNTAXTREE_H

--- a/test/tests/outputs/format/test_json.py
+++ b/test/tests/outputs/format/test_json.py
@@ -108,11 +108,13 @@ class TestJSON(unittest.TestCase):
         self.assertIn("associated_types", f)
         self.assertEquals(["FunctionName"], f["associated_types"])
         self.assertEqual(f["subblock_types"]["ParsedFunction"]["class"], "MooseParsedFunction")
+        self.assertEqual(f["subblock_types"]["ParsedFunction"]["label"], "MooseApp")
 
         a = data["Adaptivity"]
         i = a["subblocks"]["Indicators"]["star"]["subblock_types"]["AnalyticalIndicator"]
         self.assertIn("all", i["parameters"]["outputs"]["reserved_values"])
         self.assertIn("none", i["parameters"]["outputs"]["reserved_values"])
+
 
     def testJson(self):
         """
@@ -125,6 +127,7 @@ class TestJSON(unittest.TestCase):
         self.check_basic_json(data)
         # Make sure the default dump has test objects
         self.assertIn("ApplyInputParametersTest", data)
+        self.assertEqual(data["Functions"]["star"]["subblock_types"]["PostprocessorFunction"]["label"], "MooseTestApp")
 
     def testNoTestObjects(self):
         # Make sure test objects are removed from the output


### PR DESCRIPTION
This just adds the "label" (ie "MooseApp" or "MooseTestApp") to each action/object in the JSON dump.

@aeslaughter It looks like the file information where an object/action is registered is working. Did you find a place where it isn't? 
The case where the C++ class name is different from the registered name is also handled, if the "class" key exists it specifies the class name, otherwise it is assumed to be the same.

refs #9408

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
