### PR TITLE
Add turn_off_exodus_output option to the PetscJacobianTester

### DIFF
--- a/modules/heat_conduction/test/tests/recover/tests
+++ b/modules/heat_conduction/test/tests/recover/tests
@@ -61,7 +61,7 @@
     run_sim = True
     petsc_version = '>=3.9'
     method = 'OPT'
-    cli_args = 'Executioner/num_steps=2 Outputs/exodus=false'
+    cli_args = 'Executioner/num_steps=2'
     skip = 'AD Thermal Contact not yet implemented'
     requirement = 'AD heat conduction and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"

--- a/modules/heat_conduction/test/tests/verify_against_analytical/tests
+++ b/modules/heat_conduction/test/tests/verify_against_analytical/tests
@@ -25,7 +25,7 @@
     run_sim = True
     petsc_version = '>=3.9'
     method = 'OPT'
-    cli_args = 'Executioner/num_steps=5 Outputs/exodus=false'
+    cli_args = 'Executioner/num_steps=5'
     requirement = 'AD heat conduction and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"
     issues = "#5658 #12633"
@@ -57,7 +57,6 @@
     run_sim = True
     petsc_version = '>=3.9'
     method = 'OPT'
-    cli_args = 'Outputs/exodus=false'
     requirement = 'AD heat conduction and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"
     issues = "#5658 #12633"

--- a/modules/misc/test/tests/kernels/diffusion/tests
+++ b/modules/misc/test/tests/kernels/diffusion/tests
@@ -23,7 +23,7 @@
     run_sim = True
     petsc_version = '>=3.9'
     method = 'OPT'
-    cli_args = 'Executioner/num_steps=5 Outputs/exodus=false'
+    cli_args = 'Executioner/num_steps=5'
     requirement = 'AD heat conduction and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"
     issues = "#5658 #12633"
@@ -53,7 +53,6 @@
     run_sim = True
     petsc_version = '>=3.9'
     method = 'OPT'
-    cli_args = 'Outputs/exodus=false'
     requirement = 'AD heat conduction and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"
     issues = "#5658 #12633"

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -25,6 +25,7 @@ class PetscJacobianTester(RunApp):
         params.addParam('run_sim', False, "Whether to actually run the simulation, testing the Jacobian "
                                           "at every non-linear iteration of every time step. This is only "
                                           "relevant for petsc versions >= 3.9.")
+        params.addParam('turn_off_exodus_output', True, "Whether to set exodus=false in Outputs")
         return params
 
     def checkRunnable(self, options):
@@ -45,6 +46,9 @@ class PetscJacobianTester(RunApp):
             self.libmesh_dir = os.environ['LIBMESH_DIR']
         else:
             self.libmesh_dir = os.path.join(self.moose_dir, 'libmesh', 'installed')
+
+        if self.specs['turn_off_exodus_output']:
+            self.specs['cli_args'][:0] = ['Outputs/exodus=false']
 
         if map(int, util.getPetscVersion(self.libmesh_dir).split(".")) < [3, 9]:
             self.old_petsc = True

--- a/test/tests/kernels/diffusion_with_hanging_node/tests
+++ b/test/tests/kernels/diffusion_with_hanging_node/tests
@@ -40,7 +40,7 @@
     type = PetscJacobianTester
     input = 'simple_diffusion.i'
     run_sim = True
-    cli_args = 'Outputs/exodus=false -snes_test_jacobian_view'
+    cli_args = '-snes_test_jacobian_view'
     requirement = 'The SMP Jacobian shall be perfect for the hanging-node problem'
   [../]
 []

--- a/test/tests/materials/ad_material/tests
+++ b/test/tests/materials/ad_material/tests
@@ -52,6 +52,7 @@
     difference_tol = 1e-5
     run_sim = True
     petsc_version = '>=3.9'
+    turn_off_exodus_output = False
     requirement = 'AD shall work with stateful material properties and the Jacobian shall be beautiful'
     design = "jacobian_definition.md"
     issues = "#5658"


### PR DESCRIPTION
This option defaults to True. This option helps eliminate race conditions
that can occur when a test developer writes both PetscJacobianTester
and Exodiff tests.

Closes #12975
