### PR TITLE
correct d2Fdcdstrain in phasefield model

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeIsotropicLinearElasticPFFractureStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIsotropicLinearElasticPFFractureStress.C
@@ -138,7 +138,7 @@ ComputeIsotropicLinearElasticPFFractureStress::computeQpStress()
 
   // 2nd derivative wrt c and strain = 0.0 if we used the previous step's history varible
   if (_use_current_hist)
-    _d2Fdcdstrain[_qp] = -stress0pos * (1.0 - c) * (1 - _kdamage);
+    _d2Fdcdstrain[_qp] = -stress0pos * 2.0 * (1.0 - c) * (1 - _kdamage);
 
   // Used in StressDivergencePFFracTensors off-diagonal Jacobian
   _dstress_dc[_qp] = -stress0pos * 2.0 * (1.0 - c) * (1 - _kdamage);

--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticPFFractureStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticPFFractureStress.C
@@ -100,7 +100,7 @@ ComputeLinearElasticPFFractureStress::computeQpStress()
   _d2Fdc2[_qp] = cfactor * G0_pos * 2.0;
 
   // 2nd derivative wrt c and strain
-  _d2Fdcdstrain[_qp] = -cfactor * stress0pos * (1.0 - c);
+  _d2Fdcdstrain[_qp] = -cfactor * stress0pos * 2.0 * (1.0 - c);
 
   // Used in StressDivergencePFFracTensors off-diagonal Jacobian
   _dstress_dc[_qp] = -cfactor * stress0pos * 2.0 * (1.0 - c);

--- a/modules/tensor_mechanics/src/materials/HyperElasticPhaseFieldIsoDamage.C
+++ b/modules/tensor_mechanics/src/materials/HyperElasticPhaseFieldIsoDamage.C
@@ -206,7 +206,7 @@ HyperElasticPhaseFieldIsoDamage::computeQpJacobian()
   // 2nd derivative wrt c and strain = 0.0 if we used the previous step's history varible
   if (_use_current_hist)
     _d2Fdcdstrain[_qp] =
-        -_df_dstretch_inc.innerProductTranspose(dG0_df) * (1.0 - _c[_qp]) * (1 - _kdamage);
+        -_df_dstretch_inc.innerProductTranspose(dG0_df) * 2.0 * (1.0 - _c[_qp]) * (1 - _kdamage);
 
   _dstress_dc[_qp] = _fe.mixedProductIkJl(_fe) * _dpk2_dc;
 }


### PR DESCRIPTION
d2Fdcdstrain is corrected to be -stress0pos * 2.0 * (1.0 - c) * (1 - _kdamage)

see [discussion](https://groups.google.com/forum/#!topic/moose-users/fbwCP5FWwoQ) in the user group.

Resolves #11654

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
