### PR TITLE
Bug illustration: compute=false stateful Materials not initing with Dirac Kernels

### DIFF
--- a/test/include/materials/ComputeFalseMaterial.h
+++ b/test/include/materials/ComputeFalseMaterial.h
@@ -1,0 +1,61 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COMPUTEFALSEMATERIAL_H
+#define COMPUTEFALSEMATERIAL_H
+
+#include "InputParameters.h"
+#include "Material.h"
+
+// Forward declaration
+class ComputeFalseMaterial;
+
+template <>
+InputParameters validParams<ComputeFalseMaterial>();
+
+/**
+ * ComputeFalseMaterial is an example of a compute = false Material that computes a vector
+ * of Properties and a Real-number Property, both of which have Old values
+ */
+class ComputeFalseMaterial : public Material
+{
+public:
+  ComputeFalseMaterial(const InputParameters & parameters);
+
+  /// sets our _qp to qp.  Our _qp may be different from the Material that is using the Properties from this Material
+  void setQp(unsigned qp);
+
+  /// Compute the vector and real-number of Properties at _qp
+  void computeQpThings();
+
+  ///@{ Retained as empty methods to avoid a warning from Material.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
+  void resetQpProperties() final {}
+  void resetProperties() final {}
+  ///@}
+
+protected:
+  virtual void initQpStatefulProperties() override;
+
+  /// size of the vector
+  const unsigned _vector_size;
+
+  /// the vector computed by this Material
+  MaterialProperty<std::vector<Real>> & _compute_false_vector;
+
+  /// the old values of the vector computed by this Material
+  const MaterialProperty<std::vector<Real>> & _compute_false_vector_old;
+
+  /// the scalar computed by this Material
+  MaterialProperty<Real> & _compute_false_scalar;
+
+  /// the old values of the scalar computed by this Material
+  const MaterialProperty<Real> & _compute_false_scalar_old;
+};
+
+#endif // COMPUTEFALSEMATERIAL_H

--- a/test/include/materials/UseComputeFalseMaterial.h
+++ b/test/include/materials/UseComputeFalseMaterial.h
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef USECOMPUTEFALSEMATERIAL_H
+#define USECOMPUTEFALSEMATERIAL_H
+
+#include "Material.h"
+#include "ComputeFalseMaterial.h"
+
+// Forward declaration
+class UseComputeFalseMaterial;
+
+template <>
+InputParameters validParams<UseComputeFalseMaterial>();
+
+/**
+ * UseComputeFalseMaterial instructs a compute=false material
+ * called _compute_false_material to compute something using
+ * its computeQpThings method.
+ * UseComputeFalseMaterial does not actually use the results
+ * of that calculation.
+ */
+class UseComputeFalseMaterial : public Material
+{
+public:
+  UseComputeFalseMaterial(const InputParameters & parameters);
+
+  virtual void computeQpProperties() override;
+
+protected:
+  ComputeFalseMaterial & _compute_false_material;
+};
+
+#endif // USECOMPUTEFALSEMATERIAL_H

--- a/test/src/materials/ComputeFalseMaterial.C
+++ b/test/src/materials/ComputeFalseMaterial.C
@@ -1,0 +1,63 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeFalseMaterial.h"
+
+registerMooseObject("MooseTestApp", ComputeFalseMaterial);
+
+template <>
+InputParameters
+validParams<ComputeFalseMaterial>()
+{
+  InputParameters params = validParams<Material>();
+  params.addClassDescription(
+      "Simple example of a Material with compute = false.  It has one vector Material property "
+      "called 'compute_false_vector', and one Real property called 'compute_false_scalar'.  Both "
+      "of these have Old values");
+  params.addParam<unsigned>("vector_size", 2, "Size of the vector computed by this class");
+  params.set<bool>("compute") = false;
+  params.suppressParameter<bool>("compute");
+  return params;
+}
+
+ComputeFalseMaterial::ComputeFalseMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _vector_size(getParam<unsigned>("vector_size")),
+    _compute_false_vector(declareProperty<std::vector<Real>>("compute_false_vector")),
+    _compute_false_vector_old(getMaterialPropertyOld<std::vector<Real>>("compute_false_vector")),
+    _compute_false_scalar(declareProperty<Real>("compute_false_scalar")),
+    _compute_false_scalar_old(getMaterialPropertyOld<Real>("compute_false_scalar"))
+{
+}
+
+void
+ComputeFalseMaterial::setQp(unsigned qp)
+{
+  _qp = qp;
+}
+
+void
+ComputeFalseMaterial::initQpStatefulProperties()
+{
+  _compute_false_vector[_qp].assign(_vector_size, 1.0);
+  _compute_false_scalar[_qp] = 1.0;
+}
+
+void
+ComputeFalseMaterial::computeQpThings()
+{
+  if (_compute_false_vector[_qp].size() != _vector_size)
+    mooseError("Size = " + Moose::stringify(_compute_false_vector[_qp].size()) +
+               ".  It should be " + Moose::stringify(_vector_size) +
+               ".  initQpStatefulProperties did not get called for this element\n");
+
+  for (unsigned i = 0; i < _vector_size; ++i)
+    _compute_false_vector[_qp][i] = i + _compute_false_vector_old[_qp][i];
+  _compute_false_scalar[_qp] = _compute_false_scalar_old[_qp] * _qp;
+}

--- a/test/src/materials/UseComputeFalseMaterial.C
+++ b/test/src/materials/UseComputeFalseMaterial.C
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "UseComputeFalseMaterial.h"
+
+registerMooseObject("MooseTestApp", UseComputeFalseMaterial);
+
+template <>
+InputParameters
+validParams<UseComputeFalseMaterial>()
+{
+  InputParameters params = validParams<Material>();
+  params.addClassDescription("Instructs a ComputeFalseMaterial to use its computeQpThings method");
+  params.addRequiredParam<MaterialName>("compute_false_material",
+                                        "Name of the ComputeFalseMaterial");
+  return params;
+}
+
+UseComputeFalseMaterial::UseComputeFalseMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _compute_false_material(dynamic_cast<ComputeFalseMaterial &>(
+        getMaterialByName(getParam<MaterialName>("compute_false_material"))))
+{
+}
+
+void
+UseComputeFalseMaterial::computeQpProperties()
+{
+  _compute_false_material.setQp(_qp);
+  _compute_false_material.computeQpThings();
+}

--- a/test/tests/materials/discrete/computefalse.i
+++ b/test/tests/materials/discrete/computefalse.i
@@ -1,0 +1,42 @@
+# Illustrates the use of the ComputeFalseMaterial
+[Materials]
+  [./compute_false]
+    type = ComputeFalseMaterial
+  [../]
+  [./use_compute_false]
+    type = UseComputeFalseMaterial
+    compute_false_material = 'compute_false'
+  [../]
+[]
+
+[DiracKernels]
+  [./dirac]
+    type = MaterialPointSource
+    point = '0.5 0 0'
+    material_prop = compute_false_scalar
+    variable = u
+  [../]
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diffusion]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 1
+  end_time = 1
+[]


### PR DESCRIPTION
This is ready for review/fixing.

This illustrates that when a compute=false Material has stateful Material Properties, initQpStatefulProperties is not being called for Dirac Kernels that need the Properties.

ComputeFalseMaterial has vector and a scalar stateful Properties
UseComputeFalseMaterial just instructs ComputeFalseMaterial to compute those Properties

computefalse.i has a DiracKernel that uses the ComputeFalseMaterial properties.
Without the DiracKernel, the simulation runs fine:
 - initQpStatefulProperties is correctly called for each element in the mesh.

With the DiracKernel, the simulation crashes in the first timestep, as
 - the vector of properties is not correctly sized, because initQpStatefulProperties hasn't been called for the 'Dirac element'

Can someone fix this, please

I've tried to use the same kind of architecture as used in TensorMechanics.  I'm sorry if it's a little convoluted.

Refs #12545

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
