### PR TITLE
Fix ad_gravity race condition

### DIFF
--- a/modules/tensor_mechanics/test/tests/gravity/tests
+++ b/modules/tensor_mechanics/test/tests/gravity/tests
@@ -28,5 +28,6 @@
     requirement = 'The Jacobian for the AD gravity problem shall be perfect'
     issues = '#13100'
     design = 'jacobian_definitions.md'
+    cli_args = "Outputs/active=''"
   [../]
 []


### PR DESCRIPTION
We've helped improve the number of cases where these race conditions
happen by setting exodus=false for PetscJacobian test cases. But when
the exodus output is named block, this doesn't work. The quick solution
here is to set Outputs/active=''

Refs #13101
