### PR TITLE
MaterialOutputAction Refactor

### DIFF
--- a/framework/include/actions/MaterialOutputAction.h
+++ b/framework/include/actions/MaterialOutputAction.h
@@ -36,11 +36,6 @@ public:
 
   virtual void act() override;
 
-  /**
-   * Builds the objects necessary for material property output
-   */
-  void buildMaterialOutputObjects(FEProblemBase * problem_ptr);
-
 private:
   /**
    * Helper method for testing if the material exists as a block or boundary material
@@ -63,7 +58,9 @@ private:
    * act() method.
    */
   template <typename T>
-  void materialOutputHelper(const std::string & property_name, std::shared_ptr<Material> material);
+  std::vector<std::string> materialOutputHelper(const std::string & property_name,
+                                                std::shared_ptr<Material> material,
+                                                bool get_names_only);
 
   /**
    * A method for creating an AuxVariable and associated action
@@ -86,9 +83,6 @@ private:
   /// Map of variable name that contains the blocks to which the variable should be restricted
   std::map<std::string, std::set<SubdomainID>> _block_variable_map;
 
-  /// Set of variable names for boundary
-  std::set<std::string> _variable_names;
-
   /// List of variables for the current Material object
   std::set<std::string> _material_variable_names;
 
@@ -100,9 +94,10 @@ private:
 };
 
 template <typename T>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper(const std::string & /*property_name*/,
-                                           std::shared_ptr<Material> /*material*/)
+                                           std::shared_ptr<Material> /*material*/,
+                                           bool /*get_names_only*/)
 {
   mooseError("Unknown type, you must create a specialization of materialOutputHelper");
 }

--- a/framework/include/actions/MaterialOutputAction.h
+++ b/framework/include/actions/MaterialOutputAction.h
@@ -33,7 +33,6 @@ public:
    * @param params Input parameters for this action object
    */
   MaterialOutputAction(InputParameters params);
-
   virtual void act() override;
 
 private:
@@ -50,29 +49,32 @@ private:
    * @tparam T The type of material property that automatic output is being performed
    * @param property_name The name of the material property to output
    * @param material A pointer to the Material object containing the property of interest
+   * @param get_names_only A bool used to indicate that only the variable names should be returned
+   *
+   * @return A vector of names that can be used as AuxVariable names
    *
    * By default this function produces an mooseError, you must create a specialization for any type
-   * that you
-   * wish to have the automatic output capability. Also, you need to add a test for this type within
-   * the
-   * act() method.
+   * that you wish to have the automatic output capability. Also, you need to add a test for this
+   * type within the act() method.
    */
   template <typename T>
   std::vector<std::string> materialOutputHelper(const std::string & property_name,
-                                                std::shared_ptr<Material> material,
+                                                const Material & material,
                                                 bool get_names_only);
 
   /**
-   * A method for creating an AuxVariable and associated action
-   * @param type The action type to create
+   * A method for retrieving and partially filling the InputParameters object for an AuxVariable
+   * @param type The type of AuxVariable
    * @param property_name The property name to associated with that action
    * @param variable_name The AuxVariable name to create
-   * @param material A pointer to the Material object containing the property of interest
+   * @param material A Material object containing the property of interest
+   *
+   * @return An InputParameter object with common properties added.
    */
-  std::shared_ptr<MooseObjectAction> createAction(const std::string & type,
-                                                  const std::string & property_name,
-                                                  const std::string & variable_name,
-                                                  std::shared_ptr<Material> material);
+  InputParameters getParams(const std::string & type,
+                            const std::string & property_name,
+                            const std::string & variable_name,
+                            const Material & material);
 
   /// Pointer the MaterialData object storing the block restricted materials
   std::shared_ptr<MaterialData> _block_material_data;
@@ -96,7 +98,7 @@ private:
 template <typename T>
 std::vector<std::string>
 MaterialOutputAction::materialOutputHelper(const std::string & /*property_name*/,
-                                           std::shared_ptr<Material> /*material*/,
+                                           const Material & /*material*/,
                                            bool /*get_names_only*/)
 {
   mooseError("Unknown type, you must create a specialization of materialOutputHelper");

--- a/framework/include/actions/SetupDebugAction.h
+++ b/framework/include/actions/SetupDebugAction.h
@@ -19,27 +19,12 @@ class MooseObjectAction;
 template <>
 InputParameters validParams<SetupDebugAction>();
 
-/**
- *
- */
 class SetupDebugAction : public Action
 {
 public:
   SetupDebugAction(InputParameters parameters);
 
   virtual void act() override;
-
-protected:
-  /**
-   * Helper method for creating Output actions
-   * @param type The type of object to create (e.g., TopResidualDebugOutput)
-   * @param name The name to give the object being created
-   * @return A pointer to the OutputAction that was generated
-   */
-  MooseObjectAction * createOutputAction(const std::string & type, const std::string & name);
-
-  /// Parameters from the action being created (AddOutputAction)
-  InputParameters _action_params;
 };
 
 #endif /* SETUPDEBUGACTION_H */

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -228,7 +228,10 @@ CommonOutputAction::hasConsole()
        it != _awh.actionBlocksWithActionEnd("add_output");
        it++)
   {
-    MooseObjectAction * moa = static_cast<MooseObjectAction *>(*it);
+    MooseObjectAction * moa = dynamic_cast<MooseObjectAction *>(*it);
+    if (!moa)
+      continue;
+
     const std::string & type = moa->getMooseObjectType();
     InputParameters & params = moa->getObjectParams();
     if (type.compare("Console") == 0 && params.get<bool>("output_screen"))

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -16,30 +16,32 @@
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
+#include "libmesh/utility.h"
+
 // Declare the output helper specializations
 template <>
-void MaterialOutputAction::materialOutputHelper<Real>(const std::string & material_name,
-                                                      std::shared_ptr<Material> material);
+std::vector<std::string> MaterialOutputAction::materialOutputHelper<Real>(
+    const std::string & material_name, std::shared_ptr<Material> material, bool get_names_only);
 
 template <>
-void
-MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & material_name,
-                                                            std::shared_ptr<Material> material);
+std::vector<std::string> MaterialOutputAction::materialOutputHelper<RealVectorValue>(
+    const std::string & material_name, std::shared_ptr<Material> material, bool get_names_only);
 
 template <>
-void
-MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & material_name,
-                                                            std::shared_ptr<Material> material);
+std::vector<std::string> MaterialOutputAction::materialOutputHelper<RealTensorValue>(
+    const std::string & material_name, std::shared_ptr<Material> material, bool get_names_only);
 
 template <>
-void MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & material_name,
-                                                               std::shared_ptr<Material> material);
+std::vector<std::string> MaterialOutputAction::materialOutputHelper<RankTwoTensor>(
+    const std::string & material_name, std::shared_ptr<Material> material, bool get_names_only);
 
 template <>
-void MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & material_name,
-                                                                std::shared_ptr<Material> material);
+std::vector<std::string> MaterialOutputAction::materialOutputHelper<RankFourTensor>(
+    const std::string & material_name, std::shared_ptr<Material> material, bool get_names_only);
 
-registerMooseAction("MooseApp", MaterialOutputAction, "setup_material_output");
+registerMooseAction("MooseApp", MaterialOutputAction, "add_output_aux_variables");
+
+registerMooseAction("MooseApp", MaterialOutputAction, "add_aux_kernel");
 
 template <>
 InputParameters
@@ -57,28 +59,23 @@ MaterialOutputAction::MaterialOutputAction(InputParameters params)
 void
 MaterialOutputAction::act()
 {
-  // Error if _problem is NULL, I don't know how this would happen
-  if (_problem.get() == NULL)
-    mooseError("FEProblemBase pointer is NULL, it is needed for auto material property output");
+  mooseAssert(_problem,
+              "FEProblemBase pointer is nullptr, it is needed for auto material property output");
 
-  buildMaterialOutputObjects(_problem.get());
-}
-
-void
-MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
-{
   // Do nothing if the application does not have output
   if (!_app.actionWarehouse().hasActions("add_output"))
     return;
 
+  bool get_names_only = _current_task == "add_output_aux_variables" ? true : false;
+
   // Set the pointers to the MaterialData objects (Note, these pointers are not available at
   // construction)
-  _block_material_data = problem_ptr->getMaterialData(Moose::BLOCK_MATERIAL_DATA);
-  _boundary_material_data = problem_ptr->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA);
+  _block_material_data = _problem->getMaterialData(Moose::BLOCK_MATERIAL_DATA);
+  _boundary_material_data = _problem->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA);
 
   // A complete list of all Material objects
   const std::vector<std::shared_ptr<Material>> & materials =
-      problem_ptr->getMaterialWarehouse().getObjects();
+      _problem->getMaterialWarehouse().getObjects();
 
   // Handle setting of material property output in [Outputs] sub-blocks
   // Output objects can enable material property output, the following code examines the parameters
@@ -93,7 +90,8 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
   {
     // Extract the Output action
     AddOutputAction * action = dynamic_cast<AddOutputAction *>(act);
-    mooseAssert(action != NULL, "No AddOutputAction with the name " << act->name() << " exists");
+    if (!action)
+      continue;
 
     // Add the material property names from the output object parameters to the list of properties
     // to output
@@ -109,6 +107,7 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
   }
 
   // Loop through each material object
+  std::set<std::string> material_names;
   for (const auto & mat : materials)
   {
     // Extract the names of the output objects to which the material properties will be exported
@@ -140,6 +139,7 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
       // list
       // or if the list is empty (all properties)
       const std::set<std::string> names = mat->getSuppliedItems();
+      std::vector<std::string> curr_material_names;
       for (const auto & name : names)
       {
         // Add the material property for output
@@ -148,19 +148,34 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
                 output_properties.end())
         {
           if (hasProperty<Real>(name))
-            materialOutputHelper<Real>(name, mat);
+          {
+            curr_material_names = materialOutputHelper<Real>(name, mat, get_names_only);
+            material_names.insert(curr_material_names.begin(), curr_material_names.end());
+          }
 
           else if (hasProperty<RealVectorValue>(name))
-            materialOutputHelper<RealVectorValue>(name, mat);
+          {
+            curr_material_names = materialOutputHelper<RealVectorValue>(name, mat, get_names_only);
+            material_names.insert(curr_material_names.begin(), curr_material_names.end());
+          }
 
           else if (hasProperty<RealTensorValue>(name))
-            materialOutputHelper<RealTensorValue>(name, mat);
+          {
+            curr_material_names = materialOutputHelper<RealTensorValue>(name, mat, get_names_only);
+            material_names.insert(curr_material_names.begin(), curr_material_names.end());
+          }
 
           else if (hasProperty<RankTwoTensor>(name))
-            materialOutputHelper<RankTwoTensor>(name, mat);
+          {
+            curr_material_names = materialOutputHelper<RankTwoTensor>(name, mat, get_names_only);
+            material_names.insert(curr_material_names.begin(), curr_material_names.end());
+          }
 
           else if (hasProperty<RankFourTensor>(name))
-            materialOutputHelper<RankFourTensor>(name, mat);
+          {
+            curr_material_names = materialOutputHelper<RankFourTensor>(name, mat, get_names_only);
+            material_names.insert(curr_material_names.begin(), curr_material_names.end());
+          }
 
           else
             mooseWarning("The type for material property '",
@@ -178,26 +193,32 @@ MaterialOutputAction::buildMaterialOutputObjects(FEProblemBase * problem_ptr)
     }
   }
 
-  // Create the AuxVariables
-  FEType fe_type(
-      CONSTANT,
-      MONOMIAL); // currently only elemental variables are support for material property output
-  for (const auto & var_name : _variable_names)
-    problem_ptr->addAuxVariable(var_name, fe_type);
-
-  // When a Material object has 'output_properties' defined all other properties not listed must be
-  // added to
-  // the hide list for the output objects so that properties that are not desired do not appear.
-  for (const auto & it : _material_variable_names_map)
+  if (_current_task == "add_output_aux_variables")
   {
-    std::set<std::string> hide;
-    std::set_difference(_variable_names.begin(),
-                        _variable_names.end(),
-                        it.second.begin(),
-                        it.second.end(),
-                        std::inserter(hide, hide.begin()));
 
-    _output_warehouse.addInterfaceHideVariables(it.first, hide);
+    // Create the AuxVariables
+    FEType fe_type(
+        CONSTANT,
+        MONOMIAL); // currently only elemental variables are support for material property output
+    for (const auto & var_name : material_names)
+      _problem->addAuxVariable(var_name, fe_type);
+  }
+  else
+  {
+    // When a Material object has 'output_properties' defined all other properties not listed must
+    // be added to the hide list for the output objects so that properties that are not desired do
+    // not appear.
+    for (const auto & it : _material_variable_names_map)
+    {
+      std::set<std::string> hide;
+      std::set_difference(material_names.begin(),
+                          material_names.end(),
+                          it.second.begin(),
+                          it.second.end(),
+                          std::inserter(hide, hide.begin()));
+
+      _output_warehouse.addInterfaceHideVariables(it.first, hide);
+    }
   }
 }
 
@@ -207,9 +228,6 @@ MaterialOutputAction::createAction(const std::string & type,
                                    const std::string & variable_name,
                                    std::shared_ptr<Material> material)
 {
-  // Append the list of variables to create
-  _variable_names.insert(variable_name);
-
   // Append the list of output variables for the current material
   _material_variable_names.insert(variable_name);
 
@@ -243,75 +261,111 @@ MaterialOutputAction::createAction(const std::string & type,
 }
 
 template <>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper<Real>(const std::string & property_name,
-                                                 std::shared_ptr<Material> material)
+                                                 std::shared_ptr<Material> material,
+                                                 bool get_names_only)
 {
-  _awh.addActionBlock(createAction("MaterialRealAux", property_name, property_name, material));
+  std::vector<std::string> names = {property_name};
+  if (!get_names_only)
+    _awh.addActionBlock(createAction("MaterialRealAux", property_name, property_name, material));
+
+  return names;
 }
 
 template <>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper<RealVectorValue>(const std::string & property_name,
-                                                            std::shared_ptr<Material> material)
+                                                            std::shared_ptr<Material> material,
+                                                            bool get_names_only)
 {
-  char suffix[3] = {'x', 'y', 'z'};
+  std::array<char, 3> suffix = {{'x', 'y', 'z'}};
+
+  std::vector<std::string> names(3);
 
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {
     std::ostringstream oss;
     oss << property_name << "_" << suffix[i];
+    names[i] = oss.str();
 
-    std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
-        createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
-    action->getObjectParams().set<unsigned int>("component") = i;
-    _awh.addActionBlock(action);
+    if (!get_names_only)
+    {
+      std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
+          createAction("MaterialRealVectorValueAux", property_name, oss.str(), material));
+      action->getObjectParams().set<unsigned int>("component") = i;
+      _awh.addActionBlock(action);
+    }
   }
+
+  return names;
 }
 
 template <>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper<RealTensorValue>(const std::string & property_name,
-                                                            std::shared_ptr<Material> material)
+                                                            std::shared_ptr<Material> material,
+                                                            bool get_names_only)
 {
+  std::vector<std::string> names(LIBMESH_DIM * LIBMESH_DIM);
+
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
     {
       std::ostringstream oss;
       oss << property_name << "_" << i << j;
+      names[i * LIBMESH_DIM + j] = oss.str();
 
-      std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
-          createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
-      action->getObjectParams().set<unsigned int>("row") = i;
-      action->getObjectParams().set<unsigned int>("column") = j;
-      _awh.addActionBlock(action);
+      if (!get_names_only)
+      {
+        std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
+            createAction("MaterialRealTensorValueAux", property_name, oss.str(), material));
+        action->getObjectParams().set<unsigned int>("row") = i;
+        action->getObjectParams().set<unsigned int>("column") = j;
+        _awh.addActionBlock(action);
+      }
     }
+
+  return names;
 }
 
 template <>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper<RankTwoTensor>(const std::string & property_name,
-                                                          std::shared_ptr<Material> material)
+                                                          std::shared_ptr<Material> material,
+                                                          bool get_names_only)
 {
+  std::vector<std::string> names(LIBMESH_DIM * LIBMESH_DIM);
+
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
     {
       std::ostringstream oss;
       oss << property_name << "_" << i << j;
+      names[i * LIBMESH_DIM + j] = oss.str();
 
-      std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
-          createAction("MaterialRankTwoTensorAux", property_name, oss.str(), material));
-      action->getObjectParams().set<unsigned int>("i") = i;
-      action->getObjectParams().set<unsigned int>("j") = j;
-      _awh.addActionBlock(action);
+      if (!get_names_only)
+      {
+        std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
+            createAction("MaterialRankTwoTensorAux", property_name, oss.str(), material));
+        action->getObjectParams().set<unsigned int>("i") = i;
+        action->getObjectParams().set<unsigned int>("j") = j;
+        _awh.addActionBlock(action);
+      }
     }
+
+  return names;
 }
 
 template <>
-void
+std::vector<std::string>
 MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & property_name,
-                                                           std::shared_ptr<Material> material)
+                                                           std::shared_ptr<Material> material,
+                                                           bool get_names_only)
 {
+  std::vector<std::string> names(Utility::pow<4>(LIBMESH_DIM));
+
+  unsigned int counter = 0;
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
     for (unsigned int j = 0; j < LIBMESH_DIM; ++j)
       for (unsigned int k = 0; k < LIBMESH_DIM; ++k)
@@ -319,13 +373,19 @@ MaterialOutputAction::materialOutputHelper<RankFourTensor>(const std::string & p
         {
           std::ostringstream oss;
           oss << property_name << "_" << i << j << k << l;
+          names[counter++] = oss.str();
 
-          std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
-              createAction("MaterialRankFourTensorAux", property_name, oss.str(), material));
-          action->getObjectParams().set<unsigned int>("i") = i;
-          action->getObjectParams().set<unsigned int>("j") = j;
-          action->getObjectParams().set<unsigned int>("k") = k;
-          action->getObjectParams().set<unsigned int>("l") = l;
-          _awh.addActionBlock(action);
+          if (!get_names_only)
+          {
+            std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
+                createAction("MaterialRankFourTensorAux", property_name, oss.str(), material));
+            action->getObjectParams().set<unsigned int>("i") = i;
+            action->getObjectParams().set<unsigned int>("j") = j;
+            action->getObjectParams().set<unsigned int>("k") = k;
+            action->getObjectParams().set<unsigned int>("l") = l;
+            _awh.addActionBlock(action);
+          }
         }
+
+  return names;
 }

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -16,7 +16,7 @@
 #include "MooseObjectAction.h"
 #include "ActionFactory.h"
 
-registerMooseAction("MooseApp", SetupDebugAction, "setup_debug");
+registerMooseAction("MooseApp", SetupDebugAction, "add_output");
 
 template <>
 InputParameters
@@ -36,18 +36,17 @@ validParams<SetupDebugAction>()
       "show_material_props",
       false,
       "Print out the material properties supplied for each block, face, neighbor, and/or sideset");
+
+  params.addClassDescription(
+      "Adds various debugging type Outputters to the simulation system based on user parameters");
+
   return params;
 }
 
-SetupDebugAction::SetupDebugAction(InputParameters parameters)
-  : Action(parameters), _action_params(_action_factory.getValidParams("AddOutputAction"))
+SetupDebugAction::SetupDebugAction(InputParameters parameters) : Action(parameters)
 {
   _awh.showActions(getParam<bool>("show_actions"));
   _awh.showParser(getParam<bool>("show_parser"));
-
-  // Set the ActionWarehouse pointer in the parameters that will be passed to the actions created
-  // with this action
-  _action_params.set<ActionWarehouse *>("awh") = &_awh;
 }
 
 void
@@ -55,40 +54,26 @@ SetupDebugAction::act()
 {
   // Material properties
   if (_pars.get<bool>("show_material_props"))
-    createOutputAction("MaterialPropertyDebugOutput", "_moose_material_property_debug_output");
+  {
+    const std::string type = "MaterialPropertyDebugOutput";
+    auto params = _factory.getValidParams(type);
+    _problem->addOutput(type, "_moose_material_property_debug_output", params);
+  }
 
   // Variable residusl norms
   if (_pars.get<bool>("show_var_residual_norms"))
-    createOutputAction("VariableResidualNormsDebugOutput",
-                       "_moose_variable_residual_norms_debug_output");
+  {
+    const std::string type = "VariableResidualNormsDebugOutput";
+    auto params = _factory.getValidParams(type);
+    _problem->addOutput(type, "_moose_variable_residual_norms_debug_output", params);
+  }
 
   // Top residuals
   if (_pars.get<unsigned int>("show_top_residuals") > 0)
   {
-    MooseObjectAction * action =
-        createOutputAction("TopResidualDebugOutput", "_moose_top_residual_debug_output");
-    action->getObjectParams().set<unsigned int>("num_residuals") =
-        _pars.get<unsigned int>("show_top_residuals");
+    const std::string type = "TopResidualDebugOutput";
+    auto params = _factory.getValidParams(type);
+    params.set<unsigned int>("num_residuals") = _pars.get<unsigned int>("show_top_residuals");
+    _problem->addOutput(type, "_moose_top_residual_debug_output", params);
   }
-}
-
-MooseObjectAction *
-SetupDebugAction::createOutputAction(const std::string & type, const std::string & name)
-{
-  // Set the 'type =' parameters for the desired object
-  _action_params.set<std::string>("type") = type;
-
-  // Create the action
-  std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
-      _action_factory.create("AddOutputAction", name, _action_params));
-
-  // Set the object parameters
-  InputParameters & object_params = action->getObjectParams();
-  object_params.set<bool>("_built_by_moose") = true;
-
-  // Add the action to the warehouse
-  _awh.addActionBlock(action);
-
-  // Return the pointer to the action
-  return action.get();
 }

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -204,6 +204,10 @@ addActionTypes(Syntax & syntax)
   registerTask("create_problem_custom", false);
   registerTask("create_problem_complete", false);
 
+  // Deprecated tasks
+  registerTask("setup_material_output", false);
+  registerTask("setup_debug", false);
+
   /**************************/
   /****** Dependencies ******/
   /**************************/
@@ -267,9 +271,11 @@ addActionTypes(Syntax & syntax)
                            "(add_transfer)"
                            "(copy_nodal_vars, copy_nodal_aux_vars)"
                            "(add_material)"
+                           "(setup_material_output)" // DEPRECATED: Remove by 12/31/2018
                            "(add_output_aux_variables)"
                            "(add_algebraic_rm)"
                            "(init_problem)"
+                           "(setup_debug)" // DEPRECATED: Remove by 12/31/2018
                            "(add_output)"
                            "(add_postprocessor)"
                            "(add_vector_postprocessor)" // MaterialVectorPostprocessor requires this

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -185,7 +185,6 @@ addActionTypes(Syntax & syntax)
   registerTask("set_global_params", false);
   registerTask("setup_adaptivity", false);
   registerTask("meta_action", false);
-  registerTask("setup_debug", false);
   registerTask("setup_residual_debug", false);
   registerTask("setup_oversampling", false);
   registerTask("deprecated_block", false);
@@ -271,7 +270,6 @@ addActionTypes(Syntax & syntax)
                            "(add_output_aux_variables)"
                            "(add_algebraic_rm)"
                            "(init_problem)"
-                           "(setup_debug)"
                            "(add_output)"
                            "(add_postprocessor)"
                            "(add_vector_postprocessor)" // MaterialVectorPostprocessor requires this

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -198,7 +198,7 @@ addActionTypes(Syntax & syntax)
   registerTask("ready_to_init", true);
 
   // Output related actions
-  registerTask("setup_material_output", true);
+  registerTask("add_output_aux_variables", true);
   registerTask("check_output", true);
 
   registerTask("create_problem_default", true);
@@ -268,7 +268,7 @@ addActionTypes(Syntax & syntax)
                            "(add_transfer)"
                            "(copy_nodal_vars, copy_nodal_aux_vars)"
                            "(add_material)"
-                           "(setup_material_output)"
+                           "(add_output_aux_variables)"
                            "(add_algebraic_rm)"
                            "(init_problem)"
                            "(setup_debug)"

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -990,7 +990,10 @@ MooseApp::getCheckpointDirectories() const
   for (const auto & action : actions)
   {
     // Get the parameters from the MooseObjectAction
-    MooseObjectAction * moose_object_action = static_cast<MooseObjectAction *>(action);
+    MooseObjectAction * moose_object_action = dynamic_cast<MooseObjectAction *>(action);
+    if (!moose_object_action)
+      continue;
+
     const InputParameters & params = moose_object_action->getObjectParams();
 
     // Loop through the actions and add the necessary directories to the list to check


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

This PR refactors MaterialOutputAction so that it no longer adds objects during the wrong tasks. Additionally it is no longer a meta-action.
