### PR TITLE
New virtual function Real p_from_T_v(Real T, Real v) added

### DIFF
--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -280,6 +280,14 @@ public:
   virtual void e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const;
 
   /**
+   * Pressure from temperature and specific volume
+   *
+   * @param[in] T     temperature
+   * @param[in] v     specific volume
+   */
+  virtual Real p_from_T_v(Real T, Real v) const;
+
+  /**
    * Specific enthalpy from pressure and temperature
    *
    * @param[in] p   pressure (Pa)

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -499,6 +499,11 @@ SinglePhaseFluidProperties::e_from_p_rho(Real, Real, Real &, Real &, Real &) con
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
 }
 
+Real SinglePhaseFluidProperties::p_from_T_v(Real, Real) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
+}
+
 Real SinglePhaseFluidProperties::h_from_p_T(Real, Real) const
 {
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");


### PR DESCRIPTION
The newly added virtual function Real SinglePhaseFluidProperties::p_from_T_v(Real T, Real v) is required for a simple mixture model for gases in RELAP-7. This function needs to be overwritten by classes derived from SinglePhaseFluidProperties in order to be used for mixture calculations.

Closes #12142