### PR TITLE
Increase maximum # of linear iterations for coupled_vector_gradient test

### DIFF
--- a/test/tests/kernels/vector_fe/coupled_vector_gradient.i
+++ b/test/tests/kernels/vector_fe/coupled_vector_gradient.i
@@ -157,8 +157,10 @@
   num_steps = 3
   solve_type = 'NEWTON'
   petsc_options = '-ksp_converged_reason -snes_converged_reason'
+  petsc_options_iname = '-ksp_gmres_restart'
+  petsc_options_value = '100'
   nl_max_its = 3
-  l_max_its = 20
+  l_max_its = 100
   dtmin = 1
 []
 


### PR DESCRIPTION
Some dummy made the maximum number of linear iterations equal to 20, which prevents convergence of the linear solve for high processor counts, which in turn slows the convergence of the non-linear solve. I want to keep the maximum number of non-linear iterations small since it indicates the accuracy of the Jacobian, but the maximum of linear iterations should absolutely be increased.
