### PR TITLE
Fix --recover

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -290,6 +290,10 @@ class TestHarness:
 
         # Augment the Testers with additional information directly from the TestHarness
         for tester in testers:
+
+            # Initialize the status system for each tester object immediately after creation
+            tester.initStatusSystem(self.options)
+
             self.augmentParameters(file, tester)
 
         # Short circuit this loop if we've only been asked to parse Testers

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -69,9 +69,6 @@ class Job(object):
         self.error = self.status.error
         self.finished = self.status.finished
 
-        # Initialize the Tester statuses
-        self.__tester.initStatusSystem(self.options)
-
     def getDAG(self):
         """ Return the DAG associated with this tester """
         return self.__job_dag


### PR DESCRIPTION
The status system within the tester object need to be initialized as
soon as they are created. Or rather, before any method tries to
adjust that tester's status.

Closes #11467
