### PR TITLE
GrainTracker Optimizations / New Timers

### DIFF
--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -124,6 +124,12 @@ public:
   class FeatureData
   {
   public:
+    /**
+     * The primary underlying container type used to hold the data in each FeatureData.
+     * Supported types are std::set<dof_id_type> or std::vector<dof_id_type>.
+     */
+    using container_type = std::set<dof_id_type>;
+
     FeatureData() : FeatureData(std::numeric_limits<std::size_t>::max(), Status::INACTIVE) {}
 
     FeatureData(std::size_t var_index,
@@ -241,20 +247,20 @@ public:
     friend std::ostream & operator<<(std::ostream & out, const FeatureData & feature);
 
     /// Holds the ghosted ids for a feature (the ids which will be used for stitching
-    std::set<dof_id_type> _ghosted_ids;
+    container_type _ghosted_ids;
 
     /// Holds the local ids in the interior of a feature.
     /// This data structure is only maintained on the local processor
-    std::set<dof_id_type> _local_ids;
+    container_type _local_ids;
 
     /// Holds the ids surrounding the feature
-    std::set<dof_id_type> _halo_ids;
+    container_type _halo_ids;
 
     /// Holds halo ids that extend onto a non-topologically connected surface
-    std::set<dof_id_type> _disjoint_halo_ids;
+    container_type _disjoint_halo_ids;
 
     /// Holds the nodes that belong to the feature on a periodic boundary
-    std::set<dof_id_type> _periodic_nodes;
+    container_type _periodic_nodes;
 
     /// The Moose variable where this feature was found (often the "order parameter")
     std::size_t _var_index;
@@ -517,10 +523,10 @@ protected:
    * It exits as soon as any intersection is detected.
    */
   template <class InputIterator>
-  static inline bool setsIntersect(InputIterator first1,
-                                   InputIterator last1,
-                                   InputIterator first2,
-                                   InputIterator last2)
+  static bool setsIntersect(InputIterator first1,
+                            InputIterator last1,
+                            InputIterator first2,
+                            InputIterator last2)
   {
     while (first1 != last1 && first2 != last2)
     {
@@ -693,6 +699,18 @@ protected:
   const bool _is_master;
 
 private:
+  template <class T>
+  static void sort(std::set<T> & /*container*/)
+  {
+    // Sets are already sorted, do nothing
+  }
+
+  template <class T>
+  static void sort(std::vector<T> & container)
+  {
+    std::sort(container.begin(), container.end());
+  }
+
   /**
    * This method consolidates all of the merged information from _partial_feature_sets into
    * the _feature_sets vectors.

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -128,7 +128,7 @@ public:
      * The primary underlying container type used to hold the data in each FeatureData.
      * Supported types are std::set<dof_id_type> or std::vector<dof_id_type>.
      */
-    using container_type = std::set<dof_id_type>;
+    using container_type = std::vector<dof_id_type>;
 
     FeatureData() : FeatureData(std::numeric_limits<std::size_t>::max(), Status::INACTIVE) {}
 
@@ -719,6 +719,14 @@ private:
 
   /// Keeps track of whether we are distributing the merge work
   const bool _distribute_merge_work;
+
+  /// Timers
+  PerfID _execute_timer;
+  PerfID _merge_timer;
+  PerfID _finalize_timer;
+  PerfID _comm_and_merge;
+  PerfID _expand_halos;
+  PerfID _update_field_info;
 };
 
 template <>

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -132,7 +132,7 @@ public:
      * Note: Testing has shown that the vector container is nearly 10x faster. There's really
      * no reason to use sets.
      */
-    using container_type = std::vector<dof_id_type>;
+    using container_type = std::set<dof_id_type>;
 
     FeatureData() : FeatureData(std::numeric_limits<std::size_t>::max(), Status::INACTIVE) {}
 
@@ -704,15 +704,27 @@ protected:
 
 private:
   template <class T>
-  static void sort(std::set<T> & /*container*/)
+  static inline void sort(std::set<T> & /*container*/)
   {
     // Sets are already sorted, do nothing
   }
 
   template <class T>
-  static void sort(std::vector<T> & container)
+  static inline void sort(std::vector<T> & container)
   {
     std::sort(container.begin(), container.end());
+  }
+
+  template <class T>
+  static inline void reserve(std::set<T> & /*container*/, std::size_t /*size*/)
+  {
+    // Sets are trees, no reservations necessary
+  }
+
+  template <class T>
+  static inline void reserve(std::vector<T> & container, std::size_t size)
+  {
+    container.reserve(size);
   }
 
   /**
@@ -725,12 +737,14 @@ private:
   const bool _distribute_merge_work;
 
   /// Timers
-  PerfID _execute_timer;
-  PerfID _merge_timer;
-  PerfID _finalize_timer;
-  PerfID _comm_and_merge;
-  PerfID _expand_halos;
-  PerfID _update_field_info;
+  const PerfID _execute_timer;
+  const PerfID _merge_timer;
+  const PerfID _finalize_timer;
+  const PerfID _comm_and_merge;
+  const PerfID _expand_halos;
+  const PerfID _update_field_info;
+  const PerfID _prepare_for_transfer;
+  const PerfID _consolidate_merged_features;
 };
 
 template <>

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -126,7 +126,11 @@ public:
   public:
     /**
      * The primary underlying container type used to hold the data in each FeatureData.
-     * Supported types are std::set<dof_id_type> or std::vector<dof_id_type>.
+     * Supported types are std::set<dof_id_type> (with minor adjustmnets)
+     * or std::vector<dof_id_type>.
+     *
+     * Note: Testing has shown that the vector container is nearly 10x faster. There's really
+     * no reason to use sets.
      */
     using container_type = std::vector<dof_id_type>;
 

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -242,6 +242,13 @@ private:
 
   /// Boolean to indicate whether this is a Steady or Transient solve
   const bool _is_transient;
+
+  /// Timers
+  PerfID _finalize_timer;
+  PerfID _remap_timer;
+  PerfID _track_grains;
+  PerfID _broadcast_update;
+  PerfID _update_field_info;
 };
 
 /**

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -244,11 +244,11 @@ private:
   const bool _is_transient;
 
   /// Timers
-  PerfID _finalize_timer;
-  PerfID _remap_timer;
-  PerfID _track_grains;
-  PerfID _broadcast_update;
-  PerfID _update_field_info;
+  const PerfID _finalize_timer;
+  const PerfID _remap_timer;
+  const PerfID _track_grains;
+  const PerfID _broadcast_update;
+  const PerfID _update_field_info;
 };
 
 /**

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -197,7 +197,13 @@ FeatureFloodCount::FeatureFloodCount(const InputParameters & parameters)
     _halo_ids(_maps_size),
     _is_elemental(getParam<MooseEnum>("flood_entity_type") == "ELEMENTAL"),
     _is_master(processor_id() == 0),
-    _distribute_merge_work(_app.n_processors() >= _maps_size && _maps_size > 1)
+    _distribute_merge_work(_app.n_processors() >= _maps_size && _maps_size > 1),
+    _execute_timer(registerTimedSection("execute", 1)),
+    _merge_timer(registerTimedSection("mergeFeatures", 2)),
+    _finalize_timer(registerTimedSection("finalize", 1)),
+    _comm_and_merge(registerTimedSection("communicateAndMerge", 2)),
+    _expand_halos(registerTimedSection("expandEdgeHalos", 2)),
+    _update_field_info(registerTimedSection("updateFieldInfo", 2))
 {
   if (_var_index_mode)
     _var_index_maps.resize(_maps_size);
@@ -293,6 +299,8 @@ FeatureFloodCount::meshChanged()
 void
 FeatureFloodCount::execute()
 {
+  TIME_SECTION(_execute_timer);
+
   // Iterate only over boundaries if restricted
   if (_is_boundary_restricted)
   {
@@ -344,6 +352,8 @@ FeatureFloodCount::execute()
 void
 FeatureFloodCount::communicateAndMerge()
 {
+  TIME_SECTION(_comm_and_merge);
+
   // First we need to transform the raw data into a usable data structure
   prepareDataForTransfer();
 
@@ -611,6 +621,8 @@ FeatureFloodCount::buildFeatureIdToLocalIndices(unsigned int max_id)
 void
 FeatureFloodCount::finalize()
 {
+  TIME_SECTION(_finalize_timer);
+
   // Gather all information on processor zero and merge
   communicateAndMerge();
 
@@ -1017,7 +1029,7 @@ FeatureFloodCount::deserialize(std::vector<std::string> & serialized_buffers, un
 void
 FeatureFloodCount::mergeSets()
 {
-  Moose::perf_log.push("mergeSets()", "FeatureFloodCount");
+  TIME_SECTION(_merge_timer);
 
   // When working with _distribute_merge_work all of the maps will be empty except for one
   for (auto map_num = decltype(_maps_size)(0); map_num < _maps_size; ++map_num)
@@ -1067,15 +1079,11 @@ FeatureFloodCount::mergeSets()
 
     } // it1 loop
   }   // map loop
-
-  Moose::perf_log.pop("mergeSets()", "FeatureFloodCount");
 }
 
 void
 FeatureFloodCount::consolidateMergedFeatures(std::vector<std::list<FeatureData>> * saved_data)
 {
-  Moose::perf_log.push("consolidateMergedFeatures()", "FeatureFloodCount");
-
   /**
    * Now that the merges are complete we need to adjust the centroid, and halos.
    * Additionally, To make several of the sorting and tracking algorithms more straightforward,
@@ -1136,7 +1144,6 @@ FeatureFloodCount::consolidateMergedFeatures(std::vector<std::list<FeatureData>>
    * IMPORTANT: FeatureFloodCount::_feature_count is set on rank 0 at this point but
    * we can't broadcast it here because this routine is not collective.
    */
-  Moose::perf_log.pop("consolidateMergedFeatures()", "FeatureFloodCount");
 }
 
 bool
@@ -1403,6 +1410,8 @@ FeatureFloodCount::expandEdgeHalos(unsigned int num_layers_to_expand)
 {
   if (num_layers_to_expand == 0)
     return;
+
+  TIME_SECTION(_expand_halos);
 
   for (auto & list_ref : _partial_feature_sets)
   {

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1569,7 +1569,7 @@ FeatureFloodCount::visitNeighborsHelper(const T * curr_entity,
           {
             // If we didn't flood the immediate neighbor, mark it with a halo instead
             if (!flood(neighbor, current_index, feature))
-              feature->_halo_ids.insert(neighbor->id());
+              feature->_halo_ids.insert(feature->_halo_ids.end(), neighbor->id());
           }
         }
       }
@@ -1697,6 +1697,7 @@ FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshBase & mesh)
         updateBBoxExtremesHelper(_bboxes[region], *mesh.elem_ptr(elem_id));
 
       FeatureData::container_type set_union;
+      set_union.reserve(_halo_ids.size() + _disjoint_halo_ids.size());
       std::set_union(
           _halo_ids.begin(),
           _halo_ids.end(),
@@ -1786,7 +1787,7 @@ FeatureFloodCount::FeatureData::merge(FeatureData && rhs)
 
   FeatureData::container_type set_union;
 
-  // TODO: Reserve space?
+  set_union.reserve(_local_ids.size() + rhs._local_ids.size());
   std::set_union(_local_ids.begin(),
                  _local_ids.end(),
                  rhs._local_ids.begin(),
@@ -1795,6 +1796,7 @@ FeatureFloodCount::FeatureData::merge(FeatureData && rhs)
   _local_ids.swap(set_union);
 
   set_union.clear();
+  set_union.reserve(_periodic_nodes.size() + rhs._periodic_nodes.size());
   std::set_union(_periodic_nodes.begin(),
                  _periodic_nodes.end(),
                  rhs._periodic_nodes.begin(),
@@ -1803,6 +1805,7 @@ FeatureFloodCount::FeatureData::merge(FeatureData && rhs)
   _periodic_nodes.swap(set_union);
 
   set_union.clear();
+  set_union.reserve(_ghosted_ids.size() + rhs._ghosted_ids.size());
   std::set_union(_ghosted_ids.begin(),
                  _ghosted_ids.end(),
                  rhs._ghosted_ids.begin(),
@@ -1829,6 +1832,7 @@ FeatureFloodCount::FeatureData::merge(FeatureData && rhs)
     std::move(rhs._bboxes.begin(), rhs._bboxes.end(), std::back_inserter(_bboxes));
 
   set_union.clear();
+  set_union.reserve(_disjoint_halo_ids.size() + rhs._disjoint_halo_ids.size());
   std::set_union(_disjoint_halo_ids.begin(),
                  _disjoint_halo_ids.end(),
                  rhs._disjoint_halo_ids.begin(),
@@ -1837,6 +1841,7 @@ FeatureFloodCount::FeatureData::merge(FeatureData && rhs)
   _disjoint_halo_ids.swap(set_union);
 
   set_union.clear();
+  set_union.reserve(_halo_ids.size() + rhs._halo_ids.size());
   std::set_union(_halo_ids.begin(),
                  _halo_ids.end(),
                  rhs._halo_ids.begin(),
@@ -1875,7 +1880,7 @@ FeatureFloodCount::FeatureData::consolidate(FeatureData && rhs)
   mooseAssert(_id == rhs._id, "Mismatched auxiliary id in merge");
 
   FeatureData::container_type set_union;
-
+  _local_ids.reserve(_local_ids.size() + rhs._local_ids.size());
   std::set_union(_local_ids.begin(),
                  _local_ids.end(),
                  rhs._local_ids.begin(),

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_remapping_test.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_remapping_test.i
@@ -264,4 +264,9 @@
 [Outputs]
   csv = true
   exodus = true
+  [./perf_graph]
+    type = PerfGraphOutput
+    execute_on = 'initial final'  # Default is "final"
+    level = 2                     # Default is 1
+  [../]
 []

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_volume.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_volume.i
@@ -39,7 +39,7 @@
                0  0  0'
     opposite_corners = '-0.5 -0.5 0
                         1    1    0'
-    inside = '1'
+    inside = 1
     outside = 0
     variable = gr1
   [../]

--- a/modules/phase_field/test/tests/grain_tracker_test/tests
+++ b/modules/phase_field/test/tests/grain_tracker_test/tests
@@ -174,7 +174,7 @@
     rel_err = 1.e-3
 
     # Lots of adaptivity, slower test
-    min_parallel = 4
+    min_parallel = 6
   [../]
 
   [./grain_tracker_volume_single]
@@ -184,7 +184,7 @@
     rel_err = 1.e-3
 
     # Lots of adaptivity, slower test
-    min_parallel = 4
+    min_parallel = 6
   [../]
 
   # This test should work the same with the FeatureFloodCount object
@@ -195,5 +195,8 @@
     csvdiff = 'grain_tracker_volume_out_grain_volumes_0000.csv grain_tracker_volume_out.csv'
     prereq = grain_tracker_volume
     rel_err = 1.e-3
+
+    # Lots of adaptivity, slower test
+    min_parallel = 6
   [../]
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

UPDATE: Very sad, but I actually had these graphs exactly backwards! The vectors are nearly 10x slower! 
After doing tons of profiling, the extra time is in the `gather_packed_range`. With this PR, you can switch back and forth with a single line of code and observe (on a big enough) problem. 

Original Story:
This has been tested on Falcon. Vectors are nearly 10x the speed of sets in these tests. The code is still very generic right now, but I will likely go back through and remove std::set compatible code in the future for readability.

![figure_1](https://user-images.githubusercontent.com/3036960/43050195-15734fd4-8dc2-11e8-8828-bde862c13bd2.png)

