### PR TITLE
Marking existing methods as virtual

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -471,19 +471,23 @@ public:
   std::set<std::string> & getRecoverableData() { return _recoverable_data; }
 
   /**
-   * Create a Backup from the current App.  A Backup contains all the data necessary to be able
-   * to restore the state of an App.
+   * Create a Backup from the current App. A Backup contains all the data necessary to be able to
+   * restore the state of an App.
+   *
+   * This method should be overridden in external or MOOSE-wrapped applications.
    */
-  std::shared_ptr<Backup> backup();
+  virtual std::shared_ptr<Backup> backup();
 
   /**
-   * Restore a Backup.  This sets the App's state.
+   * Restore a Backup. This sets the App's state.
    *
    * @param backup The Backup holding the data for the app
    * @param for_restart Whether this restoration is explicitly for the first restoration of restart
-   * data
+   * data.
+   *
+   * This method should be overridden in external or MOOSE-wrapped applications.
    */
-  void restore(std::shared_ptr<Backup> backup, bool for_restart = false);
+  virtual void restore(std::shared_ptr<Backup> backup, bool for_restart = false);
 
   /**
    * Returns a string to be printed at the beginning of a simulation


### PR DESCRIPTION
These methods should be marked as virtual so that they can be properly overridden in
external or MOOSE-wrapped applications.

closes #11872

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
