### PR TITLE
Don't calculate equilibrium mass fractions uneccesarily

### DIFF
--- a/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
@@ -538,6 +538,9 @@ protected:
   const Real _Tlower;
   /// Temperature above which the Spycher & Pruess (2010) model is used (K)
   const Real _Tupper;
+  /// Minimum Z - below this value all CO2 will be dissolved. This reduces the
+  /// computational burden when small values of Z are present
+  const Real _Zmin;
 };
 
 #endif // POROUSFLOWBRINECO2_H


### PR DESCRIPTION
When the amount of CO2 is small, it is all dissolved so the
equilibrium mass fraction calculation isn't required.

This is the lowest hanging fruit here, but still can make a noticeable difference.

For example, for the heavy tests `theis_brineco2` we see a ~10% reduction in time

| | Time |
|---|---|
| Before | 114 s |
| After    | 102 s |

Refs #12812
