### PR TITLE
add const qualifiers in GenericFunctionMaterial.h

### DIFF
--- a/framework/include/materials/GenericFunctionMaterial.h
+++ b/framework/include/materials/GenericFunctionMaterial.h
@@ -41,8 +41,8 @@ protected:
   unsigned int _num_props;
 
   std::vector<MaterialProperty<Real> *> _properties;
-  std::vector<MaterialProperty<Real> *> _properties_old;
-  std::vector<MaterialProperty<Real> *> _properties_older;
+  std::vector<const MaterialProperty<Real> *> _properties_old;
+  std::vector<const MaterialProperty<Real> *> _properties_older;
   std::vector<Function *> _functions;
 
 private:


### PR DESCRIPTION
We need const qualifiers for _properties_old and _properties_older as getMaterialPropertyOld etc. give a const reference.

refs #12910

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
