### PR TITLE
Updating fp_interrogator

### DIFF
--- a/modules/fluid_properties/include/userobjects/FluidPropertiesInterrogator.h
+++ b/modules/fluid_properties/include/userobjects/FluidPropertiesInterrogator.h
@@ -14,7 +14,6 @@
 
 class FluidPropertiesInterrogator;
 class FluidProperties;
-class LiquidFluidPropertiesInterface;
 class SinglePhaseFluidProperties;
 class VaporMixtureFluidProperties;
 class TwoPhaseFluidProperties;
@@ -118,17 +117,6 @@ protected:
                                   const Real & p,
                                   const Real & T,
                                   const Real & vel);
-
-  /**
-   * Outputs liquid-specific properties
-   *
-   * @param[in] liquid_fp   Liquid fluid properties
-   * @param[in] p   Pressure
-   * @param[in] T   Temperature
-   */
-  void outputLiquidSpecificProperties(const LiquidFluidPropertiesInterface * const liquid_fp,
-                                      const Real & p,
-                                      const Real & T);
 
   /**
    * Outputs static properties for a vapor mixture fluid properties object

--- a/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
+++ b/modules/fluid_properties/src/userobjects/FluidPropertiesInterrogator.C
@@ -9,7 +9,6 @@
 
 #include "FluidPropertiesInterrogator.h"
 #include "FluidProperties.h"
-#include "LiquidFluidPropertiesInterface.h"
 #include "SinglePhaseFluidProperties.h"
 #include "VaporMixtureFluidProperties.h"
 #include "TwoPhaseFluidProperties.h"
@@ -177,12 +176,6 @@ FluidPropertiesInterrogator::execute1Phase(const SinglePhaseFluidProperties * co
     outputHeader(description + " STATIC properties");
     outputStaticProperties(fp_1phase, rho, e, p, T);
 
-    // output liquid-only property values
-    const LiquidFluidPropertiesInterface * const liquid_fp =
-        dynamic_cast<const LiquidFluidPropertiesInterface * const>(fp_1phase);
-    if (liquid_fp)
-      outputLiquidSpecificProperties(liquid_fp, p, T);
-
     // output stagnation property values
     if (isParamValid("vel") || specified["rho,rhou,rhoE"])
     {
@@ -313,8 +306,10 @@ FluidPropertiesInterrogator::execute2Phase()
     const Real T = getParam<Real>("T");
     const Real p_sat = _fp_2phase->p_sat(T);
     const Real h_lat = _fp_2phase->h_lat(p_sat, T);
+    const Real sigma = _fp_2phase->sigma_from_T(T);
     outputProperty("Saturation pressure", p_sat, "Pa");
     outputProperty("Latent heat of vaporization", h_lat, "J/kg");
+    outputProperty("Surface tension", sigma, "N/m");
   }
   if (specified["p,T"])
   {
@@ -482,15 +477,6 @@ FluidPropertiesInterrogator::outputStaticProperties(const SinglePhaseFluidProper
   outputProperty("Specific heat at constant volume", cv, "J/(kg-K)");
   outputProperty("Thermal conductivity", k, "W/(m-K)");
   outputProperty("Volumetric expansion coefficient", beta, "1/K");
-  _console << std::endl;
-}
-
-void
-FluidPropertiesInterrogator::outputLiquidSpecificProperties(
-    const LiquidFluidPropertiesInterface * const liquid_fp, const Real & p, const Real & T)
-{
-  const Real sigma = liquid_fp->sigma_from_p_T(p, T);
-  outputProperty("Surface tension", sigma, "N/m");
   _console << std::endl;
 }
 

--- a/modules/fluid_properties/test/include/userobjects/TestTwoPhaseFluidProperties.h
+++ b/modules/fluid_properties/test/include/userobjects/TestTwoPhaseFluidProperties.h
@@ -31,6 +31,8 @@ public:
   virtual Real T_sat(Real p) const override;
   virtual Real p_sat(Real T) const override;
   virtual Real dT_sat_dp(Real p) const override;
+  virtual Real sigma_from_T(Real T) const override;
+  virtual Real dsigma_dT_from_T(Real T) const override;
   virtual bool supportsPhaseChange() const override;
 };
 

--- a/modules/fluid_properties/test/src/userobjects/TestTwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/test/src/userobjects/TestTwoPhaseFluidProperties.C
@@ -53,6 +53,18 @@ TestTwoPhaseFluidProperties::p_sat(Real T) const
 
 Real TestTwoPhaseFluidProperties::dT_sat_dp(Real /*p*/) const { return 2; }
 
+Real
+TestTwoPhaseFluidProperties::sigma_from_T(Real T) const
+{
+  return 5 * T;
+}
+
+Real
+TestTwoPhaseFluidProperties::dsigma_dT_from_T(Real /*T*/) const
+{
+  return 5;
+}
+
 bool
 TestTwoPhaseFluidProperties::supportsPhaseChange() const
 {

--- a/modules/fluid_properties/test/tests/fp_interrogator/tests
+++ b/modules/fluid_properties/test/tests/fp_interrogator/tests
@@ -302,7 +302,8 @@ Latent heat of vaporization:           4.5931000000e\+08  J/kg'
 --------------------------------------------------------------------------------
 Critical pressure:                                   25  Pa
 Saturation pressure:                                900  Pa
-Latent heat of vaporization:           6.8896500000e\+05  J/kg'
+Latent heat of vaporization:           6.8896500000e\+05  J/kg
+Surface tension:                                   1500  N/m'
 
     requirement = "The fluid properties interrogator shall output two-phase "
       "fluid properties for (T) input with a two-phase fluid properties object."


### PR DESCRIPTION
Surface tension API was moved to TwoPhaseFluidProperties, so the
fluid property interrogator was changed to print the surface tension
when people specify saturation temperature.

Refs #13167

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
