### PR TITLE
Handle PBS Timeouts

### DIFF
--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -204,6 +204,10 @@ class QueueManager(Scheduler):
 
         return command
 
+    def hasTimedOutOrFailed(self, job_data):
+        """ return bool on exceeding walltime """
+        return False
+
     def _isProcessReady(self, job_data):
         """
         Return bool on `run_tests --spec_file` submission results being available. Due to the
@@ -225,6 +229,12 @@ class QueueManager(Scheduler):
             # result file exists (jobs are finished)
             if os.path.exists(os.path.join(job_data.job_dir, self.__job_storage_file)):
                 pass
+
+            # ask derived scheduler if this job has failed
+            elif self.hasTimedOutOrFailed(job_data):
+                for job in job_data.jobs.getJobs():
+                    job.setStatus(job.crash)
+                is_ready = False
 
             # result does not yet exist but will in the future
             else:

--- a/scripts/are_queued_jobs_finished.py
+++ b/scripts/are_queued_jobs_finished.py
@@ -25,7 +25,7 @@ class Jobs:
 
 def hasTimedOutOrFailed(meta):
     """
-    determine which scheduler plugin was used to launch jobs, and queuery that
+    determine which scheduler plugin was used to launch jobs, and query that
     system for current status on job
     """
     if meta.get('QUEUEING', '') == 'RunPBS':
@@ -39,11 +39,8 @@ def hasTimedOutOrFailed(meta):
 def isNotFinished(jobs):
     for path, meta in jobs.yieldJobsResultPath():
         if type(meta) == type({}) and meta.get('QUEUEING', {}):
-            if os.path.exists(os.path.join(path, '.previous_test_results.json')):
-                pass
-            elif hasTimedOutOrFailed(meta):
-                pass
-            else:
+            if (not os.path.exists(os.path.join(path, '.previous_test_results.json'))
+                and not hasTimedOutOrFailed(meta)):
                 return True
 
 def usage():


### PR DESCRIPTION
If PBS kills a job due to walltime issues, the TestHarness will
consider the job 'QUEUED' indefinitely.

Refs #11520
