### PR TITLE
Minor edits to GrandPotentialKernelAction.

### DIFF
--- a/modules/phase_field/doc/content/source/action/GrandPotentialKernelAction.md
+++ b/modules/phase_field/doc/content/source/action/GrandPotentialKernelAction.md
@@ -84,14 +84,12 @@ All of the inputs in these groups are explained below:
       mobility_name_gr = L
       kappa_gr = kappa
       free_energies_gr = 'omegab omegam'
-      energy_barrier_gr = mu
 
       additional_ops = 'phi'
       gamma_grxop = gamma
       mobility_name_op = L_phi
       kappa_op = kappa
       free_energies_op = 'omegab omegam'
-      energy_barrier_op = mu
     [../]
   [../]
 []

--- a/modules/phase_field/src/action/GrandPotentialKernelAction.C
+++ b/modules/phase_field/src/action/GrandPotentialKernelAction.C
@@ -20,7 +20,8 @@ InputParameters
 validParams<GrandPotentialKernelAction>()
 {
   InputParameters parameters = validParams<Action>();
-
+  parameters.addClassDescription(
+      "Automatically generate most or all of the kernels for the grand potential model");
   parameters.addRequiredParam<std::vector<NonlinearVariableName>>(
       "chemical_potentials", "List of chemical potential variables");
   parameters.addRequiredParam<std::vector<MaterialPropertyName>>(
@@ -212,6 +213,7 @@ GrandPotentialKernelAction::act()
     params.set<bool>("use_displaced_mesh") = displaced_mesh;
     params.set<MaterialPropertyName>("kappa_name") = kappa;
     params.set<MaterialPropertyName>("mob_name") = mob_name;
+    params.set<std::vector<VariableName>>("args") = v2;
     kernel_name = "ACInt_" + var_name;
     _problem->addKernel("ACInterface", kernel_name, params);
 


### PR DESCRIPTION
First, adds an extra "args" to one kernel in the GrandPotentialKernelAction to reduce warning messages.
Second, deletes two lines from the example code in the .md file as the syntax was eliminated.
Closes #11831 