### PR TITLE
Specific heat derivatives to Fluid Properties module

### DIFF
--- a/modules/fluid_properties/include/userobjects/HelmholtzFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HelmholtzFluidProperties.h
@@ -55,6 +55,8 @@ public:
 
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  using SinglePhaseFluidProperties::cp_from_p_T;
+
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -72,6 +72,7 @@ public:
   virtual Real g_from_v_e(Real v, Real e) const override;
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real molarMass() const override;
+  virtual Real cv_from_p_T(Real p, Real T) const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
   virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -71,6 +71,7 @@ public:
   virtual Real g_from_v_e(Real v, Real e) const override;
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real molarMass() const override;
+  virtual Real cp_from_p_T(Real p, Real T) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;
   virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   virtual Real k_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -33,6 +33,7 @@ public:
   virtual Real c_from_v_e(Real v, Real e) const override;
   virtual void c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real & dc_de) const override;
   virtual Real cp_from_v_e(Real v, Real e) const override;
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
   virtual Real cv_from_v_e(Real v, Real e) const override;
   virtual Real mu_from_v_e(Real v, Real e) const override;
   virtual Real k_from_v_e(Real v, Real e) const override;
@@ -72,7 +73,7 @@ public:
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real molarMass() const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
-  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;
   virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   virtual Real k_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -72,6 +72,7 @@ public:
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real molarMass() const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
+  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;
   virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   virtual Real k_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidPropertiesPT.h
@@ -33,6 +33,8 @@ public:
 
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  using SinglePhaseFluidProperties::cp_from_p_T;
+
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
   virtual Real c_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NaClFluidProperties.h
@@ -81,6 +81,8 @@ public:
 
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  using SinglePhaseFluidProperties::cp_from_p_T;
+
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
   virtual void rho_mu(Real pressure, Real temperature, Real & rho, Real & mu) const override;

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -49,6 +49,8 @@ public:
   /// Isobaric specific heat capacity (J/kg/K)
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+
   /// Isochoric specific heat capacity (J/kg/K)
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -49,7 +49,8 @@ public:
   /// Isobaric specific heat capacity (J/kg/K)
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
-  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+  virtual void cp_from_p_T(
+      Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
 
   /// Isochoric specific heat capacity (J/kg/K)
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -555,6 +555,17 @@ public:
   virtual Real cp_from_p_T(Real pressure, Real temperature) const;
 
   /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param[in] pressure    fluid pressure (Pa)
+   * @param[in] temperature fluid temperature (K)
+   * @param[out] cp         isobaric specific heat (J/kg/K)
+   * @param[out] dcp_dp     derivative of isobaric specific heat capacity w.r.t. pressure (J/kg/K/Pa)
+   * @param[out] dcp_dT     derivative of isobaric specific heat capacity w.r.t. temperature (J/kg/K/K)
+   */
+  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const;
+
+  /**
    * Isochoric specific heat
    * @param pressure fluid pressure (Pa)
    * @param temperature fluid temperature (K)

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -99,6 +99,18 @@ public:
   virtual Real cp_from_v_e(Real v, Real e) const;
 
   /**
+   * Isobaric (constant pressure) specific heat from specific volume and specific
+   * internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cp     isobaric specific heat (J/kg/K)
+   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume (J/K/m$^3$)
+   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific inernal energy (1/K)
+   */
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const;
+
+  /**
    * Isochoric (constant-volume) specific heat from specific volume and specific
    * internal energy
    *
@@ -560,10 +572,11 @@ public:
    * @param[in] pressure    fluid pressure (Pa)
    * @param[in] temperature fluid temperature (K)
    * @param[out] cp         isobaric specific heat (J/kg/K)
-   * @param[out] dcp_dp     derivative of isobaric specific heat capacity w.r.t. pressure (J/kg/K/Pa)
-   * @param[out] dcp_dT     derivative of isobaric specific heat capacity w.r.t. temperature (J/kg/K/K)
+   * @param[out] dcp_dp     derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
+   * @param[out] dcp_dT     derivative of isobaric specific heat w.r.t. temperature (J/kg/K/K)
    */
-  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const;
+  virtual void
+  cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const;
 
   /**
    * Isochoric specific heat

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -76,6 +76,7 @@ public:
   virtual Real criticalTemperature() const override;
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
+  virtual Real cv_from_p_T(Real p, Real T) const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
   virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -75,12 +75,11 @@ public:
   virtual Real criticalTemperature() const override;
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
-  virtual Real mu_from_p_T(Real pressure, Real temperature) const override;
-  virtual void mu_from_p_T(
-      Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
-  virtual Real k_from_p_T(Real pressure, Real temperature) const override;
-  virtual void
-  k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
+  virtual Real cp_from_p_T(Real p, Real T) const override;
+  virtual Real mu_from_p_T(Real p, Real T) const override;
+  virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
+  virtual Real k_from_p_T(Real p, Real T) const override;
+  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
   virtual Real c2_from_p_rho(Real pressure, Real rho) const;
 

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -33,6 +33,7 @@ public:
   virtual Real c_from_v_e(Real v, Real e) const override;
   virtual void c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real & dc_de) const override;
   virtual Real cp_from_v_e(Real v, Real e) const override;
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
   virtual Real cv_from_v_e(Real v, Real e) const override;
   virtual Real mu_from_v_e(Real v, Real e) const override;
   virtual Real k_from_v_e(Real v, Real e) const override;
@@ -76,7 +77,7 @@ public:
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
-  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;
   virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   virtual Real k_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -76,6 +76,7 @@ public:
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
+  virtual void cp_from_p_T(Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;
   virtual void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
   virtual Real k_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -141,6 +141,8 @@ public:
 
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  using SinglePhaseFluidProperties::cp_from_p_T;
+
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
   virtual Real c_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -80,6 +80,8 @@ public:
 
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
+  using SinglePhaseFluidProperties::cp_from_p_T;
+
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
   virtual Real mu_from_p_T(Real pressure, Real temperature) const override;

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -431,6 +431,14 @@ Real IdealGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperatu
   return _cp;
 }
 
+void
+IdealGasFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0.0;
+  dcp_dT = 0.0;
+}
+
 Real IdealGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _mu;

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -98,6 +98,14 @@ IdealGasFluidProperties::c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real
 
 Real IdealGasFluidProperties::cp_from_v_e(Real, Real) const { return _cp; }
 
+void
+IdealGasFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
+{
+  cp = cp_from_v_e(v, e);
+  dcp_dv = 0.0;
+  dcp_de = 0.0;
+}
+
 Real
 IdealGasFluidProperties::cp() const
 {
@@ -432,7 +440,8 @@ Real IdealGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperatu
 }
 
 void
-IdealGasFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+IdealGasFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
 {
   cp = cp_from_p_T(pressure, temperature);
   dcp_dp = 0.0;

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -434,6 +434,11 @@ IdealGasFluidProperties::T_from_p_h(Real, Real h) const
   return h / _gamma / _cv;
 }
 
+Real IdealGasFluidProperties::cv_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _cv;
+}
+
 Real IdealGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _cp;

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -426,6 +426,11 @@ IdealGasFluidProperties::T_from_p_h(Real, Real h) const
   return h / _gamma / _cv;
 }
 
+Real IdealGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _cp;
+}
+
 Real IdealGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _mu;

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -80,7 +80,8 @@ Real SimpleFluidProperties::cp_from_p_T(Real /*pressure*/, Real /*temperature*/)
 }
 
 void
-SimpleFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+SimpleFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
 {
   cp = cp_from_p_T(pressure, temperature);
   dcp_dp = 0.0;

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -79,6 +79,14 @@ Real SimpleFluidProperties::cp_from_p_T(Real /*pressure*/, Real /*temperature*/)
   return _cp;
 }
 
+void
+SimpleFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0.0;
+  dcp_dT = 0.0;
+}
+
 Real SimpleFluidProperties::cv_from_p_T(Real /*pressure*/, Real /*temperature*/) const
 {
   return _cv;

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -398,6 +398,12 @@ Real SinglePhaseFluidProperties::cp_from_p_T(Real, Real) const
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
 }
 
+void
+SinglePhaseFluidProperties::cp_from_p_T(Real, Real, Real &, Real &, Real &) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
+}
+
 Real SinglePhaseFluidProperties::cv_from_p_T(Real, Real) const
 {
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -63,6 +63,12 @@ Real SinglePhaseFluidProperties::cp_from_v_e(Real, Real) const
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
 }
 
+void
+SinglePhaseFluidProperties::cp_from_v_e(Real, Real, Real &, Real &, Real &) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
+}
+
 Real SinglePhaseFluidProperties::cv_from_v_e(Real, Real) const
 {
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -452,6 +452,11 @@ StiffenedGasFluidProperties::criticalInternalEnergy() const
   return _e_c;
 }
 
+Real StiffenedGasFluidProperties::cv_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _cv;
+}
+
 Real StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _cp;

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -102,6 +102,15 @@ StiffenedGasFluidProperties::c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, 
 
 Real StiffenedGasFluidProperties::cp_from_v_e(Real, Real) const { return _cp; }
 
+void
+StiffenedGasFluidProperties::cp_from_v_e(
+    Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
+{
+  cp = cp_from_v_e(v, e);
+  dcp_dv = 0.0;
+  dcp_de = 0.0;
+}
+
 Real StiffenedGasFluidProperties::cv_from_v_e(Real, Real) const { return _cv; }
 
 Real StiffenedGasFluidProperties::mu_from_v_e(Real, Real) const { return _mu; }
@@ -443,14 +452,14 @@ StiffenedGasFluidProperties::criticalInternalEnergy() const
   return _e_c;
 }
 
-Real
-StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
+Real StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _cp;
 }
 
 void
-StiffenedGasFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+StiffenedGasFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
 {
   cp = cp_from_p_T(pressure, temperature);
   dcp_dp = 0.0;

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -449,6 +449,14 @@ StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperatur
   return _cp;
 }
 
+void
+StiffenedGasFluidProperties::cp_from_p_T(Real pressure , Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0.0;
+  dcp_dT = 0.0;
+}
+
 Real StiffenedGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _mu;

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -443,6 +443,12 @@ StiffenedGasFluidProperties::criticalInternalEnergy() const
   return _e_c;
 }
 
+Real
+StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
+{
+  return _cp;
+}
+
 Real StiffenedGasFluidProperties::mu_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _mu;

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -85,4 +85,6 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
 
   REL_TEST(_fp->k_from_p_T(p, T), 0.0, REL_TOL_CONSISTENCY);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  REL_TEST(_fp->cp_from_p_T(p, T), 987.13756097561, REL_TOL_SAVED_VALUE);
 }

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -47,6 +47,7 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
 
   REL_TEST(_fp->c_from_v_e(v, e), 398.896207251962, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_v_e(v, e), 987.13756097561, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, REL_TOL_DERIVATIVE);
   REL_TEST(_fp->cv_from_v_e(v, e), 700.09756097561, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->mu_from_v_e(v, e), 0.0, 1e-15);
   REL_TEST(_fp->k_from_v_e(v, e), 0.0, 1e-15);

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -87,6 +87,7 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
   REL_TEST(_fp->k_from_p_T(p, T), 0.0, REL_TOL_CONSISTENCY);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
+  REL_TEST(_fp->cv_from_p_T(p, T), 700.09756097561, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_p_T(p, T), 987.13756097561, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -87,4 +87,5 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
   REL_TEST(_fp->cp_from_p_T(p, T), 987.13756097561, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -93,6 +93,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
   DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
   DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
+  DERIV_TEST(_fp->cp_from_p_T, _fp->cp_from_p_T, p, T, tol);
 
   p = 5.0E7;
   T = 90.0;
@@ -102,6 +103,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->e, _fp->e_dpT, p, T, tol);
   DERIV_TEST(_fp->h, _fp->h_dpT, p, T, tol);
   DERIV_TEST(_fp->k, _fp->k_dpT, p, T, tol);
+  DERIV_TEST(_fp->cp_from_p_T, _fp->cp_from_p_T, p, T, tol);
 
   Real henry, dhenry_dT;
   _fp->henryConstant_dT(T, henry, dhenry_dT);

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -83,4 +83,6 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
 
   REL_TEST(_fp->k_from_p_T(p, T), 0.6, REL_TOL_CONSISTENCY);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  REL_TEST(_fp->cp_from_p_T(p, T), 4267.6, REL_TOL_SAVED_VALUE);
 }

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -85,6 +85,7 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
   REL_TEST(_fp->k_from_p_T(p, T), 0.6, REL_TOL_CONSISTENCY);
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
+  REL_TEST(_fp->cv_from_p_T(p, T), 1816, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_p_T(p, T), 4267.6, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -85,4 +85,5 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
   DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
   REL_TEST(_fp->cp_from_p_T(p, T), 4267.6, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
 }

--- a/unit/src/StiffenedGasFluidPropertiesTest.C
+++ b/unit/src/StiffenedGasFluidPropertiesTest.C
@@ -47,6 +47,7 @@ TEST_F(StiffenedGasFluidPropertiesTest, testAll)
 
   REL_TEST(_fp->c_from_v_e(v, e), 1.299581997797754e3, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_v_e(v, e), 4267.6, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, REL_TOL_DERIVATIVE);
   REL_TEST(_fp->cv_from_v_e(v, e), 1816, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->mu_from_v_e(v, e), 0.001, 1e-15);
   REL_TEST(_fp->k_from_v_e(v, e), 0.6, 1e-15);


### PR DESCRIPTION
Added `cp_from_p_T(Real p, Real T)` to stiffened gas and ideal gas EOS to allow applications to use these EOS interchangeably with application-specific EOS.

Added `cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT)` to stiffened gas, simple, and ideal gas EOS to allow applications to compute derivatives as-needed.

Added `cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de)` to stiffened gas and ideal gas EOS to allow applications to compute derivatives as-needed.

Updated unit test coverage.

Closes #12838