### PR TITLE
Corrected the numbers of iterations for multi-step time integrators

### DIFF
--- a/framework/doc/content/utilities/MooseDocs/generate.md
+++ b/framework/doc/content/utilities/MooseDocs/generate.md
@@ -1,15 +1,15 @@
 # Documenting MOOSE
 
 MOOSE and MOOSE-based applications generally focus on creating C++ objects (e.g., Kernels, BCs,
-etc.), so it is important that these object are documented to allow other developers and users to
+etc.), so it is important that these objects are documented to allow other developers and users to
 understand the purpose of these objects. The [MooseDocs System](MooseDocs/index.md) aims to make
 documenting objects straightforward and natural. Moreover, accessing the object documentation is
 simple and allows for documentation to remain up-to-date as the code continues to advance.
 
-In order to ensure that MOOSE documentation continues to improve requirements exist for
+In order to ensure that MOOSE documentation continues to improve, requirements exist for
 documenting new and changing code within MOOSE:
 
-1. Any new MooseObject must have all parameters and a class description.
+1. Any new MooseObject must have descriptions for the class and all parameters.
 1. Any new MooseObject must also include an associated markdown description page.
 1. Developers who modify existing classes should update the existing markdown documentation file.
 1. All new tests must contain a 'requirement' and link to 'design' and 'issues'.
@@ -33,11 +33,11 @@ The string supplied in this function will appear in the parameter tables within 
 that is generated.  For example, see the parameter table for [/BoxMarker.md].
 
 Secondly, a short description of the class should be supplied in the `addClassDescription`
-function. For example, in the [Diffusion](/Diffusion.md) object the following class description.
+function. For example, the [Diffusion](/Diffusion.md) object has the following class description:
 
 !listing framework/src/kernels/Diffusion.C line=addClassDescription
 
-When the documentation for this object is generated this string is added to the first portion of the
+When the documentation for this object is generated, this string is added to the first portion of the
 page and the system overview table. For example, the [Kernels overview](systems/Kernels/index.md)
 includes a table with each object listed; the table includes the class description from the source
 code.
@@ -53,16 +53,16 @@ The documentation for the classes within MOOSE and the modules are located withi
 directory where the class is registered: "framework/doc" contains all core MOOSE level objects,
 "modules/tensor_mechanics/doc" contains object for the tensor mechanics modules, etc.
 
-When adding documentation the MOOSE modules executable must exist, this is accomplished by using the
-following commands.
+When adding documentation, the MOOSE modules executable must exist; this is accomplished by using the
+following commands:
 
 ```bash
 cd ~/projects/moose/modules
 make -j16 # 16 should be replaced by the number of cores on your system
 ```
 
-If you are writing a documentation for a new class with MOOSE or the modules, you can use the
-MooseDocs executable to build a documentation stub for your new class.
+If you are writing a documentation page for a new class with MOOSE or the modules, you can use the
+MooseDocs executable to build a documentation stub for your new class:
 
 ```bash
 cd ~/projects/moose/modules/doc
@@ -72,31 +72,31 @@ cd ~/projects/moose/modules/doc
 This generate command needs to be run only when you add a new object (e.g., Kernel,
 BoundaryCondition, etc.) to your application.
 
-After the stub files have been created the a local, live version of the website should
+After the stub files have been created, a local, live version of the website should
 be used to add content (see the [Live Website](#live-website) section below).
 
 ## Live Website
 
-A local website can be created and served, this is done by running the following commands.  When
+A local website can be created and served; this is done by running the following commands.  When
 this command completes, which can take several minutes, a message will be printed and the site will
-be hosted at [http://127.0.0.1:8000](http://127.0.0.1:8000).
+be hosted at [http://127.0.0.1:8000](http://127.0.0.1:8000):
 
 ```bash
 cd ~/projects/moose/modules/doc
 ./moosedocs.py build --serve
 ```
 
-Once the server is running the markdown files within the repository may be modified, when the
-changes are saved the local server will automatically update the content.
+Once the server is running, the markdown files within the repository may be modified. When
+changes are saved, the local server will automatically update the content.
 The content added or modified should follow the
 [Standards for Documentation Pages](MooseDocs/standards.md) guidelines.
 
 ## Requirement, Design, and Issues
 
-MOOSE follows strict software quality standards, to meet these standards every test within MOOSE
+MOOSE follows strict software quality standards. To meet these standards, every test within MOOSE
 must provide three items with each test of the test specification.
 
-1. +requirement+: A sort description that explains what the "requirement" that the test is
+1. +requirement+: A description of the "requirement" that the test is
    testing. The text for the requirement must be listed in the test specification file ("tests" file).
 
 1. +design+: A list of markdown files associated with the test that explain the systems, objects,
@@ -104,3 +104,20 @@ must provide three items with each test of the test specification.
 
 1. +issues+: A list of [github issues](https://github.com/idaholab/moose/issues/) that are
    associated with the test and items being tested.
+
+These items are provided in the associated "tests" file. For example,
+
+```
+[Tests]
+  [./my_test]
+    type = 'CSVDiff'
+    input = 'my_test.i'
+    csvdiff = 'my_test.csv'
+
+    requirement = "MyObject shall do some kind of thing. Maybe this description has "
+                  "multiple lines."
+    design = 'MyObject.md some_relevant_file.md'
+    issues = '#1234 #1235 #1236'
+  [../]
+[]
+```

--- a/framework/include/timeintegrators/TimeIntegrator.h
+++ b/framework/include/timeintegrators/TimeIntegrator.h
@@ -24,7 +24,8 @@ namespace libMesh
 {
 template <typename T>
 class NumericVector;
-}
+class NonlinearImplicitSystem;
+} // namespace libMesh
 
 template <>
 InputParameters validParams<TimeIntegrator>();
@@ -66,6 +67,10 @@ public:
   virtual void init() {}
   virtual void preSolve() {}
   virtual void preStep() {}
+
+  /**
+   * Solves the time step and sets the number of nonlinear and linear iterations.
+   */
   virtual void solve();
 
   /**
@@ -95,10 +100,33 @@ public:
   virtual int order() = 0;
   virtual void computeTimeDerivatives() = 0;
 
+  /**
+   * Gets the total number of nonlinear iterations over all stages of the time step.
+   */
+  virtual unsigned int getNumNonlinearIterations() const { return _n_nonlinear_iterations; }
+
+  /**
+   * Gets the total number of linear iterations over all stages of the time step.
+   */
+  virtual unsigned int getNumLinearIterations() const { return _n_linear_iterations; }
+
 protected:
+  /**
+   * Gets the number of nonlinear iterations in the most recent solve.
+   */
+  unsigned int getNumNonlinearIterationsLastSolve() const;
+
+  /**
+   * Gets the number of linear iterations in the most recent solve.
+   */
+  unsigned int getNumLinearIterationsLastSolve() const;
+
   FEProblemBase & _fe_problem;
   SystemBase & _sys;
   NonlinearSystemBase & _nl;
+
+  /// Nonlinear implicit system, if applicable; otherwise, nullptr
+  const NonlinearImplicitSystem * _nonlinear_implicit_system;
 
   /// solution vector for u^dot
   NumericVector<Number> & _u_dot;
@@ -118,6 +146,11 @@ protected:
   NumericVector<Number> & _Re_time;
   /// residual vector for non-time contributions
   NumericVector<Number> & _Re_non_time;
+
+  /// Total number of nonlinear iterations over all stages of the time step
+  unsigned int _n_nonlinear_iterations;
+  /// Total number of linear iterations over all stages of the time step
+  unsigned int _n_linear_iterations;
 };
 
 #endif /* TIMEINTEGRATOR_H */

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -183,16 +183,22 @@ NonlinearSystem::solve()
   {
     _time_integrator->solve();
     _time_integrator->postSolve();
+    _n_iters = _time_integrator->getNumNonlinearIterations();
+    _n_linear_iters = _time_integrator->getNumLinearIterations();
   }
   else
+  {
     system().solve();
+    _n_iters = _transient_sys.n_nonlinear_iterations();
+#ifdef LIBMESH_HAVE_PETSC
+    _n_linear_iters = solver.get_total_linear_iterations();
+#endif
+  }
 
   // store info about the solve
-  _n_iters = _transient_sys.n_nonlinear_iterations();
   _final_residual = _transient_sys.final_nonlinear_residual();
 
 #ifdef LIBMESH_HAVE_PETSC
-  _n_linear_iters = solver.get_total_linear_iterations();
   if (_use_coloring_finite_difference)
 #if PETSC_VERSION_LESS_THAN(3, 2, 0)
     MatFDColoringDestroy(_fdcoloring);

--- a/framework/src/timeintegrators/AStableDirk4.C
+++ b/framework/src/timeintegrators/AStableDirk4.C
@@ -90,9 +90,16 @@ AStableDirk4::computeTimeDerivatives()
 void
 AStableDirk4::solve()
 {
-  if (_t_step == 1 && _safe_start)
-    _bootstrap_method->solve();
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
 
+  if (_t_step == 1 && _safe_start)
+  {
+    _bootstrap_method->solve();
+    _n_nonlinear_iterations = _bootstrap_method->getNumNonlinearIterations();
+    _n_linear_iterations = _bootstrap_method->getNumLinearIterations();
+  }
   else
   {
     // Time at end of step
@@ -124,6 +131,10 @@ AStableDirk4::solve()
 
       // Do the solve
       _fe_problem.getNonlinearSystemBase().system().solve();
+
+      // Update the iteration counts
+      _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+      _n_linear_iterations += getNumLinearIterationsLastSolve();
     }
   }
 }

--- a/framework/src/timeintegrators/ActuallyExplicitEuler.C
+++ b/framework/src/timeintegrators/ActuallyExplicitEuler.C
@@ -150,13 +150,16 @@ ActuallyExplicitEuler::solve()
   {
     case CONSISTENT:
     {
-      _linear_solver->solve(mass_matrix,
-                            _explicit_euler_update,
-                            _explicit_residual,
-                            es.parameters.get<Real>("linear solver tolerance"),
-                            es.parameters.get<unsigned int>("linear solver maximum iterations"));
+      const auto num_its_and_final_tol = _linear_solver->solve(
+          mass_matrix,
+          _explicit_euler_update,
+          _explicit_residual,
+          es.parameters.get<Real>("linear solver tolerance"),
+          es.parameters.get<unsigned int>("linear solver maximum iterations"));
 
       converged = checkLinearConvergence();
+
+      _n_linear_iterations = num_its_and_final_tol.first;
 
       break;
     }
@@ -177,6 +180,8 @@ ActuallyExplicitEuler::solve()
       auto sum = _explicit_euler_update.sum();
       converged = std::isfinite(sum);
 
+      _n_linear_iterations = 0;
+
       break;
     }
     case LUMP_PRECONDITIONED:
@@ -184,13 +189,16 @@ ActuallyExplicitEuler::solve()
       mass_matrix.vector_mult(_mass_matrix_diag, *_ones);
       _mass_matrix_diag.reciprocal();
 
-      _linear_solver->solve(mass_matrix,
-                            _explicit_euler_update,
-                            _explicit_residual,
-                            es.parameters.get<Real>("linear solver tolerance"),
-                            es.parameters.get<unsigned int>("linear solver maximum iterations"));
+      const auto num_its_and_final_tol = _linear_solver->solve(
+          mass_matrix,
+          _explicit_euler_update,
+          _explicit_residual,
+          es.parameters.get<Real>("linear solver tolerance"),
+          es.parameters.get<unsigned int>("linear solver maximum iterations"));
 
       converged = checkLinearConvergence();
+
+      _n_linear_iterations = num_its_and_final_tol.first;
 
       break;
     }

--- a/framework/src/timeintegrators/ExplicitRK2.C
+++ b/framework/src/timeintegrators/ExplicitRK2.C
@@ -61,6 +61,10 @@ ExplicitRK2::solve()
   Real time_old = _fe_problem.timeOld();
   Real time_stage2 = time_old + a() * _dt;
 
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // There is no work to do for the first stage (Y_1 = y_n).  The
   // first solve therefore happens in the second stage.  Note that the
   // non-time Kernels (which should be marked implicit=false) are
@@ -71,6 +75,8 @@ ExplicitRK2::solve()
   _fe_problem.timeOld() = time_old;
   _fe_problem.time() = time_stage2;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Advance solutions old->older, current->old.  Also moves Material
   // properties and other associated state forward in time.
@@ -84,6 +90,8 @@ ExplicitRK2::solve()
   _fe_problem.timeOld() = time_stage2;
   _fe_problem.time() = time_new;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Reset time at beginning of step to its original value
   _fe_problem.timeOld() = time_old;

--- a/framework/src/timeintegrators/ExplicitTVDRK2.C
+++ b/framework/src/timeintegrators/ExplicitTVDRK2.C
@@ -70,6 +70,10 @@ ExplicitTVDRK2::solve()
   Real time_old = _fe_problem.timeOld();
   Real time_stage2 = time_old + _dt;
 
+  // Reset numbers of iterations
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // There is no work to do for the first stage (Y_1 = y_n).  The
   // first solve therefore happens in the second stage.  Note that the
   // non-time Kernels (which should be marked implicit=false) are
@@ -80,6 +84,8 @@ ExplicitTVDRK2::solve()
   _fe_problem.timeOld() = time_old;
   _fe_problem.time() = time_stage2;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Advance solutions old->older, current->old.  Also moves Material
   // properties and other associated state forward in time.
@@ -93,6 +99,8 @@ ExplicitTVDRK2::solve()
   _fe_problem.timeOld() = time_stage2;
   _fe_problem.time() = time_new;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Reset time at beginning of step to its original value
   _fe_problem.timeOld() = time_old;

--- a/framework/src/timeintegrators/ImplicitMidpoint.C
+++ b/framework/src/timeintegrators/ImplicitMidpoint.C
@@ -50,12 +50,18 @@ ImplicitMidpoint::solve()
   Real time_old = _fe_problem.timeOld();
   Real time_half = (time_new + time_old) / 2.;
 
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // Compute first stage
   _fe_problem.initPetscOutput();
   _console << "1st stage\n";
   _stage = 1;
   _fe_problem.time() = time_half;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Compute second stage
   _fe_problem.initPetscOutput();
@@ -63,6 +69,8 @@ ImplicitMidpoint::solve()
   _stage = 2;
   _fe_problem.time() = time_new;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 }
 
 void

--- a/framework/src/timeintegrators/LStableDirk2.C
+++ b/framework/src/timeintegrators/LStableDirk2.C
@@ -56,12 +56,18 @@ LStableDirk2::solve()
   // Time at stage 1
   Real time_stage1 = time_old + _alpha * _dt;
 
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // Compute first stage
   _fe_problem.initPetscOutput();
   _console << "1st stage\n";
   _stage = 1;
   _fe_problem.time() = time_stage1;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Compute second stage
   _fe_problem.initPetscOutput();
@@ -70,6 +76,8 @@ LStableDirk2::solve()
   _fe_problem.timeOld() = time_stage1;
   _fe_problem.time() = time_new;
   _fe_problem.getNonlinearSystemBase().system().solve();
+  _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+  _n_linear_iterations += getNumLinearIterationsLastSolve();
 
   // Reset time at beginning of step to its original value
   _fe_problem.timeOld() = time_old;

--- a/framework/src/timeintegrators/LStableDirk3.C
+++ b/framework/src/timeintegrators/LStableDirk3.C
@@ -68,6 +68,10 @@ LStableDirk3::solve()
   // Time at end of step
   Real time_old = _fe_problem.timeOld();
 
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // A for-loop would increment _stage too far, so we use an extra
   // loop counter.
   for (unsigned int current_stage = 1; current_stage < 4; ++current_stage)
@@ -87,6 +91,10 @@ LStableDirk3::solve()
 
     // Do the solve
     _fe_problem.getNonlinearSystemBase().system().solve();
+
+    // Update the iteration counts
+    _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+    _n_linear_iterations += getNumLinearIterationsLastSolve();
   }
 }
 

--- a/framework/src/timeintegrators/LStableDirk4.C
+++ b/framework/src/timeintegrators/LStableDirk4.C
@@ -63,6 +63,10 @@ LStableDirk4::solve()
   // Time at end of step
   Real time_old = _fe_problem.timeOld();
 
+  // Reset iteration counts
+  _n_nonlinear_iterations = 0;
+  _n_linear_iterations = 0;
+
   // A for-loop would increment _stage too far, so we use an extra
   // loop counter.
   for (unsigned int current_stage = 1; current_stage <= _n_stages; ++current_stage)
@@ -82,6 +86,10 @@ LStableDirk4::solve()
 
     // Do the solve
     _fe_problem.getNonlinearSystemBase().system().solve();
+
+    // Update the iteration counts
+    _n_nonlinear_iterations += getNumNonlinearIterationsLastSolve();
+    _n_linear_iterations += getNumLinearIterationsLastSolve();
   }
 }
 

--- a/test/tests/postprocessors/num_iterations/gold/a_stable_dirk4.csv
+++ b/test/tests/postprocessors/num_iterations/gold/a_stable_dirk4.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,37,10
+0.0002,20,8

--- a/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_consistent.csv
+++ b/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_consistent.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,1,0
+0.0002,1,0

--- a/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_lump_preconditioned.csv
+++ b/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_lump_preconditioned.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,10,0
+0.0002,10,0

--- a/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_lumped.csv
+++ b/test/tests/postprocessors/num_iterations/gold/actually_explicit_euler_lumped.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,0,0
+0.0002,0,0

--- a/test/tests/postprocessors/num_iterations/gold/bdf2.csv
+++ b/test/tests/postprocessors/num_iterations/gold/bdf2.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/crank_nicolson.csv
+++ b/test/tests/postprocessors/num_iterations/gold/crank_nicolson.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/explicit_euler.csv
+++ b/test/tests/postprocessors/num_iterations/gold/explicit_euler.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/explicit_midpoint.csv
+++ b/test/tests/postprocessors/num_iterations/gold/explicit_midpoint.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,12,4
+0.0002,10,4

--- a/test/tests/postprocessors/num_iterations/gold/explicit_tvd_rk2.csv
+++ b/test/tests/postprocessors/num_iterations/gold/explicit_tvd_rk2.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/heun.csv
+++ b/test/tests/postprocessors/num_iterations/gold/heun.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/implicit_euler.csv
+++ b/test/tests/postprocessors/num_iterations/gold/implicit_euler.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,4,2
+0.0002,4,2

--- a/test/tests/postprocessors/num_iterations/gold/implicit_midpoint.csv
+++ b/test/tests/postprocessors/num_iterations/gold/implicit_midpoint.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,16,4
+0.0002,14,4

--- a/test/tests/postprocessors/num_iterations/gold/l_stable_dirk2.csv
+++ b/test/tests/postprocessors/num_iterations/gold/l_stable_dirk2.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,15,4
+0.0002,14,4

--- a/test/tests/postprocessors/num_iterations/gold/l_stable_dirk3.csv
+++ b/test/tests/postprocessors/num_iterations/gold/l_stable_dirk3.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,20,6
+0.0002,18,6

--- a/test/tests/postprocessors/num_iterations/gold/l_stable_dirk4.csv
+++ b/test/tests/postprocessors/num_iterations/gold/l_stable_dirk4.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,37,10
+0.0002,35,10

--- a/test/tests/postprocessors/num_iterations/gold/ralston.csv
+++ b/test/tests/postprocessors/num_iterations/gold/ralston.csv
@@ -1,0 +1,4 @@
+time,num_linear_iterations,num_nonlinear_iterations
+0,0,0
+0.0001,13,4
+0.0002,12,4

--- a/test/tests/postprocessors/num_iterations/num_iterations.i
+++ b/test/tests/postprocessors/num_iterations/num_iterations.i
@@ -1,0 +1,70 @@
+# This tests if the correct number of nonlinear and linear iterations for a time
+# step are recovered for each time integrator scheme.
+#
+# The gold files for each time integrator scheme were created manually by
+# observing the numbers of iterations per time step.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./time_der]
+    type = TimeDerivative
+    variable = u
+  [../]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  [./TimeIntegrator]
+    # The time integrator type is provided by the tests file
+  [../]
+  num_steps = 2
+  abort_on_solve_fail = true
+  dt = 1e-4
+
+  nl_abs_tol = 1e-8
+  nl_rel_tol = 0
+  nl_max_its = 5
+[]
+
+[Postprocessors]
+  [./num_nonlinear_iterations]
+    type = NumNonlinearIterations
+  [../]
+  [./num_linear_iterations]
+    type = NumLinearIterations
+  [../]
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/postprocessors/num_iterations/tests
+++ b/test/tests/postprocessors/num_iterations/tests
@@ -1,0 +1,215 @@
+[Tests]
+  [./a_stable_dirk4]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'a_stable_dirk4.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=AStableDirk4
+      Executioner/TimeIntegrator/safe_start=true
+      Outputs/file_base=a_stable_dirk4'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./actually_explicit_euler_consistent]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'actually_explicit_euler_consistent.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ActuallyExplicitEuler
+      Executioner/TimeIntegrator/solve_type=consistent
+      Outputs/file_base=actually_explicit_euler_consistent'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./actually_explicit_euler_lumped]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'actually_explicit_euler_lumped.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ActuallyExplicitEuler
+      Executioner/TimeIntegrator/solve_type=lumped
+      Outputs/file_base=actually_explicit_euler_lumped'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./actually_explicit_euler_lump_preconditioned]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'actually_explicit_euler_lump_preconditioned.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ActuallyExplicitEuler
+      Executioner/TimeIntegrator/solve_type=lump_preconditioned
+      Outputs/file_base=actually_explicit_euler_lump_preconditioned'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./bdf2]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'bdf2.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=BDF2
+      Outputs/file_base=bdf2'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./crank_nicolson]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'crank_nicolson.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=CrankNicolson
+      Outputs/file_base=crank_nicolson'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./explicit_euler]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'explicit_euler.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ExplicitEuler
+      Outputs/file_base=explicit_euler'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./explicit_midpoint]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'explicit_midpoint.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ExplicitMidpoint
+      Outputs/file_base=explicit_midpoint'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./explicit_tvd_rk2]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'explicit_tvd_rk2.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ExplicitTVDRK2
+      Outputs/file_base=explicit_tvd_rk2'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./heun]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'heun.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=Heun
+      Outputs/file_base=heun'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./implicit_euler]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'implicit_euler.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ImplicitEuler
+      Outputs/file_base=implicit_euler'
+    max_parallel = 1
+  [../]
+  [./implicit_midpoint]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'implicit_midpoint.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=ImplicitMidpoint
+      Outputs/file_base=implicit_midpoint'
+    max_parallel = 1
+  [../]
+  [./l_stable_dirk2]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'l_stable_dirk2.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=LStableDirk2
+      Outputs/file_base=l_stable_dirk2'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./l_stable_dirk3]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'l_stable_dirk3.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=LStableDirk3
+      Outputs/file_base=l_stable_dirk3'
+    max_parallel = 1
+  [../]
+  [./l_stable_dirk4]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'l_stable_dirk4.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=LStableDirk4
+      Outputs/file_base=l_stable_dirk4'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+  [./ralston]
+    type = 'CSVDiff'
+    input = 'num_iterations.i'
+    csvdiff = 'ralston.csv'
+    cli_args = '
+      Executioner/TimeIntegrator/type=Ralston
+      Outputs/file_base=ralston'
+    max_parallel = 1
+
+    requirement = "Time integrators shall report the correct number of nonlinear"
+                  " and linear iterations, even if there are multiple stages."
+    design = 'TimeIntegrator/index.md'
+    issues = '#11444'
+  [../]
+[]


### PR DESCRIPTION
I added a test for each time integrator, which may have been a bit excessive, but since the iteration counting isn't confined to the base, it seemed the safest route. On my machine, these tests took 4 seconds total. At the very least, we should have tests for one single-stage time integrator and all of the time integrators that override `solve()`.

Closes #11444

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
