### PR TITLE
Fixing LLVM 8 warnings

### DIFF
--- a/framework/include/meshgenerators/RinglebMeshGenerator.h
+++ b/framework/include/meshgenerators/RinglebMeshGenerator.h
@@ -25,7 +25,6 @@ class RinglebMeshGenerator : public MeshGenerator
 {
 public:
   RinglebMeshGenerator(const InputParameters & parameters);
-  RinglebMeshGenerator(const RinglebMeshGenerator & /* other_mesh */) = default;
 
   // No copy
   RinglebMeshGenerator & operator=(const RinglebMeshGenerator & other_mesh) = delete;

--- a/framework/include/meshgenerators/SpiralAnnularMeshGenerator.h
+++ b/framework/include/meshgenerators/SpiralAnnularMeshGenerator.h
@@ -25,7 +25,6 @@ class SpiralAnnularMeshGenerator : public MeshGenerator
 {
 public:
   SpiralAnnularMeshGenerator(const InputParameters & parameters);
-  SpiralAnnularMeshGenerator(const SpiralAnnularMeshGenerator & /* other_mesh */) = default;
 
   // No copy
   SpiralAnnularMeshGenerator & operator=(const SpiralAnnularMeshGenerator & other_mesh) = delete;


### PR DESCRIPTION
refs #12984

Unused and unneeded constructors are causing a compilation warning because they can't be generated without a proper copy constructor in the parent. 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
