### PR TITLE
Automatic dual/non-dual types

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -662,7 +662,7 @@ protected:
   std::map<std::string, std::vector<VariableValue *>> _default_value;
 
   /// Will hold the default value for optional coupled variables for automatic differentiation.
-  std::map<std::string, MooseArray<ADReal> *> _ad_default_value;
+  std::map<std::string, MooseArray<DualReal> *> _ad_default_value;
 
   /// Will hold the default value for optional vector coupled variables.
   std::map<std::string, VectorVariableValue *> _default_vector_value;
@@ -677,7 +677,7 @@ protected:
   VariableGradient _default_gradient;
 
   /// This will always be zero because the default values for optionally coupled variables is always constant
-  MooseArray<ADRealGradient> _ad_default_gradient;
+  MooseArray<DualRealGradient> _ad_default_gradient;
 
   /// This will always be zero because the default values for optionally coupled variables is always constant
   VariableSecond _default_second;
@@ -687,11 +687,11 @@ protected:
 
   /// Zero value of a variable
   const VariableValue & _zero;
-  const MooseArray<ADReal> & _ad_zero;
+  const MooseArray<DualReal> & _ad_zero;
 
   /// Zero gradient of a variable
   const VariableGradient & _grad_zero;
-  const MooseArray<ADRealGradient> & _ad_grad_zero;
+  const MooseArray<DualRealGradient> & _ad_grad_zero;
 
   /// Zero second derivative of a variable
   const VariableSecond & _second_zero;
@@ -874,7 +874,7 @@ template <ComputeStage compute_stage>
 typename VariableValueType<compute_stage>::type *
 Coupleable::getADDefaultValue(const std::string & var_name)
 {
-  std::map<std::string, MooseArray<ADReal> *>::iterator default_value_it =
+  std::map<std::string, MooseArray<DualReal> *>::iterator default_value_it =
       _ad_default_value.find(var_name);
   if (default_value_it == _ad_default_value.end())
   {

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -189,7 +189,7 @@ private:
 
 // template <>
 // const MaterialProperty<Real> *
-// castToMatProp<ADReal, Real>(PropertyValue const * const & prop_to_be_cast)
+// castToMatProp<DualReal, Real>(PropertyValue const * const & prop_to_be_cast)
 // {
 //   return dynamic_cast<const MaterialProperty<Real> *>(prop_to_be_cast);
 // }

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1470,9 +1470,9 @@ public:
   std::vector<Real> _real_zero;
   std::vector<VariableValue> _scalar_zero;
   std::vector<VariableValue> _zero;
-  std::vector<MooseArray<ADReal>> _ad_zero;
+  std::vector<MooseArray<DualReal>> _ad_zero;
   std::vector<VariableGradient> _grad_zero;
-  std::vector<MooseArray<ADRealGradient>> _ad_grad_zero;
+  std::vector<MooseArray<DualRealGradient>> _ad_grad_zero;
   std::vector<VariableSecond> _second_zero;
   std::vector<VariablePhiSecond> _second_phi_zero;
   std::vector<Point> _point_zero;

--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -338,7 +338,7 @@ template <>
 void dataStore(std::ostream & stream, std::stringstream *& s, void * context);
 
 inline void
-dataStore(std::ostream & stream, ADReal & dn, void * context)
+dataStore(std::ostream & stream, DualReal & dn, void * context)
 {
   dataStore(stream, dn.value(), context);
   for (auto i = beginIndex(dn.derivatives()); i < dn.derivatives().size(); ++i)
@@ -347,7 +347,7 @@ dataStore(std::ostream & stream, ADReal & dn, void * context)
 
 template <std::size_t N>
 inline void
-dataStore(std::ostream & stream, ADReal (&dn)[N], void * context)
+dataStore(std::ostream & stream, DualReal (&dn)[N], void * context)
 {
   for (std::size_t i = 0; i < N; ++i)
     dataStore(stream, dn[i], context);
@@ -610,7 +610,7 @@ template <>
 void dataLoad(std::istream & stream, std::stringstream *& s, void * context);
 
 inline void
-dataLoad(std::istream & stream, ADReal & dn, void * context)
+dataLoad(std::istream & stream, DualReal & dn, void * context)
 {
   dataLoad(stream, dn.value(), context);
 

--- a/framework/include/utils/ColumnMajorMatrix.h
+++ b/framework/include/utils/ColumnMajorMatrix.h
@@ -13,7 +13,7 @@
 // MOOSE includes
 #include "Moose.h" // using namespace libMesh
 #include "MooseError.h"
-#include "ADReal.h"
+#include "DualReal.h"
 
 #include "libmesh/type_tensor.h"
 #include "libmesh/dense_matrix.h"

--- a/framework/include/utils/DualReal.h
+++ b/framework/include/utils/DualReal.h
@@ -27,7 +27,7 @@ using MetaPhysicL::NumberArray;
 
 #define AD_MAX_DOFS_PER_ELEM 50
 
-typedef DualNumber<Real, NumberArray<AD_MAX_DOFS_PER_ELEM, Real>> ADReal;
+typedef DualNumber<Real, NumberArray<AD_MAX_DOFS_PER_ELEM, Real>> DualReal;
 
 #ifndef LIBMESH_DUAL_NUMBER_COMPARE_TYPES
 

--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -2,7 +2,7 @@
 #define MOOSEADWRAPPER_H
 
 #include "MooseError.h"
-#include "ADReal.h"
+#include "DualReal.h"
 #include "RankTwoTensor.h"
 #include "RankFourTensor.h"
 
@@ -102,15 +102,15 @@ public:
   MooseADWrapper(bool use_ad = false);
   MooseADWrapper(MooseADWrapper<Real> &&) = default;
 
-  typedef ADReal DNType;
+  typedef DualReal DNType;
 
   const Real & value() const { return _val; }
 
   Real & value() { return _val; }
 
-  const ADReal & dn(bool = true) const;
+  const DualReal & dn(bool = true) const;
 
-  ADReal & dn(bool = true);
+  DualReal & dn(bool = true);
 
   void copyDualNumberToValue();
 
@@ -122,7 +122,7 @@ public:
 private:
   bool _use_ad;
   Real _val;
-  mutable std::unique_ptr<ADReal> _dual_number;
+  mutable std::unique_ptr<DualReal> _dual_number;
   friend void dataStore<Real>(std::ostream &, MooseADWrapper<Real> &, void *);
   friend void dataLoad<Real>(std::istream &, MooseADWrapper<Real> &, void *);
 };
@@ -134,15 +134,15 @@ public:
   MooseADWrapper(bool use_ad = false);
   MooseADWrapper(MooseADWrapper<VectorValue<Real>> &&) = default;
 
-  typedef VectorValue<ADReal> DNType;
+  typedef VectorValue<DualReal> DNType;
 
   const VectorValue<Real> & value() const { return _val; }
 
   VectorValue<Real> & value() { return _val; }
 
-  const VectorValue<ADReal> & dn(bool = true) const;
+  const VectorValue<DualReal> & dn(bool = true) const;
 
-  VectorValue<ADReal> & dn(bool = true);
+  VectorValue<DualReal> & dn(bool = true);
 
   void copyDualNumberToValue();
 
@@ -154,7 +154,7 @@ public:
 private:
   bool _use_ad;
   VectorValue<Real> _val;
-  mutable std::unique_ptr<VectorValue<ADReal>> _dual_number;
+  mutable std::unique_ptr<VectorValue<DualReal>> _dual_number;
   friend void
   dataStore<VectorValue<Real>>(std::ostream &, MooseADWrapper<VectorValue<Real>> &, void *);
   friend void
@@ -168,15 +168,15 @@ public:
   MooseADWrapper(bool use_ad = false);
   MooseADWrapper(MooseADWrapper<TensorValue<Real>> &&) = default;
 
-  typedef TensorValue<ADReal> DNType;
+  typedef TensorValue<DualReal> DNType;
 
   const TensorValue<Real> & value() const { return _val; }
 
   TensorValue<Real> & value() { return _val; }
 
-  const TensorValue<ADReal> & dn(bool = true) const;
+  const TensorValue<DualReal> & dn(bool = true) const;
 
-  TensorValue<ADReal> & dn(bool = true);
+  TensorValue<DualReal> & dn(bool = true);
 
   void copyDualNumberToValue();
 
@@ -188,7 +188,7 @@ public:
 private:
   bool _use_ad;
   TensorValue<Real> _val;
-  mutable std::unique_ptr<TensorValue<ADReal>> _dual_number;
+  mutable std::unique_ptr<TensorValue<DualReal>> _dual_number;
   friend void
   dataStore<TensorValue<Real>>(std::ostream &, MooseADWrapper<TensorValue<Real>> &, void *);
   friend void
@@ -202,15 +202,15 @@ public:
   MooseADWrapper(bool use_ad = false);
   MooseADWrapper(MooseADWrapper<RankTwoTensorTempl<Real>> &&) = default;
 
-  typedef RankTwoTensorTempl<ADReal> DNType;
+  typedef RankTwoTensorTempl<DualReal> DNType;
 
   const RankTwoTensorTempl<Real> & value() const { return _val; }
 
   RankTwoTensorTempl<Real> & value() { return _val; }
 
-  const RankTwoTensorTempl<ADReal> & dn(bool = true) const;
+  const RankTwoTensorTempl<DualReal> & dn(bool = true) const;
 
-  RankTwoTensorTempl<ADReal> & dn(bool = true);
+  RankTwoTensorTempl<DualReal> & dn(bool = true);
 
   void copyDualNumberToValue();
 
@@ -224,7 +224,7 @@ public:
 private:
   bool _use_ad;
   RankTwoTensorTempl<Real> _val;
-  mutable std::unique_ptr<RankTwoTensorTempl<ADReal>> _dual_number;
+  mutable std::unique_ptr<RankTwoTensorTempl<DualReal>> _dual_number;
   friend void dataStore<RankTwoTensorTempl<Real>>(std::ostream &,
                                                   MooseADWrapper<RankTwoTensorTempl<Real>> &,
                                                   void *);
@@ -240,15 +240,15 @@ public:
   MooseADWrapper(bool use_ad = false);
   MooseADWrapper(MooseADWrapper<RankFourTensorTempl<Real>> &&) = default;
 
-  typedef RankFourTensorTempl<ADReal> DNType;
+  typedef RankFourTensorTempl<DualReal> DNType;
 
   const RankFourTensorTempl<Real> & value() const { return _val; }
 
   RankFourTensorTempl<Real> & value() { return _val; }
 
-  const RankFourTensorTempl<ADReal> & dn(bool = true) const;
+  const RankFourTensorTempl<DualReal> & dn(bool = true) const;
 
-  RankFourTensorTempl<ADReal> & dn(bool = true);
+  RankFourTensorTempl<DualReal> & dn(bool = true);
 
   void copyDualNumberToValue();
 
@@ -262,7 +262,7 @@ public:
 private:
   bool _use_ad;
   RankFourTensorTempl<Real> _val;
-  mutable std::unique_ptr<RankFourTensorTempl<ADReal>> _dual_number;
+  mutable std::unique_ptr<RankFourTensorTempl<DualReal>> _dual_number;
   friend void dataStore<RankFourTensorTempl<Real>>(std::ostream &,
                                                    MooseADWrapper<RankFourTensorTempl<Real>> &,
                                                    void *);

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -11,7 +11,7 @@
 #define MOOSETYPES_H
 
 #include "Moose.h"
-#include "ADReal.h"
+#include "DualReal.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/id_types.h"
@@ -75,7 +75,7 @@ class MooseArray;
 template <typename>
 class RankTwoTensorTempl;
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
+typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
 template <typename>
 class RankFourTensorTempl;
 template <typename>
@@ -98,6 +98,14 @@ class TypeTensor;
 template <unsigned int, typename>
 class TypeNTensor;
 }
+
+/**
+ * Convenience macros for automatic dual/non-dual typing
+ */
+#define ADReal typename RealType<compute_stage>::type
+#define ADRealVectorValue typename RealVectorValueType<compute_stage>::type
+#define ADRealTensorValue typename RealTensorValueType<compute_stage>::type
+#define ADRankTwoTensor typename RankTwoTensorType<compute_stage>::type
 
 /**
  * MOOSE typedefs
@@ -175,13 +183,13 @@ typedef MooseArray<std::vector<TypeNTensor<3, Real>>> VectorVariableTestSecond;
 typedef MooseArray<std::vector<VectorValue<Real>>> VectorVariableTestCurl;
 
 template <template <class> class W>
-using TemplateDN = W<ADReal>;
+using TemplateDN = W<DualReal>;
 
-typedef TemplateDN<VectorValue> ADRealVectorValue;
-typedef TemplateDN<TensorValue> ADRealTensorValue;
+typedef TemplateDN<VectorValue> DualRealVectorValue;
+typedef TemplateDN<TensorValue> DualRealTensorValue;
 
-typedef ADRealVectorValue ADRealGradient;
-typedef ADRealTensorValue ADRealTensor;
+typedef DualRealVectorValue DualRealGradient;
+typedef DualRealTensorValue ADRealTensor;
 
 enum ComputeStage
 {
@@ -197,7 +205,7 @@ struct VariableValueType
 template <>
 struct VariableValueType<JACOBIAN>
 {
-  typedef MooseArray<ADReal> type;
+  typedef MooseArray<DualReal> type;
 };
 template <ComputeStage compute_stage>
 struct VariableGradientType
@@ -207,7 +215,7 @@ struct VariableGradientType
 template <>
 struct VariableGradientType<JACOBIAN>
 {
-  typedef MooseArray<ADRealGradient> type;
+  typedef MooseArray<DualRealGradient> type;
 };
 template <ComputeStage compute_stage>
 struct VariableSecondType
@@ -228,7 +236,7 @@ struct RealType
 template <>
 struct RealType<JACOBIAN>
 {
-  typedef ADReal type;
+  typedef DualReal type;
 };
 template <ComputeStage compute_stage>
 struct RealVectorValueType
@@ -238,7 +246,7 @@ struct RealVectorValueType
 template <>
 struct RealVectorValueType<JACOBIAN>
 {
-  typedef ADRealVectorValue type;
+  typedef DualRealVectorValue type;
 };
 template <ComputeStage compute_stage>
 struct RealTensorValueType
@@ -248,7 +256,7 @@ struct RealTensorValueType
 template <>
 struct RealTensorValueType<JACOBIAN>
 {
-  typedef ADRealTensorValue type;
+  typedef DualRealTensorValue type;
 };
 template <ComputeStage compute_stage>
 struct RankTwoTensorType
@@ -258,7 +266,7 @@ struct RankTwoTensorType
 template <>
 struct RankTwoTensorType<JACOBIAN>
 {
-  typedef ADRankTwoTensor type;
+  typedef DualRankTwoTensor type;
 };
 
 template <ComputeStage compute_stage>

--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -11,7 +11,7 @@
 #define RANKFOURTENSOR_H
 
 #include "Moose.h"
-#include "ADReal.h"
+#include "DualReal.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/tuple_of.h"
@@ -49,7 +49,7 @@ void mooseSetToZero(T & v);
 template <>
 void mooseSetToZero<RankFourTensorTempl<Real>>(RankFourTensorTempl<Real> & v);
 template <>
-void mooseSetToZero<RankFourTensorTempl<ADReal>>(RankFourTensorTempl<ADReal> & v);
+void mooseSetToZero<RankFourTensorTempl<DualReal>>(RankFourTensorTempl<DualReal> & v);
 
 /**
  * RankFourTensorTempl is designed to handle any N-dimensional fourth order tensor, C.
@@ -460,6 +460,6 @@ RankFourTensorTempl<T>::operator/(const T2 & b) const ->
 }
 
 typedef RankFourTensorTempl<Real> RankFourTensor;
-typedef RankFourTensorTempl<ADReal> ADRankFourTensor;
+typedef RankFourTensorTempl<DualReal> ADRankFourTensor;
 
 #endif // RANKFOURTENSOR_H

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -11,7 +11,7 @@
 #define RANKTWOTENSOR_H
 
 #include "Moose.h"
-#include "ADReal.h"
+#include "DualReal.h"
 
 // Any requisite includes here
 #include "libmesh/libmesh.h"
@@ -56,7 +56,7 @@ void mooseSetToZero<RankTwoTensorTempl<Real>>(RankTwoTensorTempl<Real> & v);
  * Needed by DerivativeMaterialInterface
  */
 template <>
-void mooseSetToZero<RankTwoTensorTempl<ADReal>>(RankTwoTensorTempl<ADReal> & v);
+void mooseSetToZero<RankTwoTensorTempl<DualReal>>(RankTwoTensorTempl<DualReal> & v);
 
 /**
  * RankTwoTensorTempl is designed to handle the Stress or Strain Tensor for a fully anisotropic
@@ -486,7 +486,7 @@ private:
 };
 
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
+typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
 
 template <typename T>
 template <typename T2>

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -987,15 +987,15 @@ protected:
   FieldVariableCurl _curl_u_old, _curl_u_old_bak;
   FieldVariableCurl _curl_u_older;
 
-  MooseArray<ADReal> _ad_u;
-  MooseArray<ADRealGradient> _ad_grad_u;
+  MooseArray<DualReal> _ad_u;
+  MooseArray<DualRealGradient> _ad_grad_u;
   MooseArray<ADRealTensor> _ad_second_u;
-  std::vector<ADReal> _ad_dofs;
+  std::vector<DualReal> _ad_dofs;
 
-  MooseArray<ADReal> _neighbor_ad_u;
-  MooseArray<ADRealGradient> _neighbor_ad_grad_u;
+  MooseArray<DualReal> _neighbor_ad_u;
+  MooseArray<DualRealGradient> _neighbor_ad_grad_u;
   MooseArray<ADRealTensor> _neighbor_ad_second_u;
-  std::vector<ADReal> _neighbor_ad_dofs;
+  std::vector<DualReal> _neighbor_ad_dofs;
 
   FieldVariableValue _u_neighbor;
   FieldVariableValue _u_old_neighbor;

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -123,7 +123,7 @@ ADKernel<compute_stage>::computeJacobian()
   {
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      ADReal residual =
+      DualReal residual =
           computeQpResidual(); // This will also compute the derivative with respect to all dofs
       for (_j = 0; _j < _var.phiSize(); _j++)
         _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * residual.derivatives()[ad_offset + _j];
@@ -172,7 +172,7 @@ ADKernel<compute_stage>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     {
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       {
-        ADReal residual =
+        DualReal residual =
             computeQpResidual(); // This will also compute the derivative with respect to all dofs
 
         for (_j = 0; _j < jvar.phiSize(); _j++)

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3981,7 +3981,7 @@ FEProblemBase::createQRules(QuadratureType type, Order order, Order volume_order
     _zero[tid].resize(max_qpts, 0);
     _ad_zero[tid].resize(max_qpts, 0);
     _grad_zero[tid].resize(max_qpts, RealGradient(0.));
-    _ad_grad_zero[tid].resize(max_qpts, ADRealGradient(0));
+    _ad_grad_zero[tid].resize(max_qpts, DualRealGradient(0));
     _second_zero[tid].resize(max_qpts, RealTensor(0.));
     _second_phi_zero[tid].resize(max_qpts,
                                  std::vector<RealTensor>(getMaxShapeFunctions(), RealTensor(0.)));

--- a/framework/src/utils/ColumnMajorMatrix.C
+++ b/framework/src/utils/ColumnMajorMatrix.C
@@ -180,8 +180,8 @@ ColumnMajorMatrixTempl<T>::eigen(ColumnMajorMatrixTempl<T> & eval,
 
 template <>
 void
-ColumnMajorMatrixTempl<ADReal>::eigen(ColumnMajorMatrixTempl<ADReal> &,
-                                      ColumnMajorMatrixTempl<ADReal> &) const
+ColumnMajorMatrixTempl<DualReal>::eigen(ColumnMajorMatrixTempl<DualReal> &,
+                                        ColumnMajorMatrixTempl<DualReal> &) const
 {
   mooseError("Eigen solves with AD types is not supported.");
 }
@@ -260,10 +260,10 @@ ColumnMajorMatrixTempl<T>::eigenNonsym(ColumnMajorMatrixTempl<T> & eval_real,
 
 template <>
 void
-ColumnMajorMatrixTempl<ADReal>::eigenNonsym(ColumnMajorMatrixTempl<ADReal> &,
-                                            ColumnMajorMatrixTempl<ADReal> &,
-                                            ColumnMajorMatrixTempl<ADReal> &,
-                                            ColumnMajorMatrixTempl<ADReal> &) const
+ColumnMajorMatrixTempl<DualReal>::eigenNonsym(ColumnMajorMatrixTempl<DualReal> &,
+                                              ColumnMajorMatrixTempl<DualReal> &,
+                                              ColumnMajorMatrixTempl<DualReal> &,
+                                              ColumnMajorMatrixTempl<DualReal> &) const
 {
   mooseError("Eigen solves with AD types is not supported.");
 }
@@ -343,7 +343,7 @@ ColumnMajorMatrixTempl<T>::checkShapeEquality(const ColumnMajorMatrixTempl<T> & 
 
 template <>
 void
-ColumnMajorMatrixTempl<ADReal>::inverse(ColumnMajorMatrixTempl<ADReal> &) const
+ColumnMajorMatrixTempl<DualReal>::inverse(ColumnMajorMatrixTempl<DualReal> &) const
 {
   mooseError("Inverse solves with AD types is not supported for the ColumnMajorMatrix class.");
 }
@@ -371,4 +371,4 @@ ColumnMajorMatrixTempl<T>::norm()
 }
 
 template class ColumnMajorMatrixTempl<Real>;
-template class ColumnMajorMatrixTempl<ADReal>;
+template class ColumnMajorMatrixTempl<DualReal>;

--- a/framework/src/utils/MooseADWrapper.C
+++ b/framework/src/utils/MooseADWrapper.C
@@ -6,20 +6,20 @@
 MooseADWrapper<Real>::MooseADWrapper(bool use_ad) : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)
-    _dual_number = libmesh_make_unique<ADReal>();
+    _dual_number = libmesh_make_unique<DualReal>();
 }
 
-const ADReal &
+const DualReal &
 MooseADWrapper<Real>::dn(bool) const
 {
   if (!_dual_number)
-    _dual_number = libmesh_make_unique<ADReal>(_val);
+    _dual_number = libmesh_make_unique<DualReal>(_val);
   else if (!_use_ad)
     _dual_number->value() = _val;
   return *_dual_number;
 }
 
-ADReal &
+DualReal &
 MooseADWrapper<Real>::dn(bool)
 {
   return *_dual_number;
@@ -37,7 +37,7 @@ MooseADWrapper<Real>::markAD(bool use_ad)
   if (!use_ad && _use_ad)
     _dual_number = nullptr;
   else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<ADReal>();
+    _dual_number = libmesh_make_unique<DualReal>();
   _use_ad = use_ad;
 }
 
@@ -56,21 +56,21 @@ MooseADWrapper<VectorValue<Real>>::MooseADWrapper(bool use_ad)
   : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)
-    _dual_number = libmesh_make_unique<VectorValue<ADReal>>();
+    _dual_number = libmesh_make_unique<VectorValue<DualReal>>();
 }
 
-const VectorValue<ADReal> &
+const VectorValue<DualReal> &
 MooseADWrapper<VectorValue<Real>>::dn(bool) const
 {
   if (!_dual_number)
-    _dual_number = libmesh_make_unique<VectorValue<ADReal>>(_val);
+    _dual_number = libmesh_make_unique<VectorValue<DualReal>>(_val);
   else if (!_use_ad)
     for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
       (*_dual_number)(i).value() = _val(i);
   return *_dual_number;
 }
 
-VectorValue<ADReal> &
+VectorValue<DualReal> &
 MooseADWrapper<VectorValue<Real>>::dn(bool)
 {
   return *_dual_number;
@@ -89,7 +89,7 @@ MooseADWrapper<VectorValue<Real>>::markAD(bool use_ad)
   if (!use_ad && _use_ad)
     _dual_number = nullptr;
   else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<VectorValue<ADReal>>();
+    _dual_number = libmesh_make_unique<VectorValue<DualReal>>();
   _use_ad = use_ad;
 }
 
@@ -108,14 +108,14 @@ MooseADWrapper<TensorValue<Real>>::MooseADWrapper(bool use_ad)
   : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)
-    _dual_number = libmesh_make_unique<TensorValue<ADReal>>();
+    _dual_number = libmesh_make_unique<TensorValue<DualReal>>();
 }
 
-const TensorValue<ADReal> &
+const TensorValue<DualReal> &
 MooseADWrapper<TensorValue<Real>>::dn(bool) const
 {
   if (!_dual_number)
-    _dual_number = libmesh_make_unique<TensorValue<ADReal>>(_val);
+    _dual_number = libmesh_make_unique<TensorValue<DualReal>>(_val);
   else if (!_use_ad)
     for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
       for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -123,7 +123,7 @@ MooseADWrapper<TensorValue<Real>>::dn(bool) const
   return *_dual_number;
 }
 
-TensorValue<ADReal> &
+TensorValue<DualReal> &
 MooseADWrapper<TensorValue<Real>>::dn(bool)
 {
   return *_dual_number;
@@ -143,7 +143,7 @@ MooseADWrapper<TensorValue<Real>>::markAD(bool use_ad)
   if (!use_ad && _use_ad)
     _dual_number = nullptr;
   else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<TensorValue<ADReal>>();
+    _dual_number = libmesh_make_unique<TensorValue<DualReal>>();
   _use_ad = use_ad;
 }
 
@@ -162,14 +162,14 @@ MooseADWrapper<RankTwoTensorTempl<Real>>::MooseADWrapper(bool use_ad)
   : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<ADReal>>();
+    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>();
 }
 
-const RankTwoTensorTempl<ADReal> &
+const RankTwoTensorTempl<DualReal> &
 MooseADWrapper<RankTwoTensorTempl<Real>>::dn(bool) const
 {
   if (!_dual_number)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<ADReal>>(_val);
+    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>(_val);
   else if (!_use_ad)
     for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
       for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -177,7 +177,7 @@ MooseADWrapper<RankTwoTensorTempl<Real>>::dn(bool) const
   return *_dual_number;
 }
 
-RankTwoTensorTempl<ADReal> &
+RankTwoTensorTempl<DualReal> &
 MooseADWrapper<RankTwoTensorTempl<Real>>::dn(bool)
 {
   return *_dual_number;
@@ -197,7 +197,7 @@ MooseADWrapper<RankTwoTensorTempl<Real>>::markAD(bool use_ad)
   if (!use_ad && _use_ad)
     _dual_number = nullptr;
   else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<ADReal>>();
+    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>();
   _use_ad = use_ad;
 }
 
@@ -217,14 +217,14 @@ MooseADWrapper<RankFourTensorTempl<Real>>::MooseADWrapper(bool use_ad)
   : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<ADReal>>();
+    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>();
 }
 
-const RankFourTensorTempl<ADReal> &
+const RankFourTensorTempl<DualReal> &
 MooseADWrapper<RankFourTensorTempl<Real>>::dn(bool) const
 {
   if (!_dual_number)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<ADReal>>(_val);
+    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>(_val);
   else if (!_use_ad)
     for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
       for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -234,7 +234,7 @@ MooseADWrapper<RankFourTensorTempl<Real>>::dn(bool) const
   return *_dual_number;
 }
 
-RankFourTensorTempl<ADReal> &
+RankFourTensorTempl<DualReal> &
 MooseADWrapper<RankFourTensorTempl<Real>>::dn(bool)
 {
   return *_dual_number;
@@ -256,7 +256,7 @@ MooseADWrapper<RankFourTensorTempl<Real>>::markAD(bool use_ad)
   if (!use_ad && _use_ad)
     _dual_number = nullptr;
   else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<ADReal>>();
+    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>();
   _use_ad = use_ad;
 }
 

--- a/framework/src/utils/RankFourTensor.C
+++ b/framework/src/utils/RankFourTensor.C
@@ -36,7 +36,7 @@ mooseSetToZero<RankFourTensorTempl<Real>>(RankFourTensorTempl<Real> & v)
 }
 template <>
 void
-mooseSetToZero<RankFourTensorTempl<ADReal>>(RankFourTensorTempl<ADReal> & v)
+mooseSetToZero<RankFourTensorTempl<DualReal>>(RankFourTensorTempl<DualReal> & v)
 {
   v.zero();
 }
@@ -380,8 +380,8 @@ RankFourTensorTempl<T>::invSymm() const
 }
 
 template <>
-RankFourTensorTempl<ADReal>
-RankFourTensorTempl<ADReal>::invSymm() const
+RankFourTensorTempl<DualReal>
+RankFourTensorTempl<DualReal>::invSymm() const
 {
   mooseError("The invSymm operation calls to LAPACK, so AD is not supported.");
   return {};
@@ -911,17 +911,17 @@ RankFourTensorTempl<T>::isIsotropic() const
 }
 
 template class RankFourTensorTempl<Real>;
-template class RankFourTensorTempl<ADReal>;
+template class RankFourTensorTempl<DualReal>;
 
 #define RankTwoTensorMultInstantiate(TemplateClass)                                                \
   template RankTwoTensorTempl<Real> RankFourTensorTempl<Real>::operator*(                          \
       const TemplateClass<Real> & a) const;                                                        \
-  template RankTwoTensorTempl<ADReal> RankFourTensorTempl<ADReal>::operator*(                      \
+  template RankTwoTensorTempl<DualReal> RankFourTensorTempl<DualReal>::operator*(                  \
       const TemplateClass<Real> & a) const;                                                        \
-  template RankTwoTensorTempl<ADReal> RankFourTensorTempl<Real>::operator*(                        \
-      const TemplateClass<ADReal> & a) const;                                                      \
-  template RankTwoTensorTempl<ADReal> RankFourTensorTempl<ADReal>::operator*(                      \
-      const TemplateClass<ADReal> & a) const
+  template RankTwoTensorTempl<DualReal> RankFourTensorTempl<Real>::operator*(                      \
+      const TemplateClass<DualReal> & a) const;                                                    \
+  template RankTwoTensorTempl<DualReal> RankFourTensorTempl<DualReal>::operator*(                  \
+      const TemplateClass<DualReal> & a) const
 
 RankTwoTensorMultInstantiate(RankTwoTensorTempl);
 RankTwoTensorMultInstantiate(TensorValue);
@@ -929,27 +929,27 @@ RankTwoTensorMultInstantiate(TypeTensor);
 
 template RankFourTensorTempl<Real> RankFourTensorTempl<Real>::
 operator+(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
 operator+(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<Real>::
-operator+(const RankFourTensorTempl<ADReal> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
-operator+(const RankFourTensorTempl<ADReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<Real>::
+operator+(const RankFourTensorTempl<DualReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
+operator+(const RankFourTensorTempl<DualReal> & a) const;
 
 template RankFourTensorTempl<Real> RankFourTensorTempl<Real>::
 operator-(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
 operator-(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<Real>::
-operator-(const RankFourTensorTempl<ADReal> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
-operator-(const RankFourTensorTempl<ADReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<Real>::
+operator-(const RankFourTensorTempl<DualReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
+operator-(const RankFourTensorTempl<DualReal> & a) const;
 
 template RankFourTensorTempl<Real> RankFourTensorTempl<Real>::
 operator*(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
 operator*(const RankFourTensorTempl<Real> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<Real>::
-operator*(const RankFourTensorTempl<ADReal> & a) const;
-template RankFourTensorTempl<ADReal> RankFourTensorTempl<ADReal>::
-operator*(const RankFourTensorTempl<ADReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<Real>::
+operator*(const RankFourTensorTempl<DualReal> & a) const;
+template RankFourTensorTempl<DualReal> RankFourTensorTempl<DualReal>::
+operator*(const RankFourTensorTempl<DualReal> & a) const;

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -47,7 +47,7 @@ mooseSetToZero<RankTwoTensorTempl<Real>>(RankTwoTensorTempl<Real> & v)
 
 template <>
 void
-mooseSetToZero<RankTwoTensorTempl<ADReal>>(RankTwoTensorTempl<ADReal> & v)
+mooseSetToZero<RankTwoTensorTempl<DualReal>>(RankTwoTensorTempl<DualReal> & v)
 {
   v.zero();
 }
@@ -1000,9 +1000,11 @@ RankTwoTensorTempl<T>::syev(const char * calculation_type,
 
 template <>
 void
-RankTwoTensorTempl<ADReal>::syev(const char *, std::vector<ADReal> &, std::vector<ADReal> &) const
+RankTwoTensorTempl<DualReal>::syev(const char *,
+                                   std::vector<DualReal> &,
+                                   std::vector<DualReal> &) const
 {
-  mooseError("ADRankTwoTensor does not sypport the syev method");
+  mooseError("DualRankTwoTensor does not sypport the syev method");
 }
 
 template <typename T>
@@ -1044,9 +1046,9 @@ RankTwoTensorTempl<T>::getRUDecompositionRotation(RankTwoTensorTempl<T> & rot) c
 
 template <>
 void
-RankTwoTensorTempl<ADReal>::getRUDecompositionRotation(RankTwoTensorTempl<ADReal> &) const
+RankTwoTensorTempl<DualReal>::getRUDecompositionRotation(RankTwoTensorTempl<DualReal> &) const
 {
-  mooseError("ADRankTwoTensor does not support getRUDecompositionRotation");
+  mooseError("DualRankTwoTensor does not support getRUDecompositionRotation");
 }
 
 template <typename T>
@@ -1145,4 +1147,4 @@ RankTwoTensorTempl<T>::setToIdentity()
 }
 
 template class RankTwoTensorTempl<Real>;
-template class RankTwoTensorTempl<ADReal>;
+template class RankTwoTensorTempl<DualReal>;

--- a/modules/tensor_mechanics/include/kernels/ADStressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/ADStressDivergenceTensors.h
@@ -28,7 +28,7 @@ class ADStressDivergenceTensors;
 template <typename>
 class RankTwoTensorTempl;
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
+typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
 
 declareADValidParams(ADStressDivergenceTensors);
 

--- a/modules/tensor_mechanics/include/kernels/ADStressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/ADStressDivergenceTensors.h
@@ -57,7 +57,7 @@ protected:
   std::vector<unsigned int> _disp_var;
 
   /// Gradient of test function averaged over the element. Used in volumetric locking correction calculation.
-  std::vector<typename RealType<compute_stage>::type> _avg_grad_test;
+  std::vector<ADReal> _avg_grad_test;
 
   /// Flag for volumetric locking correction
   const bool _volumetric_locking_correction;

--- a/modules/tensor_mechanics/include/materials/ADComputeIncrementalSmallStrain.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeIncrementalSmallStrain.h
@@ -34,8 +34,7 @@ protected:
    * Computes the current and old deformation gradients and passes back the
    * total strain increment tensor.
    */
-  virtual void computeTotalStrainIncrement(
-      typename RankTwoTensorType<compute_stage>::type & total_strain_increment);
+  virtual void computeTotalStrainIncrement(ADRankTwoTensor & total_strain_increment);
 
   usingComputeIncrementalStrainBaseMembers;
 };

--- a/modules/tensor_mechanics/include/materials/ADComputeIncrementalStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeIncrementalStrainBase.h
@@ -43,8 +43,7 @@ protected:
   void initialSetup() override;
   virtual void initQpStatefulProperties() override;
 
-  void
-  subtractEigenstrainIncrementFromStrain(typename RankTwoTensorType<compute_stage>::type & strain);
+  void subtractEigenstrainIncrementFromStrain(ADRankTwoTensor & strain);
 
   std::vector<const VariableGradient *> _grad_disp_old;
 

--- a/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
@@ -32,7 +32,7 @@ class ADComputeStrainBase;
 template <typename>
 class RankTwoTensorTempl;
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
+typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
 
 declareADValidParams(ADComputeStrainBase);
 

--- a/modules/tensor_mechanics/include/materials/ADComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeStressBase.h
@@ -29,11 +29,11 @@ class ADComputeStressBase;
 template <typename>
 class RankTwoTensorTempl;
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
+typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
 template <typename>
 class RankFourTensorTempl;
 typedef RankFourTensorTempl<Real> RankFourTensor;
-typedef RankFourTensorTempl<ADReal> ADRankFourTensor;
+typedef RankFourTensorTempl<DualReal> ADRankFourTensor;
 
 declareADValidParams(ADComputeStressBase);
 

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
@@ -46,7 +46,7 @@ void
 ADComputeFiniteStrainElasticStress<compute_stage>::computeQpStress()
 {
   // Calculate the stress in the intermediate configuration
-  typename RankTwoTensorType<compute_stage>::type intermediate_stress;
+  ADRankTwoTensor intermediate_stress;
 
   intermediate_stress =
       _elasticity_tensor[_qp] * (_strain_increment[_qp] + _elastic_strain_old[_qp]);

--- a/modules/tensor_mechanics/src/materials/ADComputeIncrementalSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeIncrementalSmallStrain.C
@@ -28,10 +28,10 @@ template <ComputeStage compute_stage>
 void
 ADComputeIncrementalSmallStrain<compute_stage>::computeProperties()
 {
-  typename RealType<compute_stage>::type volumetric_strain = 0.0;
+  ADReal volumetric_strain = 0.0;
   for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
   {
-    typename RankTwoTensorType<compute_stage>::type total_strain_increment;
+    ADRankTwoTensor total_strain_increment;
     computeTotalStrainIncrement(total_strain_increment);
 
     _strain_increment[_qp] = total_strain_increment;
@@ -77,10 +77,10 @@ ADComputeIncrementalSmallStrain<compute_stage>::computeProperties()
 template <ComputeStage compute_stage>
 void
 ADComputeIncrementalSmallStrain<compute_stage>::computeTotalStrainIncrement(
-    typename RankTwoTensorType<compute_stage>::type & total_strain_increment)
+    ADRankTwoTensor & total_strain_increment)
 {
   // Deformation gradient
-  typename RankTwoTensorType<compute_stage>::type A(
+  ADRankTwoTensor A(
       (*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp], (*_grad_disp[2])[_qp]); // Deformation gradient
   RankTwoTensor Fbar((*_grad_disp_old[0])[_qp],
                      (*_grad_disp_old[1])[_qp],

--- a/modules/tensor_mechanics/src/materials/ADComputeIncrementalStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeIncrementalStrainBase.C
@@ -57,7 +57,7 @@ ADComputeIncrementalStrainBase<compute_stage>::initQpStatefulProperties()
 template <ComputeStage compute_stage>
 void
 ADComputeIncrementalStrainBase<compute_stage>::subtractEigenstrainIncrementFromStrain(
-    typename RankTwoTensorType<compute_stage>::type & strain)
+    ADRankTwoTensor & strain)
 {
   for (unsigned int i = 0; i < _eigenstrains.size(); ++i)
   {

--- a/modules/tensor_mechanics/src/materials/ADComputeSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeSmallStrain.C
@@ -26,12 +26,12 @@ template <ComputeStage compute_stage>
 void
 ADComputeSmallStrain<compute_stage>::computeProperties()
 {
-  typename RealType<compute_stage>::type volumetric_strain = 0.0;
+  ADReal volumetric_strain = 0.0;
 
   for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
   {
     // strain = (grad_disp + grad_disp^T)/2
-    typename RankTwoTensorType<compute_stage>::type grad_tensor(
+    ADRankTwoTensor grad_tensor(
         (*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp], (*_grad_disp[2])[_qp]);
 
     _total_strain[_qp] = (grad_tensor + grad_tensor.transpose()) / 2.0;
@@ -47,8 +47,7 @@ ADComputeSmallStrain<compute_stage>::computeProperties()
   {
     if (_volumetric_locking_correction)
     {
-      typename RealType<compute_stage>::type correction =
-          (volumetric_strain - _total_strain[_qp].trace()) / 3.0;
+      ADReal correction = (volumetric_strain - _total_strain[_qp].trace()) / 3.0;
       _total_strain[_qp](0, 0) += correction;
       _total_strain[_qp](1, 1) += correction;
       _total_strain[_qp](2, 2) += correction;


### PR DESCRIPTION
Depends on #12703. The meat is in dccc1cd and da64d86. This turned out to be surprisingly simple as you can override the typedefs.

Refs #12719