### PR TITLE
Adds the derivatives of surface tension sigma.

### DIFF
--- a/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TwoPhaseFluidProperties.h
@@ -71,6 +71,21 @@ public:
   virtual Real h_lat(Real p, Real T) const;
 
   /**
+   * Computes surface tension sigma of
+   * saturated liquid in contact with saturated vapor
+   *
+   * @param T  temperature
+   */
+  virtual Real sigma_from_T(Real T) const;
+
+  /**
+   * Computes dsigma/dT along the saturation line
+   *
+   * @param[in] T          temperature (K)
+   */
+  virtual Real dsigma_dT_from_T(Real T) const;
+
+  /**
    * Returns true if phase change is supported, otherwise false
    */
   virtual bool supportsPhaseChange() const = 0;

--- a/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
@@ -60,3 +60,13 @@ TwoPhaseFluidProperties::h_lat(Real p, Real T) const
 {
   return _fp_vapor->h_from_p_T(p, T) - _fp_liquid->h_from_p_T(p, T);
 }
+
+Real TwoPhaseFluidProperties::sigma_from_T(Real /*T*/) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " is not implemented.");
+}
+
+Real TwoPhaseFluidProperties::dsigma_dT_from_T(Real /*T*/) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " is not implemented.");
+}

--- a/modules/fluid_properties/test/include/utils/SinglePhaseFluidPropertiesTestUtils.h
+++ b/modules/fluid_properties/test/include/utils/SinglePhaseFluidPropertiesTestUtils.h
@@ -29,6 +29,15 @@
     REL_TEST(df_db, df_db_fd, tol);                                                                \
   }
 
+// Macro for performing a derivative test (1d function)
+#define DERIV_TEST_1D(f, dfda, a, tol)                                                             \
+  {                                                                                                \
+    const Real da = REL_PERTURBATION * a;                                                          \
+    const Real df_da_fd = (f(a + da) - f(a - da)) / (2 * da);                                      \
+    Real df_da = dfda(a);                                                                          \
+    REL_TEST(df_da, df_da_fd, tol);                                                                \
+  }
+
 // Macro for testing that a "not implemented" error message is thrown for f(a,b)
 #define NOT_IMPLEMENTED_TEST_VALUE(f)                                                              \
   {                                                                                                \


### PR DESCRIPTION
Adds the derivative of surface tension sigma.
    
 Sigma is a function of T only and describes the surface
 tension of saturated liquid in contact with saturated vapor.
 Therefore it is implemented, along with its derivative, as
 a function of T only in TwoPhaseFluidProperties now.
    
 The LiquidFluidPropertiesInterface class containing
 sigma_from_p_T is going to be removed in later versions of
 MOOSE.
    
 Closes #13167