### PR TITLE
Placed app_test_LIB before app_LIBS on link line

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -316,8 +316,7 @@ endif
 # and https://stackoverflow.com/questions/9459980/c-global-variable-not-initialized-when-linked-through-static-libraries-but-ok#11336506
 # for more explanations/details.
 compilertype := unknown
-applibs := $(app_LIBS)
-applibs += $(app_test_LIB)
+applibs :=  $(app_test_LIB) $(app_LIBS)
 ifeq ($(libmesh_static),yes)
   ifneq (,$(findstring clang,$(CXX)))
     compilertype := clang


### PR DESCRIPTION
This PR addresses Issue #11364.  It reorders the libraries on the link line for `$(app_EXEC)` in `framework/app.mk`.  In particular, it places `$(app_test_LIB)` directly before `$(app_LIB)`.  After some linking errors in my app ("undefined reference"-type errors), I saw that this was necessary to resolve the library dependencies in `$(app_test_LIB)`.  

See this [moose-users topic](https://groups.google.com/forum/#!topic/moose-users/CIpbIfa9EBc) for more discussion.

closes #11364 