### PR TITLE
Resolve tensor mechanics regression test diffs on Falcon.

### DIFF
--- a/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/tests
+++ b/modules/tensor_mechanics/test/tests/capped_mohr_coulomb/tests
@@ -8,6 +8,9 @@
     type = 'CSVDiff'
     input = 'small_deform2.i'
     csvdiff = 'small_deform2.csv'
+    override_columns = 's_xx s_xy s_zz s_yy'
+    override_rel_err = '2e-3 1e-3 1e-3 1e-3'
+    override_abs_zero = '1e-6 6e-4 1e-6 1e-6'
   [../]
   [./small3]
     type = 'CSVDiff'
@@ -48,6 +51,9 @@
     type = 'CSVDiff'
     input = 'small_deform12.i'
     csvdiff = 'small_deform12.csv'
+    override_columns = 's_xx s_xy s_zz s_yy'
+    override_rel_err = '1e-3 1e-3 1e-3 2e-3'
+    override_abs_zero = '1e-6 5e-4 1e-6 1e-6'
   [../]
   [./small13]
     type = 'CSVDiff'
@@ -94,6 +100,9 @@
     type = 'CSVDiff'
     input = 'small_deform24.i'
     csvdiff = 'small_deform24.csv'
+    override_columns = 's_xx s_xy s_yy'
+    override_rel_err = '3e-3 1e-3 3e-3'
+    override_abs_zero = '1e-6 6e-2 1e-6'
   [../]
   [./small25]
     type = 'CSVDiff'

--- a/modules/tensor_mechanics/test/tests/static_deformations/tests
+++ b/modules/tensor_mechanics/test/tests/static_deformations/tests
@@ -40,6 +40,9 @@
     type = 'CSVDiff'
     input = 'beam_cosserat_01.i'
     csvdiff = 'beam_cosserat_01_soln_0001.csv'
+    override_columns = 'wc_y'
+    override_rel_err = '1e-5'
+    override_abs_zero = '5e-6'
   [../]
   [./beam_cosserat_01_slippery]
     type = 'CSVDiff'

--- a/modules/tensor_mechanics/test/tests/tensile/tests
+++ b/modules/tensor_mechanics/test/tests/tensile/tests
@@ -251,6 +251,9 @@
     type = 'CSVDiff'
     input = 'small_deform2_update_version.i'
     csvdiff = 'small_deform2_update_version.csv'
+    override_columns = 's_xx s_xy s_zz s_yy'
+    override_rel_err = '2e-3 1e-3 1e-3 1e-3'
+    override_abs_zero = '1e-6 6e-4 1e-6 1e-6'
   [../]
   [./small_deform3_update]
     type = 'CSVDiff'


### PR DESCRIPTION
Fixing regression test diffs on Falcon by using custom tolerances with CSVDiff. Issue #7387.

