### PR TITLE
Fixes for subdomain_id_type == boundary_id_type.

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -274,7 +274,7 @@ protected:
   std::map<std::string, int> _props_to_flags;
 
 private:
-  /// Small helper function to call storeMatPropName
+  /// Small helper function to call store{Subdomain,Boundary}MatPropName
   void registerPropName(std::string prop_name, bool is_get, Prop_State state);
 
   /// Check and throw an error if the execution has progerssed past the construction stage
@@ -402,10 +402,10 @@ Material::getZeroMaterialProperty(const std::string & prop_name)
   // Register this material on these blocks and boundaries as a zero property with relaxed
   // consistency checking
   for (std::set<SubdomainID>::const_iterator it = blockIDs().begin(); it != blockIDs().end(); ++it)
-    _fe_problem.storeZeroMatProp(*it, prop_name);
+    _fe_problem.storeSubdomainZeroMatProp(*it, prop_name);
   for (std::set<BoundaryID>::const_iterator it = boundaryIDs().begin(); it != boundaryIDs().end();
        ++it)
-    _fe_problem.storeZeroMatProp(*it, prop_name);
+    _fe_problem.storeBoundaryZeroMatProp(*it, prop_name);
 
   // set values for all qpoints to zero
   // (in multiapp scenarios getMaxQps can return different values in each app; we need the max)

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -40,11 +40,6 @@ InputParameters validParams<MaterialPropertyInterface>();
 class MaterialPropertyInterface
 {
 public:
-  MaterialPropertyInterface(const MooseObject * moose_object);
-  MaterialPropertyInterface(const MooseObject * moose_object,
-                            const std::set<SubdomainID> & block_ids);
-  MaterialPropertyInterface(const MooseObject * moose_object,
-                            const std::set<BoundaryID> & boundary_ids);
   MaterialPropertyInterface(const MooseObject * moose_object,
                             const std::set<SubdomainID> & block_ids,
                             const std::set<BoundaryID> & boundary_ids);

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -22,14 +22,6 @@ InputParameters validParams<TwoMaterialPropertyInterface>();
 class TwoMaterialPropertyInterface : public MaterialPropertyInterface
 {
 public:
-  TwoMaterialPropertyInterface(const MooseObject * moose_object);
-
-  TwoMaterialPropertyInterface(const MooseObject * moose_object,
-                               const std::set<SubdomainID> & blocks_ids);
-
-  TwoMaterialPropertyInterface(const MooseObject * moose_object,
-                               const std::set<BoundaryID> & boundary_ids);
-
   TwoMaterialPropertyInterface(const MooseObject * moose_object,
                                const std::set<SubdomainID> & blocks_ids,
                                const std::set<BoundaryID> & boundary_ids);

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -125,13 +125,6 @@ public:
   const std::set<BoundaryID> & getBoundaryIDs() const;
 
   /**
-   * Templated helper that returns either block or boundary IDs depending on
-   * the template argument
-   */
-  template <typename T>
-  const std::set<T> & getBlockOrBoundaryIDs() const;
-
-  /**
    * Calls BoundaryInfo::build_node_list()/build_side_list() and *makes separate copies* of
    * Nodes/Elems in those lists.
    *

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1247,8 +1247,8 @@ public:
    * @param tid the THREAD_ID of the caller
    * @return Boolean indicating whether material properties need to be stored
    */
-  bool needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid);
-  bool needMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid);
+  bool needBoundaryMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid);
+  bool needSubdomainMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid);
   ///@}
 
   /**

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -357,7 +357,7 @@ public:
    * @param block_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeMatPropName(SubdomainID block_id, const std::string & name);
+  virtual void storeSubdomainMatPropName(SubdomainID block_id, const std::string & name);
 
   /**
    * Adds the given material property to a storage map based on boundary ids
@@ -367,7 +367,7 @@ public:
    * @param boundary_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeMatPropName(BoundaryID boundary_id, const std::string & name);
+  virtual void storeBoundaryMatPropName(BoundaryID boundary_id, const std::string & name);
 
   /**
    * Adds to a map based on block ids of material properties for which a zero
@@ -377,7 +377,7 @@ public:
    * @param block_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeZeroMatProp(SubdomainID block_id, const MaterialPropertyName & name);
+  virtual void storeSubdomainZeroMatProp(SubdomainID block_id, const MaterialPropertyName & name);
 
   /**
    * Adds to a map based on boundary ids of material properties for which a zero
@@ -387,7 +387,7 @@ public:
    * @param boundary_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeZeroMatProp(BoundaryID boundary_id, const MaterialPropertyName & name);
+  virtual void storeBoundaryZeroMatProp(BoundaryID boundary_id, const MaterialPropertyName & name);
 
   /**
    * Adds to a map based on block ids of material properties to validate
@@ -395,9 +395,9 @@ public:
    * @param block_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeDelayedCheckMatProp(const std::string & requestor,
-                                        SubdomainID block_id,
-                                        const std::string & name);
+  virtual void storeSubdomainDelayedCheckMatProp(const std::string & requestor,
+                                                 SubdomainID block_id,
+                                                 const std::string & name);
 
   /**
    * Adds to a map based on boundary ids of material properties to validate
@@ -406,9 +406,9 @@ public:
    * @param boundary_id The block id for the MaterialProperty
    * @param name The name of the property
    */
-  virtual void storeDelayedCheckMatProp(const std::string & requestor,
-                                        BoundaryID boundary_id,
-                                        const std::string & name);
+  virtual void storeBoundaryDelayedCheckMatProp(const std::string & requestor,
+                                                BoundaryID boundary_id,
+                                                const std::string & name);
 
   /**
    * Checks block material properties integrity
@@ -585,24 +585,9 @@ protected:
   bool _computing_nonlinear_residual;
 
 private:
-  /**
-   * Helper method for performing material property checks
-   * @param props Reference to the map of properties known
-   * @param check_props Reference to the map of properties to check
-   * @param type - string describing the type of the material property being checked
-   * \see checkBlockMatProps
-   * \see checkBoundaryMatProps
-   */
-  template <typename T>
-  void checkMatProps(std::map<T, std::set<std::string>> & props,
-                     std::map<T, std::multimap<std::string, std::string>> & check_props,
-                     std::map<T, std::set<MaterialPropertyName>> & zero_props);
-
-  ///@{ Helper functions for checkMatProps
-  template <typename T>
-  std::string restrictionTypeName();
-  std::string restrictionCheckName(SubdomainID check_id);
-  std::string restrictionCheckName(BoundaryID check_id);
+  ///@{ Helper functions for checking MaterialProperties
+  std::string restrictionSubdomainCheckName(SubdomainID check_id);
+  std::string restrictionBoundaryCheckName(BoundaryID check_id);
   ///@}
 
   friend class Restartable;

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -502,13 +502,13 @@ public:
    * Indicated whether this system needs material properties on boundaries.
    * @return Boolean if IntegratedBCs are active
    */
-  bool needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid) const;
+  bool needBoundaryMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid) const;
 
   /**
    * Indicates whether this system needs material properties on internal sides.
    * @return Boolean if DGKernels are active
    */
-  bool needMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid) const;
+  bool needSubdomainMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid) const;
 
   /**
    * Getter for _doing_dg

--- a/framework/src/bcs/IntegratedBCBase.C
+++ b/framework/src/bcs/IntegratedBCBase.C
@@ -46,7 +46,7 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters)
   : BoundaryCondition(parameters, false), // False is because this is NOT nodal
     RandomInterface(parameters, _fe_problem, _tid, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    MaterialPropertyInterface(this, boundaryIDs()),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
     _current_elem(_assembly.elem()),
     _current_elem_volume(_assembly.elemVolume()),
     _current_side(_assembly.side()),

--- a/framework/src/dampers/ElementDamper.C
+++ b/framework/src/dampers/ElementDamper.C
@@ -31,7 +31,7 @@ validParams<ElementDamper>()
 
 ElementDamper::ElementDamper(const InputParameters & parameters)
   : Damper(parameters),
-    MaterialPropertyInterface(this),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _assembly(_subproblem.assembly(_tid)),
     _coord_sys(_assembly.coordSystem()),

--- a/framework/src/dampers/NodalDamper.C
+++ b/framework/src/dampers/NodalDamper.C
@@ -31,7 +31,7 @@ validParams<NodalDamper>()
 
 NodalDamper::NodalDamper(const InputParameters & parameters)
   : Damper(parameters),
-    MaterialPropertyInterface(this),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS),
     _tid(parameters.get<THREAD_ID>("_tid")),
     _assembly(_subproblem.assembly(_tid)),
     _coord_sys(_assembly.coordSystem()),

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -58,7 +58,7 @@ DiracKernel::DiracKernel(const InputParameters & parameters)
     FunctionInterface(this),
     UserObjectInterface(this),
     TransientInterface(this),
-    MaterialPropertyInterface(this),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS),
     PostprocessorInterface(this),
     GeometricSearchInterface(this),
     Restartable(this, "DiracKernels"),

--- a/framework/src/indicators/Indicator.C
+++ b/framework/src/indicators/Indicator.C
@@ -48,7 +48,7 @@ Indicator::Indicator(const InputParameters & parameters)
     UserObjectInterface(this),
     Restartable(this, "Indicators"),
     OutputInterface(parameters),
-    MaterialPropertyInterface(this, blockIDs()),
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _sys(*getCheckedPointerParam<SystemBase *>("_sys")),

--- a/framework/src/interfacekernels/InterfaceKernel.C
+++ b/framework/src/interfacekernels/InterfaceKernel.C
@@ -82,7 +82,7 @@ InterfaceKernel::InterfaceKernel(const InputParameters & parameters)
         this, false, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
     Restartable(this, "InterfaceKernels"),
     MeshChangedInterface(parameters),
-    TwoMaterialPropertyInterface(this, boundaryIDs()),
+    TwoMaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
     _tid(parameters.get<THREAD_ID>("_tid")),

--- a/framework/src/kernels/KernelBase.C
+++ b/framework/src/kernels/KernelBase.C
@@ -65,7 +65,7 @@ KernelBase::KernelBase(const InputParameters & parameters)
     TransientInterface(this),
     PostprocessorInterface(this),
     VectorPostprocessorInterface(this),
-    MaterialPropertyInterface(this, blockIDs()),
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
     RandomInterface(parameters,
                     *parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"),
                     parameters.get<THREAD_ID>("_tid"),

--- a/framework/src/loops/ComputeMaterialsObjectThread.C
+++ b/framework/src/loops/ComputeMaterialsObjectThread.C
@@ -71,7 +71,7 @@ ComputeMaterialsObjectThread::~ComputeMaterialsObjectThread() {}
 void
 ComputeMaterialsObjectThread::subdomainChanged()
 {
-  _need_internal_side_material = _fe_problem.needMaterialOnSide(_subdomain, _tid);
+  _need_internal_side_material = _fe_problem.needSubdomainMaterialOnSide(_subdomain, _tid);
   _fe_problem.subdomainSetup(_subdomain, _tid);
 
   std::set<MooseVariableFEBase *> needed_moose_vars;
@@ -111,7 +111,7 @@ ComputeMaterialsObjectThread::onElement(const Elem * elem)
 void
 ComputeMaterialsObjectThread::onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id)
 {
-  if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
+  if (_fe_problem.needBoundaryMaterialOnSide(bnd_id, _tid))
   {
     _assembly[_tid]->reinit(elem, side);
     unsigned int face_n_points = _assembly[_tid]->qRuleFace()->n_points();

--- a/framework/src/loops/ProjectMaterialProperties.C
+++ b/framework/src/loops/ProjectMaterialProperties.C
@@ -63,7 +63,7 @@ ProjectMaterialProperties::~ProjectMaterialProperties() {}
 void
 ProjectMaterialProperties::subdomainChanged()
 {
-  _need_internal_side_material = _fe_problem.needMaterialOnSide(_subdomain, _tid);
+  _need_internal_side_material = _fe_problem.needSubdomainMaterialOnSide(_subdomain, _tid);
 }
 
 void
@@ -105,7 +105,7 @@ ProjectMaterialProperties::onElement(const Elem * elem)
 void
 ProjectMaterialProperties::onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id)
 {
-  if (_fe_problem.needMaterialOnSide(bnd_id, _tid))
+  if (_fe_problem.needBoundaryMaterialOnSide(bnd_id, _tid))
   {
     _assembly[_tid]->reinit(elem, side);
 

--- a/framework/src/markers/QuadraturePointMarker.C
+++ b/framework/src/markers/QuadraturePointMarker.C
@@ -45,7 +45,7 @@ validParams<QuadraturePointMarker>()
 QuadraturePointMarker::QuadraturePointMarker(const InputParameters & parameters)
   : Marker(parameters),
     Coupleable(this, false),
-    MaterialPropertyInterface(this, blockIDs()),
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
     _qrule(_assembly.qRule()),
     _q_point(_assembly.qPoints()),
     _qp(0)

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -170,11 +170,11 @@ Material::registerPropName(std::string prop_name, bool is_get, Material::Prop_St
 
   // Store material properties for block ids
   for (const auto & block_id : blockIDs())
-    _fe_problem.storeMatPropName(block_id, prop_name);
+    _fe_problem.storeSubdomainMatPropName(block_id, prop_name);
 
   // Store material properties for the boundary ids
   for (const auto & boundary_id : boundaryIDs())
-    _fe_problem.storeMatPropName(boundary_id, prop_name);
+    _fe_problem.storeBoundaryMatPropName(boundary_id, prop_name);
 }
 
 std::set<OutputName>

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -22,23 +22,6 @@ validParams<MaterialPropertyInterface>()
   return params;
 }
 
-MaterialPropertyInterface::MaterialPropertyInterface(const MooseObject * moose_object)
-  : MaterialPropertyInterface(moose_object, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS)
-{
-}
-
-MaterialPropertyInterface::MaterialPropertyInterface(const MooseObject * moose_object,
-                                                     const std::set<SubdomainID> & block_ids)
-  : MaterialPropertyInterface(moose_object, block_ids, Moose::EMPTY_BOUNDARY_IDS)
-{
-}
-
-MaterialPropertyInterface::MaterialPropertyInterface(const MooseObject * moose_object,
-                                                     const std::set<BoundaryID> & boundary_ids)
-  : MaterialPropertyInterface(moose_object, Moose::EMPTY_BLOCK_IDS, boundary_ids)
-{
-}
-
 MaterialPropertyInterface::MaterialPropertyInterface(const MooseObject * moose_object,
                                                      const std::set<SubdomainID> & block_ids,
                                                      const std::set<BoundaryID> & boundary_ids)
@@ -135,12 +118,12 @@ MaterialPropertyInterface::checkMaterialProperty(const std::string & name)
   // If the material property is boundary restrictable, add to the list of materials to check
   if (_mi_boundary_restricted)
     for (const auto & bnd_id : _mi_boundary_ids)
-      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, bnd_id, name);
+      _mi_feproblem.storeBoundaryDelayedCheckMatProp(_mi_name, bnd_id, name);
 
   // The default is to assume block restrictions
   else
     for (const auto & blk_ids : _mi_block_ids)
-      _mi_feproblem.storeDelayedCheckMatProp(_mi_name, blk_ids, name);
+      _mi_feproblem.storeSubdomainDelayedCheckMatProp(_mi_name, blk_ids, name);
 }
 
 void

--- a/framework/src/materials/TwoMaterialPropertyInterface.C
+++ b/framework/src/materials/TwoMaterialPropertyInterface.C
@@ -21,28 +21,6 @@ validParams<TwoMaterialPropertyInterface>()
   return params;
 }
 
-TwoMaterialPropertyInterface::TwoMaterialPropertyInterface(const MooseObject * moose_object)
-  : MaterialPropertyInterface(moose_object),
-    _neighbor_material_data(_mi_feproblem.getMaterialData(Moose::NEIGHBOR_MATERIAL_DATA,
-                                                          _mi_params.get<THREAD_ID>("_tid")))
-{
-}
-
-TwoMaterialPropertyInterface::TwoMaterialPropertyInterface(const MooseObject * moose_object,
-                                                           const std::set<SubdomainID> & blocks_ids)
-  : MaterialPropertyInterface(moose_object, blocks_ids),
-    _neighbor_material_data(_mi_feproblem.getMaterialData(Moose::NEIGHBOR_MATERIAL_DATA,
-                                                          _mi_params.get<THREAD_ID>("_tid")))
-{
-}
-TwoMaterialPropertyInterface::TwoMaterialPropertyInterface(
-    const MooseObject * moose_object, const std::set<BoundaryID> & boundary_ids)
-  : MaterialPropertyInterface(moose_object, boundary_ids),
-    _neighbor_material_data(_mi_feproblem.getMaterialData(Moose::NEIGHBOR_MATERIAL_DATA,
-                                                          _mi_params.get<THREAD_ID>("_tid")))
-{
-}
-
 TwoMaterialPropertyInterface::TwoMaterialPropertyInterface(
     const MooseObject * moose_object,
     const std::set<SubdomainID> & blocks_ids,

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1962,20 +1962,6 @@ MooseMesh::getBoundaryIDs() const
   return getMesh().get_boundary_info().get_boundary_ids();
 }
 
-template <>
-const std::set<SubdomainID> &
-MooseMesh::getBlockOrBoundaryIDs() const
-{
-  return meshSubdomains();
-}
-
-template <>
-const std::set<BoundaryID> &
-MooseMesh::getBlockOrBoundaryIDs() const
-{
-  return getBoundaryIDs();
-}
-
 void
 MooseMesh::buildNodeListFromSideList()
 {

--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -129,7 +129,7 @@ AddSideSetsFromBoundingBox::modify()
       if (_bounding_box.contains_point(**node) == inside)
       {
         // read out boundary ids for nodes
-        std::vector<short int> boundary_id_list = boundary_info.boundary_ids(*node);
+        std::vector<boundary_id_type> boundary_id_list = boundary_info.boundary_ids(*node);
         std::vector<boundary_id_type> boundary_id_old_list =
             _mesh_ptr->getBoundaryIDs(_boundary_id_old);
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -1076,6 +1076,7 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
         ;
       setscalarvaltype(Real, double, Real);
       setscalarvaltype(int, int, long);
+      setscalarvaltype(unsigned short, unsigned int, long);
       setscalarvaltype(long, int, long);
       setscalarvaltype(unsigned int, unsigned int, long);
       setscalarvaltype(unsigned long, unsigned int, long);

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5292,13 +5292,13 @@ FEProblemBase::registerRandomInterface(RandomInterface & random_interface, const
 }
 
 bool
-FEProblemBase::needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
+FEProblemBase::needBoundaryMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
 {
   if (_bnd_mat_side_cache[tid].find(bnd_id) == _bnd_mat_side_cache[tid].end())
   {
     _bnd_mat_side_cache[tid][bnd_id] = false;
 
-    if (_nl->needMaterialOnSide(bnd_id, tid) || _aux->needMaterialOnSide(bnd_id))
+    if (_nl->needBoundaryMaterialOnSide(bnd_id, tid) || _aux->needMaterialOnSide(bnd_id))
       _bnd_mat_side_cache[tid][bnd_id] = true;
 
     else if (_side_user_objects.hasActiveBoundaryObjects(bnd_id, tid))
@@ -5309,13 +5309,13 @@ FEProblemBase::needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
 }
 
 bool
-FEProblemBase::needMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid)
+FEProblemBase::needSubdomainMaterialOnSide(SubdomainID subdomain_id, THREAD_ID tid)
 {
   if (_block_mat_side_cache[tid].find(subdomain_id) == _block_mat_side_cache[tid].end())
   {
     _block_mat_side_cache[tid][subdomain_id] = false;
 
-    if (_nl->needMaterialOnSide(subdomain_id, tid))
+    if (_nl->needSubdomainMaterialOnSide(subdomain_id, tid))
       _block_mat_side_cache[tid][subdomain_id] = true;
     else if (_internal_side_user_objects.hasActiveBlockObjects(subdomain_id, tid))
       _block_mat_side_cache[tid][subdomain_id] = true;

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -2714,12 +2714,13 @@ NonlinearSystemBase::setMooseKSPNormType(MooseEnum kspnorm)
 }
 
 bool
-NonlinearSystemBase::needMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid) const
+NonlinearSystemBase::needBoundaryMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid) const
 {
   return _integrated_bcs.hasActiveBoundaryObjects(bnd_id, tid);
 }
 
-bool NonlinearSystemBase::needMaterialOnSide(SubdomainID /*subdomain_id*/, THREAD_ID /*tid*/) const
+bool NonlinearSystemBase::needSubdomainMaterialOnSide(SubdomainID /*subdomain_id*/,
+                                                      THREAD_ID /*tid*/) const
 {
   return _doing_dg;
 }

--- a/framework/src/userobject/ElementUserObject.C
+++ b/framework/src/userobject/ElementUserObject.C
@@ -29,7 +29,7 @@ validParams<ElementUserObject>()
 ElementUserObject::ElementUserObject(const InputParameters & parameters)
   : UserObject(parameters),
     BlockRestrictable(this),
-    MaterialPropertyInterface(this, blockIDs()),
+    MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
     UserObjectInterface(this),
     Coupleable(this, false),
     MooseVariableDependencyInterface(),

--- a/framework/src/userobject/GeneralUserObject.C
+++ b/framework/src/userobject/GeneralUserObject.C
@@ -23,7 +23,7 @@ validParams<GeneralUserObject>()
 
 GeneralUserObject::GeneralUserObject(const InputParameters & parameters)
   : UserObject(parameters),
-    MaterialPropertyInterface(this),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS),
     TransientInterface(this),
     DependencyResolverInterface(),
     UserObjectInterface(this),

--- a/framework/src/userobject/InternalSideUserObject.C
+++ b/framework/src/userobject/InternalSideUserObject.C
@@ -24,7 +24,7 @@ validParams<InternalSideUserObject>()
 InternalSideUserObject::InternalSideUserObject(const InputParameters & parameters)
   : UserObject(parameters),
     BlockRestrictable(this),
-    TwoMaterialPropertyInterface(this, blockIDs()),
+    TwoMaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
     NeighborCoupleable(this, false, false),
     MooseVariableDependencyInterface(),
     UserObjectInterface(this),

--- a/framework/src/userobject/SideUserObject.C
+++ b/framework/src/userobject/SideUserObject.C
@@ -25,7 +25,7 @@ validParams<SideUserObject>()
 SideUserObject::SideUserObject(const InputParameters & parameters)
   : UserObject(parameters),
     BoundaryRestrictableRequired(this, false), // false for applying to sidesets
-    MaterialPropertyInterface(this, boundaryIDs()),
+    MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
     Coupleable(this, false),
     MooseVariableDependencyInterface(),
     UserObjectInterface(this),

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -1248,7 +1248,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
         std::vector<boundary_id_type>::iterator it_bd = parent_elem_boundary_ids.begin();
         for (; it_bd != parent_elem_boundary_ids.end(); ++it_bd)
         {
-          if (_fe_problem->needMaterialOnSide(*it_bd, 0))
+          if (_fe_problem->needBoundaryMaterialOnSide(*it_bd, 0))
             (*_bnd_material_data)[0]->copy(*libmesh_elem, *parent_elem, side);
         }
       }


### PR DESCRIPTION
While investigating some other issue, I discovered that MOOSE did not
build when libmesh was configured with
```
--with-subdomain-id-bytes=4
--with-boundary-id-bytes=4
--with-unique-id-bytes=4
```
as this causes BoundaryID and SubdomainID to be the same types, and we
had functions that were overloaded on that type.

Refs #9844.
