### PR TITLE
parser,mesh-generators: several small fixes and tweaks

### DIFF
--- a/framework/include/meshgenerators/MeshExtruderGenerator.h
+++ b/framework/include/meshgenerators/MeshExtruderGenerator.h
@@ -47,9 +47,9 @@ protected:
   class QueryElemSubdomainID : public MeshTools::Generation::QueryElemSubdomainIDBase
   {
   public:
-    QueryElemSubdomainID(std::vector<SubdomainID> existing_subdomains,
+    QueryElemSubdomainID(const std::vector<SubdomainID> & existing_subdomains,
                          std::vector<unsigned int> layers,
-                         std::vector<unsigned int> new_ids,
+                         const std::vector<unsigned int> & new_ids,
                          unsigned int num_layers);
 
     /// The override from the base class for obtaining a new id based on the old (original) element and the specified layer
@@ -59,11 +59,8 @@ protected:
     /// Data structure for holding the old -> new id mapping based on the layer number
     std::map<unsigned int, std::map<SubdomainID, unsigned int>> _layer_data;
 
-/// The total number of layers in the extrusion.  This is
-/// currently only used for a sanity check in dbg mode.
-#ifndef NDEBUG
+    /// The total number of layers in the extrusion.
     unsigned int _num_layers;
-#endif
   };
 
 private:

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -103,7 +103,7 @@ MeshExtruderGenerator::generate()
     changeID(*mesh, getParam<std::vector<BoundaryName>>("top_sideset"), old_top);
 
   // Update the dimension
-  mesh->set_mesh_dimension(mesh->mesh_dimension() + 1);
+  mesh->set_mesh_dimension(source_mesh->mesh_dimension() + 1);
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
@@ -126,21 +126,20 @@ MeshExtruderGenerator::changeID(MeshBase & mesh,
 }
 
 MeshExtruderGenerator::QueryElemSubdomainID::QueryElemSubdomainID(
-    std::vector<SubdomainID> existing_subdomains,
+    const std::vector<SubdomainID> & existing_subdomains,
     std::vector<unsigned int> layers,
-    std::vector<unsigned int> new_ids,
-    unsigned int libmesh_dbg_var(num_layers))
-  : QueryElemSubdomainIDBase()
-#ifndef NDEBUG
-    ,
-    _num_layers(num_layers)
-#endif
+    const std::vector<unsigned int> & new_ids,
+    unsigned int num_layers)
+  : QueryElemSubdomainIDBase(), _num_layers(num_layers)
 {
   // Setup our stride depending on whether the user passed unique sets in new ids or just a single
   // set of new ids
-  const unsigned int zero = 0;
   const unsigned int stride =
-      existing_subdomains.size() == new_ids.size() ? zero : existing_subdomains.size();
+      existing_subdomains.size() == new_ids.size() ? 0 : existing_subdomains.size();
+
+  if (layers.size() == 0)
+    for (unsigned int i = 0; i < _num_layers; i++)
+      layers.push_back(i);
 
   // Populate the data structure
   for (unsigned int i = 0; i < layers.size(); ++i)

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -73,7 +73,11 @@ StackGenerator::generate()
   int dim = static_cast<int>(_dim);
 
   if (dim != int(mesh->mesh_dimension()))
-    mooseError("The first mesh's dimension and the dimension provided don't match !");
+    paramError("dim",
+               "incompatible mesh dimensions: dim=",
+               dim,
+               " and first mesh dimension is ",
+               mesh->mesh_dimension());
 
   // Reserve spaces for the other meshes (no need to store the first one another time)
   _meshes.reserve(_input_names.size() - 1);

--- a/framework/src/meshgenerators/StitchedMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchedMeshGenerator.C
@@ -28,7 +28,9 @@ validParams<StitchedMeshGenerator>()
   params.addParam<bool>(
       "clear_stitched_boundary_ids", true, "Whether or not to clear the stitchd boundary IDs");
   params.addRequiredParam<std::vector<std::vector<std::string>>>(
-      "stitch_boundaries_pairs", "Pairs of boundaries to be stitched together");
+      "stitch_boundaries_pairs",
+      "Pairs of boundaries to be stitched together between the 1st mesh in inputs and each "
+      "consecutive mesh");
   params.addParam<MooseEnum>(
       "algorithm",
       algorithm,
@@ -93,7 +95,7 @@ StitchedMeshGenerator::generate()
         for (auto & ss_name_map_pair : sideset_id_name_map)
           error << " " << ss_name_map_pair.first << " : " << ss_name_map_pair.second << "\n";
 
-        mooseError(error.str());
+        paramError("stitch_boundaries_pairs", error.str());
       }
     }
 
@@ -121,7 +123,7 @@ StitchedMeshGenerator::generate()
         for (auto & ss_name_map_pair : sideset_id_name_map)
           error << " " << ss_name_map_pair.first << " : " << ss_name_map_pair.second << "\n";
 
-        mooseError(error.str());
+        paramError("stitch_boundaries_pairs", error.str());
       }
     }
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -331,7 +331,8 @@ Parser::walkRaw(std::string /*fullpath*/, std::string /*nodepath*/, hit::Node * 
                              n,
                              "section '",
                              curr_identifier,
-                             "' does not have an associated \"Action\".\nDid you misspell it?");
+                             "' does not have an associated \"Action\".\nDid you misspell it?") +
+               "\n";
     return;
   }
 
@@ -1418,7 +1419,7 @@ Parser::setVectorParameter(const std::string & full_name,
     }
     catch (hit::Error & err)
     {
-      _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what());
+      _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what()) + "\n";
       return;
     }
   }
@@ -1492,8 +1493,10 @@ Parser::setDoubleIndexParameter(const std::string & full_name,
   for (unsigned j = 0; j < first_tokenized_vector.size(); ++j)
     if (!MooseUtils::tokenizeAndConvert<T>(first_tokenized_vector[j], param->set()[j]))
     {
-      _errmsg += hit::errormsg(
-          _input_filename, _root->find(full_name), "invalid format for parameter ", full_name);
+      _errmsg +=
+          hit::errormsg(
+              _input_filename, _root->find(full_name), "invalid format for parameter ", full_name) +
+          "\n";
       return;
     }
 
@@ -1525,7 +1528,7 @@ Parser::setScalarComponentParameter(const std::string & full_name,
   }
   catch (hit::Error & err)
   {
-    _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what());
+    _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what()) + "\n";
     return;
   }
 
@@ -1538,7 +1541,8 @@ Parser::setScalarComponentParameter(const std::string & full_name,
                              ": size ",
                              vec.size(),
                              " is not a multiple of ",
-                             LIBMESH_DIM);
+                             LIBMESH_DIM) +
+               "\n";
     return;
   }
 
@@ -1569,7 +1573,7 @@ Parser::setVectorComponentParameter(const std::string & full_name,
   }
   catch (hit::Error & err)
   {
-    _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what());
+    _errmsg += hit::errormsg(_input_filename, _root->find(full_name), err.what()) + "\n";
     return;
   }
 
@@ -1582,7 +1586,8 @@ Parser::setVectorComponentParameter(const std::string & full_name,
                              ": size ",
                              vec.size(),
                              " is not a multiple of ",
-                             LIBMESH_DIM);
+                             LIBMESH_DIM) +
+               "\n";
     return;
   }
 
@@ -1719,7 +1724,8 @@ Parser::setScalarParameter<RealTensorValue, RealTensorValue>(
                              ": size is ",
                              vec.size(),
                              " but should be ",
-                             LIBMESH_DIM * LIBMESH_DIM);
+                             LIBMESH_DIM * LIBMESH_DIM) +
+               "\n";
     return;
   }
 
@@ -1865,14 +1871,16 @@ Parser::setVectorParameter<VariableName, VariableName>(
     for (unsigned int i = 0; i < vec.size(); ++i)
       if (var_names[i] == "")
       {
-        _errmsg += hit::errormsg(
-            _input_filename,
-            _root->find(full_name),
-            "invalid value for ",
-            full_name,
-            ":\n"
-            "    MOOSE does not currently support a coupled vector where some parameters are ",
-            "reals and others are variables");
+        _errmsg +=
+            hit::errormsg(
+                _input_filename,
+                _root->find(full_name),
+                "invalid value for ",
+                full_name,
+                ":\n"
+                "    MOOSE does not currently support a coupled vector where some parameters are ",
+                "reals and others are variables") +
+            "\n";
         return;
       }
       else


### PR DESCRIPTION
* fix missing newlines caused by recent changes in #12663
* Fix MeshExtruderGenerator shortcut to name subdomains for *all* layers without naming every layer-subdomain combo remapping
* Fix MeshExtruderGenerator bug where mesh was assigned wrong new dimension.
* Improve some mesh generator error messages using paramError

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
