### PR TITLE
GrainTracker tolerate failure

### DIFF
--- a/modules/phase_field/examples/grain_growth/3D_6000_gr.i
+++ b/modules/phase_field/examples/grain_growth/3D_6000_gr.i
@@ -11,12 +11,10 @@
   zmin = 0
   zmax = 180
   elem_type = HEX8
-
-  parallel_type = distributed
 []
 
 [GlobalParams]
-  op_num = 25
+  op_num = 28
   var_name_base = gr
 []
 
@@ -47,7 +45,6 @@
     [../]
   [../]
 []
-
 
 [AuxVariables]
   [./bnds]
@@ -168,8 +165,8 @@
   type = Transient
   scheme = bdf2
   solve_type = PJFNK #Preconditioned JFNK (default)
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre    boomeramg'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'asm     '
   l_tol = 1.0e-4
   l_max_its = 30
   nl_max_its = 20
@@ -196,7 +193,7 @@
 []
 
 [Outputs]
-  exodus = true
+  nemesis = true
   checkpoint = true
   csv = true
   [./console]

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -182,7 +182,7 @@ protected:
   const unsigned short _halo_level;
 
   /// Depth of renumbering recursion (a depth of zero means no recursion)
-  static const unsigned int _max_renumbering_recursion = 4;
+  const unsigned short _max_remap_recursion_depth;
 
   /// The number of reserved order parameters
   const unsigned short _n_reserve_ops;
@@ -196,6 +196,9 @@ protected:
 
   /// Inidicates whether remapping should be done or not (remapping is independent of tracking)
   const bool _remap;
+
+  /// Indicates whether we should continue after a remap failure (will result in non-physical results)
+  const bool _tolerate_failure;
 
   /// A reference to the nonlinear system (used for retrieving solution vectors)
   NonlinearSystemBase & _nl;

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -452,6 +452,9 @@ GrainTracker::trackGrains()
       _console << '\n' << std::endl;
     }
 
+    // Before we track grains, lets sort them so that we get parallel consistent answers
+    std::sort(_feature_sets.begin(), _feature_sets.end());
+
     /**
      * To track grains across time steps, we will loop over our unique grains and link each one up
      * with one of our new unique grains. The criteria for doing this will be to find the unique

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -65,10 +65,12 @@ GrainTracker::GrainTracker(const InputParameters & parameters)
     GrainTrackerInterface(),
     _tracking_step(getParam<int>("tracking_step")),
     _halo_level(getParam<unsigned short>("halo_level")),
+    _max_remap_recursion_depth(getParam<unsigned short>("max_remap_recursion_depth")),
     _n_reserve_ops(getParam<unsigned short>("reserve_op")),
     _reserve_op_index(_n_reserve_ops <= _n_vars ? _n_vars - _n_reserve_ops : 0),
     _reserve_op_threshold(getParam<Real>("reserve_op_threshold")),
     _remap(getParam<bool>("remap_grains")),
+    _tolerate_failure(getParam<bool>("tolerate_failure")),
     _nl(_fe_problem.getNonlinearSystemBase()),
     _feature_sets_old(declareRestartableData<std::vector<FeatureData>>("unique_grains")),
     _poly_ic_uo(parameters.isParamValid("polycrystal_ic_uo")
@@ -82,6 +84,11 @@ GrainTracker::GrainTracker(const InputParameters & parameters)
     _max_curr_grain_id(0),
     _is_transient(_subproblem.isTransient())
 {
+  if (_tolerate_failure)
+    paramInfo("tolerate_failure",
+              "Tolerate failure has been set to true. Non-physical simulation results "
+              "are possible, you will be notified in the event of a failed remapping operation.");
+
   if (_tracking_step > 0 && _poly_ic_uo)
     mooseError("Can't start tracking after the initial condition when using a polycrystal_ic_uo");
 }
@@ -821,9 +828,13 @@ GrainTracker::remapGrains()
      */
     bool any_grains_remapped = false;
     bool grains_remapped;
+
+    std::set<unsigned int> notify_ids;
     do
     {
       grains_remapped = false;
+      notify_ids.clear();
+
       for (auto & grain1 : _feature_sets)
       {
         // We need to remap any grains represented on any variable index above the cuttoff
@@ -835,10 +846,10 @@ GrainTracker::remapGrains()
                      << ", remapping to another variable\n"
                      << COLOR_DEFAULT;
 
-          for (auto max = decltype(_max_renumbering_recursion)(0);
-               max <= _max_renumbering_recursion;
+          for (auto max = decltype(_max_remap_recursion_depth)(0);
+               max <= _max_remap_recursion_depth;
                ++max)
-            if (max < _max_renumbering_recursion)
+            if (max < _max_remap_recursion_depth)
             {
               if (attemptGrainRenumber(grain1, 0, max))
                 break;
@@ -846,10 +857,14 @@ GrainTracker::remapGrains()
             else if (!attemptGrainRenumber(grain1, 0, max))
             {
               _console << std::flush;
-              mooseError(COLOR_RED,
-                         "Unable to find any suitable order parameters for remapping."
-                         " Perhaps you need more op variables?\n\n",
-                         COLOR_DEFAULT);
+              std::stringstream oss;
+              oss << "Unable to find any suitable order parameters for remapping while working "
+                  << "with Grain #" << grain1._id << ", which is on a reserve order parameter.\n"
+                  << "\n\nPossible Resolutions:\n"
+                  << "\t- Add more order parameters to your simulation (8 for 2D, 28 for 3D)\n"
+                  << "\t- Increase adaptivity or reduce your grain boundary widths\n"
+                  << "\t- Make sure you are not starting with too many grains for the mesh size\n";
+              mooseError(oss.str());
             }
 
           grains_remapped = true;
@@ -871,30 +886,47 @@ GrainTracker::remapGrains()
                        << grain2._id << " (variable index: " << grain1._var_index << ")\n"
                        << COLOR_DEFAULT;
 
-            for (auto max = decltype(_max_renumbering_recursion)(0);
-                 max <= _max_renumbering_recursion;
+            for (auto max = decltype(_max_remap_recursion_depth)(0);
+                 max <= _max_remap_recursion_depth;
                  ++max)
-              if (max < _max_renumbering_recursion)
+            {
+              if (max < _max_remap_recursion_depth)
               {
                 if (attemptGrainRenumber(grain1, 0, max))
+                {
+                  grains_remapped = true;
                   break;
+                }
               }
               else if (!attemptGrainRenumber(grain1, 0, max) &&
                        !attemptGrainRenumber(grain2, 0, max))
               {
-                _console << std::flush;
-                mooseError(COLOR_RED,
-                           "Unable to find any suitable order parameters for remapping."
-                           " Perhaps you need more op variables?\n\n",
-                           COLOR_DEFAULT);
+                notify_ids.insert(grain1._id);
+                notify_ids.insert(grain2._id);
               }
-
-            grains_remapped = true;
+            }
           }
         }
       }
       any_grains_remapped |= grains_remapped;
     } while (grains_remapped);
+
+    if (!notify_ids.empty())
+    {
+      _console << std::flush;
+      std::stringstream oss;
+      oss << "Unable to find any suitable order parameters for remapping while working "
+          << "with the following grain IDs:\n"
+          << Moose::stringify(notify_ids, ", ", "", true) << "\n\nPossible Resolutions:\n"
+          << "\t- Add more order parameters to your simulation (8 for 2D, 28 for 3D)\n"
+          << "\t- Increase adaptivity or reduce your grain boundary widths\n"
+          << "\t- Make sure you are not starting with too many grains for the mesh size\n";
+
+      if (_tolerate_failure)
+        mooseWarning(oss.str());
+      else
+        mooseError(oss.str());
+    }
 
     // Verify that split grains are still intact
     for (auto & split_pair : split_pairs)

--- a/modules/phase_field/src/postprocessors/GrainTrackerInterface.C
+++ b/modules/phase_field/src/postprocessors/GrainTrackerInterface.C
@@ -20,6 +20,13 @@ validParams<GrainTrackerInterface>()
       "halo_level", 2, "The thickness of the halo surrounding each feature.");
   params.addParam<bool>(
       "remap_grains", true, "Indicates whether remapping should be done or not (default: true)");
+  params.addParam<bool>("tolerate_failure",
+                        false,
+                        "Allow the grain tracker to continue when it fails to find suitable grains "
+                        "for remapping. This will allow the simulation to continue but it will "
+                        "also allow non-physical grain coalesnce. DO NOT USE for production "
+                        "results!");
+
   params.addParam<unsigned short>(
       "reserve_op",
       0,
@@ -33,6 +40,13 @@ validParams<GrainTrackerInterface>()
                         "Terminate with an error if a grain is created "
                         "(does not include initial callback to start simulation)");
 
+  params.addParam<unsigned short>("max_remap_recursion_depth",
+                                  6,
+                                  "The recursion depth allowed when searching for remapping "
+                                  "candidates. Note: Setting this value high may result in very "
+                                  "computationally expensive searches with little benefit. "
+                                  "(Recommended level: 6)");
+
   params.addRangeCheckedParam<short>(
       "verbosity_level",
       1,
@@ -43,6 +57,8 @@ validParams<GrainTrackerInterface>()
 
   params.addRequiredCoupledVarWithAutoBuild(
       "variable", "var_name_base", "op_num", "Array of coupled variables");
+
+  params.addParamNamesToGroup("tolerate_failure max_remap_recursion_depth", "Advanced");
 
   // Set suitable default parameters for grain tracking
   params.set<Real>("threshold") = 0.1; // flood out to a fairly low value for grain remapping

--- a/modules/phase_field/test/tests/grain_tracker_test/tests
+++ b/modules/phase_field/test/tests/grain_tracker_test/tests
@@ -132,6 +132,17 @@
     petsc_version = '>=3.5.0'
   [../]
 
+  [./tolerate_remap_failure]
+    type = 'RunApp'
+    input = 'grain_tracker_remapping_test.i'
+    cli_args = 'UserObjects/grain_tracker/tolerate_failure=true UserObjects/voronoi/grain_num=15 Executioner/num_steps=6 UserObjects/voronoi/coloring_algorithm=bt Outputs/exodus=false Outputs/csv=false'
+    expect_out = "Unable to find any suitable order parameters for remapping"
+    allow_warnings = true
+    valgrind = 'NONE'
+    method = '!DBG' # slow test
+    min_parallel = 2
+  [../]
+
   ###################################################
   # Faux grain tracker
   ###################################################


### PR DESCRIPTION
This PR adds the capability for the GrainTracker to fail to remap grains. It adds in info and warnings when doing so since this may result in non-physical simulation behavior. The capability will be useful for studying bad cases and for looking at performance.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
