### PR TITLE
Fix scaling of residuals for kinematic contact

### DIFF
--- a/modules/combined/test/tests/sliding_block/in_and_out/constraint/frictionless_kinematic_out.cmp
+++ b/modules/combined/test/tests/sliding_block/in_and_out/constraint/frictionless_kinematic_out.cmp
@@ -1,8 +1,8 @@
 
 #  *****************************************************************
 #             EXODIFF	(Version: 2.83) Modified: 2015-08-20
-#             Authors:  Richard Drake, rrdrake@sandia.gov           
-#                       Greg Sjaardema, gdsjaar@sandia.gov          
+#             Authors:  Richard Drake, rrdrake@sandia.gov
+#                       Greg Sjaardema, gdsjaar@sandia.gov
 #             Run on    2018/04/23   15:43:52 MDT
 #  *****************************************************************
 
@@ -24,14 +24,14 @@ COORDINATES absolute 1.e-6    # min separation not calculated
 
 TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:              15 @ t16
 
-GLOBAL VARIABLES absolute 1.e-7 floor 0.0
-	contact_pressure  # min:               0 @ t1	max:       10745.055 @ t3
+GLOBAL VARIABLES absolute 5.e-7 floor 0.0
+	contact_pressure  absolute 3e-2 # min:               0 @ t1	max:       10745.055 @ t3
 	penetration       # min:               0 @ t1	max:     0.069671154 @ t10
 
-NODAL VARIABLES absolute 1.e-7 floor 0.0
+NODAL VARIABLES absolute 3.e-6 floor 0.0
 	accum_slip_x          # min:               0 @ t1,n1	max:               0 @ t1,n1
 	accum_slip_y          # min:               0 @ t1,n1	max:               0 @ t1,n1
-	contact_pressure      # min:               0 @ t1,n1	max:       13497.377 @ t3,n221
+	contact_pressure      absolute 3e-2 # min:               0 @ t1,n1	max:       13497.377 @ t3,n221
 	disp_x                # min:               0 @ t1,n1	max:     0.059671154 @ t10,n220
 	disp_y                # min:               0 @ t1,n1	max:              15 @ t16,n217
 	inc_slip_x            # min:               0 @ t1,n1	max:               0 @ t1,n1
@@ -44,4 +44,3 @@ NODAL VARIABLES absolute 1.e-7 floor 0.0
 # No NODESET VARIABLES
 
 # No SIDESET VARIABLES
-

--- a/modules/combined/test/tests/sliding_block/in_and_out/constraint/tests
+++ b/modules/combined/test/tests/sliding_block/in_and_out/constraint/tests
@@ -29,6 +29,22 @@
     max_time = 800
     custom_cmp = 'frictionless_kinematic_out.cmp'
   [../]
+  [./frictionless_kinematic_scaled]
+    type = 'Exodiff'
+    input = 'frictionless_kinematic.i'
+    exodiff = 'frictionless_kinematic_out.e'
+    heavy = true
+    min_parallel = 4
+    abs_zero = 1e-7
+    max_time = 800
+    cli_args = 'Variables/disp_x/scaling=1e-6 Variables/disp_y/scaling=1e-6'
+    prereq = 'frictionless_kinematic'
+    custom_cmp = 'frictionless_kinematic_out.cmp'
+    requirement = "Kinematic contact shall produce the same results regardless of whether
+                   variable scaling is used or not"
+    design = 'MechanicalContactConstraint.md'
+    issues = '#11601'
+  [../]
   [./frictionless_penalty]
     type = 'Exodiff'
     input = 'frictionless_penalty.i'

--- a/modules/contact/include/MechanicalContactConstraint.h
+++ b/modules/contact/include/MechanicalContactConstraint.h
@@ -113,6 +113,7 @@ protected:
   const unsigned int _mesh_dimension;
 
   std::vector<unsigned int> _vars;
+  std::vector<MooseVariable *> _var_objects;
 
   MooseVariable * _nodal_area_var;
   SystemBase & _aux_system;


### PR DESCRIPTION
Now kinematic contact results will be the same (within tolerance) regardless of whether variable scaling is used.

Closes #11601
