### PR TITLE
Return None instead of null string

### DIFF
--- a/framework/scripts/get_repo_revision.py
+++ b/framework/scripts/get_repo_revision.py
@@ -61,7 +61,7 @@ class VersionInfo:
                 self.SHA1 = shellCommand('git show ' + self.hideSignature() + ' -s --format=%h', cwd).strip()
                 self.is_git_repo = True
             except: # subprocess.CalledProcessError:
-                self.SHA1 = ""
+                self.SHA1 = None
 
         return self.SHA1
 


### PR DESCRIPTION
Calling logic is specifically handling a None case, but was receiving a null string instead. Which resulted in nothing being
printed for version output.

Closes #12483
