### PR TITLE
Give MooseMesh::clone() non-pure-virtual-error error implementation.

### DIFF
--- a/framework/include/mesh/AnnularMesh.h
+++ b/framework/include/mesh/AnnularMesh.h
@@ -29,7 +29,6 @@ public:
   // No copy
   AnnularMesh & operator=(const AnnularMesh & other_mesh) = delete;
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/DistributedGeneratedMesh.h
+++ b/framework/include/mesh/DistributedGeneratedMesh.h
@@ -29,7 +29,6 @@ public:
   // No copy
   DistributedGeneratedMesh & operator=(const DistributedGeneratedMesh & other_mesh) = delete;
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/FileMesh.h
+++ b/framework/include/mesh/FileMesh.h
@@ -25,7 +25,6 @@ public:
   FileMesh(const FileMesh & other_mesh);
   virtual ~FileMesh(); // empty dtor required for unique_ptr with forward declarations
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/GeneratedMesh.h
+++ b/framework/include/mesh/GeneratedMesh.h
@@ -29,7 +29,6 @@ public:
   // No copy
   GeneratedMesh & operator=(const GeneratedMesh & other_mesh) = delete;
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/ImageMesh.h
+++ b/framework/include/mesh/ImageMesh.h
@@ -27,7 +27,6 @@ public:
   ImageMesh(const InputParameters & parameters);
   ImageMesh(const ImageMesh & other_mesh);
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -84,7 +84,7 @@ public:
   /**
    * Clone method.  Allocates memory you are responsible to clean up.
    */
-  virtual MooseMesh & clone() const = 0;
+  virtual MooseMesh & clone() const;
 
   /**
    * A safer version of the clone() method that hands back an

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -90,13 +90,8 @@ public:
    * A safer version of the clone() method that hands back an
    * allocated object wrapped in a smart pointer. This makes it much
    * less likely that the caller will leak the memory in question.
-   *
-   * TODO: this currently has a base class mooseError implementation
-   * for forwards compatibility purposes, but eventually it will be
-   * transistioned to a pure virtual, replacing the original non-safe
-   * clone() function above.
    */
-  virtual std::unique_ptr<MooseMesh> safeClone() const;
+  virtual std::unique_ptr<MooseMesh> safeClone() const = 0;
 
   /**
    * Initialize the Mesh object.  Most of the time this will turn around

--- a/framework/include/mesh/PatternedMesh.h
+++ b/framework/include/mesh/PatternedMesh.h
@@ -40,7 +40,6 @@ public:
   PatternedMesh(const PatternedMesh & other_mesh);
   virtual ~PatternedMesh();
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/StitchedMesh.h
+++ b/framework/include/mesh/StitchedMesh.h
@@ -35,7 +35,6 @@ public:
 
   virtual ~StitchedMesh();
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/mesh/TiledMesh.h
+++ b/framework/include/mesh/TiledMesh.h
@@ -23,7 +23,6 @@ public:
   TiledMesh(const InputParameters & parameters);
   TiledMesh(const TiledMesh & other_mesh);
 
-  virtual MooseMesh & clone() const override;
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -113,13 +113,6 @@ AnnularMesh::getMaxInDimension(unsigned int component) const
   }
 }
 
-MooseMesh &
-AnnularMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new AnnularMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 AnnularMesh::safeClone() const
 {

--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -156,13 +156,6 @@ DistributedGeneratedMesh::getMaxInDimension(unsigned int component) const
   }
 }
 
-MooseMesh &
-DistributedGeneratedMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new DistributedGeneratedMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 DistributedGeneratedMesh::safeClone() const
 {

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -42,13 +42,6 @@ FileMesh::FileMesh(const FileMesh & other_mesh)
 
 FileMesh::~FileMesh() {}
 
-MooseMesh &
-FileMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new FileMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 FileMesh::safeClone() const
 {

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -131,13 +131,6 @@ GeneratedMesh::getMaxInDimension(unsigned int component) const
   }
 }
 
-MooseMesh &
-GeneratedMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new GeneratedMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 GeneratedMesh::safeClone() const
 {

--- a/framework/src/mesh/ImageMesh.C
+++ b/framework/src/mesh/ImageMesh.C
@@ -56,13 +56,6 @@ ImageMesh::ImageMesh(const ImageMesh & other_mesh)
 {
 }
 
-MooseMesh &
-ImageMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new ImageMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 ImageMesh::safeClone() const
 {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1858,6 +1858,12 @@ MooseMesh::getNormalByBoundaryID(BoundaryID id) const
   return (*_boundary_to_normal_map)[id];
 }
 
+MooseMesh &
+MooseMesh::clone() const
+{
+  mooseError("MooseMesh::clone() is no longer supported, use MooseMesh::safeClone() instead.");
+}
+
 void
 MooseMesh::init()
 {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1858,12 +1858,6 @@ MooseMesh::getNormalByBoundaryID(BoundaryID id) const
   return (*_boundary_to_normal_map)[id];
 }
 
-std::unique_ptr<MooseMesh>
-MooseMesh::safeClone() const
-{
-  mooseError("The safeClone() functionality must be implemented in derived classes!");
-}
-
 void
 MooseMesh::init()
 {

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -97,13 +97,6 @@ PatternedMesh::PatternedMesh(const PatternedMesh & other_mesh)
 
 PatternedMesh::~PatternedMesh() {}
 
-MooseMesh &
-PatternedMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new PatternedMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 PatternedMesh::safeClone() const
 {

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -79,13 +79,6 @@ StitchedMesh::StitchedMesh(const StitchedMesh & other_mesh)
 
 StitchedMesh::~StitchedMesh() {}
 
-MooseMesh &
-StitchedMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new StitchedMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 StitchedMesh::safeClone() const
 {

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -77,13 +77,6 @@ TiledMesh::TiledMesh(const TiledMesh & other_mesh)
 {
 }
 
-MooseMesh &
-TiledMesh::clone() const
-{
-  mooseDeprecated("MooseMesh::clone() is deprecated, call MooseMesh::safeClone() instead.");
-  return *(new TiledMesh(*this));
-}
-
 std::unique_ptr<MooseMesh>
 TiledMesh::safeClone() const
 {


### PR DESCRIPTION
This change is still backwards-compatible for compiling and existing apps that wrote their own MooseMesh-derived `clone()` functions will still work, but it removes the non-safe implementations from the framework, and will stop the further propagation of the old interface, so I think it should be safe to merge.

This PR also makes the new `safeClone()` method pure virtual, and would therefore theoretically break any App that had implemented its own `MooseMesh`-derived type, but luckily that type of thing does not appear to be too common, and all the Apps we actually test are passing.

Refs #11579.

