### PR TITLE
Get the right thread copy when requesting ThreadedGeneralUserObject

### DIFF
--- a/framework/include/userobject/UserObjectInterface.h
+++ b/framework/include/userobject/UserObjectInterface.h
@@ -72,15 +72,15 @@ private:
   /// Thread ID
   THREAD_ID _uoi_tid;
 
-  /// Check if the user object is a DiscreteElementUserObject
-  bool isDiscreteUserObject(const UserObject & uo) const;
+  /// Check if the threaded copy of the user object is needed
+  bool needThreadedCopy(const UserObject & uo) const;
 };
 
 template <class T>
 const T &
 UserObjectInterface::getUserObject(const std::string & name)
 {
-  unsigned int tid = isDiscreteUserObject(getUserObjectBase(name)) ? _uoi_tid : 0;
+  unsigned int tid = needThreadedCopy(getUserObjectBase(name)) ? _uoi_tid : 0;
   return _uoi_feproblem.getUserObject<T>(_uoi_params.get<UserObjectName>(name), tid);
 }
 
@@ -88,7 +88,7 @@ template <class T>
 const T &
 UserObjectInterface::getUserObjectByName(const std::string & name)
 {
-  unsigned int tid = isDiscreteUserObject(getUserObjectBaseByName(name)) ? _uoi_tid : 0;
+  unsigned int tid = needThreadedCopy(getUserObjectBaseByName(name)) ? _uoi_tid : 0;
   return _uoi_feproblem.getUserObject<T>(name, tid);
 }
 

--- a/framework/src/userobject/UserObjectInterface.C
+++ b/framework/src/userobject/UserObjectInterface.C
@@ -10,6 +10,7 @@
 // MOOSE includes
 #include "UserObjectInterface.h"
 #include "DiscreteElementUserObject.h"
+#include "ThreadedGeneralUserObject.h"
 #include "InputParameters.h"
 
 UserObjectInterface::UserObjectInterface(const MooseObject * moose_object)
@@ -32,7 +33,8 @@ UserObjectInterface::getUserObjectBaseByName(const std::string & name)
 }
 
 bool
-UserObjectInterface::isDiscreteUserObject(const UserObject & uo) const
+UserObjectInterface::needThreadedCopy(const UserObject & uo) const
 {
-  return dynamic_cast<const DiscreteElementUserObject *>(&uo) != NULL;
+  return (dynamic_cast<const DiscreteElementUserObject *>(&uo) != NULL) ||
+         (dynamic_cast<const ThreadedGeneralUserObject *>(&uo) != NULL);
 }


### PR DESCRIPTION
When ThreadedGeneralUserObject is requested via UserObjectInterface, we
respect the thread ID and give users back the corresponding thread copy.

Refs #11834

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
