### PR TITLE
libMesh update + deprecated code fixes

### DIFF
--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -75,7 +75,7 @@ template <typename T>
 void
 setLinearSolverDefaults(FEProblemBase & problem, LinearSolver<T> & linear_solver)
 {
-  petscSetKSPDefaults(problem, libmesh_cast_ref<PetscLinearSolver<T> &>(linear_solver).ksp());
+  petscSetKSPDefaults(problem, libMesh::cast_ref<PetscLinearSolver<T> &>(linear_solver).ksp());
 }
 
 /**

--- a/framework/src/loops/CacheChangedListsThread.C
+++ b/framework/src/loops/CacheChangedListsThread.C
@@ -28,7 +28,7 @@ void
 CacheChangedListsThread::onElement(const Elem * elem)
 {
   if (elem->refinement_flag() == Elem::INACTIVE && elem->has_children() &&
-      elem->child(0)->refinement_flag() == Elem::JUST_REFINED)
+      elem->child_ptr(0)->refinement_flag() == Elem::JUST_REFINED)
     _refined_elements.push_back(elem);
 
   if (elem->refinement_flag() == Elem::JUST_COARSENED)
@@ -40,7 +40,7 @@ CacheChangedListsThread::onElement(const Elem * elem)
       std::vector<const Elem *> & children = _coarsened_element_children[elem];
 
       for (unsigned int child = 0; child < elem->n_children(); child++)
-        children.push_back(elem->child(child));
+        children.push_back(elem->child_ptr(child));
     }
   }
 }

--- a/framework/src/loops/ProjectMaterialProperties.C
+++ b/framework/src/loops/ProjectMaterialProperties.C
@@ -149,7 +149,7 @@ ProjectMaterialProperties::onInternalSide(const Elem * elem, unsigned int /*side
   {
     for (unsigned int child = 0; child < elem->n_children(); child++)
     {
-      Elem * child_elem = elem->child(child);
+      const Elem * child_elem = elem->child_ptr(child);
 
       for (unsigned int side = 0; side < child_elem->n_sides(); side++)
       {

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -131,7 +131,7 @@ MaterialPropertyStorage::prolongStatefulProps(
     if (input_child == -1 && input_child_side != -1 && !elem.is_child_on_side(child, parent_side))
       continue;
 
-    const Elem * child_elem = elem.child(child);
+    const Elem * child_elem = elem.child_ptr(child);
 
     mooseAssert(child < refinement_map.size(), "Refinement_map vector not initialized");
     const std::vector<QpMap> & child_map = refinement_map[child];

--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -1269,7 +1269,7 @@ build_cube(UnstructuredMesh & mesh,
   // Set RemoteElem neighbors
   for (auto & elem_ptr : mesh.element_ptr_range())
     for (unsigned int s = 0; s < elem_ptr->n_sides(); s++)
-      if (!elem_ptr->neighbor(s) && !boundary_info.n_boundary_ids(elem_ptr, s))
+      if (!elem_ptr->neighbor_ptr(s) && !boundary_info.n_boundary_ids(elem_ptr, s))
         elem_ptr->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
 
   if (verbose)

--- a/framework/src/mesh/DistributedGeneratedMesh.C
+++ b/framework/src/mesh/DistributedGeneratedMesh.C
@@ -1303,7 +1303,14 @@ build_cube(UnstructuredMesh & mesh,
   if (verbose)
     Moose::out << "Getting ready to prepare for use" << std::endl;
 
-  mesh.prepare_for_use(true, true); // No need to renumber or find neighbors - done did it.
+  // No need to renumber or find neighbors - done did it.
+  // Avoid deprecation message/error by _also_ setting
+  // allow_renumbering(false). This is a bit silly, but we want to
+  // catch cases where people are purely using the old "skip"
+  // interface and not the new flag setting one.
+  mesh.allow_renumbering(false);
+  mesh.prepare_for_use(/*skip_renumber (ignored!) = */ false,
+                       /*skip_find_neighbors = */ true);
 
   if (verbose)
     for (auto & elem_ptr : mesh.element_ptr_range())

--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -129,7 +129,8 @@ AddSideSetsFromBoundingBox::modify()
       if (_bounding_box.contains_point(**node) == inside)
       {
         // read out boundary ids for nodes
-        std::vector<boundary_id_type> boundary_id_list = boundary_info.boundary_ids(*node);
+        std::vector<boundary_id_type> boundary_id_list;
+        boundary_info.boundary_ids(*node, boundary_id_list);
         std::vector<boundary_id_type> boundary_id_old_list =
             _mesh_ptr->getBoundaryIDs(_boundary_id_old);
 

--- a/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
+++ b/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
@@ -58,6 +58,7 @@ BreakBoundaryOnSubdomain::modify()
 
   // create a list of new boundary names
   std::set<std::string> new_boundary_name_set;
+  std::vector<boundary_id_type> side_boundary_ids;
   for (const auto & elem : mesh.active_element_ptr_range())
   {
     auto subdomain_id = elem->subdomain_id();
@@ -66,7 +67,7 @@ BreakBoundaryOnSubdomain::modify()
       subdomain_name = std::to_string(subdomain_id);
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      auto side_boundary_ids = boundary_info.boundary_ids(elem, side);
+      boundary_info.boundary_ids(elem, side, side_boundary_ids);
       for (auto i = beginIndex(side_boundary_ids); i < side_boundary_ids.size(); ++i)
         if (breaking_boundary_ids.count(side_boundary_ids[i]) > 0)
           new_boundary_name_set.emplace(boundary_info.sideset_name(side_boundary_ids[i]) + "_to_" +
@@ -102,7 +103,8 @@ BreakBoundaryOnSubdomain::modify()
       subdomain_name = std::to_string(subdomain_id);
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      auto side_boundary_ids = boundary_info.boundary_ids(elem, side);
+      std::vector<boundary_id_type> side_boundary_ids;
+      boundary_info.boundary_ids(elem, side, side_boundary_ids);
       for (auto i = beginIndex(side_boundary_ids); i < side_boundary_ids.size(); ++i)
       {
         if (breaking_boundary_ids.count(side_boundary_ids[i]) > 0)

--- a/framework/src/meshmodifiers/ParsedAddSideset.C
+++ b/framework/src/meshmodifiers/ParsedAddSideset.C
@@ -117,7 +117,7 @@ ParsedAddSideset::modify()
         continue;
 
       // check expression
-      std::unique_ptr<Elem> curr_side = elem->side(side);
+      std::unique_ptr<Elem> curr_side = elem->side_ptr(side);
       _func_params[0] = curr_side->centroid()(0);
       _func_params[1] = curr_side->centroid()(1);
       _func_params[2] = curr_side->centroid()(2);

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -72,7 +72,7 @@ SideSetsFromPoints::modify()
         continue;
 
       // See if this point is on this side
-      std::unique_ptr<Elem> elem_side = elem->side(side);
+      std::unique_ptr<const Elem> elem_side = elem->side_ptr(side);
 
       if (elem_side->contains_point(_points[i]))
       {

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3843,6 +3843,13 @@ FEProblemBase::init()
   }
 
   _nl->dofMap()._dof_coupling = _cm.get();
+
+  // If there are no variables, make sure to pass a nullptr coupling
+  // matrix, to avoid warnings about non-nullptr yet empty
+  // CouplingMatrices.
+  if (n_vars == 0)
+    _nl->dofMap()._dof_coupling = nullptr;
+
   _nl->dofMap().attach_extra_sparsity_function(&extraSparsity, _nl.get());
   _nl->dofMap().attach_extra_send_list_function(&extraSendList, _nl.get());
   _aux->dofMap().attach_extra_send_list_function(&extraSendList, _aux.get());

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -342,7 +342,7 @@ NonlinearSystem::setupColoringFiniteDifferencedPreconditioner()
   MatFDColoringCreate(petsc_mat->mat(), iscoloring, &_fdcoloring);
   MatFDColoringSetFromOptions(_fdcoloring);
   MatFDColoringSetFunction(_fdcoloring,
-                           (PetscErrorCode(*)(void)) & libMesh::__libmesh_petsc_snes_fd_residual,
+                           (PetscErrorCode(*)(void)) & libMesh::libmesh_petsc_snes_fd_residual,
                            &petsc_nonlinear_solver);
 #if !PETSC_RELEASE_LESS_THAN(3, 5, 0)
   MatFDColoringSetUp(petsc_mat->mat(), iscoloring, _fdcoloring);

--- a/framework/src/transfers/DTKInterpolationEvaluator.C
+++ b/framework/src/transfers/DTKInterpolationEvaluator.C
@@ -52,7 +52,7 @@ DTKInterpolationEvaluator::evaluate(const Teuchos::ArrayRCP<GlobalOrdinal> & ele
 
   for (GlobalOrdinal i = 0; i < num_values; i++)
   {
-    Elem * elem = mesh.elem(elements[i]);
+    Elem * elem = mesh.elem_ptr(elements[i]);
 
     Point p;
 

--- a/framework/src/userobject/PerflogDumper.C
+++ b/framework/src/userobject/PerflogDumper.C
@@ -30,6 +30,7 @@ PerflogDumper::PerflogDumper(const InputParameters & parameters) : GeneralUserOb
 void
 PerflogDumper::execute()
 {
+#ifdef LIBMESH_ENABLE_DEPRECATED
   auto & log = Moose::perf_log.get_log_raw();
   std::ofstream f(_pars.get<std::string>("outfile"));
   if (!f.good())
@@ -48,4 +49,8 @@ PerflogDumper::execute()
   }
   if (!f.good())
     mooseError("PerfLogDumper: error writing file '", _pars.get<std::string>("outfile"), "'");
+#else
+  mooseWarning("The version of libMesh you are using does not support direct access "
+               "to the underlying PerfLog container, no log information will be dumped.");
+#endif
 }

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -377,7 +377,7 @@ SolutionUserObject::directValue(const Elem * elem, const std::string & var_name)
 
   // Get the element id and associated dof
   dof_id_type elem_id = elem->id();
-  dof_id_type dof_id = _system->get_mesh().elem(elem_id)->dof_number(sys_num, var_num, 0);
+  dof_id_type dof_id = _system->get_mesh().elem_ptr(elem_id)->dof_number(sys_num, var_num, 0);
 
   // Return the desired value
   return directValue(dof_id);
@@ -533,7 +533,7 @@ SolutionUserObject::updateExodusTimeInterpolation(Real time)
       for (const auto & var_name : _system_variables)
       {
         if (_local_variable_nodal[var_name])
-          _exodusII_io->copy_nodal_solution(*_system, var_name, _exodus_index1 + 1);
+          _exodusII_io->copy_nodal_solution(*_system, var_name, var_name, _exodus_index1 + 1);
         else
           _exodusII_io->copy_elemental_solution(*_system, var_name, var_name, _exodus_index1 + 1);
       }
@@ -545,7 +545,7 @@ SolutionUserObject::updateExodusTimeInterpolation(Real time)
       for (const auto & var_name : _system_variables)
       {
         if (_local_variable_nodal[var_name])
-          _exodusII_io->copy_nodal_solution(*_system2, var_name, _exodus_index2 + 1);
+          _exodusII_io->copy_nodal_solution(*_system2, var_name, var_name, _exodus_index2 + 1);
         else
           _exodusII_io->copy_elemental_solution(*_system2, var_name, var_name, _exodus_index2 + 1);
       }

--- a/framework/src/utils/RayTracing.C
+++ b/framework/src/utils/RayTracing.C
@@ -51,7 +51,7 @@ sideIntersectedByLine(const Elem * elem,
       continue;
 
     // Get a simplified side element
-    std::unique_ptr<Elem> side_elem = elem->side(i);
+    std::unique_ptr<const Elem> side_elem = elem->side_ptr(i);
 
     if (dim == 3)
     {

--- a/framework/src/vectorpostprocessors/WorkBalance.C
+++ b/framework/src/vectorpostprocessors/WorkBalance.C
@@ -138,12 +138,12 @@ public:
 
   virtual void onInternalSide(const Elem * elem, unsigned int side) override
   {
-    if (elem->neighbor(side)->processor_id() != _this_pid)
+    if (elem->neighbor_ptr(side)->processor_id() != _this_pid)
     {
       _local_num_partition_sides++;
 
       // Build the side so we can compute its volume
-      auto side_elem = elem->build_side(side);
+      auto side_elem = elem->build_side_ptr(side);
       _local_partition_surface_area += side_elem->volume();
     }
   }

--- a/test/src/ics/DataStructIC.C
+++ b/test/src/ics/DataStructIC.C
@@ -39,7 +39,7 @@ DataStructIC::initialSetup()
     unsigned int n_nodes = current_elem->n_vertices();
     for (unsigned int i = 0; i < n_nodes; ++i)
     {
-      const Node * current_node = current_elem->get_node(i);
+      const Node * current_node = current_elem->node_ptr(i);
 
       _data[current_node->id()] = current_node->id() * 2.0; // double the node_id
     }

--- a/test/src/markers/CircleMarker.C
+++ b/test/src/markers/CircleMarker.C
@@ -44,7 +44,7 @@ CircleMarker::computeElementMarker()
 {
   Point centroid = _current_elem->centroid();
 
-  if ((centroid - _p).size() < _r)
+  if ((centroid - _p).norm() < _r)
     return _inside;
 
   return _outside;

--- a/test/src/markers/TwoCircleMarker.C
+++ b/test/src/markers/TwoCircleMarker.C
@@ -53,8 +53,8 @@ TwoCircleMarker::computeElementMarker()
 {
   Point centroid = _current_elem->centroid();
 
-  if (((centroid - _p1).size() < _r1) ||
-      (((centroid - _p2).size() < _r2) && (_fe_problem.time() < _shut_off_time)))
+  if (((centroid - _p1).norm() < _r1) ||
+      (((centroid - _p2).norm() < _r2) && (_fe_problem.time() < _shut_off_time)))
     return _inside;
 
   return _outside;

--- a/test/src/mesh_modifiers/BreakMeshByBlockManualBase.C
+++ b/test/src/mesh_modifiers/BreakMeshByBlockManualBase.C
@@ -40,15 +40,15 @@ BreakMeshByBlockManualBase::duplicateAndSetLocalNode(dof_id_type element_id, dof
   // method used to duplicate existing nodes given an element and a local node.
   // The new node is added to the mesh and assigned to specified element.
 
-  Elem * elem = _mesh_ptr->getMesh().elem(element_id);   // retrieve element
-  dof_id_type original_node_id = elem->node(local_node); // find original node id
+  Elem * elem = _mesh_ptr->getMesh().elem_ptr(element_id);  // retrieve element
+  dof_id_type original_node_id = elem->node_id(local_node); // find original node id
 
   // duplicate node
   Node * new_node =
-      Node::build(_mesh_ptr->getMesh().node(original_node_id), _mesh_ptr->getMesh().n_nodes())
+      Node::build(_mesh_ptr->getMesh().node_ref(original_node_id), _mesh_ptr->getMesh().n_nodes())
           .release();
   // assign node to the correct process (i.e. the same process the orignal node had)
-  new_node->processor_id() = _mesh_ptr->getMesh().node(original_node_id).processor_id();
+  new_node->processor_id() = _mesh_ptr->getMesh().node_ref(original_node_id).processor_id();
   // add node to the mesh
   _mesh_ptr->getMesh().add_node(new_node);
 
@@ -63,7 +63,7 @@ BreakMeshByBlockManualBase::setElemNode(dof_id_type element_id,
 {
 
   // method used to set a local node given element and global node id
-  Elem * elem = _mesh_ptr->getMesh().elem(element_id);          // retrieve element
+  Elem * elem = _mesh_ptr->getMesh().elem_ptr(element_id);      // retrieve element
   Node * new_node = _mesh_ptr->getMesh().node_ptr(global_node); // retrieve node
   elem->set_node(local_node) = _mesh_ptr->getMesh().node_ptr(new_node->id());
 }

--- a/test/src/mesh_modifiers/BreakMeshByBlockManual_2DJunction.C
+++ b/test/src/mesh_modifiers/BreakMeshByBlockManual_2DJunction.C
@@ -87,14 +87,14 @@ BreakMeshByBlockManual_2DJunction::addInterfaceBoundary()
   SubdomainID interface_id = 100;
   if (!_split_interface)
   {
-    elem = _mesh_ptr->getMesh().elem(0);
+    elem = _mesh_ptr->getMesh().elem_ptr(0);
     boundary_info.add_side(elem->id(), 0, interface_id);
     boundary_info.add_side(elem->id(), 2, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(1);
+    elem = _mesh_ptr->getMesh().elem_ptr(1);
     boundary_info.add_side(elem->id(), 2, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(2);
+    elem = _mesh_ptr->getMesh().elem_ptr(2);
     boundary_info.add_side(elem->id(), 0, interface_id);
 
     // rename the boundary
@@ -102,18 +102,18 @@ BreakMeshByBlockManual_2DJunction::addInterfaceBoundary()
   }
   else
   {
-    elem = _mesh_ptr->getMesh().elem(0);
+    elem = _mesh_ptr->getMesh().elem_ptr(0);
     boundary_info.add_side(elem->id(), 0, 0);
     boundary_info.sideset_name(0) = "Block1_Block2";
 
     boundary_info.add_side(elem->id(), 2, 5);
     boundary_info.sideset_name(5) = "Block1_Block3";
 
-    elem = _mesh_ptr->getMesh().elem(1);
+    elem = _mesh_ptr->getMesh().elem_ptr(1);
     boundary_info.add_side(elem->id(), 2, 6);
     boundary_info.sideset_name(6) = "Block2_Block4";
 
-    elem = _mesh_ptr->getMesh().elem(2);
+    elem = _mesh_ptr->getMesh().elem_ptr(2);
     boundary_info.add_side(elem->id(), 0, 7);
     boundary_info.sideset_name(7) = "Block3_Block4";
   }

--- a/test/src/mesh_modifiers/BreakMeshByBlockManual_3Blocks.C
+++ b/test/src/mesh_modifiers/BreakMeshByBlockManual_3Blocks.C
@@ -143,22 +143,22 @@ BreakMeshByBlockManual_3Blocks::addInterfaceBoundary()
   SubdomainID interface_id = 100;
   if (!_split_interface)
   {
-    elem = _mesh_ptr->getMesh().elem(0);
+    elem = _mesh_ptr->getMesh().elem_ptr(0);
     boundary_info.add_side(elem->id(), 4, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(1);
+    elem = _mesh_ptr->getMesh().elem_ptr(1);
     boundary_info.add_side(elem->id(), 4, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(2);
+    elem = _mesh_ptr->getMesh().elem_ptr(2);
     boundary_info.add_side(elem->id(), 4, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(3);
+    elem = _mesh_ptr->getMesh().elem_ptr(3);
     boundary_info.add_side(elem->id(), 4, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(4);
+    elem = _mesh_ptr->getMesh().elem_ptr(4);
     boundary_info.add_side(elem->id(), 3, interface_id);
 
-    elem = _mesh_ptr->getMesh().elem(6);
+    elem = _mesh_ptr->getMesh().elem_ptr(6);
     boundary_info.add_side(elem->id(), 0, interface_id);
 
     // rename the boundary
@@ -166,28 +166,28 @@ BreakMeshByBlockManual_3Blocks::addInterfaceBoundary()
   }
   else
   {
-    elem = _mesh_ptr->getMesh().elem(0);
+    elem = _mesh_ptr->getMesh().elem_ptr(0);
     boundary_info.add_side(elem->id(), 4, 0);
 
-    elem = _mesh_ptr->getMesh().elem(2);
+    elem = _mesh_ptr->getMesh().elem_ptr(2);
     boundary_info.add_side(elem->id(), 4, 0);
 
-    elem = _mesh_ptr->getMesh().elem(3);
+    elem = _mesh_ptr->getMesh().elem_ptr(3);
     boundary_info.add_side(elem->id(), 4, 0);
 
     // rename the boundary
     boundary_info.sideset_name(0) = "Block1_Block2";
 
-    elem = _mesh_ptr->getMesh().elem(1);
+    elem = _mesh_ptr->getMesh().elem_ptr(1);
     boundary_info.add_side(elem->id(), 4, 4);
 
     // rename the boundary
     boundary_info.sideset_name(4) = "Block1_Block3";
 
-    elem = _mesh_ptr->getMesh().elem(4);
+    elem = _mesh_ptr->getMesh().elem_ptr(4);
     boundary_info.add_side(elem->id(), 3, 5);
 
-    elem = _mesh_ptr->getMesh().elem(6);
+    elem = _mesh_ptr->getMesh().elem_ptr(6);
     boundary_info.add_side(elem->id(), 0, 5);
 
     // rename the boundary

--- a/test/src/partitioner/PartitionerWeightTest.C
+++ b/test/src/partitioner/PartitionerWeightTest.C
@@ -46,7 +46,7 @@ PartitionerWeightTest::computeElementWeight(Elem & elem)
 dof_id_type
 PartitionerWeightTest::computeSideWeight(Elem & elem, unsigned int side)
 {
-  auto side_elem = elem.build_side(side);
+  auto side_elem = elem.build_side_ptr(side);
   auto centroid = side_elem->centroid();
   if (centroid(0) == 0.5)
     return 20;

--- a/test/src/userobjects/RandomHitSolutionModifier.C
+++ b/test/src/userobjects/RandomHitSolutionModifier.C
@@ -58,12 +58,12 @@ RandomHitSolutionModifier::execute()
     if (elem && (elem->processor_id() == processor_id()))
     {
       Real closest_distance = std::numeric_limits<unsigned int>::max();
-      Node * closest_node = NULL;
+      const Node * closest_node = NULL;
 
       // Find the node on that element that is closest.
       for (unsigned int n = 0; n < elem->n_nodes(); n++)
       {
-        Node * cur_node = elem->get_node(n);
+        const Node * cur_node = elem->node_ptr(n);
         Real cur_distance = (hit - *cur_node).norm();
 
         if (cur_distance < closest_distance)

--- a/test/src/userobjects/TrackDiracFront.C
+++ b/test/src/userobjects/TrackDiracFront.C
@@ -42,7 +42,7 @@ TrackDiracFront::execute()
   if (_var_value[_qp] > 0.4 && _var_value[_qp] < 0.6)
   {
     Elem * elem = localElementConnectedToCurrentNode();
-    _dirac_points.push_back(std::make_pair(elem, *_current_node));
+    _dirac_points.push_back(std::make_pair(elem, Point(*_current_node)));
   }
 }
 


### PR DESCRIPTION
Brief summary of changes in this update:
* Require and test for C++11 std::begin/end support for C arrays.
* Use parallel_sync in Parallel::Sort.
* More range-based for loops for Node and Elem iteration.
* Nemesis: various fixes for writing/reading communication maps (cmaps).
* Nemesis: add ability to plot ErrorVector.
* Apply -march/mtune flag when profiling as well.
* Lots of warning fixes.
* Add configure option for turning on/off -Werror.
* Add configure option --enable-paranoid-warnings.
* LaplaceMeshSmoother: restrict smoothing to specified subdomains.
* MeshTools::find_boundary_nodes: Add overload that builds a std::set.
* PetscMatrix: Add support for MATHYPRE, MatHYPRESetPreallocation.
* Several fixes for --disable-deprecated configuration.
* Add PetscDMWrapper for eventual geometric multigrid support.
* BoundaryInfo::build_foo_list(): sort vector before returning.
* b8d24a9 Avoid calling set_dof_coupling() with an empty/non-nullptr CouplingMatrix.
* TypeVector/TypeTensor: make default constructors public.
* TypeTensor: Add operator*=(TypeTenosr&).
* Add support for StandardType<Tuple>.
* Simplify loose_bounding_box for 'bi/tri/linear' elements.
* Cache n_processors() rather than calling it every loop iteration.
* Add "fuzzy" BoundingBox::intersects() function.
* Fix bug with --enable-petsc-hypre-required when PETSc is not found.
* Fix bug when writing discontinuous ExodusII files with subdomain-restricted variables.
* Add unit test for DofCoupling with variable groups.
* Add optimized DofObject::dof_number() overload.
* Fix bug in Evaluable multi-predicate.
* AbaqusIO: support more element type strings.

Refs #000.

