### PR TITLE
Throw a better error when case is incorrect in registration

### DIFF
--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -237,6 +237,9 @@ Factory::deprecatedMessage(const std::string obj_name)
 void
 Factory::reportUnregisteredError(const std::string & obj_name) const
 {
+  // Make sure that we don't have an improperly registered object first
+  _app.checkRegistryLabels();
+
   std::ostringstream oss;
   std::set<std::string> paths = _app.getLoadedLibraryPaths();
 


### PR DESCRIPTION
If an object is used in the input file and it's registered incorrectly,
the parser won't even be able to build that object and would normally
just tell the user it wasn't registered. This is not a useful error because
the object might indeed be registered, but just under a nonsense label.
To combat this case we'll check to make sure that the label is OK right
before we are going to die anyway due to an unregistered error.

Note: There's not really a good way to test for this condition, it would
require a separate poorly registered object somewhere, but since we report
all incorrectly registered objects, that entire application would only
serve to report this error. It's still worth reporting because it's a
relatively easy mistake to make in a new app (e.g. case difference).

closes #11644

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
