### PR TITLE
Make add_variables parameter control only non linear variable creation 

### DIFF
--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -344,7 +344,7 @@ TensorMechanicsAction::actOutputGeneration()
   //
   // Add variables (optional)
   //
-  if (_current_task == "add_aux_variable" && getParam<bool>("add_variables"))
+  if (_current_task == "add_aux_variable")
   {
     // Loop through output aux variables
     for (auto out : _generate_output)

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xy.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xy.i
@@ -20,38 +20,6 @@
 [AuxVariables]
   [./temp]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_xy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -62,6 +30,7 @@
     out_of_plane_direction = z
     planar_formulation = GENERALIZED_PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_xy stress_yy stress_zz strain_xx strain_xy strain_yy strain_zz'
   [../]
 []
 
@@ -70,63 +39,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_xy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xy
-    index_j = 1
-    index_i = 0
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_xy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xy
-    index_j = 1
-    index_i = 0
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xz.i
@@ -22,38 +22,6 @@
   [../]
   [./disp_y]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_xz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -64,6 +32,7 @@
     out_of_plane_direction = y
     planar_formulation = GENERALIZED_PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_xz stress_yy stress_zz strain_xx strain_xz strain_yy strain_zz'
   [../]
 []
 
@@ -72,63 +41,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_xz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xz
-    index_j = 2
-    index_i = 0
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_xz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xz
-    index_j = 2
-    index_i = 0
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/gps_yz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/gps_yz.i
@@ -22,38 +22,6 @@
   [../]
   [./disp_x]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -64,6 +32,7 @@
     out_of_plane_direction = x
     planar_formulation = GENERALIZED_PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_yz stress_yy stress_zz strain_xx strain_yz strain_yy strain_zz'
   [../]
 []
 
@@ -72,63 +41,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_yz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yz
-    index_j = 2
-    index_i = 1
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_yz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yz
-    index_j = 2
-    index_i = 1
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xy.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xy.i
@@ -16,38 +16,6 @@
 [AuxVariables]
   [./temp]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_xy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -57,6 +25,7 @@
     out_of_plane_direction = z
     planar_formulation = PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_xy stress_yy stress_zz strain_xx strain_xy strain_yy strain_zz'
   [../]
 []
 
@@ -65,63 +34,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_xy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xy
-    index_j = 1
-    index_i = 0
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_xy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xy
-    index_j = 1
-    index_i = 0
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xz.i
@@ -18,38 +18,6 @@
   [../]
   [./disp_y]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_xz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -59,6 +27,7 @@
     out_of_plane_direction = y
     planar_formulation = PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_xz stress_yy stress_zz strain_xx strain_xz strain_yy strain_zz'
   [../]
 []
 
@@ -67,63 +36,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_xz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xz
-    index_j = 2
-    index_i = 0
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_xz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xz
-    index_j = 2
-    index_i = 0
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_yz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_yz.i
@@ -18,38 +18,6 @@
   [../]
   [./disp_x]
   [../]
-  [./stress_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./stress_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_xx]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_yy]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
-  [./strain_zz]
-    order = CONSTANT
-    family = MONOMIAL
-  [../]
 []
 
 [Modules/TensorMechanics/Master]
@@ -59,6 +27,7 @@
     out_of_plane_direction = x
     planar_formulation = PLANE_STRAIN
     eigenstrain_names = 'eigenstrain'
+    generate_output = 'stress_xx stress_yz stress_yy stress_zz strain_xx strain_yz strain_yy strain_zz'
   [../]
 []
 
@@ -67,63 +36,6 @@
     type = FunctionAux
     variable = temp
     function = tempfunc
-  [../]
-  [./stress_xx]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./stress_yz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yz
-    index_j = 2
-    index_i = 1
-  [../]
-  [./stress_yy]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./stress_zz]
-    type = RankTwoAux
-    rank_two_tensor = stress
-    variable = stress_zz
-    index_j = 2
-    index_i = 2
-  [../]
-
-  [./strain_xx]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_xx
-    index_j = 0
-    index_i = 0
-  [../]
-  [./strain_yz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yz
-    index_j = 2
-    index_i = 1
-  [../]
-  [./strain_yy]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_yy
-    index_j = 1
-    index_i = 1
-  [../]
-  [./strain_zz]
-    type = RankTwoAux
-    rank_two_tensor = total_strain
-    variable = strain_zz
-    index_j = 2
-    index_i = 2
   [../]
 []
 


### PR DESCRIPTION
Closes #11684.

As per @dschwen recommendation on the issue I've made the add_variables parameter only control the creation of Variables and not AuxVariables. 

I've also modified some existing tests to use this the approach of specifying Variables in the input file but using action for AuxVariable creation. 
