### PR TITLE
More mesh generator work

### DIFF
--- a/framework/include/meshgenerators/TiledMeshGenerator.h
+++ b/framework/include/meshgenerators/TiledMeshGenerator.h
@@ -33,9 +33,9 @@ protected:
   std::unique_ptr<MeshBase> & _input;
 
   /// The mesh width in the x, y and z directions
-  const Real _x_width;
-  const Real _y_width;
-  const Real _z_width;
+  Real _x_width;
+  Real _y_width;
+  Real _z_width;
 };
 
 #endif // TILEDMESHGENERATOR_H

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -22,7 +22,7 @@ validParams<MeshExtruderGenerator>()
 {
   InputParameters params = validParams<MeshGenerator>();
 
-  params.addParam<MeshGeneratorName>("input", "the mesh we want to extrude");
+  params.addRequiredParam<MeshGeneratorName>("input", "the mesh we want to extrude");
   params.addClassDescription("Takes a 1D or 2D mesh and extrudes the entire structure along the "
                              "specified axis increasing the dimensionality of the mesh.");
   params.addRequiredParam<RealVectorValue>("extrusion_vector",

--- a/framework/src/meshgenerators/TiledMeshGenerator.C
+++ b/framework/src/meshgenerators/TiledMeshGenerator.C
@@ -25,7 +25,7 @@ validParams<TiledMeshGenerator>()
 {
   InputParameters params = validParams<MeshGenerator>();
 
-  params.addParam<MeshGeneratorName>("input", "The mesh we want to repeat");
+  params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to repeat");
 
   params.addParam<Real>("x_width", 0, "The tile width in the x direction");
   params.addParam<Real>("y_width", 0, "The tile width in the y direction");

--- a/framework/src/meshgenerators/TiledMeshGenerator.C
+++ b/framework/src/meshgenerators/TiledMeshGenerator.C
@@ -59,8 +59,7 @@ validParams<TiledMeshGenerator>()
 }
 
 TiledMeshGenerator::TiledMeshGenerator(const InputParameters & parameters)
-  : MeshGenerator(parameters),
-    _input(getMesh("input"))
+  : MeshGenerator(parameters), _input(getMesh("input"))
 {
   if (dynamic_pointer_cast<DistributedMesh>(_input) != nullptr)
     mooseError("TiledMeshGenerator only works with ReplicatedMesh.");
@@ -75,19 +74,19 @@ TiledMeshGenerator::generate()
   // Getting the x,y,z widths
   std::set<subdomain_id_type> sub_ids;
   mesh->subdomain_ids(sub_ids);
-  BoundingBox bbox(Point(0,0,0), Point(0,0,0));
-  for(auto id : sub_ids)
+  BoundingBox bbox(Point(0, 0, 0), Point(0, 0, 0));
+  for (auto id : sub_ids)
   {
     BoundingBox sub_bbox = MeshTools::create_subdomain_bounding_box(*mesh, id);
-    if(bbox.min() == bbox.max())
+    if (bbox.min() == bbox.max())
       bbox = sub_bbox;
     else
       bbox.union_with(sub_bbox);
   }
 
-  _x_width = bbox.max()(0)-bbox.min()(0);
-  _y_width = bbox.max()(1)-bbox.min()(1);
-  _z_width = bbox.max()(2)-bbox.min()(2);
+  _x_width = bbox.max()(0) - bbox.min()(0);
+  _y_width = bbox.max()(1) - bbox.min()(1);
+  _z_width = bbox.max()(2) - bbox.min()(2);
 
   boundary_id_type left =
       mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("left_boundary"));

--- a/framework/src/meshgenerators/TiledMeshGenerator.C
+++ b/framework/src/meshgenerators/TiledMeshGenerator.C
@@ -74,14 +74,12 @@ TiledMeshGenerator::generate()
   // Getting the x,y,z widths
   std::set<subdomain_id_type> sub_ids;
   mesh->subdomain_ids(sub_ids);
-  BoundingBox bbox(Point(0, 0, 0), Point(0, 0, 0));
+  BoundingBox bbox(Point(std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max()),
+  Point(std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest()));
   for (auto id : sub_ids)
   {
     BoundingBox sub_bbox = MeshTools::create_subdomain_bounding_box(*mesh, id);
-    if (bbox.min() == bbox.max())
-      bbox = sub_bbox;
-    else
-      bbox.union_with(sub_bbox);
+    bbox.union_with(sub_bbox);
   }
 
   _x_width = bbox.max()(0) - bbox.min()(0);

--- a/framework/src/meshgenerators/TiledMeshGenerator.C
+++ b/framework/src/meshgenerators/TiledMeshGenerator.C
@@ -74,8 +74,12 @@ TiledMeshGenerator::generate()
   // Getting the x,y,z widths
   std::set<subdomain_id_type> sub_ids;
   mesh->subdomain_ids(sub_ids);
-  BoundingBox bbox(Point(std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max(), std::numeric_limits<Real>::max()),
-  Point(std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest(), std::numeric_limits<Real>::lowest()));
+  BoundingBox bbox(Point(std::numeric_limits<Real>::max(),
+                         std::numeric_limits<Real>::max(),
+                         std::numeric_limits<Real>::max()),
+                   Point(std::numeric_limits<Real>::lowest(),
+                         std::numeric_limits<Real>::lowest(),
+                         std::numeric_limits<Real>::lowest()));
   for (auto id : sub_ids)
   {
     BoundingBox sub_bbox = MeshTools::create_subdomain_bounding_box(*mesh, id);

--- a/test/tests/meshgenerators/tiled_mesh_generator/tiled_mesh_generator.i
+++ b/test/tests/meshgenerators/tiled_mesh_generator/tiled_mesh_generator.i
@@ -7,9 +7,6 @@
   [./tmg]
     type = TiledMeshGenerator
     input = fmg
-    x_width = 10
-    y_width = 10
-    z_width = 10
 
     left_boundary = left
     right_boundary = right


### PR DESCRIPTION
- Make the "input" parameter required for the MeshGenerators.
- Make TiledMeshGenerator compute the x,y and z widths of the mesh to repeat instead of it being user-provided.