### PR TITLE
Fix update_and_rebuild_libmesh.sh to exit non zero if build fails.

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -120,11 +120,9 @@ fi
 LIBMESH_JOBS=${MOOSE_JOBS:-1}
 
 if [ -z "${MOOSE_MAKE}" ]; then
-  make -j ${JOBS:-$LIBMESH_JOBS} && \
-    make install
+  (make -j ${JOBS:-$LIBMESH_JOBS} && make install) || exit 1
 else
-  ${MOOSE_MAKE} && \
-    ${MOOSE_MAKE} install
+  (${MOOSE_MAKE} && ${MOOSE_MAKE} install) || exit 1
 fi
 
 # Local Variables:


### PR DESCRIPTION
The exit status of `make && make install` in `update_and_rebuild_libmesh.sh` was never checked.

Before #11260 the default exit status was the exit status of these make commands.
#11260 introduced additional commands after the make commands, so the exit status of the script was the exit status of those commands, which would always succeed.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
