### PR TITLE
Add a TestHarness parameter to skip test based on JIT availability

### DIFF
--- a/framework/src/utils/FunctionParserUtils.C
+++ b/framework/src/utils/FunctionParserUtils.C
@@ -18,13 +18,15 @@ validParams<FunctionParserUtils>()
 {
   InputParameters params = emptyInputParameters();
 
-#ifdef LIBMESH_HAVE_FPARSER_JIT
   params.addParam<bool>(
       "enable_jit",
+#ifdef LIBMESH_HAVE_FPARSER_JIT
       true,
+#else
+      false,
+#endif
       "Enable just-in-time compilation of function expressions for faster evaluation");
   params.addParamNamesToGroup("enable_jit", "Advanced");
-#endif
   params.addParam<bool>(
       "enable_ad_cache", true, "Enable cacheing of function derivatives for faster startup time");
   params.addParam<bool>(
@@ -59,6 +61,13 @@ FunctionParserUtils::FunctionParserUtils(const InputParameters & parameters)
     _fail_on_evalerror(parameters.get<bool>("fail_on_evalerror")),
     _nan(std::numeric_limits<Real>::quiet_NaN())
 {
+#ifndef LIBMESH_HAVE_FPARSER_JIT
+  if (_enable_jit)
+  {
+    mooseWarning("Tried to enable FParser JIT but libmesh does not have it compiled in.");
+    _enable_jit = false;
+  }
+#endif
 }
 
 void

--- a/modules/combined/examples/mortar/tests
+++ b/modules/combined/examples/mortar/tests
@@ -6,6 +6,7 @@
     # input we can run on something much smaller...
     cli_args = 'Mesh/nx=2 Mesh/ny=2'
     check_input = True
+    fparser_jit = True
   [../]
   [./mortar_gradient]
     type = RunApp

--- a/modules/combined/examples/periodic_strain/tests
+++ b/modules/combined/examples/periodic_strain/tests
@@ -6,6 +6,7 @@
     # input we can run on something much smaller...
     cli_args = 'Mesh/nx=2 Mesh/ny=2'
     check_input = True
+    fparser_jit = True
   [../]
   [./strain_3D]
     type = RunApp
@@ -13,5 +14,6 @@
     # Checking input on smaller mesh
     cli_args = 'Mesh/nx=2 Mesh/ny=2 Mesh/nz=2'
     check_input = True
+    fparser_jit = True
   [../]
 []

--- a/modules/combined/examples/phase_field-mechanics/tests
+++ b/modules/combined/examples/phase_field-mechanics/tests
@@ -3,6 +3,7 @@
     type = RunApp
     input = 'Conserved.i'
     check_input = True
+    fparser_jit = True
   [../]
   [./EBSD_reconstruction_grain_growth_mech]
     type = RunApp
@@ -23,6 +24,7 @@
     # it takes to run.
     cli_args = 'Mesh/nx=2 Mesh/ny=2'
     check_input = True
+    fparser_jit = True
   [../]
   [./grain_texture]
     type = RunApp

--- a/modules/combined/test/tests/eigenstrain/tests
+++ b/modules/combined/test/tests/eigenstrain/tests
@@ -3,16 +3,19 @@
     type = 'Exodiff'
     input = 'variable.i'
     exodiff = 'variable_out.e'
+    fparser_jit = True
   [../]
   [./variable_finite]
     type = 'Exodiff'
     input = 'variable_finite.i'
     exodiff = 'variable_finite_out.e'
+    fparser_jit = True
   [../]
   [./variable_cahnhilliard]
     type = 'Exodiff'
     input = 'variable_cahnhilliard.i'
     exodiff = 'variable_cahnhilliard_out.e'
+    fparser_jit = True
   [../]
   [./composite]
     type = 'Exodiff'
@@ -23,5 +26,6 @@
     type = 'Exodiff'
     input = 'inclusion.i'
     exodiff = 'inclusion_out.e'
+    fparser_jit = True
   [../]
 []

--- a/modules/phase_field/examples/cahn-hilliard/tests
+++ b/modules/phase_field/examples/cahn-hilliard/tests
@@ -8,10 +8,12 @@
     type = RunApp
     input = 'Parsed_CH.i'
     check_input = True
+    fparser_jit = True
   [../]
   [./Parsed_SplitCH]
     type = RunApp
     input = 'Parsed_SplitCH.i'
     check_input = True
+    fparser_jit = True
   [../]
 []

--- a/modules/phase_field/test/tests/MultiPhase/tests
+++ b/modules/phase_field/test/tests/MultiPhase/tests
@@ -3,6 +3,7 @@
     type = 'Exodiff'
     input = 'derivativetwophasematerial.i'
     exodiff = 'derivativetwophasematerial_out.e'
+    fparser_jit = True
   [../]
   [./orderparameterfunctionmaterial]
     type = 'Exodiff'
@@ -34,6 +35,7 @@
     type = 'Exodiff'
     input = 'lagrangemult.i'
     exodiff = 'lagrangemult_out.e'
+    fparser_jit = True
   [../]
   [./penalty]
     type = 'Exodiff'

--- a/modules/phase_field/test/tests/TotalFreeEnergy/tests
+++ b/modules/phase_field/test/tests/TotalFreeEnergy/tests
@@ -9,5 +9,6 @@
     type = 'Exodiff'
     input = 'TotalFreeEnergy_2var_test.i'
     exodiff = 'TotalFreeEnergy_2var_test_out.e-s004'
+    fparser_jit = True
   [../]
 []

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -148,6 +148,7 @@ class TestHarness:
             checks['cxx11'] = set(['ALL'])
             checks['asio'] =  set(['ALL'])
             checks['boost'] = set(['ALL'])
+            checks['fparser_jit'] = set(['ALL'])
         else:
             checks['compiler'] = util.getCompilers(self.libmesh_dir)
             checks['petsc_version'] = util.getPetscVersion(self.libmesh_dir)
@@ -169,6 +170,7 @@ class TestHarness:
             checks['cxx11'] =  util.getLibMeshConfigOption(self.libmesh_dir, 'cxx11')
             checks['asio'] =  util.getIfAsioExists(self.moose_dir)
             checks['boost'] =  util.getLibMeshConfigOption(self.libmesh_dir, 'boost')
+            checks['fparser_jit'] =  util.getLibMeshConfigOption(self.libmesh_dir, 'fparser_jit')
 
         # Override the MESH_MODE option if using the '--distributed-mesh'
         # or (deprecated) '--parallel-mesh' option.

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -65,6 +65,7 @@ class Tester(MooseObject):
         params.addParam('unique_id',     ['ALL'], "A test that runs only if libmesh is configured with --enable-unique-id ('ALL', 'TRUE', 'FALSE')")
         params.addParam('cxx11',         ['ALL'], "A test that runs only if CXX11 is available ('ALL', 'TRUE', 'FALSE')")
         params.addParam('asio',          ['ALL'], "A test that runs only if ASIO is available ('ALL', 'TRUE', 'FALSE')")
+        params.addParam("fparser_jit",   ['ALL'], "A test that runs only if FParser JIT is available ('ALL', 'TRUE', 'FALSE')")
         params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
         params.addParam('env_vars',      [], "A test that only runs if all the environment variables listed exist")
         params.addParam('should_execute', True, 'Whether or not the executable needs to be run.  Use this to chain together multiple tests based off of one executeable invocation')
@@ -487,7 +488,7 @@ class Tester(MooseObject):
 
         # PETSc and SLEPc is being explicitly checked above
         local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot', \
-                        'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id', 'slepc', 'petsc_version_release', 'boost']
+                        'petsc_debug', 'curl', 'tbb', 'superlu', 'cxx11', 'asio', 'unique_id', 'slepc', 'petsc_version_release', 'boost', 'fparser_jit']
         for check in local_checks:
             test_platforms = set()
             operator_display = '!='

--- a/python/TestHarness/tests/test_ExtraInfo.py
+++ b/python/TestHarness/tests/test_ExtraInfo.py
@@ -32,7 +32,7 @@ class TestHarnessTester(TestHarnessTestCase):
                    'SLEPC_VERSION', 'MESH_MODE', 'METHOD', 'BOOST',
                    'PETSC_DEBUG', 'LIBRARY_MODE', 'PETSC_VERSION',
                    'CURL', 'TBB', 'SLEPC', 'VTK', 'UNIQUE_ID',
-                   'COMPILER']
+                   'COMPILER', 'FPARSER_JIT']
 
         # Verify all special TestHarness 'checks' are printed. We
         # will use the --ignore feature to force the test to run

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -88,7 +88,7 @@
     type = PythonUnitTest
     input = test_Allocations.py
   [../]
-  [./exra_info]
+  [./extra_info]
     type = PythonUnitTest
     input = test_ExtraInfo.py
   [../]

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -118,6 +118,10 @@ LIBMESH_OPTIONS = {
                      'default'   : 'FALSE',
                      'options'   : {'TRUE' : '1', 'FALSE' : '0'}
                    },
+  'fparser_jit' :  { 're_option' : r'#define\s+LIBMESH_HAVE_FPARSER_JIT\s+(\d+)',
+                     'default'   : 'FALSE',
+                     'options'   : {'TRUE' : '1', 'FALSE' : '0'}
+                   },
 }
 
 

--- a/test/tests/test_harness/extra_info
+++ b/test/tests/test_harness/extra_info
@@ -23,5 +23,6 @@
     cxx11 = true
     asio = true
     boost = true
+    fparser_jit = true
   [../]
 []


### PR DESCRIPTION
This also makes it so that the `enable_jit` parameter always exists. If FParser JIT is not compiled in then a warning is shown when an input file tries to enable it.

closes #11554
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
