### PR TITLE
Be more specific for Outputs page

### DIFF
--- a/framework/doc/content/syntax/Postprocessors/index.md
+++ b/framework/doc/content/syntax/Postprocessors/index.md
@@ -28,7 +28,7 @@ cd tests/postprocessors/element_extreme_value
 The data from this calculation is reported in the terminal output by default and if [Exodus.md]
 output is enabled the values will automatically be included in the output file. It is also possible
 to export the data to a comma separated value (csv) file by enabling the [CSV.md]
-object within the [Outputs](Outputs/index.md) block.
+object within the [Outputs](syntax/Outputs/index.md) block.
 
 ```bash
 Postprocessor Values:


### PR DESCRIPTION
Mastodon has a block Mastodon/Outputs, so when building its docs this page has problems locating which
page it should use. Ideally, this would be a fix that occurs in Mastodon, but I don't have a good way
to do that at the moment nor do I have any ideas to how it could even be done. So, for now just fix up
MOOSE and hope this doesn't continue to happen.

(refs #9638)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
