### PR TITLE
Better logic on finding neighboring intersected elements

### DIFF
--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -70,10 +70,15 @@ public:
    */
   Real length() const { return (_p0 - _p1).norm(); }
 
+  /**
+   * Direction of line segment
+   */
+  Point direction() const { return _dir; }
+
 private:
   bool closest_point(const Point & p, bool clamp_to_segment, Point & closest_p) const;
 
-  Point _p0, _p1;
+  Point _p0, _p1, _dir;
 };
 
 #endif // LINESEGMENT_H

--- a/framework/src/utils/LineSegment.C
+++ b/framework/src/utils/LineSegment.C
@@ -12,7 +12,10 @@
 #include "libmesh/plane.h"
 #include "libmesh/vector_value.h"
 
-LineSegment::LineSegment(const Point & p0, const Point & p1) : _p0(p0), _p1(p1) {}
+LineSegment::LineSegment(const Point & p0, const Point & p1)
+  : _p0(p0), _p1(p1), _dir((_p1 - _p0).unit())
+{
+}
 
 bool
 LineSegment::closest_point(const Point & p, bool clamp_to_segment, Point & closest_p) const


### PR DESCRIPTION
Close #12414.
This temporary fix also makes the current ray tracing work with adapted meshes.
