### PR TITLE
PorousFlow doco enhancements

### DIFF
--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/governing_equations.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/governing_equations.md
@@ -403,12 +403,16 @@ input file.
 | Equation | Kernel |
 | --- | --- |
 | $\frac{\partial}{\partial t}\left(\phi\sum_{\beta}S_{\beta}\rho_{\beta}\chi_{\beta}^{\kappa}\right)$ | [`PorousFlowMassTimeDerivative`](PorousFlowMassTimeDerivative.md) |
+| $(\rho)(\dot{P}/M - A\dot{T} + \alpha_{B}\dot{\epsilon}_{v})$ | [`PorousFlowFullySaturatedMassTimeDerivative`](PorousFlowFullySaturatedMassTimeDerivative.md) |
 | $\frac{\partial}{\partial t}\left((1 - \phi)C^{\kappa}\right)$ | [`PorousFlowDesorpedMassTimeDerivative`](PorousFlowDesorpedMassTimeDerivative.md) |
 | $-\nabla\cdot \sum_{\beta}\chi_{\beta}^{\kappa} \rho_{\beta}\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla P_{\beta} - \rho_{\beta} \mathbf{g})$ | [`PorousFlowAdvectiveFlux`](PorousFlowAdvectiveFlux.md) |
 | $-\nabla\cdot \sum_{\beta}\rho_{\beta}{\mathcal{D}}_{\beta}^{\kappa}\nabla \chi_{\beta}^{\kappa}$ | [`PorousFlowDispersiveFlux`](PorousFlowDispersiveFlux.md) |
+| $-\nabla\cdot ((\rho)k(\nabla P - \rho \mathbf{g})/\mu)$ | [`PorousFlowFullySaturatedDarcyBase`](PorousFlowFullySaturatedDarcyBase.md) |
+| $-\nabla\cdot (\rho\chi^{\kappa} k(\nabla P - \rho \mathbf{g})/\mu)$ | [`PorousFlowFullySaturatedDarcyFlow`](PorousFlowFullySaturatedDarcyFlow.md) |
 | $\frac{\partial}{\partial t}\left((1-\phi)\rho_{R}C_{R}T + \phi\sum_{\beta}S_{\beta}\rho_{\beta}\mathcal{E}_{\beta}\right)$ | [`PorousFlowEnergyTimeDerivative`](PorousFlowEnergyTimeDerivative.md) |
 | $-\nabla\cdot \left(\lambda \nabla T\right)$ | [`PorousFlowHeatConduction`](PorousFlowHeatConduction.md) |
 | $-\nabla\cdot \sum_{\beta}h_{\beta} \rho_{\beta}\frac{k\,k_{\mathrm{r,}\beta}}{\mu_{\beta}}(\nabla P_{\beta} - \rho_{\beta} \mathbf{g})$ | [`PorousFlowHeatAdvection`](PorousFlowHeatAdvection.md) |
+| $-\nabla\cdot ((\rho)h k(\nabla P - \rho \mathbf{g})/\mu)$ | [`PorousFlowFullySaturatedHeatAdvection`](PorousFlowFullySaturatedHeatAdvection.md) |
 | $\mathcal{E}\nabla\cdot\mathbf{v}_{s}$ | [`PorousFlowHeatVolumetricExpansion`](PorousFlowHeatVolumetricExpansion.md) |
 | $-\nu (1-\phi)\sigma^{\mathrm{eff}}_{ij}\frac{\partial}{\partial t}\epsilon_{ij}^{\mathrm{plastic}}$ | [`PorousFlowPlasticHeatEnergy`](PorousFlowPlasticHeatEnergy.md) |
 | $\phi\sum_{\beta}S_{\beta}\rho_{\beta}\chi_{\beta}^{\kappa}\nabla\cdot\mathbf{v}_{s}$ | [`PorousFlowMassVolumetricExpansion`](PorousFlowMassVolumetricExpansion.md) |

--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_01.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_01.md
@@ -13,7 +13,7 @@ equation
 \nabla_{i}\left(\frac{k_{ij}}{\mu}\left(\nabla_{j}P - \rho g_{j}\right)\right)
 \ .
 \end{equation}
-This is the simplest type of equation that PorousFlow solves.  It is often used in thermo-poro-elasticity, but PorousFlow is often employed to solve much more complex equations.  See [governing equations](/porous_flow/governing_equations.md) for further details.  In this equation:
+This is the simplest type of equation that PorousFlow solves.  It is often used in thermo-poro-elasticity, but PorousFlow is often employed to solve much more complex equations.  See [governing equations](/porous_flow/governing_equations.md) for further details, and [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md) and [PorousFlowFullySaturatedDarcyBase](PorousFlowFullySaturatedDarcyBase.md) for the derivation of [eq:basicthm] from the general governing equations.  In this equation:
 
 - $P$ is the fluid porepressure (units of Pa)
 - an over-dot represents a time derivative
@@ -49,7 +49,7 @@ In these equations
 - $\alpha_{T}$ is the volumetric thermal expansion coefficient of the drained porous skeleton (units K$^{-1}$)
 - $\alpha_{f}$ is the volumetric thermal expansion coefficient of the fluid (units K$^{-1}$)
 
-The derivation of [eq:basicthm] from
+The [derivation](PorousFlowFullySaturatedMassTimeDerivative.md) of [eq:basicthm] from
 the [full PorousFlow equations](governing_equations.md) assumes that $M$ and $A$ are constant.
 
 In this tutorial page we will be solving fluid flow only, so the
@@ -67,7 +67,9 @@ The DE of [eq:basicthm] is implemented in the following way
 
 !listing modules/porous_flow/examples/tutorial/01.i start=[Variables] end=[BCs]
 
-There is just one variable --- the porepressure --- and there is no coupling with heat or mechanics.  Gravity is set to zero.  In this tutorial page, the only boundary condition is to fix the porepressure to 1$\,$MPa at the injection area (the other boundaries default to zero flux):
+There is just one variable --- the porepressure --- and there is no coupling with heat or mechanics.  Gravity is set to zero.  The [`PorousFlowBasicTHM`](PorousFlowBasicTHM.md) has other optional inputs that you are encouraged to explore, including setting the temperature to a non-default value, or to the value of an AuxVariable (your fluid properties may depend on temperature, even in an isothermal situation).
+
+In this tutorial page, the only boundary condition is to fix the porepressure to 1$\,$MPa at the injection area (the other boundaries default to zero flux):
 
 !listing modules/porous_flow/examples/tutorial/01.i start=[BCs] end=[Modules]
 

--- a/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedDarcyBase.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedDarcyBase.md
@@ -1,14 +1,17 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PorousFlowFullySaturatedDarcyBase
 
-!alert construction title=Undocumented Class
-The PorousFlowFullySaturatedDarcyBase has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
-
 !syntax description /Kernels/PorousFlowFullySaturatedDarcyBase
+
+Describes the differential term
+\begin{equation}
+-\nabla\cdot ((\rho)k(\nabla P - \rho \mathbf{g})/\mu) \ .
+\end{equation}
+The nomenclature is described [here](nomenclature.md).  This is fully-saturated, single-component, single-phase Darcy flow.
+
+The multiplication by $\rho$ is optional: this is indicated by the parenthases.  The reason for this is that the time-derivative part described by [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md) linearises if the total differential equation is not multiplied by density.  Please see that page for a full description of the effects of not multiplying by density.
+
+!alert note
+No [upwinding](upwinding.md) is performed, which means many [nodal Material properties](tutorial_09.md) are not needed and [numerical diffusion](numerical_diffusion.md) is reduced.  However, the numerics are less well controlled: the whole point of full upwinding is to prevent over-shoots and under-shoots.
 
 !syntax parameters /Kernels/PorousFlowFullySaturatedDarcyBase
 

--- a/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedDarcyFlow.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedDarcyFlow.md
@@ -1,14 +1,18 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PorousFlowFullySaturatedDarcyFlow
 
-!alert construction title=Undocumented Class
-The PorousFlowFullySaturatedDarcyFlow has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
-
 !syntax description /Kernels/PorousFlowFullySaturatedDarcyFlow
+
+Describes the differential term
+\begin{equation}
+-\nabla\cdot ((\rho)\chi^{\kappa} k(\nabla P - \rho \mathbf{g})/\mu) \ .
+\end{equation}
+The nomenclature is described [here](nomenclature.md).  This is fully-saturated, multi-component, single-phase Darcy flow for fluid component $\kappa$.
+
+!alert note
+Although the multiplication by $\rho$ is optional, you should almost always set `multiply_by_density=true`
+
+!alert note
+No [upwinding](upwinding.md) is performed, which means many [nodal Material properties](tutorial_09.md) are not needed and [numerical diffusion](numerical_diffusion.md) is reduced.  However, the numerics are less well controlled: the whole point of full upwinding is to prevent over-shoots and under-shoots in the mass fraction, etc.
 
 !syntax parameters /Kernels/PorousFlowFullySaturatedDarcyFlow
 

--- a/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedHeatAdvection.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedHeatAdvection.md
@@ -1,14 +1,19 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PorousFlowFullySaturatedHeatAdvection
 
-!alert construction title=Undocumented Class
-The PorousFlowFullySaturatedHeatAdvection has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
-
 !syntax description /Kernels/PorousFlowFullySaturatedHeatAdvection
+
+Describes the differential term
+\begin{equation}
+-\nabla\cdot ((\rho)h k(\nabla P - \rho \mathbf{g})/\mu) \ .
+\end{equation}
+The nomenclature is described [here](nomenclature.md).  This is fully-saturated, multi-component, single-phase Darcy flow for fluid component $\kappa$.
+
+!alert note
+Although the multiplication by $\rho$ is optional, you should almost always set `multiply_by_density=true`
+
+!alert note
+No [upwinding](upwinding.md) is performed, which means many [nodal Material properties](tutorial_09.md) are not needed and [numerical diffusion](numerical_diffusion.md) is reduced.  However, the numerics are less well controlled: the whole point of full upwinding is to prevent over-shoots and under-shoots in the temperature, etc.
+
 
 !syntax parameters /Kernels/PorousFlowFullySaturatedHeatAdvection
 

--- a/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedMassTimeDerivative.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Kernels/PorousFlowFullySaturatedMassTimeDerivative.md
@@ -2,13 +2,86 @@
 
 # PorousFlowFullySaturatedMassTimeDerivative
 
-!alert construction title=Undocumented Class
-The PorousFlowFullySaturatedMassTimeDerivative has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
-
 !syntax description /Kernels/PorousFlowFullySaturatedMassTimeDerivative
+
+Consider a fully-saturated, single-phase, single-component fluid in a
+THM simulation.  The time-derivatve terms from the [fluid governing equation](governing_equations.md) are
+\begin{equation}
+\frac{\partial}{\partial t} \phi \rho + \phi\rho\dot{\epsilon}_{v} \ ,
+\end{equation}
+where $\dot{\epsilon}_{v} = \nabla\cdot {\mathbf v}_{s}$ and all other nomenclature is described [here](nomenclature.md).  Using the
+[THM evolution of porosity](porosity.md), along with the
+assumption that the fluid bulk modulus, $K_{f}$, and its volumetric
+thermal expansion coefficient, $\alpha_{f}$, are constant, and the fluid density is given by
+\begin{equation}
+\rho = \rho_{0}\exp(P/K_{f} - \alpha_{f} T) \ ,
+\end{equation}
+the time derivative terms may be written as
+\begin{equation}
+\label{poromecheq}
+\rho \left( \frac{1}{M}\dot{P} + \alpha_{B}\dot{\epsilon}_{v} -
+A\dot{T} \right) \ .
+\end{equation}
+Here $M$ is the so-called Biot Modulus:
+\begin{equation}
+\label{biotmoddef}
+\frac{1}{M} = \frac{\phi}{K_{f}} + \frac{(1 - \alpha_{B})(\alpha_{B} -
+  \phi)}{K} \ ,
+\end{equation}
+and $A$ is an effective volumetric thermal expansion coefficient:
+\begin{equation}
+\label{constthermexpdef}
+A = (\alpha_{B} - \phi)\alpha_{T} + \phi\alpha_{f} \ .
+\end{equation}
+Notice that disregarding the premultiplication by $\rho$, the above
+time-derivative terms in [poromecheq] would be linear in the variables $P$,
+displacement, and $T$, if $M$ and $A$ were constant.
+
+In standard poro-mechanics it is usual to calculate $M$ and $A$ at the
+initial stage of simulation, and keep them fixed forever afterwards.
+Of course this is an approximation since $M$ and $A$ were derived
+using the explicit assumption of a porosity that depended on $P$,
+$\epsilon_{v}$, and $T$, but it makes finding analytical solutions
+much easier.  Therefore, PorousFlow offers the following Materials and
+Kernels.  Using these Materials and Kernel allows immediate and precise
+comparison with analytical and numerical solutions of poro-mechanics.
+
+1. [PorousFlowConstantBiotModulus](PorousFlowConstantBiotModulus.md) Material, which computes $M$ given by [biotmoddef] during the initial stage of simulation, and keeps it fixed thereafter.  It requires a Porosity Material, but that Material's Property is only used during the initial computation.
+
+2. [PorousFlowConstantThermalExpansionCoefficient](PorousFlowConstantThermalExpansionCoefficient.md) Material, which computes $A$ given by [constthermexpdef] during the the initial stage of simulation, and keeps it fixed thereafter.  It requires a Porosity Material, but that Material's Property is only used during the initial computation.
+
+3. The `PorousFlowFullySaturatedMassTimeDerivative` Kernel, which computes one of the following contributions, depending upon the `coupling_type` flag:
+
+- $(\rho) \dot{P}/M$ for fluid-flow-only problems;
+- $(\rho)(\dot{P}/M - A\dot{T})$ for TH problems;
+- $(\rho)(\dot{P}/M + \alpha_{B}\dot{\epsilon}_{v})$ for HM problems;
+- $(\rho)(\dot{P}/M + \alpha_{B}\dot{\epsilon}_{v} - A\dot{T})$ for THM problems.
+
+The `PorousFlowFullySaturatedMassTimeDerivative` Kernel does not employ lumping, which is largely unecessary in this single-phase, single-component situation.  This means only ``quad-point'' Materials are needed.  In fact, when using all the FullySaturated flow Kernels (see [governing equations](governing_equations.md)) standard Materials evaluated at the quadpoints are needed, which saves on computation time and input-file length.
+
+In each case, the initial pre-multiplication by $\rho$ is optional
+(indicated by the parenthases around $\rho$).
+
+When the Kernel is pre-multiplied by $\rho$, which is the default,
+it is computing the time derivative of fluid mass.  This allows
+the Kernel to be easily used with the remainder of PorousFlow: the
+BCs, the Postprocessors, the AuxKernels, and the DiracKernels are all
+based on mass.
+
+When the pre-multiplication is not performed, this Kernel is computing the
+time derivative of fluid volume.  This has two great advantages:
+
+- the time-derivatives are linearised, resulting in excellent nonlinear convergence;
+- comparing with results from poro-mechanics theory is straightforward.
+
+However, this means additional care must be taken.
+
+- The flow Kernel [PorousFlowFullySaturatedDarcyBase](PorousFlowFullySaturatedDarcyBase.md) should also not pre-multiply by density.
+- The BCs, Postprocessors, AuxKernels, and DiracKernels must be written in such a way to operate in the fluid-volume scenario rather than the default fluid-mass scenario.
+- The flag `consistent_with_displaced_mesh` should be set `false` in the [PorousFlowVolumetricStrain](PorousFlowVolumetricStrain.md) Material.
+
+
+
 
 !syntax parameters /Kernels/PorousFlowFullySaturatedMassTimeDerivative
 

--- a/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowConstantBiotModulus.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowConstantBiotModulus.md
@@ -2,6 +2,19 @@
 
 !syntax description /Materials/PorousFlowConstantBiotModulus
 
+The Biot Modulus is defined to be
+\begin{equation}
+\label{biotmoddef}
+\frac{1}{M} = \frac{\phi}{K_{f}} + \frac{(1 - \alpha_{B})(\alpha_{B} -
+  \phi)}{K} \ ,
+\end{equation}
+where $\phi$ is the porosity, $K_{f}$ is the fluid bulk modulus, $\alpha_{B}$ is the Biot coefficient and $K$ is the drained bulk modulus of the porous skeleton.
+
+This Material is designed to work with the [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md) Kernel.
+
+!alert note
+This quantity is computed during the initial stage of the simulation and is kept fixed thereafter.
+
 !syntax parameters /Materials/PorousFlowConstantBiotModulus
 
 !syntax inputs /Materials/PorousFlowConstantBiotModulus

--- a/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowConstantThermalExpansionCoefficient.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowConstantThermalExpansionCoefficient.md
@@ -2,6 +2,18 @@
 
 !syntax description /Materials/PorousFlowConstantThermalExpansionCoefficient
 
+This Material computes
+\begin{equation}
+\label{constthermexpdef}
+A = (\alpha_{B} - \phi)\alpha_{T} + \phi\alpha_{f} \ ,
+\end{equation}
+where $\alpha_{B}$ is the Biot Modulus, $\phi$ is the porosity, $\alpha_{T}$ is the drained volumetric thermal expansion coefficient, and $\alpha_{f}$ is the fluid thermal volumetric expansion coefficient.
+
+This Material is designed to work with the [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md) Kernel.
+
+!alert note
+This quantity is computed during the initial stage of the simulation and is kept fixed thereafter.
+
 !syntax parameters /Materials/PorousFlowConstantThermalExpansionCoefficient
 
 !syntax inputs /Materials/PorousFlowConstantThermalExpansionCoefficient

--- a/modules/porous_flow/doc/content/documentation/systems/PorousFlowBasicTHM/PorousFlowBasicTHM.md
+++ b/modules/porous_flow/doc/content/documentation/systems/PorousFlowBasicTHM/PorousFlowBasicTHM.md
@@ -1,15 +1,80 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # PorousFlowBasicTHM
 
-!alert construction title=Undocumented Class
-The PorousFlowBasicTHM has not been documented, if you would like to contribute to MOOSE by writing
-documentation, please see [/generate.md]. The content contained on this page explains the typical
-documentation associated with an action; however, what is contained is ultimately determined by what
-is necessary to make the documentation clear for users.
+This action allows simple simulation of fully-saturated, single-phase,
+single-component fluid flow.  The fluid flow may be optionally coupled
+to mechanics and/or heat flow using the `coupling_type` flag.
 
-!syntax description /PorousFlowBasicTHM/PorousFlowBasicTHM
+The fluid equation is a *simplified* form of the full [PorousFlow fluid equation](governing_equations.md) (see [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md) and [PorousFlowFullySaturatedDarcyBase](PorousFlowFullySaturatedDarcyBase.md) for the derivation):
+\begin{equation}
+\label{eq:basicthm}
+0 = (\rho)\left(\frac{\dot{P}}{M} + \alpha_{B}\dot{\epsilon}_{v} - A\dot{T}\right) -
+\nabla_{i}\left((\rho) k_{ij}\left(\nabla_{j}P - \rho g_{j}\right)/\mu\right)
+\ .
+\end{equation}
+Note that the fluid-mass time derivative is close to linear, and is perfectly linear if `multiply_by_density=false`, and this also almost linearises the flow term.  Extremely good nonlinear convergence should therefore be expected, but there are some knock-on effects that are documented in [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md).
+
+In fully-saturated, single-phase simulations [upwinding](upwinding.md)
+is typically unnecessary.  Moreover, the standard PorousFlow Kernels
+are somewhat inefficient in the fully-saturated case since Material
+Properties such as relative permeabilities and saturations actually do
+not need to be computed.
+
+In fully-saturated, single-phase, single-component simulations, the
+[mass lumping](lumping.md) is also typically unncessary.  More
+importantly, in many real-life situations, as may be seen in
+[eq:basicthm] the time derivative of the fluid mass may be linearised,
+which leads to improved convergence.
+
+To simulate [eq:basicthm] the `PorousFlowBasicTHM` Action employs the following Kernels:
+
+- [PorousFlowFullySaturatedMassTimeDerivative](PorousFlowFullySaturatedMassTimeDerivative.md), if the simulation is of Transient type.
+- [PorousFlowFullySaturatedDarcyBase](PorousFlowFullySaturatedDarcyBase.md)
+
+For isothermal simulations, the fluid properties may still depend on temperature, so the `temperature` input parameter may be set to any real number, or to an AuxVariable if desired.
+
+For anisothermal simulations, the energy equation reads
+\begin{equation}
+0 = \frac{\partial}{\partial t}\left((1-\phi)\rho_{R}C_{R}T + \phi\rho\mathcal{E}\right) - \nabla\cdot (\rho h k(\nabla P - \rho \mathbf{g})/\mu) - \nabla\cdot(\lambda \nabla T) + \left((1-\phi)\rho_{R}C_{R}T + \phi\rho\mathcal{E}\right)\nabla\cdot v_{s} \ ,
+\end{equation}
+where the final term is only used if coupling with mechanics is also desired.  To simulate this DE, `PorousFlowBasicTHM` uses the following kernels:
+
+- [PorousFlowEnergyTimeDerivative](PorousFlowEnergyTimeDerivative.md) if the simulation is of Transient type
+- [PorousFlowFullySaturatedHeatAdvection](PorousFlowFullySaturatedHeatAdvection.md) with `multiply_by_density=true` (irrespective of the setting of this flag in the `PorousflowBasicTHM` Action)
+- [PorousFlowHeatConduction](PorousFlowHeatConduction.md)
+- [PorousFlowHeatVolumetricExpansion](PorousFlowHeatVolumetricExpansion.md) if coupling with temperature and mechanics is desired, and if the simulation is of Transient type
+
+For simulations that couple fluid flow to mechanics, the equations are already written in [governing equations](governing_equations.md), and `PorousFlowBasicTHM` implements these by using the following kernels:
+
+- [StressDivergenceTensors](Kernels/StressDivergenceTensors.md)
+- [Gravity](Gravity.md)
+- [PorousFlowEffectiveStressCoupling](PorousFlowEffectiveStressCoupling.md)
+
+`PorousFlowBasicTHM` adds many Materials automatically, however, to run a simulation you will need to provide more Materials for each mesh block, depending on your simulation type, viz:
+
+- One of the `PorousFlowPermeability` classes, eg [PorousFlowPermeabilityConst](PorousFlowPermeabilityConst.md)
+- [PorousFlowConstantBiotModulus](PorousFlowConstantBiotModulus.md)
+- [PorousFlowConstantThermalExpansionCoefficient](PorousFlowConstantThermalExpansionCoefficient.md)
+- [PorousFlowPorosity](PorousFlowPorosity.md)
+- [PorousFlowMatrixInternalEnergy](PorousFlowMatrixInternalEnergy.md)
+- A thermal conductivity calculator, eg [PorousFlowThermalConductivityIdeal](PorousFlowThermalConductivityIdeal.md)
+- An elasticity tensor, eg, [ComputeIsotropicElasticityTensor](ComputeIsotropicElasticityTensor.md)
+- A strain calculator, eg, [ComputeSmallStrain](ComputeSmallStrain.md)
+- A thermal expansion eigenstrain calculator, eg, [ComputeThermalExpansionEigenstrain](ComputeThermalExpansionEigenstrain.md)
+- A stress calculator, eg [ComputeLinearElasticStress](ComputeLinearElasticStress.md)
+
+!alert note
+Since upwinding and no mass lumping of the fluid mass are used (for simplicity, efficiency and to reduce [numerical diffusion](numerical_diffusion.md)), the results may be slightly different to simulations that employ upwinding and mass lumping.
+
+A simple example of using `PorousFlowBasicTHM` is documented in the [PorousFlow tutorial](tutorial_01.md) with input file:
+
+!listing modules/porous_flow/examples/tutorial/01.i
+
+A TH example that uses `PorousFlowBasicTHM` is also documented in the [PorousFlow tutorial](tutorial_03.md) with input file:
+
+!listing modules/porous_flow/examples/tutorial/03.i
+
+A THM example that uses `PorousFlowBasicTHM` is also documented in the [PorousFlow tutorial](tutorial_04.md) with input file:
+
+!listing modules/porous_flow/examples/tutorial/04.i
 
 !syntax parameters /PorousFlowBasicTHM/PorousFlowBasicTHM
-
-!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeThermalExpansionEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeThermalExpansionEigenstrain.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This model computes the eigenstrain tensor resulting from isotropic thermal expansion where the constant thermal expansion is defined by a user-supplied scalar coefficient, $\alpha$.
+This model computes the eigenstrain tensor resulting from isotropic thermal expansion where the constant thermal expansion is defined by a user-supplied scalar linear thermal-expansion coefficient, $\alpha$.
 The thermal expansion eigenstrain is then computed as
 \begin{equation}
 \boldsymbol{\epsilon}^{thermal} = \alpha \cdot \left( T - T_{stress\_free} \right) \mathbf{I}


### PR DESCRIPTION
In the tutorial i mention that you can control the temperature via an AuxVariable or Real in isothermal situations
PorousFlowBasicTHM Action extensively documented, and all the Materials and Kernels that this uses also fully documented.
In ComputeThermalExpansionEigenstrain.md i mention that alpha is the *linear* (not volumetric) thermal expansion coefficient

Fixes #11458

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
