### PR TITLE
Some tensor mechanics test requirements, issues, and design page links

### DIFF
--- a/modules/tensor_mechanics/test/tests/1D_spherical/tests
+++ b/modules/tensor_mechanics/test/tests/1D_spherical/tests
@@ -6,6 +6,9 @@
     compiler = 'CLANG GCC'
     cli_args = 'Modules/TensorMechanics/Master/all/incremental=false
                 Materials/stress/type=ComputeLinearElasticStress'
+    issues = '#6256 #7555'
+    design = 'source/Materials/ComputeRSphericalSmallStrain.md source/Materials/stress/ComputeLinearElasticStress.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeRSphericalSmallStrain class, called through the TensorMechanicsMaster action, shall compute the total linearized solution for the displacement of a solid isotropic elastic sphere with a pressure applied to the outer surface using a 1D spherical symmetric formulation with total small strain assumptions.'
   [../]
   [./smallStrain_1DSphere_incremental]
     type = Exodiff
@@ -15,11 +18,17 @@
     cli_args = 'Modules/TensorMechanics/Master/all/incremental=true
                 Materials/stress/type=ComputeFiniteStrainElasticStress'
     prereq = 'smallStrain_1DSphere'
+    issues = '#6256 #7555'
+    design = 'source/Materials/ComputeRSphericalIncrementalStrain.md source/Materials/stress/ComputeFiniteStrainElasticStress.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeRSphericalIncrementalStrain class, called through the TensorMechanicsMaster action, shall find the linearized incremental strain displacement of a solid isotropic elastic sphere with a pressure applied to the outer surface using a 1D spherical symmetric formulation with incremental small strain assumptions.'
   [../]
   [./finiteStrain_1DSphere_hollow]
     type = Exodiff
     input = 'finiteStrain_1DSphere_hollow.i'
     exodiff = 'finiteStrain_1DSphere_hollow_out.e'
     compiler = 'CLANG GCC'
+    issues = '#6256 #7555'
+    design = 'source/Materials/ComputeRSphericalFStrain.md source/Materials/stress/ComputeFiniteStrainElasticStress.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeRSphericalFiniteStrain class, called through the TensorMechanicsMaster action, shall find the finite incremental strain displacement of a thick walled hollow isotropic elastic sphere under an applied load using a 1D spherical symmetric fomulation with incremental finite strain assumptions.'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/anisotropic_patch/tests
+++ b/modules/tensor_mechanics/test/tests/anisotropic_patch/tests
@@ -4,5 +4,8 @@
     input = 'anisotropic_patch_test.i'
     exodiff = 'anisotropic_patch_test_out.e'
     scale_refine = 1
+    issues = '#4716 #7555'
+    design = 'source/Materials/ComputeLinearElasticStress.md source/Materials/ComputeSmallStrain.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The mechanics system shall be capable of accurately computing the elastic response of an anisotropic elastic material where 6 components of a symmetric elasticity tensor are output on an irregular patch of elements with total small strain assumptions'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/finite_strain_elastic/tests
+++ b/modules/tensor_mechanics/test/tests/finite_strain_elastic/tests
@@ -3,6 +3,9 @@
     type = 'Exodiff'
     input = 'finite_strain_elastic_new_test.i'
     exodiff = 'finite_strain_elastic_new_test_out.e'
+    issues = '#4716 #7555'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md source/Materials/ComputeFiniteStrain.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress for a finite strain formulation found with the Taylor expansion from Rashid(1993) on a unit 3D cube in a Cartesian system using the TensorMechanicsMaster action.'
   [../]
   [./new_Bbar]
     type = 'Exodiff'
@@ -10,11 +13,17 @@
     exodiff = 'finite_strain_elastic_new_test_out.e'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'new'
+    issues = '#8235 #4716'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md source/Materials/ComputeFiniteStrain.md tensor_mechanics/VolumetricLocking.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress for a finite strain formulation found with the Taylor expansion from Rashid(1993) on a unit 3D cube in a Cartesian system using the volumetric locking correction b-bar formulation.'
   [../]
   [./fake_plastic]
     type = 'Exodiff'
     input = 'finite_strain_fake_plastic.i'
     exodiff = 'finite_strain_fake_plastic_out.e'
+    issues = '#9212 #7555'
+    design = 'source/Materials/ComputeMultiPlasticityStress tensor_mechanics/VolumetricLocking.md'
+    requirement = 'The ComputeMultiPlasticityStress class shall, when supplied with no plastic models, reduce to and produce the solely elastic stress solution for a finite strain fomulation, using the TensorMechanicsMaster action.'
   [../]
   [./fake_plastic_Bbar]
     type = 'Exodiff'
@@ -22,11 +31,17 @@
     exodiff = 'finite_strain_fake_plastic_out.e'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'fake_plastic'
+    issues = '#9212 #8235'
+    design = 'source/Materials/ComputeMultiPlasticityStress tensor_mechanics/VolumetricLocking.md'
+    requirement = 'The ComputeMultiPlasticityStress class shall, when supplied with no plastic models, reduce to and produce the solely elastic stress solution for a finite strain fomulation, using the volumetric locking correction b-bar formulation.'
   [../]
   [./rotation_new]
     type = 'Exodiff'
     input = 'elastic_rotation_test.i'
     exodiff = 'elastic_rotation_test_out.e'
+    issues = '#4716 #7555'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress based on a finite strain fomulation and then follow the stress as the mesh is rotated 90 degrees in accordance with Kamojjala et al.(2015) using the TensorMechanicsMaster action.'
   [../]
   [./rotation_new_Bbar]
     type = 'Exodiff'
@@ -34,11 +49,17 @@
     exodiff = 'elastic_rotation_test_out.e'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'rotation_new'
+    issues = '#4716 #8235'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md tensor_mechanics/VolumetricLocking.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress based on a finite strain fomulation and then follow the stress as the mesh is rotated 90 degrees in accordance with Kamojjala et al.(2015) using the volumetric locking correction b-bar formulation.'
   [../]
   [./eigen_sol]
     type = 'Exodiff'
     input = 'finite_strain_elastic_eigen_sol.i'
     exodiff = 'finite_strain_elastic_eigen_sol_out.e'
+    issues = '#4716 #7555'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md source/Materials/ComputeFiniteStrain.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress for a finite strain formulation using a direct eigensolution to perform the polar decomposition of stretch and rotation on a unit 3D cube in a Cartesian system using the TensorMechanicsMaster action.'
   [../]
   [./eigen_sol_Bbar]
     type = 'Exodiff'
@@ -46,10 +67,16 @@
     exodiff = 'finite_strain_elastic_eigen_sol_out.e'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'eigen_sol'
+    issues = '#8235 #4716'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md source/Materials/ComputeFiniteStrain.md tensor_mechanics/VolumetricLocking.md'
+    requirement = 'The ComputeFiniteStrainElasticStress class shall compute the elastic stress for a finite strain formulation using a direct eigensolution to perform the polar decomposition of stretch and rotation on a unit 3D cube in a Cartesian system using the volumetric locking correction b-bar formulation.'
   [../]
   [./stress_errorcheck]
     type = 'RunException'
     input = 'finite_strain_stress_errorcheck.i'
     expect_err = 'This linear elastic stress calculation only works for small strains; use ComputeFiniteStrainElasticStress for simulations using incremental and finite strains.'
+    issues = '#4716 #7555'
+    design = 'source/Materials/ComputeFiniteStrainElasticStress.md source/Materials/ComputeLinearElasticStress.md syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The ComputeLinearElasticStress class shall generate an error if a user attempts to run a problem using ComputeLinearElasticStress with a finite strain formulation.'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/pressure/pressure_test.i
+++ b/modules/tensor_mechanics/test/tests/pressure/pressure_test.i
@@ -10,7 +10,6 @@
 
 
 [Mesh]
-  # Comment
   type = FileMesh
   file = pressure_test.e
   displacements = 'disp_x disp_y disp_z'

--- a/modules/tensor_mechanics/test/tests/pressure/tests
+++ b/modules/tensor_mechanics/test/tests/pressure/tests
@@ -3,6 +3,9 @@
     type = Exodiff
     input = 'pressure_test.i'
     exodiff = 'pressure_test_out.e'
+    issues = '#4781'
+    design = 'syntax/BCs/Pressure/index.md'
+    requirement = 'The Pressure boundary condition action shall create the objects needed to apply pressure boundary conditions on a 3D model as demonstrated by correctly computing the response of an elastic small-strain isotropic unit cube with pressure applied on three faces to create a hydrostatic pressure.'
   [../]
   [./3D_Bbar]
     type = Exodiff
@@ -10,5 +13,8 @@
     exodiff = 'pressure_test_out.e'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = '3D'
+    issues = '#4781 #8235'
+    design = 'syntax/BCs/Pressure/index.md'
+    requirement = 'The Pressure boundary condition action shall create the objects needed to apply pressure boundary conditions on a 3D model as demonstrated by correctly computing the response of an elastic small-strain isotropic unit cube with pressure applied on three faces to create a hydrostatic pressure using the volumetric locking correction b-bar formulation.'
   [../]
 []


### PR DESCRIPTION
Includes the sqa documentation for the design and requirements for a small set of isotropic elastic tensor mechanics tests.

Refs #9638
