### PR TITLE
Better formatting in ReferenceResidualProblem

### DIFF
--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -318,7 +318,7 @@ Console::output(const ExecFlagType & type)
     if (_nonlinear_iter == 0)
       _old_nonlinear_norm = std::numeric_limits<Real>::max();
 
-    _console << std::setw(2) << _nonlinear_iter
+    _console << std::right << std::setw(2) << _nonlinear_iter
              << " Nonlinear |R| = " << outputNorm(_old_nonlinear_norm, _norm) << '\n';
 
     _old_nonlinear_norm = _norm;
@@ -330,7 +330,7 @@ Console::output(const ExecFlagType & type)
     if (_linear_iter == 0)
       _old_linear_norm = std::numeric_limits<Real>::max();
 
-    _console << std::setw(7) << _linear_iter
+    _console << std::right << std::setw(7) << _linear_iter
              << " Linear |R| = " << outputNorm(_old_linear_norm, _norm) << '\n';
 
     _old_linear_norm = _norm;

--- a/modules/contact/src/ReferenceResidualProblem.C
+++ b/modules/contact/src/ReferenceResidualProblem.C
@@ -349,7 +349,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
 
   if (_group_soln_var_names.size() > 0)
   {
-    _console << "Solution, reference convergence variable norms:" << std::endl;
+    _console << "   Solution, reference convergence variable norms:\n";
     unsigned int maxwsv = 0;
     unsigned int maxwrv = 0;
     for (unsigned int i = 0; i < _group_soln_var_names.size(); ++i)
@@ -361,9 +361,9 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
     }
 
     for (unsigned int i = 0; i < _group_soln_var_names.size(); ++i)
-      _console << std::setw(maxwsv + 2) << std::left << _group_soln_var_names[i] + ":"
+      _console << "   " << std::setw(maxwsv + 2) << std::left << _group_soln_var_names[i] + ":"
                << _group_resid[i] << "  " << std::setw(maxwrv + 2)
-               << _group_ref_resid_var_names[i] + ":" << _group_ref_resid[i] << std::endl;
+               << _group_ref_resid_var_names[i] + ":" << _group_ref_resid[i] << '\n';
   }
 
   NonlinearSystemBase & system = getNonlinearSystemBase();


### PR DESCRIPTION
refs #12054

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

```
 0 Nonlinear |R| = 5.228107e+02
   Solution, reference convergence variable norms:
   disp_x:      521.665  saved_x: 56185.2
   disp_y:      1.8144  saved_y: 774.365
   temperature: 34.5391  saved_t: 66.9317
      0 Linear |R| = 5.228107e+02
      1 Linear |R| = 5.227841e+02
      2 Linear |R| = 3.441295e+02
      3 Linear |R| = 3.327429e+02
      4 Linear |R| = 1.069647e+02
 1 Nonlinear |R| = 7.704761e+02
   Solution, reference convergence variable norms:
   disp_x:      455.435  saved_x: 55835.9
   disp_y:      621.454  saved_y: 991.689
   temperature: 2.77764  saved_t: 124.535
      0 Linear |R| = 7.704761e+02
      1 Linear |R| = 7.586218e+02
      2 Linear |R| = 4.604890e+02
 2 Nonlinear |R| = 4.603634e+02
```