### PR TITLE
Fix preprocessor macro check for threaded general user objects

### DIFF
--- a/framework/include/userobject/ThreadedGeneralUserObject.h
+++ b/framework/include/userobject/ThreadedGeneralUserObject.h
@@ -16,7 +16,7 @@
 class ThreadedGeneralUserObject : public GeneralUserObject
 {
 public:
-  ThreadedGeneralUserObject(const InputParameters & parameters) : GeneralUserObject(parameters) {}
+  ThreadedGeneralUserObject(const InputParameters & parameters);
   virtual ~ThreadedGeneralUserObject() = default;
   virtual void threadJoin(const UserObject &) override;
   virtual void subdomainSetup() override{};

--- a/framework/src/userobject/GeneralUserObject.C
+++ b/framework/src/userobject/GeneralUserObject.C
@@ -30,12 +30,6 @@ GeneralUserObject::GeneralUserObject(const InputParameters & parameters)
     PostprocessorInterface(this),
     VectorPostprocessorInterface(this)
 {
-#if !defined(LIBMESH_HAVE_OPENMP) && !defined(LIBMESH_HAVE_TBB_API)
-  if (getParam<bool>("threaded"))
-    mooseError(name(),
-               ": You cannot use threaded general user objects with pthreads. To enable this "
-               "functionality configure libMesh with OpenMP or TBB.");
-#endif
   _supplied_vars.insert(name());
 }
 

--- a/framework/src/userobject/ThreadedGeneralUserObject.C
+++ b/framework/src/userobject/ThreadedGeneralUserObject.C
@@ -9,6 +9,16 @@
 
 #include "ThreadedGeneralUserObject.h"
 
+ThreadedGeneralUserObject::ThreadedGeneralUserObject(const InputParameters & parameters)
+  : GeneralUserObject(parameters)
+{
+#if !defined(LIBMESH_HAVE_OPENMP) && !defined(LIBMESH_HAVE_TBB_API)
+  mooseError(name(),
+             ": You cannot use threaded general user objects with pthreads. To enable this "
+             "functionality configure libMesh with OpenMP or TBB.");
+#endif
+}
+
 void
 ThreadedGeneralUserObject::threadJoin(const UserObject &)
 {


### PR DESCRIPTION
This was an oversight in #11979 - forgot to update+move the check for
tbb/openmp into the new threadedgeneraluserobject class.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
