### PR TITLE
Fix spelling mistake causing config to cross streams

### DIFF
--- a/python/MooseDocs/extensions/config.py
+++ b/python/MooseDocs/extensions/config.py
@@ -22,7 +22,7 @@ class ConfigExtension(command.CommandExtension):
         command.CommandExtension.__init__(self, *args, **kwargs)
         self.local_config = dict()
 
-    def reint(self):
+    def reinit(self):
         self.local_config.clear()
 
     def extend(self, reader, renderer):


### PR DESCRIPTION
(refs #9638)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
