### PR TITLE
Drop unused configure flag.

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -124,7 +124,6 @@ if [ -z "$go_fast" ]; then
                --enable-silent-rules \
                --enable-unique-id \
                --disable-warnings \
-               --enable-unique-ptr \
                --with-thread-model=openmp \
                --disable-maintainer-mode \
                --enable-petsc-hypre-required \


### PR DESCRIPTION
--enable-unique-ptr is now the (required) default, and configure warns
if you still provide it.

Refs libMesh/libmesh#1635.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
