### PR TITLE
Input porosity to PorousFlowPorosity classes is now constant monomial.

### DIFF
--- a/modules/porous_flow/src/materials/PorousFlowPorosity.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosity.C
@@ -25,7 +25,9 @@ validParams<PorousFlowPorosity>()
   params.addRequiredCoupledVar("porosity_zero",
                                "The porosity at zero volumetric strain and "
                                "reference temperature and reference effective "
-                               "porepressure and reference chemistry");
+                               "porepressure and reference chemistry.  This must be a real number "
+                               "or a constant monomial variable (not a linear lagrange or other "
+                               "type of variable)");
   params.addParam<Real>("thermal_expansion_coeff",
                         "Volumetric thermal expansion coefficient of the drained porous solid "
                         "skeleton (only used if thermal=true)");
@@ -62,7 +64,7 @@ PorousFlowPorosity::PorousFlowPorosity(const InputParameters & parameters)
     _fluid(getParam<bool>("fluid")),
     _thermal(getParam<bool>("thermal")),
     _chemical(getParam<bool>("chemical")),
-    _phi0(_nodal_material ? coupledNodalValue("porosity_zero") : coupledValue("porosity_zero")),
+    _phi0(coupledValue("porosity_zero")),
     _biot(getParam<Real>("biot_coefficient")),
     _exp_coeff(isParamValid("thermal_expansion_coeff") ? getParam<Real>("thermal_expansion_coeff")
                                                        : 0.0),
@@ -214,7 +216,8 @@ PorousFlowPorosity::datNegInfinityQp(unsigned pvar) const
 Real
 PorousFlowPorosity::atZeroQp() const
 {
-  Real result = _phi0[_qp];
+  // note the [0] below: _phi0 is a constant monomial and we use [0] regardless of _nodal_material
+  Real result = _phi0[0];
   if (_chemical)
   {
     if (_t_step == 0 && !_app.isRestarting())

--- a/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
+++ b/modules/porous_flow/src/materials/PorousFlowPorosityConst.C
@@ -16,7 +16,11 @@ InputParameters
 validParams<PorousFlowPorosityConst>()
 {
   InputParameters params = validParams<PorousFlowPorosityBase>();
-  params.addRequiredCoupledVar("porosity", "The porosity (assumed constant for this material)");
+  params.addRequiredCoupledVar(
+      "porosity",
+      "The porosity (assumed indepenent of porepressure, temperature, "
+      "strain, etc, for this material).  This should be a real number, or "
+      "a constant monomial variable (not a linear lagrange or other kind of variable).");
   params.addClassDescription("This Material calculates the porosity assuming it is constant");
   return params;
 }
@@ -29,7 +33,8 @@ PorousFlowPorosityConst::PorousFlowPorosityConst(const InputParameters & paramet
 void
 PorousFlowPorosityConst::initQpStatefulProperties()
 {
-  _porosity[_qp] = _input_porosity[_qp];
+  // note the [0] below: _phi0 is a constant monomial and we use [0] regardless of _nodal_material
+  _porosity[_qp] = _input_porosity[0];
 }
 
 void


### PR DESCRIPTION
Only the [0] value of this is used, not [_qp], because it is a constant monomial.  This is advantageous because it means that we get the same values, and can be assured of non-erroneous indexing, regardless of whether this is a nodal Material (computing values of porosity at the nodes of the element) or an ordinary Material.

Fixes #11620

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
