### PR TITLE
Changes to avoid naming conflicts with multiple plasticity or creep models

### DIFF
--- a/modules/tensor_mechanics/include/materials/LinearViscoelasticStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/LinearViscoelasticStressUpdate.h
@@ -55,8 +55,6 @@ public:
 protected:
   virtual void initQpStatefulProperties() override;
 
-  std::string _base_name;
-
   /// Creep strain
   MaterialProperty<RankTwoTensor> & _creep_strain;
   const MaterialProperty<RankTwoTensor> & _creep_strain_old;

--- a/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
@@ -143,9 +143,6 @@ protected:
   /// Number of internal parameters
   const unsigned _num_intnl;
 
-  /// String prepended to various MaterialProperties that are defined by this class
-  const std::string _base_name;
-
   /// Maximum number of Newton-Raphson iterations allowed in the return-map process
   const unsigned _max_nr_its;
 

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -35,8 +35,7 @@ InputParameters validParams<RadialReturnStressUpdate>();
 class RadialReturnStressUpdate : public StressUpdateBase, public SingleVariableReturnMappingSolution
 {
 public:
-  RadialReturnStressUpdate(const InputParameters & parameters,
-                           const std::string inelastic_strain_name = "");
+  RadialReturnStressUpdate(const InputParameters & parameters);
 
   /**
    * A radial return (J2) mapping method is performed with return mapping

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -95,6 +95,10 @@ public:
   void resetQpProperties() final {}
   void resetProperties() final {}
   ///@}
+
+protected:
+  /// Name used as a prefix for all material properties related to the stress update model.
+  const std::string _base_name;
 };
 
 #endif // STRESSUPDATEBASE_H

--- a/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/HyperbolicViscoplasticityStressUpdate.C
@@ -33,15 +33,19 @@ validParams<HyperbolicViscoplasticityStressUpdate>()
                                 "Viscoplasticity coefficient, scales the hyperbolic function");
   params.addRequiredParam<Real>("c_beta",
                                 "Viscoplasticity coefficient inside the hyperbolic sin function");
-  params.addParam<std::string>(
-      "plastic_prepend", "", "String that is prepended to the plastic_strain Material Property");
+  params.addDeprecatedParam<std::string>(
+      "plastic_prepend",
+      "",
+      "String that is prepended to the plastic_strain Material Property",
+      "This has been replaced by the 'base_name' parameter");
+  params.set<std::string>("effective_inelastic_strain_name") = "effective_plastic_strain";
 
   return params;
 }
 
 HyperbolicViscoplasticityStressUpdate::HyperbolicViscoplasticityStressUpdate(
     const InputParameters & parameters)
-  : RadialReturnStressUpdate(parameters, "plastic"),
+  : RadialReturnStressUpdate(parameters),
     _plastic_prepend(getParam<std::string>("plastic_prepend")),
     _yield_stress(parameters.get<Real>("yield_stress")),
     _hardening_constant(parameters.get<Real>("hardening_constant")),
@@ -51,8 +55,10 @@ HyperbolicViscoplasticityStressUpdate::HyperbolicViscoplasticityStressUpdate(
     _hardening_variable(declareProperty<Real>("hardening_variable")),
     _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
 
-    _plastic_strain(declareProperty<RankTwoTensor>(_plastic_prepend + "plastic_strain")),
-    _plastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_plastic_prepend + "plastic_strain"))
+    _plastic_strain(
+        declareProperty<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain")),
+    _plastic_strain_old(
+        getMaterialPropertyOld<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
@@ -16,7 +16,6 @@ InputParameters
 validParams<LinearViscoelasticStressUpdate>()
 {
   InputParameters params = validParams<StressUpdateBase>();
-  params.addParam<std::string>("base_name", "optional string prepended to the creep strain name");
   params.addParam<std::string>(
       "apparent_creep_strain",
       "apparent_creep_strain",
@@ -34,11 +33,8 @@ validParams<LinearViscoelasticStressUpdate>()
 
 LinearViscoelasticStressUpdate::LinearViscoelasticStressUpdate(const InputParameters & parameters)
   : StressUpdateBase(parameters),
-    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") : std::string()),
-    _creep_strain(declareProperty<RankTwoTensor>(
-        isParamValid("base_name") ? _base_name + "_creep_strain" : "creep_strain")),
-    _creep_strain_old(getMaterialPropertyOld<RankTwoTensor>(
-        isParamValid("base_name") ? _base_name + "_creep_strain" : "creep_strain")),
+    _creep_strain(declareProperty<RankTwoTensor>(_base_name + "creep_strain")),
+    _creep_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "creep_strain")),
     _apparent_creep_strain(getMaterialProperty<RankTwoTensor>("apparent_creep_strain")),
     _apparent_elasticity_tensor(getMaterialProperty<RankFourTensor>("apparent_elasticity_tensor")),
     _instantaneous_elasticity_tensor_inv(

--- a/modules/tensor_mechanics/src/materials/MultiParameterPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/MultiParameterPlasticityStressUpdate.C
@@ -24,12 +24,6 @@ validParams<MultiParameterPlasticityStressUpdate>()
   params.addClassDescription("Return-map and Jacobian algorithms for plastic models where the "
                              "yield function and flow directions depend on multiple functions of "
                              "stress");
-  params.addParam<std::string>("base_name",
-                               "Optional parameter that allows the user to define "
-                               "multiple plastic models on the same block, and the "
-                               "plastic_internal_parameter, plastic_yield_function, "
-                               "plastic_NR_iterations and plastic_linesearch_needed Material "
-                               "Properties will be prepended by this string");
   params.addRangeCheckedParam<unsigned int>(
       "max_NR_iterations",
       20,
@@ -89,7 +83,6 @@ MultiParameterPlasticityStressUpdate::MultiParameterPlasticityStressUpdate(
     _Cij(num_sp, std::vector<Real>(num_sp)),
     _num_yf(num_yf),
     _num_intnl(num_intnl),
-    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _max_nr_its(getParam<unsigned>("max_NR_iterations")),
     _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
     _smoothing_tol(getParam<Real>("smoothing_tol")),

--- a/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/PowerLawCreepStressUpdate.C
@@ -31,14 +31,18 @@ validParams<PowerLawCreepStressUpdate>()
   params.addParam<Real>("gas_constant", 8.3143, "Universal gas constant");
   params.addParam<Real>("start_time", 0.0, "Start time (if not zero)");
   params.addCoupledVar("temperature", 0.0, "Coupled temperature");
-  params.addParam<std::string>(
-      "creep_prepend", "", "String that is prepended to the creep_strain Material Property");
+  params.addDeprecatedParam<std::string>(
+      "creep_prepend",
+      "",
+      "String that is prepended to the creep_strain Material Property",
+      "This has been replaced by the 'base_name' parameter");
+  params.set<std::string>("effective_inelastic_strain_name") = "effective_creep_strain";
 
   return params;
 }
 
 PowerLawCreepStressUpdate::PowerLawCreepStressUpdate(const InputParameters & parameters)
-  : RadialReturnStressUpdate(parameters, "creep"),
+  : RadialReturnStressUpdate(parameters),
     _creep_prepend(getParam<std::string>("creep_prepend")),
     _coefficient(parameters.get<Real>("coefficient")),
     _n_exponent(parameters.get<Real>("n_exponent")),
@@ -48,8 +52,9 @@ PowerLawCreepStressUpdate::PowerLawCreepStressUpdate(const InputParameters & par
     _start_time(getParam<Real>("start_time")),
     _has_temp(isCoupled("temperature")),
     _temperature(_has_temp ? coupledValue("temperature") : _zero),
-    _creep_strain(declareProperty<RankTwoTensor>(_creep_prepend + "creep_strain")),
-    _creep_strain_old(getMaterialPropertyOld<RankTwoTensor>(_creep_prepend + "creep_strain"))
+    _creep_strain(declareProperty<RankTwoTensor>(_base_name + _creep_prepend + "creep_strain")),
+    _creep_strain_old(
+        getMaterialPropertyOld<RankTwoTensor>(_base_name + _creep_prepend + "creep_strain"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -25,17 +25,21 @@ validParams<RadialReturnStressUpdate>()
   params.addParam<Real>("max_inelastic_increment",
                         1e-4,
                         "The maximum inelastic strain increment allowed in a time step");
+  params.addRequiredParam<std::string>(
+      "effective_inelastic_strain_name",
+      "Name of the material property that stores the effective inelastic strain");
+  params.addParamNamesToGroup("effective_inelastic_strain_name", "Advanced");
+
   return params;
 }
 
-RadialReturnStressUpdate::RadialReturnStressUpdate(const InputParameters & parameters,
-                                                   const std::string inelastic_strain_name)
+RadialReturnStressUpdate::RadialReturnStressUpdate(const InputParameters & parameters)
   : StressUpdateBase(parameters),
     SingleVariableReturnMappingSolution(parameters),
-    _effective_inelastic_strain(
-        declareProperty<Real>("effective_" + inelastic_strain_name + "_strain")),
-    _effective_inelastic_strain_old(
-        getMaterialPropertyOld<Real>("effective_" + inelastic_strain_name + "_strain")),
+    _effective_inelastic_strain(declareProperty<Real>(
+        _base_name + getParam<std::string>("effective_inelastic_strain_name"))),
+    _effective_inelastic_strain_old(getMaterialPropertyOld<Real>(
+        _base_name + getParam<std::string>("effective_inelastic_strain_name"))),
     _max_inelastic_increment(parameters.get<Real>("max_inelastic_increment"))
 {
 }

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -20,6 +20,11 @@ validParams<StressUpdateBase>()
                              "yield surface, plastic strains, internal parameters, etc).  This "
                              "class is intended to be a parent class for classes with specific "
                              "constitutive models.");
+  params.addParam<std::string>(
+      "base_name",
+      "Optional parameter that defines a prefix for all material "
+      "properties related to this stress update model. This allows for "
+      "multiple models of the same type to be used without naming conflicts.");
   // The return stress increment classes are intended to be iterative materials, so must set compute
   // = false for all inheriting classes
   params.set<bool>("compute") = false;
@@ -27,7 +32,11 @@ validParams<StressUpdateBase>()
   return params;
 }
 
-StressUpdateBase::StressUpdateBase(const InputParameters & parameters) : Material(parameters) {}
+StressUpdateBase::StressUpdateBase(const InputParameters & parameters)
+  : Material(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "")
+{
+}
 
 void
 StressUpdateBase::setQp(unsigned int qp)

--- a/modules/tensor_mechanics/test/tests/recompute_radial_return/tests
+++ b/modules/tensor_mechanics/test/tests/recompute_radial_return/tests
@@ -5,13 +5,23 @@
     exodiff = 'isotropic_plasticity_incremental_strain_out.e'
     compiler = 'CLANG GCC'
   [../]
+  [./isotropic_plasticity_incremental_base_name]
+    type = Exodiff
+    input = 'isotropic_plasticity_incremental_strain.i'
+    cli_args = "Materials/isotropic_plasticity/base_name=base
+                Modules/TensorMechanics/Master/all/generate_output=''"
+    exodiff = 'isotropic_plasticity_incremental_strain_out.e'
+    exodiff_opts = '-allow_name_mismatch'
+    compiler = 'CLANG GCC'
+    prereq = isotropic_plasticity_incremental
+  [../]
   [./isotropic_plasticity_incremental_Bbar]
     type = Exodiff
     input = 'isotropic_plasticity_incremental_strain.i'
     exodiff = 'isotropic_plasticity_incremental_strain_out.e'
     compiler = 'CLANG GCC'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
-    prereq = 'isotropic_plasticity_incremental'
+    prereq = 'isotropic_plasticity_incremental_base_name'
   [../]
   [./isotropic_plasticity_finite]
     type = Exodiff


### PR DESCRIPTION
closes #11368

Add base_name parameter to models that derive from RadialReturnStressUpdate
Change how the naming of effective inelastic strain variables is controlled
Deprecate creep_prepend and plastic_prepend parameters
