### PR TITLE
Refactoring FPE functions from global to new guard util

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -197,8 +197,6 @@ private:
   MPI_Comm _orig;
 };
 
-void enableFPE(bool on = true);
-
 // MOOSE Requires PETSc to run, this CPP check will cause a compile error if PETSc is not found
 #ifndef LIBMESH_HAVE_PETSC
 #error PETSc has not been detected, please ensure your environment is set up properly then rerun the libmesh build script and try to compile MOOSE again.

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -533,6 +533,9 @@ public:
   /// Returns whether the Application is running in check input mode
   bool checkInput() const { return _check_input; }
 
+  /// Returns whether FPE trapping is turned on (either because of debug or user requested)
+  inline bool getFPTrapFlag() const { return _trap_fpe; }
+
   /**
    * WARNING: This is an internal method for MOOSE, if you need the add new ExecFlagTypes then
    * use the registerExecFlag macro as done in Moose.C/h.
@@ -691,6 +694,9 @@ protected:
 
   /// Whether or not this is a restart run
   bool _restart;
+
+  /// Whether or not FPE trapping should be turned on.
+  bool _trap_fpe;
 
   /// The base name to recover from.  If blank then we will find the newest recovery file.
   std::string _recover_base;

--- a/framework/include/utils/FloatingPointExceptionGuard.h
+++ b/framework/include/utils/FloatingPointExceptionGuard.h
@@ -1,0 +1,48 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef FLOATINGPOINTEXCEPTIONGUARD_H
+#define FLOATINGPOINTEXCEPTIONGUARD_H
+
+#include "MooseApp.h"
+#include "libmesh/libmesh.h"
+
+/**
+ * Scope guard for starting and stopping Floating Point Exception Trapping
+ */
+class FloatingPointExceptionGuard
+{
+public:
+  /**
+   * Instantiation turns on FPE Trapping as long as trapping is enabled on the application. By
+   * default trapping is enabled when the DEBUG symbol is defined (dbg mode), but can be overridden
+   * and turned on and off for any particular simulation run.
+   */
+  FloatingPointExceptionGuard(const MooseApp & moose_app)
+    : _trapping_enabled(moose_app.getFPTrapFlag())
+  {
+    if (_trapping_enabled)
+      libMesh::enableFPE(true);
+  }
+
+  /**
+   * Stop FPE Trapping on destruction
+   */
+  ~FloatingPointExceptionGuard()
+  {
+    if (_trapping_enabled)
+      libMesh::enableFPE(false);
+  }
+
+private:
+  /// Determine whether or not PFE trapping needs to be toggled off.
+  const bool _trapping_enabled;
+};
+
+#endif

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -339,22 +339,6 @@ swapLibMeshComm(MPI_Comm new_comm)
 #endif // LIBMESH_HAVE_PETSC
 }
 
-void
-enableFPE(bool on)
-{
-  if (_trap_fpe)
-    libMesh::enableFPE(on);
-}
-
-/**
- * Initialize global variables
- */
-#ifdef DEBUG
-bool _trap_fpe = true;
-#else
-bool _trap_fpe = false;
-#endif
-
 static bool _color_console = isatty(fileno(stdout));
 
 bool

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -276,6 +276,11 @@ MooseApp::MooseApp(InputParameters parameters)
     _distributed_mesh_on_command_line(false),
     _recover(false),
     _restart(false),
+#ifdef DEBUG
+    _trap_fpe(true),
+#else
+    _trap_fpe(false),
+#endif
     _recover_suffix("cpr"),
     _half_transient(false),
     _check_input(getParam<bool>("check_input")),
@@ -435,9 +440,9 @@ MooseApp::setupOptions()
   if (isParamValid("trap_fpe") && isParamValid("no_trap_fpe"))
     mooseError("Cannot use both \"--trap-fpe\" and \"--no-trap-fpe\" flags.");
   if (isParamValid("trap_fpe"))
-    Moose::_trap_fpe = true;
+    _trap_fpe = true;
   else if (isParamValid("no_trap_fpe"))
-    Moose::_trap_fpe = false;
+    _trap_fpe = false;
 
   // Turn all warnings in MOOSE to errors (almost see next logic block)
   Moose::_warnings_are_errors = getParam<bool>("error");

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -82,6 +82,7 @@
 #include "InputParameterWarehouse.h"
 #include "TimeIntegrator.h"
 #include "LineSearch.h"
+#include "FloatingPointExceptionGuard.h"
 
 #include "libmesh/exodusII_io.h"
 #include "libmesh/quadrature.h"
@@ -2119,7 +2120,7 @@ FEProblemBase::projectSolution()
 {
   Moose::perf_log.push("projectSolution()", "Utility");
 
-  Moose::enableFPE();
+  FloatingPointExceptionGuard fpe_guard(_app);
 
   ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
   ComputeInitialConditionThread cic(*this);
@@ -2160,8 +2161,6 @@ FEProblemBase::projectSolution()
       }
     }
   }
-
-  Moose::enableFPE(false);
 
   _nl->solution().close();
   _nl->solution().localize(*_nl->system().current_local_solution, _nl->dofMap().get_send_list());

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -62,6 +62,7 @@
 #include "ElementPairLocator.h"
 #include "ODETimeKernel.h"
 #include "AllLocalDofIndicesThread.h"
+#include "FloatingPointExceptionGuard.h"
 
 // libMesh
 #include "libmesh/nonlinear_solver.h"
@@ -549,7 +550,7 @@ NonlinearSystemBase::computeResidualTags(const std::set<TagID> & tags)
   // not suppose to do anythin on matrix
   deactiveAllMatrixTags();
 
-  Moose::enableFPE();
+  FloatingPointExceptionGuard fpe_guard(_app);
 
   for (const auto & numeric_vec : _vecs_to_zero_for_residual)
     if (hasVector(numeric_vec))
@@ -602,7 +603,6 @@ NonlinearSystemBase::computeResidualTags(const std::set<TagID> & tags)
 
   // not supposed to do anything on matrix
   activeAllMatrixTags();
-  Moose::enableFPE(false);
   Moose::perf_log.pop("compute_residual()", "Execution");
 }
 
@@ -2211,7 +2211,7 @@ NonlinearSystemBase::computeJacobianTags(const std::set<TagID> & tags)
 {
   Moose::perf_log.push("compute_jacobian()", "Execution");
 
-  Moose::enableFPE();
+  FloatingPointExceptionGuard fpe_guard(_app);
 
   try
   {
@@ -2223,8 +2223,6 @@ NonlinearSystemBase::computeJacobianTags(const std::set<TagID> & tags)
     // calling stopSolve(), it is now up to PETSc to return a
     // "diverged" reason during the next solve.
   }
-
-  Moose::enableFPE(false);
 
   Moose::perf_log.pop("compute_jacobian()", "Execution");
 }
@@ -2247,7 +2245,7 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
 {
   Moose::perf_log.push("compute_jacobian_block()", "Execution");
 
-  Moose::enableFPE();
+  FloatingPointExceptionGuard fpe_guard(_app);
 
   for (unsigned int i = 0; i < blocks.size(); i++)
   {
@@ -2344,8 +2342,6 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
 
     jacobian.close();
   }
-
-  Moose::enableFPE(false);
 
   Moose::perf_log.pop("compute_jacobian_block()", "Execution");
 }


### PR DESCRIPTION
Removing the global _trap_fpe variable and creating a new
utility that is exception safe when toggling FPE trapping.

closes #11592

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
