### PR TITLE
Remove test that fails due to trimmed output

### DIFF
--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -77,16 +77,6 @@
     requirement = 'If tecplot api is not available, tecplot output will be given in ASCII format'
   [../]
 
-  [./dump_test]
-    type = 'RunApp'
-    input = 'IGNORED'
-    expect_out = 'type\s*=\s*ADDiffusion' 
-    cli_args = '--dump'
-    issues = '#1404 #1131'
-    design = 'command_line_usage.md'
-    requirement = 'We shall be able to dump the possible input file syntax for a given MOOSE application'
-  [../]
-
   [./gnuplot_ps_out_test]
     type = 'CheckFiles'
     input = 'output_test_gnuplot_ps.i'


### PR DESCRIPTION
This functionality is well tested within the python unit testing

(refs #12658)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
