### PR TITLE
IterationAdaptiveDT parameter check fix

### DIFF
--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -131,8 +131,14 @@ IterationAdaptiveDT::IterationAdaptiveDT(const InputParameters & parameters)
   if (isParamValid("timestep_limiting_function"))
     _max_function_change =
         isParamValid("max_function_change") ? getParam<Real>("max_function_change") : -1;
-  else if (isParamValid("max_function_change"))
-    mooseError("'timestep_limiting_function' must be used for 'max_function_change' to be used");
+  else
+  {
+    if (isParamValid("max_function_change"))
+      mooseError("'timestep_limiting_function' must be used for 'max_function_change' to be used");
+    if (_force_step_every_function_point)
+      mooseError("'timestep_limiting_function' must be used for 'force_step_every_function_point' "
+                 "to be used");
+  }
 }
 
 void

--- a/test/tests/time_steppers/iteration_adaptive/hit_function_knot.i
+++ b/test/tests/time_steppers/iteration_adaptive/hit_function_knot.i
@@ -58,9 +58,6 @@
     type = IterationAdaptiveDT
     dt = 0.9
     optimal_iterations = 10
-    force_step_every_function_point = true
-    max_function_change = 1e20
-    timestep_limiting_function = knot
   [../]
 []
 

--- a/test/tests/time_steppers/iteration_adaptive/tests
+++ b/test/tests/time_steppers/iteration_adaptive/tests
@@ -1,14 +1,38 @@
 [Tests]
+  issues = '#5535'
+  design = 'source/timesteppers/IterationAdaptiveDT.md'
   [./test_hit_knot]
     type = 'Exodiff'
     input = 'hit_function_knot.i'
+    cli_args = 'Executioner/TimeStepper/timestep_limiting_function=knot Executioner/TimeStepper/max_function_change=1e20
+    Executioner/TimeStepper/force_step_every_function_point=true'
     exodiff = 'hit_function_knot_out.e'
+    requirement = "MOOSE shall support the ability to force time steps consistent with points specified in a function."
+  [../]
+  [./test_hit_knot_err1]
+    type = 'RunException'
+    input = 'hit_function_knot.i'
+    cli_args = 'Executioner/TimeStepper/force_step_every_function_point=true'
+    expect_err = "'timestep_limiting_function' must be used for 'force_step_every_function_point' to be used"
+    requirement = "MOOSE shall check that a timestep limiting function has
+    been defined when a user specifies the 'force_step_every_function_point'
+    parameter as true."
+  [../]
+  [./test_hit_knot_err2]
+    type = 'RunException'
+    input = 'hit_function_knot.i'
+    cli_args = 'Executioner/TimeStepper/max_function_change=1e20'
+    expect_err = "'timestep_limiting_function' must be used for 'max_function_change' to be used"
+    requirement = "MOOSE shall check that a timestep limiting function has
+    been defined when a user specifies a value for the 'max_function_change' parameter."
   [../]
 
   [./test_grow_init_dt]
     type = 'Exodiff'
     input = 'adapt_tstep_grow_init_dt.i'
     exodiff = 'adapt_tstep_grow_init_dt_out.e'
+    requirement = "MOOSE shall support the ability to grow the time step size
+    when specifying the initial value of dt in the TimeStepper."
   [../]
 
   [./test_grow_init_dt_restart]
@@ -16,12 +40,16 @@
     input = 'adapt_tstep_grow_init_dt_restart.i'
     exodiff = 'adapt_tstep_grow_init_dt_restart_out.e'
     prereq = 'test_grow_init_dt'
+    requirement = "MOOSE shall support the ability to grow the time step size
+    when specifying the initial value of dt in the TimeStepper after a restart."
   [../]
 
   [./test_grow_dtfunc]
     type = 'Exodiff'
     input = 'adapt_tstep_grow_dtfunc.i'
     exodiff = 'adapt_tstep_grow_dtfunc_out.e'
+    requirement = "MOOSE shall support the ability to grow the time step size
+    when specifying the values of t and dt in the TimeStepper."
   [../]
 
   [./test_grow_dtfunc_restart]
@@ -29,12 +57,16 @@
     input = 'adapt_tstep_grow_dtfunc_restart.i'
     exodiff = 'adapt_tstep_grow_dtfunc_restart_out.e'
     prereq = 'test_grow_dtfunc'
+    requirement = "MOOSE shall support the ability to grow the time step size
+    when specifying the values of t and dt in the TimeStepper after a restart."
   [../]
 
   [./test_shrink_init_dt]
     type = 'Exodiff'
     input = 'adapt_tstep_shrink_init_dt.i'
     exodiff = 'adapt_tstep_shrink_init_dt_out.e'
+    requirement = "MOOSE shall support the ability to limit the time step size
+    based on the optimal iterations and linear_iteration ratio."
   [../]
 
   [./test_shrink_init_dt_restart]
@@ -42,17 +74,23 @@
     input = 'adapt_tstep_shrink_init_dt_restart.i'
     exodiff = 'adapt_tstep_shrink_init_dt_restart_out.e'
     prereq = 'test_shrink_init_dt'
+    requirement = "MOOSE shall support the ability to limit the time step size
+    based on the optimal iterations and linear_iteration ratio after a restart."
   [../]
 
   [./test_pps_lim]
     type = 'Exodiff'
     input = 'adapt_tstep_pps_lim.i'
     exodiff = 'adapt_tstep_pps_lim_out.e'
+    requirement = "MOOSE shall support the ability to limit the time step size
+    based on a postprocessor value."
   [../]
 
   [./test_reject_large_dt]
     type = 'Exodiff'
     input = 'adapt_tstep_reject_large_dt.i'
     exodiff = 'adapt_tstep_reject_large_dt_out.e'
+    requirement = "MOOSE shall support the ability to reject a time step based
+    on a threshold value for the ratio of the ideal step size to the limit."
   [../]
 []


### PR DESCRIPTION
Added code to catch when force_step_every_function_point is set but a timestep limiting function has not been specified. Also added tests to check the mooseError output for this case as well as the similar condition involving max_function_change. Closes #13157.
