### PR TITLE
Add MooseMesh::safeClone()

### DIFF
--- a/framework/include/mesh/AnnularMesh.h
+++ b/framework/include/mesh/AnnularMesh.h
@@ -30,6 +30,8 @@ public:
   AnnularMesh & operator=(const AnnularMesh & other_mesh) = delete;
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
+
   virtual void buildMesh() override;
   virtual Real getMinInDimension(unsigned int component) const override;
   virtual Real getMaxInDimension(unsigned int component) const override;

--- a/framework/include/mesh/DistributedGeneratedMesh.h
+++ b/framework/include/mesh/DistributedGeneratedMesh.h
@@ -30,6 +30,8 @@ public:
   DistributedGeneratedMesh & operator=(const DistributedGeneratedMesh & other_mesh) = delete;
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
+
   virtual void buildMesh() override;
   virtual Real getMinInDimension(unsigned int component) const override;
   virtual Real getMaxInDimension(unsigned int component) const override;

--- a/framework/include/mesh/FileMesh.h
+++ b/framework/include/mesh/FileMesh.h
@@ -26,6 +26,7 @@ public:
   virtual ~FileMesh(); // empty dtor required for unique_ptr with forward declarations
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/include/mesh/GeneratedMesh.h
+++ b/framework/include/mesh/GeneratedMesh.h
@@ -30,6 +30,8 @@ public:
   GeneratedMesh & operator=(const GeneratedMesh & other_mesh) = delete;
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
+
   virtual void buildMesh() override;
   virtual Real getMinInDimension(unsigned int component) const override;
   virtual Real getMaxInDimension(unsigned int component) const override;

--- a/framework/include/mesh/ImageMesh.h
+++ b/framework/include/mesh/ImageMesh.h
@@ -28,6 +28,7 @@ public:
   ImageMesh(const ImageMesh & other_mesh);
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -87,6 +87,13 @@ public:
   virtual MooseMesh & clone() const = 0;
 
   /**
+   * A safer version of the clone() method that hands back an
+   * allocated object wrapped in a smart pointer. This makes it much
+   * less likely that the caller will leak the memory in question.
+   */
+  virtual std::unique_ptr<MooseMesh> safeClone() const = 0;
+
+  /**
    * Initialize the Mesh object.  Most of the time this will turn around
    * and call build_mesh so the child class can build the Mesh object.
    *

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -90,8 +90,13 @@ public:
    * A safer version of the clone() method that hands back an
    * allocated object wrapped in a smart pointer. This makes it much
    * less likely that the caller will leak the memory in question.
+   *
+   * TODO: this currently has a base class mooseError implementation
+   * for forwards compatibility purposes, but eventually it will be
+   * transistioned to a pure virtual, replacing the original non-safe
+   * clone() function above.
    */
-  virtual std::unique_ptr<MooseMesh> safeClone() const = 0;
+  virtual std::unique_ptr<MooseMesh> safeClone() const;
 
   /**
    * Initialize the Mesh object.  Most of the time this will turn around

--- a/framework/include/mesh/PatternedMesh.h
+++ b/framework/include/mesh/PatternedMesh.h
@@ -41,6 +41,7 @@ public:
   virtual ~PatternedMesh();
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/include/mesh/StitchedMesh.h
+++ b/framework/include/mesh/StitchedMesh.h
@@ -36,6 +36,7 @@ public:
   virtual ~StitchedMesh();
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/include/mesh/TiledMesh.h
+++ b/framework/include/mesh/TiledMesh.h
@@ -24,6 +24,7 @@ public:
   TiledMesh(const TiledMesh & other_mesh);
 
   virtual MooseMesh & clone() const override;
+  virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;
 

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -119,6 +119,12 @@ AnnularMesh::clone() const
   return *(new AnnularMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+AnnularMesh::safeClone() const
+{
+  return libmesh_make_unique<AnnularMesh>(*this);
+}
+
 void
 AnnularMesh::buildMesh()
 {

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -116,6 +116,7 @@ AnnularMesh::getMaxInDimension(unsigned int component) const
 MooseMesh &
 AnnularMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new AnnularMesh(*this));
 }
 

--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -162,6 +162,12 @@ DistributedGeneratedMesh::clone() const
   return *(new DistributedGeneratedMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+DistributedGeneratedMesh::safeClone() const
+{
+  return libmesh_make_unique<DistributedGeneratedMesh>(*this);
+}
+
 namespace
 {
 

--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -159,6 +159,7 @@ DistributedGeneratedMesh::getMaxInDimension(unsigned int component) const
 MooseMesh &
 DistributedGeneratedMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new DistributedGeneratedMesh(*this));
 }
 

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -45,6 +45,7 @@ FileMesh::~FileMesh() {}
 MooseMesh &
 FileMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new FileMesh(*this));
 }
 

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -48,6 +48,12 @@ FileMesh::clone() const
   return *(new FileMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+FileMesh::safeClone() const
+{
+  return libmesh_make_unique<FileMesh>(*this);
+}
+
 void
 FileMesh::buildMesh()
 {

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -134,6 +134,7 @@ GeneratedMesh::getMaxInDimension(unsigned int component) const
 MooseMesh &
 GeneratedMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new GeneratedMesh(*this));
 }
 

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -137,6 +137,12 @@ GeneratedMesh::clone() const
   return *(new GeneratedMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+GeneratedMesh::safeClone() const
+{
+  return libmesh_make_unique<GeneratedMesh>(*this);
+}
+
 void
 GeneratedMesh::buildMesh()
 {

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -62,6 +62,12 @@ ImageMesh::clone() const
   return *(new ImageMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+ImageMesh::safeClone() const
+{
+  return libmesh_make_unique<ImageMesh>(*this);
+}
+
 void
 ImageMesh::buildMesh()
 {

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -59,6 +59,7 @@ ImageMesh::ImageMesh(const ImageMesh & other_mesh)
 MooseMesh &
 ImageMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new ImageMesh(*this));
 }
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1858,6 +1858,12 @@ MooseMesh::getNormalByBoundaryID(BoundaryID id) const
   return (*_boundary_to_normal_map)[id];
 }
 
+std::unique_ptr<MooseMesh>
+MooseMesh::safeClone() const
+{
+  mooseError("The safeClone() functionality must be implemented in derived classes!");
+}
+
 void
 MooseMesh::init()
 {

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -100,6 +100,7 @@ PatternedMesh::~PatternedMesh() {}
 MooseMesh &
 PatternedMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new PatternedMesh(*this));
 }
 

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -103,6 +103,12 @@ PatternedMesh::clone() const
   return *(new PatternedMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+PatternedMesh::safeClone() const
+{
+  return libmesh_make_unique<PatternedMesh>(*this);
+}
+
 void
 PatternedMesh::buildMesh()
 {

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -85,6 +85,12 @@ StitchedMesh::clone() const
   return *(new StitchedMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+StitchedMesh::safeClone() const
+{
+  return libmesh_make_unique<StitchedMesh>(*this);
+}
+
 void
 StitchedMesh::buildMesh()
 {

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -82,6 +82,7 @@ StitchedMesh::~StitchedMesh() {}
 MooseMesh &
 StitchedMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new StitchedMesh(*this));
 }
 

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -83,6 +83,12 @@ TiledMesh::clone() const
   return *(new TiledMesh(*this));
 }
 
+std::unique_ptr<MooseMesh>
+TiledMesh::safeClone() const
+{
+  return libmesh_make_unique<TiledMesh>(*this);
+}
+
 std::string
 TiledMesh::getFileName() const
 {

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -80,6 +80,7 @@ TiledMesh::TiledMesh(const TiledMesh & other_mesh)
 MooseMesh &
 TiledMesh::clone() const
 {
+  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
   return *(new TiledMesh(*this));
 }
 

--- a/framework/src/meshmodifiers/MeshExtruder.C
+++ b/framework/src/meshmodifiers/MeshExtruder.C
@@ -66,9 +66,7 @@ MeshExtruder::MeshExtruder(const InputParameters & parameters)
 void
 MeshExtruder::modify()
 {
-  // When we clone, we're responsible to clean up after ourselves!
-  // TODO: traditionally clone() methods return pointers...
-  MooseMesh * source_mesh = &(_mesh_ptr->clone());
+  std::unique_ptr<MooseMesh> source_mesh = _mesh_ptr->safeClone();
 
   if (source_mesh->getMesh().mesh_dimension() == 3)
     mooseError("You cannot extrude a 3D mesh!");
@@ -110,9 +108,6 @@ MeshExtruder::modify()
 
   // Update the dimension
   _mesh_ptr->getMesh().set_mesh_dimension(source_mesh->getMesh().mesh_dimension() + 1);
-
-  // Clean up the source mesh we allocated
-  delete source_mesh;
 }
 
 void

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -279,7 +279,7 @@ OversampleOutput::cloneMesh()
       mooseWarning("Recovering or Restarting with Oversampling may not work (especially with "
                    "adapted meshes)!!  Refs #2295");
 
-    _cloned_mesh_ptr.reset(&(_mesh_ptr->clone()));
+    _cloned_mesh_ptr = _mesh_ptr->safeClone();
   }
 
   // Make sure that the mesh pointer points to the newly cloned mesh


### PR DESCRIPTION
~~Also temporarily add `mooseError()` calls to all existing `MooseMesh::clone()` calls to see if any of the apps break. If they don't, we might not even need to to deprecate this and we could just remove it instead...~~

`safeClone()` is currently implemented as an error in the base class, but I am preparing PRs for the internal apps which define their own Meshes so that it will eventually become pure virtual.
 
Discovered while reviewing #11505.

