### PR TITLE
initial_stress input parameter removed from TensorMechanics

### DIFF
--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrainElasticStress.h
@@ -33,14 +33,6 @@ protected:
   virtual void initQpStatefulProperties() override;
   virtual void computeQpStress() override;
 
-  /**
-   * InitialStress Deprecation: remove this method
-   *
-   * Rotates initial_stress via rotation_increment.
-   * In large-strain scenarios this must be used before addQpInitialStress
-   */
-  virtual void rotateQpInitialStress();
-
   const MaterialProperty<RankTwoTensor> & _strain_increment;
   const MaterialProperty<RankTwoTensor> & _rotation_increment;
   const MaterialProperty<RankTwoTensor> & _stress_old;

--- a/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultiPlasticityStress.h
@@ -585,14 +585,6 @@ protected:
                                            const std::vector<Real> & cumulative_pm);
 
 private:
-  // InitialStress Deprecation: remove _step_one parameter
-  /// True if this is the first timestep (timestep < 2). In the first timestep,
-  /// an initial stress is needed to subdivide.  This boolean variable
-  /// eliminates the use of the _app.isRestarting() in this class.
-  /// This boolean is delcared as a reference so that the variable is restartable
-  /// data:  if we restart, the code will not think it is the first timestep again.
-  bool & _step_one;
-
   RankTwoTensor rot(const RankTwoTensor & tens);
 };
 

--- a/modules/tensor_mechanics/include/materials/ComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStressBase.h
@@ -34,26 +34,6 @@ protected:
   virtual void computeQpProperties() override;
   virtual void computeQpStress() = 0;
 
-  /**
-   * InitialStress Deprecation: remove this method
-   *
-   * Adds initial stress, if it is provided, to _stress[_qp].  This
-   * function should NOT be used if you calculate stress using
-   *
-   * stress = stress_old + elasticity * strain_increment
-   *
-   * because stress_old will already include initial stress.  However
-   * this function SHOULD be used if your code uses
-   *
-   * stress = elasticity * (elastic_strain_old + strain_increment)
-   * or
-   * stress = elasticity * elastic_strain
-   *
-   * since in these cases the elastic_strain and elastic_strain_old
-   * will not include any contribution from initial stress.
-   */
-  void addQpInitialStress();
-
   const std::string _base_name;
   const std::string _elasticity_tensor_name;
 
@@ -74,15 +54,6 @@ protected:
 
   /// Parameter which decides whether to store old stress. This is required for HHT time integration and Rayleigh damping
   const bool _store_stress_old;
-
-  /// Whether initial stress was provided.  InitialStress Deprecation: remove this.
-  const bool _initial_stress_provided;
-
-  /// Initial stress, if provided. InitialStress Deprecation: remove this.
-  MaterialProperty<RankTwoTensor> * _initial_stress;
-
-  /// Old value of initial stress, which is needed to correctly implement finite-strain rotations.  InitialStress Deprecation: remove this.
-  const MaterialProperty<RankTwoTensor> * _initial_stress_old;
 };
 
 #endif // COMPUTESTRESSBASE_H

--- a/modules/tensor_mechanics/src/materials/ComputeCosseratLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeCosseratLinearElasticStress.C
@@ -38,7 +38,6 @@ void
 ComputeCosseratLinearElasticStress::computeQpStress()
 {
   _stress[_qp] = _elasticity_tensor[_qp] * _mechanical_strain[_qp];
-  addQpInitialStress(); // InitialStress Deprecation: remove this line
   _stress_couple[_qp] = _elastic_flexural_rigidity_tensor[_qp] * _curvature[_qp];
 
   _elastic_strain[_qp] = _mechanical_strain[_qp];

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrainElasticStress.C
@@ -59,21 +59,9 @@ ComputeFiniteStrainElasticStress::computeQpStress()
   _stress[_qp] =
       _rotation_increment[_qp] * intermediate_stress * _rotation_increment[_qp].transpose();
 
-  // InitialStress Deprecation: remove the following 2 lines
-  rotateQpInitialStress();
-  addQpInitialStress();
-
   // Assign value for elastic strain, which is equal to the mechanical strain
   _elastic_strain[_qp] = _mechanical_strain[_qp];
 
   // Compute dstress_dstrain
   _Jacobian_mult[_qp] = _elasticity_tensor[_qp]; // This is NOT the exact jacobian
-}
-
-void
-ComputeFiniteStrainElasticStress::rotateQpInitialStress()
-{
-  if (_initial_stress_provided)
-    (*_initial_stress)[_qp] = _rotation_increment[_qp] * (*_initial_stress_old)[_qp] *
-                              _rotation_increment[_qp].transpose();
 }

--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
@@ -40,7 +40,6 @@ ComputeLinearElasticStress::computeQpStress()
 {
   // stress = C * e
   _stress[_qp] = _elasticity_tensor[_qp] * _mechanical_strain[_qp];
-  addQpInitialStress(); // InitialStress Deprecation: remove this line
 
   // Assign value for elastic strain, which is equal to the mechanical strain
   _elastic_strain[_qp] = _mechanical_strain[_qp];

--- a/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultiPlasticityStress.C
@@ -164,9 +164,7 @@ ComputeMultiPlasticityStress::ComputeMultiPlasticityStress(const InputParameters
     _my_elasticity_tensor(RankFourTensor()),
     _my_strain_increment(RankTwoTensor()),
     _my_flexural_rigidity_tensor(RankFourTensor()),
-    _my_curvature(RankTwoTensor()),
-    _step_one(
-        declareRestartableData<bool>("step_one", true)) // InitialStress Deprecation: remove this
+    _my_curvature(RankTwoTensor())
 {
   if (_epp_tol <= 0)
     mooseError("ComputeMultiPlasticityStress: ep_plastic_tolerance must be positive");
@@ -501,10 +499,6 @@ ComputeMultiPlasticityStress::plasticStep(const RankTwoTensor & stress_old,
   Real step_size = 1.0;
   Real time_simulated = 0.0;
 
-  // InitialStress Deprecation: remove the following 2 lines
-  if (_t_step >= 2)
-    _step_one = false;
-
   // the "good" variables hold the latest admissible stress
   // and internal parameters.
   RankTwoTensor stress_good = stress_old;
@@ -517,13 +511,6 @@ ComputeMultiPlasticityStress::plasticStep(const RankTwoTensor & stress_old,
   // Following is necessary because I want strain_increment to be "const"
   // but I also want to be able to subdivide an initial_stress
   RankTwoTensor this_strain_increment = strain_increment;
-  // InitialStress Deprecation: remove following 6 lines
-  if (isParamValid("initial_stress") && _step_one)
-  {
-    RankFourTensor E_inv = E_ijkl.invSymm();
-    this_strain_increment += E_inv * stress_old;
-    stress_good = RankTwoTensor();
-  }
 
   RankTwoTensor dep = step_size * this_strain_increment;
 

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -191,13 +191,7 @@ ComputeMultipleInelasticStress::computeQpStressIntermediateConfiguration()
     // If the elasticity tensor values have changed and the tensor is isotropic,
     // use the old strain to calculate the old stress
     if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
-    {
       _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + _strain_increment[_qp]);
-      // InitialStress Deprecation: remove these lines
-      if (_perform_finite_strain_rotations)
-        rotateQpInitialStress();
-      addQpInitialStress();
-    }
     else
       _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * _strain_increment[_qp];
 
@@ -270,14 +264,8 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
 
       // form the trial stress, with the check for changed elasticity constants
       if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
-      {
         _stress[_qp] =
             _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
-        // InitialStress Deprecation: remove these lines
-        if (_perform_finite_strain_rotations)
-          rotateQpInitialStress();
-        addQpInitialStress();
-      }
       else
         _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
 
@@ -395,13 +383,7 @@ ComputeMultipleInelasticStress::updateQpStateSingleModel(
   // If the elasticity tensor values have changed and the tensor is isotropic,
   // use the old strain to calculate the old stress
   if (_is_elasticity_tensor_guaranteed_isotropic || !_perform_finite_strain_rotations)
-  {
     _stress[_qp] = _elasticity_tensor[_qp] * (_elastic_strain_old[_qp] + elastic_strain_increment);
-    // InitialStress Deprecation: remove these lines
-    if (_perform_finite_strain_rotations)
-      rotateQpInitialStress();
-    addQpInitialStress();
-  }
   else
     _stress[_qp] = _stress_old[_qp] + _elasticity_tensor[_qp] * elastic_strain_increment;
 

--- a/modules/tensor_mechanics/src/materials/ComputeSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeSmearedCrackingStress.C
@@ -268,10 +268,6 @@ ComputeSmearedCrackingStress::computeQpStress()
 
     // Calculate stress in intermediate configuration
     _stress[_qp] = _local_elasticity_tensor * _elastic_strain[_qp];
-    // InitialStress Deprecation: remove these lines
-    if (_perform_finite_strain_rotations)
-      rotateQpInitialStress();
-    addQpInitialStress();
 
     _Jacobian_mult[_qp] = _local_elasticity_tensor;
     force_elasticity_rotation = true;

--- a/modules/tensor_mechanics/src/materials/ComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStressBase.C
@@ -16,15 +16,6 @@ InputParameters
 validParams<ComputeStressBase>()
 {
   InputParameters params = validParams<Material>();
-  params.addDeprecatedParam<std::vector<FunctionName>>(
-      "initial_stress",
-      "A list of functions describing the initial stress.  If provided, there "
-      "must be 9 of these, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
-      "zz components respectively.  If not provided, all components of the "
-      "initial stress will be zero",
-      "This functionality was deprecated on 12 October 2017 and is set to be"
-      "removed on 12 March 2018.  Please use ComputeEigenstrainFromInitialStress"
-      "instead");
   params.addParam<std::string>("base_name",
                                "Optional parameter that allows the user to define "
                                "multiple mechanics material systems on the same "
@@ -49,36 +40,11 @@ ComputeStressBase::ComputeStressBase(const InputParameters & parameters)
     _elasticity_tensor(getMaterialPropertyByName<RankFourTensor>(_elasticity_tensor_name)),
     _extra_stress(getDefaultMaterialProperty<RankTwoTensor>(_base_name + "extra_stress")),
     _Jacobian_mult(declareProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
-    _store_stress_old(getParam<bool>("store_stress_old")),
-    // InitialStress Deprecation: remove the following
-    _initial_stress_provided(getParam<std::vector<FunctionName>>("initial_stress").size() ==
-                             LIBMESH_DIM * LIBMESH_DIM),
-    _initial_stress(_initial_stress_provided
-                        ? &declareProperty<RankTwoTensor>(_base_name + "initial_stress")
-                        : nullptr),
-    _initial_stress_old(_initial_stress_provided
-                            ? &getMaterialPropertyOld<RankTwoTensor>(_base_name + "initial_stress")
-                            : nullptr)
+    _store_stress_old(getParam<bool>("store_stress_old"))
 {
 
   if (getParam<bool>("use_displaced_mesh"))
     mooseError("The stress calculator needs to run on the undisplaced mesh.");
-
-  // InitialStress Deprecation: remove following initial stress stuff
-  const std::vector<FunctionName> & fcn_names(
-      getParam<std::vector<FunctionName>>("initial_stress"));
-  const unsigned num = fcn_names.size();
-
-  if (!(num == 0 || num == LIBMESH_DIM * LIBMESH_DIM))
-    mooseError("Either zero or ",
-               LIBMESH_DIM * LIBMESH_DIM,
-               " initial stress functions must be provided.  You supplied ",
-               num,
-               "\n");
-
-  _initial_stress_fcn.resize(num);
-  for (unsigned i = 0; i < num; ++i)
-    _initial_stress_fcn[i] = &getFunctionByName(fcn_names[i]);
 }
 
 void
@@ -86,33 +52,13 @@ ComputeStressBase::initQpStatefulProperties()
 {
   _elastic_strain[_qp].zero();
   _stress[_qp].zero();
-  // InitialStress Deprecation: remove the following
-  if (_initial_stress_provided)
-  {
-    for (unsigned i = 0; i < LIBMESH_DIM; ++i)
-      for (unsigned j = 0; j < LIBMESH_DIM; ++j)
-        (*_initial_stress)[_qp](i, j) =
-            _initial_stress_fcn[i * LIBMESH_DIM + j]->value(_t, _q_point[_qp]);
-  }
-  addQpInitialStress();
 }
 
 void
 ComputeStressBase::computeQpProperties()
 {
-  // InitialStress Deprecation: remove the following 2 lines
-  if (_initial_stress_provided)
-    (*_initial_stress)[_qp] = (*_initial_stress_old)[_qp];
-
   computeQpStress();
 
   // Add in extra stress
   _stress[_qp] += _extra_stress[_qp];
-}
-
-void
-ComputeStressBase::addQpInitialStress()
-{
-  if (_initial_stress_provided)
-    _stress[_qp] += (*_initial_stress)[_qp];
 }


### PR DESCRIPTION
This parameter has been deprecated since October 2017.
Old input files can be easily converted to the newer way of using ComputeEigenstrainFromInitialStress: there are about 100 examples to follow in the test suite.

Fixes #10074

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
