### PR TITLE
Mesh generator cleanup

### DIFF
--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -78,7 +78,7 @@ protected:
     mesh_params.set<std::string>("_type") = "GeneratedMesh";
     mesh_params.set<MooseEnum>("dim") = "3";
     _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-    _mesh->setMeshBase(_mesh->constructMeshBase());
+    _mesh->setMeshBase(_mesh->buildMeshBaseObject());
 
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -78,6 +78,7 @@ protected:
     mesh_params.set<std::string>("_type") = "GeneratedMesh";
     mesh_params.set<MooseEnum>("dim") = "3";
     _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
+    _mesh->setMeshBase(_mesh->constructMeshBase());
 
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();

--- a/framework/include/mesh/FileMesh.h
+++ b/framework/include/mesh/FileMesh.h
@@ -43,8 +43,12 @@ protected:
   /// Auxiliary object for restart
   std::unique_ptr<ExodusII_IO> _exreader;
 
+  /// The requested dimension of the mesh. For some file meshes, this is not required may be implied
+  /// from the element type(s).
+  const unsigned int _dim;
+
   /// Timers
-  PerfID _read_mesh_timer;
+  const PerfID _read_mesh_timer;
 };
 
 #endif // FILEMESH_H

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -96,6 +96,18 @@ public:
   virtual std::unique_ptr<MooseMesh> safeClone() const = 0;
 
   /**
+   * Method to construct a libMesh::MeshBase object that is normally set and used by the MooseMesh
+   * object during the "init()" phase.
+   */
+  std::unique_ptr<MeshBase> constructMeshBase();
+
+  /**
+   * Method to set the mesh_base object. If this method is NOT called prior to calling init(), a
+   * MeshBase object will be automatically constructed and set.
+   */
+  void setMeshBase(std::unique_ptr<MeshBase> mesh_base);
+
+  /**
    * Initialize the Mesh object.  Most of the time this will turn around
    * and call build_mesh so the child class can build the Mesh object.
    *

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -78,10 +78,15 @@ public:
   MooseMesh(const InputParameters & parameters);
   MooseMesh(const MooseMesh & other_mesh);
 
-  /**
-   * Destructor
-   */
   virtual ~MooseMesh();
+
+  // The type of libMesh::MeshBase that will be used
+  enum class ParallelType
+  {
+    DEFAULT,
+    REPLICATED,
+    DISTRIBUTED
+  };
 
   /**
    * Clone method.  Allocates memory you are responsible to clean up.
@@ -99,7 +104,7 @@ public:
    * Method to construct a libMesh::MeshBase object that is normally set and used by the MooseMesh
    * object during the "init()" phase.
    */
-  std::unique_ptr<MeshBase> constructMeshBase();
+  std::unique_ptr<MeshBase> buildMeshBaseObject(ParallelType override_type = ParallelType::DEFAULT);
 
   /**
    * Method to set the mesh_base object. If this method is NOT called prior to calling init(), a
@@ -850,7 +855,7 @@ protected:
 
   /// Can be set to DISTRIBUTED, REPLICATED, or DEFAULT.  Determines whether
   /// the underlying libMesh mesh is a ReplicatedMesh or DistributedMesh.
-  MooseEnum _mesh_parallel_type;
+  ParallelType _parallel_type;
 
   /// False by default.  Final value is determined by several factors
   /// including the 'distribution' setting in the input file, and whether

--- a/framework/include/mesh/PatternedMesh.h
+++ b/framework/include/mesh/PatternedMesh.h
@@ -38,7 +38,7 @@ class PatternedMesh : public MooseMesh
 public:
   PatternedMesh(const InputParameters & parameters);
   PatternedMesh(const PatternedMesh & other_mesh);
-  virtual ~PatternedMesh();
+  virtual ~PatternedMesh() = default;
 
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 

--- a/framework/include/mesh/StitchedMesh.h
+++ b/framework/include/mesh/StitchedMesh.h
@@ -33,8 +33,6 @@ public:
   StitchedMesh(const InputParameters & parameters);
   StitchedMesh(const StitchedMesh & other_mesh);
 
-  virtual ~StitchedMesh();
-
   virtual std::unique_ptr<MooseMesh> safeClone() const override;
 
   virtual void buildMesh() override;

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -66,6 +66,9 @@ protected:
   std::unique_ptr<MeshBase> &
   getMeshByName(const MeshGeneratorName & input_mesh_generator_parameter_name);
 
+  /// References to the mesh and displaced mesh (currently in the ActionWarehouse)
+  std::shared_ptr<MooseMesh> & _mesh;
+
 private:
   /// A list of generators that are required to run before this generator may run
   std::vector<std::string> _depends_on;

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -13,6 +13,9 @@
 #include "MooseObject.h"
 #include "Restartable.h"
 
+// Included so mesh generators don't need to include this when constructing MeshBase objects
+#include "MooseMesh.h"
+
 #include "libmesh/mesh_base.h"
 
 // Forward declarations

--- a/framework/src/actions/AddMeshGeneratorAction.C
+++ b/framework/src/actions/AddMeshGeneratorAction.C
@@ -34,5 +34,8 @@ AddMeshGeneratorAction::act()
   if (_app.isRecovering())
     return;
 
+  if (!_mesh)
+    mooseError("No mesh file was supplied and no generation block was provided");
+
   _app.addMeshGenerator(_type, _name, _moose_object_pars);
 }

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -220,9 +220,9 @@ SetupMeshAction::act()
   }
   else if (_current_task == "set_mesh_base")
   {
-    _mesh->setMeshBase(_mesh->constructMeshBase());
+    _mesh->setMeshBase(_mesh->buildMeshBaseObject());
     if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
-      _displaced_mesh->setMeshBase(_displaced_mesh->constructMeshBase());
+      _displaced_mesh->setMeshBase(_displaced_mesh->buildMeshBaseObject());
   }
   else if (_current_task == "init_mesh")
   {

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -16,7 +16,7 @@
 #include "Factory.h"
 
 registerMooseAction("MooseApp", SetupMeshAction, "setup_mesh");
-
+registerMooseAction("MooseApp", SetupMeshAction, "set_mesh_base");
 registerMooseAction("MooseApp", SetupMeshAction, "init_mesh");
 
 template <>
@@ -217,6 +217,12 @@ SetupMeshAction::act()
     _mesh = _factory.create<MooseMesh>(_type, "mesh", _moose_object_pars);
     if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
       _displaced_mesh = _factory.create<MooseMesh>(_type, "displaced_mesh", _moose_object_pars);
+  }
+  else if (_current_task == "set_mesh_base")
+  {
+    _mesh->setMeshBase(_mesh->constructMeshBase());
+    if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
+      _displaced_mesh->setMeshBase(_displaced_mesh->constructMeshBase());
   }
   else if (_current_task == "init_mesh")
   {

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -97,6 +97,7 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("determine_system_type",        Executioner,            true);
 
   registerMooseObjectTask("setup_mesh",                   MooseMesh,              false);
+  registerMooseObjectTask("set_mesh_base",                MooseMesh,              false);
   registerMooseObjectTask("init_mesh",                    MooseMesh,              false);
   registerMooseObjectTask("add_mesh_modifier",            MeshModifier,           false);
   registerMooseObjectTask("add_mesh_generator",           MeshGenerator,           false);
@@ -233,9 +234,10 @@ addActionTypes(Syntax & syntax)
                            "(set_global_params)"
                            "(setup_recover_file_base)"
                            "(add_mesh_generator)"
-                           "(execute_mesh_generators)"
-                           "(check_copy_nodal_vars)"
                            "(setup_mesh)"
+                           "(execute_mesh_generators)"
+                           "(set_mesh_base)"
+                           "(check_copy_nodal_vars)"
                            "(add_partitioner)"
                            "(add_geometric_rm)"
                            "(init_mesh)"

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -172,7 +172,7 @@ addActionTypes(Syntax & syntax)
   registerTask("uniform_refine_mesh", false);
   registerTask("prepare_mesh", false);
   registerTask("add_geometric_rm", true);
-  registerTask("setup_mesh_complete", false); // calls prepare
+  registerTask("setup_mesh_complete", true); // calls prepare
 
   registerTask("init_displaced_problem", false);
 

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -100,7 +100,7 @@ addActionTypes(Syntax & syntax)
   registerMooseObjectTask("set_mesh_base",                MooseMesh,              false);
   registerMooseObjectTask("init_mesh",                    MooseMesh,              false);
   registerMooseObjectTask("add_mesh_modifier",            MeshModifier,           false);
-  registerMooseObjectTask("add_mesh_generator",           MeshGenerator,           false);
+  registerMooseObjectTask("add_mesh_generator",           MeshGenerator,          false);
 
   registerMooseObjectTask("add_kernel",                   Kernel,                 false);
   appendMooseObjectTask  ("add_kernel",                   EigenKernel);
@@ -233,8 +233,8 @@ addActionTypes(Syntax & syntax)
                            "(common_output)"
                            "(set_global_params)"
                            "(setup_recover_file_base)"
-                           "(add_mesh_generator)"
                            "(setup_mesh)"
+                           "(add_mesh_generator)"
                            "(execute_mesh_generators)"
                            "(set_mesh_base)"
                            "(check_copy_nodal_vars)"

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1540,7 +1540,7 @@ MooseApp::executeMeshGenerators()
     }
 
     // Prepare the final mesh
-    _final_generated_mesh->prepare_for_use();
+    //    _final_generated_mesh->prepare_for_use();
   }
 }
 

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1538,9 +1538,6 @@ MooseApp::executeMeshGenerators()
         }
       }
     }
-
-    // Prepare the final mesh
-    //    _final_generated_mesh->prepare_for_use();
   }
 }
 
@@ -1589,12 +1586,11 @@ MooseApp::createMinimalApp()
 {
   TIME_SECTION(_create_minimal_app_timer);
 
-  // SetupMeshAction (setup_mesh)
+  // SetupMeshAction
   {
     // Build the Action parameters
     InputParameters action_params = _action_factory.getValidParams("SetupMeshAction");
     action_params.set<std::string>("type") = "GeneratedMesh";
-    action_params.set<std::string>("task") = "setup_mesh";
 
     // Create The Action
     std::shared_ptr<MooseObjectAction> action = std::static_pointer_cast<MooseObjectAction>(
@@ -1606,19 +1602,6 @@ MooseApp::createMinimalApp()
     params.set<unsigned int>("nx") = 1;
 
     // Add Action to the warehouse
-    _action_warehouse.addActionBlock(action);
-  }
-
-  // SetupMeshAction (init_mesh)
-  {
-    // Action parameters
-    InputParameters action_params = _action_factory.getValidParams("SetupMeshAction");
-    action_params.set<std::string>("type") = "GeneratedMesh";
-    action_params.set<std::string>("task") = "init_mesh";
-
-    // Build the action
-    std::shared_ptr<Action> action =
-        _action_factory.create("SetupMeshAction", "Mesh", action_params);
     _action_warehouse.addActionBlock(action);
   }
 

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -32,14 +32,15 @@ validParams<FileMesh>()
 FileMesh::FileMesh(const InputParameters & parameters)
   : MooseMesh(parameters),
     _file_name(getParam<MeshFileName>("file")),
+    _dim(getParam<MooseEnum>("dim")),
     _read_mesh_timer(registerTimedSection("readMesh", 2))
 {
-  getMesh().set_mesh_dimension(getParam<MooseEnum>("dim"));
 }
 
 FileMesh::FileMesh(const FileMesh & other_mesh)
   : MooseMesh(other_mesh),
     _file_name(other_mesh._file_name),
+    _dim(other_mesh._dim),
     _read_mesh_timer(other_mesh._read_mesh_timer)
 {
 }
@@ -57,7 +58,7 @@ FileMesh::buildMesh()
 {
   TIME_SECTION(_read_mesh_timer);
 
-  std::string _file_name = getParam<MeshFileName>("file");
+  getMesh().set_mesh_dimension(getParam<MooseEnum>("dim"));
 
   if (_is_nemesis)
   {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2001,7 +2001,7 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
   {
     if (override_type == ParallelType::DISTRIBUTED)
       mooseError("The requested override_type of \"Distributed\" may not be used when MOOSE is "
-                 "running with a DistributedMesh");
+                 "running with a ReplicatedMesh");
 
     mesh = libmesh_make_unique<ReplicatedMesh>(_communicator, dim);
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1455,6 +1455,7 @@ MooseMesh::dimensionWidth(unsigned int component) const
 Real
 MooseMesh::getMinInDimension(unsigned int component) const
 {
+  mooseAssert(_mesh, "The MeshBase has not been constructed");
   mooseAssert(component < _bounds.size(), "Requested dimension out of bounds");
 
   return _bounds[component][MIN];
@@ -1463,6 +1464,7 @@ MooseMesh::getMinInDimension(unsigned int component) const
 Real
 MooseMesh::getMaxInDimension(unsigned int component) const
 {
+  mooseAssert(_mesh, "The MeshBase has not been constructed");
   mooseAssert(component < _bounds.size(), "Requested dimension out of bounds");
 
   return _bounds[component][MAX];

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -54,11 +54,6 @@ StitchedMesh::StitchedMesh(const InputParameters & parameters)
   // The StitchedMesh class only works with ReplicatedMesh
   errorIfDistributedMesh("StitchedMesh");
 
-  // Get the original mesh
-  _original_mesh = dynamic_cast<ReplicatedMesh *>(&getMesh());
-  if (!_original_mesh)
-    mooseError("StitchedMesh does not support DistributedMesh");
-
   if (_stitch_boundaries.size() % 2 != 0)
     mooseError("There must be an even amount of stitch_boundaries in ", name());
 
@@ -77,8 +72,6 @@ StitchedMesh::StitchedMesh(const StitchedMesh & other_mesh)
 {
 }
 
-StitchedMesh::~StitchedMesh() {}
-
 std::unique_ptr<MooseMesh>
 StitchedMesh::safeClone() const
 {
@@ -88,6 +81,9 @@ StitchedMesh::safeClone() const
 void
 StitchedMesh::buildMesh()
 {
+  // Get the original mesh
+  _original_mesh = static_cast<ReplicatedMesh *>(&getMesh());
+
   // Read the first mesh into the original mesh... then we'll stitch all of the others into that
   _original_mesh->read(_files[0]);
 

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -102,7 +102,7 @@ GeneratedMeshGenerator::GeneratedMeshGenerator(const InputParameters & parameter
 std::unique_ptr<MeshBase>
 GeneratedMeshGenerator::generate()
 {
-  std::unique_ptr<ReplicatedMesh> mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  auto mesh = _mesh->constructMeshBase();
 
   MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
 

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -102,6 +102,7 @@ GeneratedMeshGenerator::GeneratedMeshGenerator(const InputParameters & parameter
 std::unique_ptr<MeshBase>
 GeneratedMeshGenerator::generate()
 {
+  // Have MOOSE construct the correct libMesh::Mesh object using Mesh block and CLI parameters.
   auto mesh = _mesh->constructMeshBase();
 
   MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
@@ -168,22 +169,25 @@ GeneratedMeshGenerator::generate()
   // Apply the bias if any exists
   if (_bias_x != 1.0 || _bias_y != 1.0 || _bias_z != 1.0)
   {
+    const auto MIN = std::numeric_limits<Real>::max();
 
     // Biases
-    Real bias[3] = {_bias_x, _bias_y, _bias_z};
+    std::array<Real, LIBMESH_DIM> bias = {
+        {_bias_x, _dim > 1 ? _bias_y : 1.0, _dim > 2 ? _bias_z : 1.0}};
 
     // "width" of the mesh in each direction
-    Real width[3] = {_xmax - _xmin, _ymax - _ymin, _zmax - _zmin};
+    std::array<Real, LIBMESH_DIM> width = {
+        {_xmax - _xmin, _dim > 1 ? _ymax - _ymin : 0, _dim > 2 ? _zmax - _zmin : 0}};
 
     // Min mesh extent in each direction.
-    Real mins[3] = {_xmin, _ymin, _zmin};
+    std::array<Real, LIBMESH_DIM> mins = {{_xmin, _dim > 1 ? _ymin : MIN, _dim > 2 ? _zmin : MIN}};
 
     // Number of elements in each direction.
-    unsigned int nelem[3] = {_nx, _ny, _nz};
+    std::array<unsigned int, LIBMESH_DIM> nelem = {{_nx, _dim > 1 ? _ny : 1, _dim > 2 ? _nz : 1}};
 
     // We will need the biases raised to integer powers in each
     // direction, so let's pre-compute those...
-    std::vector<std::vector<Real>> pows(LIBMESH_DIM);
+    std::array<std::vector<Real>, LIBMESH_DIM> pows;
     for (unsigned int dir = 0; dir < LIBMESH_DIM; ++dir)
     {
       pows[dir].resize(nelem[dir] + 1);
@@ -219,6 +223,9 @@ GeneratedMeshGenerator::generate()
             // of using "integer_part", since that could be off by a
             // lot (e.g. we want 3.9999 to map to 4.0 instead of 3.0).
             int index = round(float_index);
+
+            mooseAssert(index >= static_cast<int>(0) && index < static_cast<int>(pows[dir].size()),
+                        "Scaled \"index\" out of range");
 
             // Move node to biased location.
             node(dir) =

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -103,7 +103,7 @@ std::unique_ptr<MeshBase>
 GeneratedMeshGenerator::generate()
 {
   // Have MOOSE construct the correct libMesh::Mesh object using Mesh block and CLI parameters.
-  auto mesh = _mesh->constructMeshBase();
+  auto mesh = _mesh->buildMeshBaseObject();
 
   MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
 

--- a/framework/src/meshgenerators/MeshGenerator.C
+++ b/framework/src/meshgenerators/MeshGenerator.C
@@ -22,7 +22,9 @@ validParams<MeshGenerator>()
 }
 
 MeshGenerator::MeshGenerator(const InputParameters & parameters)
-  : MooseObject(parameters), Restartable(this, "MeshGenerators")
+  : MooseObject(parameters),
+    Restartable(this, "MeshGenerators"),
+    _mesh(_app.actionWarehouse().mesh())
 {
 }
 

--- a/modules/tensor_mechanics/src/actions/LineElementAction.C
+++ b/modules/tensor_mechanics/src/actions/LineElementAction.C
@@ -18,9 +18,7 @@
 #include "libmesh/string_to_enum.h"
 #include <algorithm>
 
-registerMooseAction("TensorMechanicsApp", LineElementAction, "meta_action");
-
-registerMooseAction("TensorMechanicsApp", LineElementAction, "setup_mesh_complete");
+registerMooseAction("TensorMechanicsApp", LineElementAction, "create_problem");
 
 registerMooseAction("TensorMechanicsApp", LineElementAction, "add_variable");
 
@@ -365,7 +363,7 @@ void
 LineElementAction::act()
 {
   // Get the subdomain involved in the action once the mesh setup is complete
-  if (_current_task == "setup_mesh_complete")
+  if (_current_task == "create_problem")
   {
     // get subdomain IDs
     for (auto & name : _subdomain_names)

--- a/test/tests/mesh/no_mesh_block/generators_no_mesh_block.i
+++ b/test/tests/mesh/no_mesh_block/generators_no_mesh_block.i
@@ -1,0 +1,49 @@
+[MeshGenerators]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 3
+    ny = 3
+    nz = 4
+    bias_x = 2
+    bias_z = 0.5
+  []
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [leftBC]
+    type = DirichletBC
+    variable = u
+    boundary = 10
+    value = 1
+  []
+  [rightBC]
+    type = DirichletBC
+    variable = u
+    boundary = 11
+    value = 0
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/mesh/no_mesh_block/no_mesh_block.i
+++ b/test/tests/mesh/no_mesh_block/no_mesh_block.i
@@ -1,0 +1,39 @@
+# No Mesh Block!
+
+[Variables]
+  [u]
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [leftBC]
+    type = DirichletBC
+    variable = u
+    boundary = 10
+    value = 1
+  []
+  [rightBC]
+    type = DirichletBC
+    variable = u
+    boundary = 11
+    value = 0
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/mesh/no_mesh_block/tests
+++ b/test/tests/mesh/no_mesh_block/tests
@@ -1,0 +1,22 @@
+[Tests]
+  [./no_mesh_block_err]
+    type = 'RunException'
+    input = 'no_mesh_block.i'
+    expect_err = "No mesh file was supplied and no generation block was provided"
+
+    issues = #2408
+    design = "Mesh/index.md"
+    requirement = "The system shall issue an error if no Mesh block is provided."
+  [../]
+
+  [./generators_no_mesh_block_err]
+    type = 'RunException'
+    input = 'generators_no_mesh_block.i'
+    expect_err = "No mesh file was supplied and no generation block was provided"
+
+    issues = #2408
+    design = "Mesh/index.md"
+    requirement = "The system shall issue an error if no Mesh block is provided even when MeshGenerators are provided."
+  [../]
+
+[]

--- a/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_elements_in_bounding_box.i
+++ b/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_elements_in_bounding_box.i
@@ -27,6 +27,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_nodes_found.i
+++ b/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_nodes_found.i
@@ -28,6 +28,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_side_sets_found.i
+++ b/test/tests/meshgenerators/generate_sidesets_bounding_box/error_no_side_sets_found.i
@@ -18,6 +18,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_elements_in_bounding_box.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_elements_in_bounding_box.i
@@ -27,6 +27,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_nodes_found.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_nodes_found.i
@@ -28,6 +28,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_side_sets_found.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/error_no_side_sets_found.i
@@ -18,6 +18,10 @@
   []
 []
 
+[Mesh]
+  type = MeshGeneratorMesh
+[]
+
 [Variables]
   [./u]
   [../]

--- a/unit/include/ParsedFunctionTest.h
+++ b/unit/include/ParsedFunctionTest.h
@@ -36,7 +36,7 @@ protected:
     mesh_params.set<std::string>("_type") = "GneratedMesh";
 
     _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
-    _mesh->setMeshBase(_mesh->constructMeshBase());
+    _mesh->setMeshBase(_mesh->buildMeshBaseObject());
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();

--- a/unit/include/ParsedFunctionTest.h
+++ b/unit/include/ParsedFunctionTest.h
@@ -36,6 +36,7 @@ protected:
     mesh_params.set<std::string>("_type") = "GneratedMesh";
 
     _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
+    _mesh->setMeshBase(_mesh->constructMeshBase());
 
     InputParameters problem_params = _factory->getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();


### PR DESCRIPTION
Moving towards a single and consistent way to build the right kind of Mesh between the Mesh and MeshGenerator systems. This PR changes the GeneratedMeshGenerator object to new API in MooseMesh to construct the right kind of MeshBase object.

TODO: We need to evaluate individual MeshGenerators to decide which ones need to be updated. Actually, all should be updated to use the new API, but some might need to force a particular Mesh type.