### PR TITLE
Add one option to remove extra residual evaluation if a linear solver is chosen

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -145,6 +145,7 @@ setSolverOptions(SolverParams & solver_params)
 
     case Moose::ST_LINEAR:
       setSinglePetscOption("-snes_type", "ksponly");
+      setSinglePetscOption("-snes_monitor_cancel");
       break;
   }
 

--- a/test/tests/kernels/2d_diffusion/tests
+++ b/test/tests/kernels/2d_diffusion/tests
@@ -36,4 +36,11 @@
     petsc_version = '>=3.8.4'
     prereq = testdirichlet
   [../]
+
+  [./actual_linear_solver]
+    type = RunApp
+    input = '2d_diffusion_test.i'
+    cli_args = 'Executioner/solve_type=linear Outputs/exodus=false'
+    absent_out = 'Nonlinear \|R\|'
+  [../]
 []

--- a/test/tests/kernels/2d_diffusion/tests
+++ b/test/tests/kernels/2d_diffusion/tests
@@ -42,5 +42,8 @@
     input = '2d_diffusion_test.i'
     cli_args = 'Executioner/solve_type=linear Outputs/exodus=false'
     absent_out = 'Nonlinear \|R\|'
+    requirement = 'MOOSE should not compute an extra residual if the linear solver is used'
+    issues = '#11760'
+    design = 'FEProblem.md'
   [../]
 []


### PR DESCRIPTION
Closes #11760 #11761

