### PR TITLE
Make table/figure captions same size as text

### DIFF
--- a/framework/doc/content/css/moose.css
+++ b/framework/doc/content/css/moose.css
@@ -321,7 +321,7 @@ blockquote {
 }
 
 .moose-caption{
-  font-size:120%;
+  font-size:100%;
 }
 
 .moose-caption-heading{


### PR DESCRIPTION
ref #9638

The table and figure captions currently use a font larger than the text, which looks odd. In scientific papers, they usually have the same, if not smaller, font.