### PR TITLE
Allow tests to specify trim threshold

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -41,7 +41,7 @@ class Tester(MooseObject):
 
         params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
         params.addParam('tags',      [], "A list of strings")
-        params.addParam('max_buffer_size', 100000, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
+        params.addParam('max_buffer_size', util.MAX_BUFFER_SIZE, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -41,7 +41,8 @@ class Tester(MooseObject):
 
         params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
         params.addParam('tags',      [], "A list of strings")
-        params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
+        params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions. "
+                                                 "If 'max_buffer_size' is not set, the default value of 'None' triggers a reasonable value (e.g. 100 kB)")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -41,7 +41,7 @@ class Tester(MooseObject):
 
         params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
         params.addParam('tags',      [], "A list of strings")
-        params.addParam('max_buffer_size', util.MAX_BUFFER_SIZE, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
+        params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -41,6 +41,7 @@ class Tester(MooseObject):
 
         params.addParam('valgrind', 'NONE', "Set to (NONE, NORMAL, HEAVY) to determine which configurations where valgrind will run.")
         params.addParam('tags',      [], "A list of strings")
+        params.addParam('max_buffer_size', 100000, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
@@ -312,7 +313,7 @@ class Tester(MooseObject):
         self.errfile.flush()
 
         # store the contents of output, and close the file
-        self.joined_out = util.readOutput(self.outfile, self.errfile, options)
+        self.joined_out = util.readOutput(self.outfile, self.errfile, options, max_size=self.specs['max_buffer_size'])
         self.outfile.close()
         self.errfile.close()
 

--- a/python/TestHarness/tests/test_TrimOutput.py
+++ b/python/TestHarness/tests/test_TrimOutput.py
@@ -15,4 +15,11 @@ class TestHarnessTester(TestHarnessTestCase):
         Verify output exceeded buffer, and is therfore trimmed
         """
         output = self.runTests('--no-color', '-i', 'trimmed_output', '-v')
-        self.assertNotIn('Ouput trimmed', output)
+        self.assertIn('Output trimmed', output)
+
+    def testNoTrimOutput(self):
+        """
+        Verify trimming did not take place
+        """
+        output = self.runTests('--no-color', '-i', 'always_ok', '-v')
+        self.assertNotIn('Output trimmed', output)

--- a/python/TestHarness/tests/test_TrimOutput.py
+++ b/python/TestHarness/tests/test_TrimOutput.py
@@ -1,0 +1,18 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testTrimOutput(self):
+        """
+        Verify output exceeded buffer, and is therfore trimmed
+        """
+        output = self.runTests('--no-color', '-i', 'trimmed_output', '-v')
+        self.assertNotIn('Ouput trimmed', output)

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -179,7 +179,7 @@
   [./trim_output]
     type = PythonUnitTest
     input = test_TrimOutput.py
-    requirement = "TestHarness shall trim output once threshold is exceeded"
+    requirement = "TestHarness shall trim output once threshold has exceeded"
     issues = '#12167'
   [../]
 []

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -176,4 +176,10 @@
     requirement = "TestHarness shall be able to submit jobs to a PBS third party scheduler"
     issues = '#12138'
   [../]
+  [./trim_output]
+    type = PythonUnitTest
+    input = test_TrimOutput.py
+    requirement = "TestHarness shall trim output once threshold is exceeded"
+    issues = '#12167'
+  [../]
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -13,9 +13,6 @@ from mooseutils import colorText
 from collections import OrderedDict
 import json
 
-## readOutput threshold in bytes (100k)
-MAX_BUFFER_SIZE=100000
-
 TERM_COLS = int(os.getenv('MOOSE_TERM_COLS', '110'))
 TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njcst')
 
@@ -726,7 +723,10 @@ def getOutputFromFiles(tester, options):
 # This function reads output from the file (i.e. the test output)
 # but trims it down to the specified size.  It'll save the first two thirds
 # of the requested size and the last third trimming from the middle
-def readOutput(f, e, options, max_size=MAX_BUFFER_SIZE):
+def readOutput(f, e, options, max_size=None):
+    if max_size is None:
+        max_size = 100000
+
     first_part = int(max_size*(2.0/3.0))
     second_part = int(max_size*(1.0/3.0))
     output = ''

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -717,7 +717,7 @@ def getOutputFromFiles(tester, options):
     for file_path in output_files:
         with open(file_path, 'r') as f:
             file_output += "#"*80 + "\nOutput from " + file_path \
-                           + "\n" + "#"*80 + "\n" + readOutput(f, None, options)
+                           + "\n" + "#"*80 + "\n" + readOutput(f, None, options, max_size=tester.specs['max_buffer_size'])
     return file_output
 
 # This function reads output from the file (i.e. the test output)
@@ -731,7 +731,7 @@ def readOutput(f, e, options, max_size=100000):
     f.seek(0)
     if e:
         e.seek(0)
-    if options.no_trimmed_output:
+    if options.no_trimmed_output or max_size == -1:
         output += f.read()
         if e:
             output += e.read()

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -13,6 +13,9 @@ from mooseutils import colorText
 from collections import OrderedDict
 import json
 
+## readOutput threshold in bytes (100k)
+MAX_BUFFER_SIZE=100000
+
 TERM_COLS = int(os.getenv('MOOSE_TERM_COLS', '110'))
 TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njcst')
 
@@ -723,7 +726,7 @@ def getOutputFromFiles(tester, options):
 # This function reads output from the file (i.e. the test output)
 # but trims it down to the specified size.  It'll save the first two thirds
 # of the requested size and the last third trimming from the middle
-def readOutput(f, e, options, max_size=100000):
+def readOutput(f, e, options, max_size=MAX_BUFFER_SIZE):
     first_part = int(max_size*(2.0/3.0))
     second_part = int(max_size*(1.0/3.0))
     output = ''

--- a/test/tests/test_harness/trimmed_output
+++ b/test/tests/test_harness/trimmed_output
@@ -1,0 +1,7 @@
+[Tests]
+  [./trim_output]
+    type = RunApp
+    input = good.i
+    max_buffer_size = 100
+  [../]
+[]


### PR DESCRIPTION
Some tests need to scrutinize output within the frame which was trimmed.

This feature will probably be abused in the fact that no one will use an
actual number. -1 effectively turns off trimming (equivalent to --no-trimmed-output).

Added a unittest which _does_ set a real number. A real small one.
Which triggers the code that injects "Output trimmed". This is what the
unittest will search for.

Closes #12167
