### PR TITLE
Add ability to checkout large_media

### DIFF
--- a/python/MooseDocs/main.py
+++ b/python/MooseDocs/main.py
@@ -14,6 +14,8 @@ MOOSE run_tests.
 """
 import argparse
 import logging
+import os
+from mooseutils import mooseutils
 
 from commands import build, check, verify
 from common import log
@@ -40,12 +42,24 @@ def command_line_options():
     verify.command_line_options(subparser, parent)
     return parser.parse_args()
 
+def init_large_media():
+    """
+    Be sure large_media is checked out.
+    """
+    get_large_media = os.path.join(os.getenv('MOOSE_DIR'), 'scripts', 'get_large_media.sh')
+    large_media_git = os.path.join(os.getenv('MOOSE_DIR'), 'large_media', '.git')
+    if os.path.exists(get_large_media) and not os.path.exists(large_media_git):
+        print 'Checking out large_media...'
+        mooseutils.shellCommand(get_large_media, os.getenv('MOOSE_DIR'))
+        print 'Done.'
+
 def run():
     """
     Parse the command line options and run the correct command.
     """
 
     options = command_line_options()
+    init_large_media()
     log.init_logging(getattr(logging, options.level))
 
     if options.command == 'build':

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -367,3 +367,18 @@ def run_profile(function, *args, **kwargs):
     ps.print_stats()
     print(s.getvalue())
     return out
+
+def shellCommand(command, cwd=None):
+    """
+    Run a command in the shell.
+    We can ignore anything on stderr as that can potentially mess up the output
+    of an otherwise successful command.
+    """
+    with open(os.devnull, 'w') as devnull:
+        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=devnull, cwd=cwd)
+        p.wait()
+        retcode = p.returncode
+        if retcode != 0:
+            raise Exception("Exception raised while running the command: %s in directory %s" % (command, cwd))
+
+        return p.communicate()[0]

--- a/scripts/get_large_media.sh
+++ b/scripts/get_large_media.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+# Test for git repository
+git_dir=`git rev-parse --show-cdup 2>/dev/null`
+if [[ "x$git_dir" == "x" ]]; then
+    git submodule update --init large_media
+    if [[ $? != 0 ]]; then
+        echo "git submodule command failed, are your proxy settings correct?"
+        exit 1
+    fi
+fi
+exit 0


### PR DESCRIPTION
Augment moosedocs with the ability to call a shell script which will checkout
moose's large_media submodule when necessary.

Closes #13076
