### PR TITLE
fix hit python bindings build for certain environments.

### DIFF
--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -1,8 +1,14 @@
 CXX ?= g++
 
-PYTHONPREFIX ?= `python-config --prefix`
-PYTHONCFLAGS ?= `python-config --cflags`
-PYTHONLDFLAGS ?= `python-config --ldflags`
+# some systems have python2 but no python2-config command - fall back to python-config for them
+pyconfig := python2-config
+ifeq (, $(shell which python2-config))
+  pyconfig := python-config
+endif
+
+PYTHONPREFIX ?= `$(pyconfig) --prefix`
+PYTHONCFLAGS ?= `$(pyconfig) --cflags`
+PYTHONLDFLAGS ?= `$(pyconfig) --ldflags`
 
 hit: main.cc parse.cc lex.cc lex.h parse.h
 	$(CXX) -std=c++11 -g $(CXXFLAGS) $< parse.cc lex.cc -o $@

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -37,9 +37,15 @@ hit_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(hit_srcfiles))
 pyhit_srcfiles  := $(hit_DIR)/hit.cpp $(hit_DIR)/lex.cc $(hit_DIR)/parse.cc
 pyhit_LIB       := $(FRAMEWORK_DIR)/../python/hit.so
 
+# some systems have python2 but no python2-config command - fall back to python-config for them
+pyconfig := python2-config
+ifeq (, $(shell which python2-config))
+  pyconfig := python-config
+endif
+
 hit $(pyhit_LIB): $(pyhit_srcfiles)
 	@echo "Building and linking "$@"..."
-	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`python-config --prefix`/lib `python-config --includes` `python-config --ldflags` $^ -o $(pyhit_LIB))'
+	@bash -c '(cd "$(hit_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared -L`$(pyconfig) --prefix`/lib `$(pyconfig) --includes` `$(pyconfig) --ldflags` $^ -o $(pyhit_LIB))'
 
 #
 # gtest


### PR DESCRIPTION
Mismatches between python interpreters pointed to by "python2" and
"python-config" cause broken .so bindings builds.  Change to use
"python2-config" to match our changed bang lines naming python2.

fixes #11556

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
