### PR TITLE
Fixing the ChangeOverTimePostprocessor so it runs in recover

### DIFF
--- a/framework/include/postprocessors/ChangeOverTimePostprocessor.h
+++ b/framework/include/postprocessors/ChangeOverTimePostprocessor.h
@@ -47,7 +47,7 @@ protected:
   const PostprocessorValue & _pps_value_old;
 
   /// initial post-processor value
-  Real _pps_value_initial;
+  Real & _pps_value_initial;
 };
 
 #endif /* CHANGEOVERTIMEPOSTPROCESSOR_H */

--- a/framework/src/postprocessors/ChangeOverTimePostprocessor.C
+++ b/framework/src/postprocessors/ChangeOverTimePostprocessor.C
@@ -37,7 +37,8 @@ ChangeOverTimePostprocessor::ChangeOverTimePostprocessor(const InputParameters &
     _compute_relative_change(getParam<bool>("compute_relative_change")),
     _take_absolute_value(getParam<bool>("take_absolute_value")),
     _pps_value(getPostprocessorValue("postprocessor")),
-    _pps_value_old(getPostprocessorValueOld("postprocessor"))
+    _pps_value_old(getPostprocessorValueOld("postprocessor")),
+    _pps_value_initial(declareRestartableData<Real>("pps_value_initial"))
 {
   if (_change_with_respect_to_initial)
   {

--- a/test/tests/postprocessors/change_over_time/tests
+++ b/test/tests/postprocessors/change_over_time/tests
@@ -21,7 +21,5 @@
     input = 'change_over_time.i'
     cli_args = "Postprocessors/change_over_time/change_with_respect_to_initial=true Outputs/file_base='change_over_time_initial'"
     csvdiff = 'change_over_time_initial.csv'
-    # This fails in recover because the initial value is lost
-    recover = false
   [../]
 []


### PR DESCRIPTION
`_pps_value_initial` had to be declared as restartable, so that the
correct value is used after restart/recover.  Without it the value was
lost.

Closes #11289

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
