### PR TITLE
Fallback to non displaced problem if none is present

### DIFF
--- a/framework/include/outputs/Output.h
+++ b/framework/include/outputs/Output.h
@@ -19,6 +19,7 @@
 
 // Forward declarations
 class Output;
+class MooseMesh;
 
 // libMesh forward declarations
 namespace libMesh
@@ -178,6 +179,9 @@ protected:
 
   /// Reference the the libMesh::EquationSystems object that contains the data
   EquationSystems * _es_ptr;
+
+  /// A convenience pointer to the current mesh (reference or displaced depending on "use_displaced")
+  MooseMesh * _mesh_ptr;
 
   /// Flag for forcing call to outputSetup() with every call to output() (restartable)
   bool _sequence;

--- a/framework/include/outputs/OversampleOutput.h
+++ b/framework/include/outputs/OversampleOutput.h
@@ -35,9 +35,6 @@ InputParameters validParams<OversampleOutput>();
  * changes to the libMesh::EquationsSystems() pointer (_es_ptr), i.e., this pointer is
  * will point to the oversampled system, if oversamping is utilized.
  *
- * Additionally, the class adds a pointer to the mesh object (_mesh_ptr) that again
- * points to the correct mesh depending on the use of oversampling.
- *
  * The use of oversampling is triggered by setting the oversample input parameter to a
  * integer value greater than 0, indicating the number of refinements to perform.
  *
@@ -75,11 +72,6 @@ protected:
    * Performs the update of the solution vector for the oversample/re-positioned mesh
    */
   virtual void updateOversample();
-
-  /**
-   * A convenience pointer to the current mesh (reference or displaced depending on "use_displaced")
-   */
-  MooseMesh * _mesh_ptr;
 
   /// The number of oversampling refinements
   const unsigned int _refinements;

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -55,8 +55,6 @@ validParams<OversampleOutput>()
 
 OversampleOutput::OversampleOutput(const InputParameters & parameters)
   : AdvancedOutput(parameters),
-    _mesh_ptr(getParam<bool>("use_displaced") ? &_problem_ptr->getDisplacedProblem()->mesh()
-                                              : &_problem_ptr->mesh()),
     _refinements(getParam<unsigned int>("refinements")),
     _oversample(_refinements > 0 || isParamValid("file")),
     _change_position(isParamValid("position")),
@@ -271,7 +269,7 @@ OversampleOutput::cloneMesh()
   if (isParamValid("file"))
   {
     InputParameters mesh_params = emptyInputParameters();
-    mesh_params += _problem_ptr->mesh().parameters();
+    mesh_params += _mesh_ptr->parameters();
     mesh_params.set<MeshFileName>("file") = getParam<MeshFileName>("file");
     mesh_params.set<bool>("nemesis") = false;
     mesh_params.set<bool>("skip_partitioning") = false;
@@ -290,7 +288,7 @@ OversampleOutput::cloneMesh()
       mooseWarning("Recovering or Restarting with Oversampling may not work (especially with "
                    "adapted meshes)!!  Refs #2295");
 
-    _cloned_mesh_ptr.reset(&(_problem_ptr->mesh().clone()));
+    _cloned_mesh_ptr.reset(&(_mesh_ptr->clone()));
   }
 
   // Make sure that the mesh pointer points to the newly cloned mesh

--- a/test/tests/outputs/displaced/non_displaced_fallback.i
+++ b/test/tests/outputs/displaced/non_displaced_fallback.i
@@ -1,0 +1,34 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[AuxVariables]
+  [./a]
+  [../]
+[]
+
+[AuxKernels]
+  [./a_ak]
+    type = ConstantAux
+    variable = a
+    value = 1.
+    execute_on = initial
+  [../]
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  [./exodus]
+    type = Exodus
+    use_displaced = true
+  [../]
+[]

--- a/test/tests/outputs/displaced/tests
+++ b/test/tests/outputs/displaced/tests
@@ -8,4 +8,13 @@
     recover = false
     max_parallel = 1
   [../]
+
+  [./non_displaced_fallback]
+    type = 'RunException'
+    input = 'non_displaced_fallback.i'
+    expect_err = "Parameter 'use_displaced' ignored, there is no displaced problem in your simulation."
+    requirement = "If the user requested the output of a displaced problem and there is none present, the system shall fallback to using the non-displaced problem."
+    design = "Outputs/index.md"
+    issues = "11309"
+  [../]
 []

--- a/test/tests/outputs/displaced/tests
+++ b/test/tests/outputs/displaced/tests
@@ -15,6 +15,6 @@
     expect_err = "Parameter 'use_displaced' ignored, there is no displaced problem in your simulation."
     requirement = "If the user requested the output of a displaced problem and there is none present, the system shall fallback to using the non-displaced problem."
     design = "Outputs/index.md"
-    issues = "11309"
+    issues = "#11309"
   [../]
 []


### PR DESCRIPTION
If users required output on displaced mesh via 'use_displaced = true',
but there is no displaced problem, MOOSE should use the non-displaced
problem instead and warn the user about this fact.

Closes #11309

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
