### PR TITLE
abs() to std::abs()

### DIFF
--- a/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
@@ -134,7 +134,7 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
     Real sum = x_orientation(0) * y_orientation(0) + x_orientation(1) * y_orientation(1) +
                x_orientation(2) * y_orientation(2);
 
-    if (abs(sum) > 1e-4)
+    if (std::abs(sum) > 1e-4)
       mooseError("NodalRotationalInertia: x_orientation and y_orientation should be perpendicular "
                  "to each other.");
 


### PR DESCRIPTION
Regular `abs()` breaks on older clang versions.

refs #11344
closes #11392 
closes #11391

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
