### PR TITLE
Fixings in CoefTimeDerivative kernel

### DIFF
--- a/framework/include/kernels/CoefTimeDerivative.h
+++ b/framework/include/kernels/CoefTimeDerivative.h
@@ -12,16 +12,14 @@
 
 #include "TimeDerivative.h"
 
-// Forward Declarations
 class CoefTimeDerivative;
 
-/**
- * validParams returns the parameters that this Kernel accepts / needs
- * The actual body of the function MUST be in the .C file.
- */
 template <>
 InputParameters validParams<CoefTimeDerivative>();
 
+/**
+ * Time derivative term multiplied by a coefficient
+ */
 class CoefTimeDerivative : public TimeDerivative
 {
 public:
@@ -31,10 +29,8 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  /**
-   * This MooseArray will hold the reference we need to our
-   * material property from the Material class
-   */
+  /// The coefficient the time derivative is multiplied with
   Real _coef;
 };
+
 #endif // COEFTIMEDERIVATIVE_H

--- a/framework/src/kernels/CoefTimeDerivative.C
+++ b/framework/src/kernels/CoefTimeDerivative.C
@@ -28,8 +28,6 @@ CoefTimeDerivative::CoefTimeDerivative(const InputParameters & parameters)
 Real
 CoefTimeDerivative::computeQpResidual()
 {
-  // We're reusing the TimeDerivative Kernel's residual
-  // so that we don't have to recode that.
   return _coef * TimeDerivative::computeQpResidual();
 }
 


### PR DESCRIPTION
- add class doco
- do not lie about member variable `_coef`
- do not explain C++ inheritance in the code
- removing cpt. Obvious' comments

Refs #000

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
