### PR TITLE
Update includes for enum forward declarations

### DIFF
--- a/framework/include/preconditioners/PhysicsBasedPreconditioner.h
+++ b/framework/include/preconditioners/PhysicsBasedPreconditioner.h
@@ -13,8 +13,10 @@
 // MOOSE includes
 #include "MoosePreconditioner.h"
 
+// libMesh includes
 #include "libmesh/preconditioner.h"
 #include "libmesh/linear_implicit_system.h"
+#include "libmesh/enum_preconditioner_type.h"
 
 // C++ includes
 #include <vector>

--- a/framework/src/actions/AdaptivityAction.C
+++ b/framework/src/actions/AdaptivityAction.C
@@ -18,8 +18,10 @@
 #include "MooseEnum.h"
 #include "MooseVariableFE.h"
 
+// libMesh includes
 #include "libmesh/transient_system.h"
 #include "libmesh/system_norm.h"
+#include "libmesh/enum_norm_type.h"
 
 registerMooseAction("MooseApp", AdaptivityAction, "setup_adaptivity");
 

--- a/framework/src/dirackernels/DiracKernelInfo.C
+++ b/framework/src/dirackernels/DiracKernelInfo.C
@@ -13,6 +13,7 @@
 // LibMesh
 #include "libmesh/point_locator_base.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_point_locator_type.h"
 
 DiracKernelInfo::DiracKernelInfo()
   : _point_locator(), _point_equal_distance_sq(libMesh::TOLERANCE * libMesh::TOLERANCE)

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -17,6 +17,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/point_locator_base.h"
+#include "libmesh/enum_point_locator_type.h"
 
 registerMooseObject("MooseApp", SideSetsFromPoints);
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -20,6 +20,9 @@
 #include "FormattedTable.h"
 #include "NonlinearSystem.h"
 
+// libMesh includes
+#include "libmesh/enum_norm_type.h"
+
 registerMooseObject("MooseApp", Console);
 
 template <>

--- a/framework/src/outputs/VariableResidualNormsDebugOutput.C
+++ b/framework/src/outputs/VariableResidualNormsDebugOutput.C
@@ -14,7 +14,9 @@
 #include "Material.h"
 #include "NonlinearSystemBase.h"
 
+// libMesh includes
 #include "libmesh/transient_system.h"
+#include "libmesh/enum_norm_type.h"
 
 registerMooseObject("MooseApp", VariableResidualNormsDebugOutput);
 

--- a/framework/src/postprocessors/VariableResidual.C
+++ b/framework/src/postprocessors/VariableResidual.C
@@ -13,6 +13,9 @@
 #include "MooseVariable.h"
 #include "NonlinearSystemBase.h"
 
+// libMesh includes
+#include "libmesh/enum_norm_type.h"
+
 registerMooseObject("MooseApp", VariableResidual);
 
 template <>

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -10,7 +10,6 @@
 #include "libmesh/libmesh_config.h"
 
 #include "EigenProblem.h"
-
 #include "Assembly.h"
 #include "AuxiliarySystem.h"
 #include "DisplacedProblem.h"
@@ -20,8 +19,10 @@
 #include "OutputWarehouse.h"
 #include "Function.h"
 
+// libMesh includes
 #include "libmesh/system.h"
 #include "libmesh/eigen_solver.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 registerMooseObject("MooseApp", EigenProblem);
 

--- a/framework/src/timeintegrators/ActuallyExplicitEuler.C
+++ b/framework/src/timeintegrators/ActuallyExplicitEuler.C
@@ -17,6 +17,7 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/preconditioner.h"
+#include "libmesh/enum_convergence_flags.h"
 
 registerMooseObject("MooseApp", ActuallyExplicitEuler);
 

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -16,6 +16,7 @@
 #include "MooseVariableFE.h"
 #include "RotationMatrix.h"
 
+// libMesh includes
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh_function.h"
 #include "libmesh/numeric_vector.h"
@@ -24,6 +25,7 @@
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/enum_xdr_mode.h"
 
 registerMooseObject("MooseApp", SolutionUserObject);
 

--- a/framework/src/utils/ArbitraryQuadrature.C
+++ b/framework/src/utils/ArbitraryQuadrature.C
@@ -9,6 +9,9 @@
 
 #include "ArbitraryQuadrature.h"
 
+// libMesh includes
+#include "libmesh/enum_quadrature_type.h"
+
 ArbitraryQuadrature::ArbitraryQuadrature(const unsigned int d, const Order o) : QBase(d, o) {}
 
 QuadratureType

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -17,6 +17,9 @@
 #include "MooseVariableScalar.h"
 #include "NonlinearSystem.h"
 
+// libMesh includes
+#include "libmesh/enum_norm_type.h"
+
 registerMooseObject("ContactApp", ReferenceResidualProblem);
 
 template <>


### PR DESCRIPTION
There were just a few changes required to allow us to forward-declare a bunch of enums at the libMesh level (thereby reducing header file dependencies). This change does not seem to extend to many of the apps (I haven't found any that require changes yet) so I think it's a net positive overall.

Refs libMesh/libmesh#1713.
