### PR TITLE
Had fluid properties doc/config.yml allow test objects

### DIFF
--- a/modules/fluid_properties/doc/config.yml
+++ b/modules/fluid_properties/doc/config.yml
@@ -19,6 +19,7 @@ Extensions:
         includes:
             - framework/include
             - modules/fluid_properties/include
+        allow-test-objects: True
     globals:
         type: MooseDocs.extensions.panoptic
         shortcuts: !include framework/doc/globals.yml

--- a/modules/fluid_properties/doc/content/documentation/systems/AuxKernels/TwoPhaseAverageDensityAux.md
+++ b/modules/fluid_properties/doc/content/documentation/systems/AuxKernels/TwoPhaseAverageDensityAux.md
@@ -1,0 +1,11 @@
+# TwoPhaseAverageDensityAux
+
+!syntax description /AuxKernels/TwoPhaseAverageDensityAux
+
+!syntax parameters /AuxKernels/TwoPhaseAverageDensityAux
+
+!syntax inputs /AuxKernels/TwoPhaseAverageDensityAux
+
+!syntax children /AuxKernels/TwoPhaseAverageDensityAux
+
+!bibtex bibliography

--- a/modules/fluid_properties/doc/content/documentation/systems/Materials/MultiComponentFluidPropertiesMaterialPT.md
+++ b/modules/fluid_properties/doc/content/documentation/systems/Materials/MultiComponentFluidPropertiesMaterialPT.md
@@ -1,0 +1,21 @@
+<!-- MOOSE Documentation Stub: Remove this when content is added. -->
+
+# MultiComponentFluidPropertiesMaterialPT
+
+!alert construction title=Undocumented Class
+The MultiComponentFluidPropertiesMaterialPT class has not been documented, if
+you would like to contribute to MOOSE by writing documentation, please see
+[/generate.md]. The content contained on this page explains the typical
+documentation associated with a MooseObject; however, what is contained is
+ultimately determined by what is necessary to make the documentation clear for
+users.
+
+!syntax description /Materials/MultiComponentFluidPropertiesMaterialPT
+
+!syntax parameters /Materials/MultiComponentFluidPropertiesMaterialPT
+
+!syntax inputs /Materials/MultiComponentFluidPropertiesMaterialPT
+
+!syntax children /Materials/MultiComponentFluidPropertiesMaterialPT
+
+!bibtex bibliography


### PR DESCRIPTION
Apps depending on the fluid properties module that have documentation
allowing test objects have broken documentation due to the lack of
pages for test objects in fluid properties.

Refs #11641

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
