### PR TITLE
Remove RNG patterning

### DIFF
--- a/framework/src/ics/RandomIC.C
+++ b/framework/src/ics/RandomIC.C
@@ -35,7 +35,15 @@ RandomIC::RandomIC(const InputParameters & parameters)
     _range(_max - _min)
 {
   mooseAssert(_range > 0.0, "Min > Max for RandomIC!");
-  MooseRandom::seed(getParam<unsigned int>("seed"));
+  unsigned int processor_seed = getParam<unsigned int>("seed");
+  MooseRandom::seed(processor_seed);
+
+  if (processor_id() > 0)
+  {
+    for (processor_id_type i = 0; i < processor_id(); ++i)
+      processor_seed = MooseRandom::randl();
+    MooseRandom::seed(processor_seed);
+  }
 }
 
 Real


### PR DESCRIPTION
This hack would marginally improve `RandomIC` by removing the random number patterns in parallel without touching the serial case. It would also avoid pattern shifting for small seed increments (< `n_processors()`).

It is not a replacement for a parallel reproducible UO based random initial condition, just a suggestion for a temporary fix.

## Before

![pattern](https://user-images.githubusercontent.com/202302/43153946-ed848a64-8f2f-11e8-9104-04b0604b0e02.png)

## After

![no_pattern](https://user-images.githubusercontent.com/202302/43153948-ef93a146-8f2f-11e8-9dd6-d46fadca90f6.png)

Refs #11901