### PR TITLE
Include header_symlinks

### DIFF
--- a/framework/scripts/build_coverage.py
+++ b/framework/scripts/build_coverage.py
@@ -69,6 +69,7 @@ def buildCMD(options):
                         '--gcov-tool', options.cov_tool,
                         '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/src*',
                         '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/include*',
+                        '--extract', os.getcwd() + '/combined.info', '*' + options.application[0] + '/build/header_symlinks*',
                         '--output-file', options.outfile ])
 
         # Build genhtml command if --generate-html was used


### PR DESCRIPTION
It would seem a recent change to moose, altered the path where the headers being
hit are located.

Sort of related, the .lcovrc file which controlled passing/failing CSS color
schemes, has been restored (80% should be green not yellow).

Closes #13050