### PR TITLE
Assembly:prepare split into prepareJacobianBlock and prepareResidual

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -453,6 +453,12 @@ public:
   /// Create pair of variables requiring nonlocal jacobian contributions
   void initNonlocalCoupling();
 
+  /// Sizes and zeroes the Jacobian blocks used for the current element
+  void prepareJacobianBlock();
+
+  /// Sizes and zeroes the residual for the current element
+  void prepareResidual();
+
   void prepare();
   void prepareNonlocal();
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1471,6 +1471,17 @@ public:
 
   const VectorPostprocessorData & getVectorPostprocessorData() const;
 
+  /**
+   * Returns _has_jacobian
+   */
+  bool hasJacobian() const;
+
+  /**
+   * Returns _const_jacobian (whether a MOOSE object has specified that
+   * the Jacobian is the same as the previous time it was computed)
+   */
+  bool constJacobian() const;
+
 protected:
   MooseMesh & _mesh;
   EquationSystems _eq;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1111,7 +1111,7 @@ Assembly::initNonlocalCoupling()
 }
 
 void
-Assembly::prepare()
+Assembly::prepareJacobianBlock()
 {
   for (const auto & it : _cm_entry)
   {
@@ -1128,6 +1128,11 @@ Assembly::prepare()
       _jacobian_block_used[tag][vi][vj] = 0;
     }
   }
+}
+
+void
+Assembly::prepareResidual()
+{
   const std::vector<MooseVariableFEBase *> & vars = _sys.getVariables(_tid);
   for (const auto & var : vars)
     for (auto tag = beginIndex(_sub_Re); tag < _sub_Re.size(); tag++)
@@ -1135,6 +1140,13 @@ Assembly::prepare()
       _sub_Re[tag][var->number()].resize(var->dofIndices().size());
       _sub_Re[tag][var->number()].zero();
     }
+}
+
+void
+Assembly::prepare()
+{
+  prepareJacobianBlock();
+  prepareResidual();
 }
 
 void

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -411,7 +411,9 @@ DisplacedProblem::prepare(const Elem * elem, THREAD_ID tid)
 
   _displaced_nl.prepare(tid);
   _displaced_aux.prepare(tid);
-  _assembly[tid]->prepare();
+  if (!_mproblem.hasJacobian() || !_mproblem.constJacobian())
+    _assembly[tid]->prepareJacobianBlock();
+  _assembly[tid]->prepareResidual();
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -960,7 +960,9 @@ FEProblemBase::prepare(const Elem * elem, THREAD_ID tid)
 
   _nl->prepare(tid);
   _aux->prepare(tid);
-  _assembly[tid]->prepare();
+  if (!_has_jacobian || !_const_jacobian)
+    _assembly[tid]->prepareJacobianBlock();
+  _assembly[tid]->prepareResidual();
   if (_has_nonlocal_coupling)
     _assembly[tid]->prepareNonlocal();
 
@@ -5464,4 +5466,16 @@ void
 FEProblemBase::needsPreviousNewtonIteration(bool state /* = true*/)
 {
   _needs_old_newton_iter = state;
+}
+
+bool
+FEProblemBase::hasJacobian() const
+{
+  return _has_jacobian;
+}
+
+bool
+FEProblemBase::constJacobian() const
+{
+  return _const_jacobian;
 }


### PR DESCRIPTION
Also prepareResidualWithoutZeroing created that will allow me to save on zeroing time in my simple App
FEProblemBase now calls Assembly::prepareJacobianBlock only if the _jacobian_const=false, or t_step<=1 or app.isRestarting()

Please review this thoroughly - i'm playing with things i don't understand

Refs #11789

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
