### PR TITLE
Fixed the class name for the errorIfDistributedMesh function argument.

### DIFF
--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -63,7 +63,7 @@ void
 AddSideSetsFromBoundingBox::modify()
 {
   // this modifier is not designed for working with distributed mesh
-  _mesh_ptr->errorIfDistributedMesh("BreakBoundaryOnSubdomain");
+  _mesh_ptr->errorIfDistributedMesh("AddSideSetsFromBoundingBox");
 
   // Check that we have access to the mesh
   if (!_mesh_ptr)

--- a/framework/src/meshmodifiers/MeshSideSet.C
+++ b/framework/src/meshmodifiers/MeshSideSet.C
@@ -39,13 +39,13 @@ void
 MeshSideSet::modify()
 {
   // this modifier is not designed for working with distributed mesh
-  _mesh_ptr->errorIfDistributedMesh("BreakBoundaryOnSubdomain");
+  _mesh_ptr->errorIfDistributedMesh("MeshSideSet");
 
   // Reference the the libMesh::MeshBase
   auto & mesh = _mesh_ptr->getMesh();
   auto & boundary_info = mesh.get_boundary_info();
 
-  // get IDs of all boundaries to be broken
+  // get IDs of all boundaries with which a new block is created
   std::set<BoundaryID> mesh_boundary_ids;
   if (isParamValid("boundaries"))
   {


### PR DESCRIPTION
Closes #11787

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
