### PR TITLE
Increase unit test coverage in fluid properties module

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -87,17 +87,17 @@ public:
   virtual void
   rho_mu(Real pressure, Real temperature, Real xnacl, Real & rho, Real & mu) const override;
 
-  virtual void rho_mu_dpT(Real pressure,
-                          Real temperature,
-                          Real xnacl,
-                          Real & rho,
-                          Real & drho_dp,
-                          Real & drho_dT,
-                          Real & drho_dx,
-                          Real & mu,
-                          Real & dmu_dp,
-                          Real & dmu_dT,
-                          Real dmu_dx) const override;
+  virtual void rho_mu_dpTx(Real pressure,
+                           Real temperature,
+                           Real xnacl,
+                           Real & rho,
+                           Real & drho_dp,
+                           Real & drho_dT,
+                           Real & drho_dx,
+                           Real & mu,
+                           Real & dmu_dp,
+                           Real & dmu_dT,
+                           Real & dmu_dx) const override;
 
   virtual Real h(Real pressure, Real temperature, Real xnacl) const override;
 

--- a/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/MultiComponentFluidPropertiesPT.h
@@ -98,7 +98,7 @@ public:
   virtual void rho_mu(Real pressure, Real temperature, Real xmass, Real & rho, Real & mu) const = 0;
 
   /**
-   * Density and viscosity and their derivatives wrt pressure and temperature
+   * Density and viscosity and their derivatives wrt pressure, temperature and mass fraction
    * @param pressure fluid pressure (Pa)
    * @param temperature fluid temperature (K)
    * @param xmass mass fraction (-)
@@ -111,17 +111,17 @@ public:
    * @param[out] dmu_dT derivative of viscosity wrt temperature
    * @param[out] dmu_dx derivative of viscosity wrt mass fraction
    */
-  virtual void rho_mu_dpT(Real pressure,
-                          Real temperature,
-                          Real xmass,
-                          Real & rho,
-                          Real & drho_dp,
-                          Real & drho_dT,
-                          Real & drho_dx,
-                          Real & mu,
-                          Real & dmu_dp,
-                          Real & dmu_dT,
-                          Real dmu_dx) const = 0;
+  virtual void rho_mu_dpTx(Real pressure,
+                           Real temperature,
+                           Real xmass,
+                           Real & rho,
+                           Real & drho_dp,
+                           Real & drho_dT,
+                           Real & drho_dx,
+                           Real & mu,
+                           Real & dmu_dp,
+                           Real & dmu_dT,
+                           Real & dmu_dx) const = 0;
 
   /**
    * Enthalpy

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -207,17 +207,17 @@ BrineFluidProperties::rho_mu(
 }
 
 void
-BrineFluidProperties::rho_mu_dpT(Real pressure,
-                                 Real temperature,
-                                 Real xnacl,
-                                 Real & rho,
-                                 Real & drho_dp,
-                                 Real & drho_dT,
-                                 Real & drho_dx,
-                                 Real & mu,
-                                 Real & dmu_dp,
-                                 Real & dmu_dT,
-                                 Real dmu_dx) const
+BrineFluidProperties::rho_mu_dpTx(Real pressure,
+                                  Real temperature,
+                                  Real xnacl,
+                                  Real & rho,
+                                  Real & drho_dp,
+                                  Real & drho_dT,
+                                  Real & drho_dx,
+                                  Real & mu,
+                                  Real & dmu_dp,
+                                  Real & dmu_dT,
+                                  Real & dmu_dx) const
 {
   this->rho_dpTx(pressure, temperature, xnacl, rho, drho_dp, drho_dT, drho_dx);
   this->mu_dpTx(pressure, temperature, xnacl, mu, dmu_dp, dmu_dT, dmu_dx);

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -760,9 +760,17 @@ CO2FluidProperties::k(Real pressure, Real temperature) const
 
 void
 CO2FluidProperties::k_dpT(
-    Real /*pressure*/, Real /*temperature*/, Real & /*k*/, Real & /*dk_dp*/, Real & /*dk_dT*/) const
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
 {
-  mooseError(name(), ": k_dpT() is not implemented");
+  k = this->k(pressure, temperature);
+  // Calculate derivatives using finite differences. Note: this will be slow as
+  // multiple calculations of density are required
+  const Real eps = 1.0e-6;
+  const Real peps = pressure * eps;
+  const Real Teps = temperature * eps;
+
+  dk_dp = (this->k(pressure + peps, temperature) - k) / peps;
+  dk_dT = (this->k(pressure, temperature + Teps) - k) / Teps;
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -272,6 +272,10 @@ MethaneFluidProperties::s(Real /*pressure*/, Real temperature) const
     entropy = _a1[0] * std::log(temperature);
     for (std::size_t i = 1; i < _a1.size(); ++i)
       entropy += _a1[i] * MathUtils::pow(temperature, i) / static_cast<Real>(i);
+
+    // As entropy is obtained from cp by integration in this formulation, a zero
+    // shift is required in this regime, see Irvine and Liley (1984)
+    entropy -= 39.768;
   }
 
   // convert to J/kg/K by multiplying by 1000
@@ -291,8 +295,14 @@ MethaneFluidProperties::h(Real /*pressure*/, Real temperature) const
     for (std::size_t i = 0; i < _a0.size(); ++i)
       enthalpy += _a0[i] * MathUtils::pow(temperature, i + 1) / (i + 1.0);
   else
+  {
     for (std::size_t i = 0; i < _a1.size(); ++i)
       enthalpy += _a1[i] * MathUtils::pow(temperature, i + 1) / (i + 1.0);
+
+    // As enthalpy is obtained from cp by integration in this formulation, a zero
+    // shift is required in this regime, see Irvine and Liley (1984)
+    enthalpy -= 1.4837e3;
+  }
 
   // convert to J/kg by multiplying by 1000
   return enthalpy * 1000.0;

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -53,6 +53,8 @@ protected:
     tab_gen_uo_params.set<Real>("pressure_max") = 2e6;
     tab_gen_uo_params.set<unsigned int>("num_T") = 6;
     tab_gen_uo_params.set<unsigned int>("num_p") = 6;
+    MultiMooseEnum properties("density enthalpy internal_energy viscosity k cv cp entropy");
+    tab_gen_uo_params.set<MultiMooseEnum>("interpolated_properties") = properties;
     _fe_problem->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
     _tab_gen_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
 

--- a/unit/src/BrineFluidPropertiesTest.C
+++ b/unit/src/BrineFluidPropertiesTest.C
@@ -221,3 +221,41 @@ TEST_F(BrineFluidPropertiesTest, derivatives)
 
   REL_TEST(dmu_dx, dmu_dx_fd, 1.0e-3);
 }
+
+/**
+ * Verify that the methods that return multiple properties in one call return identical
+ * values as the individual methods
+ */
+TEST_F(BrineFluidPropertiesTest, combined)
+{
+  const Real tol = REL_TOL_SAVED_VALUE;
+  const Real p = 1.0e6;
+  const Real T = 350.0;
+  const Real x = 0.1047;
+
+  // Single property methods
+  Real rho, drho_dp, drho_dT, drho_dx, mu, dmu_dp, dmu_dT, dmu_dx;
+  _fp->rho_dpTx(p, T, x, rho, drho_dp, drho_dT, drho_dx);
+  _fp->mu_dpTx(p, T, x, mu, dmu_dp, dmu_dT, dmu_dx);
+
+  // Combined property methods
+  Real rho2, mu2;
+  _fp->rho_mu(p, T, x, rho2, mu2);
+
+  ABS_TEST(rho, rho2, tol);
+  ABS_TEST(mu, mu2, tol);
+
+  // Combined property method with derivatives
+  Real drho2_dp, drho2_dT, drho2_dx, dmu2_dp, dmu2_dT, dmu2_dx;
+  _fp->rho_mu_dpTx(p, T, x, rho2, drho2_dp, drho2_dT, drho2_dx, mu2, dmu2_dp, dmu2_dT, dmu2_dx);
+
+  ABS_TEST(rho, rho2, tol);
+  ABS_TEST(mu, mu2, tol);
+  ABS_TEST(drho_dp, drho2_dp, tol);
+  ABS_TEST(drho_dT, drho2_dT, tol);
+  ABS_TEST(drho_dx, drho2_dx, tol);
+  ABS_TEST(mu, mu2, tol);
+  ABS_TEST(dmu_dp, dmu2_dp, tol);
+  ABS_TEST(dmu_dT, dmu2_dT, tol);
+  ABS_TEST(dmu_dx, dmu2_dx, tol);
+}

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -227,6 +227,7 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->mu, _fp->mu_dpT, p, T, tol);
   DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
   DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
+  DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
 
   // Viscosity from density and temperature
   T = 360.0;

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -77,6 +77,14 @@ TEST_F(MethaneFluidPropertiesTest, properties)
   REL_TEST(_fp->c(p, T), 481.7, tol);
   REL_TEST(_fp->mu(p, T), 0.01276e-3, tol);
   REL_TEST(_fp->k(p, T), 0.04113, tol);
+
+  // Test s, h and cp for temperatures > 755K as well as these methods have a
+  // different formulation in this regime
+  T = 800.0;
+
+  REL_TEST(_fp->h(p, T), 2132.0e3, tol);
+  REL_TEST(_fp->s(p, T), 13.83e3, tol);
+  REL_TEST(_fp->cp(p, T), 3.934e3, tol);
 }
 
 /**
@@ -88,7 +96,7 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   const Real tol = REL_TOL_DERIVATIVE;
 
   const Real p = 10.0e6;
-  const Real T = 350.0;
+  Real T = 350.0;
 
   DERIV_TEST(_fp->rho, _fp->rho_dpT, p, T, tol);
   DERIV_TEST(_fp->mu, _fp->mu_dpT, p, T, tol);
@@ -96,13 +104,18 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
   DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
 
+  // Test derivative of enthalpy for T > 755 as well as it has a different formulation
+  T = 800.0;
+  DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
+
   // Henry's constant
+  T = 350.0;
   const Real dT = 1.0e-4;
 
   Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
   Real Kh = 0.0, dKh_dT = 0.0;
   _fp->henryConstant_dT(T, Kh, dKh_dT);
-  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_DERIVATIVE);
+  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_SAVED_VALUE);
   REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
 }
 

--- a/unit/src/TabulatedFluidPropertiesTest.C
+++ b/unit/src/TabulatedFluidPropertiesTest.C
@@ -172,6 +172,27 @@ TEST_F(TabulatedFluidPropertiesTest, generateTabulatedData)
   REL_TEST(_tab_gen_fp->s(p, T), _co2_fp->s(p, T), 1.0e-4);
 }
 
+// Test that all fluid properties are properly passed back to the given user object
+// if they are not tabulated
+TEST_F(TabulatedFluidPropertiesTest, passthrough)
+{
+  Real p = 1.5e6;
+  Real T = 450.0;
+  const Real tol = REL_TOL_SAVED_VALUE;
+
+  // As the flags for interpolation in TabulatedFluidProperties default to false,
+  // properties will be passed through to the given userobject
+  ABS_TEST(_tab_fp->rho(p, T), _co2_fp->rho(p, T), tol);
+  ABS_TEST(_tab_fp->h(p, T), _co2_fp->h(p, T), tol);
+  ABS_TEST(_tab_fp->e(p, T), _co2_fp->e(p, T), tol);
+  ABS_TEST(_tab_fp->mu(p, T), _co2_fp->mu(p, T), tol);
+  ABS_TEST(_tab_fp->k(p, T), _co2_fp->k(p, T), tol);
+  ABS_TEST(_tab_fp->cp(p, T), _co2_fp->cp(p, T), tol);
+  ABS_TEST(_tab_fp->cv(p, T), _co2_fp->cv(p, T), tol);
+  ABS_TEST(_tab_fp->s(p, T), _co2_fp->s(p, T), tol);
+  ABS_TEST(_tab_fp->henryConstant(T), _co2_fp->henryConstant(T), tol);
+}
+
 /**
  * Test that the fluid name is correctly returned
  */

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -342,6 +342,9 @@ TEST_F(Water97FluidPropertiesTest, properties)
   REL_TEST(_fp->c(p1, T1), 1634.69054, tol);
   REL_TEST(_fp->c(p2, T2), 1240.71337, tol);
 
+  // Lower tolerance for cv as it is compared with values from NIST
+  REL_TEST(_fp->cv(p0, T0), 4.1207e3, REL_TOL_EXTERNAL_VALUE);
+
   // Region 2 properties
   p0 = 3.5e3;
   p1 = 3.5e3;
@@ -368,6 +371,9 @@ TEST_F(Water97FluidPropertiesTest, properties)
   REL_TEST(_fp->c(p0, T0), 427.920172, tol);
   REL_TEST(_fp->c(p1, T1), 644.289068, tol);
   REL_TEST(_fp->c(p2, T2), 480.386523, tol);
+
+  // Lower tolerance for cv as it is compared with values from NIST
+  REL_TEST(_fp->cv(p0, T0), 1.4415e3, REL_TOL_EXTERNAL_VALUE);
 
   // Region 3 properties
   p0 = 25.5837018e6;
@@ -397,6 +403,9 @@ TEST_F(Water97FluidPropertiesTest, properties)
   REL_TEST(_fp->c(p1, T1), 383.444594, 1.0e-5);
   REL_TEST(_fp->c(p2, T2), 760.696041, 1.0e-5);
 
+  // Lower tolerance for cv as it is compared with values from NIST
+  REL_TEST(_fp->cv(p0, T0), 3.1910e3, REL_TOL_EXTERNAL_VALUE);
+
   // Region 5 properties
   p0 = 0.5e6;
   p1 = 30.0e6;
@@ -423,6 +432,9 @@ TEST_F(Water97FluidPropertiesTest, properties)
   REL_TEST(_fp->c(p0, T0), 917.06869, tol);
   REL_TEST(_fp->c(p1, T1), 928.548002, tol);
   REL_TEST(_fp->c(p2, T2), 1067.36948, tol);
+
+  // Lower tolerance for cv as it is compared with values from NIST
+  REL_TEST(_fp->cv(p0, T0), 2.1534e3, REL_TOL_EXTERNAL_VALUE);
 
   // Viscosity
   REL_TEST(_fp->mu_from_rho_T(998.0, 298.15), 889.735100e-6, tol);


### PR DESCRIPTION
I found an error in the methane formulation for enthalpy at high temperatures, and found that it wasn't tested here. So I've gone through and attempted to test all of the methods in these user objects in the unit test suite. 

This should make the line coverage in these objects nearly 100%.

Closes #11580