### PR TITLE
Add 'stale' github app configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 1
+
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+closeComment: >
+  Closing due to 30 days of inactivity.
+  See http://mooseframework.org/moose/framework_development/patch_to_code.html
+
+# Limit to only `issues` or `pulls`
+# only: issues
+only: pulls


### PR DESCRIPTION
For https://probot.github.io/apps/stale/
All the config options can be seen here: https://github.com/probot/stale

This is an attempt to auto close PRs when they haven't been active, saving @permcody  some time.
This is configured for 30 days until a comment is added to a stale PR stating that it is going to be closed. Then people have a day to comment or add some activity before it is automatically closed.
If somebody has better numbers than 30 and 1, let me know.

I am hoping the `only: pulls` actually works, otherwise we will go from ~745 issues to 20 :)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
