### PR TITLE
Fix the Jacobian for SoretDiffusion

### DIFF
--- a/modules/phase_field/src/kernels/SoretDiffusion.C
+++ b/modules/phase_field/src/kernels/SoretDiffusion.C
@@ -53,7 +53,7 @@ SoretDiffusion::computeQpResidual()
 Real
 SoretDiffusion::computeQpJacobian()
 {
-  return _is_coupled ? 0.0 : computeQpCJacobian();
+  return (_is_coupled && _c_var != _var.number()) ? 0.0 : computeQpCJacobian();
 }
 
 Real


### PR DESCRIPTION
When computing the full Jacobian thread, in `Kernel.C` if `jvar_num == _var.number()` we call `computeQpJacobian`. If a user has coupled in a concentration variable whose var number is the same as `_var.number()` then previously we would just return 0 here. This was realized during the discussion [here](https://groups.google.com/forum/#!topic/moose-users/akFIlbyUXnc).
