### PR TITLE
Fix improper substring slicing in hit lexer rewind function.

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -102,9 +102,13 @@ Lexer::rewind()
 {
   if (!peek()) // don't do anything if we are at EOF
     return;
+
   auto tmp = lastToken();
+  if (tmp >= _start)
+    return;
+
   // subtract newlines that may have been ignored
-  _line_count -= lineCount(_input.substr(tmp, _start));
+  _line_count -= lineCount(_input.substr(tmp, _start - tmp));
   _pos = tmp;
   if (_pos < _start)
     _start = _pos;
@@ -354,6 +358,8 @@ lexString(Lexer * l)
     quote = "\"";
   else if (l->peek() == '\'')
     quote = "'";
+  else
+    return l->error("the parser is horribly broken");
 
   // this is a loop in order to enable consecutive string literals to be parsed
   while (l->accept(quote))

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -418,13 +418,13 @@ private:
 };
 
 /// parse is *the* function in the hit namespace.  It takes the given hit input text and
-/// parses and builds a hit tree returning the root node.  It throws an exceptions if input
+/// parses and builds a hit tree returning the root node.  It throws an exception if input
 /// contains any invalid hit syntax.  fname is label given as a convenience (and can be any
 /// string) used to prefix any error messages generated during the parsing process.  The caller
 /// accepts ownership of the returned root node and is responsible for destructing it.
 Node * parse(const std::string & fname, const std::string & input);
 
-/// parses the file checking for errors, but don't return any built node tree.
+/// parses the file checking for errors but does not return any node tree.
 inline void
 check(const std::string & fname, const std::string & input)
 {
@@ -440,7 +440,7 @@ check(const std::string & fname, const std::string & input)
 void merge(Node * from, Node * into);
 
 /// explode walks the tree converting/exploding any fields that have path separators into them into
-/// actually sections/subsections/etc. with the final path element as the field name.  For example,
+/// actuall sections/subsections/etc. with the final path element as the field name.  For example,
 /// "foo/bar=42" becomes nodes with the structure "[foo] bar=42 []".  If nodes for sections already
 /// exist in the tree, the fields will be moved into them rather than new sections created.  The
 /// returned node is the root of the exploded tree.

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -95,7 +95,11 @@ private:
 
 TEST(HitTests, LineNumbers)
 {
-  LineCase cases[] = {{"[hello] foo='bar'\n\n\n boo='far'\n\n[]", {1, 1, 2, 4, 5, 6}}};
+  // list of expected line numbers for nodes starts at line 1 and skips root and blankline nodes
+  LineCase cases[] = {
+      {"[hello] foo='bar'\n\n\n boo='far'\n\n[]", {1, 1, 4}},
+      {"[hello]\n  foo='bar'\n[]\n[goodbye]\n  boo=42\n[]", {1, 2, 4, 5}},
+      {"[hello]\n\n # comment\n foo='bar' 'baz' # another comment\n\nboo=42[]", {1, 3, 4, 4, 6}}};
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(LineCase); i++)
   {


### PR DESCRIPTION
And add tests to prevent regressions.  Incorrect line numbers were being
recorded under certain circumstances. Fixes issue introduced by fix for
issue #11622.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
