### PR TITLE
Adding UserObject interface for global strain  

### DIFF
--- a/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class GlobalDisplacementAux;
-class GlobalStrainUOInterface;
+class GlobalStrainUserObjectInterface;
 class RankTwoTensor;
 
 template <>
@@ -33,7 +33,7 @@ protected:
 
   bool _output_global_disp;
 
-  const GlobalStrainUOInterface & _pst;
+  const GlobalStrainUserObjectInterface & _pst;
   const VectorValue<bool> & _periodic_dir;
 
   const unsigned int _dim;

--- a/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class GlobalDisplacementAux;
-class GlobalStrainUserObject;
+class GlobalStrainUOInterface;
 class RankTwoTensor;
 
 template <>
@@ -33,7 +33,7 @@ protected:
 
   bool _output_global_disp;
 
-  const GlobalStrainUserObject & _pst;
+  const GlobalStrainUOInterface & _pst;
   const VectorValue<bool> & _periodic_dir;
 
   const unsigned int _dim;

--- a/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class ComputeGlobalStrain;
-class GlobalStrainUserObject;
+class GlobalStrainUOInterface;
 class RankTwoTensor;
 
 template <>
@@ -37,7 +37,7 @@ protected:
   const VariableValue & _scalar_global_strain;
   MaterialProperty<RankTwoTensor> & _global_strain;
 
-  const GlobalStrainUserObject & _pst;
+  const GlobalStrainUOInterface & _pst;
   const VectorValue<bool> & _periodic_dir;
 
   const unsigned int _dim;

--- a/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class ComputeGlobalStrain;
-class GlobalStrainUOInterface;
+class GlobalStrainUserObjectInterface;
 class RankTwoTensor;
 
 template <>
@@ -37,7 +37,7 @@ protected:
   const VariableValue & _scalar_global_strain;
   MaterialProperty<RankTwoTensor> & _global_strain;
 
-  const GlobalStrainUOInterface & _pst;
+  const GlobalStrainUserObjectInterface & _pst;
   const VectorValue<bool> & _periodic_dir;
 
   const unsigned int _dim;

--- a/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
+++ b/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class GlobalStrain;
-class GlobalStrainUserObject;
+class GlobalStrainUOInterface;
 class RankTwoTensor;
 class RankFourTensor;
 
@@ -34,7 +34,7 @@ public:
 protected:
   virtual void assignComponentIndices(Order var_order);
 
-  const GlobalStrainUserObject & _pst;
+  const GlobalStrainUOInterface & _pst;
   const RankTwoTensor & _pst_residual;
   const RankFourTensor & _pst_jacobian;
   const VectorValue<bool> & _periodic_dir;

--- a/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
+++ b/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
@@ -14,7 +14,7 @@
 
 // Forward Declarations
 class GlobalStrain;
-class GlobalStrainUOInterface;
+class GlobalStrainUserObjectInterface;
 class RankTwoTensor;
 class RankFourTensor;
 
@@ -34,7 +34,7 @@ public:
 protected:
   virtual void assignComponentIndices(Order var_order);
 
-  const GlobalStrainUOInterface & _pst;
+  const GlobalStrainUserObjectInterface & _pst;
   const RankTwoTensor & _pst_residual;
   const RankFourTensor & _pst_jacobian;
   const VectorValue<bool> & _periodic_dir;

--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUOInterface.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUOInterface.h
@@ -1,0 +1,28 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef GLOBALSTRAINUOINTERFACE_H
+#define GLOBALSTRAINUOINTERFACE_H
+
+#include "UserObject.h"
+#include "RankTwoTensor.h"
+#include "RankFourTensor.h"
+/**
+ * This class provides interface for extracting the periodic directions, residual, and jacobian
+ * values from UserObjects associated with global strain calculation
+ */
+class GlobalStrainUOInterface
+{
+public:
+  virtual const RankTwoTensor & getResidual() const = 0;
+  virtual const RankFourTensor & getJacobian() const = 0;
+  virtual const VectorValue<bool> & getPeriodicDirections() const = 0;
+};
+
+#endif // GLOBALSTRAINUOINTERFACE_H

--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
@@ -11,7 +11,7 @@
 #define GLOBALSTRAINUSEROBJECT_H
 
 #include "ElementUserObject.h"
-#include "GlobalStrainUOInterface.h"
+#include "GlobalStrainUserObjectInterface.h"
 
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
@@ -21,7 +21,7 @@ class GlobalStrainUserObject;
 template <>
 InputParameters validParams<GlobalStrainUserObject>();
 
-class GlobalStrainUserObject : public ElementUserObject, public GlobalStrainUOInterface
+class GlobalStrainUserObject : public ElementUserObject, public GlobalStrainUserObjectInterface
 {
 public:
   GlobalStrainUserObject(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
@@ -11,6 +11,8 @@
 #define GLOBALSTRAINUSEROBJECT_H
 
 #include "ElementUserObject.h"
+#include "GlobalStrainUOInterface.h"
+
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
@@ -19,7 +21,7 @@ class GlobalStrainUserObject;
 template <>
 InputParameters validParams<GlobalStrainUserObject>();
 
-class GlobalStrainUserObject : public ElementUserObject
+class GlobalStrainUserObject : public ElementUserObject, public GlobalStrainUOInterface
 {
 public:
   GlobalStrainUserObject(const InputParameters & parameters);
@@ -28,9 +30,9 @@ public:
   void execute() override;
   void threadJoin(const UserObject & uo) override;
   void finalize() override;
-  virtual const RankTwoTensor & getResidual() const;
-  virtual const RankFourTensor & getJacobian() const;
-  virtual const VectorValue<bool> & getPeriodicDirections() const;
+  virtual const RankTwoTensor & getResidual() const override;
+  virtual const RankFourTensor & getJacobian() const override;
+  virtual const VectorValue<bool> & getPeriodicDirections() const override;
 
   /**
    * Calculate additional applied stresses

--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObjectInterface.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObjectInterface.h
@@ -7,8 +7,8 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#ifndef GLOBALSTRAINUOINTERFACE_H
-#define GLOBALSTRAINUOINTERFACE_H
+#ifndef GLOBALSTRAINUSEROBJECTINTERFACE_H
+#define GLOBALSTRAINUSEROBJECTINTERFACE_H
 
 #include "UserObject.h"
 #include "RankTwoTensor.h"
@@ -17,7 +17,7 @@
  * This class provides interface for extracting the periodic directions, residual, and jacobian
  * values from UserObjects associated with global strain calculation
  */
-class GlobalStrainUOInterface
+class GlobalStrainUserObjectInterface
 {
 public:
   virtual const RankTwoTensor & getResidual() const = 0;
@@ -25,4 +25,4 @@ public:
   virtual const VectorValue<bool> & getPeriodicDirections() const = 0;
 };
 
-#endif // GLOBALSTRAINUOINTERFACE_H
+#endif // GLOBALSTRAINUSEROBJECTINTERFACE_H

--- a/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "GlobalDisplacementAux.h"
-#include "GlobalStrainUserObject.h"
+#include "GlobalStrainUOInterface.h"
 
 // MOOSE includes
 #include "Assembly.h"
@@ -42,7 +42,7 @@ GlobalDisplacementAux::GlobalDisplacementAux(const InputParameters & parameters)
     _scalar_global_strain(coupledScalarValue("scalar_global_strain")),
     _component(getParam<unsigned int>("component")),
     _output_global_disp(getParam<bool>("output_global_displacement")),
-    _pst(getUserObject<GlobalStrainUserObject>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
     _periodic_dir(_pst.getPeriodicDirections()),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements")),

--- a/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "GlobalDisplacementAux.h"
-#include "GlobalStrainUOInterface.h"
+#include "GlobalStrainUserObjectInterface.h"
 
 // MOOSE includes
 #include "Assembly.h"
@@ -42,7 +42,7 @@ GlobalDisplacementAux::GlobalDisplacementAux(const InputParameters & parameters)
     _scalar_global_strain(coupledScalarValue("scalar_global_strain")),
     _component(getParam<unsigned int>("component")),
     _output_global_disp(getParam<bool>("output_global_displacement")),
-    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUserObjectInterface>("global_strain_uo")),
     _periodic_dir(_pst.getPeriodicDirections()),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements")),

--- a/modules/tensor_mechanics/src/materials/ComputeGlobalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeGlobalStrain.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ComputeGlobalStrain.h"
-#include "GlobalStrainUserObject.h"
+#include "GlobalStrainUOInterface.h"
 
 // MOOSE includes
 #include "RankTwoTensor.h"
@@ -39,7 +39,7 @@ ComputeGlobalStrain::ComputeGlobalStrain(const InputParameters & parameters)
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _scalar_global_strain(coupledScalarValue("scalar_global_strain")),
     _global_strain(declareProperty<RankTwoTensor>(_base_name + "global_strain")),
-    _pst(getUserObject<GlobalStrainUserObject>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
     _periodic_dir(_pst.getPeriodicDirections()),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements"))

--- a/modules/tensor_mechanics/src/materials/ComputeGlobalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeGlobalStrain.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ComputeGlobalStrain.h"
-#include "GlobalStrainUOInterface.h"
+#include "GlobalStrainUserObjectInterface.h"
 
 // MOOSE includes
 #include "RankTwoTensor.h"
@@ -39,7 +39,7 @@ ComputeGlobalStrain::ComputeGlobalStrain(const InputParameters & parameters)
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _scalar_global_strain(coupledScalarValue("scalar_global_strain")),
     _global_strain(declareProperty<RankTwoTensor>(_base_name + "global_strain")),
-    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUserObjectInterface>("global_strain_uo")),
     _periodic_dir(_pst.getPeriodicDirections()),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements"))

--- a/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
+++ b/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "GlobalStrain.h"
-#include "GlobalStrainUserObject.h"
+#include "GlobalStrainUOInterface.h"
 
 // MOOSE includes
 #include "Assembly.h"
@@ -33,7 +33,7 @@ validParams<GlobalStrain>()
 
 GlobalStrain::GlobalStrain(const InputParameters & parameters)
   : ScalarKernel(parameters),
-    _pst(getUserObject<GlobalStrainUserObject>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
     _pst_residual(_pst.getResidual()),
     _pst_jacobian(_pst.getJacobian()),
     _periodic_dir(_pst.getPeriodicDirections()),

--- a/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
+++ b/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "GlobalStrain.h"
-#include "GlobalStrainUOInterface.h"
+#include "GlobalStrainUserObjectInterface.h"
 
 // MOOSE includes
 #include "Assembly.h"
@@ -33,7 +33,7 @@ validParams<GlobalStrain>()
 
 GlobalStrain::GlobalStrain(const InputParameters & parameters)
   : ScalarKernel(parameters),
-    _pst(getUserObject<GlobalStrainUOInterface>("global_strain_uo")),
+    _pst(getUserObject<GlobalStrainUserObjectInterface>("global_strain_uo")),
     _pst_residual(_pst.getResidual()),
     _pst_jacobian(_pst.getJacobian()),
     _periodic_dir(_pst.getPeriodicDirections()),

--- a/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
+++ b/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
@@ -32,7 +32,7 @@ validParams<GlobalStrainUserObject>()
 
 GlobalStrainUserObject::GlobalStrainUserObject(const InputParameters & parameters)
   : ElementUserObject(parameters),
-    GlobalStrainUOInterface(),
+    GlobalStrainUserObjectInterface(),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _dstress_dstrain(getMaterialProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
     _stress(getMaterialProperty<RankTwoTensor>(_base_name + "stress")),

--- a/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
+++ b/modules/tensor_mechanics/src/userobjects/GlobalStrainUserObject.C
@@ -32,6 +32,7 @@ validParams<GlobalStrainUserObject>()
 
 GlobalStrainUserObject::GlobalStrainUserObject(const InputParameters & parameters)
   : ElementUserObject(parameters),
+    GlobalStrainUOInterface(),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _dstress_dstrain(getMaterialProperty<RankFourTensor>(_base_name + "Jacobian_mult")),
     _stress(getMaterialProperty<RankTwoTensor>(_base_name + "stress")),


### PR DESCRIPTION
Adding UserObject interface for `GlobalStrainUserObject` so that different global strain calculations can be incorporated easily. 

Refs #11314 