### PR TITLE
fix Attribute comparison

### DIFF
--- a/framework/include/base/Attributes.h
+++ b/framework/include/base/Attributes.h
@@ -57,6 +57,7 @@ public:
   }
 
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_vals);
 
 protected:
@@ -89,6 +90,7 @@ public:
   }
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_vals);
   clonefunc(AttribExecOns);
 
@@ -105,6 +107,7 @@ public:
   }
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_vals);
   clonefunc(AttribSubdomains);
 
@@ -122,6 +125,7 @@ public:
   }
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_vals, _must_be_restricted);
   clonefunc(AttribBoundaries);
 
@@ -136,6 +140,7 @@ public:
   AttribThread(TheWarehouse & w, THREAD_ID t) : Attribute(w, "thread"), _val(t) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribThread);
 
@@ -150,6 +155,7 @@ public:
   AttribPreIC(TheWarehouse & w, bool pre_ic) : Attribute(w, "pre_ic"), _val(pre_ic) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribPreIC);
 
@@ -164,6 +170,7 @@ public:
   AttribPreAux(TheWarehouse & w, bool pre_aux) : Attribute(w, "pre_aux"), _val(pre_aux) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribPreAux);
 
@@ -177,6 +184,7 @@ public:
   AttribName(TheWarehouse & w, const std::string & name) : Attribute(w, "name"), _val(name) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribName);
 
@@ -192,6 +200,7 @@ public:
   }
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribSystem);
 
@@ -205,6 +214,7 @@ public:
   AttribVar(TheWarehouse & w, int var) : Attribute(w, "variable"), _val(var) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribVar);
 
@@ -222,6 +232,7 @@ public:
   AttribInterfaces(TheWarehouse & w, unsigned int mask) : Attribute(w, "interfaces"), _val(mask) {}
   virtual void initFrom(const MooseObject * obj) override;
   virtual bool isMatch(const Attribute & other) const override;
+  virtual bool isEqual(const Attribute & other) const override;
   hashfunc(_val);
   clonefunc(AttribInterfaces);
 

--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -38,7 +38,7 @@ public:
 
   inline bool operator==(const Attribute & other) const
   {
-    return _id == other._id && isMatch(other);
+    return _id == other._id && isEqual(other);
   }
   inline bool operator!=(const Attribute & other) const { return !(*this == other); }
 
@@ -57,10 +57,14 @@ public:
 
   /// initFrom reads and stores the desired meta-data from obj for later matching comparisons.
   virtual void initFrom(const MooseObject * obj) = 0;
-  /// isMatch returns true if the meta-data stored in this attribute has the same value as that
-  /// stored in other. isMatch does not need to check/compare the values from the instances' id()
-  /// functions.
+  /// isMatch returns true if the meta-data stored in this attribute is equivalent to that
+  /// stored in other. This is is for query matching - not exact equivalence. isMatch does not need
+  /// to check/compare the values from the instances' id() functions.
   virtual bool isMatch(const Attribute & other) const = 0;
+  /// isEqual returns true if the meta-data stored in this attribute is identical to that
+  /// stored in other. isEqual does not need to check/compare the values from the instances' id()
+  /// functions.
+  virtual bool isEqual(const Attribute & other) const = 0;
   /// clone creates and returns and identical (deep) copy of this attribute - i.e. the result of
   /// clone should return true if passed into isMatch.
   virtual std::unique_ptr<Attribute> clone() const = 0;

--- a/framework/src/base/Attributes.C
+++ b/framework/src/base/Attributes.C
@@ -39,6 +39,19 @@ AttribTagBase::isMatch(const Attribute & other) const
   return false;
 }
 
+bool
+AttribTagBase::isEqual(const Attribute & other) const
+{
+  auto a = dynamic_cast<const AttribTagBase *>(&other);
+  if (!a || a->_vals.size() != _vals.size())
+    return false;
+
+  for (size_t i = 0; i < a->_vals.size(); i++)
+    if (a->_vals[i] != _vals[i])
+      return false;
+  return true;
+}
+
 void
 AttribMatrixTags::initFrom(const MooseObject * obj)
 {
@@ -93,6 +106,19 @@ AttribExecOns::isMatch(const Attribute & other) const
   return false;
 }
 
+bool
+AttribExecOns::isEqual(const Attribute & other) const
+{
+  auto a = dynamic_cast<const AttribExecOns *>(&other);
+  if (!a || a->_vals.size() != _vals.size())
+    return false;
+
+  for (size_t i = 0; i < a->_vals.size(); i++)
+    if (a->_vals[i] != _vals[i])
+      return false;
+  return true;
+}
+
 void
 AttribSubdomains::initFrom(const MooseObject * obj)
 {
@@ -123,6 +149,19 @@ AttribSubdomains::isMatch(const Attribute & other) const
       return true;
   }
   return false;
+}
+
+bool
+AttribSubdomains::isEqual(const Attribute & other) const
+{
+  auto a = dynamic_cast<const AttribSubdomains *>(&other);
+  if (!a || a->_vals.size() != _vals.size())
+    return false;
+
+  for (size_t i = 0; i < a->_vals.size(); i++)
+    if (a->_vals[i] != _vals[i])
+      return false;
+  return true;
 }
 
 void
@@ -157,6 +196,19 @@ AttribBoundaries::isMatch(const Attribute & other) const
   return false;
 }
 
+bool
+AttribBoundaries::isEqual(const Attribute & other) const
+{
+  auto a = dynamic_cast<const AttribBoundaries *>(&other);
+  if (!a || a->_vals.size() != _vals.size())
+    return false;
+
+  for (size_t i = 0; i < a->_vals.size(); i++)
+    if (a->_vals[i] != _vals[i])
+      return false;
+  return true;
+}
+
 void
 AttribThread::initFrom(const MooseObject * obj)
 {
@@ -167,6 +219,11 @@ AttribThread::isMatch(const Attribute & other) const
 {
   auto a = dynamic_cast<const AttribThread *>(&other);
   return a && (a->_val == _val);
+}
+bool
+AttribThread::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
 }
 
 void
@@ -180,6 +237,12 @@ AttribPreIC::isMatch(const Attribute & other) const
   return a && (a->_val == _val);
 }
 
+bool
+AttribPreIC::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
+}
+
 void
 AttribPreAux::initFrom(const MooseObject * /*obj*/)
 {
@@ -189,6 +252,12 @@ AttribPreAux::isMatch(const Attribute & other) const
 {
   auto a = dynamic_cast<const AttribPreAux *>(&other);
   return a && (a->_val == _val);
+}
+
+bool
+AttribPreAux::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
 }
 
 void
@@ -203,6 +272,12 @@ AttribName::isMatch(const Attribute & other) const
   return a && (a->_val == _val);
 }
 
+bool
+AttribName::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
+}
+
 void
 AttribSystem::initFrom(const MooseObject * /*obj*/)
 {
@@ -212,6 +287,12 @@ AttribSystem::isMatch(const Attribute & other) const
 {
   auto a = dynamic_cast<const AttribSystem *>(&other);
   return a && (a->_val == _val);
+}
+
+bool
+AttribSystem::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
 }
 
 void
@@ -226,6 +307,12 @@ AttribVar::isMatch(const Attribute & other) const
 {
   auto a = dynamic_cast<const AttribVar *>(&other);
   return a && (a->_val == _val);
+}
+
+bool
+AttribVar::isEqual(const Attribute & other) const
+{
+  return isMatch(other);
 }
 
 void
@@ -252,4 +339,11 @@ AttribInterfaces::isMatch(const Attribute & other) const
 {
   auto a = dynamic_cast<const AttribInterfaces *>(&other);
   return a && (a->_val & _val);
+}
+
+bool
+AttribInterfaces::isEqual(const Attribute & other) const
+{
+  auto a = dynamic_cast<const AttribInterfaces *>(&other);
+  return a && (a->_val == _val);
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1544,7 +1544,11 @@ MooseApp::addExecFlag(const ExecFlagType & flag)
     // the ID to be set after construction. This was the lesser of two evils: const_cast or
     // friend class with mutable members.
     ExecFlagType & non_const_flag = const_cast<ExecFlagType &>(flag);
-    non_const_flag.setID(_execute_flags.getNextValidID());
+    auto it = _execute_flags.find(flag.name());
+    if (it != _execute_flags.items().end())
+      non_const_flag.setID(it->id());
+    else
+      non_const_flag.setID(_execute_flags.getNextValidID());
   }
   _execute_flags.addAvailableFlags(flag);
 }

--- a/framework/src/base/TheWarehouse.C
+++ b/framework/src/base/TheWarehouse.C
@@ -56,7 +56,7 @@ public:
       bool ismatch = true;
       for (auto & cond : conds)
       {
-        if (*data[cond->id()] != *cond.get())
+        if (!data[cond->id()]->isMatch(*cond))
         {
           ismatch = false;
           break;

--- a/unit/src/TheWarehouseTests.C
+++ b/unit/src/TheWarehouseTests.C
@@ -68,6 +68,7 @@ public:
     auto o = static_cast<const TestAttrib *>(&other);
     return val == o->val;
   }
+  virtual bool isEqual(const Attribute & other) const override { return isMatch(other); }
 
   virtual size_t hash() const override
   {


### PR DESCRIPTION
Previously the same function was used for doing query matches on
attributes and for comparing attribute equality (e.g. as used by stl
containers like map, set, unordered map, etc.).  This was wrong.  Hash
collisions resulted in equality comparisons that returned true for
non-identical attribute instances because the query-comparison (isMatch)
was used.  This resulted in the wrong query id being returned for
certain queries (one that was query-equivalent but not identical).

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
