### PR TITLE
Patch to allow SideAveragePP with volumetric locking correction in SolidMechanics

### DIFF
--- a/modules/solid_mechanics/src/materials/NonlinearRZ.C
+++ b/modules/solid_mechanics/src/materials/NonlinearRZ.C
@@ -84,7 +84,13 @@ NonlinearRZ::computeIncrementalDeformationGradient(std::vector<ColumnMajorMatrix
 
   if (_volumetric_locking_correction)
   {
-    Fhat_average /= volume;
+    // Check for the case when Materials are being reinit by a SideIntegralPP
+    // active on the axis of rotation on a solid axisymmetric model
+    // where the r coordinate will be zero
+    if (volume != 0.0)
+      Fhat_average /= volume;
+    else
+      Fhat_average *= 0.0;
     const Real det_Fhat_average(detMatrix(Fhat_average));
 
     // Finalize volumetric locking correction


### PR DESCRIPTION
Solid mechanics version of the patch for tensor mechanics in #12448 which allows for volumetric locking correction to be used in conjugation with a SideUserObject postprocessor

@bwspenc would you please review?

Closes #12489