### PR TITLE
PetscContactLineSearch requires PETSc >= 3.6.0

### DIFF
--- a/framework/src/problems/FEProblem.C
+++ b/framework/src/problems/FEProblem.C
@@ -60,8 +60,8 @@ FEProblem::addLineSearch(const InputParameters & parameters)
   if (enum_line_search == Moose::LS_CONTACT)
   {
 #ifdef LIBMESH_HAVE_PETSC
-#if PETSC_VERSION_LESS_THAN(3, 3, 0)
-    mooseError("Shell line searches only became available in Petsc in version 3.3!");
+#if PETSC_VERSION_LESS_THAN(3, 6, 0)
+    mooseError("Shell line searches only became available in Petsc in version 3.6.0!");
 #else
     InputParameters ls_params = _factory.getValidParams("PetscContactLineSearch");
 

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/tests
@@ -57,6 +57,8 @@
     allow_warnings = true
     abs_zero = 1e-8
     rel_err = 5e-4
+    # The linesearch used by this test requires PETSc >= 3.6.0.
+    petsc_version = '>=3.6.0'
   [../]
   [./mu_0_0_kin]
     type = 'CSVDiff'

--- a/modules/combined/test/tests/sliding_block/in_and_out/constraint/tests
+++ b/modules/combined/test/tests/sliding_block/in_and_out/constraint/tests
@@ -48,5 +48,7 @@
     min_parallel = 4
     abs_zero = 1e-7
     max_time = 800
+    # The linesearch used by this test requires PETSc >= 3.6.0.
+    petsc_version = '>=3.6.0'
   [../]
 []

--- a/modules/contact/src/PetscContactLineSearch.C
+++ b/modules/contact/src/PetscContactLineSearch.C
@@ -10,9 +10,7 @@
 #include "PetscContactLineSearch.h"
 
 #ifdef LIBMESH_HAVE_PETSC
-#if PETSC_VERSION_LESS_THAN(3, 3, 0)
-#else
-
+#if !PETSC_VERSION_LESS_THAN(3, 6, 0)
 #include "FEProblem.h"
 #include "NonlinearSystem.h"
 #include "libmesh/petsc_nonlinear_solver.h"
@@ -53,11 +51,7 @@ PetscContactLineSearch::lineSearch()
   KSP ksp;
   SNES snes = _solver->snes();
 
-#if PETSC_VERSION_LESS_THAN(3, 4, 0)
-  ierr = SNESGetSNESLineSearch(snes, &line_search);
-#else
   ierr = SNESGetLineSearch(snes, &line_search);
-#endif
   LIBMESH_CHKERR(ierr);
   ierr = SNESLineSearchGetVecs(line_search, &X, &F, &Y, &W, &G);
   LIBMESH_CHKERR(ierr);
@@ -200,5 +194,5 @@ PetscContactLineSearch::lineSearch()
   _old_contact_state = std::move(contact_state_stored);
 }
 
-#endif // PETSC_VERSION_LESS_THAN(3, 3, 0)
+#endif // !PETSC_VERSION_LESS_THAN(3, 3, 0)
 #endif // LIBMESH_HAVE_PETSC


### PR DESCRIPTION
The private header we are currently using was added in
petsc/petsc@af0996ce; this commit first appeared in PETSc 3.6.0.  In a
later commit, @lindsayad will try to remove the use of this private
header completely.

Refs #10951.

@gardnerru 