### PR TITLE
Delete remote elements if its needed

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -864,6 +864,16 @@ public:
   /// Helper type for building periodic node maps
   using PeriodicNodeInfo = std::pair<const Node *, BoundaryID>;
 
+  /**
+   * Set whether we need to delete remote elements
+   */
+  void needsRemoteElemDeletion(bool need_delete) { _need_delete = need_delete; }
+
+  /**
+   * Whether we need to delete remote elements
+   */
+  bool needsRemoteElemDeletion() const { return _need_delete; }
+
 protected:
   /// Deprecated (DO NOT USE)
   std::vector<std::unique_ptr<GhostingFunctor>> _ghosting_functors;
@@ -1184,6 +1194,9 @@ private:
   PerfID _read_recovered_mesh_timer;
   PerfID _ghost_ghosted_boundaries_timer;
   PerfID _add_mortar_interface_timer;
+
+  /// Whether we need to delete remote elements after init'ing the EquationSystems
+  bool _need_delete;
 };
 
 /**

--- a/framework/src/actions/AddRelationshipManager.C
+++ b/framework/src/actions/AddRelationshipManager.C
@@ -35,14 +35,4 @@ AddRelationshipManager::act()
     action_ptr->addRelationshipManagers(rm_type);
 
   _app.attachRelationshipManagers(rm_type);
-
-  if (_current_task == "attach_algebraic_rm")
-  {
-    // If we're doing Algebraic then we're done adding ghosting functors
-    // and we can tell the mesh that it's safe to remove remote elements again
-    _mesh->getMesh().allow_remote_element_removal(true);
-
-    if (_problem->getDisplacedProblem())
-      _problem->getDisplacedProblem()->mesh().getMesh().allow_remote_element_removal(true);
-  }
 }

--- a/framework/src/actions/CreateDisplacedProblemAction.C
+++ b/framework/src/actions/CreateDisplacedProblemAction.C
@@ -155,6 +155,17 @@ CreateDisplacedProblemAction::act()
 
       addProxyGeometricRelationshipManagers(undisplaced_nl, displaced_nl);
       addProxyGeometricRelationshipManagers(displaced_nl, undisplaced_nl);
+
+      // When adding the geometric relationship mangers we told the mesh not to allow remote element
+      // removal during the initial MeshBase::prepare_for_use call. If we're using a distributed
+      // mesh we need to make sure we now allow remote element removal and then delete the remote
+      // elmeents after the EquationSystems init
+      if (_mesh->isDistributedMesh())
+      {
+        _mesh->needsRemoteElemDeletion(true);
+        if (_displaced_mesh)
+          _displaced_mesh->needsRemoteElemDeletion(true);
+      }
     }
   }
 }

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -15,6 +15,10 @@
 
 registerMooseAction("MooseApp", SetupMeshCompleteAction, "prepare_mesh");
 
+registerMooseAction("MooseApp",
+                    SetupMeshCompleteAction,
+                    "delete_remote_elements_post_equation_systems_init");
+
 registerMooseAction("MooseApp", SetupMeshCompleteAction, "execute_mesh_modifiers");
 
 registerMooseAction("MooseApp", SetupMeshCompleteAction, "uniform_refine_mesh");
@@ -87,6 +91,15 @@ SetupMeshCompleteAction::act()
         if (_displaced_mesh)
           Adaptivity::uniformRefine(_displaced_mesh.get());
       }
+    }
+  }
+  else if (_current_task == "delete_remote_elements_post_equation_systems_init")
+  {
+    if (_mesh->needsRemoteElemDeletion())
+    {
+      _mesh->getMesh().delete_remote_elements();
+      if (_displaced_mesh)
+        _displaced_mesh->getMesh().delete_remote_elements();
     }
   }
   else

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -169,6 +169,7 @@ addActionTypes(Syntax & syntax)
   registerTask("execute_mesh_generators", true);
   registerTask("uniform_refine_mesh", false);
   registerTask("prepare_mesh", false);
+  registerTask("delete_remote_elements_post_equation_systems_init", false);
   registerTask("setup_mesh_complete", true); // calls prepare
   registerTask("add_geometric_rm", false);
   registerTask("attach_geometric_rm", true);
@@ -285,6 +286,7 @@ addActionTypes(Syntax & syntax)
                            "(add_algebraic_rm)"
                            "(attach_algebraic_rm)"
                            "(init_problem)"
+                           "(delete_remote_elements_post_equation_systems_init)"
                            "(add_output)"
                            "(add_postprocessor)"
                            "(add_vector_postprocessor)" // MaterialVectorPostprocessor requires this
@@ -389,8 +391,6 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
   registerSyntax("DynamicObjectRegistrationAction", "Problem");
   registerSyntax("SetupMeshAction", "Mesh");
   registerSyntax("SetupMeshCompleteAction", "Mesh");
-  //  registerSyntaxTask("SetupMeshCompleteAction", "Mesh", "prepare_mesh");
-  //  registerSyntaxTask("SetupMeshCompleteAction", "Mesh", "setup_mesh_complete");
   registerSyntax("CreateDisplacedProblemAction", "Mesh");
   registerSyntax("AddMeshModifierAction", "MeshModifiers/*");
   registerSyntax("AddMeshGeneratorAction", "MeshGenerators/*");

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -206,7 +206,8 @@ MooseMesh::MooseMesh(const InputParameters & parameters)
     _init_timer(registerTimedSection("init", 2)),
     _read_recovered_mesh_timer(registerTimedSection("readRecoveredMesh", 2)),
     _ghost_ghosted_boundaries_timer(registerTimedSection("GhostGhostedBoundaries", 3)),
-    _add_mortar_interface_timer(registerTimedSection("addMortarInterface", 5))
+    _add_mortar_interface_timer(registerTimedSection("addMortarInterface", 5)),
+    _need_delete(false)
 {
   if (isParamValid("ghosting_patch_size") && (_patch_update_strategy != Moose::Iteration))
     mooseError("Ghosting patch size parameter has to be set in the mesh block "


### PR DESCRIPTION
Previously the CreateDisplacedProblemAction was telling the mesh not
to delete remote elements when adding the geometric ghosting functors.
During the addition of algebraic relationship managers we told the mesh
that its allowed to delete remote elements now...but then we never actually
call prepare_for_use again so the mesh never got distributed (e.g. we
never deleted the remotes). Now we've added an explicit task that will
manually delete the remote elements post EquationSystems init in the cases
where we told the distributed mesh NOT to delete remotes during the prepare_for_use
call
