### PR TITLE
Remove some references to the water steam eos module

### DIFF
--- a/stork/Makefile.app
+++ b/stork/Makefile.app
@@ -38,7 +38,6 @@ RICHARDS            := no
 SOLID_MECHANICS     := no
 STOCHASTIC_TOOLS    := no
 TENSOR_MECHANICS    := no
-WATER_STEAM_EOS     := no
 XFEM                := no
 POROUS_FLOW         := no
 

--- a/stork/unit/Makefile
+++ b/stork/unit/Makefile
@@ -38,7 +38,6 @@ RICHARDS                  := no
 SOLID_MECHANICS           := no
 STOCHASTIC_TOOLS          := no
 TENSOR_MECHANICS          := no
-WATER_STEAM_EOS           := no
 XFEM                      := no
 POROUS_FLOW               := no
 LEVEL_SET                 := no

--- a/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/Makefile
@@ -38,7 +38,6 @@ RICHARDS                  := no
 SOLID_MECHANICS           := no
 # tensor_mechanics is required by Steps 9-10.
 TENSOR_MECHANICS          := yes
-WATER_STEAM_EOS           := no
 XFEM                      := no
 include $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################

--- a/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/unit/Makefile
@@ -35,7 +35,6 @@ RICHARDS                  := no
 SOLID_MECHANICS           := no
 # tensor_mechanics is required by Steps 9-10.
 TENSOR_MECHANICS          := yes
-WATER_STEAM_EOS           := no
 XFEM                      := no
 include           $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################


### PR DESCRIPTION
Looks like I missed some references to water steam eos in #10259 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
