### PR TITLE
Adding Pressure BC for multi-app runs

### DIFF
--- a/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressure/CoupledPressureAction.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressure/CoupledPressureAction.md
@@ -1,0 +1,5 @@
+# Coupled Pressure Action
+
+## Description
+
+The `CoupledPressure` Action is used to create a set of pressure boundary conditions for a string of displacement variables; the typical use case for this action is when the pressure is computed in a field variable, for example by a multi-app. See the description, example use, and parameters on the [CoupledPressure](/CoupledPressure/index.md) action system page.

--- a/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressure/index.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressure/index.md
@@ -1,0 +1,42 @@
+# Coupled Pressure Action System
+
+!syntax description /BCs/CoupledPressure/CoupledPressureAction
+
+## Description
+
+The Coupled Pressure Action, given in the input file as simply `CoupledPressureBC`, is designed to simplify the input file when several variables have the same pressure boundary condition magnitude applied in the normal component.
+Transfer of pressure variable from an multi-app is a good example of a use case for the Coupled Pressure Action.
+
+## Constructed MooseObjects
+
+The Coupled Pressure Action is used to construct only the [Coupled Pressure boundary condition](/BCs/CoupledPressureBC.md).
+
+!table id=pressure_BC_action_table caption=Correspondence Among Action Functionality and MooseObjects
+| Functionality     | Replaced Classes   | Associated Parameters   |
+|-------------------|--------------------|-------------------------|
+| A pressure traction force given by a variable | [Coupled Pressure BC](/BCs/CoupledPressureBC.md) | `displacements` : a string of the displacement variables to which the Coupled Pressure BC should be applied |
+|  |  | `pressure` : a variable prescribing the pressure to be applied |
+
+The Pressure Action only applies the pressure traction in the same component direction as the `displacements` variables are listed.
+That is, for the argument `displacements = 'disp_x disp_y disp_z'`, the Pressure Action will create three separate Pressure BCs:
+
+- For the variable `disp_x`, the parameter setting `component = 0` is used
+- For the variable `disp_y`, the parameter setting `component = 1` is used
+- For the variable `disp_z`, the parameter setting `component = 2` is used
+
+!alert note title=Displacement Variable-Component Relationship is Relative
+Note that the location of each of the variables in the `displacements` string determines the value of the corresponding component.
+
+## Example Input Syntax
+
+!listing modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.i block=BCs/CoupledPressure
+
+!syntax parameters /BCs/CoupledPressure/CoupledPressureAction
+
+## Associated Actions
+
+!syntax list /BCs/CoupledPressure objects=True actions=False subsystems=False
+
+!syntax list /BCs/CoupledPressure objects=False actions=False subsystems=True
+
+!syntax list /BCs/CoupledPressure objects=False actions=True subsystems=False

--- a/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressureBC.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/BCs/CoupledPressureBC.md
@@ -1,0 +1,24 @@
+# Coupled Pressure BC
+
+## Description
+
+The boundary condition `CoupledPressureBC` applies a force computed in a variable to a mesh boundary.
+A `component` of the normal vector to the mesh surface (0, 1, or 2 corresponding to the $\hat{x}$, $\hat{y}$, and $\hat{z}$ vector components) is used to determine the direction in which to apply the traction.
+
+!alert note
+The boundary condition is always applied to the displaced mesh.
+
+The `CoupledPressureBC` is typically used in a multi-app scenario.
+The pressure variable can be computed by a sub-app (it can be for example a flow code) and then transferred into an auxiliary variable, which is then coupled into this boundary condition so that it is applied in the master app.
+
+A set of `CoupledPressure` boundary conditions applied to multiple variables in multiple components can be defined with the [CoupledPressureAction](/BCs/CoupledPressure/CoupledPressureAction.md).
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.i block=BCs/side3_x
+
+!syntax parameters /BCs/CoupledPressureBC
+
+!syntax inputs /BCs/CoupledPressureBC
+
+!syntax children /BCs/CoupledPressureBC

--- a/modules/tensor_mechanics/include/actions/CoupledPressureAction.h
+++ b/modules/tensor_mechanics/include/actions/CoupledPressureAction.h
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COUPLEDPRESSUREACTION_H
+#define COUPLEDPRESSUREACTION_H
+
+#include "Action.h"
+
+class CoupledPressureAction;
+
+template <>
+InputParameters validParams<CoupledPressureAction>();
+
+/**
+ * Action that sets up pressure boundary condition on displacement variables
+ */
+class CoupledPressureAction : public Action
+{
+public:
+  CoupledPressureAction(const InputParameters & params);
+
+  virtual void act() override;
+
+protected:
+  std::vector<std::vector<AuxVariableName>> _save_in_vars;
+  std::vector<bool> _has_save_in_vars;
+};
+
+#endif // PRESSUREACTION_H

--- a/modules/tensor_mechanics/include/bcs/CoupledPressureBC.h
+++ b/modules/tensor_mechanics/include/bcs/CoupledPressureBC.h
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COUPLEDPRESSUREBC_H
+#define COUPLEDPRESSUREBC_H
+
+#include "IntegratedBC.h"
+
+class CoupledPressureBC;
+
+template <>
+InputParameters validParams<CoupledPressureBC>();
+
+/**
+ * Pressure boundary condition using coupled variable to apply pressure in a given direction
+ */
+class CoupledPressureBC : public IntegratedBC
+{
+public:
+  CoupledPressureBC(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+
+  /// Will hold 0, 1, or 2 corresponding to x, y, or z.
+  const unsigned int _component;
+  /// The values of pressure to be imposed
+  const VariableValue & _pressure;
+};
+
+#endif /* COUPLEDPRESSUREBC_H */

--- a/modules/tensor_mechanics/src/actions/CoupledPressureAction.C
+++ b/modules/tensor_mechanics/src/actions/CoupledPressureAction.C
@@ -1,0 +1,98 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CoupledPressureAction.h"
+#include "Factory.h"
+#include "FEProblem.h"
+#include "Conversion.h"
+
+registerMooseAction("TensorMechanicsApp", CoupledPressureAction, "add_bc");
+
+template <>
+InputParameters
+validParams<CoupledPressureAction>()
+{
+  InputParameters params = validParams<Action>();
+  params.addClassDescription("Set up Coupled Pressure boundary conditions");
+
+  params.addRequiredParam<std::vector<BoundaryName>>(
+      "boundary", "The list of boundary IDs from the mesh where the pressure will be applied");
+
+  params.addParam<NonlinearVariableName>("disp_x", "The x displacement");
+  params.addParam<NonlinearVariableName>("disp_y", "The y displacement");
+  params.addParam<NonlinearVariableName>("disp_z", "The z displacement");
+
+  params.addParam<std::vector<NonlinearVariableName>>(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+
+  params.addParam<std::vector<AuxVariableName>>("save_in_disp_x",
+                                                "The save_in variables for x displacement");
+  params.addParam<std::vector<AuxVariableName>>("save_in_disp_y",
+                                                "The save_in variables for y displacement");
+  params.addParam<std::vector<AuxVariableName>>("save_in_disp_z",
+                                                "The save_in variables for z displacement");
+
+  params.addParam<VariableName>("pressure", "The variable that contains the pressure");
+  return params;
+}
+
+CoupledPressureAction::CoupledPressureAction(const InputParameters & params) : Action(params)
+{
+  _save_in_vars.push_back(getParam<std::vector<AuxVariableName>>("save_in_disp_x"));
+  _save_in_vars.push_back(getParam<std::vector<AuxVariableName>>("save_in_disp_y"));
+  _save_in_vars.push_back(getParam<std::vector<AuxVariableName>>("save_in_disp_z"));
+
+  _has_save_in_vars.push_back(params.isParamValid("save_in_disp_x"));
+  _has_save_in_vars.push_back(params.isParamValid("save_in_disp_y"));
+  _has_save_in_vars.push_back(params.isParamValid("save_in_disp_z"));
+}
+
+void
+CoupledPressureAction::act()
+{
+  const std::string kernel_name = "CoupledPressureBC";
+
+  std::vector<NonlinearVariableName> displacements;
+  if (isParamValid("displacements"))
+    displacements = getParam<std::vector<NonlinearVariableName>>("displacements");
+  else
+  {
+    // Legacy parameter scheme for displacements
+    if (!isParamValid("disp_x"))
+      mooseError("Specify displacement variables using the `displacements` parameter.");
+    displacements.push_back(getParam<NonlinearVariableName>("disp_x"));
+
+    if (isParamValid("disp_y"))
+    {
+      displacements.push_back(getParam<NonlinearVariableName>("disp_y"));
+      if (isParamValid("disp_z"))
+        displacements.push_back(getParam<NonlinearVariableName>("disp_z"));
+    }
+  }
+
+  // Create pressure BCs
+  for (unsigned int i = 0; i < displacements.size(); ++i)
+  {
+    // Create unique kernel name for each of the components
+    std::string unique_kernel_name = kernel_name + "_" + _name + "_" + Moose::stringify(i);
+
+    InputParameters params = _factory.getValidParams(kernel_name);
+    params.applySpecificParameters(parameters(), {"boundary"});
+    params.set<std::vector<VariableName>>("pressure") = {getParam<VariableName>("pressure")};
+    params.set<bool>("use_displaced_mesh") = true;
+    params.set<unsigned int>("component") = i;
+    params.set<NonlinearVariableName>("variable") = displacements[i];
+
+    if (_has_save_in_vars[i])
+      params.set<std::vector<AuxVariableName>>("save_in") = _save_in_vars[i];
+
+    _problem->addBoundaryCondition(kernel_name, unique_kernel_name, params);
+  }
+}

--- a/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
+++ b/modules/tensor_mechanics/src/base/TensorMechanicsApp.C
@@ -82,6 +82,8 @@ TensorMechanicsApp::associateSyntax(Syntax & syntax, ActionFactory & action_fact
 
   registerSyntax("EmptyAction", "BCs/Pressure");
   registerSyntax("PressureAction", "BCs/Pressure/*");
+  registerSyntax("EmptyAction", "BCs/CoupledPressure");
+  registerSyntax("CoupledPressureAction", "BCs/CoupledPressure/*");
 
   registerSyntax("GeneralizedPlaneStrainAction",
                  "Modules/TensorMechanics/GeneralizedPlaneStrain/*");

--- a/modules/tensor_mechanics/src/bcs/CoupledPressureBC.C
+++ b/modules/tensor_mechanics/src/bcs/CoupledPressureBC.C
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CoupledPressureBC.h"
+
+registerMooseObject("TensorMechanicsApp", CoupledPressureBC);
+
+template <>
+InputParameters
+validParams<CoupledPressureBC>()
+{
+  InputParameters params = validParams<IntegratedBC>();
+  params.addClassDescription(
+      "Applies a pressure from a variable on a given boundary in a given direction");
+  params.addRequiredRangeCheckedParam<unsigned int>(
+      "component", "component<3", "The component for the pressure");
+  params.addRequiredCoupledVar("pressure", "Coupled variable containing the pressure");
+  params.set<bool>("use_displaced_mesh") = true;
+  return params;
+}
+
+CoupledPressureBC::CoupledPressureBC(const InputParameters & parameters)
+  : IntegratedBC(parameters),
+    _component(getParam<unsigned int>("component")),
+    _pressure(coupledValue("pressure"))
+{
+}
+
+Real
+CoupledPressureBC::computeQpResidual()
+{
+  return _pressure[_qp] * _normals[_qp](_component) * _test[_i][_qp];
+}

--- a/modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.exodiff
+++ b/modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.exodiff
@@ -1,0 +1,6 @@
+COORDINATES absolute 1.e-6
+TIME STEPS relative 1.e-6 floor 0.0
+NODAL VARIABLES relative 1.e-5 floor 1e-6
+	disp_x
+	disp_y
+	disp_z

--- a/modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.i
+++ b/modules/tensor_mechanics/test/tests/coupled_pressure/coupled_pressure_test.i
@@ -1,0 +1,167 @@
+#
+# Pressure Test
+#
+# This test is designed to compute pressure loads on three faces of a unit cube.
+# The pressure is computed as an auxiliary variable. It should give the same result
+# as pressure_test.i
+#
+# The mesh is composed of one block with a single element.  Symmetry bcs are
+# applied to the faces opposite the pressures.  Poisson's ratio is zero,
+# which makes it trivial to check displacements.
+#
+
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  type = FileMesh
+  file = pressure_test.e
+[]
+
+[Functions]
+  [./rampConstant]
+    type = PiecewiseLinear
+    x = '0. 1. 2.'
+    y = '0. 1. 1.'
+    scale_factor = 1.0
+  [../]
+  [./zeroRamp]
+    type = PiecewiseLinear
+    x = '0. 1. 2.'
+    y = '0. 0. 1.'
+    scale_factor = 2.0
+  [../]
+  [./rampUnramp]
+    type = PiecewiseLinear
+    x = '0. 1. 2.'
+    y = '0. 1. 0.'
+    scale_factor = 10.0
+  [../]
+[]
+
+[AuxVariables]
+  [./pressure_1]
+  [../]
+  [./pressure_2]
+  [../]
+  [./pressure_3]
+  [../]
+[]
+
+[AuxKernels]
+  [./side1_pressure_ak]
+    type = FunctionAux
+    variable = pressure_1
+    boundary = 1
+    function = rampConstant
+  [../]
+  [./side2_pressure_ak]
+    type = FunctionAux
+    variable = pressure_2
+    boundary = 2
+    function = zeroRamp
+  [../]
+  [./side3_pressure_ak]
+    type = FunctionAux
+    variable = pressure_3
+    boundary = 3
+    function = rampUnramp
+  [../]
+[]
+
+[Modules]
+  [./TensorMechanics]
+    [./Master]
+      [./all]
+        strain = SMALL
+        add_variables = true
+      [../]
+    [../]
+  [../]
+[]
+
+[BCs]
+  [./no_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 4
+    value = 0.0
+  [../]
+  [./no_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 5
+    value = 0.0
+  [../]
+  [./no_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = 6
+    value = 0.0
+  [../]
+  [./CoupledPressure]
+    [./Side1]
+      boundary = '1'
+      pressure = pressure_1
+      displacements = 'disp_x disp_y disp_z'
+    [../]
+    [./Side2]
+      boundary = '2'
+      pressure = pressure_2
+      displacements = 'disp_x disp_y disp_z'
+    [../]
+  [../]
+
+  [./side3_x]
+    type = CoupledPressureBC
+    variable = 'disp_x'
+    boundary = '3'
+    pressure = pressure_3
+    component = 0
+  [../]
+  [./side3_y]
+    type = CoupledPressureBC
+    variable = 'disp_y'
+    boundary = '3'
+    pressure = pressure_3
+    component = 1
+  [../]
+  [./side3_z]
+    type = CoupledPressureBC
+    variable = 'disp_z'
+    boundary = '3'
+    pressure = pressure_3
+    component = 2
+  [../]
+[]
+
+[Materials]
+  [./Elasticity_tensor]
+    type = ComputeElasticityTensor
+    fill_method = symmetric_isotropic
+    C_ijkl = '0 0.5e6'
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = PJFNK
+  nl_abs_tol = 1e-10
+  l_max_its = 20
+  start_time = 0.0
+  dt = 1.0
+  num_steps = 2
+  end_time = 2.0
+[]
+
+[Outputs]
+  [./out]
+    type = Exodus
+    elemental_as_nodal = true
+  [../]
+[]

--- a/modules/tensor_mechanics/test/tests/coupled_pressure/gold/coupled_pressure_test_out.e
+++ b/modules/tensor_mechanics/test/tests/coupled_pressure/gold/coupled_pressure_test_out.e
@@ -1,0 +1,1 @@
+../../pressure/gold/pressure_test_out.e

--- a/modules/tensor_mechanics/test/tests/coupled_pressure/pressure_test.e
+++ b/modules/tensor_mechanics/test/tests/coupled_pressure/pressure_test.e
@@ -1,0 +1,1 @@
+../pressure/pressure_test.e

--- a/modules/tensor_mechanics/test/tests/coupled_pressure/tests
+++ b/modules/tensor_mechanics/test/tests/coupled_pressure/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [./coupled_pressure]
+    type = Exodiff
+    input = 'coupled_pressure_test.i'
+    exodiff = 'coupled_pressure_test_out.e'
+    custom_cmp = 'coupled_pressure_test.exodiff'
+    requirement = "The system shall allow to apply a pressure boundary condition from a variable"
+    design = 'CoupledPressureBC.md'
+    issues = '#11558'
+  [../]
+[]


### PR DESCRIPTION
In coupled runs, the external app computes pressure which is then
transferred into an auxiliary variable. In order to use this externally
computed variable this BC use the variable to impose pressure BC.

Closes #11558

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
