### PR TITLE
Fix outfile race during valgrind

### DIFF
--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -285,6 +285,8 @@ class Scheduler(MooseObject):
 
             for job_container in concurrent_jobs:
                 tester = job_container.getTester()
+                if not tester.getRunnable(self.options):
+                    continue
                 output_files = tester.getOutputFiles()
 
                 # check if we have colliding output files

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -532,7 +532,7 @@ class Tester(MooseObject):
                 tmp_reason = 'Valgrind==NONE'
             elif self.specs['valgrind'].upper() == 'HEAVY' and options.valgrind_mode.upper() == 'NORMAL':
                 tmp_reason = 'Valgrind==HEAVY'
-            elif self.specs['min_parallel'] > 1 or self.specs['min_threads'] > 1:
+            elif int(self.specs['min_parallel']) > 1 or int(self.specs['min_threads']) > 1:
                 tmp_reason = 'Valgrind requires serial'
             if tmp_reason != '':
                 reasons['valgrind'] = tmp_reason


### PR DESCRIPTION
This was uncovered when #11187 got merged.
Previously the `min_parallel` check for valgrind was broken because it was comparing a string vs an int when `min_parallel` was specified in the test spec file. #11187 caused it to be a proper int vs int comparison. This then caused the right conditions to show the outfile race condition.

I also enforce `min_parallel` and `min_threads` to an int so that the syntax `min_parallel = '1'` works.
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
