### PR TITLE
Range-based for-loops for Mesh entities

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -675,13 +675,11 @@ MooseMesh::nodeToActiveSemilocalElemMap()
     Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
     if (!_node_to_active_semilocal_elem_map_built)
     {
-      MeshBase::const_element_iterator el = getMesh().semilocal_elements_begin();
-      const MeshBase::const_element_iterator end = getMesh().semilocal_elements_end();
-
-      for (; el != end; ++el)
-        if ((*el)->active())
-          for (unsigned int n = 0; n < (*el)->n_nodes(); n++)
-            _node_to_active_semilocal_elem_map[(*el)->node(n)].push_back((*el)->id());
+      for (const auto & elem :
+           as_range(getMesh().semilocal_elements_begin(), getMesh().semilocal_elements_end()))
+        if (elem->active())
+          for (unsigned int n = 0; n < elem->n_nodes(); n++)
+            _node_to_active_semilocal_elem_map[elem->node_id(n)].push_back(elem->id());
 
       _node_to_active_semilocal_elem_map_built =
           true; // MUST be set at the end for double-checked locking to work!
@@ -1305,12 +1303,8 @@ MooseMesh::detectPairedSidesets()
   BoundaryInfo & boundary_info = getMesh().get_boundary_info();
   std::vector<boundary_id_type> face_ids;
 
-  MeshBase::const_element_iterator el = getMesh().level_elements_begin(0);
-  const MeshBase::const_element_iterator end_el = getMesh().level_elements_end(0);
-  for (; el != end_el; ++el)
+  for (auto & elem : as_range(getMesh().level_elements_begin(0), getMesh().level_elements_end(0)))
   {
-    Elem * elem = *el;
-
     // dimension of the current element and its normals
     unsigned int side_dim = elem->dim() - 1;
     const std::vector<Point> & normals = fe_faces[side_dim]->get_normals();
@@ -1826,11 +1820,8 @@ MooseMesh::changeBoundaryId(const boundary_id_type old_id,
   std::vector<boundary_id_type> old_ids;
 
   // Only level-0 elements store BCs.  Loop over them.
-  MeshBase::element_iterator el = getMesh().level_elements_begin(0);
-  const MeshBase::element_iterator end_el = getMesh().level_elements_end(0);
-  for (; el != end_el; ++el)
+  for (auto & elem : as_range(getMesh().level_elements_begin(0), getMesh().level_elements_end(0)))
   {
-    Elem * elem = *el;
     unsigned int n_sides = elem->n_sides();
     for (unsigned int s = 0; s != n_sides; ++s)
     {
@@ -2569,11 +2560,8 @@ MooseMesh::addMortarInterface(const std::string & name,
   iface->_slave = slave;
   iface->_name = name;
 
-  MeshBase::element_iterator el = _mesh->level_elements_begin(0);
-  const MeshBase::element_iterator end_el = _mesh->level_elements_end(0);
-  for (; el != end_el; ++el)
+  for (auto & elem : as_range(_mesh->level_elements_begin(0), _mesh->level_elements_end(0)))
   {
-    Elem * elem = *el;
     if (elem->subdomain_id() == domain_id)
       iface->_elems.push_back(elem);
   }

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -64,14 +64,12 @@ BoundingBoxNodeSet::modify()
   const bool inside = (_location == "INSIDE");
 
   // Loop over the elements and assign node set id to nodes within the bounding box
-  for (auto node = mesh.active_nodes_begin(); node != mesh.active_nodes_end(); ++node)
-  {
-    if (_bounding_box.contains_point(**node) == inside)
+  for (auto & node : as_range(mesh.active_nodes_begin(), mesh.active_nodes_end()))
+    if (_bounding_box.contains_point(*node) == inside)
     {
-      boundary_info.add_node(*node, boundary_ids[0]);
+      boundary_info.add_node(node, boundary_ids[0]);
       found_node = true;
     }
-  }
 
   // Unless at least one processor found a node in the bounding box,
   // the user probably specified it incorrectly.

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -149,15 +149,8 @@ OversampleOutput::initOversample()
   DistributedMesh * dist_mesh = dynamic_cast<DistributedMesh *>(&source_es.get_mesh());
   if (dist_mesh)
   {
-    for (MeshBase::element_iterator it = dist_mesh->active_local_elements_begin(),
-                                    end = dist_mesh->active_local_elements_end();
-         it != end;
-         ++it)
-    {
-      Elem * elem = *it;
-
+    for (auto & elem : dist_mesh->active_local_element_ptr_range())
       dist_mesh->add_extra_ghost_elem(elem);
-    }
   }
 
   // Initialize the _mesh_functions vector

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -237,14 +237,12 @@ OversampleOutput::updateOversample()
       }
 
       // Now loop over the nodes of the oversampled mesh setting values for each variable.
-      for (MeshBase::const_node_iterator nd = _mesh_ptr->localNodesBegin();
-           nd != _mesh_ptr->localNodesEnd();
-           ++nd)
+      for (const auto & node : as_range(_mesh_ptr->localNodesBegin(), _mesh_ptr->localNodesEnd()))
         for (unsigned int var_num = 0; var_num < _mesh_functions[sys_num].size(); ++var_num)
-          if ((*nd)->n_dofs(sys_num, var_num))
-            dest_sys.solution->set(
-                (*nd)->dof_number(sys_num, var_num, 0),
-                (*_mesh_functions[sys_num][var_num])(**nd - _position)); // 0 value is for component
+          if (node->n_dofs(sys_num, var_num))
+            dest_sys.solution->set(node->dof_number(sys_num, var_num, 0),
+                                   (*_mesh_functions[sys_num][var_num])(
+                                       *node - _position)); // 0 value is for component
 
       dest_sys.solution->close();
     }

--- a/framework/src/outputs/TopResidualDebugOutput.C
+++ b/framework/src/outputs/TopResidualDebugOutput.C
@@ -62,18 +62,15 @@ TopResidualDebugOutput::printTopResiduals(const NumericVector<Number> & residual
   vec.resize(residual.local_size());
 
   unsigned int j = 0;
-  MeshBase::node_iterator it = mesh.local_nodes_begin();
-  const MeshBase::node_iterator end = mesh.local_nodes_end();
-  for (; it != end; ++it)
+  for (const auto & node : mesh.local_node_ptr_range())
   {
-    Node & node = *(*it);
-    dof_id_type nd = node.id();
+    dof_id_type nd = node->id();
 
-    for (unsigned int var = 0; var < node.n_vars(_sys.number()); ++var)
-      if (node.n_dofs(_sys.number(), var) >
+    for (unsigned int var = 0; var < node->n_vars(_sys.number()); ++var)
+      if (node->n_dofs(_sys.number(), var) >
           0) // this check filters scalar variables (which are clearly not a dof on every node)
       {
-        dof_id_type dof_idx = node.dof_number(_sys.number(), var, 0);
+        dof_id_type dof_idx = node->dof_number(_sys.number(), var, 0);
         vec[j] = TopResidualDebugOutputTopResidualData(var, nd, residual(dof_idx));
         j++;
       }

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -55,28 +55,22 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
                                    const unsigned int to_var,
                                    NumericVector<Number> & to_vector)
 {
+  for (auto & node : mesh.local_node_ptr_range())
   {
-    MeshBase::node_iterator it = mesh.local_nodes_begin();
-    MeshBase::node_iterator it_end = mesh.local_nodes_end();
+    unsigned int n_comp = node->n_comp(from_system, from_var);
 
-    for (; it != it_end; ++it)
+    mooseAssert(node->n_comp(from_system, from_var) == node->n_comp(to_system, to_var),
+                "Number of components does not match in each system");
+
+    for (unsigned int i = 0; i < n_comp; i++)
     {
-      Node * node = *it;
+      dof_id_type from_dof = node->dof_number(from_system, from_var, i);
+      dof_id_type to_dof = node->dof_number(to_system, to_var, i);
 
-      unsigned int n_comp = node->n_comp(from_system, from_var);
-
-      mooseAssert(node->n_comp(from_system, from_var) == node->n_comp(to_system, to_var),
-                  "Number of components does not match in each system");
-
-      for (unsigned int i = 0; i < n_comp; i++)
-      {
-        dof_id_type from_dof = node->dof_number(from_system, from_var, i);
-        dof_id_type to_dof = node->dof_number(to_system, to_var, i);
-
-        to_vector.set(to_dof, from_vector(from_dof));
-      }
+      to_vector.set(to_dof, from_vector(from_dof));
     }
   }
+
   {
     MeshBase::element_iterator it = mesh.local_elements_begin();
     MeshBase::element_iterator it_end = mesh.local_elements_end();

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -71,26 +71,19 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
     }
   }
 
+  for (auto & elem : as_range(mesh.local_elements_begin(), mesh.local_elements_end()))
   {
-    MeshBase::element_iterator it = mesh.local_elements_begin();
-    MeshBase::element_iterator it_end = mesh.local_elements_end();
+    unsigned int n_comp = elem->n_comp(from_system, from_var);
 
-    for (; it != it_end; ++it)
+    mooseAssert(elem->n_comp(from_system, from_var) == elem->n_comp(to_system, to_var),
+                "Number of components does not match in each system");
+
+    for (unsigned int i = 0; i < n_comp; i++)
     {
-      Elem * elem = *it;
+      dof_id_type from_dof = elem->dof_number(from_system, from_var, i);
+      dof_id_type to_dof = elem->dof_number(to_system, to_var, i);
 
-      unsigned int n_comp = elem->n_comp(from_system, from_var);
-
-      mooseAssert(elem->n_comp(from_system, from_var) == elem->n_comp(to_system, to_var),
-                  "Number of components does not match in each system");
-
-      for (unsigned int i = 0; i < n_comp; i++)
-      {
-        dof_id_type from_dof = elem->dof_number(from_system, from_var, i);
-        dof_id_type to_dof = elem->dof_number(to_system, to_var, i);
-
-        to_vector.set(to_dof, from_vector(from_dof));
-      }
+      to_vector.set(to_dof, from_vector(from_dof));
     }
   }
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4911,13 +4911,11 @@ FEProblemBase::checkDisplacementOrders()
 {
   if (_displaced_problem)
   {
-    MeshBase::const_element_iterator it = _displaced_mesh->activeLocalElementsBegin(),
-                                     end = _displaced_mesh->activeLocalElementsEnd();
-
     bool mesh_has_second_order_elements = false;
-    for (; it != end; ++it)
+    for (const auto & elem : as_range(_displaced_mesh->activeLocalElementsBegin(),
+                                      _displaced_mesh->activeLocalElementsEnd()))
     {
-      if ((*it)->default_order() == SECOND)
+      if (elem->default_order() == SECOND)
       {
         mesh_has_second_order_elements = true;
         break;

--- a/framework/src/transfers/DTKInterpolationAdapter.C
+++ b/framework/src/transfers/DTKInterpolationAdapter.C
@@ -80,17 +80,15 @@ DTKInterpolationAdapter::DTKInterpolationAdapter(Teuchos::RCP<const Teuchos::Mpi
   {
     GlobalOrdinal i = 0;
 
-    MeshBase::const_element_iterator end = mesh.local_elements_end();
-    for (MeshBase::const_element_iterator it = mesh.local_elements_begin(); it != end; ++it)
+    for (const auto & elem : as_range(mesh.local_elements_begin(), mesh.local_elements_end()))
     {
-      const Elem & elem = *(*it);
-      elements[i] = elem.id();
+      elements[i] = elem->id();
 
       for (GlobalOrdinal j = 0; j < n_nodes_per_elem; j++)
-        connectivity[(j * n_local_elem) + i] = elem.node_id(j);
+        connectivity[(j * n_local_elem) + i] = elem->node_id(j);
 
       {
-        Point centroid = elem.centroid();
+        Point centroid = elem->centroid();
         for (GlobalOrdinal j = 0; j < from_dim; j++)
           elem_centroid_coordinates[(j * n_local_elem) + i] = centroid(j) + offset(j);
       }
@@ -337,13 +335,10 @@ DTKInterpolationAdapter::get_element_topology(const Elem * elem)
 void
 DTKInterpolationAdapter::get_semi_local_nodes(std::set<GlobalOrdinal> & semi_local_nodes)
 {
-  MeshBase::const_element_iterator end = mesh.local_elements_end();
-  for (MeshBase::const_element_iterator it = mesh.local_elements_begin(); it != end; ++it)
+  for (const auto & elem : as_range(mesh.local_elements_begin(), mesh.local_elements_end()))
   {
-    const Elem & elem = *(*it);
-
-    for (unsigned int j = 0; j < elem.n_nodes(); j++)
-      semi_local_nodes.insert(elem.node_id(j));
+    for (unsigned int j = 0; j < elem->n_nodes(); j++)
+      semi_local_nodes.insert(elem->node_id(j));
   }
 }
 

--- a/framework/src/transfers/MultiAppCopyTransfer.C
+++ b/framework/src/transfers/MultiAppCopyTransfer.C
@@ -92,20 +92,13 @@ MultiAppCopyTransfer::transfer(FEProblemBase & to_problem, FEProblemBase & from_
     mooseError("The meshes must be identical to utilize MultiAppCopyTransfer.");
 
   // Transfer node dofs
-  MeshBase::const_node_iterator node_it = to_mesh.local_nodes_begin();
-  MeshBase::const_node_iterator node_end = to_mesh.local_nodes_end();
-  for (; node_it != node_end; ++node_it)
-    transferDofObject(*node_it, from_mesh.node_ptr((*node_it)->id()), to_var, from_var);
+  for (const auto & node : as_range(to_mesh.local_nodes_begin(), to_mesh.local_nodes_end()))
+    transferDofObject(node, from_mesh.node_ptr(node->id()), to_var, from_var);
 
   // Transfer elem dofs
-  MeshBase::const_element_iterator elem_it = to_mesh.local_elements_begin();
-  MeshBase::const_element_iterator elem_end = to_mesh.local_elements_end();
-  Elem * to_elem;
-  Elem * from_elem;
-  for (; elem_it != elem_end; ++elem_it)
+  for (auto & to_elem : as_range(to_mesh.local_elements_begin(), to_mesh.local_elements_end()))
   {
-    to_elem = *elem_it;
-    from_elem = from_mesh.elem_ptr(to_elem->id());
+    Elem * from_elem = from_mesh.elem_ptr(to_elem->id());
     mooseAssert(to_elem->type() == from_elem->type(), "The elements must be the same type.");
     transferDofObject(to_elem, from_elem, to_var, from_var);
   }

--- a/framework/src/transfers/MultiAppInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppInterpolationTransfer.C
@@ -131,13 +131,8 @@ MultiAppInterpolationTransfer::execute()
 
       if (from_is_nodal)
       {
-        MeshBase::const_node_iterator from_nodes_it = from_mesh->local_nodes_begin();
-        MeshBase::const_node_iterator from_nodes_end = from_mesh->local_nodes_end();
-
-        for (; from_nodes_it != from_nodes_end; ++from_nodes_it)
+        for (const auto & from_node : from_mesh->local_node_ptr_range())
         {
-          Node * from_node = *from_nodes_it;
-
           // Assuming LAGRANGE!
           dof_id_type from_dof = from_node->dof_number(from_sys_num, from_var_num, 0);
 
@@ -147,13 +142,9 @@ MultiAppInterpolationTransfer::execute()
       }
       else
       {
-        MeshBase::const_element_iterator from_elements_it = from_mesh->local_elements_begin();
-        MeshBase::const_element_iterator from_elements_end = from_mesh->local_elements_end();
-
-        for (; from_elements_it != from_elements_end; ++from_elements_it)
+        for (const auto & from_elem :
+             as_range(from_mesh->local_elements_begin(), from_mesh->local_elements_end()))
         {
-          Elem * from_elem = *from_elements_it;
-
           // Assuming CONSTANT MONOMIAL
           dof_id_type from_dof = from_elem->dof_number(from_sys_num, from_var_num, 0);
 
@@ -189,13 +180,8 @@ MultiAppInterpolationTransfer::execute()
 
           if (is_nodal)
           {
-            MeshBase::const_node_iterator node_it = mesh->local_nodes_begin();
-            MeshBase::const_node_iterator node_end = mesh->local_nodes_end();
-
-            for (; node_it != node_end; ++node_it)
+            for (const auto & node : mesh->local_node_ptr_range())
             {
-              Node * node = *node_it;
-
               Point actual_position = *node + _multi_app->position(i);
 
               if (node->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this node
@@ -219,13 +205,8 @@ MultiAppInterpolationTransfer::execute()
           }
           else // Elemental
           {
-            MeshBase::const_element_iterator elem_it = mesh->local_elements_begin();
-            MeshBase::const_element_iterator elem_end = mesh->local_elements_end();
-
-            for (; elem_it != elem_end; ++elem_it)
+            for (auto & elem : as_range(mesh->local_elements_begin(), mesh->local_elements_end()))
             {
-              Elem * elem = *elem_it;
-
               Point centroid = elem->centroid();
               Point actual_position = centroid + _multi_app->position(i);
 
@@ -348,13 +329,8 @@ MultiAppInterpolationTransfer::execute()
 
         if (from_is_nodal)
         {
-          MeshBase::const_node_iterator from_nodes_it = from_mesh->local_nodes_begin();
-          MeshBase::const_node_iterator from_nodes_end = from_mesh->local_nodes_end();
-
-          for (; from_nodes_it != from_nodes_end; ++from_nodes_it)
+          for (const auto & from_node : from_mesh->local_node_ptr_range())
           {
-            Node * from_node = *from_nodes_it;
-
             // Assuming LAGRANGE!
             dof_id_type from_dof = from_node->dof_number(from_sys_num, from_var_num, 0);
 
@@ -364,13 +340,9 @@ MultiAppInterpolationTransfer::execute()
         }
         else
         {
-          MeshBase::const_element_iterator from_elements_it = from_mesh->local_elements_begin();
-          MeshBase::const_element_iterator from_elements_end = from_mesh->local_elements_end();
-
-          for (; from_elements_it != from_elements_end; ++from_elements_it)
+          for (auto & from_element :
+               as_range(from_mesh->local_elements_begin(), from_mesh->local_elements_end()))
           {
-            Elem * from_element = *from_elements_it;
-
             // Assuming LAGRANGE!
             dof_id_type from_dof = from_element->dof_number(from_sys_num, from_var_num, 0);
 
@@ -386,13 +358,8 @@ MultiAppInterpolationTransfer::execute()
       // Now do the interpolation to the target system
       if (is_nodal)
       {
-        MeshBase::const_node_iterator node_it = to_mesh->local_nodes_begin();
-        MeshBase::const_node_iterator node_end = to_mesh->local_nodes_end();
-
-        for (; node_it != node_end; ++node_it)
+        for (auto & node : as_range(to_mesh->local_nodes_begin(), to_mesh->local_nodes_end()))
         {
-          Node * node = *node_it;
-
           if (node->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this node
           {
             std::vector<Point> pts;
@@ -414,13 +381,8 @@ MultiAppInterpolationTransfer::execute()
       }
       else // Elemental
       {
-        MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
-        MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
-
-        for (; elem_it != elem_end; ++elem_it)
+        for (auto & elem : as_range(to_mesh->local_elements_begin(), to_mesh->local_elements_end()))
         {
-          Elem * elem = *elem_it;
-
           Point centroid = elem->centroid();
 
           if (elem->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this elem
@@ -463,14 +425,14 @@ MultiAppInterpolationTransfer::getNearestNode(const Point & p,
   distance = std::numeric_limits<Real>::max();
   Node * nearest = NULL;
 
-  for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it)
+  for (auto & node : as_range(nodes_begin, nodes_end))
   {
-    Real current_distance = (p - *(*node_it)).norm();
+    Real current_distance = (p - *node).norm();
 
     if (current_distance < distance)
     {
       distance = current_distance;
-      nearest = *node_it;
+      nearest = node;
     }
   }
 

--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -126,13 +126,8 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
 
     if (is_nodal)
     {
-      MeshBase::const_node_iterator node_it = to_mesh->local_nodes_begin();
-      MeshBase::const_node_iterator node_end = to_mesh->local_nodes_end();
-
-      for (; node_it != node_end; ++node_it)
+      for (const auto & node : to_mesh->local_node_ptr_range())
       {
-        Node * node = *node_it;
-
         // Skip this node if the variable has no dofs at it.
         if (node->n_dofs(sys_num, var_num) < 1)
           continue;
@@ -161,13 +156,8 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
     }
     else // Elemental
     {
-      MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
-      MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
-
-      for (; elem_it != elem_end; ++elem_it)
+      for (auto & elem : as_range(to_mesh->local_elements_begin(), to_mesh->local_elements_end()))
       {
-        Elem * elem = *elem_it;
-
         Point centroid = elem->centroid();
 
         // Skip this element if the variable has no dofs at it.
@@ -356,13 +346,8 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
 
     if (is_nodal)
     {
-      MeshBase::const_node_iterator node_it = to_mesh->local_nodes_begin();
-      MeshBase::const_node_iterator node_end = to_mesh->local_nodes_end();
-
-      for (; node_it != node_end; ++node_it)
+      for (const auto & node : to_mesh->local_node_ptr_range())
       {
-        Node * node = *node_it;
-
         // Skip this node if the variable has no dofs at it.
         if (node->n_dofs(sys_num, var_num) < 1)
           continue;
@@ -403,13 +388,8 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
     }
     else // Elemental
     {
-      MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
-      MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
-
-      for (; elem_it != elem_end; ++elem_it)
+      for (auto & elem : as_range(to_mesh->local_elements_begin(), to_mesh->local_elements_end()))
       {
-        Elem * elem = *elem_it;
-
         // Skip this element if the variable has no dofs at it.
         if (elem->n_dofs(sys_num, var_num) < 1)
           continue;

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -134,13 +134,9 @@ MultiAppNearestNodeTransfer::execute()
         else
         {
           target_local_nodes.resize(to_mesh->n_local_nodes());
-          MeshBase::const_node_iterator nodes_begin = to_mesh->local_nodes_begin();
-          MeshBase::const_node_iterator nodes_end = to_mesh->local_nodes_end();
-
           unsigned int i = 0;
-          for (MeshBase::const_node_iterator nodes_it = nodes_begin; nodes_it != nodes_end;
-               ++nodes_it, ++i)
-            target_local_nodes[i] = *nodes_it;
+          for (auto & node : to_mesh->local_node_ptr_range())
+            target_local_nodes[i++] = node;
         }
 
         for (const auto & node : target_local_nodes)
@@ -180,13 +176,8 @@ MultiAppNearestNodeTransfer::execute()
       }
       else // Elemental
       {
-        MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
-        MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
-
-        for (; elem_it != elem_end; ++elem_it)
+        for (auto & elem : as_range(to_mesh->local_elements_begin(), to_mesh->local_elements_end()))
         {
-          Elem * elem = *elem_it;
-
           Point centroid = elem->centroid();
 
           // Skip this element if the variable has no dofs at it.
@@ -416,13 +407,9 @@ MultiAppNearestNodeTransfer::execute()
       else
       {
         target_local_nodes.resize(to_mesh->n_local_nodes());
-        MeshBase::const_node_iterator nodes_begin = to_mesh->local_nodes_begin();
-        MeshBase::const_node_iterator nodes_end = to_mesh->local_nodes_end();
-
         unsigned int i = 0;
-        for (MeshBase::const_node_iterator nodes_it = nodes_begin; nodes_it != nodes_end;
-             ++nodes_it, ++i)
-          target_local_nodes[i] = *nodes_it;
+        for (auto & node : to_mesh->local_node_ptr_range())
+          target_local_nodes[i++] = node;
       }
 
       for (const auto & node : target_local_nodes)
@@ -466,13 +453,8 @@ MultiAppNearestNodeTransfer::execute()
     }
     else // Elemental
     {
-      MeshBase::const_element_iterator elem_it = to_mesh->local_elements_begin();
-      MeshBase::const_element_iterator elem_end = to_mesh->local_elements_end();
-
-      for (; elem_it != elem_end; ++elem_it)
+      for (auto & elem : as_range(to_mesh->local_elements_begin(), to_mesh->local_elements_end()))
       {
-        Elem * elem = *elem_it;
-
         // Skip this element if the variable has no dofs at it.
         if (elem->n_dofs(sys_num, var_num) < 1)
           continue;
@@ -560,11 +542,8 @@ MultiAppNearestNodeTransfer::getNearestNode(const Point & p,
   }
   else
   {
-    SimpleRange<MeshBase::const_node_iterator> range(
-        local ? mesh->localNodesBegin() : mesh->getMesh().nodes_begin(),
-        local ? mesh->localNodesEnd() : mesh->getMesh().nodes_end());
-
-    for (auto & node : range)
+    for (auto & node : as_range(local ? mesh->localNodesBegin() : mesh->getMesh().nodes_begin(),
+                                local ? mesh->localNodesEnd() : mesh->getMesh().nodes_end()))
     {
       Real current_distance = (p - *node).norm();
 
@@ -640,12 +619,8 @@ MultiAppNearestNodeTransfer::getLocalNodes(MooseMesh * mesh, std::vector<Node *>
   else
   {
     local_nodes.resize(mesh->getMesh().n_local_nodes());
-
-    MeshBase::const_node_iterator nodes_begin = mesh->localNodesBegin();
-    MeshBase::const_node_iterator nodes_end = mesh->localNodesEnd();
-
     unsigned int i = 0;
-    for (MeshBase::const_node_iterator node_it = nodes_begin; node_it != nodes_end; ++node_it, ++i)
-      local_nodes[i] = *node_it;
+    for (auto & node : as_range(mesh->localNodesBegin(), mesh->localNodesEnd()))
+      local_nodes[i++] = node;
   }
 }

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -124,13 +124,8 @@ MultiAppPostprocessorInterpolationTransfer::execute()
 
         vars.push_back(_to_var_name);
 
-        MeshBase::const_node_iterator node_it = mesh.localNodesBegin();
-        MeshBase::const_node_iterator node_end = mesh.localNodesEnd();
-
-        for (; node_it != node_end; ++node_it)
+        for (const auto & node : as_range(mesh.localNodesBegin(), mesh.localNodesEnd()))
         {
-          Node * node = *node_it;
-
           if (node->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this node
           {
             std::vector<Point> pts;

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -96,13 +96,8 @@ MultiAppUserObjectTransfer::execute()
 
           if (is_nodal)
           {
-            MeshBase::const_node_iterator node_it = mesh->local_nodes_begin();
-            MeshBase::const_node_iterator node_end = mesh->local_nodes_end();
-
-            for (; node_it != node_end; ++node_it)
+            for (auto & node : mesh->local_node_ptr_range())
             {
-              Node * node = *node_it;
-
               if (node->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this node
               {
                 // The zero only works for LAGRANGE!
@@ -118,13 +113,8 @@ MultiAppUserObjectTransfer::execute()
           }
           else // Elemental
           {
-            MeshBase::const_element_iterator elem_it = mesh->local_elements_begin();
-            MeshBase::const_element_iterator elem_end = mesh->local_elements_end();
-
-            for (; elem_it != elem_end; ++elem_it)
+            for (auto & elem : as_range(mesh->local_elements_begin(), mesh->local_elements_end()))
             {
-              Elem * elem = *elem_it;
-
               Point centroid = elem->centroid();
 
               if (elem->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this elem
@@ -192,13 +182,8 @@ MultiAppUserObjectTransfer::execute()
 
         if (is_nodal)
         {
-          MeshBase::const_node_iterator node_it = to_mesh->nodes_begin();
-          MeshBase::const_node_iterator node_end = to_mesh->nodes_end();
-
-          for (; node_it != node_end; ++node_it)
+          for (auto & node : to_mesh->node_ptr_range())
           {
-            Node * node = *node_it;
-
             if (node->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this node
             {
               // See if this node falls in this bounding box
@@ -219,13 +204,8 @@ MultiAppUserObjectTransfer::execute()
         }
         else // Elemental
         {
-          MeshBase::const_element_iterator elem_it = to_mesh->elements_begin();
-          MeshBase::const_element_iterator elem_end = to_mesh->elements_end();
-
-          for (; elem_it != elem_end; ++elem_it)
+          for (auto & elem : as_range(to_mesh->elements_begin(), to_mesh->elements_end()))
           {
-            Elem * elem = *elem_it;
-
             if (elem->n_dofs(to_sys_num, to_var_num) > 0) // If this variable has dofs at this elem
             {
               Point centroid = elem->centroid();

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -109,13 +109,8 @@ MultiAppVariableValueSampleTransfer::execute()
 
           MooseMesh & mesh = _multi_app->appProblemBase(i).mesh();
 
-          MeshBase::const_node_iterator node_it = mesh.localNodesBegin();
-          MeshBase::const_node_iterator node_end = mesh.localNodesEnd();
-
-          for (; node_it != node_end; ++node_it)
+          for (const auto & node : as_range(mesh.localNodesBegin(), mesh.localNodesEnd()))
           {
-            Node * node = *node_it;
-
             if (node->n_dofs(sys_num, var_num) > 0) // If this variable has dofs at this node
             {
               // The zero only works for LAGRANGE!

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -637,14 +637,9 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
 
             // Sometime, we own nodes but do not own the elements the nodes connected to
             {
-              MeshBase::const_node_iterator node_it =
-                  dmm->_nl->system().get_mesh().local_nodes_begin();
-              const MeshBase::const_node_iterator node_end =
-                  dmm->_nl->system().get_mesh().local_nodes_end();
               bool is_on_current_block = false;
-              for (; node_it != node_end; ++node_it)
+              for (auto & node : dmm->_nl->system().get_mesh().local_node_ptr_range())
               {
-                Node * node = *node_it;
                 const unsigned int n_comp = node->n_comp(dmm->_nl->system().number(), v);
 
                 // skip it if no dof

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -617,14 +617,10 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
           for (const auto & bit : *(dmm->_block_ids))
           {
             subdomain_id_type b = bit.second;
-            MeshBase::const_element_iterator el =
-                dmm->_nl->system().get_mesh().active_local_subdomain_elements_begin(b);
-            MeshBase::const_element_iterator end_el =
-                dmm->_nl->system().get_mesh().active_local_subdomain_elements_end(b);
-            for (; el != end_el; ++el)
+            for (const auto & elem :
+                 as_range(dmm->_nl->system().get_mesh().active_local_subdomain_elements_begin(b),
+                          dmm->_nl->system().get_mesh().active_local_subdomain_elements_end(b)))
             {
-              const Elem * elem = *el;
-
               // Get the degree of freedom indices for the given variable off the current element.
               std::vector<dof_id_type> evindices;
               dofmap.dof_indices(elem, evindices, v);

--- a/modules/phase_field/src/postprocessors/AverageGrainVolume.C
+++ b/modules/phase_field/src/postprocessors/AverageGrainVolume.C
@@ -107,11 +107,8 @@ void
 AverageGrainVolume::execute()
 {
   auto num_features = _feature_volumes.size();
-
-  const auto end = _mesh.getMesh().active_local_elements_end();
-  for (auto el = _mesh.getMesh().active_local_elements_begin(); el != end; ++el)
+  for (const auto & elem : _mesh.getMesh().active_local_element_ptr_range())
   {
-    const Elem * elem = *el;
     _fe_problem.prepare(elem, 0);
     _fe_problem.reinitElem(elem, 0);
 

--- a/modules/phase_field/src/postprocessors/FauxGrainTracker.C
+++ b/modules/phase_field/src/postprocessors/FauxGrainTracker.C
@@ -156,12 +156,8 @@ FauxGrainTracker::execute()
 {
   Moose::perf_log.push("execute()", "FauxGrainTracker");
 
-  const MeshBase::element_iterator end = _mesh.getMesh().active_local_elements_end();
-  for (MeshBase::element_iterator el = _mesh.getMesh().active_local_elements_begin(); el != end;
-       ++el)
+  for (const auto & current_elem : _mesh.getMesh().active_local_element_ptr_range())
   {
-    const Elem * current_elem = *el;
-
     // Loop over elements or nodes and populate the data structure with the first variable with a
     // value above a threshold
     if (_is_elemental)

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -287,11 +287,8 @@ FeatureFloodCount::meshChanged()
 void
 FeatureFloodCount::execute()
 {
-  const auto end = _mesh.getMesh().active_local_elements_end();
-  for (auto el = _mesh.getMesh().active_local_elements_begin(); el != end; ++el)
+  for (const auto & current_elem : _mesh.getMesh().active_local_element_ptr_range())
   {
-    const Elem * current_elem = *el;
-
     // Loop over elements or nodes
     if (_is_elemental)
     {

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -346,12 +346,10 @@ EBSDReader::buildNodeWeightMaps()
   libMesh::MeshBase & mesh = _mesh.getMesh();
 
   // Loop through each node in mesh and calculate eta values for each grain associated with the node
-  MeshBase::const_node_iterator ni = mesh.active_nodes_begin();
-  const MeshBase::const_node_iterator nend = mesh.active_nodes_end();
-  for (; ni != nend; ++ni)
+  for (const auto & node : as_range(mesh.active_nodes_begin(), mesh.active_nodes_end()))
   {
     // Get node_id
-    const dof_id_type node_id = (*ni)->id();
+    const dof_id_type node_id = node->id();
 
     // Initialize map entries for current node
     _node_to_grain_weight_map[node_id].assign(getGrainNum(), 0.0);

--- a/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
+++ b/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
@@ -118,11 +118,8 @@ PolycrystalUserObjectBase::execute()
    *    the flood routine on the same entity as long as new discoveries are being made. We know
    *    this information from the return value of flood.
    */
-  const auto end = _mesh.getMesh().active_local_elements_end();
-  for (auto el = _mesh.getMesh().active_local_elements_begin(); el != end; ++el)
+  for (const auto & current_elem : _mesh.getMesh().active_local_element_ptr_range())
   {
-    const Elem * current_elem = *el;
-
     // Loop over elements or nodes
     if (_is_elemental)
       while (flood(current_elem, invalid_size_t, nullptr))

--- a/modules/phase_field/src/utils/PolycrystalICTools.C
+++ b/modules/phase_field/src/utils/PolycrystalICTools.C
@@ -161,10 +161,8 @@ PolycrystalICTools::buildElementalGrainAdjacencyMatrix(
   std::vector<std::set<dof_id_type>> halo_ids(n_grains);
 
   std::unique_ptr<PointLocatorBase> point_locator = mesh.getMesh().sub_point_locator();
-  const auto end = mesh.getMesh().active_elements_end();
-  for (auto el = mesh.getMesh().active_elements_begin(); el != end; ++el)
+  for (const auto & elem : mesh.getMesh().active_element_ptr_range())
   {
-    const Elem * elem = *el;
     std::map<dof_id_type, unsigned int>::const_iterator grain_it =
         element_to_grain.find(elem->id());
     mooseAssert(grain_it != element_to_grain.end(), "Element not found in map");

--- a/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
+++ b/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
@@ -109,10 +109,8 @@ FeatureVolumeVectorPostprocessor::execute()
 
   // Reset the volume vector
   _feature_volumes.assign(num_features, 0);
-  const auto end = _mesh.getMesh().active_local_elements_end();
-  for (auto el = _mesh.getMesh().active_local_elements_begin(); el != end; ++el)
+  for (const auto & elem : _mesh.getMesh().active_local_element_ptr_range())
   {
-    const Elem * elem = *el;
     _fe_problem.prepare(elem, 0);
     _fe_problem.reinitElem(elem, 0);
 

--- a/modules/richards/src/base/RichardsMultiphaseProblem.C
+++ b/modules/richards/src/base/RichardsMultiphaseProblem.C
@@ -94,18 +94,13 @@ RichardsMultiphaseProblem::updateSolution(NumericVector<Number> & vec_solution,
   // For parallel procs i believe that i have to use local_nodes_begin, rather than just nodes_begin
   // _mesh comes from SystemBase (_mesh = getNonlinearSystemBase().subproblem().mesh(), and
   // subproblem is this object)
-  MeshBase::node_iterator nit = _mesh.getMesh().local_nodes_begin();
-  const MeshBase::node_iterator nend = _mesh.getMesh().local_nodes_end();
-
-  for (; nit != nend; ++nit)
+  for (const auto & node : _mesh.getMesh().local_node_ptr_range())
   {
-    const Node & node = *(*nit);
-
     // dofs[0] is the dof number of the bounded variable at this node
     // dofs[1] is the dof number of the lower variable at this node
     std::vector<dof_id_type> dofs(2);
-    dofs[0] = node.dof_number(sys_num, _bounded_var_num, 0);
-    dofs[1] = node.dof_number(sys_num, _lower_var_num, 0);
+    dofs[0] = node->dof_number(sys_num, _bounded_var_num, 0);
+    dofs[1] = node->dof_number(sys_num, _lower_var_num, 0);
 
     // soln[0] is the value of the bounded variable at this node
     // soln[1] is the value of the lower variable at this node

--- a/modules/tensor_mechanics/src/dampers/ElementJacobianDamper.C
+++ b/modules/tensor_mechanics/src/dampers/ElementJacobianDamper.C
@@ -76,11 +76,8 @@ ElementJacobianDamper::computeDamping(const NumericVector<Number> & /* solution 
   std::vector<Point> point_copies;
 
   // Loop over elements in the mesh
-  const MeshBase::element_iterator end = _mesh->getMesh().active_local_elements_end();
-  for (auto el = _mesh->getMesh().active_local_elements_begin(); el != end; ++el)
+  for (auto & current_elem : _mesh->getMesh().active_local_element_ptr_range())
   {
-    Elem * current_elem = *el;
-
     point_copies.clear();
     point_copies.reserve(current_elem->n_nodes());
 

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -340,13 +340,9 @@ XFEM::buildEFAMesh()
 {
   _efa_mesh.reset();
 
-  MeshBase::element_iterator elem_it = _mesh->elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh->elements_end();
-
   // Load all existing elements in to EFA mesh
-  for (elem_it = _mesh->elements_begin(); elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh->element_ptr_range())
   {
-    Elem * elem = *elem_it;
     std::vector<unsigned int> quad;
     for (unsigned int i = 0; i < elem->n_nodes(); ++i)
       quad.push_back(elem->node(i));
@@ -359,9 +355,8 @@ XFEM::buildEFAMesh()
   }
 
   // Restore fragment information for elements that have been previously cut
-  for (elem_it = _mesh->elements_begin(); elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh->element_ptr_range())
   {
-    Elem * elem = *elem_it;
     std::map<unique_id_type, XFEMCutElem *>::iterator cemit = _cut_elem_map.find(elem->unique_id());
     if (cemit != _cut_elem_map.end())
     {
@@ -781,9 +776,6 @@ XFEM::markCutEdgesByState(Real time)
         _efa_mesh.addElemEdgeIntersection(elem->id(), edge_id_keep, distance_keep);
       else
       {
-        MeshBase::element_iterator elem_it = _mesh->elements_begin();
-        const MeshBase::element_iterator elem_end = _mesh->elements_end();
-
         Point growth_direction(0.0, 0.0, 0.0);
 
         growth_direction(0) = -normal_keep(1);
@@ -799,9 +791,8 @@ XFEM::markCutEdgesByState(Real time)
 
         XFEMCrackGrowthIncrement2DCut geometric_cut(x0, y0, x1, y1, time * 0.9, time * 0.9);
 
-        for (; elem_it != elem_end; ++elem_it)
+        for (const auto & elem : _mesh->element_ptr_range())
         {
-          const Elem * elem = *elem_it;
           std::vector<CutEdgeForCrackGrowthIncr> elem_cut_edges;
           EFAElement2D * CEMElem = getEFAElem2D(elem);
 
@@ -1909,10 +1900,8 @@ XFEM::setSolution(SystemBase & sys,
                   NumericVector<Number> & old_solution,
                   NumericVector<Number> & older_solution)
 {
-  const auto nodes_end = _mesh->local_nodes_end();
-  for (auto node_it = _mesh->local_nodes_begin(); node_it != nodes_end; ++node_it)
+  for (auto & node : _mesh->local_node_ptr_range())
   {
-    Node * node = *node_it;
     auto mit = stored_solution.find(node->unique_id());
     if (mit != stored_solution.end())
     {

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -1915,10 +1915,8 @@ XFEM::setSolution(SystemBase & sys,
     }
   }
 
-  const auto elems_end = _mesh->local_elements_end();
-  for (auto elem_it = _mesh->local_elements_begin(); elem_it != elems_end; ++elem_it)
+  for (auto & elem : as_range(_mesh->local_elements_begin(), _mesh->local_elements_end()))
   {
-    Elem * elem = *elem_it;
     auto mit = stored_solution.find(elem->unique_id());
     if (mit != stored_solution.end())
     {

--- a/test/src/userobjects/GhostUserObject.C
+++ b/test/src/userobjects/GhostUserObject.C
@@ -56,14 +56,9 @@ GhostUserObject::execute()
   {
     const auto & mesh = _subproblem.mesh().getMesh();
 
-    const auto end = mesh.active_elements_end();
-    for (auto el = mesh.active_elements_begin(); el != end; ++el)
-    {
-      const auto & elem = *el;
-
+    for (const auto & elem : mesh.active_element_ptr_range())
       if (elem->processor_id() != my_processor_id)
         _ghost_data.emplace(elem->id());
-    }
   }
 }
 


### PR DESCRIPTION
As of the recent libmesh update, it is now possible to streamline several of the framework's for-loops over elements and nodes by making them range-based and using the `as_range()` helper function.

Refs #6993.
