### PR TITLE
Clean up fluid properties unit tests

### DIFF
--- a/unit/include/SinglePhaseFluidPropertiesPTUtils.h
+++ b/unit/include/SinglePhaseFluidPropertiesPTUtils.h
@@ -1,0 +1,70 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef SINGLEPHASEFLUIDPROPERTIESPTUTILS_H
+#define SINGLEPHASEFLUIDPROPERTIESPTUTILS_H
+
+#include "Utils.h"
+#include "SinglePhaseFluidPropertiesPT.h"
+
+// Macro for performing a derivative test
+#define DERIV_TEST(f, fd, a, b, tol)                                                               \
+  {                                                                                                \
+    const Real epsilon = 1.0e-6;                                                                   \
+    const Real da = epsilon * a;                                                                   \
+    const Real db = epsilon * b;                                                                   \
+    const Real df_da_fd = (f(a + da, b) - f(a - da, b)) / (2.0 * da);                              \
+    const Real df_db_fd = (f(a, b + db) - f(a, b - db)) / (2.0 * db);                              \
+                                                                                                   \
+    Real f_value, df_da, df_db;                                                                    \
+    fd(a, b, f_value, df_da, df_db);                                                               \
+                                                                                                   \
+    REL_TEST(f(a, b), f_value, REL_TOL_CONSISTENCY);                                               \
+    REL_TEST(df_da, df_da_fd, tol);                                                                \
+    REL_TEST(df_db, df_db_fd, tol);                                                                \
+  }
+
+// Test methods that return multiple properties
+template <typename U>
+void
+combinedProperties(const U & f, Real p, Real T, Real tol)
+{
+  // Single property methods
+  Real rho, drho_dp, drho_dT;
+  f->rho_dpT(p, T, rho, drho_dp, drho_dT);
+  Real mu, dmu_dp, dmu_dT;
+  f->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
+  Real e, de_dp, de_dT;
+  f->e_dpT(p, T, e, de_dp, de_dT);
+
+  // Combined property methods
+  Real rho2, drho2_dp, drho2_dT, mu2, dmu2_dp, dmu2_dT, e2, de2_dp, de2_dT;
+  f->rho_mu(p, T, rho2, mu2);
+
+  ABS_TEST(rho, rho2, tol);
+  ABS_TEST(mu, mu2, tol);
+
+  f->rho_mu_dpT(p, T, rho2, drho2_dp, drho2_dT, mu2, dmu2_dp, dmu2_dT);
+  ABS_TEST(rho, rho2, tol);
+  ABS_TEST(drho_dp, drho2_dp, tol);
+  ABS_TEST(drho_dT, drho2_dT, tol);
+  ABS_TEST(mu, mu2, tol);
+  ABS_TEST(dmu_dp, dmu2_dp, tol);
+  ABS_TEST(dmu_dT, dmu2_dT, tol);
+
+  f->rho_e_dpT(p, T, rho2, drho2_dp, drho2_dT, e2, de2_dp, de2_dT);
+  ABS_TEST(rho, rho2, tol);
+  ABS_TEST(drho_dp, drho2_dp, tol);
+  ABS_TEST(drho_dT, drho2_dT, tol);
+  ABS_TEST(e, e2, tol);
+  ABS_TEST(de_dp, de2_dp, tol);
+  ABS_TEST(de_dT, de2_dT, tol);
+}
+
+#endif // SINGLEPHASEFLUIDPROPERTIESPTUTILS_H

--- a/unit/include/SinglePhaseFluidPropertiesUtils.h
+++ b/unit/include/SinglePhaseFluidPropertiesUtils.h
@@ -10,32 +10,7 @@
 #ifndef SINGLEPHASEFLUIDPROPERTIESUTILS_H
 #define SINGLEPHASEFLUIDPROPERTIESUTILS_H
 
-// Relative tolerance to be used when comparing to a value from external fluid
-// property packages, which might be using different underlying models
-#define REL_TOL_EXTERNAL_VALUE 1e-3
-
-// Relative tolerance to be used when comparing to a value computed directly
-// from the code at an earlier date, to ensure that implementations are not
-// inadvertently changed
-#define REL_TOL_SAVED_VALUE 1e-12
-
-// Relative tolerance to be used for consistency checks - computing properties
-// in different ways at the same state
-#define REL_TOL_CONSISTENCY 1e-10
-
-// Relative tolerance to be used when comparing a derivative value to a finite
-// difference approximation
-#define REL_TOL_DERIVATIVE 1e-6
-
-// Macro for computing relative error
-#define REL_TEST(value, ref_value, tol)                                                            \
-  if (std::abs(ref_value) < 1e-15)                                                                 \
-    ABS_TEST(value, ref_value, tol);                                                               \
-  else                                                                                             \
-    EXPECT_LE(std::abs((value) - (ref_value)) / (ref_value), (tol));
-
-// Macro for computing absolute error
-#define ABS_TEST(value, ref_value, tol) EXPECT_LE(std::abs(((value) - (ref_value))), (tol))
+#include "Utils.h"
 
 // Relative perturbation for derivative tests
 #define REL_PERTURBATION 1e-6

--- a/unit/include/Utils.h
+++ b/unit/include/Utils.h
@@ -10,11 +10,31 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#define REL_TEST(name, value, ref_value, tol)                                                      \
-  EXPECT_LE(std::abs(((value) - (ref_value)) / (ref_value)), (tol)) << "    - failed " << name     \
-                                                                    << " check"
+// Relative tolerance to be used when comparing to a value from external fluid
+// property packages, which might be using different underlying models
+#define REL_TOL_EXTERNAL_VALUE 1e-3
 
-#define ABS_TEST(name, value, ref_value, tol)                                                      \
-  EXPECT_LE(std::abs(((value) - (ref_value))), (tol)) << "    - failed " << name << " check"
+// Relative tolerance to be used when comparing to a value computed directly
+// from the code at an earlier date, to ensure that implementations are not
+// inadvertently changed
+#define REL_TOL_SAVED_VALUE 1e-12
+
+// Relative tolerance to be used for consistency checks - computing properties
+// in different ways at the same state
+#define REL_TOL_CONSISTENCY 1e-10
+
+// Relative tolerance to be used when comparing a derivative value to a finite
+// difference approximation
+#define REL_TOL_DERIVATIVE 1e-6
+
+// Macro for computing relative error
+#define REL_TEST(value, ref_value, tol)                                                            \
+  if (std::abs(ref_value) < 1e-15)                                                                 \
+    ABS_TEST(value, ref_value, tol);                                                               \
+  else                                                                                             \
+    EXPECT_LE(std::abs((value) - (ref_value)) / (ref_value), (tol));
+
+// Macro for computing absolute error
+#define ABS_TEST(value, ref_value, tol) EXPECT_LE(std::abs(((value) - (ref_value))), (tol))
 
 #endif // UTILS_H

--- a/unit/include/Water97FluidPropertiesTest.h
+++ b/unit/include/Water97FluidPropertiesTest.h
@@ -12,7 +12,7 @@
 
 #include "MooseObjectUnitTest.h"
 #include "Water97FluidProperties.h"
-#include "Utils.h"
+#include "SinglePhaseFluidPropertiesPTUtils.h"
 
 class Water97FluidPropertiesTest : public MooseObjectUnitTest
 {
@@ -31,43 +31,6 @@ protected:
     InputParameters uo_pars = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "fp", uo_pars);
     _fp = &_fe_problem->getUserObject<Water97FluidProperties>("fp");
-  }
-
-  void regionDerivatives(Real p, Real T, Real tol)
-  {
-    // Finite differencing parameters
-    Real dp = 1.0e1;
-    Real dT = 1.0e-4;
-
-    // density
-    Real drho_dp_fd = (_fp->rho(p + dp, T) - _fp->rho(p - dp, T)) / (2.0 * dp);
-    Real drho_dT_fd = (_fp->rho(p, T + dT) - _fp->rho(p, T - dT)) / (2.0 * dT);
-    Real rho = 0.0, drho_dp = 0.0, drho_dT = 0.0;
-    _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
-
-    ABS_TEST("rho", rho, _fp->rho(p, T), 1.0e-15);
-    REL_TEST("drho_dp", drho_dp, drho_dp_fd, tol);
-    REL_TEST("drho_dT", drho_dT, drho_dT_fd, tol);
-
-    // enthalpy
-    Real dh_dp_fd = (_fp->h(p + dp, T) - _fp->h(p - dp, T)) / (2.0 * dp);
-    Real dh_dT_fd = (_fp->h(p, T + dT) - _fp->h(p, T - dT)) / (2.0 * dT);
-    Real h = 0.0, dh_dp = 0.0, dh_dT = 0.0;
-    _fp->h_dpT(p, T, h, dh_dp, dh_dT);
-
-    ABS_TEST("h", h, _fp->h(p, T), 1.0e-15);
-    REL_TEST("dh_dp", dh_dp, dh_dp_fd, tol);
-    REL_TEST("dh_dT", dh_dT, dh_dT_fd, tol);
-
-    // internal energy
-    Real de_dp_fd = (_fp->e(p + dp, T) - _fp->e(p - dp, T)) / (2.0 * dp);
-    Real de_dT_fd = (_fp->e(p, T + dT) - _fp->e(p, T - dT)) / (2.0 * dT);
-    Real e = 0.0, de_dp = 0.0, de_dT = 0.0;
-    _fp->e_dpT(p, T, e, de_dp, de_dT);
-
-    ABS_TEST("e", e, _fp->e(p, T), 1.0e-15);
-    REL_TEST("de_dp", de_dp, de_dp_fd, tol);
-    REL_TEST("de_dT", de_dT, de_dT_fd, tol);
   }
 
   const Water97FluidProperties * _fp;

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -11,6 +11,37 @@
 #include "Utils.h"
 
 /**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(BrineFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "brine"); }
+
+/**
+ * Test that the molar masses are correctly returned
+ */
+TEST_F(BrineFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_fp->molarMassH2O(), 18.015e-3, REL_TOL_CONSISTENCY);
+  ABS_TEST(_fp->molarMassNaCl(), 58.443e-3, REL_TOL_CONSISTENCY);
+
+  // Molar mass of water with salt mass fraction 0.1
+  const Real x = 0.1;
+  const Real M = 1.0 / (x / _fp->molarMassNaCl() + (1.0 - x) / _fp->molarMassH2O());
+  ABS_TEST(_fp->molarMass(x), M, REL_TOL_CONSISTENCY);
+}
+
+/**
+ * Test that the correct fluid component userobject is returned
+ */
+TEST_F(BrineFluidPropertiesTest, getComponent)
+{
+  auto & water_fp = _fp->getComponent(BrineFluidProperties::WATER);
+  auto & nacl_fp = _fp->getComponent(BrineFluidProperties::NACL);
+
+  EXPECT_EQ(water_fp.fluidName(), "water");
+  EXPECT_EQ(nacl_fp.fluidName(), "nacl");
+}
+
+/**
  * Verify calculation of brine vapor pressure using data from
  * Haas, Physical properties of the coexisting phases and thermochemical
  * properties of the H2O component in boiling NaCl solutions, Geological Survey
@@ -18,9 +49,9 @@
  */
 TEST_F(BrineFluidPropertiesTest, vapor)
 {
-  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.185), 1.34e6, 1.0e-2);
-  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.267), 1.21e6, 1.0e-2);
-  REL_TEST("vapor", _fp->vaporPressure(473.15, 0.312), 1.13e6, 1.0e-2);
+  REL_TEST(_fp->vaporPressure(473.15, 0.185), 1.34e6, 1.0e-2);
+  REL_TEST(_fp->vaporPressure(473.15, 0.267), 1.21e6, 1.0e-2);
+  REL_TEST(_fp->vaporPressure(473.15, 0.312), 1.13e6, 1.0e-2);
 }
 
 /**
@@ -32,9 +63,9 @@ TEST_F(BrineFluidPropertiesTest, vapor)
  */
 TEST_F(BrineFluidPropertiesTest, solubility)
 {
-  REL_TEST("halite solubility", _fp->haliteSolubility(659.65), 0.442, 2.0e-2);
-  REL_TEST("halite solubility", _fp->haliteSolubility(818.65), 0.6085, 2.0e-2);
-  REL_TEST("halite solubility", _fp->haliteSolubility(903.15), 0.7185, 2.0e-2);
+  REL_TEST(_fp->haliteSolubility(659.65), 0.442, 2.0e-2);
+  REL_TEST(_fp->haliteSolubility(818.65), 0.6085, 2.0e-2);
+  REL_TEST(_fp->haliteSolubility(903.15), 0.7185, 2.0e-2);
 }
 
 /**
@@ -66,35 +97,35 @@ TEST_F(BrineFluidPropertiesTest, properties)
   Real x1 = 0.2261;
 
   // Density
-  REL_TEST("density", _fp->rho(p0, T0, x0), 1068.52, 1.0e-2);
-  REL_TEST("density", _fp->rho(p0, T1, x0), 959.27, 1.0e-2);
-  REL_TEST("density", _fp->rho(p1, T1, x1), 1065.58, 1.0e-2);
+  REL_TEST(_fp->rho(p0, T0, x0), 1068.52, 1.0e-2);
+  REL_TEST(_fp->rho(p0, T1, x0), 959.27, 1.0e-2);
+  REL_TEST(_fp->rho(p1, T1, x1), 1065.58, 1.0e-2);
 
   // Viscosity
-  REL_TEST("viscosity", _fp->mu(p0, T0, x0), 679.8e-6, 2.0e-2);
-  REL_TEST("viscosity", _fp->mu(p0, T1, x0), 180.0e-6, 2.0e-2);
-  REL_TEST("viscosity", _fp->mu(p1, T1, x1), 263.1e-6, 2.0e-2);
+  REL_TEST(_fp->mu(p0, T0, x0), 679.8e-6, 2.0e-2);
+  REL_TEST(_fp->mu(p0, T1, x0), 180.0e-6, 2.0e-2);
+  REL_TEST(_fp->mu(p1, T1, x1), 263.1e-6, 2.0e-2);
 
   // Thermal conductivity
-  REL_TEST("thermal conductivity", _fp->k(p0, T0, x0), 0.630, 4.0e-2);
-  REL_TEST("thermal conductivity", _fp->k(p0, T1, x0), 0.649, 4.0e-2);
-  REL_TEST("thermal conductivity", _fp->k(p1, T1, x1), 0.633, 4.0e-2);
+  REL_TEST(_fp->k(p0, T0, x0), 0.630, 4.0e-2);
+  REL_TEST(_fp->k(p0, T1, x0), 0.649, 4.0e-2);
+  REL_TEST(_fp->k(p1, T1, x1), 0.633, 4.0e-2);
 
   // Enthalpy
   p0 = 10.0e6;
   T0 = 573.15;
 
-  REL_TEST("enthalpy", _fp->e(p0, T0, 0.0), 1330.0e3, 1.0e-2);
-  REL_TEST("enthalpy", _fp->e(p0, T0, 0.2), 1100.0e3, 1.0e-2);
-  REL_TEST("enthalpy", _fp->e(p0, T0, 0.364), 970.0e3, 1.0e-2);
+  REL_TEST(_fp->e(p0, T0, 0.0), 1330.0e3, 1.0e-2);
+  REL_TEST(_fp->e(p0, T0, 0.2), 1100.0e3, 1.0e-2);
+  REL_TEST(_fp->e(p0, T0, 0.364), 970.0e3, 1.0e-2);
 
   // cp
   p0 = 17.9e6;
   x0 = 0.01226;
 
-  REL_TEST("cp", _fp->cp(p0, 323.15, x0), 4.1e3, 1.0e-2);
-  REL_TEST("cp", _fp->cp(p0, 473.15, x0), 4.35e3, 1.0e-2);
-  REL_TEST("cp", _fp->cp(p0, 623.15, x0), 8.1e3, 1.0e-2);
+  REL_TEST(_fp->cp(p0, 323.15, x0), 4.1e3, 1.0e-2);
+  REL_TEST(_fp->cp(p0, 473.15, x0), 4.35e3, 1.0e-2);
+  REL_TEST(_fp->cp(p0, 623.15, x0), 8.1e3, 1.0e-2);
 }
 
 /**
@@ -120,10 +151,10 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   Real rho = 0.0, drho_dp = 0.0, drho_dT = 0.0, drho_dx = 0.0;
   _fp->rho_dpTx(p, T, x, rho, drho_dp, drho_dT, drho_dx);
 
-  ABS_TEST("rho", rho, _fp->rho(p, T, x), 1.0e-15);
-  REL_TEST("drho_dp", drho_dp, drho_dp_fd, 1.0e-3);
-  REL_TEST("drho_dT", drho_dT, drho_dT_fd, 1.0e-3);
-  REL_TEST("drho_dx", drho_dx, drho_dx_fd, 1.0e-3);
+  ABS_TEST(rho, _fp->rho(p, T, x), REL_TOL_CONSISTENCY);
+  REL_TEST(drho_dp, drho_dp_fd, 1.0e-3);
+  REL_TEST(drho_dT, drho_dT_fd, 1.0e-3);
+  REL_TEST(drho_dx, drho_dx_fd, 1.0e-3);
 
   // Enthalpy
   Real dh_dp_fd = (_fp->h(p + dp, T, x) - _fp->h(p - dp, T, x)) / (2.0 * dp);
@@ -133,10 +164,10 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   Real h = 0.0, dh_dp = 0.0, dh_dT = 0.0, dh_dx = 0.0;
   _fp->h_dpTx(p, T, x, h, dh_dp, dh_dT, dh_dx);
 
-  ABS_TEST("h", h, _fp->h(p, T, x), 1.0e-15);
-  REL_TEST("dh_dp", dh_dp, dh_dp_fd, 1.0e-3);
-  REL_TEST("dh_dT", dh_dT, dh_dT_fd, 1.0e-3);
-  REL_TEST("dh_dx", dh_dx, dh_dx_fd, 1.0e-3);
+  ABS_TEST(h, _fp->h(p, T, x), REL_TOL_CONSISTENCY);
+  REL_TEST(dh_dp, dh_dp_fd, 1.0e-3);
+  REL_TEST(dh_dT, dh_dT_fd, 1.0e-3);
+  REL_TEST(dh_dx, dh_dx_fd, 1.0e-3);
 
   // Internal energy
   Real de_dp_fd = (_fp->e(p + dp, T, x) - _fp->e(p - dp, T, x)) / (2.0 * dp);
@@ -146,10 +177,10 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   Real e = 0.0, de_dp = 0.0, de_dT = 0.0, de_dx = 0.0;
   _fp->e_dpTx(p, T, x, e, de_dp, de_dT, de_dx);
 
-  ABS_TEST("e", e, _fp->e(p, T, x), 1.0e-15);
-  REL_TEST("de_dp", de_dp, de_dp_fd, 1.0e-1);
-  REL_TEST("de_dT", de_dT, de_dT_fd, 1.0e-3);
-  REL_TEST("de_dx", de_dx, de_dx_fd, 1.0e-3);
+  ABS_TEST(e, _fp->e(p, T, x), REL_TOL_CONSISTENCY);
+  REL_TEST(de_dp, de_dp_fd, 1.0e-1);
+  REL_TEST(de_dT, de_dT_fd, 1.0e-3);
+  REL_TEST(de_dx, de_dx_fd, 1.0e-3);
 
   // Viscosity
   Real dmu_dp_fd = (_fp->mu(p + dp, T, x) - _fp->mu(p - dp, T, x)) / (2.0 * dp);
@@ -158,10 +189,10 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   Real mu = 0.0, dmu_dp = 0.0, dmu_dT = 0.0, dmu_dx = 0.0;
   _fp->mu_dpTx(p, T, x, mu, dmu_dp, dmu_dT, dmu_dx);
 
-  ABS_TEST("mu", mu, _fp->mu(p, T, x), 1.0e-15);
-  REL_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-3);
-  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
-  REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-6);
+  ABS_TEST(mu, _fp->mu(p, T, x), REL_TOL_CONSISTENCY);
+  REL_TEST(dmu_dp, dmu_dp_fd, 1.0e-3);
+  REL_TEST(dmu_dT, dmu_dT_fd, 1.0e-6);
+  REL_TEST(dmu_dx, dmu_dx_fd, 1.0e-6);
 
   // Verify that derivatives wrt x are defined when x = 0
   x = 0.0;
@@ -170,23 +201,23 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
   _fp->rho_dpTx(p, T, x, rho, drho_dp, drho_dT, drho_dx);
   drho_dx_fd = (_fp->rho(p, T, x + dx) - _fp->rho(p, T, x)) / dx;
 
-  REL_TEST("drho_dx", drho_dx, drho_dx_fd, 1.0e-3);
+  REL_TEST(drho_dx, drho_dx_fd, 1.0e-3);
 
   // Enthalpy
   _fp->h_dpTx(p, T, x, h, dh_dp, dh_dT, dh_dx);
   dh_dx_fd = (_fp->h(p, T, x + dx) - _fp->h(p, T, x)) / dx;
 
-  REL_TEST("dh_dx", dh_dx, dh_dx_fd, 1.0e-3);
+  REL_TEST(dh_dx, dh_dx_fd, 1.0e-3);
 
   // Internal energy
   _fp->e_dpTx(p, T, x, e, de_dp, de_dT, de_dx);
   de_dx_fd = (_fp->e(p, T, x + dx) - _fp->e(p, T, x)) / dx;
 
-  REL_TEST("de_dx", de_dx, de_dx_fd, 1.0e-3);
+  REL_TEST(de_dx, de_dx_fd, 1.0e-3);
 
   // Viscosity
   dmu_dx_fd = (_fp->mu(p, T, x + dx) - _fp->mu(p, T, x)) / dx;
   _fp->mu_dpTx(p, T, x, mu, dmu_dp, dmu_dT, dmu_dx);
 
-  REL_TEST("dmu_dx", dmu_dx, dmu_dx_fd, 1.0e-3);
+  REL_TEST(dmu_dx, dmu_dx_fd, 1.0e-3);
 }

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -8,25 +8,38 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "CO2FluidPropertiesTest.h"
-#include "Utils.h"
+#include "SinglePhaseFluidPropertiesPTUtils.h"
 
 /**
- * Verify that critical properties are correctly returned
+ * Test that the fluid name is correctly returned
  */
-TEST_F(CO2FluidPropertiesTest, criticalProperties)
+TEST_F(CO2FluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "co2"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(CO2FluidPropertiesTest, molarMass)
 {
-  ABS_TEST("critical pressure", _fp->criticalPressure(), 7.3773e6, 1.0e-12);
-  ABS_TEST("critical temperature", _fp->criticalTemperature(), 304.1282, 1.0e-12);
-  ABS_TEST("critical density", _fp->criticalDensity(), 467.6, 1.0e-12);
+  ABS_TEST(_fp->molarMass(), 44.0098e-3, REL_TOL_SAVED_VALUE);
 }
 
 /**
- * Verify that triple point properties are correctly returned
+ * Test that the critical properties are correctly returned
+ */
+TEST_F(CO2FluidPropertiesTest, criticalProperties)
+{
+  ABS_TEST(_fp->criticalPressure(), 7.3773e6, REL_TOL_SAVED_VALUE);
+  ABS_TEST(_fp->criticalTemperature(), 304.1282, REL_TOL_SAVED_VALUE);
+  ABS_TEST(_fp->criticalDensity(), 467.6, REL_TOL_SAVED_VALUE);
+}
+
+/**
+ * Test that the triple point properties are correctly returned
  */
 TEST_F(CO2FluidPropertiesTest, triplePointProperties)
 {
-  ABS_TEST("triple point pressure", _fp->triplePointPressure(), 0.51795e6, 1.0e-12);
-  ABS_TEST("triple point temperature", _fp->triplePointTemperature(), 216.592, 1.0e-12);
+  ABS_TEST(_fp->triplePointPressure(), 0.51795e6, REL_TOL_SAVED_VALUE);
+  ABS_TEST(_fp->triplePointTemperature(), 216.592, REL_TOL_SAVED_VALUE);
 }
 
 /**
@@ -40,9 +53,11 @@ TEST_F(CO2FluidPropertiesTest, triplePointProperties)
  */
 TEST_F(CO2FluidPropertiesTest, melting)
 {
-  REL_TEST("melting", _fp->meltingPressure(217.03), 2.57e6, 1.0e-2);
-  REL_TEST("melting", _fp->meltingPressure(235.29), 95.86e6, 1.0e-2);
-  REL_TEST("melting", _fp->meltingPressure(266.04), 286.77e6, 1.0e-2);
+  const Real tol = 10.0 * REL_TOL_EXTERNAL_VALUE;
+
+  REL_TEST(_fp->meltingPressure(217.03), 2.57e6, tol);
+  REL_TEST(_fp->meltingPressure(235.29), 95.86e6, tol);
+  REL_TEST(_fp->meltingPressure(266.04), 286.77e6, tol);
 }
 
 /**
@@ -52,7 +67,7 @@ TEST_F(CO2FluidPropertiesTest, melting)
  */
 TEST_F(CO2FluidPropertiesTest, sublimation)
 {
-  REL_TEST("sublimation", _fp->sublimationPressure(194.6857), 0.101325e6, 1.0e-4);
+  REL_TEST(_fp->sublimationPressure(194.6857), 0.101325e6, REL_TOL_EXTERNAL_VALUE);
 }
 
 /**
@@ -66,20 +81,22 @@ TEST_F(CO2FluidPropertiesTest, sublimation)
  */
 TEST_F(CO2FluidPropertiesTest, vapor)
 {
+  const Real tol = 10.0 * REL_TOL_EXTERNAL_VALUE;
+
   // Vapor pressure
-  REL_TEST("vapor", _fp->vaporPressure(217.0), 0.52747e6, 1.0e-2);
-  REL_TEST("vapor", _fp->vaporPressure(245.0), 1.51887e6, 1.0e-2);
-  REL_TEST("vapor", _fp->vaporPressure(303.8), 7.32029e6, 1.0e-2);
+  REL_TEST(_fp->vaporPressure(217.0), 0.52747e6, tol);
+  REL_TEST(_fp->vaporPressure(245.0), 1.51887e6, tol);
+  REL_TEST(_fp->vaporPressure(303.8), 7.32029e6, tol);
 
   // Saturated vapor density
-  REL_TEST("saturated vapor density", _fp->saturatedVaporDensity(217.0), 14.0017, 1.0e-2);
-  REL_TEST("saturated vapor density", _fp->saturatedVaporDensity(245.0), 39.5048, 1.0e-2);
-  REL_TEST("saturated vapor density", _fp->saturatedVaporDensity(303.8), 382.30, 1.0e-2);
+  REL_TEST(_fp->saturatedVaporDensity(217.0), 14.0017, tol);
+  REL_TEST(_fp->saturatedVaporDensity(245.0), 39.5048, tol);
+  REL_TEST(_fp->saturatedVaporDensity(303.8), 382.30, tol);
 
   // Saturated liquid density
-  REL_TEST("saturated liquid density", _fp->saturatedLiquidDensity(217.0), 1177.03, 1.0e-2);
-  REL_TEST("saturated liquid density", _fp->saturatedLiquidDensity(245.0), 1067.89, 1.0e-2);
-  REL_TEST("saturated liquid density", _fp->saturatedLiquidDensity(303.8), 554.14, 1.0e-2);
+  REL_TEST(_fp->saturatedLiquidDensity(217.0), 1177.03, tol);
+  REL_TEST(_fp->saturatedLiquidDensity(245.0), 1067.89, tol);
+  REL_TEST(_fp->saturatedLiquidDensity(303.8), 554.14, tol);
 }
 
 /**
@@ -92,9 +109,11 @@ TEST_F(CO2FluidPropertiesTest, vapor)
  */
 TEST_F(CO2FluidPropertiesTest, partialDensity)
 {
-  REL_TEST("partial density", _fp->partialDensity(373.15), 1182.8, 5.0e-2);
-  REL_TEST("partial density", _fp->partialDensity(473.35), 880.0, 5.0e-2);
-  REL_TEST("partial density", _fp->partialDensity(573.15), 593.8, 5.0e-2);
+  const Real tol = 50.0 * REL_TOL_EXTERNAL_VALUE;
+
+  REL_TEST(_fp->partialDensity(373.15), 1182.8, tol);
+  REL_TEST(_fp->partialDensity(473.35), 880.0, tol);
+  REL_TEST(_fp->partialDensity(573.15), 593.8, tol);
 }
 
 /**
@@ -104,10 +123,12 @@ TEST_F(CO2FluidPropertiesTest, partialDensity)
  */
 TEST_F(CO2FluidPropertiesTest, henry)
 {
-  REL_TEST("henry", _fp->henryConstant(300.0), 173.63e6, 1.0e-3);
-  REL_TEST("henry", _fp->henryConstant(400.0), 579.84e6, 1.0e-3);
-  REL_TEST("henry", _fp->henryConstant(500.0), 520.79e6, 1.0e-3);
-  REL_TEST("henry", _fp->henryConstant(600.0), 259.53e6, 1.0e-3);
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+
+  REL_TEST(_fp->henryConstant(300.0), 173.63e6, tol);
+  REL_TEST(_fp->henryConstant(400.0), 579.84e6, tol);
+  REL_TEST(_fp->henryConstant(500.0), 520.79e6, tol);
+  REL_TEST(_fp->henryConstant(600.0), 259.53e6, tol);
 }
 
 /**
@@ -118,16 +139,15 @@ TEST_F(CO2FluidPropertiesTest, henry)
  */
 TEST_F(CO2FluidPropertiesTest, thermalConductivity)
 {
-  REL_TEST("thermal conductivity", _fp->k_from_rho_T(23.435, 250.0), 13.45e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k_from_rho_T(18.579, 300.0), 17.248e-3, 1.0e-3);
-  REL_TEST("thermal conductivity", _fp->k_from_rho_T(11.899, 450.0), 29.377e-3, 1.0e-3);
-}
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
 
-TEST_F(CO2FluidPropertiesTest, thermalConductivity2)
-{
-  REL_TEST("thermal conductivity", _fp->k(1.0e6, 250.0), 1.34504e-2, 1.0e-6);
-  REL_TEST("thermal conductivity", _fp->k(1.0e6, 300.0), 1.72483e-2, 3.0e-6);
-  REL_TEST("thermal conductivity", _fp->k(1.0e6, 450.0), 2.93767e-2, 1.0e-6);
+  REL_TEST(_fp->k_from_rho_T(23.435, 250.0), 13.45e-3, tol);
+  REL_TEST(_fp->k_from_rho_T(18.579, 300.0), 17.248e-3, tol);
+  REL_TEST(_fp->k_from_rho_T(11.899, 450.0), 29.377e-3, tol);
+
+  REL_TEST(_fp->k(1.0e6, 250.0), 1.34504e-2, tol);
+  REL_TEST(_fp->k(1.0e6, 300.0), 1.72483e-2, tol);
+  REL_TEST(_fp->k(1.0e6, 450.0), 2.93767e-2, tol);
 }
 
 /**
@@ -137,16 +157,15 @@ TEST_F(CO2FluidPropertiesTest, thermalConductivity2)
  */
 TEST_F(CO2FluidPropertiesTest, viscosity)
 {
-  REL_TEST("viscosity", _fp->mu_from_rho_T(20.199, 280.0), 14.15e-6, 1.0e-3);
-  REL_TEST("viscosity", _fp->mu_from_rho_T(15.105, 360.0), 17.94e-6, 1.0e-3);
-  REL_TEST("viscosity", _fp->mu_from_rho_T(10.664, 500.0), 24.06e-6, 1.0e-3);
-}
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
 
-TEST_F(CO2FluidPropertiesTest, viscosity2)
-{
-  REL_TEST("viscosity", _fp->mu(1.0e6, 280.0), 1.41505e-05, 3.0e-6);
-  REL_TEST("viscosity", _fp->mu(1.0e6, 360.0), 1.79395e-05, 2.0e-6);
-  REL_TEST("viscosity", _fp->mu(1.0e6, 500.0), 2.40643e-05, 1.0e-6);
+  REL_TEST(_fp->mu_from_rho_T(20.199, 280.0), 14.15e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(15.105, 360.0), 17.94e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(10.664, 500.0), 24.06e-6, tol);
+
+  REL_TEST(_fp->mu(1.0e6, 280.0), 1.41505e-05, tol);
+  REL_TEST(_fp->mu(1.0e6, 360.0), 1.79395e-05, tol);
+  REL_TEST(_fp->mu(1.0e6, 500.0), 2.40643e-05, tol);
 }
 
 /**
@@ -161,33 +180,36 @@ TEST_F(CO2FluidPropertiesTest, propertiesSW)
   // Pressure = 1 MPa, temperature = 280 K
   Real p = 1.0e6;
   Real T = 280.0;
-  REL_TEST("density", _fp->rho(p, T), 20.199, 1.0e-3);
-  REL_TEST("enthalpy", _fp->h(p, T), -26.385e3, 1.0e-3);
-  REL_TEST("internal energy", _fp->e(p, T), -75.892e3, 1.0e-3);
-  REL_TEST("entropy", _fp->s(p, T), -0.51326e3, 1.0e-3);
-  REL_TEST("cp", _fp->cp(p, T), 0.92518e3, 1.0e-3);
-  REL_TEST("cv", _fp->cv(p, T), 0.67092e3, 1.0e-3);
-  REL_TEST("c", _fp->c(p, T), 252.33, 1.0e-3);
+
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+
+  REL_TEST(_fp->rho(p, T), 20.199, tol);
+  REL_TEST(_fp->h(p, T), -26.385e3, tol);
+  REL_TEST(_fp->e(p, T), -75.892e3, tol);
+  REL_TEST(_fp->s(p, T), -0.51326e3, tol);
+  REL_TEST(_fp->cp(p, T), 0.92518e3, tol);
+  REL_TEST(_fp->cv(p, T), 0.67092e3, tol);
+  REL_TEST(_fp->c(p, T), 252.33, tol);
 
   // Pressure = 1 MPa, temperature = 500 K
   T = 500.0;
-  REL_TEST("density", _fp->rho(p, T), 10.664, 1.0e-3);
-  REL_TEST("enthalpy", _fp->h(p, T), 185.60e3, 1.0e-3);
-  REL_TEST("internal energy", _fp->e(p, T), 91.829e3, 1.0e-3);
-  REL_TEST("entropy", _fp->s(p, T), 0.04225e3, 1.0e-3);
-  REL_TEST("cp", _fp->cp(p, T), 1.0273e3, 1.0e-3);
-  REL_TEST("cv", _fp->cv(p, T), 0.82823e3, 1.0e-3);
-  REL_TEST("c", _fp->c(p, T), 339.81, 1.0e-3);
+  REL_TEST(_fp->rho(p, T), 10.664, tol);
+  REL_TEST(_fp->h(p, T), 185.60e3, tol);
+  REL_TEST(_fp->e(p, T), 91.829e3, tol);
+  REL_TEST(_fp->s(p, T), 0.04225e3, tol);
+  REL_TEST(_fp->cp(p, T), 1.0273e3, tol);
+  REL_TEST(_fp->cv(p, T), 0.82823e3, tol);
+  REL_TEST(_fp->c(p, T), 339.81, tol);
 
   // Pressure = 10 MPa, temperature = 500 K
   p = 10.0e6;
-  REL_TEST("density", _fp->rho(p, T), 113.07, 1.0e-3);
-  REL_TEST("enthalpy", _fp->h(p, T), 157.01e3, 1.0e-3);
-  REL_TEST("internal energy", _fp->e(p, T), 68.569e3, 1.0e-3);
-  REL_TEST("entropy", _fp->s(p, T), -0.4383e3, 1.0e-3);
-  REL_TEST("cp", _fp->cp(p, T), 1.1624e3, 1.0e-3);
-  REL_TEST("cv", _fp->cv(p, T), 0.85516e3, 1.0e-3);
-  REL_TEST("c", _fp->c(p, T), 337.45, 1.0e-3);
+  REL_TEST(_fp->rho(p, T), 113.07, tol);
+  REL_TEST(_fp->h(p, T), 157.01e3, tol);
+  REL_TEST(_fp->e(p, T), 68.569e3, tol);
+  REL_TEST(_fp->s(p, T), -0.4383e3, tol);
+  REL_TEST(_fp->cp(p, T), 1.1624e3, tol);
+  REL_TEST(_fp->cv(p, T), 0.85516e3, tol);
+  REL_TEST(_fp->c(p, T), 337.45, tol);
 }
 
 /**
@@ -196,47 +218,20 @@ TEST_F(CO2FluidPropertiesTest, propertiesSW)
  */
 TEST_F(CO2FluidPropertiesTest, derivatives)
 {
-  Real p = 1.0e6;
+  const Real tol = REL_TOL_DERIVATIVE;
+
+  const Real p = 1.0e6;
   Real T = 350.0;
 
-  // Finite differencing parameters
-  Real dp = 1.0e1;
-  Real dT = 1.0e-4;
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->mu, _fp->mu_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
 
-  // density
-  Real drho_dp_fd = (_fp->rho(p + dp, T) - _fp->rho(p - dp, T)) / (2.0 * dp);
-  Real drho_dT_fd = (_fp->rho(p, T + dT) - _fp->rho(p, T - dT)) / (2.0 * dT);
-  Real rho = 0.0, drho_dp = 0.0, drho_dT = 0.0;
-  _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
-
-  ABS_TEST("rho", rho, _fp->rho(p, T), 1.0e-15);
-  REL_TEST("drho_dp", drho_dp, drho_dp_fd, 1.0e-6);
-  REL_TEST("drho_dT", drho_dT, drho_dT_fd, 1.0e-6);
-
-  // enthalpy
-  Real dh_dp_fd = (_fp->h(p + dp, T) - _fp->h(p - dp, T)) / (2.0 * dp);
-  Real dh_dT_fd = (_fp->h(p, T + dT) - _fp->h(p, T - dT)) / (2.0 * dT);
-  Real h = 0.0, dh_dp = 0.0, dh_dT = 0.0;
-  _fp->h_dpT(p, T, h, dh_dp, dh_dT);
-
-  ABS_TEST("h", h, _fp->h(p, T), 1.0e-15);
-  REL_TEST("dh_dp", dh_dp, dh_dp_fd, 1.0e-6);
-  REL_TEST("dh_dT", dh_dT, dh_dT_fd, 1.0e-6);
-
-  // internal energy
-  Real de_dp_fd = (_fp->e(p + dp, T) - _fp->e(p - dp, T)) / (2.0 * dp);
-  Real de_dT_fd = (_fp->e(p, T + dT) - _fp->e(p, T - dT)) / (2.0 * dT);
-  Real e = 0.0, de_dp = 0.0, de_dT = 0.0;
-  _fp->e_dpT(p, T, e, de_dp, de_dT);
-
-  ABS_TEST("e", e, _fp->e(p, T), 1.0e-15);
-  REL_TEST("de_dp", de_dp, de_dp_fd, 1.0e-6);
-  REL_TEST("de_dT", de_dT, de_dT_fd, 1.0e-6);
-
-  // Viscosity
-  rho = 15.105;
+  // Viscosity from density and temperature
   T = 360.0;
-  Real drho = 1.0e-4;
+  const Real drho = 1.0e-4;
+  Real rho, drho_dp, drho_dT;
   _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
 
   Real dmu_drho_fd =
@@ -244,38 +239,51 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
-  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  REL_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-6);
+  ABS_TEST(mu, _fp->mu_from_rho_T(rho, T), REL_TOL_CONSISTENCY);
+  REL_TEST(dmu_drho, dmu_drho_fd, tol);
 
   // To properly test derivative wrt temperature, use p and T and calculate density,
   // so that the change in density wrt temperature is included
-  p = 1.0e6;
+  const Real dp = 1.0e1;
+  const Real dT = 1.0e-4;
   _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
+
   Real dmu_dT_fd = (_fp->mu_from_rho_T(_fp->rho(p, T + dT), T + dT) -
                     _fp->mu_from_rho_T(_fp->rho(p, T - dT), T - dT)) /
                    (2.0 * dT);
 
-  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+  REL_TEST(dmu_dT, dmu_dT_fd, tol);
 
   Real dmu_dp_fd = (_fp->mu(p + dp, T) - _fp->mu(p - dp, T)) / (2.0 * dp);
   Real dmu_dp = 0.0;
   _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
 
-  ABS_TEST("mu", mu, _fp->mu(p, T), 1.0e-15);
-  REL_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-6);
+  ABS_TEST(mu, _fp->mu(p, T), REL_TOL_CONSISTENCY);
+  REL_TEST(dmu_dp, dmu_dp_fd, tol);
 
   _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
   dmu_dT_fd = (_fp->mu(p, T + dT) - _fp->mu(p, T - dT)) / (2.0 * dT);
 
-  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+  REL_TEST(dmu_dT, dmu_dT_fd, tol);
 
   // Henry's constant
-  T = 300.0;
 
   Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
   Real Kh = 0.0, dKh_dT = 0.0;
   _fp->henryConstant_dT(T, Kh, dKh_dT);
-  REL_TEST("henry", Kh, _fp->henryConstant(T), 1.0e-6);
-  REL_TEST("dhenry_dT", dKh_dT_fd, dKh_dT, 1.0e-6);
+  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_CONSISTENCY);
+  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Verify that the methods that return multiple properties in one call return identical
+ * values as the individual methods
+ */
+TEST_F(CO2FluidPropertiesTest, combined)
+{
+  const Real p = 1.0e6;
+  const Real T = 300.0;
+
+  combinedProperties(_fp, p, T, REL_TOL_SAVED_VALUE);
 }

--- a/unit/src/PorousFlowBrineCO2Test.C
+++ b/unit/src/PorousFlowBrineCO2Test.C
@@ -41,8 +41,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumConstants)
   _fp->equilibriumConstantH2O(T, K0H2O, dK0H2O_dT);
   _fp->equilibriumConstantCO2(T, K0CO2, dK0CO2_dT);
 
-  ABS_TEST("K0H2O", K0H2O, 0.412597711705, 1.0e-10);
-  ABS_TEST("K0CO2", K0CO2, 74.0435888596, 1.0e-10);
+  ABS_TEST(K0H2O, 0.412597711705, 1.0e-10);
+  ABS_TEST(K0CO2, 74.0435888596, 1.0e-10);
 
   Real K0H2O_2, dK0H2O_2_dT, K0CO2_2, dK0CO2_2_dT;
   _fp->equilibriumConstantH2O(T + dT, K0H2O_2, dK0H2O_2_dT);
@@ -50,8 +50,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumConstants)
 
   Real dK0H2O_dT_fd = (K0H2O_2 - K0H2O) / dT;
   Real dK0CO2_dT_fd = (K0CO2_2 - K0CO2) / dT;
-  REL_TEST("dK0H2O_dT", dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
-  REL_TEST("dK0CO2_dT", dK0CO2_dT, dK0CO2_dT_fd, 1.0e-6);
+  REL_TEST(dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
+  REL_TEST(dK0CO2_dT, dK0CO2_dT_fd, 1.0e-6);
 
   // Test the high temperature formulation
   T = 450.0;
@@ -59,16 +59,16 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumConstants)
   _fp->equilibriumConstantH2O(T, K0H2O, dK0H2O_dT);
   _fp->equilibriumConstantCO2(T, K0CO2, dK0CO2_dT);
 
-  ABS_TEST("K0H2O", K0H2O, 8.75944517916, 1.0e-10);
-  ABS_TEST("K0CO2", K0CO2, 105.013867434, 1.0e-10);
+  ABS_TEST(K0H2O, 8.75944517916, 1.0e-10);
+  ABS_TEST(K0CO2, 105.013867434, 1.0e-10);
 
   _fp->equilibriumConstantH2O(T + dT, K0H2O_2, dK0H2O_2_dT);
   _fp->equilibriumConstantCO2(T + dT, K0CO2_2, dK0CO2_2_dT);
 
   dK0H2O_dT_fd = (K0H2O_2 - K0H2O) / dT;
   dK0CO2_dT_fd = (K0CO2_2 - K0CO2) / dT;
-  REL_TEST("dK0H2O_dT", dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
-  REL_TEST("dK0CO2_dT", dK0CO2_dT, dK0CO2_dT_fd, 1.0e-5);
+  REL_TEST(dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
+  REL_TEST(dK0CO2_dT, dK0CO2_dT_fd, 1.0e-5);
 }
 
 /*
@@ -97,8 +97,8 @@ TEST_F(PorousFlowBrineCO2Test, fugacityCoefficients)
                                    dphiH2O_dp,
                                    dphiH2O_dT);
 
-  ABS_TEST("phiCO2", phiCO2, 0.401938, 1.0e-6);
-  ABS_TEST("phiH2O", phiH2O, 0.0898968, 1.0e-6);
+  ABS_TEST(phiCO2, 0.401938, 1.0e-6);
+  ABS_TEST(phiH2O, 0.0898968, 1.0e-6);
 
   // Test the high temperature formulation
   T = 423.15;
@@ -110,15 +110,15 @@ TEST_F(PorousFlowBrineCO2Test, fugacityCoefficients)
   phiH2O = _fp->fugacityCoefficientH2OHighTemp(p, T, co2_density, xco2, yh2o);
   phiCO2 = _fp->fugacityCoefficientCO2HighTemp(p, T, co2_density, xco2, yh2o);
 
-  ABS_TEST("phiH2O", phiH2O, 0.156304067968, 1.0e-10);
-  ABS_TEST("phiCO2", phiCO2, 0.641936764138, 1.0e-10);
+  ABS_TEST(phiH2O, 0.156304067968, 1.0e-10);
+  ABS_TEST(phiCO2, 0.641936764138, 1.0e-10);
 
   // Test that the same results are returned in fugacityCoefficientsHighTemp()
   Real phiCO2_2, phiH2O_2;
   _fp->fugacityCoefficientsHighTemp(p, T, co2_density, xco2, yh2o, phiCO2_2, phiH2O_2);
 
-  ABS_TEST("phiH2O", phiH2O, phiH2O_2, 1.0e-12);
-  ABS_TEST("phiCO2", phiCO2, phiCO2_2, 1.0e-12);
+  ABS_TEST(phiH2O, phiH2O_2, 1.0e-12);
+  ABS_TEST(phiCO2, phiCO2_2, 1.0e-12);
 }
 
 /*
@@ -133,16 +133,16 @@ TEST_F(PorousFlowBrineCO2Test, activityCoefficients)
   Real gammaH2O = _fp->activityCoefficientH2O(T, xco2);
   Real gammaCO2 = _fp->activityCoefficientCO2(T, xco2);
 
-  ABS_TEST("gammaH2O", gammaH2O, 1.0, 1.0e-10);
-  ABS_TEST("gammaCO2", gammaCO2, 1.0, 1.0e-10);
+  ABS_TEST(gammaH2O, 1.0, 1.0e-10);
+  ABS_TEST(gammaCO2, 1.0, 1.0e-10);
 
   T = 450.0;
 
   gammaH2O = _fp->activityCoefficientH2O(T, xco2);
   gammaCO2 = _fp->activityCoefficientCO2(T, xco2);
 
-  ABS_TEST("gammaH2O", gammaH2O, 1.00022113664, 1.0e-10);
-  ABS_TEST("gammaCO2", gammaCO2, 0.956736800255, 1.0e-10);
+  ABS_TEST(gammaH2O, 1.00022113664, 1.0e-10);
+  ABS_TEST(gammaCO2, 0.956736800255, 1.0e-10);
 }
 
 /*
@@ -161,46 +161,46 @@ TEST_F(PorousFlowBrineCO2Test, activityCoefficientCO2Brine)
   // Low temperature regime
   Real gamma, dgamma_dp, dgamma_dT, dgamma_dX;
   _fp->activityCoefficient(p, T, Xnacl, gamma, dgamma_dp, dgamma_dT, dgamma_dX);
-  ABS_TEST("gamma", gamma, 1.43276649338, 1.0e-8);
+  ABS_TEST(gamma, 1.43276649338, 1.0e-8);
 
   Real gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX;
   _fp->activityCoefficient(p + dp, T, Xnacl, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
 
   Real dgamma_dp_fd = (gamma_2 - gamma) / dp;
-  REL_TEST("dgamma_dp", dgamma_dp, dgamma_dp_fd, 1.0e-6);
+  REL_TEST(dgamma_dp, dgamma_dp_fd, 1.0e-6);
 
   _fp->activityCoefficient(p, T + dT, Xnacl, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
 
   Real dgamma_dT_fd = (gamma_2 - gamma) / dT;
-  REL_TEST("dgamma_dT", dgamma_dT, dgamma_dT_fd, 1.0e-6);
+  REL_TEST(dgamma_dT, dgamma_dT_fd, 1.0e-6);
 
   _fp->activityCoefficient(p, T, Xnacl + dx, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
 
   Real dgamma_dX_fd = (gamma_2 - gamma) / dx;
-  REL_TEST("dgamma_dX", dgamma_dX, dgamma_dX_fd, 1.0e-6);
+  REL_TEST(dgamma_dX, dgamma_dX_fd, 1.0e-6);
 
   // High temperature regime
   T = 523.15;
   _fp->activityCoefficientHighTemp(T, Xnacl, gamma, dgamma_dT, dgamma_dX);
-  ABS_TEST("gamma", gamma, 1.50047006243, 1.0e-8);
+  ABS_TEST(gamma, 1.50047006243, 1.0e-8);
 
   _fp->activityCoefficientHighTemp(T + dT, Xnacl, gamma_2, dgamma_2_dT, dgamma_2_dX);
   dgamma_dT_fd = (gamma_2 - gamma) / dT;
-  REL_TEST("dgamma_dT", dgamma_dT, dgamma_dT_fd, 1.0e-6);
+  REL_TEST(dgamma_dT, dgamma_dT_fd, 1.0e-6);
 
   _fp->activityCoefficientHighTemp(T, Xnacl + dx, gamma_2, dgamma_2_dT, dgamma_2_dX);
   dgamma_dX_fd = (gamma_2 - gamma) / dx;
-  REL_TEST("dgamma_dX", dgamma_dX, dgamma_dX_fd, 1.0e-6);
+  REL_TEST(dgamma_dX, dgamma_dX_fd, 1.0e-6);
 
   // Check that both formulations return gamma = 1 for Xnacl = 0
   Xnacl = 0.0;
   T = 350.0;
   _fp->activityCoefficient(p, T, Xnacl, gamma, dgamma_dp, dgamma_dT, dgamma_dX);
-  ABS_TEST("gamma", gamma, 1.0, 1.0e-12);
+  ABS_TEST(gamma, 1.0, 1.0e-12);
 
   T = 523.15;
   _fp->activityCoefficientHighTemp(T, Xnacl, gamma, dgamma_dT, dgamma_dX);
-  ABS_TEST("gamma", gamma, 1.0, 1.0e-12);
+  ABS_TEST(gamma, 1.0, 1.0e-12);
 }
 
 /*
@@ -213,13 +213,13 @@ TEST_F(PorousFlowBrineCO2Test, partialDensity)
 
   Real partial_density, dpartial_density_dT;
   _fp->partialDensityCO2(T, partial_density, dpartial_density_dT);
-  ABS_TEST("partialDensity", partial_density, 893.332, 1.0e-3);
+  ABS_TEST(partial_density, 893.332, 1.0e-3);
 
   Real partial_density_2, dpartial_density_2_dT;
   _fp->partialDensityCO2(T + dT, partial_density_2, dpartial_density_2_dT);
 
   Real dpartial_density_dT_fd = (partial_density_2 - partial_density) / dT;
-  REL_TEST("dpartial_density_dT", dpartial_density_dT, dpartial_density_dT_fd, 1.0e-6);
+  REL_TEST(dpartial_density_dT, dpartial_density_dT_fd, 1.0e-6);
 }
 
 /*
@@ -240,8 +240,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
   Real X2, dX2_dp, dX2_dT, dX2_dX, Y2, dY2_dp, dY2_dT, dY2_dX;
   _fp->equilibriumMassFractions(p, T, Xnacl, X, dX_dp, dX_dT, dX_dX, Y, dY_dp, dY_dT, dY_dX);
 
-  ABS_TEST("Xco2", X, 0.00355727945939, 1.0e-10);
-  ABS_TEST("Yh2o", Y, 0.0171978439739, 1.0e-10);
+  ABS_TEST(X, 0.00355727945939, 1.0e-10);
+  ABS_TEST(Y, 0.0171978439739, 1.0e-10);
 
   // Derivative wrt pressure
   _fp->equilibriumMassFractions(
@@ -252,8 +252,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
   Real dX_dp_fd = (X2 - X1) / (2.0 * dp);
   Real dY_dp_fd = (Y2 - Y1) / (2.0 * dp);
 
-  REL_TEST("dXco2_dp", dX_dp, dX_dp_fd, 1.0e-6);
-  REL_TEST("dYh2o_dp", dY_dp, dY_dp_fd, 1.0e-6);
+  REL_TEST(dX_dp, dX_dp_fd, 1.0e-6);
+  REL_TEST(dY_dp, dY_dp_fd, 1.0e-6);
 
   // Derivative wrt temperature
   _fp->equilibriumMassFractions(
@@ -264,8 +264,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
   Real dX_dT_fd = (X2 - X1) / (2.0 * dT);
   Real dY_dT_fd = (Y2 - Y1) / (2.0 * dT);
 
-  REL_TEST("dXco2_dT", dX_dT, dX_dT_fd, 1.0e-5);
-  REL_TEST("dYh2o_dT", dY_dT, dY_dT_fd, 1.0e-5);
+  REL_TEST(dX_dT, dX_dT_fd, 1.0e-5);
+  REL_TEST(dY_dT, dY_dT_fd, 1.0e-5);
 
   // Derivative wrt salt mass fraction
   _fp->equilibriumMassFractions(
@@ -276,8 +276,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
   Real dX_dX_fd = (X2 - X1) / (2.0 * dx);
   Real dY_dX_fd = (Y2 - Y1) / (2.0 * dx);
 
-  REL_TEST("dXco2_dX", dX_dX, dX_dX_fd, 1.0e-6);
-  REL_TEST("dYh2o_dX", dY_dX, dY_dX_fd, 1.0e-6);
+  REL_TEST(dX_dX, dX_dX_fd, 1.0e-6);
+  REL_TEST(dY_dX, dY_dX_fd, 1.0e-6);
 
   // High temperature regime
   p = 10.0e6;
@@ -288,8 +288,8 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
 
   _fp->equilibriumMassFractions(p, T, Xnacl, X, dX_dp, dX_dT, dX_dX, Y, dY_dp, dY_dT, dY_dX);
 
-  ABS_TEST("Xco2", X, 0.0162994976121, 1.0e-10);
-  ABS_TEST("Yh2o", Y, 0.24947151051, 1.0e-10);
+  ABS_TEST(X, 0.0162994976121, 1.0e-10);
+  ABS_TEST(Y, 0.24947151051, 1.0e-10);
 }
 
 /*
@@ -318,11 +318,11 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Real Xh2o = fsp[0].mass_fraction[0];
   Real Yh2o = fsp[1].mass_fraction[0];
   Real Xnacl2 = fsp[0].mass_fraction[2];
-  ABS_TEST("Xco2", Xco2, Z, 1.0e-8);
-  ABS_TEST("Yco2", Yco2, 0.0, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, 0.0, 1.0e-8);
-  ABS_TEST("Xnacl", Xnacl2, Xnacl, 1.0e-8);
+  ABS_TEST(Xco2, Z, 1.0e-8);
+  ABS_TEST(Yco2, 0.0, 1.0e-8);
+  ABS_TEST(Xh2o, 1.0 - Z, 1.0e-8);
+  ABS_TEST(Yh2o, 0.0, 1.0e-8);
+  ABS_TEST(Xnacl2, Xnacl, 1.0e-8);
 
   // Verify derivatives
   Real dXco2_dp = fsp[0].dmass_fraction_dp[1];
@@ -335,15 +335,15 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Real dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
   Real dXnacl_dX = fsp[0].dmass_fraction_dX[2];
 
-  ABS_TEST("dXco2_dp", dXco2_dp, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dT", dXco2_dT, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dX", dXco2_dX, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dZ", dXco2_dZ, 1.0, 1.0e-8);
-  ABS_TEST("dYco2_dp", dYco2_dp, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dT", dYco2_dT, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dX", dYco2_dX, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dZ", dYco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST("dXnacl_dX", dXnacl_dX, 1.0, 1.0e-8);
+  ABS_TEST(dXco2_dp, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dT, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dZ, 1.0, 1.0e-8);
+  ABS_TEST(dYco2_dp, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dT, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dXnacl_dX, 1.0, 1.0e-8);
 
   // Gas region
   Z = 0.995;
@@ -356,11 +356,11 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
   Real Ynacl = fsp[1].mass_fraction[2];
-  ABS_TEST("Xco2", Xco2, 0.0, 1.0e-8);
-  ABS_TEST("Yco2", Yco2, Z, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 0.0, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST("Ynacl", Ynacl, 0.0, 1.0e-8);
+  ABS_TEST(Xco2, 0.0, 1.0e-8);
+  ABS_TEST(Yco2, Z, 1.0e-8);
+  ABS_TEST(Xh2o, 0.0, 1.0e-8);
+  ABS_TEST(Yh2o, 1.0 - Z, 1.0e-8);
+  ABS_TEST(Ynacl, 0.0, 1.0e-8);
 
   // Verify derivatives
   dXco2_dp = fsp[0].dmass_fraction_dp[1];
@@ -372,15 +372,15 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   dYco2_dX = fsp[1].dmass_fraction_dX[1];
   dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
   Real dYnacl_dX = fsp[1].dmass_fraction_dX[2];
-  ABS_TEST("dXco2_dp", dXco2_dp, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dT", dXco2_dT, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dX", dXco2_dX, 0.0, 1.0e-8);
-  ABS_TEST("dXco2_dZ", dXco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dp", dYco2_dp, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dT", dYco2_dT, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dX", dYco2_dX, 0.0, 1.0e-8);
-  ABS_TEST("dYnacl_dZ", dYnacl_dX, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dX", dYco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dp, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dT, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dp, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dT, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(dYnacl_dX, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
 
   // Two phase region. In this region, the mass fractions and derivatives can
   // be verified using the equilibrium mass fraction derivatives that have
@@ -409,10 +409,10 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Yco2 = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST("Xco2", Xco2, Xco2_eq, 1.0e-8);
-  ABS_TEST("Yco2", Yco2, 1.0 - Yh2o_eq, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 1.0 - Xco2_eq, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, Yh2o_eq, 1.0e-8);
+  ABS_TEST(Xco2, Xco2_eq, 1.0e-8);
+  ABS_TEST(Yco2, 1.0 - Yh2o_eq, 1.0e-8);
+  ABS_TEST(Xh2o, 1.0 - Xco2_eq, 1.0e-8);
+  ABS_TEST(Yh2o, Yh2o_eq, 1.0e-8);
 
   // Verify derivatives wrt p, T
   dXco2_dp = fsp[0].dmass_fraction_dp[1];
@@ -424,14 +424,14 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   dYco2_dX = fsp[1].dmass_fraction_dX[1];
   dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
 
-  ABS_TEST("dXco2_dp", dXco2_dp, dXco2_dp_eq, 1.0e-8);
-  ABS_TEST("dXco2_dT", dXco2_dT, dXco2_dT_eq, 1.0e-8);
-  ABS_TEST("dXco2_dX", dXco2_dX, dXco2_dX_eq, 1.0e-8);
-  ABS_TEST("dXco2_dZ", dXco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST("dYco2_dp", dYco2_dp, -dYh2o_dp_eq, 1.0e-8);
-  ABS_TEST("dYco2_dT", dYco2_dT, -dYh2o_dT_eq, 1.0e-8);
-  ABS_TEST("dYco2_dX", dYco2_dX, -dYh2o_dX_eq, 1.0e-8);
-  ABS_TEST("dYco2_dZ", dYco2_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dXco2_dp, dXco2_dp_eq, 1.0e-8);
+  ABS_TEST(dXco2_dT, dXco2_dT_eq, 1.0e-8);
+  ABS_TEST(dXco2_dX, dXco2_dX_eq, 1.0e-8);
+  ABS_TEST(dXco2_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dYco2_dp, -dYh2o_dp_eq, 1.0e-8);
+  ABS_TEST(dYco2_dT, -dYh2o_dT_eq, 1.0e-8);
+  ABS_TEST(dYco2_dX, -dYh2o_dX_eq, 1.0e-8);
+  ABS_TEST(dYco2_dZ, 0.0, 1.0e-8);
 
   // Use finite differences to verify derivative wrt Z is unaffected by Z
   const Real dZ = 1.0e-8;
@@ -442,8 +442,8 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Real Xco22 = fsp[0].mass_fraction[1];
   Real Yco22 = fsp[1].mass_fraction[1];
 
-  ABS_TEST("dXco2_dZ", dXco2_dZ, (Xco21 - Xco22) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST("dXYco2_dZ", dYco2_dZ, (Yco21 - Yco22) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dXco2_dZ, (Xco21 - Xco22) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dYco2_dZ, (Yco21 - Yco22) / (2.0 * dZ), 1.0e-8);
 }
 
 /*
@@ -477,9 +477,9 @@ TEST_F(PorousFlowBrineCO2Test, gasProperties)
   Real viscosity = _co2_fp->mu(p, T);
   Real enthalpy = _co2_fp->h(p, T);
 
-  ABS_TEST("gas density", gas_density, density, 1.0e-8);
-  ABS_TEST("gas viscosity", gas_viscosity, viscosity, 1.0e-8);
-  ABS_TEST("gas enthalpy", gas_enthalpy, enthalpy, 1.0e-8);
+  ABS_TEST(gas_density, density, 1.0e-8);
+  ABS_TEST(gas_viscosity, viscosity, 1.0e-8);
+  ABS_TEST(gas_enthalpy, enthalpy, 1.0e-8);
 
   // Verify derivatives
   Real ddensity_dp = fsp[1].ddensity_dp;
@@ -503,9 +503,9 @@ TEST_F(PorousFlowBrineCO2Test, gasProperties)
   Real mu2 = fsp[1].viscosity;
   Real h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   const Real dT = 1.0e-3;
   _fp->gasProperties(p, T + dT, fsp);
@@ -518,9 +518,9 @@ TEST_F(PorousFlowBrineCO2Test, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Note: mass fraction changes with Z
   const Real dZ = 1.0e-8;
@@ -536,9 +536,9 @@ TEST_F(PorousFlowBrineCO2Test, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  ABS_TEST("ddensity_dZ", ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST("dviscosity_dZ", dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -581,9 +581,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   Real co2_enthalpy = _co2_fp->h(p, T);
   Real enthalpy = (1.0 - Z) * brine_enthalpy + Z * (co2_enthalpy + hdis);
 
-  ABS_TEST("liquid density", liquid_density, density, 1.0e-12);
-  ABS_TEST("liquid viscosity", liquid_viscosity, viscosity, 1.0e-12);
-  ABS_TEST("liquid enthalpy", liquid_enthalpy, enthalpy, 1.0e-12);
+  ABS_TEST(liquid_density, density, 1.0e-12);
+  ABS_TEST(liquid_viscosity, viscosity, 1.0e-12);
+  ABS_TEST(liquid_enthalpy, enthalpy, 1.0e-12);
 
   // Verify fluid density and viscosity derivatives
   Real ddensity_dp = fsp[0].ddensity_dp;
@@ -611,9 +611,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   Real mu2 = fsp[0].viscosity;
   Real h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
 
   // Derivatives wrt temperature
   const Real dT = 1.0e-4;
@@ -627,9 +627,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Derivatives wrt Xnacl
   const Real dx = 1.0e-8;
@@ -643,9 +643,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dX", ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
-  REL_TEST("dviscosity_dX", dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
-  REL_TEST("denthalpy_dX", denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
 
   // Derivatives wrt Z
   const Real dZ = 1.0e-8;
@@ -661,9 +661,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dZ", ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST("dviscosity_dZ", dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 
   // Two-phase region
   Z = 0.045;
@@ -699,9 +699,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
 
   // Derivatives wrt temperature
   _fp->massFractions(p, T + dT, Xnacl, Z, phase_state, fsp);
@@ -716,9 +716,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Derivatives wrt Xnacl
   _fp->massFractions(p, T, Xnacl + dx, Z, phase_state, fsp);
@@ -733,9 +733,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dX", ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
-  REL_TEST("dviscosity_dX", dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
-  REL_TEST("denthalpy_dX", denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
 
   // Derivatives wrt Z
   _fp->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
@@ -750,9 +750,9 @@ TEST_F(PorousFlowBrineCO2Test, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  ABS_TEST("ddensity_dZ", ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST("dviscosity_dZ", dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -791,7 +791,7 @@ TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
   // Calculate the gas saturation and derivatives
   _fp->saturationTwoPhase(p, T, Xnacl, Z, fsp);
 
-  ABS_TEST("gas saturation", fsp[1].saturation, gas_saturation, 1.0e-8);
+  ABS_TEST(fsp[1].saturation, gas_saturation, 1.0e-8);
 
   // Test the derivatives
   const Real dp = 1.0e-1;
@@ -812,7 +812,7 @@ TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
   _fp->saturationTwoPhase(p - dp, T, Xnacl, Z, fsp);
   Real gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dp", dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
 
   // Derivative wrt temperature
   const Real dT = 1.0e-4;
@@ -826,7 +826,7 @@ TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
   _fp->saturationTwoPhase(p, T - dT, Xnacl, Z, fsp);
   gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dT", dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
 
   // Derivative wrt Xnacl
   const Real dx = 1.0e-8;
@@ -840,7 +840,7 @@ TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
   _fp->saturationTwoPhase(p, T, Xnacl - dx, Z, fsp);
   gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dX", dgas_saturation_dX, (gsat1 - gsat2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(dgas_saturation_dX, (gsat1 - gsat2) / (2.0 * dx), 1.0e-6);
 
   // Derivative wrt Z
   const Real dZ = 1.0e-8;
@@ -853,7 +853,7 @@ TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
   _fp->saturationTwoPhase(p, T, Xnacl, Z - dZ, fsp);
   gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dZ", dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -881,7 +881,7 @@ TEST_F(PorousFlowBrineCO2Test, totalMassFraction)
   Real liquid_pressure = p + _pc->capillaryPressure(1.0 - s);
   _fp->liquidProperties(liquid_pressure, T, Xnacl, fsp);
   _fp->saturationTwoPhase(p, T, Xnacl, Z, fsp);
-  ABS_TEST("gas saturation", fsp[1].saturation, s, 1.0e-8);
+  ABS_TEST(fsp[1].saturation, s, 1.0e-8);
 }
 
 /*
@@ -897,13 +897,13 @@ TEST_F(PorousFlowBrineCO2Test, henryConstant)
 
   Real Kh, dKh_dT, dKh_dX;
   _fp->henryConstant(T, Xnacl, Kh, dKh_dT, dKh_dX);
-  REL_TEST("Henry constant", Kh, 7.46559e+08, 1.0e-3);
+  REL_TEST(Kh, 7.46559e+08, 1.0e-3);
 
   T = 473.15;
   Xnacl = 0.2;
 
   _fp->henryConstant(T, Xnacl, Kh, dKh_dT, dKh_dX);
-  REL_TEST("Henry constant", Kh, 1.66069e+09, 1.0e-3);
+  REL_TEST(Kh, 1.66069e+09, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
@@ -911,14 +911,14 @@ TEST_F(PorousFlowBrineCO2Test, henryConstant)
   _fp->henryConstant(T + dT, Xnacl, Kh, dKh_dT, dKh_dX);
   _fp->henryConstant(T - dT, Xnacl, Kh2, dKh2_dT, dKh2_dX);
 
-  REL_TEST("dKh_dT", dKh_dT, (Kh - Kh2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(dKh_dT, (Kh - Kh2) / (2.0 * dT), 1.0e-5);
 
   // Test the derivative wrt Xnacl
   const Real dx = 1.0e-8;
   _fp->henryConstant(T, Xnacl + dx, Kh, dKh_dT, dKh_dX);
   _fp->henryConstant(T, Xnacl - dx, Kh2, dKh2_dT, dKh2_dX);
 
-  REL_TEST("dKh_dX", dKh_dX, (Kh - Kh2) / (2.0 * dx), 1.0e-5);
+  REL_TEST(dKh_dX, (Kh - Kh2) / (2.0 * dx), 1.0e-5);
 }
 
 /*
@@ -935,14 +935,14 @@ TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolutionGas)
   // Enthalpy of dissolution of CO2 in brine
   Real hdis, dhdis_dT, dhdis_dX;
   _fp->enthalpyOfDissolutionGas(T, Xnacl, hdis, dhdis_dT, dhdis_dX);
-  REL_TEST("hdis", hdis, -3.20130e5, 1.0e-3);
+  REL_TEST(hdis, -3.20130e5, 1.0e-3);
 
   // T = 350C
   T = 623.15;
 
   // Enthalpy of dissolution of CO2 in brine
   _fp->enthalpyOfDissolutionGas(T, Xnacl, hdis, dhdis_dT, dhdis_dX);
-  REL_TEST("hdis", hdis, 9.83813e+05, 1.0e-3);
+  REL_TEST(hdis, 9.83813e+05, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
@@ -950,14 +950,14 @@ TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolutionGas)
   _fp->enthalpyOfDissolutionGas(T + dT, Xnacl, hdis1, dhdis1_dT, dhdis1_dX);
   _fp->enthalpyOfDissolutionGas(T - dT, Xnacl, hdis2, dhdis2_dT, dhdis2_dX);
 
-  REL_TEST("dhdis_dT", dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
 
   // Test the derivative wrt salt mass fraction
   const Real dx = 1.0e-8;
   _fp->enthalpyOfDissolutionGas(T, Xnacl + dx, hdis1, dhdis1_dT, dhdis1_dX);
   _fp->enthalpyOfDissolutionGas(T, Xnacl - dx, hdis2, dhdis2_dT, dhdis2_dX);
 
-  REL_TEST("dhdis_dX", dhdis_dX, (hdis1 - hdis2) / (2.0 * dx), 1.0e-5);
+  REL_TEST(dhdis_dX, (hdis1 - hdis2) / (2.0 * dx), 1.0e-5);
 }
 
 /*
@@ -974,14 +974,14 @@ TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolution)
   // Enthalpy of dissolution of CO2 in water
   Real hdis, dhdis_dT;
   _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST("hdis", hdis, -3.38185e5, 1.0e-3);
+  REL_TEST(hdis, -3.38185e5, 1.0e-3);
 
   // T = 350C
   T = 623.15;
 
   // Enthalpy of dissolution of CO2 in water
   _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST("hdis", hdis, 5.78787e5, 1.0e-3);
+  REL_TEST(hdis, 5.78787e5, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
@@ -989,7 +989,7 @@ TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolution)
   _fp->enthalpyOfDissolution(T + dT, hdis1, dhdis1_dT);
   _fp->enthalpyOfDissolution(T - dT, hdis2, dhdis2_dT);
 
-  REL_TEST("dhdis_dT", dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
 }
 
 /**
@@ -1005,8 +1005,8 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
   Real yh2o, xco2;
   Real co2_density = _co2_fp->rho(p, T);
   _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
-  ABS_TEST("yh2o", yh2o, 0.161429471353, 1.0e-10);
-  ABS_TEST("xco2", xco2, 0.0236967010229, 1.0e-10);
+  ABS_TEST(yh2o, 0.161429471353, 1.0e-10);
+  ABS_TEST(xco2, 0.0236967010229, 1.0e-10);
 
   // Mass fraction equivalent to molality of 2
   p = 30.0e6;
@@ -1014,8 +1014,8 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
   Xnacl = 0.105;
 
   _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
-  ABS_TEST("yh2o", yh2o, 0.0468195468869, 1.0e-10);
-  ABS_TEST("xco2", xco2, 0.023664581533, 1.0e-10);
+  ABS_TEST(yh2o, 0.0468195468869, 1.0e-10);
+  ABS_TEST(xco2, 0.023664581533, 1.0e-10);
 
   // Mass fraction equivalent to molality of 4
   T = 523.15;
@@ -1023,8 +1023,8 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
 
   co2_density = _co2_fp->rho(p, T);
   _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
-  ABS_TEST("yh2o", yh2o, 0.253292227782, 1.0e-10);
-  ABS_TEST("xco2", xco2, 0.016834474171, 1.0e-10);
+  ABS_TEST(yh2o, 0.253292227782, 1.0e-10);
+  ABS_TEST(xco2, 0.016834474171, 1.0e-10);
 }
 
 /**
@@ -1040,31 +1040,31 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMoleFractions)
 
   Real x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX;
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.00696382327418, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0236534984353, 1.0e-8);
+  ABS_TEST(y, 0.00696382327418, 1.0e-8);
+  ABS_TEST(x, 0.0236534984353, 1.0e-8);
 
   // Intermediate temperature regime
   T = 373.15;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.0194363435584, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0201949380648, 1.0e-8);
+  ABS_TEST(y, 0.0194363435584, 1.0e-8);
+  ABS_TEST(x, 0.0201949380648, 1.0e-8);
 
   // High temperature regime
   p = 30.0e6;
   T = 523.15;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.286116587269, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0409622847096, 1.0e-8);
+  ABS_TEST(y, 0.286116587269, 1.0e-8);
+  ABS_TEST(x, 0.0409622847096, 1.0e-8);
 
   // High temperature regime with low pressure
   p = 1.0e6;
   T = 523.15;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 1.0, 1.0e-10);
-  ABS_TEST("xco2", x, 0.0, 1.0e-10);
+  ABS_TEST(y, 1.0, 1.0e-10);
+  ABS_TEST(x, 0.0, 1.0e-10);
 
   // Test brine (Xnacl = 0.1)
   // Low temperature regime
@@ -1073,21 +1073,21 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMoleFractions)
   Xnacl = 0.1;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.00657324509341, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0152851189462, 1.0e-8);
+  ABS_TEST(y, 0.00657324509341, 1.0e-8);
+  ABS_TEST(x, 0.0152851189462, 1.0e-8);
 
   // Intermediate temperature regime
   T = 373.15;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.0183104919388, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0132647919449, 1.0e-8);
+  ABS_TEST(y, 0.0183104919388, 1.0e-8);
+  ABS_TEST(x, 0.0132647919449, 1.0e-8);
 
   // High temperature regime
   p = 30.0e6;
   T = 523.15;
 
   _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST("yh2o", y, 0.270258370983, 1.0e-8);
-  ABS_TEST("xco2", x, 0.0246589523314, 1.0e-8);
+  ABS_TEST(y, 0.270258370983, 1.0e-8);
+  ABS_TEST(x, 0.0246589523314, 1.0e-8);
 }

--- a/unit/src/PorousFlowFluidStateFlashTest.C
+++ b/unit/src/PorousFlowFluidStateFlashTest.C
@@ -19,13 +19,13 @@ TEST_F(PorousFlowFluidStateFlashTest, rachfordRice)
   Real vmf = 0.2316623869599;
   std::vector<Real> zi = {0.6};
   std::vector<Real> Ki = {1.338, 0.576};
-  ABS_TEST("rachfordRice", _fp->rachfordRice(vmf, zi, Ki), 0.0, 1.0e-8);
+  ABS_TEST(_fp->rachfordRice(vmf, zi, Ki), 0.0, 1.0e-8);
 
   // Four fluid components
   vmf = 0.20329862165314910428;
   zi = {0.6, 0.01, 0.01};
   Ki = {1.338, 0.613, 0.222, 0.576};
-  ABS_TEST("rachfordRice", _fp->rachfordRice(vmf, zi, Ki), 0.0, 1.0e-8);
+  ABS_TEST(_fp->rachfordRice(vmf, zi, Ki), 0.0, 1.0e-8);
 }
 
 /**
@@ -37,12 +37,12 @@ TEST_F(PorousFlowFluidStateFlashTest, vaporMassFraction)
   // Test calculation using example data
   std::vector<Real> zi = {0.6};
   std::vector<Real> Ki = {1.338, 0.576};
-  ABS_TEST("vaporMassFraction", _fp->vaporMassFraction(zi, Ki), 0.2316623869599, 1.0e-8);
+  ABS_TEST(_fp->vaporMassFraction(zi, Ki), 0.2316623869599, 1.0e-8);
 
   // Four fluid components
   zi = {0.6, 0.01, 0.01};
   Ki = {1.338, 0.613, 0.222, 0.576};
-  ABS_TEST("rachfordRice", _fp->vaporMassFraction(zi, Ki), 0.20329862165314910428, 1.0e-8);
+  ABS_TEST(_fp->vaporMassFraction(zi, Ki), 0.20329862165314910428, 1.0e-8);
 }
 
 /**
@@ -60,7 +60,7 @@ TEST_F(PorousFlowFluidStateFlashTest, rachfordRiceDeriv)
   Real rr2 = _fp->rachfordRice(vmf + dvmf, zi, Ki);
   Real fd = (rr2 - rr1) / (2.0 * dvmf);
 
-  ABS_TEST("rachfordRiceDeriv", _fp->rachfordRiceDeriv(vmf, zi, Ki), fd, 1.0e-8);
+  ABS_TEST(_fp->rachfordRiceDeriv(vmf, zi, Ki), fd, 1.0e-8);
 
   // Four fluid components
   vmf = 0.6;
@@ -71,5 +71,5 @@ TEST_F(PorousFlowFluidStateFlashTest, rachfordRiceDeriv)
   rr2 = _fp->rachfordRice(vmf + dvmf, zi, Ki);
   fd = (rr2 - rr1) / (2.0 * dvmf);
 
-  ABS_TEST("rachfordRiceDeriv", _fp->rachfordRiceDeriv(vmf, zi, Ki), fd, 1.0e-8);
+  ABS_TEST(_fp->rachfordRiceDeriv(vmf, zi, Ki), fd, 1.0e-8);
 }

--- a/unit/src/PorousFlowWaterNCGTest.C
+++ b/unit/src/PorousFlowWaterNCGTest.C
@@ -36,8 +36,8 @@ TEST_F(PorousFlowWaterNCGTest, equilibriumMassFraction)
   Real dXncg_dp_fd = (Xncg2 - Xncg1) / (2.0 * dp);
   Real dYh2o_dp_fd = (Yh2o2 - Yh2o1) / (2.0 * dp);
 
-  REL_TEST("dXncg_dp", dXncg_dp, dXncg_dp_fd, 1.0e-6);
-  REL_TEST("dYh2o_dp", dYh2o_dp, dYh2o_dp_fd, 1.0e-6);
+  REL_TEST(dXncg_dp, dXncg_dp_fd, 1.0e-6);
+  REL_TEST(dYh2o_dp, dYh2o_dp_fd, 1.0e-6);
 
   _fp->equilibriumMassFractions(
       p, T - dT, Xncg1, dXncg1_dp, dXncg1_dT, Yh2o1, dYh2o1_dp, dYh2o1_dT);
@@ -47,8 +47,8 @@ TEST_F(PorousFlowWaterNCGTest, equilibriumMassFraction)
   Real dXncg_dT_fd = (Xncg2 - Xncg1) / (2.0 * dT);
   Real dYh2o_dT_fd = (Yh2o2 - Yh2o1) / (2.0 * dT);
 
-  REL_TEST("dXncg_dT", dXncg_dT, dXncg_dT_fd, 1.0e-6);
-  REL_TEST("dYh2o_dT", dYh2o_dT, dYh2o_dT_fd, 1.0e-6);
+  REL_TEST(dXncg_dT, dXncg_dT_fd, 1.0e-6);
+  REL_TEST(dYh2o_dT, dYh2o_dT_fd, 1.0e-6);
 }
 
 /*
@@ -72,10 +72,10 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Real Yncg = fsp[1].mass_fraction[1];
   Real Xh2o = fsp[0].mass_fraction[0];
   Real Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST("Xncg", Xncg, Z, 1.0e-8);
-  ABS_TEST("Yncg", Yncg, 0.0, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, 0.0, 1.0e-8);
+  ABS_TEST(Xncg, Z, 1.0e-8);
+  ABS_TEST(Yncg, 0.0, 1.0e-8);
+  ABS_TEST(Xh2o, 1.0 - Z, 1.0e-8);
+  ABS_TEST(Yh2o, 0.0, 1.0e-8);
 
   // Verify derivatives
   Real dXncg_dp = fsp[0].dmass_fraction_dp[1];
@@ -84,12 +84,12 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Real dYncg_dp = fsp[1].dmass_fraction_dp[1];
   Real dYncg_dT = fsp[1].dmass_fraction_dT[1];
   Real dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST("dXncg_dp", dXncg_dp, 0.0, 1.0e-8);
-  ABS_TEST("dXncg_dT", dXncg_dT, 0.0, 1.0e-8);
-  ABS_TEST("dXncg_dZ", dXncg_dZ, 1.0, 1.0e-8);
-  ABS_TEST("dYncg_dp", dYncg_dp, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dT", dYncg_dT, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dZ", dYncg_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dp, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dT, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dZ, 1.0, 1.0e-8);
+  ABS_TEST(dYncg_dp, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dT, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dZ, 0.0, 1.0e-8);
 
   // Gas region
   Z = 0.995;
@@ -101,10 +101,10 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Yncg = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST("Xncg", Xncg, 0.0, 1.0e-8);
-  ABS_TEST("Yncg", Yncg, Z, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 0.0, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, 1.0 - Z, 1.0e-8);
+  ABS_TEST(Xncg, 0.0, 1.0e-8);
+  ABS_TEST(Yncg, Z, 1.0e-8);
+  ABS_TEST(Xh2o, 0.0, 1.0e-8);
+  ABS_TEST(Yh2o, 1.0 - Z, 1.0e-8);
 
   // Verify derivatives
   dXncg_dp = fsp[0].dmass_fraction_dp[1];
@@ -113,12 +113,12 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   dYncg_dp = fsp[1].dmass_fraction_dp[1];
   dYncg_dT = fsp[1].dmass_fraction_dT[1];
   dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST("dXncg_dp", dXncg_dp, 0.0, 1.0e-8);
-  ABS_TEST("dXncg_dT", dXncg_dT, 0.0, 1.0e-8);
-  ABS_TEST("dXncg_dZ", dXncg_dZ, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dp", dYncg_dp, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dT", dYncg_dT, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dZ", dYncg_dZ, 1.0, 1.0e-8);
+  ABS_TEST(dXncg_dp, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dT, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dp, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dT, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dZ, 1.0, 1.0e-8);
 
   // Two phase region. In this region, the mass fractions and derivatives can
   //  be verified using the equilibrium mass fraction derivatives that have
@@ -137,10 +137,10 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Yncg = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST("Xncg", Xncg, Xncg_eq, 1.0e-8);
-  ABS_TEST("Yncg", Yncg, 1.0 - Yh2o_eq, 1.0e-8);
-  ABS_TEST("Xh2o", Xh2o, 1.0 - Xncg_eq, 1.0e-8);
-  ABS_TEST("Yh2o", Yh2o, Yh2o_eq, 1.0e-8);
+  ABS_TEST(Xncg, Xncg_eq, 1.0e-8);
+  ABS_TEST(Yncg, 1.0 - Yh2o_eq, 1.0e-8);
+  ABS_TEST(Xh2o, 1.0 - Xncg_eq, 1.0e-8);
+  ABS_TEST(Yh2o, Yh2o_eq, 1.0e-8);
 
   // Verify derivatives wrt p and T
   dXncg_dp = fsp[0].dmass_fraction_dp[1];
@@ -149,12 +149,12 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   dYncg_dp = fsp[1].dmass_fraction_dp[1];
   dYncg_dT = fsp[1].dmass_fraction_dT[1];
   dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST("dXncg_dp", dXncg_dp, dXncg_dp_eq, 1.0e-8);
-  ABS_TEST("dXncg_dT", dXncg_dT, dXncg_dT_eq, 1.0e-8);
-  ABS_TEST("dXncg_dZ", dXncg_dZ, 0.0, 1.0e-8);
-  ABS_TEST("dYncg_dp", dYncg_dp, -dYh2o_dp_eq, 1.0e-8);
-  ABS_TEST("dYncg_dT", dYncg_dT, -dYh2o_dT_eq, 1.0e-8);
-  ABS_TEST("dYncg_dZ", dYncg_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dXncg_dp, dXncg_dp_eq, 1.0e-8);
+  ABS_TEST(dXncg_dT, dXncg_dT_eq, 1.0e-8);
+  ABS_TEST(dXncg_dZ, 0.0, 1.0e-8);
+  ABS_TEST(dYncg_dp, -dYh2o_dp_eq, 1.0e-8);
+  ABS_TEST(dYncg_dT, -dYh2o_dT_eq, 1.0e-8);
+  ABS_TEST(dYncg_dZ, 0.0, 1.0e-8);
 
   // Use finite differences to verify derivative wrt Z is unaffected by Z
   const Real dZ = 1.0e-8;
@@ -165,8 +165,8 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Real Xncg2 = fsp[0].mass_fraction[1];
   Real Yncg2 = fsp[1].mass_fraction[1];
 
-  ABS_TEST("dXncg_dZ", dXncg_dZ, (Xncg1 - Xncg2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST("dXYncg_dZ", dYncg_dZ, (Yncg1 - Yncg2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dXncg_dZ, (Xncg1 - Xncg2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dYncg_dZ, (Yncg1 - Yncg2) / (2.0 * dZ), 1.0e-8);
 }
 
 /*
@@ -196,9 +196,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   Real enthalpy =
       Z * _ncg_fp->h(Z * p, T) + (1.0 - Z) * _water_fp->h(_water_fp->vaporPressure(T), T);
 
-  ABS_TEST("gas density", gas_density, density, 1.0e-8);
-  ABS_TEST("gas viscosity", gas_viscosity, viscosity, 1.0e-8);
-  ABS_TEST("gas enthalpy", gas_enthalpy, enthalpy, 1.0e-8);
+  ABS_TEST(gas_density, density, 1.0e-8);
+  ABS_TEST(gas_viscosity, viscosity, 1.0e-8);
+  ABS_TEST(gas_enthalpy, enthalpy, 1.0e-8);
 
   // Verify derivatives
   Real ddensity_dp = fsp[1].ddensity_dp;
@@ -222,9 +222,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   Real mu2 = fsp[1].viscosity;
   Real h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   const Real dT = 1.0e-3;
   _fp->gasProperties(p, T + dT, fsp);
@@ -237,9 +237,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Note: mass fraction changes with Z
   const Real dZ = 1.0e-8;
@@ -255,9 +255,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dZ", ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST("dviscosity_dZ", dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 
   // Check derivatives in the two phase region as well. Note that the mass fractions
   // vary with pressure and temperature in this region
@@ -288,9 +288,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   _fp->massFractions(p, T + dT, Z, phase_state, fsp);
   _fp->gasProperties(p, T + dT, fsp);
@@ -304,9 +304,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
   _fp->gasProperties(p, T, fsp);
@@ -320,9 +320,9 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  ABS_TEST("ddensity_dZ", ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST("dviscosity_dZ", dviscosity_dT, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -344,8 +344,8 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   Real density = _water_fp->rho(p, T);
   Real viscosity = _water_fp->mu(p, T);
 
-  ABS_TEST("liquid density", liquid_density, density, 1.0e-12);
-  ABS_TEST("liquid viscosity", liquid_viscosity, viscosity, 1.0e-12);
+  ABS_TEST(liquid_density, density, 1.0e-12);
+  ABS_TEST(liquid_viscosity, viscosity, 1.0e-12);
 
   // Verify derivatives
   Real ddensity_dp = fsp[0].ddensity_dp;
@@ -369,9 +369,9 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   Real mu2 = fsp[0].viscosity;
   Real h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dp", ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST("dviscosity_dp", dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
 
   const Real dT = 1.0e-4;
   _fp->liquidProperties(p, T + dT, fsp);
@@ -384,9 +384,9 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("ddensity_dT", ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("dviscosity_dT", dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
 
   Real Z = 0.0001;
   const Real dZ = 1.0e-8;
@@ -406,11 +406,11 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   _fp->liquidProperties(p, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
 
   // Density and viscosity don't depend on Z, so derivatives should be 0
-  ABS_TEST("ddensity_dZ", ddensity_dZ, 0.0, 1.0e-12);
-  ABS_TEST("dviscosity_dZ", dviscosity_dZ, 0.0, 1.0e-12);
+  ABS_TEST(ddensity_dZ, 0.0, 1.0e-12);
+  ABS_TEST(dviscosity_dZ, 0.0, 1.0e-12);
 
   // Check enthalpy calculations in the two phase region as well. Note that the mass fractions
   // vary with pressure and temperature in this region
@@ -429,7 +429,7 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   _fp->liquidProperties(p - dp, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("denthalpy_dp", denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
 
   _fp->massFractions(p, T + dT, Z, phase_state, fsp);
   _fp->liquidProperties(p, T + dT, fsp);
@@ -439,7 +439,7 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   _fp->liquidProperties(p, T - dT, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST("denthalpy_dT", denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
 
   _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
   _fp->liquidProperties(p, T, fsp);
@@ -449,7 +449,7 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   _fp->liquidProperties(p, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  ABS_TEST("denthalpy_dZ", denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-5);
+  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-5);
 }
 
 /*
@@ -485,7 +485,7 @@ TEST_F(PorousFlowWaterNCGTest, twoPhase)
   // Calculate the gas saturation and derivatives
   _fp->saturationTwoPhase(p, T, Z, fsp);
 
-  ABS_TEST("gas saturation", fsp[1].saturation, gas_saturation, 1.0e-8);
+  ABS_TEST(fsp[1].saturation, gas_saturation, 1.0e-8);
 
   // Test the derivatives
   const Real dp = 1.0e-1;
@@ -504,7 +504,7 @@ TEST_F(PorousFlowWaterNCGTest, twoPhase)
   _fp->saturationTwoPhase(p - dp, T, Z, fsp);
   Real gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dp", dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
 
   // Derivative wrt T
   const Real dT = 1.0e-4;
@@ -518,7 +518,7 @@ TEST_F(PorousFlowWaterNCGTest, twoPhase)
   _fp->saturationTwoPhase(p, T - dT, Z, fsp);
   gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dT", dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
 
   // Derivative wrt Z
   const Real dZ = 1.0e-8;
@@ -531,7 +531,7 @@ TEST_F(PorousFlowWaterNCGTest, twoPhase)
   _fp->saturationTwoPhase(p, T, Z - dZ, fsp);
   gsat2 = fsp[1].saturation;
 
-  REL_TEST("dgas_saturation_dZ", dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -556,7 +556,7 @@ TEST_F(PorousFlowWaterNCGTest, totalMassFraction)
   Real liquid_pressure = p + _pc->capillaryPressure(1.0 - s);
   _fp->liquidProperties(liquid_pressure, T, fsp);
   _fp->saturationTwoPhase(p, T, Z, fsp);
-  ABS_TEST("gas saturation", fsp[1].saturation, s, 1.0e-8);
+  ABS_TEST(fsp[1].saturation, s, 1.0e-8);
 }
 
 /*
@@ -572,14 +572,14 @@ TEST_F(PorousFlowWaterNCGTest, enthalpyOfDissolution)
   // Enthalpy of dissolution of NCG in water
   Real hdis, dhdis_dT;
   _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST("hdis", hdis, -3.45731e5, 1.0e-3);
+  REL_TEST(hdis, -3.45731e5, 1.0e-3);
 
   // T = 350C
   T = 623.15;
 
   // Enthalpy of dissolution of NCG in water
   _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST("hdis", hdis, 1.23423e+06, 1.0e-3);
+  REL_TEST(hdis, 1.23423e+06, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
@@ -587,5 +587,5 @@ TEST_F(PorousFlowWaterNCGTest, enthalpyOfDissolution)
   _fp->enthalpyOfDissolution(T + dT, hdis, dhdis_dT);
   _fp->enthalpyOfDissolution(T - dT, hdis2, dhdis2_dT);
 
-  REL_TEST("dhdis_dT", dhdis_dT, (hdis - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(dhdis_dT, (hdis - hdis2) / (2.0 * dT), 1.0e-5);
 }

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -8,7 +8,20 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SimpleFluidPropertiesTest.h"
-#include "Utils.h"
+#include "SinglePhaseFluidPropertiesPTUtils.h"
+
+/**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(SimpleFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "simple_fluid"); }
+
+/**
+ * Test that the default molar mass is correctly returned
+ */
+TEST_F(SimpleFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_fp->molarMass(), 1.8e-2, REL_TOL_SAVED_VALUE);
+}
 
 /**
  * Verify calculation of the fluid properties
@@ -26,41 +39,42 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   const Real henry = 0.0;
   const Real pp_coef = 0.0;
 
-  Real P, T;
+  const Real tol = REL_TOL_CONSISTENCY;
 
-  P = 1E3;
-  T = 200;
-  REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
-  REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
-  REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
-  REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
-  REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
-  REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
-  REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
-  ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
+  Real p = 1.0E3;
+  Real T = 200.0;
 
-  P = 1E7;
-  T = 300;
-  REL_TEST("beta", _fp->beta(P, T), thermal_exp, 1.0E-8);
-  REL_TEST("cp", _fp->cp(P, T), cp, 1.0E-8);
-  REL_TEST("cv", _fp->cv(P, T), cv, 1.0E-8);
-  REL_TEST("c", _fp->c(P, T), std::sqrt(bulk_modulus / _fp->rho(P, T)), 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("k", _fp->k(P, T), thermal_cond, 1.0E-8);
-  REL_TEST("s", _fp->s(P, T), entropy, 1.0E-8);
-  REL_TEST("rho", _fp->rho(P, T), density0 * std::exp(P / bulk_modulus - thermal_exp * T), 1.0E-8);
-  REL_TEST("e", _fp->e(P, T), cv * T, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("mu", _fp->mu(P, T), visc, 1.0E-8);
-  REL_TEST("h", _fp->h(P, T), cv * T + P / _fp->rho(P, T), 1.0E-8);
-  REL_TEST("h2", _fp2->h(P, T), cv * T + P * pp_coef / _fp2->rho(P, T), 1.0E-8);
-  ABS_TEST("henry", _fp->henryConstant(T), henry, 1.0E-8);
+  ABS_TEST(_fp->beta(p, T), thermal_exp, tol);
+  ABS_TEST(_fp->cp(p, T), cp, tol);
+  ABS_TEST(_fp->cv(p, T), cv, tol);
+  ABS_TEST(_fp->c(p, T), std::sqrt(bulk_modulus / _fp->rho(p, T)), tol);
+  ABS_TEST(_fp->k(p, T), thermal_cond, tol);
+  ABS_TEST(_fp->k(p, T), thermal_cond, tol);
+  ABS_TEST(_fp->s(p, T), entropy, tol);
+  ABS_TEST(_fp->rho(p, T), density0 * std::exp(p / bulk_modulus - thermal_exp * T), tol);
+  ABS_TEST(_fp->e(p, T), cv * T, tol);
+  ABS_TEST(_fp->mu(p, T), visc, tol);
+  ABS_TEST(_fp->mu(p, T), visc, tol);
+  ABS_TEST(_fp->h(p, T), cv * T + p / _fp->rho(p, T), tol);
+  ABS_TEST(_fp2->h(p, T), cv * T + p * pp_coef / _fp2->rho(p, T), tol);
+  ABS_TEST(_fp->henryConstant(T), henry, tol);
+
+  p = 1.0E7;
+  T = 300.0;
+  ABS_TEST(_fp->beta(p, T), thermal_exp, tol);
+  ABS_TEST(_fp->cp(p, T), cp, tol);
+  ABS_TEST(_fp->cv(p, T), cv, tol);
+  ABS_TEST(_fp->c(p, T), std::sqrt(bulk_modulus / _fp->rho(p, T)), tol);
+  ABS_TEST(_fp->k(p, T), thermal_cond, tol);
+  ABS_TEST(_fp->k(p, T), thermal_cond, tol);
+  ABS_TEST(_fp->s(p, T), entropy, tol);
+  ABS_TEST(_fp->rho(p, T), density0 * std::exp(p / bulk_modulus - thermal_exp * T), tol);
+  ABS_TEST(_fp->e(p, T), cv * T, tol);
+  ABS_TEST(_fp->mu(p, T), visc, tol);
+  ABS_TEST(_fp->mu(p, T), visc, tol);
+  ABS_TEST(_fp->h(p, T), cv * T + p / _fp->rho(p, T), tol);
+  ABS_TEST(_fp2->h(p, T), cv * T + p * pp_coef / _fp2->rho(p, T), tol);
+  ABS_TEST(_fp->henryConstant(T), henry, tol);
 }
 
 /**
@@ -69,100 +83,39 @@ TEST_F(SimpleFluidPropertiesTest, properties)
  */
 TEST_F(SimpleFluidPropertiesTest, derivatives)
 {
-  const Real dP = 1.0E1;
-  const Real dT = 1.0E-4;
+  const Real tol = REL_TOL_DERIVATIVE;
 
-  Real fd;
-  Real P, T;
+  Real p = 1.0E7;
+  Real T = 10.0;
 
-  Real rho, drho_dp, drho_dT;
-  P = 1E7;
-  T = 10;
-  _fp->rho_dpT(P, T, rho, drho_dp, drho_dT);
-  fd = (_fp->rho(P + dP, T) - _fp->rho(P - dP, T)) / (2.0 * dP);
-  REL_TEST("drho_dP", drho_dp, fd, 1.0E-8);
-  fd = (_fp->rho(P, T + dT) - _fp->rho(P, T - dT)) / (2.0 * dT);
-  REL_TEST("drho_dT", drho_dT, fd, 1.0E-8);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->mu, _fp->mu_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
+  DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
 
-  P = 5E7;
-  T = 90;
-  _fp->rho_dpT(P, T, rho, drho_dp, drho_dT);
-  fd = (_fp->rho(P + dP, T) - _fp->rho(P - dP, T)) / (2.0 * dP);
-  REL_TEST("drho_dP", drho_dp, fd, 1.0E-8);
-  fd = (_fp->rho(P, T + dT) - _fp->rho(P, T - dT)) / (2.0 * dT);
-  REL_TEST("drho_dT", drho_dT, fd, 1.0E-8);
+  p = 5.0E7;
+  T = 90.0;
 
-  Real e, de_dp, de_dT;
-  P = 1E6;
-  T = 20;
-  _fp->e_dpT(P, T, e, de_dp, de_dT);
-  fd = (_fp->e(P + dP, T) - _fp->e(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("de_dP", de_dp, fd, 1.0E-8);
-  fd = (_fp->e(P, T + dT) - _fp->e(P, T - dT)) / (2.0 * dT);
-  REL_TEST("de_dT", de_dT, fd, 1.0E-8);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->mu, _fp->mu_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
+  DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
 
-  P = 5E6;
-  T = 90;
-  _fp->e_dpT(P, T, e, de_dp, de_dT);
-  fd = (_fp->e(P + dP, T) - _fp->e(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("de_dP", de_dp, fd, 1.0E-8);
-  fd = (_fp->e(P, T + dT) - _fp->e(P, T - dT)) / (2.0 * dT);
-  REL_TEST("de_dT", de_dT, fd, 1.0E-8);
+  Real henry, dhenry_dT;
+  _fp->henryConstant_dT(T, henry, dhenry_dT);
+  ABS_TEST(dhenry_dT, 0.0, tol);
+}
 
-  Real mu, dmu_dp, dmu_dT;
-  P = 1E6;
-  T = 10;
-  _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
-  fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);
-  fd = (_fp->mu(P, T + dT) - _fp->mu(P, T - dT)) / (2.0 * dT);
-  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
+/**
+ * Verify that the methods that return multiple properties in one call return identical
+ * values as the individual methods
+ */
+TEST_F(SimpleFluidPropertiesTest, combined)
+{
+  const Real p = 1.0e6;
+  const Real T = 300.0;
 
-  Real k, dk_dp, dk_dT;
-  _fp->k_dpT(P, T, k, dk_dp, dk_dT);
-  fd = (_fp->k(P + dP, T) - _fp->k(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dk_dp", dk_dp, fd, 1.0E-8);
-  fd = (_fp->k(P, T + dT) - _fp->k(P, T - dT)) / (2.0 * dT);
-  ABS_TEST("dk_dT", dk_dT, fd, 1.0E-8);
-
-  P = 2E6;
-  T = 80;
-  _fp->mu_dpT(P, T, mu, dmu_dp, dmu_dT);
-  fd = (_fp->mu(P + dP, T) - _fp->mu(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dmu_dp", dmu_dp, fd, 1.0E-8);
-  fd = (_fp->mu(P, T + dT) - _fp->mu(P, T - dT)) / (2.0 * dT);
-  ABS_TEST("dmu_dT", dmu_dT, fd, 1.0E-8);
-
-  _fp->k_dpT(P, T, k, dk_dp, dk_dT);
-  fd = (_fp->k(P + dP, T) - _fp->k(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dk_dp", dk_dp, fd, 1.0E-8);
-  fd = (_fp->k(P, T + dT) - _fp->k(P, T - dT)) / (2.0 * dT);
-  ABS_TEST("dk_dT", dk_dT, fd, 1.0E-8);
-
-  Real h, dh_dp, dh_dT;
-  P = 1E6;
-  T = 10;
-  _fp->h_dpT(P, T, h, dh_dp, dh_dT);
-  fd = (_fp->h(P + dP, T) - _fp->h(P - dP, T)) / (2.0 * dP);
-  REL_TEST("dh_dP", dh_dp, fd, 1.0E-8);
-  fd = (_fp->h(P, T + dT) - _fp->h(P, T - dT)) / (2.0 * dT);
-  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
-  _fp2->h_dpT(P, T, h, dh_dp, dh_dT);
-  fd = (_fp2->h(P + dP, T) - _fp2->h(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dh_dP", dh_dp, fd, 1.0E-8);
-  fd = (_fp2->h(P, T + dT) - _fp2->h(P, T - dT)) / (2.0 * dT);
-  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
-
-  P = 4E6;
-  T = 90;
-  _fp->h_dpT(P, T, h, dh_dp, dh_dT);
-  fd = (_fp->h(P + dP, T) - _fp->h(P - dP, T)) / (2.0 * dP);
-  REL_TEST("dh_dP", dh_dp, fd, 1.0E-8);
-  fd = (_fp->h(P, T + dT) - _fp->h(P, T - dT)) / (2.0 * dT);
-  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
-  _fp2->h_dpT(P, T, h, dh_dp, dh_dT);
-  fd = (_fp2->h(P + dP, T) - _fp2->h(P - dP, T)) / (2.0 * dP);
-  ABS_TEST("dh_dP", dh_dp, fd, 1.0E-8);
-  fd = (_fp2->h(P, T + dT) - _fp2->h(P, T - dT)) / (2.0 * dT);
-  REL_TEST("dh_dT", dh_dT, fd, 1.0E-8);
+  combinedProperties(_fp, p, T, REL_TOL_SAVED_VALUE);
 }

--- a/unit/src/SodiumPropertiesTest.C
+++ b/unit/src/SodiumPropertiesTest.C
@@ -17,12 +17,12 @@
  */
 TEST_F(SodiumPropertiesTest, testSodium)
 {
-  double T = 500; // K
-  REL_TEST("thermal_conductivity", _fp->k(T), 80.09125, 1.0E-5);
-  REL_TEST("enthalpy", _fp->h(T), 381886.450000, 1.0E-5);
-  REL_TEST("heat_capacity", _fp->heatCapacity(T), 1345.578559, 1.0E-2);
-  REL_TEST("temperature", _fp->temperature(_fp->h(T)), T, 1.0E-5);
-  REL_TEST("density", _fp->rho(T), 896.9929544, 1E-05);
-  REL_TEST("drhodT", _fp->drho_dT(T), -0.224167872, 1E-05);
-  REL_TEST("drhodh", _fp->drho_dh(_fp->h(T)), -0.00016659590, 1E-2);
+  Real T = 500; // K
+  REL_TEST(_fp->k(T), 80.09125, 1.0E-5);
+  REL_TEST(_fp->h(T), 381886.450000, 1.0E-5);
+  REL_TEST(_fp->heatCapacity(T), 1345.578559, 1.0E-2);
+  REL_TEST(_fp->temperature(_fp->h(T)), T, 1.0E-5);
+  REL_TEST(_fp->rho(T), 896.9929544, 1E-05);
+  REL_TEST(_fp->drho_dT(T), -0.224167872, 1E-05);
+  REL_TEST(_fp->drho_dh(_fp->h(T)), -0.00016659590, 1E-2);
 }

--- a/unit/src/TabulatedFluidPropertiesTest.C
+++ b/unit/src/TabulatedFluidPropertiesTest.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "TabulatedFluidPropertiesTest.h"
-#include "Utils.h"
+#include "SinglePhaseFluidPropertiesPTUtils.h"
 
 #include <fstream>
 
@@ -114,43 +114,43 @@ TEST_F(TabulatedFluidPropertiesTest, fromFile)
   const_cast<TabulatedFluidProperties *>(_tab_fp)->initialSetup();
 
   // Fluid properties
-  REL_TEST("density", _tab_fp->rho(p, T), _co2_fp->rho(p, T), 1.0e-4);
-  REL_TEST("enthalpy", _tab_fp->h(p, T), _co2_fp->h(p, T), 1.0e-4);
-  REL_TEST("internal_energy", _tab_fp->e(p, T), _co2_fp->e(p, T), 1.0e-4);
-  REL_TEST("viscosity", _tab_fp->mu(p, T), _co2_fp->mu(p, T), 1.0e-4);
-  REL_TEST("k", _tab_fp->k(p, T), _co2_fp->k(p, T), 1.0e-4);
-  REL_TEST("cp", _tab_fp->cp(p, T), _co2_fp->cp(p, T), 1.0e-4);
-  REL_TEST("cv", _tab_fp->cv(p, T), _co2_fp->cv(p, T), 1.0e-4);
-  REL_TEST("entropy", _tab_fp->s(p, T), _co2_fp->s(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->rho(p, T), _co2_fp->rho(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->h(p, T), _co2_fp->h(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->e(p, T), _co2_fp->e(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->mu(p, T), _co2_fp->mu(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->k(p, T), _co2_fp->k(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->cp(p, T), _co2_fp->cp(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->cv(p, T), _co2_fp->cv(p, T), 1.0e-4);
+  REL_TEST(_tab_fp->s(p, T), _co2_fp->s(p, T), 1.0e-4);
 
   // Fluid properties and derivatives
   Real rho, drho_dp, drho_dT, rhoc, drhoc_dp, drhoc_dT;
   _tab_fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
   _co2_fp->rho_dpT(p, T, rhoc, drhoc_dp, drhoc_dT);
-  REL_TEST("density", rho, rhoc, 1.0e-4);
-  REL_TEST("ddensity_dp", drho_dp, drhoc_dp, 1.0e-3);
-  REL_TEST("ddensity_dT", drho_dT, drhoc_dT, 1.0e-3);
+  REL_TEST(rho, rhoc, 1.0e-4);
+  REL_TEST(drho_dp, drhoc_dp, 1.0e-3);
+  REL_TEST(drho_dT, drhoc_dT, 1.0e-3);
 
   Real h, dh_dp, dh_dT, hc, dhc_dp, dhc_dT;
   _tab_fp->h_dpT(p, T, h, dh_dp, dh_dT);
   _co2_fp->h_dpT(p, T, hc, dhc_dp, dhc_dT);
-  REL_TEST("enthalpy", h, hc, 1.0e-4);
-  REL_TEST("denthalpy_dp", dh_dp, dhc_dp, 1.0e-3);
-  REL_TEST("denthalpy_dT", dh_dT, dhc_dT, 1.0e-3);
+  REL_TEST(h, hc, 1.0e-4);
+  REL_TEST(dh_dp, dhc_dp, 1.0e-3);
+  REL_TEST(dh_dT, dhc_dT, 1.0e-3);
 
   Real mu, dmu_dp, dmu_dT, muc, dmuc_dp, dmuc_dT;
   _tab_fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
   _co2_fp->mu_dpT(p, T, muc, dmuc_dp, dmuc_dT);
-  REL_TEST("viscosity", mu, muc, 1.0e-4);
-  REL_TEST("dviscosity_dp", dmu_dp, dmuc_dp, 1.0e-3);
-  REL_TEST("dviscosity_dT", dmu_dT, dmuc_dT, 1.0e-3);
+  REL_TEST(mu, muc, 1.0e-4);
+  REL_TEST(dmu_dp, dmuc_dp, 1.0e-3);
+  REL_TEST(dmu_dT, dmuc_dT, 1.0e-3);
 
   Real e, de_dp, de_dT, ec, dec_dp, dec_dT;
   _tab_fp->e_dpT(p, T, e, de_dp, de_dT);
   _co2_fp->e_dpT(p, T, ec, dec_dp, dec_dT);
-  REL_TEST("internal_energy", e, ec, 1.0e-4);
-  REL_TEST("dinternal_energy_dp", de_dp, dec_dp, 1.0e-3);
-  REL_TEST("dinternal_energy_dT", de_dT, dec_dT, 1.0e-3);
+  REL_TEST(e, ec, 1.0e-4);
+  REL_TEST(de_dp, dec_dp, 1.0e-3);
+  REL_TEST(de_dT, dec_dT, 1.0e-3);
 }
 
 // Test generation of tabulated fluid properties
@@ -162,12 +162,37 @@ TEST_F(TabulatedFluidPropertiesTest, generateTabulatedData)
   // Generate the tabulated data
   const_cast<TabulatedFluidProperties *>(_tab_gen_fp)->initialSetup();
 
-  REL_TEST("density", _tab_gen_fp->rho(p, T), _co2_fp->rho(p, T), 1.0e-4);
-  REL_TEST("enthalpy", _tab_gen_fp->h(p, T), _co2_fp->h(p, T), 1.0e-4);
-  REL_TEST("internal_energy", _tab_gen_fp->e(p, T), _co2_fp->e(p, T), 1.0e-4);
-  REL_TEST("viscosity", _tab_gen_fp->mu(p, T), _co2_fp->mu(p, T), 1.0e-4);
-  REL_TEST("k", _tab_gen_fp->k(p, T), _co2_fp->k(p, T), 1.0e-4);
-  REL_TEST("cp", _tab_gen_fp->cp(p, T), _co2_fp->cp(p, T), 1.0e-4);
-  REL_TEST("cv", _tab_gen_fp->cv(p, T), _co2_fp->cv(p, T), 1.0e-4);
-  REL_TEST("entropy", _tab_gen_fp->s(p, T), _co2_fp->s(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->rho(p, T), _co2_fp->rho(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->h(p, T), _co2_fp->h(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->e(p, T), _co2_fp->e(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->mu(p, T), _co2_fp->mu(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->k(p, T), _co2_fp->k(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->cp(p, T), _co2_fp->cp(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->cv(p, T), _co2_fp->cv(p, T), 1.0e-4);
+  REL_TEST(_tab_gen_fp->s(p, T), _co2_fp->s(p, T), 1.0e-4);
+}
+
+/**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(TabulatedFluidPropertiesTest, fluidName) { EXPECT_EQ(_tab_fp->fluidName(), "co2"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(TabulatedFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_tab_fp->molarMass(), 44.0098e-3, REL_TOL_SAVED_VALUE);
+}
+
+/**
+ * Verify that the methods that return multiple properties in one call return identical
+ * values as the individual methods
+ */
+TEST_F(TabulatedFluidPropertiesTest, combined)
+{
+  const Real p = 1.0e6;
+  const Real T = 300.0;
+
+  combinedProperties(_tab_fp, p, T, REL_TOL_SAVED_VALUE);
 }

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -10,22 +10,32 @@
 #include "Water97FluidPropertiesTest.h"
 
 /**
- * Verify that critical properties are correctly returned
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(Water97FluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "water"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(Water97FluidPropertiesTest, molarMass) { ABS_TEST(_fp->molarMass(), 18.015e-3, 1.0e-15); }
+
+/**
+ * Test that the critical properties are correctly returned
  */
 TEST_F(Water97FluidPropertiesTest, criticalProperties)
 {
-  ABS_TEST("critical pressure", _fp->criticalPressure(), 22.064e6, 1.0e-12);
-  ABS_TEST("critical temperature", _fp->criticalTemperature(), 647.096, 1.0e-12);
-  ABS_TEST("critical density", _fp->criticalDensity(), 322.0, 1.0e-12);
+  ABS_TEST(_fp->criticalPressure(), 22.064e6, 1.0e-15);
+  ABS_TEST(_fp->criticalTemperature(), 647.096, 1.0e-15);
+  ABS_TEST(_fp->criticalDensity(), 322.0, 1.0e-15);
 }
 
 /**
- * Verify that triple point properties are correctly returned
+ * Test that the triple point properties are correctly returned
  */
 TEST_F(Water97FluidPropertiesTest, triplePointProperties)
 {
-  ABS_TEST("triple point pressure", _fp->triplePointPressure(), 611.657, 1.0e-12);
-  ABS_TEST("triple point temperature", _fp->triplePointTemperature(), 273.16, 1.0e-12);
+  ABS_TEST(_fp->triplePointPressure(), 611.657, 1.0e-15);
+  ABS_TEST(_fp->triplePointTemperature(), 273.16, 1.0e-15);
 }
 
 /**
@@ -106,8 +116,8 @@ TEST_F(Water97FluidPropertiesTest, inRegion)
  */
 TEST_F(Water97FluidPropertiesTest, b23)
 {
-  REL_TEST("b23T", _fp->b23T(16.5291643e6), 623.15, 1.0e-8);
-  REL_TEST("b23p", _fp->b23p(623.15), 16.5291643e6, 1.0e-8);
+  REL_TEST(_fp->b23T(16.5291643e6), 623.15, 1.0e-8);
+  REL_TEST(_fp->b23p(623.15), 16.5291643e6, 1.0e-8);
 }
 
 /**
@@ -117,10 +127,7 @@ TEST_F(Water97FluidPropertiesTest, b23)
  * Revised Release on the IAPWS Industrial Formulation 1997 for the
  * Thermodynamic Properties of Water and Steam, IAPWS 2007
  */
-TEST_F(Water97FluidPropertiesTest, b2bc)
-{
-  REL_TEST("b2bc", _fp->b2bc(100.0e6), 0.3516004323e7, 1.0e-8);
-}
+TEST_F(Water97FluidPropertiesTest, b2bc) { REL_TEST(_fp->b2bc(100.0e6), 0.3516004323e7, 1.0e-8); }
 
 /**
  * Verify calculation of the boundary between regions 3a and 3b for the
@@ -131,10 +138,7 @@ TEST_F(Water97FluidPropertiesTest, b2bc)
  * Industrial Formulation 1997 for the Thermodynamic Properties of Water and
  * Steam
  */
-TEST_F(Water97FluidPropertiesTest, b3ab)
-{
-  REL_TEST("b3ab", _fp->b3ab(25.0e6), 2.095936454e6, 1.0e-8);
-}
+TEST_F(Water97FluidPropertiesTest, b3ab) { REL_TEST(_fp->b3ab(25.0e6), 2.095936454e6, 1.0e-8); }
 
 /**
  * Verify calculation of water properties in region 4 (saturation line)
@@ -144,9 +148,9 @@ TEST_F(Water97FluidPropertiesTest, b3ab)
  */
 TEST_F(Water97FluidPropertiesTest, vaporPressure)
 {
-  REL_TEST("vaporPressure", _fp->vaporPressure(300), 3.53658941e3, 1.0e-8);
-  REL_TEST("vaporPressure", _fp->vaporPressure(500), 2.63889776e6, 1.0e-8);
-  REL_TEST("vaporPressure", _fp->vaporPressure(600), 12.3443146e6, 1.0e-8);
+  REL_TEST(_fp->vaporPressure(300), 3.53658941e3, 1.0e-8);
+  REL_TEST(_fp->vaporPressure(500), 2.63889776e6, 1.0e-8);
+  REL_TEST(_fp->vaporPressure(600), 12.3443146e6, 1.0e-8);
 }
 
 /**
@@ -157,9 +161,9 @@ TEST_F(Water97FluidPropertiesTest, vaporPressure)
  */
 TEST_F(Water97FluidPropertiesTest, vaporTemperature)
 {
-  REL_TEST("vaporPressure", _fp->vaporTemperature(0.1e6), 372.755919, 1.0e-8);
-  REL_TEST("vaporPressure", _fp->vaporTemperature(1.0e6), 453.035632, 1.0e-8);
-  REL_TEST("vaporPressure", _fp->vaporTemperature(10.0e6), 584.149488, 1.0e-8);
+  REL_TEST(_fp->vaporTemperature(0.1e6), 372.755919, 1.0e-8);
+  REL_TEST(_fp->vaporTemperature(1.0e6), 453.035632, 1.0e-8);
+  REL_TEST(_fp->vaporTemperature(10.0e6), 584.149488, 1.0e-8);
 }
 
 /**
@@ -234,58 +238,60 @@ TEST_F(Water97FluidPropertiesTest, subregion3)
  */
 TEST_F(Water97FluidPropertiesTest, subregion3Density)
 {
-  REL_TEST("rho", _fp->densityRegion3(50.0e6, 630.0), 1.0 / 0.001470853100, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(80.0e6, 670.0), 1.0 / 0.001503831359, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(50.0e6, 710.0), 1.0 / 0.002204728587, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(80.0e6, 750.0), 1.0 / 0.001973692940, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(20.0e6, 630.0), 1.0 / 0.001761696406, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(30.0e6, 650.0), 1.0 / 0.001819560617, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(26.0e6, 656.0), 1.0 / 0.002245587720, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(30.0e6, 670.0), 1.0 / 0.002506897702, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(26.0e6, 661.0), 1.0 / 0.002970225962, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(30.0e6, 675.0), 1.0 / 0.003004627086, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(26.0e6, 671.0), 1.0 / 0.005019029401, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(30.0e6, 690.0), 1.0 / 0.004656470142, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.6e6, 649.0), 1.0 / 0.002163198378, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(24.0e6, 650.0), 1.0 / 0.002166044161, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.6e6, 652.0), 1.0 / 0.002651081407, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(24.0e6, 654.0), 1.0 / 0.002967802335, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.6e6, 653.0), 1.0 / 0.003273916816, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(24.0e6, 655.0), 1.0 / 0.003550329864, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.5e6, 655.0), 1.0 / 0.004545001142, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(24.0e6, 660.0), 1.0 / 0.005100267704, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.0e6, 660.0), 1.0 / 0.006109525997, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(24.0e6, 670.0), 1.0 / 0.006427325645, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.6e6, 646.0), 1.0 / 0.002117860851, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(23.0e6, 646.0), 1.0 / 0.002062374674, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.6e6, 648.6), 1.0 / 0.002533063780, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.8e6, 649.3), 1.0 / 0.002572971781, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.6e6, 649.0), 1.0 / 0.002923432711, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.8e6, 649.7), 1.0 / 0.002913311494, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.6e6, 649.1), 1.0 / 0.003131208996, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.8e6, 649.9), 1.0 / 0.003221160278, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.6e6, 649.4), 1.0 / 0.003715596186, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.8e6, 650.2), 1.0 / 0.003664754790, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(21.1e6, 640.0), 1.0 / 0.001970999272, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(21.8e6, 643.0), 1.0 / 0.002043919161, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(21.1e6, 644.0), 1.0 / 0.005251009921, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(21.8e6, 648.0), 1.0 / 0.005256844741, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(19.1e6, 635.0), 1.0 / 0.001932829079, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(20.0e6, 638.0), 1.0 / 0.001985387227, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(17.0e6, 626.0), 1.0 / 0.008483262001, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(20.0e6, 640.0), 1.0 / 0.006227528101, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(21.5e6, 644.6), 1.0 / 0.002268366647, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.0e6, 646.1), 1.0 / 0.002296350553, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.5e6, 648.6), 1.0 / 0.002832373260, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.3e6, 647.9), 1.0 / 0.002811424405, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.15e6, 647.5), 1.0 / 0.003694032281, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.3e6, 648.1), 1.0 / 0.003622226305, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.11e6, 648.0), 1.0 / 0.004528072649, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.3e6, 649.0), 1.0 / 0.004556905799, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.0e6, 646.84), 1.0 / 0.002698354719, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.064e6, 647.05), 1.0 / 0.002717655648, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.0e6, 646.89), 1.0 / 0.003798732962, 1.0e-8);
-  REL_TEST("rho", _fp->densityRegion3(22.064e6, 647.15), 1.0 / 0.003701940010, 1.0e-8);
+  const Real tol = 1.0e-8;
+
+  REL_TEST(_fp->densityRegion3(50.0e6, 630.0), 1.0 / 0.001470853100, tol);
+  REL_TEST(_fp->densityRegion3(80.0e6, 670.0), 1.0 / 0.001503831359, tol);
+  REL_TEST(_fp->densityRegion3(50.0e6, 710.0), 1.0 / 0.002204728587, tol);
+  REL_TEST(_fp->densityRegion3(80.0e6, 750.0), 1.0 / 0.001973692940, tol);
+  REL_TEST(_fp->densityRegion3(20.0e6, 630.0), 1.0 / 0.001761696406, tol);
+  REL_TEST(_fp->densityRegion3(30.0e6, 650.0), 1.0 / 0.001819560617, tol);
+  REL_TEST(_fp->densityRegion3(26.0e6, 656.0), 1.0 / 0.002245587720, tol);
+  REL_TEST(_fp->densityRegion3(30.0e6, 670.0), 1.0 / 0.002506897702, tol);
+  REL_TEST(_fp->densityRegion3(26.0e6, 661.0), 1.0 / 0.002970225962, tol);
+  REL_TEST(_fp->densityRegion3(30.0e6, 675.0), 1.0 / 0.003004627086, tol);
+  REL_TEST(_fp->densityRegion3(26.0e6, 671.0), 1.0 / 0.005019029401, tol);
+  REL_TEST(_fp->densityRegion3(30.0e6, 690.0), 1.0 / 0.004656470142, tol);
+  REL_TEST(_fp->densityRegion3(23.6e6, 649.0), 1.0 / 0.002163198378, tol);
+  REL_TEST(_fp->densityRegion3(24.0e6, 650.0), 1.0 / 0.002166044161, tol);
+  REL_TEST(_fp->densityRegion3(23.6e6, 652.0), 1.0 / 0.002651081407, tol);
+  REL_TEST(_fp->densityRegion3(24.0e6, 654.0), 1.0 / 0.002967802335, tol);
+  REL_TEST(_fp->densityRegion3(23.6e6, 653.0), 1.0 / 0.003273916816, tol);
+  REL_TEST(_fp->densityRegion3(24.0e6, 655.0), 1.0 / 0.003550329864, tol);
+  REL_TEST(_fp->densityRegion3(23.5e6, 655.0), 1.0 / 0.004545001142, tol);
+  REL_TEST(_fp->densityRegion3(24.0e6, 660.0), 1.0 / 0.005100267704, tol);
+  REL_TEST(_fp->densityRegion3(23.0e6, 660.0), 1.0 / 0.006109525997, tol);
+  REL_TEST(_fp->densityRegion3(24.0e6, 670.0), 1.0 / 0.006427325645, tol);
+  REL_TEST(_fp->densityRegion3(22.6e6, 646.0), 1.0 / 0.002117860851, tol);
+  REL_TEST(_fp->densityRegion3(23.0e6, 646.0), 1.0 / 0.002062374674, tol);
+  REL_TEST(_fp->densityRegion3(22.6e6, 648.6), 1.0 / 0.002533063780, tol);
+  REL_TEST(_fp->densityRegion3(22.8e6, 649.3), 1.0 / 0.002572971781, tol);
+  REL_TEST(_fp->densityRegion3(22.6e6, 649.0), 1.0 / 0.002923432711, tol);
+  REL_TEST(_fp->densityRegion3(22.8e6, 649.7), 1.0 / 0.002913311494, tol);
+  REL_TEST(_fp->densityRegion3(22.6e6, 649.1), 1.0 / 0.003131208996, tol);
+  REL_TEST(_fp->densityRegion3(22.8e6, 649.9), 1.0 / 0.003221160278, tol);
+  REL_TEST(_fp->densityRegion3(22.6e6, 649.4), 1.0 / 0.003715596186, tol);
+  REL_TEST(_fp->densityRegion3(22.8e6, 650.2), 1.0 / 0.003664754790, tol);
+  REL_TEST(_fp->densityRegion3(21.1e6, 640.0), 1.0 / 0.001970999272, tol);
+  REL_TEST(_fp->densityRegion3(21.8e6, 643.0), 1.0 / 0.002043919161, tol);
+  REL_TEST(_fp->densityRegion3(21.1e6, 644.0), 1.0 / 0.005251009921, tol);
+  REL_TEST(_fp->densityRegion3(21.8e6, 648.0), 1.0 / 0.005256844741, tol);
+  REL_TEST(_fp->densityRegion3(19.1e6, 635.0), 1.0 / 0.001932829079, tol);
+  REL_TEST(_fp->densityRegion3(20.0e6, 638.0), 1.0 / 0.001985387227, tol);
+  REL_TEST(_fp->densityRegion3(17.0e6, 626.0), 1.0 / 0.008483262001, tol);
+  REL_TEST(_fp->densityRegion3(20.0e6, 640.0), 1.0 / 0.006227528101, tol);
+  REL_TEST(_fp->densityRegion3(21.5e6, 644.6), 1.0 / 0.002268366647, tol);
+  REL_TEST(_fp->densityRegion3(22.0e6, 646.1), 1.0 / 0.002296350553, tol);
+  REL_TEST(_fp->densityRegion3(22.5e6, 648.6), 1.0 / 0.002832373260, tol);
+  REL_TEST(_fp->densityRegion3(22.3e6, 647.9), 1.0 / 0.002811424405, tol);
+  REL_TEST(_fp->densityRegion3(22.15e6, 647.5), 1.0 / 0.003694032281, tol);
+  REL_TEST(_fp->densityRegion3(22.3e6, 648.1), 1.0 / 0.003622226305, tol);
+  REL_TEST(_fp->densityRegion3(22.11e6, 648.0), 1.0 / 0.004528072649, tol);
+  REL_TEST(_fp->densityRegion3(22.3e6, 649.0), 1.0 / 0.004556905799, tol);
+  REL_TEST(_fp->densityRegion3(22.0e6, 646.84), 1.0 / 0.002698354719, tol);
+  REL_TEST(_fp->densityRegion3(22.064e6, 647.05), 1.0 / 0.002717655648, tol);
+  REL_TEST(_fp->densityRegion3(22.0e6, 646.89), 1.0 / 0.003798732962, tol);
+  REL_TEST(_fp->densityRegion3(22.064e6, 647.15), 1.0 / 0.003701940010, tol);
 }
 
 /**
@@ -307,6 +313,8 @@ TEST_F(Water97FluidPropertiesTest, properties)
 {
   Real p0, p1, p2, T0, T1, T2;
 
+  const Real tol = 1.0e-8;
+
   // Region 1 properties
   p0 = 3.0e6;
   p1 = 80.0e6;
@@ -315,24 +323,24 @@ TEST_F(Water97FluidPropertiesTest, properties)
   T1 = 300.0;
   T2 = 500.0;
 
-  REL_TEST("rho", _fp->rho(p0, T0), 1.0 / 0.00100215168, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p1, T1), 1.0 / 0.000971180894, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p2, T2), 1.0 / 0.00120241800, 1.0e-8);
-  REL_TEST("h", _fp->h(p0, T0), 115.331273e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p1, T1), 184.142828e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p2, T2), 975.542239e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p0, T0), 112.324818e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p1, T1), 106.448356e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p2, T2), 971.934985e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p0, T0), 0.392294792e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p1, T1), 0.368563852e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p2, T2), 2.58041912e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p0, T0), 4.17301218e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p1, T1), 4.01008987e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p2, T2), 4.65580682e3, 1.0e-8);
-  REL_TEST("c", _fp->c(p0, T0), 1507.73921, 1.0e-8);
-  REL_TEST("c", _fp->c(p1, T1), 1634.69054, 1.0e-8);
-  REL_TEST("c", _fp->c(p2, T2), 1240.71337, 1.0e-8);
+  REL_TEST(_fp->rho(p0, T0), 1.0 / 0.00100215168, tol);
+  REL_TEST(_fp->rho(p1, T1), 1.0 / 0.000971180894, tol);
+  REL_TEST(_fp->rho(p2, T2), 1.0 / 0.00120241800, tol);
+  REL_TEST(_fp->h(p0, T0), 115.331273e3, tol);
+  REL_TEST(_fp->h(p1, T1), 184.142828e3, tol);
+  REL_TEST(_fp->h(p2, T2), 975.542239e3, tol);
+  REL_TEST(_fp->e(p0, T0), 112.324818e3, tol);
+  REL_TEST(_fp->e(p1, T1), 106.448356e3, tol);
+  REL_TEST(_fp->e(p2, T2), 971.934985e3, tol);
+  REL_TEST(_fp->s(p0, T0), 0.392294792e3, tol);
+  REL_TEST(_fp->s(p1, T1), 0.368563852e3, tol);
+  REL_TEST(_fp->s(p2, T2), 2.58041912e3, tol);
+  REL_TEST(_fp->cp(p0, T0), 4.17301218e3, tol);
+  REL_TEST(_fp->cp(p1, T1), 4.01008987e3, tol);
+  REL_TEST(_fp->cp(p2, T2), 4.65580682e3, tol);
+  REL_TEST(_fp->c(p0, T0), 1507.73921, tol);
+  REL_TEST(_fp->c(p1, T1), 1634.69054, tol);
+  REL_TEST(_fp->c(p2, T2), 1240.71337, tol);
 
   // Region 2 properties
   p0 = 3.5e3;
@@ -342,24 +350,24 @@ TEST_F(Water97FluidPropertiesTest, properties)
   T1 = 700.0;
   T2 = 700.0;
 
-  REL_TEST("rho", _fp->rho(p0, T0), 1.0 / 39.4913866, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p1, T1), 1.0 / 92.3015898, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p2, T2), 1.0 / 0.00542946619, 1.0e-8);
-  REL_TEST("h", _fp->h(p0, T0), 2549.91145e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p1, T1), 3335.68375e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p2, T2), 2631.49474e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p0, T0), 2411.6916e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p1, T1), 3012.62819e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p2, T2), 2468.61076e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p0, T0), 8.52238967e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p1, T1), 10.1749996e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p2, T2), 5.17540298e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p0, T0), 1.91300162e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p1, T1), 2.08141274e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p2, T2), 10.3505092e3, 1.0e-8);
-  REL_TEST("c", _fp->c(p0, T0), 427.920172, 1.0e-8);
-  REL_TEST("c", _fp->c(p1, T1), 644.289068, 1.0e-8);
-  REL_TEST("c", _fp->c(p2, T2), 480.386523, 1.0e-8);
+  REL_TEST(_fp->rho(p0, T0), 1.0 / 39.4913866, tol);
+  REL_TEST(_fp->rho(p1, T1), 1.0 / 92.3015898, tol);
+  REL_TEST(_fp->rho(p2, T2), 1.0 / 0.00542946619, tol);
+  REL_TEST(_fp->h(p0, T0), 2549.91145e3, tol);
+  REL_TEST(_fp->h(p1, T1), 3335.68375e3, tol);
+  REL_TEST(_fp->h(p2, T2), 2631.49474e3, tol);
+  REL_TEST(_fp->e(p0, T0), 2411.6916e3, tol);
+  REL_TEST(_fp->e(p1, T1), 3012.62819e3, tol);
+  REL_TEST(_fp->e(p2, T2), 2468.61076e3, tol);
+  REL_TEST(_fp->s(p0, T0), 8.52238967e3, tol);
+  REL_TEST(_fp->s(p1, T1), 10.1749996e3, tol);
+  REL_TEST(_fp->s(p2, T2), 5.17540298e3, tol);
+  REL_TEST(_fp->cp(p0, T0), 1.91300162e3, tol);
+  REL_TEST(_fp->cp(p1, T1), 2.08141274e3, tol);
+  REL_TEST(_fp->cp(p2, T2), 10.3505092e3, tol);
+  REL_TEST(_fp->c(p0, T0), 427.920172, tol);
+  REL_TEST(_fp->c(p1, T1), 644.289068, tol);
+  REL_TEST(_fp->c(p2, T2), 480.386523, tol);
 
   // Region 3 properties
   p0 = 25.5837018e6;
@@ -370,24 +378,24 @@ TEST_F(Water97FluidPropertiesTest, properties)
   T2 = 750.0;
 
   // Note: lower tolerance in this region as density is calculated using backwards equation
-  REL_TEST("rho", _fp->rho(p0, T0), 500.0, 1.0e-5);
-  REL_TEST("rho", _fp->rho(p1, T1), 200.0, 1.0e-5);
-  REL_TEST("rho", _fp->rho(p2, T2), 500.0, 1.0e-5);
-  REL_TEST("h", _fp->h(p0, T0), 1863.43019e3, 1.0e-5);
-  REL_TEST("h", _fp->h(p1, T1), 2375.12401e3, 1.0e-5);
-  REL_TEST("h", _fp->h(p2, T2), 2258.68845e3, 1.0e-5);
-  REL_TEST("e", _fp->e(p0, T0), 1812.26279e3, 1.0e-5);
-  REL_TEST("e", _fp->e(p1, T1), 2263.65868e3, 1.0e-5);
-  REL_TEST("e", _fp->e(p2, T2), 2102.06932e3, 1.0e-5);
-  REL_TEST("s", _fp->s(p0, T0), 4.05427273e3, 1.0e-5);
-  REL_TEST("s", _fp->s(p1, T1), 4.85438792e3, 1.0e-5);
-  REL_TEST("s", _fp->s(p2, T2), 4.46971906e3, 1.0e-5);
-  REL_TEST("cp", _fp->cp(p0, T0), 13.8935717e3, 1.0e-4);
-  REL_TEST("cp", _fp->cp(p1, T1), 44.6579342e3, 1.0e-5);
-  REL_TEST("cp", _fp->cp(p2, T2), 6.34165359e3, 1.0e-5);
-  REL_TEST("c", _fp->c(p0, T0), 502.005554, 1.0e-5);
-  REL_TEST("c", _fp->c(p1, T1), 383.444594, 1.0e-5);
-  REL_TEST("c", _fp->c(p2, T2), 760.696041, 1.0e-5);
+  REL_TEST(_fp->rho(p0, T0), 500.0, 1.0e-5);
+  REL_TEST(_fp->rho(p1, T1), 200.0, 1.0e-5);
+  REL_TEST(_fp->rho(p2, T2), 500.0, 1.0e-5);
+  REL_TEST(_fp->h(p0, T0), 1863.43019e3, 1.0e-5);
+  REL_TEST(_fp->h(p1, T1), 2375.12401e3, 1.0e-5);
+  REL_TEST(_fp->h(p2, T2), 2258.68845e3, 1.0e-5);
+  REL_TEST(_fp->e(p0, T0), 1812.26279e3, 1.0e-5);
+  REL_TEST(_fp->e(p1, T1), 2263.65868e3, 1.0e-5);
+  REL_TEST(_fp->e(p2, T2), 2102.06932e3, 1.0e-5);
+  REL_TEST(_fp->s(p0, T0), 4.05427273e3, 1.0e-5);
+  REL_TEST(_fp->s(p1, T1), 4.85438792e3, 1.0e-5);
+  REL_TEST(_fp->s(p2, T2), 4.46971906e3, 1.0e-5);
+  REL_TEST(_fp->cp(p0, T0), 13.8935717e3, 1.0e-4);
+  REL_TEST(_fp->cp(p1, T1), 44.6579342e3, 1.0e-5);
+  REL_TEST(_fp->cp(p2, T2), 6.34165359e3, 1.0e-5);
+  REL_TEST(_fp->c(p0, T0), 502.005554, 1.0e-5);
+  REL_TEST(_fp->c(p1, T1), 383.444594, 1.0e-5);
+  REL_TEST(_fp->c(p2, T2), 760.696041, 1.0e-5);
 
   // Region 5 properties
   p0 = 0.5e6;
@@ -397,88 +405,88 @@ TEST_F(Water97FluidPropertiesTest, properties)
   T1 = 1500.0;
   T2 = 2000.0;
 
-  REL_TEST("rho", _fp->rho(p0, T0), 1.0 / 1.38455090, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p1, T1), 1.0 / 0.0230761299, 1.0e-8);
-  REL_TEST("rho", _fp->rho(p2, T2), 1.0 / 0.0311385219, 1.0e-8);
-  REL_TEST("h", _fp->h(p0, T0), 5219.76855e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p1, T1), 5167.23514e3, 1.0e-8);
-  REL_TEST("h", _fp->h(p2, T2), 6571.22604e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p0, T0), 4527.4931e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p1, T1), 4474.95124e3, 1.0e-8);
-  REL_TEST("e", _fp->e(p2, T2), 5637.07038e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p0, T0), 9.65408875e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p1, T1), 7.72970133e3, 1.0e-8);
-  REL_TEST("s", _fp->s(p2, T2), 8.53640523e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p0, T0), 2.61609445e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p1, T1), 2.72724317e3, 1.0e-8);
-  REL_TEST("cp", _fp->cp(p2, T2), 2.88569882e3, 1.0e-8);
-  REL_TEST("c", _fp->c(p0, T0), 917.06869, 1.0e-8);
-  REL_TEST("c", _fp->c(p1, T1), 928.548002, 1.0e-8);
-  REL_TEST("c", _fp->c(p2, T2), 1067.36948, 1.0e-8);
+  REL_TEST(_fp->rho(p0, T0), 1.0 / 1.38455090, tol);
+  REL_TEST(_fp->rho(p1, T1), 1.0 / 0.0230761299, tol);
+  REL_TEST(_fp->rho(p2, T2), 1.0 / 0.0311385219, tol);
+  REL_TEST(_fp->h(p0, T0), 5219.76855e3, tol);
+  REL_TEST(_fp->h(p1, T1), 5167.23514e3, tol);
+  REL_TEST(_fp->h(p2, T2), 6571.22604e3, tol);
+  REL_TEST(_fp->e(p0, T0), 4527.4931e3, tol);
+  REL_TEST(_fp->e(p1, T1), 4474.95124e3, tol);
+  REL_TEST(_fp->e(p2, T2), 5637.07038e3, tol);
+  REL_TEST(_fp->s(p0, T0), 9.65408875e3, tol);
+  REL_TEST(_fp->s(p1, T1), 7.72970133e3, tol);
+  REL_TEST(_fp->s(p2, T2), 8.53640523e3, tol);
+  REL_TEST(_fp->cp(p0, T0), 2.61609445e3, tol);
+  REL_TEST(_fp->cp(p1, T1), 2.72724317e3, tol);
+  REL_TEST(_fp->cp(p2, T2), 2.88569882e3, tol);
+  REL_TEST(_fp->c(p0, T0), 917.06869, tol);
+  REL_TEST(_fp->c(p1, T1), 928.548002, tol);
+  REL_TEST(_fp->c(p2, T2), 1067.36948, tol);
 
   // Viscosity
-  REL_TEST("mu", _fp->mu_from_rho_T(998.0, 298.15), 889.735100e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(1200.0, 298.15), 1437.649467e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(1000.0, 373.15), 307.883622e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(1.0, 433.15), 14.538324e-6, 1.0e-7);
-  REL_TEST("mu", _fp->mu_from_rho_T(1000.0, 433.15), 217.685358e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(1.0, 873.15), 32.619287e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(100.0, 873.15), 35.802262e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(600.0, 873.15), 77.430195e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(1.0, 1173.15), 44.217245e-6, 1.0e-7);
-  REL_TEST("mu", _fp->mu_from_rho_T(100.0, 1173.15), 47.640433e-6, 1.0e-8);
-  REL_TEST("mu", _fp->mu_from_rho_T(400.0, 1173.15), 64.154608e-6, 1.0e-8);
+  REL_TEST(_fp->mu_from_rho_T(998.0, 298.15), 889.735100e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(1200.0, 298.15), 1437.649467e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(1000.0, 373.15), 307.883622e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(1.0, 433.15), 14.538324e-6, 1.0e-7);
+  REL_TEST(_fp->mu_from_rho_T(1000.0, 433.15), 217.685358e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(1.0, 873.15), 32.619287e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(100.0, 873.15), 35.802262e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(600.0, 873.15), 77.430195e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(1.0, 1173.15), 44.217245e-6, 1.0e-7);
+  REL_TEST(_fp->mu_from_rho_T(100.0, 1173.15), 47.640433e-6, tol);
+  REL_TEST(_fp->mu_from_rho_T(400.0, 1173.15), 64.154608e-6, tol);
 
-  ABS_TEST("mu", _fp->mu(1e6, 298.15), 889.898581797e-6, 2e-8);
-  ABS_TEST("mu", _fp->mu(2e6, 298.15), 889.763899645e-6, 1e-8);
-  ABS_TEST("mu", _fp->mu(1e6, 373.15), 281.825180491e-6, 1e-8);
-  ABS_TEST("mu", _fp->mu(2e6, 373.15), 282.09550632e-6, 1e-8);
-  ABS_TEST("mu", _fp->mu(1e6, 433.15), 170.526801634e-6, 1e-8);
-  ABS_TEST("mu", _fp->mu(2e6, 433.15), 170.780193827e-6, 1e-8);
-  ABS_TEST("mu", _fp->mu(1e6, 873.15), 3.2641885983e-5, 1e-12);
-  ABS_TEST("mu", _fp->mu(2e6, 873.15), 3.26820969808e-5, 1e-12);
-  ABS_TEST("mu", _fp->mu(1e6, 1173.15), 4.42374919686e-5, 1e-12);
-  ABS_TEST("mu", _fp->mu(2e6, 1173.15), 4.42823959629e-5, 1e-12);
+  ABS_TEST(_fp->mu(1e6, 298.15), 889.898581797e-6, 2e-8);
+  ABS_TEST(_fp->mu(2e6, 298.15), 889.763899645e-6, 1e-8);
+  ABS_TEST(_fp->mu(1e6, 373.15), 281.825180491e-6, 1e-8);
+  ABS_TEST(_fp->mu(2e6, 373.15), 282.09550632e-6, 1e-8);
+  ABS_TEST(_fp->mu(1e6, 433.15), 170.526801634e-6, 1e-8);
+  ABS_TEST(_fp->mu(2e6, 433.15), 170.780193827e-6, 1e-8);
+  ABS_TEST(_fp->mu(1e6, 873.15), 3.2641885983e-5, 1e-12);
+  ABS_TEST(_fp->mu(2e6, 873.15), 3.26820969808e-5, 1e-12);
+  ABS_TEST(_fp->mu(1e6, 1173.15), 4.42374919686e-5, 1e-12);
+  ABS_TEST(_fp->mu(2e6, 1173.15), 4.42823959629e-5, 1e-12);
 
   // Thermal conductivity
-  REL_TEST("k", _fp->k(1.0e6, 323.15), 0.641, 1.0e-4);
-  REL_TEST("k", _fp->k(20.0e6, 623.15), 0.4541, 1.0e-4);
-  REL_TEST("k", _fp->k(50.0e6, 773.15), 0.2055, 1.0e-4);
+  REL_TEST(_fp->k(1.0e6, 323.15), 0.641, 1.0e-4);
+  REL_TEST(_fp->k(20.0e6, 623.15), 0.4541, 1.0e-4);
+  REL_TEST(_fp->k(50.0e6, 773.15), 0.2055, 1.0e-4);
 
-  ABS_TEST("k", _fp->k(1.0e6, 323.15), 0.640972, 5e-7);
-  ABS_TEST("k", _fp->k(20.0e6, 623.15), 0.454131, 7e-7);
-  ABS_TEST("k", _fp->k(50.0e6, 773.15), 0.205485, 5e-7);
+  ABS_TEST(_fp->k(1.0e6, 323.15), 0.640972, 5e-7);
+  ABS_TEST(_fp->k(20.0e6, 623.15), 0.454131, 7e-7);
+  ABS_TEST(_fp->k(50.0e6, 773.15), 0.205485, 5e-7);
 
   // Backwards equation T(p,h)
   // Region 1
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(3.0e6, 500.0e3), 0.391798509e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(80.0e6, 500.0e3), 0.378108626e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(80.0e6, 1500.0e3), 0.611041229e3, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(3.0e6, 500.0e3), 0.391798509e3, tol);
+  REL_TEST(_fp->temperature_from_ph(80.0e6, 500.0e3), 0.378108626e3, tol);
+  REL_TEST(_fp->temperature_from_ph(80.0e6, 1500.0e3), 0.611041229e3, tol);
 
   // Region 2 (subregion a)
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(1.0e3, 3000.0e3), 0.534433241e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(3.0e6, 3000.0e3), 0.575373370e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(3.0e6, 4000.0e3), 0.101077577e4, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(1.0e3, 3000.0e3), 0.534433241e3, tol);
+  REL_TEST(_fp->temperature_from_ph(3.0e6, 3000.0e3), 0.575373370e3, tol);
+  REL_TEST(_fp->temperature_from_ph(3.0e6, 4000.0e3), 0.101077577e4, tol);
 
   // Region 2 (subregion b)
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(5.0e6, 3500.0e3), 0.801299102e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(5.0e6, 4000.0e3), 0.101531583e4, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(25.0e6, 3500.0e3), 0.875279054e3, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(5.0e6, 3500.0e3), 0.801299102e3, tol);
+  REL_TEST(_fp->temperature_from_ph(5.0e6, 4000.0e3), 0.101531583e4, tol);
+  REL_TEST(_fp->temperature_from_ph(25.0e6, 3500.0e3), 0.875279054e3, tol);
 
   // Region 2 (subregion c)
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(40.0e6, 2700.0e3), 0.743056411e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(60.0e6, 2700.0e3), 0.791137067e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(60.0e6, 3200.0e3), 0.882756860e3, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(40.0e6, 2700.0e3), 0.743056411e3, tol);
+  REL_TEST(_fp->temperature_from_ph(60.0e6, 2700.0e3), 0.791137067e3, tol);
+  REL_TEST(_fp->temperature_from_ph(60.0e6, 3200.0e3), 0.882756860e3, tol);
 
   // Region 3 (subregion a)
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(20.0e6, 1700.0e3), 0.6293083892e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(50.0e6, 2000.0e3), 0.6905718338e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(100.0e6, 2100.0e3), 0.7336163014e3, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(20.0e6, 1700.0e3), 0.6293083892e3, tol);
+  REL_TEST(_fp->temperature_from_ph(50.0e6, 2000.0e3), 0.6905718338e3, tol);
+  REL_TEST(_fp->temperature_from_ph(100.0e6, 2100.0e3), 0.7336163014e3, tol);
 
   // Region 3 (subregion b)
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(20.0e6, 2500.0e3), 0.6418418053e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(50.0e6, 2400.0e3), 0.7351848618e3, 1.0e-8);
-  REL_TEST("T(p,h)", _fp->temperature_from_ph(100.0e6, 2700.0e3), 0.8420460876e3, 1.0e-8);
+  REL_TEST(_fp->temperature_from_ph(20.0e6, 2500.0e3), 0.6418418053e3, tol);
+  REL_TEST(_fp->temperature_from_ph(50.0e6, 2400.0e3), 0.7351848618e3, tol);
+  REL_TEST(_fp->temperature_from_ph(100.0e6, 2700.0e3), 0.8420460876e3, tol);
 }
 
 /**
@@ -487,35 +495,45 @@ TEST_F(Water97FluidPropertiesTest, properties)
  */
 TEST_F(Water97FluidPropertiesTest, derivatives)
 {
+  const Real tol = REL_TOL_DERIVATIVE;
+
   // Region 1
   Real p = 3.0e6;
   Real T = 300.0;
-  regionDerivatives(p, T, 1.0e-6);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
 
   // Region 2
   p = 3.5e3;
   T = 300.0;
-  regionDerivatives(p, T, 1.0e-6);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
 
   // Region 3
   p = 26.0e6;
   T = 650.0;
-  regionDerivatives(p, T, 1.0e-2);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, 1.0e-2);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, 1.0e-2);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, 1.0e-2);
 
   // Region 4 (saturation curve)
   T = 300.0;
-  Real dT = 1.0e-4;
+  const Real dT = 1.0e-4;
 
   Real dpSat_dT_fd = (_fp->vaporPressure(T + dT) - _fp->vaporPressure(T - dT)) / (2.0 * dT);
   Real pSat = 0.0, dpSat_dT = 0.0;
   _fp->vaporPressure_dT(T, pSat, dpSat_dT);
 
-  REL_TEST("dvaporPressure_dT", dpSat_dT, dpSat_dT_fd, 1.0e-6);
+  REL_TEST(dpSat_dT, dpSat_dT_fd, 1.0e-6);
 
   // Region 5
   p = 30.0e6;
   T = 1500.0;
-  regionDerivatives(p, T, 1.0e-6);
+  DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
+  DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
 
   // Viscosity
   Real rho = 998.0, drho_dp = 0.0, drho_dT = 0.0;
@@ -527,20 +545,19 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   Real mu = 0.0, dmu_drho = 0.0, dmu_dT = 0.0;
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
 
-  ABS_TEST("mu", mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
-  REL_TEST("dmu_drho", dmu_drho, dmu_drho_fd, 1.0e-6);
+  ABS_TEST(mu, _fp->mu_from_rho_T(rho, T), 1.0e-15);
+  REL_TEST(dmu_drho, dmu_drho_fd, 1.0e-6);
 
   // To properly test derivative wrt temperature, use p and T and calculate density,
   // so that the change in density wrt temperature is included
   p = 1.0e6;
-  dT = 1.0e-4;
   _fp->rho_dpT(p, T, rho, drho_dp, drho_dT);
   _fp->mu_drhoT_from_rho_T(rho, T, drho_dT, mu, dmu_drho, dmu_dT);
   Real dmu_dT_fd = (_fp->mu_from_rho_T(_fp->rho(p, T + dT), T + dT) -
                     _fp->mu_from_rho_T(_fp->rho(p, T - dT), T - dT)) /
                    (2.0 * dT);
 
-  REL_TEST("dmu_dT", dmu_dT, dmu_dT_fd, 1.0e-6);
+  REL_TEST(dmu_dT, dmu_dT_fd, 1.0e-6);
 
   // Check derivative of viscosity wrt pressure
   Real dp = 1.0e1;
@@ -549,5 +566,17 @@ TEST_F(Water97FluidPropertiesTest, derivatives)
   Real dmu_dp = 0.0;
   _fp->mu_dpT(p, T, mu, dmu_dp, dmu_dT);
 
-  REL_TEST("dmu_dp", dmu_dp, dmu_dp_fd, 1.0e-5);
+  REL_TEST(dmu_dp, dmu_dp_fd, 1.0e-5);
+}
+
+/**
+ * Verify that the methods that return multiple properties in one call return identical
+ * values as the individual methods
+ */
+TEST_F(Water97FluidPropertiesTest, combined)
+{
+  const Real p = 1.0e6;
+  const Real T = 300.0;
+
+  combinedProperties(_fp, p, T, REL_TOL_SAVED_VALUE);
 }


### PR DESCRIPTION
I found this branch on my laptop that I did a while ago but never pushed.

There are a few parts:

- There were `ABS_TEST` and `REL_TEST` macros defined in two headers, so I have removed one so that there is only one of each defined
- Added `SinglePhaseFluidPropertiesPTUtils.h` that includes a `DERIV_TEST` macro (like but not quite the same as the one in `SinglePhaseFluidPropertiesUtils.h`), and a method that tests all of the fluid properties methods that return more than one property (like `rho_mu` that is used in porous flow) to reduce code duplication in these tests
- Added a heap of additional unit tests of methods that were not already unit tested

Closes #11576 