### PR TITLE
Fix [-Wpessimizing-move] warning on clang 3.9.0.

### DIFF
--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -194,7 +194,7 @@ public:
     size_t count() { return _w->count(_attribs); }
 
     /// attribs returns a copy of the constructed Attribute list for the query in its current state.
-    std::vector<std::unique_ptr<Attribute>> attributes() { return std::move(clone()._attribs); }
+    std::vector<std::unique_ptr<Attribute>> attributes() { return clone()._attribs; }
 
     /// queryInto executes the query and stores the results in the given vector.  All results must
     /// be castable to the templated type T.


### PR DESCRIPTION
Not sure why this doesn't show up as an error on our -Werror builds,
perhaps it is just a warning on older clangs.

Refs #12424.

The actual text of the warning is below:

TheWarehouse.h:197:67: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    std::vector<std::unique_ptr<Attribute>> attributes() { return std::move(clone()._attribs); }
                                                                  ^
TheWarehouse.h:197:67: note: remove std::move call here
    std::vector<std::unique_ptr<Attribute>> attributes() { return std::move(clone()._attribs); }
                                                                  ^~~~~~~~~~                ~
1 warning generated.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
