### PR TITLE
Point to a specific commit in test issues field.

### DIFF
--- a/python/MooseDocs/common/get_requirements.py
+++ b/python/MooseDocs/common/get_requirements.py
@@ -65,7 +65,8 @@ def _add_requirements(out, location, filename):
             if local_issues is None:
                 msg = "The 'issues' parameter is missing from '%s' in %s. It must be defined at " \
                       "the top level and/or within the individual test specification. It " \
-                      "should contain a space separated list of issue numbers (include the #)."
+                      "should contain a space separated list of issue numbers (include the #) or " \
+                      "a git commit SHA."
                 LOG.error(msg, child.name, filename)
                 local_issues = ''
 

--- a/python/MooseDocs/extensions/sqa.py
+++ b/python/MooseDocs/extensions/sqa.py
@@ -153,7 +153,10 @@ class SQARequirementsCommand(command.CommandComponent):
                 p = tokens.Paragraph(item, 'p')
                 tokens.String(p, content=u'Issues: ')
                 for issue in req.issues:
-                    url = u"https://github.com/idaholab/moose/issues/{}".format(issue[1:])
+                    if issue.startswith('#'):
+                        url = u"https://github.com/idaholab/moose/issues/{}".format(issue[1:])
+                    else:
+                        url = u"https://github.com/idaholab/moose/commit/{}".format(issue[1:])
                     tokens.Link(p, url=url, string=unicode(issue))
                     tokens.Space(p)
 

--- a/test/tests/kernels/scalar_constraint/tests
+++ b/test/tests/kernels/scalar_constraint/tests
@@ -7,10 +7,7 @@
     max_parallel = 4
     design = 'syntax/ScalarKernels/index.md'
     requirement = 'MOOSE shall solve the constrained Neumann problem using the Lagrange multiplier approach.'
-    # This test was originally merged in cbf6d2235379f6ad75908b0f9d4be792dbce6c3d,
-    # once Andrew adds the ability to parse git commits in the issues
-    # field, we can replace the #000.
-    issues = '#000'
+    issues = 'cbf6d2235379f6ad75908b0f9d4be792dbce6c3d'
   [../]
 
   [./kernel_disp]


### PR DESCRIPTION
This is a new feature of the moosedocs system that lets us refer to
commits that were made in SVN and don't have a valid ticket number.

Refs #12376, #12382.
