### PR TITLE
System/Mesh information improvements

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -330,6 +330,11 @@ public:
   bool isSplitMesh() const;
 
   /**
+   * Whether or not we are running with pre-split (distributed mesh)
+   */
+  bool isUseSplit() const;
+
+  /**
    * Return true if the recovery file base is set
    */
   bool hasRecoverFileBase();
@@ -709,6 +714,9 @@ protected:
 
   /// Whether or not we are performing a split mesh operation (--split-mesh)
   bool _split_mesh;
+
+  /// Whether or not we are using a (pre-)split mesh (automatically DistributedMesh)
+  const bool _use_split;
 
   /// Whether or not FPE trapping should be turned on.
   bool _trap_fpe;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -570,7 +570,7 @@ public:
   /**
    * Returns the Relationship managers info suitable for printing.
    */
-  std::vector<std::pair<std::string, std::string>> getRelationshipManagerInfo();
+  std::vector<std::pair<std::string, std::string>> getRelationshipManagerInfo() const;
 
   /**
    * Return the app level ExecFlagEnum, this contains all the available flags for the app.

--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -42,7 +42,7 @@ std::string indent(unsigned int spaces);
  *
  * This includes the versions and timestamps
  */
-std::string outputFrameworkInformation(MooseApp & app);
+std::string outputFrameworkInformation(const MooseApp & app);
 
 /**
  * Output the mesh information
@@ -63,12 +63,12 @@ std::string outputNonlinearSystemInformation(FEProblemBase & problem);
 /**
  * Output action RelationshipManager information
  */
-std::string outputRelationshipManagerInformation(MooseApp & app);
+std::string outputRelationshipManagerInformation(const MooseApp & app);
 
 /**
  * Output execution information
  */
-std::string outputExecutionInformation(MooseApp & app, FEProblemBase & problem);
+std::string outputExecutionInformation(const MooseApp & app, FEProblemBase & problem);
 
 /**
  * Output the output information
@@ -80,7 +80,7 @@ std::string outputOutputInformation(MooseApp & app);
  * @param system The libMesh system to output
  * @see outputAuxiliarySystemInformation outputNonlinearSystemInformation
  */
-std::string outputSystemInformationHelper(const System & system);
+std::string outputSystemInformationHelper(System & system);
 
 /**
  * Helper function function for stringstream formatting

--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -47,8 +47,7 @@ std::string outputFrameworkInformation(const MooseApp & app);
 /**
  * Output the mesh information
  */
-std::string
-outputMeshInformation(const MooseApp & app, FEProblemBase & problem, bool verbose = true);
+std::string outputMeshInformation(FEProblemBase & problem, bool verbose = true);
 
 /**
  * Output the Auxiliary system information

--- a/framework/include/outputs/ConsoleUtils.h
+++ b/framework/include/outputs/ConsoleUtils.h
@@ -47,7 +47,8 @@ std::string outputFrameworkInformation(MooseApp & app);
 /**
  * Output the mesh information
  */
-std::string outputMeshInformation(FEProblemBase & problem, bool verbose = true);
+std::string
+outputMeshInformation(const MooseApp & app, FEProblemBase & problem, bool verbose = true);
 
 /**
  * Output the Auxiliary system information

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -161,7 +161,7 @@ SetupMeshAction::act()
   if (_current_task == "setup_mesh")
   {
     // switch non-file meshes to be a file-mesh if using a pre-split mesh configuration.
-    if (_app.parameters().get<bool>("use_split"))
+    if (_app.isUseSplit())
     {
       auto split_file = _app.parameters().get<std::string>("split_file");
 
@@ -185,19 +185,20 @@ SetupMeshAction::act()
             mooseError(
                 "Cannot use split mesh for a non-file mesh without specifying --split-file on "
                 "command line");
-          MOOSE_ABORT;
         }
 
         _type = "FileMesh";
         auto new_pars = validParams<FileMesh>();
+
+        // Keep existing parameters where possible
+        new_pars.applyParameters(_moose_object_pars);
+
         new_pars.set<MeshFileName>("file") = split_file;
         new_pars.set<MooseApp *>("_moose_app") = _moose_object_pars.get<MooseApp *>("_moose_app");
-        new_pars.set<MooseEnum>("parallel_type") = "distributed";
         _moose_object_pars = new_pars;
       }
       else
       {
-        _moose_object_pars.set<MooseEnum>("parallel_type") = "distributed";
         if (split_file != "")
           _moose_object_pars.set<MeshFileName>("file") = split_file;
         else

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1555,7 +1555,7 @@ MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType rm_type)
 }
 
 std::vector<std::pair<std::string, std::string>>
-MooseApp::getRelationshipManagerInfo()
+MooseApp::getRelationshipManagerInfo() const
 {
   std::vector<std::pair<std::string, std::string>> info_strings;
   info_strings.reserve(_relationship_managers.size());

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -277,6 +277,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _recover(false),
     _restart(false),
     _split_mesh(false),
+    _use_split(parameters.get<bool>("use_split")),
 #ifdef DEBUG
     _trap_fpe(true),
 #else
@@ -822,6 +823,12 @@ bool
 MooseApp::isSplitMesh() const
 {
   return _split_mesh;
+}
+
+bool
+MooseApp::isUseSplit() const
+{
+  return _use_split;
 }
 
 bool

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -194,11 +194,11 @@ MooseMesh::MooseMesh(const InputParameters & parameters)
       _use_distributed_mesh = true;
       break;
     case 1: // SERIAL
-      if (_app.getDistributedMeshOnCommandLine() || _is_nemesis)
+      if (_app.getDistributedMeshOnCommandLine() || _is_nemesis || _app.isUseSplit())
         _parallel_type_overridden = true;
       break;
     case 2: // DEFAULT
-      // The user did not specify 'distribution = XYZ' in the input file,
+      // The user did not specify 'parallel_type = XYZ' in the input file,
       // so we allow the --distributed-mesh command line arg to possibly turn
       // on DistributedMesh.  If the command line arg is not present, we pick ReplicatedMesh.
       if (_app.getDistributedMeshOnCommandLine())
@@ -208,8 +208,9 @@ MooseMesh::MooseMesh(const InputParameters & parameters)
       // No default switch needed for MooseEnum
   }
 
-  // If the user specifies 'nemesis = true' in the Mesh block, we must use DistributedMesh.
-  if (_is_nemesis)
+  // If the user specifies 'nemesis = true' in the Mesh block, or they are using --use-split,
+  // we must use DistributedMesh.
+  if (_is_nemesis || _app.isUseSplit())
     _use_distributed_mesh = true;
 
   unsigned dim = getParam<MooseEnum>("dim");

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -583,7 +583,7 @@ Console::outputSystemInformation()
     _console << ConsoleUtils::outputFrameworkInformation(_app);
 
   if (_system_info_flags.contains("mesh"))
-    _console << ConsoleUtils::outputMeshInformation(*_problem_ptr);
+    _console << ConsoleUtils::outputMeshInformation(_app, *_problem_ptr);
 
   if (_system_info_flags.contains("nonlinear"))
   {
@@ -620,7 +620,7 @@ Console::meshChanged()
 {
   if (_print_mesh_changed_info)
   {
-    _console << ConsoleUtils::outputMeshInformation(*_problem_ptr, /*verbose = */ false);
+    _console << ConsoleUtils::outputMeshInformation(_app, *_problem_ptr, /*verbose = */ false);
 
     std::string output = ConsoleUtils::outputNonlinearSystemInformation(*_problem_ptr);
     if (!output.empty())

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -583,7 +583,7 @@ Console::outputSystemInformation()
     _console << ConsoleUtils::outputFrameworkInformation(_app);
 
   if (_system_info_flags.contains("mesh"))
-    _console << ConsoleUtils::outputMeshInformation(_app, *_problem_ptr);
+    _console << ConsoleUtils::outputMeshInformation(*_problem_ptr);
 
   if (_system_info_flags.contains("nonlinear"))
   {
@@ -620,7 +620,7 @@ Console::meshChanged()
 {
   if (_print_mesh_changed_info)
   {
-    _console << ConsoleUtils::outputMeshInformation(_app, *_problem_ptr, /*verbose = */ false);
+    _console << ConsoleUtils::outputMeshInformation(*_problem_ptr, /*verbose = */ false);
 
     std::string output = ConsoleUtils::outputNonlinearSystemInformation(*_problem_ptr);
     if (!output.empty())

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -51,7 +51,7 @@ outputFrameworkInformation(const MooseApp & app)
 }
 
 std::string
-outputMeshInformation(const MooseApp & app, FEProblemBase & problem, bool verbose)
+outputMeshInformation(FEProblemBase & problem, bool verbose)
 {
   std::stringstream oss;
   oss << std::left;
@@ -62,7 +62,7 @@ outputMeshInformation(const MooseApp & app, FEProblemBase & problem, bool verbos
   if (verbose)
   {
     bool forced = moose_mesh.isParallelTypeForced();
-    bool pre_split = app.isUseSplit();
+    bool pre_split = problem.getMooseApp().isUseSplit();
 
     // clang-format off
     oss << "Mesh: " << '\n'

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -51,7 +51,7 @@ outputFrameworkInformation(MooseApp & app)
 }
 
 std::string
-outputMeshInformation(FEProblemBase & problem, bool verbose)
+outputMeshInformation(const MooseApp & app, FEProblemBase & problem, bool verbose)
 {
   std::stringstream oss;
   oss << std::left;
@@ -61,13 +61,23 @@ outputMeshInformation(FEProblemBase & problem, bool verbose)
 
   if (verbose)
   {
+    bool forced = moose_mesh.isParallelTypeForced();
+    bool pre_split = app.isUseSplit();
+
+    // clang-format off
     oss << "Mesh: " << '\n'
         << std::setw(console_field_width)
         << "  Parallel Type: " << (moose_mesh.isDistributedMesh() ? "distributed" : "replicated")
-        << (moose_mesh.isParallelTypeForced() ? " (forced) " : "") << '\n'
+        << (forced || pre_split ? " (" : "")
+        << (forced ? "forced" : "")
+        << (forced && pre_split ? ", " : "")
+        << (pre_split ? "pre-split" : "")
+        << (forced || pre_split ? ")" : "")
+        << '\n'
         << std::setw(console_field_width) << "  Mesh Dimension: " << mesh.mesh_dimension() << '\n'
         << std::setw(console_field_width) << "  Spatial Dimension: " << mesh.spatial_dimension()
         << '\n';
+    // clang-format on
   }
 
   oss << std::setw(console_field_width) << "  Nodes:" << '\n'
@@ -144,8 +154,9 @@ outputSystemInformationHelper(const System & system)
 #ifndef LIBMESH_ENABLE_INFINITE_ELEMENTS
     for (unsigned int vg = 0; vg < system.n_variable_groups(); vg++)
     {
-      oss << "\"" << libMesh::Utility::enum_to_string<FEFamily>(
-                         system.get_dof_map().variable_group(vg).type().family)
+      oss << "\""
+          << libMesh::Utility::enum_to_string<FEFamily>(
+                 system.get_dof_map().variable_group(vg).type().family)
           << "\" ";
       curr_string_pos = oss.tellp();
       insertNewline(oss, begin_string_pos, curr_string_pos);
@@ -154,10 +165,12 @@ outputSystemInformationHelper(const System & system)
 #else
     for (unsigned int vg = 0; vg < system.n_variable_groups(); vg++)
     {
-      oss << "\"" << libMesh::Utility::enum_to_string<FEFamily>(
-                         system.get_dof_map().variable_group(vg).type().family)
-          << "\", \"" << libMesh::Utility::enum_to_string<FEFamily>(
-                             system.get_dof_map().variable_group(vg).type().radial_family)
+      oss << "\""
+          << libMesh::Utility::enum_to_string<FEFamily>(
+                 system.get_dof_map().variable_group(vg).type().family)
+          << "\", \""
+          << libMesh::Utility::enum_to_string<FEFamily>(
+                 system.get_dof_map().variable_group(vg).type().radial_family)
           << "\" ";
       curr_string_pos = oss.tellp();
       insertNewline(oss, begin_string_pos, curr_string_pos);
@@ -169,8 +182,9 @@ outputSystemInformationHelper(const System & system)
     oss << std::setw(console_field_width) << "  Infinite Element Mapping: ";
     for (unsigned int vg = 0; vg < system.n_variable_groups(); vg++)
     {
-      oss << "\"" << libMesh::Utility::enum_to_string<InfMapType>(
-                         system.get_dof_map().variable_group(vg).type().inf_map)
+      oss << "\""
+          << libMesh::Utility::enum_to_string<InfMapType>(
+                 system.get_dof_map().variable_group(vg).type().inf_map)
           << "\" ";
       curr_string_pos = oss.tellp();
       insertNewline(oss, begin_string_pos, curr_string_pos);
@@ -190,8 +204,9 @@ outputSystemInformationHelper(const System & system)
 #else
       oss << "\""
           << Utility::enum_to_string<Order>(system.get_dof_map().variable_group(vg).type().order)
-          << "\", \"" << Utility::enum_to_string<Order>(
-                             system.get_dof_map().variable_group(vg).type().radial_order)
+          << "\", \""
+          << Utility::enum_to_string<Order>(
+                 system.get_dof_map().variable_group(vg).type().radial_order)
           << "\" ";
 #endif
       curr_string_pos = oss.tellp();

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -32,7 +32,7 @@ indent(unsigned int spaces)
 }
 
 std::string
-outputFrameworkInformation(MooseApp & app)
+outputFrameworkInformation(const MooseApp & app)
 {
   std::stringstream oss;
   oss << std::left;
@@ -117,7 +117,7 @@ outputNonlinearSystemInformation(FEProblemBase & problem)
 }
 
 std::string
-outputSystemInformationHelper(const System & system)
+outputSystemInformationHelper(System & system)
 {
   std::stringstream oss;
   oss << std::left;
@@ -219,7 +219,7 @@ outputSystemInformationHelper(const System & system)
 }
 
 std::string
-outputRelationshipManagerInformation(MooseApp & app)
+outputRelationshipManagerInformation(const MooseApp & app)
 {
   std::stringstream oss;
   oss << std::left;
@@ -237,7 +237,7 @@ outputRelationshipManagerInformation(MooseApp & app)
 }
 
 std::string
-outputExecutionInformation(MooseApp & app, FEProblemBase & problem)
+outputExecutionInformation(const MooseApp & app, FEProblemBase & problem)
 {
 
   std::stringstream oss;

--- a/test/tests/mesh/splitting/tests
+++ b/test/tests/mesh/splitting/tests
@@ -2,10 +2,9 @@
   [./make_split]
     type = 'CheckFiles'
     input = 'simple_diffusion.i'
-    cli_args = '--split-mesh 3 --split-file foo'
+    cli_args = '--split-mesh 3 --split-file foo Mesh/parallel_type=replicated'
     check_files = 'foo.cpr/3/header.cpr foo.cpr/3/split-3-0.cpr foo.cpr/3/split-3-1.cpr foo.cpr/3/split-3-2.cpr'
     recover = false
-    mesh_mode = REPLICATED
 
     issues = '#10623'
     design = 'Mesh/splitting.md'
@@ -23,6 +22,34 @@
     issues = '#10623'
     design = 'Mesh/splitting.md'
     requirement = 'A mesh can be pre-split properly and used to generate equivalent results to running a simulation with the unsplit mesh.'
+  [../]
+
+  [./check_pre_split]
+    type = 'RunApp'
+    input = 'simple_diffusion.i'
+    cli_args = '--use-split --split-file foo UserObjects/splittester/type=SplitTester Outputs/exodus=false'
+    expect_out = 'Parallel Type:\s+distributed \(pre-split\)'
+    prereq = 'make_split'
+    min_parallel = 3
+    max_parallel = 3
+
+    issues = '#11825'
+    design = 'Mesh/splitting.md'
+    requirement = 'Console output should include an indicator that a pre-split mesh is being used when using --split-mesh in distributed = auto mode'
+  [../]
+
+  [./check_forced_pre_split]
+    type = 'RunApp'
+    input = 'simple_diffusion.i'
+    cli_args = '--use-split --split-file foo Mesh/parallel_type=replicated UserObjects/splittester/type=SplitTester Outputs/exodus=false'
+    expect_out = 'Parallel Type:\s+distributed \(forced, pre-split\)'
+    prereq = 'make_split'
+    min_parallel = 3
+    max_parallel = 3
+
+    issues = '#11825'
+    design = 'Mesh/splitting.md'
+    requirement = 'Console output should include an indicator that a pre-split mesh is being used when using --split-mesh in distributed = auto mode'
   [../]
 
   [./split_with_distributed_error]
@@ -43,12 +70,11 @@
     cli_args = '--split-mesh 2 --split-file geometric_neighbors Mesh/parallel_type=replicated'
     check_files = 'geometric_neighbors.cpr/2/header.cpr geometric_neighbors.cpr/2/split-2-0.cpr geometric_neighbors.cpr/2/split-2-1.cpr'
     recover = false
-    mesh_mode = DISTRIBUTED
     compiler = 'GCC CLANG'
 
     issues = '#11434'
     design = 'Mesh/splitting.md'
-    requirement = 'The mesh splitter will throw an error when an attempt is made to split a "DistributedMesh".'
+    requirement = 'The mesh splitter capability will honor geometric RelationshipManager objects.'
   [../]
 
   [./split_with_RM_part2]
@@ -57,7 +83,6 @@
     cli_args = '--use-split --split-file geometric_neighbors Outputs/file_base=geometric_edge_two_2D_out'
     exodiff = 'geometric_edge_two_2D_out.e'
     recover = false
-    mesh_mode = DISTRIBUTED
     compiler = 'GCC CLANG'
 
     min_parallel = 2
@@ -66,6 +91,6 @@
 
     issues = '#11434'
     design = 'Mesh/splitting.md'
-    requirement = 'The mesh splitter will throw an error when an attempt is made to split a "DistributedMesh".'
+    requirement = 'Meshes that are pre-split with active RelationshipManager objects work the same as if using an online DistributedMesh.'
   [../]
 []


### PR DESCRIPTION
This PR enhances and cleans up Console output and fixes a few bugs in the `--use-split` capability. 
When the split-mesh flag is used, it ignores the settings in the Mesh block completely. I don't think this is the right behavior so I added the applyParameters to pick up other parameters that might apply (even if it's a different mesh type). Also cleaned up the logic for distributed_type. Instead of setting it SetupMeshAction, I'm following the precedence we already have for setting and overriding it in MooseMesh.

Unecessary restrictions removed from a few tests.
New tests for checking console output added.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
