### PR TITLE
testroot uses run_tests_args instead of cli_args

### DIFF
--- a/modules/functional_expansion_tools/testroot
+++ b/modules/functional_expansion_tools/testroot
@@ -1,2 +1,2 @@
 app_name = functional_expansion_tools
-cli_args = '--error'
+run_tests_args = '--error'

--- a/modules/testroot
+++ b/modules/testroot
@@ -1,5 +1,5 @@
 app_name = combined/combined
-cli_args = '--color-first-directory'
+run_tests_args = '--color-first-directory'
 allow_warnings = false
 allow_unused = false
 allow_override = false

--- a/python/FactorySystem/Parser.py
+++ b/python/FactorySystem/Parser.py
@@ -144,7 +144,7 @@ class Parser:
             for key, value in default_values.iterparams():
                 if key in params.keys():
                     if key == 'cli_args':
-                      params[key] += ' ' + value + ' '
+                      params[key].append(value)
                     else:
                       params[key] = value
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -35,8 +35,8 @@ def findTestRoot(start=os.getcwd(), method=os.environ.get('METHOD', 'opt')):
                 data = f.read()
             root = hit.parse(fname, data)
             args = []
-            if root.find('cli_args'):
-                args = shlex.split(root.param('cli_args'))
+            if root.find('run_tests_args'):
+                args = shlex.split(root.param('run_tests_args'))
 
             hit_node = HitNode(hitnode=root)
             hit_parse(hit_node, root, '')


### PR DESCRIPTION
Since all the parameters in the `testroot` file override `Tester` parameters, we should separate the `run_tests` arguments from the `cli_args` since `cli_args` is a valid `Tester` parameter.

If somebody does set `cli_args` this also fixes the problem where each character is a separate entry in a list.

It doesn't look like this change will affect any apps...

closes #11204

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
