### PR TITLE
Make RankTwoTensor derive from RealTensorValue

### DIFF
--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -113,9 +113,6 @@ public:
   /// C_ijkl*a_kl
   RankTwoTensor operator*(const RankTwoTensor & a) const;
 
-  /// C_ijkl*a_kl
-  RealTensorValue operator*(const RealTensorValue & a) const;
-
   /// C_ijkl*a
   RankFourTensor operator*(const Real a) const;
 
@@ -164,15 +161,9 @@ public:
 
   /**
    * Rotate the tensor using
-   * C_ijkl = R_im R_in R_ko R_lp C_mnop
-   */
-  void rotate(const RealTensorValue & R);
-
-  /**
-   * Rotate the tensor using
    * C_ijkl = R_im R_jn R_ko R_lp C_mnop
    */
-  void rotate(const RankTwoTensor & R);
+  void rotate(const RealTensorValue & R);
 
   /**
    * Transpose the tensor by swapping the first pair with the second pair of indices

--- a/framework/include/utils/RankThreeTensor.h
+++ b/framework/include/utils/RankThreeTensor.h
@@ -92,9 +92,6 @@ public:
   /// b_i = r_ijk * a_jk
   RealVectorValue operator*(const RankTwoTensor & a) const;
 
-  /// r_ijk*a_kl
-  // RealTensorValue operator*(const RealTensorValue & a) const;
-
   /// r_ijk*a
   RankThreeTensor operator*(const Real a) const;
 
@@ -137,12 +134,6 @@ public:
    * r_ijk = R_im R_in R_ko r_mno
    */
   void rotate(const RealTensorValue & R);
-
-  /**
-   * Rotate the tensor using
-   * r_ijk = R_im R_in R_ko R_lp r_mno
-   */
-  void rotate(const RankTwoTensor & R);
 
   /// Static method for use in validParams for getting the "fill_method"
   static MooseEnum fillMethodEnum();

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -45,7 +45,7 @@ void mooseSetToZero<RankTwoTensor>(RankTwoTensor & v);
  * The entries are accessed by index, with i, j equal to 1, 2, or 3, or
  * internally i, j = 0, 1, 2.
  */
-class RankTwoTensor
+class RankTwoTensor : public RealTensorValue
 {
 public:
   // Select initialization
@@ -77,7 +77,7 @@ public:
 
   /**
    * Constructor that takes in 3 vectors and uses them to create rows
-   * _vals[0][i] = row1(i), _vals[1][i] = row2(i), _vals[2][i] = row3(i)
+   * _coords[0][i] = row1(i), _coords[1][i] = row2(i), _coords[2][i] = row3(i)
    */
   RankTwoTensor(const TypeVector<Real> & row1,
                 const TypeVector<Real> & row2,
@@ -110,12 +110,12 @@ public:
   static RankTwoTensor Identity() { return RankTwoTensor(initIdentity); }
 
   /// Gets the value for the index specified.  Takes index = 0,1,2
-  inline Real & operator()(unsigned int i, unsigned int j) { return _vals[i * N + j]; }
+  inline Real & operator()(unsigned int i, unsigned int j) { return _coords[i * N + j]; }
 
   /// Gets the value for the index specified.  Takes index = 0,1,2, used for const
-  inline Real operator()(unsigned int i, unsigned int j) const { return _vals[i * N + j]; }
+  inline Real operator()(unsigned int i, unsigned int j) const { return _coords[i * N + j]; }
 
-  /// zeroes all _vals components
+  /// zeroes all _coords components
   void zero();
 
   /// Static method for use in validParams for getting the "fill_method"
@@ -124,40 +124,40 @@ public:
   /**
    * fillFromInputVector takes 6 or 9 inputs to fill in the Rank-2 tensor.
    * If 6 inputs, then symmetry is assumed S_ij = S_ji, and
-   *   _vals[0][0] = input[0]
-   *   _vals[1][1] = input[1]
-   *   _vals[2][2] = input[2]
-   *   _vals[1][2] = input[3]
-   *   _vals[0][2] = input[4]
-   *   _vals[0][1] = input[5]
+   *   _coords[0][0] = input[0]
+   *   _coords[1][1] = input[1]
+   *   _coords[2][2] = input[2]
+   *   _coords[1][2] = input[3]
+   *   _coords[0][2] = input[4]
+   *   _coords[0][1] = input[5]
    * If 9 inputs then input order is [0][0], [1][0], [2][0], [0][1], [1][1], ..., [2][2]
    */
   void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method = autodetect);
 
 public:
-  /// returns _vals[r][i], ie, row r, with r = 0, 1, 2
+  /// returns _coords[r][i], ie, row r, with r = 0, 1, 2
   TypeVector<Real> row(const unsigned int r) const;
 
-  /// returns _vals[i][c], ie, column c, with c = 0, 1, 2
+  /// returns _coords[i][c], ie, column c, with c = 0, 1, 2
   TypeVector<Real> column(const unsigned int c) const;
 
   /**
    * Returns a rotated version of the tensor data given a rank two tensor rotation tensor
-   * _vals[i][j] = R_ij * R_jl * _vals[k][l]
+   * _coords[i][j] = R_ij * R_jl * _coords[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
   RankTwoTensor rotated(const RealTensorValue & R) const;
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
-   * _vals[i][j] = R_ij * R_jl * _vals[k][l]
+   * _coords[i][j] = R_ij * R_jl * _coords[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
   void rotate(const RealTensorValue & R);
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
-   * _vals[i][j] = R_ij * R_jl * _vals[k][l]
+   * _coords[i][j] = R_ij * R_jl * _coords[k][l]
    * @param R rotation matrix as a RankTwoTensor
    */
   void rotate(const RankTwoTensor & R);
@@ -174,40 +174,40 @@ public:
    */
   RankTwoTensor transpose() const;
 
-  /// sets _vals to a, and returns _vals
+  /// sets _coords to a, and returns _coords
   RankTwoTensor & operator=(const RankTwoTensor & a);
 
-  /// adds a to _vals
+  /// adds a to _coords
   RankTwoTensor & operator+=(const RankTwoTensor & a);
 
-  /// returns _vals + a
+  /// returns _coords + a
   RankTwoTensor operator+(const RankTwoTensor & a) const;
 
-  /// sets _vals -= a and returns vals
+  /// sets _coords -= a and returns vals
   RankTwoTensor & operator-=(const RankTwoTensor & a);
 
-  /// returns _vals - a
+  /// returns _coords - a
   RankTwoTensor operator-(const RankTwoTensor & a) const;
 
-  /// returns -_vals
+  /// returns -_coords
   RankTwoTensor operator-() const;
 
-  /// performs _vals *= a
+  /// performs _coords *= a
   RankTwoTensor & operator*=(const Real a);
 
-  /// returns _vals*a
+  /// returns _coords*a
   RankTwoTensor operator*(const Real a) const;
 
-  /// performs _vals /= a
+  /// performs _coords /= a
   RankTwoTensor & operator/=(const Real a);
 
-  /// returns _vals/a
+  /// returns _coords/a
   RankTwoTensor operator/(const Real a) const;
 
   /// Defines multiplication with a vector to get a vector
   TypeVector<Real> operator*(const TypeVector<Real> & a) const;
 
-  /// performs _vals *= a (component by component) and returns the result
+  /// performs _coords *= a (component by component) and returns the result
   RankTwoTensor & operator*=(const RankTwoTensor & a);
 
   /// Defines multiplication with another RankTwoTensor
@@ -219,10 +219,10 @@ public:
   /// Defines logical equality with another RankTwoTensor
   bool operator==(const RankTwoTensor & a) const;
 
-  /// Sets _vals to the values in a ColumnMajorMatrix (must be 3x3)
+  /// Sets _coords to the values in a ColumnMajorMatrix (must be 3x3)
   RankTwoTensor & operator=(const ColumnMajorMatrix & a);
 
-  /// returns _vals_ij * a_ij (sum on i, j)
+  /// returns _coords_ij * a_ij (sum on i, j)
   Real doubleContraction(const RankTwoTensor & a) const;
 
   /// returns C_ijkl = a_ij * b_kl
@@ -240,20 +240,20 @@ public:
   /// return positive projection tensor of eigen-decomposition
   RankFourTensor positveProjectionEigenDecomposition() const;
 
-  /// returns A_ij - de_ij*tr(A)/3, where A are the _vals
+  /// returns A_ij - de_ij*tr(A)/3, where A are the _coords
   RankTwoTensor deviatoric() const;
 
-  /// returns the trace of the tensor, ie _vals[i][i] (sum i = 0, 1, 2)
+  /// returns the trace of the tensor, ie _coords[i][i] (sum i = 0, 1, 2)
   Real trace() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then this returns
+   * Denote the _coords[i][j] by A_ij, then this returns
    * d(trace)/dA_ij
    */
   RankTwoTensor dtrace() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then
+   * Denote the _coords[i][j] by A_ij, then
    * S_ij = A_ij - de_ij*tr(A)/3
    * Then this returns (S_ij + S_ji)*(S_ij + S_ji)/8
    * Note the explicit symmeterisation
@@ -266,13 +266,13 @@ public:
   Real secondInvariant() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then this returns
+   * Denote the _coords[i][j] by A_ij, then this returns
    * d(secondInvariant)/dA_ij
    */
   RankTwoTensor dsecondInvariant() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then this returns
+   * Denote the _coords[i][j] by A_ij, then this returns
    * d^2(secondInvariant)/dA_ij/dA_kl
    */
   RankFourTensor d2secondInvariant() const;
@@ -302,7 +302,7 @@ public:
   RankFourTensor d2sin3Lode(const Real r0) const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then
+   * Denote the _coords[i][j] by A_ij, then
    * S_ij = A_ij - de_ij*tr(A)/3
    * Then this returns det(S + S.transpose())/2
    * Note the explicit symmeterisation
@@ -310,13 +310,13 @@ public:
   Real thirdInvariant() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then
+   * Denote the _coords[i][j] by A_ij, then
    * this returns d(thirdInvariant()/dA_ij
    */
   RankTwoTensor dthirdInvariant() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then this returns
+   * Denote the _coords[i][j] by A_ij, then this returns
    * d^2(thirdInvariant)/dA_ij/dA_kl
    */
   RankFourTensor d2thirdInvariant() const;
@@ -325,7 +325,7 @@ public:
   Real det() const;
 
   /**
-   * Denote the _vals[i][j] by A_ij, then this returns
+   * Denote the _coords[i][j] by A_ij, then this returns
    * d(det)/dA_ij
    */
   RankTwoTensor ddet() const;
@@ -336,14 +336,14 @@ public:
   /// Print the rank two tensor
   void print(std::ostream & stm = Moose::out) const;
 
-  /// Add identity times a to _vals
+  /// Add identity times a to _coords
   void addIa(const Real a);
 
-  /// Sqrt(_vals[i][j]*_vals[i][j])
+  /// Sqrt(_coords[i][j]*_coords[i][j])
   Real L2norm() const;
 
   /**
-   * sets _vals[0][0], _vals[0][1], _vals[1][0], _vals[1][1] to input,
+   * sets _coords[0][0], _coords[0][1], _coords[1][0], _coords[1][1] to input,
    * and the remainder to zero
    */
   void surfaceFillFromInputVector(const std::vector<Real> & input);
@@ -382,7 +382,7 @@ public:
   void d2symmetricEigenvalues(std::vector<RankFourTensor> & deriv) const;
 
   /**
-   * Uses the petscblaslapack.h LAPACKsyev_ routine to find, for symmetric _vals:
+   * Uses the petscblaslapack.h LAPACKsyev_ routine to find, for symmetric _coords:
    *  (1) the eigenvalues (if calculation_type == "N")
    *  (2) the eigenvalues and eigenvectors (if calculation_type == "V")
    * @param calculation_type If "N" then calculation eigenvalues only
@@ -437,9 +437,6 @@ public:
 private:
   static constexpr unsigned int N = LIBMESH_DIM;
   static constexpr unsigned int N2 = N * N;
-
-  /// The values of the rank-two tensor stored by index=(i * LIBMESH_DIM + j)
-  Real _vals[N2];
 
   template <class T>
   friend void dataStore(std::ostream &, T &, void *);

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -104,19 +104,13 @@ public:
       Real S11, Real S21, Real S31, Real S12, Real S22, Real S32, Real S13, Real S23, Real S33);
 
   /// Copy constructor from RealTensorValue
-  RankTwoTensor(const TypeTensor<Real> & a);
+  RankTwoTensor(const RealTensorValue & a) : RealTensorValue(a) {}
+
+  /// Copy constructor from TypeTensor<Real>
+  RankTwoTensor(const TypeTensor<Real> & a) : RealTensorValue(a) {}
 
   // Named constructors
   static RankTwoTensor Identity() { return RankTwoTensor(initIdentity); }
-
-  /// Gets the value for the index specified.  Takes index = 0,1,2
-  inline Real & operator()(unsigned int i, unsigned int j) { return _coords[i * N + j]; }
-
-  /// Gets the value for the index specified.  Takes index = 0,1,2, used for const
-  inline Real operator()(unsigned int i, unsigned int j) const { return _coords[i * N + j]; }
-
-  /// zeroes all _coords components
-  void zero();
 
   /// Static method for use in validParams for getting the "fill_method"
   static MooseEnum fillMethodEnum();
@@ -135,9 +129,6 @@ public:
   void fillFromInputVector(const std::vector<Real> & input, FillMethod fill_method = autodetect);
 
 public:
-  /// returns _coords[r][i], ie, row r, with r = 0, 1, 2
-  TypeVector<Real> row(const unsigned int r) const;
-
   /// returns _coords[i][c], ie, column c, with c = 0, 1, 2
   TypeVector<Real> column(const unsigned int c) const;
 
@@ -146,14 +137,7 @@ public:
    * _coords[i][j] = R_ij * R_jl * _coords[k][l]
    * @param R rotation matrix as a RealTensorValue
    */
-  RankTwoTensor rotated(const RealTensorValue & R) const;
-
-  /**
-   * rotates the tensor data given a rank two tensor rotation tensor
-   * _coords[i][j] = R_ij * R_jl * _coords[k][l]
-   * @param R rotation matrix as a RealTensorValue
-   */
-  void rotate(const RealTensorValue & R);
+  RankTwoTensor rotated(const RankTwoTensor & R) const;
 
   /**
    * rotates the tensor data given a rank two tensor rotation tensor
@@ -207,14 +191,11 @@ public:
   /// Defines multiplication with a vector to get a vector
   TypeVector<Real> operator*(const TypeVector<Real> & a) const;
 
-  /// performs _coords *= a (component by component) and returns the result
-  RankTwoTensor & operator*=(const RankTwoTensor & a);
-
-  /// Defines multiplication with another RankTwoTensor
-  RankTwoTensor operator*(const RankTwoTensor & a) const;
-
   /// Defines multiplication with a TypeTensor<Real>
   RankTwoTensor operator*(const TypeTensor<Real> & a) const;
+
+  /// Defines multiplication with a TypeTensor<Real>
+  RankTwoTensor & operator*=(const TypeTensor<Real> & a);
 
   /// Defines logical equality with another RankTwoTensor
   bool operator==(const RankTwoTensor & a) const;
@@ -245,6 +226,9 @@ public:
 
   /// returns the trace of the tensor, ie _coords[i][i] (sum i = 0, 1, 2)
   Real trace() const;
+
+  /// retuns the inverse of the tensor
+  RankTwoTensor inverse() const;
 
   /**
    * Denote the _coords[i][j] by A_ij, then this returns
@@ -321,17 +305,11 @@ public:
    */
   RankFourTensor d2thirdInvariant() const;
 
-  /// Calculate the determinant of the tensor
-  Real det() const;
-
   /**
    * Denote the _coords[i][j] by A_ij, then this returns
    * d(det)/dA_ij
    */
   RankTwoTensor ddet() const;
-
-  /// Calculate the inverse of the tensor
-  RankTwoTensor inverse() const;
 
   /// Print the rank two tensor
   void print(std::ostream & stm = Moose::out) const;
@@ -446,8 +424,6 @@ private:
   friend class RankFourTensor;
   friend class RankThreeTensor;
 };
-
-inline RankTwoTensor operator*(Real a, const RankTwoTensor & b) { return b * a; }
 
 template <>
 void dataStore(std::ostream & stream, RankTwoTensor &, void *);

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -133,20 +133,6 @@ RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const
   return result;
 }
 
-RealTensorValue RankFourTensor::operator*(const RealTensorValue & b) const
-{
-  RealTensorValue result;
-
-  unsigned int index = 0;
-  for (unsigned int i = 0; i < N; ++i)
-    for (unsigned int j = 0; j < N; ++j)
-      for (unsigned int k = 0; k < N; ++k)
-        for (unsigned int l = 0; l < N; ++l)
-          result(i, j) += _vals[index++] * b(k, l);
-
-  return result;
-}
-
 RankFourTensor RankFourTensor::operator*(const Real b) const
 {
   RankFourTensor result;
@@ -422,51 +408,6 @@ RankFourTensor::rotate(const RealTensorValue & R)
         }
       }
     }
-  }
-}
-
-void
-RankFourTensor::rotate(const RankTwoTensor & R)
-{
-  RankFourTensor old = *this;
-
-  unsigned int index = 0;
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    unsigned int j1 = 0;
-    for (unsigned int j = 0; j < N; ++j)
-    {
-      unsigned int k1 = 0;
-      for (unsigned int k = 0; k < N; ++k)
-      {
-        unsigned int l1 = 0;
-        for (unsigned int l = 0; l < N; ++l)
-        {
-          unsigned int index2 = 0;
-          Real sum = 0.0;
-          for (unsigned int m = 0; m < N; ++m)
-          {
-            const Real a = R._coords[i1 + m];
-            for (unsigned int n = 0; n < N; ++n)
-            {
-              const Real ab = a * R._coords[j1 + n];
-              for (unsigned int o = 0; o < N; ++o)
-              {
-                const Real abc = ab * R._coords[k1 + o];
-                for (unsigned int p = 0; p < N; ++p)
-                  sum += abc * R._coords[l1 + p] * old._vals[index2++];
-              }
-            }
-          }
-          _vals[index++] = sum;
-          l1 += N;
-        }
-        k1 += N;
-      }
-      j1 += N;
-    }
-    i1 += N;
   }
 }
 

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -126,8 +126,8 @@ RankTwoTensor RankFourTensor::operator*(const RankTwoTensor & b) const
   {
     Real tmp = 0;
     for (unsigned int kl = 0; kl < N2; ++kl)
-      tmp += _vals[index++] * b._vals[kl];
-    result._vals[ij] = tmp;
+      tmp += _vals[index++] * b._coords[kl];
+    result._coords[ij] = tmp;
   }
 
   return result;
@@ -447,15 +447,15 @@ RankFourTensor::rotate(const RankTwoTensor & R)
           Real sum = 0.0;
           for (unsigned int m = 0; m < N; ++m)
           {
-            const Real a = R._vals[i1 + m];
+            const Real a = R._coords[i1 + m];
             for (unsigned int n = 0; n < N; ++n)
             {
-              const Real ab = a * R._vals[j1 + n];
+              const Real ab = a * R._coords[j1 + n];
               for (unsigned int o = 0; o < N; ++o)
               {
-                const Real abc = ab * R._vals[k1 + o];
+                const Real abc = ab * R._coords[k1 + o];
                 for (unsigned int p = 0; p < N; ++p)
-                  sum += abc * R._vals[l1 + p] * old._vals[index2++];
+                  sum += abc * R._coords[l1 + p] * old._vals[index2++];
               }
             }
           }
@@ -844,9 +844,9 @@ RankFourTensor::innerProductTranspose(const RankTwoTensor & b) const
   unsigned int index = 0;
   for (unsigned int ij = 0; ij < N2; ++ij)
   {
-    Real bb = b._vals[ij];
+    Real bb = b._coords[ij];
     for (unsigned int kl = 0; kl < N2; ++kl)
-      result._vals[kl] += _vals[index++] * bb;
+      result._coords[kl] += _vals[index++] * bb;
   }
 
   return result;

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -298,42 +298,6 @@ RankThreeTensor::rotate(const RealTensorValue & R)
 }
 
 void
-RankThreeTensor::rotate(const RankTwoTensor & R)
-{
-  RankThreeTensor old = *this;
-
-  unsigned int index = 0;
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    unsigned int j1 = 0;
-    for (unsigned int j = 0; j < N; ++j)
-    {
-      unsigned int k1 = 0;
-      for (unsigned int k = 0; k < N; ++k)
-      {
-        Real sum = 0.0;
-        unsigned int index2 = 0;
-        for (unsigned int m = 0; m < N; ++m)
-        {
-          Real a = R._coords[i1 + m];
-          for (unsigned int n = 0; n < N; ++n)
-          {
-            Real ab = a * R._coords[j1 + n];
-            for (unsigned int o = 0; o < N; ++o)
-              sum += ab * R._coords[k1 + o] * old._vals[index2++];
-          }
-        }
-        _vals[index++] = sum;
-        k1 += N;
-      }
-      j1 += N;
-    }
-    i1 += N;
-  }
-}
-
-void
 RankThreeTensor::fillGeneralFromInputVector(const std::vector<Real> & input)
 {
   if (input.size() != 27)

--- a/framework/src/utils/RankThreeTensor.C
+++ b/framework/src/utils/RankThreeTensor.C
@@ -103,7 +103,7 @@ RealVectorValue RankThreeTensor::operator*(const RankTwoTensor & a) const
     unsigned int i1 = i * N2;
     for (unsigned int j1 = 0; j1 < N2; j1 += N)
       for (unsigned int k = 0; k < N; ++k)
-        sum += _vals[i1 + j1 + k] * a._vals[j1 + k];
+        sum += _vals[i1 + j1 + k] * a._coords[j1 + k];
     result(i) = sum;
   }
 
@@ -264,7 +264,7 @@ RankThreeTensor::mixedProductRankFour(const RankTwoTensor & a) const
         {
           for (unsigned int m = 0; m < N; ++m)
             for (unsigned int n = 0; n < N; ++n)
-              result._vals[index] += (*this)(m, i, j) * a._vals[m * N + n] * (*this)(n, k, l);
+              result._vals[index] += (*this)(m, i, j) * a._coords[m * N + n] * (*this)(n, k, l);
           index++;
         }
 
@@ -316,12 +316,12 @@ RankThreeTensor::rotate(const RankTwoTensor & R)
         unsigned int index2 = 0;
         for (unsigned int m = 0; m < N; ++m)
         {
-          Real a = R._vals[i1 + m];
+          Real a = R._coords[i1 + m];
           for (unsigned int n = 0; n < N; ++n)
           {
-            Real ab = a * R._vals[j1 + n];
+            Real ab = a * R._coords[j1 + n];
             for (unsigned int o = 0; o < N; ++o)
-              sum += ab * R._vals[k1 + o] * old._vals[index2++];
+              sum += ab * R._coords[k1 + o] * old._vals[index2++];
           }
         }
         _vals[index++] = sum;
@@ -363,7 +363,7 @@ RankThreeTensor::doubleContraction(const RankTwoTensor & b) const
 
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N2; ++j)
-      result(i) += _vals[i * N2 + j] * b._vals[j];
+      result(i) += _vals[i * N2 + j] * b._coords[j];
 
   return result;
 }

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -41,14 +41,14 @@ template <>
 void
 dataStore(std::ostream & stream, RankTwoTensor & rtt, void * context)
 {
-  dataStore(stream, rtt._vals, context);
+  dataStore(stream, rtt._coords, context);
 }
 
 template <>
 void
 dataLoad(std::istream & stream, RankTwoTensor & rtt, void * context)
 {
-  dataLoad(stream, rtt._vals, context);
+  dataLoad(stream, rtt._coords, context);
 }
 
 MooseEnum
@@ -62,7 +62,7 @@ RankTwoTensor::RankTwoTensor()
   mooseAssert(N == 3, "RankTwoTensor is currently only tested for 3 dimensions.");
 
   for (unsigned int i = 0; i < N2; i++)
-    _vals[i] = 0.0;
+    _coords[i] = 0.0;
 }
 
 RankTwoTensor::RankTwoTensor(const InitMethod init)
@@ -90,14 +90,14 @@ RankTwoTensor::RankTwoTensor(const TypeVector<Real> & row1,
 {
   // Initialize the Tensor matrix from the passed in vectors
   for (unsigned int i = 0; i < N; i++)
-    _vals[i] = row1(i);
+    _coords[i] = row1(i);
 
   for (unsigned int i = 0; i < N; i++)
-    _vals[N + i] = row2(i);
+    _coords[N + i] = row2(i);
 
   const unsigned int two_n = N * 2;
   for (unsigned int i = 0; i < N; i++)
-    _vals[two_n + i] = row3(i);
+    _coords[two_n + i] = row3(i);
 }
 
 RankTwoTensor
@@ -159,7 +159,7 @@ void
 RankTwoTensor::zero()
 {
   for (unsigned int i(0); i < N2; i++)
-    _vals[i] = 0.0;
+    _coords[i] = 0.0;
 }
 
 void
@@ -263,7 +263,7 @@ RankTwoTensor::rotate(const RealTensorValue & R)
       temp(i, j) = tmp;
     }
   for (unsigned int i = 0; i < N2; i++)
-    _vals[i] = temp._vals[i];
+    _coords[i] = temp._coords[i];
 }
 
 void
@@ -278,23 +278,23 @@ RankTwoTensor::rotate(const RankTwoTensor & R)
     {
       // tmp += R(i,k)*R(j,l)*(*this)(k,l);
       // clang-format off
-      Real tmp = R._vals[i1 + 0] * R._vals[j1 + 0] * (*this)(0, 0) +
-                 R._vals[i1 + 0] * R._vals[j1 + 1] * (*this)(0, 1) +
-                 R._vals[i1 + 0] * R._vals[j1 + 2] * (*this)(0, 2) +
-                 R._vals[i1 + 1] * R._vals[j1 + 0] * (*this)(1, 0) +
-                 R._vals[i1 + 1] * R._vals[j1 + 1] * (*this)(1, 1) +
-                 R._vals[i1 + 1] * R._vals[j1 + 2] * (*this)(1, 2) +
-                 R._vals[i1 + 2] * R._vals[j1 + 0] * (*this)(2, 0) +
-                 R._vals[i1 + 2] * R._vals[j1 + 1] * (*this)(2, 1) +
-                 R._vals[i1 + 2] * R._vals[j1 + 2] * (*this)(2, 2);
+      Real tmp = R._coords[i1 + 0] * R._coords[j1 + 0] * (*this)(0, 0) +
+                 R._coords[i1 + 0] * R._coords[j1 + 1] * (*this)(0, 1) +
+                 R._coords[i1 + 0] * R._coords[j1 + 2] * (*this)(0, 2) +
+                 R._coords[i1 + 1] * R._coords[j1 + 0] * (*this)(1, 0) +
+                 R._coords[i1 + 1] * R._coords[j1 + 1] * (*this)(1, 1) +
+                 R._coords[i1 + 1] * R._coords[j1 + 2] * (*this)(1, 2) +
+                 R._coords[i1 + 2] * R._coords[j1 + 0] * (*this)(2, 0) +
+                 R._coords[i1 + 2] * R._coords[j1 + 1] * (*this)(2, 1) +
+                 R._coords[i1 + 2] * R._coords[j1 + 2] * (*this)(2, 2);
       // clang-format on
-      temp._vals[i1 + j] = tmp;
+      temp._coords[i1 + j] = tmp;
       j1 += N;
     }
     i1 += N;
   }
   for (unsigned int i = 0; i < N2; i++)
-    _vals[i] = temp._vals[i];
+    _coords[i] = temp._coords[i];
 }
 
 RankTwoTensor
@@ -324,7 +324,7 @@ RankTwoTensor::transpose() const
   for (unsigned int i = 0; i < N; ++i)
   {
     for (unsigned int j = 0; j < N; ++j)
-      result._vals[i1 + j] = (*this)(j, i);
+      result._coords[i1 + j] = (*this)(j, i);
     i1 += N;
   }
 
@@ -335,7 +335,7 @@ RankTwoTensor &
 RankTwoTensor::operator=(const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N2; ++i)
-    _vals[i] = a._vals[i];
+    _coords[i] = a._coords[i];
 
   return *this;
 }
@@ -344,7 +344,7 @@ RankTwoTensor &
 RankTwoTensor::operator+=(const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N2; ++i)
-    _vals[i] += a._vals[i];
+    _coords[i] += a._coords[i];
 
   return *this;
 }
@@ -354,7 +354,7 @@ RankTwoTensor::operator+(const RankTwoTensor & b) const
 {
   RankTwoTensor result;
   for (unsigned int i = 0; i < N2; ++i)
-    result._vals[i] = _vals[i] + b._vals[i];
+    result._coords[i] = _coords[i] + b._coords[i];
   return result;
 }
 
@@ -362,7 +362,7 @@ RankTwoTensor &
 RankTwoTensor::operator-=(const RankTwoTensor & a)
 {
   for (unsigned int i = 0; i < N2; ++i)
-    _vals[i] -= a._vals[i];
+    _coords[i] -= a._coords[i];
 
   return *this;
 }
@@ -372,7 +372,7 @@ RankTwoTensor::operator-(const RankTwoTensor & b) const
 {
   RankTwoTensor result;
   for (unsigned int i = 0; i < N2; ++i)
-    result._vals[i] = _vals[i] - b._vals[i];
+    result._coords[i] = _coords[i] - b._coords[i];
   return result;
 }
 
@@ -381,7 +381,7 @@ RankTwoTensor::operator-() const
 {
   RankTwoTensor result;
   for (unsigned int i = 0; i < N2; ++i)
-    result._vals[i] = -_vals[i];
+    result._coords[i] = -_coords[i];
   return result;
 }
 
@@ -389,7 +389,7 @@ RankTwoTensor &
 RankTwoTensor::operator*=(const Real a)
 {
   for (unsigned int i = 0; i < N2; ++i)
-    _vals[i] *= a;
+    _coords[i] *= a;
   return *this;
 }
 
@@ -397,7 +397,7 @@ RankTwoTensor RankTwoTensor::operator*(const Real b) const
 {
   RankTwoTensor result;
   for (unsigned int i = 0; i < N2; ++i)
-    result._vals[i] = _vals[i] * b;
+    result._coords[i] = _coords[i] * b;
   return result;
 }
 
@@ -417,7 +417,7 @@ RankTwoTensor::operator/(const Real b) const
   RankTwoTensor result;
 
   for (unsigned int i = 0; i < N2; ++i)
-    result._vals[i] = _vals[i] / b;
+    result._coords[i] = _coords[i] / b;
 
   return result;
 }
@@ -430,7 +430,7 @@ TypeVector<Real> RankTwoTensor::operator*(const TypeVector<Real> & b) const
   {
     unsigned int i1 = i * N;
     for (unsigned int j = 0; j < N; ++j)
-      result(i) += _vals[i1 + j] * b(j);
+      result(i) += _coords[i1 + j] * b(j);
   }
 
   return result;
@@ -449,7 +449,7 @@ RankTwoTensor::operator*=(const RankTwoTensor & a)
     for (unsigned int j = 0; j < N; ++j)
     {
       for (unsigned int k = 0; k < N; ++k)
-        _vals[i1 + k] += s._vals[i1 + j] * a._vals[j1 + k];
+        _coords[i1 + k] += s._coords[i1 + j] * a._coords[j1 + k];
       j1 += N;
     }
     i1 += N;
@@ -469,7 +469,7 @@ RankTwoTensor RankTwoTensor::operator*(const RankTwoTensor & b) const
     for (unsigned int j = 0; j < N; ++j)
     {
       for (unsigned int k = 0; k < N; ++k)
-        result._vals[i1 + k] += _vals[i1 + j] * b._vals[j1 + k];
+        result._coords[i1 + k] += _coords[i1 + j] * b._coords[j1 + k];
       j1 += N;
     }
     i1 += N;
@@ -487,7 +487,7 @@ RankTwoTensor RankTwoTensor::operator*(const TypeTensor<Real> & b) const
     for (unsigned int j = 0; j < N; ++j)
     {
       for (unsigned int k = 0; k < N; ++k)
-        result._vals[i1 + k] += _vals[i1 + j] * b(j, k);
+        result._coords[i1 + k] += _coords[i1 + j] * b(j, k);
     }
     i1 += N;
   }
@@ -515,7 +515,7 @@ RankTwoTensor::operator=(const ColumnMajorMatrix & a)
   const Real * cmm_rawdata = a.rawData();
   for (unsigned int i = 0; i < N; ++i)
     for (unsigned int j = 0; j < N; ++j)
-      _vals[i * N + j] = cmm_rawdata[i + j * N];
+      _coords[i * N + j] = cmm_rawdata[i + j * N];
 
   return *this;
 }
@@ -526,7 +526,7 @@ RankTwoTensor::doubleContraction(const RankTwoTensor & b) const
   Real result = 0.0;
 
   for (unsigned int i = 0; i < N2; ++i)
-    result += _vals[i] * b._vals[i];
+    result += _coords[i] * b._coords[i];
 
   return result;
 }
@@ -539,9 +539,9 @@ RankTwoTensor::outerProduct(const RankTwoTensor & b) const
   unsigned int index = 0;
   for (unsigned int ij = 0; ij < N2; ++ij)
   {
-    const Real a = _vals[ij];
+    const Real a = _coords[ij];
     for (unsigned int kl = 0; kl < N2; ++kl)
-      result._vals[index++] = a * b._vals[kl];
+      result._vals[index++] = a * b._coords[kl];
   }
 
   return result;
@@ -983,7 +983,7 @@ RankTwoTensor::L2norm() const
   Real norm = 0.0;
   for (unsigned int i = 0; i < N2; ++i)
   {
-    Real v = _vals[i];
+    Real v = _coords[i];
     norm += v * v;
   }
   return std::sqrt(norm);

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -118,19 +118,6 @@ RankTwoTensor::initializeFromColumns(const TypeVector<Real> & col0,
       col0(0), col0(1), col0(2), col1(0), col1(1), col1(2), col2(0), col2(1), col2(2));
 }
 
-RankTwoTensor::RankTwoTensor(const TypeTensor<Real> & a)
-{
-  (*this)(0, 0) = a(0, 0);
-  (*this)(0, 1) = a(0, 1);
-  (*this)(0, 2) = a(0, 2);
-  (*this)(1, 0) = a(1, 0);
-  (*this)(1, 1) = a(1, 1);
-  (*this)(1, 2) = a(1, 2);
-  (*this)(2, 0) = a(2, 0);
-  (*this)(2, 1) = a(2, 1);
-  (*this)(2, 2) = a(2, 2);
-}
-
 RankTwoTensor::RankTwoTensor(Real S11, Real S22, Real S33, Real S23, Real S13, Real S12)
 {
   (*this)(0, 0) = S11;
@@ -153,13 +140,6 @@ RankTwoTensor::RankTwoTensor(
   (*this)(0, 2) = S13;
   (*this)(1, 2) = S23;
   (*this)(2, 2) = S33;
-}
-
-void
-RankTwoTensor::zero()
-{
-  for (unsigned int i(0); i < N2; i++)
-    _coords[i] = 0.0;
 }
 
 void
@@ -212,17 +192,6 @@ RankTwoTensor::fillFromInputVector(const std::vector<Real> & input, FillMethod f
 }
 
 TypeVector<Real>
-RankTwoTensor::row(const unsigned int r) const
-{
-  RealVectorValue result;
-
-  for (unsigned int i = 0; i < N; i++)
-    result(i) = (*this)(r, i);
-
-  return result;
-}
-
-TypeVector<Real>
 RankTwoTensor::column(const unsigned int c) const
 {
   RealVectorValue result;
@@ -234,36 +203,11 @@ RankTwoTensor::column(const unsigned int c) const
 }
 
 RankTwoTensor
-RankTwoTensor::rotated(const RealTensorValue & R) const
+RankTwoTensor::rotated(const RankTwoTensor & R) const
 {
   RankTwoTensor result(*this);
   result.rotate(R);
   return result;
-}
-
-void
-RankTwoTensor::rotate(const RealTensorValue & R)
-{
-  RankTwoTensor temp;
-  for (unsigned int i = 0; i < N; i++)
-    for (unsigned int j = 0; j < N; j++)
-    {
-      // tmp += R(i,k)*R(j,l)*(*this)(k,l);
-      // clang-format off
-      Real tmp = R(i, 0) * R(j, 0) * (*this)(0, 0) +
-                 R(i, 0) * R(j, 1) * (*this)(0, 1) +
-                 R(i, 0) * R(j, 2) * (*this)(0, 2) +
-                 R(i, 1) * R(j, 0) * (*this)(1, 0) +
-                 R(i, 1) * R(j, 1) * (*this)(1, 1) +
-                 R(i, 1) * R(j, 2) * (*this)(1, 2) +
-                 R(i, 2) * R(j, 0) * (*this)(2, 0) +
-                 R(i, 2) * R(j, 1) * (*this)(2, 1) +
-                 R(i, 2) * R(j, 2) * (*this)(2, 2);
-      // clang-format on
-      temp(i, j) = tmp;
-    }
-  for (unsigned int i = 0; i < N2; i++)
-    _coords[i] = temp._coords[i];
 }
 
 void
@@ -318,181 +262,85 @@ RankTwoTensor::rotateXyPlane(Real a)
 RankTwoTensor
 RankTwoTensor::transpose() const
 {
-  RankTwoTensor result;
-
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < N; ++j)
-      result._coords[i1 + j] = (*this)(j, i);
-    i1 += N;
-  }
-
-  return result;
+  return RealTensorValue::transpose();
 }
 
 RankTwoTensor &
 RankTwoTensor::operator=(const RankTwoTensor & a)
 {
-  for (unsigned int i = 0; i < N2; ++i)
-    _coords[i] = a._coords[i];
-
+  RealTensorValue::operator=(a);
   return *this;
 }
 
 RankTwoTensor &
 RankTwoTensor::operator+=(const RankTwoTensor & a)
 {
-  for (unsigned int i = 0; i < N2; ++i)
-    _coords[i] += a._coords[i];
-
+  RealTensorValue::operator+=(a);
   return *this;
 }
 
 RankTwoTensor
 RankTwoTensor::operator+(const RankTwoTensor & b) const
 {
-  RankTwoTensor result;
-  for (unsigned int i = 0; i < N2; ++i)
-    result._coords[i] = _coords[i] + b._coords[i];
-  return result;
+  return RealTensorValue::operator+(b);
 }
 
 RankTwoTensor &
 RankTwoTensor::operator-=(const RankTwoTensor & a)
 {
-  for (unsigned int i = 0; i < N2; ++i)
-    _coords[i] -= a._coords[i];
-
+  RealTensorValue::operator-=(a);
   return *this;
 }
 
 RankTwoTensor
 RankTwoTensor::operator-(const RankTwoTensor & b) const
 {
-  RankTwoTensor result;
-  for (unsigned int i = 0; i < N2; ++i)
-    result._coords[i] = _coords[i] - b._coords[i];
-  return result;
+  return RealTensorValue::operator-(b);
 }
 
 RankTwoTensor
 RankTwoTensor::operator-() const
 {
-  RankTwoTensor result;
-  for (unsigned int i = 0; i < N2; ++i)
-    result._coords[i] = -_coords[i];
-  return result;
+  return RealTensorValue::operator-();
 }
 
 RankTwoTensor &
 RankTwoTensor::operator*=(const Real a)
 {
-  for (unsigned int i = 0; i < N2; ++i)
-    _coords[i] *= a;
+  RealTensorValue::operator*=(a);
   return *this;
 }
 
-RankTwoTensor RankTwoTensor::operator*(const Real b) const
-{
-  RankTwoTensor result;
-  for (unsigned int i = 0; i < N2; ++i)
-    result._coords[i] = _coords[i] * b;
-  return result;
-}
+RankTwoTensor RankTwoTensor::operator*(const Real b) const { return RealTensorValue::operator*(b); }
 
 RankTwoTensor &
 RankTwoTensor::operator/=(const Real a)
 {
-  for (unsigned int i = 0; i < N; ++i)
-    for (unsigned int j = 0; j < N; ++j)
-      (*this)(i, j) /= a;
-
+  RealTensorValue::operator/=(a);
   return *this;
 }
 
 RankTwoTensor
 RankTwoTensor::operator/(const Real b) const
 {
-  RankTwoTensor result;
-
-  for (unsigned int i = 0; i < N2; ++i)
-    result._coords[i] = _coords[i] / b;
-
-  return result;
+  return RealTensorValue::operator/(b);
 }
 
 TypeVector<Real> RankTwoTensor::operator*(const TypeVector<Real> & b) const
 {
-  RealVectorValue result;
-
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    unsigned int i1 = i * N;
-    for (unsigned int j = 0; j < N; ++j)
-      result(i) += _coords[i1 + j] * b(j);
-  }
-
-  return result;
-}
-
-RankTwoTensor &
-RankTwoTensor::operator*=(const RankTwoTensor & a)
-{
-  RankTwoTensor s(*this);
-  this->zero();
-
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    unsigned int j1 = 0;
-    for (unsigned int j = 0; j < N; ++j)
-    {
-      for (unsigned int k = 0; k < N; ++k)
-        _coords[i1 + k] += s._coords[i1 + j] * a._coords[j1 + k];
-      j1 += N;
-    }
-    i1 += N;
-  }
-
-  return *this;
-}
-
-RankTwoTensor RankTwoTensor::operator*(const RankTwoTensor & b) const
-{
-  RankTwoTensor result;
-
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    unsigned int j1 = 0;
-    for (unsigned int j = 0; j < N; ++j)
-    {
-      for (unsigned int k = 0; k < N; ++k)
-        result._coords[i1 + k] += _coords[i1 + j] * b._coords[j1 + k];
-      j1 += N;
-    }
-    i1 += N;
-  }
-  return result;
+  return RealTensorValue::operator*(b);
 }
 
 RankTwoTensor RankTwoTensor::operator*(const TypeTensor<Real> & b) const
 {
-  RankTwoTensor result;
+  return RealTensorValue::operator*(b);
+}
 
-  unsigned int i1 = 0;
-  for (unsigned int i = 0; i < N; ++i)
-  {
-    for (unsigned int j = 0; j < N; ++j)
-    {
-      for (unsigned int k = 0; k < N; ++k)
-        result._coords[i1 + k] += _coords[i1 + j] * b(j, k);
-    }
-    i1 += N;
-  }
-
-  return result;
+RankTwoTensor &
+RankTwoTensor::operator*=(const TypeTensor<Real> & a)
+{
+  *this = *this * a;
+  return *this;
 }
 
 bool
@@ -523,12 +371,8 @@ RankTwoTensor::operator=(const ColumnMajorMatrix & a)
 Real
 RankTwoTensor::doubleContraction(const RankTwoTensor & b) const
 {
-  Real result = 0.0;
-
-  for (unsigned int i = 0; i < N2; ++i)
-    result += _coords[i] * b._coords[i];
-
-  return result;
+  // deprecate this!
+  return RealTensorValue::contract(b);
 }
 
 RankFourTensor
@@ -651,7 +495,7 @@ RankTwoTensor
 RankTwoTensor::deviatoric() const
 {
   RankTwoTensor deviatoric(*this);
-  deviatoric.addIa(-1.0 / 3.0 * trace()); // actually construct deviatoric part
+  deviatoric.addIa(-1.0 / 3.0 * tr()); // actually construct deviatoric part
   return deviatoric;
 }
 
@@ -675,7 +519,7 @@ RankTwoTensor::secondInvariant() const
   Real result = 0.0;
 
   // RankTwoTensor deviatoric(*this);
-  // deviatoric.addIa(-1.0/3.0 * trace()); // actually construct deviatoric part
+  // deviatoric.addIa(-1.0/3.0 * tr()); // actually construct deviatoric part
   // result = 0.5*(deviatoric + deviatoric.transpose()).doubleContraction(deviatoric +
   // deviatoric.transpose());
   result = Utility::pow<2>((*this)(0, 0) - (*this)(1, 1)) / 6.0;
@@ -712,12 +556,14 @@ RankTwoTensor::d2secondInvariant() const
 Real
 RankTwoTensor::trace() const
 {
-  Real result = 0.0;
+  // deprecate this!
+  return tr();
+}
 
-  for (unsigned int i = 0; i < N; ++i)
-    result += (*this)(i, i);
-
-  return result;
+RankTwoTensor
+RankTwoTensor::inverse() const
+{
+  return RealTensorValue::inverse();
 }
 
 RankTwoTensor
@@ -904,18 +750,6 @@ RankTwoTensor::d2sin3Lode(const Real r0) const
   return deriv;
 }
 
-Real
-RankTwoTensor::det() const
-{
-  Real result = 0.0;
-
-  result = (*this)(0, 0) * ((*this)(1, 1) * (*this)(2, 2) - (*this)(2, 1) * (*this)(1, 2));
-  result -= (*this)(1, 0) * ((*this)(0, 1) * (*this)(2, 2) - (*this)(2, 1) * (*this)(0, 2));
-  result += (*this)(2, 0) * ((*this)(0, 1) * (*this)(1, 2) - (*this)(1, 1) * (*this)(0, 2));
-
-  return result;
-}
-
 RankTwoTensor
 RankTwoTensor::ddet() const
 {
@@ -932,30 +766,6 @@ RankTwoTensor::ddet() const
   d(2, 2) = (*this)(0, 0) * (*this)(1, 1) - (*this)(1, 0) * (*this)(0, 1);
 
   return d;
-}
-
-RankTwoTensor
-RankTwoTensor::inverse() const
-{
-  RankTwoTensor inv;
-
-  inv(0, 0) = (*this)(1, 1) * (*this)(2, 2) - (*this)(2, 1) * (*this)(1, 2);
-  inv(0, 1) = (*this)(0, 2) * (*this)(2, 1) - (*this)(0, 1) * (*this)(2, 2);
-  inv(0, 2) = (*this)(0, 1) * (*this)(1, 2) - (*this)(0, 2) * (*this)(1, 1);
-  inv(1, 0) = (*this)(1, 2) * (*this)(2, 0) - (*this)(1, 0) * (*this)(2, 2);
-  inv(1, 1) = (*this)(0, 0) * (*this)(2, 2) - (*this)(0, 2) * (*this)(2, 0);
-  inv(1, 2) = (*this)(0, 2) * (*this)(1, 0) - (*this)(0, 0) * (*this)(1, 2);
-  inv(2, 0) = (*this)(1, 0) * (*this)(2, 1) - (*this)(1, 1) * (*this)(2, 0);
-  inv(2, 1) = (*this)(0, 1) * (*this)(2, 0) - (*this)(0, 0) * (*this)(2, 1);
-  inv(2, 2) = (*this)(0, 0) * (*this)(1, 1) - (*this)(0, 1) * (*this)(1, 0);
-
-  Real det = (*this).det();
-
-  if (det == 0)
-    mooseError("Rank Two Tensor is singular");
-
-  inv /= det;
-  return inv;
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/FiniteStrainHyperElasticViscoPlastic.C
+++ b/modules/tensor_mechanics/src/materials/FiniteStrainHyperElasticViscoPlastic.C
@@ -225,7 +225,7 @@ FiniteStrainHyperElasticViscoPlastic::computeQpStress()
 
     for (unsigned int istep = 0; istep < num_substep; ++istep)
     {
-      _dfgrd_tmp = (istep + 1) * delta_dfgrd / num_substep + _deformation_gradient_old[_qp];
+      _dfgrd_tmp = (istep + 1.0) * delta_dfgrd / num_substep + _deformation_gradient_old[_qp];
       if (!solveQp())
       {
         converge = false;

--- a/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulomb.C
+++ b/modules/tensor_mechanics/src/userobjects/TensorMechanicsPlasticMohrCoulomb.C
@@ -153,9 +153,9 @@ TensorMechanicsPlasticMohrCoulomb::df_dsig(const RankTwoTensor & stress, const R
     std::vector<Real> eigvals;
     std::vector<RankTwoTensor> deigvals;
     stress.dsymmetricEigenvalues(eigvals, deigvals);
-    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2 * mean_stress) * sin_angle;
+    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2.0 * mean_stress) * sin_angle;
     RankTwoTensor dtmp =
-        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2 * dmean_stress) * sin_angle;
+        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2.0 * dmean_stress) * sin_angle;
     Real denom = std::sqrt(smooth(stress) + 0.25 * Utility::pow<2>(tmp));
     return dmean_stress * sin_angle +
            (0.5 * dsmooth(stress) * dmean_stress + 0.25 * tmp * dtmp) / denom;
@@ -170,10 +170,9 @@ TensorMechanicsPlasticMohrCoulomb::df_dsig(const RankTwoTensor & stress, const R
     Real sibar2 = stress.secondInvariant();
     RankTwoTensor dsibar2 = stress.dsecondInvariant();
     Real denom = std::sqrt(smooth(stress) + sibar2 * Utility::pow<2>(kk));
-    return dmean_stress * sin_angle +
-           (0.5 * dsmooth(stress) * dmean_stress + 0.5 * dsibar2 * Utility::pow<2>(kk) +
-            sibar2 * kk * dkk) /
-               denom;
+    return dmean_stress * sin_angle + (0.5 * dsmooth(stress) * dmean_stress +
+                                       0.5 * dsibar2 * Utility::pow<2>(kk) + sibar2 * kk * dkk) /
+                                          denom;
   }
 }
 
@@ -248,9 +247,9 @@ TensorMechanicsPlasticMohrCoulomb::dflowPotential_dstress(const RankTwoTensor & 
     stress.dsymmetricEigenvalues(eigvals, deigvals);
     stress.d2symmetricEigenvalues(d2eigvals);
 
-    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2 * mean_stress) * sin_angle;
+    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2.0 * mean_stress) * sin_angle;
     RankTwoTensor dtmp =
-        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2 * dmean_stress) * sin_angle;
+        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2.0 * dmean_stress) * sin_angle;
     Real denom = std::sqrt(smooth(stress) + 0.25 * Utility::pow<2>(tmp));
     Real denom3 = Utility::pow<3>(denom);
     Real d2smooth_over_denom = d2smooth(stress) / denom;
@@ -330,12 +329,12 @@ TensorMechanicsPlasticMohrCoulomb::dflowPotential_dintnl(const RankTwoTensor & s
     std::vector<Real> eigvals;
     std::vector<RankTwoTensor> deigvals;
     stress.dsymmetricEigenvalues(eigvals, deigvals);
-    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2 * mean_stress) * sin_angle;
+    Real tmp = eigvals[2] - eigvals[0] + (eigvals[2] + eigvals[0] - 2.0 * mean_stress) * sin_angle;
     Real dtmp_dintnl = (eigvals[2] + eigvals[0] - 2 * mean_stress) * dsin_angle;
     RankTwoTensor dtmp_dstress =
-        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2 * dmean_stress) * sin_angle;
+        deigvals[2] - deigvals[0] + (deigvals[2] + deigvals[0] - 2.0 * dmean_stress) * sin_angle;
     RankTwoTensor d2tmp_dstress_dintnl =
-        (deigvals[2] + deigvals[0] - 2 * dmean_stress) * dsin_angle;
+        (deigvals[2] + deigvals[0] - 2.0 * dmean_stress) * dsin_angle;
     Real denom = std::sqrt(smooth(stress) + 0.25 * Utility::pow<2>(tmp));
     return dmean_stress * dsin_angle + 0.25 * dtmp_dintnl * dtmp_dstress / denom +
            0.25 * tmp * d2tmp_dstress_dintnl / denom -

--- a/modules/tensor_mechanics/test/tests/interaction_integral/tests
+++ b/modules/tensor_mechanics/test/tests/interaction_integral/tests
@@ -44,7 +44,7 @@
    type = 'CSVDiff'
    input = 'interaction_integral_3d_rot.i'
    csvdiff = 'interaction_integral_3d_rot_out.csv interaction_integral_3d_rot_out_II_KI_1_0001.csv interaction_integral_3d_rot_out_II_KI_2_0001.csv interaction_integral_3d_rot_out_II_KII_1_0001.csv interaction_integral_3d_rot_out_II_KII_2_0001.csv interaction_integral_3d_rot_out_II_KIII_1_0001.csv interaction_integral_3d_rot_out_II_KIII_2_0001.csv'
-   abs_zero = 1e-8
+   abs_zero = 2e-8
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
  [../]
  [./ii_2d_chk_q]
@@ -96,6 +96,6 @@
    exodiff = 'interaction_integral_3d_rot_out.e'
    max_parallel = 1           # nl_its and lin_its will not be the same in parallel and serial
    prereq = 'ii_3d_rot'
-   abs_zero = 1e-8
+   abs_zero = 2e-8
  [../]
 []


### PR DESCRIPTION
This should make it easier to swap out RealTensorValue material properties for RankTwoTensor properties. Let's see what the fall out of this is going to be...

Refs #11388