### PR TITLE
Only trim output during print operations

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -449,7 +449,7 @@ class TestHarness:
         # Print what ever status the tester has at the time
         if self.options.verbose or (tester.isFail() and not self.options.quiet):
             output = 'Working Directory: ' + tester.getTestDir() + '\nRunning command: ' + tester.getCommand(self.options) + '\n'
-            output += job.getOutput()
+            output += util.trimOutput(job, self.options)
             output = output.replace('\r', '\n')  # replace the carriage returns with newlines
             lines = output.split('\n')
 
@@ -817,6 +817,7 @@ class TestHarness:
         outputgroup.add_argument("--yaml", action="store_true", dest="yaml", help="Dump the parameters for the testers in Yaml Format")
         outputgroup.add_argument("--dump", action="store_true", dest="dump", help="Dump the parameters for the testers in GetPot Format")
         outputgroup.add_argument("--no-trimmed-output", action="store_true", dest="no_trimmed_output", help="Do not trim the output")
+        outputgroup.add_argument("--no-trimmed-output-on-error", action="store_true", dest="no_trimmed_output_on_error", help="Do not trim output for tests which cause an error")
 
         queuegroup = parser.add_argument_group('Queue Options', 'Options controlling which queue manager to use')
         queuegroup.add_argument('--pbs', nargs=1, action='store', metavar='session_name', help='Launch tests using PBS as your scheduler. You must supply a name to identify this session with')

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -315,7 +315,7 @@ class Tester(MooseObject):
         self.errfile.flush()
 
         # store the contents of output, and close the file
-        self.joined_out = util.readOutput(self.outfile, self.errfile, options, max_size=self.specs['max_buffer_size'])
+        self.joined_out = util.readOutput(self.outfile, self.errfile)
         self.outfile.close()
         self.errfile.close()
 

--- a/python/TestHarness/tests/test_TrimOutput.py
+++ b/python/TestHarness/tests/test_TrimOutput.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+import subprocess
 from TestHarnessTestCase import TestHarnessTestCase
 
 class TestHarnessTester(TestHarnessTestCase):
@@ -23,3 +24,14 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         output = self.runTests('--no-color', '-i', 'always_ok', '-v')
         self.assertNotIn('Output trimmed', output)
+
+    def testNoTrimmedOutputOnError(self):
+        """
+        Verify trimming does not take place with a failed test using
+        appropriate arguments
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'no_trim_on_error', '--no-trimmed-output-on-error', '-v')
+
+        e = cm.exception
+        self.assertNotIn('Output trimmed', e.output)

--- a/test/tests/test_harness/500_num_steps.i
+++ b/test/tests/test_harness/500_num_steps.i
@@ -1,0 +1,50 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 2
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.01
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 500
+  dt = 0.01
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/test_harness/no_trim_on_error
+++ b/test/tests/test_harness/no_trim_on_error
@@ -1,0 +1,7 @@
+[Tests]
+  [./output_not_trimmed_on_error]
+    type = RunApp
+    input = 500_num_steps.i
+    expect_out = "Not going to find this text"
+  [../]
+[]


### PR DESCRIPTION
Allow the testers full access to the output log while optionally
trimming output during printing operations.

Allow the entire output log to be printed regardless of size, if
the test failed while using --no-trim-output-on-error arguments.

Add add unittest for this behavior.

Closes #12937
