### PR TITLE
Compute Multiple Inelastic Stress docs

### DIFF
--- a/modules/tensor_mechanics/doc/content/bib/tensor_mechanics.bib
+++ b/modules/tensor_mechanics/doc/content/bib/tensor_mechanics.bib
@@ -217,7 +217,7 @@
   Pages = {195--210},
   Year = {1982}}
 
-  @article{Adams1967gps,
+@article{Adams1967gps,
   author = {Donald F. Adams and Douglas R. Doner},
   title = {Transverse Normal Loading of a Unidirectional Composite},
   journal = {Journal of Composite Materials},
@@ -227,9 +227,9 @@
   year = {1967},
   doi = {10.1177/002199836700100205},
   url = {https://doi.org/10.1177/002199836700100205}
-  }
+}
 
-  @article{Adams1984gps,
+@article{Adams1984gps,
   title = {Finite element micromechanical analysis of a unidirectional composite including longitudinal shear loading},
   author = {Donald F. Adams and David A. Crane},
   journal = {Computers \& Structures},
@@ -240,9 +240,9 @@
   issn = {0045-7949},
   doi = {https://doi.org/10.1016/0045-7949(84)90160-3},
   url = {http://www.sciencedirect.com/science/article/pii/0045794984901603}
-  }
+}
 
-  @article{Li1999gps,
+@article{Li1999gps,
   author = {Li, Shuguang},
   title = {On the unit cell for micromechanical analysis of fibre-reinforced composites},
   journal = {Proceedings of the Royal Society of London A: Mathematical, Physical and Engineering Sciences},
@@ -253,15 +253,15 @@
   issn = {1364-5021},
   doi = {10.1098/rspa.1999.0336},
   url = {http://rspa.royalsocietypublishing.org/content/455/1983/815}
-  }
+}
 
-  @manual{Abaqus2014gps,
+@manual{Abaqus2014gps,
   title = {ABAQUS/CAE User's Manual, 27.1.2 Choosing the element's dimensionality, Version 6.14},
   author = {ABAQUS},
   year = {2014}
-  }
+}
 
-  @article{Li2005gps,
+@article{Li2005gps,
   title = {Variational principles for generalized plane strain problems and their applications},
   author = {Shuguang Li and Szu-Hui Lim},
   journal = {Composites Part A: Applied Science and Manufacturing},
@@ -272,4 +272,15 @@
   issn = {1359-835X},
   doi = {https://doi.org/10.1016/j.compositesa.2004.06.036},
   url = {http://www.sciencedirect.com/science/article/pii/S1359835X04001885}
-  }
+}
+
+@article{simo1985cto,
+  title={Consistent tangent operators for rate-independent elastoplasticity},
+  author={Simo, Juan C and Taylor, Robert Leroy},
+  journal={Computer Methods in Applied Mechanics and Engineering},
+  volume={48},
+  number={1},
+  pages={101--118},
+  year={1985},
+  publisher={Elsevier}
+}

--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/C0TimoshenkoBeam.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/C0TimoshenkoBeam.md
@@ -1,15 +1,15 @@
 # C0 Timoshenko Beam Element
 
-!media media/tensor_mechanics_beam_representation.png
-       style=width:40%;margin-left:30px;float=right;
-       id=fig_beam
-       caption=Beam element with 2 nodes and 3 translational and 3 rotational degrees of freedom at each node.
-
 A beam element [fig_beam] is used to model the response of a structural element that is long in one dimension compared to its cross-section. There are two popular formulation of beam elements:
 
-- Euler-Bernoulli beam element: used to model bending deformation in long and slender beams. The two main assumptions in this beam theory are that: (i) the beam cross-section is rigid and does not deform under the application of transverse or lateral loads, and (ii) the cross-section of the beam remains planar and normal to the deformed axis of the beam.
+!media media/tensor_mechanics_beam_representation.png
+      style=width:50%;margin-left:2%;float:right
+      id=fig_beam
+      caption=Beam element with 2 nodes and 3 translational and 3 rotational degrees of freedom at each node.
 
-- Timoshenko beam element [citep:timoshenko_correction_1921, timoshenko_transverse_1922]: used to model both shear and bending deformation in short and thick beams. The beam cross-section does not deform in this beam theory as well and it remains planar. But the cross-section need not be normal to the deformed axis of the beam. The Euler-Bernoulli beam element can be derived as a special case of the Timoshenko beam element.
+1. +Euler-Bernoulli beam element+: used to model bending deformation in long and slender beams. The two main assumptions in this beam theory are that: (i) the beam cross-section is rigid and does not deform under the application of transverse or lateral loads, and (ii) the cross-section of the beam remains planar and normal to the deformed axis of the beam.
+
+1. +Timoshenko beam element+ [citep:timoshenko_correction_1921, timoshenko_transverse_1922]: used to model both shear and bending deformation in short and thick beams. The beam cross-section does not deform in this beam theory as well and it remains planar. But the cross-section need not be normal to the deformed axis of the beam. The Euler-Bernoulli beam element can be derived as a special case of the Timoshenko beam element.
 
 Therefore, a C0 Timoshenko beam element is implemented in MOOSE. This element has two nodes and each node has 6 degrees of freedom (DOFs) - 3 translational and 3 rotational displacements. All the 12 DOFs are considered to be independent and the variation of both translational and rotational displacements along the length of the beam are modeled using first order Lagrange shape functions. The independent rotational DOFs at the nodes makes it easier to model the shear deformation which results in non-perpendicular cross-sections with respect to the beam axis.
 
@@ -174,7 +174,7 @@ R_j^0 = \int_{0}^{{}^0L} \rho A \left(\frac{x}{{}^0L} {\ddot{u}_j}^0 + \frac{{}^
 \begin{equation}
 R_j^1 = \int_{0}^{{}^0L} \rho A \left(\frac{x}{{}^0L} {\ddot{u}_j}^0 + \frac{{}^0L - x}{{}^0L} {\ddot{u}_j}^1 \right) \frac{{}^0L - x}{{}^0L} dx
 \end{equation}
-where $\rho$ is the density of the beam, which is assumed to be constant through the length of the beam, and ${\ddot{u}_j}^i$ is the translational acceleration at node $i$ in $j^{th}$ direction.  
+where $\rho$ is the density of the beam, which is assumed to be constant through the length of the beam, and ${\ddot{u}_j}^i$ is the translational acceleration at node $i$ in $j^{th}$ direction.
 
 The residual for the $j^{th}$ rotational degree of freedom can be obtained as follows:
 \begin{equation}

--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/index.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/index.md
@@ -82,13 +82,14 @@ Now you're ready to start creating your own mechanics simulations.
 Explore the different ways to use the tensor mechanics module by browsing the
 introductory theory pages on the various models:
 
+- [Volumetric Locking Correction](tensor_mechanics/VolumetricLocking.md)
+- [Smeared Cracking](Materials/ComputeSmearedCrackingStress.md)
+- [Multiple Inelastic Stresses](Materials/ComputeMultipleInelasticStress.md)
 - [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md)
 - [Fracture Integrals](tensor_mechanics/FractureIntegrals.md)
-- Smeared Cracking
 - Crystal Plasticity
-- Multiple Inelastic Stresses
 - [C0 Timoshenko Beam](tensor_mechanics/C0TimoshenkoBeam.md)
-- [Volumetric Locking Correction](tensor_mechanics/VolumetricLocking.md)
+
 
 !col-end!
 !row-end!

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMultipleInelasticStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMultipleInelasticStress.md
@@ -1,14 +1,324 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeMultipleInelasticStress
-
-!alert construction title=Undocumented Class
-The ComputeMultipleInelasticStress has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Compute Multiple Inelastic Stress
 
 !syntax description /Materials/ComputeMultipleInelasticStress
+
+## Description
+
+`ComputeMultipleInelasticStress` computes the stress, the consistent tangent
+operator (or an approximation), and a decomposition of the strain
+into elastic and inelastic components for a series of different inelastic
+material models (e.g. creep and plasticity) which inherit from `StressUpdateBase`.
+By default finite strains are assumed.
+The elastic strain is calculated by subtracting the computed inelastic strain
+increment tensor from the mechanical strain increment tensor.
+\begin{equation}
+  \label{cmis_elastic_strain_definition}
+  \Delta \epsilon^{el} = \Delta \epsilon^{mech} - \Delta \epsilon^{inel}
+\end{equation}
+Mechanical strain, $\epsilon^{mech}$, is considered to be the sum of the elastic
+and inelastic (e.g. plastic and creep) strains.
+
+!alert! note title=Default Finite Strain Formulation
+This class uses the finite incremental strain formulation as a default. Users may
+elect to use a small incremental strain formulation and set
++`perform_finite_strain_rotations = false`+ if the simulation will only ever use
+small strains.
+This class is not intended for use with a total small linearize strain formulation.
+!alert-end!
+
+`ComputeMultipleInelasticStress` is designed to be used in conjunction with a
+separate model or set of models that computes the inelastic strain for a given
+stress state. These inelastic models must derive from the `StressUpdateBase` class.
+The Tensor Mechanics module contains a wide variety of such models, including
+
+- [LinearViscoelasticStressUpdate](/LinearViscoelasticStressUpdate.md)
+- `MultiParameterPlasticityStressUpdate`
+- [RadialReturnStressUpdate](/RadialReturnStressUpdate.md)
+
+!alert note title=Compatible Inelastic +`StressUpdate`+ Material Models
+All of the inelastic material models that are compatible with
++`ComputeMultipleInelasicStress`+ follow the nomenclature convention of +`StressUpdate`+
+as a suffix to the class name.
+
+`ComputeMultipleInelasticStress` can accomodate as few as zero inelastic models (in which case the
+algorithm from [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md)
+is applied) to as many inelastic material models as is required by the physics.
+If more than one inelastic material model is supplied to `ComputeMultipleInelasticStress`,
+it is recommended that all of the inelastic models inherit from the same base class.
+
+
+## Multiple Inelastic Models
+
+!media tensor_mechanics/flowchart_ComputeMultipleInelasticStress.png
+       id=fig:multiple_materials
+       style=width:55%;margin-left:2%;float:right
+       caption=The `ComputeMultipleInelasticStress` algorithm for calculating the
+               strains and stresses for multiple inelastic material models.
+
+The algorithm used to compute the stress for multiple inelastic models is shown
+in [fig:multiple_materials].
+
+When multiple inelastic models are given, `ComputeMultipleInelasticStress` iterates
+over the specified inelastic models until the change in stress is within
+a user-specified tolerance.
+
+### Inner Iteration over Inelastic Models
+
+The inner iteration over the multiple inelastic material models is shown in the
+green components in [fig:multiple_materials].
+
+When each inelastic model is evaluated, a trial stress is computed using the
+current elastic strain, which is the total mechanical strain minus the current
+summation of inelastic strain for all inelastic models. This trial stress can be
+expressed as
+\begin{equation}
+  \label{eqn:trial_stress}
+  \sigma^{tr}_i = \begin{cases}
+                    C_{ijkl} \cdot \left( \epsilon^{el}_{old} + \Delta \epsilon^{el}_i \right) & \text{if $C_{ijkl}$ is isotropic}  \\
+                    \sigma_{old} + C_{ijkl} \cdot \left( \Delta \epsilon^{el}_i \right) & \text{if $C_{ijkl}$ is anisotropic}
+                  \end{cases}
+\end{equation}
+where $C_{ijkl}$ is the elasticity tensor for the material.
+
+The $i^{th}$ inelastic material model, represented by the blue element
+[fig:multiple_materials], is then called. The inelastic material model calculates
+the inelastic strain increment necessary to produce an admissible stress, as a
+function of the trial stress. The total inelastic strain increment is updated
+for each model's contribution. The details of this calculation vary by model
+and can include the effects of plasticity or creep.
+
+The elastic and inelastic strain increments,
+stress, and, optionally, the consistent tangent operator are returned to
+`ComputeMultipleInelasticStress` from the $i^{th}$ inelastic material model.
+
+### Outer Iteration over Stress Difference
+
+After each inelastic model is called to compute an update to the stress tensor,
+the minimum and maximum values of each component of the stress tensor, over the
+course of those iterations, are stored to two tensors denoted as
+$\boldsymbol{\sigma}_{max}$ and $\boldsymbol{\sigma}_{min}$, respectively. An
+$L^2$ norm of the difference of these two tensors is then computed as
+\begin{equation}
+  \label{eqn:l2_norm_stress}
+  L^2 \left(\Delta \boldsymbol{\sigma} \right) = \sqrt{\Delta \sigma_{ij} \Delta \sigma_{ij}}
+    \text{, where } \Delta \boldsymbol{\sigma} = \boldsymbol{\sigma}_{max} - \boldsymbol{\sigma}_{min}
+\end{equation}
+The $L^2$ norm of the stress difference is compared to the absolute and relative
+tolerances to determine if the solution from the combined inelastic material
+models is converged
+\begin{equation}
+  \label{eqn:l2_norm_convergence}
+  L^2 \left(\Delta \boldsymbol{\sigma} \right) < \text{absolute tolerance, or }
+  \frac{L^2 \left(\Delta \boldsymbol{\sigma} \right)}{L^2 \left(\Delta \boldsymbol{\sigma}_o \right)} < \text{relative tolerance}
+\end{equation}
+where $L^2 \left(\Delta \sigma_o \right)$ is the $L^2$ norm from the very first
+outer iteration over all of the inelastic material models.
+The solution will not converge if the outer iteration loop, shown in the top half
+of [fig:multiple_materials], exceeds the maximum number of iterations set by the
+user.
+
+### Finalize Strains and the Jacobian Multiplier
+
+Once convergence on the stress is obtained, the calculation of the inelastic
+strains is finalized by by applying a weighting factor, as shown in
+[fig:multiple_materials]. This weighting factor has a default value of unity.
+
+#### Jacobian Multiplier and the Consistent Tangent Operator
+
+The Jacobian multiplier, which is used in the [StressDivergenceTensors](Kernels/StressDivergenceTensors.md)
+kernel to condition the Jacobian calculation, must be calculated from the combination
+of all the different inelastic material models. There are three options used to
+calculate the combined Jacobian multiplier: Elastic, Partial, and Nonlinear, which
+are set by the individual elastic material models.
+\begin{equation}
+  \label{eqn:combined_jacobian_mult}
+  \mathbf{J}_m = \begin{cases}
+                  \mathbf{C} & \text{Elastic option} \\
+                  \mathbf{A}^{-1} \cdot \mathbf{C} \text{, where }
+                      \mathbf{A} = \mathbf{I} + \sum_i \mathbf{H}^{cto}_i & \text{Partial option} \\
+                  \prod_i \mathbf{H}^{cto}_i \cdot \mathbf{C}^{-1}  & \text{Nonlinear option}
+                 \end{cases}
+\end{equation}
+where $\mathbf{J}_m$ is the Jacobian multiplier, $\mathbf{C}$ is the elasticity
+tensor, $\mathbf{I}$ is the Rank-4 identity tensor, and $\mathbf{H}^{cto}$ is the
+consistent tangent operator.
+
+The consistent tangent operator, defined in [eqn:elastic_cto] provides the information
+on how the stress changes with respect to changes in the displacement variables.
+\begin{equation}
+  \label{eqn:elastic_cto}
+  \delta \sigma_{ij} = H_{ijkl} \delta \epsilon_{kl}
+\end{equation}
+where $\delta \epsilon_{kl}$ is an arbitrary change in the total strain
+(which occurs because the displacements are changed) and $\delta \sigma_{ij}$
+is the resulting change in the stress.
+In a purely elastic situation $H_{ijkl} = C_{ijkl}$ (the elasticity tensor), but
+the inelastic mapping of changes in the stress as a result of changes in the
+displacement variables is more complicated.
+In a plastic material model, the proposed values
+of displacements for the current time step where used to calculate a trial
+inadmissible stress, $\sigma_{trial}$, [eqn:trial_stress], that was brought back
+to the yield surface through a radial return algorithm. A slight change in the
+proposed displacement variables will produce a slightly different trial stress
+and so on.
+Other inelastic material models follow a similar pattern.
+
+The user can chose to force all of the inelastic material models to use the elasticity
+tensor as the consistent tangent operator by setting `tangent_operator = elastic`.
+This setting will reduce the computational load of the inelastic material models
+but may hamper the convergence of the simulation.
+By default, the inelastic material models are allowed to compute the consistent
+tangent operator implemented in each individual inelastic model with the
+`tangent_operator = nonlinear` option.
+
+#### Material Time Step Size Limitations
+
+Prior to calculating the final strain values, the algorithm checks the size of
+the current time step against any limitations on the size of the time step as
+optionally defined by the inelastic material models.
+As described in the Material Time Step Limiter section, the time step size
+involves a post processor to ensure that the current time step size is reasonable
+for each of the inelastic material models used in the simulation.
+
+At the end of the alogrithm, the final value of the elastic and inelastic
+strain tensors are calculated as shown in the last element of [fig:multiple_materials].
+
+
+## Single Inelastic Model
+
+`ComputeMultipleInelasticStress` can also be used to calculate the inelastic
+strain and the stress when only a single inelastic material model is provided.
+
+!media tensor_mechanics/flowchart_ComputeMultipleInelasticStress-SingleModel.png
+       id=fig:single_material
+       style=width:40%;margin-right:2%;float:left
+       caption=The optimized algorithm for calculating the strains and stress
+               in the case when only a single inelastic material model is specified.
+
+The algorithm, shown in [fig:single_material], used for a single inelastic material
+model is an optimized version of the multiple materials algorithm.
+With no need to iterate over multiple inelastic models, both the inner and outer
+iterations from [fig:multiple_materials] are removed from the algorithm in [fig:single_material].
+
+The initial elastic strain increment guess is assumed to be the initial mechanical
+strian increment, and the trial stress for the single inelastic model is calculated
+from that elastic strain increment as in [eqn:trial_stress].
+These stress and strain values are passed directly to the inelastic material model.
+
+The material model computes the admissible stress and strain states, as indicated
+by the blue element in [fig:single_material]. An optional consistent tangent
+operator matrix is also returned by the inelastic material model.
+As in the multiple inelastic models alogrithm, the user may force the use of the
+Elastic option by setting `tangent_operator = elastic`.
+By default, the inelastic material model is allowed to compute the consistent
+tangent operator implemented in each individual inelastic model with the
+`tangent_operator = nonlinear` option.
+
+The consistent tangent operator is then used to find the Jacobian multiplier with
+\begin{equation}
+  \label{eqn:single_model_jacobian_mult}
+  \mathbf{J}_m = \begin{cases}
+                  \mathbf{C} & \text{Elastic option} \\
+                  \left(\mathbf{I} + \mathbf{H}^{cto}\right)^{-1} \cdot \mathbf{C} & \text{Partial option} \\
+                  \mathbf{H}^{cto}  & \text{Nonlinear option}
+                 \end{cases}
+\end{equation}
+where $\mathbf{J}_m$ is the Jacobian multiplier, $\mathbf{C}$ is the elasticity
+tensor, $\mathbf{I}$ is the Rank-4 identity tensor, and $\mathbf{H}^{cto}$ is the
+consistent tangent operator, as discussed in the multiple inelastic material
+models section.
+
+The maximum size of the allowable time step is then optionally calculated by the
+inelastic material model, as described in the section below on the Material Time
+Step Limiter. At the conclusion of the algorithm, the value of the elastic and
+inelastic strain states are updated as shown in [fig:single_material].
+
+### Cycle Through One Inelastic Model per Time Step
+
+`ComputeMultipleInelasticStress` also includes an option to run a series of inelastic
+models in a rotating fashion such that only a single inelastic model is run on a
+timestep. This option uses the same algorithm as in [fig:single_material] to determine
+the strains and stress value based on the rotated single inelastic model.
+A separate method is then employed to propagate the strain and stress values to
+the other inelastic material models for storage as old material property values.
+
+## Other Calculations Performed by `StressUpdate` Materials
+
+The `ComputeMultipleInelasticStress` material relies on two helper calculations
+to aid the simulation in converging.
+These helper computations are defined within the specific inelastic models, and
+only a brief overview is given here.
+These methods are represented within the blue inelastic material model boxes in
+[fig:multiple_materials] and [fig:single_material].
+For specific details of the implementations, see the documentation pages for the
+individual inelastic `StressUpdate` materials.
+
+The first helper computation, the consistent tangent operator, is an optional
+feature which is implemented for only certain inelastic
+stress material models, and the material time step limiter is implemented in the
+models which use the [Radial Return Stress Update](/RadialReturnStressUpdate.md)
+algorithm.
+
+### Consistent Tangent Operator
+
+The consistent tangent operator is used to improve the convergence of mechanics
+problems (see a reference such as [cite:simo1985cto] for an introduction to
+consistent tangent operators).
+The Jacobian matrix, [eqn:combined_jacobian_mult] and [eqn:single_model_jacobian_mult],
+is used to capture how the change in the residual calculation changes with respect
+to changes in the displacement variables.
+To calculate the Jacobian, MOOSE relies on knowing how the stress changes with
+respect to changes in the displacement variables.
+
+Because the change of the stress with respect to the change in displacements is
+material specific, the value of the consistent tangent operator
+is computed in each inelastic material model. By default the consistent tangent
+operator is set equal to the elasticity tensor (the option Elastic in
+[eqn:combined_jacobian_mult] and [eqn:single_model_jacobian_mult]).
+Inelastic material models which use either the Partial or Nonlinear options in
+[eqn:combined_jacobian_mult] or [eqn:single_model_jacobian_mult] define a material
+specific consistent tangent operator.
+
+Generally Partial consistent tangent operators should be implemented for
+non-yielding materials (e.g. volumetric swelling) and Full consistent tangent
+operators should be implemented for yielding material models (e.g. plasticity).
+
+### Material Time Step Limiter
+
+In some cases, particularly in creep, limits on the time step are required by the
+material model formulation. Each inelastic material model is responsible for
+calculating the maximum time step allowable for that material model.
+The [MaterialTimeStepPostprocessor](/Postprocessors/MaterialTimeStepPostprocessor.md)
+finds the minumum time step size limits from the entire simulation domain. The
+postprocessor then interfaces with the [IterationAdaptiveDT](/Executioner/TimeStepper/IterationAdaptiveDT.md)
+to restrict the time step size based on the limit calculated in the previous
+time step.
+
+
+## Example Input Files
+
+The input settings for multiple inelastic material models and a single inelastic
+model are similiar, and examples of both are shown below.
+
+### Multiple Inelastic Models
+
+For multiple inelastic models, all of the inelastic material
+model names must be listed as arguements to the `inelastic_models` parameter.
+The inelastic material blocks must also be present.
+
+!listing modules/tensor_mechanics/test/tests/combined_creep_plasticity/combined_creep_plasticity.i block=Materials
+
+### Single Inelastic Model
+
+For a single inelastic material model the input syntax is simply condensed
+
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Materials/stress
+
+and only a single inelastic material model is included in the input. This example
+includes the `max_inelastic_increment` parameter which is used to limit the time
+step size.
+
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Materials/isoplas
 
 !syntax parameters /Materials/ComputeMultipleInelasticStress
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/RadialReturnStressUpdate.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/RadialReturnStressUpdate.md
@@ -14,9 +14,8 @@ surface.  Because the von Mises yield surface in the deviatoric stress space has
 circle, the _plastic correction stress_ is always directed towards the center of the yield surface
 circle.
 
-In addition to the Sumo and Hughes textbook [cite:simo2006computational], *Introduction to
-Computational Plasticity* by Dunnu and Petrinic (2004) is an excellent reference for users working
-with the Radial Return Stress Update materials; several of the isotropic plasticity and creep
+In addition to the [cite:simo2006computational] textbook, [cite:dunne2005introduction] is an excellent reference for users working
+with the `RadialReturnStressUpdate` materials; several of the isotropic plasticity and creep
 effective plastic strain increment algorithms are taken from [cite:dunne2005introduction].
 
 ### The Radial Return Stress Update Description
@@ -30,7 +29,7 @@ as is required to achieve convergence.
 ## Radial Return Algorithm Overview
 
 !media media/tensor_mechanics-RadialReturnStressSpace.png
-       style=width:350;float:right;
+       style=width:30%;margin-left:2%;float:right
        caption=A trial stress is shown outside of the deviatoric yield surface and the radial return
                  stress which is normal to the yield surface.
 
@@ -71,7 +70,7 @@ Creep and Linear Strain Hardening, `ComputeMultipleInelasticStress` will iterate
 the calculated stress until the return stress has reached a stable value.
 
 Users can print out any of these strains and stresses using the `RankTwoAux` as described on the
-[Introduction/Visualizing Tensors](auto::/introduction/VisualizingTensors) page.
+[Visualizing Tensors](/tensor_mechanics/VisualizingTensors.md) page.
 
 ## Writing a New Stress Update Material
 New radial return models must inherit from `RadialReturnStressUpdate` and must overwrite the six
@@ -94,10 +93,12 @@ virtual methods.
 Additionally, new radial return methods must also overwrite a single method from the MOOSE `Material`
 class.
 
-- +resetQpProperties+: Set the material property used in the iteration, usually $ \Delta p $, to zero
+- +resetQpProperties+: Set the material property used in the iteration, usually $\Delta p$, to zero
   at the start the iteration.  This method is necessary to avoid incorrect material property values.
 
 More details on how to write the equivalent yield surface equation for a creep model are given in
 Dunne and Petrinic.
+
+<!-- !syntax children /Materials/RadialReturnStressUpdate -->
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Postprocessors/MaterialTimeStepPostprocessor.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Postprocessors/MaterialTimeStepPostprocessor.md
@@ -1,19 +1,80 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# MaterialTimeStepPostprocessor
-
-!alert construction title=Undocumented Class
-The MaterialTimeStepPostprocessor has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Material Time Step Postprocessor
 
 !syntax description /Postprocessors/MaterialTimeStepPostprocessor
+
+## Description
+
+The `MaterialTimeStepPostprocessor` works in conjunction with material models to
+compute the appropriate maximum time step allowed by individual material models.
+For creep or plasticity models, this maximum time step size is governed by an
+allowable inelastic strain increment, but a variety of methods could be used by
+individual material models to compute their acceptable time step.
+
+### Creep Strain Example
+
+The maximum time step size is a numerical tool used to ensure the calculation of
+physically reasonable inelastic strains and to improve convergence of the inelastic
+material model. As an example, the maximum allowable time step computation for
+a creep model has the form
+\begin{equation}
+  \label{eqn:limiting_ts}
+  \Delta t |_{limit} = \Delta t \cdot \frac{\Delta \epsilon^{inel}_{max}}{\Delta \epsilon^{inel}}
+\end{equation}
+where $\Delta \epsilon^{inel}_{max}$ is the maximum effective inelastic strain
+increment (a default value of 1e-4), set by the user, and $\Delta \epsilon^{inel}$
+is the current scalar effective inelastic strain increment.
+
+### Mesh-Wide Evaluation
+
+The `MaterialTimeStepPostprocessor` collects the time step limitations from all
+of the quadrature points in the simulation mesh and stores the minimum value.
+This minimum allowable time step size value is then used by the
+[IterationAdaptiveDT](/Executioner/TimeStepper/IterationAdaptiveDT.md)
+to restrict the time step size based on the limit calculated in the previous
+time step.
+
+Note that the [IterationAdaptiveDT](/Executioner/TimeStepper/IterationAdaptiveDT.md)
+will apply the limiting time step size value from the `MaterialTimeStepPostprocessor`
+only if that value is less than maximum time step size value calculated by the
+internal [IterationAdaptiveDT](/Executioner/TimeStepper/IterationAdaptiveDT.md)
+adaptive time step size algorithm.
+
+!alert note title=Time Step Limiter Lags Calculation
+The value of the maximum allowable time step as collected by the +`MaterialTimeStepPostprocessor`+
+is enforced in the next simulation time step.
+
+### Minimum Time Step Calculated in Material Models
+
+The calculation of the maximum allowable timestep is dependent on each individual
+material: both the maximum allowable inelastic strain increment and the method of
+calculating the current inelastic strain, [eqn:limiting_ts], are defined separately
+for each material.
+Given this material dependent nature, the maximum time step value is calculated
+separately by the [RadialReturnStressUpdate](/Materials/RadialReturnStressUpdate.md)
+materials at each quadrature point.
+The `MaterialTimeStepPostprocessor` then determines the minimum time step size
+value from all of the quadrature points in the simulation.
+
+Initially the value of the maximum time step size is set to `std::numeric_limits<Real>::max()`.
+Once the inelastic material model begins to calculate inelastic strain, the value
+of the allowable time step size varies with the inelastic strain computation.
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Postprocessors/matl_ts_min
+
+The name of the `MaterialTimeStepPostprocessor` is passed to the `IterationAdaptiveDT`
+as the argument for the `postprocessor_dtlim` parameter
+
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Executioner/TimeStepper
+
+and the `max_inelastic_increment` parameter in the inelastic material model(s)
+must be set to run the time step limit calculation.
+
+!listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Materials/isoplas
 
 !syntax parameters /Postprocessors/MaterialTimeStepPostprocessor
 
 !syntax inputs /Postprocessors/MaterialTimeStepPostprocessor
 
 !syntax children /Postprocessors/MaterialTimeStepPostprocessor
-
-!bibtex bibliography

--- a/modules/tensor_mechanics/doc/hidden.yml
+++ b/modules/tensor_mechanics/doc/hidden.yml
@@ -47,7 +47,6 @@
 - /Materials/ComputeLinearElasticPFFractureStress
 - /Materials/ComputeMultiPlasticityStress
 - /Materials/ComputeMultipleInelasticCosseratStress
-- /Materials/ComputeMultipleInelasticStress
 - /Materials/ComputePlasticHeatEnergy
 - /Materials/ComputeStrainIncrementBasedStress
 - /Materials/ComputeVariableBaseEigenStrain
@@ -77,7 +76,6 @@
 - /Materials/StrainEnergyDensity
 - /Postprocessors/Mass
 - /Postprocessors/MaterialTensorIntegral
-- /Postprocessors/MaterialTimeStepPostprocessor
 - /Postprocessors/CrackFrontData
 - /Postprocessors/InteractionIntegral
 - /UserObjects/CrystalPlasticitySlipRateGSS

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -91,24 +91,23 @@ protected:
 
   /**
    * Using _elasticity_tensor[_qp] and the consistent tangent operators,
-   * _comsistent_tangent_operator[...] computed by the inelastic models,
+   * _consistent_tangent_operator[...] computed by the inelastic models,
    * compute _Jacobian_mult[_qp]
    */
   virtual void computeQpJacobianMult();
 
   /**
    * Given a trial stress (_stress[_qp]) and a strain increment (elastic_strain_increment)
-   * let the model_number model produce an admissible stress (gets placed back in _stress[_qp]), and
-   * decompose
-   * the strain increment into an elastic part (gets placed back into elastic_strain_increment) and
-   * an
+   * let the model_number model produce an admissible stress (gets placed back
+   * in _stress[_qp]), and decompose the strain increment into an elastic part
+   * (gets placed back into elastic_strain_increment) and an
    * inelastic part (inelastic_strain_increment), as well as computing the
    * consistent_tangent_operator
    * @param model_number The inelastic model to use
-   * @param elastic_strain_increment Upon input, this is the strain increment.  Upon output, it is
-   * the elastic part of the strain increment
-   * @param inelastic_strain_increment The inelastic strain increment corresponding to the supplied
-   * strain increment
+   * @param elastic_strain_increment Upon input, this is the strain increment.
+   * Upon output, it is the elastic part of the strain increment
+   * @param inelastic_strain_increment The inelastic strain increment
+   * corresponding to the supplied strain increment
    * @param consistent_tangent_operator The consistent tangent operator
    */
   virtual void computeAdmissibleState(unsigned model_number,

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -21,11 +21,11 @@ InputParameters validParams<RadialReturnStressUpdate>();
 
 /**
  * RadialReturnStressUpdate computes the radial return stress increment for
- * an isotropic viscoplasticity plasticity model after interating on the difference
+ * an isotropic elastic-viscoplasticity model after interating on the difference
  * between new and old trial stress increments.  This radial return mapping class
  * acts as a base class for the radial return creep and plasticity classes / combinations.
  * The stress increment computed by RadialReturnStressUpdate is used by
- * ComputeRadialReturnMappingStress which computes the elastic stress for finite
+ * ComputeMultipleInelasticStress which computes the elastic stress for finite
  * strains.  This return mapping class is acceptable for finite strains but not
  * total strains.
  * This class is based on the Elasto-viscoplasticity algorithm in F. Dunne and N.

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -21,7 +21,7 @@ validParams<ComputeMultipleInelasticStress>()
   InputParameters params = validParams<ComputeFiniteStrainElasticStress>();
   params.addClassDescription("Compute state (stress and internal parameters such as plastic "
                              "strains and internal parameters) using an iterative process.  "
-                             "Combinations of creep models and plastic models may be used");
+                             "Combinations of creep models and plastic models may be used.");
   params.addParam<unsigned int>("max_iterations",
                                 30,
                                 "Maximum number of the stress update "

--- a/modules/tensor_mechanics/src/postprocessors/MaterialTimeStepPostprocessor.C
+++ b/modules/tensor_mechanics/src/postprocessors/MaterialTimeStepPostprocessor.C
@@ -26,7 +26,7 @@ validParams<MaterialTimeStepPostprocessor>()
   InputParameters params = validParams<ElementPostprocessor>();
 
   params.addClassDescription("This postprocessor estimates a timestep that reduces the increment "
-                             "change in a aux variable below a given threshold.");
+                             "change in a material property below a given threshold.");
 
   return params;
 }


### PR DESCRIPTION
Documentation for the ComputeMultipleInelasticStress class, with descriptions for both the multiple and single inelastic material model algorithms.
The submodule update includes the png and tikz tex files for the algorithm flow charts.

@WilkAndy and @tophmatthews would you read through the ComputeMultipleInelasticStress *.md file and make sure everything I've written is correct (especially with the consistent tangent operator with which I am least familiar)?

@acasagran would you read through the documentation for the time step limiter that we discussed this afternoon and review it please? I also updated the class description; please let me know if this is relevant.

@gambka would you give the two md files a good proof reading since you're good at catching my typos please?

Refs #10516 