### PR TITLE
Avoid race condition on restart files (will fix master merge)

### DIFF
--- a/test/tests/mesh/periodic_node_map/tests
+++ b/test/tests/mesh/periodic_node_map/tests
@@ -8,10 +8,12 @@
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y' Mesh/dim=2"
+    prereq = 1D
   [../]
   [./3D]
     type = 'RunApp'
     input = 'test.i'
     cli_args = "BCs/Periodic/all/auto_direction='x y z' Mesh/dim=3"
+    prereq = 2D
   [../]
 []


### PR DESCRIPTION
Tests clobbered eachother's restart files. Added `prereq`s to fix this. Those are all `RunApp` tests, so I didn't notice the race condition locally (and by dumb luck it passed the PR testing).

Refs #11891
