### PR TITLE
Don't compare small error for ad_heat_source_bar test

### DIFF
--- a/modules/heat_conduction/test/tests/heat_source_bar/ad_heat_source_bar.cmp
+++ b/modules/heat_conduction/test/tests/heat_source_bar/ad_heat_source_bar.cmp
@@ -1,0 +1,9 @@
+COORDINATES absolute 1.e-6
+
+TIME STEPS relative 1.e-6 floor 0.0
+
+GLOBAL VARIABLES relative 1.e-6 floor 0.0
+	right
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	temp

--- a/modules/heat_conduction/test/tests/heat_source_bar/tests
+++ b/modules/heat_conduction/test/tests/heat_source_bar/tests
@@ -16,6 +16,7 @@
     requirement = 'MOOSE shall reproduce an analytical solution of a heat source in a 1D ceramic bar using AD kernels'
     design = "\ADMatHeatSource"
     issues = "#12633"
+    custom_cmp = 'ad_heat_source_bar.cmp'
   [../]
   [./ad_heat_source_bar_jacobian]
     type = 'PetscJacobianTester'


### PR DESCRIPTION
The variables already verify solution so there is no need to run exodiff on a number that is on the size of 1e-9 (e.g. the global error variable).

Refs #13018
