### PR TITLE
Error if rz_coord_axis is used with solid_mechanics or tensor_mechanics

### DIFF
--- a/modules/solid_mechanics/src/materials/SolidModel.C
+++ b/modules/solid_mechanics/src/materials/SolidModel.C
@@ -236,6 +236,11 @@ SolidModel::SolidModel(const InputParameters & parameters)
   // Use the first block to figure out the coordinate system (the above check ensures that they are
   // the same)
   _coord_type = _subproblem.getCoordSystem(_block_id[0]);
+
+  if (_coord_type == Moose::COORD_RZ && _subproblem.getAxisymmetricRadialCoord() != 0)
+    mooseError(
+        "rz_coord_axis=Y is the only supported option for axisymmetric SolidMechanics models");
+
   _element = createElement();
 
   const std::vector<std::string> & dmp = getParam<std::vector<std::string>>("dep_matl_props");

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceRZTensors.C
@@ -41,6 +41,9 @@ StressDivergenceRZTensors::initialSetup()
   if (getBlockCoordSystem() != Moose::COORD_RZ)
     mooseError("The coordinate system in the Problem block must be set to RZ for axisymmetric "
                "geometries.");
+
+  if (getBlockCoordSystem() == Moose::COORD_RZ && _fe_problem.getAxisymmetricRadialCoord() != 0)
+    mooseError("rz_coord_axis=Y is the only supported option for StressDivergenceRZTensors");
 }
 
 Real

--- a/modules/tensor_mechanics/test/tests/1D_axisymmetric/tests
+++ b/modules/tensor_mechanics/test/tests/1D_axisymmetric/tests
@@ -12,14 +12,14 @@
     input = 'axisymm_plane_strain_small.i'
     exodiff = 'axisymm_plane_strain_small_out.e'
     design = 'source/materials/ComputeAxisymmetric1DSmallStrain.md'
-    requirement = 'The ComputeAxisymmetric1DIncrementalStrain class shall compute the elastic stress for a 1D axisymmetric small total strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
+    requirement = 'The ComputeAxisymmetric1DSmallStrain class shall compute the elastic stress for a 1D axisymmetric small total strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
   [../]
   [./axisymmetric_plane_strain_finite]
     type = 'Exodiff'
     input = 'axisymm_plane_strain_finite.i'
     exodiff = 'axisymm_plane_strain_finite_out.e'
     design = 'source/materials/ComputeAxisymmetric1DFiniteStrain.md'
-    requirement = 'The ComputeAxisymmetric1DIncrementalStrain class shall compute the elastic stress for a 1D axisymmetric incremental finite strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
+    requirement = 'The ComputeAxisymmetric1DFiniteStrain class shall compute the elastic stress for a 1D axisymmetric incremental finite strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
   [../]
 
   [./axisymmetric_gps_incremental]
@@ -34,13 +34,22 @@
     input = 'axisymm_gps_small.i'
     exodiff = 'axisymm_gps_small_out.e'
     design = 'source/materials/ComputeAxisymmetric1DSmallStrain.md'
-    requirement = 'The ComputeAxisymmetric1DIncrementalStrain class shall, under generalized plane strain conditions, compute the elastic stress for a 1D axisymmetric small total strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
+    requirement = 'The ComputeAxisymmetric1DSmallStrain class shall, under generalized plane strain conditions, compute the elastic stress for a 1D axisymmetric small total strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
   [../]
   [./axisymmetric_gps_finite]
     type = 'Exodiff'
     input = 'axisymm_gps_finite.i'
     exodiff = 'axisymm_gps_finite_out.e'
     design = 'source/materials/ComputeAxisymmetric1DFiniteStrain.md'
-    requirement = 'The ComputeAxisymmetric1DIncrementalStrain class shall, under generalized plane strain conditions, compute the elastic stress for a 1D axisymmetric incremental finite strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
+    requirement = 'The ComputeAxisymmetric1DFiniteStrain class shall, under generalized plane strain conditions, compute the elastic stress for a 1D axisymmetric incremental finite strain formulation under a combination of applied tensile displacement and thermal expansion loading.'
+  [../]
+  [./1d_finite_rz_coord_axis_error]
+    type = 'RunException'
+    prereq = axisymmetric_gps_finite
+    input = 'axisymm_gps_finite.i'
+    cli_args = 'Problem/rz_coord_axis=X'
+    expect_err = 'rz_coord_axis=Y is the only supported option for StressDivergenceRZTensors'
+    design = 'source/materials/ComputeAxisymmetric1DFiniteStrain.md'
+    requirement = 'The StressDivergenceRZTensors class shall generate an error if used with Problem/rz_coord_axis set to anything other than Y'
   [../]
 []


### PR DESCRIPTION
ref #12459

The `rz_coord_axis` option was added in the `Problem` block some time ago without considering its full implications. If physics models need to be formulated differently depending on the value of this parameter, the way this is currently implemented, their developers need to know this option exists and query to see whether this parameter was set, which is obviously error-prone.

We have no pressing needs to support this option in the mechanics models. This commit simply adds some checks to guard against use of this unsupported option with mechanics models.