### PR TITLE
Remove support for Intel Compilers

### DIFF
--- a/modules/doc/content/application_development/debugging.md
+++ b/modules/doc/content/application_development/debugging.md
@@ -22,7 +22,7 @@ Once the build is complete you should end up with a "debug executable" that look
 
 ## Debuggers
 
-Many different debuggers exist: `lldb`, `gdb`, `ddd`, Totalview and Intel Debugger are just a few.  While a command-line debugger (like `lldb` or `gdb`) might seem daunting at first, they are an invaluable tool for quick debugging and debugging in complicated scenarios such as when you're running on a cluster.  Learning one should be essential to any computational scientist.
+Many different debuggers exist: `lldb`, `gdb`, `ddd`, and Totalview are just a few.  While a command-line debugger (like `lldb` or `gdb`) might seem daunting at first, they are an invaluable tool for quick debugging and debugging in complicated scenarios such as when you're running on a cluster.  Learning one should be essential to any computational scientist.
 
 For debugging MOOSE-based applications we recommend `lldb` if you're using the clang compiler (default on Mac OSX) and `gdb` for the `gcc` compiler (default on Linux).
 

--- a/modules/doc/content/examples/ex21_debugging.md
+++ b/modules/doc/content/examples/ex21_debugging.md
@@ -5,7 +5,7 @@ For a more in-depth discussion of debugging with MOOSE [see the Debugging Docume
 - It's inevitable: at some point in your MOOSE application development career, you will create a bug.
 - Sometimes, print statements are sufficient to help you determine the cause of the error.
 - For more complex bugs, a debugger can be more effective than print statements in helping to pinpoint the problem.
-- Many debuggers exist: LLDB, GDB, Totalview, ddd, Intel Debugger, etc.
+- Many debuggers exist: LLDB, GDB, Totalview, ddd, etc.
 - It's typically best to use a debugger that is associated with your compiler, if one is available.
 - Here we focus on LLDB/GDB since it is relatively simple to use and is included in the MOOSE binary redistributable package.
 - A "Segmentation fault," "Segfault," or "Signal 11" error denotes a memory bug (often array access out of bounds).

--- a/modules/doc/content/getting_started/installation/manual_gcc.md
+++ b/modules/doc/content/getting_started/installation/manual_gcc.md
@@ -1,7 +1,6 @@
 ## GCC
 
-We need a modern C++11 capable compiler. Our minimum requirements are: GCC !!package minimum_gcc!!, Clang !!package minimum_clang!!,
-and Intel !!package minimum_intel!!. This section will focus on building a GCC !!package gcc!! compiler stack.
+We need a modern C++11 capable compiler. Our minimum requirements are: GCC !!package minimum_gcc!!, Clang !!package minimum_clang!!. This section will focus on building a GCC !!package gcc!! compiler stack.
 
 What version of GCC do we have?
 

--- a/modules/doc/content/getting_started/minimum_requirements.md
+++ b/modules/doc/content/getting_started/minimum_requirements.md
@@ -2,7 +2,7 @@
 
 In general, the following is required for MOOSE-based development:
 
-- C++11 compliant compiler (GCC !!package minimum_gcc!!, Clang !!package minimum_clang!!, and Intel !!package minimum_intel!! or greater)
+- C++11 compliant compiler (GCC !!package minimum_gcc!!, Clang !!package minimum_clang!! or greater)
 
   - (included in any of our redistributable packages if you choose to install one)
 

--- a/modules/doc/content/getting_started/petsc_default.md
+++ b/modules/doc/content/getting_started/petsc_default.md
@@ -24,8 +24,3 @@ F90FLAGS='-fPIC -fopenmp' \
 F77FLAGS='-fPIC -fopenmp' \
 PETSC_DIR=`pwd`
 ```
-
-!alert note
-The options used were chosen exclusively for GCC compilers. If you plan on using an Intel compiler,
-know that these options will not work (-fopenmp needs to be -openmp for one thing. fblaslapack may
-also fail as Intel provides its own).

--- a/modules/doc/content/sqa/moose_srs.md
+++ b/modules/doc/content/sqa/moose_srs.md
@@ -141,7 +141,7 @@ follow this format.
   versions of Linux.
 - 4 GB of RAM for optimized compilation (8 GB for debug compilation), 2 GB per core execution
 - 100 GB disk space
-- C++11 compatible compiler (GCC, Clang, or Intel)
+- C++11 compatible compiler (GCC, Clang)
 - Python 2.6+
 - Git
 !sqa-end!


### PR DESCRIPTION
Remove sections of documentation which state the support of Intel compilers.

Closes #12713
