### PR TITLE
Guard existence of user objects only on thread 0

### DIFF
--- a/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
@@ -36,7 +36,7 @@ TwoPhaseFluidProperties::TwoPhaseFluidProperties(const InputParameters & paramet
   // is implied that these objects will be created by a derived class. In this
   // case, we need to check that these user objects do not already exist.
   if (!isParamValid("fp_liquid"))
-    if (_fe_problem.hasUserObject(_liquid_name))
+    if (_tid == 0 && _fe_problem.hasUserObject(_liquid_name))
       paramError("fp_liquid",
                  "The two-phase fluid properties object '" + name() + "' is ",
                  "trying to create a single-phase fluid properties object with ",
@@ -45,7 +45,7 @@ TwoPhaseFluidProperties::TwoPhaseFluidProperties(const InputParameters & paramet
                  "', but a single-phase fluid properties ",
                  "object with this name already exists.");
   if (!isParamValid("fp_vapor"))
-    if (_fe_problem.hasUserObject(_vapor_name))
+    if (_tid == 0 && _fe_problem.hasUserObject(_vapor_name))
       paramError("fp_vapor",
                  "The two-phase fluid properties object '" + name() + "' is ",
                  "trying to create a single-phase fluid properties object with ",


### PR DESCRIPTION
Now that fluid properties user objects are threaded, we need to perform
the consistency check only on thread 0.

Refs #11731

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
