### PR TITLE
Change parmetis as the default partitioner in PetscExternalPartitioner

### DIFF
--- a/framework/doc/content/source/partitioner/PetscExternalPartitioner.md
+++ b/framework/doc/content/source/partitioner/PetscExternalPartitioner.md
@@ -36,11 +36,15 @@ These packages can be accessed via an unified interface in MOOSE, `PetscExternal
     type = PetscExternalPartitioner
     # specify which package you want to use
     # you could choose one of {Chaco, Party, PTScotch, ParMETIS}
-    part_package = ptscotch
+    part_package = parmetis
   []
   parallel_type = distributed
 []
 ```
+
+Note that in order to use {Chaco, Party, PTScotch}, you need to upgrade PETSc to PETSc-3.9.3 or higher
+with additional options: --download-chaco,  --download-party, and --download-ptscotch. But we do NOT encourage
+regular users to upgrade PETSc on their own. We will officially upgrade PETSc soon that will carries all these packages.
 
 ## Partitioning Examples
 

--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -24,7 +24,7 @@ validParams<PetscExternalPartitioner>()
 {
   InputParameters params = validParams<MoosePartitioner>();
 
-  MooseEnum partPackage("parmetis ptscotch chaco party hierarch", "ptscotch", false);
+  MooseEnum partPackage("parmetis ptscotch chaco party hierarch", "parmetis", false);
 
   params.addParam<MooseEnum>("part_package",
                              partPackage,


### PR DESCRIPTION
Because the current moose version of PETSc does not carry all required packages.

Closes #11849

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
