### PR TITLE
Brineco2 enthalpy

### DIFF
--- a/modules/porous_flow/doc/content/bib/porous_flow.bib
+++ b/modules/porous_flow/doc/content/bib/porous_flow.bib
@@ -1,3 +1,10 @@
+@inproceedings{battistelli1993,
+  title={{A fluid property module for the TOUGH2 simulator for saline brines with non-condensible gas}},
+  author={A. Battistelli and C. Calore and K. Pruess},
+  year={1993},
+  booktitle={Eighteenth Workshop on Geothermal Reservoir Engineering Stanford University, Stanford, California, January26-28}
+}
+
 @book{bear1972,
   author = {J. Bear},
   title = {Dynamics of fluids in porous media},
@@ -69,6 +76,16 @@
   volume = {19},
   pages = {333--342},
   year = {1979}
+}
+
+@article{duan2003,
+  title={{An improved model calculating CO$_2$ solubility in pure water and aqueous NaCl solutions from 273 to 533 K and from 0 to 2000 bar}},
+  author={Z. Duan and R. Sun},
+  journal={Chemical geology},
+  volume={193},
+  number={3-4},
+  pages={257--271},
+  year={2003}
 }
 
 @techreport{garcia2001,

--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/brineco2.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/brineco2.md
@@ -3,7 +3,8 @@
 The brine-CO$_2$ model available in PorousFlow is a high precision equation of state
 for brine and CO$_2$, including the mutual solubility of CO$_2$ into the liquid brine
 and water into the CO$_2$-rich gas phase. This model is suitable for simulations of
-geological storage of CO$_2$ in saline aquifers.
+geological storage of CO$_2$ in saline aquifers, and is valid for temperatures in the range
+$12^{\circ}C \le T \le 110^{\circ}C$ and pressures less than 60 MPa.
 
 Salt (NaCl) can be included as a nonlinear variable, allowing salt to be transported
 along with water to provide variable density brine.
@@ -47,19 +48,18 @@ equilibrium value in this two phase region.
 ### Density
 
 The density of the aqueous phase with the contribution of dissolved CO$_2$ is calculated using
-
 \begin{equation}
 \frac{1}{\rho} = \frac{1 - X_{CO2}}{\rho_b} + \frac{X_{CO2}}{\rho_{CO2}},
 \end{equation}
-
 where $\rho_b$ is the density of brine (supplied using a
 [`BrineFluidProperties`](/BrineFluidProperties.md) UserObject), $X_{CO2}$ is the
 mass fraction of CO$_2$ dissolved in the aqueous phase, and $\rho_{CO2}$ is the partial
 density of dissolved CO$_2$ [citep:garcia2001].
 
-As water vapor is only ever a small component of the gas phase, the density of the gas phase
-is assumed to be simply the density of CO$_2$ at the given pressure and temperature, calculated
-using a [`CO2FluidProperties`](/CO2FluidProperties.md) UserObject.
+As water vapor is only ever a small component of the gas phase in the temperature and pressure ranges
+that this class is valid for, the density of the gas phase is assumed to be simply the density of CO$_2$
+at the given pressure and temperature, calculated using a [`CO2FluidProperties`](/CO2FluidProperties.md)
+UserObject.
 
 ### Viscosity
 
@@ -67,6 +67,29 @@ No contribution to the viscosity of each phase due to the presence of CO$_2$ in 
 phase or water vapor in the gas phase is included. As a result, the viscosity of the aqueous
 phase is simply the viscosity of brine, while the viscosity of the gas phase is the viscosity
 of CO$_2$.
+
+### Enthalpy
+
+The enthalpy of the gas phase is simply the enthalpy of CO$_2$ at the given pressure and temperature
+values, with no contribution due to the presence of water vapor included.
+
+The enthalpy of the liquid phase is also calculated as a weighted sum of the enthalpies
+of each individual component, but also includes a contribution due to the enthalpy of
+dissolution (a change in enthalpy due to dissolution of the NCG into the water phase)
+\begin{equation}
+h_l = (1 - X_{CO2}) h_b + X_{CO2} h_{CO2,aq},
+\end{equation}
+where $h_b$ is the enthalpy of brine, and $h_{CO2,aq}$ is the enthalpy of CO$_2$ in the liquid
+phase, which includes the enthalpy of dissolution $h_{dis}$
+\begin{equation}
+h_{CO2,aq} = h_{CO2} + h_{dis}.
+\end{equation}
+
+In the range of pressures and temperatures considered, CO$_2$ may exist as a gas or a supercritical fluid. Using a linear fit to the model of [citet:duan2003], the enthalpy of
+dissolution of both gas phase and supercritical CO$_2$ is calculated as
+\begin{equation}
+h_{dis}(T) = \frac{-58353.3 + 134.519 T}{M_{CO2}}.
+\end{equation}
 
 ## Implementation
 

--- a/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowFluidStateBrineCO2.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowFluidStateBrineCO2.md
@@ -12,5 +12,3 @@ For more details, see the documentation of the [brine and CO$_2$](brineco2.md) e
 !syntax inputs /Materials/PorousFlowFluidStateBrineCO2
 
 !syntax children /Materials/PorousFlowFluidStateBrineCO2
-
-!bibtex bibliography

--- a/modules/porous_flow/doc/content/documentation/systems/UserObjects/PorousFlowBrineCO2.md
+++ b/modules/porous_flow/doc/content/documentation/systems/UserObjects/PorousFlowBrineCO2.md
@@ -15,3 +15,5 @@ For more details, see the documentation of the [brine and CO$_2$](brineco2.md) e
 !syntax inputs /UserObjects/PorousFlowBrineCO2
 
 !syntax children /UserObjects/PorousFlowBrineCO2
+
+!bibtex bibliography

--- a/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
@@ -240,6 +240,52 @@ public:
    */
   unsigned int saltComponentIndex() const { return _salt_component; };
 
+  /**
+   * Henry's constant of dissolution of gas phase CO2 in brine. From
+   * Battistelli et al, A fluid property module for the TOUGH2 simulator for saline brines
+   * with non-condensible gas, Proc. Eighteenth Workshop on Geothermal Reservoir Engineering (1993)
+   *
+   * @param temperature fluid temperature (K)
+   * @param xnacl NaCl mass fraction (kg/kg)
+   * @param[out] Kh Henry's constant (Pa)
+   * @param[out] dKh_dT derivative of Henry's constant wrt temperature
+   * @param[out] dKh_dx derivative of Henry's constant wrt salt mass fraction
+   */
+  void henryConstant(Real temperature, Real xnacl, Real & Kh, Real & dKh_dT, Real & dKh_dx) const;
+
+  /**
+   * Enthalpy of dissolution of gas phase CO2 in brine calculated using Henry's constant
+   * From Himmelblau, Partial molal heats and entropies of solution for gases dissolved
+   * in water from the freezing to the near critical point, J. Phys. Chem. 63 (1959).
+   * Correction due to salinity from Battistelli et al, A fluid property module for the
+   * TOUGH2 simulator for saline brines with non-condensible gas, Proc. Eighteenth Workshop
+   * on Geothermal Reservoir Engineering (1993).
+   *
+   * @param temperature fluid temperature (K)
+   * @param xnacl NaCl mass fraction (kg/kg)
+   * @param[out] hdis enthalpy of dissolution (J/kg)
+   * @param[out] dhdis_dT derivative of enthalpy of dissolution wrt temperature
+   * @param[out] dhdis_dx derivative of enthalpy of dissolution wrt salt mass fraction
+   */
+  void enthalpyOfDissolutionGas(
+      Real temperature, Real xnacl, Real & hdis, Real & dhdis_dT, Real & dhdis_dx) const;
+
+  /**
+   * Enthalpy of dissolution of CO2 in brine calculated using linear fit to model of
+   * Duan and Sun, An improved model calculating CO2 solubility in pure water and aqueous NaCl
+   * solutions from 273 to 533 K and from 0 to 2000 bar, Chemical geology, 193, 257--271 (2003).
+   *
+   * In the region of interest, the more complicated model given in Eq. (8) of Duan and Sun
+   * is well approximated by a simple linear fit (R^2 = 0.9997).
+   *
+   * Note: as the effect of salt mass fraction is small, it is not included in this function.
+   *
+   * @param temperature fluid temperature (K)
+   * @param[out] hdis enthalpy of dissolution (J/kg)
+   * @param[out] dhdis_dT derivative of enthalpy of dissolution wrt temperature
+   */
+  void enthalpyOfDissolution(Real temperature, Real & hdis, Real & dhdis_dT) const;
+
 protected:
   /// Check the input variables
   void checkVariables(Real pressure, Real temperature) const;


### PR DESCRIPTION
Following on from #11341, the next part of fixing #10167 adds the calculation of the enthalpy of each fluid phase (including the enthalpy change due to dissolution of a gas phase into the liquid phase) for the brine-CO2 class.

Unit test updated to verify calculation of phase enthalpies and derivatives.

Documentation of this class updated to include enthalpy formulation.

Refs #10167