### PR TITLE
Docs for tensor mechanics materials used in phase field

### DIFF
--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/Strains.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/Strains.md
@@ -1,18 +1,31 @@
 # Strain Formulations in Tensor Mechanics
 
-The tensor mechanics module offers three different types of strain calculation: Small linearized total strain, small linearized incremental strain, and finite incremental strain.
+The tensor mechanics module offers three different types of strain calculation:
+Small linearized total strain, small linearized incremental strain, and finite incremental strain.
 
 ## Small Linearized Total Strain
 
-For linear elasticity problems, the Tensor Mechanics module includes a small strain and total strain material [ComputeSmallStrain](/ComputeSmallStrain.md).  This material is useful for verifying material models with hand calculations because of the simplified strain calculations.
+For linear elasticity problems, the Tensor Mechanics module includes a small strain
+and total strain material [ComputeSmallStrain](/ComputeSmallStrain.md).  This material
+is useful for verifying material models with hand calculations because of the
+simplified strain calculations.
 
-Linearized small strain theory assumes that the gradient of displacement with respect to position is much smaller than unity, and the squared displacement gradient term is neglected in the small strain definition to give:
+Linearized small strain theory assumes that the gradient of displacement with
+respect to position is much smaller than unity, and the squared displacement
+gradient term is neglected in the small strain definition to give:
 \begin{equation}
 \epsilon = \frac{1}{2} \left( u \nabla + \nabla u \right) \quad when \quad \frac{\partial u}{ \partial x} << 1
 \end{equation}
 For more details on the linearized small strain assumption and derivation, see a Continuum Mechanics text such as [cite:malvern1969introduction] or [cite:bower2009applied], specifically [Chapter 2](http://solidmechanics.org/Text/Chapter2_1/Chapter2_1.php#Sect2_1_7).
 
-Total strain theories are path independent: in MOOSE, path independence means that the total strain, from the beginning of the entire simulation, is used to calculate stress and other material properties.  Incremental theories, on the other hand, use the increment of strain at timestep to calculate stress.  Because the total strain formulation `ComputeSmallStrain` is path independent, no old values of strain or stress from the previous timestep are stored in MOOSE.  For a comparison of total strain vs incremental strain theories with experimental data, see [cite:shammamy1967incremental].
+Total strain theories are path independent: in MOOSE, path independence means
+that the total strain, from the beginning of the entire simulation, is used to
+calculate stress and other material properties.  Incremental theories, on the other
+hand, use the increment of strain at timestep to calculate stress.  Because the
+total strain formulation `ComputeSmallStrain` is path independent, no old values
+of strain or stress from the previous timestep are stored in MOOSE.  For a comparison
+of total strain vs incremental strain theories with experimental data,
+see [cite:shammamy1967incremental].
 
 The input file syntax for small strain is
 
@@ -21,11 +34,21 @@ end=stress
 
 ## Incremental Small Strains
 
-Applicable for small linearized strains, MOOSE includes an incremental small strain material, [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md).  As in the small strain material, the incremental small strain class assumes the gradient of displacement with respect to position is much smaller than unity, and the squared displacement gradient term is neglected in the small strain definition to give:
+Applicable for small linearized strains, MOOSE includes an incremental small
+strain material, [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md).
+As in the small strain material, the incremental small strain class assumes the
+gradient of displacement with respect to position is much smaller than unity,
+and the squared displacement gradient term is neglected in the small strain definition
+to give:
 \begin{equation}
 \epsilon = \frac{1}{2} \left( u \nabla + \nabla u \right) \quad when \quad \frac{\partial u}{ \partial x} << 1
 \end{equation}
-As the class name suggests, `ComputeIncrementalSmallStrain` is an incremental formulation.  The stress increment is calculated from the current strain increment at each time step.  In this class, the rotation tensor is defined to be the rank-2 Identity tensor: no rotations are allowed in the model. Stateful properties, including `strain_old` and `stress_old`, are stored. This incremental small strain material is useful as a component of verifying more complex finite incremental strain-stress calculations.
+As the class name suggests, `ComputeIncrementalSmallStrain` is an incremental formulation.
+The stress increment is calculated from the current strain increment at each time
+step. In this class, the rotation tensor is defined to be the rank-2 Identity tensor:
+no rotations are allowed in the model. Stateful properties, including `strain_old`
+and `stress_old`, are stored. This incremental small strain material is useful as
+a component of verifying more complex finite incremental strain-stress calculations.
 
 The input file syntax for incremental small strain is
 
@@ -38,41 +61,45 @@ For finite strains, use [ComputeFiniteStrain](/ComputeFiniteStrain.md) in which 
 
 ### Incremental Deformation Gradient
 
-The finite strain mechanics approach used in the MOOSE tensor_mechanics module is the incremental corotational form from [cite:rashid1993incremental]. In this form, the generic time increment under consideration is such that $t \in [t_n, t_{n+1}]$. The
-configurations of the material element under consideration at $t = t_n$ and $t = t_{n+1}$ are denoted
-by $\kappa_n$, and $\kappa_{n + 1}$, respectively. The incremental motion over the time increment is
-assumed to be given in the form of the inverse of the deformation gradient $\hat{\mathbf{F}}$ of
+The finite strain mechanics approach used in the MOOSE tensor_mechanics module
+is the incremental corotational form from [cite:rashid1993incremental]. In this
+form, the generic time increment under consideration is such that $t \in [t_n, t_{n+1}]$.
+The configurations of the material element under consideration at $t = t_n$ and
+$t = t_{n+1}$ are denoted by $\kappa_n$, and $\kappa_{n + 1}$, respectively. The
+incremental motion over the time increment is assumed to be given in the form of
+the inverse of the deformation gradient $\hat{\boldsymbol{F}}$ of
 $\kappa_{n + 1}$ with respect to $\kappa_n$, which may be written as
 
 \begin{equation}
-\hat{\mathbf{F}}^{-1} = 1 - \frac{\partial \hat{\mathbf{u}}}{\partial \mathbf{x}},
+\hat{\boldsymbol{F}}^{-1} = 1 - \frac{\partial \hat{\boldsymbol{u}}}{\partial \boldsymbol{x}},
 \end{equation}
-where $\hat{\mathbf{u}}(\mathbf{x})$ is the incremental displacement field for the time step, and
-$\mathbf{x}$ is the position vector of materials points in $\kappa_{n+1}$. Note that
-$\hat{\mathbf{F}}$ is NOT the deformation gradient, but rather the incremental deformation gradient
+where $\hat{\boldsymbol{u}}(\boldsymbol{x})$ is the incremental displacement field for the time step, and
+$\boldsymbol{x}$ is the position vector of materials points in $\kappa_{n+1}$. Note that
+$\hat{\boldsymbol{F}}$ is NOT the deformation gradient, but rather the incremental deformation gradient
 of $\kappa_{n+1}$ with respect to $\kappa_n$. Thus,
 \begin{equation}
-\hat{\mathbf{F}} = \mathbf{F}_{n+1} \mathbf{F}_n^{-1}
+\hat{\boldsymbol{F}} = \boldsymbol{F}_{n+1} \boldsymbol{F}_n^{-1}
 \end{equation}
-where $\mathbf{F}_n$ is the total deformation gradient at time $t_n$.
+where $\boldsymbol{F}_n$ is the total deformation gradient at time $t_n$.
 
 For this form, we assume
 \begin{equation}
 \begin{aligned}
-\dot{\mathbf{F}} \mathbf{F}^{-1} =& \mathbf{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
-\mathbf{F}(t^{-}_{n+1}) =& \hat{\mathbf{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
-\mathbf{F}(t_{n+1}) =& \hat{\mathbf{R}} \hat{\mathbf{U}} = \hat{\mathbf{F}}\ (\hat{\mathbf{R}}\ \mathrm{proper\ orthogonal})
+\dot{\boldsymbol{F}} \boldsymbol{F}^{-1} =& \boldsymbol{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
+\boldsymbol{F}(t^{-}_{n+1}) =& \hat{\boldsymbol{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
+\boldsymbol{F}(t_{n+1}) =& \hat{\boldsymbol{R}} \hat{\boldsymbol{U}} = \hat{\boldsymbol{F}}\ (\hat{\boldsymbol{R}}\ \mathrm{proper\ orthogonal})
 \end{aligned}
 \end{equation}
 
-In tensor mechanics, there are two decomposition options to obtain the strain increment: TaylorExpansion and EigenSolution, with the default set to TaylorExpansion. See the
+In tensor mechanics, there are two decomposition options to obtain the strain increment:
+TaylorExpansion and EigenSolution, with the default set to TaylorExpansion. See the
 [ComputeFiniteStrain](/ComputeFiniteStrain.md) for a description of both decomposition options.
 
 ### Volumetric Locking Correction
 
-In [ComputeFiniteStrain](/ComputeFiniteStrain.md) $\hat{\mathbf{F}}$ is calculated and can optionally include a volumetric locking correction following the B-bar method:
+In [ComputeFiniteStrain](/ComputeFiniteStrain.md) $\hat{\boldsymbol{F}}$ is calculated and can optionally include a volumetric locking correction following the B-bar method:
 \begin{equation}
-\hat{\mathbf{F}}_{corr} = \hat{\mathbf{F}} \left( \frac{|\mathrm{av}_{el}(\hat{\mathbf{F}})|}{|\hat{\mathbf{F}}|} \right)^{\frac{1}{3}},
+\hat{\boldsymbol{F}}_{corr} = \hat{\boldsymbol{F}} \left( \frac{|\mathrm{av}_{el}(\hat{\boldsymbol{F}})|}{|\hat{\boldsymbol{F}}|} \right)^{\frac{1}{3}},
 \end{equation}
 where $\mathrm{av}_{el}()$ is the average value for the entire element.
 

--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/StressDivergence.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/StressDivergence.md
@@ -42,9 +42,9 @@ the stress and strain calculations are performed on the correct material configu
 !table id=strain_formulations caption=Consistent Strain and Stress Formulations
 | Theoretical Formulation                           | Tensor Mechanics Classes    |
 |---------------------------------------------------|-----------------------------|
-| Linearized elasticity total small strain problems | [ComputeLinearElasticStress](/ComputeLinearElasticStress.md) and [ComputeSmallStrain](/ComputeSmallStrain.md) (in the Tensor Mechanics master action use the argument `strain = SMALL`) |
-| Linearized elasticity incremental small strain    | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md) and [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md) (in the Tensor Mechanics master action `strain = SMALL` and `incremental = true` )|
-| Large deformation problems, including elasticity and/or plasticity | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md), or other inelastic stress material class, and [ComputeFiniteStrain](/ComputeFiniteStrain.md) (in the Tensor Mechanics master action use `strain = FINITE`) |
+| Linearized elasticity total small strain problems | [ComputeLinearElasticStress](/ComputeLinearElasticStress.md) and [ComputeSmallStrain](/ComputeSmallStrain.md) (in the [TensorMechanics/MasterAction](/Master/index.md) use the argument `strain = SMALL`) |
+| Linearized elasticity incremental small strain    | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md) and [ComputeIncrementalSmallStrain](/ComputeIncrementalSmallStrain.md) (in the [TensorMechanics/MasterAction](/Master/index.md) `strain = SMALL` and `incremental = true` )|
+| Large deformation problems, including elasticity and/or plasticity | [ComputeFiniteStrainElasticStress](/ComputeFiniteStrainElasticStress.md), or other inelastic stress material class, and [ComputeFiniteStrain](/ComputeFiniteStrain.md) (in the [TensorMechanics/MasterAction](/Master/index.md) use `strain = FINITE`) |
 
 ### Linearized Elasticity Problems
 
@@ -65,7 +65,7 @@ is rotated to the deformed mesh.  Newer material models, such as crystal plastic
 models, also rotate the strain and stress to the deformed mesh.  In these large deformation classes,
 the stress passed to the stress divergence kernel is calculated with respect to the deformed mesh, $\sigma(x)$.
 
-!alert warning prefix=False
+!alert warning title=Ensure Consistency in Stress and Strain Formulations
 As users and developers, we must take care to ensure consistency in the mesh used to calculate the
 strain and the mesh used to calculate the residual from the stress divergence equation.
 
@@ -90,21 +90,21 @@ calculations of the stress divergence kernel.
 
 The `use_displaced_mesh` parameter must be set correcting to ensure consistency in the equilibrium
 equation: if the stress is calculated with respect to the deformed mesh, the test function gradients
-must also be calculated with respect to the deformed mesh. The +Tensor Mechanics MasterAction+ is
+must also be calculated with respect to the deformed mesh. The [TensorMechanics/MasterAction](/Master/index.md) is
 designed to automatically determine and set the flag for the `use_displaced_mesh` parameter correctly
-for the selected strain formulation.  
+for the selected strain formulation.
 
 !alert note title=Use of the Tensor Mechanics MasterAction Recommended
-We recommend that users employ the Tensor Mechanics master action whenever
-possible to ensure consistency between the test function gradients and the strain
-formulation selected.
+We recommend that users employ the +[TensorMechanics/MasterAction](/Master/index.md)+
+whenever possible to ensure consistency between the test function gradients and
+the strain formulation selected.
 
 ### Linearized Elasticity Problems
 
 Small strain linearized elasticity problems should be run with the parameter `use_displaced_mesh =
 false` in the kernel to ensure all calculations across all three classes (strain, stress, and kernel)
 are computed with respect to the reference mesh. These settings are automatically
-handled with the master action use.
+handled with the [TensorMechanics/MasterAction](/Master/index.md) use.
 
 !listing modules/tensor_mechanics/tutorials/basics/part_1.1.i block=Modules/TensorMechanics/Master
 
@@ -114,7 +114,7 @@ Large deformation problems should be run with the parameter setting `use_displac
 the kernel so that the kernel and the materials all compute variables with respect to the deformed
 mesh; however, the setting of `use_displaced_mesh` should not be changed from the default
 in the materials.
-The tensor mechanics master action automatically creates the appropriate settings for all classes.
+The [TensorMechanics/MasterAction](/Master/index.md) automatically creates the appropriate settings for all classes.
 The input file syntax to set the Stress Divergence kernel for finite strain problems is:
 
 !listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i

--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/StressDivergence.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/StressDivergence.md
@@ -3,7 +3,7 @@
 A material varies from its rest shape due to stress. This departure from the rest shape is called
 deformation or displacement, and the proportion of deformation to original size is called strain. To
 determine the deformed shape and the stress, a governing equation is solved to determine the
-displacement vector $\mathbf{u}$.
+displacement vector $\boldsymbol{u}$.
 
 ## Mathematical Introduction
 
@@ -11,26 +11,34 @@ The strong form of the governing equation on the domain $\Omega$ and boundary
 $\Gamma=\Gamma_{\mathit{t_i}}\cup\Gamma_{\mathit{g_i}}$ can be stated as follows:
 \begin{equation}
 \begin{aligned}
-\nabla \cdot (\mathbf{\sigma} + \mathbf{\sigma}_0) + \mathbf{b} =& \mathbf{0} \;\mathrm{in}\;\Omega \\
-\mathbf{u} =& \mathbf{g}\;\mathrm{in}\;\Gamma_{ \mathbf{g}} \\
-\mathbf{\sigma} \cdot \mathbf{n}=&\mathbf{t}\;\mathrm{in}\;\Gamma_{ \mathbf{t}}
+\nabla \cdot (\boldsymbol{\sigma} + \boldsymbol{\sigma}_0) + \boldsymbol{b} =& \boldsymbol{0} \;\mathrm{in}\;\Omega \\
+\boldsymbol{u} =& \boldsymbol{g}\;\mathrm{in}\;\Gamma_{ \boldsymbol{g}} \\
+\boldsymbol{\sigma} \cdot \boldsymbol{n}=&\boldsymbol{t}\;\mathrm{in}\;\Gamma_{ \boldsymbol{t}}
 \end{aligned}
 \end{equation}
-where $\mathbf{\sigma}$  is the Cauchy stress tensor, $\mathbf{\sigma}_0$ is an additional source of stress (such as pore pressure), $\mathbf{u}$ is the displacement vector, $\mathbf{b}$ is the body force, $\mathbf{n}$ is the unit normal to the boundary, $\mathbf{g}$ is the prescribed displacement on the boundary and $\mathbf{t}$ is the prescribed traction on the boundary. The weak form of the residual equation is expressed as:
+where $\boldsymbol{\sigma}$  is the Cauchy stress tensor, $\boldsymbol{\sigma}_0$
+is an additional source of stress (such as pore pressure), $\boldsymbol{u}$ is
+the displacement vector, $\boldsymbol{b}$ is the body force, $\boldsymbol{n}$ is
+the unit normal to the boundary, $\boldsymbol{g}$ is the prescribed displacement
+on the boundary and $\boldsymbol{t}$ is the prescribed traction on the boundary.
+The weak form of the residual equation is expressed as:
 \begin{equation}
-  \mathbb{R} = \left( \mathbf{\sigma} + \mathbf{\sigma}_0), \nabla \phi_m \right) - \left< \mathbf{t}, \phi_m \right> - \left( \mathbf{b}, \phi_m \right)  = \mathbf{0}
+  \mathbb{R} = \left( \boldsymbol{\sigma} + \boldsymbol{\sigma}_0), \nabla \phi_m \right) - \left< \boldsymbol{t}, \phi_m \right> - \left( \boldsymbol{b}, \phi_m \right)  = \boldsymbol{0}
 \end{equation}
-where $(\cdot)$ and $\left< \cdot \right>$ represent volume and boundary integrals, respectively. The solution of the residual equation with Newton's method requires the Jacobian of the residual equation, which can be expressed as (ignoring boundary terms)
+where $(\cdot)$ and $\left< \cdot \right>$ represent volume and boundary integrals,
+respectively. The solution of the residual equation with Newton's method requires
+the Jacobian of the residual equation, which can be expressed as (ignoring boundary
+terms)
 \begin{equation}
-  \mathbb{J} = \left( \frac{\partial \mathbf{\sigma}}{\partial \nabla \mathbf{u}} , \nabla \phi_m \right),
+  \mathbb{J} = \left( \frac{\partial \boldsymbol{\sigma}}{\partial \nabla \boldsymbol{u}} , \nabla \phi_m \right),
 \end{equation}
-assuming $\mathbf{\sigma}_0$ is independent of the strain.
+assuming $\boldsymbol{\sigma}_0$ is independent of the strain.
 
 The material stress response is described by the constitutive model, where the stress is determined
-as a function of the strain, i.e. $\tilde{\mathbf{\sigma}}( \mathbf{\epsilon} -
-\mathbf{\epsilon}_0)$, where $\mathbf{\epsilon}$ is the strain and $\mathbf{\epsilon}_0$ is a stress
+as a function of the strain, i.e. $\tilde{\boldsymbol{\sigma}}( \boldsymbol{\epsilon} -
+\boldsymbol{\epsilon}_0)$, where $\boldsymbol{\epsilon}$ is the strain and $\boldsymbol{\epsilon}_0$ is a stress
 free strain. For example, in linear elasticity (only valid for small strains), the material response
-is linear, i.e.  $\mathbf{\sigma} = \mathbf{\mathcal{C}}(\mathbf{\epsilon} - \mathbf{\epsilon}_0)$.
+is linear, i.e.  $\boldsymbol{\sigma} = \boldsymbol{\mathcal{C}}(\boldsymbol{\epsilon} - \boldsymbol{\epsilon}_0)$.
 
 ## Consistency Between Stress and Strain
 

--- a/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/plug_n_play.md
+++ b/modules/tensor_mechanics/doc/content/documentation/modules/tensor_mechanics/plug_n_play.md
@@ -6,9 +6,9 @@ Tensor Mechanics module requires at least three separate classes to fully descri
 
 !alert note title=Three Tensors Are Required for a Mechanics Problem
 The three tensors that must be defined for any mechanics problem are the the strain
-$\mathbf{\epsilon}$ or strain increment, elasticity tensor $\mathbf{\mathcal{C}}$, and the stress
-$\mathbf{\sigma}$. Optional tensors include stress-free strain (also known as an eigenstrain)
-$\mathbf{\epsilon}_0$ and additional stress $\mathbf{\sigma}_0$.
+$\boldsymbol{\epsilon}$ or strain increment, elasticity tensor $\boldsymbol{\mathcal{C}}$, and the stress
+$\boldsymbol{\sigma}$. Optional tensors include stress-free strain (also known as an eigenstrain)
+$\boldsymbol{\epsilon}_0$ and additional stress $\boldsymbol{\sigma}_0$.
 
 !media media/tensor_mechanics-IntroPlugNPlay.png
        style=width:800;float:right;
@@ -20,7 +20,7 @@ reason, all material properties can be prepended by a name defined by the input 
 
 ## Strain Materials
 
-The base material class to create strains ($\mathbf{\epsilon}$) or strain increments is
+The base material class to create strains ($\boldsymbol{\epsilon}$) or strain increments is
 `ComputeStrainBase`; this class is a pure virtual class, requiring that all children override the
 `computeQpProperties()` method.  For all strains the base class defines the property `total_strain`.
 For incremental strains, both finite and small, the compute strain base class defines the properties
@@ -28,8 +28,8 @@ For incremental strains, both finite and small, the compute strain base class de
 the different types of strain formulations is available on the [Strains](tensor_mechanics/Strains.md)
 page.
 
-For small strains, use [ComputeSmallStrain](/ComputeSmallStrain.md) in which $\mathbf{\epsilon} =
-(\nabla \mathbf{u} + \nabla \mathbf{u}^T)/2$. For finite strains, use
+For small strains, use [ComputeSmallStrain](/ComputeSmallStrain.md) in which $\boldsymbol{\epsilon} =
+(\nabla \boldsymbol{u} + \nabla \boldsymbol{u}^T)/2$. For finite strains, use
 [ComputeFiniteStrain](/ComputeFiniteStrain.md) in which an incremental form is employed such that the
 strain_increment and rotation_increment are calculated.
 
@@ -41,7 +41,7 @@ FINITE` parameter, as shown below.
 
 ## Elasticity Tensor Materials
 
-The primary class for creating elasticity tensors ($\mathbf{\mathcal{C_{ijkl}}}$) is
+The primary class for creating elasticity tensors ($\boldsymbol{\mathcal{C_{ijkl}}}$) is
 [ComputeElasticityTensor](/ComputeElasticityTensor.md). This class defines the property
 `_elasticity_tensor`. Given the elastic constants required for the applicable symmetry, such as
 `symmetric9`, this material calculates the elasticity tensor. If you wish to rotate the elasticity
@@ -64,7 +64,7 @@ and for an orthotropic material, such as a metal crystal, is
 
 ## Stress Materials
 
-The base class for constitutive equations to compute a stress ($\mathbf{\sigma}$) is
+The base class for constitutive equations to compute a stress ($\boldsymbol{\sigma}$) is
 `ComputeStressBase`. The `ComputeStressBase` class defines the properties `stress` and
 `elastic_strain`. It is a pure virtual class, requiring all children to override the method
 `computeQpStress()`.
@@ -108,7 +108,7 @@ or intrinsic in English.  The term eigenstrain was introduced by
 
 Thermal strains are a volumetric change resulting from a change in temperature of the material.  The
 change in strains can be either a simple linear function of thermal change,
-e.g. ($\mathbf{\epsilon}_T = \alpha \Delta T$) or a more complex function of temperature.  The
+e.g. ($\boldsymbol{\epsilon}_T = \alpha \Delta T$) or a more complex function of temperature.  The
 thermal expansion class, [ComputeThermalExpansionEigenstrain](/ComputeThermalExpansionEigenstrain.md)
 computes the thermal strain as a linear function of temperature.  The input file syntax is
 
@@ -137,7 +137,7 @@ automatically generated derivatives, at each quadrature point.
 
 ## Extra Stress Materials
 
-Extra stresses ($\mathbf{\sigma}_0$) can also be pulled into the residual calculation after the
+Extra stresses ($\boldsymbol{\sigma}_0$) can also be pulled into the residual calculation after the
 constitutive model calculation of the stress. The extra stress material property, `extra_stress` is
 defined in the `ComputeExtraStressBase` class and is added to the stress value.
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/AuxKernels/CylindricalRankTwoAux.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/AuxKernels/CylindricalRankTwoAux.md
@@ -11,7 +11,7 @@ The AuxKernel will save the component of the tranformed Rank-2 tensor, $T^R$, as
 arguments for the `index_i` and `index_j` parameters.
 \begin{equation}
 \label{eq:cylindrical_rank_two_aux}
-T^R_{ij} = \mathbf{R} \cdot \mathbf{T} \cdot \mathbf{R}^T
+T^R_{ij} = \boldsymbol{R} \cdot \boldsymbol{T} \cdot \boldsymbol{R}^T
 \end{equation}
 The rotation tensor $R$ is defined as
 \begin{equation}

--- a/modules/tensor_mechanics/doc/content/documentation/systems/BCs/DisplacementAboutAxis.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/BCs/DisplacementAboutAxis.md
@@ -13,10 +13,10 @@ The rotating displacement value at the current node is calculated according to
 [eq:rotating_displacement]:
 \begin{equation}
 \label{eq:rotating_displacement}
-u_{rotation} = \mathbf{T}^{-1} \cdot \mathbf{R}_x^{-1} \cdot \mathbf{R}_y^{-1} \cdot \mathbf{R}_z \cdot \mathbf{R}_y \cdot \mathbf{R}_x \cdot \mathbf{T}
+u_{rotation} = \boldsymbol{T}^{-1} \cdot \boldsymbol{R}_x^{-1} \cdot \boldsymbol{R}_y^{-1} \cdot \boldsymbol{R}_z \cdot \boldsymbol{R}_y \cdot \boldsymbol{R}_x \cdot \boldsymbol{T}
 \end{equation}
-where $\mathbf{T}$ is the translation matrix for axes of rotation not centered at the coordinate
-system origin, and $\mathbf{R}_x$, $\mathbf{R}_y$, and $\mathbf{R}_z$ are rotation matrices about the
+where $\boldsymbol{T}$ is the translation matrix for axes of rotation not centered at the coordinate
+system origin, and $\boldsymbol{R}_x$, $\boldsymbol{R}_y$, and $\boldsymbol{R}_z$ are rotation matrices about the
 $\hat{x}$, $\hat{y}$, and $\hat{z}$ coordinate system axes, respectively.
 
 ## Example Input File Syntax

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/Gravity.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/Gravity.md
@@ -4,12 +4,15 @@
 
 ## Description
 
-The kernel `Gravity` provides a body force term in the stress divergence equilibrium equation to account for gravity force due to self weight.
-In a continuum mechanics problem, momentum conservation is prescribed assuming static equilibrium at each time increment,
+The kernel `Gravity` provides a body force term in the stress divergence equilibrium
+equation to account for gravity force due to self weight.
+In a continuum mechanics problem, momentum conservation is prescribed assuming
+static equilibrium at each time increment,
 \begin{equation}
-\nabla \cdot \mathbf{\sigma} + g = 0,
+\nabla \cdot \boldsymbol{\sigma} + g = 0,
 \end{equation}
-where $\mathbf{\sigma}$ is the Cauchy stress tensor and $\mathbf{g}$ is the gravity body force per unit mass.
+where $\boldsymbol{\sigma}$ is the Cauchy stress tensor and $\boldsymbol{g}$ is
+the gravity body force per unit mass.
 
 ## Example Input File Syntax
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/StressDivergenceRSphericalTensors.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/StressDivergenceRSphericalTensors.md
@@ -32,7 +32,7 @@ divergence reduces to
 In deriving the weak form of this equation, the second term in [eqn:strongformspherical]
 goes to zero and the residual contribution in the `StressDivergenceRSphericalTensors` kernel becomes
 \begin{equation}
-\mathbf{R} = \sigma_{rr} \frac{ \partial \phi_i }{ \partial r} + \frac{ \phi_i}{X_r} \left( \sigma_{\phi \phi} + \sigma_{\theta \theta} \right)
+\boldsymbol{R} = \sigma_{rr} \frac{ \partial \phi_i }{ \partial r} + \frac{ \phi_i}{X_r} \left( \sigma_{\phi \phi} + \sigma_{\theta \theta} \right)
 \end{equation}
 
 ## Example Input File syntax

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/TensorMechanics/LegacyTensorMechanicsAction.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/TensorMechanics/LegacyTensorMechanicsAction.md
@@ -1,15 +1,14 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+# Legacy Kernel-Only Tensor Mechanics Action
 
-# LegacyTensorMechanicsAction
+!alert warning title=Deprecated Action
+This legacy action will soon be deprecated in favor of the more inclusive
++[TensorMechanics/Master](/Master/index.md)+.
+See the description, example use, and parameters on the
++[TensorMechanics/Master](/Master/index.md)+ action system page.
 
-!alert construction title=Undocumented Class
-The LegacyTensorMechanicsAction has not been documented, if you would like to contribute to MOOSE by writing
-documentation, please see [/generate.md]. The content contained on this page explains the typical
-documentation associated with an action; however, what is contained is ultimately determined by what
-is necessary to make the documentation clear for users.
+## Description
 
-!syntax description /Kernels/TensorMechanics/LegacyTensorMechanicsAction
-
-!syntax parameters /Kernels/TensorMechanics/LegacyTensorMechanicsAction
-
-!bibtex bibliography
+The legacy kernel only tensor mechanics action simplifies the input file syntax
+for creating a tensor mechanics model by reducing the number of kernels required.
+See a description of the action and parameters on the
+[LegacyTensorMechanicsAction](/Kernels/TensorMechanics/index.md) action system page.

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/TensorMechanics/index.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/TensorMechanics/index.md
@@ -1,11 +1,50 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+# Legacy Kernel-Only Tensor Mechanics Action
 
+!syntax description /Kernels/TensorMechanics/LegacyTensorMechanicsAction
 
-# TensorMechanics System
+!alert warning title=Deprecated Action
+This legacy action will soon be deprecated in favor of the more inclusive
++[TensorMechanics/MasterAction](/Master/index.md)+.
+See the description, example use, and parameters on the
++[TensorMechanics/Master](/Master/index.md)+ action system page.
+
+## Description
+
+The `LegacyTensorMechanicsAction` is a convenience object that simplifies part of
+the tensor mechanics system setup. It adds StressDivergence Kernels (for the
+current coordinate system).
+
+## Constructed MooseObjects
+
+The Legacy Tensor Mechanics Action is used to construct the kernels for the
+specified coordinate system.
+
+!table id=tmMaster_action_table caption=Correspondence Among Action Functionality and MooseObjects for the Tensor Mechanics `Master` Action
+| Functionality     | Replaced Classes   | Associated Parameters   |
+|-------------------|--------------------|-------------------------|
+| Calculate stress divergence equilibrium for the given coordinate system | [StressDivergenceTensors](/Kernels/StressDivergenceTensors.md) or [StressDivergenceRZTensors](/Kernels/StressDivergenceRZTensors.md) or [StressDivergenceRSphericalTensors](/Kernels/StressDivergenceRSphericalTensors.md) | `displacements` : a string of the displacement field variables |
+
+Note that there are many variations for the calculation of the stress divergence.
+Review the theoretical introduction for the
+[Stress Divergence](tensor_mechanics/StressDivergence.md).
+Pay particular attention to the setting of the `use_displaced_mesh` parameter
+discussion; this parameter depends on the strain formulation used in the simulation.
+
+!alert note title=Use of the Tensor Mechanics MasterAction Recommended
+We recommend that users employ the +[TensorMechanics/MasterAction](/Master/index.md)+
+whenever possible to ensure consistency between the test function gradients and
+the strain formulation selected.
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/elastic_patch/elastic_patch.i block=Kernels
+
+!syntax parameters /Kernels/TensorMechanics/LegacyTensorMechanicsAction
+
+## Associated Actions
 
 !syntax list /Kernels/TensorMechanics objects=True actions=False subsystems=False
 
 !syntax list /Kernels/TensorMechanics objects=False actions=False subsystems=True
 
 !syntax list /Kernels/TensorMechanics objects=False actions=True subsystems=False
-

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DFiniteStrain.md
@@ -28,26 +28,26 @@ the $\theta$ direction.
 The incremental deformation gradient for the 1D axisymmetric system is defined as
 \begin{equation}
   \label{eqn:incremental_deformation_grad}
-  \hat{\mathbf{F}} = \mathbf{A} : \bar{\mathbf{F}}^{-1} + \mathbf{I}
+  \hat{\boldsymbol{F}} = \boldsymbol{A} : \bar{\boldsymbol{F}}^{-1} + \boldsymbol{I}
 \end{equation}
-where $\mathbf{I}$ is the Rank-2 identity tensor, and the deformation gradient,
-$\mathbf{A}$, and the old deformation gradient,
-$\bar{\mathbf{F}}$, are given as
+where $\boldsymbol{I}$ is the Rank-2 identity tensor, and the deformation gradient,
+$\boldsymbol{A}$, and the old deformation gradient,
+$\bar{\boldsymbol{F}}$, are given as
 \begin{equation}
   \label{eqn:deform_grads}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 \epsilon_{rr} & 0 & 0 \\
                 0 & \epsilon_{zz} & 0 \\
                 0 & 0 & \epsilon_{\theta \theta}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 \epsilon_{rr}|_{old} & 0 & 0 \\
                 0 & \epsilon_{zz}|_{old} & 0 \\
                 0 & 0 & \epsilon_{\theta \theta}|_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
-Note that $\bar{\mathbf{F}}$ uses the values of the strain expressions from
+Note that $\bar{\boldsymbol{F}}$ uses the values of the strain expressions from
 the previous time step.
 The components of the tensors in [eqn:deform_grads] are given as
 \begin{equation}

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DIncrementalStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DIncrementalStrain.md
@@ -28,27 +28,27 @@ the $\theta$ direction.
 The small, total, strain increment is calculated with the form
 \begin{equation}
   \label{eqn:strain_increment}
-  \Delta \mathbf{\epsilon} = \frac{1}{2} \left( \mathbf{D} + \mathbf{D}^T \right)
-  \text{ where } \mathbf{D} = \mathbf{A} - \bar{\mathbf{F}} + \mathbf{I}
+  \Delta \boldsymbol{\epsilon} = \frac{1}{2} \left( \boldsymbol{D} + \boldsymbol{D}^T \right)
+  \text{ where } \boldsymbol{D} = \boldsymbol{A} - \bar{\boldsymbol{F}} + \boldsymbol{I}
 \end{equation}
-where $\mathbf{I}$ is the Rank-2 identity tensor and the deformation gradient,
-$\mathbf{A}$, and the old deformation gradient,
-$\bar{\mathbf{F}}$, are given as
+where $\boldsymbol{I}$ is the Rank-2 identity tensor and the deformation gradient,
+$\boldsymbol{A}$, and the old deformation gradient,
+$\bar{\boldsymbol{F}}$, are given as
 \begin{equation}
   \label{eqn:deform_grads}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 \epsilon_{rr} & 0 & 0 \\
                 0 & \epsilon_{zz} & 0 \\
                 0 & 0 & \epsilon_{\theta \theta}
               \end{bmatrix}
   \text{  and  }
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 \epsilon_{rr}|_{old} & 0 & 0 \\
                 0 & \epsilon_{zz}|_{old} & 0 \\
                 0 & 0 & \epsilon_{\theta \theta}|_{old}
               \end{bmatrix}
 \end{equation}
-Note that $\bar{\mathbf{F}}$ uses the values of the strain expressions from
+Note that $\bar{\boldsymbol{F}}$ uses the values of the strain expressions from
 the previous time step.
 The components of the tensors in [eqn:deform_grads] are given as
 \begin{equation}

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeFiniteStrain.md
@@ -11,24 +11,24 @@ corotational form from
 In this form, the generic time increment under consideration is such that $t \in [t_n, t_{n+1}]$. The
 configurations of the material element under consideration at $t = t_n$ and $t = t_{n+1}$ are denoted
 by $\kappa_n$, and $\kappa_{n + 1}$, respectively. The incremental motion over the time increment is
-assumed to be given in the form of the inverse of the deformation gradient $\hat{\mathbf{F}}$ of
+assumed to be given in the form of the inverse of the deformation gradient $\hat{\boldsymbol{F}}$ of
 $\kappa_{n + 1}$ with respect to $\kappa_n$, which may be written as
 
 \begin{equation}
-\hat{\mathbf{F}}^{-1} = 1 - \frac{\partial \hat{\mathbf{u}}}{\partial \mathbf{x}},
+\hat{\boldsymbol{F}}^{-1} = 1 - \frac{\partial \hat{\boldsymbol{u}}}{\partial \boldsymbol{x}},
 \end{equation}
-where $\hat{\mathbf{u}}(\mathbf{x})$ is the incremental displacement field for the time step, and
-$\mathbf{x}$ is the position vector of materials points in $\kappa_{n+1}$. Note that
-$\hat{\mathbf{F}}$ is NOT the deformation gradient, but rather the incremental deformation gradient
-of $\kappa_{n+1}$ with respect to $\kappa_n$. Thus, $\hat{\mathbf{F}} = \mathbf{F}_{n+1}
-\mathbf{F}_n^{-1}$, where $\mathbf{F}_n$ is the total deformation gradient at time $t_n$.
+where $\hat{\boldsymbol{u}}(\boldsymbol{x})$ is the incremental displacement field for the time step, and
+$\boldsymbol{x}$ is the position vector of materials points in $\kappa_{n+1}$. Note that
+$\hat{\boldsymbol{F}}$ is NOT the deformation gradient, but rather the incremental deformation gradient
+of $\kappa_{n+1}$ with respect to $\kappa_n$. Thus, $\hat{\boldsymbol{F}} = \boldsymbol{F}_{n+1}
+\boldsymbol{F}_n^{-1}$, where $\boldsymbol{F}_n$ is the total deformation gradient at time $t_n$.
 
 For this form, we assume
 \begin{equation}
 \begin{aligned}
-\dot{\mathbf{F}} \mathbf{F}^{-1} =& \mathbf{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
-\mathbf{F}(t^{-}_{n+1}) =& \hat{\mathbf{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
-\mathbf{F}(t_{n+1}) =& \hat{\mathbf{R}} \hat{\mathbf{U}} = \hat{\mathbf{F}}\ (\hat{\mathbf{R}}\ \mathrm{proper\ orthogonal})
+\dot{\boldsymbol{F}} \boldsymbol{F}^{-1} =& \boldsymbol{D}\ \mathrm{(constant\ and\ symmetric),\ } t_n<t<t_{n+1}\\
+\boldsymbol{F}(t^{-}_{n+1}) =& \hat{\boldsymbol{U}}\ \mathrm{(symmetric\ positive\ definite)}\\
+\boldsymbol{F}(t_{n+1}) =& \hat{\boldsymbol{R}} \hat{\boldsymbol{U}} = \hat{\boldsymbol{F}}\ (\hat{\boldsymbol{R}}\ \mathrm{proper\ orthogonal})
 \end{aligned}
 \end{equation}
 
@@ -36,24 +36,24 @@ In tensor mechanics, there are two decomposition options to obtain the strain in
 increment: TaylorExpansion and EigenSolution, with the default set to TaylorExpansion.  According to
 [Rashid 1993](http://onlinelibrary.wiley.com/doi/10.1002/nme.1620362302/abstract), the stretching
 rate tensor and rotation matrix can be expressed in terms of 'incremental' deformation gradient
-$\hat{\mathbf{F}}$ as
+$\hat{\boldsymbol{F}}$ as
 \begin{equation}
-\mathbf{D} = \frac{1}{\Delta t}\log({\hat{\mathbf{C}}^{1/2}}) = \frac{1}{\Delta t}\log({(\hat{\mathbf{F}}^{T} \hat{\mathbf{F}})^{1/2}})
+\boldsymbol{D} = \frac{1}{\Delta t}\log({\hat{\boldsymbol{C}}^{1/2}}) = \frac{1}{\Delta t}\log({(\hat{\boldsymbol{F}}^{T} \hat{\boldsymbol{F}})^{1/2}})
 \end{equation}
 and
 
 \begin{equation}
-\hat{ \mathbf{R} } = \hat{\mathbf{F}} \hat{\mathbf{U}}^{-1}
+\hat{ \boldsymbol{R} } = \hat{\boldsymbol{F}} \hat{\boldsymbol{U}}^{-1}
 \end{equation}
 
 ## Taylor Expansion
 
 According to [Rashid 1993](http://onlinelibrary.wiley.com/doi/10.1002/nme.1620362302/abstract), the
-stretching rate tensor $\mathbf{D}$ and rotation matrix $\mathbf{R}$ can be approximated using Taylor
+stretching rate tensor $\boldsymbol{D}$ and rotation matrix $\boldsymbol{R}$ can be approximated using Taylor
 expansion as:
 the approximated stretching rate tensor
 \begin{equation}
-\mathbf{D}^{a} = \frac{1}{\Delta t}\{ -\frac{1}{2}(\hat{\mathbf{C}}^{-1} - \mathbf{I}) + \frac{1}{4}(\hat{\mathbf{C}}^{-1} - \mathbf{I})^{2} - \frac{1}{6}(\hat{\mathbf{C}}^{-1} - \mathbf{I})^{3} + ... \}
+\boldsymbol{D}^{a} = \frac{1}{\Delta t}\left[ -\frac{1}{2}(\hat{\boldsymbol{C}}^{-1} - \boldsymbol{I}) + \frac{1}{4}(\hat{\boldsymbol{C}}^{-1} - \boldsymbol{I})^{2} - \frac{1}{6}(\hat{\boldsymbol{C}}^{-1} - \boldsymbol{I})^{3} + ... \right]
 \end{equation}
 the approximated rotation matrix
 \begin{equation}
@@ -67,38 +67,38 @@ with
 \frac{1-\cos \theta^{a}}{4Q} =& \frac{1}{8} + Q\frac{P^{2}-12(P-1)}{32P^2} + Q^{2}\frac{(P-2)(P^{2}-10P+32)}{64P^3}\\
  +& Q^{3}\frac{1104-992P+376P^{2}-72P^{3}+5P^{4}}{512P^{4}}\\
 \cos^{2} \theta^{a} =& P + \frac{3P^{2}[1-(P+Q)]}{(P+Q)^{2}} - \frac{2P^{3}[1-(P+Q)]}{(P+Q)^{3}}\\
-P =& \frac{1}{4}(tr(\hat{\mathbf{F}}^{-1}) - 1)^{2}
+P =& \frac{1}{4}(tr(\hat{\boldsymbol{F}}^{-1}) - 1)^{2}
 \end{aligned}
 \end{equation}
-The sign of $\cos \theta^{a}$ is set by examining the sign of $(tr(\hat{\mathbf{F}}^{-1}) - 1)$.
+The sign of $\cos \theta^{a}$ is set by examining the sign of $(tr(\hat{\boldsymbol{F}}^{-1}) - 1)$.
 
 ## Eigen-Solution
 
 The stretching rate tensor can be calculated by the eigenvalues $\lambda$ and eigenvectors
-$\mathbf{v}$ of $\hat{\mathbf{C}}$.
+$\boldsymbol{v}$ of $\hat{\boldsymbol{C}}$.
 \begin{equation}
-\mathbf{D} = \log{\sqrt{\lambda_{1}}}\mathbf{N}_{1} + \log{\sqrt{\lambda_{2}}}\mathbf{N}_{2} + \log{\sqrt{\lambda_{3}}}\mathbf{N}_{3}
+\boldsymbol{D} = \log{\sqrt{\lambda_{1}}}\boldsymbol{N}_{1} + \log{\sqrt{\lambda_{2}}}\boldsymbol{N}_{2} + \log{\sqrt{\lambda_{3}}}\boldsymbol{N}_{3}
 \end{equation}
-with $\lambda$ being the eigenvalue and $\mathbf{N}$ matrix being constructed from the corresponding
+with $\lambda$ being the eigenvalue and $\boldsymbol{N}$ matrix being constructed from the corresponding
 eigenvector.
 \begin{equation}
-\mathbf{N}_{i} = \mathbf{v}_{i}\mathbf{v}_{i}^{T}
+\boldsymbol{N}_{i} = \boldsymbol{v}_{i}\boldsymbol{v}_{i}^{T}
 \end{equation}
 the 'incremental' stretching tensor
 \begin{equation}
-\hat{\mathbf{U}} = \sqrt{\lambda_{1}}\mathbf{N}_{1} + \sqrt{\lambda_{2}}\mathbf{N}_{2} + \sqrt{\lambda_{3}}\mathbf{N}_{3}
+\hat{\boldsymbol{U}} = \sqrt{\lambda_{1}}\boldsymbol{N}_{1} + \sqrt{\lambda_{2}}\boldsymbol{N}_{2} + \sqrt{\lambda_{3}}\boldsymbol{N}_{3}
 \end{equation}
 and thus
 \begin{equation}
-\hat{\mathbf{R}} = \hat{\mathbf{F}} \hat{\mathbf{U}}^{-1}
+\hat{\boldsymbol{R}} = \hat{\boldsymbol{F}} \hat{\boldsymbol{U}}^{-1}
 \end{equation}
 
 ## Volumetric Locking Correction
 
-In `ComputeFiniteStrain`, $\hat{\mathbf{F}}$ is calculated in the computeStrain method, including a
+In `ComputeFiniteStrain`, $\hat{\boldsymbol{F}}$ is calculated in the computeStrain method, including a
 volumetric locking correction of
 \begin{equation}
-\hat{\mathbf{F}}_{corr} = \hat{\mathbf{F}} \left( \frac{|\mathrm{av}_{el}(\hat{\mathbf{F}})|}{|\hat{\mathbf{F}}|} \right)^{\frac{1}{3}},
+\hat{\boldsymbol{F}}_{corr} = \hat{\boldsymbol{F}} \left( \frac{|\mathrm{av}_{el}(\hat{\boldsymbol{F}})|}{|\hat{\boldsymbol{F}}|} \right)^{\frac{1}{3}},
 \end{equation}
 where $\mathrm{av}_{el}()$ is the average value for the entire element. The strain increment and the
 rotation increment are calculated in `computeQpStrain()`. Once the strain increment is calculated, it

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeInstantaneousThermalExpansionFunctionEigenstrain.md
@@ -10,11 +10,11 @@ instantaneous thermal expansion coefficient $\alpha$ as a function of temperatur
 trapezoidal rule to perform time integration of this function, the current value of the thermal
 eigenstrain tensor, $\boldsymbol{\epsilon}^{th}_{t+1}$ is computed at a given time as:
 \begin{equation}
-\boldsymbol{\epsilon}^{th}_{t+1} = \boldsymbol{\epsilon}^{th}_{t} + \frac{1}{2}(\alpha_{(T_t)} + \alpha_{(T_{t+1})}) (T_{t+1}-T_{t}) \mathbf{I}
+\boldsymbol{\epsilon}^{th}_{t+1} = \boldsymbol{\epsilon}^{th}_{t} + \frac{1}{2}(\alpha_{(T_t)} + \alpha_{(T_{t+1})}) (T_{t+1}-T_{t}) \boldsymbol{I}
 \end{equation}
 where $t+1$ denotes quantities at the new step, and $t$ denotes quantities at the previous step, $T$
 is the temperature, $\alpha_{(T)}$ is the instantaneous thermal expansion at a given temperature, and
-$\mathbf{I}$ is the identity matrix. On the first step, the stress-free temperature is used as the
+$\boldsymbol{I}$ is the identity matrix. On the first step, the stress-free temperature is used as the
 previous step's temperature.
 
 ## Example Input File Syntax

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeInterfaceStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeInterfaceStress.md
@@ -27,19 +27,19 @@ where the $\backslash$ operator represents integer modulo. The basis $\vec e_i$
 is then orthonormalized using the modified Gram-Schmidt procedure,
 holding $\vec e_1$ constant. We construct two matrices
 \begin{equation}
-\mathbf{M} = \left( \begin{matrix}
+\boldsymbol{M} = \left( \begin{matrix}
   0 & 0 & 0 \\
   0 & \sigma_i & 0 \\
   0 & 0 & \sigma_i
   \end{matrix}  \right),
-\mathbf{S}= \left( \begin{matrix}
+\boldsymbol{S}= \left( \begin{matrix}
   \vec e_1 & \vec e_2 & \vec e_3
   \end{matrix}
   \right),
 \end{equation}
-and set the stress tensor $\mathbf{\sigma}$ to
+and set the stress tensor $\boldsymbol{\sigma}$ to
 \begin{equation}
-\mathbf{\sigma} = \left(S\cdot M\cdot S^{-1}\right)\cdot|\nabla\eta|,
+\boldsymbol{\sigma} = \left(S\cdot M\cdot S^{-1}\right)\cdot|\nabla\eta|,
 \end{equation}
 which is a basis transformation from the Eigenvector basis into the cartesian basis.
 The $|\nabla\eta|$ factor causes the integral over the stress tensor across the interface

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeIsotropicLinearElasticPFFractureStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeIsotropicLinearElasticPFFractureStress.md
@@ -48,16 +48,16 @@ F =& \Psi + \gamma \\
 To be thermodynamically consistent, the stress is related to the deformation energy density according
 to
 \begin{equation}
-\mathbf{\sigma} = \frac{\partial \Psi}{\partial \mathbf{\epsilon}}.
+\boldsymbol{\sigma} = \frac{\partial \Psi}{\partial \boldsymbol{\epsilon}}.
 \end{equation}
 Thus,
 \begin{equation}
-\mathbf{\sigma}^{\pm} = \frac{\partial \Psi^{\pm}}{\partial \mathbf{\epsilon}} = \sum_{a=1}^3 \left( \lambda \left< \epsilon_1 + \epsilon_2 + \epsilon_3 \right>_{\pm} + 2 \mu \left< \epsilon_a \right>_{\pm} \right) \mathbf{n}_a \otimes \mathbf{n}_a,
+\boldsymbol{\sigma}^{\pm} = \frac{\partial \Psi^{\pm}}{\partial \boldsymbol{\epsilon}} = \sum_{a=1}^3 \left( \lambda \left< \epsilon_1 + \epsilon_2 + \epsilon_3 \right>_{\pm} + 2 \mu \left< \epsilon_a \right>_{\pm} \right) \boldsymbol{n}_a \otimes \boldsymbol{n}_a,
 \end{equation}
-where $\mathbf{n}_a$ is the $a$th eigenvector.
+where $\boldsymbol{n}_a$ is the $a$th eigenvector.
 The stress becomes
 \begin{equation}
-\mathbf{\sigma} = \left[(1-c)^2(1-k) + k \right] \mathbf{\sigma}^{+} - \mathbf{\sigma}^{-}.
+\boldsymbol{\sigma} = \left[(1-c)^2(1-k) + k \right] \boldsymbol{\sigma}^{+} - \boldsymbol{\sigma}^{-}.
 \end{equation}
 
 ## Evolution Equation and History Variable

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMeanThermalExpansionFunctionEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMeanThermalExpansionFunctionEigenstrain.md
@@ -24,9 +24,9 @@ reference temperature, the total thermal expansion eigenstrain is computed as:
 
 \begin{equation}
 \boldsymbol{\epsilon}^{th} = \frac{\bar{\alpha}_{(T_{ref},T)}(T-T_{ref}) - \bar{\alpha}_{(T_{ref},T_{sf})}(T_{sf}-T_{ref})}
-{1 + \bar{\alpha}_{(T_{ref},T_{sf})}(T_{sf}-T_{ref})} \cdot \mathbf{I}
+{1 + \bar{\alpha}_{(T_{ref},T_{sf})}(T_{sf}-T_{ref})} \cdot \boldsymbol{I}
 \end{equation}
-where $T$ is the current temperature and $\mathbf{I}$ is the identity matrix.  Note that the
+where $T$ is the current temperature and $\boldsymbol{I}$ is the identity matrix.  Note that the
 denominator in this equation is a correction to account for the ratio of $L_{(T_{sf})}$ to
 $L_{(T_{ref})}$. As discussed in [cite:niffenegger2012proper], that ratio is very close to 1, so it
 is not strictly necessary to include that correction, but it is done here for completeness.

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMultipleInelasticStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeMultipleInelasticStress.md
@@ -13,7 +13,7 @@ The elastic strain is calculated by subtracting the computed inelastic strain
 increment tensor from the mechanical strain increment tensor.
 \begin{equation}
   \label{cmis_elastic_strain_definition}
-  \Delta \epsilon^{el} = \Delta \epsilon^{mech} - \Delta \epsilon^{inel}
+  \Delta \boldsymbol{\epsilon}^{el} = \Delta \boldsymbol{\epsilon}^{mech} - \Delta \boldsymbol{\epsilon}^{inel}
 \end{equation}
 Mechanical strain, $\epsilon^{mech}$, is considered to be the sum of the elastic
 and inelastic (e.g. plastic and creep) strains.
@@ -132,15 +132,15 @@ calculate the combined Jacobian multiplier: Elastic, Partial, and Nonlinear, whi
 are set by the individual elastic material models.
 \begin{equation}
   \label{eqn:combined_jacobian_mult}
-  \mathbf{J}_m = \begin{cases}
-                  \mathbf{C} & \text{Elastic option} \\
-                  \mathbf{A}^{-1} \cdot \mathbf{C} \text{, where }
-                      \mathbf{A} = \mathbf{I} + \sum_i \mathbf{H}^{cto}_i & \text{Partial option} \\
-                  \prod_i \mathbf{H}^{cto}_i \cdot \mathbf{C}^{-1}  & \text{Nonlinear option}
+  \boldsymbol{J}_m = \begin{cases}
+                  \boldsymbol{C} & \text{Elastic option} \\
+                  \boldsymbol{A}^{-1} \cdot \boldsymbol{C} \text{, where }
+                      \boldsymbol{A} = \boldsymbol{I} + \sum_i \boldsymbol{H}^{cto}_i & \text{Partial option} \\
+                  \prod_i \boldsymbol{H}^{cto}_i \cdot \boldsymbol{C}^{-1}  & \text{Nonlinear option}
                  \end{cases}
 \end{equation}
-where $\mathbf{J}_m$ is the Jacobian multiplier, $\mathbf{C}$ is the elasticity
-tensor, $\mathbf{I}$ is the Rank-4 identity tensor, and $\mathbf{H}^{cto}$ is the
+where $\boldsymbol{J}_m$ is the Jacobian multiplier, $\boldsymbol{C}$ is the elasticity
+tensor, $\boldsymbol{I}$ is the Rank-4 identity tensor, and $\boldsymbol{H}^{cto}$ is the
 consistent tangent operator.
 
 The consistent tangent operator, defined in [eqn:elastic_cto] provides the information
@@ -217,14 +217,14 @@ tangent operator implemented in each individual inelastic model with the
 The consistent tangent operator is then used to find the Jacobian multiplier with
 \begin{equation}
   \label{eqn:single_model_jacobian_mult}
-  \mathbf{J}_m = \begin{cases}
-                  \mathbf{C} & \text{Elastic option} \\
-                  \left(\mathbf{I} + \mathbf{H}^{cto}\right)^{-1} \cdot \mathbf{C} & \text{Partial option} \\
-                  \mathbf{H}^{cto}  & \text{Nonlinear option}
+  \boldsymbol{J}_m = \begin{cases}
+                  \boldsymbol{C} & \text{Elastic option} \\
+                  \left(\boldsymbol{I} + \boldsymbol{H}^{cto}\right)^{-1} \cdot \boldsymbol{C} & \text{Partial option} \\
+                  \boldsymbol{H}^{cto}  & \text{Nonlinear option}
                  \end{cases}
 \end{equation}
-where $\mathbf{J}_m$ is the Jacobian multiplier, $\mathbf{C}$ is the elasticity
-tensor, $\mathbf{I}$ is the Rank-4 identity tensor, and $\mathbf{H}^{cto}$ is the
+where $\boldsymbol{J}_m$ is the Jacobian multiplier, $\boldsymbol{C}$ is the elasticity
+tensor, $\boldsymbol{I}$ is the Rank-4 identity tensor, and $\boldsymbol{H}^{cto}$ is the
 consistent tangent operator, as discussed in the multiple inelastic material
 models section.
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneFiniteStrain.md
@@ -32,7 +32,7 @@ is non-zero. To solve for this out-of-plane strain, we invoke the approximation
 of the stretch rate tensor
 \begin{equation}
   \label{eqn:stretch_tensor_approx}
-  \mathbf{D} = \log \left( \sqrt{\hat{\mathbf{F}}^T \cdot \hat{\mathbf{F}}} \right) \cdot \frac{1}{dt}
+  \boldsymbol{D} = \log \left( \sqrt{\hat{\boldsymbol{F}}^T \cdot \hat{\boldsymbol{F}}} \right) \cdot \frac{1}{dt}
 \end{equation}
 and define the deformation gradient component in the out-of-plane direction as
 \begin{equation}
@@ -52,10 +52,10 @@ problems use scalar variables.
 The incremental deformation gradient for the 2D planar system is defined as
 \begin{equation}
   \label{eqn:incremental_deformation_grad}
-  \hat{\mathbf{F}} = \mathbf{A} : \bar{\mathbf{F}}^{-1} + \mathbf{I}
+  \hat{\boldsymbol{F}} = \boldsymbol{A} : \bar{\boldsymbol{F}}^{-1} + \boldsymbol{I}
 \end{equation}
-where $\mathbf{I}$ is the Rank-2 identity tensor, $\mathbf{A}$ is the deformation
-gradient, and $\bar{\mathbf{F}}$ is the old deformation gradient.
+where $\boldsymbol{I}$ is the Rank-2 identity tensor, $\boldsymbol{A}$ is the deformation
+gradient, and $\bar{\boldsymbol{F}}$ is the old deformation gradient.
 
 #### $Z$-Direction of Out-of-Plane Strain (Default)
 
@@ -64,20 +64,20 @@ the current and old deformation gradient tensors, used in
 [eqn:incremental_deformation_grad], are given as
 \begin{equation}
   \label{eqn:deform_grads}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 u_{x,x} & u_{x,y} & 0 \\
                 u_{y,x} & u_{y,y} & 0 \\
                 0 & 0 & F|^{dop}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 u_{x,x}|_{old} & u_{x,y}|_{old} & 0 \\
                 u_{y,x}|_{old} & u_{y,y}|_{old} & 0 \\
                 0 & 0 & F|^{dop}_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 where $F|^{dop}$ is defined in [eqn:dop_deform_grad].
-Note that $\bar{\mathbf{F}}$ uses the values of the strain expressions from
+Note that $\bar{\boldsymbol{F}}$ uses the values of the strain expressions from
 the previous time step.
 As in the classical presentation of the strain tensor in plane strain problems,
 the components of the deformation tensor associated with the $z$-direction are
@@ -91,17 +91,17 @@ current and old deformation gradient tensors from [eqn:incremental_deformation_g
 are formulated as
 \begin{equation}
   \label{eqn:deform_grads_xdirs}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 F|^{dop} & 0 & 0 \\
                 0 & u_{y,y} & u_{z,y} \\
                 0 & u_{y,z} & u_{z,z}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 F|^{dop}_{old} & 0 & 0 \\
                 0 & u_{y,y}|_{old} & u_{y,z}|_{old} \\
                 0 & u_{z,y}|_{old}& u_{z,z}|_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 so that the off-diagonal components of the deformation tensors associated with
 the $x$-direction are zeros.
@@ -113,17 +113,17 @@ current and old deformation gradient tensors from [eqn:incremental_deformation_g
 are formulated as
 \begin{equation}
   \label{eqn:deform_grads_ydirs}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 u_{x,x} & 0 & u_{z,x} \\
                 0 & F|^{dop} & 0 \\
                 u_{x,z} & 0 & u_{z,z}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 u_{x,x}|_{old} & 0 & u_{x,z}|_{old} \\
                 0 & F|^{dop}_{old} & 0 \\
                 u_{z,x}|_{old} & 0 & u_{z,z}|_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 so that the off-diagonal components of the deformation tensors associated with
 the $y$-direction are zeros.
@@ -137,7 +137,7 @@ The volumetric locking correction is applied to both the incremental deformation
 gradient
 \begin{equation}
   \label{eqn:vlc_fhat}
-  \hat{\mathbf{F}}|_{vlc} = \left( \frac{1}{det(\hat{\mathbf{F}})} \frac{\hat{\mathbf{F}}_{avg}}{V_{elem}} \right)^{1/3}
+  \hat{\boldsymbol{F}}|_{vlc} = \left( \frac{1}{det(\hat{\boldsymbol{F}})} \frac{\hat{\boldsymbol{F}}_{avg}}{V_{elem}} \right)^{1/3}
 \end{equation}
 and the total deformation gradient. For more details about the theory behind
 [eqn:vlc_fhat] see the

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneIncrementalStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneIncrementalStrain.md
@@ -46,11 +46,11 @@ problems use scalar variables.
 The small strain increment is calculated with the form
 \begin{equation}
   \label{eqn:strain_increment}
-  \Delta \mathbf{\epsilon} = \frac{1}{2} \left( \mathbf{D} + \mathbf{D}^T \right)
-  \text{ where } \mathbf{D} = \mathbf{A} - \bar{\mathbf{F}} + \mathbf{I}
+  \Delta \boldsymbol{\epsilon} = \frac{1}{2} \left( \boldsymbol{D} + \boldsymbol{D}^T \right)
+  \text{ where } \boldsymbol{D} = \boldsymbol{A} - \bar{\boldsymbol{F}} + \boldsymbol{I}
 \end{equation}
-where $\mathbf{I}$ is the Rank-2 identity tensor, $\mathbf{A}$ is the deformation
-gradient, and $\bar{\mathbf{F}}$ is the old deformation gradient.
+where $\boldsymbol{I}$ is the Rank-2 identity tensor, $\boldsymbol{A}$ is the deformation
+gradient, and $\bar{\boldsymbol{F}}$ is the old deformation gradient.
 
 #### $Z$-Direction of Out-of-Plane Strain (Default)
 
@@ -59,20 +59,20 @@ the current and old deformation gradient tensors, used in
 [eqn:strain_increment], are given as
 \begin{equation}
   \label{eqn:deform_grads}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 u_{x,x} & u_{x,y} & 0 \\
                 u_{y,x} & u_{y,y} & 0 \\
                 0 & 0 & F|^{dop}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 u_{x,x}|_{old} & u_{x,y}|_{old} & 0 \\
                 u_{y,x}|_{old} & u_{y,y}|_{old} & 0 \\
                 0 & 0 & F|^{dop}_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 where $F|^{dop}$ is defined in [eqn:dop_deform_grad].
-Note that $\bar{\mathbf{F}}$ uses the values of the strain expressions from
+Note that $\bar{\boldsymbol{F}}$ uses the values of the strain expressions from
 the previous time step.
 As in the classical presentation of the strain tensor in plane strain problems,
 the components of the deformation tensor associated with the $z$-direction are
@@ -86,17 +86,17 @@ current and old deformation gradient tensors from [eqn:strain_increment] are
 formulated as
 \begin{equation}
   \label{eqn:deform_grads_xdirs}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 F|^{dop} & 0 & 0 \\
                 0 & u_{y,y} & u_{z,y} \\
                 0 & u_{y,z} & u_{z,z}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 F|^{dop}_{old} & 0 & 0 \\
                 0 & u_{y,y}|_{old} & u_{y,z}|_{old} \\
                 0 & u_{z,y}|_{old}& u_{z,z}|_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 so that the off-diagonal components of the deformation tensors associated with
 the $x$-direction are zeros.
@@ -108,17 +108,17 @@ current and old deformation gradient tensors from [eqn:strain_increment] are
 formulated as
 \begin{equation}
   \label{eqn:deform_grads_ydirs}
-  \mathbf{A} = \begin{bmatrix}
+  \boldsymbol{A} = \begin{bmatrix}
                 u_{x,x} & 0 & u_{z,x} \\
                 0 & F|^{dop} & 0 \\
                 u_{x,z} & 0 & u_{z,z}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
   \qquad \text{  and  } \qquad
-  \bar{\mathbf{F}} = \begin{bmatrix}
+  \bar{\boldsymbol{F}} = \begin{bmatrix}
                 u_{x,x}|_{old} & 0 & u_{x,z}|_{old} \\
                 0 & F|^{dop}_{old} & 0 \\
                 u_{z,x}|_{old} & 0 & u_{z,z}|_{old}
-              \end{bmatrix} + \mathbf{I}
+              \end{bmatrix} + \boldsymbol{I}
 \end{equation}
 so that the off-diagonal components of the deformation tensors associated with
 the $y$-direction are zeros.
@@ -135,9 +135,9 @@ a $\bar{B}$ formulation to mitigate volumetric locking of the elements.
 The volumetric locking correction is applied to the total strain
 \begin{equation}
   \label{eqn:vlc_strain}
-  \Delta \mathbf{\epsilon}|_{vlc} = \mathbf{\epsilon} + \frac{\left( \mathbf{\epsilon}_V - tr(\mathbf{\Delta \epsilon}) \right)}{3} \cdot \mathbf{I}
+  \Delta \boldsymbol{\epsilon}|_{vlc} = \boldsymbol{\epsilon} + \frac{\left( \boldsymbol{\epsilon}_V - tr(\boldsymbol{\Delta \epsilon}) \right)}{3} \cdot \boldsymbol{I}
 \end{equation}
-where $\mathbf{\epsilon}_V$ is the volumetric strain and $\mathbf{I}$
+where $\boldsymbol{\epsilon}_V$ is the volumetric strain and $\boldsymbol{I}$
 is the Rank-2 identity tensor. For more details about the theory
 behind [eqn:vlc_strain] see the
 [Volumetric Locking Correction](/tensor_mechanics/VolumetricLocking.md)

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneSmallStrain.md
@@ -56,7 +56,7 @@ The default out-of-plane direction is along the $z$-axis. For this direction
 the strain tensor, [eqn:def_small_total_strain], is given as
 \begin{equation}
   \label{eqn:strain_tensor}
-  \mathbf{\epsilon} = \begin{bmatrix}
+  \boldsymbol{\epsilon} = \begin{bmatrix}
                 u_{x,x} & \frac{1}{2} \left(u_{x,y} + u_{y,x} \right) & 0 \\
                 \frac{1}{2} \left(u_{x,y} + u_{y,x} \right) & u_{y,y} & 0 \\
                 0 & 0 & \epsilon|^{dop}
@@ -75,7 +75,7 @@ $x$-direction, the strain tensor from [eqn:def_small_total_strain]
 is given as
 \begin{equation}
   \label{eqn:deform_grads_xdirs}
-  \mathbf{\epsilon} = \begin{bmatrix}
+  \boldsymbol{\epsilon} = \begin{bmatrix}
                 \epsilon|^{dop} & 0 & 0 \\
                 0 & u_{y,y} & \frac{1}{2} \left(u_{y,z} + u_{z,y} \right) \\
                 0 & \frac{1}{2} \left(u_{y,z} + u_{z,y} \right) & u_{z,z}
@@ -91,7 +91,7 @@ $y$-direction, the strain tensor from [eqn:def_small_total_strain]
 is given as
 \begin{equation}
   \label{eqn:deform_grads_ydirs}
-  \mathbf{\epsilon} = \begin{bmatrix}
+  \boldsymbol{\epsilon} = \begin{bmatrix}
                 u_{x,x} & 0 & \frac{1}{2} \left(u_{x,z} + u_{z,x} \right) \\
                 0 & \epsilon|^{dop} & 0 \\
                 \frac{1}{2} \left(u_{x,z} + u_{z,x} \right) & 0 & u_{z,z}
@@ -107,9 +107,9 @@ a $\bar{B}$ formulation to mitigate volumetric locking of the elements.
 The volumetric locking correction is applied to the total strain
 \begin{equation}
   \label{eqn:vlc_strain}
-  \mathbf{\epsilon}|_{vlc} = \mathbf{\epsilon} + \frac{\left( \mathbf{\epsilon}_V - tr(\mathbf{\epsilon}) \right)}{3} \cdot \mathbf{I}
+  \boldsymbol{\epsilon}|_{vlc} = \boldsymbol{\epsilon} + \frac{\left( \boldsymbol{\epsilon}_V - tr(\boldsymbol{\epsilon}) \right)}{3} \cdot \boldsymbol{I}
 \end{equation}
-where $\mathbf{\epsilon}_V$ is the volumetric strain and $\mathbf{I}$
+where $\boldsymbol{\epsilon}_V$ is the volumetric strain and $\boldsymbol{I}$
 is the Rank-2 identity tensor. For more details about the theory
 behind [eqn:vlc_strain] see the
 [Volumetric Locking Correction](/tensor_mechanics/VolumetricLocking.md)

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeSmearedCrackingStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeSmearedCrackingStress.md
@@ -4,52 +4,82 @@
 
 ## Description
 
-This class implements a fixed smeared cracking model, which represents cracking as a softening stress-strain law at the material points as opposed to introducing topographic changes to the mesh, as would be the case with a discrete cracking model.
+This class implements a fixed smeared cracking model, which represents cracking
+as a softening stress-strain law at the material points as opposed to introducing
+topographic changes to the mesh, as would be the case with a discrete cracking model.
 
-In this model, principal stresses are compared to a critical stress.  If one of the principal stresses exceeds the critical stress, the material point is considered cracked in that direction, and the model transitions to an orthotropic model, in which the stress in the cracked direction is decreased according to a softening law. Material behavior in the cracking direction is affected in two ways: reduction of the stiffness in that direction, and adjusting the stress to follow the softening curve.
+In this model, principal stresses are compared to a critical stress.  If one of
+the principal stresses exceeds the critical stress, the material point is considered
+cracked in that direction, and the model transitions to an orthotropic model, in
+which the stress in the cracked direction is decreased according to a softening
+law. Material behavior in the cracking direction is affected in two ways: reduction
+of the stiffness in that direction, and adjusting the stress to follow the softening
+curve.
 
 ### Interaction with Inelastic Models
 
-This class derives from [ComputeMultipleInelasticStrain](ComputeMultipleInelasticStress.md), and prior to cracking, allows multiple inelastic models to be active. Once cracking occurs, the inelastic strains at that material point are preserved, but those models are no longer called for the duration of the simulation, and inelastic strains from those other models are no longer permitted to evolve.
+This class derives from [ComputeMultipleInelasticStrain](ComputeMultipleInelasticStress.md),
+and prior to cracking, allows multiple inelastic models to be active. Once cracking
+occurs, the inelastic strains at that material point are preserved, but those models
+are no longer called for the duration of the simulation, and inelastic strains from
+those other models are no longer permitted to evolve.
 
 ### Cracking Direction Determination
 
-The orientation of the principal coordinate system is determined from the eigenvectors of the elastic strain tensor.  However, once a crack direction is determined, that direction remains fixed and further cracks are considered in directions perpendicular to the original crack direction.  Note that for axisymmetric problems, one crack direction is known *a priori*.  The theta or out-of-plane direction is not coupled to the $r$ and $z$ directions (i.e., no $r\theta$ or $z\theta$ shear strain/stress exists) and is therefore a known or principal direction.
+The orientation of the principal coordinate system is determined from the eigenvectors
+of the elastic strain tensor.  However, once a crack direction is determined, that
+direction remains fixed and further cracks are considered in directions perpendicular
+to the original crack direction.  Note that for axisymmetric problems, one crack
+direction is known *a priori*.  The theta or out-of-plane direction is not coupled
+to the $r$ and $z$ directions (i.e., no $r\theta$ or $z\theta$ shear strain/stress
+exists) and is therefore a known or principal direction.
 
-If we store a scalar value, $c_i$, for each of the three possible crack directions at a material point, these in combination with the principal directions (eigenvectors or rotation tensor) provide a convenient way to eliminate stress in cracked directions.  A value of 1 for $c_i$ indicates that the material point has not cracked in that direction.  A value very close to zero (not zero for numerical reasons) indicates that cracking has occurred.
+If we store a scalar value, $c_i$, for each of the three possible crack directions
+at a material point, these in combination with the principal directions (eigenvectors
+or rotation tensor) provide a convenient way to eliminate stress in cracked directions.
+A value of 1 for $c_i$ indicates that the material point has not cracked in that
+direction.  A value very close to zero (not zero for numerical reasons) indicates
+that cracking has occurred.
 
-We define a cracking tensor in the cracked orientation as $\mathbf{c}$:
+We define a cracking tensor in the cracked orientation as $\boldsymbol{c}$:
 \begin{equation}
-\mathbf{c}=
+\boldsymbol{c}=
 \begin{bmatrix}
 c_1 & & \\
 & c_2 & \\
 & & c_3
 \end{bmatrix}.
 \end{equation}
-The rotation tensor $\mathbf{R}$ is defined in terms of the eigenvectors $e_i$:
+The rotation tensor $\boldsymbol{R}$ is defined in terms of the eigenvectors $e_i$:
 \begin{equation}
-\mathbf{R}=
+\boldsymbol{R}=
 \begin{bmatrix}
 e_1 & e_2 & & e_3
 \end{bmatrix}.
 \end{equation}
-This leads to a transformation operator $\mathbf{T}$:
+This leads to a transformation operator $\boldsymbol{T}$:
 \begin{equation}
-\mathbf{T}=\mathbf{R}\mathbf{c}\mathbf{R}^T.
+\boldsymbol{T}=\boldsymbol{R}\boldsymbol{c}\boldsymbol{R}^T.
 \end{equation}
 
-$\mathbf{T}$ is useful for transforming uncracked tensors in the global frame to cracked tensors in the same frame.  For example, the cracked stress $\mathbf{\sigma}_{cg}$ in terms of the stress $\mathbf{\sigma}_g$ is (subscript $c$ indicates cracked, $l$ local frame, and $g$ global frame):
+$\boldsymbol{T}$ is useful for transforming uncracked tensors in the global frame
+to cracked tensors in the same frame.  For example, the cracked stress
+$\boldsymbol{\sigma}_{cg}$ in terms of the stress $\boldsymbol{\sigma}_g$ is
+(subscript $c$ indicates cracked, $l$ local frame, and $g$ global frame):
 \begin{equation}
 \begin{aligned}
-\mathbf{\sigma}_{cg} &= \mathbf{T}\mathbf{\sigma}_g\mathbf{T}^T \\
-&= \mathbf{RcR}^T\mathbf{\sigma}_g\mathbf{RcR}^T \\
-&= \mathbf{Rc}\mathbf{\sigma}_l\mathbf{cR}^T \\
-&= \mathbf{R}\mathbf{\sigma}_{cl}\mathbf{R}^T.
+\boldsymbol{\sigma}_{cg} & = \boldsymbol{T}\boldsymbol{\sigma}_g\boldsymbol{T}^T \\
+                         & = \boldsymbol{RcR}^T\boldsymbol{\sigma}_g\boldsymbol{RcR}^T \\
+                         & = \boldsymbol{Rc}\boldsymbol{\sigma}_l\boldsymbol{cR}^T \\
+                         & = \boldsymbol{R}\boldsymbol{\sigma}_{cl}\boldsymbol{R}^T.
 \end{aligned}
 \end{equation}
 
-When many material points have multiple cracks, the solution becomes difficult to obtain numerically.  For this reason, controls are available to limit the number and direction of cracks that are allowed. Also, there are options to control the amount of shear retention and amount of stress correction during softening, both of which can significantly affect convergence.
+When many material points have multiple cracks, the solution becomes difficult to
+obtain numerically.  For this reason, controls are available to limit the number
+and direction of cracks that are allowed. Also, there are options to control the
+amount of shear retention and amount of stress correction during softening, both
+of which can significantly affect convergence.
 
 ## Example Input File Syntax
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeStrainIncrementBasedStress.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeStrainIncrementBasedStress.md
@@ -1,14 +1,33 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeStrainIncrementBasedStress
-
-!alert construction title=Undocumented Class
-The ComputeStrainIncrementBasedStress has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Compute Strain Increment Based Stress
 
 !syntax description /Materials/ComputeStrainIncrementBasedStress
+
+## Description
+
+This stress calculator finds the value of the stress as a function of the elastic
+strain increment when a series of inelastic strains are specified in the input file.
+The stress is calculated as
+\begin{equation}
+  \label{eqn:stress}
+  \sigma_{ij} = \sigma_{ij}^{old} + C_{ijkl} \Delta \epsilon_{jk}^{el}
+\end{equation}
+where $\sigma_{ij}$ is the stress and $C_{ijkl}$ is the elasticity tensor of the
+material.
+The elastic strain increment, $\Delta \epsilon_{jk}^{el}$ is found by subtracting
+the sum of the inelastic strains from the mechanical strain:
+\begin{equation}
+  \label{eqn:elastic_strain_incr}
+  \Delta \boldsymbol{\epsilon}^{el} = \boldsymbol{\epsilon}^{mech} - \boldsymbol{\epsilon}^{mech-old}
+      - \sum_n \left( \boldsymbol{\epsilon}^{inel}_n - {\boldsymbol{\epsilon}^{inel-old}}_n \right)
+\end{equation}
+where $\boldsymbol{\epsilon}^{mech}$ is the mechanical strain and
+$\boldsymbol{\epsilon}^{inel}$ is the inelastic strain.
+In the tensor mechanics module mechanical strain is defined as the sum of the
+elastic and inelastic (e.g. creep and/or plasticity) strains.
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/plane_stress/weak_plane_stress_incremental.i block=Materials/stress
 
 !syntax parameters /Materials/ComputeStrainIncrementBasedStress
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeThermalExpansionEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeThermalExpansionEigenstrain.md
@@ -4,12 +4,15 @@
 
 ## Description
 
-This model computes the eigenstrain tensor resulting from isotropic thermal expansion where the constant thermal expansion is defined by a user-supplied scalar linear thermal-expansion coefficient, $\alpha$.
+This model computes the eigenstrain tensor resulting from isotropic thermal expansion
+where the constant thermal expansion is defined by a user-supplied scalar linear
+thermal-expansion coefficient, $\alpha$.
 The thermal expansion eigenstrain is then computed as
 \begin{equation}
-\boldsymbol{\epsilon}^{thermal} = \alpha \cdot \left( T - T_{stress\_free} \right) \mathbf{I}
+\boldsymbol{\epsilon}^{thermal} = \alpha \cdot \left( T - T_{stress\_free} \right) \boldsymbol{I}
 \end{equation}
-where $T$ is the current temperature, $T_{stress\_free}$ is the stress free temperature, and $\mathbf{I}$ is the identity matrix.
+where $T$ is the current temperature, $T_{stress\_free}$ is the stress free temperature,
+and $\boldsymbol{I}$ is the identity matrix.
 
 ## Example Input File Syntax
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeVariableBaseEigenStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeVariableBaseEigenStrain.md
@@ -1,14 +1,40 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+# Compute Variable Base EigenStrain
 
-# ComputeVariableBaseEigenStrain
-
-!alert construction title=Undocumented Class
-The ComputeVariableBaseEigenStrain has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
 
 !syntax description /Materials/ComputeVariableBaseEigenStrain
+
+## Description
+
+The material `ComputeVariableBaseEigenStrain` calculates a Rank-2 tensor eigenstrain
+as a function of a Rank-2 tensor base and a scalar material property.
+\begin{equation}
+  \label{eqn:variable_base_eigenstrain}
+  \boldsymbol{\epsilon}_{eigen} = p \boldsymbol{T} + \boldsymbol{A}
+\end{equation}
+where $\boldsymbol{\epsilon}_{eigen}$ is the calculated eigenstrain,
+$p$ is a scalar material property, $\boldsymbol{T}$ is the tensor selected by
+the user as the base of the eigenstrain, and $\boldsymbol{A}$ is the offset, or
+constant initial, eigenstrain tensor.
+The material property $p$ is used to introduce dependence of the eigenstrain on
+the user-specified variable.
+
+## Example Input File
+
+!listing modules/combined/test/tests/DiffuseCreep/variable_base_eigen_strain.i block=Materials/eigenstrain
+
+where the argument for the `base_tensor_property_name` parameter in the eigenstrain
+is the same as the property parameter `gb_tensor_prop_name` argument as shown
+
+!listing modules/combined/test/tests/DiffuseCreep/variable_base_eigen_strain.i block=Materials/aniso_tensor
+
+and the argument for the `prefactor` parameter in the eigenstrain material matches
+the function name (`f_name` parameter) in the [DerivativeParsedMaterial](/DerivativeParsedMaterial.md)
+
+!listing modules/combined/test/tests/DiffuseCreep/variable_base_eigen_strain.i block=Materials/eigenstrain_prefactor
+
+Finally, the `eigenstrain_name` parameter value must also be set for the strain calculator, and an example parameter setting is shown below:
+
+!listing modules/combined/test/tests/DiffuseCreep/variable_base_eigen_strain.i block=Materials/strain
 
 !syntax parameters /Materials/ComputeVariableBaseEigenStrain
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeVariableEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeVariableEigenstrain.md
@@ -1,14 +1,64 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# ComputeVariableEigenstrain
-
-!alert construction title=Undocumented Class
-The ComputeVariableEigenstrain has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Compute Variable Eigenstrain
 
 !syntax description /Materials/ComputeVariableEigenstrain
+
+## Description
+
+`ComputeVariableEigenstrain` calculates the eigenstrain as a function of a specified
+variable as well as the contributions of the eigenstrain to the first and second
+order derivatives of the elastic strain.
+This class is most often only used in phase field simulations where first and
+second derivatives are required and the limitation on elastic only strains is
+not overly restrictive.
+
+The Rank-2 tensor eigenstrain is calculated as a function of a Rank-2 tensor base
+and a scalar material property.
+\begin{equation}
+  \label{eqn:variable_base_eigenstrain}
+  \boldsymbol{\epsilon} = p \boldsymbol{T}
+\end{equation}
+where $\boldsymbol{\epsilon}_{eigen}$ is the computed eigenstrain,
+$p$ is a scalar material property, and $\boldsymbol{T}$ is the tensor selected by
+the user as the base of the eigenstrain.
+The material property $p$ is used to introduce dependence of the eigenstrain on
+the user-specified variable.
+
+The contributions of the eigenstrain to the first and second elastic strain
+derivatives are calculated with use of the MOOSE
+[DerivativeMaterialInterface](/framework_development/interfaces/DerivativeMaterialInterface.md)
+applied to the prefactor variables.
+\begin{equation}
+  \label{eqn:derivatives}
+  \begin{aligned}
+  \nabla \cdot \boldsymbol{\epsilon} & = \left( \nabla \cdot p \right) \boldsymbol{T} \\
+  \nabla^2 \cdot \boldsymbol{\epsilon} & = \left( \nabla^2 \cdot p \right) \boldsymbol{T}
+  \end{aligned}
+\end{equation}
+where $\nabla \cdot \boldsymbol{\epsilon}$ and $\nabla^2 \cdot \boldsymbol{\epsilon}$ are
+the first and second derivatives of the elastic strain contributions due to the
+eigenstrain.
+
+!alert warning title=Use with Elastic Strain Only
+This class assumes the presence of only elastic strain in the computation of the
+first and second derivatives.
+
+## Example Input File
+
+!listing modules/combined/test/tests/multiphase_mechanics/simpleeigenstrain.i block=Materials/eigenstrain
+
+where the argument for the `args` parameter in the eigenstrain matches the name
+of the coupled variable, here shown as an auxvariable
+
+!listing modules/combined/test/tests/multiphase_mechanics/simpleeigenstrain.i block=AuxVariables/c
+
+and the argument for the `prefactor` parameter in the eigenstrain material matches
+the function name (`f_name` parameter) in the [DerivativeParsedMaterial](/DerivativeParsedMaterial.md)
+
+!listing modules/combined/test/tests/multiphase_mechanics/simpleeigenstrain.i block=Materials/prefactor
+
+Finally, the `eigenstrain_name` parameter value must also be set for the strain calculator, and an example parameter setting is shown below:
+
+!listing modules/combined/test/tests/multiphase_mechanics/simpleeigenstrain.i block=Materials/strain
 
 !syntax parameters /Materials/ComputeVariableEigenstrain
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/EshelbyTensor.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/EshelbyTensor.md
@@ -4,13 +4,17 @@
 
 ## Description
 
-This model computes the Eshelby energy-momentum tensor $\Sigma$ [cite:eshelby_energy_1999], used in fracture integral calculations:
+This model computes the Eshelby energy-momentum tensor $\Sigma$ [citep:eshelby_energy_1999],
+used in fracture integral calculations:
 \begin{equation}
-\boldsymbol{\Sigma} = W\mathbf{I} - \mathbf{H}^T\mathbf{P}
+\boldsymbol{\Sigma} = W\boldsymbol{I} - \boldsymbol{H}^T\boldsymbol{P}
 \end{equation}
-where W is the strain energy density in the original configuration, $\mathbf{I}$ is the identity matrix, $\mathbf{H}$ is the displacement gradient, and $\mathbf{P}$ is the first Piola-Kirchoff stress tensor.
+where W is the strain energy density in the original configuration, $\boldsymbol{I}$
+is the identity matrix, $\boldsymbol{H}$ is the displacement gradient, and
+$\boldsymbol{P}$ is the first Piola-Kirchoff stress tensor.
 
-It is necessary to include this material within the input file when computing fracture integrals.
+It is necessary to include this material within the input file when computing
+fracture integrals.
 
 ## Example Input File Syntax
 
@@ -19,7 +23,3 @@ It is necessary to include this material within the input file when computing fr
 !syntax inputs /Materials/EshelbyTensor
 
 !syntax children /Materials/EshelbyTensor
-
-
-
-

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/SumTensorIncrements.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/SumTensorIncrements.md
@@ -1,14 +1,27 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# SumTensorIncrements
-
-!alert construction title=Undocumented Class
-The SumTensorIncrements has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Sum Tensor Increments
 
 !syntax description /Materials/SumTensorIncrements
+
+## Descriptions
+
+The `SumTensorIncrements` material updates a strain tensor by summing coupled
+strain increments as specified by the user.
+\begin{equation}
+  \label{eqn:sum_increment_tensor}
+  \mathbf{T} = \mathbf{T}_old + \sum_n \Delta D_n
+\end{equation}
+where $\mathbf{T}$ is the calcuated tensor and $\mathbf{D}_n$ are the coupled tensor
+increments.
+
+## Example Input File
+
+!listing modules/combined/test/tests/DiffuseCreep/stress.i block=Materials/diffuse_creep_strain
+
+where the argument for the `coupled_tensor_increment_names` parameter in the
+`SumTensorIncrements` material is the same as the property parameter
+`property_name` argument as shown
+
+!listing modules/combined/test/tests/DiffuseCreep/stress.i block=Materials/diffuse_strain_increment
 
 !syntax parameters /Materials/SumTensorIncrements
 

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/SumTensorIncrements.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/SumTensorIncrements.md
@@ -8,9 +8,9 @@ The `SumTensorIncrements` material updates a strain tensor by summing coupled
 strain increments as specified by the user.
 \begin{equation}
   \label{eqn:sum_increment_tensor}
-  \mathbf{T} = \mathbf{T}_old + \sum_n \Delta D_n
+  \boldsymbol{T} = \boldsymbol{T}_{old} + \sum_n \Delta D_n
 \end{equation}
-where $\mathbf{T}$ is the calcuated tensor and $\mathbf{D}_n$ are the coupled tensor
+where $\boldsymbol{T}$ is the calcuated tensor and $\boldsymbol{D}_n$ are the coupled tensor
 increments.
 
 ## Example Input File

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Modules/TensorMechanics/Master/CommonTensorMechanicsAction.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Modules/TensorMechanics/Master/CommonTensorMechanicsAction.md
@@ -1,4 +1,4 @@
-# CommonTensorMechanicsAction
+# Common Tensor Mechanics Action
 
 ## Description
 

--- a/modules/tensor_mechanics/include/materials/ComputeVariableEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeVariableEigenstrain.h
@@ -19,8 +19,8 @@ template <>
 InputParameters validParams<ComputeVariableEigenstrain>();
 
 /**
- * ComputeVariableEigenstrain computes an Eigenstrain that is a function of a single
- * variable defined by a base tensor and a scalar function defined in a Derivative Material.
+ * ComputeVariableEigenstrain computes an Eigenstrain that is a function of
+ * variables defined by a base tensor and a scalar function defined in a Derivative Material.
  */
 class ComputeVariableEigenstrain : public DerivativeMaterialInterface<ComputeEigenstrain>
 {


### PR DESCRIPTION
This commit includes documentation for materials that appear to be used most often by the phase field module: the variable eigenstrains.  Information for the legacy tensor mechanics action that generally refers users to the newer master action is also included.

New documentation for the ComputeStrainIncrementBasedStress class is also included; however, this class should be evaluated for deprecation. Now that we have summations of inelastic strains in the strain classes, this class may no longer be necessary.

@dschwen  please review these docs since they are more relevant to phase field simulations

Refs #10516
