### PR TITLE
Fix some deprecated calls/parameters

### DIFF
--- a/framework/src/kernels/NodalEqualValueConstraint.C
+++ b/framework/src/kernels/NodalEqualValueConstraint.C
@@ -28,7 +28,7 @@ NodalEqualValueConstraint::NodalEqualValueConstraint(const InputParameters & par
   : NodalScalarKernel(parameters)
 {
   if (_node_ids.size() != 2)
-    paramError("nodes", "invalid number of nodes: want 2, got ", _node_ids.size());
+    paramError("boundary", "invalid number of nodes: want 2, got ", _node_ids.size());
 
   unsigned int n = coupledComponents("var");
   _value.resize(n);

--- a/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVectorPostprocessorTransfer.C
@@ -59,7 +59,7 @@ void
 MultiAppVectorPostprocessorTransfer::executeToMultiapp()
 {
   VectorPostprocessorValue & vpp =
-      _multi_app->problemBase().getVectorPostprocessorValue(_master_vpp_name, _vector_name);
+      _multi_app->problemBase().getVectorPostprocessorValue(_master_vpp_name, _vector_name, false);
 
   if (vpp.size() != _multi_app->numGlobalApps())
     mooseError("VectorPostprocessor ",
@@ -78,7 +78,7 @@ void
 MultiAppVectorPostprocessorTransfer::executeFromMultiapp()
 {
   VectorPostprocessorValue & vpp =
-      _multi_app->problemBase().getVectorPostprocessorValue(_master_vpp_name, _vector_name);
+      _multi_app->problemBase().getVectorPostprocessorValue(_master_vpp_name, _vector_name, false);
 
   if (vpp.size() != _multi_app->numGlobalApps())
     mooseError("VectorPostprocessor ",

--- a/framework/src/vectorpostprocessors/LineValueSampler.C
+++ b/framework/src/vectorpostprocessors/LineValueSampler.C
@@ -97,7 +97,7 @@ LineValueSampler::getValue(Point p) const
         std::lower_bound(_id.begin(), _id.end(), position * _line_vector_norm) - _id.begin();
 
     VectorPostprocessorValue & value_vector =
-        _vpp_fe_problem->getVectorPostprocessorValue(_vpp_name, _variable_names[0]);
+        _vpp_fe_problem->getVectorPostprocessorValue(_vpp_name, _variable_names[0], false);
 
     if (MooseUtils::absoluteFuzzyEqual(_id[vec_pos], position * _line_vector_norm))
       value = value_vector[vec_pos];

--- a/test/tests/misc/check_error/check_syntax_error.i
+++ b/test/tests/misc/check_error/check_syntax_error.i
@@ -28,7 +28,7 @@
     type = NodalEqualValueConstraint
     variable = lm
     var = u
-    nodes = '2 3 4'
+    boundary = '100 101 1'
   [../]
 []
 

--- a/test/tests/misc/check_error/check_syntax_ok.i
+++ b/test/tests/misc/check_error/check_syntax_ok.i
@@ -28,7 +28,7 @@
     type = NodalEqualValueConstraint
     variable = lm
     var = u
-    nodes = '2 3'
+    boundary = '100 101'
   [../]
 []
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -542,6 +542,9 @@
     input = 'check_syntax_error.i'
     cli_args = '--check-input'
     expect_err = 'invalid number of nodes: want 2, got 3'
+    # because with distributed, not all nodes end up on one proc, so the number of received nodes
+    # in not 3
+    mesh_mode = REPLICATED
   [../]
 
   [./check_syntax_no_input]

--- a/test/tests/mortar/1d/1d.i
+++ b/test/tests/mortar/1d/1d.i
@@ -28,7 +28,7 @@
     type = NodalEqualValueConstraint
     variable = lm
     var = u
-    nodes = '2 3'
+    boundary = '100 101'
   [../]
 []
 


### PR DESCRIPTION
Fixing deprecated calls/parameters in:

* LineValueSampler
* MultiAppVectorPostprocessorTransfer
* NodalEqualValueConstraint

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
