### PR TITLE
Refactoring common functionality in unit tests

### DIFF
--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -1,0 +1,93 @@
+#ifndef MOOSEOBJECTUNITTEST_H
+#define MOOSEOBJECTUNITTEST_H
+
+#include "gtest/gtest.h"
+
+#include "MooseMesh.h"
+#include "GeneratedMesh.h"
+#include "FEProblem.h"
+#include "AppFactory.h"
+
+/**
+ * Base class for building basic unit tests for MOOSE objects that can live alone (like user
+ * objects, etc.)
+ *
+ * This class builds the basic objects that are needed in order to test a MOOSE object. Those are a
+ * mesh and an FEProblem.  To build a unit test, inherit from this class and build your test using
+ * the following template:
+ *
+ * In your .h file:
+ *
+ * class MyUnitTest : public MooseObjectUnitTest
+ * {
+ * public:
+ *   MyUnitTest() : MooseObjectUnitTest("MyAppUnitApp")
+ *   {
+ *     // if you are using the old registration system, you want to register your objects using this
+ *     // call. Otherwise, you do not need it.
+ *     registerObjects(_factory);
+ *     buildObjects();
+ *   }
+ *
+ * protected:
+ *   void registerObjects(Factory & factory)
+ *   {
+ *     // register your objects as usual, we have to be in a method like this so that the register
+ *     // macros work
+ *     registerUserObject(MyObjectThatIAmTesting);
+ *   }
+ *
+ *   void buildObjects()
+ *   {
+ *     // build your object like so
+ *     InputParameters pars = _factory.getValidParams("MyObjectThatIAmTesting");
+ *     _fe_problem->addUserObject("MyObjectThatIAmTesting", "fp", uo_pars);
+ *     _obj = &_fe_problem->getUserObject<MyObjectThatIAmTesting>("fp");
+ *   }
+ *
+ *   // member variable used later in the actual tests
+ *   const MyObjectThatIAmTesting * _obj;
+ * };
+ *
+ * In your .C file
+ *
+ * TEST_F(MyObjectThatIAmTesting, test)
+ * {
+ *   EXPECT_EQ("testing", _obj->method(par1, par2));
+ * }
+ *
+ * NOTE: Testing mesh-bound objects like Kernels, BCs, etc. is not possible with this class.
+ */
+class MooseObjectUnitTest : public ::testing::Test
+{
+public:
+  /**
+   * @param app_name The name of client's application
+   */
+  MooseObjectUnitTest(const std::string & app_name)
+    : _app(AppFactory::createAppShared(app_name, 0, nullptr)), _factory(_app->getFactory())
+  {
+    buildObjects();
+  }
+
+protected:
+  void buildObjects()
+  {
+    InputParameters mesh_params = _factory.getValidParams("GeneratedMesh");
+    mesh_params.set<std::string>("_object_name") = "name1";
+    mesh_params.set<MooseEnum>("dim") = "3";
+    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
+
+    InputParameters problem_params = _factory.getValidParams("FEProblem");
+    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
+    problem_params.set<std::string>("_object_name") = "name2";
+    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
+  }
+
+  std::unique_ptr<MooseMesh> _mesh;
+  std::shared_ptr<MooseApp> _app;
+  Factory & _factory;
+  std::shared_ptr<FEProblem> _fe_problem;
+};
+
+#endif

--- a/unit/include/BrineFluidPropertiesTest.h
+++ b/unit/include/BrineFluidPropertiesTest.h
@@ -10,35 +10,24 @@
 #ifndef BRINEFLUIDPROPERTIESTEST_H
 #define BRINEFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "Utils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "BrineFluidProperties.h"
 #include "Water97FluidProperties.h"
 #include "NaClFluidProperties.h"
 
-class MooseMesh;
-class FEProblem;
 class BrineFluidProperties;
 class SinglePhaseFluidPropertiesPT;
 
-class BrineFluidPropertiesTest : public ::testing::Test
+class BrineFluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  BrineFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory)
   {
     registerUserObject(BrineFluidProperties);
@@ -48,29 +37,12 @@ protected:
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    // The brine fluid properties
-    InputParameters uo_pars = _factory->getValidParams("BrineFluidProperties");
-    fep->addUserObject("BrineFluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<BrineFluidProperties>("fp");
-
-    // Get the water properties UserObject
+    InputParameters uo_pars = _factory.getValidParams("BrineFluidProperties");
+    _fe_problem->addUserObject("BrineFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<BrineFluidProperties>("fp");
     _water_fp = &_fp->getComponent(BrineFluidProperties::WATER);
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const BrineFluidProperties * _fp;
   const SinglePhaseFluidPropertiesPT * _water_fp;
 };

--- a/unit/include/CO2FluidPropertiesTest.h
+++ b/unit/include/CO2FluidPropertiesTest.h
@@ -10,55 +10,28 @@
 #ifndef CO2FLUIDPROPERTIESTEST_H
 #define CO2FLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "CO2FluidProperties.h"
-#include "MooseApp.h"
 
-class MooseMesh;
-class FEProblem;
-class CO2FluidProperties;
-
-class CO2FluidPropertiesTest : public ::testing::Test
+class CO2FluidPropertiesTest : public MooseObjectUnitTest
 {
+public:
+  CO2FluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
+  {
+    registerObjects(_factory);
+    buildObjects();
+  }
+
 protected:
   void registerObjects(Factory & factory) { registerUserObject(CO2FluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("CO2FluidProperties");
-    fep->addUserObject("CO2FluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<CO2FluidProperties>("fp");
+    InputParameters uo_pars = _factory.getValidParams("CO2FluidProperties");
+    _fe_problem->addUserObject("CO2FluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<CO2FluidProperties>("fp");
   }
 
-  void SetUp()
-  {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-
-    registerObjects(*_factory);
-    buildObjects();
-  }
-
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const CO2FluidProperties * _fp;
 };
 

--- a/unit/include/IdealGasFluidPropertiesPTTest.h
+++ b/unit/include/IdealGasFluidPropertiesPTTest.h
@@ -10,52 +10,29 @@
 #ifndef IDEALGASFLUIDPROPERTIESPTTEST_H
 #define IDEALGASFLUIDPROPERTIESPTTEST_H
 
-#include "gtest_include.h"
-
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "IdealGasFluidPropertiesPT.h"
-#include "MooseApp.h"
-#include "Utils.h"
 
-class IdealGasFluidPropertiesPTTest : public ::testing::Test
+class IdealGasFluidPropertiesPTTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  IdealGasFluidPropertiesPTTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(IdealGasFluidPropertiesPT); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("IdealGasFluidPropertiesPT");
-    fep->addUserObject("IdealGasFluidPropertiesPT", "fp", uo_pars);
-    _fp = &fep->getUserObject<IdealGasFluidPropertiesPT>("fp");
+    InputParameters uo_pars = _factory.getValidParams("IdealGasFluidPropertiesPT");
+    _fe_problem->addUserObject("IdealGasFluidPropertiesPT", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<IdealGasFluidPropertiesPT>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
-  const SinglePhaseFluidPropertiesPT * _fp;
+  const IdealGasFluidPropertiesPT * _fp;
 };
 
 #endif // IDEALGASFLUIDPROPERTIESPTTEST_H

--- a/unit/include/IdealGasFluidPropertiesTest.h
+++ b/unit/include/IdealGasFluidPropertiesTest.h
@@ -10,53 +10,30 @@
 #ifndef IDEALGASFLUIDPROPERTIESTEST_H
 #define IDEALGASFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "SinglePhaseFluidPropertiesUtils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "IdealGasFluidProperties.h"
 
-class IdealGasFluidPropertiesTest : public ::testing::Test
+class IdealGasFluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  IdealGasFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(IdealGasFluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("IdealGasFluidProperties");
+    InputParameters uo_pars = _factory.getValidParams("IdealGasFluidProperties");
     uo_pars.set<Real>("R") = 287.04;
     uo_pars.set<Real>("gamma") = 1.41;
-    fep->addUserObject("IdealGasFluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<IdealGasFluidProperties>("fp");
+    _fe_problem->addUserObject("IdealGasFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<IdealGasFluidProperties>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const IdealGasFluidProperties * _fp;
 };
 

--- a/unit/include/MethaneFluidPropertiesTest.h
+++ b/unit/include/MethaneFluidPropertiesTest.h
@@ -10,51 +10,28 @@
 #ifndef METHANEFLUIDPROPERTIESTEST_H
 #define METHANEFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "MethaneFluidProperties.h"
-#include "MooseApp.h"
-#include "Utils.h"
 
-class MethaneFluidPropertiesTest : public ::testing::Test
+class MethaneFluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  MethaneFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(MethaneFluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("MethaneFluidProperties");
-    fep->addUserObject("MethaneFluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<MethaneFluidProperties>("fp");
+    InputParameters uo_pars = _factory.getValidParams("MethaneFluidProperties");
+    _fe_problem->addUserObject("MethaneFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<MethaneFluidProperties>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const MethaneFluidProperties * _fp;
 };
 

--- a/unit/include/NaClFluidPropertiesTest.h
+++ b/unit/include/NaClFluidPropertiesTest.h
@@ -10,51 +10,28 @@
 #ifndef NACLFLUIDPROPERTIESTEST_H
 #define NACLFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "Utils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "NaClFluidProperties.h"
 
-class NaClFluidPropertiesTest : public ::testing::Test
+class NaClFluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  NaClFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(NaClFluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("NaClFluidProperties");
-    fep->addUserObject("NaClFluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<NaClFluidProperties>("fp");
+    InputParameters uo_pars = _factory.getValidParams("NaClFluidProperties");
+    _fe_problem->addUserObject("NaClFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<NaClFluidProperties>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const NaClFluidProperties * _fp;
 };
 

--- a/unit/include/PorousFlowFluidStateFlashTest.h
+++ b/unit/include/PorousFlowFluidStateFlashTest.h
@@ -10,52 +10,28 @@
 #ifndef POROUSFLOWFLUIDSTATEFLASHTEST_H
 #define POROUSFLOWFLUIDSTATEFLASHTEST_H
 
-#include "gtest_include.h"
-
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
-#include "MooseApp.h"
-#include "Utils.h"
+#include "MooseObjectUnitTest.h"
 #include "PorousFlowFluidStateFlash.h"
 
-class PorousFlowFluidStateFlashTest : public ::testing::Test
+class PorousFlowFluidStateFlashTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  PorousFlowFluidStateFlashTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(PorousFlowFluidStateFlash); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_params = _factory->getValidParams("PorousFlowFluidStateFlash");
-    fep->addUserObject("PorousFlowFluidStateFlash", "fp", uo_params);
-    _fp = &fep->getUserObject<PorousFlowFluidStateFlash>("fp");
+    InputParameters uo_params = _factory.getValidParams("PorousFlowFluidStateFlash");
+    _fe_problem->addUserObject("PorousFlowFluidStateFlash", "fp", uo_params);
+    _fp = &_fe_problem->getUserObject<PorousFlowFluidStateFlash>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  MooseAppPtr _app;
-  Factory * _factory;
   const PorousFlowFluidStateFlash * _fp;
 };
 

--- a/unit/include/SodiumPropertiesTest.h
+++ b/unit/include/SodiumPropertiesTest.h
@@ -10,57 +10,28 @@
 #ifndef SODIUMPROPERTIESTEST_H
 #define SODIUMPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "Utils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
-
+#include "MooseObjectUnitTest.h"
 #include "SodiumProperties.h"
 
-class MooseMesh;
-class FEProblem;
-
-class SodiumPropertiesTest : public ::testing::Test
+class SodiumPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  SodiumPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(SodiumProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    // The sodium fluid properties
-    InputParameters uo_pars = _factory->getValidParams("SodiumProperties");
-    fep->addUserObject("SodiumProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<SodiumProperties>("fp");
+    InputParameters uo_pars = _factory.getValidParams("SodiumProperties");
+    _fe_problem->addUserObject("SodiumProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<SodiumProperties>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const SodiumProperties * _fp;
 };
 

--- a/unit/include/StiffenedGasFluidPropertiesTest.h
+++ b/unit/include/StiffenedGasFluidPropertiesTest.h
@@ -7,61 +7,38 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifndef StiffenedGasFluidPropertiesTest_H
-#define StiffenedGasFluidPropertiesTest_H
+#ifndef STIFFENEDGASFLUIDPROPERTIESTEST_H
+#define STIFFENEDGASFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "SinglePhaseFluidPropertiesUtils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "StiffenedGasFluidProperties.h"
 
-class StiffenedGasFluidPropertiesTest : public ::testing::Test
+class StiffenedGasFluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  StiffenedGasFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(StiffenedGasFluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters eos_pars = _factory->getValidParams("StiffenedGasFluidProperties");
+    InputParameters eos_pars = _factory.getValidParams("StiffenedGasFluidProperties");
     eos_pars.set<Real>("gamma") = 2.35;
     eos_pars.set<Real>("q") = -1167e3;
     eos_pars.set<Real>("q_prime") = 0;
     eos_pars.set<Real>("p_inf") = 1.e9;
     eos_pars.set<Real>("cv") = 1816;
     eos_pars.set<std::string>("_object_name") = "name3";
-    fep->addUserObject("StiffenedGasFluidProperties", "fp", eos_pars);
-    _fp = &fep->getUserObject<StiffenedGasFluidProperties>("fp");
+    _fe_problem->addUserObject("StiffenedGasFluidProperties", "fp", eos_pars);
+    _fp = &_fe_problem->getUserObject<StiffenedGasFluidProperties>("fp");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const StiffenedGasFluidProperties * _fp;
 };
 
-#endif /* StiffenedGasFluidPropertiesTest_H */
+#endif /* STIFFENEDGASFLUIDPROPERTIESTEST_H */

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -10,22 +10,22 @@
 #ifndef TABULATEDFLUIDPROPERTIESTEST_H
 #define TABULATEDFLUIDPROPERTIESTEST_H
 
-#include "gtest_include.h"
-
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "TabulatedFluidProperties.h"
 #include "CO2FluidProperties.h"
-#include "MooseApp.h"
 
-class MooseMesh;
-class FEProblem;
 class CO2FluidProperties;
 class TabulatedFluidProperties;
 
-class TabulatedFluidPropertiesTest : public ::testing::Test
+class TabulatedFluidPropertiesTest : public MooseObjectUnitTest
 {
+public:
+  TabulatedFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
+  {
+    registerObjects(_factory);
+    buildObjects();
+  }
+
 protected:
   void registerObjects(Factory & factory)
   {
@@ -35,28 +35,17 @@ protected:
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
+    InputParameters co2_uo_params = _factory.getValidParams("CO2FluidProperties");
+    _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_uo_params);
+    _co2_fp = &_fe_problem->getUserObject<CO2FluidProperties>("co2_fp");
 
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters co2_uo_params = _factory->getValidParams("CO2FluidProperties");
-    fep->addUserObject("CO2FluidProperties", "co2_fp", co2_uo_params);
-    _co2_fp = &fep->getUserObject<CO2FluidProperties>("co2_fp");
-
-    InputParameters tab_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters tab_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     tab_uo_params.set<UserObjectName>("fp") = "co2_fp";
     tab_uo_params.set<FileName>("fluid_property_file") = "data/csv/fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
-    _tab_fp = &fep->getUserObject<TabulatedFluidProperties>("tab_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
+    _tab_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_fp");
 
-    InputParameters tab_gen_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters tab_gen_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     tab_gen_uo_params.set<UserObjectName>("fp") = "co2_fp";
     tab_gen_uo_params.set<Real>("temperature_min") = 400;
     tab_gen_uo_params.set<Real>("temperature_max") = 500;
@@ -64,51 +53,41 @@ protected:
     tab_gen_uo_params.set<Real>("pressure_max") = 2e6;
     tab_gen_uo_params.set<unsigned int>("num_T") = 6;
     tab_gen_uo_params.set<unsigned int>("num_p") = 6;
-    fep->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
-    _tab_gen_fp = &fep->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
+    _tab_gen_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
 
-    InputParameters unordered_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters unordered_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unordered_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unordered_uo_params.set<FileName>("fluid_property_file") = "data/csv/unordered_fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "unordered_fp", unordered_uo_params);
-    _unordered_fp = &fep->getUserObject<TabulatedFluidProperties>("unordered_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "unordered_fp", unordered_uo_params);
+    _unordered_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unordered_fp");
 
-    InputParameters unequal_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters unequal_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unequal_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unequal_uo_params.set<FileName>("fluid_property_file") = "data/csv/unequal_fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "unequal_fp", unequal_uo_params);
-    _unequal_fp = &fep->getUserObject<TabulatedFluidProperties>("unequal_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "unequal_fp", unequal_uo_params);
+    _unequal_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unequal_fp");
 
-    InputParameters missing_col_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters missing_col_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     missing_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     missing_col_uo_params.set<FileName>("fluid_property_file") =
         "data/csv/missing_col_fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "missing_col_fp", missing_col_uo_params);
-    _missing_col_fp = &fep->getUserObject<TabulatedFluidProperties>("missing_col_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "missing_col_fp", missing_col_uo_params);
+    _missing_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_col_fp");
 
-    InputParameters unknown_col_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters unknown_col_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unknown_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unknown_col_uo_params.set<FileName>("fluid_property_file") = "data/csv/unknown_fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "unknown_col_fp", unknown_col_uo_params);
-    _unknown_col_fp = &fep->getUserObject<TabulatedFluidProperties>("unknown_col_fp");
+    _fe_problem->addUserObject("TabulatedFluidProperties", "unknown_col_fp", unknown_col_uo_params);
+    _unknown_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unknown_col_fp");
 
-    InputParameters missing_data_uo_params = _factory->getValidParams("TabulatedFluidProperties");
+    InputParameters missing_data_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     missing_data_uo_params.set<UserObjectName>("fp") = "co2_fp";
     missing_data_uo_params.set<FileName>("fluid_property_file") =
         "data/csv/missing_data_fluid_props.csv";
-    fep->addUserObject("TabulatedFluidProperties", "missing_data_fp", missing_data_uo_params);
-    _missing_data_fp = &fep->getUserObject<TabulatedFluidProperties>("missing_data_fp");
-  }
-
-  void SetUp()
-  {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-
-    registerObjects(*_factory);
-    buildObjects();
+    _fe_problem->addUserObject(
+        "TabulatedFluidProperties", "missing_data_fp", missing_data_uo_params);
+    _missing_data_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_data_fp");
   }
 
   void TearDown()
@@ -118,9 +97,6 @@ protected:
     std::remove("fluid_properties.csv");
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const CO2FluidProperties * _co2_fp;
   const TabulatedFluidProperties * _tab_fp;
   const TabulatedFluidProperties * _tab_gen_fp;

--- a/unit/include/Water97FluidPropertiesTest.h
+++ b/unit/include/Water97FluidPropertiesTest.h
@@ -10,47 +10,27 @@
 #ifndef WATER97FLUIDPROPERTIESTEST_H
 #define WATER97FLUIDPROPERTIESTEST_H
 
-// CPPUnit includes
-#include "gtest_include.h"
-
-#include "MooseApp.h"
-#include "Utils.h"
-#include "FEProblem.h"
-#include "AppFactory.h"
-#include "GeneratedMesh.h"
+#include "MooseObjectUnitTest.h"
 #include "Water97FluidProperties.h"
+#include "Utils.h"
 
-class Water97FluidPropertiesTest : public ::testing::Test
+class Water97FluidPropertiesTest : public MooseObjectUnitTest
 {
-protected:
-  void SetUp()
+public:
+  Water97FluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
   {
-    const char * argv[] = {"foo", NULL};
-
-    _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
-    _factory = &_app->getFactory();
-    registerObjects(*_factory);
+    registerObjects(_factory);
     buildObjects();
   }
 
+protected:
   void registerObjects(Factory & factory) { registerUserObject(Water97FluidProperties); }
 
   void buildObjects()
   {
-    InputParameters mesh_params = _factory->getValidParams("GeneratedMesh");
-    mesh_params.set<MooseEnum>("dim") = "3";
-    mesh_params.set<std::string>("name") = "mesh";
-    mesh_params.set<std::string>("_object_name") = "name1";
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-
-    InputParameters problem_params = _factory->getValidParams("FEProblem");
-    problem_params.set<MooseMesh *>("mesh") = _mesh.get();
-    problem_params.set<std::string>("_object_name") = "name2";
-    auto fep = _factory->create<FEProblemBase>("FEProblem", "problem", problem_params);
-
-    InputParameters uo_pars = _factory->getValidParams("Water97FluidProperties");
-    fep->addUserObject("Water97FluidProperties", "fp", uo_pars);
-    _fp = &fep->getUserObject<Water97FluidProperties>("fp");
+    InputParameters uo_pars = _factory.getValidParams("Water97FluidProperties");
+    _fe_problem->addUserObject("Water97FluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<Water97FluidProperties>("fp");
   }
 
   void regionDerivatives(Real p, Real T, Real tol)
@@ -90,9 +70,6 @@ protected:
     REL_TEST("de_dT", de_dT, de_dT_fd, tol);
   }
 
-  std::unique_ptr<MooseMesh> _mesh; // mesh must destruct last and so be declared first
-  std::shared_ptr<MooseApp> _app;
-  Factory * _factory;
   const Water97FluidProperties * _fp;
 };
 

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "BrineFluidPropertiesTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of brine vapor pressure using data from

--- a/unit/src/IdealGasFluidPropertiesPTTest.C
+++ b/unit/src/IdealGasFluidPropertiesPTTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "IdealGasFluidPropertiesPTTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of the fluid properties

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "IdealGasFluidPropertiesTest.h"
+#include "SinglePhaseFluidPropertiesUtils.h"
 
 TEST_F(IdealGasFluidPropertiesTest, testAll)
 {

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "MethaneFluidPropertiesTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of Henry's constant using data from

--- a/unit/src/NaClFluidPropertiesTest.C
+++ b/unit/src/NaClFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "NaClFluidPropertiesTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of the NACL properties the solid halite phase.

--- a/unit/src/PorousFlowBrineCO2Test.C
+++ b/unit/src/PorousFlowBrineCO2Test.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "PorousFlowBrineCO2Test.h"
+#include "Utils.h"
 
 /**
  * Verify that the correct name is supplied

--- a/unit/src/PorousFlowFluidStateFlashTest.C
+++ b/unit/src/PorousFlowFluidStateFlashTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "PorousFlowFluidStateFlashTest.h"
+#include "Utils.h"
 
 /**
  * Verify construction of the Rachford-Rice equation

--- a/unit/src/PorousFlowWaterNCGTest.C
+++ b/unit/src/PorousFlowWaterNCGTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "PorousFlowWaterNCGTest.h"
+#include "Utils.h"
 
 /**
  * Verify that the correct name is supplied

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SimpleFluidPropertiesTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of the fluid properties

--- a/unit/src/SodiumPropertiesTest.C
+++ b/unit/src/SodiumPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SodiumPropertiesTest.h"
+#include "Utils.h"
 
 /**
  * Verify calculation of Sodium Properties from ANL/RE-95/2 report

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "StiffenedGasFluidPropertiesTest.h"
+#include "SinglePhaseFluidPropertiesUtils.h"
 
 TEST_F(StiffenedGasFluidPropertiesTest, testAll)
 {


### PR DESCRIPTION
To test a single MOOSE object, we provide a common base class that
builds the necessary stuff. Then, the user class just builds the stuff
it needs and plug it in MOOSE and test it.

Closes #11401

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
