### PR TITLE
The porous_flow module depends on the rdg module.

### DIFF
--- a/modules/modules.mk
+++ b/modules/modules.mk
@@ -33,6 +33,7 @@ ifeq ($(POROUS_FLOW),yes)
         TENSOR_MECHANICS            := yes
         FLUID_PROPERTIES            := yes
         CHEMICAL_REACTIONS          := yes
+        RDG                         := yes
 endif
 
 ifeq ($(NAVIER_STOKES),yes)
@@ -133,8 +134,7 @@ ifeq ($(POROUS_FLOW),yes)
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/porous_flow
   APPLICATION_NAME   := porous_flow
 
-  #Dependency on tensor_mechanics, fluid_properties and chemical_reactions
-  DEPEND_MODULES     := tensor_mechanics fluid_properties chemical_reactions
+  DEPEND_MODULES     := tensor_mechanics fluid_properties chemical_reactions rdg
   SUFFIX             := pflow
   include $(FRAMEWORK_DIR)/app.mk
 endif


### PR DESCRIPTION
We needed to update the modules.mk file to reflect this dependency,
this should get falcon building again.

Refs #12348.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
