### PR TITLE
Make interface kernels work with boundary restricted stateful materials

### DIFF
--- a/framework/doc/content/documentation/systems/InterfaceKernels/index.md
+++ b/framework/doc/content/documentation/systems/InterfaceKernels/index.md
@@ -1,11 +1,30 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-
 # InterfaceKernels System
+
+Interface kernels are meant to assist in coupling different physics across sub-domains. The most straightforward example is the case in which one wants to set the flux of a specie A in subdomain 0 equal to the flux of a specie B in subdomain 1 at the boundary between subdomains 0 and 1. In mathematical terms, we might be interested in establishing the condition:
+
+\begin{equation}
+-D_0 \frac{\partial c_0}{\partial x} = -D_1 \frac{\partial c_1}{\partial x}
+\end{equation}
+
+where $D_i$ is the diffusion coefficient of specie $i$ in subdomain $i$, and $c_i$ is the concentration of specie $i$ in subdomain $i$. An example of this condition is shown in the MOOSE test directory; see files below:
+
+[2d_interface/coupled_value_coupled_flux.i]
+
+[InterfaceDiffusion.C]
+
+[InterfaceDiffusion.h]
+
+Interface kernels can be used to provide any general flux condition at an interface, and even more generally can be used to impose any interfacial condition that requires access to values of different variables and gradients of different variables on either side of an interface. In an input file, the user will specify at a minimum the following parameters:
+
+- `type`: The type of interface kernel to be used
+- `variable`: This is the "master" variable. Note that the master variable must exist on the same subdomain as the sideset specified in the `boundary` parameter. The existence of a "master" and "slave" or "neighbor" variable ensures that the interface kernel residual and jacobian functions get called the correct number of times. `variable` could be $c_0$ from our example above.
+- `neighbor_var`: The "slave" variable. This could be $c_1$ from our example above.
+- `boundary`: The interfacial boundary between the subdomains. Note that this must be a sideset and again must exist on the same subdomain as the master variable. The fact that this boundary is a sideset allows access to variable gradients.
+
+For additional information about the interface kernel system, don't hesitate to email the moose list at [moose-users@googlegroups.com](mailto:moose-users@googlegroups.com).
 
 !syntax list /InterfaceKernels objects=True actions=False subsystems=False
 
 !syntax list /InterfaceKernels objects=False actions=False subsystems=True
 
 !syntax list /InterfaceKernels objects=False actions=True subsystems=False
-

--- a/framework/src/loops/ComputeJacobianThread.C
+++ b/framework/src/loops/ComputeJacobianThread.C
@@ -248,6 +248,7 @@ ComputeJacobianThread::onInterface(const Elem * elem, unsigned int side, Boundar
       // still remember to swap back during stack unwinding.
       SwapBackSentinel face_sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
       _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
+      _fe_problem.reinitMaterialsBoundary(bnd_id, _tid);
 
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);

--- a/framework/src/loops/ComputeMaterialsObjectThread.C
+++ b/framework/src/loops/ComputeMaterialsObjectThread.C
@@ -191,22 +191,6 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
     {
       _assembly[_tid]->reinitElemAndNeighbor(elem, side, neighbor, neighbor_side);
 
-      // Face Materials
-      if (_discrete_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(_subdomain, _tid))
-        _bnd_material_props.initStatefulProps(
-            *_bnd_material_data[_tid],
-            _discrete_materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(_subdomain, _tid),
-            face_n_points,
-            *elem,
-            side);
-      if (_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(_subdomain, _tid))
-        _bnd_material_props.initStatefulProps(
-            *_bnd_material_data[_tid],
-            _materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(_subdomain, _tid),
-            face_n_points,
-            *elem,
-            side);
-
       // Neighbor Materials
       if (_discrete_materials[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(
               neighbor->subdomain_id(), _tid))

--- a/framework/src/loops/ComputeResidualThread.C
+++ b/framework/src/loops/ComputeResidualThread.C
@@ -147,6 +147,7 @@ ComputeResidualThread::onInterface(const Elem * elem, unsigned int side, Boundar
       // still remember to swap back during stack unwinding.
       SwapBackSentinel face_sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
       _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
+      _fe_problem.reinitMaterialsBoundary(bnd_id, _tid);
 
       SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
       _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -457,8 +457,6 @@ NonlinearSystemBase::addInterfaceKernel(std::string interface_kernel_name,
     _interface_kernels.addObject(interface_kernel, tid);
     _vars[tid].addBoundaryVars(boundary_ids, interface_kernel->getCoupledVars());
   }
-
-  _doing_dg = true;
 }
 
 void

--- a/test/include/interfacekernels/InterfaceDiffusion.h
+++ b/test/include/interfacekernels/InterfaceDiffusion.h
@@ -30,8 +30,8 @@ protected:
   virtual Real computeQpResidual(Moose::DGResidualType type);
   virtual Real computeQpJacobian(Moose::DGJacobianType type);
 
-  Real _D;
-  Real _D_neighbor;
+  const MaterialProperty<Real> & _D;
+  const MaterialProperty<Real> & _D_neighbor;
 };
 
 #endif

--- a/test/src/interfacekernels/InterfaceDiffusion.C
+++ b/test/src/interfacekernels/InterfaceDiffusion.C
@@ -18,26 +18,24 @@ InputParameters
 validParams<InterfaceDiffusion>()
 {
   InputParameters params = validParams<InterfaceKernel>();
-  params.addParam<Real>("D", 1., "The diffusion coefficient.");
-  params.addParam<Real>("D_neighbor", 1., "The neighboring diffusion coefficient.");
+  params.addParam<MaterialPropertyName>("D", "D", "The diffusion coefficient.");
+  params.addParam<MaterialPropertyName>(
+      "D_neighbor", "D_neighbor", "The neighboring diffusion coefficient.");
   return params;
 }
 
 InterfaceDiffusion::InterfaceDiffusion(const InputParameters & parameters)
-  : InterfaceKernel(parameters), _D(getParam<Real>("D")), _D_neighbor(getParam<Real>("D_neighbor"))
+  : InterfaceKernel(parameters),
+    _D(getMaterialProperty<Real>("D")),
+    _D_neighbor(getMaterialProperty<Real>("D_neighbor"))
 {
-  if (!parameters.isParamValid("boundary"))
-  {
-    mooseError("In order to use the InterfaceDiffusion dgkernel, you must specify a boundary where "
-               "it will live.");
-  }
 }
 
 Real
 InterfaceDiffusion::computeQpResidual(Moose::DGResidualType type)
 {
-  Real r = 0.5 * (-_D * _grad_u[_qp] * _normals[_qp] +
-                  -_D_neighbor * _grad_neighbor_value[_qp] * _normals[_qp]);
+  Real r = 0.5 * (-_D[_qp] * _grad_u[_qp] * _normals[_qp] +
+                  -_D_neighbor[_qp] * _grad_neighbor_value[_qp] * _normals[_qp]);
 
   switch (type)
   {
@@ -62,20 +60,20 @@ InterfaceDiffusion::computeQpJacobian(Moose::DGJacobianType type)
   {
 
     case Moose::ElementElement:
-      jac -= 0.5 * _D * _grad_phi[_j][_qp] * _normals[_qp] * _test[_i][_qp];
+      jac -= 0.5 * _D[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test[_i][_qp];
       break;
 
     case Moose::NeighborNeighbor:
-      jac +=
-          0.5 * _D_neighbor * _grad_phi_neighbor[_j][_qp] * _normals[_qp] * _test_neighbor[_i][_qp];
+      jac += 0.5 * _D_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] *
+             _test_neighbor[_i][_qp];
       break;
 
     case Moose::NeighborElement:
-      jac += 0.5 * _D * _grad_phi[_j][_qp] * _normals[_qp] * _test_neighbor[_i][_qp];
+      jac += 0.5 * _D[_qp] * _grad_phi[_j][_qp] * _normals[_qp] * _test_neighbor[_i][_qp];
       break;
 
     case Moose::ElementNeighbor:
-      jac -= 0.5 * _D_neighbor * _grad_phi_neighbor[_j][_qp] * _normals[_qp] * _test[_i][_qp];
+      jac -= 0.5 * _D_neighbor[_qp] * _grad_phi_neighbor[_j][_qp] * _normals[_qp] * _test[_i][_qp];
       break;
   }
 

--- a/test/tests/interfacekernels/1d_interface/coupled_value_coupled_flux.i
+++ b/test/tests/interfacekernels/1d_interface/coupled_value_coupled_flux.i
@@ -64,8 +64,6 @@
     variable = u
     neighbor_var = v
     boundary = master0_interface
-    D = 4
-    D_neighbor = 2
   [../]
 []
 
@@ -87,6 +85,26 @@
     variable = v
     boundary = 'master0_interface'
     v = u
+  [../]
+[]
+
+[Materials]
+  [./stateful]
+    type = StatefulMaterial
+    initial_diffusivity = 1
+    boundary = master0_interface
+  [../]
+  [./general]
+    type = GenericConstantMaterial
+    block = '0 1'
+    prop_names = 'dummy'
+    prop_values = '1'
+  [../]
+  [./boundary]
+    type = GenericConstantMaterial
+    boundary = 'master0_interface'
+    prop_names = 'D D_neighbor'
+    prop_values = '4 2'
   [../]
 []
 

--- a/test/tests/interfacekernels/1d_interface/tests
+++ b/test/tests/interfacekernels/1d_interface/tests
@@ -3,6 +3,10 @@
     type = 'Exodiff'
     input = 'coupled_value_coupled_flux.i'
     exodiff = 'coupled_value_coupled_flux_out.e'
+    requirement = "Interface kernels shall provide integrated conditions between subdomains,"
+                  " and shall work with boundary restricted materials with stateful properties."
+    design = 'InterfaceKernels/index.md'
+    issues = '#11258 #869'
   [../]
   # This test ensures that shape functions for the NEIGHBORING variable are used in test_neighbor
   # and phi_neighbor; this is relevant when _var and _neighbor_var use a different space of shape


### PR DESCRIPTION
- Interface kernels are fundamentally different from DG, so should not set `_doing_dg = true`
    - Allows working stateful since not trying to access stateful neighbor material properties that don't exist
- deletes some duplicate code in `ComputeMaterialObjects::onInternalSide`
- Add documentation of interface kernels taken from web-site
- Should remove need to comment out code in #11575

Closes #11258 
