### PR TITLE
Remove unnecessary Jacobian materials from ComputeMaterialsObjectThread

### DIFF
--- a/framework/include/loops/ComputeMaterialsObjectThread.h
+++ b/framework/include/loops/ComputeMaterialsObjectThread.h
@@ -56,8 +56,7 @@ protected:
 
   /// Reference to the Material object warehouses
   const MaterialWarehouse & _materials;
-  const MaterialWarehouse & _residual_materials;
-  const MaterialWarehouse & _jacobian_materials;
+  const MaterialWarehouse & _ad_materials;
   const MaterialWarehouse & _discrete_materials;
 
   std::vector<std::unique_ptr<Assembly>> & _assembly;

--- a/framework/src/loops/ComputeMaterialsObjectThread.C
+++ b/framework/src/loops/ComputeMaterialsObjectThread.C
@@ -40,8 +40,7 @@ ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(
     _bnd_material_props(bnd_material_props),
     _neighbor_material_props(neighbor_material_props),
     _materials(_fe_problem.getComputeMaterialWarehouse()),
-    _residual_materials(_fe_problem.getResidualMaterialsWarehouse()),
-    _jacobian_materials(_fe_problem.getJacobianMaterialsWarehouse()),
+    _ad_materials(_fe_problem.getResidualMaterialsWarehouse()),
     _discrete_materials(_fe_problem.getDiscreteMaterialWarehouse()),
     _assembly(assembly),
     _need_internal_side_material(false),
@@ -64,8 +63,7 @@ ComputeMaterialsObjectThread::ComputeMaterialsObjectThread(ComputeMaterialsObjec
     _bnd_material_props(x._bnd_material_props),
     _neighbor_material_props(x._neighbor_material_props),
     _materials(x._materials),
-    _residual_materials(x._residual_materials),
-    _jacobian_materials(x._jacobian_materials),
+    _ad_materials(x._ad_materials),
     _discrete_materials(x._discrete_materials),
     _assembly(x._assembly),
     _need_internal_side_material(x._need_internal_side_material),
@@ -83,24 +81,16 @@ ComputeMaterialsObjectThread::subdomainChanged()
 
   std::set<MooseVariableFEBase *> needed_moose_vars;
   _materials.updateVariableDependency(needed_moose_vars, _tid);
-  if (_fe_problem.currentlyComputingJacobian())
-    _jacobian_materials.updateVariableDependency(needed_moose_vars, _tid);
-  else
-    _residual_materials.updateVariableDependency(needed_moose_vars, _tid);
+  _ad_materials.updateVariableDependency(needed_moose_vars, _tid);
   _fe_problem.setActiveElementalMooseVariables(needed_moose_vars, _tid);
 }
 
 void
 ComputeMaterialsObjectThread::onElement(const Elem * elem)
 {
-  MaterialWarehouse const * ad_materials;
-  if (_fe_problem.currentlyComputingJacobian())
-    ad_materials = &_jacobian_materials;
-  else
-    ad_materials = &_residual_materials;
   if (_materials.hasActiveBlockObjects(_subdomain, _tid) ||
       _discrete_materials.hasActiveBlockObjects(_subdomain, _tid) ||
-      ad_materials->hasActiveBlockObjects(_subdomain, _tid))
+      _ad_materials.hasActiveBlockObjects(_subdomain, _tid))
   {
     _fe_problem.prepare(elem, _tid);
     _fe_problem.reinitElem(elem, _tid);
@@ -121,9 +111,9 @@ ComputeMaterialsObjectThread::onElement(const Elem * elem)
                                           _materials.getActiveBlockObjects(_subdomain, _tid),
                                           n_points,
                                           *elem);
-      if (ad_materials->hasActiveBlockObjects(_subdomain, _tid))
+      if (_ad_materials.hasActiveBlockObjects(_subdomain, _tid))
         _material_props.initStatefulProps(*_material_data[_tid],
-                                          ad_materials->getActiveBlockObjects(_subdomain, _tid),
+                                          _ad_materials.getActiveBlockObjects(_subdomain, _tid),
                                           n_points,
                                           *elem);
     }
@@ -171,14 +161,9 @@ ComputeMaterialsObjectThread::onBoundary(const Elem * elem, unsigned int side, B
                                               face_n_points,
                                               *elem,
                                               side);
-      MaterialWarehouse const * ad_materials;
-      if (_fe_problem.currentlyComputingJacobian())
-        ad_materials = &_jacobian_materials;
-      else
-        ad_materials = &_residual_materials;
-      if (ad_materials->hasActiveBoundaryObjects(bnd_id, _tid))
+      if (_ad_materials.hasActiveBoundaryObjects(bnd_id, _tid))
         _bnd_material_props.initStatefulProps(*_bnd_material_data[_tid],
-                                              ad_materials->getActiveBoundaryObjects(bnd_id, _tid),
+                                              _ad_materials.getActiveBoundaryObjects(bnd_id, _tid),
                                               face_n_points,
                                               *elem,
                                               side);
@@ -212,15 +197,10 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
             face_n_points,
             *elem,
             side);
-      MaterialWarehouse const * ad_materials;
-      if (_fe_problem.currentlyComputingJacobian())
-        ad_materials = &_jacobian_materials;
-      else
-        ad_materials = &_residual_materials;
-      if ((*ad_materials)[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(_subdomain, _tid))
+      if (_ad_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(_subdomain, _tid))
         _bnd_material_props.initStatefulProps(
             *_bnd_material_data[_tid],
-            (*ad_materials)[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(_subdomain, _tid),
+            _ad_materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(_subdomain, _tid),
             face_n_points,
             *elem,
             side);
@@ -255,16 +235,11 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
             face_n_points,
             *neighbor,
             neighbor_side);
-      MaterialWarehouse const * ad_materials;
-      if (_fe_problem.currentlyComputingJacobian())
-        ad_materials = &_jacobian_materials;
-      else
-        ad_materials = &_residual_materials;
-      if ((*ad_materials)[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(
+      if (_ad_materials[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(
               neighbor->subdomain_id(), _tid))
         _neighbor_material_props.initStatefulProps(
             *_neighbor_material_data[_tid],
-            (*ad_materials)[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(
+            _ad_materials[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(
                 neighbor->subdomain_id(), _tid),
             face_n_points,
             *neighbor,


### PR DESCRIPTION
`ComputeMaterialsObjectThread` is only ever called during initial setup and
its only real purpose is to initialize stateful properties (despite the class
name which suggests it does something more). We use this thread to initialize
old values and it's sufficient to only do this through operation on the AD
residual materials.

Refs #5658

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
