### PR TITLE
Call plt.savefig() instead of plt.show() in git_commit_history.py

### DIFF
--- a/scripts/git_commit_history.py
+++ b/scripts/git_commit_history.py
@@ -321,4 +321,4 @@ if __name__ == '__main__':
         fig.savefig(options.output)
 
     plt.tight_layout()
-    plt.show()
+    plt.savefig('git_commit_history.pdf', format='pdf')


### PR DESCRIPTION
This way the script can be run non-interactively...

Refs #000.

@aeslaughter we can also do both if you prefer, but it's nice to just be able to run the script and quickly get a PDF.
