### PR TITLE
Make displaced mesh an actual copy of the undisplaced

### DIFF
--- a/framework/src/actions/PartitionerAction.C
+++ b/framework/src/actions/PartitionerAction.C
@@ -34,9 +34,4 @@ PartitionerAction::act()
   std::shared_ptr<MoosePartitioner> mp =
       _factory.create<MoosePartitioner>(_type, _name, _moose_object_pars);
   _mesh->setCustomPartitioner(mp.get());
-  if (_displaced_mesh)
-  {
-    _displaced_mesh->setIsCustomPartitionerRequested(true);
-    _displaced_mesh->setCustomPartitioner(mp.get());
-  }
 }

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -215,23 +215,18 @@ SetupMeshAction::act()
     }
 
     _mesh = _factory.create<MooseMesh>(_type, "mesh", _moose_object_pars);
-    if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
-      _displaced_mesh = _factory.create<MooseMesh>(_type, "displaced_mesh", _moose_object_pars);
   }
+
   else if (_current_task == "set_mesh_base")
-  {
     _mesh->setMeshBase(_mesh->buildMeshBaseObject());
-    if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
-      _displaced_mesh->setMeshBase(_displaced_mesh->buildMeshBaseObject());
-  }
+
   else if (_current_task == "init_mesh")
   {
     _mesh->init();
 
     if (isParamValid("displacements") && getParam<bool>("use_displaced_mesh"))
     {
-      // Initialize the displaced mesh
-      _displaced_mesh->init();
+      _displaced_mesh = _mesh->safeClone();
 
       std::vector<std::string> displacements = getParam<std::vector<std::string>>("displacements");
       if (displacements.size() < _displaced_mesh->dimension())

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1516,34 +1516,7 @@ MooseApp::executeMeshGenerators()
 
           // For all of the rest we need to make a copy
           for (; output_it != outputs.end(); ++output_it)
-          {
             (*output_it) = copy_from.clone();
-
-            (*output_it)->get_boundary_info() = copy_from.get_boundary_info();
-
-            (*output_it)->set_subdomain_name_map() = copy_from.get_subdomain_name_map();
-
-            // Get references to BoundaryInfo objects to make the code below cleaner...
-            const BoundaryInfo & first_boundary_info = copy_from.get_boundary_info();
-            BoundaryInfo & boundary_info = (*output_it)->get_boundary_info();
-
-            // Use the first BoundaryInfo object to build the list of side boundary ids
-            std::vector<boundary_id_type> side_boundaries;
-            first_boundary_info.build_side_boundary_ids(side_boundaries);
-
-            // Assign those boundary ids in our BoundaryInfo object
-            for (const auto & side_bnd_id : side_boundaries)
-              boundary_info.sideset_name(side_bnd_id) =
-                  first_boundary_info.get_sideset_name(side_bnd_id);
-
-            // Do the same thing for node boundary ids
-            std::vector<boundary_id_type> node_boundaries;
-            first_boundary_info.build_node_boundary_ids(node_boundaries);
-
-            for (const auto & node_bnd_id : node_boundaries)
-              boundary_info.nodeset_name(node_bnd_id) =
-                  first_boundary_info.get_nodeset_name(node_bnd_id);
-          }
         }
       }
     }


### PR DESCRIPTION
We make use of the enhanced copy construction capability in libmesh. Using copy construction ensures that the partitioning is the same between undisplaced and displaced meshes regardless of whether we are using `DistributedMesh` or `ReplicatedMesh`
