### PR TITLE
Rewrite periodic node map using new algorithm

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -24,6 +24,7 @@
 #include "libmesh/elem_range.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/node_range.h"
+#include "libmesh/nanoflann.hpp"
 
 // forward declaration
 class MooseMesh;
@@ -824,6 +825,9 @@ public:
    * otherwise.
    */
   virtual std::string getFileName() const { return ""; }
+
+  /// Helper type for building periodic node maps
+  using PeriodicNodeInfo = std::pair<const Node *, BoundaryID>;
 
 protected:
   /// Deprecated (DO NOT USE)

--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -12,6 +12,7 @@
 
 // Moose includes
 #include "MooseMesh.h"
+#include "PointListAdaptor.h"
 
 #include "libmesh/nanoflann.hpp"
 #include "libmesh/utility.h"
@@ -32,89 +33,13 @@ public:
                       std::vector<std::size_t> & return_index,
                       std::vector<Real> & return_dist_sqr);
 
-  /**
-   * PointListAdaptor is required to use libMesh Point coordinate type with
-   * nanoflann KDTree library. The member functions within the PointListAdaptor
-   * are used by nanoflann library.
-   */
-  template <unsigned int KDDim>
-  class PointListAdaptor
-  {
-  private:
-    const std::vector<Point> & _pts;
-
-  public:
-    PointListAdaptor(const std::vector<Point> & pts) : _pts(pts) {}
-
-    /**
-     * libMesh \p Point coordinate type
-     */
-    using coord_t = Real;
-    /**
-     * Must return the number of data points
-     */
-    inline size_t kdtree_get_point_count() const { return _pts.size(); }
-
-    /**
-     * Returns the distance between the vector "p1[0:size-1]"
-     * and the data point with index "idx_p2" stored in the class
-     */
-    inline coord_t kdtree_distance(const coord_t * p1, const size_t idx_p2, size_t /*size*/) const
-    {
-      mooseAssert(idx_p2 <= _pts.size(),
-                  "The point index should be less than"
-                  "total number of points used to build"
-                  "the KDTree.");
-
-      const Point & p2(_pts[idx_p2]);
-
-      coord_t dist = 0.0;
-
-      for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
-        dist += Utility::pow<2>(p1[i] - p2(i));
-
-      return dist;
-    }
-
-    /**
-     * Returns the dim'th component of the idx'th point in the class:
-     * Since this is inlined and the "dim" argument is typically an immediate
-     * value, the
-     *  "if's" are actually solved at compile time.
-     */
-    inline coord_t kdtree_get_pt(const size_t idx, int dim) const
-    {
-      mooseAssert(dim < (int)LIBMESH_DIM,
-                  "The required component number should be less than the LIBMESH_DIM.");
-      mooseAssert(idx < _pts.size(),
-                  "The index of the point should be less"
-                  "than total number of points used to"
-                  "construct the KDTree.");
-
-      const Point & p(_pts[idx]);
-
-      return p(dim);
-    }
-
-    /**
-     * Optional bounding-box computation. This function is called by the nanoflann library.
-     * If the return value is false, the standard bbox computation loop in the nanoflann
-     * library is activated.
-     */
-    template <class BBOX>
-    bool kdtree_get_bbox(BBOX & /* bb */) const
-    {
-      return false;
-    }
-  };
-
   using KdTreeT = nanoflann::KDTreeSingleIndexAdaptor<
-      nanoflann::L2_Simple_Adaptor<Real, PointListAdaptor<LIBMESH_DIM>>,
-      PointListAdaptor<LIBMESH_DIM>,
+      nanoflann::L2_Simple_Adaptor<Real, PointListAdaptor<Point>>,
+      PointListAdaptor<Point>,
       LIBMESH_DIM>;
 
 protected:
-  PointListAdaptor<LIBMESH_DIM> _point_list_adaptor;
+  PointListAdaptor<Point> _point_list_adaptor;
   std::unique_ptr<KdTreeT> _kd_tree;
 };
 

--- a/framework/include/utils/PointListAdaptor.h
+++ b/framework/include/utils/PointListAdaptor.h
@@ -1,0 +1,120 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef POINTLISTADAPTOR_H
+#define POINTLISTADAPTOR_H
+
+#include "libmesh/nanoflann.hpp"
+#include "libmesh/utility.h"
+
+#include <iterator>
+
+template <typename PointObject>
+class PointListAdaptor
+{
+public:
+  using Iterator = typename std::vector<PointObject>::const_iterator;
+
+  PointListAdaptor(Iterator begin, Iterator end)
+    : _begin(begin), _end(end), _size(std::distance(begin, end))
+  {
+  }
+
+private:
+  /// begin iterator of the underlying point type vector
+  const Iterator _begin;
+
+  /// end iterator of the underlying point type vector
+  const Iterator _end;
+
+  /// number of elements pointed to
+  std::size_t _size;
+
+public:
+  /**
+   * libMesh \p Point coordinate type
+   */
+  using coord_t = Real;
+
+  /**
+   * Must return the number of data points
+   */
+  inline size_t kdtree_get_point_count() const { return _size; }
+
+  /**
+   * get a Point reference from the PointData object at index idx in the list
+   */
+  const Point & getPoint(const PointObject & item) const;
+
+  /**
+   * Returns the distance between the vector "p1[0:size-1]"
+   * and the data point with index "idx_p2" stored in the class
+   */
+  inline coord_t kdtree_distance(const coord_t * p1, const size_t idx_p2, size_t /*size*/) const
+  {
+    mooseAssert(idx_p2 < _size,
+                "The point index should be less than"
+                "total number of points used to build"
+                "the KDTree.");
+
+    auto it = _begin;
+    std::advance(it, idx_p2);
+    const Point & p2 = getPoint(*it);
+
+    coord_t dist = 0.0;
+
+    for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
+      dist += Utility::pow<2>(p1[i] - p2(i));
+
+    return dist;
+  }
+
+  /**
+   * Returns the dim'th component of the idx'th point in the class:
+   * Since this is inlined and the "dim" argument is typically an immediate
+   * value, the
+   *  "if's" are actually solved at compile time.
+   */
+  inline coord_t kdtree_get_pt(const size_t idx, int dim) const
+  {
+    mooseAssert(dim < (int)LIBMESH_DIM,
+                "The required component number should be less than the LIBMESH_DIM.");
+    mooseAssert(idx < _size,
+                "The index of the point should be less"
+                "than total number of points used to"
+                "construct the KDTree.");
+
+    auto it = _begin;
+    std::advance(it, idx);
+    const Point & p = getPoint(*it);
+
+    return p(dim);
+  }
+
+  /**
+   * Optional bounding-box computation. This function is called by the nanoflann library.
+   * If the return value is false, the standard bbox computation loop in the nanoflann
+   * library is activated.
+   */
+  template <class BBOX>
+  bool kdtree_get_bbox(BBOX & /* bb */) const
+  {
+    return false;
+  }
+};
+
+// Specialization for PointListAdaptor<Point> (provide your own for custom types)
+template <>
+inline const Point &
+PointListAdaptor<Point>::getPoint(const Point & item) const
+{
+  return item;
+}
+
+#endif // POINTLISTADAPTOR_H

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1219,6 +1219,8 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
   {
     // unfortunately libMesh does not give us a pointer, so we have to look it up ourselves
     auto node = _mesh->node_ptr(std::get<0>(t));
+    mooseAssert(node != nullptr,
+                "libMesh::BoundaryInfo::build_node_list() returned an ID for a non-existing node");
     auto bc_id = std::get<1>(t);
     periodic_nodes.emplace_back(node, bc_id);
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -14,6 +14,7 @@
 #include "MooseUtils.h"
 #include "MooseApp.h"
 #include "RelationshipManager.h"
+#include "PointListAdaptor.h"
 
 #include <utility>
 
@@ -1193,77 +1194,96 @@ MooseMesh::getBoundaryName(BoundaryID boundary_id)
     return boundary_info.get_nodeset_name(boundary_id);
 }
 
+// specialization for PointListAdaptor<MooseMesh::PeriodicNodeInfo>
+template <>
+inline const Point &
+PointListAdaptor<MooseMesh::PeriodicNodeInfo>::getPoint(
+    const MooseMesh::PeriodicNodeInfo & item) const
+{
+  return *(item.first);
+}
+
 void
 MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & periodic_node_map,
                                 unsigned int var_number,
                                 PeriodicBoundaries * pbs) const
 {
-  mooseAssert(!Threads::in_threads,
-              "This function should only be called outside of a threaded "
-              "region due to the use of PointLocator");
-
   TIME_SECTION(_build_periodic_node_map_timer);
 
+  // clear existing map
   periodic_node_map.clear();
 
-  std::unique_ptr<PointLocatorBase> point_locator = getMesh().sub_point_locator();
+  // get periodic nodes
+  std::vector<PeriodicNodeInfo> periodic_nodes;
+  for (const auto & t : getMesh().get_boundary_info().build_node_list())
+  {
+    // unfortunately libMesh does not give us a pointer, so we have to look it up ourselves
+    auto node = _mesh->node_ptr(std::get<0>(t));
+    auto bc_id = std::get<1>(t);
+    periodic_nodes.emplace_back(node, bc_id);
+  }
 
-  // Get a const reference to the BoundaryInfo object that we will use several times below...
-  const BoundaryInfo & boundary_info = getMesh().get_boundary_info();
+  // sort by boundary id
+  std::sort(periodic_nodes.begin(),
+            periodic_nodes.end(),
+            [](const PeriodicNodeInfo & a, const PeriodicNodeInfo & b) -> bool {
+              return a.second > b.second;
+            });
 
-  // A typedef makes the code below easier to read...
-  typedef std::multimap<dof_id_type, dof_id_type>::iterator IterType;
+  // build kd-tree
+  using KDTreeType = nanoflann::KDTreeSingleIndexAdaptor<
+      nanoflann::L2_Simple_Adaptor<Real, PointListAdaptor<PeriodicNodeInfo>>,
+      PointListAdaptor<PeriodicNodeInfo>,
+      LIBMESH_DIM>;
+  const unsigned int max_leaf_size = 20; // slightly affects runtime
+  auto point_list =
+      PointListAdaptor<PeriodicNodeInfo>(periodic_nodes.begin(), periodic_nodes.end());
+  auto kd_tree = libmesh_make_unique<KDTreeType>(
+      LIBMESH_DIM, point_list, nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size));
+  mooseAssert(kd_tree != nullptr, "KDTree was not properly initialized.");
+  kd_tree->buildIndex();
 
-  // Container to catch IDs passed back from the BoundaryInfo object
-  std::vector<boundary_id_type> bc_ids;
+  // data structures for kd-tree search
+  nanoflann::SearchParams search_params;
+  std::vector<std::pair<std::size_t, Real>> ret_matches;
 
-  for (const auto & elem : getMesh().active_element_ptr_range())
-    for (unsigned int s = 0; s < elem->n_sides(); ++s)
+  // iterate over periodic nodes (boundary ids are in contiguous blocks)
+  PeriodicBoundaryBase * periodic = nullptr;
+  BoundaryID current_bc_id = BoundaryInfo::invalid_id;
+  for (auto & pair : periodic_nodes)
+  {
+    // entering a new block of boundary IDs
+    if (pair.second != current_bc_id)
     {
-      if (elem->neighbor_ptr(s))
-        continue;
-
-      boundary_info.boundary_ids(elem, s, bc_ids);
-      for (const auto & boundary_id : bc_ids)
-      {
-        const PeriodicBoundaryBase * periodic = pbs->boundary(boundary_id);
-        if (periodic && periodic->is_my_variable(var_number))
-        {
-          const Elem * neigh = pbs->neighbor(boundary_id, *point_locator, elem, s);
-          unsigned int s_neigh =
-              boundary_info.side_with_boundary_id(neigh, periodic->pairedboundary);
-
-          std::unique_ptr<const Elem> elem_side = elem->build_side_ptr(s);
-          std::unique_ptr<const Elem> neigh_side = neigh->build_side_ptr(s_neigh);
-
-          // At this point we have matching sides - lets find matching nodes
-          for (unsigned int i = 0; i < elem_side->n_nodes(); ++i)
-          {
-            const Node * master_node = elem->node_ptr(i);
-            Point master_point = periodic->get_corresponding_pos(*master_node);
-            for (unsigned int j = 0; j < neigh_side->n_nodes(); ++j)
-            {
-              const Node * slave_node = neigh_side->node_ptr(j);
-              if (master_point.absolute_fuzzy_equals(*slave_node))
-              {
-                // Avoid inserting any duplicates
-                std::pair<IterType, IterType> iters =
-                    periodic_node_map.equal_range(master_node->id());
-                bool found = false;
-                for (IterType map_it = iters.first; map_it != iters.second; ++map_it)
-                  if (map_it->second == slave_node->id())
-                    found = true;
-                if (!found)
-                {
-                  periodic_node_map.insert(std::make_pair(master_node->id(), slave_node->id()));
-                  periodic_node_map.insert(std::make_pair(slave_node->id(), master_node->id()));
-                }
-              }
-            }
-          }
-        }
-      }
+      current_bc_id = pair.second;
+      periodic = pbs->boundary(current_bc_id);
+      if (periodic && !periodic->is_my_variable(var_number))
+        periodic = nullptr;
     }
+
+    // variable is not periodic at this node, skip
+    if (!periodic)
+      continue;
+
+    // clear result buffer
+    ret_matches.clear();
+
+    // id of the current node
+    const auto id = pair.first->id();
+
+    // position where we expect a periodic partner for the current node and boundary
+    Point search_point = periodic->get_corresponding_pos(*pair.first);
+
+    // search at the expected point
+    kd_tree->radiusSearch(&(search_point)(0), libMesh::TOLERANCE, ret_matches, search_params);
+    for (auto & match_pair : ret_matches)
+    {
+      const auto & match = periodic_nodes[match_pair.first];
+      // add matched node if the boundary id is the corresponding id in the periodic pair
+      if (match.second == periodic->pairedboundary)
+        periodic_node_map.emplace(id, match.first->id());
+    }
+  }
 }
 
 void

--- a/framework/src/utils/KDTree.C
+++ b/framework/src/utils/KDTree.C
@@ -13,7 +13,7 @@
 #include "libmesh/nanoflann.hpp"
 
 KDTree::KDTree(std::vector<Point> & master_points, unsigned int max_leaf_size)
-  : _point_list_adaptor(master_points),
+  : _point_list_adaptor(master_points.begin(), master_points.end()),
     _kd_tree(libmesh_make_unique<KdTreeT>(
         LIBMESH_DIM, _point_list_adaptor, nanoflann::KDTreeSingleIndexAdaptorParams(max_leaf_size)))
 {

--- a/test/include/userobjects/PeriodicNodeMapTester.h
+++ b/test/include/userobjects/PeriodicNodeMapTester.h
@@ -25,6 +25,8 @@ class PeriodicNodeMapTester : public ElementUserObject
 public:
   PeriodicNodeMapTester(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
+
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;

--- a/test/include/userobjects/PeriodicNodeMapTester.h
+++ b/test/include/userobjects/PeriodicNodeMapTester.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef PERIODICNODEMAPTESTER_H
+#define PERIODICNODEMAPTESTER_H
+
+#include "ElementUserObject.h"
+
+class PeriodicNodeMapTester;
+
+template <>
+InputParameters validParams<PeriodicNodeMapTester>();
+
+/**
+ * Test MooseMesh::buildPeriodicNodeMap()
+ */
+class PeriodicNodeMapTester : public ElementUserObject
+{
+public:
+  PeriodicNodeMapTester(const InputParameters & parameters);
+
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual void finalize() override;
+
+  virtual void threadJoin(const UserObject &) override{};
+
+protected:
+  /// Coupled variable id
+  unsigned int _v_var;
+
+  /// mesh dimension
+  unsigned int _dim;
+
+  ///@{ periodic size per component
+  std::array<Real, LIBMESH_DIM> _periodic_min;
+  std::array<Real, LIBMESH_DIM> _periodic_max;
+  ///@}
+
+  /// We time the periodic node list build ourselves to ste the level to 1
+  PerfID _perf_buildmap;
+};
+
+#endif // PERIODICNODEMAPTESTER_H

--- a/test/src/userobjects/PeriodicNodeMapTester.C
+++ b/test/src/userobjects/PeriodicNodeMapTester.C
@@ -1,0 +1,92 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PeriodicNodeMapTester.h"
+#include "NonlinearSystemBase.h"
+
+registerMooseObject("MooseTestApp", PeriodicNodeMapTester);
+
+template <>
+InputParameters
+validParams<PeriodicNodeMapTester>()
+{
+  InputParameters params = validParams<ElementUserObject>();
+  params.addClassDescription("Test MooseMesh::buildPeriodicNodeMap()");
+  params.addCoupledVar("v", "coupled variable (should be periodic)");
+  return params;
+}
+
+PeriodicNodeMapTester::PeriodicNodeMapTester(const InputParameters & parameters)
+  : ElementUserObject(parameters),
+    _v_var(coupled("v")),
+    _dim(_mesh.dimension()),
+    _perf_buildmap(registerTimedSection("buildPeriodicNodeMap", 1))
+{
+  // collect mesh periodicity data
+  for (unsigned int i = 0; i < _dim; ++i)
+  {
+    if (!_mesh.isRegularOrthogonal() || !_mesh.isTranslatedPeriodic(_v_var, i))
+      paramError("v", "Variable must be periodic in all directions");
+
+    _periodic_min[i] = _mesh.getMinInDimension(i);
+    _periodic_max[i] = _mesh.getMaxInDimension(i);
+  }
+}
+
+void
+PeriodicNodeMapTester::initialize()
+{
+  // get a fresh point locator
+  auto point_locator = _mesh.getPointLocator();
+
+  // Get a pointer to the PeriodicBoundaries buried in libMesh
+  auto pbs = _fe_problem.getNonlinearSystemBase().dofMap().get_periodic_boundaries();
+
+  // rebuild periodic node map (this is the heaviest part by far)
+  std::multimap<dof_id_type, dof_id_type> periodic_node_map;
+  {
+    TIME_SECTION(_perf_buildmap);
+    _mesh.buildPeriodicNodeMap(periodic_node_map, _v_var, pbs);
+  }
+
+  // analyze map
+  unsigned int n_corner = 0;
+  for (auto item : periodic_node_map)
+  {
+    auto & p = _mesh.nodeRef(item.first);
+    bool corner = true;
+    for (unsigned int i = 0; i < _dim; ++i)
+      corner = corner && (MooseUtils::absoluteFuzzyEqual(p(i), _periodic_min[i]) ||
+                          MooseUtils::absoluteFuzzyEqual(p(i), _periodic_max[i]));
+    if (corner)
+      n_corner++;
+  }
+
+  // we need 2 periodicity entries in 1D
+  if (_dim == 1 && n_corner != 2)
+    mooseWarning("Expected 2 entries in 1D, but found ", n_corner);
+
+  // we need 8 periodicity entries in 2D
+  if (_dim == 2 && n_corner != 8)
+    mooseWarning("Expected 8 entries in 2D, but found ", n_corner);
+
+  // we need 24 periodicity entries in 3D
+  if (_dim == 3 && n_corner != 24)
+    mooseWarning("Expected 24 entries in 2D, but found ", n_corner);
+}
+
+void
+PeriodicNodeMapTester::execute()
+{
+}
+
+void
+PeriodicNodeMapTester::finalize()
+{
+}

--- a/test/src/userobjects/PeriodicNodeMapTester.C
+++ b/test/src/userobjects/PeriodicNodeMapTester.C
@@ -28,6 +28,11 @@ PeriodicNodeMapTester::PeriodicNodeMapTester(const InputParameters & parameters)
     _dim(_mesh.dimension()),
     _perf_buildmap(registerTimedSection("buildPeriodicNodeMap", 1))
 {
+}
+
+void
+PeriodicNodeMapTester::initialSetup()
+{
   // collect mesh periodicity data
   for (unsigned int i = 0; i < _dim; ++i)
   {
@@ -59,7 +64,11 @@ PeriodicNodeMapTester::initialize()
   unsigned int n_corner = 0;
   for (auto item : periodic_node_map)
   {
-    auto & p = _mesh.nodeRef(item.first);
+    Node * node_ptr = _mesh.nodePtr(item.first);
+    if (node_ptr == nullptr)
+      mooseError("Non-existing node found in periodic_node_map");
+
+    Point p(*node_ptr);
     bool corner = true;
     for (unsigned int i = 0; i < _dim; ++i)
       corner = corner && (MooseUtils::absoluteFuzzyEqual(p(i), _periodic_min[i]) ||

--- a/test/tests/mesh/periodic_node_map/test.i
+++ b/test/tests/mesh/periodic_node_map/test.i
@@ -1,0 +1,42 @@
+[Mesh]
+  type = GeneratedMesh
+  nx = 4
+  ny = 4
+  nz = 4
+[../]
+
+[Variables]
+  [./c]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = c
+  [../]
+[]
+
+[BCs]
+  [./Periodic]
+    [./all]
+    [../]
+  [../]
+[]
+
+[UserObjects]
+  [./test]
+    type = PeriodicNodeMapTester
+    v = c
+    execute_on = 'INITIAL'
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  nl_abs_step_tol = 1e-9
+[]
+
+[Outputs]
+  perf_graph = true
+[]

--- a/test/tests/mesh/periodic_node_map/tests
+++ b/test/tests/mesh/periodic_node_map/tests
@@ -3,18 +3,15 @@
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x' Mesh/dim=1"
-    recover = false
   [../]
   [./2D]
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y' Mesh/dim=2"
-    recover = false
   [../]
   [./3D]
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y z' Mesh/dim=3"
-    recover = false
   [../]
 []

--- a/test/tests/mesh/periodic_node_map/tests
+++ b/test/tests/mesh/periodic_node_map/tests
@@ -3,15 +3,18 @@
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x' Mesh/dim=1"
+    recover = false
   [../]
   [./2D]
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y' Mesh/dim=2"
+    recover = false
   [../]
   [./3D]
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y z' Mesh/dim=3"
+    recover = false
   [../]
 []

--- a/test/tests/mesh/periodic_node_map/tests
+++ b/test/tests/mesh/periodic_node_map/tests
@@ -1,0 +1,17 @@
+[Tests]
+  [./1D]
+    type = 'RunApp'
+    input = 'test.i'
+    cli_args = "BCs/Periodic/all/auto_direction='x' Mesh/dim=1"
+  [../]
+  [./2D]
+    type = 'RunApp'
+    input = 'test.i'
+    cli_args = "BCs/Periodic/all/auto_direction='x y' Mesh/dim=2"
+  [../]
+  [./3D]
+    type = 'RunApp'
+    input = 'test.i'
+    cli_args = "BCs/Periodic/all/auto_direction='x y z' Mesh/dim=3"
+  [../]
+[]


### PR DESCRIPTION
This produces the expected map without missing relations and closes #11891

In a 30x30x30 mesh with PBC in all direction this takes the time to build a periodic node map from ~33s down to ~0.006s.

Also in this PR I refactor the `KDTree` class and add a more generic `PointListAdaptor` which takes an iterator pair to a vector of objects (a member function specialization needs to be provided to get a `Point` out of such objects). This is code I developed for Magpie and has turned out to be useful (and is used in the new `buildPeriodicNodeMap` function). The iterator pair allows kd-trees to index sub ranges of vectors for added flexibility.