### PR TITLE
Revert PR #11371 to change the console behavior back

### DIFF
--- a/framework/src/outputs/OutputWarehouse.C
+++ b/framework/src/outputs/OutputWarehouse.C
@@ -182,7 +182,9 @@ OutputWarehouse::mooseConsole()
     // Reset
     _console_buffer.clear();
     _console_buffer.str("");
-
+  }
+  else
+  {
     if (!_buffer_action_console_outputs)
     {
       // this will cause messages to console before its construction immediately flushed and

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -171,5 +171,6 @@
     issues = "#5178"
     design = "Outputs/index.md Console.md"
     method = "opt" # dbg has libMesh stuff show up
+    deleted = "#5178" # tempararily disable this test for console refactoring
   [../]
 []


### PR DESCRIPTION
Reverts #11371
Closes #11435 

The test is retained but removed from testing. It can be reactivated after console refactoring.
