### PR TITLE
add Factory::createUnique, store FEProblemBase as a unique_ptr

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -194,7 +194,7 @@ protected:
   std::shared_ptr<MooseMesh> & _displaced_mesh;
 
   /// Convenience reference to a problem this action works on
-  std::shared_ptr<FEProblemBase> & _problem;
+  std::unique_ptr<FEProblemBase> & _problem;
 
   /// Convenience reference to an executioner
   std::shared_ptr<Executioner> & _executioner;

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -42,7 +42,7 @@ class MooseApp;
 /**
  * Typedef for function to build objects
  */
-typedef std::shared_ptr<Action> (*buildActionPtr)(const InputParameters & parameters);
+typedef std::unique_ptr<Action> (*buildActionPtr)(const InputParameters & parameters);
 
 /**
  * Typedef for validParams
@@ -53,10 +53,10 @@ typedef InputParameters (*paramsActionPtr)();
  * Build an object of type T
  */
 template <class T>
-std::shared_ptr<Action>
+std::unique_ptr<Action>
 buildAction(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 /**

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -187,8 +187,6 @@ public:
   std::shared_ptr<MooseMesh> & mesh() { return _mesh; }
   std::shared_ptr<MooseMesh> & displacedMesh() { return _displaced_mesh; }
 
-  std::shared_ptr<FEProblemBase> & problemBase() { return _problem; }
-  std::shared_ptr<FEProblem> problem();
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
 
@@ -245,9 +243,6 @@ protected:
 
   /// Possible mesh for displaced problem
   std::shared_ptr<MooseMesh> _displaced_mesh;
-
-  /// Problem class
-  std::shared_ptr<FEProblemBase> _problem;
 
 private:
   /// Last task to run before (optional) early termination - blank means no early termination.

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -131,7 +131,7 @@ using paramsPtr = InputParameters (*)();
 /**
  * alias for method to build objects
  */
-using buildPtr = MooseObjectPtr (*)(const InputParameters & parameters);
+using buildPtr = std::unique_ptr<MooseObject> (*)(const InputParameters & parameters);
 
 /**
  * alias for registered Object iterator
@@ -142,10 +142,10 @@ using registeredMooseObjectIterator = std::map<std::string, paramsPtr>::iterator
  * Build an object of type T
  */
 template <class T>
-MooseObjectPtr
+std::unique_ptr<MooseObject>
 buildObject(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 /**
@@ -284,8 +284,7 @@ public:
   std::shared_ptr<MooseObject> create(const std::string & obj_name,
                                       const std::string & name,
                                       InputParameters parameters,
-                                      THREAD_ID tid = 0,
-                                      bool print_deprecated = true);
+                                      THREAD_ID tid = 0);
 
   /**
    * Build an object (must be registered)
@@ -301,14 +300,26 @@ public:
                             InputParameters parameters,
                             THREAD_ID tid = 0)
   {
-    std::shared_ptr<T> new_object =
-        std::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
-    if (!new_object)
+    return std::shared_ptr<T>(createUnique<T>(obj_name, name, parameters, tid).release());
+  }
+
+  /**
+   * Creates and allocates an object.  obj_name is the c++ type of the object, name is the input
+   * file object name.  parameters contains the filled out (input file) configuration for the
+   * object, and tid is the thread ID for which this object will be created for.
+   */
+  template <typename T>
+  std::unique_ptr<T> createUnique(const std::string & obj_name,
+                                  const std::string & name,
+                                  InputParameters parameters,
+                                  THREAD_ID tid = 0)
+  {
+    T * raw = dynamic_cast<T *>(createRaw(obj_name, name, parameters, tid).release());
+    if (!raw)
       mooseError("We expected to create an object of type '" + demangle(typeid(T).name()) +
                  "'.\nInstead we received a parameters object for type '" + obj_name +
                  "'.\nDid you call the wrong \"add\" method in your Action?");
-
-    return new_object;
+    return std::unique_ptr<T>(raw);
   }
 
   /**
@@ -389,6 +400,12 @@ protected:
 
   /// Constructed Moose Object types
   std::set<std::string> _constructed_types;
+
+private:
+  std::unique_ptr<MooseObject> createRaw(const std::string & obj_name,
+                                         const std::string & name,
+                                         InputParameters parameters,
+                                         THREAD_ID tid = 0);
 };
 
 #endif /* FACTORY_H */

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -557,6 +557,16 @@ public:
    */
   const ExecFlagEnum & getExecuteOnEnum() const { return _execute_flags; }
 
+  /**
+   * This function is a legacy function that should not be used going forward.  It exists to allow
+   * actions to retroactively be able to "see" the problem object even though they were created
+   * before the problem object existed - they store a reference to this master unique pointer.
+   */
+  std::unique_ptr<FEProblemBase> & problemBaseRef() { return _problem_base; }
+
+  /// Returns the simulation problem object if any currently exists, or nullptr otherwise.
+  FEProblemBase * problemBase() { return _problem_base.get(); }
+
 protected:
   /**
    * Whether or not this MooseApp has cached a Backup to use for restart / recovery
@@ -738,6 +748,13 @@ private:
    * []
    */
   void createMinimalApp();
+
+  /**
+   * Action objects store a reference to this member via the problemBaseRef legacy member function.
+   * This unique pointer gets set to non-nullptr when the CreateProblemAction's _problem member
+   * variable (which is a reference to this unique pointer) gets set in its act function.
+   */
+  std::unique_ptr<FEProblemBase> _problem_base;
 
   /// Where the restartable data is held (indexed on tid)
   RestartableDatas _restartable_data;

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -81,13 +81,18 @@ protected:
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
+
+    // Normally, CreateProblemAction sets the global app problem pointer, but for cases like in unit
+    // tests, this doesn't happen - so we set it here.
+    _app->problemBaseRef() =
+        _factory.createUnique<FEProblem>("FEProblem", "problem", problem_params);
+    _fe_problem = _app->problemBase();
   }
 
   std::unique_ptr<MooseMesh> _mesh;
   std::shared_ptr<MooseApp> _app;
   Factory & _factory;
-  std::shared_ptr<FEProblem> _fe_problem;
+  FEProblemBase * _fe_problem;
 };
 
 #endif

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -94,8 +94,8 @@ class MooseObject;
 class Action;
 
 using paramsPtr = InputParameters (*)();
-using buildPtr = std::shared_ptr<MooseObject> (*)(const InputParameters & parameters);
-using buildActionPtr = std::shared_ptr<Action> (*)(const InputParameters & parameters);
+using buildPtr = std::unique_ptr<MooseObject> (*)(const InputParameters & parameters);
+using buildActionPtr = std::unique_ptr<Action> (*)(const InputParameters & parameters);
 
 /// Holds details and meta-data info for a particular MooseObject or Action for use in the
 /// registry.
@@ -127,17 +127,17 @@ struct RegistryEntry
 };
 
 template <class T>
-std::shared_ptr<MooseObject>
+std::unique_ptr<MooseObject>
 buildObj(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 template <class T>
-std::shared_ptr<Action>
+std::unique_ptr<Action>
 buildAct(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 /// The registry is used as a global singleton to collect information on all available MooseObject

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -157,8 +157,7 @@ private:
   ///@{
 
   /// The factory is allowed to call addInputParameters.
-  friend MooseObjectPtr
-  Factory::create(const std::string &, const std::string &, InputParameters, THREAD_ID, bool);
+  friend Factory;
 
   /// Only controls are allowed to call getControllableParameter. The
   /// Control::getControllableParameter is the only method that calls getControllableParameter.

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -61,7 +61,7 @@ Action::Action(InputParameters parameters)
     _current_task(_awh.getCurrentTaskName()),
     _mesh(_awh.mesh()),
     _displaced_mesh(_awh.displacedMesh()),
-    _problem(_awh.problemBase()),
+    _problem(_app.problemBaseRef()),
     _executioner(_app.executioner())
 {
 }

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -64,7 +64,7 @@ ActionWarehouse::clear()
   // destructor) we must guarantee that ActionWarehouse::clear()
   // releases all the resources which have to be released _before_ the
   // _comm object owned by the MooseApp is destroyed.
-  _problem.reset();
+  _app.problemBaseRef().reset();
   _displaced_mesh.reset();
   _mesh.reset();
 }
@@ -408,14 +408,6 @@ ActionWarehouse::printInputFile(std::ostream & out)
   }
 
   out << tree.print("");
-}
-
-std::shared_ptr<FEProblem>
-ActionWarehouse::problem()
-{
-  mooseDeprecated(
-      "ActionWarehouse::problem() is deprecated, please use ActionWarehouse::problemBase() \n");
-  return std::dynamic_pointer_cast<FEProblem>(_problem);
 }
 
 std::string

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -34,9 +34,9 @@ CreateExecutionerAction::CreateExecutionerAction(InputParameters params) : Moose
 void
 CreateExecutionerAction::act()
 {
-  std::shared_ptr<EigenProblem> eigen_problem = std::dynamic_pointer_cast<EigenProblem>(_problem);
+  auto eigen_problem = dynamic_cast<EigenProblem *>(_problem.get());
   if (eigen_problem)
-    _moose_object_pars.set<EigenProblem *>("_eigen_problem") = eigen_problem.get();
+    _moose_object_pars.set<EigenProblem *>("_eigen_problem") = eigen_problem;
 
   std::shared_ptr<Executioner> executioner =
       _factory.create<Executioner>(_type, "Executioner", _moose_object_pars);

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -78,15 +78,16 @@ CreateProblemAction::act()
       _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
       _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();
 
-      _problem =
-          _factory.create<FEProblemBase>(_type, getParam<std::string>("name"), _moose_object_pars);
+      _problem = _factory.createUnique<FEProblemBase>(
+          _type, getParam<std::string>("name"), _moose_object_pars);
+
       if (!_problem.get())
         mooseError("Problem has to be of a FEProblemBase type");
 
       // if users provide a problem type, the type has to be an EigenProblem or its derived subclass
       // when uing an eigen executioner
       if (_app.useEigenvalue() && _type != "EigenProblem" &&
-          !(std::dynamic_pointer_cast<EigenProblem>(_problem)))
+          !(dynamic_cast<EigenProblem *>(_problem.get())))
         mooseError("Problem has to be of a EigenProblem (or derived subclass) type when using "
                    "eigen executioner");
     }

--- a/framework/src/actions/InitProblemAction.C
+++ b/framework/src/actions/InitProblemAction.C
@@ -25,8 +25,7 @@ InitProblemAction::InitProblemAction(InputParameters params) : Action(params) {}
 void
 InitProblemAction::act()
 {
-  if (_problem.get())
-    _problem->init();
-  else
+  if (!_problem)
     mooseError("Problem doesn't exist in InitProblemAction!");
+  _problem->init();
 }

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -83,11 +83,18 @@ MooseObjectPtr
 Factory::create(const std::string & obj_name,
                 const std::string & name,
                 InputParameters parameters,
-                THREAD_ID tid /* =0 */,
-                bool print_deprecated /* =true */)
+                THREAD_ID tid /* =0 */)
 {
-  if (print_deprecated)
-    mooseDeprecated("Factory::create() is deprecated, please use Factory::create<T>() instead");
+  mooseDeprecated("Factory::create() is deprecated, please use Factory::create<T>() instead");
+  return createRaw(obj_name, name, parameters, tid);
+}
+
+std::unique_ptr<MooseObject>
+Factory::createRaw(const std::string & obj_name,
+                   const std::string & name,
+                   InputParameters parameters,
+                   THREAD_ID tid /* =0 */)
+{
 
   // Pointer to the object constructor
   std::map<std::string, buildPtr>::iterator it = _name_to_build_pointer.find(obj_name);
@@ -110,16 +117,12 @@ Factory::create(const std::string & obj_name,
   _constructed_types.insert(obj_name);
 
   // add FEProblem pointers to object's params object
-  if (_app.actionWarehouse().problemBase())
-    _app.actionWarehouse().problemBase()->setInputParametersFEProblem(params);
+  if (_app.problemBase())
+    _app.problemBase()->setInputParametersFEProblem(params);
 
   // call the function pointer to build the object
   buildPtr & func = it->second;
   auto obj = (*func)(params);
-
-  auto fep = std::dynamic_pointer_cast<FEProblemBase>(obj);
-  if (fep)
-    _app.actionWarehouse().problemBase() = fep;
 
   // Make sure no unexpected parameters were added by the object's constructor or by the action
   // initiating this create call.  All parameters modified by the constructor must have already

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1378,8 +1378,6 @@ void
 MooseApp::setRestart(const bool & value)
 {
   _restart = value;
-
-  std::shared_ptr<FEProblemBase> fe_problem = _action_warehouse.problemBase();
 }
 
 void


### PR DESCRIPTION
FEProblemBase master storage location has also been moved from the
ActionWarehouse to MooseApp.

ref #11533

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
