### PR TITLE
disallow empty field values for HIT

### DIFF
--- a/framework/contrib/hit/lex.cc
+++ b/framework/contrib/hit/lex.cc
@@ -329,7 +329,7 @@ lexEq(Lexer * l)
   return lexString;
 }
 
-void
+size_t
 consumeUnquotedString(Lexer * l)
 {
   while (true)
@@ -340,6 +340,7 @@ consumeUnquotedString(Lexer * l)
       break;
   }
   l->backup();
+  return l->pos() - l->start();
 }
 
 void
@@ -376,8 +377,8 @@ lexString(Lexer * l)
 
   if (!charIn(l->peek(), "'\""))
   {
-    consumeUnquotedString(l);
-    l->emit(TokType::String);
+    if (consumeUnquotedString(l))
+      l->emit(TokType::String);
     return lexHit;
   }
 
@@ -431,16 +432,16 @@ lexNumber(Lexer * l)
   if (n == 0)
   {
     // fall back to string
-    consumeUnquotedString(l);
-    l->emit(TokType::String);
+    if (consumeUnquotedString(l))
+      l->emit(TokType::String);
     return lexHit;
   }
 
   if (!charIn(l->peek(), allspace + "[") && l->peek() != '\0')
   {
     // fall back to string
-    consumeUnquotedString(l);
-    l->emit(TokType::String);
+    if (consumeUnquotedString(l))
+      l->emit(TokType::String);
     return lexHit;
   }
 
@@ -470,7 +471,7 @@ lexHit(Lexer * l)
     l->emit(TokType::EOF);
     return NULL;
   }
-  return l->error("invalid character '" + std::string(1, c) + "'");
+  return l->error("invalid character '" + std::string(1, c) + "' - did you leave a field value blank after a previous '='?");
 }
 
 } // namespace hit

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -481,6 +481,10 @@ Field::render(int indent, const std::string & indent_text, int maxlen)
       s += quote + unquoted.substr(pos, std::string::npos) + quote;
     }
   }
+  else if (_val.size() == 0)
+    s += "''";
+  else if (quote == "" && _val.find_first_of("\n\r \t") != std::string::npos)
+    s += "'" + _val + "'";
   else
     s += _val;
 

--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -860,7 +860,7 @@ parseField(Parser * p, Node * n)
   else if (valtok.type == TokType::Error)
     p->error(valtok, valtok.val);
   else
-    p->error(valtok, "unexpected field token type");
+    p->error(valtok, "missing value for field '" + fieldtok.val + "' - found '" + valtok.val + "'");
   n->addChild(field);
 }
 

--- a/framework/src/outputs/formatters/InputFileFormatter.C
+++ b/framework/src/outputs/formatters/InputFileFormatter.C
@@ -128,6 +128,9 @@ InputFileFormatter::printParams(const std::string & /*prefix*/,
         }
         else
           quotes = "";
+
+        if (value.size() == 0)
+          value = "(no_default)";
         oss << quotes << value << quotes;
         l_offset -= value.size();
       }

--- a/framework/src/outputs/formatters/JsonInputFileFormatter.C
+++ b/framework/src/outputs/formatters/JsonInputFileFormatter.C
@@ -157,6 +157,8 @@ JsonInputFileFormatter::addParameters(const moosecontrib::Json::Value & params)
     std::string required;
     if (param["required"].asBool())
       required = "(required)";
+    if (def.size() == 0 && required.size() == 0)
+      def = "(no_default)";
     std::string l = name + indent + " = " + def + required;
     if (l.size() > max_len)
       max_len = l.size();

--- a/modules/functional_expansion_tools/test/tests/standard_use/tests
+++ b/modules/functional_expansion_tools/test/tests/standard_use/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'functional_expansion_tools/index.md'
-  issues = #10577
+  issues = '#10577'
   [./interface_coupling]
     type = Exodiff
     input = interface_coupled.i

--- a/test/tests/mesh/no_mesh_block/tests
+++ b/test/tests/mesh/no_mesh_block/tests
@@ -4,7 +4,7 @@
     input = 'no_mesh_block.i'
     expect_err = "No mesh file was supplied and no generation block was provided"
 
-    issues = #2408
+    issues = '#2408'
     design = "Mesh/index.md"
     requirement = "The system shall issue an error if no Mesh block is provided."
   [../]
@@ -14,7 +14,7 @@
     input = 'generators_no_mesh_block.i'
     expect_err = "No mesh file was supplied and no generation block was provided"
 
-    issues = #2408
+    issues = '#2408'
     design = "Mesh/index.md"
     requirement = "The system shall issue an error if no Mesh block is provided even when MeshGenerators are provided."
   [../]

--- a/test/tests/misc/app_name/tests
+++ b/test/tests/misc/app_name/tests
@@ -5,7 +5,7 @@
     expect_out = "MooseTestApp"
     input = 'IGNORED'
     input_switch = ''
-    issues = #11337
+    issues = '#11337'
     design = MooseApp.md
     requirement = "The compiled application shall be capable of returning the name used for registering objects."
   [../]

--- a/test/tests/multiapps/time_offset/tests
+++ b/test/tests/multiapps/time_offset/tests
@@ -4,7 +4,7 @@
     input = master.i
     exodiff = master_out_sub_app0.e
 
-    issues = #12755
+    issues = '#12755'
     requirement = "The system shall support a time offset between the master and a subapp when using the Multiapp system."
     design = "TransientMultiApp.md"
   []

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -40,6 +40,8 @@ TEST(HitTests, FailCases)
   PassFailCase cases[] = {
       {"comment in path", "[hello#world] []"},
       {"comment in field", "hello#world=foo"},
+      {"missing string", "[hello] foo = []"},
+      {"missing string 2", "[hello] foo = \n bar = 42[]"},
       {"invalid path char '='", "[hello=world] []"},
       {"invalid path char '&'", "[hello&world] []"},
       {"invalid path char '['", "[hello[world] []"},


### PR DESCRIPTION
Previously:

```
[foo]
  bar =
[]
```

was allowed.  Now it is not.  Related error messages have been improved.
Fixes #13210.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
