### PR TITLE
Fix ADHeatConductionTimeDerivative to take AD material properties

### DIFF
--- a/modules/heat_conduction/include/kernels/ADHeatConductionTimeDerivative.h
+++ b/modules/heat_conduction/include/kernels/ADHeatConductionTimeDerivative.h
@@ -26,10 +26,10 @@ protected:
   virtual ADResidual precomputeQpResidual() override;
 
   /// Specific heat material property
-  const MaterialProperty<Real> & _specific_heat;
+  const ADMaterialProperty(Real) & _specific_heat;
 
   /// Density material property
-  const MaterialProperty<Real> & _density;
+  const ADMaterialProperty(Real) & _density;
 
   usingTimeKernelMembers;
 };


### PR DESCRIPTION
Change material properties to the correct AD implementation
Closes #13110 
