### PR TITLE
MeshGenerator updates

### DIFF
--- a/framework/include/meshgenerators/PatternedMeshGenerator.h
+++ b/framework/include/meshgenerators/PatternedMeshGenerator.h
@@ -51,9 +51,9 @@ protected:
   // Holds a mesh for each row, these will be stitched together in the end
   std::vector<std::unique_ptr<ReplicatedMesh>> _row_meshes;
 
-  const Real _x_width;
-  const Real _y_width;
-  const Real _z_width;
+  Real _x_width;
+  Real _y_width;
+  Real _z_width;
 };
 
 #endif // PATTERNEDMESHGENERATOR_H

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -102,9 +102,6 @@ MeshExtruderGenerator::generate()
   if (isParamValid("top_sideset"))
     changeID(*mesh, getParam<std::vector<BoundaryName>>("top_sideset"), old_top);
 
-  // Update the dimension
-  mesh->set_mesh_dimension(source_mesh->mesh_dimension() + 1);
-
   return dynamic_pointer_cast<MeshBase>(mesh);
 }
 

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -26,9 +26,12 @@ validParams<PatternedMeshGenerator>()
   InputParameters params = validParams<MeshGenerator>();
 
   params.addRequiredParam<std::vector<MeshGeneratorName>>("inputs", "The input MeshGenerators.");
-  params.addRangeCheckedParam<Real>("x_width", "x_width>=0", "The tile width in the x direction");
-  params.addRangeCheckedParam<Real>("y_width", "y_width>=0", "The tile width in the y direction");
-  params.addRangeCheckedParam<Real>("z_width", "z_width>=0", "The tile width in the z direction");
+  params.addRangeCheckedParam<Real>(
+      "x_width", 0, "x_width>=0", "The tile width in the x direction");
+  params.addRangeCheckedParam<Real>(
+      "y_width", 0, "y_width>=0", "The tile width in the y direction");
+  params.addRangeCheckedParam<Real>(
+      "z_width", 0, "z_width>=0", "The tile width in the z direction");
 
   // Boundaries : user has to provide id or name for each boundary
   // If an id is provided, any provided name for this particular boundary will be ignored.
@@ -61,26 +64,14 @@ validParams<PatternedMeshGenerator>()
 PatternedMeshGenerator::PatternedMeshGenerator(const InputParameters & parameters)
   : MeshGenerator(parameters),
     _input_names(getParam<std::vector<MeshGeneratorName>>("inputs")),
-    _pattern(getParam<std::vector<std::vector<unsigned int>>>("pattern"))
+    _pattern(getParam<std::vector<std::vector<unsigned int>>>("pattern")),
+    _x_width(getParam<Real>("x_width")),
+    _y_width(getParam<Real>("y_width")),
+    _z_width(getParam<Real>("z_width"))
 {
   _mesh_ptrs.reserve(_input_names.size());
   for (auto i = beginIndex(_input_names); i < _input_names.size(); ++i)
     _mesh_ptrs.push_back(&getMeshByName(_input_names[i]));
-
-  if (isParamValid("x_width"))
-    _x_width = getParam<Real>("x_width");
-  else
-    _x_width = -1;
-
-  if (isParamValid("y_width"))
-    _y_width = getParam<Real>("y_width");
-  else
-    _y_width = -1;
-
-  if (isParamValid("z_width"))
-    _z_width = getParam<Real>("z_width");
-  else
-    _z_width = -1;
 }
 
 std::unique_ptr<MeshBase>
@@ -129,13 +120,13 @@ PatternedMeshGenerator::generate()
     mooseError("The bottom boundary has not been initialized properly.");
 
   // Check if the user has provided the x, y and z widths.
-  // If not (their value is -1), compute them
+  // If not (their value is 0 by default), compute them
   auto bbox = MeshTools::create_bounding_box(*_meshes[0]);
-  if (_x_width < 0)
+  if (_x_width == 0)
     _x_width = bbox.max()(0) - bbox.min()(0);
-  if (_y_width < 0)
+  if (_y_width == 0)
     _y_width = bbox.max()(1) - bbox.min()(1);
-  if (_z_width < 0)
+  if (_z_width == 0)
     _z_width = bbox.max()(2) - bbox.min()(2);
 
   // Build each row mesh

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -16,6 +16,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_tools.h"
+#include "MooseMeshUtils.h"
 
 registerMooseObject("MooseApp", PatternedMeshGenerator);
 
@@ -34,7 +35,6 @@ validParams<PatternedMeshGenerator>()
       "z_width", 0, "z_width>=0", "The tile width in the z direction");
 
   // Boundaries : user has to provide id or name for each boundary
-  // If an id is provided, any provided name for this particular boundary will be ignored.
 
   // x boundary names
   params.addParam<BoundaryName>("left_boundary", "left", "name of the left (x) boundary");

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -44,14 +44,6 @@ validParams<PatternedMeshGenerator>()
   params.addParam<BoundaryName>("top_boundary", "top", "name of the top (y) boundary");
   params.addParam<BoundaryName>("bottom_boundary", "bottom", "name of the bottom (y) boundary");
 
-  // x boundary ids
-  params.addParam<boundary_id_type>("left_boundary_id", "id of the left (x) boundary");
-  params.addParam<boundary_id_type>("right_boundary_id", "id of the right (x) boundary");
-
-  // y boundary ids
-  params.addParam<boundary_id_type>("top_boundary_id", "name of the top (y) boundary");
-  params.addParam<boundary_id_type>("bottom_boundary_id", "name of the bottom (y) boundary");
-
   params.addRequiredParam<std::vector<std::vector<unsigned int>>>(
       "pattern", "A double-indexed array starting with the upper-left corner");
 
@@ -89,25 +81,16 @@ PatternedMeshGenerator::generate()
   // Data structure that holds each row
   _row_meshes.resize(_pattern.size());
 
-  // Trying to get the boundaries by name
-  boundary_id_type left =
-      _meshes[0]->get_boundary_info().get_id_by_name(getParam<BoundaryName>("left_boundary"));
-  boundary_id_type right =
-      _meshes[0]->get_boundary_info().get_id_by_name(getParam<BoundaryName>("right_boundary"));
-  boundary_id_type top =
-      _meshes[0]->get_boundary_info().get_id_by_name(getParam<BoundaryName>("top_boundary"));
-  boundary_id_type bottom =
-      _meshes[0]->get_boundary_info().get_id_by_name(getParam<BoundaryName>("bottom_boundary"));
+  // Getting the boundaries provided by the user
+  std::vector<BoundaryName> boundary_names = {getParam<BoundaryName>("left_boundary"),
+                                              getParam<BoundaryName>("right_boundary"),
+                                              getParam<BoundaryName>("top_boundary"),
+                                              getParam<BoundaryName>("bottom_boundary")};
 
-  // For each boundary, check if the user provided an id
-  if (isParamValid("left_boundary_id"))
-    left = getParam<boundary_id_type>("left_boundary_id");
-  if (isParamValid("right_boundary_id"))
-    right = getParam<boundary_id_type>("right_boundary_id");
-  if (isParamValid("top_boundary_id"))
-    top = getParam<boundary_id_type>("top_boundary_id");
-  if (isParamValid("bottom_boundary_id"))
-    bottom = getParam<boundary_id_type>("bottom_boundary_id");
+  std::vector<boundary_id_type> ids =
+      MooseMeshUtils::getBoundaryIDs(*_meshes[0], boundary_names, true);
+
+  boundary_id_type left = ids[0], right = ids[1], top = ids[2], bottom = ids[3];
 
   // Check if all the boundaries have been initialized
   if (left == -123)

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -41,16 +41,16 @@ validParams<StackGenerator>()
   params.addParam<BoundaryName>("bottom_boundary", "bottom", "name of the bottom (y) boundary");
 
   // y boundary ids (2D case)
-  params.addParam<boundary_id_type>("top_boundary_id", "name of the top (y) boundary");
-  params.addParam<boundary_id_type>("bottom_boundary_id", "name of the bottom (y) boundary");
+  // params.addParam<boundary_id_type>("top_boundary_id", "name of the top (y) boundary");
+  // params.addParam<boundary_id_type>("bottom_boundary_id", "name of the bottom (y) boundary");
 
   // z boundary names (3D case)
   params.addParam<BoundaryName>("front_boundary", "front", "name of the front (z) boundary");
   params.addParam<BoundaryName>("back_boundary", "back", "name of the back (z) boundary");
 
   // z boundary ids (3D case)
-  params.addParam<boundary_id_type>("front_boundary_id", "name of the front (z) boundary");
-  params.addParam<boundary_id_type>("back_boundary_id", "name of the back (z) boundary");
+  // params.addParam<boundary_id_type>("front_boundary_id", "name of the front (z) boundary");
+  // params.addParam<boundary_id_type>("back_boundary_id", "name of the back (z) boundary");
 
   params.addClassDescription("Use the supplied meshes and stitch them on top of each other");
 
@@ -105,32 +105,17 @@ StackGenerator::generate()
       mooseError("Mesh from MeshGenerator : ", _input_names[i + 1], " is not in ", _dim, "D.");
   }
 
-  boundary_id_type first =
-      mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("top_boundary"));
-  boundary_id_type second =
-      mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("bottom_boundary"));
-
+  // Getting the boundaries provided by the user
+  std::vector<BoundaryName> boundary_names = {getParam<BoundaryName>("top_boundary"),
+                                              getParam<BoundaryName>("bottom_boundary")};
   if (dim == 3)
-  {
-    first = mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("front_boundary"));
-    second = mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("back_boundary"));
-  }
+    boundary_names = {getParam<BoundaryName>("front_boundary"),
+                      getParam<BoundaryName>("back_boundary")};
 
-  // Check if the user provided boundary ids instead of names
-  if (dim == 3)
-  {
-    if (isParamValid("front_boundary_id"))
-      first = getParam<boundary_id_type>("front_boundary_id");
-    if (isParamValid("back_boundary_id"))
-      second = getParam<boundary_id_type>("back_boundary_id");
-  }
-  if (dim == 2)
-  {
-    if (isParamValid("top_boundary_id"))
-      first = getParam<boundary_id_type>("top_boundary_id");
-    if (isParamValid("bottom_boundary_id"))
-      second = getParam<boundary_id_type>("bottom_boundary_id");
-  }
+  std::vector<boundary_id_type> ids =
+      MooseMeshUtils::getBoundaryIDs(*_meshes[0], boundary_names, true);
+
+  boundary_id_type first = ids[0], second = ids[1];
 
   // Getting the width of each mesh
   std::vector<Real> heights;

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -116,7 +116,7 @@ StackGenerator::generate()
     second = mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("back_boundary"));
   }
 
-  //Check if the user provided boundary ids instead of names
+  // Check if the user provided boundary ids instead of names
   if (dim == 3)
   {
     if (isParamValid("front_boundary_id"))

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -17,6 +17,7 @@
 #include "libmesh/bounding_box.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/point.h"
+#include "MooseMeshUtils.h"
 
 #include <typeinfo>
 
@@ -40,17 +41,9 @@ validParams<StackGenerator>()
   params.addParam<BoundaryName>("top_boundary", "top", "name of the top (y) boundary");
   params.addParam<BoundaryName>("bottom_boundary", "bottom", "name of the bottom (y) boundary");
 
-  // y boundary ids (2D case)
-  // params.addParam<boundary_id_type>("top_boundary_id", "name of the top (y) boundary");
-  // params.addParam<boundary_id_type>("bottom_boundary_id", "name of the bottom (y) boundary");
-
   // z boundary names (3D case)
   params.addParam<BoundaryName>("front_boundary", "front", "name of the front (z) boundary");
   params.addParam<BoundaryName>("back_boundary", "back", "name of the back (z) boundary");
-
-  // z boundary ids (3D case)
-  // params.addParam<boundary_id_type>("front_boundary_id", "name of the front (z) boundary");
-  // params.addParam<boundary_id_type>("back_boundary_id", "name of the back (z) boundary");
 
   params.addClassDescription("Use the supplied meshes and stitch them on top of each other");
 

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -40,9 +40,17 @@ validParams<StackGenerator>()
   params.addParam<BoundaryName>("top_boundary", "top", "name of the top (y) boundary");
   params.addParam<BoundaryName>("bottom_boundary", "bottom", "name of the bottom (y) boundary");
 
+  // y boundary ids (2D case)
+  params.addParam<boundary_id_type>("top_boundary_id", "name of the top (y) boundary");
+  params.addParam<boundary_id_type>("bottom_boundary_id", "name of the bottom (y) boundary");
+
   // z boundary names (3D case)
   params.addParam<BoundaryName>("front_boundary", "front", "name of the front (z) boundary");
   params.addParam<BoundaryName>("back_boundary", "back", "name of the back (z) boundary");
+
+  // z boundary ids (3D case)
+  params.addParam<boundary_id_type>("front_boundary_id", "name of the front (z) boundary");
+  params.addParam<boundary_id_type>("back_boundary_id", "name of the back (z) boundary");
 
   params.addClassDescription("Use the supplied meshes and stitch them on top of each other");
 
@@ -106,6 +114,22 @@ StackGenerator::generate()
   {
     first = mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("front_boundary"));
     second = mesh->get_boundary_info().get_id_by_name(getParam<BoundaryName>("back_boundary"));
+  }
+
+  //Check if the user provided boundary ids instead of names
+  if (dim == 3)
+  {
+    if (isParamValid("front_boundary_id"))
+      first = getParam<boundary_id_type>("front_boundary_id");
+    if (isParamValid("back_boundary_id"))
+      second = getParam<boundary_id_type>("back_boundary_id");
+  }
+  if (dim == 2)
+  {
+    if (isParamValid("top_boundary_id"))
+      first = getParam<boundary_id_type>("top_boundary_id");
+    if (isParamValid("bottom_boundary_id"))
+      second = getParam<boundary_id_type>("bottom_boundary_id");
   }
 
   // Getting the width of each mesh

--- a/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
+++ b/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
@@ -24,10 +24,10 @@
                0 1 0 0 0 0 0 0 0 0 0 0 1 0 ;
                0 1 0 0 0 0 0 0 0 0 0 0 1 0 ;
                0 0 0 0 0 0 0 0 0 0 0 0 0 0'
-    bottom_boundary_id = 1
-    right_boundary_id = 2
-    top_boundary_id = 3
-    left_boundary_id = 4
+    bottom_boundary = 1
+    right_boundary = 2
+    top_boundary = 3
+    left_boundary = 4
   []
 []
 

--- a/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
+++ b/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
@@ -28,9 +28,8 @@
     right_boundary_id = 2
     top_boundary_id = 3
     left_boundary_id = 4
-    y_width = 1.2
-    x_width = 1.2
-    #parallel_type = replicated
+    #y_width = 1.2
+    #x_width = 1.2
   []
 []
 

--- a/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
+++ b/test/tests/meshgenerators/patterned_mesh_generator/patterned_mesh_generator.i
@@ -28,8 +28,6 @@
     right_boundary_id = 2
     top_boundary_id = 3
     left_boundary_id = 4
-    #y_width = 1.2
-    #x_width = 1.2
   []
 []
 


### PR DESCRIPTION
- StackGenerator : make it work with boundary ids as well as boundary names
- MeshExtruderGenerator : Remove the explicit dimension update at the very end, because it's done implicitly by MeshTools::Generation::build_extrusion
- PatternedMeshGenerator : Make it compute the x, y and z widths of the meshes (the user can still provide them if he wants to).
Refs #11640