### PR TITLE
Improve documentation for the scalar_constraint_kernel.i test

### DIFF
--- a/test/include/kernels/ScalarLagrangeMultiplier.h
+++ b/test/include/kernels/ScalarLagrangeMultiplier.h
@@ -18,8 +18,25 @@ template <>
 InputParameters validParams<ScalarLagrangeMultiplier>();
 
 /**
- * Implements coupling of Lagrange multiplier (as a scalar variable) to a simple constraint of type
- * (g(u) - c = 0)
+ * This Kernel is part of a test [0] that solves the constrained
+ * Neumann problem:
+ *
+ * -\nabla^2 \phi = f
+ * -\partial u / \partial n = g
+ * \int \phi = V_0
+ *
+ * where V_0 is a given constant, using a Lagrange multiplier
+ * approach. Without the integral constraint, this problem is not
+ * well-posed since it has only flux boundary conditions.
+ *
+ * In particular, this Kernel implements the residual contribution for
+ * the lambda term in Eq. (5), and the Jacobian contributions
+ * corresponding to (9) and (10) in our detailed description [1] of
+ * the problem.
+ *
+ * See also: test/src/scalarkernels/PostprocessorCED.C
+ * [0]: kernels/scalar_constraints/scalar_constraint_kernel.i
+ * [1]: https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf
  */
 class ScalarLagrangeMultiplier : public Kernel
 {

--- a/test/include/scalarkernels/PostprocessorCED.h
+++ b/test/include/scalarkernels/PostprocessorCED.h
@@ -18,7 +18,24 @@ template <>
 InputParameters validParams<PostprocessorCED>();
 
 /**
+ * This Kernel is part of a test [0] that solves the constrained
+ * Neumann problem:
  *
+ * -\nabla^2 \phi = f
+ * -\partial u / \partial n = g
+ * \int \phi = V_0
+ *
+ * where V_0 is a given constant, using a Lagrange multiplier
+ * approach. Without the integral constraint, this problem is not
+ * well-posed since it has only flux boundary conditions.
+ *
+ * In particular, this Kernel implements the residual contribution
+ * corresponding to equation (6) in the detailed description [1] of
+ * this problem.
+ *
+ * See also: test/src/kernels/ScalarLagrangeMultiplier.C
+ * [0]: kernels/scalar_constraints/scalar_constraint_kernel.i
+ * [1]: https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf
  */
 class PostprocessorCED : public ScalarKernel
 {

--- a/test/src/kernels/ScalarLagrangeMultiplier.C
+++ b/test/src/kernels/ScalarLagrangeMultiplier.C
@@ -24,7 +24,8 @@ InputParameters
 validParams<ScalarLagrangeMultiplier>()
 {
   InputParameters params = validParams<Kernel>();
-  params.addClassDescription("This class is used to solve a constrained Neumann problem with a Lagrange multiplier approach.");
+  params.addClassDescription("This class is used to solve a constrained Neumann problem with a "
+                             "Lagrange multiplier approach.");
   params.addRequiredCoupledVar("lambda", "Lagrange multiplier variable");
 
   return params;

--- a/test/src/kernels/ScalarLagrangeMultiplier.C
+++ b/test/src/kernels/ScalarLagrangeMultiplier.C
@@ -24,6 +24,7 @@ InputParameters
 validParams<ScalarLagrangeMultiplier>()
 {
   InputParameters params = validParams<Kernel>();
+  params.addClassDescription("This class is used to solve a constrained Neumann problem with a Lagrange multiplier approach.");
   params.addRequiredCoupledVar("lambda", "Lagrange multiplier variable");
 
   return params;
@@ -45,6 +46,15 @@ ScalarLagrangeMultiplier::computeQpResidual()
 void
 ScalarLagrangeMultiplier::computeOffDiagJacobianScalar(unsigned int jvar)
 {
+  // Note: Here we are assembling the contributions for _both_ Eq. (9) and (10)
+  // in the detailed writeup on this problem [0]. This is important to highlight
+  // because it is slightly different from the way things usually work in MOOSE
+  // because we are computing Jacobian contributions _for a different equation_
+  // than the equation which this Kernel is assigned in the input file. We do
+  // this for both simplicity (results in slightly less code) and efficiency:
+  // the contribution is symmetric, so it can be computed once and used twice.
+  //
+  // [0]: https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf
   DenseMatrix<Number> & ken = _assembly.jacobianBlock(_var.number(), jvar);
   DenseMatrix<Number> & kne = _assembly.jacobianBlock(jvar, _var.number());
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);

--- a/test/src/scalarkernels/PostprocessorCED.C
+++ b/test/src/scalarkernels/PostprocessorCED.C
@@ -20,9 +20,12 @@ InputParameters
 validParams<PostprocessorCED>()
 {
   InputParameters params = validParams<ScalarKernel>();
-  params.addClassDescription("This class is used to solve a constrained Neumann problem with a Lagrange multiplier approach.");
-  params.addRequiredParam<PostprocessorName>("pp_name", "Name of the Postprocessor value we are trying to equate with 'value'.");
-  params.addRequiredParam<Real>("value", "Given (constant) which we want the integral of the solution variable to match.");
+  params.addClassDescription("This class is used to solve a constrained Neumann problem with a "
+                             "Lagrange multiplier approach.");
+  params.addRequiredParam<PostprocessorName>(
+      "pp_name", "Name of the Postprocessor value we are trying to equate with 'value'.");
+  params.addRequiredParam<Real>(
+      "value", "Given (constant) which we want the integral of the solution variable to match.");
 
   return params;
 }

--- a/test/src/scalarkernels/PostprocessorCED.C
+++ b/test/src/scalarkernels/PostprocessorCED.C
@@ -20,8 +20,9 @@ InputParameters
 validParams<PostprocessorCED>()
 {
   InputParameters params = validParams<ScalarKernel>();
-  params.addRequiredParam<PostprocessorName>("pp_name", "");
-  params.addRequiredParam<Real>("value", "");
+  params.addClassDescription("This class is used to solve a constrained Neumann problem with a Lagrange multiplier approach.");
+  params.addRequiredParam<PostprocessorName>("pp_name", "Name of the Postprocessor value we are trying to equate with 'value'.");
+  params.addRequiredParam<Real>("value", "Given (constant) which we want the integral of the solution variable to match.");
 
   return params;
 }
@@ -65,6 +66,13 @@ PostprocessorCED::computeJacobian()
 Real
 PostprocessorCED::computeQpJacobian()
 {
+  // Note: Here, the true on-diagonal Jacobian contribution is
+  // actually zero, i.e. we are not making any approximation
+  // here. That is because the "lambda"-equation in this system of
+  // equations does not depend on lambda. For more information, see
+  // the detailed writeup [0].
+  //
+  // [0]: https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf
   return 0.;
 }
 
@@ -76,5 +84,12 @@ PostprocessorCED::computeOffDiagJacobian(unsigned int /*jvar*/)
 Real
 PostprocessorCED::computeQpOffDiagJacobian(unsigned int /*jvar*/)
 {
+  // The off-diagonal contribution for this ScalarKernel (derivative
+  // wrt the "primal" field variable) is not _actually_ zero, but we
+  // are computing it elsewhere (see ScalarLagrangeMultiplier.C) so
+  // here we simply return zero. For more information on this, see the
+  // detailed writeup [0].
+  //
+  // [0]: https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf
   return 0.;
 }

--- a/test/tests/kernels/scalar_constraint/scalar_constraint_kernel.i
+++ b/test/tests/kernels/scalar_constraint/scalar_constraint_kernel.i
@@ -42,8 +42,6 @@
   [../]
 []
 
-# NL
-
 [Variables]
   [./u]
     family = LAGRANGE
@@ -88,25 +86,25 @@
   [./bottom]
     type = FunctionNeumannBC
     variable = u
-    boundary = '0'
+    boundary = 'bottom'
     function = bottom_bc_fn
   [../]
   [./right]
     type = FunctionNeumannBC
     variable = u
-    boundary = '1'
+    boundary = 'right'
     function = right_bc_fn
   [../]
   [./top]
     type = FunctionNeumannBC
     variable = u
-    boundary = '2'
+    boundary = 'top'
     function = top_bc_fn
   [../]
   [./left]
     type = FunctionNeumannBC
     variable = u
-    boundary = '3'
+    boundary = 'left'
     function = left_bc_fn
   [../]
 []
@@ -126,18 +124,27 @@
 []
 
 [Preconditioning]
-  active = 'pc'
-
   [./pc]
     type = SMP
     full = true
-    solve_type = 'PJFNK'
+    solve_type = 'NEWTON'
   [../]
-[] # End preconditioning block
+[]
 
 [Executioner]
   type = Steady
-  nl_rel_tol = 1e-15
+  nl_rel_tol = 1e-9
+  l_tol = 1.e-10
+  nl_max_its = 10
+  # This example builds an indefinite matrix, so "-pc_type hypre -pc_hypre_type boomeramg" cannot
+  # be used reliably on this problem. ILU(0) seems to do OK in both serial and parallel in my testing,
+  # I have not seen any zero pivot issues.
+  petsc_options_iname = '-pc_type -sub_pc_type'
+  petsc_options_value = 'bjacobi  ilu'
+  # This is a linear problem, so we don't need to recompute the
+  # Jacobian. This isn't a big deal for a Steady problems, however, as
+  # there is only one solve.
+  solve_type = 'LINEAR'
 []
 
 [Outputs]

--- a/test/tests/kernels/scalar_constraint/tests
+++ b/test/tests/kernels/scalar_constraint/tests
@@ -5,7 +5,7 @@
     exodiff = 'scalar_constraint_kernel_out.e'
     # This problem only has 4 elements and therefore does not seem to run on > 4 procs.
     max_parallel = 4
-    design = 'ScalarKernels/index.md'
+    design = 'syntax/ScalarKernels/index.md'
     requirement = 'MOOSE shall solve the constrained Neumann problem using the Lagrange multiplier approach.'
     # This test was originally merged in cbf6d2235379f6ad75908b0f9d4be792dbce6c3d,
     # once Andrew adds the ability to parse git commits in the issues
@@ -18,7 +18,7 @@
     input = 'scalar_constraint_kernel_disp.i'
     exodiff = 'scalar_constraint_kernel_disp_out.e'
     max_parallel = 1
-    design = 'ScalarKernels/index.md'
+    design = 'syntax/ScalarKernels/index.md'
     requirement = 'MOOSE shall solve the constrained Neumann problem using the Lagrange multiplier approach when displacements are active.'
     issues = '#7699'
   [../]
@@ -28,7 +28,7 @@
     input = 'scalar_constraint_bc.i'
     exodiff = 'scalar_constraint_bc_out.e'
     max_parallel = 1
-    design = 'ScalarKernels/index.md'
+    design = 'syntax/ScalarKernels/index.md'
     requirement = 'MOOSE shall support the ability to set Dirichlet boundary conditions using the Lagrange multiplier approach.'
     issues = '#1800'
   [../]

--- a/test/tests/kernels/scalar_constraint/tests
+++ b/test/tests/kernels/scalar_constraint/tests
@@ -3,7 +3,14 @@
     type = 'Exodiff'
     input = 'scalar_constraint_kernel.i'
     exodiff = 'scalar_constraint_kernel_out.e'
-    max_parallel = 1
+    # This problem only has 4 elements and therefore does not seem to run on > 4 procs.
+    max_parallel = 4
+    design = 'ScalarKernels/index.md'
+    requirement = 'MOOSE shall solve the constrained Neumann problem using the Lagrange multiplier approach.'
+    # This test was originally merged in cbf6d2235379f6ad75908b0f9d4be792dbce6c3d,
+    # once Andrew adds the ability to parse git commits in the issues
+    # field, we can replace the #000.
+    issues = '#000'
   [../]
 
   [./kernel_disp]
@@ -11,6 +18,9 @@
     input = 'scalar_constraint_kernel_disp.i'
     exodiff = 'scalar_constraint_kernel_disp_out.e'
     max_parallel = 1
+    design = 'ScalarKernels/index.md'
+    requirement = 'MOOSE shall solve the constrained Neumann problem using the Lagrange multiplier approach when displacements are active.'
+    issues = '#7699'
   [../]
 
   [./bc]
@@ -18,5 +28,8 @@
     input = 'scalar_constraint_bc.i'
     exodiff = 'scalar_constraint_bc_out.e'
     max_parallel = 1
+    design = 'ScalarKernels/index.md'
+    requirement = 'MOOSE shall support the ability to set Dirichlet boundary conditions using the Lagrange multiplier approach.'
+    issues = '#1800'
   [../]
 []


### PR DESCRIPTION
What this test is actually doing (and how it does it) was sufficiently complicated and undocumented that it took me a while to actually figure it out in the process of answering a question on the moose-users mailing list with @lindsayad. While figuring it out, I wrote up some detailed [documentation](https://github.com/idaholab/large_media/blob/master/scalar_constraint_kernel.pdf) which is now referred to in the various `Kernels` and `ScalarKernels` employed by the test. Once there is an official moosedocs way of documenting complex tests like this, I will convert the PDF description into a markdown file...

Refs #9638.
