### PR TITLE
Attempt to reinstante 2 tests

### DIFF
--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -663,11 +663,10 @@
     input = 'line_sink03.i'
     ratio_tol = 1E-7
     difference_tol = 1E10
-    skip = 'Only works sporadically -- too many qps?'
     cli_args = 'Executioner/num_steps=1'
     threading = '!pthreads'
     requirement = "PorousFlow shall compute all Jacobian entries of all Kernels"
-    issues = '#6845'
+    issues = '#6845 #10471'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   [../]
   [./line_sink01_5]
@@ -697,11 +696,10 @@
     input = 'line_sink04.i'
     ratio_tol = 1E-7
     difference_tol = 1E10
-    skip = 'Only works sporadically -- too many qps?'
     cli_args = 'Executioner/num_steps=1'
     threading = '!pthreads'
     requirement = "PorousFlow shall compute all Jacobian entries of all Kernels"
-    issues = '#6845'
+    issues = '#6845 #10471'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   [../]
 


### PR DESCRIPTION
These tests have been skipped since their inception due to having too many qps in the Dirac Kernels, which is likely due to a subtle framework bug.  But currently i can't get the tests to fail.  So perhaps the bug has been fixed.  i'm trying to un-skip the tests and see what happens.

Refs #10471

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
