### PR TITLE
Minor tensor mechanics docs clean up

### DIFF
--- a/modules/tensor_mechanics/doc/content/documentation/systems/BCs/Pressure.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/BCs/Pressure.md
@@ -1,21 +1,30 @@
 # Pressure
 
+!syntax description /BCs/Pressure
+
 ## Description
 
-The boundary condition, `Pressure` applies a force to a mesh boundary in the magnitude specified by the user.
-A `component` of the normal vector to the mesh surface (0, 1, or 2 corresponding to the $\hat{x}$, $\hat{y}$, and $\hat{z}$ vector components) is used to determine the direction in which to apply the traction.
+The boundary condition, `Pressure` applies a force to a mesh boundary in the magnitude
+specified by the user.
+A `component` of the normal vector to the mesh surface (0, 1, or 2 corresponding
+to the $\hat{x}$, $\hat{y}$, and $\hat{z}$ vector components) is used to determine
+the direction in which to apply the traction.
 The boundary condition is always applied to the displaced mesh.
 
-The magnitude of the `Pressure` boundary condition can be specified as either a scalar (use the input parameter `factor`), a `function` parameter, or a `Postprocessor` name.
+The magnitude of the `Pressure` boundary condition can be specified as either a
+scalar (use the input parameter `factor`), a `function` parameter, or a `Postprocessor`
+name.
 
-A set of `Pressure` boundary conditions applied to multiple variables in multiple components can be defined with the [PressureAction](/BCs/Pressure/index.md).
+!alert note title=Can Be Created with the Pressure Action
+A set of +`Pressure`+ boundary conditions applied to multiple variables in multiple
+components can be defined with the [PressureAction](/BCs/Pressure/index.md).
 
 ## Example Input File Syntax
 
 !listing modules/tensor_mechanics/test/tests/1D_spherical/finiteStrain_1DSphere_hollow.i block=BCs/outerPressure
 
-!syntax list /BCs/Pressure objects=True actions=False subsystems=False
+!syntax parameters /BCs/Pressure
 
-!syntax list /BCs/Pressure objects=False actions=True subsystems=False
+!syntax inputs /BCs/Pressure
 
-!syntax list /BCs/Pressure objects=False actions=False subsystems=True
+!syntax children /BCs/Pressure

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/OutOfPlanePressure.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Kernels/OutOfPlanePressure.md
@@ -1,19 +1,27 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# OutOfPlanePressure
-
-!alert construction title=Undocumented Class
-The OutOfPlanePressure has not been documented, if you would like to contribute to MOOSE by
-writing documentation, please see [/generate.md]. The content contained on this page explains
-the typical documentation associated with a MooseObject; however, what is contained is ultimately
-determined by what is necessary to make the documentation clear for users.
+# Out-Of-Plane Pressure
 
 !syntax description /Kernels/OutOfPlanePressure
+
+## Description
+
+The `OutOfPlanePressure` kernel applies an out-of-plane pressure value in the
+out-of-plane direction of [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md)
+or 2D plane stress problems.
+Either a function or a postprocessor can be used to specify the value of the
+out-of-plane pressure at each quadrature point.
+\begin{equation}
+  \label{eqn:out_of_plane_pressure}
+  P = f \cdot \hat{n}
+\end{equation}
+where $P$ is the computed pressure, $f$ is the function or postprocessor value of
+the pressure to be applied, and $\hat{n}$ is the unit normal vector to the out-of-plane
+surface.
+Following the convention of the [Pressure](BCs/Pressure.md) boundary condition,
+the unit normal vector is considered to be positive when pointing inward towards
+the surface.
 
 !syntax parameters /Kernels/OutOfPlanePressure
 
 !syntax inputs /Kernels/OutOfPlanePressure
 
 !syntax children /Kernels/OutOfPlanePressure
-
-!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeAxisymmetric1DSmallStrain.md
@@ -2,6 +2,8 @@
 
 !syntax description /Materials/ComputeAxisymmetric1DSmallStrain
 
+## Description
+
 The material `ComputeAxisymmetric1DSmallStrain` calculates the small total
 strain for 1D Axisymmetric systems and is intended for use with
 [Generalized Plane Strain](tensor_mechanics/generalized_plane_strain.md) simulations.

--- a/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/documentation/systems/Materials/ComputeFiniteStrain.md
@@ -107,6 +107,22 @@ the rotation increment.
 
 ## Example Input File Syntax
 
+The finite strain calculator can be activated in the input file through the use of the
+TensorMechanics Master Action, as shown below.
+
+!listing modules/tensor_mechanics/test/tests/finite_strain_elastic/finite_strain_elastic_new_test.i
+         block=Modules/TensorMechanics
+
+!alert note title=Use of the Tensor Mechanics Master Action Recommended
+The [TensorMechanics Master Action](/systems/Modules/TensorMechanics/Master/index.md) is designed to
+automatically determine and set the strain and stress divergence parameters correctly for the
+selected strain formulation.  We recommend that users employ the
+[TensorMechanics Master Action](/systems/Modules/TensorMechanics/Master/index.md) whenever possible
+to ensure consistency between the test function gradients and the strain formulation selected.
+
+Although not recommended, it is possible to directly use the `ComputeFiniteStrain` material
+in the input file.
+
 !listing modules/tensor_mechanics/test/tests/volumetric_deform_grad/elastic_stress.i
          block=Materials/strain
 


### PR DESCRIPTION
Corrects a few of the minor omissions I noticed when writing the tensor mechanics docs report, mostly missing second level headers in the docs and notes about actions.

@aeslaughter would you please review?

Refs #10516 
