### PR TITLE
Changed tangent operator calculation flags to Enum

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
@@ -49,14 +49,6 @@ protected:
   /// Even if the returnMap fails, return the best values found for stress and internal parameters
   bool _ignore_failures;
 
-  /// The type of tangent operator to return.  tangent operator = d(stress_rate)/d(strain_rate).
-  enum TangentOperatorEnum
-  {
-    elastic,
-    linear,
-    nonlinear
-  } _tangent_operator_type;
-
   /// Tolerance on the plastic strain increment ("direction") constraint
   Real _epp_tol;
 

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -138,9 +138,6 @@ protected:
   /// old value of inelastic strain
   const MaterialProperty<RankTwoTensor> & _inelastic_strain_old;
 
-  /// what sort of Tangent operator to calculate
-  const enum class TangentOperatorEnum { elastic, nonlinear } _tangent_operator_type;
-
   /// number of plastic models
   const unsigned _num_models;
 

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -18,6 +18,13 @@
 
 class ComputeStressBase;
 
+enum class TangentOperatorEnum
+{
+  ELASTIC,
+  LINEAR,
+  NONLINEAR
+};
+
 template <>
 InputParameters validParams<ComputeStressBase>();
 
@@ -74,6 +81,9 @@ protected:
 
   /// Parameter which decides whether to store old stress. This is required for HHT time integration and Rayleigh damping
   const bool _store_stress_old;
+
+  /// Enum to determine calculation method for the tangent operator
+  const TangentOperatorEnum _tangent_operator_type;
 
   /// Whether initial stress was provided.  InitialStress Deprecation: remove this.
   const bool _initial_stress_provided;

--- a/modules/tensor_mechanics/include/materials/LinearViscoelasticStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/LinearViscoelasticStressUpdate.h
@@ -44,7 +44,7 @@ public:
                            const RankTwoTensor & stress_old,
                            const RankFourTensor & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
+                           const TangentOperatorEnum & tangent_operator_type,
                            RankFourTensor & tangent_operator) override;
 
   /// Reimplemented from StressUpdateBase

--- a/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
@@ -114,7 +114,7 @@ protected:
                            const RankTwoTensor & stress_old,
                            const RankFourTensor & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
+                           const TangentOperatorEnum & tangent_operator_type,
                            RankFourTensor & tangent_operator) override;
 
   virtual void propagateQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -47,7 +47,7 @@ public:
    * @param stress_old                    Old state of stress
    * @param elasticity_tensor             Rank 4 C_{ijkl}, must be isotropic
    * @param elastic_strain_old            Old state of total elastic strain
-   * @param compute_full_tangent_operator Flag currently unused by this class
+   * @param tangent_operator_type         Enum used to signify how to calculate the tangent operator
    * @param tangent_operator              Currently a copy of the elasticity tensor in this class
    */
   virtual void updateState(RankTwoTensor & strain_increment,
@@ -57,7 +57,7 @@ public:
                            const RankTwoTensor & stress_old,
                            const RankFourTensor & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
+                           const TangentOperatorEnum & tangent_operator_type,
                            RankFourTensor & tangent_operator) override;
 
   virtual Real computeReferenceResidual(const Real effective_trial_stress,

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -15,6 +15,7 @@
 #include "Material.h"
 #include "RankFourTensor.h"
 #include "RankTwoTensor.h"
+#include "ComputeStressBase.h"
 
 // Forward declaration
 class StressUpdateBase;
@@ -58,9 +59,8 @@ public:
    * an elastic strain.  Upon output: the admissible stress
    * @param stress_old The old value of stress
    * @param elasticity_tensor The elasticity tensor
-   * @param compute_full_tangent_operator The calling routine would like the full consistent tangent
-   * operator to be placed in tangent_operator, if possible.  This is irrelevant if
-   * _fe_problem.currentlyComputingJacobian() = false
+   * @param tangent_operator_type Enum to determine how the tangent modulus is calculated.  This is
+   * irrelevant if _fe_problem.currentlyComputingJacobian() = false
    * @param tangent_operator d(stress)/d(strain), or some approximation to it  If
    * compute_full_tangent_operator=false, then tangent_operator=elasticity_tensor is an appropriate
    * choice.  tangent_operator is only computed if _fe_problem.currentlyComputingJacobian() = true
@@ -72,7 +72,7 @@ public:
                            const RankTwoTensor & stress_old,
                            const RankFourTensor & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
+                           const TangentOperatorEnum & tangent_operator_type,
                            RankFourTensor & tangent_operator) = 0;
 
   /// Sets the value of the global variable _qp for inheriting classes

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -103,8 +103,6 @@ ComputeMultiPlasticityStress::ComputeMultiPlasticityStress(const InputParameters
     _max_stepsize_for_dumb(getParam<Real>("max_stepsize_for_dumb")),
     _ignore_failures(getParam<bool>("ignore_failures")),
 
-    _tangent_operator_type((TangentOperatorEnum)(int)getParam<MooseEnum>("tangent_operator")),
-
     _epp_tol(getParam<Real>("ep_plastic_tolerance")),
 
     _dummy_pm(0),
@@ -434,7 +432,7 @@ ComputeMultiPlasticityStress::quickStep(const RankTwoTensor & stress_old,
     {
       if (called_from == computeQpStress_function && _f[custom_model]->useCustomCTO())
       {
-        if (_tangent_operator_type == elastic)
+        if (_tangent_operator_type == TangentOperatorEnum::ELASTIC)
           consistent_tangent_operator = E_ijkl;
         else
         {
@@ -1598,7 +1596,7 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
                                                         const std::vector<Real> & cumulative_pm)
 {
 
-  if (_tangent_operator_type == elastic)
+  if (_tangent_operator_type == TangentOperatorEnum::ELASTIC)
     return E_ijkl;
 
   // Typically act_at_some_step = act, but it is possible
@@ -1723,7 +1721,7 @@ ComputeMultiPlasticityStress::consistentTangentOperator(const RankTwoTensor & st
       ind1++;
     }
 
-  if (_tangent_operator_type == linear)
+  if (_tangent_operator_type == TangentOperatorEnum::LINEAR)
     return strain_coeff;
 
   RankFourTensor stress_coeff(RankFourTensor::initIdentitySymmetricFour);

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticCosseratStress.C
@@ -64,7 +64,7 @@ ComputeMultipleInelasticCosseratStress::computeQpStress()
 void
 ComputeMultipleInelasticCosseratStress::computeQpJacobianMult()
 {
-  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+  if (_tangent_operator_type == TangentOperatorEnum::ELASTIC)
     _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
   else
   {

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -83,7 +83,6 @@ ComputeMultipleInelasticStress::ComputeMultipleInelasticStress(const InputParame
     _inelastic_strain(declareProperty<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
     _inelastic_strain_old(
         getMaterialPropertyOld<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
-    _tangent_operator_type(getParam<MooseEnum>("tangent_operator").getEnum<TangentOperatorEnum>()),
     _num_models(getParam<std::vector<MaterialName>>("inelastic_models").size()),
     _inelastic_weights(isParamValid("combined_inelastic_strain_weights")
                            ? getParam<std::vector<Real>>("combined_inelastic_strain_weights")
@@ -189,7 +188,7 @@ ComputeMultipleInelasticStress::finiteStrainRotation(const bool force_elasticity
       _rotation_increment[_qp] * _inelastic_strain[_qp] * _rotation_increment[_qp].transpose();
   if (force_elasticity_rotation ||
       !(_is_elasticity_tensor_guaranteed_isotropic &&
-        (_tangent_operator_type == TangentOperatorEnum::elastic || _num_models == 0)))
+        (_tangent_operator_type == TangentOperatorEnum::ELASTIC || _num_models == 0)))
     _Jacobian_mult[_qp].rotate(_rotation_increment[_qp]);
 }
 
@@ -323,7 +322,7 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
 void
 ComputeMultipleInelasticStress::computeQpJacobianMult()
 {
-  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+  if (_tangent_operator_type == TangentOperatorEnum::ELASTIC)
     _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
   else
   {
@@ -385,6 +384,6 @@ ComputeMultipleInelasticStress::computeAdmissibleState(unsigned model_number,
                                      _stress_old[_qp],
                                      _elasticity_tensor[_qp],
                                      _elastic_strain_old[_qp],
-                                     _tangent_operator_type == TangentOperatorEnum::nonlinear,
+                                     _tangent_operator_type,
                                      consistent_tangent_operator);
 }

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -16,6 +16,7 @@ InputParameters
 validParams<ComputeStressBase>()
 {
   InputParameters params = validParams<Material>();
+
   params.addDeprecatedParam<std::vector<FunctionName>>(
       "initial_stress",
       "A list of functions describing the initial stress.  If provided, there "
@@ -35,6 +36,9 @@ validParams<ComputeStressBase>()
                         "stress state, required for the HHT time "
                         "integration scheme and Rayleigh damping, needs "
                         "to be stored");
+  MooseEnum tangent_operator("elastic linear nonlinear", "nonlinear");
+  params.addParam<MooseEnum>(
+      "tangent_operator", tangent_operator, "Type of tangent operator to return.");
   params.suppressParameter<bool>("use_displaced_mesh");
   return params;
 }
@@ -50,6 +54,7 @@ ComputeStressBase::ComputeStressBase(const InputParameters & parameters)
     _extra_stress(getDefaultMaterialProperty<RankTwoTensor>(_base_name + "extra_stress")),
     _Jacobian_mult(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
     _store_stress_old(getParam<bool>("store_stress_old")),
+    _tangent_operator_type(getParam<MooseEnum>("tangent_operator").getEnum<TangentOperatorEnum>()),
     // InitialStress Deprecation: remove the following
     _initial_stress_provided(getParam<std::vector<FunctionName>>("initial_stress").size() ==
                              LIBMESH_DIM * LIBMESH_DIM),

--- a/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
@@ -62,7 +62,7 @@ LinearViscoelasticStressUpdate::updateState(RankTwoTensor & strain_increment,
                                             const RankTwoTensor & /*stress_old*/,
                                             const RankFourTensor & elasticity_tensor,
                                             const RankTwoTensor & elastic_strain_old,
-                                            bool /*compute_full_tangent_operator*/,
+                                            const TangentOperatorEnum & /*tangent_operator_type*/,
                                             RankFourTensor & tangent_operator)
 {
   RankTwoTensor current_mechanical_strain =

--- a/modules/tensor_mechanics/src/materials/MultiParameterPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/MultiParameterPlasticityStressUpdate.C
@@ -50,7 +50,6 @@ validParams<MultiParameterPlasticityStressUpdate>()
                                 "is set very low then precision-loss might be encountered: if the "
                                 "code detects precision loss then it also deems the return-map "
                                 "process has converged.");
-  MooseEnum tangent_operator("elastic nonlinear", "nonlinear");
   params.addParam<Real>("min_step_size",
                         1.0,
                         "In order to help the Newton-Raphson procedure, the applied strain "
@@ -148,7 +147,7 @@ MultiParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increme
                                                   const RankTwoTensor & stress_old,
                                                   const RankFourTensor & elasticity_tensor,
                                                   const RankTwoTensor & /*elastic_strain_old*/,
-                                                  bool compute_full_tangent_operator,
+                                                  const TangentOperatorEnum & tangent_operator_type,
                                                   RankFourTensor & tangent_operator)
 {
   initializeReturnProcess();
@@ -319,7 +318,7 @@ MultiParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increme
                  _ok_intnl,
                  smoothed_q,
                  step_size,
-                 compute_full_tangent_operator,
+                 (tangent_operator_type != TangentOperatorEnum::ELASTIC),
                  _dvar_dtrial);
       if (static_cast<Real>(step_iter) > _iter[_qp])
         _iter[_qp] = static_cast<Real>(step_iter);
@@ -364,7 +363,7 @@ MultiParameterPlasticityStressUpdate::updateState(RankTwoTensor & strain_increme
                                gaE_total,
                                smoothed_q,
                                elasticity_tensor,
-                               compute_full_tangent_operator,
+                               (tangent_operator_type != TangentOperatorEnum::ELASTIC),
                                _dvar_dtrial,
                                tangent_operator);
 }

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -64,7 +64,7 @@ RadialReturnStressUpdate::updateState(RankTwoTensor & strain_increment,
                                       const RankTwoTensor & /*stress_old*/,
                                       const RankFourTensor & elasticity_tensor,
                                       const RankTwoTensor & elastic_strain_old,
-                                      bool /*compute_full_tangent_operator*/,
+                                      const TangentOperatorEnum & /*tangent_operator_type*/,
                                       RankFourTensor & tangent_operator)
 {
   // compute the deviatoric trial stress and trial strain from the current intermediate
@@ -109,7 +109,7 @@ RadialReturnStressUpdate::updateState(RankTwoTensor & strain_increment,
 
   /**
    * Note!  The tangent operator for this class, and derived class is
-   * currently just the elasticity tensor, irrespective of compute_full_tangent_operator
+   * currently just the elasticity tensor, irrespective of tangent_operator_type
    */
   tangent_operator = elasticity_tensor;
 }


### PR DESCRIPTION
Moved TangentOperatorEnum to a class in ComputeStressBase.
Changed call in StressUpdateBase::updateState to take a TangentOperatorEnum instead of a flag to calculate the tangent operator or not.

Ref #11219


