### PR TITLE
Fix peacock crash when filename with unicode exists

### DIFF
--- a/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
+++ b/python/peacock/ExodusViewer/plugins/ExodusFilterProxyModel.py
@@ -19,7 +19,7 @@ class ExodusFilterProxyModel(QtCore.QSortFilterProxyModel):
     """
     def filterAcceptsRow(self, row, parent):
         index0 = self.sourceModel().index(row, 0, parent)
-        filename = str(self.sourceModel().filePath(index0))
+        filename = self.sourceModel().filePath(index0)
 
         if os.path.isdir(filename):
             return True

--- a/python/peacock/ExodusViewer/plugins/FilePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/FilePlugin.py
@@ -90,16 +90,6 @@ class FilePlugin(QtWidgets.QGroupBox, ExodusPlugin):
         self.BottomLayout.addWidget(self.ComponentList)
         self.MainLayout.addLayout(self.BottomLayout)
 
-        # File dialog
-        self.FileOpenDialog = QtWidgets.QFileDialog()
-        self.FileOpenDialog.setWindowTitle('Select ExodusII File(s)')
-        self.FileOpenDialog.setNameFilter('ExodusII Files (*.e)')
-        self.FileOpenDialog.setDirectory(os.getcwd())
-
-        self.FileOpenDialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        self.FileOpenDialog.setOption(QtWidgets.QFileDialog.DontUseNativeDialog)
-        self.FileOpenDialog.setProxyModel(ExodusFilterProxyModel())
-
         self.MainLayout.setSpacing(0)
         self.TopLayout.setSpacing(10)
         self.BottomLayout.setSpacing(10)
@@ -282,9 +272,17 @@ class FilePlugin(QtWidgets.QGroupBox, ExodusPlugin):
         """
         Callback for opening an additional file.
         """
+        fd = QtWidgets.QFileDialog()
+        fd.setWindowTitle('Select ExodusII File(s)')
+        fd.setNameFilter('ExodusII Files (*.e)')
+        fd.setDirectory(os.getcwd())
 
-        if self.FileOpenDialog.exec_() == QtWidgets.QDialog.Accepted:
-            filenames = [str(fname) for fname in list(self.FileOpenDialog.selectedFiles())]
+        fd.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
+        fd.setOption(QtWidgets.QFileDialog.DontUseNativeDialog)
+        fd.setProxyModel(ExodusFilterProxyModel())
+
+        if fd.exec_() == QtWidgets.QDialog.Accepted:
+            filenames = [str(fname) for fname in list(fd.selectedFiles())]
             if self.FileList.count() == 0:
                 self.onSetFilenames(filenames)
         else:


### PR DESCRIPTION
This just prevents peacock from crashing when there exists a filename with unicode characters in a directory that peacock tries to read.

Moose related files with unicode characters still don't work. We probably need to eliminate the explicit use of `str()` in various places for that to work.

@aeslaughter This gets triggered on startup because `ExodusViewer/plugins/FilePlugin.py` creates a file dialog in its constructor and uses `ExodusFilterProxyModel` as its model. I guess that immediately populates the model with the files in the current directory.

closes #11993

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
