### PR TITLE
Skip old PETSc (3.7.x or lower) in external petsc solver module

### DIFF
--- a/modules/external_petsc_solver/include/petscsolver/PETScDiffusionFDM.h
+++ b/modules/external_petsc_solver/include/petscsolver/PETScDiffusionFDM.h
@@ -5,6 +5,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include "libmesh/petsc_macro.h"
 #include <petscdm.h>
 #include <petscdmda.h>
 #include <petscts.h>

--- a/modules/external_petsc_solver/src/petscsolver/PETScDiffusionFDM.C
+++ b/modules/external_petsc_solver/src/petscsolver/PETScDiffusionFDM.C
@@ -90,7 +90,9 @@ PetscErrorCode
 externalPETScDiffusionFDMSolve(TS ts, Vec u, PetscReal dt, PetscReal time)
 {
   PetscErrorCode ierr;
+#if !PETSC_VERSION_LESS_THAN(3, 8, 0)
   PetscInt current_step;
+#endif
   DM da;
 
   PetscFunctionBeginUser;
@@ -112,10 +114,14 @@ externalPETScDiffusionFDMSolve(TS ts, Vec u, PetscReal dt, PetscReal time)
   CHKERRQ(ierr);
   ierr = TSSetTime(ts, time - dt);
   CHKERRQ(ierr);
+#if !PETSC_VERSION_LESS_THAN(3, 8, 0)
   ierr = TSGetStepNumber(ts, &current_step);
   CHKERRQ(ierr);
   ierr = TSSetMaxSteps(ts, current_step + 1);
   CHKERRQ(ierr);
+#else
+  SETERRQ(PetscObjectComm((PetscObject)ts), PETSC_ERR_SUP, "Require PETSc-3.8.x or higher ");
+#endif
   /*  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    Sets various TS parameters from user options
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/modules/external_petsc_solver/test/tests/external_petsc_problem/tests
+++ b/modules/external_petsc_solver/test/tests/external_petsc_problem/tests
@@ -9,5 +9,6 @@
     design = "ExternalProblem.md"
     allow_warnings = true
     issues = "#12595"
+    petsc_version = '>=3.8.0'
   []
 []

--- a/modules/external_petsc_solver/test/tests/external_petsc_problem/tests
+++ b/modules/external_petsc_solver/test/tests/external_petsc_problem/tests
@@ -10,5 +10,6 @@
     allow_warnings = true
     issues = "#12595"
     petsc_version = '>=3.8.0'
+    library_mode = 'DYNAMIC'
   []
 []


### PR DESCRIPTION
Closes #12733

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
