### PR TITLE
Add memory units to documentation

### DIFF
--- a/framework/doc/content/source/postprocessors/MemoryUsage.md
+++ b/framework/doc/content/source/postprocessors/MemoryUsage.md
@@ -8,6 +8,9 @@ This postprocessor collects various memory usage metrics:
 - virtual memory
 - major page faults (how often disk swap is accessed)
 
+The units for memory default to MegaBytes, but users can report usage in other
+units through the mem_units parameter: (bytes, kilobytes, megabytes, gigabytes).
+
 The data can be reduced in parallel as
 
 - maximum out of all MPI ranks

--- a/framework/doc/content/source/vectorpostprocessors/VectorMemoryUsage.md
+++ b/framework/doc/content/source/vectorpostprocessors/VectorMemoryUsage.md
@@ -8,8 +8,8 @@ This vector postprocessor generates multiple output columns with one row per MPI
 |---------------|--------------|
 | `hardware_id` | Ranks with a common hardware ID share common RAM (i.e. are located on the same compute node)|
 | `total_ram`   | Total available RAM on the compute node the respective MPI rank is located on.|
-| `physical_mem`| Physical memory the current rank uses.|
-| `virtual_mem` | Virtual memory the current rank uses (the amount returned strongly depends on the operating system and does not reflect the physical RAM used by the simualtion).|
+| `physical_mem`| Physical memory the current rank uses (default unit: MBs).|
+| `virtual_mem` | Virtual memory the current rank uses (the amount returned strongly depends on the operating system and does not reflect the physical RAM used by the simualtion - default unit: MBs).|
 | `page_faults` | Number of hard page faults encountered by the MPI rank. This number is only available on Linux systems and indicates the amount of swap activity (indicating low performance due to insufficient available RAM)|
 | `node_utilization`| Indicates which fraction of the total RAM available on the compute node is occupied by MOOSE processes of the current simulation.|
 

--- a/framework/include/postprocessors/MemoryUsage.h
+++ b/framework/include/postprocessors/MemoryUsage.h
@@ -12,6 +12,7 @@
 
 #include "GeneralPostprocessor.h"
 #include "MemoryUsageReporter.h"
+#include "MemoryUtils.h"
 
 class MemoryUsage;
 
@@ -48,6 +49,9 @@ protected:
     max_process,
     min_process
   } _value_type;
+
+  /// The units in which to report memory statistics (kilobyte, megabyte, etc).
+  MemoryUtils::MemUnit _mem_units;
 
   /// memory usage metric in bytes
   Real _value;

--- a/framework/include/utils/MemoryUtils.h
+++ b/framework/include/utils/MemoryUtils.h
@@ -28,8 +28,16 @@ struct Stats
   std::size_t _page_faults;
 };
 
+enum class MemUnit
+{
+  Bytes,
+  Kilobytes,
+  Megabytes,
+  Gigabytes,
+};
+
 /// get all memory stats for the current process
-void getMemoryStats(Stats & stats);
+void getMemoryStats(Stats & stats, MemUnit units = MemUnit::Megabytes);
 
 } // namespace MemoryUtils
 

--- a/framework/include/vectorpostprocessors/VectorMemoryUsage.h
+++ b/framework/include/vectorpostprocessors/VectorMemoryUsage.h
@@ -12,6 +12,7 @@
 
 #include "GeneralVectorPostprocessor.h"
 #include "MemoryUsageReporter.h"
+#include "MemoryUtils.h"
 
 class VectorMemoryUsage;
 
@@ -34,10 +35,13 @@ public:
   virtual void finalize() override;
 
 protected:
-  /// hardware id for the phyical node the rank is located at
+  /// The units in which to report memory statistics (kilobyte, megabyte, etc).
+  MemoryUtils::MemUnit _mem_units;
+
+  /// hardware id for the physical node the rank is located at
   VectorPostprocessorValue & _col_hardware_id;
 
-  /// total RAM available on the phyical node the rank is located at
+  /// total RAM available on the physical node the rank is located at
   VectorPostprocessorValue & _col_total_ram;
 
   /// physical memory usage per rank

--- a/framework/src/postprocessors/MemoryUsage.C
+++ b/framework/src/postprocessors/MemoryUsage.C
@@ -25,6 +25,9 @@ validParams<MemoryUsage>()
   MooseEnum value_type("total average max_process min_process", "total");
   params.addParam<MooseEnum>(
       "value_type", value_type, "Aggregation method to apply to the requested memory metric.");
+  MooseEnum mem_units("bytes kilobytes megabytes gigabytes", "megabytes");
+  params.addParam<MooseEnum>(
+      "mem_units", mem_units, "The unit used to report memory usage, default: Megabytes");
   params.addParam<bool>("report_peak_value",
                         true,
                         "If the postprocessor is executed more than once "
@@ -38,6 +41,7 @@ MemoryUsage::MemoryUsage(const InputParameters & parameters)
     MemoryUsageReporter(this),
     _mem_type(getParam<MooseEnum>("mem_type").getEnum<MemType>()),
     _value_type(getParam<MooseEnum>("value_type").getEnum<ValueType>()),
+    _mem_units(getParam<MooseEnum>("mem_units").getEnum<MemoryUtils::MemUnit>()),
     _value(0.0),
     _peak_value(0.0),
     _report_peak_value(getParam<bool>("report_peak_value"))
@@ -54,7 +58,7 @@ void
 MemoryUsage::execute()
 {
   MemoryUtils::Stats stats;
-  MemoryUtils::getMemoryStats(stats);
+  MemoryUtils::getMemoryStats(stats, _mem_units);
 
   // get the requested per core metric
   switch (_mem_type)

--- a/framework/src/vectorpostprocessors/VectorMemoryUsage.C
+++ b/framework/src/vectorpostprocessors/VectorMemoryUsage.C
@@ -26,12 +26,16 @@ validParams<VectorMemoryUsage>()
                         "If the vectorpostprocessor is executed more than once "
                         "during a time step, report the aggregated peak "
                         "value.");
+  MooseEnum mem_units("bytes kilobytes megabytes gigabytes", "megabytes");
+  params.addParam<MooseEnum>(
+      "mem_units", mem_units, "The unit used to report memory usage, default: Megabytes");
   return params;
 }
 
 VectorMemoryUsage::VectorMemoryUsage(const InputParameters & parameters)
   : GeneralVectorPostprocessor(parameters),
     MemoryUsageReporter(this),
+    _mem_units(getParam<MooseEnum>("mem_units").getEnum<MemoryUtils::MemUnit>()),
     _col_hardware_id(declareVector("hardware_id")),
     _col_total_ram(declareVector("total_ram")),
     _col_physical_mem(declareVector("physical_mem")),
@@ -69,6 +73,7 @@ VectorMemoryUsage::execute()
 {
   MemoryUtils::Stats stats;
   MemoryUtils::getMemoryStats(stats);
+  MemoryUtils::getMemoryStats(stats, _mem_units);
 
   if (_report_peak_value)
   {

--- a/test/tests/postprocessors/memory_usage/vector_memory_usage.i
+++ b/test/tests/postprocessors/memory_usage/vector_memory_usage.i
@@ -38,6 +38,7 @@
     type = VectorMemoryUsage
     execute_on = 'INITIAL TIMESTEP_END NONLINEAR LINEAR'
     report_peak_value = true
+    mem_units = kilobytes # or bytes, megabytes, gigabytes
   [../]
 []
 


### PR DESCRIPTION
Additionally, add the ability for users to control the reporting unit for
memory in both MemoryUsage and VectorMemoryUsage.

closes #12394

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
