### PR TITLE
factory: allow duplicate registrations of identical objects

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -164,10 +164,11 @@ public:
   template <typename T>
   void reg(const std::string & obj_name, const std::string & file = "", int line = -1)
   {
-    reg(obj_name, &buildObject<T>, &validParams<T>, "", "", file, line);
+    reg("", obj_name, &buildObject<T>, &validParams<T>, "", "", file, line);
   }
 
-  void reg(const std::string & obj_name,
+  void reg(const std::string & label,
+           const std::string & obj_name,
            const buildPtr & build_ptr,
            const paramsPtr & params_ptr,
            const std::string & deprecated_time = "",
@@ -210,7 +211,7 @@ public:
                      const std::string & file,
                      int line)
   {
-    reg(obj_name, &buildObject<T>, &validParams<T>, t_str, "", file, line);
+    reg("", obj_name, &buildObject<T>, &validParams<T>, t_str, "", file, line);
   }
 
   /**
@@ -229,7 +230,7 @@ public:
                    const std::string & file,
                    int line)
   {
-    reg(dep_obj, &buildObject<T>, &validParams<T>, time_str, replacement_name, file, line);
+    reg("", dep_obj, &buildObject<T>, &validParams<T>, time_str, replacement_name, file, line);
   }
 
   /**
@@ -389,6 +390,11 @@ protected:
 
   /// Constructed Moose Object types
   std::set<std::string> _constructed_types;
+
+  /// set<label/appname, objectname> used to track if an object previously added is being added
+  /// again - which is okay/allowed, while still allowing us to detect/reject cases of duplicate
+  /// object name registration where the label/appname is not identical.
+  std::set<std::pair<std::string, std::string>> _objects_by_label;
 };
 
 #endif /* FACTORY_H */

--- a/framework/src/base/Registry.C
+++ b/framework/src/base/Registry.C
@@ -66,7 +66,8 @@ Registry::registerObjectsTo(Factory & f, const std::set<std::string> & labels)
       if (name.empty())
         name = obj._classname;
 
-      f.reg(name,
+      f.reg(obj._label,
+            name,
             obj._build_ptr,
             obj._params_ptr,
             obj._deprecated_time,


### PR DESCRIPTION
fixes #12106.  I couldn't think of a good way to test this.  To test it right, we would need multiple apps that depend on each other.  This PR should enable some serious cleanup and simplification of app/module dependency handling code in [Foo]App.C files - all the register[Stuff] functions maybe could be consolidated into a single function and Apps would no longer need to explicitly register all transitive app/module dependency things (objects, exec flags, etc.).

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
