### PR TITLE
Use local files in PeacockApp tests

### DIFF
--- a/python/peacock/tests/peacock_app/PeacockApp/bad_mesh.i
+++ b/python/peacock/tests/peacock_app/PeacockApp/bad_mesh.i
@@ -1,0 +1,1 @@
+../../common/bad_mesh.i

--- a/python/peacock/tests/peacock_app/PeacockApp/simple_diffusion.i
+++ b/python/peacock/tests/peacock_app/PeacockApp/simple_diffusion.i
@@ -1,0 +1,1 @@
+../../common/simple_diffusion.i

--- a/python/peacock/tests/peacock_app/PeacockApp/simple_diffusion2.i
+++ b/python/peacock/tests/peacock_app/PeacockApp/simple_diffusion2.i
@@ -1,0 +1,1 @@
+../../common/simple_diffusion2.i

--- a/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
+++ b/python/peacock/tests/peacock_app/PeacockApp/test_PeacockApp.py
@@ -46,7 +46,7 @@ class Tests(Testing.PeacockTester):
         self.check_current_tab(tabs, self.input.tabName())
 
     def testPeacockAppWithInput(self):
-        self.create_app(["../../common/transient.i", Testing.find_moose_test_exe()])
+        self.create_app(["transient.i", Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.input.tabName())
         tab = tabs.currentWidget()
@@ -111,7 +111,7 @@ class Tests(Testing.PeacockTester):
 
     def testAllCommandLine(self):
         d = os.getcwd()
-        args = ["-i" , "%s/../../common/transient.i" % d,
+        args = ["-i" , "transient.i",
                 "-e", Testing.find_moose_test_exe(),
                 "-r", "%s/gold/out_transient.e" % d,
                 "-p", "%s/../gold/out_transient.csv" % d,
@@ -129,7 +129,7 @@ class Tests(Testing.PeacockTester):
         self.check_postprocessor()
 
     def testOnlyInputFileWithExeInPath(self):
-        input_file = os.path.abspath('../../common/transient.i')
+        input_file = os.path.abspath('transient.i')
         dirname = os.path.dirname(Testing.find_moose_test_exe())
         with Testing.remember_cwd():
             os.chdir(dirname)
@@ -142,7 +142,7 @@ class Tests(Testing.PeacockTester):
 
     def testWrongExe(self):
         # use the test/moose_test-opt to try to process a modules/combined input file
-        input_file = os.path.join("../../common/transient_heat_test.i")
+        input_file = "transient_heat_test.i"
         self.create_app([input_file, Testing.find_moose_test_exe()])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.input.tabName())
@@ -160,13 +160,13 @@ class Tests(Testing.PeacockTester):
 
     def testAutoRun(self):
         Testing.remove_file("out_transient.e")
-        self.create_app(["--run", "../../common/transient.i", Testing.find_moose_test_exe(), "-w", os.getcwd()])
+        self.create_app(["--run", "transient.i", Testing.find_moose_test_exe(), "-w", os.getcwd()])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.result.tabName())
         self.check_result()
 
     def testBadMesh(self):
-        self.create_app(["../../common/bad_mesh.i", Testing.find_moose_test_exe(), "-w", os.getcwd()])
+        self.create_app(["bad_mesh.i", Testing.find_moose_test_exe(), "-w", os.getcwd()])
         tabs = self.app.main_widget.tab_plugin
         t = self.input.InputFileEditorPlugin.tree
         self.check_current_tab(tabs, self.input.tabName())
@@ -202,7 +202,7 @@ class Tests(Testing.PeacockTester):
         we were seeing that the MeshPlugin wasn't getting reset properly.
         """
         cwd = os.getcwd()
-        diffusion1 = "../../common/simple_diffusion.i"
+        diffusion1 = "simple_diffusion.i"
         self.create_app([diffusion1, Testing.find_moose_test_exe(), "-w", cwd])
         tabs = self.app.main_widget.tab_plugin
         self.check_current_tab(tabs, self.input.tabName())
@@ -224,7 +224,7 @@ class Tests(Testing.PeacockTester):
         self.vtkwin.onWrite(fname)
         self.assertFalse(Testing.gold_diff(fname))
 
-        diffusion2 = "../../common/simple_diffusion2.i"
+        diffusion2 = "simple_diffusion2.i"
         self.app.main_widget.setTab(self.input.tabName())
         self.input.setInputFile(diffusion2)
         self.app.main_widget.setTab(self.exe.tabName())

--- a/python/peacock/tests/peacock_app/PeacockApp/transient.i
+++ b/python/peacock/tests/peacock_app/PeacockApp/transient.i
@@ -1,0 +1,1 @@
+../../common/transient.i

--- a/python/peacock/tests/peacock_app/PeacockApp/transient_heat_test.i
+++ b/python/peacock/tests/peacock_app/PeacockApp/transient_heat_test.i
@@ -1,0 +1,1 @@
+../../common/transient_heat_test.i


### PR DESCRIPTION
These tests seem to fail randomly. This is most
likely due to there being a window when we set
the input file in the common dir, the mesh gets generated,
then we change directory to the test dir.
During this time other tests might be doing the same thing,
causing corruption in the mesh file, which generates VTK errors,
which causes crashes.

closes #11296

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
