### PR TITLE
Restrict test so that it doesn't run with 64-bit indices

### DIFF
--- a/test/tests/relationship_managers/evaluable/tests
+++ b/test/tests/relationship_managers/evaluable/tests
@@ -5,6 +5,7 @@
     exodiff = 'evaluable_out.e'
     petsc_version = '>3.8'
     mesh_mode = 'REPLICATED'
+    dof_id_bytes = 4 # Metis gives different partitions with 64-bit dof indices
 
     min_parallel = 3
     max_parallel = 3


### PR DESCRIPTION
refs #12194

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
