### PR TITLE
Fix VectorPostprocessorName options in peacock parameter editor.

### DIFF
--- a/python/peacock/Input/ParamsTable.py
+++ b/python/peacock/Input/ParamsTable.py
@@ -489,6 +489,9 @@ class ParamsTable(QtWidgets.QTableWidget, MooseWidget):
             list of paths that will be used as options, or None
         """
         for key, value in self.type_to_block_map.iteritems():
-            if key in cpp_type:
+            # The key (ie something like VectorPostprocessorName) can
+            # also be inside a vector
+            vector_key = "vector<%s>" % key
+            if key == cpp_type or vector_key in cpp_type:
                 return value
         return None


### PR DESCRIPTION
It could happen that peacock would look for VectorPostprocessors
in PostProcessors/* rather than VectorPostprocessors/*.

In the faulty function, `cpp_type` is `VectorPostprocessName`.
If the `PostprocessorName` key happened before the `VectorPostprocessorName` then we would search in the wrong place.

closes #11273 
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
