### PR TITLE
fix missing path normalization in HIT Node::find

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -337,6 +337,7 @@ Node::findInner(const std::string & path, const std::string & prefix)
     else
       fullpath = prefix + "/" + child->path();
 
+    fullpath = pathNorm(fullpath);
     if (fullpath == path)
       return child;
     else if (path.find(fullpath) == std::string::npos)

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -252,6 +252,12 @@ TEST(HitTests, ParseFields)
        "foo",
        "barbaz",
        hit::Field::Kind::String},
+      {"path-normalize-find #12313",
+       "[foo][/bar]baz=42[][]",
+       "foo/bar/baz",
+       "42",
+       hit::Field::Kind::Int},
+
   };
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(ValCase); i++)


### PR DESCRIPTION
previously, the find function built/searched paths in a way that could
result in a non-normalized path (e.g. with consecutive '/' characters)
being compared to a normalized path - resulting in failed node tree
searches where actual matches existed.  This fixes that.

fixes #12313

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
