### PR TITLE
Generalize ADTimeKernel

### DIFF
--- a/framework/doc/content/source/bcs/ADFunctionDirichletBC.md
+++ b/framework/doc/content/source/bcs/ADFunctionDirichletBC.md
@@ -1,6 +1,6 @@
 # ADFunctionDirichletBC
 
-!syntax description /BCs/ADFunctionDirichletBC<RESIDUAL>
+!syntax description /BCs/ADFunctionDirichletBC
 
 ## Description
 
@@ -34,8 +34,8 @@ Note that `ADFunctionDirichletBC` computes its Jacobian using automatic differen
 
 !listing test/tests/bcs/ad_bcs/ad_bc.i block=BCs
 
-!syntax parameters /BCs/ADFunctionDirichletBC<RESIDUAL>
+!syntax parameters /BCs/ADFunctionDirichletBC
 
-!syntax inputs /BCs/ADFunctionDirichletBC<RESIDUAL>
+!syntax inputs /BCs/ADFunctionDirichletBC
 
-!syntax children /BCs/ADFunctionDirichletBC<RESIDUAL>
+!syntax children /BCs/ADFunctionDirichletBC

--- a/framework/doc/content/source/bcs/ADLagrangeVecFunctionDirichletBC.md
+++ b/framework/doc/content/source/bcs/ADLagrangeVecFunctionDirichletBC.md
@@ -1,6 +1,6 @@
 # ADLagrangeVecFunctionDirichletBC
 
-!syntax description /BCs/ADLagrangeVecFunctionDirichletBC<RESIDUAL>
+!syntax description /BCs/ADLagrangeVecFunctionDirichletBC
 
 ## Description
 
@@ -30,8 +30,8 @@ or more sidesets corresponding to the boundary subset $\partial \Omega_D$.
 
 Note that this BC computes its Jacobian using automatic differentiation
 
-!syntax parameters /BCs/ADLagrangeVecFunctionDirichletBC<RESIDUAL>
+!syntax parameters /BCs/ADLagrangeVecFunctionDirichletBC
 
-!syntax inputs /BCs/ADLagrangeVecFunctionDirichletBC<RESIDUAL>
+!syntax inputs /BCs/ADLagrangeVecFunctionDirichletBC
 
-!syntax children /BCs/ADLagrangeVecFunctionDirichletBC<RESIDUAL>
+!syntax children /BCs/ADLagrangeVecFunctionDirichletBC

--- a/framework/doc/content/source/dgkernels/ADDGDiffusion.md
+++ b/framework/doc/content/source/dgkernels/ADDGDiffusion.md
@@ -2,8 +2,8 @@
 
 Use DG to compute a diffusion term, and AD is adopted for Jacobian calculation.
 
-!syntax parameters /DGKernels/ADDGDiffusion<RESIDUAL>
+!syntax parameters /DGKernels/ADDGDiffusion
 
-!syntax inputs /DGKernels/ADDGDiffusion<RESIDUAL>
+!syntax inputs /DGKernels/ADDGDiffusion
 
-!syntax children /DGKernels/ADDGDiffusion<RESIDUAL>
+!syntax children /DGKernels/ADDGDiffusion

--- a/framework/doc/content/source/kernels/ADCoupledTimeDerivative.md
+++ b/framework/doc/content/source/kernels/ADCoupledTimeDerivative.md
@@ -40,8 +40,8 @@ kernel block below:
 test/tests/kernels/coupled_time_derivative/ad_coupled_time_derivative_test.i
 block=Kernels label=false
 
-!syntax parameters /Kernels/ADCoupledTimeDerivative<RESIDUAL>
+!syntax parameters /Kernels/ADCoupledTimeDerivative
 
-!syntax inputs /Kernels/ADCoupledTimeDerivative<RESIDUAL>
+!syntax inputs /Kernels/ADCoupledTimeDerivative
 
-!syntax children /Kernels/ADCoupledTimeDerivative<RESIDUAL>
+!syntax children /Kernels/ADCoupledTimeDerivative

--- a/framework/doc/content/source/kernels/ADDiffusion.md
+++ b/framework/doc/content/source/kernels/ADDiffusion.md
@@ -18,8 +18,8 @@ element solution of the weak formulation.
 The Jacobian in `ADDiffusion` is computed using forward automatic
 differentiation.
 
-!syntax parameters /Kernels/ADDiffusion<RESIDUAL>
+!syntax parameters /Kernels/ADDiffusion
 
-!syntax inputs /Kernels/ADDiffusion<RESIDUAL>
+!syntax inputs /Kernels/ADDiffusion
 
-!syntax children /Kernels/ADDiffusion<RESIDUAL>
+!syntax children /Kernels/ADDiffusion

--- a/framework/doc/content/source/kernels/ADTimeDerivative.md
+++ b/framework/doc/content/source/kernels/ADTimeDerivative.md
@@ -27,8 +27,8 @@ block for a transient diffusion problem that demonstrates the
 
 !listing test/tests/kernels/ad_transient_diffusion/ad_transient_diffusion.i block=Kernels
 
-!syntax parameters /Kernels/ADTimeDerivative<RESIDUAL>
+!syntax parameters /Kernels/ADTimeDerivative
 
-!syntax inputs /Kernels/ADTimeDerivative<RESIDUAL>
+!syntax inputs /Kernels/ADTimeDerivative
 
-!syntax children /Kernels/ADTimeDerivative<RESIDUAL>
+!syntax children /Kernels/ADTimeDerivative

--- a/framework/doc/content/source/kernels/ADVectorDiffusion.md
+++ b/framework/doc/content/source/kernels/ADVectorDiffusion.md
@@ -6,8 +6,8 @@
 except it is applied to vector finite element variables and the Jacobian is
 computed automatically using automatic differentiation.
 
-!syntax parameters /Kernels/ADVectorDiffusion<RESIDUAL>
+!syntax parameters /Kernels/ADVectorDiffusion
 
-!syntax inputs /Kernels/ADVectorDiffusion<RESIDUAL>
+!syntax inputs /Kernels/ADVectorDiffusion
 
-!syntax children /Kernels/ADVectorDiffusion<RESIDUAL>
+!syntax children /Kernels/ADVectorDiffusion

--- a/framework/doc/content/source/kernels/ADVectorTimeDerivative.md
+++ b/framework/doc/content/source/kernels/ADVectorTimeDerivative.md
@@ -33,8 +33,8 @@ block for a transient diffusion problem that demonstrates the
 
 !listing test/tests/kernels/ad_transient_diffusion/ad_transient_vector_diffusion.i block=Kernels
 
-!syntax parameters /Kernels/ADVectorTimeDerivative<RESIDUAL>
+!syntax parameters /Kernels/ADVectorTimeDerivative
 
-!syntax inputs /Kernels/ADVectorTimeDerivative<RESIDUAL>
+!syntax inputs /Kernels/ADVectorTimeDerivative
 
-!syntax children /Kernels/ADVectorTimeDerivative<RESIDUAL>
+!syntax children /Kernels/ADVectorTimeDerivative

--- a/framework/include/kernels/ADKernelGrad.h
+++ b/framework/include/kernels/ADKernelGrad.h
@@ -14,7 +14,7 @@
 
 #define usingTemplKernelGradMembers(T) usingTemplKernelMembers(T)
 #define usingKernelGradMembers usingTemplKernelGradMembers(Real)
-#define usingVectorKernelGradMembers usingTemplKernelMembers(RealVectorGrad)
+#define usingVectorKernelGradMembers usingTemplKernelMembers(RealVectorValue)
 
 template <typename, ComputeStage>
 class ADKernelGradTempl;

--- a/framework/include/kernels/ADKernelGrad.h
+++ b/framework/include/kernels/ADKernelGrad.h
@@ -12,8 +12,9 @@
 
 #include "ADKernel.h"
 
-#define usingKernelGradMembers usingKernelMembers
-#define usingVectorKernelGradMembers usingVectorKernelMembers
+#define usingTemplKernelGradMembers(T) usingTemplKernelMembers(T)
+#define usingKernelGradMembers usingTemplKernelGradMembers(Real)
+#define usingVectorKernelGradMembers usingTemplKernelMembers(RealVectorGrad)
 
 template <typename, ComputeStage>
 class ADKernelGradTempl;

--- a/framework/include/kernels/ADTimeDerivative.h
+++ b/framework/include/kernels/ADTimeDerivative.h
@@ -30,4 +30,7 @@ protected:
   usingTimeKernelValueMembers;
 };
 
+#define usingTimeDerivativeMembers usingTemplTimeKernelValueMembers(Real)
+#define usingVectorTimeDerivativeMembers usingTemplTimeKernelValueMembers(RealVectorValue)
+
 #endif // ADTIMEDERIVATIVE_H

--- a/framework/include/kernels/ADTimeDerivative.h
+++ b/framework/include/kernels/ADTimeDerivative.h
@@ -10,7 +10,7 @@
 #ifndef ADTIMEDERIVATIVE_H
 #define ADTIMEDERIVATIVE_H
 
-#include "ADTimeKernel.h"
+#include "ADTimeKernelValue.h"
 
 // Forward Declaration
 template <ComputeStage>
@@ -19,7 +19,7 @@ class ADTimeDerivative;
 declareADValidParams(ADTimeDerivative);
 
 template <ComputeStage compute_stage>
-class ADTimeDerivative : public ADTimeKernel<compute_stage>
+class ADTimeDerivative : public ADTimeKernelValue<compute_stage>
 {
 public:
   ADTimeDerivative(const InputParameters & parameters);
@@ -27,7 +27,7 @@ public:
 protected:
   virtual ADResidual precomputeQpResidual() override;
 
-  usingTimeKernelMembers;
+  usingTimeKernelValueMembers;
 };
 
 #endif // ADTIMEDERIVATIVE_H

--- a/framework/include/kernels/ADTimeKernel.h
+++ b/framework/include/kernels/ADTimeKernel.h
@@ -38,7 +38,7 @@ declareADValidParams(ADTimeKernel);
 declareADValidParams(ADVectorTimeKernel);
 
 #define usingTemplTimeKernelMembers(type)                                                          \
-  usingTemplKernelValueMembers(type);                                                              \
+  usingTemplKernelMembers(type);                                                                   \
   using ADTimeKernelTempl<type, compute_stage>::_u_dot
 
 #define usingTimeKernelMembers usingTemplTimeKernelMembers(Real)

--- a/framework/include/kernels/ADTimeKernel.h
+++ b/framework/include/kernels/ADTimeKernel.h
@@ -10,14 +10,14 @@
 #ifndef ADTIMEKERNEL_H
 #define ADTIMEKERNEL_H
 
-#include "ADKernelValue.h"
+#include "ADKernel.h"
 
 /**
  * All AD time kernels should inherit from this class
  *
  */
 template <typename T, ComputeStage compute_stage>
-class ADTimeKernelTempl : public ADKernelValueTempl<T, compute_stage>
+class ADTimeKernelTempl : public ADKernelTempl<T, compute_stage>
 {
 public:
   ADTimeKernelTempl(const InputParameters & parameters);
@@ -26,7 +26,7 @@ protected:
   /// Holds the time derivatives at the quadrature points
   const ADTemplateVariableValue & _u_dot;
 
-  usingTemplKernelValueMembers(T);
+  usingTemplKernelMembers(T);
 };
 
 template <ComputeStage compute_stage>

--- a/framework/include/kernels/ADTimeKernelGrad.h
+++ b/framework/include/kernels/ADTimeKernelGrad.h
@@ -13,7 +13,8 @@
 #include "ADKernelGrad.h"
 
 /**
- * All AD time kernels should inherit from this class
+ * AD time kernels should inherit from this class when the time portion of the weak residual is
+ * multiplied by the gradient of the test function
  */
 template <typename T, ComputeStage compute_stage>
 class ADTimeKernelGradTempl : public ADKernelGradTempl<T, compute_stage>

--- a/framework/include/kernels/ADTimeKernelGrad.h
+++ b/framework/include/kernels/ADTimeKernelGrad.h
@@ -1,0 +1,46 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef ADTIMEKERNELGRAD_H
+#define ADTIMEKERNELGRAD_H
+
+#include "ADKernelGrad.h"
+
+/**
+ * All AD time kernels should inherit from this class
+ */
+template <typename T, ComputeStage compute_stage>
+class ADTimeKernelGradTempl : public ADKernelGradTempl<T, compute_stage>
+{
+public:
+  ADTimeKernelGradTempl(const InputParameters & parameters);
+
+protected:
+  /// Holds the time derivatives at the quadrature points
+  const ADTemplateVariableValue & _u_dot;
+
+  usingTemplKernelGradMembers(T);
+};
+
+template <ComputeStage compute_stage>
+using ADTimeKernelGrad = ADTimeKernelGradTempl<Real, compute_stage>;
+template <ComputeStage compute_stage>
+using ADVectorTimeKernelGrad = ADTimeKernelGradTempl<RealVectorValue, compute_stage>;
+
+declareADValidParams(ADTimeKernelGrad);
+declareADValidParams(ADVectorTimeKernelGrad);
+
+#define usingTemplTimeKernelGradMembers(type)                                                      \
+  usingTemplKernelMembers(type);                                                                   \
+  using ADTimeKernelGradTempl<type, compute_stage>::_u_dot
+
+#define usingTimeKernelGradMembers usingTemplTimeKernelGradMembers(Real)
+#define usingVectorTimeKernelGradMembers usingTemplTimeKernelGradMembers(RealVectorValue)
+
+#endif // ADTIMEKERNELGRAD_H

--- a/framework/include/kernels/ADTimeKernelValue.h
+++ b/framework/include/kernels/ADTimeKernelValue.h
@@ -1,0 +1,46 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef ADTIMEKERNELVALUE_H
+#define ADTIMEKERNELVALUE_H
+
+#include "ADKernelValue.h"
+
+/**
+ * All AD time kernels should inherit from this class
+ */
+template <typename T, ComputeStage compute_stage>
+class ADTimeKernelValueTempl : public ADKernelValueTempl<T, compute_stage>
+{
+public:
+  ADTimeKernelValueTempl(const InputParameters & parameters);
+
+protected:
+  /// Holds the time derivatives at the quadrature points
+  const ADTemplateVariableValue & _u_dot;
+
+  usingTemplKernelValueMembers(T);
+};
+
+template <ComputeStage compute_stage>
+using ADTimeKernelValue = ADTimeKernelValueTempl<Real, compute_stage>;
+template <ComputeStage compute_stage>
+using ADVectorTimeKernelValue = ADTimeKernelValueTempl<RealVectorValue, compute_stage>;
+
+declareADValidParams(ADTimeKernelValue);
+declareADValidParams(ADVectorTimeKernelValue);
+
+#define usingTemplTimeKernelValueMembers(type)                                                     \
+  usingTemplKernelMembers(type);                                                                   \
+  using ADTimeKernelValueTempl<type, compute_stage>::_u_dot
+
+#define usingTimeKernelValueMembers usingTemplTimeKernelValueMembers(Real)
+#define usingVectorTimeKernelValueMembers usingTemplTimeKernelValueMembers(RealVectorValue)
+
+#endif // ADTIMEKERNEL_H

--- a/framework/include/kernels/ADTimeKernelValue.h
+++ b/framework/include/kernels/ADTimeKernelValue.h
@@ -13,7 +13,8 @@
 #include "ADKernelValue.h"
 
 /**
- * All AD time kernels should inherit from this class
+ * AD time kernels should inherit from this class when the time portion of the weak residual is
+ * multiplied by the test function
  */
 template <typename T, ComputeStage compute_stage>
 class ADTimeKernelValueTempl : public ADKernelValueTempl<T, compute_stage>

--- a/framework/include/kernels/ADVectorTimeDerivative.h
+++ b/framework/include/kernels/ADVectorTimeDerivative.h
@@ -10,7 +10,7 @@
 #ifndef ADVECTORTIMEDERIVATIVE_H
 #define ADVECTORTIMEDERIVATIVE_H
 
-#include "ADTimeKernel.h"
+#include "ADTimeKernelValue.h"
 
 // Forward Declaration
 template <ComputeStage>
@@ -19,7 +19,7 @@ class ADVectorTimeDerivative;
 declareADValidParams(ADVectorTimeDerivative);
 
 template <ComputeStage compute_stage>
-class ADVectorTimeDerivative : public ADVectorTimeKernel<compute_stage>
+class ADVectorTimeDerivative : public ADVectorTimeKernelValue<compute_stage>
 {
 public:
   ADVectorTimeDerivative(const InputParameters & parameters);
@@ -27,7 +27,7 @@ public:
 protected:
   virtual ADRealVectorValue precomputeQpResidual() override;
 
-  usingVectorTimeKernelMembers;
+  usingVectorTimeKernelValueMembers;
 };
 
 #endif // ADVECTORTIMEDERIVATIVE_H

--- a/framework/include/loops/#ComputeNodalAuxVarsThread.h#
+++ b/framework/include/loops/#ComputeNodalAuxVarsThread.h#
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#ifndef COMPUTENODALAUXVARSTHREAD_H
+#define COMPUTENODALAUXVARSTHREAD_H
+
+// MOOSE includes
+#include "ThreadedNodeLoop.h"
+
+#include "libmesh/node_range.h"
+
+// Forward declarations
+class AuxiliarySystem;
+class AuxKernel;
+class FEProblemBase;
+template <typename T>
+class MooseObjectWarehouse;
+
+;
+
+  std::set<SubdomainID> _block_ids;
+};
+
+#endif // COMPUTENODALAUXVARSTHREAD_H

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -35,6 +35,8 @@ InputParameters validParams<MaterialPropertyInterface>();
 #define adGetADMaterialPropertyByName this->template getADMaterialPropertyByName
 #define adGetMaterialPropertyByName this->template getMaterialPropertyByName
 #define adGetMaterialPropertyOldByName this->template getMaterialPropertyOldByName
+#define adHasMaterialProperty this->template hasMaterialProperty
+#define adHasMaterialPropertyByName this->template hasMaterialPropertyByName
 
 /**
  * \class MaterialPropertyInterface
@@ -506,7 +508,7 @@ MaterialPropertyInterface::hasMaterialProperty(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
-  return _material_data->haveProperty<T>(prop_name);
+  return hasMaterialPropertyByName<T>(prop_name);
 }
 
 template <typename T>

--- a/framework/src/kernels/ADTimeDerivative.C
+++ b/framework/src/kernels/ADTimeDerivative.C
@@ -13,13 +13,13 @@ registerADMooseObject("MooseApp", ADTimeDerivative);
 
 defineADValidParams(
     ADTimeDerivative,
-    ADTimeKernel,
+    ADTimeKernelValue,
     params.addClassDescription("The time derivative operator with the weak form of $(\\psi_i, "
                                "\\frac{\\partial u_h}{\\partial t})$."););
 
 template <ComputeStage compute_stage>
 ADTimeDerivative<compute_stage>::ADTimeDerivative(const InputParameters & parameters)
-  : ADTimeKernel<compute_stage>(parameters)
+  : ADTimeKernelValue<compute_stage>(parameters)
 {
 }
 

--- a/framework/src/kernels/ADTimeKernel.C
+++ b/framework/src/kernels/ADTimeKernel.C
@@ -16,7 +16,7 @@
 
 #include "libmesh/quadrature.h"
 
-defineADValidParams(ADTimeKernel, ADKernelValue, params.set<MultiMooseEnum>("vector_tags") = "time";
+defineADValidParams(ADTimeKernel, ADKernel, params.set<MultiMooseEnum>("vector_tags") = "time";
                     params.set<MultiMooseEnum>("matrix_tags") = "system time";);
 defineADValidParams(ADVectorTimeKernel,
                     ADVectorKernelValue,
@@ -25,7 +25,7 @@ defineADValidParams(ADVectorTimeKernel,
 
 template <typename T, ComputeStage compute_stage>
 ADTimeKernelTempl<T, compute_stage>::ADTimeKernelTempl(const InputParameters & parameters)
-  : ADKernelValueTempl<T, compute_stage>(parameters), _u_dot(_var.template adUDot<compute_stage>())
+  : ADKernelTempl<T, compute_stage>(parameters), _u_dot(_var.template adUDot<compute_stage>())
 {
 }
 

--- a/framework/src/kernels/ADTimeKernel.C
+++ b/framework/src/kernels/ADTimeKernel.C
@@ -19,7 +19,7 @@
 defineADValidParams(ADTimeKernel, ADKernel, params.set<MultiMooseEnum>("vector_tags") = "time";
                     params.set<MultiMooseEnum>("matrix_tags") = "system time";);
 defineADValidParams(ADVectorTimeKernel,
-                    ADVectorKernelValue,
+                    ADVectorKernel,
                     params.set<MultiMooseEnum>("vector_tags") = "time";
                     params.set<MultiMooseEnum>("matrix_tags") = "system time";);
 

--- a/framework/src/kernels/ADTimeKernelGrad.C
+++ b/framework/src/kernels/ADTimeKernelGrad.C
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADTimeKernelGrad.h"
+
+// MOOSE includes
+#include "Assembly.h"
+#include "MooseVariableFE.h"
+#include "SystemBase.h"
+
+#include "libmesh/quadrature.h"
+
+defineADValidParams(ADTimeKernelGrad,
+                    ADKernelGrad,
+                    params.set<MultiMooseEnum>("vector_tags") = "time";
+                    params.set<MultiMooseEnum>("matrix_tags") = "system time";);
+defineADValidParams(ADVectorTimeKernelGrad,
+                    ADVectorKernelGrad,
+                    params.set<MultiMooseEnum>("vector_tags") = "time";
+                    params.set<MultiMooseEnum>("matrix_tags") = "system time";);
+
+template <typename T, ComputeStage compute_stage>
+ADTimeKernelGradTempl<T, compute_stage>::ADTimeKernelGradTempl(const InputParameters & parameters)
+  : ADKernelGradTempl<T, compute_stage>(parameters), _u_dot(_var.template adUDot<compute_stage>())
+{
+}
+
+template class ADTimeKernelGradTempl<Real, RESIDUAL>;
+template class ADTimeKernelGradTempl<Real, JACOBIAN>;
+template class ADTimeKernelGradTempl<RealVectorValue, RESIDUAL>;
+template class ADTimeKernelGradTempl<RealVectorValue, JACOBIAN>;

--- a/framework/src/kernels/ADTimeKernelValue.C
+++ b/framework/src/kernels/ADTimeKernelValue.C
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADTimeKernelValue.h"
+
+// MOOSE includes
+#include "Assembly.h"
+#include "MooseVariableFE.h"
+#include "SystemBase.h"
+
+#include "libmesh/quadrature.h"
+
+defineADValidParams(ADTimeKernelValue,
+                    ADKernelValue,
+                    params.set<MultiMooseEnum>("vector_tags") = "time";
+                    params.set<MultiMooseEnum>("matrix_tags") = "system time";);
+defineADValidParams(ADVectorTimeKernelValue,
+                    ADVectorKernelValue,
+                    params.set<MultiMooseEnum>("vector_tags") = "time";
+                    params.set<MultiMooseEnum>("matrix_tags") = "system time";);
+
+template <typename T, ComputeStage compute_stage>
+ADTimeKernelValueTempl<T, compute_stage>::ADTimeKernelValueTempl(const InputParameters & parameters)
+  : ADKernelValueTempl<T, compute_stage>(parameters), _u_dot(_var.template adUDot<compute_stage>())
+{
+}
+
+template class ADTimeKernelValueTempl<Real, RESIDUAL>;
+template class ADTimeKernelValueTempl<Real, JACOBIAN>;
+template class ADTimeKernelValueTempl<RealVectorValue, RESIDUAL>;
+template class ADTimeKernelValueTempl<RealVectorValue, JACOBIAN>;

--- a/framework/src/kernels/ADVectorTimeDerivative.C
+++ b/framework/src/kernels/ADVectorTimeDerivative.C
@@ -13,13 +13,13 @@ registerADMooseObject("MooseApp", ADVectorTimeDerivative);
 
 defineADValidParams(
     ADVectorTimeDerivative,
-    ADVectorTimeKernel,
+    ADVectorTimeKernelValue,
     params.addClassDescription("The time derivative operator with the weak form of $(\\psi_i, "
                                "\\frac{\\partial u_h}{\\partial t})$."););
 
 template <ComputeStage compute_stage>
 ADVectorTimeDerivative<compute_stage>::ADVectorTimeDerivative(const InputParameters & parameters)
-  : ADVectorTimeKernel<compute_stage>(parameters)
+  : ADVectorTimeKernelValue<compute_stage>(parameters)
 {
 }
 

--- a/modules/heat_conduction/doc/content/source/kernels/ADHeatConduction.md
+++ b/modules/heat_conduction/doc/content/source/kernels/ADHeatConduction.md
@@ -11,12 +11,12 @@ where $k$ denotes the thermal conductivity of the material. $k$ can either be an
 
 This class inherits from the [ADDiffusion](/ADDiffusion.md) class.
 
-!syntax description /Kernels/ADHeatConduction<RESIDUAL>
+!syntax description /Kernels/ADHeatConduction
 
-!syntax parameters /Kernels/ADHeatConduction<RESIDUAL>
+!syntax parameters /Kernels/ADHeatConduction
 
-!syntax inputs /Kernels/ADHeatConduction<RESIDUAL>
+!syntax inputs /Kernels/ADHeatConduction
 
-!syntax children /Kernels/ADHeatConduction<RESIDUAL>
+!syntax children /Kernels/ADHeatConduction
 
 !bibtex bibliography

--- a/modules/heat_conduction/doc/content/source/kernels/ADHeatConductionTimeDerivative.md
+++ b/modules/heat_conduction/doc/content/source/kernels/ADHeatConductionTimeDerivative.md
@@ -19,8 +19,8 @@ where $u_h$ is the approximate solution and $\psi_i$ is a finite element test fu
 The Jacobian is given by automatic differentiation, and should be perfect as long as $c_p$ and $\rho$
 are provided using `ADMaterial` derived objects.
 
-!syntax parameters /Kernels/ADHeatConductionTimeDerivative<RESIDUAL>
+!syntax parameters /Kernels/ADHeatConductionTimeDerivative
 
-!syntax inputs /Kernels/ADHeatConductionTimeDerivative<RESIDUAL>
+!syntax inputs /Kernels/ADHeatConductionTimeDerivative
 
-!syntax children /Kernels/ADHeatConductionTimeDerivative<RESIDUAL>
+!syntax children /Kernels/ADHeatConductionTimeDerivative

--- a/modules/heat_conduction/doc/content/source/kernels/ADMatHeatSource.md
+++ b/modules/heat_conduction/doc/content/source/kernels/ADMatHeatSource.md
@@ -21,10 +21,10 @@ the finite dimensional space $\mathcal{S}^h$ for the unknown ($u$).
 Here, $f$ is given as a material property with an optional constant scalar. The
 Jacobian is calculated automatically via automatic differentiation.
 
-!syntax parameters /Kernels/ADMatHeatSource<RESIDUAL>
+!syntax parameters /Kernels/ADMatHeatSource
 
-!syntax inputs /Kernels/ADMatHeatSource<RESIDUAL>
+!syntax inputs /Kernels/ADMatHeatSource
 
-!syntax children /Kernels/ADMatHeatSource<RESIDUAL>
+!syntax children /Kernels/ADMatHeatSource
 
 !bibtex bibliography

--- a/modules/heat_conduction/include/kernels/ADHeatConductionTimeDerivative.h
+++ b/modules/heat_conduction/include/kernels/ADHeatConductionTimeDerivative.h
@@ -31,7 +31,7 @@ protected:
   /// Density material property
   const ADMaterialProperty(Real) & _density;
 
-  usingTimeKernelMembers;
+  usingTimeDerivativeMembers;
 };
 
 #endif // ADHEATCONDUCTIONTIMEDERIVATIVE_H

--- a/modules/level_set/include/kernels/LevelSetAdvection.h
+++ b/modules/level_set/include/kernels/LevelSetAdvection.h
@@ -11,14 +11,14 @@
 #define LEVELSETADVECTION_H
 
 // MOOSE includes
-#include "Kernel.h"
+#include "ADKernelValue.h"
 #include "LevelSetVelocityInterface.h"
 
 // Forward declarations
+template <ComputeStage>
 class LevelSetAdvection;
 
-template <>
-InputParameters validParams<LevelSetAdvection>();
+declareADValidParams(LevelSetAdvection);
 
 /**
  * Advection Kernel for the levelset equation.
@@ -27,14 +27,18 @@ InputParameters validParams<LevelSetAdvection>();
  * where \vec{v} is the interface velocity that is a set of
  * coupled variables.
  */
-class LevelSetAdvection : public LevelSetVelocityInterface<Kernel>
+template <ComputeStage compute_stage>
+class LevelSetAdvection : public LevelSetVelocityInterface<ADKernelValue<compute_stage>>
 {
 public:
   LevelSetAdvection(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
-  virtual Real computeQpJacobian() override;
+  virtual ADResidual precomputeQpResidual() override;
+
+  usingKernelValueMembers;
+  using LevelSetVelocityInterface<ADKernelValue<compute_stage>>::computeQpVelocity;
+  using LevelSetVelocityInterface<ADKernelValue<compute_stage>>::_velocity;
 };
 
 #endif // LEVELSETADVECTION_H

--- a/modules/level_set/include/kernels/LevelSetAdvectionSUPG.h
+++ b/modules/level_set/include/kernels/LevelSetAdvectionSUPG.h
@@ -11,26 +11,30 @@
 #define LEVELSETADVECTIONSUPG_H
 
 // MOOSE includes
-#include "Kernel.h"
+#include "ADKernelGrad.h"
 #include "LevelSetVelocityInterface.h"
 
 // Forward declarations
+template <ComputeStage>
 class LevelSetAdvectionSUPG;
 
-template <>
-InputParameters validParams<LevelSetAdvectionSUPG>();
+declareADValidParams(LevelSetAdvectionSUPG);
 
 /**
  * SUPG stabilization for the advection portion of the level set equation.
  */
-class LevelSetAdvectionSUPG : public LevelSetVelocityInterface<Kernel>
+template <ComputeStage compute_stage>
+class LevelSetAdvectionSUPG : public LevelSetVelocityInterface<ADKernelGrad<compute_stage>>
 {
 public:
   LevelSetAdvectionSUPG(const InputParameters & parameters);
 
 protected:
-  Real computeQpResidual() override;
-  Real computeQpJacobian() override;
+  virtual ADVectorResidual precomputeQpResidual() override;
+
+  usingKernelGradMembers;
+  using LevelSetVelocityInterface<ADKernelGrad<compute_stage>>::computeQpVelocity;
+  using LevelSetVelocityInterface<ADKernelGrad<compute_stage>>::_velocity;
 };
 
 #endif // LEVELSETADVECTIONSUPG_H

--- a/modules/level_set/include/kernels/LevelSetForcingFunctionSUPG.h
+++ b/modules/level_set/include/kernels/LevelSetForcingFunctionSUPG.h
@@ -11,26 +11,34 @@
 #define LEVELSETFORCINGFUNCTIONSUPG_H
 
 // MOOSE includes
-#include "BodyForce.h"
+#include "ADKernelGrad.h"
 #include "LevelSetVelocityInterface.h"
 
 // Forward declarations
+template <ComputeStage>
 class LevelSetForcingFunctionSUPG;
 
-template <>
-InputParameters validParams<LevelSetForcingFunctionSUPG>();
+declareADValidParams(LevelSetForcingFunctionSUPG);
 
 /**
  * SUPG stabilization term for a forcing function.
  */
-class LevelSetForcingFunctionSUPG : public LevelSetVelocityInterface<BodyForce>
+template <ComputeStage compute_stage>
+class LevelSetForcingFunctionSUPG : public LevelSetVelocityInterface<ADKernelGrad<compute_stage>>
 {
 public:
   LevelSetForcingFunctionSUPG(const InputParameters & parameters);
 
 protected:
-  Real computeQpResidual() override;
-  Real computeQpJacobian() override;
+  virtual ADVectorResidual precomputeQpResidual() override;
+
+  /// Function value
+  Function & _function;
+
+  usingKernelGradMembers;
+  using LevelSetVelocityInterface<ADKernelGrad<compute_stage>>::computeQpVelocity;
+  using LevelSetVelocityInterface<ADKernelGrad<compute_stage>>::_velocity;
+  using LevelSetVelocityInterface<ADKernelGrad<compute_stage>>::_q_point;
 };
 
 #endif // LEVELSETFORCINGFUNCTIONSUPG_H

--- a/modules/level_set/include/kernels/LevelSetOlssonReinitialization.h
+++ b/modules/level_set/include/kernels/LevelSetOlssonReinitialization.h
@@ -11,38 +11,34 @@
 #define LEVELSETOLSSONREINITIALIZATION_H
 
 // MOOSE includes
-#include "Kernel.h"
+#include "ADKernelGrad.h"
 
 // Forward declarations
+template <ComputeStage>
 class LevelSetOlssonReinitialization;
 
-template <>
-InputParameters validParams<LevelSetOlssonReinitialization>();
+declareADValidParams(LevelSetOlssonReinitialization);
 
 /**
  * Implements the re-initialization equation proposed by Olsson et. al. (2007).
  */
-class LevelSetOlssonReinitialization : public Kernel
+template <ComputeStage compute_stage>
+class LevelSetOlssonReinitialization : public ADKernelGrad<compute_stage>
 {
 public:
   LevelSetOlssonReinitialization(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual() override;
-  virtual Real computeQpJacobian() override;
+  virtual ADVectorResidual precomputeQpResidual() override;
 
   /// Gradient of the level set variable at time, \tau = 0.
-  const VariableGradient & _grad_levelset_0;
+  const ADVariableGradient & _grad_levelset_0;
 
   /// Interface thickness
   const PostprocessorValue & _epsilon;
 
-  ///@{
-  /// Helper members to avoid initializing variables in computeQpResidual/Jacobian
-  RealVectorValue _f;
-  Real _s;
-  RealVectorValue _n_hat;
-  ///@}
+  usingKernelGradMembers;
+  using ADKernelGrad<compute_stage>::getPostprocessorValue;
 };
 
 #endif // LEVELSETOLSSONREINITIALIZATION_H

--- a/modules/level_set/include/kernels/LevelSetTimeDerivativeSUPG.h
+++ b/modules/level_set/include/kernels/LevelSetTimeDerivativeSUPG.h
@@ -11,19 +11,20 @@
 #define LEVELSETTIMEDERIVATIVESUPG_H
 
 // MOOSE includes
-#include "TimeDerivative.h"
+#include "ADTimeKernelGrad.h"
 #include "LevelSetVelocityInterface.h"
 
 // Forward declarations
+template <ComputeStage>
 class LevelSetTimeDerivativeSUPG;
 
-template <>
-InputParameters validParams<LevelSetTimeDerivativeSUPG>();
+declareADValidParams(LevelSetTimeDerivativeSUPG);
 
 /**
  * Applies SUPG stabilization to the time derivative.
  */
-class LevelSetTimeDerivativeSUPG : public LevelSetVelocityInterface<TimeDerivative>
+template <ComputeStage compute_stage>
+class LevelSetTimeDerivativeSUPG : public LevelSetVelocityInterface<ADTimeKernelGrad<compute_stage>>
 {
 public:
   LevelSetTimeDerivativeSUPG(const InputParameters & parameters);

--- a/modules/level_set/include/kernels/LevelSetTimeDerivativeSUPG.h
+++ b/modules/level_set/include/kernels/LevelSetTimeDerivativeSUPG.h
@@ -29,8 +29,11 @@ public:
   LevelSetTimeDerivativeSUPG(const InputParameters & parameters);
 
 protected:
-  Real computeQpResidual() override;
-  Real computeQpJacobian() override;
+  virtual ADVectorResidual precomputeQpResidual() override;
+
+  usingTimeKernelGradMembers;
+  using LevelSetVelocityInterface<ADTimeKernelGrad<compute_stage>>::computeQpVelocity;
+  using LevelSetVelocityInterface<ADTimeKernelGrad<compute_stage>>::_velocity;
 };
 
 #endif // LEVELSETTIMEDERIVATIVESUPG_H

--- a/modules/level_set/src/kernels/LevelSetAdvection.C
+++ b/modules/level_set/src/kernels/LevelSetAdvection.C
@@ -10,35 +10,26 @@
 // MOOSE includes
 #include "LevelSetAdvection.h"
 
-registerMooseObject("LevelSetApp", LevelSetAdvection);
+registerADMooseObject("LevelSetApp", LevelSetAdvection);
 
-template <>
-InputParameters
-validParams<LevelSetAdvection>()
-{
-  InputParameters params = validParams<Kernel>();
-  params.addClassDescription("Implements the level set advection equation: $\\vec{v}\\cdot\\nabla "
-                             "u = 0$, where the weak form is $(\\psi_i, \\vec{v}\\cdot\\nabla u) = "
-                             "0$.");
-  params += validParams<LevelSetVelocityInterface<>>();
-  return params;
-}
+defineADValidParams(LevelSetAdvection,
+                    ADKernelValue,
+                    params.addClassDescription(
+                        "Implements the level set advection equation: $\\vec{v}\\cdot\\nabla "
+                        "u = 0$, where the weak form is $(\\psi_i, \\vec{v}\\cdot\\nabla u) = "
+                        "0$.");
+                    params += validParams<LevelSetVelocityInterface<>>(););
 
-LevelSetAdvection::LevelSetAdvection(const InputParameters & parameters)
-  : LevelSetVelocityInterface<Kernel>(parameters)
+template <ComputeStage compute_stage>
+LevelSetAdvection<compute_stage>::LevelSetAdvection(const InputParameters & parameters)
+  : LevelSetVelocityInterface<ADKernelValue<compute_stage>>(parameters)
 {
 }
 
-Real
-LevelSetAdvection::computeQpResidual()
+template <ComputeStage compute_stage>
+ADResidual
+LevelSetAdvection<compute_stage>::precomputeQpResidual()
 {
   computeQpVelocity();
-  return _test[_i][_qp] * (_velocity * _grad_u[_qp]);
-}
-
-Real
-LevelSetAdvection::computeQpJacobian()
-{
-  computeQpVelocity();
-  return _test[_i][_qp] * (_velocity * _grad_phi[_j][_qp]);
+  return _velocity * _grad_u[_qp];
 }

--- a/modules/level_set/src/kernels/LevelSetTimeDerivativeSUPG.C
+++ b/modules/level_set/src/kernels/LevelSetTimeDerivativeSUPG.C
@@ -11,19 +11,17 @@
 
 registerMooseObject("LevelSetApp", LevelSetTimeDerivativeSUPG);
 
-template <>
-InputParameters
-validParams<LevelSetTimeDerivativeSUPG>()
-{
-  InputParameters params = validParams<TimeDerivative>();
-  params.addClassDescription(
-      "SUPG stablization terms for the time derivative of the level set equation.");
-  params += validParams<LevelSetVelocityInterface<>>();
-  return params;
-}
+defineADValidParams(
+    LevelSetTimeDerivativeSUPG,
+    ADTimeKernelGrad,
+    params.addClassDescription(
+        "SUPG stablization terms for the time derivative of the level set equation.");
+    params += validParams<LevelSetVelocityInterface<>>(););
 
-LevelSetTimeDerivativeSUPG::LevelSetTimeDerivativeSUPG(const InputParameters & parameters)
-  : LevelSetVelocityInterface<TimeDerivative>(parameters)
+template <ComputeStage compute_stage>
+LevelSetTimeDerivativeSUPG<compute_stage>::LevelSetTimeDerivativeSUPG(
+    const InputParameters & parameters)
+  : LevelSetVelocityInterface<ADTimeKernelGrad<compute_stage>>(parameters)
 {
 }
 

--- a/modules/level_set/src/kernels/LevelSetTimeDerivativeSUPG.C
+++ b/modules/level_set/src/kernels/LevelSetTimeDerivativeSUPG.C
@@ -9,7 +9,7 @@
 
 #include "LevelSetTimeDerivativeSUPG.h"
 
-registerMooseObject("LevelSetApp", LevelSetTimeDerivativeSUPG);
+registerADMooseObject("LevelSetApp", LevelSetTimeDerivativeSUPG);
 
 defineADValidParams(
     LevelSetTimeDerivativeSUPG,
@@ -25,18 +25,11 @@ LevelSetTimeDerivativeSUPG<compute_stage>::LevelSetTimeDerivativeSUPG(
 {
 }
 
-Real
-LevelSetTimeDerivativeSUPG::computeQpResidual()
+template <ComputeStage compute_stage>
+ADVectorResidual
+LevelSetTimeDerivativeSUPG<compute_stage>::precomputeQpResidual()
 {
   computeQpVelocity();
   Real tau = _current_elem->hmin() / (2 * _velocity.norm());
-  return tau * _velocity * _grad_test[_i][_qp] * _u_dot[_qp];
-}
-
-Real
-LevelSetTimeDerivativeSUPG::computeQpJacobian()
-{
-  computeQpVelocity();
-  Real tau = _current_elem->hmin() / (2 * _velocity.norm());
-  return tau * _velocity * _grad_test[_i][_qp] * _phi[_j][_qp] * _du_dot_du[_qp];
+  return tau * _velocity * _u_dot[_qp];
 }

--- a/modules/misc/doc/content/source/kernels/ADMatDiffusion.md
+++ b/modules/misc/doc/content/source/kernels/ADMatDiffusion.md
@@ -12,10 +12,10 @@ The complete Jacobian contributions are provided by automatic differentiation as
 
 This class inherits from the [ADDiffusion](/ADDiffusion.md) class.
 
-!syntax parameters /Kernels/ADMatDiffusion<RESIDUAL>
+!syntax parameters /Kernels/ADMatDiffusion
 
-!syntax inputs /Kernels/ADMatDiffusion<RESIDUAL>
+!syntax inputs /Kernels/ADMatDiffusion
 
-!syntax children /Kernels/ADMatDiffusion<RESIDUAL>
+!syntax children /Kernels/ADMatDiffusion
 
 !bibtex bibliography

--- a/modules/misc/doc/content/source/kernels/ADThermoDiffusion.md
+++ b/modules/misc/doc/content/source/kernels/ADThermoDiffusion.md
@@ -13,10 +13,10 @@ species concentration, temperature, and other material parameters. $S$ is kept
 agnostic in this formulation and ultimately needs to be formulated in a separate
 material property definition.
 
-!syntax parameters /Kernels/ADThermoDiffusion<RESIDUAL>
+!syntax parameters /Kernels/ADThermoDiffusion
 
-!syntax inputs /Kernels/ADThermoDiffusion<RESIDUAL>
+!syntax inputs /Kernels/ADThermoDiffusion
 
-!syntax children /Kernels/ADThermoDiffusion<RESIDUAL>
+!syntax children /Kernels/ADThermoDiffusion
 
 !bibtex bibliography

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMass.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMass.md
@@ -3,10 +3,10 @@
 This object computes the residual and Jacobian contribution of the
 incompressible version of the mass continuity equation, e.g. $\nabla\cdot\vec u$.
 
-!syntax description /Kernels/INSADMass<RESIDUAL>
+!syntax description /Kernels/INSADMass
 
-!syntax parameters /Kernels/INSADMass<RESIDUAL>
+!syntax parameters /Kernels/INSADMass
 
-!syntax inputs /Kernels/INSADMass<RESIDUAL>
+!syntax inputs /Kernels/INSADMass
 
-!syntax children /Kernels/INSADMass<RESIDUAL>
+!syntax children /Kernels/INSADMass

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMassPSPG.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMassPSPG.md
@@ -10,10 +10,10 @@ on-diagonal dependence, the saddle point nature of the incompressible equations
 is removed and equal order shape functions can be used for velocity and pressure
 variables.
 
-!syntax description /Kernels/INSADMassPSPG<RESIDUAL>
+!syntax description /Kernels/INSADMassPSPG
 
-!syntax parameters /Kernels/INSADMassPSPG<RESIDUAL>
+!syntax parameters /Kernels/INSADMassPSPG
 
-!syntax inputs /Kernels/INSADMassPSPG<RESIDUAL>
+!syntax inputs /Kernels/INSADMassPSPG
 
-!syntax children /Kernels/INSADMassPSPG<RESIDUAL>
+!syntax children /Kernels/INSADMassPSPG

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumAdvection.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumAdvection.md
@@ -5,10 +5,10 @@ incompressible Navier Stokes momentum equation. Note that in the code we right
 multiply by $\vec u$, e.g. we perform $\nabla\vec u \cdot \vec u$ because
 $\nabla \vec u$ is stored in [Jacobian matrix form](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant).
 
-!syntax description /Kernels/INSADMomentumAdvection<RESIDUAL>
+!syntax description /Kernels/INSADMomentumAdvection
 
-!syntax parameters /Kernels/INSADMomentumAdvection<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumAdvection
 
-!syntax inputs /Kernels/INSADMomentumAdvection<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumAdvection
 
-!syntax children /Kernels/INSADMomentumAdvection<RESIDUAL>
+!syntax children /Kernels/INSADMomentumAdvection

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumForces.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumForces.md
@@ -6,10 +6,10 @@ $\vec g$ is a gravity vector, and $\vec f$ represents an optionally user
 specified body vector force. Note that the gravity and body forces are specified
 through inputs to the [`INSADMaterial`](/INSADMaterial.md).
 
-!syntax description /Kernels/INSADMomentumForces<RESIDUAL>
+!syntax description /Kernels/INSADMomentumForces
 
-!syntax parameters /Kernels/INSADMomentumForces<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumForces
 
-!syntax inputs /Kernels/INSADMomentumForces<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumForces
 
-!syntax children /Kernels/INSADMomentumForces<RESIDUAL>
+!syntax children /Kernels/INSADMomentumForces

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumPressure.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumPressure.md
@@ -5,10 +5,10 @@ incompressible Navier Stokes momentum equation. The user can specify a boolean
 for the `integrate_p_by_parts` input parameter to determine whether this term
 will be integrated by parts for the weak form.
 
-!syntax description /Kernels/INSADMomentumPressure<RESIDUAL>
+!syntax description /Kernels/INSADMomentumPressure
 
-!syntax parameters /Kernels/INSADMomentumPressure<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumPressure
 
-!syntax inputs /Kernels/INSADMomentumPressure<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumPressure
 
-!syntax children /Kernels/INSADMomentumPressure<RESIDUAL>
+!syntax children /Kernels/INSADMomentumPressure

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumSUPG.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumSUPG.md
@@ -7,10 +7,10 @@ residual of the momentum equation. This term adds additional (consistent)
 streamline diffusion such that higher Reynolds numbers can be simulated without
 producing crippling oscillations.
 
-!syntax description /Kernels/INSADMomentumSUPG<RESIDUAL>
+!syntax description /Kernels/INSADMomentumSUPG
 
-!syntax parameters /Kernels/INSADMomentumSUPG<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumSUPG
 
-!syntax inputs /Kernels/INSADMomentumSUPG<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumSUPG
 
-!syntax children /Kernels/INSADMomentumSUPG<RESIDUAL>
+!syntax children /Kernels/INSADMomentumSUPG

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumTimeDerivative.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumTimeDerivative.md
@@ -4,10 +4,10 @@ This object adds the $\rho\frac{\partial \vec u}{\partial t}$ term of the
 incompressible Navier Stokes momentum equation where $\rho$ is the density,
 $\vec u$ is the velocity, and $t$ is time.
 
-!syntax description /Kernels/INSADMomentumTimeDerivative<RESIDUAL>
+!syntax description /Kernels/INSADMomentumTimeDerivative
 
-!syntax parameters /Kernels/INSADMomentumTimeDerivative<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumTimeDerivative
 
-!syntax inputs /Kernels/INSADMomentumTimeDerivative<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumTimeDerivative
 
-!syntax children /Kernels/INSADMomentumTimeDerivative<RESIDUAL>
+!syntax children /Kernels/INSADMomentumTimeDerivative

--- a/modules/navier_stokes/doc/content/source/kernels/INSADMomentumViscous.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADMomentumViscous.md
@@ -5,10 +5,10 @@ incompressible Navier Stokes momentum equation. Note that we have used the
 condition that $\nabla \cdot \vec u = 0$ to arrive at the above form (e.g. we
 are using the *Laplacian* form of the viscous term).
 
-!syntax description /Kernels/INSADMomentumViscous<RESIDUAL>
+!syntax description /Kernels/INSADMomentumViscous
 
-!syntax parameters /Kernels/INSADMomentumViscous<RESIDUAL>
+!syntax parameters /Kernels/INSADMomentumViscous
 
-!syntax inputs /Kernels/INSADMomentumViscous<RESIDUAL>
+!syntax inputs /Kernels/INSADMomentumViscous
 
-!syntax children /Kernels/INSADMomentumViscous<RESIDUAL>
+!syntax children /Kernels/INSADMomentumViscous

--- a/modules/navier_stokes/doc/content/source/kernels/INSADTemperatureAdvection.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADTemperatureAdvection.md
@@ -6,10 +6,10 @@ specific heat capacity,
 $\vec u$ is the velocity (represented by `_U` in the code), and $\nabla T$ is the temperature gradient
 (represented by `_grad_u` in the code).
 
-!syntax description /Kernels/INSADTemperatureAdvection<RESIDUAL>
+!syntax description /Kernels/INSADTemperatureAdvection
 
-!syntax parameters /Kernels/INSADTemperatureAdvection<RESIDUAL>
+!syntax parameters /Kernels/INSADTemperatureAdvection
 
-!syntax inputs /Kernels/INSADTemperatureAdvection<RESIDUAL>
+!syntax inputs /Kernels/INSADTemperatureAdvection
 
-!syntax children /Kernels/INSADTemperatureAdvection<RESIDUAL>
+!syntax children /Kernels/INSADTemperatureAdvection

--- a/modules/navier_stokes/doc/content/source/materials/INSADMaterial.md
+++ b/modules/navier_stokes/doc/content/source/materials/INSADMaterial.md
@@ -4,10 +4,10 @@ This object computes strong residuals that are then used in stabilization
 kernels as well as in the core INSAD kernels where the strong and weak forms are
 the same, e.g. terms that have no integration by parts.
 
-!syntax description /Materials/INSADMaterial<RESIDUAL>
+!syntax description /Materials/INSADMaterial
 
-!syntax parameters /Materials/INSADMaterial<RESIDUAL>
+!syntax parameters /Materials/INSADMaterial
 
-!syntax inputs /Materials/INSADMaterial<RESIDUAL>
+!syntax inputs /Materials/INSADMaterial
 
-!syntax children /Materials/INSADMaterial<RESIDUAL>
+!syntax children /Materials/INSADMaterial

--- a/modules/navier_stokes/doc/content/source/materials/INSADTauMaterial.md
+++ b/modules/navier_stokes/doc/content/source/materials/INSADTauMaterial.md
@@ -3,10 +3,10 @@
 This object computes the stabilization parameter $\tau$ for use in
 pressure-stablized and streamline-upwind kernels.
 
-!syntax description /Materials/INSADTauMaterial<RESIDUAL>
+!syntax description /Materials/INSADTauMaterial
 
-!syntax parameters /Materials/INSADTauMaterial<RESIDUAL>
+!syntax parameters /Materials/INSADTauMaterial
 
-!syntax inputs /Materials/INSADTauMaterial<RESIDUAL>
+!syntax inputs /Materials/INSADTauMaterial
 
-!syntax children /Materials/INSADTauMaterial<RESIDUAL>
+!syntax children /Materials/INSADTauMaterial

--- a/modules/navier_stokes/include/kernels/INSADMomentumTimeDerivative.h
+++ b/modules/navier_stokes/include/kernels/INSADMomentumTimeDerivative.h
@@ -10,7 +10,7 @@
 #ifndef INSADMOMENTUMTIMEDERIVATIVE_H
 #define INSADMOMENTUMTIMEDERIVATIVE_H
 
-#include "ADTimeKernel.h"
+#include "ADTimeKernelValue.h"
 
 // Forward Declarations
 template <ComputeStage compute_stage>
@@ -24,7 +24,7 @@ declareADValidParams(INSADMomentumTimeDerivative);
  * for this.
  */
 template <ComputeStage compute_stage>
-class INSADMomentumTimeDerivative : public ADVectorTimeKernel<compute_stage>
+class INSADMomentumTimeDerivative : public ADVectorTimeKernelValue<compute_stage>
 {
 public:
   INSADMomentumTimeDerivative(const InputParameters & parameters);
@@ -36,7 +36,7 @@ protected:
 
   const ADMaterialProperty(Real) & _rho;
 
-  usingVectorTimeKernelMembers;
+  usingVectorTimeKernelValueMembers;
 };
 
 #endif // INSADMOMENTUMTIMEDERIVATIVE_H

--- a/modules/navier_stokes/src/kernels/INSADMomentumTimeDerivative.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumTimeDerivative.C
@@ -13,7 +13,7 @@ registerADMooseObject("NavierStokesApp", INSADMomentumTimeDerivative);
 
 defineADValidParams(
     INSADMomentumTimeDerivative,
-    ADTimeKernel,
+    ADTimeKernelValue,
     params.addClassDescription("This class computes the time derivative for the incompressible "
                                "Navier-Stokes momentum equation.");
     params.addCoupledVar("temperature",
@@ -25,7 +25,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 INSADMomentumTimeDerivative<compute_stage>::INSADMomentumTimeDerivative(
     const InputParameters & parameters)
-  : ADVectorTimeKernel<compute_stage>(parameters), _rho(adGetADMaterialProperty<Real>("rho_name"))
+  : ADVectorTimeKernelValue<compute_stage>(parameters),
+    _rho(adGetADMaterialProperty<Real>("rho_name"))
 {
 }
 

--- a/modules/phase_field/doc/content/source/kernels/ADSplitCHParsed.md
+++ b/modules/phase_field/doc/content/source/kernels/ADSplitCHParsed.md
@@ -1,6 +1,6 @@
 # ADSplitCHParsed
 
-!syntax description /Kernels/ADSplitCHParsed<RESIDUAL>
+!syntax description /Kernels/ADSplitCHParsed
 
 Implements the weak form
 
@@ -18,10 +18,10 @@ It is used together with [`ADSplitCHWRes`](/ADSplitCHWRes.md) and
 two first order PDEs using a concentration order parameter and a chemical
 potential variable.
 
-!syntax parameters /Kernels/ADSplitCHParsed<RESIDUAL>
+!syntax parameters /Kernels/ADSplitCHParsed
 
-!syntax inputs /Kernels/ADSplitCHParsed<RESIDUAL>
+!syntax inputs /Kernels/ADSplitCHParsed
 
-!syntax children /Kernels/ADSplitCHParsed<RESIDUAL>
+!syntax children /Kernels/ADSplitCHParsed
 
 !bibtex bibliography

--- a/modules/phase_field/doc/content/source/kernels/ADSplitCHWRes.md
+++ b/modules/phase_field/doc/content/source/kernels/ADSplitCHWRes.md
@@ -1,6 +1,6 @@
 # ADSplitCHWRes
 
-!syntax description /Kernels/ADSplitCHWRes<RESIDUAL>
+!syntax description /Kernels/ADSplitCHWRes
 
 This kernel implements the weak form
 
@@ -18,10 +18,10 @@ potential variable.
 For an implementation with an anisotropic (tensorial) mobility see
 [`ADSplitCHWResAniso`](/ADSplitCHWResAniso.md).
 
-!syntax parameters /Kernels/ADSplitCHWRes<RESIDUAL>
+!syntax parameters /Kernels/ADSplitCHWRes
 
-!syntax inputs /Kernels/ADSplitCHWRes<RESIDUAL>
+!syntax inputs /Kernels/ADSplitCHWRes
 
-!syntax children /Kernels/ADSplitCHWRes<RESIDUAL>
+!syntax children /Kernels/ADSplitCHWRes
 
 !bibtex bibliography

--- a/modules/phase_field/doc/content/source/kernels/ADSplitCHWResAniso.md
+++ b/modules/phase_field/doc/content/source/kernels/ADSplitCHWResAniso.md
@@ -1,14 +1,14 @@
 # ADSplitCHWResAniso
 
-!syntax description /Kernels/ADSplitCHWResAniso<RESIDUAL>
+!syntax description /Kernels/ADSplitCHWResAniso
 
 This is anisotropic version of [`ADSplitCHWRes`](/ADSplitCHWRes.md) and expects
 a tensor valued mobility $M$.
 
-!syntax parameters /Kernels/ADSplitCHWResAniso<RESIDUAL>
+!syntax parameters /Kernels/ADSplitCHWResAniso
 
-!syntax inputs /Kernels/ADSplitCHWResAniso<RESIDUAL>
+!syntax inputs /Kernels/ADSplitCHWResAniso
 
-!syntax children /Kernels/ADSplitCHWResAniso<RESIDUAL>
+!syntax children /Kernels/ADSplitCHWResAniso
 
 !bibtex bibliography

--- a/modules/phase_field/doc/content/source/materials/ADMathFreeEnergy.md
+++ b/modules/phase_field/doc/content/source/materials/ADMathFreeEnergy.md
@@ -14,10 +14,10 @@ This free energy can be used with the AD version of the split Cahn-Hilliard
 equation ([`ADSplitCHWRes`](/ADSplitCHWRes.md) and
 [`ADSplitCHParsed`](/ADSplitCHParsed.md)).
 
-!syntax parameters /Materials/ADMathFreeEnergy<RESIDUAL>
+!syntax parameters /Materials/ADMathFreeEnergy
 
-!syntax inputs /Materials/ADMathFreeEnergy<RESIDUAL>
+!syntax inputs /Materials/ADMathFreeEnergy
 
-!syntax children /Materials/ADMathFreeEnergy<RESIDUAL>
+!syntax children /Materials/ADMathFreeEnergy
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADGravity.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADGravity.md
@@ -1,6 +1,6 @@
 # ADGravity
 
-!syntax description /Kernels/ADGravity<RESIDUAL>
+!syntax description /Kernels/ADGravity
 
 ## Description
 
@@ -18,8 +18,8 @@ the ADGravity body force per unit mass.
 
 !listing modules/tensor_mechanics/test/tests/gravity/ad_gravity_test.i block=Kernels/gravity_y
 
-!syntax parameters /Kernels/ADGravity<RESIDUAL>
+!syntax parameters /Kernels/ADGravity
 
-!syntax inputs /Kernels/ADGravity<RESIDUAL>
+!syntax inputs /Kernels/ADGravity
 
-!syntax children /Kernels/ADGravity<RESIDUAL>
+!syntax children /Kernels/ADGravity

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceRSphericalTensors.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceRSphericalTensors.md
@@ -1,6 +1,6 @@
 # ADStressDivergenceRSphericalTensors
 
-!syntax description /Kernels/ADStressDivergenceRSphericalTensors<RESIDUAL>
+!syntax description /Kernels/ADStressDivergenceRSphericalTensors
 
 ## Description
 
@@ -33,10 +33,10 @@ In deriving the weak form of this equation, the second term in
 The coordinate type in the `[Problem]` block of the input file must be set to
 `coord_type = RSPHERICAL`.
 
-!syntax parameters /Kernels/ADStressDivergenceRSphericalTensors<RESIDUAL>
+!syntax parameters /Kernels/ADStressDivergenceRSphericalTensors
 
 !include modules/tensor_mechanics/common/seealsoADStressDivergenceKernels.md
 
-!syntax inputs /Kernels/ADStressDivergenceRSphericalTensors<RESIDUAL>
+!syntax inputs /Kernels/ADStressDivergenceRSphericalTensors
 
-!syntax children /Kernels/ADStressDivergenceRSphericalTensors<RESIDUAL>
+!syntax children /Kernels/ADStressDivergenceRSphericalTensors

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceRZTensors.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceRZTensors.md
@@ -1,6 +1,6 @@
 # ADStressDivergenceRZTensors
 
-!syntax description /Kernels/ADStressDivergenceRZTensors<RESIDUAL>
+!syntax description /Kernels/ADStressDivergenceRZTensors
 
 ## Description
 
@@ -39,10 +39,10 @@ input files and when adding extra stresses.
 The coordinate type in the `[Problem]` block of the input file must be set to
 `coord_type = RZ`.
 
-!syntax parameters /Kernels/ADStressDivergenceRZTensors<RESIDUAL>
+!syntax parameters /Kernels/ADStressDivergenceRZTensors
 
 !include modules/tensor_mechanics/common/seealsoADStressDivergenceKernels.md
 
-!syntax inputs /Kernels/ADStressDivergenceRZTensors<RESIDUAL>
+!syntax inputs /Kernels/ADStressDivergenceRZTensors
 
-!syntax children /Kernels/ADStressDivergenceRZTensors<RESIDUAL>
+!syntax children /Kernels/ADStressDivergenceRZTensors

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceTensors.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADStressDivergenceTensors.md
@@ -1,6 +1,6 @@
 # ADStressDivergenceTensors
 
-!syntax description /Kernels/ADStressDivergenceTensors<RESIDUAL>
+!syntax description /Kernels/ADStressDivergenceTensors
 
 ## Description
 
@@ -17,10 +17,10 @@ calculator for the Cartesian system.
 
 ## Example Input File syntax
 
-!syntax parameters /Kernels/ADStressDivergenceTensors<RESIDUAL>
+!syntax parameters /Kernels/ADStressDivergenceTensors
 
 !include modules/tensor_mechanics/common/seealsoADStressDivergenceKernels.md
 
-!syntax inputs /Kernels/ADStressDivergenceTensors<RESIDUAL>
+!syntax inputs /Kernels/ADStressDivergenceTensors
 
-!syntax children /Kernels/ADStressDivergenceTensors<RESIDUAL>
+!syntax children /Kernels/ADStressDivergenceTensors

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZFiniteStrain.md
@@ -1,6 +1,6 @@
 # ADComputeAxisymmetricRZFiniteStrain
 
-!syntax description /Materials/ADComputeAxisymmetricRZFiniteStrain<RESIDUAL>
+!syntax description /Materials/ADComputeAxisymmetricRZFiniteStrain
 
 ## Description
 
@@ -16,10 +16,10 @@ default 3D Cartesian simulations, as described in the
 
 ## Example Input File
 
-!syntax parameters /Materials/ADComputeAxisymmetricRZFiniteStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeAxisymmetricRZFiniteStrain
 
-!syntax inputs /Materials/ADComputeAxisymmetricRZFiniteStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeAxisymmetricRZFiniteStrain
 
-!syntax children /Materials/ADComputeAxisymmetricRZFiniteStrain<RESIDUAL>
+!syntax children /Materials/ADComputeAxisymmetricRZFiniteStrain
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZIncrementalStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZIncrementalStrain.md
@@ -1,6 +1,6 @@
 # ADComputeAxisymmetricRZIncrementalStrain
 
-!syntax description /Materials/ADComputeAxisymmetricRZIncrementalStrain<RESIDUAL>
+!syntax description /Materials/ADComputeAxisymmetricRZIncrementalStrain
 
 ## Description
 
@@ -14,8 +14,8 @@ deformation gradient is passed to the strain and rotation methods used by
 default 3D Cartesian simulations, as described in the
 [Incremental Finite Strain Class](ADComputeIncrementalSmallStrain.md) page.
 
-!syntax parameters /Materials/ADComputeAxisymmetricRZIncrementalStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeAxisymmetricRZIncrementalStrain
 
-!syntax inputs /Materials/ADComputeAxisymmetricRZIncrementalStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeAxisymmetricRZIncrementalStrain
 
-!syntax children /Materials/ADComputeAxisymmetricRZIncrementalStrain<RESIDUAL>
+!syntax children /Materials/ADComputeAxisymmetricRZIncrementalStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeAxisymmetricRZSmallStrain.md
@@ -1,6 +1,6 @@
 # ADComputeAxisymmetricRZSmallStrain
 
-!syntax description /Materials/ADComputeAxisymmetricRZSmallStrain<RESIDUAL>
+!syntax description /Materials/ADComputeAxisymmetricRZSmallStrain
 
 ## Description
 
@@ -15,8 +15,8 @@ axisymmetric problem. The axisymmetric specific
 calculate the total strain component $\epsilon_{\theta \theta}$ before
 calculating the total strain measure with the small strain assumptions.
 
-!syntax parameters /Materials/ADComputeAxisymmetricRZSmallStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeAxisymmetricRZSmallStrain
 
-!syntax inputs /Materials/ADComputeAxisymmetricRZSmallStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeAxisymmetricRZSmallStrain
 
-!syntax children /Materials/ADComputeAxisymmetricRZSmallStrain<RESIDUAL>
+!syntax children /Materials/ADComputeAxisymmetricRZSmallStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeEigenstrain.md
@@ -1,6 +1,6 @@
 # ADComputeEigenstrain
 
-!syntax description /Materials/ADComputeEigenstrain<RESIDUAL>
+!syntax description /Materials/ADComputeEigenstrain
 
 ## Description
 
@@ -21,10 +21,10 @@ Based on the number and values of constants provided as the argument to the `eig
 
 !listing modules/tensor_mechanics/test/tests/visco/gen_kv_driving.i block=Materials/eigen
 
-!syntax parameters /Materials/ADComputeEigenstrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeEigenstrain
 
-!syntax inputs /Materials/ADComputeEigenstrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeEigenstrain
 
-!syntax children /Materials/ADComputeEigenstrain<RESIDUAL>
+!syntax children /Materials/ADComputeEigenstrain
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeFiniteStrain.md
@@ -1,6 +1,6 @@
 # ADComputeFiniteStrain
 
-!syntax description /Materials/ADComputeFiniteStrain<RESIDUAL>
+!syntax description /Materials/ADComputeFiniteStrain
 
 ## Description
 
@@ -186,10 +186,10 @@ in the TensorMechanics module overview. In addition, be aware of the loading
 cycle limitations while using finite strains as outlined in the section
 [Large Strain Closed Loop Loading Cycle](/tensor_mechanics/Strains.md#large_strain_closed_loop_loading_cycle).
 
-!syntax parameters /Materials/ADComputeFiniteStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeFiniteStrain
 
-!syntax inputs /Materials/ADComputeFiniteStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeFiniteStrain
 
-!syntax children /Materials/ADComputeFiniteStrain<RESIDUAL>
+!syntax children /Materials/ADComputeFiniteStrain
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeFiniteStrainElasticStress.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeFiniteStrainElasticStress.md
@@ -1,6 +1,6 @@
 # ADComputeFiniteStrainElasticStress
 
-!syntax description /Materials/ADComputeFiniteStrainElasticStress<RESIDUAL>
+!syntax description /Materials/ADComputeFiniteStrainElasticStress
 
 ## Description
 
@@ -26,8 +26,8 @@ where $\Delta \boldsymbol{\epsilon}$ is the strain increment; this strain
 measure is also the sum of the mechanical elastic strain and any eigenstrains in
 the system.
 
-!syntax parameters /Materials/ADComputeFiniteStrainElasticStress<RESIDUAL>
+!syntax parameters /Materials/ADComputeFiniteStrainElasticStress
 
-!syntax inputs /Materials/ADComputeFiniteStrainElasticStress<RESIDUAL>
+!syntax inputs /Materials/ADComputeFiniteStrainElasticStress
 
-!syntax children /Materials/ADComputeFiniteStrainElasticStress<RESIDUAL>
+!syntax children /Materials/ADComputeFiniteStrainElasticStress

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeGreenLagrangeStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeGreenLagrangeStrain.md
@@ -1,6 +1,6 @@
 # ADComputeGreenLagrangeStrain
 
-!syntax description /Materials/ADComputeGreenLagrangeStrain<RESIDUAL>
+!syntax description /Materials/ADComputeGreenLagrangeStrain
 
 The Green-Lagrange strain $E$ is a non-linear total strain
 
@@ -13,10 +13,10 @@ ADComputeLinearElasticStress to compute a second Piola-Kirchhoff stress (use the
 ADStressDivergence kernel on the *undisplaced* mesh). This combination is
 called a St. Venant-Kirchhoff hyper elasticity model.
 
-!syntax parameters /Materials/ADComputeGreenLagrangeStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeGreenLagrangeStrain
 
-!syntax inputs /Materials/ADComputeGreenLagrangeStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeGreenLagrangeStrain
 
-!syntax children /Materials/ADComputeGreenLagrangeStrain<RESIDUAL>
+!syntax children /Materials/ADComputeGreenLagrangeStrain
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeIncrementalSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeIncrementalSmallStrain.md
@@ -1,6 +1,6 @@
 # ADComputeIncrementalSmallStrain
 
-!syntax description /Materials/ADComputeIncrementalSmallStrain<RESIDUAL>
+!syntax description /Materials/ADComputeIncrementalSmallStrain
 
 ## Description
 
@@ -25,8 +25,8 @@ properties, including `strain_old` and `stress_old`, are stored. This
 incremental small strain material is useful as a component of verifying more
 complex finite incremental strain-stress calculations.
 
-!syntax parameters /Materials/ADComputeIncrementalSmallStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeIncrementalSmallStrain
 
-!syntax inputs /Materials/ADComputeIncrementalSmallStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeIncrementalSmallStrain
 
-!syntax children /Materials/ADComputeIncrementalSmallStrain<RESIDUAL>
+!syntax children /Materials/ADComputeIncrementalSmallStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeLinearElasticStress.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeLinearElasticStress.md
@@ -1,6 +1,6 @@
 # ADComputeLinearElasticStress
 
-!syntax description /Materials/ADComputeLinearElasticStress<RESIDUAL>
+!syntax description /Materials/ADComputeLinearElasticStress
 
 ## Description
 
@@ -23,8 +23,8 @@ where $\boldsymbol{\epsilon}^{total}$ is the total strain formulation; this
 strain measure is also the sum of the mechanical elastic strain and any
 eigenstrains in the system.
 
-!syntax parameters /Materials/ADComputeLinearElasticStress<RESIDUAL>
+!syntax parameters /Materials/ADComputeLinearElasticStress
 
-!syntax inputs /Materials/ADComputeLinearElasticStress<RESIDUAL>
+!syntax inputs /Materials/ADComputeLinearElasticStress
 
-!syntax children /Materials/ADComputeLinearElasticStress<RESIDUAL>
+!syntax children /Materials/ADComputeLinearElasticStress

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeMultipleInelasticStress.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeMultipleInelasticStress.md
@@ -1,6 +1,6 @@
 # ADComputeMultipleInelasticStress
 
-!syntax description /Materials/ADComputeMultipleInelasticStress<RESIDUAL>
+!syntax description /Materials/ADComputeMultipleInelasticStress
 
 ## Description
 
@@ -222,10 +222,10 @@ step size.
 
 !listing modules/tensor_mechanics/test/tests/material_limit_time_step/elas_plas/nafems_nl1_lim.i block=Materials/isoplas
 
-!syntax parameters /Materials/ADComputeMultipleInelasticStress<RESIDUAL>
+!syntax parameters /Materials/ADComputeMultipleInelasticStress
 
-!syntax inputs /Materials/ADComputeMultipleInelasticStress<RESIDUAL>
+!syntax inputs /Materials/ADComputeMultipleInelasticStress
 
-!syntax children /Materials/ADComputeMultipleInelasticStress<RESIDUAL>
+!syntax children /Materials/ADComputeMultipleInelasticStress
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalFiniteStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalFiniteStrain.md
@@ -1,6 +1,6 @@
 # ADComputeRSphericalFiniteStrain
 
-!syntax description /Materials/ADComputeRSphericalFiniteStrain<RESIDUAL>
+!syntax description /Materials/ADComputeRSphericalFiniteStrain
 
 ## Description
 
@@ -48,8 +48,8 @@ Once the deformation gradient is calculated for the 1D geometry, the deformation
 gradient is passed to the strain and rotation methods used by default 3D
 Cartesian simulations, as described in the [Finite Strain Class](ADComputeFiniteStrain.md) page.
 
-!syntax parameters /Materials/ADComputeRSphericalFiniteStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeRSphericalFiniteStrain
 
-!syntax inputs /Materials/ADComputeRSphericalFiniteStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeRSphericalFiniteStrain
 
-!syntax children /Materials/ADComputeRSphericalFiniteStrain<RESIDUAL>
+!syntax children /Materials/ADComputeRSphericalFiniteStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalIncrementalStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalIncrementalStrain.md
@@ -1,6 +1,6 @@
 # ADComputeRSphericalIncrementalStrain
 
-!syntax description /Materials/ADComputeRSphericalIncrementalStrain<RESIDUAL>
+!syntax description /Materials/ADComputeRSphericalIncrementalStrain
 
 ## Description
 
@@ -56,8 +56,8 @@ while the calculation of the total strain components $\epsilon_{\theta \theta}$
 and $\epsilon_{\phi \phi}$ are found with
 [eq:polar_azimuthal_rspherical_strains].
 
-!syntax parameters /Materials/ADComputeRSphericalIncrementalStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeRSphericalIncrementalStrain
 
-!syntax inputs /Materials/ADComputeRSphericalIncrementalStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeRSphericalIncrementalStrain
 
-!syntax children /Materials/ADComputeRSphericalIncrementalStrain<RESIDUAL>
+!syntax children /Materials/ADComputeRSphericalIncrementalStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeRSphericalSmallStrain.md
@@ -1,6 +1,6 @@
 # Compute R-Spherical Small Strain
 
-!syntax description /Materials/ADComputeRSphericalSmallStrain<RESIDUAL>
+!syntax description /Materials/ADComputeRSphericalSmallStrain
 
 ## Description
 
@@ -55,8 +55,8 @@ while the calculation of the total strain components $\epsilon_{\theta \theta}$
 and $\epsilon_{\phi \phi}$ are found with
 [eq:polar_azimuthal_rspherical_strains].
 
-!syntax parameters /Materials/ADComputeRSphericalSmallStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeRSphericalSmallStrain
 
-!syntax inputs /Materials/ADComputeRSphericalSmallStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeRSphericalSmallStrain
 
-!syntax children /Materials/ADComputeRSphericalSmallStrain<RESIDUAL>
+!syntax children /Materials/ADComputeRSphericalSmallStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeSmallStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeSmallStrain.md
@@ -1,6 +1,6 @@
 # ADComputeSmallStrain
 
-!syntax description /Materials/ADComputeSmallStrain<RESIDUAL>
+!syntax description /Materials/ADComputeSmallStrain
 
 ## Description
 
@@ -32,10 +32,10 @@ no old values of strain or stress from the previous timestep are stored in
 MOOSE. For a comparison of total strain vs incremental strain theories with
 experimental data, see [cite!shammamy1967incremental].
 
-!syntax parameters /Materials/ADComputeSmallStrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeSmallStrain
 
-!syntax inputs /Materials/ADComputeSmallStrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeSmallStrain
 
-!syntax children /Materials/ADComputeSmallStrain<RESIDUAL>
+!syntax children /Materials/ADComputeSmallStrain
 
 !bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeThermalExpansionEigenstrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeThermalExpansionEigenstrain.md
@@ -1,6 +1,6 @@
 # ADComputeThermalExpansionEigenstrain
 
-!syntax description /Materials/ADComputeThermalExpansionEigenstrain<RESIDUAL>
+!syntax description /Materials/ADComputeThermalExpansionEigenstrain
 
 ## Description
 
@@ -26,8 +26,8 @@ calculator, and an example parameter setting is shown below:
 
 !listing modules/tensor_mechanics/test/tests/thermal_expansion/ad_constant_expansion_stress_free_temp.i block=Modules/TensorMechanics/Master
 
-!syntax parameters /Materials/ADComputeThermalExpansionEigenstrain<RESIDUAL>
+!syntax parameters /Materials/ADComputeThermalExpansionEigenstrain
 
-!syntax inputs /Materials/ADComputeThermalExpansionEigenstrain<RESIDUAL>
+!syntax inputs /Materials/ADComputeThermalExpansionEigenstrain
 
-!syntax children /Materials/ADComputeThermalExpansionEigenstrain<RESIDUAL>
+!syntax children /Materials/ADComputeThermalExpansionEigenstrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ADPowerLawCreepStressUpdate.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADPowerLawCreepStressUpdate.md
@@ -1,6 +1,6 @@
 # ADPowerLawCreepStressUpdate
 
-!syntax description /Materials/ADPowerLawCreepStressUpdate<RESIDUAL>
+!syntax description /Materials/ADPowerLawCreepStressUpdate
 
 ## Description
 
@@ -32,10 +32,10 @@ This class is based on the implicit integration algorithm in
 strain return mapping stress calculator such as
 [ADComputeMultipleInelasticStress](ADComputeMultipleInelasticStress.md)
 
-!syntax parameters /Materials/ADPowerLawCreepStressUpdate<RESIDUAL>
+!syntax parameters /Materials/ADPowerLawCreepStressUpdate
 
-!syntax inputs /Materials/ADPowerLawCreepStressUpdate<RESIDUAL>
+!syntax inputs /Materials/ADPowerLawCreepStressUpdate
 
-!syntax children /Materials/ADPowerLawCreepStressUpdate<RESIDUAL>
+!syntax children /Materials/ADPowerLawCreepStressUpdate
 
 !bibtex bibliography

--- a/python/MooseDocs/tree/app_syntax.py
+++ b/python/MooseDocs/tree/app_syntax.py
@@ -90,6 +90,7 @@ def app_syntax(exe, remove=None, allow_test_objects=False, hide=None, alias=None
     # Remove <RESIDUAL>
     for node in anytree.PreOrderIter(root):
         if node.name.endswith('<RESIDUAL>'):
+            node.alias = node.fullpath
             node.name = node.name[:-10]
 
     return root

--- a/python/MooseDocs/tree/app_syntax.py
+++ b/python/MooseDocs/tree/app_syntax.py
@@ -87,6 +87,11 @@ def app_syntax(exe, remove=None, allow_test_objects=False, hide=None, alias=None
                 if node.fullpath == k:
                     node.alias = unicode(v)
 
+    # Remove <RESIDUAL>
+    for node in anytree.PreOrderIter(root):
+        if node.name.endswith('<RESIDUAL>'):
+            node.name = node.name[:-10]
+
     return root
 
 def __add_moose_object_helper(name, parent, item):


### PR DESCRIPTION
- Creates ADTimeKernel, ADTimeKernelValue, ADTimeKernelGrad.
- ADTimeDerivative now inherits from ADTimeKernelValue
- Updates level set module to use AD, the LevelSetTimeDerivativeSUPG tests ADTimeKernelGrad

(close #13115)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
