### PR TITLE
Tester.py modification for killing jobs in Windows

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -319,7 +319,11 @@ class Tester(MooseObject):
         if self.process is not None:
             try:
                 if platform.system() == "Windows":
-                    self.process.terminate()
+                    from distutils import spawn
+                    if spawn.find_executable("taskkill"):
+                        subprocess.call(['taskkill', '/F', '/T', '/PID', str(self.process.pid)])
+                    else:
+                        self.process.terminate()
                 else:
                     pgid = os.getpgid(self.process.pid)
                     os.killpg(pgid, SIGTERM)


### PR DESCRIPTION
Closes #11700
This pull request modifies the ```Tester.py``` class to be able to correctly kill processes in the Windows environment.
This modification has been tested in the RAVEN software.
