### PR TITLE
improve positiveProjectionEigenDecomposition

### DIFF
--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -225,7 +225,8 @@ public:
   RankFourTensor mixedProductIlJk(const RankTwoTensor & a) const;
 
   /// return positive projection tensor of eigen-decomposition
-  RankFourTensor positveProjectionEigenDecomposition() const;
+  RankFourTensor positiveProjectionEigenDecomposition(std::vector<Real> & eigval,
+                                                      RankTwoTensor & eigvec) const;
 
   /// returns A_ij - de_ij*tr(A)/3, where A are the _coords
   RankTwoTensor deviatoric() const;

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -474,14 +474,13 @@ RankTwoTensor::mixedProductJkIl(const RankTwoTensor & b) const
 }
 
 RankFourTensor
-RankTwoTensor::positveProjectionEigenDecomposition() const
+RankTwoTensor::positiveProjectionEigenDecomposition(std::vector<Real> & eigval,
+                                                    RankTwoTensor & eigvec) const
 {
   // The calculate of projection tensor follows
   // C. Miehe and M. Lambrecht, Commun. Numer. Meth. Engng 2001; 17:337~353
 
   // Compute eigenvectors and eigenvalues of mechanical strain
-  RankTwoTensor eigvec;
-  std::vector<Real> eigval(N);
   (*this).symmetricEigenvaluesEigenvectors(eigval, eigvec);
 
   // Separate out positive and negative eigen values

--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicLinearElasticPFFractureStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicLinearElasticPFFractureStress.C
@@ -64,10 +64,13 @@ ComputeIsotropicLinearElasticPFFractureStress::computeQpStress()
   const Real lambda = _elasticity_tensor[_qp](0, 0, 1, 1);
   const Real mu = _elasticity_tensor[_qp](0, 1, 0, 1);
 
-  // Compute eigenvectors and eigenvalues of mechanical strain
+  // Compute eigenvectors and eigenvalues of mechanical strain and projection tensor
   RankTwoTensor eigvec;
   std::vector<Real> eigval(LIBMESH_DIM);
-  _mechanical_strain[_qp].symmetricEigenvaluesEigenvectors(eigval, eigvec);
+  RankFourTensor proj_pos =
+      _mechanical_strain[_qp].positiveProjectionEigenDecomposition(eigval, eigvec);
+  RankFourTensor I4sym(RankFourTensor::initIdentitySymmetricFour);
+  RankFourTensor proj_neg = I4sym - proj_pos;
 
   // Calculate tensors of outerproduct of eigen vectors
   std::vector<RankTwoTensor> etens(LIBMESH_DIM);
@@ -153,10 +156,6 @@ ComputeIsotropicLinearElasticPFFractureStress::computeQpStress()
   // d trace(A) / dA
   RankTwoTensor I(RankTwoTensor::initIdentity);
   RankFourTensor dtraceAdA = I.outerProduct(I);
-  // projection tensor
-  RankFourTensor proj_pos = _mechanical_strain[_qp].positveProjectionEigenDecomposition();
-  RankFourTensor I4sym(RankFourTensor::initIdentitySymmetricFour);
-  RankFourTensor proj_neg = I4sym - proj_pos;
 
   _Jacobian_mult[_qp] = ((1.0 - c) * (1.0 - c) * (1 - _kdamage) + _kdamage) *
                             (lambda * dtraceAdA * MathUtils::heavyside(etr) + 2 * mu * proj_pos) +


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

closes #11638 

Now RankTwoTensor::positiveProjectionEigenDecomposition takes in references to eigval and eigvec and computes them inside. This way, in ComputeIsotropicLinearElasticPFFractureStress the eigenvalue decomposition of mechanical_strain is not solved twice, and efficiency will be improved.

