### PR TITLE
Fix 64-bit build issues.

### DIFF
--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -125,7 +125,7 @@ DistributedGeneratedMesh::DistributedGeneratedMesh(const InputParameters & param
 }
 
 Real
-DistributedGeneratedMesh::getMinInDimension(dof_id_type component) const
+DistributedGeneratedMesh::getMinInDimension(unsigned int component) const
 {
   switch (component)
   {
@@ -141,7 +141,7 @@ DistributedGeneratedMesh::getMinInDimension(dof_id_type component) const
 }
 
 Real
-DistributedGeneratedMesh::getMaxInDimension(dof_id_type component) const
+DistributedGeneratedMesh::getMaxInDimension(unsigned int component) const
 {
   switch (component)
   {
@@ -1086,13 +1086,9 @@ build_cube(UnstructuredMesh & mesh,
     // Weight by the number of nodes
     std::vector<Metis::idx_t> vwgt(num_elems, canonical_elem->n_nodes());
 
-    auto n = static_cast<Metis::idx_t>(num_elems), // number of "nodes" (elements) in the graph
-                                                   // wgtflag = 2,                                //
-                                                   // weights on vertices only, none on edges
-                                                   // numflag = 0,                                //
-                                                   // C-style 0-based numbering
-        nparts = static_cast<Metis::idx_t>(n_pieces), // number of subdomains to create
-        edgecut = 0; // the numbers of edges cut by the resulting partition
+    Metis::idx_t n = num_elems, // number of "nodes" (elements) in the graph
+        nparts = n_pieces,      // number of subdomains to create
+        edgecut = 0;            // the numbers of edges cut by the resulting partition
 
     METIS_CSR_Graph<Metis::idx_t> csr_graph;
 


### PR DESCRIPTION
These were introduced by #11505.

```
In file included from build/unity_src/mesh_Unity.C:3:0:
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:128:1: error: prototype for 'libMesh::Real DistributedGeneratedMesh::getMinInDimension(libMesh::dof_id_type) const' does not match any in class 'DistributedGeneratedMesh'
 DistributedGeneratedMesh::getMinInDimension(dof_id_type component) const
 ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:10:0,
                 from build/unity_src/mesh_Unity.C:3:
build/header_symlinks/DistributedGeneratedMesh.h:34:16: error: candidate is: virtual libMesh::Real DistributedGeneratedMesh::getMinInDimension(unsigned int) const
   virtual Real getMinInDimension(unsigned int component) const override;
                ^~~~~~~~~~~~~~~~~
In file included from build/unity_src/mesh_Unity.C:3:0:
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:144:1: error: prototype for 'libMesh::Real DistributedGeneratedMesh::getMaxInDimension(libMesh::dof_id_type) const' does not match any in class 'DistributedGeneratedMesh'
 DistributedGeneratedMesh::getMaxInDimension(dof_id_type component) const
 ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:10:0,
                 from build/unity_src/mesh_Unity.C:3:
build/header_symlinks/DistributedGeneratedMesh.h:35:16: error: candidate is: virtual libMesh::Real DistributedGeneratedMesh::getMaxInDimension(unsigned int) const
   virtual Real getMaxInDimension(unsigned int component) const override;
                ^~~~~~~~~~~~~~~~~
In file included from build/unity_src/mesh_Unity.C:3:0:
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C: In function 'void build_cube(libMesh::UnstructuredMesh&, unsigned int, unsigned int, unsigned int, libMesh::Real, libMesh::Real, libMesh::Real, libMesh::Real, libMesh::Real, libMesh::Real, libMesh::ElemType, bool)':
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:1089:5: error: inconsistent deduction for 'auto': 'long int' and then 'int'
     auto n = static_cast<Metis::idx_t>(num_elems), // number of "nodes" (elements) in the graph
     ^~~~
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:1175:49: error: cannot convert 'int*' to 'Metis::idx_t* {aka long int*}' for argument '12' to 'int Metis::METIS_PartGraphRecursive(Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::real_t*, Metis::real_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*)'
                                         &part[0]);
                                                 ^
/opt/civet/build_0/moose/framework/src/mesh/DistributedGeneratedMesh.C:1191:44: error: cannot convert 'int*' to 'Metis::idx_t* {aka long int*}' for argument '12' to 'int Metis::METIS_PartGraphKway(Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*, Metis::real_t*, Metis::real_t*, Metis::idx_t*, Metis::idx_t*, Metis::idx_t*)'
                                    &part[0]);
                                            ^
/opt/civet/build_0/moose/framework/build.mk:92: recipe for target '/opt/civet/build_0/moose/framework/build/unity_src/mesh_Unity.x86_64-unknown-linux-gnu.opt.lo' failed
make: *** [/opt/civet/build_0/moose/framework/build/unity_src/mesh_Unity.x86_64-unknown-linux-gnu.opt.lo] Error 1
```

