### PR TITLE
Fix AnalyzeJacobian race conditions

### DIFF
--- a/modules/tensor_mechanics/test/tests/creep_tangent_operator/tests
+++ b/modules/tensor_mechanics/test/tests/creep_tangent_operator/tests
@@ -36,15 +36,18 @@
     type = 'AnalyzeJacobian'
     input = 'creep.i'
     cli_args = 'Materials/elastic_strain/inelastic_models="creep_ten creep_zero"'
+    prereq = ten_jacobian
   [../]
   [./sum_jacobian]
     type = 'AnalyzeJacobian'
     input = 'creep.i'
     cli_args = 'Materials/elastic_strain/inelastic_models="creep_nine creep_one"'
+    prereq = zero_jacobian
   [../]
   [./cycle_jacobian]
     type = 'AnalyzeJacobian'
     input = 'creep.i'
     cli_args = 'Materials/elastic_strain/inelastic_models="creep_ten creep_ten2" Materials/elastic_strain/cycle_models=true'
+    prereq = sum_jacobian
   [../]
 []

--- a/python/TestHarness/testers/AnalyzeJacobian.py
+++ b/python/TestHarness/testers/AnalyzeJacobian.py
@@ -9,13 +9,13 @@
 
 import os, sys
 from TestHarness import util
-from Tester import Tester
+from FileTester import FileTester
 
-class AnalyzeJacobian(Tester):
+class AnalyzeJacobian(FileTester):
 
     @staticmethod
     def validParams():
-        params = Tester.validParams()
+        params = FileTester.validParams()
         params.addRequiredParam('input',  "The input file to use for this test.")
         params.addParam('test_name',      "The name of the test - populated automatically")
         params.addParam('expect_out',     "A regular expression that must occur in the input in order for the test to be considered passing.")
@@ -25,10 +25,16 @@ class AnalyzeJacobian(Tester):
 
         return params
 
-
     def __init__(self, name, params):
-        Tester.__init__(self, name, params)
+        FileTester.__init__(self, name, params)
 
+    def getOutputFiles(self):
+        # analizejacobian.py outputs files prefixed with the input file name
+        return [self.specs['input']]
+
+    def prepare(self, options):
+        # We do not know what file(s) analizejacobian.py produces
+        return
 
     # Check if numpy is available
     def checkRunnable(self, options):

--- a/python/TestHarness/tests/test_Duplicate.py
+++ b/python/TestHarness/tests/test_Duplicate.py
@@ -22,9 +22,19 @@ class TestHarnessTester(TestHarnessTestCase):
 
         self.assertRegexpMatches(e.output, r'tests/test_harness.*?FAILED \(OUTFILE RACE CONDITION\)')
 
+        # Use a different spec file, which makes use of the AnalyzeJacobian tester. The is because
+        # a race condition, when caught, will invalidate the rest of the tests with out testing them.
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'duplicate_outputs_analyzejacobian')
+
+        e = cm.exception
+
+        self.assertRegexpMatches(e.output, r'tests/test_harness.*?FAILED \(OUTFILE RACE CONDITION\)')
+
     def testDuplicateOutputsOK(self):
         """
-        Test for duplicate output files in the same directory
+        Test for duplicate output files in the same directory that will _not_ overwrite eachother due to
+        proper prereqs set.
         """
         output = self.runTests('-i', 'duplicate_outputs_ok')
         output += self.runTests('-i', 'duplicate_outputs_ok', '--heavy')

--- a/test/tests/test_harness/duplicate_outputs_analyzejacobian
+++ b/test/tests/test_harness/duplicate_outputs_analyzejacobian
@@ -1,0 +1,10 @@
+[Tests]
+  [./a]
+    type = 'AnalyzeJacobian'
+    input = 'good.i'
+  [../]
+  [./b]
+    type = 'AnalyzeJacobian'
+    input = 'good.i'
+  [../]
+[]

--- a/test/tests/test_harness/duplicate_outputs_ok
+++ b/test/tests/test_harness/duplicate_outputs_ok
@@ -58,4 +58,15 @@
     cli_args = 'Outputs/exodus=true Outputs/file_base=depend_out'
     check_files = 'depend_out.e'
   [../]
+
+  [./h]
+    type = 'AnalyzeJacobian'
+    input = 'good.i'
+  [../]
+
+  [./i]
+    type = 'AnalyzeJacobian'
+    input = 'good.i'
+    prereq = h
+  [../]
 []


### PR DESCRIPTION
A race condition exists when multiple AnalyzeJacobian using the
same input file runs simultaneously.

This change detects these issues. Also added a unittest for this
case scenario.

During the creation of this PR and the unittests, a typo in fact,
a new issue was discovered #11454 which will require a different
approach.

Closes #11433
