### PR TITLE
Allow the mesh viewer in the input tab to expand when resizing

### DIFF
--- a/python/peacock/ExodusViewer/plugins/CameraPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/CameraPlugin.py
@@ -20,6 +20,7 @@ class CameraPlugin(QtWidgets.QGroupBox, ExodusPlugin):
 
     def __init__(self, **kwargs):
         super(CameraPlugin, self).__init__(**kwargs)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Minimum)
 
         self.MainLayout = QtWidgets.QHBoxLayout(self)
 

--- a/python/peacock/Input/BlockHighlighterPlugin.py
+++ b/python/peacock/Input/BlockHighlighterPlugin.py
@@ -25,7 +25,7 @@ class BlockHighlighterPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     def __init__(self, **kwargs):
         super(BlockHighlighterPlugin, self).__init__(**kwargs)
 
-        self.setSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Minimum)
         self.MainLayout = QtWidgets.QHBoxLayout(self)
         self.MainLayout.setSpacing(10)
         self.setEnabled(False)


### PR DESCRIPTION
It wasn't expanding in the vertical direction. Setting the two bottom widgets to just Minimum allows the mesh viewer to expand properly.

closes #11983

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
