### PR TITLE
Update PetscSupport.C to support PETSc-master

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -354,7 +354,11 @@ petscConverged(KSP ksp, PetscInt n, PetscReal rnorm, KSPConvergedReason * reason
       break;
 #if !PETSC_VERSION_LESS_THAN(3, 6, 0) // A new convergence enum in PETSc 3.6
     case MooseLinearConvergenceReason::DIVERGED_PCSETUP_FAILED:
+#if PETSC_VERSION_LESS_THAN(3, 11, 0) && PETSC_VERSION_RELEASE
       *reason = KSP_DIVERGED_PCSETUP_FAILED;
+#else
+      *reason = KSP_DIVERGED_PC_FAILED;
+#endif
       break;
 #endif
     default:


### PR DESCRIPTION
KSP_DIVERGED_PCSETUP_FAILED is changed to KSP_DIVERGED_PC_FAILED

Closes #12879

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
