### PR TITLE
Fix sqa_check.py script so that PYTHONPATH doesn't have to be set

### DIFF
--- a/scripts/sqa_check.py
+++ b/scripts/sqa_check.py
@@ -3,6 +3,10 @@ import os
 import sys
 import subprocess
 import argparse
+
+moose_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(moose_dir, 'python'))
+
 import mooseutils
 
 def get_options():


### PR DESCRIPTION
refs #12083

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
