### PR TITLE
Add Jacobians for MaskedBodyForce

### DIFF
--- a/framework/src/kernels/BodyForce.C
+++ b/framework/src/kernels/BodyForce.C
@@ -22,7 +22,7 @@ validParams<BodyForce>()
   params.addClassDescription("Demonstrates the multiple ways that scalar values can be introduced "
                              "into kernels, e.g. (controllable) constants, functions, and "
                              "postprocessors. Implements the weak form $(\\psi_i, -f)$.");
-  params.addParam<Real>("value", 1.0, "Coefficent to multiply by the body force term");
+  params.addParam<Real>("value", 1.0, "Coefficient to multiply by the body force term");
   params.addParam<FunctionName>("function", "1", "A function that describes the body force");
   params.addParam<PostprocessorName>(
       "postprocessor", 1, "A postprocessor whose value is multiplied by the body force");

--- a/modules/phase_field/doc/content/source/kernels/MaskedBodyForce.md
+++ b/modules/phase_field/doc/content/source/kernels/MaskedBodyForce.md
@@ -1,13 +1,16 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
 # MaskedBodyForce
 
-!alert construction title=Undocumented Class
-The MaskedBodyForce has not been documented. The content contained on this page
-includes the basic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
-
 !syntax description /Kernels/MaskedBodyForce
+
+Implements a kernel for a source term/body force limited to a certain region by
+a mask $m$ (material property). A function or a postprocessor can also be supplied
+to multiply the source term by. Contributions added by this kernel have the form
+\begin{equation}
+-m C f P
+\end{equation}
+where $m$ is the mask (supplied as a material property), $C$ is the constant source
+term/body force, $f$ is a function (optional), and $P$ is the value of a postprocessor
+(optional).
 
 !syntax parameters /Kernels/MaskedBodyForce
 

--- a/modules/phase_field/include/kernels/MaskedBodyForce.h
+++ b/modules/phase_field/include/kernels/MaskedBodyForce.h
@@ -11,6 +11,8 @@
 #define MASKEDBODYFORCE_H
 
 #include "BodyForce.h"
+#include "JvarMapInterface.h"
+#include "DerivativeMaterialInterface.h"
 
 // Forward Declarations
 class MaskedBodyForce;
@@ -25,15 +27,30 @@ InputParameters validParams<MaskedBodyForce>();
  * body force in certain regions of the mesh.
  */
 
-class MaskedBodyForce : public BodyForce
+class MaskedBodyForce : public DerivativeMaterialInterface<JvarMapKernelInterface<BodyForce>>
 {
 public:
   MaskedBodyForce(const InputParameters & parameters);
+  virtual void initialSetup();
 
 protected:
   virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   const MaterialProperty<Real> & _mask;
+
+  /// number of coupled variables
+  const unsigned int _nvar;
+
+  /// name of the nonlinear variable (needed to retrieve the derivative material properties)
+  VariableName _v_name;
+
+  /// derivative of the mask wrt the kernel's nonlinear variable
+  const MaterialProperty<Real> & _dmaskdv;
+
+  ///  Reaction rate derivatives w.r.t. other coupled variables
+  std::vector<const MaterialProperty<Real> *> _dmaskdarg;
 };
 
 #endif


### PR DESCRIPTION
Closes #9004 

Tests of the residual contribution already exist and are not affected by the changes.
Tested both on-diagonal and off-diagonal Jacobian contributions successfully using `analyzejacobian.py`.