### PR TITLE
Fix memory unit prefixes

### DIFF
--- a/framework/include/postprocessors/MemoryUsage.h
+++ b/framework/include/postprocessors/MemoryUsage.h
@@ -50,8 +50,8 @@ protected:
     min_process
   } _value_type;
 
-  /// The units in which to report memory statistics (kilobyte, megabyte, etc).
-  MemoryUtils::MemUnit _mem_units;
+  /// The unit prefix for the reported memory statistics (kilobyte, megabyte, etc).
+  MemoryUtils::MemUnits _mem_units;
 
   /// memory usage metric in bytes
   Real _value;

--- a/framework/include/utils/MemoryUtils.h
+++ b/framework/include/utils/MemoryUtils.h
@@ -11,12 +11,10 @@
 #define MEMORYUTILS_H
 
 #include "Moose.h"
+#include "MooseEnum.h"
 
 namespace MemoryUtils
 {
-
-/// get the total amount of physical RAM available
-std::size_t getTotalRAM();
 
 /// get the MPI hostname
 std::string getMPIProcessorName();
@@ -28,16 +26,28 @@ struct Stats
   std::size_t _page_faults;
 };
 
-enum class MemUnit
+enum class MemUnits
 {
   Bytes,
+  Kibibytes,
+  Mebibytes,
+  Gibibytes = 3,
   Kilobytes,
   Megabytes,
-  Gigabytes,
+  Gigabytes = 6,
 };
 
+/// get the moose enum for the mem_unit_prefix parameter
+MooseEnum getMemUnitsEnum();
+
+/// get the total amount of physical RAM available
+std::size_t getTotalRAM();
+
 /// get all memory stats for the current process
-void getMemoryStats(Stats & stats, MemUnit units = MemUnit::Megabytes);
+void getMemoryStats(Stats & stats);
+
+/// convert bytes to selected unit prefix
+std::size_t convertBytes(std::size_t bytes, MemUnits unit);
 
 } // namespace MemoryUtils
 

--- a/framework/include/vectorpostprocessors/VectorMemoryUsage.h
+++ b/framework/include/vectorpostprocessors/VectorMemoryUsage.h
@@ -35,8 +35,8 @@ public:
   virtual void finalize() override;
 
 protected:
-  /// The units in which to report memory statistics (kilobyte, megabyte, etc).
-  MemoryUtils::MemUnit _mem_units;
+  /// The unit prefix for the reported memory statistics (kilobyte, megabyte, etc).
+  MemoryUtils::MemUnits _mem_units;
 
   /// hardware id for the physical node the rank is located at
   VectorPostprocessorValue & _col_hardware_id;

--- a/framework/src/postprocessors/MemoryUsage.C
+++ b/framework/src/postprocessors/MemoryUsage.C
@@ -25,9 +25,9 @@ validParams<MemoryUsage>()
   MooseEnum value_type("total average max_process min_process", "total");
   params.addParam<MooseEnum>(
       "value_type", value_type, "Aggregation method to apply to the requested memory metric.");
-  MooseEnum mem_units("bytes kilobytes megabytes gigabytes", "megabytes");
-  params.addParam<MooseEnum>(
-      "mem_units", mem_units, "The unit used to report memory usage, default: Megabytes");
+  params.addParam<MooseEnum>("mem_units",
+                             MemoryUtils::getMemUnitsEnum(),
+                             "The unit prefix used to report memory usage, default: Mebibytes");
   params.addParam<bool>("report_peak_value",
                         true,
                         "If the postprocessor is executed more than once "
@@ -41,7 +41,7 @@ MemoryUsage::MemoryUsage(const InputParameters & parameters)
     MemoryUsageReporter(this),
     _mem_type(getParam<MooseEnum>("mem_type").getEnum<MemType>()),
     _value_type(getParam<MooseEnum>("value_type").getEnum<ValueType>()),
-    _mem_units(getParam<MooseEnum>("mem_units").getEnum<MemoryUtils::MemUnit>()),
+    _mem_units(getParam<MooseEnum>("mem_units").getEnum<MemoryUtils::MemUnits>()),
     _value(0.0),
     _peak_value(0.0),
     _report_peak_value(getParam<bool>("report_peak_value"))
@@ -58,17 +58,17 @@ void
 MemoryUsage::execute()
 {
   MemoryUtils::Stats stats;
-  MemoryUtils::getMemoryStats(stats, _mem_units);
+  MemoryUtils::getMemoryStats(stats);
 
   // get the requested per core metric
   switch (_mem_type)
   {
     case MemType::physical_memory:
-      _value = stats._physical_memory;
+      _value = MemoryUtils::convertBytes(stats._physical_memory, _mem_units);
       break;
 
     case MemType::virtual_memory:
-      _value = stats._virtual_memory;
+      _value = MemoryUtils::convertBytes(stats._virtual_memory, _mem_units);
       break;
 
     case MemType::page_faults:


### PR DESCRIPTION
Repairs the node utilization fraction column and fixes the unit prefix names (kilo/kibi etc.)

Closes #12951 