### PR TITLE
Expand ParsedFunction doc

### DIFF
--- a/framework/doc/content/source/functions/MooseParsedFunction.md
+++ b/framework/doc/content/source/functions/MooseParsedFunction.md
@@ -9,8 +9,13 @@ expression can be a function of time (t) or coordinate (x, y, or z).  The expres
 can include common mathematical functions.  Examples include `4e4+1e2*t`,
 `sqrt(x*x+y*y+z*z)`, and `if(t\textless=1.0, 0.1*t, (1.0+0.1)*cos(pi/2*(t-1.0)) - 1.0)`.
 
-Constant variables may be used in the expression if they have been declared with `vars`
-and defined with `vals`.
+Additional variables may be declared in the `vars` parameter vector. The
+corresponding `vals` parameter vector should list the items these variables are
+bound to. Variables can be bound to:
+
+- Constant number literals (for example `vars = kB` and `vals = 8.61733e-5`)
+- A PostProcessor name (providing the value form the PP's last execution)
+- A Function name (providing an immediate evaluation of the specified function)
 
 Further information can be found at the
 [function parser site](http://warp.povusers.org/FunctionParser/).

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -20,9 +20,11 @@ validParams<MooseParsedFunctionBase>()
 {
   InputParameters params = emptyInputParameters();
   params.addParam<std::vector<std::string>>(
-      "vars", "The constant variables (excluding t,x,y,z) in the forcing function.");
+      "vars",
+      "Variables (excluding t,x,y,z) that are bound to the values provided by the corresponding "
+      "items in the vals vector.");
   params.addParam<std::vector<std::string>>(
-      "vals", "Constant numeric values or postprocessor names for vars.");
+      "vals", "Constant numeric values, postprocessor names, or function names for vars.");
   return params;
 }
 


### PR DESCRIPTION
Spells out what `vars` and `vals` are used for and what can be referenced by `vals`.

Refs #12179