### PR TITLE
Limit full reinitialization test to 'opt' only

### DIFF
--- a/modules/level_set/test/tests/reinitialization/tests
+++ b/modules/level_set/test/tests/reinitialization/tests
@@ -5,5 +5,6 @@
     input = master.i
     exodiff = master_out.e
     cli_args = Executioner/num_steps=2
+    method = 'opt' # complete reinitilization solve, debug is slow and not needed
   [../]
 []


### PR DESCRIPTION
This test is a large test that the complete reinitialization problem works, the components of this test are used in other smaller tests. Running in
debug is not necessary and can be slow on certain systems.

(refs #8465)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
