### PR TITLE
Add the algorithm parameter in StitchedMeshGenerator.

### DIFF
--- a/framework/include/meshgenerators/StitchedMeshGenerator.h
+++ b/framework/include/meshgenerators/StitchedMeshGenerator.h
@@ -44,6 +44,9 @@ protected:
 
   /// The meshes to be stitched together.
   std::vector<std::unique_ptr<ReplicatedMesh>> _meshes;
+
+  /// Type of algorithm used to find matching nodes (binary or exhaustive)
+  MooseEnum _algorithm;
 };
 
 #endif // STITCHEDMESHGENERATOR_H

--- a/framework/include/meshgenerators/StitchedMeshGenerator.h
+++ b/framework/include/meshgenerators/StitchedMeshGenerator.h
@@ -12,6 +12,7 @@
 
 #include "MeshGenerator.h"
 #include "libmesh/replicated_mesh.h"
+#include "MooseEnum.h"
 
 // Forward declarations
 class StitchedMeshGenerator;


### PR DESCRIPTION
This parameter enables the use of the exhaustive algorithm when searching for matching nodes.
Previously, only the binary search was used.
Refs #11640.
