### PR TITLE
Multiline equation fixes in the phase field documentation

### DIFF
--- a/modules/phase_field/doc/content/documentation/modules/phase_field/MultiPhase/KKSDerivations.md
+++ b/modules/phase_field/doc/content/documentation/modules/phase_field/MultiPhase/KKSDerivations.md
@@ -57,19 +57,19 @@ with the $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a}=\phi_j 
 derivative.
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \frac{\partial R}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
 &=& \phi_j  \frac{\partial^2F}{\partial c_a^2} \\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 For $\mu$
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
 &=& -\phi_j \\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 ## KKSCHBulk
@@ -160,11 +160,11 @@ v
 Let's get back to the original residual with $\frac{dF}{dc}$. Then
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}\\
 &=& \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from KKS}\\
 &=& \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 # Allen-Cahn  Kernels
@@ -172,7 +172,7 @@ J &=& \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}\\
 For the bulk Allen-Cahn residual we need to calculate the term
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 R=\frac{dF}{d\eta}&=&\frac{d}{d\eta}\left([1-h(\eta)]F_a + h(\eta)F_b+wg(\eta) \right)\\
 &=& \frac{dF_a}{d\eta}+\frac{d}{d\eta}\left(h(\eta)F_b-h(\eta)F_a + wg(\eta)\right)\\
 &=& \frac{dF_a}{d\eta}+F_b\frac{dh}{d\eta}-F_a\frac{dh}{d\eta}+h(\eta)\frac{dF_b}{d\eta}-h(\eta)\frac{dF_a}{d\eta} +w\frac{dg}{d\eta}\\
@@ -180,7 +180,7 @@ R=\frac{dF}{d\eta}&=&\frac{d}{d\eta}\left([1-h(\eta)]F_a + h(\eta)F_b+wg(\eta) \
 &=& \frac{dh}{d\eta}(F_b-F_a) + \underbrace{[1-h(\eta)]\frac{dF_a}{d\eta} + h(\eta)\frac{dF_b}{d\eta}}_{\text{chain rule term}} +w\frac{dg}{d\eta}\\
 &=& \frac{dh}{d\eta}(F_b-F_a) + [1-h(\eta)]\frac{dF_a}{dc_a}\frac{dc_a}{d\eta} + h(\eta)\frac{dF_b}{dc_b}\frac{dc_b}{d\eta} +w\frac{dg}{d\eta}\\
 &=& \frac{dh}{d\eta}(F_b-F_a) + \frac{dF_a}{dc_a}\left([1-h(\eta)]\frac{dc_a}{d\eta} + h(\eta)\frac{dc_b}{d\eta}\right) +w\frac{dg}{d\eta}
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 The _chain rule term_ results from the fact that $c_a$ and $c_b$ are dependent
@@ -188,18 +188,18 @@ on $\eta$ (see eqs. (25) and (26) in KKS). Setting
 $\lambda = [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2}$ we get
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 \frac{dc_a}{d\eta} &=& \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_b}{dc_b^2}\\
 \frac{dc_b}{d\eta} &=& \frac1\lambda \frac{dh}{d\eta}(c_a-c_b)\frac{d^2F_a}{dc_a^2}.
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 Substituting this in we get
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 R &=& \frac{dh}{d\eta}(F_b-F_a) + \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)\frac1\lambda\underbrace{\left([1-h(\eta)] \frac{d^2F_b}{dc_b^2} + h(\eta)\frac{d^2F_a}{dc_a^2}\right)}_{=\lambda} +w\frac{dg}{d\eta}.
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 This simplifies to
@@ -231,10 +231,10 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta}=\phi_
 derivative.
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta} \\
 &=&-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j \\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 (The implicit dependence of $F_a(c_a)$ and $F_b(c_a)$ on $\eta$ through $c_a(c,\eta)$
@@ -273,10 +273,10 @@ An instance of this kernel is needed for each compnent of the problem.
 ### Residual
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 R&=&-\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)\\
 &=&\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 ### Jacobian
@@ -289,10 +289,10 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta} = \ph
 derivative.
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 #### Off-diagonal
@@ -305,27 +305,27 @@ $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a} = \phi_j \frac{\
 derivative.
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 Similarly for $c_b$,
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 For any variable other than $c_a$ or $c_b$, for example temperature $T$:
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 

--- a/modules/phase_field/doc/content/documentation/modules/phase_field/Phase_Field_Equations.md
+++ b/modules/phase_field/doc/content/documentation/modules/phase_field/Phase_Field_Equations.md
@@ -30,8 +30,8 @@ where $c_i$ is a conserved variable and $M_i$ is the associated mobility.  The e
 nonconserved order parameters is represented with an Allen-Cahn equation, according to
 
 \begin{equation}
-\frac{\partial \eta_j}{\partial t} = - L_j \frac{\delta F}{\delta \eta_j}, \label{eq:AC}
-\end{equation}
+\frac{\partial \eta_j}{\partial t} = - L_j \frac{\delta F}{\delta \eta_j},
+\end{equation}, <!-- %\label{eq:AC} -->
 
 where $\eta_j$ is an order parameter and $L_j$ is the order parameter mobility.
 
@@ -55,7 +55,7 @@ combining the equations listed above and evaluating the functional derivatives
 ([further explanations](Derivationexplanations)), the evolution of the variables is described as
 
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
   \frac{\partial c_i}{\partial t} = &
     \nabla \cdot M_i \nabla \left(
         \frac{\partial f_{loc}}{\partial c_i}
@@ -92,7 +92,7 @@ combining the equations listed above and evaluating the functional derivatives
           \right)
       }_{\text{for}\, \kappa(\eta)}}
     \right).
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 !alert warning
@@ -112,9 +112,9 @@ function $\psi_m$ and applying the divergence theorem to lower the derivative or
 Allen-Cahn equation yields
 
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
 	\boldsymbol{\mathcal{R}}_{\eta_i} &=& \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right) - \left<L\kappa_j \nabla \eta_j \cdot \vec{n}, \psi_m \right>,
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 where the $(*,*)$ operator represents a volume integral with an inner product and the
@@ -124,11 +124,11 @@ in two ways.
 
 The first is to directly solve the equation according to
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
 	\boldsymbol{\mathcal{R}}_{c_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right) + \left( M_i  \nabla \left( \frac{\partial f_{loc} }{\partial c_i} + \frac{\partial E_d}{\partial c_i} \right), \nabla \psi_m \right)  - \\
 	&& \left< M_i \nabla \left(  \kappa_i \nabla^2 c_i  \right)  \cdot \vec{n}, \psi_m \right>
 	+ \left< M_i \nabla \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_{d}}{\partial c_i } \right)  \cdot \vec{n}, \psi_m \right> -  \left< \kappa_i \nabla^2 c_i, M_i \nabla \psi_m \cdot \vec{n} \right>.
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 The second approach is to split the fourth order equation into two second order equations, such that
@@ -136,10 +136,10 @@ two variables are solved, the concentration $c_i$ and the chemical potential $\m
 the two residual equations are
 
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
 	\boldsymbol{\mathcal{R}}_{\mu_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right) - \left< M_i  \nabla \mu_i \cdot \vec{n}, \psi_m \right>\\
   \boldsymbol{\mathcal{R}}_{c_i} &=& \left( \nabla c_i, \nabla(\kappa_i \psi_m) \right) -  \left< \nabla c_i\cdot \vec{n}, \kappa_i \psi_m \right> + \left( \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 Note that we have reversed which equation is used to solve for each variable from what might be
@@ -159,9 +159,9 @@ required. If you choose not to use them, you would develop your kernels in the u
 
 The Allen-Cahn residual equation, without boundary terms, is shown here:
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
 \boldsymbol{\mathcal{R}}_{\eta_i} &=& \left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right) + \left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right) + L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right)
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 It is divided into three pieces, each implemented in their own kernel, as shown below
 
@@ -185,10 +185,10 @@ $\left(M_i \left( \nabla \frac{\partial f_{loc} }{\partial c_i} + \nabla  \frac{
 
 In the split form of the Cahn-Hilliard solution, the two residual equations are
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
 	\boldsymbol{\mathcal{R}}_{\mu_i} &=& \left(  \frac{\partial c_i}{\partial t}, \psi_m \right) + \left( M_i  \nabla \mu_i, \nabla \psi_m \right) \\
   \boldsymbol{\mathcal{R}}_{c_i} &=& \left( \left( -\kappa_i \nabla^2 c_i +  \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right), \psi_m \right)
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
@@ -245,11 +245,11 @@ f_{loc} = \frac{1}{4}(1 + c)^2(1 - c)^2
 and its derivatives are
 
 \begin{equation}
-\begin{eqnarray}
+\begin{aligned}
   \frac{\partial f_{loc}}{\partial c} &=& c(c^2 - 1) \\
   \frac{\partial^2 f_{loc}}{\partial c^2} &=& 3 c^2 - 1 \\
   \frac{\partial^3 f_{loc}}{\partial c^3} &=& 6 c.
-\end{eqnarray}
+\end{aligned}
 \end{equation}
 
 The second and third derivatives would be required to use the direct solution method (via

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSACBulkC.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSACBulkC.md
@@ -8,10 +8,10 @@ An instance of this kernel is needed for each solute species of the problem.
 ### Residual
 
 $$
-\begin{eqnarray*}
+\begin{aligned}
 R&=&-\frac{dh}{d\eta}\left(-\frac{dF_a}{dc_a}(c_a-c_b)\right)\\
 &=&\frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b)
-\end{eqnarray*}
+\end{aligned}
 $$
 
 ### Jacobian
@@ -24,10 +24,10 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta} = \ph
 derivative.
 
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial \eta} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{d^2h}{d\eta^2}\phi_j\frac{dF_a}{dc_a}(c_a-c_b)\\
-\end{eqnarray*}
+\end{aligned}
 $$
 
 #### Off-diagonal
@@ -40,27 +40,27 @@ $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a} = \phi_j \frac{\
 derivative.
 
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial c_a} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{dh}{d\eta} \phi_j \left( \frac{d^2 F_a}{dc_a^2}(c_a-c_b) + \frac{d F_a}{d c_a}\right)\\
-\end{eqnarray*}
+\end{aligned}
 $$
 
 Similarly for $c_b$,
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial c_b} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& -\frac{dh}{d\eta} \phi_j  \frac{d F_a}{d c_a}\\
-\end{eqnarray*}
+\end{aligned}
 $$
 
 For any variable other than $c_a$ or $c_b$, for example temperature $T$:
 
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial T} \left( \frac{dh}{d\eta}\frac{dF_a}{dc_a}(c_a-c_b) \right)\\
 &=& \frac{dh}{d\eta} \phi_j  \frac{\partial}{\partial T}\left(\frac{d F_a}{d c_a}\right) ( c_a - c_b)\\
-\end{eqnarray*}
+\end{aligned}
 $$
 
 

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSACBulkF.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSACBulkF.md
@@ -20,10 +20,10 @@ with the $\frac{\partial \eta}{\partial u_j}\frac{\partial}{\partial \eta}=\phi_
 derivative.
 
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& -\phi_j \frac{\partial}{\partial \eta}\left( \frac{dh}{d\eta}(F_a-F_b) \right) + w \phi_j \frac{\partial}{\partial \eta}\frac{dg}{d\eta} \\
 &=&-\frac{d^2h}{d\eta^2}\phi_j(F_a-F_b) + w\frac{d^2g}{d\eta^2}\phi_j \\
-\end{eqnarray*}
+\end{aligned}
 $$
 
 (The implicit dependence of $F_a(c_a)$ and $F_b(c_a)$ on $\eta$ through $c_a(c,\eta)$

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSCHBulk.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSCHBulk.md
@@ -88,11 +88,11 @@ which is given as equation (23) in KKS. Following the off-diagonal  derivation w
 Let's get back to the original residual with $\frac{dF}{dc}$. Then
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{d}{dc} \nabla \frac{dF}{dc}\\
 &=& \phi_j  \nabla \frac{d^2F}{dc^2} \quad,\quad \text{with (29) from KKS}\\
 &=& \phi_j  \nabla \frac{\frac{d^2F_b}{dc_b^2}\frac{d^2F_a}{dc_a^2}}{  [1-h(\eta)]\frac{d^2F_b}{dc_b^2}+h(\eta)\frac{d^2F_a}{dc_a^2} }\\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 !syntax parameters /Kernels/KKSCHBulk

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiACBulkC.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiACBulkC.md
@@ -20,27 +20,27 @@ function for phase $i$ defined in [cite:Folch05] (referred to as $g_i$ there, bu
 If the non-linear variable is $\eta_1$, the on-diagonal Jacobian is
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
 &=& -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1^2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1^2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1^2} c_3 \right)
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 #### Off-diagonal: Phase Concentrations
 
 Since $\frac{\partial F_1}{\partial c_1}$ appears in the residual, the off-diagonal Jacobian for $c_1$ is a little more complicated than for $c_2$ or $c_3$.
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c_1} \\
 &=& -\phi_j \left( \frac{\partial ^2 F_1}{\partial c_1^2} \left[ \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right] + \frac{\partial F_1}{\partial c_1} \frac{\partial h_1}{\partial \eta_1} \right)
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 For $c_2$,
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c_2} \\
 &=& -\phi_j \frac{\partial F_1}{\partial  c_1} \frac{\partial  h_2}{\partial  \eta_1}
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 and similarly for $c_3$. $c_1$ then $c_2$, and $c_3$ are handled first in the code. For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 
@@ -48,27 +48,27 @@ and similarly for $c_3$. $c_1$ then $c_2$, and $c_3$ are handled first in the co
 
 If the non-linear variable is $\eta_1$, the off-diagonal Jacobian for $\eta_2$ is
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial \eta_2} \\
 &=& -\phi_j \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial \eta_2} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial \eta_2} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial \eta_3} c_3 \right)
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 and similar for $\eta_3$.
 
 For any other coupled variables, for example temperature $T$
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial T} \\
 &=& -\phi_j \frac{\partial ^2 F_1}{\partial c_1 \partial T} \left( \frac{\partial  h_1}{\partial \eta_1 } c_1 + \frac{\partial  h_2}{\partial \eta_1} c_2 + \frac{\partial  h_3}{\partial \eta_1} c_3 \right)
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 What's implemented in the code for the off-diagonal Jacobian for $\eta_2$,$\eta_3$ and any other coupled variables such as $T$ is the generalization for the above two equations for non-linear variable $v$:
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial v} \\
 &=& -\phi_j \left[ \frac{\partial^2 F_1}{\partial c_1 \partial v} \left( \frac{\partial h_1}{\partial \eta_1 } c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 + \frac{\partial h_3}{\partial \eta_1} c_3 \right) +  \frac{\partial F_1}{\partial c_1} \left( \frac{\partial ^2 h_1}{\partial \eta_1 \partial v} c_1 + \frac{\partial ^2 h_2}{\partial \eta_1 \partial v} c_2 + \frac{\partial ^2 h_3}{\partial \eta_1 \partial v} c_3 \right) \right]
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 (This handles everything except for $c_1$, $c_2$, $c_3$, which are handled separately first). For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiACBulkF.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiACBulkF.md
@@ -17,10 +17,10 @@ function for phase $i$ defined in [cite:Folch05] (referred to as $g_i$ there, bu
 
 If the non-linear variable is $\eta_1$, the on-diagonal Jacobian is
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
 &=& \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1^2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1^2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1^2} F_3 + W_1 \frac{\partial ^2 g}{\partial \eta_1^2} \right)
-\end{eqnarray*}
+\end{aligned}
 $$
 
 
@@ -28,26 +28,26 @@ $$
 
 Off-diagonal Jacobian for $\eta_2$ (similar for $\eta_3$):
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial \eta_2} \\
 &=& \phi_j \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  \eta_2} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  \eta_2} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  \eta_2} F_3 \right)
-\end{eqnarray*}
+\end{aligned}
 $$
 
 Off-diagonal Jacobian for $c_1$ (similar for $c_2, c_3$):
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c_1} \\
 &=& \phi_j \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  c_1}
-\end{eqnarray*}
+\end{aligned}
 $$
 
 These statements can be generalized for non-linear variable $v$ as:
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial v} \\
 &=& \left( \frac{\partial ^2 h_1}{\partial  \eta_1 \partial  v} F_1 + \frac{\partial ^2 h_2}{\partial  \eta_1 \partial  v} F_2 + \frac{\partial ^2 h_3}{\partial  \eta_1 \partial  v} F_3 + \frac{\partial  h_1}{\partial  \eta_1} \frac{\partial  F_1}{\partial  v} + \frac{\partial  h_2}{\partial  \eta_1} \frac{\partial  F_2}{\partial  v} + \frac{\partial  h_3}{\partial  \eta_1} \frac{\partial  F_3}{\partial  v}\right)
-\end{eqnarray*}
+\end{aligned}
 $$
 For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiPhaseConcentration.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSMultiPhaseConcentration.md
@@ -16,35 +16,35 @@ where $c_i$ is the phase concentration for phase $i$, $c$ is the physical solute
 
 Since the non-linear variable for this kernel is $c_n$, the on-diagonal Jacobian is
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c_n} \\
 &=& \phi_j h_n
-\end{eqnarray*}
+\end{aligned}
 $$
 
 #### Off-diagonal
 
 For the physical concentration $c$, the off-diagonal Jacobian is
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c} \\
 &=& - \phi_j
-\end{eqnarray*}
+\end{aligned}
 $$
 For phase concentrations $c_i$ other than $c_n$,:
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial c_i} \\
 &=& \phi_j h_i
-\end{eqnarray*}
+\end{aligned}
 $$
 
 Finally for the order parameters, such as $\eta_1$,
 $$
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial R}{\partial \eta_1} \\
 &=& \phi_j \left( \frac{\partial h_1}{\partial \eta_1} c_1 + \frac{\partial h_2}{\partial \eta_1} c_2 +  \frac{\partial h_3}{\partial \eta_1} c_3      \right)
-\end{eqnarray*}
+\end{aligned}
 $$
 For the off-diagonal Jacobians we also need to multiply by $L$, the Allen-Cahn mobility.
 

--- a/modules/phase_field/doc/content/documentation/systems/Kernels/KKSSplitCHCRes.md
+++ b/modules/phase_field/doc/content/documentation/systems/Kernels/KKSSplitCHCRes.md
@@ -34,19 +34,19 @@ with the $\frac{\partial c_a}{\partial u_j}\frac{\partial}{\partial c_a}=\phi_j 
 derivative.
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \frac{\partial R}{\partial u_j} = \phi_j \frac{\partial}{\partial c_a} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
 &=& \phi_j  \frac{\partial^2F}{\partial c_a^2} \\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 For $\mu$
 
 \begin{equation}
-\begin{eqnarray*}
+\begin{aligned}
 J &=& \phi_j \frac{\partial}{\partial \mu} \left( \frac{\partial F}{\partial c_a} - \mu \right)\\
 &=& -\phi_j \\
-\end{eqnarray*}
+\end{aligned}
 \end{equation}
 
 !syntax parameters /Kernels/KKSSplitCHCRes


### PR DESCRIPTION
Replace eqnarray with aligned. The former triggers KaTeX failures.

Refs #7909