### PR TITLE
Start cleaning up Console

### DIFF
--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -398,15 +398,8 @@ Console::writeTimestepInformation()
   // Write timestep data for transient executioners
   if (_transient)
   {
-    // Get the length of the time step string
-    std::ostringstream time_step_string;
-    time_step_string << timeStep();
-    unsigned int n = time_step_string.str().size();
-    if (n < 2)
-      n = 2;
-
     // Write time step and time information
-    oss << std::endl << "Time Step " << std::setw(n) << timeStep();
+    oss << "\nTime Step " << timeStep();
 
     // Set precision
     if (_precision > 0)
@@ -418,7 +411,7 @@ Console::writeTimestepInformation()
       oss << std::scientific;
 
     // Print the time
-    oss << ", time = " << time() << std::endl;
+    oss << ", time = " << time() << '\n';
 
     // Show old time information, if desired
     if (_verbose)
@@ -434,7 +427,7 @@ Console::writeTimestepInformation()
   }
 
   // Output to the screen
-  _console << oss.str();
+  _console << oss.str() << std::flush;
 }
 
 void

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -222,7 +222,7 @@ class RunApp(Tester):
         if reason != '':
             self.setStatus(self.fail, reason)
 
-        return reason
+        return output
 
     def processResults(self, moose_dir, options, output):
         """
@@ -238,6 +238,4 @@ class RunApp(Tester):
         # TODO: because RunParallel is now setting every successful status message,
                 refactor testFileOutput and processResults.
         """
-        self.testFileOutput(moose_dir, options, output)
-
-        return output
+        return self.testFileOutput(moose_dir, options, output)

--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -67,7 +67,7 @@ class RunException(RunApp):
             output += "#"*80 + "\n\nUnable to match the following pattern against the program's output:\n\n" + specs['expect_err'] + "\n"
 
         if reason == '':
-            reason = RunApp.testFileOutput(self, moose_dir, options, output)
+            RunApp.testFileOutput(self, moose_dir, options, output)
 
         if reason != '':
             self.setStatus(self.fail, reason)

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -88,14 +88,14 @@
     # Test the transient console output, with negative start-time
     type = RunApp
     input = 'console_transient.i'
-    expect_out = 'Time Step  4, time = -0.600000'
+    expect_out = 'Time Step\s+4, time = -0.600000'
   [../]
   [./transient_perf_int]
     # Test the transient console output with a perf log interval
     type = RunApp
     input = 'console_transient.i'
     cli_args = 'Outputs/screen/perf_log_interval=6'
-    expect_out = 'Time Step  6.*?Moose Test Performance.*?Time Step  7'
+    expect_out = 'Time Step\s+6.*?Moose Test Performance.*?Time Step\s+7'
   [../]
   [./_console]
     # Test the used of MooseObject::_console method


### PR DESCRIPTION
refs #11600

Removing a few unneeded `std::endl` calls in the Timestep output. 
Also removing unneeded width logic. Note: That the width is sized to the field size with a minimum of 2. This is just unecessary and is almost always a no-op and sometimes provides one character of whitespace. Just get rid of it!