### PR TITLE
Tweak search, reduce index size 

### DIFF
--- a/framework/doc/content/js/init.js
+++ b/framework/doc/content/js/init.js
@@ -52,11 +52,13 @@ function mooseSearch() {
     var results = fuse.search(box.value);
 
     console.log(results);
-    if (results.length > 0)
+    var n = results.length;
+    if (n > 0)
     {
         element.innerHTML = '';
-        for (var item of results)
+        for (var i = 0; i < n && i < 100; ++i)
         {
+            var item = results[i];
             var div = document.createElement("div");
             div.className = 'moose-search-result';
 
@@ -67,7 +69,7 @@ function mooseSearch() {
             a.setAttribute("href", item.location);
 
             if (item.name != item.text) {
-              section = document.createElement("span");
+              var section = document.createElement("span");
               section.innerHTML = ' &mdash; ' + item.text;
               a.appendChild(section);
             } else {

--- a/framework/doc/content/js/init.js
+++ b/framework/doc/content/js/init.js
@@ -30,8 +30,8 @@
 
 var options = {
   shouldSort: true,
-  threshold: 0.5,
-  minMatchCharLength: 2,
+  threshold: 0.3,
+  minMatchCharLength: 3,
   keys: [
     {
       name: "name",
@@ -51,7 +51,7 @@ function mooseSearch() {
     var fuse = new Fuse(index_data, options);
     var results = fuse.search(box.value);
 
-    console.log(results.length);
+    console.log(results);
     if (results.length > 0)
     {
         element.innerHTML = '';
@@ -59,15 +59,24 @@ function mooseSearch() {
         {
             var div = document.createElement("div");
             div.className = 'moose-search-result';
-            element.appendChild(div);
 
             var title = document.createElement("div");
             title.className = 'moose-search-result-title';
             var a = document.createElement("a");
             a.innerHTML = item.name;
             a.setAttribute("href", item.location);
+
+            if (item.name != item.text) {
+              section = document.createElement("span");
+              section.innerHTML = ' &mdash; ' + item.text;
+              a.appendChild(section);
+            } else {
+              a.setAttribute("style", "font-weight: bold");
+            }
+
             title.appendChild(a);
             div.appendChild(title);
+            element.appendChild(div);
         }
     }
     else

--- a/python/MooseDocs/tree/page.py
+++ b/python/MooseDocs/tree/page.py
@@ -13,6 +13,7 @@ import shutil
 import logging
 import codecs
 import types
+import urlparse
 
 import anytree
 
@@ -264,9 +265,12 @@ class MarkdownNode(FileNode):
         if (self._index is None) and (self._result is not None):
             self._index = []
             for section in anytree.search.findall_by_attr(self._result, 'section'):
-                name = '{}:{}'.format(self.name, section['data-section-text'])
+                name = self.name
+                if name.endswith('.md'):
+                    name = name[:-3]
                 text = section['data-section-text']
-                location = '{}#{}'.format(self.destination.replace(self.base, home), section['id'])
+                location = urlparse.urlsplit(self.destination.replace(self.base, home)) \
+                    ._replace(scheme=None, netloc=None, fragment=str(section['id'])).geturl()
                 self._index.append(dict(name=name, text=text, location=location))
 
     def build(self):


### PR DESCRIPTION
Remove protocol and domain from the search links (this is unnecessary redundant data). Do not mush title and section together on the server, do it on the client instead (saves index space and allows for more flexibility on the client).

![image](https://user-images.githubusercontent.com/202302/38953485-1b8c57d6-430c-11e8-85e0-1399031aecb0.png)

Refs #11265