### PR TITLE
Add neighbor material property storage

### DIFF
--- a/framework/include/loops/ComputeMaterialsObjectThread.h
+++ b/framework/include/loops/ComputeMaterialsObjectThread.h
@@ -30,6 +30,7 @@ public:
                                std::vector<std::shared_ptr<MaterialData>> & neighbor_material_data,
                                MaterialPropertyStorage & material_props,
                                MaterialPropertyStorage & bnd_material_props,
+                               MaterialPropertyStorage & neighbor_material_props,
                                std::vector<Assembly *> & assembly);
 
   // Splitting Constructor
@@ -53,6 +54,7 @@ protected:
   std::vector<std::shared_ptr<MaterialData>> & _neighbor_material_data;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
+  MaterialPropertyStorage & _neighbor_material_props;
 
   /// Reference to the Material object warehouses
   const MaterialWarehouse & _materials;
@@ -63,6 +65,7 @@ protected:
 
   const bool _has_stateful_props;
   const bool _has_bnd_stateful_props;
+  const bool _has_neighbor_stateful_props;
 };
 
 #endif // COMPUTERESIDUALTHREAD_H

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1178,6 +1178,10 @@ public:
    */
   const MaterialPropertyStorage & getMaterialPropertyStorage() { return _material_props; }
   const MaterialPropertyStorage & getBndMaterialPropertyStorage() { return _bnd_material_props; }
+  const MaterialPropertyStorage & getNeighborMaterialPropertyStorage()
+  {
+    return _neighbor_material_props;
+  }
   ///@}
 
   ///@{
@@ -1520,6 +1524,7 @@ protected:
   // material properties
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
+  MaterialPropertyStorage & _neighbor_material_props;
 
   std::vector<std::shared_ptr<MaterialData>> _material_data;
   std::vector<std::shared_ptr<MaterialData>> _bnd_material_data;

--- a/test/tests/dgkernels/2d_diffusion_dg/dg_stateful.i
+++ b/test/tests/dgkernels/2d_diffusion_dg/dg_stateful.i
@@ -1,0 +1,91 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = MONOMIAL
+    [./InitialCondition]
+      type = ConstantIC
+      value = 1
+    [../]
+  [../]
+[]
+
+[Functions]
+  [./forcing_fn]
+    type = ParsedFunction
+    value = 2*pow(e,-x-(y*y))*(1-2*y*y)
+  [../]
+  [./exact_fn]
+    type = ParsedGradFunction
+    value = pow(e,-x-(y*y))
+    grad_x = -pow(e,-x-(y*y))
+    grad_y = -2*y*pow(e,-x-(y*y))
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./abs]
+    type = Reaction
+    variable = u
+  [../]
+  [./forcing]
+    type = BodyForce
+    variable = u
+    function = forcing_fn
+  [../]
+[]
+
+[DGKernels]
+  [./dg_diff]
+    type = DGDiffusion
+    variable = u
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[BCs]
+  [./all]
+    type = DGFunctionDiffusionDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    function = exact_fn
+    epsilon = -1
+    sigma = 6
+  [../]
+[]
+
+[Materials]
+  [./stateful]
+    type = StatefulMaterial
+    initial_diffusivity = 1
+    boundary = 'left'
+  [../]
+  [./general]
+    type = GenericConstantMaterial
+    block = '0'
+    prop_names = 'dummy'
+    prop_values = '1'
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  nl_rel_tol = 1e-10
+[]

--- a/test/tests/dgkernels/2d_diffusion_dg/tests
+++ b/test/tests/dgkernels/2d_diffusion_dg/tests
@@ -6,4 +6,11 @@
     group = 'requirements adaptive'
     max_parallel = 1
   [../]
+  [./stateful_props]
+    type = 'RunApp'
+    input = 'dg_stateful.i'
+    requirement = 'DGKernels shall coexist with stateful material properties'
+    issues = '#11766'
+    design = 'DGKernels/index.md'
+  [../]
 []


### PR DESCRIPTION
Mirrors `_material_props` and `_bnd_material_props`. Key changes are that:

- We initialize `_neighbor_material_data` with `_neighbor_material_props` instead of `_bnd_material_props`
- in `ComputeMaterialsObjectThread::onInternalSide` we check whether `_has_neighbor_stateful_props` instead of `_has_bnd_stateful_props`

Closes #11766