### PR TITLE
Add max_parallel to coefficient_time_derivative test

### DIFF
--- a/test/tests/kernels/coefficient_time_derivative/tests
+++ b/test/tests/kernels/coefficient_time_derivative/tests
@@ -3,5 +3,6 @@
     type = 'Exodiff'
     input = 'coefficient_time_derivative_diffusion.i'
     exodiff = 'coefficient_time_derivative_diffusion_out.e'
+    max_parallel = 10 # see #11232 #11236 #11231 #11230
   [../]
 []


### PR DESCRIPTION
This test was introduced in #11098 
I don't know if somebody wants to take a proper look at this and see if there is a better fix.
This just adds `max_parallel=10` to the test to prevent our various parallel sweeps from breaking.

closes #11230
closes #11231
closes #11232
closes #11236

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
