### PR TITLE
Fix potential bug in MultiAppNearestNodeTransfer.

### DIFF
--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -593,7 +593,7 @@ MultiAppNearestNodeTransfer::bboxMinDistance(Point p, BoundingBox bbox)
         all_points[x + 2 * y + 4 * z] =
             Point(source_points[x](0), source_points[y](1), source_points[z](2));
 
-  Real min_distance = 0.;
+  Real min_distance = std::numeric_limits<Real>::max();
 
   for (unsigned int i = 0; i < 8; i++)
   {


### PR DESCRIPTION
It was not possible for MultiAppNearestNodeTransfer::bboxMinDistance()
to return anything other than 0, but this apparently has never been a
problem as sub apps have always been located inside/on master apps,
and 0 was the correct minimum distance?

Sterling Harper added this in a9f6751bb46

Refs #2126


