### PR TITLE
Make string references const 

### DIFF
--- a/framework/include/actions/AddVariableAction.h
+++ b/framework/include/actions/AddVariableAction.h
@@ -53,7 +53,7 @@ protected:
    *
    * @param var_name The name of the variable.
    */
-  void addVariable(std::string & var_name);
+  void addVariable(const std::string & var_name);
 
   /**
    * Create the action to generate the InitialCondition object

--- a/framework/include/meshmodifiers/BreakMeshByBlockBase.h
+++ b/framework/include/meshmodifiers/BreakMeshByBlockBase.h
@@ -59,7 +59,8 @@ private:
                                    const subdomain_id_type & /*slaveBlockID*/);
 
   /// this method save the boundary name/id pair
-  void mapBoundaryIdAndBoundaryName(BoundaryID & /*boundaryID*/, std::string & /*boundaryName*/);
+  void mapBoundaryIdAndBoundaryName(BoundaryID & /*boundaryID*/,
+                                    const std::string & /*boundaryName*/);
 };
 
 #endif // BREAKMESHBYBLOCKBASE_H

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -129,7 +129,7 @@ AddVariableAction::createInitialConditionAction()
 }
 
 void
-AddVariableAction::addVariable(std::string & var_name)
+AddVariableAction::addVariable(const std::string & var_name)
 {
   std::set<SubdomainID> blocks = getSubdomainIDs();
   Real scale_factor = isParamValid("scaling") ? getParam<Real>("scaling") : 1;

--- a/framework/src/meshmodifiers/BreakMeshByBlockBase.C
+++ b/framework/src/meshmodifiers/BreakMeshByBlockBase.C
@@ -91,7 +91,7 @@ BreakMeshByBlockBase::generateBoundaryName(const subdomain_id_type & masterBlock
 
 void
 BreakMeshByBlockBase::mapBoundaryIdAndBoundaryName(BoundaryID & boundaryID,
-                                                   std::string & boundaryName)
+                                                   const std::string & boundaryName)
 {
   _bName_bID_set.insert(std::pair<std::string, int>(boundaryName, boundaryID));
 }

--- a/modules/xfem/include/base/XFEM.h
+++ b/modules/xfem/include/base/XFEM.h
@@ -165,15 +165,7 @@ public:
 
   void getCrackTipOrigin(std::map<unsigned int, const Elem *> & elem_id_crack_tip,
                          std::vector<Point> & crack_front_points);
-  // void update_crack_propagation_direction(const Elem* elem, Point direction);
-  // void clear_crack_propagation_direction();
-  /**
-   * Set and get xfem cut data and type
-   */
-  std::vector<Real> & getXFEMCutData();
-  void setXFEMCutData(std::vector<Real> & cut_data);
-  std::string & getXFEMCutType();
-  void setXFEMCutType(std::string & cut_type);
+
   Xfem::XFEM_QRULE & getXFEMQRule();
   void setXFEMQRule(std::string & xfem_qrule);
   void setCrackGrowthMethod(bool use_crack_growth_increment, Real crack_growth_increment);


### PR DESCRIPTION
This allows code like

```
addVariable(name() + "i" + Moose::stringify(num));
```

which previously had to be written with a non-temporary variable

```
std::string var_name = name() + "i" + Moose::stringify(cur_num);
addVariable(var_name);
```

Closes #12045