### PR TITLE
Temporary patch for axisymmetric VLC + side PP

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
@@ -141,7 +141,12 @@ ComputeFiniteStrain::computeQpIncrements(RankTwoTensor & total_strain_increment,
     case DecompMethod::TaylorExpansion:
     {
       // inverse of _Fhat
-      RankTwoTensor invFhat(_Fhat[_qp].inverse());
+      RankTwoTensor invFhat;
+      static const RankTwoTensor zero;
+      if (_Fhat[_qp] == zero)
+        invFhat.zero();
+      else
+        invFhat = _Fhat[_qp].inverse();
 
       // A = I - _Fhat^-1
       RankTwoTensor A(RankTwoTensor::initIdentity);

--- a/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_centerline_VLC.i
+++ b/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_centerline_VLC.i
@@ -1,0 +1,91 @@
+# Simple test to check for use of AxisymmetricCenterlineAverageValue with
+# volumetric_locking_correction activated in a tensor mechanics simulation
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[GlobalParams]
+  displacements = 'disp_r disp_z'
+  volumetric_locking_correction = true
+[]
+
+[Problem]
+  coord_type = RZ
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+  [../]
+[]
+
+[AuxVariables]
+  [./temperature]
+    initial_condition = 298.0
+  [../]
+[]
+
+[BCs]
+  [./symmetry_x]
+    type = PresetBC
+    variable = disp_r
+    value = 0
+    boundary = left
+  [../]
+  [./roller_z]
+    type = PresetBC
+    variable = disp_z
+    value = 0
+    boundary = bottom
+  [../]
+  [./top_load]
+    type = FunctionPresetBC
+    variable = disp_z
+    function = -0.01*t
+    boundary = top
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 1e10
+    poissons_ratio = 0.3
+  [../]
+  [./_elastic_strain]
+    type = ComputeFiniteStrainElasticStress
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  line_search = 'none'
+
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+  nl_max_its = 15
+
+  l_tol = 1e-6
+  l_max_its = 50
+
+  start_time = 0.0
+  end_time = 0.3
+  dt = 0.1
+[]
+
+[Postprocessors]
+  [./center_temperature]
+    type = AxisymmetricCenterlineAverageValue
+    variable = temperature
+    boundary = left
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  perf_graph = true
+[]

--- a/modules/tensor_mechanics/test/tests/2D_geometries/gold/2D-RZ_centerline_VLC_out.csv
+++ b/modules/tensor_mechanics/test/tests/2D_geometries/gold/2D-RZ_centerline_VLC_out.csv
@@ -1,0 +1,5 @@
+time,center_temperature
+0,0
+0.1,298
+0.2,298
+0.3,298

--- a/modules/tensor_mechanics/test/tests/2D_geometries/tests
+++ b/modules/tensor_mechanics/test/tests/2D_geometries/tests
@@ -147,4 +147,12 @@
     design = 'source/materials/ComputeAxisymmetricRZFiniteStrain.md VolumetricLocking.md'
     requirement = 'The ComputeAxisymmetricRZFiniteStrain class shall compute the reaction forces on the top surface of a cylinder which is loaded axially in tension when using the B-bar volumetric locking correction.'
   [../]
+  [./axisymmetric_vlc_centerline_pp]
+    type = CSVDiff
+    input = '2D-RZ_centerline_VLC.i'
+    csvdiff = '2D-RZ_centerline_VLC_out.csv'
+    design = 'VolumetricLocking.md source/postprocessors/AxisymmetricCenterlineAverageValue.md'
+    issues = '#12437 #10866'
+    requirement  = 'The volumetric locking correction option in ComputeAxisymmetricRZFiniteStrain shall reinit material properties without inverting a zero tensor when called from a side postprocessor applied to the axis of rotation in an axisymmetric simulation.'
+  [../]
 []


### PR DESCRIPTION
Implementation of the patch to `ComputeFiniteStrain` for axisymmetricRZ simulations as suggested by @permcody. This patch is only necessary for finite strain axisymmetricRZ simulations with volumetric locking correction when a Side postprocessor is used. When #12444 hopefully this patch can be removed.

Closes #12437, Closes #10866
