### PR TITLE
Don't test with pthreads on 1D radial example

### DIFF
--- a/modules/porous_flow/examples/co2_intercomparison/1Dradial/tests
+++ b/modules/porous_flow/examples/co2_intercomparison/1Dradial/tests
@@ -27,5 +27,6 @@
     type = RunApp
     input = '1Dradial.i'
     check_input = true
+    threading = '!pthreads'
   [../]
 []


### PR DESCRIPTION
New example introduced in #12015 doesn't skip when using pthreads, which breaks our min clang testing.
`FAIL porous_flow/examples/co2_intercomparison/1Dradial.1Dradial FAILED`
See https://civet.inl.gov/job/222404/

This seems to be a somewhat frequent problem, we probably need to catch this on PRs...

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
