### PR TITLE
Report error if getting nodal values of non-nodal variable

### DIFF
--- a/framework/doc/content/documentation/framework_development/interfaces/Coupleable.md
+++ b/framework/doc/content/documentation/framework_development/interfaces/Coupleable.md
@@ -1,0 +1,88 @@
+# Coupleable
+
+This class provides API for coupling different kinds of variables values into MOOSE systems.
+The following table summarizes the methods and kinds of values they provide:
+
+| Method | Description |
+| - | - |
+coupledValue | Values of a coupled variable in q-points
+coupledGradient | Gradients of a coupled variable in q-points
+coupledSecond | Second derivatives of a coupled variable in q-points
+coupledNodalValue | Values of a coupled variable at nodes.
+coupledVectorValue | Values of a coupled vector variable in q-points
+coupledCurl | Curl of a coupled vector variable in q-points
+coupledDot | Time derivative of a coupled variable
+coupledDotDu | Derivative of a time derivative of a coupled variable
+coupledNodalDot | Nodal value of the time derivative of a coupled variable
+coupledVectorDot | Time derivative of a coupled vector variable
+
+For values, gradients and second derivatives, users can request old and older values in case they are running a transient simulation.
+In case of old and older values, the methods are called `coupledValueOld` and `coupledValueOlder`, respectively.
+Similarly,
+
+## Optional Coupling
+
+To determine if a variable was coupled, users can use `isCoupled` method.
+The typical use case looks like this:
+
+```
+_value(isCoupled("v") ? coupledValue("v") : _zero)
+```
+
+However, this use case became obsolete and now it is recommended to use default values for optionally coupled variables, see the following example:
+
+```
+validParams<Class>()
+{
+  InputParameters params = validParams<BaseClass>();
+  params.addCoupledVar("v", 2., "Coupled value");
+  ...
+}
+
+Class::Class(...) : BaseClass(...),
+  _v(coupledValue('v'))
+```
+
+The advantage here is that users can provide arbitrary default values to their variables.
+
+## Coupling of Vectors of Variables
+
+Users can couple a vector of variables using the following syntax:
+
+```
+v = 'a b c'
+```
+
+This syntax provides 3 variables coupled as a variable `v` in a MOOSE object using the `Coupleable` interface.
+The number of components coupled into can be obtained by `coupledComponents` method.
+Then, individual components can be obtained by calling `coupledValue` (or any other method mentioned above) passing in the variable name (as usual) and the component index. See the following example:
+
+Declarations:
+
+```
+class B : public A
+{
+  ...
+protected:
+  unsigned int _n_vars;
+  std::vector<MooseVariable *> _vars;
+};
+```
+
+Implementation:
+
+```
+validParams<B>()
+{
+  InputParameters params = validParams<A>();
+  params.addRequiredCoupledVar("v", "Coupled value");
+  ...
+}
+
+B::B(...) : A(...),
+  _n_vars(coupledComponents("v"))
+{
+  for (unsigned int i = 0; i < _n_vars; i++)
+    _vars.push_back(dynamic_cast<MooseVariable *>(getVar("v", i)));
+}
+```

--- a/framework/doc/content/documentation/framework_development/interfaces/index.md
+++ b/framework/doc/content/documentation/framework_development/interfaces/index.md
@@ -1,5 +1,6 @@
 # Interfaces
 
 - [DerivativeMaterialInterface](interfaces/DerivativeMaterialInterface.md)
+- [Coupleable](interfaces/Coupleable.md)
 - [SetupInterface (execute_on)](interfaces/SetupInterface.md)
 - [TaggingInterface](interfaces/TaggingInterface.md)

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -957,6 +957,11 @@ Coupleable::coupledNodalValue(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   if (var == NULL)
     mooseError("Call corresponding vector variable method");
+  if (!var->isNodal())
+    mooseError(_c_name,
+               ": Trying to get nodal values of variable '",
+               var->name(),
+               "', but it is not nodal.");
 
   if (!_coupleable_neighbor)
     return (_c_is_implicit) ? var->dofValues() : var->dofValuesOld();
@@ -976,6 +981,11 @@ Coupleable::coupledNodalValueOld(const std::string & var_name, unsigned int comp
   MooseVariable * var = getVar(var_name, comp);
   if (var == NULL)
     mooseError("Call corresponding vector variable method");
+  if (!var->isNodal())
+    mooseError(_c_name,
+               ": Trying to get old nodal values of variable '",
+               var->name(),
+               "', but it is not nodal.");
 
   if (!_coupleable_neighbor)
     return (_c_is_implicit) ? var->dofValuesOld() : var->dofValuesOlder();
@@ -995,6 +1005,11 @@ Coupleable::coupledNodalValueOlder(const std::string & var_name, unsigned int co
   MooseVariable * var = getVar(var_name, comp);
   if (var == NULL)
     mooseError("Call corresponding vector variable method");
+  if (!var->isNodal())
+    mooseError(_c_name,
+               ": Trying to get older nodal values of variable '",
+               var->name(),
+               "', but it is not nodal.");
   if (_c_is_implicit)
   {
     if (!_coupleable_neighbor)

--- a/test/include/materials/CoupledNodalMaterial.h
+++ b/test/include/materials/CoupledNodalMaterial.h
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COUPLEDNODALMATERIAL_H
+#define COUPLEDNODALMATERIAL_H
+
+#include "Material.h"
+
+class CoupledNodalMaterial;
+
+template <>
+InputParameters validParams<CoupledNodalMaterial>();
+
+/**
+ * Material for testing coupling of nodal values
+ */
+class CoupledNodalMaterial : public Material
+{
+public:
+  CoupledNodalMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// The time level of the coupled variable
+  MooseEnum _lag;
+  /// Values of the coupled variable
+  const VariableValue & _coupled_val;
+};
+
+#endif // COUPLEDNODALMATERIAL_H

--- a/test/src/materials/CoupledNodalMaterial.C
+++ b/test/src/materials/CoupledNodalMaterial.C
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CoupledNodalMaterial.h"
+
+registerMooseObject("MooseTestApp", CoupledNodalMaterial);
+
+template <>
+InputParameters
+validParams<CoupledNodalMaterial>()
+{
+  InputParameters params = validParams<Material>();
+  params.addRequiredCoupledVar("coupled", "Coupled value");
+  MooseEnum lag("CURRENT OLD OLDER", "CURRENT", false);
+  params.addParam<MooseEnum>("lag", lag, "Determine the time level of the coupled value");
+  return params;
+}
+
+CoupledNodalMaterial::CoupledNodalMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _lag(getParam<MooseEnum>("lag")),
+    _coupled_val(_lag == 0 ? coupledNodalValue("coupled")
+                           : (_lag == 1 ? coupledNodalValueOld("coupled")
+                                        : coupledNodalValueOlder("coupled")))
+{
+}
+
+void
+CoupledNodalMaterial::computeQpProperties()
+{
+}

--- a/test/tests/misc/check_error/coupled_nodal_for_non_nodal_variable.i
+++ b/test/tests/misc/check_error/coupled_nodal_for_non_nodal_variable.i
@@ -1,0 +1,27 @@
+# Checking that coupling a constant monomial variable into an object that expects
+# a nodal variable will report an error
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+  elem_type = EDGE2
+[]
+
+[Variables]
+  [./v]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Materials]
+  [./m]
+    type = CoupledNodalMaterial
+    coupled = v
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -690,4 +690,31 @@
     input = 'kernel_with_vector_var.i'
     expect_err = 'No standard variable named u found. Did you specify a vector variable when you meant to specify a standard variable'
   [../]
+
+  [./coupled_nodal_for_non_nodal_variable]
+    type = 'RunException'
+    input = 'coupled_nodal_for_non_nodal_variable.i'
+    expect_err = 'm: Trying to get nodal values of variable \'v\', but it is not nodal.'
+    requirement = "The system shall report an error if users try to get nodal values of non-nodal variables."
+    design = 'Coupleable.md'
+    issues = '#11623'
+  [../]
+  [./coupled_nodal_for_non_nodal_variable_old]
+    type = 'RunException'
+    input = 'coupled_nodal_for_non_nodal_variable.i'
+    cli_args = 'Materials/m/lag=OLD'
+    expect_err = 'm: Trying to get old nodal values of variable \'v\', but it is not nodal.'
+    requirement = "The system shall report an error if users try to get old nodal values of non-nodal variables."
+    design = 'Coupleable.md'
+    issues = '#11623'
+  [../]
+  [./coupled_nodal_for_non_nodal_variable_older]
+    type = 'RunException'
+    input = 'coupled_nodal_for_non_nodal_variable.i'
+    cli_args = 'Materials/m/lag=OLDER'
+    expect_err = 'm: Trying to get older nodal values of variable \'v\', but it is not nodal.'
+    requirement = "The system shall report an error if users try to get older nodal values of non-nodal variables."
+    design = 'Coupleable.md'
+    issues = '#11623'
+  [../]
 []


### PR DESCRIPTION
If users request nodal values via `coupledNodalValueXYZ` of a non-nodal
variable, the system should report an error.

Closes #11623

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
