### PR TITLE
Don't print stderr when testing for python2-config

### DIFF
--- a/framework/contrib/hit/Makefile
+++ b/framework/contrib/hit/Makefile
@@ -2,7 +2,7 @@ CXX ?= g++
 
 # some systems have python2 but no python2-config command - fall back to python-config for them
 pyconfig := python2-config
-ifeq (, $(shell which python2-config))
+ifeq (, $(shell which python2-config 2>/dev/null))
   pyconfig := python-config
 endif
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -39,7 +39,7 @@ pyhit_LIB       := $(FRAMEWORK_DIR)/../python/hit.so
 
 # some systems have python2 but no python2-config command - fall back to python-config for them
 pyconfig := python2-config
-ifeq (, $(shell which python2-config))
+ifeq (, $(shell which python2-config 2>/dev/null))
   pyconfig := python-config
 endif
 


### PR DESCRIPTION
Most systems don't seem to print anything out when you
execute the command "which foo". However, on falcon, which
is SUSE 11, it prints out an error message stating that it
couldn't be found.

refs #11556

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
