### PR TITLE
Fix some deprecated usage of the old perf log parameters

### DIFF
--- a/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
+++ b/modules/chemical_reactions/examples/calcium_bicarbonate/calcium_bicarbonate.i
@@ -260,6 +260,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   exodus = true
 []

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species.i
@@ -113,7 +113,7 @@
 [Outputs]
   file_base = 1species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species_without_action.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/1species_without_action.i
@@ -120,7 +120,7 @@
 [Outputs]
   file_base = 1species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species.i
@@ -159,7 +159,7 @@
 [Outputs]
   file_base = 2species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_eqaux.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_eqaux.i
@@ -244,7 +244,7 @@
 [Outputs]
   file_base = 2species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
   hide = 'pa2_logk pab_logk'
 []

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_with_density.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_with_density.i
@@ -147,7 +147,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_without_action.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/2species_without_action.i
@@ -239,7 +239,7 @@
 [Outputs]
   file_base = 2species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/calcium_bicarbonate.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/calcium_bicarbonate.i
@@ -188,6 +188,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   csv = true
 []

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/co2_h2o.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/co2_h2o.i
@@ -140,6 +140,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   csv = true
 []

--- a/modules/chemical_reactions/test/tests/aqueous_equilibrium/water_dissociation.i
+++ b/modules/chemical_reactions/test/tests/aqueous_equilibrium/water_dissociation.i
@@ -93,6 +93,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   csv = true
 []

--- a/modules/chemical_reactions/test/tests/jacobian/2species.i
+++ b/modules/chemical_reactions/test/tests/jacobian/2species.i
@@ -91,7 +91,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium.i
+++ b/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium.i
@@ -101,7 +101,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium_with_density.i
+++ b/modules/chemical_reactions/test/tests/jacobian/2species_equilibrium_with_density.i
@@ -105,7 +105,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_convreact.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_convreact.i
@@ -78,7 +78,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_convreact2.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_convreact2.i
@@ -82,7 +82,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_diffreact.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_diffreact.i
@@ -77,7 +77,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_diffreact2.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_diffreact2.i
@@ -81,7 +81,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_equilsub.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_equilsub.i
@@ -78,7 +78,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/coupled_equilsub2.i
+++ b/modules/chemical_reactions/test/tests/jacobian/coupled_equilsub2.i
@@ -82,7 +82,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/jacobian/primary_convection.i
+++ b/modules/chemical_reactions/test/tests/jacobian/primary_convection.i
@@ -59,7 +59,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Preconditioning]

--- a/modules/chemical_reactions/test/tests/kinetic_rate/arrhenius.i
+++ b/modules/chemical_reactions/test/tests/kinetic_rate/arrhenius.i
@@ -158,6 +158,6 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []

--- a/modules/chemical_reactions/test/tests/parser/equilibrium_action.i
+++ b/modules/chemical_reactions/test/tests/parser/equilibrium_action.i
@@ -128,7 +128,7 @@
 [Outputs]
   file_base = equilibrium_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/parser/equilibrium_without_action.i
+++ b/modules/chemical_reactions/test/tests/parser/equilibrium_without_action.i
@@ -217,7 +217,7 @@
 [Outputs]
   file_base = equilibrium_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []
 

--- a/modules/chemical_reactions/test/tests/parser/kinetic_action.i
+++ b/modules/chemical_reactions/test/tests/parser/kinetic_action.i
@@ -82,6 +82,6 @@
 [Outputs]
   file_base = kinetic_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []

--- a/modules/chemical_reactions/test/tests/parser/kinetic_without_action.i
+++ b/modules/chemical_reactions/test/tests/parser/kinetic_without_action.i
@@ -141,6 +141,6 @@
 [Outputs]
   file_base = kinetic_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []

--- a/modules/chemical_reactions/test/tests/solid_kinetics/2species.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/2species.i
@@ -125,6 +125,6 @@
 [Outputs]
   file_base = 2species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []

--- a/modules/chemical_reactions/test/tests/solid_kinetics/2species_without_action.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/2species_without_action.i
@@ -130,6 +130,6 @@
 [Outputs]
   file_base = 2species_out
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = true
 []

--- a/modules/chemical_reactions/test/tests/solid_kinetics/calcite_dissolution.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/calcite_dissolution.i
@@ -167,6 +167,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   csv = true
 []

--- a/modules/chemical_reactions/test/tests/solid_kinetics/calcite_precipitation.i
+++ b/modules/chemical_reactions/test/tests/solid_kinetics/calcite_precipitation.i
@@ -165,6 +165,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   csv = true
 []

--- a/modules/combined/examples/phase_field-mechanics/grain_texture.i
+++ b/modules/combined/examples/phase_field-mechanics/grain_texture.i
@@ -164,7 +164,7 @@
   execute_on = 'INITIAL TIMESTEP_END'
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
   [./console]
     type = Console
     max_rows = 20

--- a/modules/combined/examples/phase_field-mechanics/kks_mechanics_VTS.i
+++ b/modules/combined/examples/phase_field-mechanics/kks_mechanics_VTS.i
@@ -712,7 +712,6 @@
   [../]
 #[./console]
 #    type = Console
-#    perf_log = true
 #    output_file = true
 #  [../]
 []

--- a/modules/combined/examples/thermomechanics/circle_thermal_expansion_stress.i
+++ b/modules/combined/examples/thermomechanics/circle_thermal_expansion_stress.i
@@ -141,5 +141,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/examples/xfem/xfem_mechanics_prescribed_growth.i
+++ b/modules/combined/examples/xfem/xfem_mechanics_prescribed_growth.i
@@ -125,7 +125,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/examples/xfem/xfem_thermomechanics_stress_growth.i
+++ b/modules/combined/examples/xfem/xfem_thermomechanics_stress_growth.i
@@ -175,7 +175,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d.i
@@ -176,7 +176,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     max_rows = 25
   [../]
 []

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d_sm.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/2d_sm.i
@@ -219,7 +219,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     max_rows = 25
   [../]
 []

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy.i
@@ -164,7 +164,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     max_rows = 25
   [../]
 []

--- a/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy_sm.i
+++ b/modules/combined/test/tests/axisymmetric_2d3d_solution_function/3dy_sm.i
@@ -199,7 +199,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     max_rows = 25
   [../]
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
@@ -375,7 +375,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3.i
@@ -377,7 +377,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
@@ -374,7 +374,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
@@ -374,7 +374,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
@@ -322,7 +322,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
@@ -313,7 +313,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/overclosure_removal/overclosure.i
+++ b/modules/combined/test/tests/contact_verification/overclosure_removal/overclosure.i
@@ -186,7 +186,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/automatic_patch_update/sliding_update.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/automatic_patch_update/sliding_update.i
@@ -107,5 +107,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug.i
@@ -336,7 +336,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug_sm.i
@@ -328,7 +328,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
@@ -356,7 +356,7 @@
 [Outputs]
   file_base = brick1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
@@ -347,7 +347,7 @@
 [Outputs]
   file_base = brick1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
@@ -335,7 +335,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
@@ -327,7 +327,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2.i
@@ -336,7 +336,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2_sm.i
@@ -328,7 +328,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug_sm.i
@@ -304,7 +304,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
@@ -337,7 +337,7 @@
 [Outputs]
   file_base = brick2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
@@ -324,7 +324,7 @@
 [Outputs]
   file_base = brick2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
@@ -316,7 +316,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
@@ -303,7 +303,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2_sm.i
@@ -304,7 +304,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
@@ -337,7 +337,7 @@
 [Outputs]
   file_base = brick3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
@@ -325,7 +325,7 @@
 [Outputs]
   file_base = brick3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
@@ -316,7 +316,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
@@ -304,7 +304,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2_sm.i
@@ -305,7 +305,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
@@ -337,7 +337,7 @@
 [Outputs]
   file_base = brick4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
@@ -328,7 +328,7 @@
 [Outputs]
   file_base = brick4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
@@ -316,7 +316,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
@@ -304,7 +304,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2_sm.i
@@ -305,7 +305,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen.i
@@ -311,7 +311,7 @@
 [Outputs]
   file_base = cyl1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_mu_0_2_pen_sm.i
@@ -294,7 +294,7 @@
 [Outputs]
   file_base = cyl1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template1.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template1_sm.i
@@ -294,7 +294,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template2.i
@@ -318,7 +318,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_1/cyl1_template2_sm.i
@@ -295,7 +295,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen.i
@@ -311,7 +311,7 @@
 [Outputs]
   file_base = cyl2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_mu_0_2_pen_sm.i
@@ -291,7 +291,7 @@
 [Outputs]
   file_base = cyl2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template1.i
@@ -317,7 +317,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template1_sm.i
@@ -297,7 +297,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template2.i
@@ -318,7 +318,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_2/cyl2_template2_sm.i
@@ -298,7 +298,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen.i
@@ -312,7 +312,7 @@
 [Outputs]
   file_base = cyl3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_mu_0_2_pen_sm.i
@@ -289,7 +289,7 @@
 [Outputs]
   file_base = cyl3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template1.i
@@ -315,7 +315,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template1_sm.i
@@ -295,7 +295,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template2.i
@@ -319,7 +319,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_3/cyl3_template2_sm.i
@@ -296,7 +296,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen.i
@@ -312,7 +312,7 @@
 [Outputs]
   file_base = cyl4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_mu_0_2_pen_sm.i
@@ -289,7 +289,7 @@
 [Outputs]
   file_base = cyl4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template1.i
@@ -311,7 +311,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template1_sm.i
@@ -288,7 +288,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template2.i
@@ -312,7 +312,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/cyl_4/cyl4_template2_sm.i
@@ -289,7 +289,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
@@ -312,7 +312,7 @@
 [Outputs]
   file_base = plane1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
@@ -295,7 +295,7 @@
 [Outputs]
   file_base = plane1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
@@ -291,7 +291,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
@@ -277,7 +277,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2.i
@@ -292,7 +292,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2_sm.i
@@ -278,7 +278,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
@@ -312,7 +312,7 @@
 [Outputs]
   file_base = plane2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
@@ -295,7 +295,7 @@
 [Outputs]
   file_base = plane2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
@@ -291,7 +291,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
@@ -274,7 +274,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2.i
@@ -292,7 +292,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2_sm.i
@@ -275,7 +275,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
@@ -313,7 +313,7 @@
 [Outputs]
   file_base = plane3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
@@ -294,7 +294,7 @@
 [Outputs]
   file_base = plane3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -296,7 +296,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
@@ -274,7 +274,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2.i
@@ -297,7 +297,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2_sm.i
@@ -278,7 +278,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
@@ -313,7 +313,7 @@
 [Outputs]
   file_base = plane4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
@@ -294,7 +294,7 @@
 [Outputs]
   file_base = plane4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
@@ -296,7 +296,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
@@ -277,7 +277,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2.i
@@ -297,7 +297,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2_sm.i
@@ -278,7 +278,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen.i
@@ -305,7 +305,7 @@
 [Outputs]
   file_base = ring1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_mu_0_2_pen_sm.i
@@ -283,7 +283,7 @@
 [Outputs]
   file_base = ring1_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template1.i
@@ -306,7 +306,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template1_sm.i
@@ -282,7 +282,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template2.i
@@ -307,7 +307,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_1/ring1_template2_sm.i
@@ -283,7 +283,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen.i
@@ -305,7 +305,7 @@
 [Outputs]
   file_base = ring2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_mu_0_2_pen_sm.i
@@ -286,7 +286,7 @@
 [Outputs]
   file_base = ring2_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template1.i
@@ -304,7 +304,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template1_sm.i
@@ -281,7 +281,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template2.i
@@ -305,7 +305,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_2/ring2_template2_sm.i
@@ -282,7 +282,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen.i
@@ -306,7 +306,7 @@
 [Outputs]
   file_base = ring3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_mu_0_2_pen_sm.i
@@ -281,7 +281,7 @@
 [Outputs]
   file_base = ring3_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1.i
@@ -306,7 +306,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template1_sm.i
@@ -280,7 +280,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template2.i
@@ -307,7 +307,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_3/ring3_template2_sm.i
@@ -281,7 +281,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen.i
@@ -306,7 +306,7 @@
 [Outputs]
   file_base = ring4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_mu_0_2_pen_sm.i
@@ -283,7 +283,7 @@
 [Outputs]
   file_base = ring4_mu_0_2_pen_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template1.i
@@ -305,7 +305,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template1_sm.i
@@ -285,7 +285,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template2.i
@@ -306,7 +306,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/ring_4/ring4_template2_sm.i
@@ -286,7 +286,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d.i
@@ -220,7 +220,7 @@
   file_base = single_point_2d_out_glued_kin
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./console]
     type = Console

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_contact_line_search.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_contact_line_search.i
@@ -221,7 +221,7 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./console]
     type = Console

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional.i
@@ -220,7 +220,7 @@
   file_base = single_point_2d_out_frictional_0_2_kin
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./console]
     type = Console

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_frictional_sm.i
@@ -213,7 +213,7 @@
   file_base = single_point_2d_out_frictional_0_2_kin
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./console]
     type = Console

--- a/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/single_pnt_2d/single_point_2d_sm.i
@@ -213,7 +213,7 @@
   file_base = single_point_2d_out_glued_kin
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./console]
     type = Console

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d.i
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d.i
@@ -203,7 +203,7 @@
   file_base = single_point_2d_out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./console]
     type = Console
     max_rows = 5

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d_predictor.i
@@ -207,7 +207,7 @@
   file_base = single_point_2d_predictor_out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./console]
     type = Console
     max_rows = 5

--- a/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d_tp.i
+++ b/modules/combined/test/tests/frictional_contact/single_point_2d/single_point_2d_tp.i
@@ -202,7 +202,7 @@
   file_base = single_point_2d_tp_out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./console]
     type = Console
     max_rows = 5

--- a/modules/combined/test/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
+++ b/modules/combined/test/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i
@@ -231,7 +231,7 @@
 [Outputs]
   file_base = sliding_elastic_blocks_2d_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
+++ b/modules/combined/test/tests/frictional_contact/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d_tp.i
@@ -231,7 +231,7 @@
 [Outputs]
   file_base = sliding_elastic_blocks_2d_tp_out
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./exodus]
     type = Exodus
     elemental_as_nodal = true

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D.i
@@ -166,7 +166,6 @@
   exodus = true
   [./Console]
     type = Console
-    perf_log = true
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl3D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl3D.i
@@ -167,7 +167,6 @@
   exodus = true
    [./Console]
     type = Console
-    perf_log = true
    [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/sphere2DRZ.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/sphere2DRZ.i
@@ -168,7 +168,6 @@
   exodus = true
   [./Console]
     type = Console
-    perf_log = true
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/sphere3D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/sphere3D.i
@@ -162,7 +162,6 @@
   exodus = true
   [./Console]
     type = Console
-    perf_log = true
   [../]
 []
 

--- a/modules/combined/test/tests/grain_texture/EulerAngle2RGBAction.i
+++ b/modules/combined/test/tests/grain_texture/EulerAngle2RGBAction.i
@@ -154,5 +154,5 @@
 [Outputs]
   execute_on = 'initial timestep_end'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/grain_texture/EulerAngleProvider2RGBAux_bicrystal.i
+++ b/modules/combined/test/tests/grain_texture/EulerAngleProvider2RGBAux_bicrystal.i
@@ -156,5 +156,5 @@
 [Outputs]
   execute_on = 'initial timestep_end'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/grain_texture/random_grain_orientation.i
+++ b/modules/combined/test/tests/grain_texture/random_grain_orientation.i
@@ -136,5 +136,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/heat_conduction_xfem/heat.i
+++ b/modules/combined/test/tests/heat_conduction_xfem/heat.i
@@ -111,7 +111,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/test/tests/inelastic_strain/creep/creep_nl1.i
+++ b/modules/combined/test/tests/inelastic_strain/creep/creep_nl1.i
@@ -427,7 +427,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/test/tests/inelastic_strain/creep/creep_nl1_sm.i
+++ b/modules/combined/test/tests/inelastic_strain/creep/creep_nl1_sm.i
@@ -405,7 +405,6 @@
   file_base=creep_nl1_out
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1.i
+++ b/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1.i
@@ -399,7 +399,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_cycle.i
+++ b/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_cycle.i
@@ -403,7 +403,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_cycle_sm.i
+++ b/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_cycle_sm.i
@@ -373,7 +373,6 @@
   file_base=elas_plas_nl1_cycle_out
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_sm.i
+++ b/modules/combined/test/tests/inelastic_strain/elas_plas/elas_plas_nl1_sm.i
@@ -370,7 +370,6 @@
   file_base=elas_plas_nl1_out
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/LSH_mod.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/LSH_mod.i
@@ -193,5 +193,5 @@
 [Outputs]
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod.i
@@ -201,5 +201,5 @@
 [Outputs]
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod_optimised.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod_optimised.i
@@ -208,5 +208,5 @@
 [Outputs]
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod_small_strain.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/j2_hard1_mod_small_strain.i
@@ -202,5 +202,5 @@
 [Outputs]
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/LSH_necking.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/LSH_necking.i
@@ -169,5 +169,5 @@
   exodus = true
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/j2_hard1_necking.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/j2_hard1_necking.i
@@ -193,5 +193,5 @@
   exodus = true
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/j2_hard1_neckingRZ.i
+++ b/modules/combined/test/tests/j2_plasticity_vs_LSH/necking/j2_hard1_neckingRZ.i
@@ -198,5 +198,5 @@
   exodus = true
   csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/joule_heating/jouleheating.i
+++ b/modules/combined/test/tests/joule_heating/jouleheating.i
@@ -110,5 +110,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/multiphase_mechanics/nonsplit_gradderiv.i
+++ b/modules/combined/test/tests/multiphase_mechanics/nonsplit_gradderiv.i
@@ -146,6 +146,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   exodus = true
 []

--- a/modules/combined/test/tests/multiphase_mechanics/nonsplit_gradderiv_action.i
+++ b/modules/combined/test/tests/multiphase_mechanics/nonsplit_gradderiv_action.i
@@ -116,7 +116,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   file_base = nonsplit_gradderiv_out
   exodus = true
 []

--- a/modules/combined/test/tests/sliding_block/in_and_out/constraint/frictionless_penalty_contact_line_search.i
+++ b/modules/combined/test/tests/sliding_block/in_and_out/constraint/frictionless_penalty_contact_line_search.i
@@ -190,7 +190,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   print_linear_residuals = false
   [./exodus]
     type = Exodus

--- a/modules/combined/test/tests/solid_mechanics/Wave_1_D/HHT_time_integration/wave_bc_1d.i
+++ b/modules/combined/test/tests/solid_mechanics/Wave_1_D/HHT_time_integration/wave_bc_1d.i
@@ -334,5 +334,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/solid_mechanics/Wave_1_D/Newmark_time_integration/wave_bc_1d.i
+++ b/modules/combined/test/tests/solid_mechanics/Wave_1_D/Newmark_time_integration/wave_bc_1d.i
@@ -325,5 +325,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/solid_mechanics/Wave_1_D/Rayleigh_HHT/wave_bc_1d.i
+++ b/modules/combined/test/tests/solid_mechanics/Wave_1_D/Rayleigh_HHT/wave_bc_1d.i
@@ -340,5 +340,5 @@
   exodus = true
   csv = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/solid_mechanics/Wave_1_D/Rayleigh_Newmark/wave_bc_1d.i
+++ b/modules/combined/test/tests/solid_mechanics/Wave_1_D/Rayleigh_Newmark/wave_bc_1d.i
@@ -332,5 +332,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/variable_heat_capacity_heat_conduction/consistent_heat_capacity.i
+++ b/modules/combined/test/tests/variable_heat_capacity_heat_conduction/consistent_heat_capacity.i
@@ -102,5 +102,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/combined/test/tests/variable_heat_capacity_heat_conduction/consistent_specific_heat.i
+++ b/modules/combined/test/tests/variable_heat_capacity_heat_conduction/consistent_specific_heat.i
@@ -114,5 +114,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/fluid_properties/test/tests/tabulated/tabulated.i
+++ b/modules/fluid_properties/test/tests/tabulated/tabulated.i
@@ -184,5 +184,5 @@
   csv = true
   file_base = tabulated_out
   execute_on = 'TIMESTEP_END'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/heat_conduction/test/tests/joule_heating/transient_jouleheating.i
+++ b/modules/heat_conduction/test/tests/joule_heating/transient_jouleheating.i
@@ -108,5 +108,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/heat_conduction/test/tests/recover/recover.i
+++ b/modules/heat_conduction/test/tests/recover/recover.i
@@ -140,7 +140,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     max_rows = 25
   [../]
 []

--- a/modules/heat_conduction/test/tests/verify_against_analytical/1D_transient.i
+++ b/modules/heat_conduction/test/tests/verify_against_analytical/1D_transient.i
@@ -93,5 +93,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/heat_conduction/test/tests/verify_against_analytical/2d_steady_state_final_prob.i
+++ b/modules/heat_conduction/test/tests/verify_against_analytical/2d_steady_state_final_prob.i
@@ -115,5 +115,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/navier_stokes/test/tests/ins/lid_driven/lid_driven_split.i
+++ b/modules/navier_stokes/test/tests/ins/lid_driven/lid_driven_split.i
@@ -242,7 +242,6 @@
   type = Transient
   dt = 1.e-4
   dtmin = 1.e-6
-  perf_log = true
   petsc_options_iname = '-ksp_gmres_restart '
   petsc_options_value = '300                '
 

--- a/modules/phase_field/examples/anisotropic_transport/diffusion.i
+++ b/modules/phase_field/examples/anisotropic_transport/diffusion.i
@@ -71,5 +71,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/cahn-hilliard/Math_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Math_CH.i
@@ -82,5 +82,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_CH.i
@@ -113,5 +113,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
+++ b/modules/phase_field/examples/cahn-hilliard/Parsed_SplitCH.i
@@ -116,5 +116,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
+++ b/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
@@ -212,5 +212,5 @@
 [Outputs]
   exodus = true
   checkpoint = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/grain_growth/3D_6000_gr.i
+++ b/modules/phase_field/examples/grain_growth/3D_6000_gr.i
@@ -198,7 +198,5 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
-    perf_log_interval = 1
   [../]
 []

--- a/modules/phase_field/examples/measure_interface_energy/1Dinterface_energy.i
+++ b/modules/phase_field/examples/measure_interface_energy/1Dinterface_energy.i
@@ -193,5 +193,5 @@
     type = Console
     execute_on = 'FAILED INITIAL NONLINEAR TIMESTEP_END final'
   [../]
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/examples/rigidbodymotion/AC_CH_Multigrain.i
+++ b/modules/phase_field/examples/rigidbodymotion/AC_CH_Multigrain.i
@@ -236,7 +236,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   [./display]
     type = Console
     max_rows = 12

--- a/modules/phase_field/test/tests/CahnHilliardFluxBC/anisotropic.i
+++ b/modules/phase_field/test/tests/CahnHilliardFluxBC/anisotropic.i
@@ -159,5 +159,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/CahnHilliardFluxBC/anisotropic_split.i
+++ b/modules/phase_field/test/tests/CahnHilliardFluxBC/anisotropic_split.i
@@ -165,5 +165,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/CahnHilliardFluxBC/isotropic.i
+++ b/modules/phase_field/test/tests/CahnHilliardFluxBC/isotropic.i
@@ -123,5 +123,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/CahnHilliardFluxBC/isotropic_split.i
+++ b/modules/phase_field/test/tests/CahnHilliardFluxBC/isotropic_split.i
@@ -136,5 +136,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/DeformedGrain/DeformedGrain.i
+++ b/modules/phase_field/test/tests/DeformedGrain/DeformedGrain.i
@@ -117,5 +117,5 @@
   exodus = true
   interval = 1
   show = bnds
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/actions/Nonconserved_highorder.i
+++ b/modules/phase_field/test/tests/actions/Nonconserved_highorder.i
@@ -69,5 +69,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/actions/both_direct_2vars.i
+++ b/modules/phase_field/test/tests/actions/both_direct_2vars.i
@@ -88,7 +88,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   [./out]
     type = Exodus
     refinements = 2

--- a/modules/phase_field/test/tests/actions/both_split_2vars.i
+++ b/modules/phase_field/test/tests/actions/both_split_2vars.i
@@ -87,6 +87,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   exodus = true
 []

--- a/modules/phase_field/test/tests/actions/conserved_forward_split_1var.i
+++ b/modules/phase_field/test/tests/actions/conserved_forward_split_1var.i
@@ -103,6 +103,6 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   exodus = true
 []

--- a/modules/phase_field/test/tests/anisotropic_interfaces/kobayashi.i
+++ b/modules/phase_field/test/tests/anisotropic_interfaces/kobayashi.i
@@ -111,6 +111,6 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   execute_on = 'INITIAL FINAL'
 []

--- a/modules/phase_field/test/tests/anisotropic_mobility/diffusion.i
+++ b/modules/phase_field/test/tests/anisotropic_mobility/diffusion.i
@@ -69,5 +69,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/anisotropic_mobility/nonsplit.i
+++ b/modules/phase_field/test/tests/anisotropic_mobility/nonsplit.i
@@ -88,5 +88,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/anisotropic_mobility/split.i
+++ b/modules/phase_field/test/tests/anisotropic_mobility/split.i
@@ -89,5 +89,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_advanced_op.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_advanced_op.i
@@ -121,7 +121,7 @@
 
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Problem]

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_ebsd.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_ebsd.i
@@ -194,5 +194,5 @@
 [Outputs]
   execute_on = 'initial'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/grain_tracker_test/split_grain.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/split_grain.i
@@ -180,5 +180,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/phase_field/test/tests/phase_field_crystal/PFCTrad/pfct_newton_split1_asm5.i
+++ b/modules/phase_field/test/tests/phase_field_crystal/PFCTrad/pfct_newton_split1_asm5.i
@@ -128,5 +128,4 @@
 [Outputs]
   execute_on = 'initial timestep_end linear'
   exodus = true
-  perf_log = true
 []

--- a/modules/phase_field/test/tests/reconstruction/euler2rgb_no_grain_region.i
+++ b/modules/phase_field/test/tests/reconstruction/euler2rgb_no_grain_region.i
@@ -148,5 +148,5 @@
   csv = true
   exodus = true
   execute_on = 'INITIAL TIMESTEP_END'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
@@ -250,7 +250,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   console = true
   csv = true
   exodus = true

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
@@ -251,7 +251,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   console = true
   csv = true
   exodus = true

--- a/modules/porous_flow/examples/tutorial/13.i
+++ b/modules/porous_flow/examples/tutorial/13.i
@@ -402,6 +402,6 @@
 
 [Outputs]
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   exodus = true
 []

--- a/modules/porous_flow/test/tests/chemistry/2species_equilibrium.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_equilibrium.i
@@ -227,5 +227,5 @@
 [Outputs]
   print_linear_residuals = true
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/2species_equilibrium_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_equilibrium_2phase.i
@@ -255,5 +255,5 @@
 [Outputs]
   print_linear_residuals = true
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/2species_predis.i
+++ b/modules/porous_flow/test/tests/chemistry/2species_predis.i
@@ -222,5 +222,5 @@
 [Outputs]
   print_linear_residuals = true
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/dissolution.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution.i
@@ -193,5 +193,5 @@
 [Outputs]
   interval = 10
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/dissolution_limited.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution_limited.i
@@ -194,5 +194,5 @@
 [Outputs]
   interval = 10
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/dissolution_limited_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/dissolution_limited_2phase.i
@@ -214,5 +214,5 @@
 [Outputs]
   interval = 10
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/except19.i
+++ b/modules/porous_flow/test/tests/chemistry/except19.i
@@ -134,5 +134,5 @@
 []
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/except20.i
+++ b/modules/porous_flow/test/tests/chemistry/except20.i
@@ -134,5 +134,5 @@
 []
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/except22.i
+++ b/modules/porous_flow/test/tests/chemistry/except22.i
@@ -131,5 +131,5 @@
 []
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/precipitation.i
+++ b/modules/porous_flow/test/tests/chemistry/precipitation.i
@@ -192,5 +192,5 @@
 [Outputs]
   interval = 10
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/precipitation_2phase.i
+++ b/modules/porous_flow/test/tests/chemistry/precipitation_2phase.i
@@ -212,5 +212,5 @@
 [Outputs]
   interval = 10
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/chemistry/precipitation_porosity_change.i
+++ b/modules/porous_flow/test/tests/chemistry/precipitation_porosity_change.i
@@ -180,5 +180,5 @@
 []
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/dirackernels/squarepulse1.i
+++ b/modules/porous_flow/test/tests/dirackernels/squarepulse1.i
@@ -96,7 +96,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   file_base = squarepulse1
   csv = true
   execute_on = 'initial timestep_end'

--- a/modules/porous_flow/test/tests/dirackernels/theis1.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis1.i
@@ -125,7 +125,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   file_base = theis1
   csv = true
   execute_on = 'final'

--- a/modules/porous_flow/test/tests/dirackernels/theis2.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis2.i
@@ -113,7 +113,7 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
   file_base = theis2
   csv = true
   execute_on = 'final'

--- a/modules/porous_flow/test/tests/dirackernels/theis3.i
+++ b/modules/porous_flow/test/tests/dirackernels/theis3.i
@@ -211,7 +211,7 @@
 [Outputs]
   file_base = theis3
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   exodus = true
   [./csv]
     type = CSV

--- a/modules/porous_flow/test/tests/dispersion/disp01.i
+++ b/modules/porous_flow/test/tests/dispersion/disp01.i
@@ -210,5 +210,5 @@
 [Outputs]
   csv = true
   execute_on = 'final'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/dispersion/disp01_heavy.i
+++ b/modules/porous_flow/test/tests/dispersion/disp01_heavy.i
@@ -212,5 +212,5 @@
 [Outputs]
   csv = true
   execute_on = 'final'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/fluidstate/brineco2.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2.i
@@ -320,5 +320,5 @@
   csv = true
   file_base = brineco2
   execute_on = 'TIMESTEP_END'
-  print_perf_log = false
+  perf_graph = false
 []

--- a/modules/porous_flow/test/tests/fluidstate/brineco2_2.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2_2.i
@@ -375,5 +375,5 @@
   csv = true
   file_base = brineco2_2
   execute_on = 'initial timestep_end'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/fluidstate/brineco2_hightemp.i
+++ b/modules/porous_flow/test/tests/fluidstate/brineco2_hightemp.i
@@ -320,5 +320,5 @@
 [Outputs]
   csv = true
   execute_on = 'TIMESTEP_END'
-  print_perf_log = false
+  perf_graph = false
 []

--- a/modules/porous_flow/test/tests/fluidstate/theis.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis.i
@@ -243,7 +243,7 @@
 
 [Outputs]
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   [./csvout]
     type = CSV
     execute_on = timestep_end

--- a/modules/porous_flow/test/tests/fluidstate/theis_brineco2.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis_brineco2.i
@@ -264,7 +264,7 @@
 
 [Outputs]
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   [./csvout]
     type = CSV
     execute_on = timestep_end

--- a/modules/porous_flow/test/tests/fluidstate/theis_tabulated.i
+++ b/modules/porous_flow/test/tests/fluidstate/theis_tabulated.i
@@ -249,7 +249,7 @@
 
 [Outputs]
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   [./csvout]
     type = CSV
     file_base = theis_csvout

--- a/modules/porous_flow/test/tests/gravity/grav02e.i
+++ b/modules/porous_flow/test/tests/gravity/grav02e.i
@@ -210,6 +210,6 @@
   execute_on = 'initial timestep_end'
   file_base = grav02e
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = false
 []

--- a/modules/porous_flow/test/tests/gravity/grav02f.i
+++ b/modules/porous_flow/test/tests/gravity/grav02f.i
@@ -216,6 +216,6 @@
   execute_on = 'initial timestep_end'
   file_base = grav02f
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = false
 []

--- a/modules/porous_flow/test/tests/gravity/grav02g.i
+++ b/modules/porous_flow/test/tests/gravity/grav02g.i
@@ -216,6 +216,6 @@
   execute_on = 'initial timestep_end'
   file_base = grav02g
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = false
 []

--- a/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm.i
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm.i
@@ -310,5 +310,5 @@
 [Outputs]
   execute_on = 'initial timestep_end'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm2.i
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm2.i
@@ -373,5 +373,5 @@
 [Outputs]
   execute_on = 'initial timestep_end'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/porous_flow/test/tests/sinks/injection_production_eg.i
+++ b/modules/porous_flow/test/tests/sinks/injection_production_eg.i
@@ -264,7 +264,7 @@
 [Outputs]
   execute_on = timestep_end
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
   exodus = true
   csv = false
 []

--- a/modules/rdg/test/tests/advection_1d/1d_aefv_square_wave.i
+++ b/modules/rdg/test/tests/advection_1d/1d_aefv_square_wave.i
@@ -115,5 +115,5 @@
     file_base = 1d_aefv_square_wave_none_out
     interval = 2
   [../]
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/rdg/test/tests/advection_1d/block_restrictable.i
+++ b/modules/rdg/test/tests/advection_1d/block_restrictable.i
@@ -174,5 +174,5 @@
     type = Exodus
     interval = 2
   [../]
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/richards/test/tests/gravity_head_2/gh16.i
+++ b/modules/richards/test/tests/gravity_head_2/gh16.i
@@ -289,5 +289,4 @@
   interval = 100000
   exodus = true
   csv = true
-  perf_log = false
 []

--- a/modules/solid_mechanics/test/tests/cracking/cracking_plane_stress.i
+++ b/modules/solid_mechanics/test/tests/cracking/cracking_plane_stress.i
@@ -384,7 +384,6 @@
   [../]
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
  csv = true

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i
@@ -340,7 +340,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./out]
     type = Exodus

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim_no_comb.i
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim_no_comb.i
@@ -336,7 +336,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./out]
     type = Exodus

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i
@@ -282,7 +282,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/solid_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim_no_comb.i
+++ b/modules/solid_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim_no_comb.i
@@ -277,7 +277,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/tensor_mechanics/examples/bridge/bridge.i
+++ b/modules/tensor_mechanics/examples/bridge/bridge.i
@@ -162,5 +162,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/examples/bridge/bridge_large_strain.i
+++ b/modules/tensor_mechanics/examples/bridge/bridge_large_strain.i
@@ -164,5 +164,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_elastic.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_elastic.i
@@ -568,7 +568,6 @@
   console = true
   #[./console]
   #  type = Console
-  #  perf_log = true
   #  output_linear = false
   #[../]
 []

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_only.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_only.i
@@ -520,7 +520,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = false
   [../]
 []

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_wp.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_wp.i
@@ -523,7 +523,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = false
   [../]
 []

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_wp_sticky_longitudinal.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_mc_wp_sticky_longitudinal.i
@@ -613,7 +613,6 @@
   console = true
   #[./console]
   #  type = Console
-  #  perf_log = true
   #  output_linear = false
   #[../]
 []

--- a/modules/tensor_mechanics/examples/coal_mining/cosserat_wp_only.i
+++ b/modules/tensor_mechanics/examples/coal_mining/cosserat_wp_only.i
@@ -526,7 +526,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = false
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
+++ b/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_finiteStrain_resid.i
@@ -200,5 +200,5 @@
   exodus = true
   #csv = true
   print_linear_residuals = false
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/CylindricalRankTwoAux/test.i
+++ b/modules/tensor_mechanics/test/tests/CylindricalRankTwoAux/test.i
@@ -111,5 +111,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small.i
@@ -512,5 +512,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass.i
@@ -355,5 +355,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass2.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass2.i
@@ -343,5 +343,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass_inertia_damping.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass_inertia_damping.i
@@ -469,5 +469,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass_inertia_damping_action.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_added_mass_inertia_damping_action.i
@@ -197,5 +197,5 @@
   exodus = true
   csv = true
 
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_rayleigh_hht.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_rayleigh_hht.i
@@ -532,5 +532,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_rayleigh_hht_action.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_euler_small_rayleigh_hht_action.i
@@ -186,5 +186,5 @@
   file_base = 'dyn_euler_small_rayleigh_hht_out'
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_timoshenko_small.i
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/dyn_timoshenko_small.i
@@ -510,5 +510,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y.i
@@ -230,5 +230,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y_action.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y_action.i
@@ -155,5 +155,5 @@
 [Outputs]
   file_base = 'euler_finite_rot_y_out'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_z.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_z.i
@@ -230,5 +230,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
@@ -201,5 +201,5 @@
   file_base = out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_linesearch.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_linesearch.i
@@ -203,5 +203,5 @@
   file_base = crysp_linesearch_out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_substep.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_substep.i
@@ -201,5 +201,5 @@
   file_base = crysp_substep_out
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/creep_tangent_operator/creep.i
+++ b/modules/tensor_mechanics/test/tests/creep_tangent_operator/creep.i
@@ -149,7 +149,7 @@
 
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [Debug]

--- a/modules/tensor_mechanics/test/tests/dynamics/acceleration_bc/AccelerationBC_test.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/acceleration_bc/AccelerationBC_test.i
@@ -259,5 +259,5 @@
 [Outputs]
   csv = true
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/linear_constraint/disp_mid.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/linear_constraint/disp_mid.i
@@ -186,10 +186,9 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/prescribed_displacement/3D_QStatic_1_Ramped_Displacement.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/prescribed_displacement/3D_QStatic_1_Ramped_Displacement.i
@@ -345,5 +345,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/prescribed_displacement/3D_QStatic_1_Ramped_Displacement_with_gravity.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/prescribed_displacement/3D_QStatic_1_Ramped_Displacement_with_gravity.i
@@ -353,5 +353,5 @@
 [Outputs]
   exodus = true
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_hht.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_hht.i
@@ -301,5 +301,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_newmark.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_newmark.i
@@ -292,5 +292,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_newmark_material_dependent.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/rayleigh_damping/rayleigh_newmark_material_dependent.i
@@ -303,5 +303,5 @@
 [Outputs]
   file_base = 'rayleigh_newmark_out'
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/time_integration/hht_test.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/time_integration/hht_test.i
@@ -288,5 +288,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/time_integration/newmark_test.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/time_integration/newmark_test.i
@@ -279,5 +279,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_hht.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_hht.i
@@ -298,5 +298,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_newmark.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_newmark.i
@@ -327,5 +327,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_hht.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_hht.i
@@ -305,5 +305,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_newmark.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_newmark.i
@@ -324,5 +324,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/isotropicSD_plasticity/isotropicSD.i
+++ b/modules/tensor_mechanics/test/tests/isotropicSD_plasticity/isotropicSD.i
@@ -377,7 +377,7 @@
 
 
 [Outputs]
-  print_perf_log = false
+  perf_graph = false
   csv = true
 []
 

--- a/modules/tensor_mechanics/test/tests/isotropicSD_plasticity/powerRuleHardening.i
+++ b/modules/tensor_mechanics/test/tests/isotropicSD_plasticity/powerRuleHardening.i
@@ -382,7 +382,7 @@
 
 
 [Outputs]
-  print_perf_log = false
+  perf_graph = false
   csv = true
 []
 

--- a/modules/tensor_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i
+++ b/modules/tensor_mechanics/test/tests/material_limit_time_step/creep/nafems_test5a_lim.i
@@ -351,7 +351,7 @@
 
 [Outputs]
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   [./out]
     type = Exodus

--- a/modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i
+++ b/modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i
@@ -285,7 +285,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 [] # Outputs

--- a/modules/tensor_mechanics/test/tests/multi/paper5.i
+++ b/modules/tensor_mechanics/test/tests/multi/paper5.i
@@ -344,5 +344,5 @@
   file_base = paper5
   exodus = false
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/test/tests/orthotropic_plasticity/orthotropic.i
+++ b/modules/tensor_mechanics/test/tests/orthotropic_plasticity/orthotropic.i
@@ -308,6 +308,6 @@
 
 
 [Outputs]
-  print_perf_log = false
+  perf_graph = false
   csv = true
 []

--- a/modules/tensor_mechanics/test/tests/orthotropic_plasticity/powerRuleHardening.i
+++ b/modules/tensor_mechanics/test/tests/orthotropic_plasticity/powerRuleHardening.i
@@ -319,6 +319,6 @@
 []
 
 [Outputs]
-  print_perf_log = false
+  perf_graph = false
   csv = true
 []

--- a/modules/tensor_mechanics/test/tests/recompute_radial_return/isotropic_plasticity_incremental_strain.i
+++ b/modules/tensor_mechanics/test/tests/recompute_radial_return/isotropic_plasticity_incremental_strain.i
@@ -122,5 +122,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_1.1.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_1.1.i
@@ -68,5 +68,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_1.2.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_1.2.i
@@ -71,5 +71,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.1.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.1.i
@@ -74,5 +74,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.2.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.2.i
@@ -76,5 +76,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.3.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.3.i
@@ -106,7 +106,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   print_linear_residuals = false
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_2.4.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_2.4.i
@@ -109,7 +109,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   print_linear_residuals = false
 []

--- a/modules/tensor_mechanics/tutorials/basics/part_3_1.i
+++ b/modules/tensor_mechanics/tutorials/basics/part_3_1.i
@@ -120,7 +120,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
   csv = true
   print_linear_residuals = false
 []

--- a/modules/xfem/test/tests/bimaterials/glued_bimaterials_2d.i
+++ b/modules/xfem/test/tests/bimaterials/glued_bimaterials_2d.i
@@ -299,7 +299,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/bimaterials/inclusion_bimaterials_2d.i
+++ b/modules/xfem/test/tests/bimaterials/inclusion_bimaterials_2d.i
@@ -286,7 +286,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_edge_cut.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_edge_cut.i
@@ -122,7 +122,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut.i
@@ -118,7 +118,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut_twice.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/corner_node_cut_twice.i
@@ -116,7 +116,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/corner_nodes_cut/edge_cut.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/edge_cut.i
@@ -116,7 +116,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/corner_nodes_cut/notch.i
+++ b/modules/xfem/test/tests/corner_nodes_cut/notch.i
@@ -108,7 +108,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/crack_tip_enrichment/edge_crack_2d.i
+++ b/modules/xfem/test/tests/crack_tip_enrichment/edge_crack_2d.i
@@ -237,7 +237,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/crack_tip_enrichment/penny_crack_3d.i
+++ b/modules/xfem/test/tests/crack_tip_enrichment/penny_crack_3d.i
@@ -204,7 +204,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/diffusion.i
+++ b/modules/xfem/test/tests/diffusion_xfem/diffusion.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/diffusion_flux_bc.i
+++ b/modules/xfem/test/tests/diffusion_xfem/diffusion_flux_bc.i
@@ -85,7 +85,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/levelsetcut.i
+++ b/modules/xfem/test/tests/diffusion_xfem/levelsetcut.i
@@ -109,7 +109,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/levelsetcut2d.i
+++ b/modules/xfem/test/tests/diffusion_xfem/levelsetcut2d.i
@@ -112,7 +112,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/levelsetcut2d_aux.i
+++ b/modules/xfem/test/tests/diffusion_xfem/levelsetcut2d_aux.i
@@ -111,7 +111,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/diffusion_xfem/levelsetcut3d.i
+++ b/modules/xfem/test/tests/diffusion_xfem/levelsetcut3d.i
@@ -113,7 +113,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/init_solution_propagation/init_solution_propagation.i
+++ b/modules/xfem/test/tests/init_solution_propagation/init_solution_propagation.i
@@ -161,7 +161,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/mechanical_constraint/glued_penalty.i
+++ b/modules/xfem/test/tests/mechanical_constraint/glued_penalty.i
@@ -143,7 +143,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/moment_fitting/diffusion_moment_fitting_four_points.i
+++ b/modules/xfem/test/tests/moment_fitting/diffusion_moment_fitting_four_points.i
@@ -93,7 +93,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/moment_fitting/diffusion_moment_fitting_six_points.i
+++ b/modules/xfem/test/tests/moment_fitting/diffusion_moment_fitting_six_points.i
@@ -99,7 +99,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/moment_fitting/solid_mechanics_moment_fitting.i
+++ b/modules/xfem/test/tests/moment_fitting/solid_mechanics_moment_fitting.i
@@ -167,7 +167,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/moving_interface/moving_bimaterial.i
+++ b/modules/xfem/test/tests/moving_interface/moving_bimaterial.i
@@ -300,7 +300,6 @@
   csv = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/moving_interface/moving_level_set.i
+++ b/modules/xfem/test/tests/moving_interface/moving_level_set.i
@@ -127,7 +127,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/pressure_bc/2d_pressure_displaced_mesh.i
+++ b/modules/xfem/test/tests/pressure_bc/2d_pressure_displaced_mesh.i
@@ -178,7 +178,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/pressure_bc/edge_2d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/edge_2d_pressure.i
@@ -163,7 +163,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/pressure_bc/edge_3d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/edge_3d_pressure.i
@@ -188,7 +188,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/pressure_bc/inclined_edge_2d_pressure.i
+++ b/modules/xfem/test/tests/pressure_bc/inclined_edge_2d_pressure.i
@@ -163,7 +163,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad8.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad8.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad9.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad9.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad9_test.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_2d_quad9_test.i
@@ -81,7 +81,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_2d_tri6.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_2d_tri6.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_3d_hex20.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_3d_hex20.i
@@ -93,7 +93,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_3d_hex27.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_3d_hex27.i
@@ -93,7 +93,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_3d_tet10.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_3d_tet10.i
@@ -93,7 +93,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/diffusion_quad9_levelsetcut.i
+++ b/modules/xfem/test/tests/second_order_elements/diffusion_quad9_levelsetcut.i
@@ -111,7 +111,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/square_branch_quad8_2d.i
+++ b/modules/xfem/test/tests/second_order_elements/square_branch_quad8_2d.i
@@ -129,7 +129,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/square_branch_quad9_2d.i
+++ b/modules/xfem/test/tests/second_order_elements/square_branch_quad9_2d.i
@@ -129,7 +129,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/second_order_elements/square_branch_tri6_2d.i
+++ b/modules/xfem/test/tests/second_order_elements/square_branch_tri6_2d.i
@@ -129,7 +129,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/side_integral/side_integral.i
+++ b/modules/xfem/test/tests/side_integral/side_integral.i
@@ -94,7 +94,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/side_integral/side_integral_3d.i
+++ b/modules/xfem/test/tests/side_integral/side_integral_3d.i
@@ -98,7 +98,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/propagating_1field.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/propagating_1field.i
@@ -91,7 +91,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/propagating_2field_1constraint.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/propagating_2field_1constraint.i
@@ -111,7 +111,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/propagating_2field_2constraint.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/propagating_2field_2constraint.i
@@ -118,7 +118,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/stationary_equal.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/stationary_equal.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/stationary_fluxjump.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/stationary_fluxjump.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/stationary_jump.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/stationary_jump.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_2d/stationary_jump_fluxjump.i
+++ b/modules/xfem/test/tests/single_var_constraint_2d/stationary_jump_fluxjump.i
@@ -89,7 +89,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_3d/stationary_equal_3d.i
+++ b/modules/xfem/test/tests/single_var_constraint_3d/stationary_equal_3d.i
@@ -95,7 +95,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_3d/stationary_fluxjump_3d.i
+++ b/modules/xfem/test/tests/single_var_constraint_3d/stationary_fluxjump_3d.i
@@ -95,7 +95,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_3d/stationary_jump_3d.i
+++ b/modules/xfem/test/tests/single_var_constraint_3d/stationary_jump_3d.i
@@ -95,7 +95,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/single_var_constraint_3d/stationary_jump_fluxjump_3d.i
+++ b/modules/xfem/test/tests/single_var_constraint_3d/stationary_jump_fluxjump_3d.i
@@ -95,7 +95,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d.i
@@ -134,7 +134,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d_sm.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/crack_propagation_2d_sm.i
@@ -139,7 +139,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d.i
@@ -212,7 +212,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_mesh.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/edge_crack_3d_mesh.i
@@ -220,7 +220,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/elliptical_crack.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/elliptical_crack.i
@@ -196,7 +196,6 @@
   execute_on = timestep_end
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/mesh_grow.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/mesh_grow.i
@@ -216,7 +216,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/penny_crack.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/penny_crack.i
@@ -220,7 +220,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/penny_crack_cfp.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/penny_crack_cfp.i
@@ -214,7 +214,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/square_branch_quad_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/square_branch_quad_2d.i
@@ -137,7 +137,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/modules/xfem/test/tests/solid_mechanics_basic/square_branch_tri_2d.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/square_branch_tri_2d.i
@@ -137,7 +137,6 @@
   exodus = true
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
   [../]
 []

--- a/test/tests/functions/vector_postprocessor_function/vector_postprocessor_function.i
+++ b/test/tests/functions/vector_postprocessor_function/vector_postprocessor_function.i
@@ -143,7 +143,6 @@
   file_base = out
   [./console]
     type = Console
-    perf_log = true
     output_linear = true
     max_rows = 10
   [../]

--- a/test/tests/materials/declare_overlap/error.i
+++ b/test/tests/materials/declare_overlap/error.i
@@ -73,5 +73,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute.i
+++ b/test/tests/materials/discrete/recompute.i
@@ -87,5 +87,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute2.i
+++ b/test/tests/materials/discrete/recompute2.i
@@ -88,5 +88,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute_block_error.i
+++ b/test/tests/materials/discrete/recompute_block_error.i
@@ -86,5 +86,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute_boundary_error.i
+++ b/test/tests/materials/discrete/recompute_boundary_error.i
@@ -85,5 +85,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute_no_calc.i
+++ b/test/tests/materials/discrete/recompute_no_calc.i
@@ -87,5 +87,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/materials/discrete/recompute_warning.i
+++ b/test/tests/materials/discrete/recompute_warning.i
@@ -85,5 +85,5 @@
 [Outputs]
   exodus = true
   print_linear_residuals = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/mesh/distributed_generated_mesh/distributed_generated_mesh.i
+++ b/test/tests/mesh/distributed_generated_mesh/distributed_generated_mesh.i
@@ -64,5 +64,5 @@
 
 [Outputs]
 #  exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/misc/check_error/multi_master.i
+++ b/test/tests/misc/check_error/multi_master.i
@@ -43,7 +43,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [MultiApps]

--- a/test/tests/misc/check_error/multi_sub.i
+++ b/test/tests/misc/check_error/multi_sub.i
@@ -51,5 +51,5 @@
   exodus = true
 
   # We can't control perf log output from a subapp
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/multiapps/full_solve_multiapp/master.i
+++ b/test/tests/multiapps/full_solve_multiapp/master.i
@@ -43,7 +43,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [MultiApps]

--- a/test/tests/outputs/console/console_transient.i
+++ b/test/tests/outputs/console/console_transient.i
@@ -54,7 +54,6 @@
   [./screen]
     type = Console
     verbose = true
-    perf_log = true
     time_precision = 6
     execute_on = 'failed nonlinear linear timestep_begin timestep_end'
   [../]

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -80,7 +80,7 @@
     # Tests that the --timing enables all logs
     type = RunApp
     input = 'console.i'
-    cli_args = 'Outputs/screen/perf_log=false --timing'
+    cli_args = '--timing'
     expect_out = 'Performance\sGraph'
     group = 'requirements'
   [../]

--- a/test/tests/outputs/exodus/variable_output_test.i
+++ b/test/tests/outputs/exodus/variable_output_test.i
@@ -96,6 +96,5 @@
   [../]
   [./console]
     Type = Console
-    perf_log = true
   [../]
 []

--- a/test/tests/postprocessors/memory_usage/print_memory_usage.i
+++ b/test/tests/postprocessors/memory_usage/print_memory_usage.i
@@ -99,5 +99,5 @@
 [Outputs]
   csv = true
   execute_on = 'INITIAL TIMESTEP_END FINAL'
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/restart/restart_refined_mesh/bad1.i
+++ b/test/tests/restart/restart_refined_mesh/bad1.i
@@ -762,7 +762,6 @@ active = ' '
 
   type =  Transient
 #  type =  SolutionTimeAdaptive
-  perf_log =  true
 
   solve_type = 'PJFNK'
   petsc_options_iname =  '-pc_type -pc_hypre_type -ksp_gmres_restart'

--- a/test/tests/restart/restart_refined_mesh/bad2.i
+++ b/test/tests/restart/restart_refined_mesh/bad2.i
@@ -775,7 +775,6 @@ active = ' '
 
   type =  Transient
 #  type =  SolutionTimeAdaptive
-  perf_log =  true
 
   solve_type = 'PJFNK'
   petsc_options_iname =  '-pc_type -pc_hypre_type -ksp_gmres_restart'

--- a/test/tests/test_harness/bad_kernel.i
+++ b/test/tests/test_harness/bad_kernel.i
@@ -48,5 +48,5 @@
 
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/test_harness/csvdiff.i
+++ b/test/tests/test_harness/csvdiff.i
@@ -54,5 +54,5 @@
 
 [Outputs]
   csv = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/test_harness/exodiff.i
+++ b/test/tests/test_harness/exodiff.i
@@ -49,5 +49,5 @@
 [Outputs]
   csv = true
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/test_harness/good.i
+++ b/test/tests/test_harness/good.i
@@ -47,5 +47,5 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/test_harness/long_running.i
+++ b/test/tests/test_harness/long_running.i
@@ -48,5 +48,5 @@
 []
 
 [Outputs]
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/time_integrators/rk-2/1d-linear.i
+++ b/test/tests/time_integrators/rk-2/1d-linear.i
@@ -90,5 +90,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/time_integrators/rk-2/2d-quadratic.i
+++ b/test/tests/time_integrators/rk-2/2d-quadratic.i
@@ -95,5 +95,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/time_integrators/tvdrk2/1d-linear.i
+++ b/test/tests/time_integrators/tvdrk2/1d-linear.i
@@ -93,5 +93,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/time_integrators/tvdrk2/2d-quadratic.i
+++ b/test/tests/time_integrators/tvdrk2/2d-quadratic.i
@@ -96,5 +96,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -85,5 +85,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/userobjects/shape_element_user_object/jacobian_test.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian_test.i
@@ -94,5 +94,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []

--- a/test/tests/userobjects/shape_element_user_object/shape_side_uo_jac_test.i
+++ b/test/tests/userobjects/shape_element_user_object/shape_side_uo_jac_test.i
@@ -68,7 +68,7 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [ICs]

--- a/test/tests/userobjects/shape_element_user_object/shape_side_uo_physics_test.i
+++ b/test/tests/userobjects/shape_element_user_object/shape_side_uo_physics_test.i
@@ -118,7 +118,7 @@ u_left = 0.5
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []
 
 [ICs]

--- a/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
+++ b/test/tests/userobjects/shape_element_user_object/simple_shape_element_uo_test.i
@@ -56,5 +56,5 @@
 
 [Outputs]
   exodus = true
-  print_perf_log = true
+  perf_graph = true
 []


### PR DESCRIPTION
Just ran some search and replace on input files.
The nightly deprecated test that run with `--error-deprecated` are dominated by these.