### PR TITLE
Update buildSideList() calls to use non-deprecated version.

### DIFF
--- a/framework/include/geomsearch/PenetrationThread.h
+++ b/framework/include/geomsearch/PenetrationThread.h
@@ -23,24 +23,23 @@ typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
 class PenetrationThread
 {
 public:
-  PenetrationThread(SubProblem & subproblem,
-                    const MooseMesh & mesh,
-                    BoundaryID master_boundary,
-                    BoundaryID slave_boundary,
-                    std::map<dof_id_type, PenetrationInfo *> & penetration_info,
-                    bool check_whether_reasonable,
-                    bool update_location,
-                    Real tangential_tolerance,
-                    bool do_normal_smoothing,
-                    Real normal_smoothing_distance,
-                    PenetrationLocator::NORMAL_SMOOTHING_METHOD normal_smoothing_method,
-                    std::vector<std::vector<FEBase *>> & fes,
-                    FEType & fe_type,
-                    NearestNodeLocator & nearest_node,
-                    const std::map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map,
-                    std::vector<dof_id_type> & elem_list,
-                    std::vector<unsigned short int> & side_list,
-                    std::vector<boundary_id_type> & id_list);
+  PenetrationThread(
+      SubProblem & subproblem,
+      const MooseMesh & mesh,
+      BoundaryID master_boundary,
+      BoundaryID slave_boundary,
+      std::map<dof_id_type, PenetrationInfo *> & penetration_info,
+      bool check_whether_reasonable,
+      bool update_location,
+      Real tangential_tolerance,
+      bool do_normal_smoothing,
+      Real normal_smoothing_distance,
+      PenetrationLocator::NORMAL_SMOOTHING_METHOD normal_smoothing_method,
+      std::vector<std::vector<FEBase *>> & fes,
+      FEType & fe_type,
+      NearestNodeLocator & nearest_node,
+      const std::map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map,
+      const std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> & bc_tuples);
 
   // Splitting Constructor
   PenetrationThread(PenetrationThread & x, Threads::split split);
@@ -80,11 +79,8 @@ protected:
 
   const std::map<dof_id_type, std::vector<dof_id_type>> & _node_to_elem_map;
 
-  std::vector<dof_id_type> & _elem_list;
-  std::vector<unsigned short int> & _side_list;
-  std::vector<boundary_id_type> & _id_list;
-
-  unsigned int _n_elems;
+  // Each boundary condition tuple has three entries, (0=elem-id, 1=side-id, 2=bc-id)
+  const std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> & _bc_tuples;
 
   THREAD_ID _tid;
 

--- a/framework/src/geomsearch/PenetrationLocator.C
+++ b/framework/src/geomsearch/PenetrationLocator.C
@@ -85,13 +85,9 @@ PenetrationLocator::detectPenetration()
 {
   Moose::perf_log.push("detectPenetration()", "Execution");
 
-  // Data structures to hold the element boundary information
-  std::vector<dof_id_type> elem_list;
-  std::vector<unsigned short int> side_list;
-  std::vector<boundary_id_type> id_list;
-
-  // Retrieve the Element Boundary data structures from the mesh
-  _mesh.buildSideList(elem_list, side_list, id_list);
+  // Get list of boundary (elem, side, id) tuples.
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_tuples =
+      _mesh.buildSideList();
 
   // Grab the slave nodes we need to worry about from the NearestNodeLocator
   NodeIdRange & slave_node_range = _nearest_node.slaveNodeRange();
@@ -111,9 +107,7 @@ PenetrationLocator::detectPenetration()
                        _fe_type,
                        _nearest_node,
                        _mesh.nodeToElemMap(),
-                       elem_list,
-                       side_list,
-                       id_list);
+                       bc_tuples);
 
   Threads::parallel_reduce(slave_node_range, pt);
 

--- a/framework/src/geomsearch/PenetrationThread.C
+++ b/framework/src/geomsearch/PenetrationThread.C
@@ -39,9 +39,7 @@ PenetrationThread::PenetrationThread(
     FEType & fe_type,
     NearestNodeLocator & nearest_node,
     const std::map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map,
-    std::vector<dof_id_type> & elem_list,
-    std::vector<unsigned short int> & side_list,
-    std::vector<boundary_id_type> & id_list)
+    const std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> & bc_tuples)
   : _subproblem(subproblem),
     _mesh(mesh),
     _master_boundary(master_boundary),
@@ -60,10 +58,7 @@ PenetrationThread::PenetrationThread(
     _fe_type(fe_type),
     _nearest_node(nearest_node),
     _node_to_elem_map(node_to_elem_map),
-    _elem_list(elem_list),
-    _side_list(side_list),
-    _id_list(id_list),
-    _n_elems(elem_list.size())
+    _bc_tuples(bc_tuples)
 {
 }
 
@@ -84,10 +79,7 @@ PenetrationThread::PenetrationThread(PenetrationThread & x, Threads::split /*spl
     _fe_type(x._fe_type),
     _nearest_node(x._nearest_node),
     _node_to_elem_map(x._node_to_elem_map),
-    _elem_list(x._elem_list),
-    _side_list(x._side_list),
-    _id_list(x._id_list),
-    _n_elems(x._n_elems)
+    _bc_tuples(x._bc_tuples)
 {
 }
 
@@ -1768,9 +1760,10 @@ void
 PenetrationThread::getSidesOnMasterBoundary(std::vector<unsigned int> & sides,
                                             const Elem * const elem)
 {
+  // For each tuple, the fields are (0=elem_id, 1=side_id, 2=bc_id)
   sides.clear();
-  for (unsigned int m = 0; m < _n_elems; ++m)
-    if (_elem_list[m] == elem->id())
-      if (_id_list[m] == static_cast<short>(_master_boundary))
-        sides.push_back(_side_list[m]);
+  for (const auto & t : _bc_tuples)
+    if (std::get<0>(t) == elem->id() &&
+        std::get<2>(t) == static_cast<boundary_id_type>(_master_boundary))
+      sides.push_back(std::get<1>(t));
 }


### PR DESCRIPTION
Remove original elem_list, side_list, id_list data structures.  We are
also able to get rid of _n_elems, since only one line of code was
using it and it's now gone.

Refs #11565.

