### PR TITLE
Fix bad petsc option in vector_postprocessor_function test

### DIFF
--- a/test/tests/functions/vector_postprocessor_function/vector_postprocessor_function.i
+++ b/test/tests/functions/vector_postprocessor_function/vector_postprocessor_function.i
@@ -85,7 +85,7 @@
   type = Transient
   solve_type = 'PJFNK'
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package ksp_gmres_restart'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -ksp_gmres_restart'
   petsc_options_value = ' lu       superlu_dist                 51'
   line_search = 'none'
   l_max_its = 50


### PR DESCRIPTION
This test will fail with PETSc 3.9.3. Up to this point, PETSc has been silently ignoring this option

Refs #8713