### PR TITLE
give threaded general user objects their own subclass

### DIFF
--- a/framework/include/userobject/ThreadedGeneralUserObject.h
+++ b/framework/include/userobject/ThreadedGeneralUserObject.h
@@ -1,0 +1,25 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef THREADEDGENERALUSEROBJECT_H
+#define THREADEDGENERALUSEROBJECT_H
+
+#include "GeneralUserObject.h"
+
+/// An instance of this object type has one copy per thread that runs on each thread.
+class ThreadedGeneralUserObject : public GeneralUserObject
+{
+public:
+  ThreadedGeneralUserObject(const InputParameters & parameters) : GeneralUserObject(parameters) {}
+  virtual ~ThreadedGeneralUserObject() = default;
+  virtual void threadJoin(const UserObject &) override;
+  virtual void subdomainSetup() override{};
+};
+
+#endif

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -65,6 +65,7 @@
 #include "SideUserObject.h"
 #include "InternalSideUserObject.h"
 #include "GeneralUserObject.h"
+#include "ThreadedGeneralUserObject.h"
 #include "InternalSideIndicator.h"
 #include "Transfer.h"
 #include "MultiAppTransfer.h"
@@ -2632,6 +2633,8 @@ FEProblemBase::addUserObject(std::string user_object_name,
     std::shared_ptr<NodalUserObject> nuo = std::dynamic_pointer_cast<NodalUserObject>(user_object);
     std::shared_ptr<GeneralUserObject> guo =
         std::dynamic_pointer_cast<GeneralUserObject>(user_object);
+    std::shared_ptr<GeneralUserObject> tguo =
+        std::dynamic_pointer_cast<ThreadedGeneralUserObject>(user_object);
 
     // Account for displaced mesh use
     if (_displaced_problem != NULL && parameters.get<bool>("use_displaced_mesh"))
@@ -2643,15 +2646,12 @@ FEProblemBase::addUserObject(std::string user_object_name,
     }
 
     // Add the object to the correct warehouse
-    if (guo)
+    if (tguo)
+      _threaded_general_user_objects.addObject(guo, tid);
+    else if (guo)
     {
-      if (guo->getParam<bool>("threaded"))
-        _threaded_general_user_objects.addObject(guo, tid);
-      else
-      {
-        _general_user_objects.addObject(guo);
-        break;
-      }
+      _general_user_objects.addObject(guo);
+      break;
     }
     else if (nuo)
       _nodal_user_objects.addObject(nuo, tid);

--- a/framework/src/userobject/GeneralUserObject.C
+++ b/framework/src/userobject/GeneralUserObject.C
@@ -16,8 +16,6 @@ validParams<GeneralUserObject>()
   InputParameters params = validParams<UserObject>();
   params += validParams<MaterialPropertyInterface>();
   params.addParam<bool>(
-      "threaded", false, "true if there should be threaded copies of this user object.");
-  params.addParam<bool>(
       "force_preaux", false, "Forces the GeneralUserObject to be executed in PREAUX");
   params.addParamNamesToGroup("force_preaux", "Advanced");
   return params;

--- a/framework/src/userobject/ThreadedGeneralUserObject.C
+++ b/framework/src/userobject/ThreadedGeneralUserObject.C
@@ -1,0 +1,16 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ThreadedGeneralUserObject.h"
+
+void
+ThreadedGeneralUserObject::threadJoin(const UserObject &)
+{
+  mooseError("ThreadedGeneralUserObject failed to override threadJoin");
+}

--- a/modules/fluid_properties/include/userobjects/FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/FluidProperties.h
@@ -10,7 +10,7 @@
 #ifndef FLUIDPROPERTIES_H
 #define FLUIDPROPERTIES_H
 
-#include "GeneralUserObject.h"
+#include "ThreadedGeneralUserObject.h"
 
 // Forward Declarations
 class FluidProperties;
@@ -18,7 +18,7 @@ class FluidProperties;
 template <>
 InputParameters validParams<FluidProperties>();
 
-class FluidProperties : public GeneralUserObject
+class FluidProperties : public ThreadedGeneralUserObject
 {
 public:
   FluidProperties(const InputParameters & parameters);

--- a/modules/fluid_properties/src/userobjects/FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/FluidProperties.C
@@ -15,11 +15,11 @@ validParams<FluidProperties>()
 {
   InputParameters params = validParams<GeneralUserObject>();
   params.registerBase("FluidProperties");
-  params.set<bool>("threaded") = true;
   return params;
 }
 
-FluidProperties::FluidProperties(const InputParameters & parameters) : GeneralUserObject(parameters)
+FluidProperties::FluidProperties(const InputParameters & parameters)
+  : ThreadedGeneralUserObject(parameters)
 {
 }
 

--- a/test/include/userobjects/PrimeProductUserObject.h
+++ b/test/include/userobjects/PrimeProductUserObject.h
@@ -10,7 +10,7 @@
 #ifndef PRIMECOUNTERUSEROBJECT_H
 #define PRIMECOUNTERUSEROBJECT_H
 
-#include "GeneralUserObject.h"
+#include "ThreadedGeneralUserObject.h"
 
 class PrimeProductUserObject;
 
@@ -22,7 +22,7 @@ InputParameters validParams<PrimeProductUserObject>();
  * its thread ID. Then when threads join the product of all prime numbers is computed, which is the
  * final value provided by this user object.
  */
-class PrimeProductUserObject : public GeneralUserObject
+class PrimeProductUserObject : public ThreadedGeneralUserObject
 {
 public:
   PrimeProductUserObject(const InputParameters & params);

--- a/test/src/userobjects/PrimeProductUserObject.C
+++ b/test/src/userobjects/PrimeProductUserObject.C
@@ -21,7 +21,7 @@ validParams<PrimeProductUserObject>()
 }
 
 PrimeProductUserObject::PrimeProductUserObject(const InputParameters & params)
-  : GeneralUserObject(params)
+  : ThreadedGeneralUserObject(params)
 {
   if (libMesh::n_threads() > 20)
     mooseError("This object works only with up to 20 threads. If you need more, add more prime "

--- a/test/tests/userobjects/threaded_general_user_object/test.i
+++ b/test/tests/userobjects/threaded_general_user_object/test.i
@@ -32,7 +32,6 @@
 [UserObjects]
   [./prime_product]
     type = PrimeProductUserObject
-    threaded = true
     execute_on = timestep_end
   [../]
 []


### PR DESCRIPTION
Since a threaded (vs not) object requires very specific code handling,
we do not generally want the ability for objects to be dynamically
toggled between threaded vs not handling - this could easily result in
unintentional, subtle errors.  Also, the new general warehouse handling
of user objects will be much better served by this as an explicit
separate class.

ref #11834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
