### PR TITLE
Modify jacobian calculation for global strain scalar kernel

### DIFF
--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
@@ -40,7 +40,7 @@ public:
 protected:
   std::string _base_name;
 
-  const MaterialProperty<RankFourTensor> & _Cijkl;
+  const MaterialProperty<RankFourTensor> & _dstress_dstrain;
   const MaterialProperty<RankTwoTensor> & _stress;
 
   RankTwoTensor _applied_stress_tensor;

--- a/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
+++ b/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
@@ -33,7 +33,7 @@ validParams<GlobalStrainUserObject>()
 GlobalStrainUserObject::GlobalStrainUserObject(const InputParameters & parameters)
   : ElementUserObject(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
-    _Cijkl(getMaterialProperty<RankFourTensor>(_base_name + "elasticity_tensor")),
+    _dstress_dstrain(getMaterialProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
     _stress(getMaterialProperty<RankTwoTensor>(_base_name + "stress")),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements")),
@@ -78,7 +78,7 @@ GlobalStrainUserObject::execute()
     _residual += _JxW[_qp] * _coord[_qp] * (_stress[_qp] - _applied_stress_tensor);
 
     // diagonal jacobian, integral of elasticity tensor components
-    _jacobian += _JxW[_qp] * _coord[_qp] * _Cijkl[_qp];
+    _jacobian += _JxW[_qp] * _coord[_qp] * _dstress_dstrain[_qp];
   }
 }
 


### PR DESCRIPTION
Use material property  `jacobian_mult` instread of `elasticity_tensor` for jacobian calculation. This approach would be beneficial for multi-phase problems having multiple elasticity tensors. The jacobian multiplier implemented in the stress calculator is used here. 

Refs #11314   
