### PR TITLE
Small patch for enabling Picard iteration for the old eigen executioner

### DIFF
--- a/framework/src/executioners/PicardSolve.C
+++ b/framework/src/executioners/PicardSolve.C
@@ -15,6 +15,7 @@
 #include "NonlinearSystem.h"
 #include "AllLocalDofIndicesThread.h"
 #include "Console.h"
+#include "EigenExecutionerBase.h"
 
 template <>
 InputParameters
@@ -208,7 +209,7 @@ PicardSolve::solve()
       {
         if (_has_picard_norm)
         {
-          _console << "\n0  Picard |R| = "
+          _console << "\n 0 Picard |R| = "
                    << Console::outputNorm(std::numeric_limits<Real>::max(), _picard_initial_norm)
                    << '\n';
 
@@ -330,6 +331,9 @@ PicardSolve::solveStep(Real begin_norm_old,
                        const std::set<dof_id_type> & relaxed_dofs)
 {
   bool auto_advance = !(_has_picard_its && _problem.isTransient());
+
+  if (dynamic_cast<EigenExecutionerBase *>(&_executioner) && _has_picard_its)
+    auto_advance = true;
 
   _executioner.preSolve();
 


### PR DESCRIPTION
Refer to #12767.

This is need for me to clean up a Picard eigen executioner in Rattlesnake. When we switch to the new eigen executioner with #12767 fixed and remove the old eigen executioner, we should remove the change in this PR.