### PR TITLE
Add strain energy density, smeared cracking TM docs

### DIFF
--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/AbruptSoftening.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/AbruptSoftening.md
@@ -1,14 +1,62 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# AbruptSoftening
-
-!alert construction title=Undocumented Class
-The AbruptSoftening has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Abrupt Softening
 
 !syntax description /Materials/AbruptSoftening
+
+## Description
+
+The material `AbruptSoftening` computes the reduced stress and stiffness
+in the direction of a crack according to a step function. The computed
+cracked stiffness ratio softens the tensile response of the material once the
+principle stress exceeds the cracking stress threshold of the material.
+
+As with the other smeared cracking softening models, which all follow the
+nomenclature convention of using the `Softening` suffix, this model is indended
+to be used with the [ComputeSmearedCrackingStress](/ComputeSmearedCrackingStress.md)
+material.
+
+### Softening Model
+
+As the class name implies, `AbruptSoftening` does not allow any gradual softening
+of the material and instantly drops the stiffness of the material in response to
+cracking.
+The tensile stress response to cracking is based on the value of the residual
+stress retained after softening, $\sigma_{res}$, and is given as
+crack is completed
+\begin{equation}
+  \label{eqn:abrupt_crack_stress}
+  \sigma = \begin{cases}
+            1 \times 10^{-16} \cdot E \epsilon_c^{init} & \text{ if } \sigma_{res} = 0 \\
+            \sigma_{res} \cdot \sigma_c & \text{ if } \sigma_{res} \neq 0
+           \end{cases}
+\end{equation}
+where the calculated stress, $\sigma$ is the principle stress along the direction
+of the crack, $\sigma_c$ is the stress threshold beyond which cracking occurs,
+$E$ is the Youngs' modulus value, and $\epsilon_c^{init}$ is the strain in
+direction of the crack when crack initiation occurred.
+The ratio of the current stiffness to the original material stiffness is
+similiarly determined based on the value of the residual stress
+\begin{equation}
+  \label{eqn:abrupt_stiffness_ratio}
+  R = \begin{cases}
+        1 \times 10^{-16} & \text{ if } \sigma_{res} = 0 \\
+        \frac{\sigma}{E \epsilon_c^{max}} & \text{ if } \sigma_{res} \neq 0
+       \end{cases}
+\end{equation}
+where $\sigma$ is the principle stress along the direction of the crack,
+$E$ is the Youngs' modulus value, and $\epsilon_c^{max}$ is the maximum strain
+in the direction of crack.
+The stiffness ratio is passed back to the
+[ComputeSmearedCrackingStress](/ComputeSmearedCrackingStress.md)
+to compute the softened cracked material stiffness.
+
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz.i block=Materials/abrupt_softening
+
+`AbruptSoftening` must be run in conjunction with the fixed smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rz.i block=Materials/elastic_stress
 
 !syntax parameters /Materials/AbruptSoftening
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeSmearedCrackingStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeSmearedCrackingStress.md
@@ -8,9 +8,13 @@ This class implements a fixed smeared cracking model, which represents cracking 
 
 In this model, principal stresses are compared to a critical stress.  If one of the principal stresses exceeds the critical stress, the material point is considered cracked in that direction, and the model transitions to an orthotropic model, in which the stress in the cracked direction is decreased according to a softening law. Material behavior in the cracking direction is affected in two ways: reduction of the stiffness in that direction, and adjusting the stress to follow the softening curve.
 
+### Interaction with Inelastic Models
+
 This class derives from [ComputeMultipleInelasticStrain](ComputeMultipleInelasticStress.md), and prior to cracking, allows multiple inelastic models to be active. Once cracking occurs, the inelastic strains at that material point are preserved, but those models are no longer called for the duration of the simulation, and inelastic strains from those other models are no longer permitted to evolve.
 
-The orientation of the principal coordinate system is determined from the eigenvectors of the elastic strain tensor.  However, once a crack direction is determined, that direction remains fixed and further cracks are considered in directions perpendicular to the original crack direction.  Note that for axisymmetric problems, one crack direction is known _a priori_.  The theta or out-of-plane direction is not coupled to the $r$ and $z$ directions (i.e., no $r\theta$ or $z\theta$ shear strain/stress exists) and is therefore a known or principal direction.
+### Cracking Direction Determination
+
+The orientation of the principal coordinate system is determined from the eigenvectors of the elastic strain tensor.  However, once a crack direction is determined, that direction remains fixed and further cracks are considered in directions perpendicular to the original crack direction.  Note that for axisymmetric problems, one crack direction is known *a priori*.  The theta or out-of-plane direction is not coupled to the $r$ and $z$ directions (i.e., no $r\theta$ or $z\theta$ shear strain/stress exists) and is therefore a known or principal direction.
 
 If we store a scalar value, $c_i$, for each of the three possible crack directions at a material point, these in combination with the principal directions (eigenvectors or rotation tensor) provide a convenient way to eliminate stress in cracked directions.  A value of 1 for $c_i$ indicates that the material point has not cracked in that direction.  A value very close to zero (not zero for numerical reasons) indicates that cracking has occurred.
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ExponentialSoftening.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ExponentialSoftening.md
@@ -1,14 +1,55 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ExponentialSoftening
-
-!alert construction title=Undocumented Class
-The ExponentialSoftening has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Exponential Softening
 
 !syntax description /Materials/ExponentialSoftening
+
+## Description
+
+The material `ExponentialSoftening` computes the reduced stress and stiffness
+in the direction of a crack according to a exponential function. The computed
+cracked stiffness ratio softens the tensile response of the material once the
+principle stress exceeds the cracking stress threshold of the material.
+
+As with the other smeared cracking softening models, which all follow the
+nomenclature convention of using the `Softening` suffix, this model is indended
+to be used with the [ComputeSmearedCrackingStress](/ComputeSmearedCrackingStress.md)
+material.
+
+### Softening Model
+
+The tensile stress response to cracking is calculated as an exponential function
+of the crack strain
+\begin{equation}
+  \label{eqn:exp_crack_stress}
+  \sigma = \sigma_c \cdot \left( \sigma_{res} + (1 - \sigma_{res}) \cdot
+       \exp \left[ \frac{\alpha \beta}{\sigma_c} \cdot \left( \epsilon_c^{max}
+       - \epsilon_c^{init} \right) \right] \right)
+\end{equation}
+where the calculated stress, $\sigma$ is the principle stress along the direction
+of the crack, $\sigma_c$ is the stress threshold beyond which cracking occurs,
+$\sigma_{res}$ is the residual stress retained after full softening due to the
+crack is completed, $\alpha$ is the initial slope of the exponential curve,
+$\beta$ is a fitting parameter, $\epsilon_c^{max}$ is the maximum strain in the
+direction of crack, and $\epsilon_c^{init}$ is the strain in direction of crack
+when crack initiation occurred.
+The ratio of the current stiffness to the original material stiffness is
+computed using the result of [eqn:exp_crack_stress]
+\begin{equation}
+  \label{eqn:exp_stiffness_ratio}
+  R = \sigma \cdot \frac{\epsilon_c^{init}}{\epsilon_c^{max}\sigma_c}
+\end{equation}
+where the definitions for the variables are the same here as in
+[eqn:exp_crack_stress]. The stiffness ratio is passed back to the
+[ComputeSmearedCrackingStress](/ComputeSmearedCrackingStress.md)
+to compute the softened cracked material stiffness.
+
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rotation.i block=Materials/exponential_softening
+
+`ExponentialSoftening` must be run in conjunction with the fixed smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_rotation.i block=Materials/cracking_stress
 
 !syntax parameters /Materials/ExponentialSoftening
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/PowerLawCreepStressUpdate.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/PowerLawCreepStressUpdate.md
@@ -17,7 +17,7 @@ This class calculates an effective trial stress, an effective creep strain rate 
 
 This class is based on the implicit integration algorithm in [cite:dunne2005introduction] pg. 146 - 149.
 
-## Example Input File Syntax
+## Example Input File
 
 !listing modules/tensor_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i block=Materials/powerlawcrp
 
@@ -30,7 +30,6 @@ This class is based on the implicit integration algorithm in [cite:dunne2005intr
 !syntax inputs /Materials/PowerLawCreepStressUpdate
 
 !syntax children /Materials/PowerLawCreepStressUpdate
-
 
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/PowerLawSoftening.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/PowerLawSoftening.md
@@ -1,14 +1,54 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# PowerLawSoftening
-
-!alert construction title=Undocumented Class
-The PowerLawSoftening has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Power Law Softening
 
 !syntax description /Materials/PowerLawSoftening
+
+## Description
+
+The material `PowerLawSoftening` computes the reduced stress and stiffness along
+the direction of a crack according to a power law equation. The computed
+reduced stiffness softens the tensile response of the material once the principle
+stress applied to a material exceeds the cracking stress threshold of the material.
+
+As with the other smeared cracking softening models, which all follow the
+nomenclature convention of using the `Softening` suffix, this model is indended
+to be used with the [ComputeSmearedCrackingStress](/ComputeSmearedCrackingStress.md)
+material.
+
+### Softening Model
+
+The tensile stress response to cracking is calculated as a function of the number
+cracks, where the presence of cracks reduces the stress reponse of the cracked material.
+The calculated stress is the principle stress in the single direction of the crack.
+\begin{equation}
+  \label{eqn:power_law_softening_stress}
+  \sigma = k E \epsilon_{principle}
+\end{equation}
+where $k$ is the reduction factor applied to the initial stiffness each time a
+new crack initiates, $E$ is the Youngs' modulus, and $\epsilon_{principle}$ is the
+strain along the direction of the crack.
+The reduction factor in [eqn:power_law_softening_stress] is a function of the
+number of cracks
+\begin{equation}
+  \label{eqn:reduction_factor}
+  k = k_0 \left( k_r\right)^n
+\end{equation}
+where $k_0$ is the initial cracking reduction factor and $n$ is the number of cracks.
+The form of [eqn:reduction_factor] gives the `PowerLawSoftening` model its name.
+
+In the context of the smeared cracking modeling approach, individual cracks are
+not tracked; therefore, [eqn:reduction_factor] is approximated by a single
+constant input parameter.
+The user should consult additional resources to determine a reasonable value for
+the initial stiffness reduction factor.
+
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_power.i block=Materials/power_law_softening
+
+`PowerLawSoftening` must be run in conjunction with the fixed smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_power.i block=Materials/elastic_stress
 
 !syntax parameters /Materials/PowerLawSoftening
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/StrainEnergyDensity.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/StrainEnergyDensity.md
@@ -1,14 +1,36 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# StrainEnergyDensity
-
-!alert construction title=Undocumented Class
-The StrainEnergyDensity has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Strain Energy Density
 
 !syntax description /Materials/StrainEnergyDensity
+
+## Description
+
+This material computes the strain energy density, $u$, which is defined as the
+area underneath the stress-strain curve:
+\begin{equation}
+  \label{eqn:sed_integral_def}
+  u = \int_x \frac{1}{2} \sigma : d \epsilon
+\end{equation}
+where $\sigma$ is the stress and $\epsilon$ is the mechanical strain. In the
+tensor mechanics module we define the mechanical strain as the sum of the
+elastic and inelastic (e.g. plastic, creep) strain without the eigenstrains.
+
+The strain energy density can be calculated either in total or in incremental
+form, based on the strain measured applied.
+In the incremental form the strain energy density integral takes the form
+\begin{equation}
+  \label{eqn:incremental_sed}
+  u = u_{old} + \frac{1}{2} \sigma : \Delta \epsilon +
+      \frac{1}{2}\sigma_{old} : \Delta \epsilon
+\end{equation}
+where $\Delta \epsilon$ is the mechancial strain increment.
+
+!alert note title=Monotonic Loading Only
+The +`StrainEnergyDensity`+ class is formulated only for monotonic loading and
+should not be used to calculate the strain energy density for cyclic loading cases.
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/strain_energy_density/incr_model_elas_plas.i block=Materials/strain_energy_density
 
 !syntax parameters /Materials/StrainEnergyDensity
 

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/incr_model_elas_plas.i
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/incr_model_elas_plas.i
@@ -75,12 +75,6 @@
     boundary = 'top'
     function = ramp_disp_y
   [../]
-#  [./Pressure]
-#    [./top]
-#      boundary = 'top'
-#      function = rampConstantUp
-#    [../]
-#  [../]
 []
 
 [Materials]


### PR DESCRIPTION
Adds documentation to the strain energy density calculation in tensor mechanics and for the softening models used by the smeared cracking material.
Includes a few grammar formatting modifications to related classes. @acasagran and/or @bwspenc please review and merge

Refs #10516
