### PR TITLE
Fix CSVDiffer with bad filename and custom columns.

### DIFF
--- a/python/TestHarness/CSVDiffer.py
+++ b/python/TestHarness/CSVDiffer.py
@@ -158,7 +158,7 @@ class CSVDiffer:
         if self.custom_columns:
            for mykey2 in self.custom_columns:
                if not found_column[mykey2]:
-                  self.addError(fname, "Variable '" + mykey2 + "' in custom_columns is missing from all CSV files" )
+                  self.addError("all CSV files", "Variable '" + mykey2 + "' in custom_columns is missing" )
 
         return self.msg
 

--- a/python/TestHarness/tests/TestHarnessTestCase.py
+++ b/python/TestHarness/tests/TestHarnessTestCase.py
@@ -37,7 +37,7 @@ class TestHarnessTestCase(unittest.TestCase):
         """
         # We need to be sure to match any of the terminal codes in the line
         status_re = r'(?P<passed>\d+) passed.*, .*(?P<skipped>\d+) skipped.*, .*(?P<failed>\d+) failed'
-        match = re.search(status_re, output)
+        match = re.search(status_re, output, re.IGNORECASE)
         self.assertNotEqual(match, None)
         self.assertEqual(match.group("passed"), str(passed))
         self.assertEqual(match.group("failed"), str(failed))

--- a/python/TestHarness/tests/test_CSVDiffer.py
+++ b/python/TestHarness/tests/test_CSVDiffer.py
@@ -74,7 +74,7 @@ class TestHarnessTester(TestHarnessTestCase):
         d.addCSVPair('out1.csv', 'col1,col2\n1,2\n1,2',' col1,col2\n1,2\n1,2')
         msg = d.diff()
         self.assertEqual(d.getNumErrors(), 1)
-        self.assertIn("In out1.csv: Variable 'col3' in custom_columns is missing from all CSV files", msg)
+        self.assertIn("In all CSV files: Variable 'col3' in custom_columns is missing", msg)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/TestHarness/tests/test_CSVDiffs.py
+++ b/python/TestHarness/tests/test_CSVDiffs.py
@@ -20,3 +20,5 @@ class TestHarnessTester(TestHarnessTestCase):
 
         e = cm.exception
         self.assertRegexpMatches(e.output, r'test_harness\.test_csvdiff.*?FAILED \(Override inputs not the same length\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.test_badfile.*?FAILED \(FILE DOES NOT EXIST\)')
+        self.checkStatus(e.output, failed=2)

--- a/test/tests/test_harness/csvdiffs
+++ b/test/tests/test_harness/csvdiffs
@@ -7,4 +7,12 @@
     override_rel_err = '1e-2'
     override_abs_zero = '1e-9'
   [../]
+  [./test_badfile]
+    type = CSVDiff
+    input = csvdiff.i
+    csvdiff = does_not_exist.csv
+    override_columns = 'abc'
+    override_rel_err = '1e-2'
+    override_abs_zero = '1e-9'
+  [../]
 []


### PR DESCRIPTION
For a `CSVDiff` test using custom columns and a bad filename, it would cause the test harness to crash with:
```
runWorker Exception: Traceback (most recent call last):
  File "python/TestHarness/schedulers/Scheduler.py", line 396, in runJob
    self.run(job) # Hand execution over to derived scheduler
  File "python/TestHarness/schedulers/RunParallel.py", line 50, in run
    output = tester.processResults(tester.getMooseDir(), self.options, job_output)
  File "python/TestHarness/testers/CSVDiff.py", line 56, in processResults
    msg = differ.diff()
  File "python/TestHarness/CSVDiffer.py", line 161, in diff
    self.addError(fname, "Variable '" + mykey2 + "' in custom_columns is missing from all CSV files" )
UnboundLocalError: local variable 'fname' referenced before assignment
```

The final custom column check was using the loop variable from the previous loop.

refs #11251

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
