### PR TITLE
Change array size of ADReal. 

### DIFF
--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -162,7 +162,7 @@ typedef MooseArray<std::vector<VectorValue<Real>>> VectorVariableTestCurl;
 /*
  * DualNumber naming
  */
-#define AD_MAX_DOFS_PER_ELEM 100
+#define AD_MAX_DOFS_PER_ELEM 50
 using MetaPhysicL::DualNumber;
 using MetaPhysicL::NumberArray;
 


### PR DESCRIPTION
For our default basis functions, in 3D this would handle 6 variables, in 2D 12 variables, so I think this is still a reasonable default. A user who needs more can change it themselves (MOOSE configure). The motivation for this change comes from out of memory errors on HPC for BISON assessment cases (@gardnerru). This is a kludgy "fix". A true fix in my mind will require dynamic instead of static memory for `DualNumbers`. E.g. if a material property is not declared as AD, the vector size for the derivatives should be zero. This means the derivatives container cannot be a static array like `MetaPhysicL::NumberArray`. 

I experimented with compile-time fixes like:

- templating one or both of the `MaterialProperty`/`ADMaterialProperty` classes in order to change the type of the data member `_value` but this ruins the design requirement that properties should be inter-operable, e.g. a user could declare an AD property in a material but then request it as a normal property in a kernel, or visa versa. 
- create old and older properties as regular `MaterialProperty`s. But then `MaterialPropertyStorage::shift` no longer works because we are swapping `MaterialProperties` containers where one contains pointers to `ADMaterialProperty` and the other contains pointers to `MaterialProperty`. We could loop over all elements and sides and manually copy from current properties to old properties, but this seems like the wrong thing to do to me.

Refs #12111
