### PR TITLE
Add reference point for global displacement calculation

### DIFF
--- a/modules/tensor_mechanics/doc/content/syntax/Modules/TensorMechanics/GlobalStrain/index.md
+++ b/modules/tensor_mechanics/doc/content/syntax/Modules/TensorMechanics/GlobalStrain/index.md
@@ -19,10 +19,12 @@ The total strain $\epsilon_{ij}^{total}$ at any point is calculated considering 
 where $\epsilon_{ij}$ are the [strain components](/ComputeSmallStrain.md) calculated from the displacement gradients, $\epsilon_{ij}^g$ are the global strain components, and $\epsilon_{ij}^0$ are the eigen strain components. An additional [displacement field](/GlobalDisplacementAux.md) $\boldsymbol u^g$ is generated to visualize the effect of the global strain as
 
 \begin{equation} \label{eq:dispg_eq}
-\boldsymbol {u}^g = \boldsymbol {r} \boldsymbol{\epsilon}^g
+\boldsymbol {u}^g = (\boldsymbol {r} - \boldsymbol {r}_{0}) \boldsymbol{\epsilon}^g
 \end{equation}
 
-where $\boldsymbol{r}$ is the position vector and $\boldsymbol{\epsilon}^g$ is the global strain tensor. Then, the total displacement is represented as
+where $\boldsymbol {r}$ is the position vector, $\boldsymbol{r}_{0}$ is the location of the reference point, and $\boldsymbol{\epsilon}^g$ is the global strain tensor. The reference point could be any fixed ($\boldsymbol {u}^{total} = \boldsymbol {0}$) point in the domain. For maintaining periodicity, it is recommended to fix the center point of the simulation domain as the reference point.
+
+The total displacement is represented as
 
 \begin{equation} \label{eq:disp_eq}
 	\boldsymbol {u}^{total} = \boldsymbol {u} + \boldsymbol {u}^g

--- a/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/GlobalDisplacementAux.h
@@ -35,6 +35,7 @@ protected:
 
   const GlobalStrainUserObjectInterface & _pst;
   const VectorValue<bool> & _periodic_dir;
+  const Point _ref_point;
 
   const unsigned int _dim;
   const unsigned int _ndisp;

--- a/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
+++ b/modules/tensor_mechanics/src/auxkernels/GlobalDisplacementAux.C
@@ -33,6 +33,9 @@ validParams<GlobalDisplacementAux>()
       "output_global_displacement", false, "Option to output global displacement only");
   params.addRequiredParam<UserObjectName>("global_strain_uo",
                                           "The name of the GlobalStrainUserObject");
+  params.addParam<Point>("reference_point",
+                         Point(0, 0, 0),
+                         "The coordinate of the center/fixed point of the simulation");
 
   // Default this object to get executed before the displaced mesh update.
   // This way the AuxVars set by this object can be used as mesh displacements.
@@ -48,6 +51,7 @@ GlobalDisplacementAux::GlobalDisplacementAux(const InputParameters & parameters)
     _output_global_disp(getParam<bool>("output_global_displacement")),
     _pst(getUserObject<GlobalStrainUserObjectInterface>("global_strain_uo")),
     _periodic_dir(_pst.getPeriodicDirections()),
+    _ref_point(parameters.get<Point>("reference_point")),
     _dim(_mesh.dimension()),
     _ndisp(coupledComponents("displacements")),
     _disp(_ndisp)
@@ -78,7 +82,7 @@ GlobalDisplacementAux::computeValue()
       for (unsigned int var = 0; var < _ndisp; ++var)
         strain(dir, var) = 0.0;
 
-  const RealVectorValue & global_disp = strain * (*_current_node);
+  const RealVectorValue & global_disp = strain * ((*_current_node) - _ref_point);
 
   if (_output_global_disp)
     return global_disp(_component);


### PR DESCRIPTION
The global displacement calculation associated with strain periodicity needs a reference point for calculating the position vector. Otherwise, the displacement changes with coordinates of the simulation domain. 

The reference point has been added to the Auxkernel and the documentation is updated accordingly.

Refs #11314
