### PR TITLE
solution is not ghosted

### DIFF
--- a/test/include/auxkernels/ElemSideNeighborLayersVarTesterAux.h
+++ b/test/include/auxkernels/ElemSideNeighborLayersVarTesterAux.h
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef ELEMSIDENEIGHBORLAYERSVARTESTERAUX_H
+#define ELEMSIDENEIGHBORLAYERSVARTESTERAUX_H
+
+#include "AuxKernel.h"
+
+// Forward Declarations
+class ElemSideNeighborLayersVarTesterAux;
+class ElemSideNeighborLayersVarTester;
+
+template <>
+InputParameters validParams<ElemSideNeighborLayersVarTesterAux>();
+
+/**
+ * This AuxKernel retrieves values from a ElemSideNeighborLayersVarTester
+ */
+class ElemSideNeighborLayersVarTesterAux : public AuxKernel
+{
+public:
+  ElemSideNeighborLayersVarTesterAux(const InputParameters & params);
+
+protected:
+  virtual Real computeValue() override;
+
+  const ElemSideNeighborLayersVarTester & _uo;
+};
+
+#endif // ELEMSIDENEIGHBORLAYERSVARTESTERAUX_H

--- a/test/include/userobjects/ElemSideNeighborLayersVarTester.h
+++ b/test/include/userobjects/ElemSideNeighborLayersVarTester.h
@@ -1,0 +1,60 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef ELEMSIDENEIGHBORLAYERSVARTESTER_H
+#define ELEMSIDENEIGHBORLAYERSVARTESTER_H
+
+#include "ElementUserObject.h"
+
+/**
+ * Tests whether a coupled variable is correctly ghosted.
+ * This code would benefit from a bit of cleaning.
+ **/
+class ElemSideNeighborLayersVarTester;
+
+template <>
+InputParameters validParams<ElemSideNeighborLayersVarTester>();
+
+class ElemSideNeighborLayersVarTester : public ElementUserObject
+{
+public:
+  ElemSideNeighborLayersVarTester(const InputParameters & parameters);
+
+  /// Cache the nodal values of u that the processor can see
+  virtual void timestepSetup() override;
+
+  virtual void execute() override{};
+  virtual void initialize() override{};
+
+  /// add _kij contributions
+  virtual void threadJoin(const UserObject & /*uo*/) override{};
+
+  virtual void finalize() override;
+
+  /**
+   * retrieve the nodal value of u for the global node id given.  If this processor cannot see the
+   * nodal values, return -1
+   */
+  Real getNodalValue(dof_id_type node_id) const;
+
+protected:
+  /// the processor rank
+  const unsigned int _rank;
+
+  /// the nodal values of u
+  MooseVariable * _u_nodal;
+
+  /// variable number for u
+  const unsigned int _u_var_num;
+
+  /// the cached data that this processor can see
+  std::map<dof_id_type, Real> _nodal_data;
+};
+
+#endif // ELEMSIDENEIGHBORLAYERSVARTESTER_H

--- a/test/src/auxkernels/ElemSideNeighborLayersVarTesterAux.C
+++ b/test/src/auxkernels/ElemSideNeighborLayersVarTesterAux.C
@@ -1,0 +1,41 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElemSideNeighborLayersVarTesterAux.h"
+#include "ElemSideNeighborLayersVarTester.h"
+
+registerMooseObject("MooseTestApp", ElemSideNeighborLayersVarTesterAux);
+
+template <>
+InputParameters
+validParams<ElemSideNeighborLayersVarTesterAux>()
+{
+  InputParameters params = validParams<AuxKernel>();
+  params.addRequiredParam<UserObjectName>(
+      "var_tester_uo",
+      "The ElemSideNeighborLayersVarTester UserObject where this Aux pulls values from");
+
+  params.addClassDescription(
+      "Aux Kernel to display nodal values from a ElemSideNeighborLayersVarTester UserObject");
+  return params;
+}
+
+ElemSideNeighborLayersVarTesterAux::ElemSideNeighborLayersVarTesterAux(
+    const InputParameters & params)
+  : AuxKernel(params), _uo(getUserObject<ElemSideNeighborLayersVarTester>("var_tester_uo"))
+{
+  if (!isNodal())
+    mooseError("This AuxKernel only supports nodal fields");
+}
+
+Real
+ElemSideNeighborLayersVarTesterAux::computeValue()
+{
+  return _uo.getNodalValue(_current_node->id());
+}

--- a/test/src/userobjects/ElemSideNeighborLayersVarTester.C
+++ b/test/src/userobjects/ElemSideNeighborLayersVarTester.C
@@ -1,0 +1,109 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org All rights reserved, see COPYRIGHT
+//* for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT Licensed
+//* under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElemSideNeighborLayersVarTester.h"
+
+#include "libmesh/parallel.h"
+
+registerMooseObject("MooseTestApp", ElemSideNeighborLayersVarTester);
+
+template <>
+InputParameters
+validParams<ElemSideNeighborLayersVarTester>()
+{
+  InputParameters params = validParams<ElementUserObject>();
+  params.addClassDescription(
+      "Tests whether a coupled variable is correctly ghosted.  This code needs to be cleaned up");
+  params.addRequiredParam<unsigned int>("rank", "The rank for which the ghosted data are recorded");
+
+  params.registerRelationshipManagers("ElementSideNeighborLayers");
+  params.addRequiredParam<unsigned short>("element_side_neighbor_layers",
+                                          "Number of layers to ghost");
+  params.addRequiredCoupledVar("u",
+                               "The variable that is ghosted.  At nodes where this is NOT ghosted, "
+                               "this UserObject will set the variable to -1, so to visualise the "
+                               "areas where it is ghosted, initialize u to a positive value");
+  return params;
+}
+
+ElemSideNeighborLayersVarTester::ElemSideNeighborLayersVarTester(const InputParameters & parameters)
+  : ElementUserObject(parameters),
+    _rank(getParam<unsigned int>("rank")),
+    _u_nodal(getVar("u", 0)),
+    _u_var_num(coupled("u", 0))
+{
+}
+
+void
+ElemSideNeighborLayersVarTester::timestepSetup()
+{
+  _nodal_data.clear();
+  auto my_processor_id = processor_id();
+
+  if (my_processor_id == _rank)
+  {
+    // here i'm looping over *all* elements for a replicated mesh and that seems a waste: only
+    // Evaluable+ghost would be better
+    for (const auto & elem : _subproblem.mesh().getMesh().active_element_ptr_range())
+    {
+      for (unsigned i = 0; i < elem->n_nodes(); ++i)
+      {
+        const dof_id_type node_id = elem->node_id(i);
+        const Node & node = _mesh.nodeRef(node_id);
+        bool semilocal = _mesh.isSemiLocal(const_cast<Node *>(&node));
+
+        // the following if statement should not be needed in distributed mesh,
+        // while in replicated mesh i don't know what to do
+        if (semilocal)
+          _nodal_data[node_id] = _u_nodal->getNodalValue(node);
+        else
+          Moose::err << "rank=" << my_processor_id << " elem=" << elem->id()
+                     << " global_node=" << node_id << " has u undefined" << std::endl;
+      }
+    }
+  }
+}
+
+void
+ElemSideNeighborLayersVarTester::finalize()
+{
+  // I bet the following can be done much more robustly but i'm running out of time
+  unsigned size_nodal_data = _nodal_data.size();
+  _communicator.broadcast(size_nodal_data, _rank);
+
+  std::vector<dof_id_type> node_list;
+  std::vector<Real> u_vals;
+  if (processor_id() == _rank)
+  {
+    for (const auto & nd : _nodal_data)
+    {
+      node_list.push_back(nd.first);
+      u_vals.push_back(nd.second);
+    }
+  }
+  else
+  {
+    node_list.resize(size_nodal_data);
+    u_vals.resize(size_nodal_data);
+  }
+
+  _communicator.broadcast(node_list, _rank);
+  _communicator.broadcast(u_vals, _rank);
+
+  for (unsigned i = 0; i < size_nodal_data; ++i)
+    _nodal_data[node_list[i]] = u_vals[i];
+}
+
+Real
+ElemSideNeighborLayersVarTester::getNodalValue(dof_id_type node_id) const
+{
+  const auto pos = _nodal_data.find(node_id);
+  if (pos != _nodal_data.end())
+    return pos->second;
+
+  return -1.0;
+}

--- a/test/tests/relationship_managers/evaluable/evaluable.i
+++ b/test/tests/relationship_managers/evaluable/evaluable.i
@@ -20,9 +20,15 @@
 [AuxVariables]
   [evaluable0]
   []
+  [ghosted0]
+  []
   [evaluable1]
   []
+  [ghosted1]
+  []
   [evaluable2]
+  []
+  [ghosted2]
   []
   [proc]
   []
@@ -36,6 +42,13 @@
     field_name = "evaluable"
     execute_on = initial
   []
+  [ghosted0]
+    type = ElementUOAux
+    variable = ghosted0
+    element_user_object = evaluable_uo0
+    field_name = "ghosted"
+    execute_on = initial
+  []
   [evaluable1]
     type = ElementUOAux
     variable = evaluable1
@@ -43,11 +56,25 @@
     field_name = "evaluable"
     execute_on = initial
   []
+  [ghosted1]
+    type = ElementUOAux
+    variable = ghosted1
+    element_user_object = evaluable_uo1
+    field_name = "ghosted"
+    execute_on = initial
+  []
   [evaluable2]
     type = ElementUOAux
     variable = evaluable2
     element_user_object = evaluable_uo2
     field_name = "evaluable"
+    execute_on = initial
+  []
+  [ghosted2]
+    type = ElementUOAux
+    variable = ghosted2
+    element_user_object = evaluable_uo2
+    field_name = "ghosted"
     execute_on = initial
   []
   [proc]

--- a/test/tests/relationship_managers/vars/vars.i
+++ b/test/tests/relationship_managers/vars/vars.i
@@ -1,0 +1,83 @@
+# illustrates what i think is a bug in the RelationshipManager
+#
+# u0 = 1 at nodes where u can be evaluated by rank=0 (and u0 = -1 otherwise)
+# u1 = 1 at nodes where u can be evaluated by rank=1 (and u1 = -1 otherwise)
+#
+# Since the ElemSideNeighborLayersVarTester UserObjects have element_side_neighbor_layers = 2,
+# when using mpirun -np 2 blah blah
+# u0 and u1 should be = 1 at all nodes save for 1 (when the mesh has 6 elements)
+#
+# Running this file with or without --distributed-mesh does not produce the expected result
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 6
+[]
+
+[GlobalParams]
+[]
+
+[Variables]
+  [u]
+    initial_condition = 1
+  []
+[]
+
+[Kernels]
+  [./u]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[AuxVariables]
+  [u0]
+  []
+  [u1]
+  []
+  [proc]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[AuxKernels]
+  [u0]
+    type = ElemSideNeighborLayersVarTesterAux
+    variable = u0
+    var_tester_uo = var_tester0
+  []
+  [u1]
+    type = ElemSideNeighborLayersVarTesterAux
+    variable = u1
+    var_tester_uo = var_tester1
+  []
+  [proc]
+    type = ProcessorIDAux
+    variable = proc
+  []
+[]
+
+[UserObjects]
+  [var_tester0]
+    type = ElemSideNeighborLayersVarTester
+    element_side_neighbor_layers = 2
+    rank = 0
+    u = u
+  []
+  [var_tester1]
+    type = ElemSideNeighborLayersVarTester
+    element_side_neighbor_layers = 2
+    rank = 1
+    u = u
+  []
+[]
+
+[Executioner]
+  type = Steady
+  nl_abs_tol = 1
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
userobjects/ElemSideNeighborLayersVarTester caches nodal solution data available to the processor of given rank

auxkernels/ElemSideNeighborLayersVarTesterAux retrieves this data

relationship_managers/vars/vars.i is a test that should show ghosting of the solution, u, to two layers out, but demonstrates that the solution is not ghosted at all.

Aside: relationship_managers/evaluable/evaluable.i test now shows ghosted layers

Refs #12557

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
