### PR TITLE
Disable check_input tests when running with valgrind

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -464,6 +464,8 @@ class Tester(MooseObject):
                 tmp_reason = 'Valgrind==HEAVY'
             elif int(self.specs['min_parallel']) > 1 or int(self.specs['min_threads']) > 1:
                 tmp_reason = 'Valgrind requires serial'
+            elif self.specs["check_input"]:
+                tmp_reason = 'check_input==True'
             if tmp_reason != '':
                 reasons['valgrind'] = tmp_reason
         # If we're running in recover mode skip tests that have recover = false

--- a/python/TestHarness/tests/test_Syntax.py
+++ b/python/TestHarness/tests/test_Syntax.py
@@ -30,3 +30,8 @@ class TestHarnessTester(TestHarnessTestCase):
         # Check that _thee_ SYNTAX test is not run
         output = self.runTests('--no-check-input', '-i', 'syntax')
         self.assertNotIn('SYNTAX PASS', output)
+
+        # Check that it is skipped when running valgrind
+        output = self.runTests('--valgrind', '-i', 'syntax')
+        self.assertIn('CHECK_INPUT==TRUE', output)
+        self.checkStatus(output, skipped=1)


### PR DESCRIPTION
closes #11532

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
