### PR TITLE
Fix run_test when in test dir

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -211,7 +211,7 @@ class TestHarness:
             self._infiles = [os.path.basename(self.options.spec_file)]
 
         else:
-            search_dir = self.base_dir
+            search_dir = os.getcwd()
 
         try:
             for dirpath, dirnames, filenames in os.walk(search_dir, followlinks=True):


### PR DESCRIPTION
This will allow only those tests found in the same directory the user
invoked `run_test` to execute (default spec filename: tests).

Closed #11516
