### PR TITLE
Consistently include <ctime> and use std::time_t.

### DIFF
--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -12,7 +12,7 @@
 
 #include <set>
 #include <vector>
-#include <time.h>
+#include <ctime>
 
 // MOOSE includes
 #include "MooseObject.h"
@@ -349,7 +349,7 @@ protected:
    * @param t_str String with the object expiration date, this must be in the form mm/dd/yyyy HH:MM
    * @return A time_t object with the expiration date
    */
-  time_t parseTime(std::string);
+  std::time_t parseTime(std::string);
 
   /**
    * Show the appropriate message for deprecated objects
@@ -377,7 +377,7 @@ protected:
   std::map<std::string, std::string> _name_to_class;
 
   /// Storage for deprecated object experiation dates
-  std::map<std::string, time_t> _deprecated_time;
+  std::map<std::string, std::time_t> _deprecated_time;
 
   /// Storage for the deprecated objects that have replacements
   std::map<std::string, std::string> _deprecated_name;

--- a/framework/include/utils/SystemInfo.h
+++ b/framework/include/utils/SystemInfo.h
@@ -11,6 +11,7 @@
 #define SYSTEMINFO_H
 
 #include <string>
+#include <ctime>
 
 class SystemInfo
 {
@@ -18,7 +19,7 @@ public:
   SystemInfo(int argc, char * argv[]);
 
   std::string getInfo() const;
-  std::string getTimeStamp(time_t * time_stamp = NULL) const;
+  std::string getTimeStamp(std::time_t * time_stamp = NULL) const;
 
   int argc() const { return _argc; };
   char ** argv() const { return _argv; };

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -168,7 +168,7 @@ Factory::restrictRegisterableObjects(const std::vector<std::string> & names)
   _registerable_objects.insert(names.begin(), names.end());
 }
 
-time_t
+std::time_t
 Factory::parseTime(const std::string t_str)
 {
   // The string must be a certain length to be valid
@@ -176,7 +176,7 @@ Factory::parseTime(const std::string t_str)
     mooseError("The deprecated time not formatted correctly; it must be given as mm/dd/yyyy HH:MM");
 
   // Store the time, the time must be specified as: mm/dd/yyyy HH:MM
-  time_t t_end;
+  std::time_t t_end;
   struct tm * t_end_info;
   time(&t_end);
   t_end_info = localtime(&t_end);
@@ -193,18 +193,18 @@ Factory::parseTime(const std::string t_str)
 void
 Factory::deprecatedMessage(const std::string obj_name)
 {
-  std::map<std::string, time_t>::iterator time_it = _deprecated_time.find(obj_name);
+  std::map<std::string, std::time_t>::iterator time_it = _deprecated_time.find(obj_name);
 
   // If the object is not deprecated return
   if (time_it == _deprecated_time.end())
     return;
 
   // Get the current time
-  time_t now;
+  std::time_t now;
   time(&now);
 
   // Get the stop time
-  time_t t_end = time_it->second;
+  std::time_t t_end = time_it->second;
 
   // Message storage
   std::ostringstream msg;

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -16,7 +16,7 @@
 #include "FEProblem.h"
 
 #include <unistd.h>
-#include <time.h>
+#include <ctime>
 
 template <>
 InputParameters
@@ -77,7 +77,7 @@ FileOutput::FileOutput(const InputParameters & parameters)
       format = "%Y-%m-%dT%T%z";
 
     // Get the current time
-    time_t now;
+    std::time_t now;
     ::time(&now); // need :: to avoid confusion with time() method of Output class
 
     // Format the time

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <istream>
 #include <iterator>
+#include <ctime>
 
 // System includes
 #include <sys/stat.h>
@@ -725,7 +726,7 @@ getLatestCheckpointFileHelper(const std::list<std::string> & checkpoint_files,
   // Create storage for newest restart files
   // Note that these might have the same modification time if the simulation was fast.
   // In that case we're going to save all of the "newest" files and sort it out momentarily
-  time_t newest_time = 0;
+  std::time_t newest_time = 0;
   std::list<std::string> newest_restart_files;
 
   // Loop through all possible files and store the newest
@@ -738,7 +739,7 @@ getLatestCheckpointFileHelper(const std::list<std::string> & checkpoint_files,
       struct stat stats;
       stat(cp_file.c_str(), &stats);
 
-      time_t mod_time = stats.st_mtime;
+      std::time_t mod_time = stats.st_mtime;
       if (mod_time > newest_time)
       {
         newest_restart_files.clear(); // If the modification time is greater, clear the list

--- a/framework/src/utils/SystemInfo.C
+++ b/framework/src/utils/SystemInfo.C
@@ -13,7 +13,6 @@
 
 #include "libmesh/libmesh_config.h"
 
-#include <ctime>
 #include <sstream>
 #include <sys/stat.h>
 #include <iomanip>
@@ -55,10 +54,10 @@ SystemInfo::getInfo() const
 
 // TODO: Update libmesh to handle this function "timestamp.h"
 std::string
-SystemInfo::getTimeStamp(time_t * time_stamp) const
+SystemInfo::getTimeStamp(std::time_t * time_stamp) const
 {
   struct tm * tm_struct;
-  time_t local_time;
+  std::time_t local_time;
 
 #ifdef LIBMESH_HAVE_LOCALE
   // Create time_put "facet"


### PR DESCRIPTION
We previously had a mixture of both `<time.h>` and `<ctime>`, this patch
tries to make sure we only have one.  This fixes a bug that came up in
idaholab/package_builder#163 when compiling with an older (more strict?)
compiler.
