### PR TITLE
Improve MooseApp::restore() API

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -646,6 +646,15 @@ public:
    */
   const ExecFlagEnum & getExecuteOnEnum() const { return _execute_flags; }
 
+  /**
+   * Method for setting the backup object to be restored at a later time. This method is called
+   * during simulation restart or recover before the application is completely setup. The backup
+   * object set here, will be restored when needed by a call to restoreCachedBackup().
+   *
+   * @param backup The Backup holding the data for the app.
+   */
+  void setBackupObject(std::shared_ptr<Backup> backup);
+
 protected:
   /**
    * Whether or not this MooseApp has cached a Backup to use for restart / recovery

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -888,10 +888,10 @@ MooseApp::registerRecoverableData(std::string name)
 std::shared_ptr<Backup>
 MooseApp::backup()
 {
+  mooseAssert(_executioner, "Executioner is nullptr");
   FEProblemBase & fe_problem = _executioner->feProblem();
 
   RestartableDataIO rdio(fe_problem);
-
   return rdio.createBackup();
 }
 
@@ -900,18 +900,10 @@ MooseApp::restore(std::shared_ptr<Backup> backup, bool for_restart)
 {
   TIME_SECTION(_restore_timer);
 
-  // This means that a Backup is coming through to use for restart / recovery
-  // We should just cache it for now
-  if (!_executioner)
-  {
-    _cached_backup = backup;
-    return;
-  }
-
+  mooseAssert(_executioner, "Executioner is nullptr");
   FEProblemBase & fe_problem = _executioner->feProblem();
 
   RestartableDataIO rdio(fe_problem);
-
   rdio.restoreBackup(backup, for_restart);
 }
 
@@ -1570,6 +1562,12 @@ void
 MooseApp::setRecover(const bool & value)
 {
   _recover = value;
+}
+
+void
+MooseApp::setBackupObject(std::shared_ptr<Backup> backup)
+{
+  _cached_backup = backup;
 }
 
 void

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -617,7 +617,7 @@ MultiApp::createApp(unsigned int i, Real start_time)
   // will be cached by the MooseApp object so that it can be used
   // during FEProblemBase::initialSetup() during runInputFile()
   if (_app.isRestarting() || _app.isRecovering())
-    app->restore(_backups[i]);
+    app->setBackupObject(_backups[i]);
 
   if (_use_positions && getParam<bool>("output_in_position"))
     app->setOutputPosition(_app.getOutputPosition() + _positions[_first_local_app + i]);


### PR DESCRIPTION
The restore() method no longer needs to worry about whether or not to cache the backup.
This functionality has been moved to a new method (setCachedBackup()), which is only
called from the Multiapp system.

closes #12692

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
