### PR TITLE
Remove output_dimension from modules tests

### DIFF
--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_xz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_xz.i
@@ -122,13 +122,7 @@
 []
 
 [Outputs]
-  [./out]
-    type = Exodus
-    output_dimension = 3
-  [../]
-  [./Console]
-    type = Console
-  [../]
+  exodus = true
 []
 
 [Postprocessors]

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_yz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_yz.i
@@ -122,13 +122,7 @@
 []
 
 [Outputs]
-  [./out]
-    type = Exodus
-    output_dimension = 3
-  [../]
-  [./Console]
-    type = Console
-  [../]
+  exodus = true
 []
 
 [Postprocessors]

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xz.i
@@ -164,8 +164,5 @@
 []
 
 [Outputs]
-  [./out]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/planar_yz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/planar_yz.i
@@ -164,8 +164,5 @@
 []
 
 [Outputs]
-  [./out]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/gps_xz.i
@@ -119,8 +119,5 @@
 
 [Outputs]
   file_base = gps_xz_small_out
-  [./exodus]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/gps_yz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/gps_yz.i
@@ -119,8 +119,5 @@
 
 [Outputs]
   file_base = gps_yz_small_out
-  [./exodus]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_xz.i
@@ -114,8 +114,5 @@
 
 [Outputs]
   file_base = planestrain_xz_small_out
-  [./exodus]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []

--- a/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_yz.i
+++ b/modules/tensor_mechanics/test/tests/2D_different_planes/planestrain_yz.i
@@ -114,8 +114,5 @@
 
 [Outputs]
   file_base = planestrain_yz_small_out
-  [./exodus]
-    type = Exodus
-    output_dimension = 3
-  [../]
+  exodus = true
 []


### PR DESCRIPTION
Closes #12931.

Removes the `output_dimension` parameter from tests not in the x-y plane in modules.