### PR TITLE
Some DualNumber related header clean-up

### DIFF
--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -12,6 +12,9 @@
 
 #include "KernelBase.h"
 
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
+
 #define usingKernelMembers                                                                         \
   using ADKernel<compute_stage>::_test;                                                            \
   using ADKernel<compute_stage>::_qp;                                                              \

--- a/framework/include/materials/ADMaterial.h
+++ b/framework/include/materials/ADMaterial.h
@@ -13,6 +13,9 @@
 #include "Material.h"
 #include "MooseTypes.h"
 
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
+
 #define usingMaterialMembers                                                                       \
   using ADMaterial<compute_stage>::_qp;                                                            \
   using ADMaterial<compute_stage>::_ad_grad_zero;                                                  \

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -25,8 +25,8 @@
 #ifdef LIBMESH_HAVE_CXX11_TYPE_TRAITS
 #include <type_traits>
 #endif
-#include "metaphysicl/dualnumber.h"
 #include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
 
 // C++ includes
 #include <string>

--- a/framework/include/utils/ColumnMajorMatrix.h
+++ b/framework/include/utils/ColumnMajorMatrix.h
@@ -18,8 +18,6 @@
 #include "libmesh/type_tensor.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
-#include "metaphysicl/dualnumber.h"
-#include "metaphysicl/numberarray.h"
 
 // C++ includes
 #include <iomanip>
@@ -473,21 +471,6 @@ ColumnMajorMatrixTempl<T>::deviatoric()
 }
 
 template <typename T>
-inline ColumnMajorMatrixTempl<T>
-ColumnMajorMatrixTempl<T>::abs()
-{
-  ColumnMajorMatrixTempl<T> & s = (*this);
-
-  ColumnMajorMatrixTempl<T> ret_matrix(_n_rows, _n_cols);
-
-  for (unsigned int j = 0; j < _n_cols; j++)
-    for (unsigned int i = 0; i < _n_rows; i++)
-      ret_matrix(i, j) = std::abs(s(i, j));
-
-  return ret_matrix;
-}
-
-template <typename T>
 inline void
 ColumnMajorMatrixTempl<T>::setDiag(T value)
 {
@@ -554,13 +537,6 @@ ColumnMajorMatrixTempl<T>::doubleContraction(const ColumnMajorMatrixTempl<T> & r
       value += (*this)(i, j) * rhs(i, j);
 
   return value;
-}
-
-template <typename T>
-inline T
-ColumnMajorMatrixTempl<T>::norm()
-{
-  return std::sqrt(doubleContraction(*this));
 }
 
 template <typename T>

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -12,9 +12,12 @@
 
 // MOOSE includes
 #include "HashMap.h"
-#include "MaterialProperty.h" // MaterialProperties
 #include "InfixIterator.h"
 #include "MooseEnumItem.h"
+#include "MooseError.h"
+#include "Moose.h"
+
+#include "libmesh/compare_types.h"
 
 // C++ includes
 #include <string>
@@ -26,6 +29,7 @@
 // Forward Declarations
 class InputParameters;
 class ExecFlagEnum;
+class MaterialProperties;
 
 namespace libMesh
 {
@@ -36,6 +40,18 @@ class Communicator;
 }
 }
 class MultiMooseEnum;
+namespace MetaPhysicL
+{
+template <typename, typename>
+class DualNumber;
+}
+namespace std
+{
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> abs(const MetaPhysicL::DualNumber<T, D> & in);
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> abs(MetaPhysicL::DualNumber<T, D> && in);
+}
 
 namespace MooseUtils
 {

--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -13,17 +13,22 @@
 #include "Moose.h"
 #include "ADReal.h"
 
-#include "libmesh/tensor_value.h"
 #include "libmesh/libmesh.h"
-#include "libmesh/vector_value.h"
 #include "libmesh/tuple_of.h"
 
 #include <petscsys.h>
 
 using libMesh::Real;
-using libMesh::RealGradient;
-using libMesh::RealTensorValue;
 using libMesh::tuple_of;
+namespace libMesh
+{
+template <typename>
+class TensorValue;
+template <typename>
+class TypeTensor;
+template <typename>
+class VectorValue;
+}
 
 // Forward declarations
 class MooseEnum;

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -15,7 +15,6 @@
 
 // Any requisite includes here
 #include "libmesh/libmesh.h"
-#include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
 
 #include <petscsys.h>
@@ -32,6 +31,15 @@ class MooseArray;
 typedef MooseArray<Real> VariableValue;
 template <typename>
 class ColumnMajorMatrixTempl;
+namespace libMesh
+{
+template <typename>
+class TypeVector;
+template <typename>
+class TypeTensor;
+template <typename>
+class TensorValue;
+}
 
 template <typename T>
 void mooseSetToZero(T & v);

--- a/framework/src/utils/ColumnMajorMatrix.C
+++ b/framework/src/utils/ColumnMajorMatrix.C
@@ -10,6 +10,9 @@
 // MOOSE includes
 #include "ColumnMajorMatrix.h"
 
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
+
 #include "libmesh/petsc_macro.h"
 
 // PETSc includes
@@ -343,6 +346,28 @@ void
 ColumnMajorMatrixTempl<ADReal>::inverse(ColumnMajorMatrixTempl<ADReal> &) const
 {
   mooseError("Inverse solves with AD types is not supported for the ColumnMajorMatrix class.");
+}
+
+template <typename T>
+inline ColumnMajorMatrixTempl<T>
+ColumnMajorMatrixTempl<T>::abs()
+{
+  ColumnMajorMatrixTempl<T> & s = (*this);
+
+  ColumnMajorMatrixTempl<T> ret_matrix(_n_rows, _n_cols);
+
+  for (unsigned int j = 0; j < _n_cols; j++)
+    for (unsigned int i = 0; i < _n_rows; i++)
+      ret_matrix(i, j) = std::abs(s(i, j));
+
+  return ret_matrix;
+}
+
+template <typename T>
+inline T
+ColumnMajorMatrixTempl<T>::norm()
+{
+  return std::sqrt(doubleContraction(*this));
 }
 
 template class ColumnMajorMatrixTempl<Real>;

--- a/framework/src/utils/MooseADWrapper.C
+++ b/framework/src/utils/MooseADWrapper.C
@@ -1,7 +1,7 @@
+#include "MooseADWrapper.h"
+
 #include "metaphysicl/numberarray.h"
 #include "metaphysicl/dualnumber.h"
-
-#include "MooseADWrapper.h"
 
 MooseADWrapper<Real>::MooseADWrapper(bool use_ad) : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -15,10 +15,14 @@
 #include "MooseException.h"
 #include "MooseUtils.h"
 #include "MatrixTools.h"
-#include "MaterialProperty.h"
 #include "PermutationTensor.h"
 
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
+
 #include "libmesh/utility.h"
+#include "libmesh/tensor_value.h"
+#include "libmesh/vector_value.h"
 
 // C++ includes
 #include <iomanip>

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -7,23 +7,23 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#include "metaphysicl/numberarray.h"
-#include "metaphysicl/dualnumber.h"
-
 #include "RankTwoTensor.h"
 
 // MOOSE includes
-#include "MaterialProperty.h"
 #include "MooseEnum.h"
 #include "MooseUtils.h"
 #include "ColumnMajorMatrix.h"
 #include "MooseRandom.h"
 #include "RankFourTensor.h"
-
 #include "Conversion.h"
+#include "MooseArray.h"
+
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/tensor_value.h"
+#include "libmesh/vector_value.h"
 #include "libmesh/utility.h"
 
 // PETSc includes

--- a/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
+++ b/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
@@ -11,6 +11,8 @@
 #include "PermutationTensor.h"
 #include "RankFourTensor.h"
 
+#include "libmesh/vector_value.h"
+
 namespace ElasticityTensorTools
 {
 


### PR DESCRIPTION
The result of this PR is that `git grep -n "include.*dualnumber\.h"` yields:
```
framework/include/kernels/ADKernel.h:16:#include "metaphysicl/dualnumber.h"
framework/include/materials/ADMaterial.h:17:#include "metaphysicl/dualnumber.h"
framework/include/restart/DataIO.h:29:#include "metaphysicl/dualnumber.h"
framework/src/utils/ColumnMajorMatrix.C:14:#include "metaphysicl/dualnumber.h"
framework/src/utils/MooseADWrapper.C:4:#include "metaphysicl/dualnumber.h"
framework/src/utils/RankFourTensor.C:21:#include "metaphysicl/dualnumber.h"
framework/src/utils/RankTwoTensor.C:22:#include "metaphysicl/dualnumber.h"
```
such that `MetaPhysicL` headers are only included in the places where they are truly needed.
