### PR TITLE
consolidate LATEST checkpoint file name handling

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -356,7 +356,13 @@ public:
   /**
    * mutator for recover_base (set by RecoverBaseAction)
    */
-  void setRecoverFileBase(std::string recover_base) { _recover_base = recover_base; }
+  void setRecoverFileBase(std::string recover_base)
+  {
+    if (recover_base.empty())
+      _recover_base = MooseUtils::getLatestAppCheckpointFileBase(getCheckpointFiles());
+    else
+      _recover_base = recover_base;
+  }
 
   /**
    * The suffix for the recovery file.

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -40,6 +40,13 @@ class MultiMooseEnum;
 namespace MooseUtils
 {
 
+/**
+ * Replaces "LATEST" placeholders with the latest checkpoint file name.  If base_only is true, then
+ * only return the base-name of the checkpoint directory - otherwise, a full mesh
+ * checkpoint file path is returned.
+ */
+std::string convertLatestCheckpoint(std::string orig, bool base_only = true);
+
 /// Computes and returns the Levenshtein distance between strings s1 and s2.
 int levenshteinDist(const std::string & s1, const std::string & s2);
 

--- a/framework/src/actions/SetupRecoverFileBaseAction.C
+++ b/framework/src/actions/SetupRecoverFileBaseAction.C
@@ -34,20 +34,7 @@ SetupRecoverFileBaseAction::act()
   if (!_app.isRecovering() || !_app.isUltimateMaster())
     return;
 
-  // Get the most current file, if it hasn't been set directly
-  if (!_app.hasRecoverFileBase())
-  {
-    // Build the list of all possible checkpoint files for recover
-    std::list<std::string> checkpoint_files = _app.getCheckpointFiles();
-
-    // Grab the most recent one
-    std::string recovery_file_base = MooseUtils::getLatestAppCheckpointFileBase(checkpoint_files);
-
-    if (recovery_file_base.empty())
-      mooseError("Unable to find suitable recovery file!");
-
-    _app.setRecoverFileBase(recovery_file_base);
-  }
+  _app.setRecoverFileBase(MooseUtils::convertLatestCheckpoint(_app.getRecoverFileBase()));
 
   // Set the recover file base in the App
   _console << "\nUsing " << _app.getRecoverFileBase() << " for recovery.\n\n";

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -94,26 +94,13 @@ FileMesh::buildMesh()
     }
     else
     {
-      auto slash_pos = _file_name.find_last_of("/");
-      auto path = _file_name.substr(0, slash_pos);
-      auto file = _file_name.substr(slash_pos + 1);
-
-      bool restarting;
       // If we are reading a mesh while restarting, then we might have
       // a solution file that relies on that mesh partitioning and/or
       // numbering.  In that case, we need to turn off repartitioning
       // and renumbering, at least at first.
-      if (file == "LATEST")
-      {
-        std::list<std::string> files = MooseUtils::listDir(path);
-
-        // Fill in the name of the LATEST file so we can open it and read it.
-        _file_name = MooseUtils::getLatestMeshCheckpointFile(files);
-        restarting = true;
-      }
-      else
-        restarting = _file_name.rfind(".cpa") < _file_name.size() ||
-                     _file_name.rfind(".cpr") < _file_name.size();
+      _file_name = MooseUtils::convertLatestCheckpoint(_file_name, false);
+      bool restarting = _file_name.rfind(".cpa") < _file_name.size() ||
+                        _file_name.rfind(".cpr") < _file_name.size();
 
       const bool skip_partitioning_later = restarting && getMesh().skip_partitioning();
       const bool allow_renumbering_later = restarting && getMesh().allow_renumbering();

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -363,23 +363,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
   if (isParamValid("restart_file_base"))
   {
     std::string restart_file_base = getParam<FileNameNoExtension>("restart_file_base");
-
-    std::size_t slash_pos = restart_file_base.find_last_of("/");
-    std::string path = restart_file_base.substr(0, slash_pos);
-    std::string file = restart_file_base.substr(slash_pos + 1);
-
-    // If the user specified LATEST as the file in their directory path, find the file with the
-    // latest timestep and the largest serial number.
-    if (file == "LATEST")
-    {
-      std::list<std::string> dir_list(1, path);
-      std::list<std::string> files = MooseUtils::getFilesInDirs(dir_list);
-      restart_file_base = MooseUtils::getLatestAppCheckpointFileBase(files);
-
-      if (restart_file_base == "")
-        mooseError("Unable to find suitable restart file");
-    }
-
+    restart_file_base = MooseUtils::convertLatestCheckpoint(restart_file_base);
     _console << "\nUsing " << restart_file_base << " for restart.\n\n";
     setRestartFile(restart_file_base);
   }

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -40,6 +40,23 @@ std::string getLatestCheckpointFileHelper(const std::list<std::string> & checkpo
 namespace MooseUtils
 {
 
+std::string
+convertLatestCheckpoint(std::string orig, bool base_only)
+{
+  auto slash_pos = orig.find_last_of("/");
+  auto path = orig.substr(0, slash_pos);
+  auto file = orig.substr(slash_pos + 1);
+  if (file != "LATEST")
+    return orig;
+
+  auto converted = MooseUtils::getLatestAppCheckpointFileBase(MooseUtils::listDir(path));
+  if (!base_only)
+    converted = MooseUtils::getLatestMeshCheckpointFile(MooseUtils::listDir(path));
+  else if (converted.empty())
+    mooseError("Unable to find suitable recovery file!");
+  return converted;
+}
+
 // this implementation is copied from
 // https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C.2B.2B
 int

--- a/test/tests/outputs/recover/tests
+++ b/test/tests/outputs/recover/tests
@@ -6,6 +6,10 @@
     check_files = 'test_recover_dir_cp/0005.xdr'
     delete_output_folders = false
     cli_args = 'Executioner/num_steps=5'
+
+    requirement = 'Correctly set up initial recover files for the part2 test.'
+    design = 'application_usage/restart_recover.md'
+    issues = '#2661'
   [../]
   [./part2]
     # Recover the solve from part1 with a specified file
@@ -17,5 +21,37 @@
     delete_output_before_running = false
     delete_output_folders = false
     recover = false
+
+    requirement = 'A simulation executed using the "--recover" flag successfully runs a simulation using the specified recover file argument.'
+    design = 'application_usage/restart_recover.md'
+    issues = '#2661'
+  [../]
+  [./part1_latest]
+    # Run simple transient problem to 5 time steps, with checkpoint files enabled
+    type = 'CheckFiles'
+    input = 'recover1.i'
+    check_files = 'test_recover_dir_cp/0005.xdr'
+    cli_args = 'Executioner/num_steps=5'
+    delete_output_before_running = true
+    prereq = part2
+
+    requirement = 'Correctly set up initial recover files for the part2_latest test.'
+    design = 'application_usage/restart_recover.md'
+    issues = '#10494 #12403'
+  [../]
+  [./part2_latest]
+    # Recover the solve from part1 with a specified file
+    type = 'Exodiff'
+    input = 'recover2.i'
+    exodiff = 'recover_out.e'
+    cli_args = '--recover test_recover_dir_cp/LATEST'
+    prereq = 'part1_latest'
+    delete_output_before_running = false
+    delete_output_folders = false
+    recover = false
+
+    requirement = 'A simulation executed using the "--recover" flag with a file argument using the placeholder "LATEST" successfully runs a simulation using most recent checkpoint/recover file from the specified directory.'
+    design = 'application_usage/restart_recover.md'
+    issues = '#10494 #12403'
   [../]
 []


### PR DESCRIPTION
Be more consistent about how we handle unspecified restart/recover base file
paths.

Fixes #10494.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
