### PR TITLE
display RUNNING instead of NA

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -475,7 +475,7 @@ class TestHarness:
 
             # Just print current status without saving results
             else:
-                print(util.formatResult(job, self.options, result='RUNNING...', caveats=False))
+                print(util.formatResult(job, self.options, result='RUNNING', caveats=False))
 
     # Print final results, close open files, and exit with the correct error code
     def cleanup(self):

--- a/python/TestHarness/tests/test_LongRunning.py
+++ b/python/TestHarness/tests/test_LongRunning.py
@@ -15,5 +15,5 @@ class TestHarnessTester(TestHarnessTestCase):
         Test for RUNNING status in the TestHarness
         """
         output = self.runTests('-i', 'long_running')
-        self.assertIn('RUNNING...', output)
+        self.assertIn('RUNNING', output)
         self.assertIn('[FINISHED]', output)

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -191,7 +191,10 @@ def formatResult(job, options, result='', color=True, **kwargs):
     # Support only one instance of a format identifier, but obey the order
     terminal_format = list(OrderedDict.fromkeys(list(TERM_FORMAT)))
     tester = job.getTester()
-    status = tester.getStatus()
+    if tester.isNoStatus():
+        status = job.getStatus()
+    else:
+        status = tester.getStatus()
     color_opts = {'code' : options.code, 'colored' : options.colored}
 
     # container for every printable item


### PR DESCRIPTION
For users specifying a pre-status format for test result printing,
this will replace NA with RUNNING.

Closes #11621
