### PR TITLE
Doco tidy-ups

### DIFF
--- a/modules/fluid_properties/doc/content/documentation/systems/Modules/FluidProperties/SimpleFluidProperties.md
+++ b/modules/fluid_properties/doc/content/documentation/systems/Modules/FluidProperties/SimpleFluidProperties.md
@@ -17,9 +17,9 @@ in the input file), while internal energy and enthalpy are given by
 \end{equation}
 and
 \begin{equation}
-  h = e + \frac{p}{\rho}
+  h = e + \gamma\frac{p}{\rho}
 \end{equation}
-respectively.
+respectively.  Here $\gamma$ is called the `porepressure_coefficient`: usually it should be set to $1$ but many analytical studies assume $\gamma=0$.
 
 !syntax parameters /Modules/FluidProperties/SimpleFluidProperties
 

--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_03.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_03.md
@@ -45,7 +45,7 @@ To model this thermo-hydro system, the `PorousFlowBasicTHM` action needs to be e
 
 !listing modules/porous_flow/examples/tutorial/03.i start=[Variables] end=[BCs]
 
-and some extra properties need to be added to the `SimpleFluidProperties`:
+and some extra properties need to be added to the [`SimpleFluidProperties`](SimpleFluidProperties.md):
 
 !listing modules/porous_flow/examples/tutorial/03.i start=[Modules] end=[Materials]
 

--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_05.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_05.md
@@ -4,11 +4,13 @@
 
 # Porous Flow Tutorial Page 05.  Using a realistic equation of state for the fluid
 
-It is trivial to add a realistic equation of state to any PorousFlow simulation.  For instance, the high-precision "Water97" equation of state may be used:
+It is trivial to add a realistic equation of state to any PorousFlow simulation.  For instance, the high-precision [`Water97`](Water97FluidProperties.md) equation of state may be used:
 
 !listing modules/porous_flow/examples/tutorial/05.i start=[Modules] end=[Materials]
 
-(The name "the_simple_fluid" could also be changed to something more appropriate.)  In this case, the initial and boundary conditions must also be changed because the Water97 equation of state is not defined for $P=0$ (an absolute vacuum).  For example:
+(The name "the_simple_fluid" could also be changed to something more appropriate.)
+
+In this case, the initial and boundary conditions must also be changed because the Water97 equation of state is not defined for $P=0$ (an absolute vacuum).  For example:
 
 !listing modules/porous_flow/examples/tutorial/05.i start=[Variables] end=[PorousFlowBasicTHM]
 
@@ -16,7 +18,7 @@ and
 
 !listing modules/porous_flow/examples/tutorial/05.i start=[BCs] end=[Modules]
 
-Using realistic high-precision equations of state can cause PorousFlow to run quite slowly, because the equations of state are so complicated to evaluate.  It is always recommended to use `TabulatedFluidProperties` in the following way:
+Using realistic high-precision equations of state can cause PorousFlow to run quite slowly, because the equations of state are so complicated to evaluate.  It is always recommended to use [`TabulatedFluidProperties`](TabulatedFluidProperties.md) in the following way:
 
 !listing modules/porous_flow/examples/tutorial/05_tabulated.i start=[Modules] end=[Materials]
 
@@ -24,7 +26,7 @@ and
 
 !listing modules/porous_flow/examples/tutorial/05_tabulated.i start=[PorousFlowBasicTHM] end=[BCs]
 
-Another advantage of using `TabulatedfluidProperties` is that the bounds on pressure and temperature imposed by the original "true" equation of state can be extrapolated past, which can help to remove problems of MOOSE trying to sample outside the original's region of validity (and thus causing the timestep to be cut).
+Another advantage of using [`TabulatedfluidProperties`](TabulatedFluidProperties.md) is that the bounds on pressure and temperature imposed by the original "true" equation of state can be extrapolated past, which can help to remove problems of MOOSE trying to sample outside the original's region of validity (and thus causing the timestep to be cut).
 
 Finally, in the case at hand, it is worth reminding the reader that `PorousFlowBasicTHM` is based on the assumptions of a constant, large fluid bulk modulus, and a constant fluid thermal expansion coefficient, which are incorrect for some fluids.  User beware!
 


### PR DESCRIPTION
PorousFlow's boundary-condition documentation had a few typos and unclear bits concerning fixing porepressures
PorousFlow's tutorial pages now point to fluid properties documentation at appropriate places
FluidProperties SimpleFluidProperties now explicitly mentions the porepressure_coefficient parameter

Fixes #11414

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
