### PR TITLE
Allow users to turn off header symlinking

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -1,5 +1,6 @@
 # Whether or not to do a Unity build
 MOOSE_UNITY ?= true
+MOOSE_HEADER_SYMLINKS ?= true
 
 #
 # MOOSE
@@ -60,6 +61,8 @@ gtest_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(gtest_srcfiles))
 #
 # header symlinks
 #
+ifeq ($(MOOSE_HEADER_SYMLINKS),true)
+
 all_header_dir := $(FRAMEWORK_DIR)/build/header_symlinks
 moose_all_header_dir := $(all_header_dir)
 
@@ -93,8 +96,14 @@ $(eval $(call all_header_dir_rule, $(all_header_dir)))
 $(call symlink_rules, $(all_header_dir), $(include_files))
 
 header_symlinks:: $(all_header_dir) $(link_names)
-
 moose_INC_DIRS := $(all_header_dir)
+
+else # No Header Symlinks
+
+moose_INC_DIRS := $(shell find $(FRAMEWORK_DIR)/include -type d)
+
+endif
+
 moose_INC_DIRS += $(shell find $(FRAMEWORK_DIR)/contrib/*/include -type d)
 moose_INC_DIRS += "$(gtest_DIR)"
 moose_INC_DIRS += "$(hit_DIR)"

--- a/modules/doc/content/application_development/build_system.md
+++ b/modules/doc/content/application_development/build_system.md
@@ -40,6 +40,9 @@ some of the environment variables you can set and their effects:
   find it unless you have very non-standard paths.
 - `MOOSE_UNITY`: defaults to `true`, set to `false` to turn off unity builds.  For more information
   see the Build System Optimization section below.
+- `MOOSE_HEADER_SYMLINKS`: defaults to `true`, set to `false` to turn off header symlinking. This is
+  an advanced option and there are very few reasons to disable this. You will likely notice a
+  dramatic slowdown if you set this to false.
 
 ## Build Methods (Creating "debug" Builds)
 


### PR DESCRIPTION
Turning off header symlinking will allow us to get better organization in our code coverage pages for the headers.

refs #13050

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
