### PR TITLE
PorousFlow Kuzmin-Turek vector instead of map

### DIFF
--- a/modules/porous_flow/include/userobjects/AdvectiveFluxCalculatorConstantVelocity.h
+++ b/modules/porous_flow/include/userobjects/AdvectiveFluxCalculatorConstantVelocity.h
@@ -34,7 +34,7 @@ protected:
   RealVectorValue _velocity;
 
   /// the nodal values of u
-  const VariableValue & _u_nodal;
+  const VariableValue & _u_at_nodes;
 
   /// Kuzmin-Turek shape function
   const VariablePhiValue & _phi;

--- a/modules/porous_flow/include/userobjects/PorousFlowAdvectiveFluxCalculatorBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowAdvectiveFluxCalculatorBase.h
@@ -65,22 +65,9 @@ protected:
   virtual Real computedU_dvar(unsigned i, unsigned pvar) const = 0;
 
   /**
-   * Returns _du_dvar[node_i] which is the set of derivatives d(u)/d(porous_flow_variable)
-   * This will have been computed during execute() by computedU_dvar()
-   * @param node_i global node id
-   */
-  const std::vector<Real> & getdU_dvar(dof_id_type node_i) const;
-
-  /**
-   * Returns _du_dvar_computed_by_thread[node_i]
-   * This is initialized to false in initialize() and potentially set to true during execute()
-   * @param node_i global node id
-   */
-  bool getdU_dvarComputedByThread(dof_id_type node_i) const;
-
-  /**
    * Returns, r, where r[global node k][a] = d(K[node_i][node_j])/d(porous_flow_variable[global node
-   * k][porous_flow_variable a]) param node_i global node id param node_j global node id
+   * k][porous_flow_variable a])
+   * @param node_i global node id param node_j global node id
    */
   const std::map<dof_id_type, std::vector<Real>> & getdK_dvar(dof_id_type node_i,
                                                               dof_id_type node_j) const;
@@ -130,17 +117,21 @@ protected:
   /// grad(Kuzmin-Turek shape function)
   const VariablePhiGradient & _grad_phi;
 
-  /// _du_dvar[i][a] = d(u[global node i])/d(porous_flow_variable[a])
-  std::map<dof_id_type, std::vector<Real>> _du_dvar;
+  /// _du_dvar[sequential_i][a] = d(u[global version of sequential node i])/d(porous_flow_variable[a])
+  std::vector<std::vector<Real>> _du_dvar;
 
   /// Whether _du_dvar has been computed by the local thread
-  std::map<dof_id_type, bool> _du_dvar_computed_by_thread;
+  std::vector<bool> _du_dvar_computed_by_thread;
 
-  /// _dkij_dvar[i][j][k][a] = d(K[global node i][global node j])/d(porous_flow_variable[global_node k][porous_flow_variable a])
-  std::map<dof_id_type, std::map<dof_id_type, std::map<dof_id_type, std::vector<Real>>>> _dkij_dvar;
+  /**
+   * _dkij_dvar[sequential_i][j][global_k][a] =
+   * d(K[sequential_i][j])/d(porous_flow_variable[global_k][porous_flow_variable a]) Here j is the
+   * j^th connection to sequential node sequential_i, and node k must be connected to node i
+   */
+  std::vector<std::vector<std::map<dof_id_type, std::vector<Real>>>> _dkij_dvar;
 
-  /// _dflux_out_dvars[i][j][pvar] = d(flux_out[global node i])/d(porous_flow_variable pvar at global node j)
-  std::map<dof_id_type, std::map<dof_id_type, std::vector<Real>>> _dflux_out_dvars;
+  /// _dflux_out_dvars[sequential_i][global_j][pvar] = d(flux_out[global version of sequential_i])/d(porous_flow_variable pvar at global node j)
+  std::vector<std::map<dof_id_type, std::vector<Real>>> _dflux_out_dvars;
 };
 
 #endif // POROUSFLOWADVECTIEFLUXCALCULATORBASE_H

--- a/modules/porous_flow/include/utils/PorousFlowConnectedNodes.h
+++ b/modules/porous_flow/include/utils/PorousFlowConnectedNodes.h
@@ -1,0 +1,142 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef POROUSFLOWCONNECTEDNODES_H
+#define POROUSFLOWCONNECTEDNODES_H
+
+#include "Moose.h"
+
+/**
+ * Class designed to hold node ID information and information
+ * about nodal connectivity.
+ * Node ID is either:
+ * - global, meaning that it is the number assigned to the node in the mesh
+ * - sequential, meaning that it is the number used within this class
+ * The sequential numbering runs from zero to number_of_nodes - 1
+ *
+ * The use case of interest in PorousFlow is where many quantities are
+ * recorded at each node in the mesh.  To record this, a std::vector<quantity>
+ * may be used.  But if the global node IDs are sparsely distributed between
+ * zero and the maximum node number, then basing the std::vector on
+ * global ID is inefficient because there are many elements in the
+ * std::vector that are unused.  Instead, a std::vector based on
+ * the sequential node ID may be used, which is optimally memory efficient.
+ * (A std::map<dof_id_type, quantity> may be used, but it is slow.)
+ *
+ * Nodal connectivity is defined between two global node IDs.  Note
+ * that it is uni-directional, meaning that if node 12 is connected to
+ * node 321, then node 321 is not necessarily connected to node 12
+ * (the user must explicitly add both the 12->321 and 321->12 connections if that is desired).
+ *
+ * This class is designed to be used as follows:
+ * (1) instantiation
+ * (2) populate the nodal information using addGlobalNode
+ * (3) finalizeAddingGlobalNodes()
+ * (4) populate the connectivity using addConnection
+ * (5) finalizeAddingConnections()
+ * (6) functions like sequentialID and sequentialNeighborsOfGlobalID are now ready for use
+ */
+class PorousFlowConnectedNodes
+{
+public:
+  PorousFlowConnectedNodes();
+
+  /// clear all data in readiness for adding global nodes and connections
+  void clear();
+
+  /**
+   * Add the given global_node_ID to the internal data structures
+   * If the global node ID has already been added this method does nothing
+   * @param global_node_ID node number in the mesh
+   */
+  void addGlobalNode(dof_id_type global_node_ID);
+
+  /// Signal that all global node IDs have been added to the internal data structures
+  void finalizeAddingGlobalNodes();
+
+  /// number of nodes known by this class
+  std::size_t numNodes() const;
+
+  /**
+   * Return the global node ID (node number in the mesh) corresponding to the provided sequential
+   * node ID
+   * @param sequential_node_ID the sequential node ID
+   */
+  dof_id_type globalID(dof_id_type sequential_node_ID) const;
+
+  /**
+   * Return the sequential node ID corresponding to the global node ID
+   * This is guaranteed to lie in the range [0, numNodes() - 1]
+   * @param global_node_ID global node ID (ie the node number in the mesh)
+   */
+  dof_id_type sequentialID(dof_id_type global_node_ID) const;
+
+  /// Vector of all global node IDs (node numbers in the mesh)
+  const std::vector<dof_id_type> & globalIDs() const;
+
+  /**
+   * Specifies that global_node_to is connected to global_node_from.
+   * Hence, globalConnectionsToGlobalID(global_node_from) will contain global_node_to.
+   * If the connection has already been added this method does nothing
+   * Recall that connections are uni-directional, so if you desire bi-directional
+   * connectivity you must call addConnection twice (the second time with arguments swapped)
+   * @param global_node_from global node ID of the 'from' node
+   * @param global_node_to global node ID of the 'to' node
+   */
+  void addConnection(dof_id_type global_node_from, dof_id_type global_node_to);
+
+  /// Signal that all global node IDs have been added to the internal data structures
+  void finalizeAddingConnections();
+
+  /**
+   * Return all the nodes (sequential node IDs) connected to the given global node ID
+   * All elements of the returned vector are guaranteed to be unique and lie in the range [0,
+   * numNodes() - 1]
+   */
+  const std::vector<dof_id_type> &
+  sequentialConnectionsToGlobalID(dof_id_type global_node_ID) const;
+
+  /**
+   * Return all the nodes (sequential node IDs) connected to the given sequential node ID
+   * All elements of the returned vector are guaranteed to be unique and lie in the range [0,
+   * numNodes() - 1]
+   */
+  const std::vector<dof_id_type> &
+  sequentialConnectionsToSequentialID(dof_id_type sequential_node_ID) const;
+
+  /// Return all the nodes (global node IDs) connected to the given global node ID
+  const std::vector<dof_id_type> & globalConnectionsToGlobalID(dof_id_type global_node_ID) const;
+
+  /// Return all the nodes (global node IDs) connected to the given sequential node ID
+  const std::vector<dof_id_type> &
+  globalConnectionsToSequentialID(dof_id_type sequential_node_ID) const;
+
+  /// Return the index of global_node_ID_to in the globalConnectionsToGlobalID(global_node_ID_from) vector
+  unsigned indexOfGlobalConnection(dof_id_type global_node_ID_from,
+                                   dof_id_type global_node_ID_to) const;
+
+  /// Return the index of sequential_node_ID_to in the sequentialConnectionsToSequentialID(sequential_node_ID_from) vector
+  unsigned indexOfSequentialConnection(dof_id_type sequential_node_ID_from,
+                                       dof_id_type sequential_node_ID_to) const;
+
+private:
+  bool _still_adding_global_nodes;
+  dof_id_type _min_global_id;
+  dof_id_type _max_global_id;
+  std::set<dof_id_type> _set_of_global_ids;
+  std::vector<dof_id_type> _global_id;
+  std::vector<dof_id_type> _sequential_id;
+
+  bool _still_adding_connections;
+  std::vector<std::set<dof_id_type>> _neighbor_sets;
+  std::vector<std::vector<dof_id_type>> _sequential_neighbors;
+  std::vector<std::vector<dof_id_type>> _global_neighbors;
+};
+
+#endif // POROUSFLOWCONNECTEDNODES_H

--- a/modules/porous_flow/src/kernels/FluxLimitedTVDAdvection.C
+++ b/modules/porous_flow/src/kernels/FluxLimitedTVDAdvection.C
@@ -47,7 +47,7 @@ FluxLimitedTVDAdvection::computeResidual()
   for (unsigned i = 0; i < _current_elem->n_nodes(); ++i)
   {
     const dof_id_type node_id_i = _current_elem->node_id(i);
-    _local_re(i) = _fluo.getFluxOut(node_id_i) / _fluo.getValence(node_id_i, node_id_i);
+    _local_re(i) = _fluo.getFluxOut(node_id_i) / _fluo.getValence(node_id_i);
   }
 
   accumulateTaggedLocalResidual();
@@ -79,7 +79,7 @@ FluxLimitedTVDAdvection::computeJacobian()
     std::vector<dof_id_type> idof_indices(
         1, _current_elem->node_ref(i).dof_number(_sys.number(), _var.number(), 0));
     // number of times node "i" is encountered in a sweep over elements
-    const unsigned valence = _fluo.getValence(node_id_i, node_id_i);
+    const unsigned valence = _fluo.getValence(node_id_i);
 
     // retrieve the derivative information from _fluo
     const std::map<dof_id_type, Real> derivs = _fluo.getdFluxOutdu(node_id_i);

--- a/modules/porous_flow/src/kernels/PorousFlowFluxLimitedTVDAdvection.C
+++ b/modules/porous_flow/src/kernels/PorousFlowFluxLimitedTVDAdvection.C
@@ -54,7 +54,7 @@ PorousFlowFluxLimitedTVDAdvection::computeResidual()
   for (unsigned i = 0; i < _current_elem->n_nodes(); ++i)
   {
     const dof_id_type node_id_i = _current_elem->node_id(i);
-    _local_re(i) = _fluo.getFluxOut(node_id_i) / _fluo.getValence(node_id_i, node_id_i);
+    _local_re(i) = _fluo.getFluxOut(node_id_i) / _fluo.getValence(node_id_i);
   }
 
   accumulateTaggedLocalResidual();
@@ -86,7 +86,7 @@ PorousFlowFluxLimitedTVDAdvection::computeJacobian()
     std::vector<dof_id_type> idof_indices(
         1, _current_elem->node_ref(i).dof_number(_sys.number(), _var.number(), 0));
     // number of times node "i" is encountered in a sweep over elements
-    const unsigned valence = _fluo.getValence(node_id_i, node_id_i);
+    const unsigned valence = _fluo.getValence(node_id_i);
 
     // retrieve the derivative information from _fluo
     const std::map<dof_id_type, std::vector<Real>> derivs = _fluo.getdFluxOut_dvars(node_id_i);

--- a/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
+++ b/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorBase.C
@@ -34,13 +34,15 @@ AdvectiveFluxCalculatorBase::AdvectiveFluxCalculatorBase(const InputParameters &
   : ElementUserObject(parameters),
     _resizing_needed(true),
     _flux_limiter_type(getParam<MooseEnum>("flux_limiter_type").getEnum<FluxLimiterTypeEnum>()),
-    _kij({}),
-    _flux_out({}),
-    _dflux_out_du({}),
-    _dflux_out_dKjk({}),
-    _valence({}),
-    _u_nodal({}),
-    _u_nodal_computed_by_thread({})
+    _kij(),
+    _flux_out(),
+    _dflux_out_du(),
+    _dflux_out_dKjk(),
+    _valence(),
+    _u_nodal(),
+    _u_nodal_computed_by_thread(),
+    _connections(),
+    _number_of_nodes(0)
 {
   if (!_execute_enum.contains(EXEC_LINEAR))
     paramError(
@@ -57,90 +59,82 @@ AdvectiveFluxCalculatorBase::timestepSetup()
   // If needed, size and initialize quantities appropriately, and compute _valence
   if (_resizing_needed)
   {
-    _kij.clear();
-
-    // QUERY: does this properly account for multiple processors, threading, and other things i
-    // haven't thought about?
+    _connections.clear();
+    // QUERY: does the following properly account for multiple processors, threading, and other
+    // things i haven't thought about?
 
     /*
-     * Initialize _kij for all nodes that can be seen by this processor and on relevant blocks
+     * Populate _connections for all nodes that can be seen by this processor and on relevant blocks
      *
      * MULTIPROC NOTE: this must loop over local elements and 2 layers of ghosted elements.
-     * The Kernel will only loop over local elements, so will only use _kij for
+     * The Kernel will only loop over local elements, so will only use _kij, etc, for
      * linked node-node pairs that appear in the local elements.  Nevertheless, we
-     * need to build _kij for the nodes in the ghosted elements in order to simplify
+     * need to build _kij, etc, for the nodes in the ghosted elements in order to simplify
      * Jacobian computations
      */
     for (const auto & elem : _subproblem.mesh().getMesh().active_element_ptr_range())
-    {
       if (this->hasBlocks(elem->subdomain_id()))
-      {
         for (unsigned i = 0; i < elem->n_nodes(); ++i)
-        {
-          const dof_id_type node_i = elem->node_id(i);
-          if (_kij.find(node_i) == _kij.end())
-            _kij[node_i] = {};
+          _connections.addGlobalNode(elem->node_id(i));
+    _connections.finalizeAddingGlobalNodes();
+    for (const auto & elem : _subproblem.mesh().getMesh().active_element_ptr_range())
+      if (this->hasBlocks(elem->subdomain_id()))
+        for (unsigned i = 0; i < elem->n_nodes(); ++i)
           for (unsigned j = 0; j < elem->n_nodes(); ++j)
-          {
-            const dof_id_type node_j = elem->node_id(j);
-            _kij[node_i][node_j] = 0.0;
-          }
-        }
-      }
-    }
+            _connections.addConnection(elem->node_id(i), elem->node_id(j));
+    _connections.finalizeAddingConnections();
+
+    _number_of_nodes = _connections.numNodes();
+
+    // initialize _kij
+    _kij.resize(_number_of_nodes);
+    for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+      _kij[sequential_i].assign(
+          _connections.sequentialConnectionsToSequentialID(sequential_i).size(), 0.0);
 
     /*
-     * Build _valence[i_j], which is the number of times the i_j pair is encountered when looping
-     * over the entire mesh (and on relevant blocks)
+     * Build _valence[i], which is the number of times the sequential node i is encountered when
+     * looping over the entire mesh (and on relevant blocks)
      *
      * MULTIPROC NOTE: this must loop over local elements and >=1 layer of ghosted elements.
      * The Kernel will only loop over local elements, so will only use _valence for
      * linked node-node pairs that appear in the local elements.  But other processors will
      * loop over neighboring elements, so avoid multiple counting of the residual and Jacobian
      * this processor must record how many times each node-node link of its local elements
-     * appears in the *global* mesh and pass that info to the Kernel
+     * appears in the local elements and >=1 layer, and pass that info to the Kernel
      */
-    _valence.clear();
+    _valence.assign(_number_of_nodes, 0);
     for (const auto & elem : _fe_problem.getEvaluableElementRange())
-    {
       if (this->hasBlocks(elem->subdomain_id()))
-      {
         for (unsigned i = 0; i < elem->n_nodes(); ++i)
         {
           const dof_id_type node_i = elem->node_id(i);
-          for (unsigned j = 0; j < elem->n_nodes(); ++j)
-          {
-            const dof_id_type node_j = elem->node_id(j);
-            const std::pair<dof_id_type, dof_id_type> i_j(node_i, node_j);
-            if (_valence.find(i_j) == _valence.end())
-              _valence[i_j] = 0;
-            _valence[i_j] += 1;
-          }
+          const dof_id_type sequential_i = _connections.sequentialID(node_i);
+          _valence[sequential_i] += 1;
         }
+
+    _u_nodal.assign(_number_of_nodes, 0.0);
+    _u_nodal_computed_by_thread.assign(_number_of_nodes, false);
+    _flux_out.assign(_number_of_nodes, 0.0);
+    _dflux_out_du.assign(_number_of_nodes, std::map<dof_id_type, Real>());
+    for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+      zeroedConnection(_dflux_out_du[sequential_i], _connections.globalID(sequential_i));
+    _dflux_out_dKjk.resize(_number_of_nodes);
+    for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+    {
+      const std::vector<dof_id_type> con_i =
+          _connections.sequentialConnectionsToSequentialID(sequential_i);
+      const std::size_t num_con_i = con_i.size();
+      _dflux_out_dKjk[sequential_i].resize(num_con_i);
+      for (std::size_t j = 0; j < con_i.size(); ++j)
+      {
+        const dof_id_type sequential_j = con_i[j];
+        const std::size_t num_con_j =
+            _connections.sequentialConnectionsToSequentialID(sequential_j).size();
+        _dflux_out_dKjk[sequential_i][j].assign(num_con_j, 0.0);
       }
     }
 
-    _u_nodal.clear();
-    _u_nodal_computed_by_thread.clear();
-    _flux_out.clear();
-    _dflux_out_du.clear();
-    _dflux_out_dKjk.clear();
-    for (auto & nodes : _kij)
-    {
-      const dof_id_type node_i = nodes.first;
-      _u_nodal[node_i] = 0.0;
-      _u_nodal_computed_by_thread[node_i] = false;
-      _flux_out[node_i] = 0.0;
-      _dflux_out_du[node_i] = {};
-      zeroedConnection(_dflux_out_du[node_i], node_i);
-      _dflux_out_dKjk[node_i] = {};
-      for (const auto & neighbour_to_i : nodes.second)
-      {
-        const dof_id_type node_j = neighbour_to_i.first;
-        _dflux_out_dKjk[node_i][node_j] = {};
-        zeroedConnection(_dflux_out_dKjk[node_i][node_j], node_j);
-      }
-    }
     _resizing_needed = false;
   }
 }
@@ -159,12 +153,10 @@ AdvectiveFluxCalculatorBase::initialize()
 {
   // Zero _kij and falsify _u_nodal_computed_by_thread ready for building in execute() and
   // finalize()
-  for (auto & nodes : _kij)
-  {
-    _u_nodal_computed_by_thread[nodes.first] = false;
-    for (auto & neighbors : nodes.second)
-      neighbors.second = 0.0;
-  }
+  _u_nodal_computed_by_thread.assign(_number_of_nodes, false);
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+    _kij[sequential_i].assign(_connections.sequentialConnectionsToSequentialID(sequential_i).size(),
+                              0.0);
 }
 
 void
@@ -175,10 +167,11 @@ AdvectiveFluxCalculatorBase::execute()
   for (unsigned i = 0; i < _current_elem->n_nodes(); ++i)
   {
     const dof_id_type node_i = _current_elem->node_id(i);
-    if (!_u_nodal_computed_by_thread[node_i])
+    const dof_id_type sequential_i = _connections.sequentialID(node_i);
+    if (!_u_nodal_computed_by_thread[sequential_i])
     {
-      _u_nodal[node_i] = computeU(i);
-      _u_nodal_computed_by_thread[node_i] = true;
+      _u_nodal[sequential_i] = computeU(i);
+      _u_nodal_computed_by_thread[sequential_i] = true;
     }
     for (unsigned j = 0; j < _current_elem->n_nodes(); ++j)
     {
@@ -194,7 +187,9 @@ AdvectiveFluxCalculatorBase::executeOnElement(
     dof_id_type global_i, dof_id_type global_j, unsigned local_i, unsigned local_j, unsigned qp)
 {
   // KT Eqn (20)
-  _kij[global_i][global_j] += _JxW[qp] * _coord[qp] * computeVelocity(local_i, local_j, qp);
+  const dof_id_type sequential_i = _connections.sequentialID(global_i);
+  const unsigned index_i_to_j = _connections.indexOfGlobalConnection(global_i, global_j);
+  _kij[sequential_i][index_i_to_j] += _JxW[qp] * _coord[qp] * computeVelocity(local_i, local_j, qp);
 }
 
 void
@@ -202,23 +197,18 @@ AdvectiveFluxCalculatorBase::threadJoin(const UserObject & uo)
 {
   const AdvectiveFluxCalculatorBase & afc = static_cast<const AdvectiveFluxCalculatorBase &>(uo);
   // add the values of _kij computed by different threads
-  for (const auto & nodes : afc._kij)
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    for (const auto & neighbors : nodes.second)
-    {
-      const dof_id_type j = neighbors.first;
-      const Real afc_val = neighbors.second;
-      _kij[i][j] += afc_val;
-    }
+    const std::size_t num_con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i).size();
+    for (std::size_t j = 0; j < num_con_i; ++j)
+      _kij[sequential_i][j] += afc._kij[sequential_i][j];
   }
+
   // gather the values of _u_nodal computed by different threads
-  for (const auto & node_u : afc._u_nodal)
-  {
-    const dof_id_type i = node_u.first;
-    if (!_u_nodal_computed_by_thread[i] && afc.getUnodalComputedByThread(i))
-      _u_nodal[i] = node_u.second;
-  }
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+    if (!_u_nodal_computed_by_thread[sequential_i] && afc._u_nodal_computed_by_thread[sequential_i])
+      _u_nodal[sequential_i] = afc._u_nodal[sequential_i];
 }
 
 void
@@ -248,347 +238,386 @@ AdvectiveFluxCalculatorBase::finalize()
   // This adds artificial diffusion, which eliminates any spurious oscillations
   // The idea is that D will remove all negative off-diagonal elements when it is added to K
   // This is identical to full upwinding
-  std::map<dof_id_type, std::map<dof_id_type, Real>> dij;
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      dDij_dKij; // dDij_dKij[i][j] = d(D[i][j])/d(K[i][j]) for i!=j
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      dDij_dKji; // dDij_dKji[i][j] = d(D[i][j])/d(K[j][i]) for i!=j
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      dDii_dKij; // dDii_dKij[i][j] = d(D[i][i])/d(K[i][j])
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      dDii_dKji; // dDii_dKji[i][j] = d(D[i][i])/d(K[j][i])
-  for (auto & nodes : _kij)
+  std::vector<std::vector<Real>> dij(_number_of_nodes);
+  std::vector<std::vector<Real>> dDij_dKij(
+      _number_of_nodes); // dDij_dKij[i][j] = d(D[i][j])/d(K[i][j]) for i!=j
+  std::vector<std::vector<Real>> dDij_dKji(
+      _number_of_nodes); // dDij_dKji[i][j] = d(D[i][j])/d(K[j][i]) for i!=j
+  std::vector<std::vector<Real>> dDii_dKij(
+      _number_of_nodes); // dDii_dKij[i][j] = d(D[i][i])/d(K[i][j])
+  std::vector<std::vector<Real>> dDii_dKji(
+      _number_of_nodes); // dDii_dKji[i][j] = d(D[i][i])/d(K[j][i])
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    dij[i] = {};
-    dij[i][i] = 0.0;
-    dDij_dKij[i] = {};
-    zeroedConnection(dDij_dKij[i], i);
-    dDij_dKji[i] = {};
-    zeroedConnection(dDij_dKji[i], i);
-    dDii_dKij[i] = {};
-    zeroedConnection(dDii_dKij[i], i);
-    dDii_dKji[i] = {};
-    zeroedConnection(dDii_dKji[i], i);
-    for (auto & neighbors : nodes.second)
+    const std::vector<dof_id_type> con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const std::size_t num_con_i = con_i.size();
+    dij[sequential_i].assign(num_con_i, 0.0);
+    dDij_dKij[sequential_i].assign(num_con_i, 0.0);
+    dDij_dKji[sequential_i].assign(num_con_i, 0.0);
+    dDii_dKij[sequential_i].assign(num_con_i, 0.0);
+    dDii_dKji[sequential_i].assign(num_con_i, 0.0);
+    const unsigned index_i_to_i =
+        _connections.indexOfSequentialConnection(sequential_i, sequential_i);
+    for (std::size_t j = 0; j < num_con_i; ++j)
     {
-      const dof_id_type j = neighbors.first;
-      if (i == j)
+      const dof_id_type sequential_j = con_i[j];
+      if (sequential_i == sequential_j)
         continue;
-      if ((_kij[i][j] <= _kij[j][i]) && (_kij[i][j] < 0))
+      const unsigned index_j_to_i =
+          _connections.indexOfSequentialConnection(sequential_j, sequential_i);
+      const Real kij = _kij[sequential_i][j];
+      const Real kji = _kij[sequential_j][index_j_to_i];
+      if ((kij <= kji) && (kij < 0.0))
       {
-        dij[i][j] = -_kij[i][j];
-        dDij_dKij[i][j] = -1.0;
-        dDii_dKij[i][j] += 1.0;
+        dij[sequential_i][j] = -kij;
+        dDij_dKij[sequential_i][j] = -1.0;
+        dDii_dKij[sequential_i][j] += 1.0;
       }
-      else if ((_kij[j][i] <= _kij[i][j]) && (_kij[j][i] < 0))
+      else if ((kji <= kij) && (kji < 0.0))
       {
-        dij[i][j] = -_kij[j][i];
-        dDij_dKji[i][j] = -1.0;
-        dDii_dKji[i][j] += 1.0;
+        dij[sequential_i][j] = -kji;
+        dDij_dKji[sequential_i][j] = -1.0;
+        dDii_dKji[sequential_i][j] += 1.0;
       }
       else
-        dij[i][j] = 0.0;
-      dij[i][i] -= dij[i][j];
+        dij[sequential_i][j] = 0.0;
+      dij[sequential_i][index_i_to_i] -= dij[sequential_i][j];
     }
   }
 
   // Calculate KuzminTurek L matrix
   // See Fig 2: L = K + D
-  std::map<dof_id_type, std::map<dof_id_type, Real>> lij;
-  for (auto & nodes : _kij)
+  std::vector<std::vector<Real>> lij(_number_of_nodes);
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    lij[i] = {};
-    for (auto & neighbors : nodes.second)
-    {
-      const dof_id_type j = neighbors.first;
-      lij[i][j] = _kij[i][j] + dij[i][j];
-    }
+    const std::vector<dof_id_type> con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const std::size_t num_con_i = con_i.size();
+    lij[sequential_i].assign(num_con_i, 0.0);
+    for (std::size_t j = 0; j < num_con_i; ++j)
+      lij[sequential_i][j] = _kij[sequential_i][j] + dij[sequential_i][j];
   }
 
   // Compute KuzminTurek R matrices
   // See Eqns (49) and (12)
-  std::map<dof_id_type, Real> rP;
-  std::map<dof_id_type, Real> rM;
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      drP; // drP[i][j] = d(rP[i])/d(u[j]).  Here j must be connected to i (ie _kij[i][j] exists)
-           // for there to be a nonzero derivative
-  std::map<dof_id_type, std::map<dof_id_type, Real>> drM;
-  std::map<dof_id_type, std::map<dof_id_type, Real>>
-      drP_dk; // drP_dk[i][j] = d(rP[i])/d(K[i][j]).   Here j must be connected to i (ie _kij[i][j]
-              // exists) for there to be a nonzero derivative
-  std::map<dof_id_type, std::map<dof_id_type, Real>> drM_dk;
-  for (const auto & nodes : _kij)
+  std::vector<Real> rP(_number_of_nodes);
+  std::vector<Real> rM(_number_of_nodes);
+  std::vector<std::vector<Real>> drP(_number_of_nodes); // drP[i][j] = d(rP[i])/d(u[j]).  Here j
+                                                        // indexes the j^th node connected to i
+  std::vector<std::vector<Real>> drM(_number_of_nodes);
+  std::vector<std::vector<Real>> drP_dk(
+      _number_of_nodes); // drP_dk[i][j] = d(rP[i])/d(K[i][j]).  Here j indexes the j^th node
+                         // connected to i
+  std::vector<std::vector<Real>> drM_dk(_number_of_nodes);
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    drP[i] = {};
-    drP_dk[i] = {};
-    rP[i] = rPlus(i, drP[i], drP_dk[i]);
-    drM[i] = {};
-    drM_dk[i] = {};
-    rM[i] = rMinus(i, drM[i], drM_dk[i]);
+    rP[sequential_i] = rPlus(sequential_i, drP[sequential_i], drP_dk[sequential_i]);
+    rM[sequential_i] = rMinus(sequential_i, drM[sequential_i], drM_dk[sequential_i]);
   }
 
   // Calculate KuzminTurek f^{a} matrix
   // This is the antidiffusive flux
   // See Eqn (50)
-  std::map<dof_id_type, std::map<dof_id_type, Real>> fa;
-  std::map<dof_id_type, std::map<dof_id_type, std::map<dof_id_type, Real>>>
-      dfa; // dfa[i][j][k] = d(fa[i][j])/du[k].  Here k can be a neighbour to i or a neighbour to j
-  std::map<dof_id_type, std::map<dof_id_type, std::map<dof_id_type, Real>>>
-      dFij_dKik; // dFij_dKik[i][j][k] = d(fa[i][j])/d(K[i][k]).  Here j must be connected to i, and
-                 // k connected to i
-  std::map<dof_id_type, std::map<dof_id_type, std::map<dof_id_type, Real>>>
-      dFij_dKjk; // dFij_dKjk[i][j][k] = d(fa[i][j])/d(K[j][k]).  Here j must be connected to i, and
-                 // k connected to j (including i itself)
-  for (const auto & nodes : _kij)
+  std::vector<std::vector<Real>> fa(
+      _number_of_nodes); // fa[sequential_i][j]  sequential_j is the j^th connection to sequential_i
+  // The derivatives are a bit complicated.
+  // If i is upwind of j then fa[i][j] depends on all nodes connected to i.
+  // But if i is downwind of j then fa[i][j] depends on all nodes connected to j.
+  std::vector<std::vector<std::map<dof_id_type, Real>>> dfa(
+      _number_of_nodes); // dfa[sequential_i][j][global_k] = d(fa[sequential_i][j])/du[global_k].
+                         // Here global_k can be a neighbor to sequential_i or a neighbour to
+                         // sequential_j (sequential_j is the j^th connection to sequential_i)
+  std::vector<std::vector<std::vector<Real>>> dFij_dKik(
+      _number_of_nodes); // dFij_dKik[sequential_i][j][k] =
+                         // d(fa[sequential_i][j])/d(K[sequential_i][k]).  Here j denotes the j^th
+                         // connection to sequential_i, while k denotes the k^th connection to
+                         // sequential_i
+  std::vector<std::vector<std::vector<Real>>> dFij_dKjk(
+      _number_of_nodes); // dFij_dKjk[sequential_i][j][k] =
+                         // d(fa[sequential_i][j])/d(K[sequential_j][k]).  Here sequential_j is the
+                         // j^th connection to sequential_i, and k denotes the k^th connection to
+                         // sequential_j (this will include sequential_i itself)
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    fa[i] = {};
-    dfa[i] = {};
-    dFij_dKik[i] = {};
-    dFij_dKjk[i] = {};
-    for (const auto & neighbors : nodes.second)
+    const std::vector<dof_id_type> con_i =
+        _connections.globalConnectionsToSequentialID(sequential_i);
+    const unsigned num_con_i = con_i.size();
+    fa[sequential_i].assign(num_con_i, 0.0);
+    dfa[sequential_i].resize(num_con_i);
+    dFij_dKik[sequential_i].resize(num_con_i);
+    dFij_dKjk[sequential_i].resize(num_con_i);
+    for (std::size_t j = 0; j < num_con_i; ++j)
     {
-      const dof_id_type j = neighbors.first;
-      fa[i][j] = 0.0;
-      dfa[i][j] = {};
-      dFij_dKik[i][j] = {};
-      dFij_dKjk[i][j] = {};
-      // The derivatives are a bit complicated.
-      // If i is upwind of j then fa[i][j] depends on all nodes connected to i.
-      // But if i is downwind of j then fa[i][j] depends on all nodes connected to j.
-      for (const auto & neighbor_to_i : _kij[i])
-      {
-        dfa[i][j][neighbor_to_i.first] = 0.0;
-        dFij_dKik[i][j][neighbor_to_i.first] = 0.0;
-      }
-      for (const auto & neighbor_to_j : _kij[j])
-      {
-        dfa[i][j][neighbor_to_j.first] = 0.0;
-        dFij_dKjk[i][j][neighbor_to_j.first] = 0.0;
-      }
+      for (const auto & global_k : con_i)
+        dfa[sequential_i][j][global_k] = 0;
+      const dof_id_type global_j = con_i[j];
+      const std::vector<dof_id_type> con_j = _connections.globalConnectionsToGlobalID(global_j);
+      const unsigned num_con_j = con_j.size();
+      for (const auto & global_k : con_j)
+        dfa[sequential_i][j][global_k] = 0;
+      dFij_dKik[sequential_i][j].assign(num_con_i, 0.0);
+      dFij_dKjk[sequential_i][j].assign(num_con_j, 0.0);
     }
   }
-  for (const auto & nodes : _kij)
+
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    const Real u_i = getUnodal(i);
-    for (const auto & neighbors : nodes.second)
+    const dof_id_type global_i = _connections.globalID(sequential_i);
+    const Real u_i = _u_nodal[sequential_i];
+    const std::vector<dof_id_type> con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const std::size_t num_con_i = con_i.size();
+    for (std::size_t j = 0; j < num_con_i; ++j)
     {
-      const dof_id_type j = neighbors.first;
-      const Real u_j = getUnodal(j);
-      if (i == j)
+      const dof_id_type sequential_j = con_i[j];
+      if (sequential_i == sequential_j)
         continue;
-      if (lij[j][i] >= lij[i][j]) // node i is upwind of node j.
+      const unsigned index_j_to_i =
+          _connections.indexOfSequentialConnection(sequential_j, sequential_i);
+      const Real Lij = lij[sequential_i][j];
+      const Real Lji = lij[sequential_j][index_j_to_i];
+      if (Lji >= Lij) // node i is upwind of node j.
       {
+        const Real Dij = dij[sequential_i][j];
+        const dof_id_type global_j = _connections.globalID(sequential_j);
+        const Real u_j = _u_nodal[sequential_j];
         Real prefactor = 0.0;
-        std::map<dof_id_type, Real>
-            dprefactor_du; // dprefactor_du[global_id] = d(prefactor)/du[global_id];
-        for (const auto & dof_deriv : drP[i])
-          dprefactor_du[dof_deriv.first] = 0.0;
-        std::map<dof_id_type, Real>
-            dprefactor_dKij; // dprefactor_dKij[global_id] = d(prefactor)/dKij[i][global_id].  Here
-                             // global_id must be connected to i for a nonzero derivative
-        zeroedConnection(dprefactor_dKij, i);
-        Real dprefactor_dKji = 0; // dprefactor_dKji = d(prefactor)/dKij[j][i]
+        std::vector<Real> dprefactor_du(num_con_i,
+                                        0.0); // dprefactor_du[j] = d(prefactor)/du[sequential_j]
+        std::vector<Real> dprefactor_dKij(
+            num_con_i, 0.0);      // dprefactor_dKij[j] = d(prefactor)/dKij[sequential_i][j].
+        Real dprefactor_dKji = 0; // dprefactor_dKji = d(prefactor)/dKij[sequential_j][index_j_to_i]
         if (u_i >= u_j)
         {
-          if (lij[j][i] <= rP[i] * dij[i][j])
+          if (Lji <= rP[sequential_i] * Dij)
           {
-            prefactor = lij[j][i];
-            dprefactor_dKij[j] += dDij_dKji[j][i];
-            dprefactor_dKji += 1.0 + dDij_dKij[j][i];
+            prefactor = Lji;
+            dprefactor_dKij[j] += dDij_dKji[sequential_j][index_j_to_i];
+            dprefactor_dKji += 1.0 + dDij_dKij[sequential_j][index_j_to_i];
           }
           else
           {
-            prefactor = rP[i] * dij[i][j];
-            for (const auto & dof_deriv : drP[i])
-              dprefactor_du[dof_deriv.first] = dof_deriv.second * dij[i][j];
-            dprefactor_dKij[j] += rP[i] * dDij_dKij[i][j];
-            dprefactor_dKji += rP[i] * dDij_dKji[i][j];
-            for (const auto & dof_deriv : drP_dk[i])
-              dprefactor_dKij[dof_deriv.first] += dof_deriv.second * dij[i][j];
+            prefactor = rP[sequential_i] * Dij;
+            for (std::size_t ind_j = 0; ind_j < num_con_i; ++ind_j)
+              dprefactor_du[ind_j] = drP[sequential_i][ind_j] * Dij;
+            dprefactor_dKij[j] += rP[sequential_i] * dDij_dKij[sequential_i][j];
+            dprefactor_dKji += rP[sequential_i] * dDij_dKji[sequential_i][j];
+            for (std::size_t ind_j = 0; ind_j < num_con_i; ++ind_j)
+              dprefactor_dKij[ind_j] += drP_dk[sequential_i][ind_j] * Dij;
           }
         }
         else
         {
-          if (lij[j][i] <= rM[i] * dij[i][j])
+          if (Lji <= rM[sequential_i] * Dij)
           {
-            prefactor = lij[j][i];
-            dprefactor_dKij[j] += dDij_dKji[j][i];
-            dprefactor_dKji += 1.0 + dDij_dKij[j][i];
+            prefactor = Lji;
+            dprefactor_dKij[j] += dDij_dKji[sequential_j][index_j_to_i];
+            dprefactor_dKji += 1.0 + dDij_dKij[sequential_j][index_j_to_i];
           }
           else
           {
-            prefactor = rM[i] * dij[i][j];
-            for (const auto & dof_deriv : drM[i])
-              dprefactor_du[dof_deriv.first] = dof_deriv.second * dij[i][j];
-            dprefactor_dKij[j] += rM[i] * dDij_dKij[i][j];
-            dprefactor_dKji += rM[i] * dDij_dKji[i][j];
-            for (const auto & dof_deriv : drM_dk[i])
-              dprefactor_dKij[dof_deriv.first] += dof_deriv.second * dij[i][j];
+            prefactor = rM[sequential_i] * Dij;
+            for (std::size_t ind_j = 0; ind_j < num_con_i; ++ind_j)
+              dprefactor_du[ind_j] = drM[sequential_i][ind_j] * Dij;
+            dprefactor_dKij[j] += rM[sequential_i] * dDij_dKij[sequential_i][j];
+            dprefactor_dKji += rM[sequential_i] * dDij_dKji[sequential_i][j];
+            for (std::size_t ind_j = 0; ind_j < num_con_i; ++ind_j)
+              dprefactor_dKij[ind_j] += drM_dk[sequential_i][ind_j] * Dij;
           }
         }
-        fa[i][j] = prefactor * (u_i - u_j);
-        dfa[i][j][i] = prefactor;
-        dfa[i][j][j] = -prefactor;
-        for (const auto & dof_deriv : dprefactor_du)
-          dfa[i][j][dof_deriv.first] += dof_deriv.second * (u_i - u_j);
-        for (const auto & dof_deriv : dprefactor_dKij)
-          dFij_dKik[i][j][dof_deriv.first] += dof_deriv.second * (u_i - u_j);
-        dFij_dKjk[i][j][i] += dprefactor_dKji * (u_i - u_j);
+        fa[sequential_i][j] = prefactor * (u_i - u_j);
+        dfa[sequential_i][j][global_i] = prefactor;
+        dfa[sequential_i][j][global_j] = -prefactor;
+        for (std::size_t ind_j = 0; ind_j < num_con_i; ++ind_j)
+        {
+          dfa[sequential_i][j][_connections.globalID(con_i[ind_j])] +=
+              dprefactor_du[ind_j] * (u_i - u_j);
+          dFij_dKik[sequential_i][j][ind_j] += dprefactor_dKij[ind_j] * (u_i - u_j);
+        }
+        dFij_dKjk[sequential_i][j][index_j_to_i] += dprefactor_dKji * (u_i - u_j);
       }
     }
   }
-  for (const auto & nodes : _kij)
+
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    for (const auto & neighbors : nodes.second)
+    const std::vector<dof_id_type> con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const std::size_t num_con_i = con_i.size();
+    for (std::size_t j = 0; j < num_con_i; ++j)
     {
-      const dof_id_type j = neighbors.first;
-      if (i == j)
+      const dof_id_type sequential_j = con_i[j];
+      if (sequential_i == sequential_j)
         continue;
-      if (lij[j][i] < lij[i][j]) // node_i is downwind of node_j.
+      const unsigned index_j_to_i =
+          _connections.indexOfSequentialConnection(sequential_j, sequential_i);
+      if (lij[sequential_j][index_j_to_i] < lij[sequential_i][j]) // node_i is downwind of node_j.
       {
-        fa[i][j] = -fa[j][i];
-        for (const auto & dof_deriv : dfa[j][i])
-          dfa[i][j][dof_deriv.first] = -dof_deriv.second;
-        for (const auto & dof_deriv : dFij_dKjk[j][i])
-          dFij_dKik[i][j][dof_deriv.first] = -dof_deriv.second;
-        for (const auto & dof_deriv : dFij_dKik[j][i])
-          dFij_dKjk[i][j][dof_deriv.first] = -dof_deriv.second;
+        fa[sequential_i][j] = -fa[sequential_j][index_j_to_i];
+        for (const auto & dof_deriv : dfa[sequential_j][index_j_to_i])
+          dfa[sequential_i][j][dof_deriv.first] = -dof_deriv.second;
+        for (std::size_t k = 0; k < num_con_i; ++k)
+          dFij_dKik[sequential_i][j][k] = -dFij_dKjk[sequential_j][index_j_to_i][k];
+        const std::size_t num_con_j =
+            _connections.sequentialConnectionsToSequentialID(sequential_j).size();
+        for (std::size_t k = 0; k < num_con_j; ++k)
+          dFij_dKjk[sequential_i][j][k] = -dFij_dKik[sequential_j][index_j_to_i][k];
       }
     }
   }
 
   // zero _flux_out and its derivatives
-  for (const auto & nodes : _kij)
-  {
-    const dof_id_type i = nodes.first;
-    _flux_out[i] = 0.0;
-    // The derivatives are a bit complicated.
-    // If i is upwind of a node "j" then _flux_out[i] depends on all nodes connected to i.
-    // But if i is downwind of a node "j" then _flux_out depends on all nodes connected with node
-    // j.
-    for (const auto & neighbors_i : nodes.second)
+  _flux_out.assign(_number_of_nodes, 0.0);
+  // The derivatives are a bit complicated.
+  // If i is upwind of a node "j" then _flux_out[i] depends on all nodes connected to i.
+  // But if i is downwind of a node "j" then _flux_out depends on all nodes connected with node
+  // j.
+  _dflux_out_du.assign(_number_of_nodes, std::map<dof_id_type, Real>());
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+    for (const auto & j : _connections.globalConnectionsToSequentialID(sequential_i))
     {
-      const dof_id_type j = neighbors_i.first;
-      _dflux_out_du[i][j] = 0.0;
-      for (const auto & neighbors_j : _kij[j])
-      {
-        _dflux_out_du[i][neighbors_j.first] = 0.0;
-        _dflux_out_dKjk[i][j][neighbors_j.first] = 0.0;
-      }
+      _dflux_out_du[sequential_i][j] = 0.0;
+      for (const auto & neighbors_j : _connections.globalConnectionsToGlobalID(j))
+        _dflux_out_du[sequential_i][neighbors_j] = 0.0;
+    }
+  _dflux_out_dKjk.resize(_number_of_nodes);
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
+  {
+    const std::vector<dof_id_type> con_i =
+        _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const std::size_t num_con_i = con_i.size();
+    _dflux_out_dKjk[sequential_i].resize(num_con_i);
+    for (std::size_t j = 0; j < num_con_i; ++j)
+    {
+      const dof_id_type sequential_j = con_i[j];
+      std::vector<dof_id_type> con_j =
+          _connections.sequentialConnectionsToSequentialID(sequential_j);
+      _dflux_out_dKjk[sequential_i][j].assign(con_j.size(), 0.0);
     }
   }
 
   // Add everything together
   // See step 3 in Fig 2, noting Eqn (36)
-  for (auto & nodes : _kij)
+  for (dof_id_type sequential_i = 0; sequential_i < _number_of_nodes; ++sequential_i)
   {
-    const dof_id_type i = nodes.first;
-    for (const auto & neighbors : nodes.second)
+    std::vector<dof_id_type> con_i = _connections.sequentialConnectionsToSequentialID(sequential_i);
+    const size_t num_con_i = con_i.size();
+    const dof_id_type index_i_to_i =
+        _connections.indexOfSequentialConnection(sequential_i, sequential_i);
+    for (std::size_t j = 0; j < num_con_i; ++j)
     {
-      const dof_id_type j = neighbors.first;
-      const Real u_j = getUnodal(j);
+      const dof_id_type sequential_j = con_i[j];
+      const dof_id_type global_j = _connections.globalID(sequential_j);
+      const Real u_j = _u_nodal[sequential_j];
 
       // negative sign because residual = -Lu (KT equation (19))
-      _flux_out[i] -= lij[i][j] * u_j + fa[i][j];
+      _flux_out[sequential_i] -= lij[sequential_i][j] * u_j + fa[sequential_i][j];
 
-      _dflux_out_du[i][j] -= lij[i][j];
-      for (const auto & dof_deriv : dfa[i][j])
-        _dflux_out_du[i][dof_deriv.first] -= dof_deriv.second;
+      _dflux_out_du[sequential_i][global_j] -= lij[sequential_i][j];
+      for (const auto & dof_deriv : dfa[sequential_i][j])
+        _dflux_out_du[sequential_i][dof_deriv.first] -= dof_deriv.second;
 
-      _dflux_out_dKjk[i][i][j] -= 1.0 * u_j; // from the K in L = K + D
+      _dflux_out_dKjk[sequential_i][index_i_to_i][j] -= 1.0 * u_j; // from the K in L = K + D
 
-      if (j == i)
-        for (const auto & dof_deriv : dDii_dKij[i])
-          _dflux_out_dKjk[i][i][dof_deriv.first] -= dof_deriv.second * u_j;
+      if (sequential_j == sequential_i)
+        for (dof_id_type k = 0; k < num_con_i; ++k)
+          _dflux_out_dKjk[sequential_i][index_i_to_i][k] -= dDii_dKij[sequential_i][k] * u_j;
       else
-        _dflux_out_dKjk[i][i][j] -= dDij_dKij[i][j] * u_j;
-      for (const auto & dof_deriv : dFij_dKik[i][j])
-        _dflux_out_dKjk[i][i][dof_deriv.first] -= dof_deriv.second;
+        _dflux_out_dKjk[sequential_i][index_i_to_i][j] -= dDij_dKij[sequential_i][j] * u_j;
+      for (dof_id_type k = 0; k < num_con_i; ++k)
+        _dflux_out_dKjk[sequential_i][index_i_to_i][k] -= dFij_dKik[sequential_i][j][k];
 
-      if (j == i)
-        for (const auto & dof_deriv : dDii_dKji[i])
-          _dflux_out_dKjk[i][dof_deriv.first][i] -= dof_deriv.second * u_j;
+      if (sequential_j == sequential_i)
+        for (unsigned k = 0; k < con_i.size(); ++k)
+        {
+          const unsigned index_k_to_i =
+              _connections.indexOfSequentialConnection(con_i[k], sequential_i);
+          _dflux_out_dKjk[sequential_i][k][index_k_to_i] -= dDii_dKji[sequential_i][k] * u_j;
+        }
       else
-        _dflux_out_dKjk[i][j][i] -= dDij_dKji[i][j] * u_j;
-      for (const auto & dof_deriv : dFij_dKjk[i][j])
-        _dflux_out_dKjk[i][j][dof_deriv.first] -= dof_deriv.second;
+      {
+        const unsigned index_j_to_i =
+            _connections.indexOfSequentialConnection(sequential_j, sequential_i);
+        _dflux_out_dKjk[sequential_i][j][index_j_to_i] -= dDij_dKji[sequential_i][j] * u_j;
+      }
+      for (unsigned k = 0;
+           k < _connections.sequentialConnectionsToSequentialID(sequential_j).size();
+           ++k)
+        _dflux_out_dKjk[sequential_i][j][k] -= dFij_dKjk[sequential_i][j][k];
     }
   }
 }
 
 Real
-AdvectiveFluxCalculatorBase::rPlus(dof_id_type node_i,
-                                   std::map<dof_id_type, Real> & dlimited_du,
-                                   std::map<dof_id_type, Real> & dlimited_dk) const
+AdvectiveFluxCalculatorBase::rPlus(dof_id_type sequential_i,
+                                   std::vector<Real> & dlimited_du,
+                                   std::vector<Real> & dlimited_dk) const
 {
-  zeroedConnection(dlimited_du, node_i);
-  zeroedConnection(dlimited_dk, node_i);
+  const std::size_t num_con = _connections.sequentialConnectionsToSequentialID(sequential_i).size();
+  dlimited_du.assign(num_con, 0.0);
+  dlimited_dk.assign(num_con, 0.0);
   if (_flux_limiter_type == FluxLimiterTypeEnum::None)
     return 0.0;
-  std::map<dof_id_type, Real> dp_du;
-  std::map<dof_id_type, Real> dp_dk;
-  const Real p = PQPlusMinus(node_i, PQPlusMinusEnum::PPlus, dp_du, dp_dk);
+  std::vector<Real> dp_du;
+  std::vector<Real> dp_dk;
+  const Real p = PQPlusMinus(sequential_i, PQPlusMinusEnum::PPlus, dp_du, dp_dk);
   if (p == 0.0)
     // Comment after Eqn (49): if P=0 then there's no antidiffusion, so no need to remove it
     return 1.0;
-  std::map<dof_id_type, Real> dq_du;
-  std::map<dof_id_type, Real> dq_dk;
-  const Real q = PQPlusMinus(node_i, PQPlusMinusEnum::QPlus, dq_du, dq_dk);
+  std::vector<Real> dq_du;
+  std::vector<Real> dq_dk;
+  const Real q = PQPlusMinus(sequential_i, PQPlusMinusEnum::QPlus, dq_du, dq_dk);
+
   const Real r = q / p;
-  std::map<dof_id_type, Real> dr_du;
-  for (const auto & node_deriv : dp_du)
-    dr_du[node_deriv.first] = dq_du[node_deriv.first] / p - q * node_deriv.second / std::pow(p, 2);
-  std::map<dof_id_type, Real> dr_dk;
-  for (const auto & node_deriv : dp_dk)
-    dr_dk[node_deriv.first] = dq_dk[node_deriv.first] / p - q * node_deriv.second / std::pow(p, 2);
   Real limited;
   Real dlimited_dr;
   limitFlux(1.0, r, limited, dlimited_dr);
-  for (const auto & node_deriv : dr_du)
-    dlimited_du[node_deriv.first] = dlimited_dr * node_deriv.second;
-  for (const auto & node_deriv : dr_dk)
-    dlimited_dk[node_deriv.first] = dlimited_dr * node_deriv.second;
+
+  const Real p2 = std::pow(p, 2);
+  for (std::size_t j = 0; j < num_con; ++j)
+  {
+    const Real dr_du = dq_du[j] / p - q * dp_du[j] / p2;
+    const Real dr_dk = dq_dk[j] / p - q * dp_dk[j] / p2;
+    dlimited_du[j] = dlimited_dr * dr_du;
+    dlimited_dk[j] = dlimited_dr * dr_dk;
+  }
   return limited;
 }
 
 Real
-AdvectiveFluxCalculatorBase::rMinus(dof_id_type node_i,
-                                    std::map<dof_id_type, Real> & dlimited_du,
-                                    std::map<dof_id_type, Real> & dlimited_dk) const
+AdvectiveFluxCalculatorBase::rMinus(dof_id_type sequential_i,
+                                    std::vector<Real> & dlimited_du,
+                                    std::vector<Real> & dlimited_dk) const
 {
-  zeroedConnection(dlimited_du, node_i);
-  zeroedConnection(dlimited_dk, node_i);
+  const std::size_t num_con = _connections.sequentialConnectionsToSequentialID(sequential_i).size();
+  dlimited_du.assign(num_con, 0.0);
+  dlimited_dk.assign(num_con, 0.0);
   if (_flux_limiter_type == FluxLimiterTypeEnum::None)
     return 0.0;
-  std::map<dof_id_type, Real> dp_du;
-  std::map<dof_id_type, Real> dp_dk;
-  const Real p = PQPlusMinus(node_i, PQPlusMinusEnum::PMinus, dp_du, dp_dk);
+  std::vector<Real> dp_du;
+  std::vector<Real> dp_dk;
+  const Real p = PQPlusMinus(sequential_i, PQPlusMinusEnum::PMinus, dp_du, dp_dk);
   if (p == 0.0)
     // Comment after Eqn (49): if P=0 then there's no antidiffusion, so no need to remove it
     return 1.0;
-  std::map<dof_id_type, Real> dq_du;
-  std::map<dof_id_type, Real> dq_dk;
-  const Real q = PQPlusMinus(node_i, PQPlusMinusEnum::QMinus, dq_du, dq_dk);
+  std::vector<Real> dq_du;
+  std::vector<Real> dq_dk;
+  const Real q = PQPlusMinus(sequential_i, PQPlusMinusEnum::QMinus, dq_du, dq_dk);
+
   const Real r = q / p;
-  std::map<dof_id_type, Real> dr_du;
-  for (const auto & node_deriv : dp_du)
-    dr_du[node_deriv.first] = dq_du[node_deriv.first] / p - q * node_deriv.second / std::pow(p, 2);
-  std::map<dof_id_type, Real> dr_dk;
-  for (const auto & node_deriv : dp_dk)
-    dr_dk[node_deriv.first] = dq_dk[node_deriv.first] / p - q * node_deriv.second / std::pow(p, 2);
   Real limited;
   Real dlimited_dr;
   limitFlux(1.0, r, limited, dlimited_dr);
-  for (const auto & node_deriv : dr_du)
-    dlimited_du[node_deriv.first] = dlimited_dr * node_deriv.second;
-  for (const auto & node_deriv : dr_dk)
-    dlimited_dk[node_deriv.first] = dlimited_dr * node_deriv.second;
+
+  const Real p2 = std::pow(p, 2);
+  for (std::size_t j = 0; j < num_con; ++j)
+  {
+    const Real dr_du = dq_du[j] / p - q * dp_du[j] / p2;
+    const Real dr_dk = dq_dk[j] / p - q * dp_dk[j] / p2;
+    dlimited_du[j] = dlimited_dr * dr_du;
+    dlimited_dk[j] = dlimited_dr * dr_dk;
+  }
   return limited;
 }
 
@@ -692,63 +721,29 @@ AdvectiveFluxCalculatorBase::limitFlux(Real a, Real b, Real & limited, Real & dl
   }
 }
 
-Real
-AdvectiveFluxCalculatorBase::getKij(dof_id_type node_i, dof_id_type node_j) const
-{
-
-  const auto & row_find = _kij.find(node_i);
-  if (row_find == _kij.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() + " Kij does not contain node " +
-               Moose::stringify(node_i));
-  const std::map<dof_id_type, Real> & kij_row = row_find->second;
-  const auto & entry_find = kij_row.find(node_j);
-  if (entry_find == kij_row.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() + " Kij on row " +
-               Moose::stringify(node_i) + " does not contain node " + Moose::stringify(node_j));
-
-  return entry_find->second;
-}
 
 const std::map<dof_id_type, Real> &
 AdvectiveFluxCalculatorBase::getdFluxOutdu(dof_id_type node_i) const
 {
-  const auto & row_find = _dflux_out_du.find(node_i);
-  if (row_find == _dflux_out_du.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " _dflux_out_du does not contain node " + Moose::stringify(node_i));
-  return row_find->second;
+  return _dflux_out_du[_connections.sequentialID(node_i)];
 }
 
-const std::map<dof_id_type, std::map<dof_id_type, Real>> &
+const std::vector<std::vector<Real>> &
 AdvectiveFluxCalculatorBase::getdFluxOutdKjk(dof_id_type node_i) const
 {
-  const auto & row_find = _dflux_out_dKjk.find(node_i);
-  if (row_find == _dflux_out_dKjk.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " _dflux_out_dKjk does not contain node " + Moose::stringify(node_i));
-  return row_find->second;
+  return _dflux_out_dKjk[_connections.sequentialID(node_i)];
 }
 
 Real
 AdvectiveFluxCalculatorBase::getFluxOut(dof_id_type node_i) const
 {
-  const auto & entry_find = _flux_out.find(node_i);
-  if (entry_find == _flux_out.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " _flux_out does not contain node " + Moose::stringify(node_i));
-  return entry_find->second;
+  return _flux_out[_connections.sequentialID(node_i)];
 }
 
 unsigned
-AdvectiveFluxCalculatorBase::getValence(dof_id_type node_i, dof_id_type node_j) const
+AdvectiveFluxCalculatorBase::getValence(dof_id_type node_i) const
 {
-  const std::pair<dof_id_type, dof_id_type> i_j(node_i, node_j);
-  const auto & entry_find = _valence.find(i_j);
-  if (entry_find == _valence.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " Valence does not contain node-pair " + Moose::stringify(node_i) + " to " +
-               Moose::stringify(node_j));
-  return entry_find->second;
+  return _valence[_connections.sequentialID(node_i)];
 }
 
 void
@@ -756,44 +751,41 @@ AdvectiveFluxCalculatorBase::zeroedConnection(std::map<dof_id_type, Real> & the_
                                               dof_id_type node_i) const
 {
   the_map.clear();
-  const auto & row_find = _kij.find(node_i);
-  if (row_find == _kij.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() + " Kij does not contain node " +
-               Moose::stringify(node_i));
-  for (const auto & nk : row_find->second)
-    the_map[nk.first] = 0.0;
+  for (const auto & node_j : _connections.globalConnectionsToGlobalID(node_i))
+    the_map[node_j] = 0.0;
 }
 
 Real
-AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
+AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type sequential_i,
                                          const PQPlusMinusEnum pq_plus_minus,
-                                         std::map<dof_id_type, Real> & derivs,
-                                         std::map<dof_id_type, Real> & dpqdk) const
+                                         std::vector<Real> & derivs,
+                                         std::vector<Real> & dpqdk) const
 {
-  // Find the value of u at node_i
-  const Real u_i = getUnodal(node_i);
+  // Find the value of u at sequential_i
+  const Real u_i = _u_nodal[sequential_i];
 
-  // We're going to sum over all nodes connected with node_i
-  // These nodes are found in _kij[node_i]
-  const auto & row_find = _kij.find(node_i);
-  if (row_find == _kij.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() + " Kij does not contain node " +
-               Moose::stringify(node_i));
-  const std::map<dof_id_type, Real> nodej_and_kij = row_find->second;
+  // Connections to sequential_i
+  const std::vector<dof_id_type> con_i =
+      _connections.sequentialConnectionsToSequentialID(sequential_i);
+  const std::size_t num_con = con_i.size();
+  // The neighbor number of sequential_i to sequential_i
+  const unsigned i_index_i = _connections.indexOfSequentialConnection(sequential_i, sequential_i);
 
   // Initialize the results
   Real result = 0.0;
-  zeroedConnection(derivs, node_i);
-  zeroedConnection(dpqdk, node_i);
+  derivs.assign(num_con, 0.0);
+  dpqdk.assign(num_con, 0.0);
 
   // Sum over all nodes connected with node_i.
-  for (const auto & nk : nodej_and_kij)
+  for (std::size_t j = 0; j < num_con; ++j)
   {
-    const dof_id_type node_j = nk.first;
-    const Real kentry = nk.second;
+    const dof_id_type sequential_j = con_i[j];
+    if (sequential_j == sequential_i)
+      continue;
+    const Real kentry = _kij[sequential_i][j];
 
     // Find the value of u at node_j
-    const Real u_j = getUnodal(node_j);
+    const Real u_j = _u_nodal[sequential_j];
     const Real ujminusi = u_j - u_i;
 
     // Evaluate the i-j contribution to the result
@@ -804,9 +796,9 @@ AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
         if (ujminusi < 0.0 && kentry < 0.0)
         {
           result += kentry * ujminusi;
-          derivs[node_j] += kentry;
-          derivs[node_i] -= kentry;
-          dpqdk[node_j] += ujminusi;
+          derivs[j] += kentry;
+          derivs[i_index_i] -= kentry;
+          dpqdk[j] += ujminusi;
         }
         break;
       }
@@ -815,9 +807,9 @@ AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
         if (ujminusi > 0.0 && kentry < 0.0)
         {
           result += kentry * ujminusi;
-          derivs[node_j] += kentry;
-          derivs[node_i] -= kentry;
-          dpqdk[node_j] += ujminusi;
+          derivs[j] += kentry;
+          derivs[i_index_i] -= kentry;
+          dpqdk[j] += ujminusi;
         }
         break;
       }
@@ -826,9 +818,9 @@ AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
         if (ujminusi > 0.0 && kentry > 0.0)
         {
           result += kentry * ujminusi;
-          derivs[node_j] += kentry;
-          derivs[node_i] -= kentry;
-          dpqdk[node_j] += ujminusi;
+          derivs[j] += kentry;
+          derivs[i_index_i] -= kentry;
+          dpqdk[j] += ujminusi;
         }
         break;
       }
@@ -837,9 +829,9 @@ AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
         if (ujminusi < 0.0 && kentry > 0.0)
         {
           result += kentry * ujminusi;
-          derivs[node_j] += kentry;
-          derivs[node_i] -= kentry;
-          dpqdk[node_j] += ujminusi;
+          derivs[j] += kentry;
+          derivs[i_index_i] -= kentry;
+          dpqdk[j] += ujminusi;
         }
         break;
       }
@@ -847,24 +839,4 @@ AdvectiveFluxCalculatorBase::PQPlusMinus(dof_id_type node_i,
   }
 
   return result;
-}
-
-Real
-AdvectiveFluxCalculatorBase::getUnodal(dof_id_type node_i) const
-{
-  const auto & node_u = _u_nodal.find(node_i);
-  if (node_u == _u_nodal.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " _u_nodal does not contain node " + Moose::stringify(node_i));
-  return node_u->second;
-}
-
-bool
-AdvectiveFluxCalculatorBase::getUnodalComputedByThread(dof_id_type node_i) const
-{
-  const auto & node_u = _u_nodal_computed_by_thread.find(node_i);
-  if (node_u == _u_nodal_computed_by_thread.end())
-    mooseError("AdvectiveFluxCalculatorBase UserObject " + name() +
-               " _u_nodal_computed_by_thread does not contain node " + Moose::stringify(node_i));
-  return node_u->second;
 }

--- a/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorConstantVelocity.C
+++ b/modules/porous_flow/src/userobjects/AdvectiveFluxCalculatorConstantVelocity.C
@@ -28,7 +28,7 @@ AdvectiveFluxCalculatorConstantVelocity::AdvectiveFluxCalculatorConstantVelocity
     const InputParameters & parameters)
   : AdvectiveFluxCalculatorBase(parameters),
     _velocity(getParam<RealVectorValue>("velocity")),
-    _u_nodal(coupledDofValues("u")),
+    _u_at_nodes(coupledDofValues("u")),
     _phi(_assembly.fePhi<Real>(getVar("u", 0)->feType())),
     _grad_phi(_assembly.feGradPhi<Real>(getVar("u", 0)->feType()))
 {
@@ -43,5 +43,5 @@ AdvectiveFluxCalculatorConstantVelocity::computeVelocity(unsigned i, unsigned j,
 Real
 AdvectiveFluxCalculatorConstantVelocity::computeU(unsigned i) const
 {
-  return _u_nodal[i];
+  return _u_at_nodes[i];
 }

--- a/modules/porous_flow/src/utils/PorousFlowConnectedNodes.C
+++ b/modules/porous_flow/src/utils/PorousFlowConnectedNodes.C
@@ -1,0 +1,195 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PorousFlowConnectedNodes.h"
+#include "Conversion.h" // for stringify
+#include "MooseError.h"
+
+PorousFlowConnectedNodes::PorousFlowConnectedNodes() { clear(); }
+
+void
+PorousFlowConnectedNodes::clear()
+{
+  _still_adding_global_nodes = true;
+  _min_global_id = std::numeric_limits<dof_id_type>::max();
+  _max_global_id = std::numeric_limits<dof_id_type>::lowest();
+  _set_of_global_ids.clear();
+  _global_id.clear();
+  _sequential_id.clear();
+  _still_adding_connections = true;
+  _neighbor_sets.clear();
+  _sequential_neighbors.clear();
+}
+
+std::size_t
+PorousFlowConnectedNodes::numNodes() const
+{
+  if (_still_adding_global_nodes)
+    return _set_of_global_ids.size();
+  return _global_id.size();
+}
+
+void
+PorousFlowConnectedNodes::addGlobalNode(dof_id_type global_node_ID)
+{
+  if (!_still_adding_global_nodes)
+    mooseError("PorousFlowConnectedNodes: addGlobalNode called, but _still_adding_global_nodes is "
+               "false.  You possibly called finalizeAddingGlobalNodes too soon.");
+  _set_of_global_ids.insert(global_node_ID);
+  _min_global_id = std::min(_min_global_id, global_node_ID);
+  _max_global_id = std::max(_max_global_id, global_node_ID);
+}
+
+void
+PorousFlowConnectedNodes::finalizeAddingGlobalNodes()
+{
+  // populate the _global_id vector with the values in the set of global IDs
+  _global_id.clear();
+  for (const auto & n : _set_of_global_ids)
+    _global_id.push_back(n);
+  _still_adding_global_nodes = false;
+  _set_of_global_ids.clear();
+
+  // populate the _sequential_id
+  _sequential_id.assign(_max_global_id - _min_global_id + 1, 0);
+  for (std::size_t i = 0; i < _global_id.size(); ++i)
+    _sequential_id[_global_id[i] - _min_global_id] = i;
+
+  // prepare the _neighbor_sets
+  _neighbor_sets.assign(_global_id.size(), std::set<dof_id_type>());
+}
+
+dof_id_type
+PorousFlowConnectedNodes::globalID(dof_id_type sequential_node_ID) const
+{
+  if (_still_adding_global_nodes)
+    mooseError("PorousFlowConnectedNodes: globalID called, but _still_adding_global_nodes is true. "
+               " Probably you should have called finalizeAddingGlobalNodes.");
+  return _global_id[sequential_node_ID];
+}
+
+dof_id_type
+PorousFlowConnectedNodes::sequentialID(dof_id_type global_node_ID) const
+{
+  if (_still_adding_global_nodes)
+    mooseError("PorousFlowConnectedNodes: sequentialID called, but _still_adding_global_nodes is "
+               "true.  Probably you should have called finalizeAddingGlobalNodes.");
+  return _sequential_id[global_node_ID - _min_global_id];
+}
+
+void
+PorousFlowConnectedNodes::addConnection(dof_id_type global_node_from, dof_id_type global_node_to)
+{
+  if (_still_adding_global_nodes)
+    mooseError("PorousFlowConnectedNodes: addConnection called, but _still_adding_global_nodes is "
+               "true.  Probably you should have called finalizeAddingGlobalNodes.");
+  if (!_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: addConnection called, but _still_adding_connections is "
+               "false.  Probably you should have called finalizeAddingConnections.");
+  _neighbor_sets[sequentialID(global_node_from)].insert(global_node_to);
+}
+
+void
+PorousFlowConnectedNodes::finalizeAddingConnections()
+{
+  _sequential_neighbors.assign(_global_id.size(), std::vector<dof_id_type>());
+  _global_neighbors.assign(_global_id.size(), std::vector<dof_id_type>());
+  for (std::size_t i = 0; i < _global_id.size(); ++i)
+    for (const auto & n : _neighbor_sets[i])
+    {
+      _sequential_neighbors[i].push_back(sequentialID(n));
+      _global_neighbors[i].push_back(n);
+    }
+  _still_adding_connections = false;
+  _neighbor_sets.clear();
+}
+
+const std::vector<dof_id_type> &
+PorousFlowConnectedNodes::sequentialConnectionsToGlobalID(dof_id_type global_node_ID) const
+{
+  if (_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: sequentialConnectionsToGlobalID called, but "
+               "_still_adding_connections is true.  Probably you should have called "
+               "finalizeAddingConnections.");
+  return _sequential_neighbors[sequentialID(global_node_ID)];
+}
+
+const std::vector<dof_id_type> &
+PorousFlowConnectedNodes::sequentialConnectionsToSequentialID(dof_id_type sequential_node_ID) const
+{
+  if (_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: sequentialConnectionsToSequentialID called, but "
+               "_still_adding_connections is true.  Probably you should have called "
+               "finalizeAddingConnections.");
+  return _sequential_neighbors[sequential_node_ID];
+}
+
+const std::vector<dof_id_type> &
+PorousFlowConnectedNodes::globalConnectionsToGlobalID(dof_id_type global_node_ID) const
+{
+  if (_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: globalConnectionsToGlobalID called, but "
+               "_still_adding_connections is true.  Probably you should have called "
+               "finalizeAddingConnections.");
+  return _global_neighbors[sequentialID(global_node_ID)];
+}
+
+const std::vector<dof_id_type> &
+PorousFlowConnectedNodes::globalConnectionsToSequentialID(dof_id_type sequential_node_ID) const
+{
+  if (_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: globalConnectionsToSequentialID called, but "
+               "_still_adding_connections is true.  Probably you should have called "
+               "finalizeAddingConnections.");
+  return _global_neighbors[sequential_node_ID];
+}
+
+const std::vector<dof_id_type> &
+PorousFlowConnectedNodes::globalIDs() const
+{
+  if (_still_adding_global_nodes)
+    mooseError("PorousFlowConnectedNodes: globalIDs called, but _still_adding_global_nodes is "
+               "true.  Probably you should have called finalizeAddingGlobalNodes.");
+  return _global_id;
+}
+
+unsigned
+PorousFlowConnectedNodes::indexOfGlobalConnection(dof_id_type global_node_ID_from,
+                                                  dof_id_type global_node_ID_to) const
+{
+  if (_still_adding_connections)
+    mooseError(
+        "PorousFlowConnectedNodes: indexOfGlobalConnection called, but _still_adding_connections "
+        "is true.  Probably you should have called finalizeAddingConnections.");
+  const std::vector<dof_id_type> con = _global_neighbors[sequentialID(global_node_ID_from)];
+  const auto it = std::find(con.begin(), con.end(), global_node_ID_to);
+  if (it == con.end())
+    mooseError("PorousFlowConnectedNode: global_node_ID_from " +
+               Moose::stringify(global_node_ID_from) + " has no connection to global_node_ID_to " +
+               Moose::stringify(global_node_ID_to));
+  return std::distance(con.begin(), it);
+}
+
+unsigned
+PorousFlowConnectedNodes::indexOfSequentialConnection(dof_id_type sequential_node_ID_from,
+                                                      dof_id_type sequential_node_ID_to) const
+{
+  if (_still_adding_connections)
+    mooseError("PorousFlowConnectedNodes: indexOfSequentialConnection called, but "
+               "_still_adding_connections is true.  Probably you should have called "
+               "finalizeAddingConnections.");
+  const std::vector<dof_id_type> con = _sequential_neighbors[sequential_node_ID_from];
+  const auto it = std::find(con.begin(), con.end(), sequential_node_ID_to);
+  if (it == con.end())
+    mooseError("PorousFlowConnectedNode: sequential_node_ID_from " +
+               Moose::stringify(sequential_node_ID_from) +
+               " has no connection to sequential_node_ID_to " +
+               Moose::stringify(sequential_node_ID_to));
+  return std::distance(con.begin(), it);
+}

--- a/unit/include/PorousFlowConnectedNodesTest.h
+++ b/unit/include/PorousFlowConnectedNodesTest.h
@@ -1,0 +1,46 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef POROUSFLOWCONNECTEDNODESTEST_H
+#define POROUSFLOWCONNECTEDNODESTEST_H
+
+#include "gtest_include.h"
+#include "PorousFlowConnectedNodes.h"
+
+class PorousFlowConnectedNodesTest : public ::testing::Test
+{
+protected:
+  void SetUp()
+  {
+    _n1 = PorousFlowConnectedNodes();
+    _n1.addGlobalNode(1);
+    _n1.addGlobalNode(12);
+    _n1.addGlobalNode(123);
+    _n1.addGlobalNode(1234);
+    _n1.finalizeAddingGlobalNodes();
+    _n1.addConnection(1, 1);
+    _n1.addConnection(1, 12);
+    _n1.addConnection(1, 123);
+    _n1.addConnection(1, 123);
+    _n1.addConnection(1, 1234);
+    _n1.addConnection(123, 1234);
+    _n1.addConnection(12, 1234);
+    _n1.finalizeAddingConnections();
+
+    _n2 = PorousFlowConnectedNodes();
+    _n2.addGlobalNode(2);
+    _n2.addGlobalNode(4);
+    _n2.addGlobalNode(6);
+  }
+
+  PorousFlowConnectedNodes _n1;
+  PorousFlowConnectedNodes _n2;
+};
+
+#endif // POROUSFLOWCONNECTEDNODESTEST_H

--- a/unit/src/PorousFlowConnectedNodesTest.C
+++ b/unit/src/PorousFlowConnectedNodesTest.C
@@ -1,0 +1,264 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PorousFlowConnectedNodesTest.h"
+
+TEST_F(PorousFlowConnectedNodesTest, errors)
+{
+  try
+  {
+    _n1.addGlobalNode(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: addGlobalNode called, but _still_adding_global_nodes "
+                  "is false.  You possibly called finalizeAddingGlobalNodes too soon.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.globalID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: globalID called, but _still_adding_global_nodes is "
+                  "true.  Probably you should have called finalizeAddingGlobalNodes.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.globalIDs();
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: globalIDs called, but _still_adding_global_nodes is "
+                  "true.  Probably you should have called finalizeAddingGlobalNodes.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.sequentialID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: sequentialID called, but _still_adding_global_nodes "
+                  "is true.  Probably you should have called finalizeAddingGlobalNodes.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.addConnection(1, 1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: addConnection called, but _still_adding_global_nodes "
+                  "is true.  Probably you should have called finalizeAddingGlobalNodes.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n1.addConnection(1, 1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos =
+        std::string(err.what())
+            .find("PorousFlowConnectedNodes: addConnection called, but _still_adding_connections "
+                  "is false.  Probably you should have called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.sequentialConnectionsToGlobalID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: sequentialConnectionsToGlobalID called, "
+                                "but _still_adding_connections is true.  Probably you should have "
+                                "called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.sequentialConnectionsToSequentialID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: sequentialConnectionsToSequentialID "
+                                "called, but _still_adding_connections is true.  Probably you "
+                                "should have called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.globalConnectionsToGlobalID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: globalConnectionsToGlobalID called, but "
+                                "_still_adding_connections is true.  Probably you should have "
+                                "called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.globalConnectionsToSequentialID(1);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: globalConnectionsToSequentialID called, "
+                                "but _still_adding_connections is true.  Probably you should have "
+                                "called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.indexOfSequentialConnection(0, 0);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: indexOfSequentialConnection called, but "
+                                "_still_adding_connections is true.  Probably you should have "
+                                "called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n1.indexOfSequentialConnection(1, 0);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNode: sequential_node_ID_from 1 has no "
+                                "connection to sequential_node_ID_to 0");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n2.indexOfGlobalConnection(0, 0);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNodes: indexOfGlobalConnection called, but "
+                                "_still_adding_connections is true.  Probably you should have "
+                                "called finalizeAddingConnections.");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+
+  try
+  {
+    _n1.indexOfGlobalConnection(1, 12);
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("PorousFlowConnectedNode: global_ID_from 1 has no connection to "
+                                "global_node_ID_to 12");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+}
+
+TEST_F(PorousFlowConnectedNodesTest, numNodes)
+{
+  EXPECT_EQ(_n1.numNodes(), 4);
+  EXPECT_EQ(_n2.numNodes(), 3);
+}
+
+TEST_F(PorousFlowConnectedNodesTest, globalID)
+{
+  EXPECT_EQ(_n1.globalID(0), 1);
+  EXPECT_EQ(_n1.globalID(1), 12);
+  EXPECT_EQ(_n1.globalID(2), 123);
+  EXPECT_EQ(_n1.globalID(3), 1234);
+  EXPECT_EQ(_n1.globalIDs()[0], 1);
+  EXPECT_EQ(_n1.globalIDs()[1], 12);
+  EXPECT_EQ(_n1.globalIDs()[2], 123);
+  EXPECT_EQ(_n1.globalIDs()[3], 1234);
+}
+
+TEST_F(PorousFlowConnectedNodesTest, sequentialID)
+{
+  EXPECT_EQ(_n1.sequentialID(1), 0);
+  EXPECT_EQ(_n1.sequentialID(12), 1);
+  EXPECT_EQ(_n1.sequentialID(123), 2);
+  EXPECT_EQ(_n1.sequentialID(1234), 3);
+}
+
+TEST_F(PorousFlowConnectedNodesTest, connections)
+{
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(1)[0], 0);
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(1)[1], 1);
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(1)[2], 2);
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(1)[3], 3);
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(12)[0], 3);
+  EXPECT_EQ(_n1.sequentialConnectionsToGlobalID(123)[0], 3);
+
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(0)[0], 0);
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(0)[1], 1);
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(0)[2], 2);
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(0)[3], 3);
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(1)[0], 3);
+  EXPECT_EQ(_n1.sequentialConnectionsToSequentialID(2)[0], 3);
+
+  EXPECT_EQ(_n1.indexOfSequentialConnection(0, 0), 0);
+  EXPECT_EQ(_n1.indexOfSequentialConnection(0, 1), 1);
+  EXPECT_EQ(_n1.indexOfSequentialConnection(0, 2), 2);
+  EXPECT_EQ(_n1.indexOfSequentialConnection(0, 3), 3);
+  EXPECT_EQ(_n1.indexOfSequentialConnection(1, 3), 0);
+  EXPECT_EQ(_n1.indexOfSequentialConnection(2, 3), 0);
+
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(1)[0], 1);
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(1)[1], 12);
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(1)[2], 123);
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(1)[3], 1234);
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(12)[0], 1234);
+  EXPECT_EQ(_n1.globalConnectionsToGlobalID(123)[0], 1234);
+
+  EXPECT_EQ(_n1.indexOfGlobalConnection(1, 1), 0);
+  EXPECT_EQ(_n1.indexOfGlobalConnection(1, 12), 1);
+  EXPECT_EQ(_n1.indexOfGlobalConnection(1, 123), 2);
+  EXPECT_EQ(_n1.indexOfGlobalConnection(1, 1234), 3);
+  EXPECT_EQ(_n1.indexOfGlobalConnection(12, 1234), 0);
+  EXPECT_EQ(_n1.indexOfGlobalConnection(123, 1234), 0);
+
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(0)[0], 1);
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(0)[1], 12);
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(0)[2], 123);
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(0)[3], 1234);
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(1)[0], 1234);
+  EXPECT_EQ(_n1.globalConnectionsToSequentialID(2)[0], 1234);
+}


### PR DESCRIPTION
I have found that using std::vector instead of std::map means reall MOOSE simulation run in about HALF the time!   This is great, but it does mean the code is a bit more obscure :grimacing:

PorousFlowConnectedNodes added.  This holds info regarding node numbering and nodal connectivity, and enables easy sequential node numbering in the std::vectors of the Kuzmin-Turek stuff

AdvectiveFluxCalculatorBase and PorousFlowAdvectiveFluxCalculatorBase now employ std::vector instead of std::map where appropriate

Other changes:
 - AdvectiveFluxCalculatorConstantVelocity has _u_nodal renamed, because its base class (AdvectiveFluxCalculatorBase) also has a different _u_nodal, and that is confusing
 - _valence in AdvectiveFluxCalculatorBase now just records the number of times a node is seen in the element loop: previously it recorded node-pair information but that is not needed by the Kernels

Refs #12696

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
