### PR TITLE
Adding a virtual function for derivatives of beta_from_p_T (SinglePhaseFluidProperties)

### DIFF
--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -46,6 +46,12 @@ public:
   /// Thermal expansion coefficient (1/K)
   virtual Real beta_from_p_T(Real pressure, Real temperature) const override;
 
+  virtual void beta_from_p_T(Real pressure,
+                             Real temperature,
+                             Real & beta,
+                             Real & dbeta_dp,
+                             Real & dbeta_dT) const override;
+
   /// Isobaric specific heat capacity (J/kg/K)
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -469,6 +469,17 @@ public:
   virtual Real beta(Real pressure, Real temperature) const;
 
   /**
+   * Thermal expansion coefficient and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] beta      beta (1/K)
+   * @param[out] dbeta_dp  derivative of the thermal expansion coefficient w.r.t. pressure
+   * @param[out] dbeta_dT  derivative of the thermal expansion coefficient w.r.t. temperature
+   */
+  virtual void beta_from_p_T(Real p, Real T, Real & beta, Real & dbeta_dp, Real & dbeta_dT) const;
+
+  /**
    * Partial pressure at saturation in a gas mixture
    *
    * @param[in] p   pressure (Pa)

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -74,6 +74,15 @@ Real SimpleFluidProperties::beta_from_p_T(Real /*pressure*/, Real /*temperature*
   return _thermal_expansion;
 }
 
+void
+SimpleFluidProperties::beta_from_p_T(
+    Real pressure, Real temperature, Real & beta, Real & dbeta_dp, Real & dbeta_dT) const
+{
+  beta = beta_from_p_T(pressure, temperature);
+  dbeta_dp = 0.0;
+  dbeta_dT = 0.0;
+}
+
 Real SimpleFluidProperties::cp_from_p_T(Real /*pressure*/, Real /*temperature*/) const
 {
   return _cp;

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -188,6 +188,12 @@ SinglePhaseFluidProperties::beta_from_p_T(Real p, Real T) const
   return -drho_dT / rho;
 }
 
+void
+SinglePhaseFluidProperties::beta_from_p_T(Real, Real, Real &, Real &, Real &) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
+}
+
 Real SinglePhaseFluidProperties::s_from_p_T(Real, Real) const
 {
   mooseError(name(), ": s_from_p_T is not implemented");


### PR DESCRIPTION
Beta is the volumetric thermal expansion coefficient.
This function needs an override in classes derived
from SinglePhaseFluidProperties.

Closes #12858

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
