### PR TITLE
Fix Intel compiler warning.

### DIFF
--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -79,7 +79,8 @@ std::string
 stringify(const T<U...> & c, const std::string & delim = ",")
 {
   std::string str;
-  const auto begin = c.begin(), end = c.end();
+  const auto begin = c.begin();
+  const auto end = c.end();
   for (auto i = begin; i != end; ++i)
     str += (i != begin ? delim : "") + stringify(*i);
   return str;


### PR DESCRIPTION
warning #3373: nonstandard use of "auto" to both deduce the type from
an initializer and to announce a trailing return type

This warning comes from icpc (ICC) 17.0.1 20161005.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
