### PR TITLE
Debugging code for restart in LayeredBase. #7570

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -145,6 +145,7 @@ template <class T>
 MooseObjectPtr
 buildObject(const InputParameters & parameters)
 {
+  std::cout << "JDH DEBUG: Factory buildObject..." << std::endl;
   return std::make_shared<T>(parameters);
 }
 
@@ -301,13 +302,17 @@ public:
                             InputParameters parameters,
                             THREAD_ID tid = 0)
   {
-    std::shared_ptr<T> new_object =
-        std::dynamic_pointer_cast<T>(create(obj_name, name, parameters, tid, false));
+    std::cout << "JDH DEBUG: beg Factory::create..." << obj_name << std::endl;
+    std::shared_ptr<MooseObject> ptr = create(obj_name, name, parameters, tid, false);
+    std::cout << "JDH DEBUG: after create" << std::endl;
+    std::shared_ptr<T> new_object = std::dynamic_pointer_cast<T>(ptr);
+    std::cout << "JDH DEBUG: after cast" << std::endl;
     if (!new_object)
       mooseError("We expected to create an object of type '" + demangle(typeid(T).name()) +
                  "'.\nInstead we received a parameters object for type '" + obj_name +
                  "'.\nDid you call the wrong \"add\" method in your Action?");
 
+    std::cout << "JDH DEBUG: end Factory::create..." << std::endl;
     return new_object;
   }
 

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -130,6 +130,7 @@ template <class T>
 std::shared_ptr<MooseObject>
 buildObj(const InputParameters & parameters)
 {
+  std::cout << "JDH DEBUG: Registry buildObj" << std::endl;
   return std::make_shared<T>(parameters);
 }
 

--- a/framework/include/userobject/LayeredBase.h
+++ b/framework/include/userobject/LayeredBase.h
@@ -36,7 +36,7 @@ InputParameters validParams<LayeredBase>();
  * partial sums for the specified number of intervals in a direction
  * (x,y,z).
  */
-class LayeredBase
+class LayeredBase : private Restartable
 {
 public:
   LayeredBase(const InputParameters & parameters);
@@ -114,10 +114,10 @@ protected:
 
 private:
   /// Value of the integral for each layer
-  std::vector<Real> _layer_values;
+  std::vector<Real> & _layer_values;
 
   /// Whether or not each layer has had any value summed into it
-  std::vector<bool> _layer_has_value;
+  std::vector<unsigned int> & _layer_has_value;
 
   /// Subproblem for the child object
   SubProblem & _layered_base_subproblem;

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -668,6 +668,11 @@ public:
         controllable.insert(it->first);
     return controllable;
   }
+  void dump() const
+  {
+    for (auto it = _params.begin(); it != _params.end(); ++it)
+      std::cout << "JDH DEBUG: " << it->first << std::endl;
+  }
 
   /**
    * Provide a set of reserved values for a parameter. These are values that are in addition

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -115,7 +115,9 @@ Factory::create(const std::string & obj_name,
 
   // call the function pointer to build the object
   buildPtr & func = it->second;
+  std::cout << "JDH DEBUG: beg create with func..." << obj_name << std::endl;
   auto obj = (*func)(params);
+  std::cout << "JDH DEBUG: end create with func" << std::endl;
 
   auto fep = std::dynamic_pointer_cast<FEProblemBase>(obj);
   if (fep)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1030,6 +1030,7 @@ MooseApp::registerRestartableData(std::string name,
                                   std::unique_ptr<RestartableDataValue> data,
                                   THREAD_ID tid)
 {
+  print_trace();
   auto & restartable_data = _restartable_data[tid];
   auto insert_pair = moose_try_emplace(restartable_data, name, std::move(data));
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2557,6 +2557,9 @@ FEProblemBase::addUserObject(std::string user_object_name,
                              const std::string & name,
                              InputParameters parameters)
 {
+  std::cout << "\nJDH DEBUG: aUO: " << user_object_name << ", " << name << ", "
+            << _displaced_problem << ", " << libMesh::n_threads() << std::endl
+            << std::endl;
   if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
     parameters.set<SubProblem *>("_subproblem") = _displaced_problem.get();
   else
@@ -2576,9 +2579,11 @@ FEProblemBase::addUserObject(std::string user_object_name,
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
   {
+    std::cout << "JDH DEBUG: in loop: " << tid << ", " << name << std::endl;
     // Create the UserObject
     std::shared_ptr<UserObject> user_object =
         _factory.create<UserObject>(user_object_name, name, parameters, tid);
+    std::cout << "JDH DEBUG: exited create" << std::endl;
     _all_user_objects.addObject(user_object, tid);
 
     // Attempt to create all the possible UserObject types


### PR DESCRIPTION
Attempting to add restart capability to LayeredBase.  This code is full of debugging statements to help understand why the constructor is being called twice.  Not at all ready for merging.

Run nearest_point_layered_average.i in test/tests/userobjects/nearest_point_layered_average/ to see the issue.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
