### PR TITLE
GrainTracker improve grammar

### DIFF
--- a/modules/phase_field/examples/grain_growth/3D_6000_gr.i
+++ b/modules/phase_field/examples/grain_growth/3D_6000_gr.i
@@ -166,7 +166,7 @@
   scheme = bdf2
   solve_type = PJFNK #Preconditioned JFNK (default)
   petsc_options_iname = '-pc_type'
-  petsc_options_value = 'asm     '
+  petsc_options_value = 'asm'
   l_tol = 1.0e-4
   l_max_its = 30
   nl_max_its = 20
@@ -199,6 +199,6 @@
   [./console]
     type = Console
     perf_log = true
-    perf_log_interval = 5
+    perf_log_interval = 1
   [../]
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Fixing up some messaging grammar now that I'm seeing increased pressure with "tolerate failure". This also narrows some scoping and make a few adjustments to the large 3D sim file.

Note to reviewer: Click the ignore whitespace button on Github.