### PR TITLE
Update libmesh

### DIFF
--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -14,6 +14,8 @@
 #include "SetupInterface.h"
 #include "Restartable.h"
 
+#include "libmesh/communicator.h"
+
 class MultiApp;
 class UserObject;
 class FEProblemBase;
@@ -347,11 +349,14 @@ protected:
   /// The number of the first app on this processor
   unsigned int _first_local_app;
 
-  /// The comm that was passed to us specifying our pool of processors
-  MPI_Comm _orig_comm;
+  /// The original comm handle
+  const MPI_Comm & _orig_comm;
+
+  /// The communicator object that holds the MPI_Comm that we're going to use
+  libMesh::Parallel::Communicator _my_communicator;
 
   /// The MPI communicator this object is going to use.
-  MPI_Comm _my_comm;
+  MPI_Comm & _my_comm;
 
   /// The number of processors in the original comm
   int _orig_num_procs;

--- a/framework/src/multiapps/FullSolveMultiApp.C
+++ b/framework/src/multiapps/FullSolveMultiApp.C
@@ -72,7 +72,7 @@ FullSolveMultiApp::solveStep(Real /*dt*/, Real /*target_time*/, bool auto_advanc
 
   int rank;
   int ierr;
-  ierr = MPI_Comm_rank(_orig_comm, &rank);
+  ierr = MPI_Comm_rank(_communicator.get(), &rank);
   mooseCheckMPIErr(ierr);
 
   bool last_solve_converged = true;

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -215,7 +215,7 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
   {
     int rank;
     int ierr;
-    ierr = MPI_Comm_rank(_orig_comm, &rank);
+    ierr = MPI_Comm_rank(_communicator.get(), &rank);
     mooseCheckMPIErr(ierr);
 
     for (unsigned int i = 0; i < _my_num_apps; i++)

--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -152,3 +152,24 @@
    fun:*alltoall*
    ...
 }
+{
+   Parmetis_all_to_all_false_positive
+   Memcheck:Cond
+   ...
+   fun:libparmetis__gkMPI_Alltoall
+   ...
+}
+{
+   Parmetis_scatter_false_positive
+   Memcheck:Cond
+   ...
+   fun:libparmetis__gkMPI_Scatterv
+   ...
+}
+{
+   Mumps_numvolsndrcv_false_positive
+   Memcheck:Cond
+   ...
+   fun:dmumps_numvolsndrcv_
+   ...
+}

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -83,8 +83,7 @@ cd $SCRIPT_DIR/..
 # Test for git repository when not using fast
 git_dir=`git rev-parse --show-cdup 2>/dev/null`
 if [[ -z "$go_fast" && -z "$skip_sub_update" && $? == 0 && "x$git_dir" == "x" ]]; then
-  git submodule init libmesh
-  git submodule update libmesh
+  git submodule update --init --recursive libmesh
   if [[ $? != 0 ]]; then
     echo "git submodule command failed, are your proxy settings correct?"
     # TODO: is this a git bug?
@@ -127,7 +126,7 @@ if [ -z "$go_fast" ]; then
                --with-thread-model=openmp \
                --disable-maintainer-mode \
                --enable-petsc-hypre-required \
-               --disable-metaphysicl \
+               --enable-metaphysicl \
                $DISABLE_TIMESTAMPS $VTK_OPTIONS $* || exit 1
 else
   # The build directory must already exist: you can't do --fast for


### PR DESCRIPTION
* Fix MPI Datatype leaks (again).
* Avoid use of MATHYPRE when Hypre is not available or PETSc is too old.
* Fix issue where hide_output() flag was not respected in Exodus output.
* Add typedef'd index_type in TypeVector, TypeTensor, TypeNTensor.
* Change return type of TypeTensor::operator*
* Convert contrib/metaphysicl from vendored directory to git submodule.
* Disable Trilinos when configured with --with-dof-id-bytes=8
* Don't assert GhostingFunctor presence before removing.
