### PR TITLE
Fix missing virtual keyword in destructors.

### DIFF
--- a/framework/include/controls/ControllableItem.h
+++ b/framework/include/controls/ControllableItem.h
@@ -33,7 +33,7 @@ class ControllableItem
 {
 public:
   ControllableItem(const MooseObjectParameterName & name, libMesh::Parameters::Value * value);
-  ~ControllableItem() = default;
+  virtual ~ControllableItem() = default;
 
   ControllableItem(const ControllableItem &) = default;
   ControllableItem(ControllableItem &&) = default;

--- a/framework/include/utils/MooseObjectName.h
+++ b/framework/include/utils/MooseObjectName.h
@@ -51,6 +51,12 @@ public:
                   const std::string & separator = std::string("/"));
 
   /**
+   * This class requires a virtual (but default) desctructor since it
+   * has virtual functions.
+   */
+  virtual ~MooseObjectName() = default;
+
+  /**
    * Build an object given a raw parameter name (e.g., from an input file parameter)
    */
   MooseObjectName(std::string name);


### PR DESCRIPTION
This issue came up in idaholab/package_builder#163 which is trying to
build MOOSE with Clang 6.0.1. I think the newer compiler is correct
and the older compiler was letting incorrect code through.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
