### PR TITLE
Mark multistage TimeIntegrators as being "experimental".

### DIFF
--- a/framework/src/timeintegrators/AStableDirk4.C
+++ b/framework/src/timeintegrators/AStableDirk4.C
@@ -31,6 +31,9 @@ AStableDirk4::AStableDirk4(const InputParameters & parameters)
     _gamma(0.5 + std::sqrt(3) / 3. * std::cos(libMesh::pi / 18.)),
     _safe_start(getParam<bool>("safe_start"))
 {
+  mooseInfo("AStableDirk4 and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
+
   // Name the stage residuals "residual_stage1", "residual_stage2", etc.
   for (unsigned int stage = 0; stage < 3; ++stage)
   {

--- a/framework/src/timeintegrators/ExplicitRK2.C
+++ b/framework/src/timeintegrators/ExplicitRK2.C
@@ -26,6 +26,9 @@ ExplicitRK2::ExplicitRK2(const InputParameters & parameters)
     _stage(1),
     _residual_old(_nl.addVector("residual_old", false, GHOSTED))
 {
+  mooseInfo("ExplicitRK2-derived TimeIntegrators (ExplicitMidpoint, Heun, Ralston) and other "
+            "multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
 }
 
 void

--- a/framework/src/timeintegrators/ExplicitTVDRK2.C
+++ b/framework/src/timeintegrators/ExplicitTVDRK2.C
@@ -28,6 +28,8 @@ ExplicitTVDRK2::ExplicitTVDRK2(const InputParameters & parameters)
     _stage(1),
     _residual_old(_nl.addVector("residual_old", false, GHOSTED))
 {
+  mooseInfo("ExplicitTVDRK2 and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
 }
 
 void

--- a/framework/src/timeintegrators/ImplicitMidpoint.C
+++ b/framework/src/timeintegrators/ImplicitMidpoint.C
@@ -28,6 +28,8 @@ ImplicitMidpoint::ImplicitMidpoint(const InputParameters & parameters)
     _stage(1),
     _residual_stage1(_nl.addVector("residual_stage1", false, GHOSTED))
 {
+  mooseInfo("ImplicitMidpoint and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
 }
 
 void

--- a/framework/src/timeintegrators/LStableDirk2.C
+++ b/framework/src/timeintegrators/LStableDirk2.C
@@ -29,6 +29,8 @@ LStableDirk2::LStableDirk2(const InputParameters & parameters)
     _residual_stage2(_nl.addVector("residual_stage2", false, GHOSTED)),
     _alpha(1. - 0.5 * std::sqrt(2))
 {
+  mooseInfo("LStableDirk2 and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
 }
 
 void

--- a/framework/src/timeintegrators/LStableDirk3.C
+++ b/framework/src/timeintegrators/LStableDirk3.C
@@ -28,6 +28,9 @@ LStableDirk3::LStableDirk3(const InputParameters & parameters)
     _gamma(-std::sqrt(2.) * std::cos(std::atan(std::sqrt(2.) / 4.) / 3.) / 2. +
            std::sqrt(6.) * std::sin(std::atan(std::sqrt(2.) / 4.) / 3.) / 2. + 1.)
 {
+  mooseInfo("LStableDirk3 and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
+
   // Name the stage residuals "residual_stage1", "residual_stage2", etc.
   for (unsigned int stage = 0; stage < 3; ++stage)
   {

--- a/framework/src/timeintegrators/LStableDirk4.C
+++ b/framework/src/timeintegrators/LStableDirk4.C
@@ -35,6 +35,9 @@ const Real LStableDirk4::_a[LStableDirk4::_n_stages][LStableDirk4::_n_stages] = 
 LStableDirk4::LStableDirk4(const InputParameters & parameters)
   : TimeIntegrator(parameters), _stage(1)
 {
+  mooseInfo("LStableDirk4 and other multistage TimeIntegrators are known not to work with "
+            "Materials/AuxKernels that accumulate 'state' and should be used with caution.");
+
   // Name the stage residuals "residual_stage1", "residual_stage2", etc.
   for (unsigned int stage = 0; stage < _n_stages; ++stage)
   {


### PR DESCRIPTION
These TimeIntegrators are known not to work with Materials,
AuxKernels, etc. that have state (e.g. VariableTimeIntegrationAux)
because they either:

* Call advanceState() internally, causing the state to be accumulated too frequently.
* Don't call advanceState() internally, causing "old" and "older" and
  things like "_dt" to not be reliable.

The following is a current list of multistage TimeIntegrators:
* LStableDirk{2,3,4}
* AStableDirk4
* ExplicitRK2 subclasses (Heun, ExplicitMidpoint, Ralston)
* ExplicitTVDRK2
* ImplicitMidpoint

See also, the discussion in #12347.
