### PR TITLE
Fix possible leak introduced in Control system re-factor

### DIFF
--- a/framework/include/utils/MooseObjectParameterName.h
+++ b/framework/include/utils/MooseObjectParameterName.h
@@ -45,6 +45,8 @@ public:
                            const std::string & param,
                            const std::string & separator = std::string("/"));
 
+  MooseObjectParameterName(const MooseObjectParameterName & rhs);
+
   /**
    * Return the parameter name.
    */

--- a/framework/src/utils/MooseObjectParameterName.C
+++ b/framework/src/utils/MooseObjectParameterName.C
@@ -30,6 +30,12 @@ MooseObjectParameterName::MooseObjectParameterName(const std::string & tag,
   _combined += _parameter;
 }
 
+MooseObjectParameterName::MooseObjectParameterName(const MooseObjectParameterName & rhs)
+  : MooseObjectName(rhs._tag, rhs._name, rhs._separator), _parameter(rhs._parameter)
+{
+  _combined = _tag + _name + _parameter;
+}
+
 MooseObjectParameterName::MooseObjectParameterName(std::string name) : MooseObjectName()
 {
   // The tag precedes the :: (this is used in _moose_base::name and control_tag::name conventions)

--- a/unit/src/TestMooseObjectParameterName.C
+++ b/unit/src/TestMooseObjectParameterName.C
@@ -178,3 +178,10 @@ TEST(MooseObjectParameterName, errors)
         << "MooseObjectParameterName failed with unexpected error: " << msg;
   }
 }
+
+TEST(MooseObjectParameterName, copy)
+{
+  MooseObjectParameterName name0("tag", "object", "param");
+  MooseObjectParameterName name1(name0);
+  EXPECT_EQ(name0, name1);
+}


### PR DESCRIPTION
There was a missing copy constructor for `MooseObjectParameterName`, see #11363.
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
