### PR TITLE
fix segfault in certain dynamic loading scenarios

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -58,7 +58,7 @@ class MooseApp : public ConsoleStreamInterface, public libMesh::ParallelObject
 public:
   virtual ~MooseApp();
 
-  TheWarehouse & theWarehouse() { return _the_warehouse; }
+  TheWarehouse & theWarehouse() { return *_the_warehouse; }
 
   /**
    * Get the name of the object. In the case of MooseApp, the name of the object is *NOT* the name
@@ -803,7 +803,7 @@ private:
     REGALL
   };
 
-  TheWarehouse _the_warehouse;
+  std::unique_ptr<TheWarehouse> _the_warehouse;
 
   /// Level of multiapp, the master is level 0. This used by the Console to indent output
   unsigned int _multiapp_level;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -307,18 +307,19 @@ MooseApp::MooseApp(InputParameters parameters)
   Registry::addKnownLabel(_type);
   Moose::registerAll(_factory, _action_factory, _syntax);
 
-  _the_warehouse.registerAttribute<AttribMatrixTags>("matrix_tags", 0);
-  _the_warehouse.registerAttribute<AttribVectorTags>("vector_tags", 0);
-  _the_warehouse.registerAttribute<AttribExecOns>("exec_ons", 0);
-  _the_warehouse.registerAttribute<AttribSubdomains>("subdomains", 0);
-  _the_warehouse.registerAttribute<AttribBoundaries>("boundaries", 0);
-  _the_warehouse.registerAttribute<AttribThread>("thread", 0);
-  _the_warehouse.registerAttribute<AttribPreIC>("pre_ic", 0);
-  _the_warehouse.registerAttribute<AttribPreAux>("pre_aux", 0);
-  _the_warehouse.registerAttribute<AttribName>("name", "dummy");
-  _the_warehouse.registerAttribute<AttribSystem>("system", "dummy");
-  _the_warehouse.registerAttribute<AttribVar>("variable", 0);
-  _the_warehouse.registerAttribute<AttribInterfaces>("interfaces", 0);
+  _the_warehouse = libmesh_make_unique<TheWarehouse>();
+  _the_warehouse->registerAttribute<AttribMatrixTags>("matrix_tags", 0);
+  _the_warehouse->registerAttribute<AttribVectorTags>("vector_tags", 0);
+  _the_warehouse->registerAttribute<AttribExecOns>("exec_ons", 0);
+  _the_warehouse->registerAttribute<AttribSubdomains>("subdomains", 0);
+  _the_warehouse->registerAttribute<AttribBoundaries>("boundaries", 0);
+  _the_warehouse->registerAttribute<AttribThread>("thread", 0);
+  _the_warehouse->registerAttribute<AttribPreIC>("pre_ic", 0);
+  _the_warehouse->registerAttribute<AttribPreAux>("pre_aux", 0);
+  _the_warehouse->registerAttribute<AttribName>("name", "dummy");
+  _the_warehouse->registerAttribute<AttribSystem>("system", "dummy");
+  _the_warehouse->registerAttribute<AttribVar>("variable", 0);
+  _the_warehouse->registerAttribute<AttribInterfaces>("interfaces", 0);
 
   if (isParamValid("_argc") && isParamValid("_argv"))
   {
@@ -404,6 +405,7 @@ MooseApp::~MooseApp()
 {
   _action_warehouse.clear();
   _executioner.reset();
+  _the_warehouse.reset();
 
   delete _input_parameter_warehouse;
 


### PR DESCRIPTION
When dynamic loading/registration is used, MOOSE calls dlclose in the
MooseApp constructor.  So all objects created from dlopen'd libs need to
be destroyed before that call.  The new warehouse now holds shared
pointers to objects that would previously have been deallocated earlier.
To fix this, make the new master warehouse a unique pointer that we
explicitly deallocate in the MooseApp destructor *before* the dlclose
call.

ref #11994

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
