### PR TITLE
Remove invalid petsc option

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -860,7 +860,7 @@ getCommonPetscFlags()
       "-dm_moose_print_embedding -dm_view -ksp_converged_reason -ksp_gmres_modifiedgramschmidt "
       "-ksp_monitor -ksp_monitor_snes_lg-snes_ksp_ew -ksp_snes_ew -snes_converged_reason "
       "-snes_ksp -snes_ksp_ew -snes_linesearch_monitor -snes_mf -snes_mf_operator -snes_monitor "
-      "-snes_test_display -snes_view -snew_ksp_ew",
+      "-snes_test_display -snes_view",
       "",
       true);
 }

--- a/modules/combined/test/tests/solid_mechanics/beam_pbp/beam_pbp_test.i
+++ b/modules/combined/test/tests/solid_mechanics/beam_pbp/beam_pbp_test.i
@@ -102,8 +102,6 @@
 
   solve_type = JFNK
 
-  petsc_options = '-snew_ksp_ew'
-
   nl_abs_tol = 1e-8
 
   l_max_its = 100

--- a/modules/combined/test/tests/solid_mechanics/beam_pbp/beam_pbp_tm.i
+++ b/modules/combined/test/tests/solid_mechanics/beam_pbp/beam_pbp_tm.i
@@ -97,8 +97,6 @@
 
   solve_type = JFNK
 
-  petsc_options = '-snew_ksp_ew'
-
   nl_abs_tol = 1e-8
 
   l_max_its = 100


### PR DESCRIPTION
The option `-ksp_monitor_snes_lg-snes_ksp_ew` looks a bit dodgy as well - possibly missing a space between them?

Closes #12016
