### PR TITLE
Gcc 8 fixes

### DIFF
--- a/framework/contrib/tinydir/include/tinydir.h
+++ b/framework/contrib/tinydir/include/tinydir.h
@@ -331,7 +331,7 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 		dir->_e->d_name
 #endif
 	);
-	strcat(file->path, file->name);
+	strncat(file->path, file->name, _TINYDIR_PATH_MAX - 1);
 #ifndef _MSC_VER
 	if (stat(file->path, &file->_s) == -1)
 	{

--- a/framework/contrib/tinydir/include/tinydir.h
+++ b/framework/contrib/tinydir/include/tinydir.h
@@ -331,7 +331,7 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 		dir->_e->d_name
 #endif
 	);
-	strncat(file->path, file->name, _TINYDIR_PATH_MAX - 1);
+  strncat(file->path, file->name, _TINYDIR_PATH_MAX - 1);
 #ifndef _MSC_VER
 	if (stat(file->path, &file->_s) == -1)
 	{

--- a/framework/src/postprocessors/FindValueOnLine.C
+++ b/framework/src/postprocessors/FindValueOnLine.C
@@ -90,7 +90,7 @@ FindValueOnLine::execute()
 
   bool found_it = false;
   Real value = 0;
-  for (auto i = decltype(_depth)(0); i < _depth; ++i)
+  for (unsigned int i = 0; i < _depth; ++i)
   {
     // find midpoint
     s = (s_left + s_right) / 2.0;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -343,9 +343,12 @@ NonlinearSystem::setupColoringFiniteDifferencedPreconditioner()
 
   MatFDColoringCreate(petsc_mat->mat(), iscoloring, &_fdcoloring);
   MatFDColoringSetFromOptions(_fdcoloring);
+  // clang-format off
   MatFDColoringSetFunction(_fdcoloring,
-                           (PetscErrorCode(*)(void)) & libMesh::libmesh_petsc_snes_fd_residual,
+                           (PetscErrorCode(*)(void))(void (*)(void)) &
+                               libMesh::libmesh_petsc_snes_fd_residual,
                            &petsc_nonlinear_solver);
+  // clang-format on
 #if !PETSC_RELEASE_LESS_THAN(3, 5, 0)
   MatFDColoringSetUp(petsc_mat->mat(), iscoloring, _fdcoloring);
 #endif

--- a/framework/src/vectorpostprocessors/SphericalAverage.C
+++ b/framework/src/vectorpostprocessors/SphericalAverage.C
@@ -82,7 +82,7 @@ SphericalAverage::execute()
     // add the volume contributed by the current quadrature point
     if (bin >= 0 && bin < static_cast<int>(_nbins))
     {
-      for (auto j = decltype(_nvals)(0); j < _nvals; ++j)
+      for (unsigned int j = 0; j < _nvals; ++j)
         (*_average[j])[bin] += (*_values[j])[_qp];
 
       _counts[bin]++;

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra
+ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror -Wno-cast-function-type
 ###############################################################################
 
 # framework

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@
 ###############################################################################
 MOOSE_DIR          ?= $(shell dirname `pwd`)
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
-ADDITIONAL_CPPFLAGS += -Wall -Wextra -Werror -Wno-cast-function-type
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework


### PR DESCRIPTION
GCC 8.2.x barfs some warnings, but when we treat warnings as error the build fails.

closes #12984