### PR TITLE
Roll-back of counterproductive Predictor results

### DIFF
--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -75,6 +75,7 @@ protected:
   ComputeResidualFunctor _nl_residual_functor;
   ComputeFDResidualFunctor _fd_residual_functor;
 
+  bool predictorMayFail() override { return true; };
   bool predictorImprovedResidual() override;
 
 private:

--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -75,8 +75,8 @@ protected:
   ComputeResidualFunctor _nl_residual_functor;
   ComputeFDResidualFunctor _fd_residual_functor;
 
-  bool predictorMayFail() override { return true; };
-  bool predictorImprovedResidual() override;
+  /// apply the active predictor (and roll it back if it increases the residual)
+  void applyPredictor(NumericVector<Number> & initial_solution) override;
 
 private:
   /**

--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -75,6 +75,8 @@ protected:
   ComputeResidualFunctor _nl_residual_functor;
   ComputeFDResidualFunctor _fd_residual_functor;
 
+  bool predictorImprovedResidual() override;
+
 private:
   /**
    * Form preconditioning matrix via a standard finite difference method

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -649,11 +649,8 @@ protected:
   void enforceNodalConstraintsResidual(NumericVector<Number> & residual);
   void enforceNodalConstraintsJacobian();
 
-  /// determine if the application of a predictor improved the residual
-  virtual bool predictorImprovedResidual() { return true; }
-
-  /// by default we do not keep an unpredicted solution copy to roll back to in case of predictor failure
-  virtual bool predictorMayFail() { return false; };
+  /// apply the active predictor
+  virtual void applyPredictor(NumericVector<Number> & initial_solution);
 
   /// solution vector from nonlinear solver
   const NumericVector<Number> * _current_solution;

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -649,8 +649,11 @@ protected:
   void enforceNodalConstraintsResidual(NumericVector<Number> & residual);
   void enforceNodalConstraintsJacobian();
 
-  /// determine if the application of  apredictor improved the residual
+  /// determine if the application of a predictor improved the residual
   virtual bool predictorImprovedResidual() { return true; }
+
+  /// by default we do not keep an unpredicted solution copy to roll back to in case of predictor failure
+  virtual bool predictorMayFail() { return false; };
 
   /// solution vector from nonlinear solver
   const NumericVector<Number> * _current_solution;

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -649,6 +649,9 @@ protected:
   void enforceNodalConstraintsResidual(NumericVector<Number> & residual);
   void enforceNodalConstraintsJacobian();
 
+  /// determine if the application of  apredictor improved the residual
+  virtual bool predictorImprovedResidual() { return true; }
+
   /// solution vector from nonlinear solver
   const NumericVector<Number> * _current_solution;
   /// ghosted form of the residual

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -670,8 +670,17 @@ NonlinearSystemBase::setInitialSolution()
   NumericVector<Number> & initial_solution(solution());
   if (_predictor.get() && _predictor->shouldApply())
   {
+    // retain a copy of the unpredicted solution
+    auto unpredicted_solution = initial_solution.clone();
+
     _predictor->apply(initial_solution);
     _fe_problem.predictorCleanup(initial_solution);
+
+    // if the prediction does not improve the residual swap the unpredicted solution back in
+    _sys.solution->close();
+    update();
+    if (!predictorImprovedResidual())
+      initial_solution.swap(*unpredicted_solution);
   }
 
   // do nodal BC


### PR DESCRIPTION
This is a rough implementation of the feature outlined in #13249. 
If a predictor increases the initial residual vs. the unpredicted solution do not apply it.

I fully expect harsh comments here. This turned out to be easy enough to draft, so don't worry about holding back.

Closes #13249 
