### PR TITLE
Extension of NaNInterface class to use mooseError and mooseWarning

### DIFF
--- a/modules/fluid_properties/doc/content/source/interfaces/NaNInterface.md
+++ b/modules/fluid_properties/doc/content/source/interfaces/NaNInterface.md
@@ -1,7 +1,5 @@
 # NaNInterface
 
-For some objects, it is sometimes desirable to have the choice of whether
-to use a signaling NaN or a quiet NaN. For example, for some simulations,
-one may want to run in debug mode but not crash on a NaN from a certain
-object. This class adds a parameter to control this behavior and an interface
-for getting the corresponding NaN.
+For some objects it is desirable to continue running despite generation of
+NaN(s). This class provides an interface for choosing whether to throw an error,
+a warning, or nothing at all, just using a quiet NaN.

--- a/modules/fluid_properties/test/tests/interfaces/nan_interface/nan_interface.i
+++ b/modules/fluid_properties/test/tests/interfaces/nan_interface/nan_interface.i
@@ -21,7 +21,6 @@
   [./FluidProperties]
     [./fp]
       type = NaNInterfaceTestFluidProperties
-      emit_on_nan=none
     [../]
   []
 []

--- a/modules/fluid_properties/test/tests/interfaces/nan_interface/nan_interface.i
+++ b/modules/fluid_properties/test/tests/interfaces/nan_interface/nan_interface.i
@@ -21,7 +21,7 @@
   [./FluidProperties]
     [./fp]
       type = NaNInterfaceTestFluidProperties
-      use_quiet_nans = true
+      emit_on_nan=none
     [../]
   []
 []

--- a/modules/fluid_properties/test/tests/interfaces/nan_interface/tests
+++ b/modules/fluid_properties/test/tests/interfaces/nan_interface/tests
@@ -1,37 +1,37 @@
 [Tests]
   [./quiet_nan]
-    type = 'RunApp'
+    type = 'RunException'
     input = 'nan_interface.i'
+    cli_args = 'Modules/FluidProperties/fp/emit_on_nan=warning'
     allow_test_objects = True
     method = 'DBG'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
+    requirement = 'The system should produce a warning when a NaN is produced and user required that the execution would not terminate'
+    expect_err = "fp: A NaN was produced."
     design = '/NaNInterface.md'
     issues = '#12234 #12350'
   [../]
   [./signaling_nan_dbg]
-    type = 'RunApp'
+    type = 'RunException'
     input = 'nan_interface.i'
-    cli_args = 'Modules/FluidProperties/fp/emit_on_nan=error'
-    should_crash = True
     allow_test_objects = True
     method = 'DBG'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
+    requirement = 'The system should report an error when a NaN is produced by a computation in DEBUG mode, by default'
+    expect_err = "fp: A NaN was produced."
     design = '/NaNInterface.md'
     issues = '#12234 #12350'
   [../]
   [./signaling_nan_opt]
     type = 'RunApp'
     input = 'nan_interface.i'
-    cli_args = 'Modules/FluidProperties/fp/emit_on_nan=error'
     allow_test_objects = True
     method = 'OPT'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
+    requirement = 'The system should not report an error when a NaN is produced by a computation in OPT mode, by default'
     design = '/NaNInterface.md'
     issues = '#12234 #12350'
   [../]

--- a/modules/fluid_properties/test/tests/interfaces/nan_interface/tests
+++ b/modules/fluid_properties/test/tests/interfaces/nan_interface/tests
@@ -6,33 +6,33 @@
     method = 'DBG'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for using either quiet or signaling NaNs'
+    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
     design = '/NaNInterface.md'
-    issues = '#12234'
+    issues = '#12234 #12350'
   [../]
   [./signaling_nan_dbg]
     type = 'RunApp'
     input = 'nan_interface.i'
-    cli_args = 'Modules/FluidProperties/fp/use_quiet_nans=false'
+    cli_args = 'Modules/FluidProperties/fp/emit_on_nan=error'
     should_crash = True
     allow_test_objects = True
     method = 'DBG'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for using either quiet or signaling NaNs'
+    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
     design = '/NaNInterface.md'
-    issues = '#12234'
+    issues = '#12234 #12350'
   [../]
   [./signaling_nan_opt]
     type = 'RunApp'
     input = 'nan_interface.i'
-    cli_args = 'Modules/FluidProperties/fp/use_quiet_nans=false'
+    cli_args = 'Modules/FluidProperties/fp/emit_on_nan=error'
     allow_test_objects = True
     method = 'OPT'
     threading = '!pthreads'
 
-    requirement = 'MOOSE shall provide an interface for using either quiet or signaling NaNs'
+    requirement = 'MOOSE shall provide an interface for producing errors, warnings, or just quiet NaNs'
     design = '/NaNInterface.md'
-    issues = '#12234'
+    issues = '#12234 #12350'
   [../]
 []


### PR DESCRIPTION
The NaNInterface class has been extended and throws either an error,
a warning, or nothing at all, just using a quiet NaN.

Closes #12350