### PR TITLE
Print error when trying to show input file mesh 

### DIFF
--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -320,13 +320,18 @@ class BlockTree(QTreeWidget, MooseWidget):
     def includeBlock(self, block, include=True):
         item = self._path_item_map.get(block.path)
         if item:
+            changed = block.included != include
             block.included = include
             if include:
-                item.setCheckState(0, Qt.Checked)
+                if item.checkState(0) == Qt.Unchecked:
+                    item.setCheckState(0, Qt.Checked)
+                    changed = True
                 self._includeParents(block)
-            else:
+            elif item.checkState(0) == Qt.Checked:
                 item.setCheckState(0, Qt.Unchecked)
-            self.changed.emit(block)
+                changed = True
+            if changed:
+                self.changed.emit(block)
 
     def _treeContextMenu(self, point):
         """

--- a/python/peacock/Input/MeshViewerPlugin.py
+++ b/python/peacock/Input/MeshViewerPlugin.py
@@ -10,6 +10,7 @@
 from peacock.ExodusViewer.plugins.VTKWindowPlugin import VTKWindowPlugin
 from peacock.utils import ExeLauncher
 from PyQt5.QtCore import pyqtSignal
+import mooseutils
 import os
 
 class MeshViewerPlugin(VTKWindowPlugin):
@@ -86,9 +87,10 @@ class MeshViewerPlugin(VTKWindowPlugin):
             ExeLauncher.runExe(exe_path, args, print_errors=False)
             self.meshEnabled.emit(True)
             self.onFileChanged(self.current_temp_mesh_file)
-        except Exception:
+        except Exception as e:
             self.meshEnabled.emit(False)
             self.onFileChanged()
+            mooseutils.mooseWarning("Error producing mesh: %s" % e)
             self.setLoadingMessage("Error producing mesh")
             self._removeFileNoError(self.current_temp_mesh_file)
 


### PR DESCRIPTION
This just logs any errors from the peacock input tab mesh viewer to the console and to the peacock log.

This is still not ideal, it would be nice to show the error in the actual mesh viewer window but the output when there is an error is too much to fit in the window.

This also doesn't address the message switching from "Error producing mesh" to "File not selected".
@aeslaughter is changing things that might help with that.

closes #11664
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
