### PR TITLE
'mu_from_p_T' and 'k_from_p_T' interface added to IdealGasFluidProperties and StiffenedGasFluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -71,6 +71,11 @@ public:
   virtual Real g_from_v_e(Real v, Real e) const override;
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real molarMass() const override;
+  virtual Real mu_from_p_T(Real p, Real T) const override;
+  virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+  virtual Real k_from_p_T(Real pressure, Real temperature) const override;
+  virtual void
+  k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   virtual Real gamma() const;
   virtual Real cv() const;

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -75,6 +75,12 @@ public:
   virtual Real criticalTemperature() const override;
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
+  virtual Real mu_from_p_T(Real pressure, Real temperature) const override;
+  virtual void mu_from_p_T(
+      Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+  virtual Real k_from_p_T(Real pressure, Real temperature) const override;
+  virtual void
+  k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   virtual Real c2_from_p_rho(Real pressure, Real rho) const;
 

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -425,3 +425,31 @@ IdealGasFluidProperties::T_from_p_h(Real, Real h) const
 {
   return h / _gamma / _cv;
 }
+
+Real IdealGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _mu;
+}
+
+void
+IdealGasFluidProperties::mu_from_p_T(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = this->mu_from_p_T(pressure, temperature);
+  dmu_dp = 0.0;
+  dmu_dT = 0.0;
+}
+
+Real IdealGasFluidProperties::k_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _k;
+}
+
+void
+IdealGasFluidProperties::k_from_p_T(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = this->k_from_p_T(pressure, temperature);
+  dk_dp = 0.0;
+  dk_dT = 0.0;
+}

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -443,6 +443,34 @@ StiffenedGasFluidProperties::criticalInternalEnergy() const
   return _e_c;
 }
 
+Real StiffenedGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _mu;
+}
+
+void
+StiffenedGasFluidProperties::mu_from_p_T(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = this->mu_from_p_T(pressure, temperature);
+  dmu_dp = 0.0;
+  dmu_dT = 0.0;
+}
+
+Real StiffenedGasFluidProperties::k_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _k;
+}
+
+void
+StiffenedGasFluidProperties::k_from_p_T(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = this->k_from_p_T(pressure, temperature);
+  dk_dp = 0.0;
+  dk_dT = 0.0;
+}
+
 Real StiffenedGasFluidProperties::pp_sat_from_p_T(Real /*p*/, Real /*T*/) const
 {
   mooseError(

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -79,4 +79,10 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
   ABS_TEST(_fp->molarMass(), 34.522988492890422, REL_TOL_SAVED_VALUE);
 
   ABS_TEST(_fp->T_from_p_h(p, h), T, REL_TOL_CONSISTENCY);
+
+  REL_TEST(_fp->mu_from_p_T(p, T), 0.0, REL_TOL_CONSISTENCY);
+  DERIV_TEST(_fp->mu_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  REL_TEST(_fp->k_from_p_T(p, T), 0.0, REL_TOL_CONSISTENCY);
+  DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -77,4 +77,10 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
   DERIV_TEST(_fp->e_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
   REL_TEST(_fp->T_from_p_h(p, h), T, REL_TOL_CONSISTENCY);
+
+  REL_TEST(_fp->mu_from_p_T(p, T), 0.001, REL_TOL_CONSISTENCY);
+  DERIV_TEST(_fp->mu_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  REL_TEST(_fp->k_from_p_T(p, T), 0.6, REL_TOL_CONSISTENCY);
+  DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }


### PR DESCRIPTION
Added `mu_from_p_T` and `k_from_p_T` interfaces to `IdealGasFluidProperties` and `StiffenedGasFluidProperties`. Added to unit tests to ensure correct implementation.

Closes #12815
