### PR TITLE
tweak .clang-format due to new options/defaults

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,3 +27,5 @@ IndentCaseLabels: true
 ConstructorInitializerIndentWidth: 2
 AlwaysBreakAfterDefinitionReturnType: TopLevel
 AlwaysBreakTemplateDeclarations: true
+
+FixNamespaceComments: false


### PR DESCRIPTION
Clang now defaults to fixing/adding closing namespace brace comments.
We don't want this (for now anyway) - so turn it off.

ref #8017

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
