### PR TITLE
Remove all use of output_iteration_info

### DIFF
--- a/modules/combined/test/tests/power_law_creep/creep_only_combined_class_sm1.i
+++ b/modules/combined/test/tests/power_law_creep/creep_only_combined_class_sm1.i
@@ -244,7 +244,6 @@
     disp_y = y_disp
     disp_z = z_disp
     temp = temp
-    output_iteration_info = false
   [../]
 
   [./thermal]

--- a/modules/combined/test/tests/power_law_creep/creep_only_combined_class_sm2.i
+++ b/modules/combined/test/tests/power_law_creep/creep_only_combined_class_sm2.i
@@ -248,7 +248,6 @@
     activation_energy = 3.0e5
     max_its = 100
     temp = temp
-    output_iteration_info = false
     legacy_return_mapping = true
   [../]
 

--- a/modules/combined/test/tests/power_law_creep/power_law_creep_restart1_sm.i
+++ b/modules/combined/test/tests/power_law_creep/power_law_creep_restart1_sm.i
@@ -166,7 +166,6 @@
     disp_y = disp_y
     disp_z = disp_z
     temp = temp
-    output_iteration_info = false
     formulation = Nonlinear3D
   [../]
 

--- a/modules/combined/test/tests/power_law_creep/power_law_creep_restart2_sm.i
+++ b/modules/combined/test/tests/power_law_creep/power_law_creep_restart2_sm.i
@@ -166,7 +166,6 @@
     disp_y = disp_y
     disp_z = disp_z
     temp = temp
-    output_iteration_info = false
     formulation = Nonlinear3D
   [../]
 

--- a/modules/combined/test/tests/power_law_creep/power_law_creep_sm.i
+++ b/modules/combined/test/tests/power_law_creep/power_law_creep_sm.i
@@ -166,7 +166,6 @@
     disp_y = disp_y
     disp_z = disp_z
     temp = temp
-    output_iteration_info = false
     formulation = Nonlinear3D
   [../]
 

--- a/modules/combined/test/tests/power_law_hardening/PowerLawHardening-SM.i
+++ b/modules/combined/test/tests/power_law_hardening/PowerLawHardening-SM.i
@@ -128,7 +128,6 @@
     strain_hardening_exponent = 0.5 #n
     relative_tolerance = 1e-10
     absolute_tolerance = 1e-12
-#    output_iteration_info = true
   [../]
 
 []

--- a/modules/solid_mechanics/test/tests/combined_creep_plasticity/combined_creep_plasticity_sm1.i
+++ b/modules/solid_mechanics/test/tests/combined_creep_plasticity/combined_creep_plasticity_sm1.i
@@ -198,7 +198,6 @@
     disp_y = disp_y
     disp_z = disp_z
     formulation = nonlinear3D
-    output_iteration_info = false
   [../]
 []
 

--- a/modules/solid_mechanics/test/tests/combined_creep_plasticity/combined_stress_relaxation_sm.i
+++ b/modules/solid_mechanics/test/tests/combined_creep_plasticity/combined_stress_relaxation_sm.i
@@ -158,7 +158,6 @@
     disp_x = disp_x
     disp_y = disp_y
     disp_z = disp_z
-    output_iteration_info = false
     relative_tolerance = 1e-14
     absolute_tolerance = 1e-14
     formulation = Nonlinear3D

--- a/modules/solid_mechanics/test/tests/combined_creep_plasticity/plasticity_only_combined_class_sm2.i
+++ b/modules/solid_mechanics/test/tests/combined_creep_plasticity/plasticity_only_combined_class_sm2.i
@@ -163,7 +163,6 @@
     hardening_constant = 1206.
     relative_tolerance = 1e-8
     absolute_tolerance = 1e-12
-#    output_iteration_info = true
   [../]
 []
 


### PR DESCRIPTION
PR #11574 is failing because it gets rid of the `output_iteration_info` parameter, which is needlessly being set to its default value in a number of tests. This just removes the setting of that everywhere in the MOOSE modules tests.

ref #11573