### PR TITLE
Vectors of out-of-plane scalar variables in plane strain 

### DIFF
--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneFiniteStrain.md
@@ -44,7 +44,9 @@ direction of the out-of-plane strain and $\epsilon|^{op}$ is a prescribed
 out-of-plane strain value: this strain value can be given either as a scalar
 variable or a nonlinear variable.
 The [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md)
-problems use scalar variables.
+problems use scalar variables. Multiple scalar variables can be provided such
+that one strain calculator is needed for multiple generalized plane strain
+models on different subdomains.
 
 
 ## Strain and Deformation Gradient Formulation

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneIncrementalStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneIncrementalStrain.md
@@ -38,7 +38,9 @@ direction of the out-of-plane strain and $\epsilon|^{op}$ is a prescribed
 out-of-plane strain value: this strain value can be given either as a scalar
 variable or a nonlinear variable.
 The [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md)
-problems use scalar variables.
+problems use scalar variables. Multiple scalar variables can be provided such
+that one strain calculator is needed for multiple generalized plane strain
+models on different subdomains.
 
 
 ## Strain and Deformation Gradient Formulation

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputePlaneSmallStrain.md
@@ -37,7 +37,9 @@ the direction of the out-of-plane strain and $\epsilon|^{op}$ is a
 prescribed out-of-plane strain value: this strain value can be
 given either as a scalar variable or a nonlinear variable.
 The [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md)
-problems use scalar variables.
+problems use scalar variables. Multiple scalar variables can be provided such
+that one strain calculator is needed for multiple generalized plane strain
+models on different subdomains.
 
 
 ## Strain and Deformation Gradient Formulation

--- a/modules/tensor_mechanics/include/materials/ComputePlaneFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneFiniteStrain.h
@@ -11,6 +11,7 @@
 #define COMPUTEPLANEFINITESTRAIN_H
 
 #include "Compute2DFiniteStrain.h"
+#include "SubblockIndexProvider.h"
 
 class ComputePlaneFiniteStrain;
 
@@ -30,9 +31,18 @@ protected:
   virtual Real computeOutOfPlaneGradDisp() override;
   virtual Real computeOutOfPlaneGradDispOld() override;
 
+  /// gets its subblock index for current element
+  unsigned int getCurrentSubblockIndex() const
+  {
+    return _subblock_id_provider ? _subblock_id_provider->getSubblockIndex(*_current_elem) : 0;
+  };
+
+  const SubblockIndexProvider * _subblock_id_provider;
+
   const bool _scalar_out_of_plane_strain_coupled;
-  const VariableValue & _scalar_out_of_plane_strain;
-  const VariableValue & _scalar_out_of_plane_strain_old;
+  unsigned int _nscalar_strains;
+  std::vector<const VariableValue *> _scalar_out_of_plane_strain;
+  std::vector<const VariableValue *> _scalar_out_of_plane_strain_old;
 
   const bool _out_of_plane_strain_coupled;
   const VariableValue & _out_of_plane_strain;

--- a/modules/tensor_mechanics/include/materials/ComputePlaneIncrementalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneIncrementalStrain.h
@@ -11,6 +11,7 @@
 #define COMPUTEPLANEINCREMENTALSTRAIN_H
 
 #include "Compute2DIncrementalStrain.h"
+#include "SubblockIndexProvider.h"
 
 class ComputePlaneIncrementalStrain;
 
@@ -27,12 +28,21 @@ public:
   ComputePlaneIncrementalStrain(const InputParameters & parameters);
 
 protected:
-  virtual Real computeOutOfPlaneGradDisp();
-  virtual Real computeOutOfPlaneGradDispOld();
+  virtual Real computeOutOfPlaneGradDisp() override;
+  virtual Real computeOutOfPlaneGradDispOld() override;
+
+  /// gets its subblock index for current element
+  unsigned int getCurrentSubblockIndex() const
+  {
+    return _subblock_id_provider ? _subblock_id_provider->getSubblockIndex(*_current_elem) : 0;
+  };
+
+  const SubblockIndexProvider * _subblock_id_provider;
 
   const bool _scalar_out_of_plane_strain_coupled;
-  const VariableValue & _scalar_out_of_plane_strain;
-  const VariableValue & _scalar_out_of_plane_strain_old;
+  unsigned int _nscalar_strains;
+  std::vector<const VariableValue *> _scalar_out_of_plane_strain;
+  std::vector<const VariableValue *> _scalar_out_of_plane_strain_old;
 
   const bool _out_of_plane_strain_coupled;
   const VariableValue & _out_of_plane_strain;

--- a/modules/tensor_mechanics/include/materials/ComputePlaneSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlaneSmallStrain.h
@@ -11,6 +11,7 @@
 #define COMPUTEPLANESMALLSTRAIN_H
 
 #include "Compute2DSmallStrain.h"
+#include "SubblockIndexProvider.h"
 
 class ComputePlaneSmallStrain;
 
@@ -30,12 +31,21 @@ public:
 protected:
   virtual Real computeOutOfPlaneStrain();
 
+  /// gets its subblock index for current element
+  unsigned int getCurrentSubblockIndex() const
+  {
+    return _subblock_id_provider ? _subblock_id_provider->getSubblockIndex(*_current_elem) : 0;
+  };
+
+  const SubblockIndexProvider * _subblock_id_provider;
+
 private:
   const bool _scalar_out_of_plane_strain_coupled;
-  const VariableValue & _scalar_out_of_plane_strain;
 
   const bool _out_of_plane_strain_coupled;
   const VariableValue & _out_of_plane_strain;
+  unsigned int _nscalar_strains;
+  std::vector<const VariableValue *> _scalar_out_of_plane_strain;
 };
 
 #endif // COMPUTEPLANESMALLSTRAIN_H

--- a/modules/tensor_mechanics/include/userobjects/SubblockIndexProvider.h
+++ b/modules/tensor_mechanics/include/userobjects/SubblockIndexProvider.h
@@ -38,4 +38,4 @@ public:
   virtual unsigned int getMaxSubblockIndex() const = 0;
 };
 
-#endif /* SCALARVARIABLEINDEXPROVIDER_H */
+#endif // SUBBLOCKINDEXPROVIDER_H

--- a/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DFiniteStrain.C
@@ -38,19 +38,13 @@ ComputeAxisymmetric1DFiniteStrain::ComputeAxisymmetric1DFiniteStrain(
     _out_of_plane_strain_old(_has_out_of_plane_strain ? coupledValueOld("out_of_plane_strain")
                                                       : _zero),
     _has_scalar_out_of_plane_strain(isParamValid("scalar_out_of_plane_strain")),
-    _nscalar_strains(
-        _has_scalar_out_of_plane_strain ? coupledScalarComponents("scalar_out_of_plane_strain") : 0)
+    _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain"))
 {
   if (_has_out_of_plane_strain && _has_scalar_out_of_plane_strain)
     mooseError("Must define only one of out_of_plane_strain or scalar_out_of_plane_strain");
 
   if (!_has_out_of_plane_strain && !_has_scalar_out_of_plane_strain)
     mooseError("Must define either out_of_plane_strain or scalar_out_of_plane_strain");
-
-  // in case when the provided scalar_out_of_plane_strain is not a coupled
-  // scalar variable, still set _nscalar_strains = 1 but return its default value 0
-  if (coupledScalarComponents("scalar_out_of_plane_strain") == 0)
-    _nscalar_strains = 1;
 
   if (_has_scalar_out_of_plane_strain)
   {

--- a/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DIncrementalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DIncrementalStrain.C
@@ -38,19 +38,13 @@ ComputeAxisymmetric1DIncrementalStrain::ComputeAxisymmetric1DIncrementalStrain(
     _out_of_plane_strain_old(_has_out_of_plane_strain ? coupledValueOld("out_of_plane_strain")
                                                       : _zero),
     _has_scalar_out_of_plane_strain(isParamValid("scalar_out_of_plane_strain")),
-    _nscalar_strains(
-        _has_scalar_out_of_plane_strain ? coupledScalarComponents("scalar_out_of_plane_strain") : 0)
+    _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain"))
 {
   if (_has_out_of_plane_strain && _has_scalar_out_of_plane_strain)
     mooseError("Must define only one of out_of_plane_strain or scalar_out_of_plane_strain");
 
   if (!_has_out_of_plane_strain && !_has_scalar_out_of_plane_strain)
     mooseError("Must define either out_of_plane_strain or scalar_out_of_plane_strain");
-
-  // in case when the provided scalar_out_of_plane_strain is not a coupled
-  // scalar variable, still set _nscalar_strains = 1 but return its default value 0
-  if (coupledScalarComponents("scalar_out_of_plane_strain") == 0)
-    _nscalar_strains = 1;
 
   if (_has_scalar_out_of_plane_strain)
   {

--- a/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeAxisymmetric1DSmallStrain.C
@@ -34,19 +34,13 @@ ComputeAxisymmetric1DSmallStrain::ComputeAxisymmetric1DSmallStrain(
     _has_out_of_plane_strain(isParamValid("out_of_plane_strain")),
     _out_of_plane_strain(_has_out_of_plane_strain ? coupledValue("out_of_plane_strain") : _zero),
     _has_scalar_out_of_plane_strain(isParamValid("scalar_out_of_plane_strain")),
-    _nscalar_strains(
-        _has_scalar_out_of_plane_strain ? coupledScalarComponents("scalar_out_of_plane_strain") : 0)
+    _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain"))
 {
   if (_has_out_of_plane_strain && _has_scalar_out_of_plane_strain)
     mooseError("Must define only one of out_of_plane_strain or scalar_out_of_plane_strain");
 
   if (!_has_out_of_plane_strain && !_has_scalar_out_of_plane_strain)
     mooseError("Must define either out_of_plane_strain or scalar_out_of_plane_strain");
-
-  // in case when the provided scalar_out_of_plane_strain is not a coupled
-  // scalar variable, still set _nscalar_strains = 1 but return its default value 0
-  if (coupledScalarComponents("scalar_out_of_plane_strain") == 0)
-    _nscalar_strains = 1;
 
   if (_has_scalar_out_of_plane_strain)
   {

--- a/modules/tensor_mechanics/src/materials/ComputePlaneSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputePlaneSmallStrain.C
@@ -18,6 +18,8 @@ validParams<ComputePlaneSmallStrain>()
   InputParameters params = validParams<Compute2DSmallStrain>();
   params.addClassDescription("Compute a small strain under generalized plane strain assumptions "
                              "where the out of plane strain is generally nonzero.");
+  params.addParam<UserObjectName>("subblock_index_provider",
+                                  "SubblockIndexProvider user object name");
   params.addCoupledVar("scalar_out_of_plane_strain",
                        "Scalar variable for generalized plane strain");
   params.addCoupledVar("out_of_plane_strain", "Nonlinear variable for plane stress condition");
@@ -27,22 +29,31 @@ validParams<ComputePlaneSmallStrain>()
 
 ComputePlaneSmallStrain::ComputePlaneSmallStrain(const InputParameters & parameters)
   : Compute2DSmallStrain(parameters),
-    _scalar_out_of_plane_strain_coupled(isCoupledScalar("scalar_out_of_plane_strain")),
-    _scalar_out_of_plane_strain(_scalar_out_of_plane_strain_coupled
-                                    ? coupledScalarValue("scalar_out_of_plane_strain")
-                                    : _zero),
+    _subblock_id_provider(isParamValid("subblock_index_provider")
+                              ? &getUserObject<SubblockIndexProvider>("subblock_index_provider")
+                              : nullptr),
+    _scalar_out_of_plane_strain_coupled(isParamValid("scalar_out_of_plane_strain")),
     _out_of_plane_strain_coupled(isCoupled("out_of_plane_strain")),
-    _out_of_plane_strain(_out_of_plane_strain_coupled ? coupledValue("out_of_plane_strain") : _zero)
+    _out_of_plane_strain(_out_of_plane_strain_coupled ? coupledValue("out_of_plane_strain")
+                                                      : _zero),
+    _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain"))
 {
   if (_out_of_plane_strain_coupled && _scalar_out_of_plane_strain_coupled)
     mooseError("Must define only one of out_of_plane_strain or scalar_out_of_plane_strain");
+
+  if (_scalar_out_of_plane_strain_coupled)
+  {
+    _scalar_out_of_plane_strain.resize(_nscalar_strains);
+    for (unsigned int i = 0; i < _nscalar_strains; ++i)
+      _scalar_out_of_plane_strain[i] = &coupledScalarValue("scalar_out_of_plane_strain", i);
+  }
 }
 
 Real
 ComputePlaneSmallStrain::computeOutOfPlaneStrain()
 {
   if (_scalar_out_of_plane_strain_coupled)
-    return _scalar_out_of_plane_strain[0];
+    return (*_scalar_out_of_plane_strain[getCurrentSubblockIndex()])[0];
   else
     return _out_of_plane_strain[_qp];
 }

--- a/modules/tensor_mechanics/test/include/userobjects/TestSubblockIndexProvider.h
+++ b/modules/tensor_mechanics/test/include/userobjects/TestSubblockIndexProvider.h
@@ -1,0 +1,45 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef TESTSUBBLOCKINDEXPROVIDER_H
+#define TESTSUBBLOCKINDEXPROVIDER_H
+
+#include "SubblockIndexProvider.h"
+
+class TestSubblockIndexProvider;
+
+template <>
+InputParameters validParams<TestSubblockIndexProvider>();
+
+/**
+ * A class used to set the subblock index for testing generalized plane strain
+ * calculations when more than one out-of-plane strain is provided on different
+ * subsets of elements.
+ */
+class TestSubblockIndexProvider : public SubblockIndexProvider
+{
+public:
+  TestSubblockIndexProvider(const InputParameters & params);
+
+  virtual void initialize() override {};
+  virtual void execute() override {};
+  virtual void finalize() override {};
+
+  /**
+   * The index of subblock this element is on.
+   */
+  virtual unsigned int getSubblockIndex(const Elem & /* elem */) const override;
+
+  /**
+   * The max index of subblock.
+   */
+  virtual unsigned int getMaxSubblockIndex() const override;
+};
+
+#endif // TESTSUBBLOCKINDEXPROVDER_H

--- a/modules/tensor_mechanics/test/src/userobjects/TestSubblockIndexProvider.C
+++ b/modules/tensor_mechanics/test/src/userobjects/TestSubblockIndexProvider.C
@@ -1,0 +1,43 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TestSubblockIndexProvider.h"
+
+registerMooseObject("TensorMechanicsTestApp", TestSubblockIndexProvider);
+
+template <>
+InputParameters
+validParams<TestSubblockIndexProvider>()
+{
+  InputParameters params = validParams<SubblockIndexProvider>();
+  params.set<ExecFlagEnum>( "execute_on" ) = EXEC_INITIAL;
+  return params;
+}
+
+TestSubblockIndexProvider::TestSubblockIndexProvider(const InputParameters & parameters)
+: SubblockIndexProvider(parameters)
+{
+}
+
+unsigned int
+TestSubblockIndexProvider::getSubblockIndex(const Elem & elem) const
+{
+  Point p = *elem.get_node(0);
+
+  if (MooseUtils::relativeFuzzyLessThan(p(0), 0.5))
+    return 0;
+  else
+    return 1;
+}
+
+unsigned int
+TestSubblockIndexProvider::getMaxSubblockIndex() const
+{
+  return 1;
+}

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_scalar_vector.i
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_scalar_vector.i
@@ -1,0 +1,277 @@
+[Mesh]
+  file = 2squares.e
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+
+  [./scalar_strain_zz1]
+    order = FIRST
+    family = SCALAR
+  [../]
+  [./scalar_strain_zz2]
+    order = FIRST
+    family = SCALAR
+  [../]
+[]
+
+[AuxVariables]
+  [./temp]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./saved_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./saved_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+
+  [./stress_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./stress_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+
+  [./strain_xx]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./strain_xy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./strain_yy]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./aux_strain_zz]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Postprocessors]
+  [./react_z1]
+    type = MaterialTensorIntegral
+    rank_two_tensor = stress
+    index_i = 2
+    index_j = 2
+    block = 1
+  [../]
+  [./react_z2]
+    type = MaterialTensorIntegral
+    rank_two_tensor = stress
+    index_i = 2
+    index_j = 2
+    block = 2
+  [../]
+[]
+
+[Modules]
+  [./TensorMechanics]
+    [./GeneralizedPlaneStrain]
+      [./gps1]
+        use_displaced_mesh = true
+        displacements = 'disp_x disp_y'
+        scalar_out_of_plane_strain = scalar_strain_zz1
+        block = '1'
+      [../]
+      [./gps2]
+        use_displaced_mesh = true
+        displacements = 'disp_x disp_y'
+        scalar_out_of_plane_strain = scalar_strain_zz2
+        block = '2'
+      [../]
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./TensorMechanics]
+    use_displaced_mesh = false
+    displacements = 'disp_x disp_y'
+    temperature = temp
+    save_in = 'saved_x saved_y'
+    block = '1 2'
+  [../]
+[]
+
+[AuxKernels]
+  [./tempfuncaux]
+    type = FunctionAux
+    variable = temp
+    function = tempfunc
+    use_displaced_mesh = false
+  [../]
+  [./stress_xx]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./stress_xy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./stress_yy]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./stress_zz]
+    type = RankTwoAux
+    rank_two_tensor = stress
+    variable = stress_zz
+    index_i = 2
+    index_j = 2
+  [../]
+
+  [./strain_xx]
+    type = RankTwoAux
+    rank_two_tensor = total_strain
+    variable = strain_xx
+    index_i = 0
+    index_j = 0
+  [../]
+  [./strain_xy]
+    type = RankTwoAux
+    rank_two_tensor = total_strain
+    variable = strain_xy
+    index_i = 0
+    index_j = 1
+  [../]
+  [./strain_yy]
+    type = RankTwoAux
+    rank_two_tensor = total_strain
+    variable = strain_yy
+    index_i = 1
+    index_j = 1
+  [../]
+  [./aux_strain_zz]
+    type = RankTwoAux
+    rank_two_tensor = total_strain
+    variable = aux_strain_zz
+    index_i = 2
+    index_j = 2
+  [../]
+[]
+
+[Functions]
+  [./tempfunc]
+    type = ParsedFunction
+    value = '(1-x)*t'
+  [../]
+[]
+
+[BCs]
+  [./bottom1x]
+    type = PresetBC
+    boundary = 1
+    variable = disp_x
+    value = 0.0
+  [../]
+  [./bottom1y]
+    type = PresetBC
+    boundary = 1
+    variable = disp_y
+    value = 0.0
+  [../]
+  [./bottom2x]
+    type = PresetBC
+    boundary = 2
+    variable = disp_x
+    value = 0.0
+  [../]
+  [./bottom2y]
+    type = PresetBC
+    boundary = 2
+    variable = disp_y
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elastic_tensor]
+    type = ComputeIsotropicElasticityTensor
+    poissons_ratio = 0.3
+    youngs_modulus = 1e6
+    block = '1 2'
+  [../]
+  [./strain1]
+    type = ComputePlaneSmallStrain
+    displacements = 'disp_x disp_y'
+    subblock_index_provider = test_subblock_index_provider
+    scalar_out_of_plane_strain = 'scalar_strain_zz1 scalar_strain_zz2'
+    block = '1 2'
+    eigenstrain_names = eigenstrain
+  [../]
+  [./thermal_strain]
+    type = ComputeThermalExpansionEigenstrain
+    temperature = temp
+    thermal_expansion_coeff = 0.02
+    stress_free_temperature = 0.5
+    block = '1 2'
+    eigenstrain_name = eigenstrain
+  [../]
+  [./stress]
+    type = ComputeLinearElasticStress
+    block = '1 2'
+  [../]
+[]
+
+[UserObjects]
+  [./test_subblock_index_provider]
+    type = TestSubblockIndexProvider
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+  line_search = none
+
+# controls for linear iterations
+  l_max_its = 100
+  l_tol = 1e-10
+
+# controls for nonlinear iterations
+  nl_max_its = 15
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-10
+
+# time control
+  start_time = 0.0
+  dt = 1.0
+  dtmin = 1.0
+  end_time = 2.0
+  num_steps = 5000
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/gold/generalized_plane_strain_scalar_vector_out.e
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/gold/generalized_plane_strain_scalar_vector_out.e
@@ -1,0 +1,1 @@
+generalized_plane_strain_squares_out.e

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/tests
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/tests
@@ -41,4 +41,12 @@
    exodiff = 'out_of_plane_pressure_out.e'
    abs_zero = 1e-9
  [../]
+ [./generalized_plane_strain_scalar_vector]
+   type = 'Exodiff'
+   input = 'generalized_plane_strain_scalar_vector.i'
+   exodiff = 'generalized_plane_strain_scalar_vector_out.e'
+   prereq = 'generalized_plane_strain_squares'
+   abs_zero = 1e-7
+   allow_test_objects = true
+ [../]
 []


### PR DESCRIPTION
Closes #11667.

Adding capability for plane strain strain calculators to accept a vector of out-of-plane scalar variables for layered generalized plane strain simulations.
