### PR TITLE
BoundaryRestrictable FeatureFloodCount

### DIFF
--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -14,6 +14,7 @@
 #include "GeneralPostprocessor.h"
 #include "InfixIterator.h"
 #include "MooseVariableDependencyInterface.h"
+#include "BoundaryRestrictable.h"
 
 #include <iterator>
 #include <list>
@@ -43,7 +44,8 @@ InputParameters validParams<FeatureFloodCount>();
  */
 class FeatureFloodCount : public GeneralPostprocessor,
                           public Coupleable,
-                          public MooseVariableDependencyInterface
+                          public MooseVariableDependencyInterface,
+                          public BoundaryRestrictable
 {
 public:
   FeatureFloodCount(const InputParameters & parameters);
@@ -296,6 +298,12 @@ public:
   const std::vector<FeatureData> & getFeatures() const { return _feature_sets; }
 
 protected:
+  /**
+   * Returns a Boolean indicating whether the entity is on one of the desired boundaries.
+   */
+  template <typename T>
+  bool isBoundaryEntity(const T * entity) const;
+
   /**
    * This method is used to populate any of the data structures used for storing field data (nodal
    * or elemental). It is called at the end of finalize and can make use of any of the data
@@ -652,6 +660,11 @@ protected:
 
   /// Convenience variable for testing master rank
   bool _is_master;
+
+  /// Indicates that this object should only run on one or more boundaries
+  bool _is_boundary_restricted;
+
+  ConstBndElemRange * _bnd_elem_range;
 };
 
 template <>

--- a/modules/phase_field/test/tests/flood_counter_aux_test/flood_counter_boundary_restrictable.i
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/flood_counter_boundary_restrictable.i
@@ -1,0 +1,110 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 20
+  ny = 20
+  nz = 0
+
+  xmax = 40
+  ymax = 40
+  zmax = 0
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./bubble_map]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Kernels]
+  active = 'diff forcing_1 forcing_2 forcing_3 forcing_4 dot'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./forcing_1]
+    type = GaussContForcing
+    variable = u
+    x_center = 1.0
+    y_center = 1.0
+    x_spread = 0.5
+    y_spread = 0.5
+    amplitude = 2.0
+  [../]
+
+  [./forcing_2]
+    type = GaussContForcing
+    variable = u
+    x_center = 20.0
+    y_center = 39.0
+    x_spread = 0.5
+    y_spread = 0.5
+    amplitude = 2.0
+  [../]
+
+  [./forcing_3]
+    type = GaussContForcing
+    variable = u
+    x_center = 39.0
+    y_center = 20.0
+    x_spread = 0.5
+    y_spread = 0.5
+    amplitude = 2.0
+  [../]
+
+  [./forcing_4]
+    type = GaussContForcing
+    variable = u
+    x_center = 15.0
+    y_center = 15.0
+    x_spread = 0.5
+    y_spread = 0.5
+    amplitude = 2.0
+  [../]
+
+  [./dot]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[AuxKernels]
+  [./mapper]
+    type = FeatureFloodCountAux
+    variable = bubble_map
+    execute_on = 'initial timestep_end'
+    flood_counter = bubbles
+  [../]
+[]
+
+[Postprocessors]
+  [./bubbles]
+    type = FeatureFloodCount
+    variable = u
+    threshold = 0.1
+    execute_on = 'initial timestep_end'
+    boundary = 'top right left bottom'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 4.0
+  num_steps = 2
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+  csv = true
+[]

--- a/modules/phase_field/test/tests/flood_counter_aux_test/gold/boundary_all.csv
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/gold/boundary_all.csv
@@ -1,0 +1,3 @@
+time,bubbles
+4,3
+8,3

--- a/modules/phase_field/test/tests/flood_counter_aux_test/gold/boundary_single.csv
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/gold/boundary_single.csv
@@ -1,0 +1,3 @@
+time,bubbles
+4,1
+8,1

--- a/modules/phase_field/test/tests/flood_counter_aux_test/tests
+++ b/modules/phase_field/test/tests/flood_counter_aux_test/tests
@@ -29,4 +29,20 @@
     allow_test_objects = true
     max_parallel = 1 # See #9886
   [../]
+
+  [./bound_restrict_single]
+    type = 'CSVDiff'
+    input = 'flood_counter_boundary_restrictable.i'
+    csvdiff = 'boundary_single.csv'
+    cli_args = 'Postprocessors/bubbles/boundary=top Outputs/file_base=boundary_single'
+    allow_test_objects = true
+  [../]
+
+  [./bound_restrict_all]
+    type = 'CSVDiff'
+    input = 'flood_counter_boundary_restrictable.i'
+    csvdiff = 'boundary_all.csv'
+    cli_args = 'Outputs/file_base=boundary_all'
+    allow_test_objects = true
+  [../]
 []


### PR DESCRIPTION
Adding experimental support for boundary restrictable FeatureFloodCount and
derived objects.

closes #11813

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Tag @tonkmr 