### PR TITLE
Add PorousFlowJoiner materials using the action system

### DIFF
--- a/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_09.md
+++ b/modules/porous_flow/doc/content/documentation/modules/porous_flow/tutorial_09.md
@@ -42,15 +42,8 @@ Almost all PorousFlow `Materials` compute derivatives, and most of them retrieve
 
 ### Joiners
 
-In the input file, you specify things like densities, relative permeabilities, etc, for each phase or component.  But most PorousFlow `Materials`, `Kernels`, etc, require these to be formatted into C++ `std::vectors`.  This is what the [`PorousFlowJoiner`](PorousFlowJoiner.md) does.  Even single-phase, single-component simulations need Joiners: they just create `std::vectors` with length 1 (so far in this tutorial you haven't seen any `PorousFlowJoiners` because the `Actions` have created them for you: lucky you!).
-
-For example:
-
-!listing modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phase.i start=[./relperm_water] end=[]
-
-The `material_property` is the `std::vector` property created (in this case `PorousFlow_relative_permeability_nodal`), that can be fed into subsequent `Kernels` and `Materials`, etc.  In this case, the `PorousFlowJoiner` joins together `PorousFlow_relative_permeability_nodal0` (created by `[./relperm_water]`) and `PorousFlow_relative_permeability_nodal1` (created by `[./relperm_gas]`).
-
-It is sometimes really difficult to know the `material_property` names to use!  This is related to knowing which `Material` to use, mentioned at the start of this Page.
+In the input file, you specify things like densities, relative permeabilities, etc, for each phase or component.  But most PorousFlow `Materials`, `Kernels`, etc, require these to be formatted into C++ `std::vectors`.  This is what the [`PorousFlowJoiner`](PorousFlowJoiner.md) does.  Even single-phase, single-component simulations need Joiners: they just create `std::vectors` with length 1. These are
+added automatically by the action system.
 
 ### What Material do I need?
 

--- a/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowAddMaterialJoiner.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowAddMaterialJoiner.md
@@ -1,0 +1,9 @@
+# PorousFlowAddMaterialJoiner
+
+!syntax description /Materials/PorousFlowAddMaterialJoiner
+
+!syntax parameters /Materials/PorousFlowAddMaterialJoiner
+
+!syntax inputs /Materials/PorousFlowAddMaterialJoiner
+
+!syntax children /Materials/PorousFlowAddMaterialJoiner

--- a/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowJoiner.md
+++ b/modules/porous_flow/doc/content/documentation/systems/Materials/PorousFlowJoiner.md
@@ -2,6 +2,9 @@
 
 !syntax description /Materials/PorousFlowJoiner
 
+This material is added automatically by the action system, so should
+not need to be included by the user.
+
 !syntax parameters /Materials/PorousFlowJoiner
 
 !syntax inputs /Materials/PorousFlowJoiner

--- a/modules/porous_flow/doc/hidden.yml
+++ b/modules/porous_flow/doc/hidden.yml
@@ -5,6 +5,7 @@
 - /Kernels/PorousFlowFullySaturatedDarcyFlow
 - /Kernels/PorousFlowFullySaturatedHeatAdvection
 - /Kernels/PorousFlowFullySaturatedMassTimeDerivative
+- /Materials/PorousFlowAddMaterialJoiner
 - /PorousFlowBasicTHM
 - /PorousFlowBasicTHM/PorousFlowBasicTHM
 - /PorousFlowFullySaturated

--- a/modules/porous_flow/examples/coal_mining/coarse_with_fluid.i
+++ b/modules/porous_flow/examples/coal_mining/coarse_with_fluid.i
@@ -865,25 +865,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity_for_aux]
     type = PorousFlowPorosity
     fluid = true
@@ -930,21 +911,12 @@
     sum_s_res = 0.4
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 4
     s_res = 0.4
     sum_s_res = 0.4
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 
   [./elasticity_tensor_0]

--- a/modules/porous_flow/examples/coal_mining/fine_with_fluid.i
+++ b/modules/porous_flow/examples/coal_mining/fine_with_fluid.i
@@ -873,25 +873,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity_for_aux]
     type = PorousFlowPorosity
     fluid = true
@@ -938,21 +919,12 @@
     sum_s_res = 0.4
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 4
     s_res = 0.4
     sum_s_res = 0.4
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 
   [./elasticity_tensor_0]

--- a/modules/porous_flow/examples/flow_through_fractured_media/coarse.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/coarse.i
@@ -191,25 +191,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro_fracture]
     type = PorousFlowPorosityConst
     porosity = 6e-4   # = a * phif
@@ -258,19 +239,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/examples/flow_through_fractured_media/coarse_3D.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/coarse_3D.i
@@ -203,25 +203,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro1]
     type = PorousFlowPorosityConst
     porosity = 6e-4   # = a * phif
@@ -260,19 +241,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability1]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_steady.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_steady.i
@@ -110,42 +110,14 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./relp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability1]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_steady.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_steady.i
@@ -110,42 +110,14 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./relp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability1]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
@@ -178,25 +178,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro_fracture]
     type = PorousFlowPorosityConst
     porosity = 1.0    # this is the true porosity of the fracture
@@ -235,19 +216,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability1]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
@@ -180,25 +180,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro_fracture]
     type = PorousFlowPorosityConst
     porosity = 6e-4   # = a * phif
@@ -237,19 +218,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability_fracture]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/examples/tutorial/10.i
+++ b/modules/porous_flow/examples/tutorial/10.i
@@ -171,20 +171,6 @@
     fp = the_simple_fluid
     phase = 0
   [../]
-  [./density_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./density_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./viscosity_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./relperm_nodal]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -192,11 +178,6 @@
     s_res = 0.1
     sum_s_res = 0.1
     phase = 0
-  [../]
-  [./relperm_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/examples/tutorial/11.i
+++ b/modules/porous_flow/examples/tutorial/11.i
@@ -430,30 +430,6 @@
     fp = tabulated_co2
     phase = 1
   [../]
-  [./density_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./density_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./viscosity_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./energy_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./enthalpy_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
   [./relperm_water_nodal]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -470,11 +446,6 @@
     s_res = 0.1
     sum_s_res = 0.2
     phase = 1
-  [../]
-  [./relperm_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity_nodal]
     type = PorousFlowPorosity

--- a/modules/porous_flow/examples/tutorial/11_2D.i
+++ b/modules/porous_flow/examples/tutorial/11_2D.i
@@ -370,30 +370,6 @@
     fp = tabulated_co2
     phase = 1
   [../]
-  [./density_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./density_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./viscosity_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./energy_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./enthalpy_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
   [./relperm_water_nodal]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -410,11 +386,6 @@
     s_res = 0.1
     sum_s_res = 0.2
     phase = 1
-  [../]
-  [./relperm_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity_nodal]
     type = PorousFlowPorosity

--- a/modules/porous_flow/examples/tutorial/13.i
+++ b/modules/porous_flow/examples/tutorial/13.i
@@ -409,25 +409,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -446,18 +427,9 @@
     phase = 0
     at_nodes = true
   [../]
-  [./relp_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./relp_qp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/include/actions/PorousFlowAddMaterialJoiner.h
+++ b/modules/porous_flow/include/actions/PorousFlowAddMaterialJoiner.h
@@ -1,0 +1,68 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef POROUSFLOWADDMATERIALJOINER_H
+#define POROUSFLOWADDMATERIALJOINER_H
+
+#include "Action.h"
+
+class PorousFlowAddMaterialJoiner;
+
+template <>
+InputParameters validParams<PorousFlowAddMaterialJoiner>();
+
+/**
+ * Action to programatically add PorousFlowJoiner materials without having
+ * to manually enter them in the input file
+ */
+class PorousFlowAddMaterialJoiner : public Action
+{
+
+public:
+  PorousFlowAddMaterialJoiner(const InputParameters & params);
+
+  virtual void act() override;
+
+protected:
+  /**
+   * Adds a PorousFlowJoiner for the given material property
+   * @param at_nodes if true: produce a nodal material, otherwise: produce a qp material
+   * @param material_property join this PorousFlow material property
+   * @param output_name The unique name given to this PorousFlowJoiner in the input file
+   * @param active if true: add PorousFlowJoiner, otherwise: do nothing
+   */
+  void addJoiner(bool at_nodes,
+                 const std::string & material_property,
+                 const std::string & output_name,
+                 bool active = true);
+
+  /**
+   * Helper method to determine if any PorousFlowJoiner materials are present in
+   * the input file, and if they are, set's flags to disable adding an identical
+   * PorousFlowJoiner material in this action (which would otherwise result in a
+   * duplciate material property error).
+   */
+  void checkJoiner();
+
+  /// Name of the PorousFlowDictator
+  std::string _dictator_name;
+  /// Flags to control adding PorousFlowJoiners for each material
+  bool _density_nodal;
+  bool _density_qp;
+  bool _viscosity_nodal;
+  bool _viscosity_qp;
+  bool _enthalpy_nodal;
+  bool _enthalpy_qp;
+  bool _internal_energy_nodal;
+  bool _internal_energy_qp;
+  bool _relperm_nodal;
+  bool _relperm_qp;
+};
+
+#endif // POROUSFLOWADDMATERIALJOINER_H

--- a/modules/porous_flow/src/actions/PorousFlowAddMaterialJoiner.C
+++ b/modules/porous_flow/src/actions/PorousFlowAddMaterialJoiner.C
@@ -1,0 +1,231 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PorousFlowAddMaterialJoiner.h"
+#include "AddMaterialAction.h"
+#include "AddUserObjectAction.h"
+#include "ActionWarehouse.h"
+#include "FEProblem.h"
+
+registerMooseAction("PorousFlowApp", PorousFlowAddMaterialJoiner, "add_joiners");
+
+template <>
+InputParameters
+validParams<PorousFlowAddMaterialJoiner>()
+{
+  InputParameters params = validParams<Action>();
+  params.addClassDescription(
+      "Adds PorousFlowJoiner materials as required for each phase-dependent property");
+  return params;
+}
+
+PorousFlowAddMaterialJoiner::PorousFlowAddMaterialJoiner(const InputParameters & params)
+  : Action(params),
+    _density_nodal(true),
+    _density_qp(true),
+    _viscosity_nodal(true),
+    _viscosity_qp(true),
+    _enthalpy_nodal(true),
+    _enthalpy_qp(true),
+    _internal_energy_nodal(true),
+    _internal_energy_qp(true),
+    _relperm_nodal(true),
+    _relperm_qp(true)
+{
+}
+
+void
+PorousFlowAddMaterialJoiner::act()
+{
+  // This task only runs after the UserObject and material actions have been added,
+  // so we can get the name of the PorousFlowDictator UserObject and all material
+  // types that are added in the input file
+  if (_current_task == "add_joiners")
+  {
+    // Get the user objects that have been added to get the name of the PorousFlowDictator
+    auto userobjects = _awh.getActions<AddUserObjectAction>();
+    for (auto & userobject : userobjects)
+      if (userobject->getMooseObjectType() == "PorousFlowDictator")
+        _dictator_name = userobject->name();
+
+    // Get the list of materials that have been added
+    auto actions = _awh.getActions<AddMaterialAction>();
+
+    // Check if there are PorousFlowJoiner materials in the input file
+    checkJoiner();
+
+    for (auto & action : actions)
+    {
+      AddMaterialAction * material = const_cast<AddMaterialAction *>(action);
+
+      // Add joiner material for PorousFlowSingleComponentFluid materials
+      if (material->getMooseObjectType() == "PorousFlowSingleComponentFluid")
+      {
+        // Input parameters for the material that is being added
+        InputParameters & pars = material->getObjectParams();
+        // Check if the material is evaluated at the nodes or qps
+        const bool at_nodes = pars.get<bool>("at_nodes");
+
+        // Key the addition of the joiner off the phase 0 fluid so it is only added once
+        if (pars.get<unsigned int>("phase") == 0)
+        {
+          // Join density and viscosity if they are calculated
+          if (pars.get<bool>("compute_density_and_viscosity"))
+          {
+            if (at_nodes)
+            {
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_density_nodal",
+                        "PorousFlow_density_nodal_all",
+                        _density_nodal);
+              addJoiner(at_nodes,
+                        "PorousFlow_viscosity_nodal",
+                        "PorousFlow_viscosity_nodal_all",
+                        _viscosity_nodal);
+            }
+            else
+            {
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_density_qp",
+                        "PorousFlow_density_qp_all",
+                        _density_qp);
+              addJoiner(at_nodes,
+                        "PorousFlow_viscosity_qp",
+                        "PorousFlow_viscosity_qp_all",
+                        _viscosity_qp);
+            }
+          }
+
+          // Join enthalpy if it is calculated
+          if (pars.get<bool>("compute_enthalpy"))
+          {
+            if (at_nodes)
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_enthalpy_nodal",
+                        "PorousFlow_enthalpy_nodal_all",
+                        _enthalpy_nodal);
+            else
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_enthalpy_qp",
+                        "PorousFlow_enthalpy_qp_all",
+                        _enthalpy_qp);
+          }
+
+          // Join internal energy if it is calculated
+          if (pars.get<bool>("compute_internal_energy"))
+          {
+            if (at_nodes)
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_internal_energy_nodal",
+                        "PorousFlow_internal_energy_nodal_all",
+                        _internal_energy_nodal);
+            else
+              addJoiner(at_nodes,
+                        "PorousFlow_fluid_phase_internal_energy_qp",
+                        "PorousFlow_internal_energy_qp_all",
+                        _internal_energy_qp);
+          }
+        }
+      }
+
+      // Add joiner materials for relative permeability materials
+      // Note: this relies on the relative permeability class starting
+      // with PorousFlowRelativePermeability
+      if (material->getMooseObjectType().find("PorousFlowRelativePermeability") == 0)
+      {
+        // Input parameters for the material that is being added
+        InputParameters & pars = material->getObjectParams();
+        // Check if the material is evaluated at the nodes or qps
+        const bool at_nodes = pars.get<bool>("at_nodes");
+
+        // Key the addition of the joiner off the phase 0 fluid so it is only added once
+        if (pars.get<unsigned int>("phase") == 0)
+        {
+          if (at_nodes)
+            addJoiner(at_nodes,
+                      "PorousFlow_relative_permeability_nodal",
+                      "PorousFlow_relative_permeability_nodal_all",
+                      _relperm_nodal);
+          else
+            addJoiner(at_nodes,
+                      "PorousFlow_relative_permeability_qp",
+                      "PorousFlow_relative_permeability_qp_all",
+                      _relperm_qp);
+        }
+      }
+    }
+  }
+}
+
+void
+PorousFlowAddMaterialJoiner::addJoiner(bool at_nodes,
+                                       const std::string & material_property,
+                                       const std::string & output_name,
+                                       bool active)
+{
+  if (active)
+  {
+    std::string material_type = "PorousFlowJoiner";
+    InputParameters params = _factory.getValidParams(material_type);
+    params.set<UserObjectName>("PorousFlowDictator") = _dictator_name;
+    params.set<bool>("at_nodes") = at_nodes;
+    params.set<std::string>("material_property") = material_property;
+    _problem->addMaterial(material_type, output_name, params);
+  }
+}
+
+void
+PorousFlowAddMaterialJoiner::checkJoiner()
+{
+  // Get the list of materials that have been added
+  auto actions = _awh.getActions<AddMaterialAction>();
+
+  for (auto & action : actions)
+  {
+    AddMaterialAction * material = const_cast<AddMaterialAction *>(action);
+
+    if (material->getMooseObjectType() == "PorousFlowJoiner")
+    {
+      // If a PorousFlowJoiner material has been included in the input file,
+      // let the user know that it should be removed
+      mooseDeprecated("PorousFlowJoiner materials are no longer required in the input "
+                      "file.\nPlease remove all PorousFlowJoiner materials from this input file");
+
+      // Input parameters for the PorousFlowJoiner
+      InputParameters & pars = material->getObjectParams();
+      const std::string prop = pars.get<std::string>("material_property");
+
+      // Set flag corresponding to the material property that has been found here
+      // so that a PorousFlowJoiner isn't added for it in this action
+      if (prop == "PorousFlow_fluid_phase_density_nodal")
+        _density_nodal = false;
+      else if (prop == "PorousFlow_fluid_phase_density_qp")
+        _density_qp = false;
+      if (prop == "PorousFlow_viscosity_nodal")
+        _viscosity_nodal = false;
+      else if (prop == "PorousFlow_viscosity_qp")
+        _viscosity_qp = false;
+      if (prop == "PorousFlow_fluid_phase_enthalpy_nodal")
+        _enthalpy_nodal = false;
+      else if (prop == "PorousFlow_fluid_phase_enthalpy_qp")
+        _enthalpy_qp = false;
+      if (prop == "PorousFlow_fluid_phase_internal_energy_nodal")
+        _internal_energy_nodal = false;
+      else if (prop == "PorousFlow_fluid_phase_internal_energy_qp")
+        _internal_energy_qp = false;
+      else if (prop == "PorousFlow_relative_permeability_nodal")
+        _relperm_nodal = false;
+      else if (prop == "PorousFlow_relative_permeability_qp")
+        _relperm_qp = false;
+      else
+      {
+      }
+    }
+  }
+}

--- a/modules/porous_flow/src/base/PorousFlowApp.C
+++ b/modules/porous_flow/src/base/PorousFlowApp.C
@@ -112,6 +112,12 @@ PorousFlowApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("PorousFlowBasicTHM", "PorousFlowBasicTHM", "add_material");
   syntax.registerActionSyntax("PorousFlowBasicTHM", "PorousFlowBasicTHM", "add_aux_variable");
   syntax.registerActionSyntax("PorousFlowBasicTHM", "PorousFlowBasicTHM", "add_aux_kernel");
+
+  registerTask("add_joiners", /*is_required=*/false);
+  addTaskDependency("add_joiners", "add_material");
+  addTaskDependency("add_joiners", "add_user_object");
+
+  syntax.registerActionSyntax("PorousFlowAddMaterialJoiner", "Materials", "add_joiners");
 }
 
 // External entry point for dynamic execute flag registration

--- a/modules/porous_flow/test/tests/actions/addjoiner.i
+++ b/modules/porous_flow/test/tests/actions/addjoiner.i
@@ -1,0 +1,156 @@
+# Tests that including PorousFlowJoiner materials doesn't cause the simulation
+# to fail due to the PorousFlowAddMaterialJoiner action adding duplicate
+# PorousFlowJoiner materials
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./p0]
+  [../]
+  [./p1]
+  [../]
+[]
+
+[Kernels]
+  [./p0]
+    type = Diffusion
+    variable = p0
+  [../]
+  [./p1]
+    type = Diffusion
+    variable = p1
+  [../]
+[]
+
+[Modules]
+  [./FluidProperties]
+    [./fluid0]
+      type = SimpleFluidProperties
+    [../]
+    [./fluid1]
+      type = SimpleFluidProperties
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    at_nodes = true
+  [../]
+  [./temperature_qp]
+    type = PorousFlowTemperature
+  [../]
+  [./ppss_nodal]
+    type = PorousFlow2PhasePP
+    at_nodes = true
+    phase0_porepressure = p0
+    phase1_porepressure = p1
+    capillary_pressure = pc
+  [../]
+  [./ppss_qp]
+    type = PorousFlow2PhasePP
+    phase0_porepressure = p0
+    phase1_porepressure = p1
+    capillary_pressure = pc
+  [../]
+  [./fluid0_nodal]
+    type = PorousFlowSingleComponentFluid
+    fp = fluid0
+    at_nodes = true
+    phase = 0
+  [../]
+  [./fluid1_nodal]
+    type = PorousFlowSingleComponentFluid
+    fp = fluid1
+    at_nodes = true
+    phase = 1
+  [../]
+  [./fluid0_qp]
+    type = PorousFlowSingleComponentFluid
+    fp = fluid0
+    phase = 0
+  [../]
+  [./fluid1_qp]
+    type = PorousFlowSingleComponentFluid
+    fp = fluid1
+    phase = 1
+  [../]
+  [./density_nodal]
+    type = PorousFlowJoiner
+    at_nodes = true
+    material_property = PorousFlow_fluid_phase_density_nodal
+  [../]
+  [./density_qp]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_fluid_phase_density_qp
+  [../]
+  [./viscosity_nodal]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_viscosity_nodal
+    at_nodes = true
+  [../]
+  [./viscosity_qp]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_viscosity_qp
+  [../]
+  [./energy_ndoal]
+    type = PorousFlowJoiner
+    at_nodes = true
+    material_property = PorousFlow_fluid_phase_internal_energy_nodal
+  [../]
+  [./energy_qp]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_fluid_phase_internal_energy_qp
+  [../]
+  [./enthalpy_nodal]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_fluid_phase_enthalpy_nodal
+    at_nodes = true
+  [../]
+  [./enthalpy_qp]
+    type = PorousFlowJoiner
+    material_property = PorousFlow_fluid_phase_enthalpy_qp
+  [../]
+  [./relperm0_nodal]
+    type = PorousFlowRelativePermeabilityConst
+    at_nodes = true
+    kr = 0.5
+    phase = 0
+  [../]
+  [./relperm1_nodal]
+    type = PorousFlowRelativePermeabilityConst
+    at_nodes = true
+    kr = 0.8
+    phase = 1
+  [../]
+  [./relperm_nodal]
+    type = PorousFlowJoiner
+    at_nodes = true
+    material_property = PorousFlow_relative_permeability_nodal
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'p0 p1'
+    number_fluid_phases = 2
+    number_fluid_components = 1
+  [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
+[]

--- a/modules/porous_flow/test/tests/actions/addjoiner_exception.i
+++ b/modules/porous_flow/test/tests/actions/addjoiner_exception.i
@@ -1,0 +1,80 @@
+# Tests that including a PorousFlowJoiner material throws the
+# informative deprecation warning rather than a duplicate material property error
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+[]
+
+[Variables]
+  [./p0]
+  [../]
+  [./p1]
+  [../]
+[]
+
+[Kernels]
+  [./p0]
+    type = Diffusion
+    variable = p0
+  [../]
+  [./p1]
+    type = Diffusion
+    variable = p1
+  [../]
+[]
+
+[Materials]
+  [./temperature]
+    type = PorousFlowTemperature
+    at_nodes = true
+  [../]
+  [./temperature_qp]
+    type = PorousFlowTemperature
+  [../]
+  [./ppss]
+    type = PorousFlow2PhasePP
+    at_nodes = true
+    phase0_porepressure = p0
+    phase1_porepressure = p1
+    capillary_pressure = pc
+  [../]
+  [./relperm0]
+    type = PorousFlowRelativePermeabilityConst
+    at_nodes = true
+    kr = 0.5
+    phase = 0
+  [../]
+  [./relperm1]
+    type = PorousFlowRelativePermeabilityConst
+    at_nodes = true
+    kr = 0.8
+    phase = 1
+  [../]
+  [./relperm]
+    type = PorousFlowJoiner
+    at_nodes = true
+    material_property = PorousFlow_relative_permeability_nodal
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[UserObjects]
+  [./dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'p0 p1'
+    number_fluid_phases = 2
+    number_fluid_components = 1
+  [../]
+  [./pc]
+    type = PorousFlowCapillaryPressureConst
+    pc = 0
+  [../]
+[]

--- a/modules/porous_flow/test/tests/actions/tests
+++ b/modules/porous_flow/test/tests/actions/tests
@@ -20,4 +20,14 @@
     input = 'fullsat_brine_except3.i'
     expect_err = 'You need to specify fp if use_brine is false'
   [../]
+  [./addjoiner]
+    type = RunApp
+    input = addjoiner.i
+  [../]
+  [./addjoiner_exception]
+    type = RunException
+    input = addjoiner_exception.i
+    expect_err = 'PorousFlowJoiner materials are no longer required in the input file'
+    cli_args = --error-deprecated
+  [../]
 []

--- a/modules/porous_flow/test/tests/aux_kernels/darcy_velocity.i
+++ b/modules/porous_flow/test/tests/aux_kernels/darcy_velocity.i
@@ -165,16 +165,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -186,31 +176,11 @@
     n = 2
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_qp]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = false
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower.i
+++ b/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower.i
@@ -187,10 +187,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -205,14 +201,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower_2D.i
+++ b/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower_2D.i
@@ -193,10 +193,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -211,14 +207,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower_except.i
+++ b/modules/porous_flow/test/tests/aux_kernels/darcy_velocity_lower_except.i
@@ -78,11 +78,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -92,16 +87,6 @@
     at_nodes = false
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/aux_kernels/properties.i
+++ b/modules/porous_flow/test/tests/aux_kernels/properties.i
@@ -317,25 +317,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1e-12 0 0 0 1e-12 0 0 0 1e-12'
@@ -352,11 +333,6 @@
     n = 3
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm0_qp]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = false
@@ -368,11 +344,6 @@
     at_nodes = false
     n = 3
     phase = 1
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./porosity_nodal]
     type = PorousFlowPorosityConst
@@ -388,24 +359,6 @@
     at_nodes = true
     specific_heat_capacity = 1.0
     density = 125
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./energy_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_qp
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
-  [./enthalpy_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/basic_advection/1phase.i
+++ b/modules/porous_flow/test/tests/basic_advection/1phase.i
@@ -91,14 +91,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -107,10 +99,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 0
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/basic_advection/2phase.i
+++ b/modules/porous_flow/test/tests/basic_advection/2phase.i
@@ -110,14 +110,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '10 0 0 0 10 0 0 0 10'
@@ -131,10 +123,6 @@
     type = PorousFlowRelativePermeabilityConst
     kr = 0.5
     phase = 1
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/basic_advection/except1.i
+++ b/modules/porous_flow/test/tests/basic_advection/except1.i
@@ -84,14 +84,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -100,10 +92,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 0
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/basic_advection/except2.i
+++ b/modules/porous_flow/test/tests/basic_advection/except2.i
@@ -84,14 +84,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -100,10 +92,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 0
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/broadbridge_white/bw01.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/bw01.i
@@ -72,21 +72,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     at_nodes = true
@@ -107,11 +92,6 @@
     Ks = 1
     C = 1.5
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/bw02.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/bw02.i
@@ -72,21 +72,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     porepressure = pressure
@@ -107,11 +92,6 @@
     Ks = 1
     C = 1.5
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/rd01.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/rd01.i
@@ -70,21 +70,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     porepressure = pressure
@@ -102,11 +87,6 @@
     m = 0.336
     seff_turnover = 0.99
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/rd02.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/rd02.i
@@ -70,21 +70,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     at_nodes = true
@@ -102,11 +87,6 @@
     m = 0.336
     seff_turnover = 0.99
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/rd03.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/rd03.i
@@ -63,21 +63,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     at_nodes = true
@@ -95,11 +80,6 @@
     m = 0.336
     seff_turnover = 0.99
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/wli01.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/wli01.i
@@ -64,21 +64,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     porepressure = pressure
@@ -99,11 +84,6 @@
     Ks = 1
     C = 1.5
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/broadbridge_white/wli02.i
+++ b/modules/porous_flow/test/tests/broadbridge_white/wli02.i
@@ -64,21 +64,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./ppss]
     type = PorousFlow1PhaseP
     at_nodes = true
@@ -99,11 +84,6 @@
     Ks = 1
     C = 1.5
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/buckley_leverett/bl01.i
+++ b/modules/porous_flow/test/tests/buckley_leverett/bl01.i
@@ -131,21 +131,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1E-10 0 0  0 1E-10 0  0 0 1E-10'
@@ -155,11 +140,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/capillary_pressure/brooks_corey1.i
+++ b/modules/porous_flow/test/tests/capillary_pressure/brooks_corey1.i
@@ -127,10 +127,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/capillary_pressure/brooks_corey2.i
+++ b/modules/porous_flow/test/tests/capillary_pressure/brooks_corey2.i
@@ -127,10 +127,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/capillary_pressure/vangenuchten1.i
+++ b/modules/porous_flow/test/tests/capillary_pressure/vangenuchten1.i
@@ -128,10 +128,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/capillary_pressure/vangenuchten2.i
+++ b/modules/porous_flow/test/tests/capillary_pressure/vangenuchten2.i
@@ -128,10 +128,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/capillary_pressure/vangenuchten3.i
+++ b/modules/porous_flow/test/tests/capillary_pressure/vangenuchten3.i
@@ -129,10 +129,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/chemistry/2species_equilibrium.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_equilibrium.i
@@ -200,20 +200,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -231,10 +217,6 @@
   [./relp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./diff]
     type = PorousFlowDiffusivityConst

--- a/modules/porous_flow/test/tests/chemistry/2species_equilibrium_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_equilibrium_2phase.i
@@ -231,25 +231,6 @@
     fp = simple_fluid
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -272,10 +253,6 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 1
   [../]
-  [./relp_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp0]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
@@ -285,11 +262,6 @@
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 1
-  [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./diff]
     type = PorousFlowDiffusivityConst

--- a/modules/porous_flow/test/tests/chemistry/2species_predis.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_predis.i
@@ -197,20 +197,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -228,10 +214,6 @@
   [./relp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./diff]
     type = PorousFlowDiffusivityConst

--- a/modules/porous_flow/test/tests/chemistry/dissolution.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution.i
@@ -188,11 +188,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/chemistry/dissolution_limited.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution_limited.i
@@ -190,11 +190,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/chemistry/dissolution_limited_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution_limited_2phase.i
@@ -213,11 +213,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/chemistry/precipitation.i
+++ b/modules/porous_flow/test/tests/chemistry/precipitation.i
@@ -188,11 +188,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/chemistry/precipitation_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/precipitation_2phase.i
@@ -211,11 +211,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/density/GravDensity01.i
+++ b/modules/porous_flow/test/tests/density/GravDensity01.i
@@ -130,10 +130,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
   [./porosity_qp]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/desorption/desorption01.i
+++ b/modules/porous_flow/test/tests/desorption/desorption01.i
@@ -144,11 +144,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/desorption/desorption02.i
+++ b/modules/porous_flow/test/tests/desorption/desorption02.i
@@ -155,20 +155,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1
@@ -197,11 +183,6 @@
     at_nodes = true
     m = 1
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh02.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh02.i
@@ -87,16 +87,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -111,11 +101,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh03.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh03.i
@@ -87,16 +87,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -111,11 +101,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh04.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh04.i
@@ -95,16 +95,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -119,11 +109,6 @@
     at_nodes = true
     m = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh05.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh05.i
@@ -95,16 +95,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -119,11 +109,6 @@
     at_nodes = true
     m = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh07.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh07.i
@@ -108,20 +108,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -136,11 +122,6 @@
     at_nodes = true
     m = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except01.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except01.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except02.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except02.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except03.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except03.i
@@ -80,16 +80,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -104,11 +94,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except04.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except04.i
@@ -80,16 +80,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -104,11 +94,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except05.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except05.i
@@ -81,16 +81,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -105,11 +95,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except06.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except06.i
@@ -79,17 +79,6 @@
     type = PorousFlowMassFraction
     at_nodes = true
   [../]
-  [./simple_fluid]
-    type = PorousFlowSingleComponentFluid
-    fp = simple_fluid
-    phase = 0
-    at_nodes = true
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -104,11 +93,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except07.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except07.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/bh_except08.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except08.i
@@ -93,21 +93,11 @@
     n = 2
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./simple_fluid]
     type = PorousFlowSingleComponentFluid
     fp = simple_fluid
     phase = 0
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
+    at_nodes = false
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except09.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except09.i
@@ -84,16 +84,7 @@
     fp = simple_fluid
     phase = 0
     at_nodes = true
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
+    compute_enthalpy = false
   [../]
   [./porosity]
     type = PorousFlowPorosityConst
@@ -105,11 +96,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except10.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except10.i
@@ -84,16 +84,7 @@
     fp = simple_fluid
     phase = 0
     at_nodes = true
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
+    compute_internal_energy = false
   [../]
   [./porosity]
     type = PorousFlowPorosityConst
@@ -105,11 +96,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except11.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except11.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/bh_except12.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except12.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/bh_except13.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except13.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/bh_except14.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except14.i
@@ -87,16 +87,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -111,11 +101,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except15.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except15.i
@@ -87,16 +87,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -107,11 +97,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/bh_except16.i
+++ b/modules/porous_flow/test/tests/dirackernels/bh_except16.i
@@ -90,16 +90,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -114,11 +104,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/pls01.i
+++ b/modules/porous_flow/test/tests/dirackernels/pls01.i
@@ -98,11 +98,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/pls02.i
+++ b/modules/porous_flow/test/tests/dirackernels/pls02.i
@@ -116,16 +116,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -140,11 +130,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/pls03.i
+++ b/modules/porous_flow/test/tests/dirackernels/pls03.i
@@ -118,11 +118,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -135,11 +130,6 @@
     s_res = 0.99
     sum_s_res = 0.99
     at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/squarepulse1.i
+++ b/modules/porous_flow/test/tests/dirackernels/squarepulse1.i
@@ -72,11 +72,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/dirackernels/theis1.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis1.i
@@ -98,20 +98,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -126,11 +112,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/theis2.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis2.i
@@ -99,20 +99,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -127,11 +113,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dirackernels/theis3.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis3.i
@@ -150,21 +150,6 @@
     compute_enthalpy = false
     compute_internal_energy = false
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -185,11 +170,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/dispersion/diff01.i
+++ b/modules/porous_flow/test/tests/dispersion/diff01.i
@@ -173,25 +173,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     porosity = 0.3
@@ -210,19 +191,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/test/tests/dispersion/disp01.i
+++ b/modules/porous_flow/test/tests/dispersion/disp01.i
@@ -178,25 +178,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./visc_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     porosity = 0.3
@@ -215,19 +196,10 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relp_nodal]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relp_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/test/tests/dispersion/disp01_heavy.i
+++ b/modules/porous_flow/test/tests/dispersion/disp01_heavy.i
@@ -180,25 +180,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-    at_nodes = true
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -218,18 +199,9 @@
     at_nodes = true
     phase = 0
   [../]
-  [./relp_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relp_qp]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-  [../]
-  [./relp_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst

--- a/modules/porous_flow/test/tests/energy_conservation/except01.i
+++ b/modules/porous_flow/test/tests/energy_conservation/except01.i
@@ -102,16 +102,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
 []
 
 [Postprocessors]

--- a/modules/porous_flow/test/tests/energy_conservation/except02.i
+++ b/modules/porous_flow/test/tests/energy_conservation/except02.i
@@ -102,16 +102,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
 []
 
 [Postprocessors]

--- a/modules/porous_flow/test/tests/energy_conservation/heat02.i
+++ b/modules/porous_flow/test/tests/energy_conservation/heat02.i
@@ -103,16 +103,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
 []
 
 [Postprocessors]

--- a/modules/porous_flow/test/tests/energy_conservation/heat03.i
+++ b/modules/porous_flow/test/tests/energy_conservation/heat03.i
@@ -305,20 +305,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '0.5 0 0   0 0.5 0   0 0 0.5'
@@ -328,11 +314,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/energy_conservation/heat04.i
+++ b/modules/porous_flow/test/tests/energy_conservation/heat04.i
@@ -361,16 +361,6 @@
     fp = the_simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
 []
 
 [Postprocessors]

--- a/modules/porous_flow/test/tests/energy_conservation/heat05.i
+++ b/modules/porous_flow/test/tests/energy_conservation/heat05.i
@@ -208,16 +208,6 @@
     fp = the_simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
 []
 
 [Postprocessors]

--- a/modules/porous_flow/test/tests/fluidstate/brineco2.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2.i
@@ -250,11 +250,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/fluidstate/brineco2_2.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2_2.i
@@ -281,11 +281,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/fluidstate/brineco2_hightemp.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2_hightemp.i
@@ -251,11 +251,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/fluidstate/brineco2_ic.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2_ic.i
@@ -147,11 +147,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/fluidstate/theis.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis.i
@@ -174,11 +174,6 @@
     n = 2
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
 []
 
 [BCs]

--- a/modules/porous_flow/test/tests/fluidstate/theis_brineco2.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis_brineco2.i
@@ -195,11 +195,6 @@
     n = 2
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
 []
 
 [BCs]

--- a/modules/porous_flow/test/tests/fluidstate/theis_tabulated.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis_tabulated.i
@@ -180,11 +180,6 @@
     n = 2
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
 []
 
 [BCs]

--- a/modules/porous_flow/test/tests/fluidstate/waterncg.i
+++ b/modules/porous_flow/test/tests/fluidstate/waterncg.i
@@ -249,11 +249,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/fluidstate/waterncg_ic.i
+++ b/modules/porous_flow/test/tests/fluidstate/waterncg_ic.i
@@ -144,11 +144,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/gravity/fully_saturated_grav01a.i
+++ b/modules/porous_flow/test/tests/gravity/fully_saturated_grav01a.i
@@ -88,14 +88,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'

--- a/modules/porous_flow/test/tests/gravity/fully_saturated_grav01b.i
+++ b/modules/porous_flow/test/tests/gravity/fully_saturated_grav01b.i
@@ -88,14 +88,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'

--- a/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
+++ b/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
@@ -103,14 +103,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'

--- a/modules/porous_flow/test/tests/gravity/grav01a.i
+++ b/modules/porous_flow/test/tests/gravity/grav01a.i
@@ -112,21 +112,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'
@@ -136,11 +121,6 @@
     at_nodes = true
     n = 1
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav01b.i
+++ b/modules/porous_flow/test/tests/gravity/grav01b.i
@@ -112,21 +112,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'
@@ -136,11 +121,6 @@
     at_nodes = true
     n = 1
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav01c.i
+++ b/modules/porous_flow/test/tests/gravity/grav01c.i
@@ -112,21 +112,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'
@@ -136,11 +121,6 @@
     at_nodes = true
     n = 1
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02a.i
+++ b/modules/porous_flow/test/tests/gravity/grav02a.i
@@ -155,21 +155,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -190,11 +175,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02b.i
+++ b/modules/porous_flow/test/tests/gravity/grav02b.i
@@ -158,21 +158,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0  0 2 0  0 0 3'
@@ -188,11 +173,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02c.i
+++ b/modules/porous_flow/test/tests/gravity/grav02c.i
@@ -157,25 +157,10 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
     porosity = 0.1
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
@@ -192,11 +177,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02d.i
+++ b/modules/porous_flow/test/tests/gravity/grav02d.i
@@ -172,21 +172,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -206,10 +191,6 @@
     n = 1
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
   [./relperm_water_nodal]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -221,11 +202,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02e.i
+++ b/modules/porous_flow/test/tests/gravity/grav02e.i
@@ -178,21 +178,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -214,11 +199,6 @@
     n = 2
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_water_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 2
@@ -228,10 +208,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 1
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02f.i
+++ b/modules/porous_flow/test/tests/gravity/grav02f.i
@@ -180,21 +180,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -220,11 +205,6 @@
     s_res = 0.1
     sum_s_res = 0.35
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_water_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 2
@@ -238,10 +218,6 @@
     phase = 1
     s_res = 0.1
     sum_s_res = 0.35
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/gravity/grav02g.i
+++ b/modules/porous_flow/test/tests/gravity/grav02g.i
@@ -179,21 +179,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -219,11 +204,6 @@
     s_res = 0.1
     sum_s_res = 0.35
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_water_qp]
     type = PorousFlowRelativePermeabilityBC
     lambda = 2
@@ -239,10 +219,6 @@
     s_res = 0.1
     sum_s_res = 0.35
     nw_phase = true
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/heat_advection/heat_advection_1d.i
+++ b/modules/porous_flow/test/tests/heat_advection/heat_advection_1d.i
@@ -154,31 +154,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1.1 0 0 0 2 0 0 0 3'
@@ -192,11 +167,6 @@
   [./massfrac]
     type = PorousFlowMassFraction
     at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./PS]
     type = PorousFlow1PhaseP

--- a/modules/porous_flow/test/tests/heat_advection/heat_advection_1d_fully_saturated.i
+++ b/modules/porous_flow/test/tests/heat_advection/heat_advection_1d_fully_saturated.i
@@ -130,33 +130,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./energy_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_qp
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1.1 0 0 0 2 0 0 0 3'

--- a/modules/porous_flow/test/tests/heat_conduction/two_phase.i
+++ b/modules/porous_flow/test/tests/heat_conduction/two_phase.i
@@ -139,16 +139,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
 []
 
 [BCs]

--- a/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm.i
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm.i
@@ -282,20 +282,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = poro
@@ -316,11 +302,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm2.i
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm2.i
@@ -339,21 +339,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -380,11 +365,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/basic_advection1.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection1.i
@@ -77,14 +77,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -93,10 +85,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 0
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/basic_advection2.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection2.i
@@ -83,14 +83,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -99,10 +91,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/basic_advection3.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection3.i
@@ -84,14 +84,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -100,10 +92,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/basic_advection4.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection4.i
@@ -92,14 +92,6 @@
     fp = methane
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '5 0 0 0 5 0 0 0 5'
@@ -108,10 +100,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/basic_advection5.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection5.i
@@ -82,14 +82,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./effective_fluid_pressure]
     type = PorousFlowEffectiveFluidPressure
   [../]
@@ -112,10 +104,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/basic_advection6.i
+++ b/modules/porous_flow/test/tests/jacobian/basic_advection6.i
@@ -107,14 +107,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./effective_fluid_pressure]
     type = PorousFlowEffectiveFluidPressure
   [../]
@@ -142,10 +134,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-  [../]
-  [./relperm_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
   [./darcy_velocity_qp]
     type = PorousFlowDarcyVelocityMaterial

--- a/modules/porous_flow/test/tests/jacobian/brineco2_gas.i
+++ b/modules/porous_flow/test/tests/jacobian/brineco2_gas.i
@@ -144,11 +144,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/brineco2_liquid.i
+++ b/modules/porous_flow/test/tests/jacobian/brineco2_liquid.i
@@ -144,11 +144,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/brineco2_liquid_2.i
+++ b/modules/porous_flow/test/tests/jacobian/brineco2_liquid_2.i
@@ -153,11 +153,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/brineco2_twophase.i
+++ b/modules/porous_flow/test/tests/jacobian/brineco2_twophase.i
@@ -144,11 +144,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/brineco2_twophase_2.i
+++ b/modules/porous_flow/test/tests/jacobian/brineco2_twophase_2.i
@@ -153,11 +153,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/chem14.i
+++ b/modules/porous_flow/test/tests/jacobian/chem14.i
@@ -106,11 +106,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     chemical = true

--- a/modules/porous_flow/test/tests/jacobian/chem15.i
+++ b/modules/porous_flow/test/tests/jacobian/chem15.i
@@ -116,11 +116,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     porosity_zero = 0.1

--- a/modules/porous_flow/test/tests/jacobian/denergy02.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy02.i
@@ -190,16 +190,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
 []
 
 [Preconditioning]

--- a/modules/porous_flow/test/tests/jacobian/denergy03.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy03.i
@@ -189,16 +189,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
 []
 
 [Preconditioning]

--- a/modules/porous_flow/test/tests/jacobian/denergy04.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy04.i
@@ -193,16 +193,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
 []
 
 [Preconditioning]

--- a/modules/porous_flow/test/tests/jacobian/denergy05.i
+++ b/modules/porous_flow/test/tests/jacobian/denergy05.i
@@ -192,16 +192,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
 []
 
 [Preconditioning]

--- a/modules/porous_flow/test/tests/jacobian/desorped_mass01.i
+++ b/modules/porous_flow/test/tests/jacobian/desorped_mass01.i
@@ -155,11 +155,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true

--- a/modules/porous_flow/test/tests/jacobian/desorped_mass_vol_exp01.i
+++ b/modules/porous_flow/test/tests/jacobian/desorped_mass_vol_exp01.i
@@ -193,11 +193,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true

--- a/modules/porous_flow/test/tests/jacobian/diff01.i
+++ b/modules/porous_flow/test/tests/jacobian/diff01.i
@@ -100,16 +100,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     porosity = 0.1
@@ -130,11 +120,6 @@
     type = PorousFlowRelativePermeabilityConst
     at_nodes = false
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/diff02.i
+++ b/modules/porous_flow/test/tests/jacobian/diff02.i
@@ -130,16 +130,6 @@
     at_nodes = false
     phase = 1
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-    at_nodes = false
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     porosity = 0.1
@@ -163,11 +153,6 @@
   [./relperm1]
     type = PorousFlowRelativePermeabilityConst
     phase = 1
-    at_nodes = false
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
     at_nodes = false
   [../]
 []

--- a/modules/porous_flow/test/tests/jacobian/diff03.i
+++ b/modules/porous_flow/test/tests/jacobian/diff03.i
@@ -131,16 +131,6 @@
     at_nodes = false
     phase = 1
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     at_nodes = false
@@ -164,11 +154,6 @@
     type = PorousFlowRelativePermeabilityConst
     at_nodes = false
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/disp01.i
+++ b/modules/porous_flow/test/tests/jacobian/disp01.i
@@ -102,16 +102,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     at_nodes = false
@@ -132,11 +122,6 @@
     type = PorousFlowRelativePermeabilityConst
     at_nodes = false
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/disp02.i
+++ b/modules/porous_flow/test/tests/jacobian/disp02.i
@@ -102,16 +102,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     at_nodes = false
@@ -132,11 +122,6 @@
     type = PorousFlowRelativePermeabilityConst
     at_nodes = false
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/disp03.i
+++ b/modules/porous_flow/test/tests/jacobian/disp03.i
@@ -99,16 +99,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     at_nodes = false
@@ -128,11 +118,6 @@
   [./relperm]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-    at_nodes = false
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
     at_nodes = false
   [../]
 []

--- a/modules/porous_flow/test/tests/jacobian/disp04.i
+++ b/modules/porous_flow/test/tests/jacobian/disp04.i
@@ -98,16 +98,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-    at_nodes = false
-  [../]
   [./poro]
     type = PorousFlowPorosityConst
     porosity = 0.1
@@ -127,11 +117,6 @@
   [./relperm]
     type = PorousFlowRelativePermeabilityConst
     phase = 0
-    at_nodes = false
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
     at_nodes = false
   [../]
 []

--- a/modules/porous_flow/test/tests/jacobian/fflux01.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux01.i
@@ -99,21 +99,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -124,11 +109,6 @@
     n = 2
     phase = 0
     at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux01_fully_saturated.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux01_fully_saturated.i
@@ -104,14 +104,6 @@
     at_nodes = false
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false

--- a/modules/porous_flow/test/tests/jacobian/fflux02.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux02.i
@@ -128,21 +128,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -153,11 +138,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux03.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux03.i
@@ -155,21 +155,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -186,11 +171,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux04.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux04.i
@@ -177,21 +177,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -208,11 +193,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux05.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux05.i
@@ -101,21 +101,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -126,11 +111,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux06.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux06.i
@@ -101,21 +101,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -126,11 +111,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux07.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux07.i
@@ -156,21 +156,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -187,11 +172,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux08.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux08.i
@@ -163,21 +163,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityKozenyCarman
     at_nodes = false
@@ -193,11 +178,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux09.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux09.i
@@ -177,21 +177,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0 0 2 0 0 0 3'
@@ -208,11 +193,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux10.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux10.i
@@ -130,21 +130,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -159,11 +144,6 @@
     Ks = 0.95
     C = 1.5
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux11.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux11.i
@@ -129,21 +129,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0 0 2 0 0 0 3'
@@ -155,11 +140,6 @@
     m = 0.6
     seff_turnover = 0.8
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux12.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux12.i
@@ -128,21 +128,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_nodal_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0 0 2 0 0 0 3'
@@ -153,11 +138,6 @@
     at_nodes = true
     m = 10
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/fflux13.i
+++ b/modules/porous_flow/test/tests/jacobian/fflux13.i
@@ -183,21 +183,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    at_nodes = false
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -214,11 +199,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/hcs01.i
+++ b/modules/porous_flow/test/tests/jacobian/hcs01.i
@@ -134,16 +134,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -160,11 +150,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/heat_advection01.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection01.i
@@ -86,11 +86,6 @@
     at_nodes = true
     temperature = temp
   [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -101,11 +96,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./PS]
     type = PorousFlow1PhaseP
@@ -129,26 +119,6 @@
     type = PorousFlowSingleComponentFluid
     fp = simple_fluid
     phase = 0
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/heat_advection01_fully_saturated.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection01_fully_saturated.i
@@ -89,22 +89,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_qp
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
 []
 
 [Preconditioning]

--- a/modules/porous_flow/test/tests/jacobian/heat_advection02.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_advection02.i
@@ -123,11 +123,6 @@
     n = 3
     phase = 1
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./ppss]
     type = PorousFlow2PhasePP
     at_nodes = false
@@ -163,31 +158,6 @@
     type = PorousFlowSingleComponentFluid
     fp = simple_fluid1
     phase = 1
-  [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/heat_vol_exp01.i
+++ b/modules/porous_flow/test/tests/jacobian/heat_vol_exp01.i
@@ -181,11 +181,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true
@@ -204,11 +199,6 @@
     at_nodes = true
     specific_heat_capacity = 1.1
     density = 0.5
-  [../]
-  [./internal_energy_fluids]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/hgs01.i
+++ b/modules/porous_flow/test/tests/jacobian/hgs01.i
@@ -134,16 +134,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -160,11 +150,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/line_sink01.i
+++ b/modules/porous_flow/test/tests/jacobian/line_sink01.i
@@ -210,26 +210,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-    at_nodes = true
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -245,11 +225,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
   [./thermal_conductivity]

--- a/modules/porous_flow/test/tests/jacobian/line_sink02.i
+++ b/modules/porous_flow/test/tests/jacobian/line_sink02.i
@@ -190,26 +190,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-    at_nodes = true
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -225,11 +205,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
   [./thermal_conductivity]

--- a/modules/porous_flow/test/tests/jacobian/line_sink03.i
+++ b/modules/porous_flow/test/tests/jacobian/line_sink03.i
@@ -211,26 +211,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-    at_nodes = true
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -246,11 +226,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
   [./thermal_conductivity]

--- a/modules/porous_flow/test/tests/jacobian/line_sink04.i
+++ b/modules/porous_flow/test/tests/jacobian/line_sink04.i
@@ -190,26 +190,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-    at_nodes = true
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -225,11 +205,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
   [./thermal_conductivity]

--- a/modules/porous_flow/test/tests/jacobian/mass01.i
+++ b/modules/porous_flow/test/tests/jacobian/mass01.i
@@ -74,11 +74,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/mass01_fully_saturated.i
+++ b/modules/porous_flow/test/tests/jacobian/mass01_fully_saturated.i
@@ -167,10 +167,6 @@
     fp = the_simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst  # only the initial vaue of this is ever used
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/mass02.i
+++ b/modules/porous_flow/test/tests/jacobian/mass02.i
@@ -73,11 +73,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass03.i
+++ b/modules/porous_flow/test/tests/jacobian/mass03.i
@@ -109,11 +109,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass04.i
+++ b/modules/porous_flow/test/tests/jacobian/mass04.i
@@ -126,11 +126,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass05.i
+++ b/modules/porous_flow/test/tests/jacobian/mass05.i
@@ -147,11 +147,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass06.i
+++ b/modules/porous_flow/test/tests/jacobian/mass06.i
@@ -77,11 +77,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass07.i
+++ b/modules/porous_flow/test/tests/jacobian/mass07.i
@@ -77,11 +77,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/mass08.i
+++ b/modules/porous_flow/test/tests/jacobian/mass08.i
@@ -135,11 +135,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true

--- a/modules/porous_flow/test/tests/jacobian/mass09.i
+++ b/modules/porous_flow/test/tests/jacobian/mass09.i
@@ -130,11 +130,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass10.i
+++ b/modules/porous_flow/test/tests/jacobian/mass10.i
@@ -136,11 +136,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true

--- a/modules/porous_flow/test/tests/jacobian/mass_vol_exp01.i
+++ b/modules/porous_flow/test/tests/jacobian/mass_vol_exp01.i
@@ -176,11 +176,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/jacobian/mass_vol_exp02.i
+++ b/modules/porous_flow/test/tests/jacobian/mass_vol_exp02.i
@@ -169,11 +169,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true

--- a/modules/porous_flow/test/tests/jacobian/pls01.i
+++ b/modules/porous_flow/test/tests/jacobian/pls01.i
@@ -78,16 +78,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1.1 0 0 0 2.2 0 0 0 3.3'
@@ -96,11 +86,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 2
     phase = 0
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
 []

--- a/modules/porous_flow/test/tests/jacobian/pls02.i
+++ b/modules/porous_flow/test/tests/jacobian/pls02.i
@@ -142,16 +142,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1 0 0 0 2 0 0 0 3'
@@ -167,11 +157,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/pls03.i
+++ b/modules/porous_flow/test/tests/jacobian/pls03.i
@@ -166,16 +166,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -192,11 +182,6 @@
     at_nodes = true
     n = 3
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/jacobian/pls04.i
+++ b/modules/porous_flow/test/tests/jacobian/pls04.i
@@ -181,26 +181,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-    at_nodes = true
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-    at_nodes = true
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-    at_nodes = true
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     at_nodes = false
@@ -216,11 +196,6 @@
     type = PorousFlowRelativePermeabilityCorey
     n = 3
     phase = 1
-    at_nodes = true
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
     at_nodes = true
   [../]
   [./thermal_conductivity]

--- a/modules/porous_flow/test/tests/jacobian/waterncg_gas.i
+++ b/modules/porous_flow/test/tests/jacobian/waterncg_gas.i
@@ -133,11 +133,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/waterncg_liquid.i
+++ b/modules/porous_flow/test/tests/jacobian/waterncg_liquid.i
@@ -133,11 +133,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/jacobian/waterncg_twophase.i
+++ b/modules/porous_flow/test/tests/jacobian/waterncg_twophase.i
@@ -133,11 +133,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_nodal
-    at_nodes = true
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/mass_conservation/mass01.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass01.i
@@ -79,11 +79,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass02.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass02.i
@@ -92,11 +92,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass03.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass03.i
@@ -74,11 +74,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass04.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass04.i
@@ -256,16 +256,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -280,11 +270,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/mass_conservation/mass05.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass05.i
@@ -116,11 +116,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass06.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass06.i
@@ -118,11 +118,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass07.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass07.i
@@ -115,11 +115,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass08.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass08.i
@@ -115,11 +115,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass09.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass09.i
@@ -115,11 +115,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/mass_conservation/mass10.i
+++ b/modules/porous_flow/test/tests/mass_conservation/mass10.i
@@ -114,11 +114,6 @@
     at_nodes = true
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/newton_cooling/nc01.i
+++ b/modules/porous_flow/test/tests/newton_cooling/nc01.i
@@ -94,21 +94,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -123,11 +108,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/newton_cooling/nc02.i
+++ b/modules/porous_flow/test/tests/newton_cooling/nc02.i
@@ -96,21 +96,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -125,11 +110,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/newton_cooling/nc06.i
+++ b/modules/porous_flow/test/tests/newton_cooling/nc06.i
@@ -113,31 +113,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
-  [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
     permeability = '1E-15 0 0 0 1E-15 0 0 0 1E-15'
@@ -147,11 +122,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/newton_cooling/nc08.i
+++ b/modules/porous_flow/test/tests/newton_cooling/nc08.i
@@ -105,20 +105,10 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./dens0_qp]
     type = PorousFlowSingleComponentFluid
     fp = idealgas
     phase = 0
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
   [../]
   [./permeability]
     type = PorousFlowPermeabilityConst
@@ -129,26 +119,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./enthalpy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_enthalpy_nodal
-  [../]
-  [./energy_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_internal_energy_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/numerical_diffusion/no_action.i
+++ b/modules/porous_flow/test/tests/numerical_diffusion/no_action.i
@@ -151,33 +151,10 @@
     fp = the_simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./relperm]
     type = PorousFlowRelativePermeabilityConst
     at_nodes = true
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity_qp]
     type = PorousFlowPorosity

--- a/modules/porous_flow/test/tests/poro_elasticity/mandel.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/mandel.i
@@ -284,21 +284,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true
@@ -318,11 +303,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/mandel_constM.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/mandel_constM.i
@@ -276,21 +276,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityHMBiotModulus
     at_nodes = true
@@ -309,11 +294,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/mandel_fully_saturated.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/mandel_fully_saturated.i
@@ -247,14 +247,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst # only the initial value of this is ever used
     porosity = 0.1

--- a/modules/porous_flow/test/tests/poro_elasticity/mandel_fully_saturated_volume.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/mandel_fully_saturated_volume.i
@@ -250,14 +250,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst # only the initial value of this is ever used
     porosity = 0.1

--- a/modules/porous_flow/test/tests/poro_elasticity/pp_generation.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/pp_generation.i
@@ -283,21 +283,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true
@@ -324,11 +309,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined.i
@@ -283,21 +283,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true
@@ -316,11 +301,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_constM.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_constM.i
@@ -291,21 +291,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityHMBiotModulus
     at_nodes = true
@@ -324,11 +309,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_fully_saturated.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_fully_saturated.i
@@ -255,11 +255,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst # the "const" is irrelevant here: all that uses Porosity is the BiotModulus, which just uses the initial value of porosity
     porosity = 0.1

--- a/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_fully_saturated_volume.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/pp_generation_unconfined_fully_saturated_volume.i
@@ -259,11 +259,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst # the "const" is irrelevant here: all that uses Porosity is the BiotModulus, which just uses the initial value of porosity
     porosity = 0.1

--- a/modules/porous_flow/test/tests/poro_elasticity/terzaghi.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/terzaghi.i
@@ -250,21 +250,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosity
     fluid = true
@@ -284,11 +269,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/terzaghi_constM.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/terzaghi_constM.i
@@ -242,21 +242,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityHMBiotModulus
     at_nodes = true
@@ -275,11 +260,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poro_elasticity/terzaghi_fully_saturated_volume.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/terzaghi_fully_saturated_volume.i
@@ -217,15 +217,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst # only the initial value of this is used
     porosity = 0.1

--- a/modules/porous_flow/test/tests/poro_elasticity/undrained_oedometer.i
+++ b/modules/porous_flow/test/tests/poro_elasticity/undrained_oedometer.i
@@ -236,11 +236,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/poroperm/PermFromPoro01.i
+++ b/modules/porous_flow/test/tests/poroperm/PermFromPoro01.i
@@ -206,20 +206,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -233,11 +219,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermFromPoro02.i
+++ b/modules/porous_flow/test/tests/poroperm/PermFromPoro02.i
@@ -206,20 +206,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -233,11 +219,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermFromPoro03.i
+++ b/modules/porous_flow/test/tests/poroperm/PermFromPoro03.i
@@ -204,20 +204,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -231,11 +217,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermFromPoro04.i
+++ b/modules/porous_flow/test/tests/poroperm/PermFromPoro04.i
@@ -197,20 +197,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -224,11 +210,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 
   [./permeability]

--- a/modules/porous_flow/test/tests/poroperm/PermFromPoro05.i
+++ b/modules/porous_flow/test/tests/poroperm/PermFromPoro05.i
@@ -197,20 +197,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -231,11 +217,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermTensorFromVar01.i
+++ b/modules/porous_flow/test/tests/poroperm/PermTensorFromVar01.i
@@ -198,20 +198,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -225,11 +211,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermTensorFromVar02.i
+++ b/modules/porous_flow/test/tests/poroperm/PermTensorFromVar02.i
@@ -206,20 +206,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -233,11 +219,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/poroperm/PermTensorFromVar03.i
+++ b/modules/porous_flow/test/tests/poroperm/PermTensorFromVar03.i
@@ -198,20 +198,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
 
   # Porosity
   [./porosity]
@@ -225,11 +211,6 @@
     at_nodes = true
     n = 0 # unimportant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d.i
@@ -91,21 +91,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -120,11 +105,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phase.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phase.i
@@ -135,21 +135,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -170,11 +155,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePS.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePS.i
@@ -147,21 +147,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -182,11 +167,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePSVG.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePSVG.i
@@ -151,21 +151,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -186,11 +171,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePSVG2.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_2phasePSVG2.i
@@ -151,21 +151,6 @@
     fp = simple_fluid1
     phase = 1
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -186,11 +171,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_3comp.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_3comp.i
@@ -120,20 +120,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -148,11 +134,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_3comp_fully_saturated.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_3comp_fully_saturated.i
@@ -118,20 +118,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_MD.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_MD.i
@@ -93,21 +93,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -122,11 +107,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated.i
@@ -84,20 +84,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -112,11 +98,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated_2.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_fully_saturated_2.i
@@ -68,15 +68,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     porosity = 0.1

--- a/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_steady.i
+++ b/modules/porous_flow/test/tests/pressure_pulse/pressure_pulse_1d_steady.i
@@ -92,21 +92,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_at_quadpoints]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -121,11 +106,6 @@
     at_nodes = true
     n = 0
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/radioactive_decay/radioactive_decay01.i
+++ b/modules/porous_flow/test/tests/radioactive_decay/radioactive_decay01.i
@@ -92,11 +92,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/relperm/brooks_corey1.i
+++ b/modules/porous_flow/test/tests/relperm/brooks_corey1.i
@@ -125,10 +125,6 @@
     lambda = 2
     nw_phase = true
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/brooks_corey2.i
+++ b/modules/porous_flow/test/tests/relperm/brooks_corey2.i
@@ -131,10 +131,6 @@
     s_res = 0.3
     sum_s_res = 0.5
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/corey1.i
+++ b/modules/porous_flow/test/tests/relperm/corey1.i
@@ -125,10 +125,6 @@
     phase = 1
     n = 1
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/corey2.i
+++ b/modules/porous_flow/test/tests/relperm/corey2.i
@@ -127,10 +127,6 @@
     phase = 1
     n = 2
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/corey3.i
+++ b/modules/porous_flow/test/tests/relperm/corey3.i
@@ -131,10 +131,6 @@
     s_res = 0.3
     sum_s_res = 0.5
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/corey4.i
+++ b/modules/porous_flow/test/tests/relperm/corey4.i
@@ -133,10 +133,6 @@
     s_res = 0.3
     sum_s_res = 0.5
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/unity.i
+++ b/modules/porous_flow/test/tests/relperm/unity.i
@@ -121,10 +121,6 @@
     type = PorousFlowRelativePermeabilityConst
     phase = 1
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/vangenuchten1.i
+++ b/modules/porous_flow/test/tests/relperm/vangenuchten1.i
@@ -125,10 +125,6 @@
     phase = 1
     m = 0.5
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/relperm/vangenuchten2.i
+++ b/modules/porous_flow/test/tests/relperm/vangenuchten2.i
@@ -130,10 +130,6 @@
     s_res = 0.3
     sum_s_res = 0.5
   [../]
-  [./kr_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
-  [../]
 []
 
 [VectorPostprocessors]

--- a/modules/porous_flow/test/tests/rogers_stallybrass_clements/rsc01.i
+++ b/modules/porous_flow/test/tests/rogers_stallybrass_clements/rsc01.i
@@ -113,21 +113,6 @@
     compute_enthalpy = false
     compute_internal_energy = false
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./relperm_water]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -139,11 +124,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/rogers_stallybrass_clements/rsc02.i
+++ b/modules/porous_flow/test/tests/rogers_stallybrass_clements/rsc02.i
@@ -113,21 +113,6 @@
     compute_enthalpy = false
     compute_internal_energy = false
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-    at_nodes = false
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./relperm_water]
     type = PorousFlowRelativePermeabilityCorey
     at_nodes = true
@@ -139,11 +124,6 @@
     at_nodes = true
     n = 1
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
   [./porosity]
     type = PorousFlowPorosityConst

--- a/modules/porous_flow/test/tests/sinks/injection_production_eg.i
+++ b/modules/porous_flow/test/tests/sinks/injection_production_eg.i
@@ -168,20 +168,6 @@
     fp = tabulated_co2
     phase = 1
   [../]
-  [./density_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./density_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./viscosity_all_nodal]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -207,11 +193,6 @@
     s_res = 0.1
     sum_s_res = 0.2
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s01.i
+++ b/modules/porous_flow/test/tests/sinks/s01.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s02.i
+++ b/modules/porous_flow/test/tests/sinks/s02.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s03.i
+++ b/modules/porous_flow/test/tests/sinks/s03.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s04.i
+++ b/modules/porous_flow/test/tests/sinks/s04.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s05.i
+++ b/modules/porous_flow/test/tests/sinks/s05.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s06.i
+++ b/modules/porous_flow/test/tests/sinks/s06.i
@@ -85,16 +85,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -109,11 +99,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s07.i
+++ b/modules/porous_flow/test/tests/sinks/s07.i
@@ -102,16 +102,6 @@
     phase = 0
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -126,11 +116,6 @@
     at_nodes = true
     n = 2
     phase = 0
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s08.i
+++ b/modules/porous_flow/test/tests/sinks/s08.i
@@ -120,16 +120,6 @@
     phase = 1
     at_nodes = true
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -150,11 +140,6 @@
     at_nodes = true
     n = 2
     phase = 1
-  [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s09.i
+++ b/modules/porous_flow/test/tests/sinks/s09.i
@@ -137,24 +137,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -175,19 +157,10 @@
     n = 2 # irrelevant in this fully-saturated situation
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 2 # irrelevant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s09_fully_saturated.i
+++ b/modules/porous_flow/test/tests/sinks/s09_fully_saturated.i
@@ -140,24 +140,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
-  [./dens_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
-  [./visc_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_viscosity_nodal
-  [../]
-  [./visc_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_viscosity_qp
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true
@@ -178,19 +160,10 @@
     n = 2 # irrelevant in this fully-saturated situation
     phase = 0
   [../]
-  [./relperm_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_relative_permeability_nodal
-  [../]
   [./relperm_qp]
     type = PorousFlowRelativePermeabilityCorey
     n = 2 # irrelevant in this fully-saturated situation
     phase = 0
-  [../]
-  [./relperm_all_qp]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_relative_permeability_qp
   [../]
 []
 

--- a/modules/porous_flow/test/tests/sinks/s10.i
+++ b/modules/porous_flow/test/tests/sinks/s10.i
@@ -105,11 +105,6 @@
     at_nodes = true
     phase = 0
   [../]
-  [./dens_all]
-    type = PorousFlowJoiner
-    at_nodes = true
-    material_property = PorousFlow_fluid_phase_density_nodal
-  [../]
   [./porosity]
     type = PorousFlowPorosityConst
     at_nodes = true

--- a/modules/porous_flow/test/tests/thermal_conductivity/ThermalCondPorosity01.i
+++ b/modules/porous_flow/test/tests/thermal_conductivity/ThermalCondPorosity01.i
@@ -151,10 +151,6 @@
     fp = simple_fluid
     phase = 0
   [../]
-  [./dens_qp_all]
-    type = PorousFlowJoiner
-    material_property = PorousFlow_fluid_phase_density_qp
-  [../]
   [./porosity_qp]
     type = PorousFlowPorosityConst
     porosity = 0.1


### PR DESCRIPTION
This removes the need to manually add `PorousFlowJoiners` for each material property that depends on fluid phase. 

What I think I have done is the following:

- Added a new action task `add_joiner` that runs *after* `add_user_objects` and `add_materials` - this is important so that this new action can find all of the required materials and user objects that have been added
- Added a new action that adds `PorousFlowJoiner` materials where required
- If a `PorousFlowJoiner` material is present in the input file, ~~then an error telling the user to delete it is thrown, as opposed to the duplicate material error that would occur otherwise~~ a `mooseDeprecated` warning is given, and the action doesn't add what would be a duplicate joiner material

And then spent ages deleting all of the `PorousFlowJoiner` materials from the tests - damn us for having so many tests!

I also updated some documentation to note that these are now added automatically.

Let me know what you think @WilkAndy 

Closes #11652