### PR TITLE
Don't run new porous_flow injection_production test with pthreads

### DIFF
--- a/modules/porous_flow/test/tests/dirackernels/tests
+++ b/modules/porous_flow/test/tests/dirackernels/tests
@@ -231,5 +231,6 @@
     type = 'Exodiff'
     input = 'injection_production.i'
     exodiff = 'injection_production_out.e'
+    threading = '!pthreads'
   [../]
 []


### PR DESCRIPTION
#11969 introduced a new test that can't run with pthreads: https://civet.inl.gov/job/219154/


<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
