### PR TITLE
Add a private param to define material type

### DIFF
--- a/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidPropertiesBase.C
@@ -17,6 +17,7 @@ validParams<PorousFlowFluidPropertiesBase>()
   MooseEnum unit_choice("Kelvin=0 Celsius=1", "Kelvin");
   params.addParam<MooseEnum>(
       "temperature_unit", unit_choice, "The unit of the temperature variable");
+  params.addPrivateParam<std::string>("pf_material_type", "fluid_properties");
   params.addClassDescription("Base class for PorousFlow fluid materials");
   return params;
 }

--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -20,6 +20,7 @@ validParams<PorousFlowMaterial>()
       "PorousFlowDictator", "The UserObject that holds the list of Porous-Flow variable names");
   params.addParam<bool>(
       "at_nodes", false, "Evaluate Material properties at nodes instead of quadpoints");
+  params.addPrivateParam<std::string>("pf_material_type", "pf_material");
   params.addClassDescription("This generalises MOOSE's Material class to allow for Materials that "
                              "hold information related to the nodes in the finite element");
   return params;

--- a/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBase.C
+++ b/modules/porous_flow/src/materials/PorousFlowRelativePermeabilityBase.C
@@ -26,6 +26,7 @@ validParams<PorousFlowRelativePermeabilityBase>()
       0,
       "sum_s_res >= 0 & sum_s_res < 1",
       "Sum of residual saturations over all phases.  Must be between 0 and 1");
+  params.addPrivateParam<std::string>("pf_material_type", "relative_permeability");
   params.addClassDescription("Base class for PorousFlow relative permeability materials");
   return params;
 }


### PR DESCRIPTION
This is an attempt to avoid hard coding names in the action. This PR adds a private param
in the base class of a material type, so that any new derived material that is added will also work. I've only added it to fluid property and relative permeability materials so far to see if it works.

This can be used in the PorousFlowAddMaterialJoiner action to decide whether a joiner material is needed.

I'm open to suggestions for better ways also.

Refs #11652