### PR TITLE
Update comparisons so we don't fail with PETSc 3.10

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -896,7 +896,7 @@ setSinglePetscOption(const std::string & name, const std::string & value)
   // Not convenient to use the usual error checking macro, because we
   // don't have a specific communicator in this helper function.
   if (ierr)
-    mooseError("Error setting PETSc option.");
+    mooseError("Error setting PETSc option: ", name);
 }
 
 void

--- a/modules/phase_field/test/tests/mobility_derivative/AC_mobility_derivative_coupled_test.i
+++ b/modules/phase_field/test/tests/mobility_derivative/AC_mobility_derivative_coupled_test.i
@@ -99,7 +99,7 @@
   scheme = 'bdf2'
 
   solve_type = 'NEWTON'
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   l_max_its = 15

--- a/modules/phase_field/test/tests/mobility_derivative/AC_mobility_derivative_test.i
+++ b/modules/phase_field/test/tests/mobility_derivative/AC_mobility_derivative_test.i
@@ -66,7 +66,7 @@
   scheme = 'bdf2'
 
   solve_type = 'NEWTON'
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   l_max_its = 15

--- a/modules/solid_mechanics/test/tests/LSH_smallstrain/LSH_smallstrain_test.i
+++ b/modules/solid_mechanics/test/tests/LSH_smallstrain/LSH_smallstrain_test.i
@@ -153,7 +153,7 @@
 
 
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = 'ksp_gmres_restart'
+  petsc_options_iname = '-ksp_gmres_restart'
   petsc_options_value = '101'
 
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d.i
@@ -196,7 +196,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d_rot.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d_rot.i
@@ -205,7 +205,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d.i
@@ -167,7 +167,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_ctefunc.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_ctefunc.i
@@ -176,7 +176,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_inst_ctefunc.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_inst_ctefunc.i
@@ -186,7 +186,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_mean_ctefunc.i
+++ b/modules/solid_mechanics/test/tests/domain_integral_thermal/j_integral_2d_mean_ctefunc.i
@@ -187,7 +187,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y.i
@@ -122,7 +122,7 @@
   solve_type = PJFNK
   line_search = 'none'
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '_ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre     boomeramg     4'
   nl_max_its = 50
   nl_rel_tol = 1e-9

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y_action.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_y_action.i
@@ -94,7 +94,7 @@
   solve_type = PJFNK
   line_search = 'none'
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '_ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre     boomeramg     4'
   nl_max_its = 50
   nl_rel_tol = 1e-9

--- a/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_z.i
+++ b/modules/tensor_mechanics/test/tests/beam/static/euler_finite_rot_z.i
@@ -122,7 +122,7 @@
   solve_type = PJFNK
   line_search = 'none'
   petsc_options = '-snes_ksp_ew'
-  petsc_options_iname = '_ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre     boomeramg     4'
   nl_max_its = 50
   nl_rel_tol = 1e-9

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
@@ -184,7 +184,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   dt = 0.2

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_linesearch.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_linesearch.i
@@ -186,7 +186,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_substep.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp_substep.i
@@ -184,7 +184,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp.i
@@ -186,7 +186,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_fileread.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_fileread.i
@@ -194,7 +194,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_linesearch.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_linesearch.i
@@ -185,7 +185,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_read_slip_prop.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_read_slip_prop.i
@@ -187,7 +187,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_save_euler.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_save_euler.i
@@ -226,7 +226,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_substep.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_substep.i
@@ -188,7 +188,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_user_object.i
+++ b/modules/tensor_mechanics/test/tests/crystal_plasticity/crysp_user_object.i
@@ -187,7 +187,7 @@
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
-  petsc_options_iname = 'pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d.i
@@ -142,7 +142,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d_rot.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/interaction_integral_2d_rot.i
@@ -151,7 +151,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d.i
@@ -113,7 +113,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_ctefunc.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_ctefunc.i
@@ -119,7 +119,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_inst_ctefunc.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_inst_ctefunc.i
@@ -120,7 +120,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_mean_ctefunc.i
+++ b/modules/tensor_mechanics/test/tests/domain_integral_thermal/j_integral_2d_mean_ctefunc.i
@@ -121,7 +121,6 @@
 
   solve_type = 'PJFNK'
 
-  petsc_options = ksp_monitor
   petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
   petsc_options_value = 'asm         31   preonly   lu      1'
 

--- a/modules/tensor_mechanics/test/tests/finite_strain_jacobian/3d_bar.i
+++ b/modules/tensor_mechanics/test/tests/finite_strain_jacobian/3d_bar.i
@@ -87,7 +87,7 @@
   type = Transient
 
   solve_type = NEWTON
-  petsc_options_iname = '_pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/modules/tensor_mechanics/test/tests/finite_strain_jacobian/bending_jacobian.i
+++ b/modules/tensor_mechanics/test/tests/finite_strain_jacobian/bending_jacobian.i
@@ -83,7 +83,7 @@
   type = Transient
 
   solve_type = NEWTON
-  petsc_options_iname = '_pc_type'
+  petsc_options_iname = '-pc_type'
   petsc_options_value = 'lu'
 
   nl_rel_tol = 1e-10

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -46,9 +46,11 @@ class PetscJacobianTester(RunApp):
         else:
             self.libmesh_dir = os.path.join(self.moose_dir, 'libmesh', 'installed')
 
-        if util.getPetscVersion(self.libmesh_dir) < '3.9':
+        if map(int, util.getPetscVersion(self.libmesh_dir).split(".")) < [3, 9]:
+            self.old_petsc = True
             self.specs['cli_args'].append('-snes_type test')
         else:
+            self.old_petsc = False
             self.specs['cli_args'].extend(['-snes_test_jacobian', '-snes_force_iteration'])
             if not self.specs['run_sim']:
                 self.specs['cli_args'].extend(['-snes_type', 'ksponly',
@@ -83,10 +85,7 @@ class PetscJacobianTester(RunApp):
             return False
 
     def processResults(self, moose_dir, options, output):
-        checks = options._checks
-        (old_petsc, _, _) = util.checkLogicVersionSingle(checks, '<3.9', 'petsc_version')
-
-        if old_petsc:
+        if self.old_petsc:
             if self.specs['state'].lower() == 'user':
                 m = re.search("Norm of matrix ratio (\S+?),? difference (\S+) \(user-defined state\)",
                               output, re.MULTILINE | re.DOTALL);

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -459,13 +459,13 @@ def checkLogicVersionSingle(checks, iversion, package):
             return (False, '!=', version)
 
     # Logical match
-    if logic == '>' and checks[package][0:5] > version[0:5]:
+    if logic == '>' and map(int, checks[package].split(".")) > map(int, version.split(".")):
         return (True, None, version)
-    elif logic == '>=' and checks[package][0:5] >= version[0:5]:
+    elif logic == '>=' and map(int, checks[package].split(".")) >= map(int, version.split(".")):
         return (True, None, version)
-    elif logic == '<' and checks[package][0:5] < version[0:5]:
+    elif logic == '<' and map(int, checks[package].split(".")) < map(int, version.split(".")):
         return (True, None, version)
-    elif logic == '<=' and checks[package][0:5] <= version[0:5]:
+    elif logic == '<=' and map(int, checks[package].split(".")) <= map(int, version.split(".")):
         return (True, None, version)
 
     return (False, logic, version)

--- a/python/jacobiandebug/analyzejacobian.py
+++ b/python/jacobiandebug/analyzejacobian.py
@@ -412,7 +412,7 @@ if __name__ == '__main__':
         libmesh_dir = os.environ['LIBMESH_DIR']
     else:
         libmesh_dir = os.path.join(moose_dir, 'libmesh', 'installed')
-    new_petsc = util.getPetscVersion(libmesh_dir) >= '3.9'
+    new_petsc = map(int, util.getPetscVersion(libmesh_dir).split(".")) >= [3, 9]
 
     # build the parameter list for the jacobian debug run
     mooseparams = moosebaseparams[:]


### PR DESCRIPTION
Previously we were comparing strings, so `"3.10" > "3.9"` would return `False`
