### PR TITLE
Hack to keep CPUs together

### DIFF
--- a/python/TestHarness/schedulers/pbs_template
+++ b/python/TestHarness/schedulers/pbs_template
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N <JOB_NAME>
-#PBS -l select=<MPI_PROCS>
+#PBS -l select=1:ncpus=<MPI_PROCS>
 #PBS -l walltime=<WALLTIME>
 <PBS_PROJECT>
 #PBS -j oe


### PR DESCRIPTION
This small change to the template should improve robustness of
nightly job runs. It will be deficient if people request more
cpus then are available on a single node.

refs #11609

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
