### PR TITLE
Changed method for calculating the tangent operator

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -12,7 +12,7 @@
 
 #include "ComputeFiniteStrainElasticStress.h"
 
-class StressUpdateBase;
+#include "StressUpdateBase.h"
 
 class ComputeMultipleInelasticStress;
 
@@ -144,6 +144,12 @@ protected:
   /// number of plastic models
   const unsigned _num_models;
 
+  /// Flags to compute tangent during updateState call
+  std::vector<bool> _tangent_computation_flag;
+
+  /// Calculation method for the tangent modulus
+  TangentCalculationMethod _tangent_calculation_method;
+
   /// _inelastic_strain = sum_i (_inelastic_weights_i * inelastic_strain_from_model_i)
   const std::vector<Real> _inelastic_weights;
 
@@ -154,6 +160,11 @@ protected:
   const bool _cycle_models;
 
   MaterialProperty<Real> & _matl_timestep_limit;
+
+  /**
+   * Rank four symmetric identity tensor
+   */
+  const RankFourTensor _identity_symmetric_four;
 
   /**
    * The user supplied list of inelastic models to use in the simulation

--- a/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
@@ -119,6 +119,11 @@ protected:
 
   virtual void propagateQpStatefulProperties() override;
 
+  virtual TangentCalculationMethod getTangentCalculationMethod() override
+  {
+    return TangentCalculationMethod::FULL;
+  }
+
   /// Internal dimensionality of tensors (currently this is 3 throughout tensor_mechanics)
   constexpr static unsigned _tensor_dimensionality = 3;
 

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -19,6 +19,22 @@
 // Forward declaration
 class StressUpdateBase;
 
+/**
+ * TangentCalculationMethod is an enum that determines the calculation method for the tangent
+ * operator. ELASTIC uses the elasticity tensor as the tangent operator: J = C. The elasticity
+ * tensor does not need to be provided by the StressUpdateBase models in this case. FULL calculates
+ * the full tangent operator tensor in each inherited class. The full tangent operator is then
+ * combined in ComputeMultipleInelasicStress by J = J_1 * C^-1 * J_2 * C^-1 * ... J_N. PARTIAL
+ * calculates the contribution to the tangent operator if the terms need to be combined before being
+ * inverted by J = (J_1 + J_2 + ... J_N)^-1 * C.
+ */
+enum class TangentCalculationMethod
+{
+  ELASTIC,
+  FULL,
+  PARTIAL
+};
+
 template <>
 InputParameters validParams<StressUpdateBase>();
 
@@ -90,6 +106,11 @@ public:
   virtual bool requiresIsotropicTensor() = 0;
 
   virtual Real computeTimeStepLimit();
+
+  virtual TangentCalculationMethod getTangentCalculationMethod()
+  {
+    return TangentCalculationMethod::ELASTIC;
+  }
 
   ///@{ Retained as empty methods to avoid a warning from Material.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
   void resetQpProperties() final {}

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -85,12 +85,15 @@ ComputeMultipleInelasticStress::ComputeMultipleInelasticStress(const InputParame
         getMaterialPropertyOld<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
     _tangent_operator_type(getParam<MooseEnum>("tangent_operator").getEnum<TangentOperatorEnum>()),
     _num_models(getParam<std::vector<MaterialName>>("inelastic_models").size()),
+    _tangent_computation_flag(_num_models, false),
+    _tangent_calculation_method(TangentCalculationMethod::ELASTIC),
     _inelastic_weights(isParamValid("combined_inelastic_strain_weights")
                            ? getParam<std::vector<Real>>("combined_inelastic_strain_weights")
                            : std::vector<Real>(_num_models, true)),
     _consistent_tangent_operator(_num_models),
     _cycle_models(getParam<bool>("cycle_models")),
-    _matl_timestep_limit(declareProperty<Real>("matl_timestep_limit"))
+    _matl_timestep_limit(declareProperty<Real>("matl_timestep_limit")),
+    _identity_symmetric_four(RankFourTensor::initIdentitySymmetricFour)
 {
   if (_inelastic_weights.size() != _num_models)
     mooseError(
@@ -115,9 +118,11 @@ ComputeMultipleInelasticStress::initialSetup()
       hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC);
 
   std::vector<MaterialName> models = getParam<std::vector<MaterialName>>("inelastic_models");
+
   for (unsigned int i = 0; i < _num_models; ++i)
   {
     StressUpdateBase * rrr = dynamic_cast<StressUpdateBase *>(&getMaterialByName(models[i]));
+
     if (rrr)
     {
       _models.push_back(rrr);
@@ -128,6 +133,40 @@ ComputeMultipleInelasticStress::initialSetup()
     }
     else
       mooseError("Model " + models[i] + " is not compatible with ComputeMultipleInelasticStress");
+  }
+
+  // Check if tangent calculation methods are consistent. If all models have
+  // TangentOperatorEnum::ELASTIC or tangent_operator is set by the user as elasic, then the tangent
+  // is never calculated: J_tot = C. If PARTIAL and NONE models are present, utilize PARTIAL
+  // formulation: J_tot = (I + J_1 + ... J_N)^-1 C. If FULL and NONE models are present, utilize
+  // FULL formulation: J_tot = J_1 * C^-1 * J_2 * C^-1 * ... J_N * C. If PARTIAL and FULL models are
+  // present, error out.
+
+  if (_tangent_operator_type != TangentOperatorEnum::elastic)
+  {
+    bool full_present = false;
+    bool partial_present = false;
+    for (unsigned int i = 0; i < _num_models; ++i)
+    {
+      if (_models[i]->getTangentCalculationMethod() == TangentCalculationMethod::FULL)
+      {
+        full_present = true;
+        _tangent_computation_flag[i] = true;
+        _tangent_calculation_method = TangentCalculationMethod::FULL;
+      }
+      else if (_models[i]->getTangentCalculationMethod() == TangentCalculationMethod::PARTIAL)
+      {
+        partial_present = true;
+        _tangent_computation_flag[i] = true;
+        _tangent_calculation_method = TangentCalculationMethod::PARTIAL;
+      }
+    }
+    if (full_present && partial_present)
+      mooseError("In ",
+                 _name,
+                 ": Models that calculate the full tangent operator and the partial tangent "
+                 "operator are being combined. Either set tangent_operator to elastic, implement "
+                 "the corrent tangent formulations, or use different models.");
   }
 }
 
@@ -189,7 +228,7 @@ ComputeMultipleInelasticStress::finiteStrainRotation(const bool force_elasticity
       _rotation_increment[_qp] * _inelastic_strain[_qp] * _rotation_increment[_qp].transpose();
   if (force_elasticity_rotation ||
       !(_is_elasticity_tensor_guaranteed_isotropic &&
-        (_tangent_operator_type == TangentOperatorEnum::elastic || _num_models == 0)))
+        (_tangent_calculation_method == TangentCalculationMethod::ELASTIC || _num_models == 0)))
     _Jacobian_mult[_qp].rotate(_rotation_increment[_qp]);
 }
 
@@ -323,8 +362,16 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
 void
 ComputeMultipleInelasticStress::computeQpJacobianMult()
 {
-  if (_tangent_operator_type == TangentOperatorEnum::elastic)
+  if (_tangent_calculation_method == TangentCalculationMethod::ELASTIC)
     _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+  else if (_tangent_calculation_method == TangentCalculationMethod::PARTIAL)
+  {
+    RankFourTensor A = _identity_symmetric_four;
+    for (unsigned i_rmm = 0; i_rmm < _num_models; ++i_rmm)
+      A += _consistent_tangent_operator[i_rmm];
+    mooseAssert(A.isSymmetric(), "Tangent operator isn't symmetric");
+    _Jacobian_mult[_qp] = A.invSymm() * _elasticity_tensor[_qp];
+  }
   else
   {
     const RankFourTensor E_inv = _elasticity_tensor[_qp].invSymm();
@@ -363,6 +410,15 @@ ComputeMultipleInelasticStress::updateQpStateSingleModel(
                          combined_inelastic_strain_increment,
                          _Jacobian_mult[_qp]);
 
+  if (_tangent_calculation_method == TangentCalculationMethod::ELASTIC)
+    _Jacobian_mult[_qp] = _elasticity_tensor[_qp];
+  else if (_tangent_calculation_method == TangentCalculationMethod::PARTIAL)
+  {
+    RankFourTensor A = _identity_symmetric_four + _Jacobian_mult[_qp];
+    mooseAssert(A.isSymmetric(), "Tangent operator isn't symmetric");
+    _Jacobian_mult[_qp] = A.invSymm() * _elasticity_tensor[_qp];
+  }
+
   _matl_timestep_limit[_qp] = _models[0]->computeTimeStepLimit();
 
   /* propagate internal variables, etc, to this timestep for those inelastic models where
@@ -378,6 +434,7 @@ ComputeMultipleInelasticStress::computeAdmissibleState(unsigned model_number,
                                                        RankTwoTensor & inelastic_strain_increment,
                                                        RankFourTensor & consistent_tangent_operator)
 {
+  const bool jac = _fe_problem.currentlyComputingJacobian();
   _models[model_number]->updateState(elastic_strain_increment,
                                      inelastic_strain_increment,
                                      _rotation_increment[_qp],
@@ -385,6 +442,14 @@ ComputeMultipleInelasticStress::computeAdmissibleState(unsigned model_number,
                                      _stress_old[_qp],
                                      _elasticity_tensor[_qp],
                                      _elastic_strain_old[_qp],
-                                     _tangent_operator_type == TangentOperatorEnum::nonlinear,
+                                     (jac && _tangent_computation_flag[model_number]),
                                      consistent_tangent_operator);
+
+  if (jac && !_tangent_computation_flag[model_number])
+  {
+    if (_tangent_calculation_method == TangentCalculationMethod::PARTIAL)
+      consistent_tangent_operator.zero();
+    else
+      consistent_tangent_operator = _elasticity_tensor[_qp];
+  }
 }

--- a/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/LinearViscoelasticStressUpdate.C
@@ -63,7 +63,7 @@ LinearViscoelasticStressUpdate::updateState(RankTwoTensor & strain_increment,
                                             const RankFourTensor & elasticity_tensor,
                                             const RankTwoTensor & elastic_strain_old,
                                             bool /*compute_full_tangent_operator*/,
-                                            RankFourTensor & tangent_operator)
+                                            RankFourTensor & /*tangent_operator*/)
 {
   RankTwoTensor current_mechanical_strain =
       elastic_strain_old + _creep_strain_old[_qp] + strain_increment;
@@ -78,6 +78,4 @@ LinearViscoelasticStressUpdate::updateState(RankTwoTensor & strain_increment,
   strain_increment -= creep_strain_increment;
   inelastic_strain_increment += creep_strain_increment;
   stress_new -= elasticity_tensor * creep_strain_increment;
-
-  tangent_operator = elasticity_tensor;
 }

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -65,7 +65,7 @@ RadialReturnStressUpdate::updateState(RankTwoTensor & strain_increment,
                                       const RankFourTensor & elasticity_tensor,
                                       const RankTwoTensor & elastic_strain_old,
                                       bool /*compute_full_tangent_operator*/,
-                                      RankFourTensor & tangent_operator)
+                                      RankFourTensor & /*tangent_operator*/)
 {
   // compute the deviatoric trial stress and trial strain from the current intermediate
   // configuration
@@ -106,12 +106,6 @@ RadialReturnStressUpdate::updateState(RankTwoTensor & strain_increment,
   stress_new = elasticity_tensor * (strain_increment + elastic_strain_old);
 
   computeStressFinalize(inelastic_strain_increment);
-
-  /**
-   * Note!  The tangent operator for this class, and derived class is
-   * currently just the elasticity tensor, irrespective of compute_full_tangent_operator
-   */
-  tangent_operator = elasticity_tensor;
 }
 
 Real


### PR DESCRIPTION
This changes the way the tangent operator is calculated in StressUpdate classes, and combined in ComputeMultipleInelasticStress. The ways to calculate the tangent are 1) ELASTIC which uses the elasticity tensor as the tangent operator: J = C. If models are elastic, the tangent modulus is never calculated in the individual models, but is assumed when combined in ComputeMultipleInelasticStress. 2) FULL calculates the full elasticity tensor in each inherited class. The full tangent operator is then combined in ComputeMultipleInelasicStress by J = J_1 * C^-1 * J_2 * C^-1 * ... J_N. 3) PARTIAL calculates the contribution to the elasticity tensor before if the terms need to be combined before being inverted by J = (I + J_1 + J_2 + ... J_N)^-1 * C.

ref #11219
