### PR TITLE
Allow optimization of PBS select statements

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -690,6 +690,13 @@ class TestHarness:
                 if ex.errno == errno.EEXIST: pass
                 else: raise
 
+        # If queueing is enabled, we need to use only one spec_file type (not tests _and_ speedtests)
+        if self.options.queueing:
+            if self.options.spec_file:
+                self.options.input_file_name = os.path.basename(self.options.spec_file)
+            elif not self.options.input_file_name:
+                self.options.input_file_name = 'tests'
+
         # Use a previous results file, or declare the variable
         self.options.results_storage = {}
         if self.useExistingStorage():
@@ -827,15 +834,6 @@ class TestHarness:
         if opts.queue_cleanup and not opts.pbs:
             print('ERROR: --queue-cleanup can not be used without additional queue options')
             sys.exit(1)
-
-        # Flatten input_file_name from ['tests', 'speedtests'] to just tests if none supplied
-        # We can not support running two spec files during one launch into a third party queue manager.
-        # This is because Jobs created by spec files, have no way of accessing other jobs created by
-        # other spec files. They only know about the jobs a single spec file generates.
-        # NOTE: Which means, tests and speedtests running simultaneously currently have a chance to
-        # clobber each others output during normal operation!?
-        if opts.pbs and not opts.input_file_name:
-            self.options.input_file_name = 'tests'
 
         # Update any keys from the environment as necessary
         if not self.options.method:

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -691,10 +691,10 @@ class TestHarness:
                 else: raise
 
         # If queueing is enabled, we need to use only one spec_file type (not tests _and_ speedtests)
-        if self.options.queueing:
-            if self.options.spec_file:
+        if self.options.queueing and self.options.spec_file:
                 self.options.input_file_name = os.path.basename(self.options.spec_file)
-            elif not self.options.input_file_name:
+
+        elif self.options.queueing and not self.options.input_file_name:
                 self.options.input_file_name = 'tests'
 
         # Use a previous results file, or declare the variable

--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -185,16 +185,18 @@ class QueueManager(Scheduler):
     def getRunTestsCommand(self, job):
         """ return the command necessary to launch the TestHarness within the third party scheduler """
 
-        # Build ['/path/to/run_tests', '-j', '#']
-        command = [os.path.join(self.harness.run_tests_dir, 'run_tests'),
-                   '-j', str(job.getMetaData().get('QUEUEING_NCPUS', 1) )]
+        # Build ['/path/to/run_tests']
+        command = [os.path.join(self.harness.run_tests_dir, 'run_tests')]
 
         # get current sys.args we are allowed to include when we launch run_tests
         args = list(self.cleanAndModifyArgs())
 
         # Build [<args>, '--spec-file' ,/path/to/tests', '-o', '/path/to']
-        args.extend(['--spec-file', os.path.join(job.getTestDir(), self.options.input_file_name),
-                     '-o', job.getTestDir()])
+        if self.options.spec_file:
+            args.extend(['--spec-file', self.options.spec_file, '-o', job.getTestDir()])
+        else:
+            args.extend(['--spec-file', os.path.join(job.getTestDir(), self.options.input_file_name),
+                         '-o', job.getTestDir()])
 
         # Build [<command>, <args>]
         command.extend(args)
@@ -345,6 +347,10 @@ class QueueManager(Scheduler):
                 if group_results.get(job.getTestName(), {}):
                     job_results = group_results[job.getTestName()]
                     (status, caveats) = self._getTesterStatusAndCaveatsFromSession(results, tester)
+
+                    if 'OVERSIZED' in caveats:
+                        caveats.remove('OVERSIZED')
+
                     tester.addCaveats(caveats)
                     tester.setStatus(status)
 

--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -7,10 +7,10 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-import os, re
+import os, re, sys
 from QueueManager import QueueManager
 from TestHarness import util # to execute qsub
-from itertools import groupby # to get most common ncpus from `pbsnode -a`
+from itertools import groupby # to get most common ncpus from `pbsnodes -a`
 
 ## This Class is responsible for maintaining an interface to the PBS scheduling syntax
 class RunPBS(QueueManager):

--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -93,10 +93,10 @@ class RunPBS(QueueManager):
     def _optimizeSelect(self, job):
         """ Determine the optimal select statement for PBS """
 
-        slots = str(job.getMetaData().get('QUEUEING_NCPUS', 1))
+        slots = int(job.getMetaData().get('QUEUEING_NCPUS', 1))
         procs_per_node = int(self._getPBSResources())
-        num_full_chunks = int(slots) / procs_per_node
-        remaining_ranks = int(slots) % procs_per_node
+        num_full_chunks = slots / procs_per_node
+        remaining_ranks = slots % procs_per_node
 
         # slots > procs_per_node
         if num_full_chunks and remaining_ranks:

--- a/python/TestHarness/schedulers/pbs_template
+++ b/python/TestHarness/schedulers/pbs_template
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N <JOB_NAME>
-#PBS -l select=1:<NCPUS>
+#PBS -l <NCPUS>
 #PBS -l walltime=<WALLTIME>
 <PBS_PROJECT>
 #PBS -j oe

--- a/python/TestHarness/schedulers/pbs_template
+++ b/python/TestHarness/schedulers/pbs_template
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N <JOB_NAME>
-#PBS -l select=1:ncpus=<MPI_PROCS>
+#PBS -l select=1:<NCPUS>
 #PBS -l walltime=<WALLTIME>
 <PBS_PROJECT>
 #PBS -j oe

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -33,7 +33,7 @@ class RunApp(Tester):
         params.addParam('command',            "The command line to execute for this test.")
 
         # Parallel/Thread testing
-        params.addParam('max_parallel', 1000, "Maximum number of MPI processes this test can be run with      (Default: 1000)")
+        params.addParam('max_parallel', 1000000, "Maximum number of MPI processes this test can be run with      (Default: 1000000)")
         params.addParam('min_parallel',    1, "Minimum number of MPI processes that this test can be run with (Default: 1)")
         params.addParam('max_threads',    16, "Max number of threads (Default: 16)")
         params.addParam('min_threads',     1, "Min number of threads (Default: 1)")


### PR DESCRIPTION
Add ability for RunPBS to better calculate the select statement.

Modify util.runCommand so it can handle large amounts of output.
In particular, `pbsnodes -a` can possibly generate enough output
to break current design:
(https://docs.python.org/2/library/subprocess.html#popen-objects).

Closes #11609
