### PR TITLE
Factory unique_ptr revive

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -200,7 +200,7 @@ protected:
   std::shared_ptr<MooseMesh> & _displaced_mesh;
 
   /// Convenience reference to a problem this action works on
-  std::shared_ptr<FEProblemBase> & _problem;
+  std::unique_ptr<FEProblemBase> & _problem;
 
   /// Timers
   PerfID _act_timer;

--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -109,8 +109,7 @@ public:
    * back to the normal behavior of mooseError - only printing a message using the given args.
    */
   template <typename... Args>
-  [[noreturn]] void paramError(const std::string & param, Args... args)
-  {
+  [[noreturn]] void paramError(const std::string & param, Args... args) {
     auto prefix = param + ": ";
     if (!_pars.inputLocation(param).empty())
       prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
@@ -193,7 +192,7 @@ protected:
   /// Reference to ActionWarehouse where we store object build by actions
   ActionWarehouse & _awh;
 
-  /// The current action (even though we have seperate instances for each action)
+  /// The current action (even though we have separate instances for each action)
   const std::string & _current_task;
 
   std::shared_ptr<MooseMesh> & _mesh;

--- a/framework/include/actions/ActionFactory.h
+++ b/framework/include/actions/ActionFactory.h
@@ -42,7 +42,7 @@ class MooseApp;
 /**
  * Typedef for function to build objects
  */
-typedef std::shared_ptr<Action> (*buildActionPtr)(const InputParameters & parameters);
+typedef std::unique_ptr<Action> (*buildActionPtr)(const InputParameters & parameters);
 
 /**
  * Typedef for validParams
@@ -53,10 +53,10 @@ typedef InputParameters (*paramsActionPtr)();
  * Build an object of type T
  */
 template <class T>
-std::shared_ptr<Action>
+std::unique_ptr<Action>
 buildAction(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 /**

--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -215,8 +215,6 @@ public:
   std::shared_ptr<MooseMesh> & mesh() { return _mesh; }
   std::shared_ptr<MooseMesh> & displacedMesh() { return _displaced_mesh; }
 
-  std::shared_ptr<FEProblemBase> & problemBase() { return _problem; }
-  std::shared_ptr<FEProblem> problem();
   MooseApp & mooseApp() { return _app; }
   const std::string & getCurrentTaskName() const { return _current_task; }
 
@@ -273,9 +271,6 @@ protected:
 
   /// Possible mesh for displaced problem
   std::shared_ptr<MooseMesh> _displaced_mesh;
-
-  /// Problem class
-  std::shared_ptr<FEProblemBase> _problem;
 
 private:
   /// Last task to run before (optional) early termination - blank means no early termination.

--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -256,7 +256,7 @@ protected:
   /// Error vector for use with the error estimator.
   std::unique_ptr<ErrorVector> _error;
 
-  std::shared_ptr<DisplacedProblem> _displaced_problem;
+  DisplacedProblem * _displaced_problem;
 
   /// A mesh refinement object for displaced mesh
   std::unique_ptr<MeshRefinement> _displaced_mesh_refinement;

--- a/framework/include/base/Factory.h
+++ b/framework/include/base/Factory.h
@@ -119,11 +119,6 @@ class InputParameters;
 #define registerExecFlag(flag) factory.regExecFlag(flag)
 
 /**
- * alias to wrap shared pointer type
- */
-using MooseObjectPtr = std::shared_ptr<MooseObject>;
-
-/**
  * alias for validParams function
  */
 using paramsPtr = InputParameters (*)();
@@ -155,7 +150,7 @@ class Factory
 {
 public:
   Factory(MooseApp & app);
-  virtual ~Factory();
+  virtual ~Factory() = default;
 
   /**
    * Register a new object
@@ -274,20 +269,6 @@ public:
   InputParameters getValidParams(const std::string & name);
 
   /**
-   * Build an object (must be registered) - THIS METHOD IS DEPRECATED (Use create<T>())
-   * @param obj_name Type of the object being constructed
-   * @param name Name for the object
-   * @param parameters Parameters this object should have
-   * @param tid The thread id that this copy will be created for
-   * @param print_deprecated controls the deprecated message
-   * @return The created object
-   */
-  std::shared_ptr<MooseObject> create(const std::string & obj_name,
-                                      const std::string & name,
-                                      InputParameters parameters,
-                                      THREAD_ID tid = 0);
-
-  /**
    * Build an object (must be registered)
    * @param obj_name Type of the object being constructed
    * @param name Name for the object
@@ -301,7 +282,7 @@ public:
                             InputParameters parameters,
                             THREAD_ID tid = 0)
   {
-    return std::shared_ptr<T>(createUnique<T>(obj_name, name, parameters, tid).release());
+    return std::shared_ptr<T>(std::move(createUnique<T>(obj_name, name, parameters, tid)));
   }
 
   /**

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -659,6 +659,13 @@ public:
    */
   void setBackupObject(std::shared_ptr<Backup> backup);
 
+  /**
+   * This function is a legacy function that should not be used going forward.  It exists to allow
+   * actions to retroactively be able to "see" the problem object even though they were created
+   * before the problem object existed - they store a reference to this master unique pointer.
+   */
+  std::unique_ptr<FEProblemBase> & problemBaseRef() { return _problem_base; }
+
 protected:
   /**
    * Whether or not this MooseApp has cached a Backup to use for restart / recovery
@@ -852,6 +859,13 @@ private:
    * []
    */
   void createMinimalApp();
+
+  /**
+   * Action objects store a reference to this member via the problemBaseRef legacy member function.
+   * This unique pointer gets set to non-nullptr when the CreateProblemAction's _problem member
+   * variable (which is a reference to this unique pointer) gets set in its act function.
+   */
+  std::unique_ptr<FEProblemBase> _problem_base;
 
   /// Where the restartable data is held (indexed on tid)
   RestartableDatas _restartable_data;

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -83,15 +83,19 @@ protected:
     InputParameters problem_params = _factory.getValidParams("FEProblem");
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "name2";
-    _fe_problem = _factory.create<FEProblem>("FEProblem", "problem", problem_params);
 
+    // Normally, CreateProblemAction sets the global app problem pointer, but for cases like in unit
+    // tests, this doesn't happen - so we set it here.
+    _app->problemBaseRef() =
+        _factory.createUnique<FEProblem>("FEProblem", "problem", problem_params);
+    _fe_problem = _app->problemBase();
     _fe_problem->createQRules(QGAUSS, FIRST, FIRST, FIRST);
   }
 
   std::unique_ptr<MooseMesh> _mesh;
   std::shared_ptr<MooseApp> _app;
   Factory & _factory;
-  std::shared_ptr<FEProblem> _fe_problem;
+  FEProblemBase * _fe_problem;
 };
 
 #endif

--- a/framework/include/base/MooseObjectUnitTest.h
+++ b/framework/include/base/MooseObjectUnitTest.h
@@ -88,7 +88,7 @@ protected:
     // tests, this doesn't happen - so we set it here.
     _app->problemBaseRef() =
         _factory.createUnique<FEProblem>("FEProblem", "problem", problem_params);
-    _fe_problem = _app->problemBase();
+    _fe_problem = _app->problemBaseRef().get();
     _fe_problem->createQRules(QGAUSS, FIRST, FIRST, FIRST);
   }
 

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -122,8 +122,8 @@ class MooseObject;
 class Action;
 
 using paramsPtr = InputParameters (*)();
-using buildPtr = std::shared_ptr<MooseObject> (*)(const InputParameters & parameters);
-using buildActionPtr = std::shared_ptr<Action> (*)(const InputParameters & parameters);
+using buildPtr = std::unique_ptr<MooseObject> (*)(const InputParameters & parameters);
+using buildActionPtr = std::unique_ptr<Action> (*)(const InputParameters & parameters);
 
 /// Holds details and meta-data info for a particular MooseObject or Action for use in the
 /// registry.
@@ -155,17 +155,17 @@ struct RegistryEntry
 };
 
 template <class T>
-std::shared_ptr<MooseObject>
+std::unique_ptr<MooseObject>
 buildObj(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 template <class T>
-std::shared_ptr<Action>
+std::unique_ptr<Action>
 buildAct(const InputParameters & parameters)
 {
-  return std::make_shared<T>(parameters);
+  return libmesh_make_unique<T>(parameters);
 }
 
 /// The registry is used as a global singleton to collect information on all available MooseObject

--- a/framework/include/loops/FlagElementsThread.h
+++ b/framework/include/loops/FlagElementsThread.h
@@ -35,7 +35,7 @@ public:
 
 protected:
   FEProblemBase & _fe_problem;
-  std::shared_ptr<DisplacedProblem> _displaced_problem;
+  DisplacedProblem * _displaced_problem;
   AuxiliarySystem & _aux_sys;
   unsigned int _system_number;
   Adaptivity & _adaptivity;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1197,8 +1197,8 @@ public:
   virtual void prepareNeighborShapes(unsigned int var, THREAD_ID tid) override;
 
   // Displaced problem /////
-  virtual void addDisplacedProblem(std::shared_ptr<DisplacedProblem> displaced_problem);
-  virtual std::shared_ptr<DisplacedProblem> getDisplacedProblem() { return _displaced_problem; }
+  virtual void addDisplacedProblem(std::unique_ptr<DisplacedProblem> && displaced_problem);
+  virtual DisplacedProblem * getDisplacedProblem() { return _displaced_problem.get(); }
 
   virtual void updateGeomSearch(
       GeometricSearchData::GeometricSearchType type = GeometricSearchData::ALL) override;
@@ -1771,7 +1771,7 @@ protected:
 
   // Displaced mesh /////
   MooseMesh * _displaced_mesh;
-  std::shared_ptr<DisplacedProblem> _displaced_problem;
+  std::unique_ptr<DisplacedProblem> _displaced_problem;
   GeometricSearchData _geometric_search_data;
 
   bool _reinit_displaced_elem;

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -167,6 +167,8 @@ private:
   Factory::create(const std::string &, const std::string &, InputParameters, THREAD_ID, bool);
   friend void Factory::releaseSharedObjects(const MooseObject &, THREAD_ID);
   ///@}
+  /// The factory is allowed to call addInputParameters.
+  friend Factory;
 
   /// Only controls are allowed to call getControllableParameter. The
   /// Control::getControllableParameter is the only method that calls getControllableParameter.

--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -163,9 +163,7 @@ private:
 
   ///@{
   /// The factory is allowed to call addInputParameters and removeInputParameters.
-  friend MooseObjectPtr
-  Factory::create(const std::string &, const std::string &, InputParameters, THREAD_ID, bool);
-  friend void Factory::releaseSharedObjects(const MooseObject &, THREAD_ID);
+  friend class Factory;
   ///@}
   /// The factory is allowed to call addInputParameters.
   friend Factory;

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -74,7 +74,8 @@ Action::Action(InputParameters parameters)
     _current_task(_awh.getCurrentTaskName()),
     _mesh(_awh.mesh()),
     _displaced_mesh(_awh.displacedMesh()),
-    _problem(_awh.problemBase()),
+    _problem(_app.problemBaseRef()),
+    _executioner(_app.executioner()),
     _act_timer(registerTimedSection("act", 4))
 {
 }

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -75,7 +75,6 @@ Action::Action(InputParameters parameters)
     _mesh(_awh.mesh()),
     _displaced_mesh(_awh.displacedMesh()),
     _problem(_app.problemBaseRef()),
-    _executioner(_app.executioner()),
     _act_timer(registerTimedSection("act", 4))
 {
 }

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -64,7 +64,7 @@ ActionWarehouse::clear()
   // destructor) we must guarantee that ActionWarehouse::clear()
   // releases all the resources which have to be released _before_ the
   // _comm object owned by the MooseApp is destroyed.
-  _problem.reset();
+  _app.problemBaseRef().reset();
   _displaced_mesh.reset();
   _mesh.reset();
 }
@@ -402,14 +402,6 @@ ActionWarehouse::printInputFile(std::ostream & out)
   }
 
   out << tree.print("");
-}
-
-std::shared_ptr<FEProblem>
-ActionWarehouse::problem()
-{
-  mooseDeprecated(
-      "ActionWarehouse::problem() is deprecated, please use ActionWarehouse::problemBase() \n");
-  return std::dynamic_pointer_cast<FEProblem>(_problem);
 }
 
 std::string

--- a/framework/src/actions/AddExternalAuxVariableAction.C
+++ b/framework/src/actions/AddExternalAuxVariableAction.C
@@ -26,7 +26,7 @@ AddExternalAuxVariableAction::AddExternalAuxVariableAction(InputParameters param
 void
 AddExternalAuxVariableAction::act()
 {
-  auto external_problem_ptr = std::dynamic_pointer_cast<ExternalProblem>(_problem);
+  auto external_problem_ptr = dynamic_cast<ExternalProblem *>(_problem.get());
 
   if (external_problem_ptr)
     external_problem_ptr->addExternalVariables();

--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -11,6 +11,7 @@
 #include "MooseApp.h"
 #include "FEProblem.h"
 #include "DisplacedProblem.h"
+#include "Assembly.h"
 
 registerMooseAction("MooseApp", CreateDisplacedProblemAction, "init_displaced_problem");
 
@@ -56,10 +57,10 @@ CreateDisplacedProblemAction::act()
     object_params.set<FEProblemBase *>("_fe_problem_base") = _problem.get();
 
     // Create the object
-    std::shared_ptr<DisplacedProblem> disp_problem =
-        _factory.create<DisplacedProblem>("DisplacedProblem", "DisplacedProblem", object_params);
+    auto disp_problem = _factory.createUnique<DisplacedProblem>(
+        "DisplacedProblem", "DisplacedProblem", object_params);
 
     // Add the Displaced Problem to FEProblemBase
-    _problem->addDisplacedProblem(disp_problem);
+    _problem->addDisplacedProblem(std::move(disp_problem));
   }
 }

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -34,9 +34,9 @@ CreateExecutionerAction::CreateExecutionerAction(InputParameters params) : Moose
 void
 CreateExecutionerAction::act()
 {
-  std::shared_ptr<EigenProblem> eigen_problem = std::dynamic_pointer_cast<EigenProblem>(_problem);
+  auto eigen_problem = dynamic_cast<EigenProblem *>(_problem.get());
   if (eigen_problem)
-    _moose_object_pars.set<EigenProblem *>("_eigen_problem") = eigen_problem.get();
+    _moose_object_pars.set<EigenProblem *>("_eigen_problem") = eigen_problem;
 
   std::shared_ptr<Executioner> executioner =
       _factory.create<Executioner>(_type, "Executioner", _moose_object_pars);

--- a/framework/src/actions/CreateProblemAction.C
+++ b/framework/src/actions/CreateProblemAction.C
@@ -42,7 +42,7 @@ CreateProblemAction::act()
     _moose_object_pars.set<MooseMesh *>("mesh") = _mesh.get();
     _moose_object_pars.set<bool>("use_nonlinear") = _app.useNonlinear();
 
-    _problem =
-        _factory.create<FEProblemBase>(_type, getParam<std::string>("name"), _moose_object_pars);
+    _problem = _factory.createUnique<FEProblemBase>(
+        _type, getParam<std::string>("name"), _moose_object_pars);
   }
 }

--- a/framework/src/actions/CreateProblemDefaultAction.C
+++ b/framework/src/actions/CreateProblemDefaultAction.C
@@ -80,12 +80,12 @@ CreateProblemDefaultAction::act()
       if (_pars.isParamSetByUser("_solve"))
         params.set<bool>("solve") = getParam<bool>("_solve");
 
-      _problem = _factory.create<FEProblemBase>(type, "MOOSE Problem", params);
+      _problem = _factory.createUnique<FEProblemBase>(type, "MOOSE Problem", params);
     }
     else
     {
       // otherwise perform necessary sanity checks
-      if (_app.useEigenvalue() && !(std::dynamic_pointer_cast<EigenProblem>(_problem)))
+      if (_app.useEigenvalue() && !(dynamic_cast<EigenProblem *>(_problem.get())))
         mooseError("Problem has to be of a EigenProblem (or derived subclass) type when using "
                    "eigen executioner");
     }

--- a/framework/src/actions/InitProblemAction.C
+++ b/framework/src/actions/InitProblemAction.C
@@ -25,8 +25,7 @@ InitProblemAction::InitProblemAction(InputParameters params) : Action(params) {}
 void
 InitProblemAction::act()
 {
-  if (_problem.get())
-    _problem->init();
-  else
+  if (!_problem)
     mooseError("Problem doesn't exist in InitProblemAction!");
+  _problem->init();
 }

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -34,6 +34,7 @@ Adaptivity::Adaptivity(FEProblemBase & subproblem)
     _mesh(_subproblem.mesh()),
     _mesh_refinement_on(false),
     _initialized(false),
+    _displaced_problem(nullptr),
     _initial_steps(0),
     _steps(0),
     _print_mesh_changed(false),

--- a/framework/src/base/Factory.C
+++ b/framework/src/base/Factory.C
@@ -15,8 +15,6 @@
 
 Factory::Factory(MooseApp & app) : _app(app) {}
 
-Factory::~Factory() {}
-
 void
 Factory::reg(const std::string & label,
              const std::string & obj_name,
@@ -83,16 +81,6 @@ Factory::getValidParams(const std::string & obj_name)
   return params;
 }
 
-MooseObjectPtr
-Factory::create(const std::string & obj_name,
-                const std::string & name,
-                InputParameters parameters,
-                THREAD_ID tid /* =0 */)
-{
-  mooseDeprecated("Factory::create() is deprecated, please use Factory::create<T>() instead");
-  return createRaw(obj_name, name, parameters, tid);
-}
-
 std::unique_ptr<MooseObject>
 Factory::createRaw(const std::string & obj_name,
                    const std::string & name,
@@ -124,8 +112,9 @@ Factory::createRaw(const std::string & obj_name,
   _constructed_types.insert(obj_name);
 
   // add FEProblem pointers to object's params object
-  if (_app.problemBase())
-    _app.problemBase()->setInputParametersFEProblem(params);
+  auto & problemBaseRef = _app.problemBaseRef();
+  if (problemBaseRef.get())
+    _app.problemBaseRef()->setInputParametersFEProblem(params);
 
   // call the function pointer to build the object
   buildPtr & func = it->second;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1560,8 +1560,6 @@ void
 MooseApp::setRestart(const bool & value)
 {
   _restart = value;
-
-  std::shared_ptr<FEProblemBase> fe_problem = _action_warehouse.problemBase();
 }
 
 void

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -424,7 +424,7 @@ MultiApp::getBoundingBox(unsigned int app, bool displaced_mesh)
 
   unsigned int local_app = globalAppToLocal(app);
   FEProblemBase & fe_problem_base = _apps[local_app]->getExecutioner()->feProblem();
-  MooseMesh & mesh = (displaced_mesh && fe_problem_base.getDisplacedProblem().get() != NULL)
+  MooseMesh & mesh = (displaced_mesh && fe_problem_base.getDisplacedProblem() != nullptr)
                          ? fe_problem_base.getDisplacedProblem()->mesh()
                          : fe_problem_base.mesh();
 

--- a/framework/src/outputs/Output.C
+++ b/framework/src/outputs/Output.C
@@ -120,7 +120,7 @@ Output::Output(const InputParameters & parameters)
 {
   if (_use_displaced)
   {
-    std::shared_ptr<DisplacedProblem> dp = _problem_ptr->getDisplacedProblem();
+    auto dp = _problem_ptr->getDisplacedProblem();
     if (dp != nullptr)
     {
       _es_ptr = &dp->es();

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4969,10 +4969,10 @@ FEProblemBase::predictorCleanup(NumericVector<Number> & /*ghosted_solution*/)
 }
 
 void
-FEProblemBase::addDisplacedProblem(std::shared_ptr<DisplacedProblem> displaced_problem)
+FEProblemBase::addDisplacedProblem(std::unique_ptr<DisplacedProblem> && displaced_problem)
 {
   _displaced_mesh = &displaced_problem->mesh();
-  _displaced_problem = displaced_problem;
+  _displaced_problem = std::move(displaced_problem);
 }
 
 void

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -755,8 +755,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             PenetrationLocator * locator;
             if (displaced)
             {
-              std::shared_ptr<DisplacedProblem> displaced_problem =
-                  dmm->_nl->_fe_problem.getDisplacedProblem();
+              auto displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
               if (!displaced_problem)
               {
                 std::ostringstream err;
@@ -859,8 +858,7 @@ DMMooseGetEmbedding_Private(DM dm, IS * embedding)
             PenetrationLocator * locator;
             if (displaced)
             {
-              std::shared_ptr<DisplacedProblem> displaced_problem =
-                  dmm->_nl->_fe_problem.getDisplacedProblem();
+              auto displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
               if (!displaced_problem)
               {
                 std::ostringstream err;
@@ -2185,7 +2183,7 @@ PetscErrorCode DMSetFromOptions_Moose(DM dm) // < 3.6.0
   ierr = PetscFree(sides);
   CHKERRQ(ierr);
   PetscInt maxcontacts = dmm->_nl->_fe_problem.geomSearchData()._penetration_locators.size();
-  std::shared_ptr<DisplacedProblem> displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
+  auto displaced_problem = dmm->_nl->_fe_problem.getDisplacedProblem();
   if (displaced_problem)
     maxcontacts = PetscMax(
         maxcontacts, (PetscInt)displaced_problem->geomSearchData()._penetration_locators.size());

--- a/modules/contact/include/ContactSlipDamper.h
+++ b/modules/contact/include/ContactSlipDamper.h
@@ -36,7 +36,7 @@ public:
 
 protected:
   AuxiliarySystem & _aux_sys;
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  DisplacedProblem * _displaced_problem;
 
   /**
    * Compute the amount of damping

--- a/modules/contact/include/MechanicalContactConstraint.h
+++ b/modules/contact/include/MechanicalContactConstraint.h
@@ -87,7 +87,7 @@ public:
   void computeContactForce(PenetrationInfo * pinfo, bool update_contact_set);
 
 protected:
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  DisplacedProblem * _displaced_problem;
   FEProblem & _fe_problem;
   Real nodalArea(PenetrationInfo & pinfo);
   Real getPenalty(PenetrationInfo & pinfo);

--- a/modules/contact/src/ContactSlipDamper.C
+++ b/modules/contact/src/ContactSlipDamper.C
@@ -44,8 +44,8 @@ validParams<ContactSlipDamper>()
 
 ContactSlipDamper::ContactSlipDamper(const InputParameters & parameters)
   : GeneralDamper(parameters),
-    _aux_sys(parameters.get<FEProblemBase *>("_fe_problem_base")->getAuxiliarySystem()),
-    _displaced_problem(parameters.get<FEProblemBase *>("_fe_problem_base")->getDisplacedProblem()),
+    _aux_sys(getParam<FEProblemBase *>("_fe_problem_base")->getAuxiliarySystem()),
+    _displaced_problem(getParam<FEProblemBase *>("_fe_problem_base")->getDisplacedProblem()),
     _num_contact_nodes(0),
     _num_sticking(0),
     _num_slipping(0),

--- a/modules/tensor_mechanics/include/dampers/ElementJacobianDamper.h
+++ b/modules/tensor_mechanics/include/dampers/ElementJacobianDamper.h
@@ -54,7 +54,7 @@ protected:
   FEProblemBase & _fe_problem;
 
   /// The displaced problem
-  MooseSharedPointer<DisplacedProblem> _displaced_problem;
+  DisplacedProblem * _displaced_problem;
 
   /// The displaced mesh
   MooseMesh * _mesh;

--- a/test/src/actions/CreateSpecialProblemAction.C
+++ b/test/src/actions/CreateSpecialProblemAction.C
@@ -54,7 +54,7 @@ CreateSpecialProblemAction::act()
     params.set<MooseMesh *>("mesh") = _mesh.get();
     params.set<bool>("use_nonlinear") = _app.useNonlinear();
 
-    _problem =
-        _factory.create<FEProblemBase>("MooseTestProblem", getParam<std::string>("name"), params);
+    _problem = _factory.createUnique<FEProblemBase>(
+        "MooseTestProblem", getParam<std::string>("name"), params);
   }
 }

--- a/unit/src/TheWarehouseTests.C
+++ b/unit/src/TheWarehouseTests.C
@@ -95,7 +95,7 @@ public:
   std::shared_ptr<TestObject> obj(int val1, int val2, int val3, int val4)
   {
     InputParameters p = _factory.getValidParams("TestObject");
-    p.set<SubProblem *>("_subproblem") = _fe_problem.get();
+    p.set<SubProblem *>("_subproblem") = _fe_problem;
     auto obj = _factory.create<TestObject>("TestObject", "dummy" + std::to_string(count++), p, 0);
     obj->vals = {val1, val2, val3, val4};
     return obj;


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Having the flexibility of creating unique_ptrs in the Factory will be useful moving forward where we just don't need shared_ptrs. Unique_ptrs are faster and lighter weight and can always be promoted to shared_ptrs when necessary.
