### PR TITLE
Add method to extract _elem_crack_origin_direction_map.

### DIFF
--- a/modules/xfem/include/base/XFEM.h
+++ b/modules/xfem/include/base/XFEM.h
@@ -244,6 +244,11 @@ public:
                         EFAElement3D * CEMElem,
                         std::vector<std::vector<Point>> & frag_faces) const;
 
+  const std::map<const Elem *, std::vector<Point>> & getCrackTipOriginMap() const
+  {
+    return _elem_crack_origin_direction_map;
+  }
+
 private:
   bool _has_secondary_cut;
 

--- a/modules/xfem/test/include/postprocessors/TestCrackCounter.h
+++ b/modules/xfem/test/include/postprocessors/TestCrackCounter.h
@@ -1,0 +1,44 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef TESTCRACKCOUNTER_H
+#define TESTCRACKCOUNTER_H
+
+#include "GeneralPostprocessor.h"
+
+// Forward Declarations
+class TestCrackCounter;
+class XFEM;
+
+template <>
+InputParameters validParams<TestCrackCounter>();
+
+class TestCrackCounter : public GeneralPostprocessor
+{
+public:
+  TestCrackCounter(const InputParameters & parameters);
+
+  /// Initialize the number of Cracks.
+  virtual void initialize();
+
+  /// Calculates the number of Cracks
+  virtual void execute();
+
+  /// Get number of Cracks
+  virtual Real getValue();
+
+protected:
+  /// Variable used to write out the number of Cracks
+  unsigned int _number_of_cracks;
+
+private:
+  std::shared_ptr<XFEM> _xfem;
+};
+
+#endif // TESTCRACKCOUNTER_H

--- a/modules/xfem/test/src/postprocessors/TestCrackCounter.C
+++ b/modules/xfem/test/src/postprocessors/TestCrackCounter.C
@@ -1,0 +1,56 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TestCrackCounter.h"
+#include "XFEM.h"
+
+registerMooseObject("XFEMTestApp", TestCrackCounter);
+
+template <>
+InputParameters
+validParams<TestCrackCounter>()
+{
+  InputParameters params = validParams<GeneralPostprocessor>();
+  params.addClassDescription(
+      "Test postprocessor for extracting the crack_tip_origin_direction_map from XFEM.");
+
+  return params;
+}
+
+TestCrackCounter::TestCrackCounter(const InputParameters & parameters)
+  : GeneralPostprocessor(parameters), _number_of_cracks(0)
+{
+  FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
+  if (fe_problem == nullptr)
+    mooseError("Problem casting _subproblem to FEProblemBase in TestCrackCounter");
+  _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());
+  if (_xfem == nullptr)
+    mooseError("Problem casting to XFEM in TestCrackCounter");
+}
+
+void
+TestCrackCounter::initialize()
+{
+  _number_of_cracks = 0;
+}
+
+void
+TestCrackCounter::execute()
+{
+  const std::map<const Elem *, std::vector<Point>> & crack_origins_map =
+      _xfem->getCrackTipOriginMap();
+
+  _number_of_cracks = crack_origins_map.size();
+}
+
+Real
+TestCrackCounter::getValue()
+{
+  return _number_of_cracks;
+}

--- a/modules/xfem/test/tests/solid_mechanics_basic/gold/test_crack_counter_out.csv
+++ b/modules/xfem/test/tests/solid_mechanics_basic/gold/test_crack_counter_out.csv
@@ -1,0 +1,3 @@
+time,number_of_cracks
+0,0
+1,4

--- a/modules/xfem/test/tests/solid_mechanics_basic/test_crack_counter.i
+++ b/modules/xfem/test/tests/solid_mechanics_basic/test_crack_counter.i
@@ -1,0 +1,151 @@
+# This test is used to verify that the pure test object (TestCrackCounter)
+# is correctly using the API for extracting the crack_tip_origin_direction_map
+# from XFEM.  The map contains information of the location of all the crack tips
+# computed by XFEM.  The TestCrackCounter postprocessor simply returns the
+# number of elements in the map which corresponds to the number of cracks.
+#
+# In this test case 4 prescribed cracks are applied.  Therefore, the
+# TestCrackCounter postprocessor returns a value of 4.
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+  volumetric_locking_correction = true
+[]
+
+[XFEM]
+  qrule = volfrac
+  output_cut_plane = true
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 11
+  ny = 11
+  xmin = 0.0
+  xmax = 1.0
+  ymin = 0.0
+  ymax = 1.0
+  elem_type = QUAD4
+[]
+
+[UserObjects]
+  [./line_seg_cut_uo]
+    type = LineSegmentCutUserObject
+    cut_data = '1.0  0.5  0.7  0.5'
+    time_start_cut = 0.0
+    time_end_cut = 0.0
+  [../]
+  [./line_seg_cut_uo2]
+    type = LineSegmentCutUserObject
+    cut_data = '0.0  0.5  0.3  0.5'
+    time_start_cut = 0.0
+    time_end_cut = 0.0
+  [../]
+  [./line_seg_cut_uo3]
+    type = LineSegmentCutUserObject
+    cut_data = '0.5  0.0  0.5  0.3'
+    time_start_cut = 0.0
+    time_end_cut = 0.0
+  [../]
+  [./line_seg_cut_uo4]
+    type = LineSegmentCutUserObject
+    cut_data = '0.5  1.0  0.5  0.7'
+    time_start_cut = 0.0
+    time_end_cut = 0.0
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    planar_formulation = plane_strain
+    add_variables = true
+  [../]
+[]
+
+[Functions]
+  [./pull]
+    type = PiecewiseLinear
+    x='0  50   100'
+    y='0  0.02 0.1'
+  [../]
+[]
+
+[BCs]
+  [./bottomx]
+    type = PresetBC
+    boundary = bottom
+    variable = disp_x
+    value = 0.0
+  [../]
+  [./bottomy]
+    type = PresetBC
+    boundary = bottom
+    variable = disp_y
+    value = 0.0
+  [../]
+  [./topx]
+    type = PresetBC
+    boundary = top
+    variable = disp_x
+    value = 0.0
+  [../]
+  [./topy]
+    type = FunctionPresetBC
+    boundary = top
+    variable = disp_y
+    function = pull
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 1e6
+    poissons_ratio = 0.3
+    block = 0
+  [../]
+
+  [./_elastic_strain]
+    type = ComputeFiniteStrainElasticStress
+    block = 0
+  [../]
+[]
+
+[Postprocessors]
+  [./number_of_cracks]
+    type = TestCrackCounter
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_value = '201                hypre    boomeramg      8'
+
+  line_search = 'none'
+
+# controls for linear iterations
+  l_max_its = 100
+  l_tol = 1e-2
+
+# controls for nonlinear iterations
+  nl_max_its = 15
+  nl_rel_tol = 1e-14
+  nl_abs_tol = 1e-9
+
+# time control
+  start_time = 0.0
+  dt = 1.0
+  end_time = 1.0
+  num_steps = 5000
+
+  max_xfem_update = 1
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/modules/xfem/test/tests/solid_mechanics_basic/tests
+++ b/modules/xfem/test/tests/solid_mechanics_basic/tests
@@ -134,4 +134,13 @@
     unique_id = true
     requirement = 'The XFEM system shall permit branched cracks to be represented in 2D by sequentially cutting a 3-noded triangle element by two prescribed evolving cutting planes'
   [../]
+  [./test_crack_counter]
+    type = CSVDiff
+    input = test_crack_counter.i
+    csvdiff = 'test_crack_counter_out.csv'
+    # XFEM requires --enable-unique-ids in libmesh
+    unique_id = true
+    requirement = 'The XFEM system shall provide an accessor function to the crack_tip_origin_direction_map'
+    allow_test_objects = true
+  [../]
 []


### PR DESCRIPTION
Adding method to extract data in an existing map in XFEM.C for use in other MOOSE objects.

Closes #12435.

