### PR TITLE
New warning message from GCC 8 compiler in BOOST

### DIFF
--- a/modules/stochastic_tools/include/distributions/BoostDistribution.h
+++ b/modules/stochastic_tools/include/distributions/BoostDistribution.h
@@ -14,6 +14,7 @@
 
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
 #include "libmesh/ignore_warnings.h"
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include <boost/math/distributions.hpp>
 #include "libmesh/restore_warnings.h"
 #else


### PR DESCRIPTION
refs #13074

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
