### PR TITLE
Why are you always (double) executing?

### DIFF
--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -829,8 +829,6 @@ void
 Transient::postExecute()
 {
   _time_stepper->postExecute();
-
-  _problem.execute(EXEC_FINAL);
 }
 
 void

--- a/modules/combined/test/tests/beam_eigenstrain_transfer/tests
+++ b/modules/combined/test/tests/beam_eigenstrain_transfer/tests
@@ -26,10 +26,10 @@
     input = 'master_uo_transfer.i'
     cli_args = 'MultiApps/sub/input_files="subapp_err_2.i subapp2_uo_transfer.i" Outputs/csv=false Outputs/exodus=false'
     expect_err = 'LineValueSampler: When calling getValue\(\) on LineValueSampler, only one variable can be provided as input to LineValueSampler.'
-    method='!DBG'
+    method='OPT OPROF' # Test triggers an assert before reaching the expected runtime error
 
     requirement = "LineValueSampler shall report an error if multiple variables"
-                  " are provided as input to the sampler when it is used with" 
+                  " are provided as input to the sampler when it is used with"
                   " MultiAppUserObjectTransfer."
     design = "LineValueSampler.md"
     issues = "#10313"


### PR DESCRIPTION
EXEC_FINAL is already being called in the `execute()` method. This is typical of all the executioners. No need to call it in `postExecute()` too

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
