### PR TITLE
Create MaterialBase and InterfaceMaterial

### DIFF
--- a/framework/include/actions/MaterialOutputAction.h
+++ b/framework/include/actions/MaterialOutputAction.h
@@ -63,19 +63,20 @@ private:
    * act() method.
    */
   template <typename T>
-  void materialOutputHelper(const std::string & property_name, std::shared_ptr<Material> material);
+  void materialOutputHelper(const std::string & property_name,
+                            std::shared_ptr<MaterialBase> material);
 
   /**
    * A method for creating an AuxVariable and associated action
    * @param type The action type to create
    * @param property_name The property name to associated with that action
    * @param variable_name The AuxVariable name to create
-   * @param material A pointer to the Material object containing the property of interest
+   * @param material A pointer to the MaterialBase object containing the property of interest
    */
   std::shared_ptr<MooseObjectAction> createAction(const std::string & type,
                                                   const std::string & property_name,
                                                   const std::string & variable_name,
-                                                  std::shared_ptr<Material> material);
+                                                  std::shared_ptr<MaterialBase> material);
 
   /// Pointer the MaterialData object storing the block restricted materials
   std::shared_ptr<MaterialData> _block_material_data;
@@ -102,7 +103,7 @@ private:
 template <typename T>
 void
 MaterialOutputAction::materialOutputHelper(const std::string & /*property_name*/,
-                                           std::shared_ptr<Material> /*material*/)
+                                           std::shared_ptr<MaterialBase> /*material*/)
 {
   mooseError("Unknown type, you must create a specialization of materialOutputHelper");
 }

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -11,32 +11,12 @@
 #define MATERIAL_H
 
 // MOOOSE includes
-#include "MooseObject.h"
-#include "BlockRestrictable.h"
-#include "BoundaryRestrictable.h"
-#include "SetupInterface.h"
+#include "MaterialBase.h"
 #include "Coupleable.h"
-#include "MooseVariableDependencyInterface.h"
-#include "ScalarCoupleable.h"
-#include "FunctionInterface.h"
-#include "DistributionInterface.h"
-#include "UserObjectInterface.h"
-#include "TransientInterface.h"
 #include "MaterialPropertyInterface.h"
-#include "PostprocessorInterface.h"
-#include "VectorPostprocessorInterface.h"
-#include "DependencyResolverInterface.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "OutputInterface.h"
-#include "RandomInterface.h"
-#include "MaterialProperty.h"
 
 // forward declarations
 class Material;
-class MooseMesh;
-class MaterialData;
-class SubProblem;
 
 template <>
 InputParameters validParams<Material>();
@@ -44,55 +24,10 @@ InputParameters validParams<Material>();
 /**
  * Materials compute MaterialProperties.
  */
-class Material : public MooseObject,
-                 public BlockRestrictable,
-                 public BoundaryRestrictable,
-                 public SetupInterface,
-                 public Coupleable,
-                 public MooseVariableDependencyInterface,
-                 public ScalarCoupleable,
-                 public FunctionInterface,
-                 public DistributionInterface,
-                 public UserObjectInterface,
-                 public TransientInterface,
-                 public MaterialPropertyInterface,
-                 public PostprocessorInterface,
-                 public VectorPostprocessorInterface,
-                 public DependencyResolverInterface,
-                 public Restartable,
-                 public MeshChangedInterface,
-                 public OutputInterface,
-                 public RandomInterface
+class Material : public MaterialBase, public Coupleable, public MaterialPropertyInterface
 {
 public:
   Material(const InputParameters & parameters);
-
-  /**
-   * Initialize stateful properties (if material has some)
-   */
-  virtual void initStatefulProperties(unsigned int n_points);
-
-  /**
-   * Performs the quadrature point loop, calling computeQpProperties
-   */
-  virtual void computeProperties();
-
-  /**
-   * Resets the properties at each quadrature point (see resetQpProperties), only called if 'compute
-   * = false'.
-   *
-   * This method is called internally by MOOSE, you probably don't want to mess with this.
-   */
-  virtual void resetProperties();
-
-  /**
-   * A method for (re)computing the properties of a Material.
-   *
-   * This is intended to be called from other objects, by first calling
-   * MaterialPropertyInterface::getMaterial and then calling this method on the Material object
-   * returned.
-   */
-  virtual void computePropertiesAtQp(unsigned int qp);
 
   ///@{
   /**
@@ -119,105 +54,24 @@ public:
   const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name);
   ///@}
 
-  ///@{
-  /**
-   * Declare the property named "name"
-   */
-  template <typename T>
-  MaterialProperty<T> & declareProperty(const std::string & prop_name);
-  template <typename T>
-  MaterialProperty<T> & declarePropertyOld(const std::string & prop_name);
-  template <typename T>
-  MaterialProperty<T> & declarePropertyOlder(const std::string & prop_name);
-  ///@}
+  using MaterialBase::getZeroMaterialProperty;
 
-  /**
-   * Return a material property that is initialized to zero by default and does
-   * not need to (but can) be declared by another material.
-   */
-  template <typename T>
-  const MaterialProperty<T> & getZeroMaterialProperty(const std::string & prop_name);
-
-  /**
-   * Return a set of properties accessed with getMaterialProperty
-   * @return A reference to the set of properties with calls to getMaterialProperty
-   */
-  virtual const std::set<std::string> & getRequestedItems() override { return _requested_props; }
-
-  /**
-   * Return a set of properties accessed with declareProperty
-   * @return A reference to the set of properties with calls to declareProperty
-   */
-  virtual const std::set<std::string> & getSuppliedItems() override { return _supplied_props; }
-
-  void checkStatefulSanity() const;
-
-  /**
-   * Get the list of output objects that this class is restricted
-   * @return A vector of OutputNames
-   */
-  std::set<OutputName> getOutputs();
-
-  /**
-   * Returns true of the MaterialData type is not associated with volume data
-   */
-  bool isBoundaryMaterial() const { return _bnd; }
-
-  /**
-   * Subdomain setup evaluating material properties when required
-   */
-  virtual void subdomainSetup() override;
+  virtual bool isBoundaryMaterial() const override { return _bnd; }
 
 protected:
-  /**
-   * Evaluate material properties on subdomain
-   */
-  virtual void computeSubdomainProperties();
+  virtual const MaterialData & materialData() const override { return *_material_data; }
+  virtual MaterialData & materialData() override { return *_material_data; }
 
-  /**
-   * Users must override this method.
-   */
-  virtual void computeQpProperties();
+  virtual const FEProblemBase & miProblem() const override { return _mi_feproblem; }
+  virtual FEProblemBase & miProblem() override { return _mi_feproblem; }
 
-  /**
-   * Resets the properties prior to calculation of traditional materials (only if 'compute =
-   * false').
-   *
-   * This method must be overridden in your class. This is called just prior to the re-calculation
-   * of
-   * traditional material properties to ensure that the properties are in a proper state for
-   * calculation.
-   */
-  virtual void resetQpProperties();
-
-  /**
-   * Initialize stateful properties at quadrature points.  Note when using this function you only
-   * need to address
-   * the "current" material properties not the old ones directly, i.e. if you have a property named
-   * "_diffusivity"
-   * and an older property named "_diffusivity_old".  You only need to initialize diffusivity.
-   * MOOSE will use
-   * copy that initial value to the old and older values as necessary.
-   */
-  virtual void initQpStatefulProperties();
-
-  SubProblem & _subproblem;
-
-  FEProblemBase & _fe_problem;
-  THREAD_ID _tid;
-  Assembly & _assembly;
+  virtual const QBase & qRule() const override { return *_qrule; }
 
   bool _bnd;
   bool _neighbor;
-
-  unsigned int _qp;
-
+  const MooseArray<Point> & _q_point;
   QBase *& _qrule;
   const MooseArray<Real> & _JxW;
-  const MooseArray<Real> & _coord;
-  const MooseArray<Point> & _q_point;
-  /// normals at quadrature points (valid only in boundary materials)
-  const MooseArray<Point> & _normals;
 
   const Elem *& _current_elem;
 
@@ -225,64 +79,6 @@ protected:
 
   /// current side of the current element
   unsigned int & _current_side;
-
-  MooseMesh & _mesh;
-
-  /// Coordinate system
-  const Moose::CoordinateSystemType & _coord_sys;
-
-  /// Set of properties accessed via get method
-  std::set<std::string> _requested_props;
-
-  /// Set of properties declared
-  std::set<std::string> _supplied_props;
-
-  /// The ids of the supplied properties, i.e. the indices where they
-  /// are stored in the _material_data->props().  Note: these ids ARE
-  /// NOT IN THE SAME ORDER AS THE _supplied_props set, which is
-  /// ordered alphabetically by name.  The intention of this container
-  /// is to allow rapid copying of MaterialProperty values in
-  /// Material::computeProperties() without looking up the ids from
-  /// the name strings each time.
-  std::set<unsigned int> _supplied_prop_ids;
-
-  /// If False MOOSE does not compute this property
-  const bool _compute;
-
-  enum ConstantTypeEnum
-  {
-    NONE,
-    ELEMENT,
-    SUBDOMAIN
-  };
-
-  /// Options of the constantness level of the material
-  const ConstantTypeEnum _constant_option;
-
-  enum QP_Data_Type
-  {
-    CURR,
-    PREV
-  };
-
-  enum Prop_State
-  {
-    CURRENT = 0x1,
-    OLD = 0x2,
-    OLDER = 0x4
-  };
-  std::map<std::string, int> _props_to_flags;
-
-private:
-  /// Small helper function to call store{Subdomain,Boundary}MatPropName
-  void registerPropName(std::string prop_name, bool is_get, Prop_State state);
-
-  /// Check and throw an error if the execution has progerssed past the construction stage
-  void checkExecutionStage();
-
-  bool _has_stateful_property;
-
-  bool _overrides_init_stateful_props = true;
 };
 
 template <typename T>
@@ -334,11 +130,11 @@ template <typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyByName(const std::string & prop_name)
 {
-  checkExecutionStage();
+  MaterialBase::checkExecutionStage();
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the
   // same memory)
   _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, Material::CURRENT);
+  registerPropName(prop_name, true, MaterialBase::CURRENT);
   return MaterialPropertyInterface::getMaterialPropertyByName<T>(prop_name);
 }
 
@@ -346,7 +142,7 @@ template <typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOldByName(const std::string & prop_name)
 {
-  registerPropName(prop_name, true, Material::OLD);
+  registerPropName(prop_name, true, MaterialBase::OLD);
   return MaterialPropertyInterface::getMaterialPropertyOldByName<T>(prop_name);
 }
 
@@ -354,68 +150,8 @@ template <typename T>
 const MaterialProperty<T> &
 Material::getMaterialPropertyOlderByName(const std::string & prop_name)
 {
-  registerPropName(prop_name, true, Material::OLDER);
+  registerPropName(prop_name, true, MaterialBase::OLDER);
   return MaterialPropertyInterface::getMaterialPropertyOlderByName<T>(prop_name);
-}
-
-template <typename T>
-MaterialProperty<T> &
-Material::declareProperty(const std::string & prop_name)
-{
-  registerPropName(prop_name, false, Material::CURRENT);
-  return _material_data->declareProperty<T>(prop_name);
-}
-
-template <typename T>
-MaterialProperty<T> &
-Material::declarePropertyOld(const std::string & prop_name)
-{
-  mooseDoOnce(
-      mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
-                      "getMaterialPropertyOld (only) if a reference is required in this class."));
-  registerPropName(prop_name, false, Material::OLD);
-  return _material_data->declarePropertyOld<T>(prop_name);
-}
-
-template <typename T>
-MaterialProperty<T> &
-Material::declarePropertyOlder(const std::string & prop_name)
-{
-  mooseDoOnce(
-      mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
-                      "getMaterialPropertyOlder (only) if a reference is required in this class."));
-  registerPropName(prop_name, false, Material::OLDER);
-  return _material_data->declarePropertyOlder<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-Material::getZeroMaterialProperty(const std::string & prop_name)
-{
-  checkExecutionStage();
-  MaterialProperty<T> & preload_with_zero = _material_data->getProperty<T>(prop_name);
-
-  _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, Material::CURRENT);
-  _fe_problem.markMatPropRequested(prop_name);
-
-  // Register this material on these blocks and boundaries as a zero property with relaxed
-  // consistency checking
-  for (std::set<SubdomainID>::const_iterator it = blockIDs().begin(); it != blockIDs().end(); ++it)
-    _fe_problem.storeSubdomainZeroMatProp(*it, prop_name);
-  for (std::set<BoundaryID>::const_iterator it = boundaryIDs().begin(); it != boundaryIDs().end();
-       ++it)
-    _fe_problem.storeBoundaryZeroMatProp(*it, prop_name);
-
-  // set values for all qpoints to zero
-  // (in multiapp scenarios getMaxQps can return different values in each app; we need the max)
-  unsigned int nqp = _mi_feproblem.getMaxQps();
-  if (nqp > preload_with_zero.size())
-    preload_with_zero.resize(nqp);
-  for (unsigned int qp = 0; qp < nqp; ++qp)
-    mooseSetToZero<T>(preload_with_zero[qp]);
-
-  return preload_with_zero;
 }
 
 #endif // MATERIAL_H

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -140,6 +140,14 @@ public:
    */
   virtual void subdomainSetup() override;
 
+  /**
+   * Retrieve the set of material properties that _this_ object depends on.
+   *
+   * @return The IDs corresponding to the material properties that
+   * MUST be reinited before evaluating this object
+   */
+  virtual const std::set<unsigned int> & getMatPropDependencies() const = 0;
+
 protected:
   /**
    * Evaluate material properties on subdomain

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -1,0 +1,315 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef MATERIALBASE_H
+#define MATERIALBASE_H
+
+// MOOOSE includes
+#include "MooseObject.h"
+#include "BlockRestrictable.h"
+#include "BoundaryRestrictable.h"
+#include "SetupInterface.h"
+#include "MooseVariableDependencyInterface.h"
+#include "ScalarCoupleable.h"
+#include "FunctionInterface.h"
+#include "DistributionInterface.h"
+#include "UserObjectInterface.h"
+#include "TransientInterface.h"
+#include "PostprocessorInterface.h"
+#include "VectorPostprocessorInterface.h"
+#include "DependencyResolverInterface.h"
+#include "Restartable.h"
+#include "MeshChangedInterface.h"
+#include "OutputInterface.h"
+#include "RandomInterface.h"
+#include "MaterialProperty.h"
+#include "MaterialData.h"
+#include "ZeroMaterial.h"
+
+// forward declarations
+class MaterialBase;
+class MooseMesh;
+class SubProblem;
+
+template <>
+InputParameters validParams<MaterialBase>();
+
+/**
+ * MaterialBases compute MaterialProperties.
+ */
+class MaterialBase : public MooseObject,
+                     public BlockRestrictable,
+                     public BoundaryRestrictable,
+                     public SetupInterface,
+                     public MooseVariableDependencyInterface,
+                     public ScalarCoupleable,
+                     public FunctionInterface,
+                     public DistributionInterface,
+                     public UserObjectInterface,
+                     public TransientInterface,
+                     public PostprocessorInterface,
+                     public VectorPostprocessorInterface,
+                     public DependencyResolverInterface,
+                     public Restartable,
+                     public MeshChangedInterface,
+                     public OutputInterface,
+                     public RandomInterface
+{
+public:
+  MaterialBase(const InputParameters & parameters);
+
+  /**
+   * Initialize stateful properties (if material has some)
+   */
+  virtual void initStatefulProperties(unsigned int n_points);
+
+  /**
+   * Performs the quadrature point loop, calling computeQpProperties
+   */
+  virtual void computeProperties();
+
+  /**
+   * Resets the properties at each quadrature point (see resetQpProperties), only called if 'compute
+   * = false'.
+   *
+   * This method is called internally by MOOSE, you probably don't want to mess with this.
+   */
+  virtual void resetProperties();
+
+  /**
+   * A method for (re)computing the properties of a MaterialBase.
+   *
+   * This is intended to be called from other objects, by first calling
+   * MaterialPropertyInterface::getMaterial and then calling this method on the MaterialBase object
+   * returned.
+   */
+  virtual void computePropertiesAtQp(unsigned int qp);
+
+  ///@{
+  /**
+   * Declare the property named "name"
+   */
+  template <typename T>
+  MaterialProperty<T> & declareProperty(const std::string & prop_name);
+  template <typename T>
+  MaterialProperty<T> & declarePropertyOld(const std::string & prop_name);
+  template <typename T>
+  MaterialProperty<T> & declarePropertyOlder(const std::string & prop_name);
+  ///@}
+
+  /**
+   * Return a material property that is initialized to zero by default and does
+   * not need to (but can) be declared by another material.
+   */
+  template <typename T>
+  const MaterialProperty<T> & getZeroMaterialProperty(const std::string & prop_name);
+
+  /**
+   * Return a set of properties accessed with getMaterialProperty
+   * @return A reference to the set of properties with calls to getMaterialProperty
+   */
+  virtual const std::set<std::string> & getRequestedItems() override { return _requested_props; }
+
+  /**
+   * Return a set of properties accessed with declareProperty
+   * @return A reference to the set of properties with calls to declareProperty
+   */
+  virtual const std::set<std::string> & getSuppliedItems() override { return _supplied_props; }
+
+  void checkStatefulSanity() const;
+
+  /**
+   * Get the list of output objects that this class is restricted
+   * @return A vector of OutputNames
+   */
+  std::set<OutputName> getOutputs();
+
+  /**
+   * Returns true of the MaterialData type is not associated with volume data
+   */
+  virtual bool isBoundaryMaterial() const = 0;
+
+  /**
+   * Subdomain setup evaluating material properties when required
+   */
+  virtual void subdomainSetup() override;
+
+protected:
+  /**
+   * Evaluate material properties on subdomain
+   */
+  virtual void computeSubdomainProperties();
+
+  /**
+   * Users must override this method.
+   */
+  virtual void computeQpProperties();
+
+  /**
+   * Resets the properties prior to calculation of traditional materials (only if 'compute =
+   * false').
+   *
+   * This method must be overridden in your class. This is called just prior to the re-calculation
+   * of
+   * traditional material properties to ensure that the properties are in a proper state for
+   * calculation.
+   */
+  virtual void resetQpProperties();
+
+  /**
+   * Initialize stateful properties at quadrature points.  Note when using this function you only
+   * need to address
+   * the "current" material properties not the old ones directly, i.e. if you have a property named
+   * "_diffusivity"
+   * and an older property named "_diffusivity_old".  You only need to initialize diffusivity.
+   * MOOSE will use
+   * copy that initial value to the old and older values as necessary.
+   */
+  virtual void initQpStatefulProperties();
+
+  virtual const MaterialData & materialData() const = 0;
+  virtual MaterialData & materialData() = 0;
+
+  virtual const FEProblemBase & miProblem() const = 0;
+  virtual FEProblemBase & miProblem() = 0;
+
+  virtual const QBase & qRule() const = 0;
+
+  SubProblem & _subproblem;
+
+  FEProblemBase & _fe_problem;
+  THREAD_ID _tid;
+  Assembly & _assembly;
+
+  unsigned int _qp;
+
+  const MooseArray<Real> & _coord;
+  /// normals at quadrature points (valid only in boundary materials)
+  const MooseArray<Point> & _normals;
+
+  MooseMesh & _mesh;
+
+  /// Coordinate system
+  const Moose::CoordinateSystemType & _coord_sys;
+
+  /// Set of properties accessed via get method
+  std::set<std::string> _requested_props;
+
+  /// Set of properties declared
+  std::set<std::string> _supplied_props;
+
+  /// The ids of the supplied properties, i.e. the indices where they
+  /// are stored in the _material_data->props().  Note: these ids ARE
+  /// NOT IN THE SAME ORDER AS THE _supplied_props set, which is
+  /// ordered alphabetically by name.  The intention of this container
+  /// is to allow rapid copying of MaterialProperty values in
+  /// MaterialBase::computeProperties() without looking up the ids from
+  /// the name strings each time.
+  std::set<unsigned int> _supplied_prop_ids;
+
+  /// If False MOOSE does not compute this property
+  const bool _compute;
+
+  enum ConstantTypeEnum
+  {
+    NONE,
+    ELEMENT,
+    SUBDOMAIN
+  };
+
+  /// Options of the constantness level of the material
+  const ConstantTypeEnum _constant_option;
+
+  enum QP_Data_Type
+  {
+    CURR,
+    PREV
+  };
+
+  enum Prop_State
+  {
+    CURRENT = 0x1,
+    OLD = 0x2,
+    OLDER = 0x4
+  };
+  std::map<std::string, int> _props_to_flags;
+
+  /// Small helper function to call store{Subdomain,Boundary}MatPropName
+  void registerPropName(std::string prop_name, bool is_get, Prop_State state);
+
+  /// Check and throw an error if the execution has progerssed past the construction stage
+  void checkExecutionStage();
+
+private:
+  bool _has_stateful_property;
+
+  bool _overrides_init_stateful_props = true;
+};
+
+template <typename T>
+MaterialProperty<T> &
+MaterialBase::declareProperty(const std::string & prop_name)
+{
+  registerPropName(prop_name, false, MaterialBase::CURRENT);
+  return materialData().declareProperty<T>(prop_name);
+}
+
+template <typename T>
+MaterialProperty<T> &
+MaterialBase::declarePropertyOld(const std::string & prop_name)
+{
+  mooseDoOnce(
+      mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
+                      "getMaterialPropertyOld (only) if a reference is required in this class."));
+  registerPropName(prop_name, false, MaterialBase::OLD);
+  return materialData().declarePropertyOld<T>(prop_name);
+}
+
+template <typename T>
+MaterialProperty<T> &
+MaterialBase::declarePropertyOlder(const std::string & prop_name)
+{
+  mooseDoOnce(
+      mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
+                      "getMaterialPropertyOlder (only) if a reference is required in this class."));
+  registerPropName(prop_name, false, MaterialBase::OLDER);
+  return materialData().declarePropertyOlder<T>(prop_name);
+}
+
+template <typename T>
+const MaterialProperty<T> &
+MaterialBase::getZeroMaterialProperty(const std::string & prop_name)
+{
+  checkExecutionStage();
+  MaterialProperty<T> & preload_with_zero = materialData().getProperty<T>(prop_name);
+
+  _requested_props.insert(prop_name);
+  registerPropName(prop_name, true, MaterialBase::CURRENT);
+  _fe_problem.markMatPropRequested(prop_name);
+
+  // Register this material on these blocks and boundaries as a zero property with relaxed
+  // consistency checking
+  for (std::set<SubdomainID>::const_iterator it = blockIDs().begin(); it != blockIDs().end(); ++it)
+    _fe_problem.storeSubdomainZeroMatProp(*it, prop_name);
+  for (std::set<BoundaryID>::const_iterator it = boundaryIDs().begin(); it != boundaryIDs().end();
+       ++it)
+    _fe_problem.storeBoundaryZeroMatProp(*it, prop_name);
+
+  // set values for all qpoints to zero
+  // (in multiapp scenarios getMaxQps can return different values in each app; we need the max)
+  unsigned int nqp = miProblem().getMaxQps();
+  if (nqp > preload_with_zero.size())
+    preload_with_zero.resize(nqp);
+  for (unsigned int qp = 0; qp < nqp; ++qp)
+    mooseSetToZero<T>(preload_with_zero[qp]);
+
+  return preload_with_zero;
+}
+
+#endif // MATERIALBASE_H

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -75,10 +75,10 @@ public:
   void swap(const Elem & elem, unsigned int side = 0);
 
   /// Reinit material properties for given element (and possible side)
-  void reinit(const std::vector<std::shared_ptr<Material>> & mats);
+  void reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats);
 
   /// Calls the reset method of Materials to ensure that they are in a proper state.
-  void reset(const std::vector<std::shared_ptr<Material>> & mats);
+  void reset(const std::vector<std::shared_ptr<MaterialBase>> & mats);
 
   /// material properties for given element (and possible side)
   void swapBack(const Elem & elem, unsigned int side = 0);

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -15,6 +15,7 @@
 #include "MooseTypes.h"
 #include "MaterialProperty.h"
 #include "MaterialData.h"
+#include "ZeroMaterial.h"
 
 // Forward declarations
 class InputParameters;
@@ -248,29 +249,6 @@ private:
   /// Storage for the boundary ids created by BoundaryRestrictable
   const std::set<BoundaryID> & _mi_boundary_ids;
 };
-
-/**
- * Helper function templates to set a variable to zero.
- * Specializations may have to be implemented (for examples see
- * RankTwoTensor, RankFourTensor).
- */
-template <typename T>
-inline void
-mooseSetToZero(T & v)
-{
-  /**
-   * The default for non-pointer types is to assign zero.
-   * This should either do something sensible, or throw a compiler error.
-   * Otherwise the T type is designed badly.
-   */
-  v = 0;
-}
-template <typename T>
-inline void
-mooseSetToZero(T *&)
-{
-  mooseError("Cannot use pointer types for MaterialProperty derivatives.");
-}
 
 template <typename T>
 const MaterialProperty<T> &

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -128,15 +128,15 @@ public:
 
   ///@{
   /**
-   * Return a Material reference - usable for computing directly.
+   * Return a MaterialBase reference - usable for computing directly.
    *
    * @param name The name of the input parameter or explicit material name.
    * @param no_warn If true, suppress warning about retrieving the material
    * potentially during its calculation. If you don't know what this is/means,
    * then you don't need it.
    */
-  Material & getMaterial(const std::string & name);
-  Material & getMaterialByName(const std::string & name, bool no_warn = false);
+  MaterialBase & getMaterial(const std::string & name);
+  MaterialBase & getMaterialByName(const std::string & name, bool no_warn = false);
   ///@}
 
   ///@{

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -15,7 +15,7 @@
 #include "HashMap.h"
 
 // Forward declarations
-class Material;
+class MaterialBase;
 class MaterialData;
 class QpMap;
 
@@ -113,7 +113,7 @@ public:
    * @param side Side of the element 'elem' (0 for volumetric material properties)
    */
   void initStatefulProps(MaterialData & material_data,
-                         const std::vector<std::shared_ptr<Material>> & mats,
+                         const std::vector<std::shared_ptr<MaterialBase>> & mats,
                          unsigned int n_qpoints,
                          const Elem & elem,
                          unsigned int side = 0);

--- a/framework/include/materials/MaterialWarehouse.h
+++ b/framework/include/materials/MaterialWarehouse.h
@@ -14,7 +14,7 @@
 #include "MooseObjectWarehouse.h"
 
 // Forward declarations
-class Material;
+class MaterialBase;
 
 /**
  * Material objects are special in that they have additional objects created automatically (see
@@ -24,10 +24,10 @@ class Material;
  * that may
  * exist.
  */
-class MaterialWarehouse : public MooseObjectWarehouse<Material>
+class MaterialWarehouse : public MooseObjectWarehouse<MaterialBase>
 {
 public:
-  const MooseObjectWarehouse<Material> & operator[](Moose::MaterialDataType data_type) const;
+  const MooseObjectWarehouse<MaterialBase> & operator[](Moose::MaterialDataType data_type) const;
 
   ///@{
   /**
@@ -49,17 +49,17 @@ public:
   /**
    * A special method unique to this class for adding Block, Neighbor, and Face material objects.
    */
-  void addObjects(std::shared_ptr<Material> block,
-                  std::shared_ptr<Material> neighbor,
-                  std::shared_ptr<Material> face,
+  void addObjects(std::shared_ptr<MaterialBase> block,
+                  std::shared_ptr<MaterialBase> neighbor,
+                  std::shared_ptr<MaterialBase> face,
                   THREAD_ID tid = 0);
 
 protected:
   /// Stroage for neighbor material objects (Block are stored in the base class)
-  MooseObjectWarehouse<Material> _neighbor_materials;
+  MooseObjectWarehouse<MaterialBase> _neighbor_materials;
 
   /// Stroage for face material objects (Block are stored in the base class)
-  MooseObjectWarehouse<Material> _face_materials;
+  MooseObjectWarehouse<MaterialBase> _face_materials;
 };
 
 #endif // MATERIALWAREHOUSE_H

--- a/framework/include/materials/ZeroMaterial.h
+++ b/framework/include/materials/ZeroMaterial.h
@@ -1,0 +1,29 @@
+#ifndef ZEROMATERIAL_H
+#define ZEROMATERIAL_H
+
+#include "MooseError.h"
+
+/**
+ * Helper function templates to set a variable to zero.
+ * Specializations may have to be implemented (for examples see
+ * RankTwoTensor, RankFourTensor).
+ */
+template <typename T>
+inline void
+mooseSetToZero(T & v)
+{
+  /**
+   * The default for non-pointer types is to assign zero.
+   * This should either do something sensible, or throw a compiler error.
+   * Otherwise the T type is designed badly.
+   */
+  v = 0;
+}
+template <typename T>
+inline void
+mooseSetToZero(T *&)
+{
+  mooseError("Cannot use pointer types for MaterialProperty derivatives.");
+}
+
+#endif

--- a/framework/include/outputs/MaterialPropertyDebugOutput.h
+++ b/framework/include/outputs/MaterialPropertyDebugOutput.h
@@ -15,7 +15,7 @@
 
 // Forward declerations
 class MaterialPropertyDebugOutput;
-class Material;
+class MaterialBase;
 
 template <>
 InputParameters validParams<MaterialPropertyDebugOutput>();
@@ -49,10 +49,10 @@ protected:
   /**
    * Builds a output streams for the properties in each material object
    * @param output The output stream to populate
-   * @param materials Vector of pointers to the Material objects of interest
+   * @param materials Vector of pointers to the MaterialBase objects of interest
    */
   void printMaterialProperties(std::stringstream & output,
-                               const std::vector<std::shared_ptr<Material>> & materials) const;
+                               const std::vector<std::shared_ptr<MaterialBase>> & materials) const;
 };
 
 #endif // MATERIALPROPERTYEBUGOUTPUT_H

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1345,16 +1345,16 @@ public:
   const MaterialWarehouse & getDiscreteMaterialWarehouse() const { return _discrete_materials; }
 
   /**
-   * Return a pointer to a Material object.  If no_warn is true, suppress
+   * Return a pointer to a MaterialBase object.  If no_warn is true, suppress
    * warning about retrieving a material reference potentially during the
    * material's calculation.
    *
    * This will return enabled or disabled objects, the main purpose is for iterative materials.
    */
-  std::shared_ptr<Material> getMaterial(std::string name,
-                                        Moose::MaterialDataType type,
-                                        THREAD_ID tid = 0,
-                                        bool no_warn = false);
+  std::shared_ptr<MaterialBase> getMaterial(std::string name,
+                                            Moose::MaterialDataType type,
+                                            THREAD_ID tid = 0,
+                                            bool no_warn = false);
 
   /*
    * Return a pointer to the MaterialData
@@ -1631,7 +1631,7 @@ protected:
    * @see checkProblemIntegrity
    */
   void checkDependMaterialsHelper(
-      const std::map<SubdomainID, std::vector<std::shared_ptr<Material>>> & materials_map);
+      const std::map<SubdomainID, std::vector<std::shared_ptr<MaterialBase>>> & materials_map);
 
   /// Verify that there are no element type/coordinate type conflicts
   void checkCoordinateSystems();

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -19,25 +19,27 @@
 // Declare the output helper specializations
 template <>
 void MaterialOutputAction::materialOutputHelper<Real>(const std::string & material_name,
-                                                      std::shared_ptr<Material> material);
+                                                      std::shared_ptr<MaterialBase> material);
 
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & material_name,
-                                                            std::shared_ptr<Material> material);
+                                                            std::shared_ptr<MaterialBase> material);
 
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & material_name,
-                                                            std::shared_ptr<Material> material);
+                                                            std::shared_ptr<MaterialBase> material);
 
 template <>
-void MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & material_name,
-                                                               std::shared_ptr<Material> material);
+void
+MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & material_name,
+                                                          std::shared_ptr<MaterialBase> material);
 
 template <>
-void MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & material_name,
-                                                                std::shared_ptr<Material> material);
+void
+MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & material_name,
+                                                           std::shared_ptr<MaterialBase> material);
 
 registerMooseAction("MooseApp", MaterialOutputAction, "setup_material_output");
 
@@ -77,7 +79,7 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
   _boundary_material_data = problem_ptr->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA);
 
   // A complete list of all Material objects
-  const std::vector<std::shared_ptr<Material>> & materials =
+  const std::vector<std::shared_ptr<MaterialBase>> & materials =
       problem_ptr->getMaterialWarehouse().getObjects();
 
   // Handle setting of material property output in [Outputs] sub-blocks
@@ -205,7 +207,7 @@ std::shared_ptr<MooseObjectAction>
 MaterialOutputAction::createAction(const std::string & type,
                                    const std::string & property_name,
                                    const std::string & variable_name,
-                                   std::shared_ptr<Material> material)
+                                   std::shared_ptr<MaterialBase> material)
 {
   // Append the list of variables to create
   _variable_names.insert(variable_name);
@@ -245,7 +247,7 @@ MaterialOutputAction::createAction(const std::string & type,
 template <>
 void
 MaterialOutputAction::materialOutputHelper<Real>(const std::string & property_name,
-                                                 std::shared_ptr<Material> material)
+                                                 std::shared_ptr<MaterialBase> material)
 {
   _awh.addActionBlock(createAction("MaterialRealAux", property_name, property_name, material));
 }
@@ -253,7 +255,7 @@ MaterialOutputAction::materialOutputHelper<Real>(const std::string & property_na
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & property_name,
-                                                            std::shared_ptr<Material> material)
+                                                            std::shared_ptr<MaterialBase> material)
 {
   char suffix[3] = {'x', 'y', 'z'};
 
@@ -272,7 +274,7 @@ MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & 
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & property_name,
-                                                            std::shared_ptr<Material> material)
+                                                            std::shared_ptr<MaterialBase> material)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
@@ -291,7 +293,7 @@ MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & 
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & property_name,
-                                                          std::shared_ptr<Material> material)
+                                                          std::shared_ptr<MaterialBase> material)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
@@ -310,7 +312,7 @@ MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & pr
 template <>
 void
 MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & property_name,
-                                                           std::shared_ptr<Material> material)
+                                                           std::shared_ptr<MaterialBase> material)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -91,7 +91,7 @@ addActionTypes(Syntax & syntax)
 
   registerMooseObjectTask("add_nodal_kernel",             NodalKernel,            false);
 
-  registerMooseObjectTask("add_material",                 Material,               false);
+  registerMooseObjectTask("add_material",                 MaterialBase,           false);
   registerMooseObjectTask("add_bc",                       BoundaryCondition,      false);
   registerMooseObjectTask("add_function",                 Function,               false);
   registerMooseObjectTask("add_distribution",             Distribution,           false);

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -264,7 +264,7 @@ BlockRestrictable::hasBlockMaterialPropertyHelper(const std::string & prop_name)
     // If block materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBlockObjects(id))
     {
-      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBlockObjects(id);
+      const std::vector<std::shared_ptr<MaterialBase>> & mats = warehouse.getActiveBlockObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/interfaces/BoundaryRestrictable.C
+++ b/framework/src/interfaces/BoundaryRestrictable.C
@@ -284,7 +284,8 @@ BoundaryRestrictable::hasBoundaryMaterialPropertyHelper(const std::string & prop
     // If boundary materials exist, populated the set of properties that were declared
     if (warehouse.hasActiveBoundaryObjects(id))
     {
-      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBoundaryObjects(id);
+      const std::vector<std::shared_ptr<MaterialBase>> & mats =
+          warehouse.getActiveBoundaryObjects(id);
       for (const auto & mat : mats)
       {
         const std::set<std::string> & mat_props = mat->getSuppliedItems();

--- a/framework/src/materials/DerivativeParsedMaterialHelper.C
+++ b/framework/src/materials/DerivativeParsedMaterialHelper.C
@@ -83,7 +83,7 @@ DerivativeParsedMaterialHelper::assembleDerivatives()
   {
     // get the master object from thread 0
     const MaterialWarehouse & material_warehouse = _fe_problem.getMaterialWarehouse();
-    const MooseObjectWarehouse<Material> & warehouse = material_warehouse[_material_data_type];
+    const MooseObjectWarehouse<MaterialBase> & warehouse = material_warehouse[_material_data_type];
 
     MooseSharedPointer<DerivativeParsedMaterialHelper> master =
         MooseSharedNamespace::dynamic_pointer_cast<DerivativeParsedMaterialHelper>(

--- a/framework/src/materials/InterfaceMaterial.C
+++ b/framework/src/materials/InterfaceMaterial.C
@@ -8,21 +8,21 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 // MOOSE includes
-#include "Material.h"
+#include "InterfaceMaterial.h"
 
 template <>
 InputParameters
-validParams<Material>()
+validParams<InterfaceMaterial>()
 {
   InputParameters params = validParams<MaterialBase>();
-  params += validParams<MaterialPropertyInterface>();
+  params += validParams<TwoMaterialPropertyInterface>();
   return params;
 }
 
-Material::Material(const InputParameters & parameters)
+InterfaceMaterial::InterfaceMaterial(const InputParameters & parameters)
   : MaterialBase(parameters),
-    Coupleable(this, false),
-    MaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
+    NeighborCoupleable(this, false, false),
+    TwoMaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
     _bnd(_material_data_type != Moose::BLOCK_MATERIAL_DATA),
     _neighbor(_material_data_type == Moose::NEIGHBOR_MATERIAL_DATA),
     _q_point(_bnd ? _assembly.qPointsFace() : _assembly.qPoints()),

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -9,277 +9,33 @@
 
 // MOOSE includes
 #include "Material.h"
-#include "SubProblem.h"
-#include "MaterialData.h"
-#include "Assembly.h"
-#include "Executioner.h"
-#include "Transient.h"
-
-#include "libmesh/quadrature.h"
 
 template <>
 InputParameters
 validParams<Material>()
 {
-  InputParameters params = validParams<MooseObject>();
-  params += validParams<BlockRestrictable>();
-  params += validParams<BoundaryRestrictable>();
-  params += validParams<TransientInterface>();
-  params += validParams<RandomInterface>();
+  InputParameters params = validParams<MaterialBase>();
   params += validParams<MaterialPropertyInterface>();
-
-  params.addParam<bool>("use_displaced_mesh",
-                        false,
-                        "Whether or not this object should use the "
-                        "displaced mesh for computation.  Note that "
-                        "in the case this is true but no "
-                        "displacements are provided in the Mesh block "
-                        "the undisplaced mesh will still be used.");
-  params.addParam<bool>("compute",
-                        true,
-                        "When false, MOOSE will not call compute methods on this material. "
-                        "The user must call computeProperties() after retrieving the Material "
-                        "via MaterialPropertyInterface::getMaterial(). "
-                        "Non-computed Materials are not sorted for dependencies.");
-  MooseEnum const_option("NONE=0 ELEMENT=1 SUBDOMAIN=2", "none");
-  params.addParam<MooseEnum>(
-      "constant_on",
-      const_option,
-      "When ELEMENT, MOOSE will only call computeQpProperties() for the 0th "
-      "quadrature point, and then copy that value to the other qps."
-      "When SUBDOMAIN, MOOSE will only call computeSubdomainProperties() for the 0th "
-      "quadrature point, and then copy that value to the other qps. Evaluations on element qps "
-      "will be skipped");
-
-  params.addPrivateParam<bool>("_neighbor", false);
-
-  // Outputs
-  params += validParams<OutputInterface>();
-  params.set<std::vector<OutputName>>("outputs") = {"none"};
-  params.addParam<std::vector<std::string>>(
-      "output_properties",
-      "List of material properties, from this material, to output (outputs "
-      "must also be defined to an output type)");
-
-  params.addParamNamesToGroup("outputs output_properties", "Outputs");
-  params.addParamNamesToGroup("use_displaced_mesh constant_on", "Advanced");
   params.registerBase("Material");
-
   return params;
 }
 
 Material::Material(const InputParameters & parameters)
-  : MooseObject(parameters),
-    BlockRestrictable(this),
-    BoundaryRestrictable(this, blockIDs(), false), // false for being _not_ nodal
-    SetupInterface(this),
+  : MaterialBase(parameters),
     Coupleable(this, false),
-    MooseVariableDependencyInterface(),
-    ScalarCoupleable(this),
-    FunctionInterface(this),
-    DistributionInterface(this),
-    UserObjectInterface(this),
-    TransientInterface(this),
     MaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
-    PostprocessorInterface(this),
-    VectorPostprocessorInterface(this),
-    DependencyResolverInterface(),
-    Restartable(this, "Materials"),
-    MeshChangedInterface(parameters),
-
-    // The false flag disables the automatic call buildOutputVariableHideList;
-    // for Material objects the hide lists are handled by MaterialOutputAction
-    OutputInterface(parameters, false),
-    RandomInterface(parameters,
-                    *parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"),
-                    parameters.get<THREAD_ID>("_tid"),
-                    false),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
     _bnd(_material_data_type != Moose::BLOCK_MATERIAL_DATA),
     _neighbor(_material_data_type == Moose::NEIGHBOR_MATERIAL_DATA),
-    _qp(std::numeric_limits<unsigned int>::max()),
+    _q_point(_bnd ? _assembly.qPointsFace() : _assembly.qPoints()),
     _qrule(_bnd ? _assembly.qRuleFace() : _assembly.qRule()),
     _JxW(_bnd ? _assembly.JxWFace() : _assembly.JxW()),
-    _coord(_assembly.coordTransformation()),
-    _q_point(_bnd ? _assembly.qPointsFace() : _assembly.qPoints()),
-    _normals(_assembly.normals()),
     _current_elem(_neighbor ? _assembly.neighbor() : _assembly.elem()),
     _current_subdomain_id(_neighbor ? _assembly.currentNeighborSubdomainID()
                                     : _assembly.currentSubdomainID()),
-    _current_side(_neighbor ? _assembly.neighborSide() : _assembly.side()),
-    _mesh(_subproblem.mesh()),
-    _coord_sys(_assembly.coordSystem()),
-    _compute(getParam<bool>("compute")),
-    _constant_option(getParam<MooseEnum>("constant_on").getEnum<ConstantTypeEnum>()),
-    _has_stateful_property(false)
+    _current_side(_neighbor ? _assembly.neighborSide() : _assembly.side())
 {
   // Fill in the MooseVariable dependencies
   const std::vector<MooseVariableFEBase *> & coupled_vars = getCoupledMooseVars();
   for (const auto & var : coupled_vars)
     addMooseVariableDependency(var);
-}
-
-void
-Material::initStatefulProperties(unsigned int n_points)
-{
-  for (_qp = 0; _qp < n_points; ++_qp)
-    initQpStatefulProperties();
-
-  // checking for statefulness of properties via this loop is necessary
-  // because owned props might have been promoted to stateful by calls to
-  // getMaterialProperty[Old/Older] from other objects.  In these cases, this
-  // object won't otherwise know that it owns stateful properties.
-  for (auto & prop : _supplied_props)
-    if (_material_data->getMaterialPropertyStorage().isStatefulProp(prop) &&
-        !_overrides_init_stateful_props)
-      mooseError(std::string("Material \"") + name() +
-                 "\" provides one or more stateful "
-                 "properties but initQpStatefulProperties() "
-                 "was not overridden in the derived class.");
-}
-
-void
-Material::initQpStatefulProperties()
-{
-  _overrides_init_stateful_props = false;
-}
-
-void
-Material::checkStatefulSanity() const
-{
-  for (const auto & it : _props_to_flags)
-    if (static_cast<int>(it.second) % 2 == 0) // Only Stateful properties declared!
-      mooseError("Material '", name(), "' requests undefined stateful property '", it.first, "'");
-}
-
-void
-Material::registerPropName(std::string prop_name, bool is_get, Material::Prop_State state)
-{
-  if (!is_get)
-  {
-    _supplied_props.insert(prop_name);
-    _supplied_prop_ids.insert(_material_data->getPropertyId(prop_name));
-
-    _props_to_flags[prop_name] |= static_cast<int>(state);
-    if (static_cast<int>(state) % 2 == 0)
-      _has_stateful_property = true;
-  }
-
-  // Store material properties for block ids
-  for (const auto & block_id : blockIDs())
-    _fe_problem.storeSubdomainMatPropName(block_id, prop_name);
-
-  // Store material properties for the boundary ids
-  for (const auto & boundary_id : boundaryIDs())
-    _fe_problem.storeBoundaryMatPropName(boundary_id, prop_name);
-}
-
-std::set<OutputName>
-Material::getOutputs()
-{
-  const std::vector<OutputName> & out = getParam<std::vector<OutputName>>("outputs");
-  return std::set<OutputName>(out.begin(), out.end());
-}
-
-void
-Material::subdomainSetup()
-{
-  if (_constant_option == ConstantTypeEnum::SUBDOMAIN)
-  {
-    unsigned int nqp = _fe_problem.getMaxQps();
-
-    MaterialProperties & props = _material_data->props();
-    for (const auto & prop_id : _supplied_prop_ids)
-      props[prop_id]->resize(nqp);
-
-    _qp = 0;
-    computeSubdomainProperties();
-
-    for (const auto & prop_id : _supplied_prop_ids)
-    {
-      for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, props[prop_id], 0);
-    }
-  }
-}
-
-void
-Material::computeSubdomainProperties()
-{
-  mooseError("computeSubdomainQpProperties in Material '", name(), "' needs to be implemented");
-}
-
-void
-Material::computeProperties()
-{
-  if (_constant_option == ConstantTypeEnum::SUBDOMAIN)
-    return;
-
-  // If this Material has the _constant_on_elem flag set, we take the
-  // value computed for _qp==0 and use it at all the quadrature points
-  // in the Elem.
-  if (_constant_option == ConstantTypeEnum::ELEMENT)
-  {
-    // Compute MaterialProperty values at the first qp.
-    _qp = 0;
-    computeQpProperties();
-
-    // Reference to *all* the MaterialProperties in the MaterialData object, not
-    // just the ones for this Material.
-    MaterialProperties & props = _material_data->props();
-
-    // Now copy the values computed at qp 0 to all the other qps.
-    for (const auto & prop_id : _supplied_prop_ids)
-    {
-      auto nqp = _qrule->n_points();
-      for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, props[prop_id], 0);
-    }
-  }
-  else
-  {
-    for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
-      computeQpProperties();
-  }
-}
-
-void
-Material::computeQpProperties()
-{
-}
-
-void
-Material::resetProperties()
-{
-  for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
-    resetQpProperties();
-}
-
-void
-Material::resetQpProperties()
-{
-  if (!_compute)
-    mooseDoOnce(mooseWarning("You disabled the computation of this (",
-                             name(),
-                             ") material by MOOSE, but have not overridden the 'resetQpProperties' "
-                             "method, this can lead to unintended values being set for material "
-                             "property values."));
-}
-
-void
-Material::computePropertiesAtQp(unsigned int qp)
-{
-  _qp = qp;
-  computeQpProperties();
-}
-
-void
-Material::checkExecutionStage()
-{
-  if (_fe_problem.startedInitialSetup())
-    mooseError("Material properties must be retrieved during material object construction to "
-               "ensure correct dependency resolution.");
 }

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -61,7 +61,7 @@ validParams<MaterialBase>()
 
   params.addParamNamesToGroup("outputs output_properties", "Outputs");
   params.addParamNamesToGroup("use_displaced_mesh constant_on", "Advanced");
-
+  params.registerBase("MaterialBase");
   return params;
 }
 

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -1,0 +1,267 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+// MOOSE includes
+#include "MaterialBase.h"
+#include "SubProblem.h"
+#include "Assembly.h"
+#include "Executioner.h"
+#include "Transient.h"
+
+#include "libmesh/quadrature.h"
+
+template <>
+InputParameters
+validParams<MaterialBase>()
+{
+  InputParameters params = validParams<MooseObject>();
+  params += validParams<BlockRestrictable>();
+  params += validParams<BoundaryRestrictable>();
+  params += validParams<TransientInterface>();
+  params += validParams<RandomInterface>();
+
+  params.addParam<bool>("use_displaced_mesh",
+                        false,
+                        "Whether or not this object should use the "
+                        "displaced mesh for computation.  Note that "
+                        "in the case this is true but no "
+                        "displacements are provided in the Mesh block "
+                        "the undisplaced mesh will still be used.");
+  params.addParam<bool>("compute",
+                        true,
+                        "When false, MOOSE will not call compute methods on this material. "
+                        "The user must call computeProperties() after retrieving the MaterialBase "
+                        "via MaterialBasePropertyInterface::getMaterialBase(). "
+                        "Non-computed MaterialBases are not sorted for dependencies.");
+  MooseEnum const_option("NONE=0 ELEMENT=1 SUBDOMAIN=2", "none");
+  params.addParam<MooseEnum>(
+      "constant_on",
+      const_option,
+      "When ELEMENT, MOOSE will only call computeQpProperties() for the 0th "
+      "quadrature point, and then copy that value to the other qps."
+      "When SUBDOMAIN, MOOSE will only call computeSubdomainProperties() for the 0th "
+      "quadrature point, and then copy that value to the other qps. Evaluations on element qps "
+      "will be skipped");
+
+  params.addPrivateParam<bool>("_neighbor", false);
+
+  // Outputs
+  params += validParams<OutputInterface>();
+  params.set<std::vector<OutputName>>("outputs") = {"none"};
+  params.addParam<std::vector<std::string>>(
+      "output_properties",
+      "List of material properties, from this material, to output (outputs "
+      "must also be defined to an output type)");
+
+  params.addParamNamesToGroup("outputs output_properties", "Outputs");
+  params.addParamNamesToGroup("use_displaced_mesh constant_on", "Advanced");
+
+  return params;
+}
+
+MaterialBase::MaterialBase(const InputParameters & parameters)
+  : MooseObject(parameters),
+    BlockRestrictable(this),
+    BoundaryRestrictable(this, blockIDs(), false), // false for being _not_ nodal
+    SetupInterface(this),
+    MooseVariableDependencyInterface(),
+    ScalarCoupleable(this),
+    FunctionInterface(this),
+    DistributionInterface(this),
+    UserObjectInterface(this),
+    TransientInterface(this),
+    PostprocessorInterface(this),
+    VectorPostprocessorInterface(this),
+    DependencyResolverInterface(),
+    Restartable(this, "MaterialBases"),
+    MeshChangedInterface(parameters),
+
+    // The false flag disables the automatic call buildOutputVariableHideList;
+    // for MaterialBase objects the hide lists are handled by MaterialBaseOutputAction
+    OutputInterface(parameters, false),
+    RandomInterface(parameters,
+                    *parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"),
+                    parameters.get<THREAD_ID>("_tid"),
+                    false),
+    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
+    _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
+    _tid(parameters.get<THREAD_ID>("_tid")),
+    _assembly(_subproblem.assembly(_tid)),
+    _qp(std::numeric_limits<unsigned int>::max()),
+    _coord(_assembly.coordTransformation()),
+    _normals(_assembly.normals()),
+    _mesh(_subproblem.mesh()),
+    _coord_sys(_assembly.coordSystem()),
+    _compute(getParam<bool>("compute")),
+    _constant_option(getParam<MooseEnum>("constant_on").getEnum<ConstantTypeEnum>()),
+    _has_stateful_property(false)
+{
+}
+
+void
+MaterialBase::initStatefulProperties(unsigned int n_points)
+{
+  for (_qp = 0; _qp < n_points; ++_qp)
+    initQpStatefulProperties();
+
+  // checking for statefulness of properties via this loop is necessary
+  // because owned props might have been promoted to stateful by calls to
+  // getMaterialProperty[Old/Older] from other objects.  In these cases, this
+  // object won't otherwise know that it owns stateful properties.
+  for (auto & prop : _supplied_props)
+    if (materialData().getMaterialPropertyStorage().isStatefulProp(prop) &&
+        !_overrides_init_stateful_props)
+      mooseError(std::string("Material \"") + name() +
+                 "\" provides one or more stateful "
+                 "properties but initQpStatefulProperties() "
+                 "was not overridden in the derived class.");
+}
+
+void
+MaterialBase::initQpStatefulProperties()
+{
+  _overrides_init_stateful_props = false;
+}
+
+void
+MaterialBase::checkStatefulSanity() const
+{
+  for (const auto & it : _props_to_flags)
+    if (static_cast<int>(it.second) % 2 == 0) // Only Stateful properties declared!
+      mooseError("Material '", name(), "' requests undefined stateful property '", it.first, "'");
+}
+
+void
+MaterialBase::registerPropName(std::string prop_name, bool is_get, MaterialBase::Prop_State state)
+{
+  if (!is_get)
+  {
+    _supplied_props.insert(prop_name);
+    _supplied_prop_ids.insert(materialData().getPropertyId(prop_name));
+
+    _props_to_flags[prop_name] |= static_cast<int>(state);
+    if (static_cast<int>(state) % 2 == 0)
+      _has_stateful_property = true;
+  }
+
+  // Store material properties for block ids
+  for (const auto & block_id : blockIDs())
+    _fe_problem.storeSubdomainMatPropName(block_id, prop_name);
+
+  // Store material properties for the boundary ids
+  for (const auto & boundary_id : boundaryIDs())
+    _fe_problem.storeBoundaryMatPropName(boundary_id, prop_name);
+}
+
+std::set<OutputName>
+MaterialBase::getOutputs()
+{
+  const std::vector<OutputName> & out = getParam<std::vector<OutputName>>("outputs");
+  return std::set<OutputName>(out.begin(), out.end());
+}
+
+void
+MaterialBase::subdomainSetup()
+{
+  if (_constant_option == ConstantTypeEnum::SUBDOMAIN)
+  {
+    unsigned int nqp = _fe_problem.getMaxQps();
+
+    MaterialProperties & props = materialData().props();
+    for (const auto & prop_id : _supplied_prop_ids)
+      props[prop_id]->resize(nqp);
+
+    _qp = 0;
+    computeSubdomainProperties();
+
+    for (const auto & prop_id : _supplied_prop_ids)
+    {
+      for (decltype(nqp) qp = 1; qp < nqp; ++qp)
+        props[prop_id]->qpCopy(qp, props[prop_id], 0);
+    }
+  }
+}
+
+void
+MaterialBase::computeSubdomainProperties()
+{
+  mooseError("computeSubdomainQpProperties in Material '", name(), "' needs to be implemented");
+}
+
+void
+MaterialBase::computeProperties()
+{
+  if (_constant_option == ConstantTypeEnum::SUBDOMAIN)
+    return;
+
+  // If this Material has the _constant_on_elem flag set, we take the
+  // value computed for _qp==0 and use it at all the quadrature points
+  // in the Elem.
+  if (_constant_option == ConstantTypeEnum::ELEMENT)
+  {
+    // Compute MaterialProperty values at the first qp.
+    _qp = 0;
+    computeQpProperties();
+
+    // Reference to *all* the MaterialProperties in the MaterialData object, not
+    // just the ones for this Material.
+    MaterialProperties & props = materialData().props();
+
+    // Now copy the values computed at qp 0 to all the other qps.
+    for (const auto & prop_id : _supplied_prop_ids)
+    {
+      auto nqp = qRule().n_points();
+      for (decltype(nqp) qp = 1; qp < nqp; ++qp)
+        props[prop_id]->qpCopy(qp, props[prop_id], 0);
+    }
+  }
+  else
+  {
+    for (_qp = 0; _qp < qRule().n_points(); ++_qp)
+      computeQpProperties();
+  }
+}
+
+void
+MaterialBase::computeQpProperties()
+{
+}
+
+void
+MaterialBase::resetProperties()
+{
+  for (_qp = 0; _qp < qRule().n_points(); ++_qp)
+    resetQpProperties();
+}
+
+void
+MaterialBase::resetQpProperties()
+{
+  if (!_compute)
+    mooseDoOnce(mooseWarning("You disabled the computation of this (",
+                             name(),
+                             ") material by MOOSE, but have not overridden the 'resetQpProperties' "
+                             "method, this can lead to unintended values being set for material "
+                             "property values."));
+}
+
+void
+MaterialBase::computePropertiesAtQp(unsigned int qp)
+{
+  _qp = qp;
+  computeQpProperties();
+}
+
+void
+MaterialBase::checkExecutionStage()
+{
+  if (_fe_problem.startedInitialSetup())
+    mooseError("Material properties must be retrieved during material object construction to "
+               "ensure correct dependency resolution.");
+}

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -64,14 +64,14 @@ MaterialData::swap(const Elem & elem, unsigned int side /* = 0*/)
 }
 
 void
-MaterialData::reinit(const std::vector<std::shared_ptr<Material>> & mats)
+MaterialData::reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats)
 {
   for (const auto & mat : mats)
     mat->computeProperties();
 }
 
 void
-MaterialData::reset(const std::vector<std::shared_ptr<Material>> & mats)
+MaterialData::reset(const std::vector<std::shared_ptr<MaterialBase>> & mats)
 {
   for (const auto & mat : mats)
     mat->resetProperties();

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -138,16 +138,16 @@ MaterialPropertyInterface::statefulPropertiesAllowed(bool stateful_allowed)
   _stateful_allowed = stateful_allowed;
 }
 
-Material &
+MaterialBase &
 MaterialPropertyInterface::getMaterial(const std::string & name)
 {
   return getMaterialByName(_mi_params.get<MaterialName>(name));
 }
 
-Material &
+MaterialBase &
 MaterialPropertyInterface::getMaterialByName(const std::string & name, bool no_warn)
 {
-  std::shared_ptr<Material> discrete =
+  std::shared_ptr<MaterialBase> discrete =
       _mi_feproblem.getMaterial(name, _material_data_type, _mi_tid, no_warn);
 
   // Check block compatibility

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -218,7 +218,7 @@ MaterialPropertyStorage::restrictStatefulProps(
 
 void
 MaterialPropertyStorage::initStatefulProps(MaterialData & material_data,
-                                           const std::vector<std::shared_ptr<Material>> & mats,
+                                           const std::vector<std::shared_ptr<MaterialBase>> & mats,
                                            unsigned int n_qpoints,
                                            const Elem & elem,
                                            unsigned int side /* = 0*/)

--- a/framework/src/materials/MaterialWarehouse.C
+++ b/framework/src/materials/MaterialWarehouse.C
@@ -9,20 +9,20 @@
 
 // MOOSE includes
 #include "MaterialWarehouse.h"
-#include "Material.h"
+#include "MaterialBase.h"
 
 void
-MaterialWarehouse::addObjects(std::shared_ptr<Material> block,
-                              std::shared_ptr<Material> neighbor,
-                              std::shared_ptr<Material> face,
+MaterialWarehouse::addObjects(std::shared_ptr<MaterialBase> block,
+                              std::shared_ptr<MaterialBase> neighbor,
+                              std::shared_ptr<MaterialBase> face,
                               THREAD_ID tid /*=0*/)
 {
-  MooseObjectWarehouse<Material>::addObject(block, tid);
+  MooseObjectWarehouse<MaterialBase>::addObject(block, tid);
   _neighbor_materials.addObject(neighbor, tid);
   _face_materials.addObject(face, tid);
 }
 
-const MooseObjectWarehouse<Material> & MaterialWarehouse::
+const MooseObjectWarehouse<MaterialBase> & MaterialWarehouse::
 operator[](Moose::MaterialDataType data_type) const
 {
   switch (data_type)
@@ -41,7 +41,7 @@ operator[](Moose::MaterialDataType data_type) const
 void
 MaterialWarehouse::initialSetup(THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::initialSetup(tid);
+  MooseObjectWarehouse<MaterialBase>::initialSetup(tid);
   _neighbor_materials.initialSetup(tid);
   _face_materials.initialSetup(tid);
 }
@@ -49,7 +49,7 @@ MaterialWarehouse::initialSetup(THREAD_ID tid /*=0*/) const
 void
 MaterialWarehouse::timestepSetup(THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::timestepSetup(tid);
+  MooseObjectWarehouse<MaterialBase>::timestepSetup(tid);
   _neighbor_materials.timestepSetup(tid);
   _face_materials.timestepSetup(tid);
 }
@@ -57,7 +57,7 @@ MaterialWarehouse::timestepSetup(THREAD_ID tid /*=0*/) const
 void
 MaterialWarehouse::subdomainSetup(THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::subdomainSetup(tid);
+  MooseObjectWarehouse<MaterialBase>::subdomainSetup(tid);
   _face_materials.subdomainSetup(tid);
 }
 
@@ -70,7 +70,7 @@ MaterialWarehouse::neighborSubdomainSetup(THREAD_ID tid /*=0*/) const
 void
 MaterialWarehouse::subdomainSetup(SubdomainID id, THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::subdomainSetup(id, tid);
+  MooseObjectWarehouse<MaterialBase>::subdomainSetup(id, tid);
   _face_materials.subdomainSetup(id, tid);
 }
 
@@ -83,7 +83,7 @@ MaterialWarehouse::neighborSubdomainSetup(SubdomainID id, THREAD_ID tid /*=0*/) 
 void
 MaterialWarehouse::residualSetup(THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::residualSetup(tid);
+  MooseObjectWarehouse<MaterialBase>::residualSetup(tid);
   _neighbor_materials.residualSetup(tid);
   _face_materials.residualSetup(tid);
 }
@@ -91,7 +91,7 @@ MaterialWarehouse::residualSetup(THREAD_ID tid /*=0*/) const
 void
 MaterialWarehouse::jacobianSetup(THREAD_ID tid /*=0*/) const
 {
-  MooseObjectWarehouse<Material>::jacobianSetup(tid);
+  MooseObjectWarehouse<MaterialBase>::jacobianSetup(tid);
   _neighbor_materials.jacobianSetup(tid);
   _face_materials.jacobianSetup(tid);
 }
@@ -99,7 +99,7 @@ MaterialWarehouse::jacobianSetup(THREAD_ID tid /*=0*/) const
 void
 MaterialWarehouse::updateActive(THREAD_ID tid /*=0*/)
 {
-  MooseObjectWarehouse<Material>::updateActive(tid);
+  MooseObjectWarehouse<MaterialBase>::updateActive(tid);
   _neighbor_materials.updateActive(tid);
   _face_materials.updateActive(tid);
 }
@@ -107,7 +107,7 @@ MaterialWarehouse::updateActive(THREAD_ID tid /*=0*/)
 void
 MaterialWarehouse::sort(THREAD_ID tid /*=0*/)
 {
-  MooseObjectWarehouse<Material>::sort(tid);
+  MooseObjectWarehouse<MaterialBase>::sort(tid);
   _neighbor_materials.sort(tid);
   _face_materials.sort(tid);
 }

--- a/framework/src/outputs/MaterialPropertyDebugOutput.C
+++ b/framework/src/outputs/MaterialPropertyDebugOutput.C
@@ -114,7 +114,7 @@ MaterialPropertyDebugOutput::printMaterialMap() const
 
 void
 MaterialPropertyDebugOutput::printMaterialProperties(
-    std::stringstream & output, const std::vector<std::shared_ptr<Material>> & materials) const
+    std::stringstream & output, const std::vector<std::shared_ptr<MaterialBase>> & materials) const
 {
   // Loop through all material objects
   for (const auto & mat : materials)

--- a/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
+++ b/modules/solid_mechanics/src/materials/CombinedCreepPlasticity.C
@@ -56,7 +56,7 @@ CombinedCreepPlasticity::initialSetup()
   for (unsigned i(0); i < block_id.size(); ++i)
   {
     std::string suffix;
-    std::vector<MooseSharedPointer<Material>> const * mats_p;
+    std::vector<MooseSharedPointer<MaterialBase>> const * mats_p;
     if (_bnd)
     {
       mats_p = &_fe_problem.getMaterialWarehouse()[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(
@@ -66,7 +66,7 @@ CombinedCreepPlasticity::initialSetup()
     else
       mats_p = &_fe_problem.getMaterialWarehouse().getActiveBlockObjects(block_id[i], _tid);
 
-    const std::vector<MooseSharedPointer<Material>> & mats = *mats_p;
+    const std::vector<MooseSharedPointer<MaterialBase>> & mats = *mats_p;
     for (unsigned int i_name(0); i_name < submodels.size(); ++i_name)
     {
       bool found = false;

--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -140,7 +140,7 @@ getCrackingModel(const std::string & name)
     mooseError("Unknown cracking model");
   return cm;
 }
-}
+} // namespace
 
 SolidModel::SolidModel(const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
@@ -967,8 +967,8 @@ SolidModel::initialSetup()
   for (unsigned i(0); i < _block_id.size(); ++i)
   {
 
-    //    const std::vector<Material*> * mats_p;
-    std::vector<MooseSharedPointer<Material>> const * mats_p;
+    //    const std::vector<MaterialBase*> * mats_p;
+    std::vector<MooseSharedPointer<MaterialBase>> const * mats_p;
     std::string suffix;
     if (_bnd)
     {
@@ -979,7 +979,7 @@ SolidModel::initialSetup()
     else
       mats_p = &_fe_problem.getMaterialWarehouse().getActiveBlockObjects(_block_id[i], _tid);
 
-    const std::vector<MooseSharedPointer<Material>> & mats = *mats_p;
+    const std::vector<MooseSharedPointer<MaterialBase>> & mats = *mats_p;
 
     for (unsigned int j = 0; j < mats.size(); ++j)
     {

--- a/modules/tensor_mechanics/src/userobjects/LinearViscoelasticityManager.C
+++ b/modules/tensor_mechanics/src/userobjects/LinearViscoelasticityManager.C
@@ -62,7 +62,7 @@ LinearViscoelasticityManager::execute()
 void
 LinearViscoelasticityManager::initialize()
 {
-  std::shared_ptr<Material> test =
+  std::shared_ptr<MaterialBase> test =
       _mi_feproblem.getMaterial(_viscoelastic_model_name, _material_data_type, _mi_tid, true);
 
   if (!test)

--- a/modules/tensor_mechanics/src/utils/GuaranteeConsumer.C
+++ b/modules/tensor_mechanics/src/utils/GuaranteeConsumer.C
@@ -11,7 +11,7 @@
 #include "GuaranteeProvider.h"
 
 #include "MooseObject.h"
-#include "Material.h"
+#include "MaterialBase.h"
 #include "MooseMesh.h"
 #include "FEProblemBase.h"
 #include "InputParameters.h"
@@ -45,7 +45,7 @@ GuaranteeConsumer::hasGuaranteedMaterialProperty(const MaterialPropertyName & pr
     // If block materials exist, look if any issue the required guarantee
     if (warehouse.hasActiveBlockObjects(id))
     {
-      const std::vector<std::shared_ptr<Material>> & mats = warehouse.getActiveBlockObjects(id);
+      const std::vector<std::shared_ptr<MaterialBase>> & mats = warehouse.getActiveBlockObjects(id);
       for (const auto & mat : mats)
       {
         const auto & mat_props = mat->getSuppliedItems();

--- a/test/include/interfacekernels/PenaltyInterfaceDiffusion.h
+++ b/test/include/interfacekernels/PenaltyInterfaceDiffusion.h
@@ -31,6 +31,9 @@ protected:
   virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
 
   const Real _penalty;
+
+  std::string _jump_prop_name;
+  const MaterialProperty<Real> * _jump;
 };
 
 #endif

--- a/test/include/materials/JumpInterfaceMaterial.h
+++ b/test/include/materials/JumpInterfaceMaterial.h
@@ -1,0 +1,38 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef JUMPINTERFACEMATERIAL_H
+#define JUMPINTERFACEMATERIAL_H
+
+#include "InterfaceMaterial.h"
+#include "MaterialProperty.h"
+
+// Forward Declarations
+class JumpInterfaceMaterial;
+
+template <>
+InputParameters validParams<JumpInterfaceMaterial>();
+
+/**
+ * Interface material calculates a variable's jump value across an interface
+ */
+class JumpInterfaceMaterial : public InterfaceMaterial
+{
+public:
+  JumpInterfaceMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+
+  const VariableValue & _value;
+  const VariableValue & _neighbor_value;
+  MaterialProperty<Real> & _jump;
+};
+
+#endif // JUMPINTERFACEMATERIAL_H

--- a/test/include/materials/NewtonMaterial.h
+++ b/test/include/materials/NewtonMaterial.h
@@ -41,7 +41,7 @@ private:
   MaterialProperty<Real> & _p;
   std::vector<unsigned int> _prop_ids;
   unsigned int _max_iterations;
-  Material & _discrete;
+  MaterialBase & _discrete;
 };
 
 #endif /* NEWTONMATERIAL_H */

--- a/test/src/materials/JumpInterfaceMaterial.C
+++ b/test/src/materials/JumpInterfaceMaterial.C
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "JumpInterfaceMaterial.h"
+
+registerMooseObject("MooseTestApp", JumpInterfaceMaterial);
+
+template <>
+InputParameters
+validParams<JumpInterfaceMaterial>()
+{
+  InputParameters params = validParams<InterfaceMaterial>();
+  params.addClassDescription("Calculates a variable's jump value across an interface.");
+  params.addRequiredCoupledVar("var", "Name of the variable");
+  params.addRequiredCoupledVar("neighbor_var", "Name of the neighbor variable");
+  return params;
+}
+
+JumpInterfaceMaterial::JumpInterfaceMaterial(const InputParameters & parameters)
+  : InterfaceMaterial(parameters),
+    _value(coupledValue("var")),
+    _neighbor_value(coupledNeighborValue("neighbor_var")),
+    _jump(declareProperty<Real>("jump"))
+{
+}
+
+void
+JumpInterfaceMaterial::computeQpProperties()
+{
+  _jump[_qp] = _value[_qp] - _neighbor_value[_qp];
+}

--- a/test/tests/interfacekernels/1d_interface/coupled_value_coupled_flux_with_jump_material.i
+++ b/test/tests/interfacekernels/1d_interface/coupled_value_coupled_flux_with_jump_material.i
@@ -1,0 +1,125 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+  xmax = 2
+[]
+
+[MeshModifiers]
+  [./subdomain1]
+    type = SubdomainBoundingBox
+    bottom_left = '1.0 0 0'
+    block_id = 1
+    top_right = '2.0 1.0 0'
+  [../]
+  [./interface]
+    type = SideSetsBetweenSubdomains
+    depends_on = subdomain1
+    master_block = '0'
+    paired_block = '1'
+    new_boundary = 'master0_interface'
+  [../]
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    block = '0'
+  [../]
+
+
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+    block = '1'
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = CoeffParamDiffusion
+    variable = u
+    D = 4
+    block = 0
+  [../]
+  [./diff_v]
+    type = CoeffParamDiffusion
+    variable = v
+    D = 2
+    block = 1
+  [../]
+[]
+
+[InterfaceKernels]
+  [./penalty_interface]
+    type = PenaltyInterfaceDiffusion
+    variable = u
+    neighbor_var = v
+    boundary = master0_interface
+    penalty = 1e6
+    jump_prop_name = jump
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 'left'
+    value = 1
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = v
+    boundary = 'right'
+    value = 0
+  [../]
+[]
+
+[Materials]
+    [./jump]
+      type = JumpInterfaceMaterial
+      var = u
+      neighbor_var = v
+      boundary = master0_interface
+    [../]
+  [./stateful]
+    type = StatefulMaterial
+    initial_diffusivity = 1
+    boundary = master0_interface
+  [../]
+  [./block0]
+    type = GenericConstantMaterial
+    block = '0'
+    prop_names = 'D'
+    prop_values = '4'
+  [../]
+  [./block1]
+    type = GenericConstantMaterial
+    block = '1'
+    prop_names = 'D'
+    prop_values = '2'
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]
+
+[Outputs]
+  exodus = true
+  print_linear_residuals = true
+[]
+
+[Debug]
+  show_var_residual_norms = true
+[]

--- a/test/tests/interfacekernels/1d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
+++ b/test/tests/interfacekernels/1d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
@@ -1,0 +1,1 @@
+coupled_value_coupled_flux_out.e

--- a/test/tests/interfacekernels/1d_interface/tests
+++ b/test/tests/interfacekernels/1d_interface/tests
@@ -18,6 +18,16 @@
     requirement = "The interface diffusion penalty method should reproduce the analytic solution"
     prereq = 'interface_diffusion'
   [../]
+  [./interface_diffusion_penalty_with_jump_material]
+    type = 'Exodiff'
+    input = 'coupled_value_coupled_flux_with_jump_material.i'
+    exodiff = 'coupled_value_coupled_flux_with_jump_material_out.e'
+    design = 'InterfaceKernels/index.md'
+    issues = '#12066'
+    requirement = "The InterfaceKernel system shall use with interface material in 1D."
+                  "In this penalty implementation, jump is calculated by an interface material."
+    prereq = 'interface_diffusion'
+  [../]
   # This test ensures that shape functions for the NEIGHBORING variable are used in test_neighbor
   # and phi_neighbor; this is relevant when _var and _neighbor_var use a different space of shape
   # functions

--- a/test/tests/interfacekernels/2d_interface/coupled_value_coupled_flux_with_jump_material.i
+++ b/test/tests/interfacekernels/2d_interface/coupled_value_coupled_flux_with_jump_material.i
@@ -1,0 +1,125 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  xmax = 2
+  ny = 2
+  ymax = 2
+[]
+
+[MeshModifiers]
+  [./subdomain1]
+    type = SubdomainBoundingBox
+    bottom_left = '0 0 0'
+    top_right = '1 1 0'
+    block_id = 1
+  [../]
+  [./interface]
+    type = SideSetsBetweenSubdomains
+    depends_on = subdomain1
+    master_block = '0'
+    paired_block = '1'
+    new_boundary = 'master0_interface'
+  [../]
+  [./break_boundary]
+    depends_on = interface
+    type = BreakBoundaryOnSubdomain
+  [../]
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    block = 0
+  [../]
+
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+    block = 1
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = CoeffParamDiffusion
+    variable = u
+    D = 4
+    block = 0
+  [../]
+  [./diff_v]
+    type = CoeffParamDiffusion
+    variable = v
+    D = 2
+    block = 1
+  [../]
+  [./source_u]
+    type = BodyForce
+    variable = u
+    value = 1
+  [../]
+[]
+
+[InterfaceKernels]
+  [./interface]
+    type = PenaltyInterfaceDiffusion
+    variable = u
+    neighbor_var = v
+    boundary = master0_interface
+    penalty = 1e6
+    jump_prop_name = jump
+  [../]
+[]
+
+[Materials]
+  [./jump]
+    type = JumpInterfaceMaterial
+    var = u
+    neighbor_var = v
+    boundary = master0_interface
+  [../]
+[]
+
+[BCs]
+  [./u]
+    type = VacuumBC
+    variable = u
+    boundary = 'left_to_0 bottom_to_0 right top'
+  [../]
+  [./v]
+    type = VacuumBC
+    variable = v
+    boundary = 'left_to_1 bottom_to_1'
+  [../]
+[]
+
+[Postprocessors]
+  [./u_int]
+    type = ElementIntegralVariablePostprocessor
+    variable = u
+    block = 0
+  [../]
+  [./v_int]
+    type = ElementIntegralVariablePostprocessor
+    variable = v
+    block = 1
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]
+
+[Outputs]
+  exodus = true
+  print_linear_residuals = true
+[]

--- a/test/tests/interfacekernels/2d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
+++ b/test/tests/interfacekernels/2d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
@@ -1,0 +1,1 @@
+coupled_value_coupled_flux_out.e

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -11,6 +11,17 @@
                   "This uses a penalty implementation that is optimally convergent."
   [../]
 
+  [./test_jump_material]
+    type = 'Exodiff'
+    input = 'coupled_value_coupled_flux_with_jump_material.i'
+    exodiff = 'coupled_value_coupled_flux_with_jump_material_out.e'
+    mesh_mode = REPLICATED
+    issues = "#12066"
+    design = "InterfaceKernels/index.md"
+    requirement = "The InterfaceKernel system shall use with interface material in 2D."
+                  "In this penalty implementation, jump is calculated by an interface material."
+  [../]
+
   [./jacobian_test]
     type = AnalyzeJacobian
     input = coupled_value_coupled_flux.i

--- a/test/tests/interfacekernels/3d_interface/coupled_value_coupled_flux_with_jump_material.i
+++ b/test/tests/interfacekernels/3d_interface/coupled_value_coupled_flux_with_jump_material.i
@@ -1,0 +1,127 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 2
+  xmax = 2
+  ny = 2
+  ymax = 2
+  nz = 2
+  zmax = 2
+[]
+
+[MeshModifiers]
+  [./subdomain1]
+    type = SubdomainBoundingBox
+    bottom_left = '0 0 0'
+    top_right = '1 1 1'
+    block_id = 1
+  [../]
+  [./break_boundary]
+    depends_on = subdomain1
+    type = BreakBoundaryOnSubdomain
+  [../]
+  [./interface]
+    type = SideSetsBetweenSubdomains
+    depends_on = break_boundary
+    master_block = '0'
+    paired_block = '1'
+    new_boundary = 'master0_interface'
+  [../]
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    block = 0
+  [../]
+
+  [./v]
+    order = FIRST
+    family = LAGRANGE
+    block = 1
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = CoeffParamDiffusion
+    variable = u
+    D = 4
+    block = 0
+  [../]
+  [./diff_v]
+    type = CoeffParamDiffusion
+    variable = v
+    D = 2
+    block = 1
+  [../]
+  [./source_u]
+    type = BodyForce
+    variable = u
+    value = 1
+  [../]
+[]
+
+[InterfaceKernels]
+  [./interface]
+    type = PenaltyInterfaceDiffusion
+    variable = u
+    neighbor_var = v
+    boundary = master0_interface
+    penalty = 1e6
+    jump_prop_name = jump
+  [../]
+[]
+
+[Materials]
+  [./jump]
+    type = JumpInterfaceMaterial
+    var = u
+    neighbor_var = v
+    boundary = master0_interface
+  [../]
+[]
+
+[BCs]
+  [./u]
+    type = VacuumBC
+    variable = u
+    boundary = 'left_to_0 bottom_to_0 back_to_0 right top front'
+  [../]
+  [./v]
+    type = VacuumBC
+    variable = v
+    boundary = 'left_to_1 bottom_to_1 back_to_1'
+  [../]
+[]
+
+[Postprocessors]
+  [./u_int]
+    type = ElementIntegralVariablePostprocessor
+    variable = u
+    block = 0
+  [../]
+  [./v_int]
+    type = ElementIntegralVariablePostprocessor
+    variable = v
+    block = 1
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+[]
+
+[Outputs]
+  exodus = true
+  print_linear_residuals = true
+[]

--- a/test/tests/interfacekernels/3d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
+++ b/test/tests/interfacekernels/3d_interface/gold/coupled_value_coupled_flux_with_jump_material_out.e
@@ -1,0 +1,1 @@
+coupled_value_coupled_flux_out.e

--- a/test/tests/interfacekernels/3d_interface/tests
+++ b/test/tests/interfacekernels/3d_interface/tests
@@ -9,4 +9,15 @@
     requirement = "The InterfaceKernel system shall operate with coupled variables in 3D. "
                   "This uses a penalty implementation that is optimally convergent."
   [../]
+
+  [./test_jump_material]
+    type = 'Exodiff'
+    input = 'coupled_value_coupled_flux_with_jump_material.i'
+    exodiff = 'coupled_value_coupled_flux_with_jump_material_out.e'
+    mesh_mode = REPLICATED
+    issues = "#12066"
+    design = "InterfaceKernels/index.md"
+    requirement = "The InterfaceKernel system shall use with interface material in 3D."
+                  "In this penalty implementation, jump is calculated by an interface material."
+  [../]
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

This PR involves a lot of work from @andrsd and @lindsayad. We create a new `MaterialBase` class and have `Material` and `InterfaceMaterial` derive from it. 

The motivation is we want to have a material (boundary/interface) that can fetch the values from neighbor element on an interface. The pertinent application is cohesive zone method implementation but it should be usefully for other cases. 

closes #12066 