### PR TITLE
Render equations in same size as regular text

### DIFF
--- a/framework/doc/content/css/moose.css
+++ b/framework/doc/content/css/moose.css
@@ -686,6 +686,8 @@ footer.page-footer {
 /* Equations */
 .moose-katex-block-equation{
   display: flex;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .moose-katex-equation{
@@ -701,6 +703,10 @@ footer.page-footer {
 
 .katex-display{
   margin: 0;
+}
+
+.katex{
+  font-size: 1em;
 }
 
 li p {


### PR DESCRIPTION
 ref #11304

Per this page:
https://github.com/Khan/KaTeX/wiki/Font-Options
the default KaTeX math font size is 21% larger than the surrounding text, which I think looks pretty ugly.  Change the css to render it the same size as the text.