### PR TITLE
Drop deprecated parameters.

### DIFF
--- a/examples/ex02_kernel/ex02_oversample.i
+++ b/examples/ex02_kernel/ex02_oversample.i
@@ -50,13 +50,11 @@
   [./refine_2]
     type = Exodus
     file_base = oversample_2
-    oversample = true
     refinements = 2
   [../]
   [./refine_4]
     type = Exodus
     file_base = oversample_4
-    oversample = true
     refinements = 4
   [../]
 []

--- a/python/peacock/tests/common/oversample.i
+++ b/python/peacock/tests/common/oversample.i
@@ -121,8 +121,6 @@
   [./refine_2]
     type = Exodus
     file_base = oversample_2
-    oversample = true
-    append_oversample = true
     refinements = 2
   [../]
 []

--- a/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
+++ b/python/peacock/tests/input_tab/OutputNames/test_OutputNames.py
@@ -41,14 +41,14 @@ class Tests(Testing.PeacockTester):
         input_file = "../../common/oversample.i"
         input_tree = self.create_tree(input_file)
         output_names = OutputNames.getOutputFiles(input_tree, input_file)
-        self.assertEqual(output_names, ["out_transient.e", "oversample_2_oversample.e"])
+        self.assertEqual(output_names, ["out_transient.e", "oversample_2.e"])
 
         outputs = input_tree.getBlockInfo("/Outputs")
         outputs.parameters_list.remove("file_base")
         del outputs.parameters["file_base"]
 
         output_names = OutputNames.getOutputFiles(input_tree, input_file)
-        self.assertEqual(output_names, ["oversample_out.e", "oversample_2_oversample.e"])
+        self.assertEqual(output_names, ["oversample_out.e", "oversample_2.e"])
 
         outputs = input_tree.getBlockInfo("/Outputs/refine_2")
         t = outputs.getTypeBlock()
@@ -56,7 +56,7 @@ class Tests(Testing.PeacockTester):
         del t.parameters["file_base"]
 
         output_names = OutputNames.getOutputFiles(input_tree, input_file)
-        self.assertEqual(output_names, ["oversample_out.e", "oversample_refine_2_oversample.e"])
+        self.assertEqual(output_names, ["oversample_out.e", "oversample_refine_2.e"])
 
     def testDate(self):
         input_file = "../../common/transient_with_date.i"


### PR DESCRIPTION
The 'oversample' and 'oversample_append' parameters have been
deprecated for a long time now, so let's get rid of them.

Refs #3847.
