### PR TITLE
fix incorrect line number calculation in hit

### DIFF
--- a/framework/contrib/hit/lex.h
+++ b/framework/contrib/hit/lex.h
@@ -111,6 +111,10 @@ public:
   /// offset by one.
   char next();
 
+  /// rewind resets the current position and start offsets backward to the first character
+  /// following the last emitted token.
+  void rewind();
+
   /// accept conditionally accepts the next byte of input if it is one of the characters in the
   /// valid set.  It returns true if a character was consumed and false otherwise.
   bool accept(const std::string & valid);


### PR DESCRIPTION
When the consecutive string literal syntax was added to hit, line number
accounting became broken.  There was a case where we "rewinded" back to
the end of a prior token across previously ignored whitespace that may
have included newlines.  Previously, this rewinding did not also rewind
the line count accordingly.  Fix this and add a test to prevent
regressions.

Fixes #11622

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
