### PR TITLE
IterationAdaptiveDT rejects step only based on PP value

### DIFF
--- a/framework/include/timesteppers/IterationAdaptiveDT.h
+++ b/framework/include/timesteppers/IterationAdaptiveDT.h
@@ -50,7 +50,6 @@ protected:
 
   void computeAdaptiveDT(Real & dt, bool allowToGrow = true, bool allowToShrink = true);
   Real computeInterpolationDT();
-  void limitDT(Real & limitedDT);
   void limitDTByFunction(Real & limitedDT);
   void limitDTToPostprocessorValue(Real & limitedDT);
 

--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -230,14 +230,6 @@ IterationAdaptiveDT::constrainStep(Real & dt)
 {
   bool at_sync_point = TimeStepper::constrainStep(dt);
 
-  limitDT(dt);
-
-  return at_sync_point;
-}
-
-void
-IterationAdaptiveDT::limitDT(Real & dt)
-{
   // Limit the timestep to postprocessor value
   limitDTToPostprocessorValue(dt);
 
@@ -255,6 +247,8 @@ IterationAdaptiveDT::limitDT(Real & dt)
                << *_tfunc_times.begin() << " dt: " << std::setw(9) << dt << '\n';
     }
   }
+
+  return at_sync_point;
 }
 
 Real
@@ -299,7 +293,7 @@ IterationAdaptiveDT::converged()
 
   // we get what the next time step should be
   Real dt_test = _dt;
-  limitDT(dt_test);
+  limitDTToPostprocessorValue(dt_test);
 
   // we cannot constrain the time step any further
   if (dt_test == 0)


### PR DESCRIPTION
The `IterationAdaptiveDT` only uses the value from the Post-Processor to check whether the current time step needs to be rejected.

Tagging @bwspenc 

#closes #11745