### PR TITLE
Check Executioner integrity check

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -195,9 +195,6 @@ protected:
 
   /// Convenience reference to a problem this action works on
   std::shared_ptr<FEProblemBase> & _problem;
-
-  /// Convenience reference to an executioner
-  std::shared_ptr<Executioner> & _executioner;
 };
 
 template <typename T>

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -237,6 +237,17 @@ public:
   Executioner * getExecutioner() const { return _executioner.get(); }
 
   /**
+   * Retrieve the Executioner for this App
+   */
+  std::shared_ptr<Executioner> & executioner()
+  {
+    mooseDeprecated("executioner() is deprecated. Use getExecutioner(), this interface will be "
+                    "removed after 10/01/2018");
+
+    return _executioner;
+  }
+
+  /**
    * Set the Executioner for this App
    */
   void setExecutioner(std::shared_ptr<Executioner> && executioner) { _executioner = executioner; }

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -234,16 +234,12 @@ public:
   /**
    * Retrieve the Executioner for this App
    */
-  Executioner * getExecutioner() const
-  {
-    mooseAssert(_executioner, "Executioner is nullptr");
-    return _executioner.get();
-  }
+  Executioner * getExecutioner() const { return _executioner.get(); }
 
   /**
-   * Retrieve the Executioner shared pointer for this App
+   * Set the Executioner for this App
    */
-  std::shared_ptr<Executioner> & executioner() { return _executioner; }
+  void setExecutioner(std::shared_ptr<Executioner> && executioner) { _executioner = executioner; }
 
   /**
    * Set a Boolean indicating whether this app will use a Nonlinear or Eigen System.

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -85,13 +85,13 @@ public:
   /**
    * Returns a Boolean indicating whether or not a task is registered with the syntax object.
    */
-  bool hasTask(const std::string & task);
+  bool hasTask(const std::string & task) const;
 
   /**
    * Returns a Boolean indicating whether the specified task is required.
    * DEPRECATED (use shouldAutoBuild).
    */
-  bool isActionRequired(const std::string & task);
+  bool isActionRequired(const std::string & task) const;
 
   /**
    * Returns a Boolean indicating whether MOOSE should attempt to automatically create an Action
@@ -154,7 +154,7 @@ public:
    * Method for determining whether a piece of syntax is associated with an Action
    * TODO: I need a better name
    */
-  std::string isAssociated(const std::string & real_id, bool * is_parent);
+  std::string isAssociated(const std::string & real_id, bool * is_parent) const;
 
   /**
    * Returns a pair of multimap iterators to all the ActionInfo objects associated with a given

--- a/framework/include/parser/Syntax.h
+++ b/framework/include/parser/Syntax.h
@@ -33,9 +33,10 @@ public:
    * Method to register a new task. Tasks are short verbs (strings) that describe a particular point
    * in the simulation setup phase.
    * @param task The task (verb) to be registered with MOOSE.
-   * @param is_required indicates whether the task is required for a sucessful simulation.
+   * @param should_autobuild indicates whether the task should be autobuilt if not supplied
+   * elsewhere.
    */
-  void registerTaskName(const std::string & task, bool is_required);
+  void registerTaskName(const std::string & task, bool should_auto_build = false);
 
   /**
    * Method to register a new task (see overload method with same name). This version also accepts
@@ -45,7 +46,7 @@ public:
    */
   void registerTaskName(const std::string & task,
                         const std::string & moose_object_type,
-                        bool is_required);
+                        bool should_auto_build = false);
 
   /**
    * Method to associate another "allowed" pluggable MOOSE system to an existing registered task.
@@ -88,8 +89,15 @@ public:
 
   /**
    * Returns a Boolean indicating whether the specified task is required.
+   * DEPRECATED (use shouldAutoBuild).
    */
   bool isActionRequired(const std::string & task);
+
+  /**
+   * Returns a Boolean indicating whether MOOSE should attempt to automatically create an Action
+   * to satisfy a task if an Action doesn't already exist to service that task.
+   */
+  bool shouldAutoBuild(const std::string & task) const;
 
   /**
    * Registration function for associating Moose Actions with syntax.
@@ -180,7 +188,7 @@ public:
                            const std::string & task) const;
 
 protected:
-  /// The list of registered tasks and a flag indicating whether or not they are required
+  /// The list of registered tasks and a flag indicating whether or not they should be auto-built.
   std::map<std::string, bool> _registered_tasks;
 
   /// The list of Moose system objects to tasks.  This map indicates which tasks are allowed to build certain MooseObjects.

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -61,8 +61,7 @@ Action::Action(InputParameters parameters)
     _current_task(_awh.getCurrentTaskName()),
     _mesh(_awh.mesh()),
     _displaced_mesh(_awh.displacedMesh()),
-    _problem(_awh.problemBase()),
-    _executioner(_app.executioner())
+    _problem(_awh.problemBase())
 {
 }
 

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -203,7 +203,7 @@ ActionWarehouse::hasActions(const std::string & task) const
 void
 ActionWarehouse::buildBuildableActions(const std::string & task)
 {
-  if (_syntax.isActionRequired(task) && _action_blocks[task].empty())
+  if (_syntax.shouldAutoBuild(task) && _action_blocks[task].empty())
   {
     bool ret_value = false;
     auto it_pair = _action_factory.getActionsByTask(task);

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -48,5 +48,5 @@ CreateExecutionerAction::act()
     mooseError("Executioner is not consistent with each other; EigenExecutioner needs an "
                "EigenProblem, and Steady and Transient need a FEProblem");
 
-  _app.executioner() = executioner;
+  _app.setExecutioner(std::move(executioner));
 }

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -71,9 +71,9 @@ CreateProblemAction::CreateProblemAction(InputParameters parameters)
 void
 CreateProblemAction::act()
 {
+  // build the problem only if we have mesh
   if (_mesh.get() != NULL)
   {
-    // build the problem only if we have mesh
     {
       _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
       _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();

--- a/framework/src/actions/SetupPredictorAction.C
+++ b/framework/src/actions/SetupPredictorAction.C
@@ -35,8 +35,8 @@ SetupPredictorAction::act()
 {
   if (_problem->isTransient())
   {
-    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
-    if (transient == NULL)
+    Transient * transient = dynamic_cast<Transient *>(_app.getExecutioner());
+    if (!transient)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
     _moose_object_pars.set<Transient *>("_executioner") = transient;

--- a/framework/src/actions/SetupTimeStepperAction.C
+++ b/framework/src/actions/SetupTimeStepperAction.C
@@ -33,8 +33,8 @@ SetupTimeStepperAction::act()
 {
   if (_problem->isTransient())
   {
-    Transient * transient = dynamic_cast<Transient *>(_executioner.get());
-    if (transient == NULL)
+    Transient * transient = dynamic_cast<Transient *>(_app.getExecutioner());
+    if (!transient)
       mooseError("You can setup time stepper only with executioners of transient type.");
 
     _moose_object_pars.set<SubProblem *>("_subproblem") = _problem.get();

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -59,9 +59,11 @@ void
 addActionTypes(Syntax & syntax)
 {
   /**
-   * The last param here indicates whether the task must be satisfied or not for a successful run.
-   * If set to true, then the ActionWarehouse will attempt to create "Action"s automatically if they
-   * have not been explicitly created by the parser or some other mechanism.
+   * The (optional) last param here indicates whether the task should trigger an Action auto-build.
+   * If a task is marked as "true". Then MOOSE will attempt to build the associated Action if one is
+   * not supplied by some other means (usually through the input file or custom Action). Only
+   * Actions that do not have required parameters and have defaults for all optional parameters can
+   * be built automatically (See ActionWarehouse.C).
    *
    * Note: Many of the actions in the "Minimal Problem" section are marked as false.  However, we
    * can generally force creation of these "Action"s as needed by registering them to syntax that we
@@ -73,7 +75,7 @@ addActionTypes(Syntax & syntax)
   /**** Register Actions ****/
   /**************************/
   registerMooseObjectTask("create_problem",               Problem,                false);
-  registerMooseObjectTask("setup_executioner",            Executioner,            true);
+  registerMooseObjectTask("setup_executioner",            Executioner,            false);
 
   // This task does not construct an object, but it needs all of the parameters that
   // would normally be used to construct an object.
@@ -161,6 +163,7 @@ addActionTypes(Syntax & syntax)
 
   registerTask("setup_dampers", true);
   registerTask("check_integrity", true);
+  registerTask("check_integrity_early", true);
   registerTask("setup_quadrature", true);
 
   /// Additional Actions
@@ -217,6 +220,7 @@ addActionTypes(Syntax & syntax)
                            "(setup_postprocessor_data)"
                            "(setup_time_integrator)"
                            "(setup_executioner)"
+                           "(check_integrity_early)"
                            "(setup_predictor)"
                            "(init_displaced_problem)"
                            "(add_aux_variable, add_variable, add_elemental_field_variable)"

--- a/framework/src/controls/TimePeriod.C
+++ b/framework/src/controls/TimePeriod.C
@@ -58,7 +58,7 @@ TimePeriod::TimePeriod(const InputParameters & parameters)
   if (isParamValid("start_time"))
     _start_time = getParam<std::vector<Real>>("start_time");
   else
-    _start_time = {_app.executioner()->getParam<Real>("start_time")};
+    _start_time = {_app.getExecutioner()->getParam<Real>("start_time")};
 
   // Set end time
   if (isParamValid("end_time"))

--- a/framework/src/interfaces/LazyCoupleable.C
+++ b/framework/src/interfaces/LazyCoupleable.C
@@ -57,7 +57,7 @@ LazyCoupleable::coupled(const std::string & var_name, unsigned int /*comp*/)
 {
   if (!_l_fe_problem)
   {
-    auto & executioner_ptr = _l_app.executioner();
+    auto executioner_ptr = _l_app.getExecutioner();
     if (!executioner_ptr)
       mooseError("Executioner is nullptr in LazyCoupleable. You cannot call the \"coupled\" method "
                  "until the add_algebraic_rm task");

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -97,16 +97,16 @@ Syntax::getSortedTaskSet()
 }
 
 bool
-Syntax::hasTask(const std::string & task)
+Syntax::hasTask(const std::string & task) const
 {
   return (_registered_tasks.find(task) != _registered_tasks.end());
 }
 
 bool
-Syntax::isActionRequired(const std::string & task)
+Syntax::isActionRequired(const std::string & task) const
 {
   mooseDeprecated("Syntax::isActionRequired is deprecated, use shouldAutoBuild() instead");
-  return _registered_tasks[task];
+  return shouldAutoBuild(task);
 }
 
 bool
@@ -185,7 +185,7 @@ Syntax::getSyntaxByAction(const std::string & action, const std::string & task)
 }
 
 std::string
-Syntax::isAssociated(const std::string & real_id, bool * is_parent)
+Syntax::isAssociated(const std::string & real_id, bool * is_parent) const
 {
   /**
    * This implementation assumes that wildcards can occur in the place of an entire token but not as

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -105,7 +105,17 @@ Syntax::hasTask(const std::string & task)
 bool
 Syntax::isActionRequired(const std::string & task)
 {
+  mooseDeprecated("Syntax::isActionRequired is deprecated, use shouldAutoBuild() instead");
   return _registered_tasks[task];
+}
+
+bool
+Syntax::shouldAutoBuild(const std::string & task) const
+{
+  auto map_pair = _registered_tasks.find(task);
+  mooseAssert(map_pair != _registered_tasks.end(), std::string("Unregistered task: ") + task);
+
+  return map_pair->second;
 }
 
 void

--- a/modules/contact/src/ContactMaster.C
+++ b/modules/contact/src/ContactMaster.C
@@ -183,7 +183,7 @@ ContactMaster::addPoints()
       continue;
 
     bool is_nonlinear =
-        _subproblem.getMooseApp().executioner()->feProblem().computingNonlinearResid();
+        _subproblem.getMooseApp().getExecutioner()->feProblem().computingNonlinearResid();
 
     if (_component == 0)
       computeContactForce(pinfo, is_nonlinear);

--- a/test/tests/misc/check_error/missing_executioner.i
+++ b/test/tests/misc/check_error/missing_executioner.i
@@ -1,0 +1,35 @@
+[Mesh]
+  type = GeneratedMesh
+  nx = 10
+  ny = 10
+  dim = 2
+[]
+
+[Variables]
+  [temp]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = temp
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = temp
+    boundary = 'left'
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = temp
+    boundary = 'right'
+    value = 1
+  []
+[]
+
+# No Executioner block

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -690,7 +690,6 @@
     input = 'kernel_with_vector_var.i'
     expect_err = 'No standard variable named u found. Did you specify a vector variable when you meant to specify a standard variable'
   [../]
-
   [./coupled_nodal_for_non_nodal_variable]
     type = 'RunException'
     input = 'coupled_nodal_for_non_nodal_variable.i'
@@ -716,5 +715,14 @@
     requirement = "The system shall report an error if users try to get older nodal values of non-nodal variables."
     design = 'Coupleable.md'
     issues = '#11623'
+  [../]
+  [./missing_executioner]
+    type = 'RunException'
+    input = 'missing_executioner.i'
+    expect_err = '"Executioner" does not exist'
+
+    requirement = 'The system shall have an integrity check that ensures an Executioner object exists in the system.'
+    design = 'Executioner/index.md'
+    issues = '#11586'
   [../]
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Check for missing executioner. Also did a lot of cleanup in the Action and App related to getting the executioner. It turns out that we were only using the convenience reference in a few places and that was a poor thing to do because we update the shared_ptr anyway so the reference to the pointer can fail. It's better to just get the executioner through the app, which is available to all Actions.
