### PR TITLE
Improved diagnostic return mapping output 

### DIFF
--- a/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
+++ b/modules/solid_mechanics/include/materials/CombinedCreepPlasticity.h
@@ -46,7 +46,7 @@ protected:
   std::map<SubdomainID, std::vector<MooseSharedPointer<ReturnMappingModel>>> _submodels;
 
   unsigned int _max_its;
-  bool _output_iteration_info;
+  bool _internal_solve_full_iteration_history;
   Real _relative_tolerance;
   Real _absolute_tolerance;
   MaterialProperty<Real> & _matl_timestep_limit;

--- a/modules/solid_mechanics/include/materials/PLC_LSH.h
+++ b/modules/solid_mechanics/include/materials/PLC_LSH.h
@@ -41,7 +41,7 @@ protected:
   Real _hardening_constant;
 
   unsigned int _max_its;
-  bool _output_iteration_info;
+  bool _internal_solve_full_iteration_history;
   Real _relative_tolerance;
   Real _absolute_tolerance;
 

--- a/modules/solid_mechanics/include/materials/ReturnMappingModel.h
+++ b/modules/solid_mechanics/include/materials/ReturnMappingModel.h
@@ -70,7 +70,6 @@ public:
     return 0.0;
   }
 
-  /// Collect info on a nested solve
   void outputIterationSummary(std::stringstream * iter_output,
                               const unsigned int total_it) override;
 

--- a/modules/solid_mechanics/include/materials/ReturnMappingModel.h
+++ b/modules/solid_mechanics/include/materials/ReturnMappingModel.h
@@ -70,6 +70,10 @@ public:
     return 0.0;
   }
 
+  /// Collect info on a nested solve
+  void outputIterationSummary(std::stringstream * iter_output,
+                              const unsigned int total_it) override;
+
 protected:
   /**
    * Perform any necessary initialization before return mapping iterations

--- a/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
+++ b/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
@@ -24,8 +24,9 @@ validParams<CombinedCreepPlasticity>()
                                                     "List of submodel ConstitutiveModels");
 
   params.addParam<unsigned int>("max_its", 30, "Maximum number of submodel iterations");
-  params.addParam<bool>(
-      "output_iteration_info", false, "Set true to output submodel iteration information");
+  params.addParam<bool>("internal_solve_full_iteration_history",
+                        false,
+                        "Set true to output submodel iteration information");
   params.addParam<Real>(
       "relative_tolerance", 1e-5, "Relative convergence tolerance for combined submodel iteration");
   params.addParam<Real>(
@@ -39,7 +40,7 @@ CombinedCreepPlasticity::CombinedCreepPlasticity(const InputParameters & paramet
   : ConstitutiveModel(parameters),
     _submodels(),
     _max_its(parameters.get<unsigned int>("max_its")),
-    _output_iteration_info(getParam<bool>("output_iteration_info")),
+    _internal_solve_full_iteration_history(getParam<bool>("internal_solve_full_iteration_history")),
     _relative_tolerance(parameters.get<Real>("relative_tolerance")),
     _absolute_tolerance(parameters.get<Real>("absolute_tolerance")),
     _matl_timestep_limit(declareProperty<Real>("matl_timestep_limit"))
@@ -108,7 +109,7 @@ CombinedCreepPlasticity::computeStress(const Elem & current_elem,
     return;
   }
 
-  if (_output_iteration_info == true)
+  if (_internal_solve_full_iteration_history == true)
   {
     _console << std::endl
              << "iteration output for CombinedCreepPlasticity solve:"
@@ -161,7 +162,7 @@ CombinedCreepPlasticity::computeStress(const Elem & current_elem,
     }
     stress_new_last = stress_new;
 
-    if (_output_iteration_info == true)
+    if (_internal_solve_full_iteration_history == true)
     {
       _console << "stress_it=" << counter
                << " rel_delS=" << (0 == first_delS ? 0 : delS / first_delS)

--- a/modules/solid_mechanics/src/materials/ElasticModel.C
+++ b/modules/solid_mechanics/src/materials/ElasticModel.C
@@ -44,8 +44,8 @@ validParams<ElasticModel>()
   params.addParam<bool>("max_inelastic_increment", "dummy");
   params.addParam<bool>("max_its", "dummy");
   params.addParam<bool>("open_pore_compressibility_factor", "dummy");
-  params.addParam<MooseEnum>("internal_solve_output", MooseEnum("dummy"), "dummy");
-  params.addParam<bool>("output_iteration_info", "dummy");
+  params.addParam<MooseEnum>("internal_solve_output_on", MooseEnum("dummy"), "dummy");
+  params.addParam<bool>("internal_solve_full_iteration_history", "dummy");
   params.addParam<bool>("plenum_pressure", "dummy");
   params.addParam<bool>("porosity", "dummy");
   params.addParam<bool>("relative_tolerance", "dummy");

--- a/modules/solid_mechanics/src/materials/ElasticModel.C
+++ b/modules/solid_mechanics/src/materials/ElasticModel.C
@@ -44,9 +44,8 @@ validParams<ElasticModel>()
   params.addParam<bool>("max_inelastic_increment", "dummy");
   params.addParam<bool>("max_its", "dummy");
   params.addParam<bool>("open_pore_compressibility_factor", "dummy");
-  params.addParam<MooseEnum>("debug_level", MooseEnum("dummy"), "dummy");
+  params.addParam<MooseEnum>("internal_solve_output", MooseEnum("dummy"), "dummy");
   params.addParam<bool>("output_iteration_info", "dummy");
-  params.addParam<bool>("output_iteration_info_on_error", "dummy");
   params.addParam<bool>("plenum_pressure", "dummy");
   params.addParam<bool>("porosity", "dummy");
   params.addParam<bool>("relative_tolerance", "dummy");

--- a/modules/solid_mechanics/src/materials/ElasticModel.C
+++ b/modules/solid_mechanics/src/materials/ElasticModel.C
@@ -44,6 +44,7 @@ validParams<ElasticModel>()
   params.addParam<bool>("max_inelastic_increment", "dummy");
   params.addParam<bool>("max_its", "dummy");
   params.addParam<bool>("open_pore_compressibility_factor", "dummy");
+  params.addParam<MooseEnum>("debug_level", MooseEnum("dummy"), "dummy");
   params.addParam<bool>("output_iteration_info", "dummy");
   params.addParam<bool>("output_iteration_info_on_error", "dummy");
   params.addParam<bool>("plenum_pressure", "dummy");

--- a/modules/solid_mechanics/src/materials/PLC_LSH.C
+++ b/modules/solid_mechanics/src/materials/PLC_LSH.C
@@ -33,8 +33,9 @@ validParams<PLC_LSH>()
 
   // Sub-Newton Iteration control parameters
   params.addParam<unsigned int>("max_its", 30, "Maximum number of sub-newton iterations");
-  params.addParam<bool>(
-      "output_iteration_info", false, "Set true to output sub-newton iteration information");
+  params.addParam<bool>("internal_solve_full_iteration_history",
+                        false,
+                        "Set true to output sub-newton iteration information");
   params.addParam<Real>(
       "relative_tolerance", 1e-5, "Relative convergence tolerance for sub-newtion iteration");
   params.addParam<Real>(
@@ -62,7 +63,7 @@ PLC_LSH::PLC_LSH(const InputParameters & parameters)
     _hardening_constant(parameters.get<Real>("hardening_constant")),
 
     _max_its(parameters.get<unsigned int>("max_its")),
-    _output_iteration_info(getParam<bool>("output_iteration_info")),
+    _internal_solve_full_iteration_history(getParam<bool>("internal_solve_full_iteration_history")),
     _relative_tolerance(parameters.get<Real>("relative_tolerance")),
     _absolute_tolerance(parameters.get<Real>("absolute_tolerance")),
 
@@ -104,7 +105,7 @@ PLC_LSH::computeStress()
   if (_t_step == 0 && !_app.isRestarting())
     return;
 
-  if (_output_iteration_info == true)
+  if (_internal_solve_full_iteration_history == true)
   {
     _console << std::endl
              << "iteration output for combined creep-plasticity solve:"
@@ -153,7 +154,7 @@ PLC_LSH::computeStress()
     }
     stress_new_last = stress_new;
 
-    if (_output_iteration_info == true)
+    if (_internal_solve_full_iteration_history == true)
     {
       _console << "stress_it=" << counter << " rel_delS=" << delS / first_delS
                << " rel_tol=" << _relative_tolerance << " abs_delS=" << delS
@@ -222,7 +223,7 @@ PLC_LSH::computeCreep(const SymmTensor & strain_increment,
 
     del_p += creep_residual / (1 / _dt - dphi_ddelp);
 
-    if (_output_iteration_info == true)
+    if (_internal_solve_full_iteration_history == true)
     {
       _console << "crp_it=" << it << " trl_strs=" << effective_trial_stress << " phi=" << phi
                << " dphi=" << dphi_ddelp << " del_p=" << del_p
@@ -310,7 +311,7 @@ PLC_LSH::computeLSH(const SymmTensor & strain_increment,
       _hardening_variable[_qp] =
           _hardening_variable_old[_qp] + (_hardening_constant * scalar_plastic_strain_increment);
 
-      if (_output_iteration_info == true)
+      if (_internal_solve_full_iteration_history == true)
       {
         _console << "pls_it=" << it << " trl_strs=" << effective_trial_stress
                  << " del_p=" << scalar_plastic_strain_increment

--- a/modules/solid_mechanics/src/materials/ReturnMappingModel.C
+++ b/modules/solid_mechanics/src/materials/ReturnMappingModel.C
@@ -160,3 +160,15 @@ ReturnMappingModel::computeTimeStepLimit()
 
   return _dt * _max_inelastic_increment / scalar_inelastic_strain_incr;
 }
+
+void
+ReturnMappingModel::outputIterationSummary(std::stringstream * iter_output,
+                                           const unsigned int total_it)
+{
+  if (iter_output)
+  {
+    *iter_output << "At element " << _current_elem->id() << " _qp=" << _qp << " Coordinates "
+                 << _q_point[_qp] << " block=" << _current_elem->subdomain_id() << '\n';
+  }
+  SingleVariableReturnMappingSolution::outputIterationSummary(iter_output, total_it);
+}

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -120,7 +120,7 @@ protected:
   const unsigned int _max_iterations;
   const Real _relative_tolerance;
   const Real _absolute_tolerance;
-  const bool _output_iteration_info;
+  const bool _internal_solve_full_iteration_history;
   ///@}
 
   /// after updateQpState, rotate the stress, elastic_strain, inelastic_strain and Jacobian_mult using _rotation_increment

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -120,6 +120,10 @@ protected:
    */
   virtual void computeStressFinalize(const RankTwoTensor & /*inelasticStrainIncrement*/) {}
 
+  /// Collect info on a nested solve
+  void outputIterationSummary(std::stringstream * iter_output,
+                              const unsigned int total_it) override;
+
   /// 3 * shear modulus
   Real _three_shear_modulus;
 

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -120,7 +120,6 @@ protected:
    */
   virtual void computeStressFinalize(const RankTwoTensor & /*inelasticStrainIncrement*/) {}
 
-  /// Collect info on a nested solve
   void outputIterationSummary(std::stringstream * iter_output,
                               const unsigned int total_it) override;
 

--- a/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
@@ -133,7 +133,7 @@ private:
     NEVER,
     ON_ERROR,
     ALWAYS
-  } _internal_solve_output;
+  } _internal_solve_output_on;
 
   enum class SolveState
   {
@@ -149,7 +149,7 @@ private:
   const unsigned int _fixed_max_its;
 
   /// Whether to output iteration information all the time (regardless of whether iterations converge)
-  const bool _output_iteration_info;
+  const bool _internal_solve_full_iteration_history;
 
   /// Relative convergence tolerance
   Real _relative_tolerance;

--- a/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
@@ -98,7 +98,7 @@ protected:
   virtual void iterationFinalize(Real /*scalar*/) {}
 
   /**
-   * Output information about convergence history of the model
+   * Output information for a single iteration step to build the convergence history of the model
    * @param iter_output            Output stream
    * @param it                     Current iteration count
    * @param effective_trial_stress Effective trial stress
@@ -106,12 +106,19 @@ protected:
    * @param residual               Current value of the residual
    * @param reference              Current value of the reference quantity
    */
-  virtual void outputIterInfo(std::stringstream * iter_output,
-                              const unsigned int it,
-                              const Real effective_trial_stress,
-                              const Real scalar,
-                              const Real residual,
-                              const Real reference_residual);
+  virtual void outputIterationStep(std::stringstream * iter_output,
+                                   const unsigned int it,
+                                   const Real effective_trial_stress,
+                                   const Real scalar,
+                                   const Real residual,
+                                   const Real reference_residual);
+
+  /**
+   * Output summary information for the convergence history of the model
+   * @param iter_output            Output stream
+   * @param total_it               Total iteration count
+   */
+  virtual void outputIterationSummary(std::stringstream * iter_output, const unsigned int total_it);
 
   /// Whether to use the legacy return mapping algorithm and compute residuals in the legacy
   /// manner.
@@ -121,6 +128,13 @@ protected:
   bool _check_range;
 
 private:
+  enum class DebugLevel
+  {
+    NONE,
+    ALL,
+    ERROR
+  } _debug_level;
+
   /// Maximum number of return mapping iterations (used only in legacy return mapping)
   unsigned int _max_its;
 
@@ -152,6 +166,9 @@ private:
   /// History of residuals used to check whether progress is still being made on decreasing the residual
   std::vector<Real> _residual_history;
 
+  /// iteration number
+  unsigned int _iteration;
+
   /**
    * Method called from within this class to perform the actual return mappping iterations.
    * @param effective_trial_stress Effective trial stress
@@ -159,8 +176,9 @@ private:
    * @param iter_output            Output stream -- if null, no output is produced
    * @return Whether the solution was successful
    */
-  bool
-  internalSolve(const Real effective_trial_stress, Real & scalar, std::stringstream * iter_output);
+  bool internalSolve(const Real effective_trial_stress,
+                     Real & scalar,
+                     std::stringstream * iter_output = nullptr);
 
   /**
    * Method called from within this class to perform the actual return mappping iterations.

--- a/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
@@ -128,12 +128,19 @@ protected:
   bool _check_range;
 
 private:
-  enum class DebugLevel
+  enum class InternalSolveOutput
   {
-    NONE,
-    ALL,
-    ERROR
-  } _debug_level;
+    NEVER,
+    ON_ERROR,
+    ALWAYS
+  } _internal_solve_output;
+
+  enum class SolveState
+  {
+    SUCCESS,
+    NAN_INF,
+    EXCEEDED_ITERATIONS
+  };
 
   /// Maximum number of return mapping iterations (used only in legacy return mapping)
   unsigned int _max_its;
@@ -169,6 +176,14 @@ private:
   /// iteration number
   unsigned int _iteration;
 
+  ///@{ Residual values, kept as members to retain solver state for summary outputting
+  Real _initial_residual;
+  Real _residual;
+  ///@}
+
+  /// MOOSE input name of the object performing the solve
+  const std::string _svrms_name;
+
   /**
    * Method called from within this class to perform the actual return mappping iterations.
    * @param effective_trial_stress Effective trial stress
@@ -176,9 +191,9 @@ private:
    * @param iter_output            Output stream -- if null, no output is produced
    * @return Whether the solution was successful
    */
-  bool internalSolve(const Real effective_trial_stress,
-                     Real & scalar,
-                     std::stringstream * iter_output = nullptr);
+  SolveState internalSolve(const Real effective_trial_stress,
+                           Real & scalar,
+                           std::stringstream * iter_output = nullptr);
 
   /**
    * Method called from within this class to perform the actual return mappping iterations.

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -38,7 +38,7 @@ validParams<ComputeMultipleInelasticStress>()
                         "update iterations over the stress change "
                         "after all update materials are called");
   params.addParam<bool>(
-      "output_iteration_info",
+      "internal_solve_full_iteration_history",
       false,
       "Set to true to output stress update iteration information over the stress change");
   params.addParam<bool>("perform_finite_strain_rotations",
@@ -75,7 +75,7 @@ ComputeMultipleInelasticStress::ComputeMultipleInelasticStress(const InputParame
     _max_iterations(parameters.get<unsigned int>("max_iterations")),
     _relative_tolerance(parameters.get<Real>("relative_tolerance")),
     _absolute_tolerance(parameters.get<Real>("absolute_tolerance")),
-    _output_iteration_info(getParam<bool>("output_iteration_info")),
+    _internal_solve_full_iteration_history(getParam<bool>("internal_solve_full_iteration_history")),
     _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
     _elasticity_tensor(getMaterialPropertyByName<RankFourTensor>(_base_name + "elasticity_tensor")),
     _elastic_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "elastic_strain")),
@@ -236,7 +236,7 @@ void
 ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_increment,
                                               RankTwoTensor & combined_inelastic_strain_increment)
 {
-  if (_output_iteration_info == true)
+  if (_internal_solve_full_iteration_history == true)
   {
     _console << std::endl
              << "iteration output for ComputeMultipleInelasticStress solve:"
@@ -317,7 +317,7 @@ ComputeMultipleInelasticStress::updateQpState(RankTwoTensor & elastic_strain_inc
     if (counter == 0 && l2norm_delta_stress > 0.0)
       first_l2norm_delta_stress = l2norm_delta_stress;
 
-    if (_output_iteration_info == true)
+    if (_internal_solve_full_iteration_history == true)
     {
       _console << "stress iteration number = " << counter << "\n"
                << " relative l2 norm delta stress = "

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -170,3 +170,15 @@ RadialReturnStressUpdate::computeTimeStepLimit()
 
   return _dt * _max_inelastic_increment / scalar_inelastic_strain_incr;
 }
+
+void
+RadialReturnStressUpdate::outputIterationSummary(std::stringstream * iter_output,
+                                                 const unsigned int total_it)
+{
+  if (iter_output)
+  {
+    *iter_output << "At element " << _current_elem->id() << " _qp=" << _qp << " Coordinates "
+                 << _q_point[_qp] << " block=" << _current_elem->subdomain_id() << '\n';
+  }
+  SingleVariableReturnMappingSolution::outputIterationSummary(iter_output, total_it);
+}

--- a/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
+++ b/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
@@ -48,13 +48,7 @@ validParams<SingleVariableReturnMappingSolution>()
       "debug_level", debug_level_enum, "When to output Newton solve information");
   params.addParam<bool>(
       "output_iteration_info", false, "Set true to output full Newton iteration history");
-  params.addDeprecatedParam<bool>(
-      "output_iteration_info_on_error",
-      false,
-      "Set true to output Newton iteration information when those iterations fail",
-      "This parameter is replaced by the 'debug_level' parameter");
-  params.addParamNamesToGroup("debug_level output_iteration_info output_iteration_info_on_error",
-                              "Debug");
+  params.addParamNamesToGroup("debug_level output_iteration_info", "Debug");
 
   return params;
 }


### PR DESCRIPTION
Refs #11573

@tophmatthews, heads up: I'm proposing to rename `outputIterInfo` to `outputIterationStep` to be able to distinguish it better from the new `outputIterationSummary` function.