### PR TITLE
Fix some peacock Python3 incompatibilities

### DIFF
--- a/python/FactorySystem/Factory.py
+++ b/python/FactorySystem/Factory.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os, sys
 import inspect
 
@@ -54,14 +55,14 @@ class Factory:
                                 if isinstance(at, bool) and at:
                                     self.register(obj, name)
                     except Exception as e:
-                        print '\nERROR: Your Plugin Tester "' + module_name + '" failed to import. (skipping)\n\n' + str(e)
+                        print('\nERROR: Your Plugin Tester "' + module_name + '" failed to import. (skipping)\n\n' + str(e))
 
 
     def printDump(self, root_node_name):
-        print "[" + root_node_name + "]"
+        print("[" + root_node_name + "]")
 
         for name, object in sorted(self.objects.iteritems()):
-            print "  [./" + name + "]"
+            print("  [./" + name + "]")
 
             params = self.validParams(name)
 
@@ -74,24 +75,24 @@ class Factory:
                     else:
                         default = str(the_param)
 
-                print "%4s%-30s = %-30s # %s" % ('', key, default, params.getDescription(key))
-            print "  [../]\n"
-        print "[]"
+                print("%4s%-30s = %-30s # %s" % ('', key, default, params.getDescription(key)))
+            print("  [../]\n")
+        print("[]")
 
 
     def printYaml(self, root_node_name):
-        print "**START YAML DATA**"
-        print "- name: /" + root_node_name
-        print "  description: !!str"
-        print "  type:"
-        print "  parameters:"
-        print "  subblocks:"
+        print("**START YAML DATA**")
+        print("- name: /" + root_node_name)
+        print("  description: !!str")
+        print("  type:")
+        print("  parameters:")
+        print("  subblocks:")
 
         for name, object in self.objects.iteritems():
-            print "  - name: /" + root_node_name + "/ + name"
-            print "    description:"
-            print "    type:"
-            print "    parameters:"
+            print("  - name: /" + root_node_name + "/ + name")
+            print("    description:")
+            print("    type:")
+            print("    parameters:")
 
             params = self.validParams(name)
             for key in params.valid:
@@ -102,10 +103,10 @@ class Factory:
                 if params.isValid(key):
                     default = str(params[key])
 
-                print "    - name: " + key
-                print "      required: " + required
-                print "      default: !!str " + default
-                print "      description: |"
-                print "        " + params.getDescription(key)
+                print("    - name: " + key)
+                print("      required: " + required)
+                print("      default: !!str " + default)
+                print("      description: |")
+                print("        " + params.getDescription(key))
 
-        print "**END YAML DATA**"
+        print("**END YAML DATA**")

--- a/python/FactorySystem/InputParameters.py
+++ b/python/FactorySystem/InputParameters.py
@@ -7,6 +7,8 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
+
 class InputParameters:
     def __init__(self, *args):
         self.valid = {}
@@ -110,12 +112,12 @@ class InputParameters:
 
         # Check that the group is a string
         if not isinstance(group, str):
-            print 'ERROR: The supplied group name must be a string'
+            print('ERROR: The supplied group name must be a string')
             return
 
         # Check that the prop_list is a list
         if not isinstance(prop_list, list):
-            print 'ERROR: The supplied properties must be supplied as a list'
+            print('ERROR: The supplied properties must be supplied as a list')
             return
 
         # Create the storage for the group if it doesn't exist
@@ -138,7 +140,7 @@ class InputParameters:
     def applyParams(self, common):
 
         if not isinstance(common, InputParameters):
-            print 'ERROR: Supplied "common" variable must of of type InputParameters'
+            print('ERROR: Supplied "common" variable must of of type InputParameters')
             return
 
         # Loop through the valid parameters in the common parameters,
@@ -154,5 +156,5 @@ class InputParameters:
             if k in self.valid:
                 value = self.valid[k]
 
-            print k.ljust(20), value
-            print ' '.ljust(20), self.desc[k]
+            print(k.ljust(20), value)
+            print(' '.ljust(20), self.desc[k])

--- a/python/FactorySystem/MooseObject.py
+++ b/python/FactorySystem/MooseObject.py
@@ -7,7 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from InputParameters import InputParameters
+from .InputParameters import InputParameters
 
 # This is the base class from which all objects should inherit
 class MooseObject(object):

--- a/python/FactorySystem/__init__.py
+++ b/python/FactorySystem/__init__.py
@@ -7,10 +7,10 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from Factory import Factory
-from InputParameters import InputParameters
-from MooseObject import MooseObject
-from Parser import Parser
-from Warehouse import Warehouse
+from .Factory import Factory
+from .InputParameters import InputParameters
+from .MooseObject import MooseObject
+from .Parser import Parser
+from .Warehouse import Warehouse
 
 __all__ = ['Factory', 'InputParameters', 'MooseObject', 'Parser', 'Warehouse']

--- a/python/chigger/RenderWindow.py
+++ b/python/chigger/RenderWindow.py
@@ -11,10 +11,10 @@
 import os
 import vtk
 
-import base
-import annotations
-import observers
-import misc
+from . import base
+from . import annotations
+from . import observers
+from . import misc
 import mooseutils
 
 VTK_MAJOR_VERSION = vtk.vtkVersion.GetVTKMajorVersion()

--- a/python/chigger/RenderWindow.py
+++ b/python/chigger/RenderWindow.py
@@ -11,11 +11,11 @@
 import os
 import vtk
 
+import mooseutils
 from . import base
 from . import annotations
 from . import observers
 from . import misc
-import mooseutils
 
 VTK_MAJOR_VERSION = vtk.vtkVersion.GetVTKMajorVersion()
 

--- a/python/chigger/__init__.py
+++ b/python/chigger/__init__.py
@@ -8,13 +8,13 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from RenderWindow import RenderWindow
-import base
-import utils
-import misc
-import annotations
-import exodus
-import geometric
-import graphs
-import filters
-import observers
+from .RenderWindow import RenderWindow
+from . import base
+from . import utils
+from . import misc
+from . import annotations
+from . import exodus
+from . import geometric
+from . import graphs
+from . import filters
+from . import observers

--- a/python/chigger/annotations/ImageAnnotation.py
+++ b/python/chigger/annotations/ImageAnnotation.py
@@ -11,7 +11,7 @@
 import math
 import vtk
 
-from ImageAnnotationSource import ImageAnnotationSource
+from .ImageAnnotationSource import ImageAnnotationSource
 from .. import base
 
 class ImageAnnotation(base.ChiggerResult):

--- a/python/chigger/annotations/TimeAnnotationSource.py
+++ b/python/chigger/annotations/TimeAnnotationSource.py
@@ -10,7 +10,7 @@
 
 import datetime
 
-from TextAnnotationSource import TextAnnotationSource
+from .TextAnnotationSource import TextAnnotationSource
 
 class TimeAnnotationSource(TextAnnotationSource):
     """

--- a/python/chigger/annotations/__init__.py
+++ b/python/chigger/annotations/__init__.py
@@ -8,9 +8,9 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ImageAnnotation import ImageAnnotation
-from TextAnnotationSource import TextAnnotationSource
-from TimeAnnotationSource import TimeAnnotationSource
+from .ImageAnnotation import ImageAnnotation
+from .TextAnnotationSource import TextAnnotationSource
+from .TimeAnnotationSource import TimeAnnotationSource
 from .. import base
 TextAnnotation = base.create_single_source_result(TextAnnotationSource)
 TimeAnnotation = base.create_single_source_result(TimeAnnotationSource)

--- a/python/chigger/base/ChiggerFilterSourceBase.py
+++ b/python/chigger/base/ChiggerFilterSourceBase.py
@@ -11,7 +11,7 @@
 import copy
 import vtk
 import mooseutils
-from ChiggerSourceBase import ChiggerSourceBase
+from .ChiggerSourceBase import ChiggerSourceBase
 
 class ChiggerFilterSourceBase(ChiggerSourceBase):
     """

--- a/python/chigger/base/ChiggerResult.py
+++ b/python/chigger/base/ChiggerResult.py
@@ -10,8 +10,8 @@
 
 import mooseutils
 from chigger import utils
-from ChiggerResultBase import ChiggerResultBase
-from ChiggerSourceBase import ChiggerSourceBase
+from .ChiggerResultBase import ChiggerResultBase
+from .ChiggerSourceBase import ChiggerSourceBase
 
 class ChiggerResult(ChiggerResultBase):
     """

--- a/python/chigger/base/ChiggerResultBase.py
+++ b/python/chigger/base/ChiggerResultBase.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerObject import ChiggerObject
+from .ChiggerObject import ChiggerObject
 
 class ChiggerResultBase(ChiggerObject):
     """

--- a/python/chigger/base/ChiggerSource.py
+++ b/python/chigger/base/ChiggerSource.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerFilterSourceBase import ChiggerFilterSourceBase
+from .ChiggerFilterSourceBase import ChiggerFilterSourceBase
 
 class ChiggerSource(ChiggerFilterSourceBase):
     """

--- a/python/chigger/base/ChiggerSource2D.py
+++ b/python/chigger/base/ChiggerSource2D.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerFilterSourceBase import ChiggerFilterSourceBase
+from .ChiggerFilterSourceBase import ChiggerFilterSourceBase
 
 class ChiggerSource2D(ChiggerFilterSourceBase):
     """

--- a/python/chigger/base/ChiggerSourceBase.py
+++ b/python/chigger/base/ChiggerSourceBase.py
@@ -10,7 +10,7 @@
 
 import vtk
 import mooseutils
-from ChiggerObject import ChiggerObject
+from .ChiggerObject import ChiggerObject
 
 class ChiggerSourceBase(ChiggerObject):
     """

--- a/python/chigger/base/ColorMap.py
+++ b/python/chigger/base/ColorMap.py
@@ -22,7 +22,7 @@ except ImportError:
 
 import vtk
 import mooseutils
-from ChiggerObject import ChiggerObject
+from .ChiggerObject import ChiggerObject
 
 def get_xml_table_values():
     """

--- a/python/chigger/base/KeyPressInteractorStyle.py
+++ b/python/chigger/base/KeyPressInteractorStyle.py
@@ -8,6 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import vtk
 from .. import utils
 
@@ -28,4 +29,4 @@ class KeyPressInteractorStyle(vtk.vtkInteractorStyleMultiTouchCamera):
         """
         key = obj.GetInteractor().GetKeySym()
         if key == 'c':
-            print '\n'.join(utils.print_camera(self.GetCurrentRenderer().GetActiveCamera()))
+            print('\n'.join(utils.print_camera(self.GetCurrentRenderer().GetActiveCamera())))

--- a/python/chigger/base/ResultGroup.py
+++ b/python/chigger/base/ResultGroup.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ChiggerResult import ChiggerResult
+from .ChiggerResult import ChiggerResult
 
 class ResultGroup(ChiggerResult):
     """

--- a/python/chigger/base/__init__.py
+++ b/python/chigger/base/__init__.py
@@ -8,20 +8,20 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ChiggerObject import ChiggerObject
+from .ChiggerObject import ChiggerObject
 
-from ChiggerSourceBase import ChiggerSourceBase
-from ChiggerFilterSourceBase import ChiggerFilterSourceBase
-from ChiggerSource import ChiggerSource
-from ChiggerSource2D import ChiggerSource2D
+from .ChiggerSourceBase import ChiggerSourceBase
+from .ChiggerFilterSourceBase import ChiggerFilterSourceBase
+from .ChiggerSource import ChiggerSource
+from .ChiggerSource2D import ChiggerSource2D
 
-from ChiggerResultBase import ChiggerResultBase
-from ChiggerResult import ChiggerResult
-from KeyPressInteractorStyle import KeyPressInteractorStyle
+from .ChiggerResultBase import ChiggerResultBase
+from .ChiggerResult import ChiggerResult
+from .KeyPressInteractorStyle import KeyPressInteractorStyle
 
-from ColorMap import ColorMap
+from .ColorMap import ColorMap
 
-from ResultGroup import ResultGroup
+from .ResultGroup import ResultGroup
 
 def create_single_source_result(source_type):
     """

--- a/python/chigger/exodus/ExodusResult.py
+++ b/python/chigger/exodus/ExodusResult.py
@@ -8,9 +8,9 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ExodusSource import ExodusSource
-from ExodusReader import ExodusReader
-from MultiAppExodusReader import MultiAppExodusReader
+from .ExodusSource import ExodusSource
+from .ExodusReader import ExodusReader
+from .MultiAppExodusReader import MultiAppExodusReader
 import mooseutils
 from .. import base
 from .. import utils

--- a/python/chigger/exodus/ExodusResult.py
+++ b/python/chigger/exodus/ExodusResult.py
@@ -8,10 +8,10 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+import mooseutils
 from .ExodusSource import ExodusSource
 from .ExodusReader import ExodusReader
 from .MultiAppExodusReader import MultiAppExodusReader
-import mooseutils
 from .. import base
 from .. import utils
 

--- a/python/chigger/exodus/ExodusResultLineSampler.py
+++ b/python/chigger/exodus/ExodusResultLineSampler.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ExodusSourceLineSampler import ExodusSourceLineSampler
+from .ExodusSourceLineSampler import ExodusSourceLineSampler
 from ..base import ChiggerResult
 
 class ExodusResultLineSampler(ChiggerResult):

--- a/python/chigger/exodus/ExodusSource.py
+++ b/python/chigger/exodus/ExodusSource.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ExodusReader import ExodusReader
+from .ExodusReader import ExodusReader
 import mooseutils
 from .. import utils
 from .. import base

--- a/python/chigger/exodus/ExodusSource.py
+++ b/python/chigger/exodus/ExodusSource.py
@@ -9,8 +9,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from .ExodusReader import ExodusReader
 import mooseutils
+from .ExodusReader import ExodusReader
 from .. import utils
 from .. import base
 from .. import filters

--- a/python/chigger/exodus/ExodusSourceLineSampler.py
+++ b/python/chigger/exodus/ExodusSourceLineSampler.py
@@ -10,7 +10,7 @@
 
 import vtk
 import numpy as np
-from ExodusSource import ExodusSource
+from .ExodusSource import ExodusSource
 import mooseutils
 from .. import geometric
 

--- a/python/chigger/exodus/ExodusSourceLineSampler.py
+++ b/python/chigger/exodus/ExodusSourceLineSampler.py
@@ -10,8 +10,8 @@
 
 import vtk
 import numpy as np
-from .ExodusSource import ExodusSource
 import mooseutils
+from .ExodusSource import ExodusSource
 from .. import geometric
 
 class ExodusSourceLineSampler(geometric.LineSource):

--- a/python/chigger/exodus/LabelExodusResult.py
+++ b/python/chigger/exodus/LabelExodusResult.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from LabelExodusSource import LabelExodusSource
+from .LabelExodusSource import LabelExodusSource
 from .. import base
 
 class LabelExodusResult(base.ChiggerResult):

--- a/python/chigger/exodus/LabelExodusSource.py
+++ b/python/chigger/exodus/LabelExodusSource.py
@@ -9,8 +9,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ExodusSource import ExodusSource
-from ExodusReader import ExodusReader
+from .ExodusSource import ExodusSource
+from .ExodusReader import ExodusReader
 import mooseutils
 from .. import base
 from .. import filters

--- a/python/chigger/exodus/LabelExodusSource.py
+++ b/python/chigger/exodus/LabelExodusSource.py
@@ -9,9 +9,9 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
+import mooseutils
 from .ExodusSource import ExodusSource
 from .ExodusReader import ExodusReader
-import mooseutils
 from .. import base
 from .. import filters
 from .. import utils

--- a/python/chigger/exodus/MultiAppExodusReader.py
+++ b/python/chigger/exodus/MultiAppExodusReader.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import glob
-from ExodusReader import ExodusReader
+from .ExodusReader import ExodusReader
 from .. import base
 
 class MultiAppExodusReader(base.ChiggerObject):

--- a/python/chigger/exodus/NemesisReader.py
+++ b/python/chigger/exodus/NemesisReader.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from MultiAppExodusReader import MultiAppExodusReader
+from .MultiAppExodusReader import MultiAppExodusReader
 
 class NemesisReader(MultiAppExodusReader):
     """

--- a/python/chigger/exodus/__init__.py
+++ b/python/chigger/exodus/__init__.py
@@ -8,17 +8,17 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ExodusReader import ExodusReader
-from MultiAppExodusReader import MultiAppExodusReader
-from NemesisReader import NemesisReader
+from .ExodusReader import ExodusReader
+from .MultiAppExodusReader import MultiAppExodusReader
+from .NemesisReader import NemesisReader
 
-from ExodusSource import ExodusSource
-from ExodusColorBar import ExodusColorBar
+from .ExodusSource import ExodusSource
+from .ExodusColorBar import ExodusColorBar
 
-from ExodusResult import ExodusResult
+from .ExodusResult import ExodusResult
 
-from LabelExodusSource import LabelExodusSource
-from LabelExodusResult import LabelExodusResult
+from .LabelExodusSource import LabelExodusSource
+from .LabelExodusResult import LabelExodusResult
 
-from ExodusSourceLineSampler import ExodusSourceLineSampler
-from ExodusResultLineSampler import ExodusResultLineSampler
+from .ExodusSourceLineSampler import ExodusSourceLineSampler
+from .ExodusResultLineSampler import ExodusResultLineSampler

--- a/python/chigger/filters/BoxClipper.py
+++ b/python/chigger/filters/BoxClipper.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ClipperFilterBase import ClipperFilterBase
+from .ClipperFilterBase import ClipperFilterBase
 
 class BoxClipper(ClipperFilterBase):
     """

--- a/python/chigger/filters/ClipperFilterBase.py
+++ b/python/chigger/filters/ClipperFilterBase.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 
 class ClipperFilterBase(ChiggerFilterBase):
     """

--- a/python/chigger/filters/ContourFilter.py
+++ b/python/chigger/filters/ContourFilter.py
@@ -11,7 +11,7 @@
 import vtk
 import mooseutils
 import chigger
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 class ContourFilter(ChiggerFilterBase):
     """
     Filter for computing and visualizing contours.

--- a/python/chigger/filters/PlaneClipper.py
+++ b/python/chigger/filters/PlaneClipper.py
@@ -10,7 +10,7 @@
 
 import copy
 import vtk
-from ClipperFilterBase import ClipperFilterBase
+from .ClipperFilterBase import ClipperFilterBase
 
 class PlaneClipper(ClipperFilterBase):
     """

--- a/python/chigger/filters/RotationalExtrusionFilter.py
+++ b/python/chigger/filters/RotationalExtrusionFilter.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 
 class RotationalExtrusionFilter(ChiggerFilterBase):
     """

--- a/python/chigger/filters/TransformFilter.py
+++ b/python/chigger/filters/TransformFilter.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 class TransformFilter(ChiggerFilterBase):
     """
     Filter for computing and visualizing contours.

--- a/python/chigger/filters/TubeFilter.py
+++ b/python/chigger/filters/TubeFilter.py
@@ -10,7 +10,7 @@
 
 import vtk
 import mooseutils
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 from .. import utils
 
 class TubeFilter(ChiggerFilterBase):

--- a/python/chigger/filters/__init__.py
+++ b/python/chigger/filters/__init__.py
@@ -10,16 +10,16 @@
 
 import vtk
 
-from ContourFilter import ContourFilter
-from TransformFilter import TransformFilter
-from TubeFilter import TubeFilter
-from RotationalExtrusionFilter import RotationalExtrusionFilter
+from .ContourFilter import ContourFilter
+from .TransformFilter import TransformFilter
+from .TubeFilter import TubeFilter
+from .RotationalExtrusionFilter import RotationalExtrusionFilter
 
-from ClipperFilterBase import ClipperFilterBase
-from PlaneClipper import PlaneClipper
-from BoxClipper import BoxClipper
+from .ClipperFilterBase import ClipperFilterBase
+from .PlaneClipper import PlaneClipper
+from .BoxClipper import BoxClipper
 
-from ChiggerFilterBase import ChiggerFilterBase
+from .ChiggerFilterBase import ChiggerFilterBase
 def create_basic_filter(vtkfilter_type):
     """
     Function for creating meta filter objects.

--- a/python/chigger/geometric/CubeSource.py
+++ b/python/chigger/geometric/CubeSource.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-import GeometricSourceMeta
+from . import GeometricSourceMeta
 from .. import base
 
 BaseType = GeometricSourceMeta.create(base.ChiggerSource)

--- a/python/chigger/geometric/CylinderSource.py
+++ b/python/chigger/geometric/CylinderSource.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-import GeometricSourceMeta
+from . import GeometricSourceMeta
 from .. import base
 
 BaseType = GeometricSourceMeta.create(base.ChiggerSource)

--- a/python/chigger/geometric/LineSource.py
+++ b/python/chigger/geometric/LineSource.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-import GeometricSourceMeta
+from . import GeometricSourceMeta
 from .. import base, filters
 
 BaseType = GeometricSourceMeta.create(base.ChiggerSource)

--- a/python/chigger/geometric/PlaneSourceMeta.py
+++ b/python/chigger/geometric/PlaneSourceMeta.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-import GeometricSourceMeta
+from . import GeometricSourceMeta
 import mooseutils
 from ..base import ColorMap
 

--- a/python/chigger/geometric/PlaneSourceMeta.py
+++ b/python/chigger/geometric/PlaneSourceMeta.py
@@ -9,8 +9,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from . import GeometricSourceMeta
 import mooseutils
+from . import GeometricSourceMeta
 from ..base import ColorMap
 
 def create(base_type):

--- a/python/chigger/geometric/__init__.py
+++ b/python/chigger/geometric/__init__.py
@@ -8,11 +8,11 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from CubeSource import CubeSource
-from CylinderSource import CylinderSource
-from LineSource import LineSource
+from .CubeSource import CubeSource
+from .CylinderSource import CylinderSource
+from .LineSource import LineSource
 
-import PlaneSourceMeta
+from . import PlaneSourceMeta
 from .. import base
 PlaneSource = PlaneSourceMeta.create(base.ChiggerSource)
 PlaneSource2D = PlaneSourceMeta.create(base.ChiggerSource2D)

--- a/python/chigger/graphs/__init__.py
+++ b/python/chigger/graphs/__init__.py
@@ -8,5 +8,5 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from Graph import Graph
-from Line import Line
+from .Graph import Graph
+from .Line import Line

--- a/python/chigger/misc/ColorBar.py
+++ b/python/chigger/misc/ColorBar.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from AxisSource import AxisSource
+from .AxisSource import AxisSource
 from .. import base
 from .. import geometric
 

--- a/python/chigger/misc/__init__.py
+++ b/python/chigger/misc/__init__.py
@@ -8,6 +8,6 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ColorBar import ColorBar
-from ChiggerBackground import ChiggerBackground
-from VolumeAxes import VolumeAxes
+from .ColorBar import ColorBar
+from .ChiggerBackground import ChiggerBackground
+from .VolumeAxes import VolumeAxes

--- a/python/chigger/observers/KeyObserver.py
+++ b/python/chigger/observers/KeyObserver.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import vtk
-from ChiggerObserver import ChiggerObserver
+from .ChiggerObserver import ChiggerObserver
 class KeyObserver(ChiggerObserver):
     """
     Class for creating key press observers to be passed in to RenderWindow object.

--- a/python/chigger/observers/TimerObserver.py
+++ b/python/chigger/observers/TimerObserver.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import vtk
-from ChiggerObserver import ChiggerObserver
+from .ChiggerObserver import ChiggerObserver
 class TimerObserver(ChiggerObserver):
     """
     Class for creating timers to be passed in to RenderWindow object.

--- a/python/chigger/observers/__init__.py
+++ b/python/chigger/observers/__init__.py
@@ -8,6 +8,6 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from ChiggerObserver import ChiggerObserver
-from TimerObserver import TimerObserver
-from KeyObserver import KeyObserver
+from .ChiggerObserver import ChiggerObserver
+from .TimerObserver import TimerObserver
+from .KeyObserver import KeyObserver

--- a/python/chigger/utils/AxisOptions.py
+++ b/python/chigger/utils/AxisOptions.py
@@ -10,7 +10,7 @@
 
 import vtk
 import mooseutils
-from Options import Options
+from .Options import Options
 
 VTK_NOTATION_ENUM = [
     vtk.vtkAxis.STANDARD_NOTATION,

--- a/python/chigger/utils/FontOptions.py
+++ b/python/chigger/utils/FontOptions.py
@@ -8,7 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from Options import Options
+from .Options import Options
 
 def get_options():
     """

--- a/python/chigger/utils/LegendOptions.py
+++ b/python/chigger/utils/LegendOptions.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import vtk
-from Options import Options
+from .Options import Options
 
 def get_options():
     """

--- a/python/chigger/utils/Options.py
+++ b/python/chigger/utils/Options.py
@@ -9,6 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #!/usr/bin/env python2
+from __future__ import print_function
 import sys
 import textwrap
 from collections import OrderedDict
@@ -254,8 +255,8 @@ class Options(object):
         """
         #@todo warning
         if name not in self.__options:
-            print 'No option with the name:', name
-            print self.__options.keys()
+            print('No option with the name:', name)
+            print(self.__options.keys())
             traceback.print_stack()
             sys.exit()
             return None

--- a/python/chigger/utils/__init__.py
+++ b/python/chigger/utils/__init__.py
@@ -8,6 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 import glob
 import shutil
@@ -15,10 +16,10 @@ import subprocess
 import numpy as np
 import vtk
 import mooseutils
-from Options import Option, Options
-import AxisOptions
-import FontOptions
-import LegendOptions
+from .Options import Option, Options
+from . import AxisOptions
+from . import FontOptions
+from . import LegendOptions
 
 def get_active_filenames(basename, pattern=None):
     """
@@ -109,7 +110,7 @@ def print_camera(camera, prefix='camera', precision=10):
     Prints vtkCamera object to screen.
     """
     if not isinstance(camera, vtk.vtkCamera):
-        print "You must supply a vtkCarmera object."
+        print("You must supply a vtkCarmera object.")
         return
 
     view_up = camera.GetViewUp()
@@ -182,6 +183,6 @@ def img2mov(pattern, output, ffmpeg='ffmpeg', duration=60, framerate=None, bitra
     cmd += [output]
 
     c = ' '.join(cmd)
-    print '{0}\n{1}\n{0}'.format('-'*(len(c)), c)
+    print('{0}\n{1}\n{0}'.format('-'*(len(c)), c))
     if not dry_run:
         subprocess.call(cmd)

--- a/python/mooseutils/AutoPropertyMixin.py
+++ b/python/mooseutils/AutoPropertyMixin.py
@@ -10,7 +10,7 @@
 """Auto python property creation."""
 import collections
 import inspect
-from MooseException import MooseException
+from .MooseException import MooseException
 
 class Property(object):
     """

--- a/python/mooseutils/ImageDiffer.py
+++ b/python/mooseutils/ImageDiffer.py
@@ -8,6 +8,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 
 class ImageDiffer(object):
@@ -82,7 +83,7 @@ class ImageDiffer(object):
 
         # Print the output
         if kwargs.pop('output', False):
-            print '\n'.join(output)
+            print('\n'.join(output))
 
         # Return the text, as a single string
         return '\n'.join(output)
@@ -98,7 +99,7 @@ class ImageDiffer(object):
 
         # Print the output
         if kwargs.pop('output', False):
-            print '\n'.join(output)
+            print('\n'.join(output))
 
         # Return the text, as a single string
         return '\n'.join(output)
@@ -176,7 +177,7 @@ if __name__ == '__main__':
         file0 = args.files[0]
         file1 = args.files[1]
     else:
-        print "You must specify one or two files for comparison, see -h"
+        print("You must specify one or two files for comparison, see -h")
 
     d = ImageDiffer(file0, file1)
-    print '\n\n' + d.message()
+    print('\n\n' + d.message())

--- a/python/mooseutils/MooseDataFrame.py
+++ b/python/mooseutils/MooseDataFrame.py
@@ -10,7 +10,7 @@
 import os
 import pandas
 
-import message
+from . import message
 
 class MooseDataFrame(object):
     """

--- a/python/mooseutils/MooseSourceParser.py
+++ b/python/mooseutils/MooseSourceParser.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 import re
 import subprocess
@@ -46,7 +47,7 @@ class MooseSourceParser(object):
         # Check that the supplied file exists
         if not os.path.exists(filename):
             #TODO: Proper exception and logging
-            print 'The supplied source/header file does not exist:', filename
+            print('The supplied source/header file does not exist:', filename)
             return
 
         # Build the flags to pass to clang
@@ -101,7 +102,7 @@ class MooseSourceParser(object):
             cursor = self._translation_unit.cursor,
         recursive = kwargs.pop('recursive', True)
         for c in cursor.get_children():
-            print ' '*4*level, c.kind, c.spelling, c.extent.start.file, c.extent.start.line
+            print(' '*4*level, c.kind, c.spelling, c.extent.start.file, c.extent.start.line)
             if recursive and c.get_children():
                 self.dump(c, level+1)
 
@@ -133,7 +134,7 @@ class MooseSourceParser(object):
 
         for cursor in self._translation_unit.cursor.walk_preorder():
             if (hasattr(cursor, 'kind')) and (cursor.kind == kind) and (name == None or cursor.spelling == name):
-                #print cursor.extent.start.file
+                #print(cursor.extent.start.file)
                 yield cursor
 
 
@@ -146,4 +147,4 @@ if __name__ == '__main__':
     parser = MooseSourceParser('%s/projects/moose/framework' % os.environ["HOME"])
     parser.parse(src)
     decl, defn = parser.method('computeQpResidual')
-    print decl, defn
+    print(decl, defn)

--- a/python/mooseutils/PostprocessorReader.py
+++ b/python/mooseutils/PostprocessorReader.py
@@ -7,8 +7,8 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from MooseDataFrame import MooseDataFrame
-import message
+from .MooseDataFrame import MooseDataFrame
+from . import message
 
 class PostprocessorReader(MooseDataFrame):
     """

--- a/python/mooseutils/VectorPostprocessorReader.py
+++ b/python/mooseutils/VectorPostprocessorReader.py
@@ -12,8 +12,8 @@ import glob
 import pandas
 import bisect
 
-from MooseDataFrame import MooseDataFrame
-import message
+from .MooseDataFrame import MooseDataFrame
+from . import message
 
 class VectorPostprocessorReader(object):
     """

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -7,17 +7,17 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from mooseutils import colorText, str2bool, find_moose_executable, runExe, check_configuration
-from mooseutils import find_moose_executable_recursive, run_executable
-from mooseutils import touch, unique_list, gold, make_chunks, camel_to_space
-from mooseutils import text_diff, git_ls_files, git_root_dir, is_git_repo, unidiff, text_unidiff
-from mooseutils import run_profile, list_files
-from message import mooseDebug, mooseWarning, mooseMessage, mooseError
-from MooseException import MooseException
-from eval_path import eval_path
-from sqa_check import sqa_check, check_requirement
-from AutoPropertyMixin import AutoPropertyMixin, Property, addProperty
-import parallel
+from .mooseutils import colorText, str2bool, find_moose_executable, runExe, check_configuration
+from .mooseutils import find_moose_executable_recursive, run_executable
+from .mooseutils import touch, unique_list, gold, make_chunks, camel_to_space
+from .mooseutils import text_diff, git_ls_files, git_root_dir, is_git_repo, unidiff, text_unidiff
+from .mooseutils import run_profile, list_files
+from .message import mooseDebug, mooseWarning, mooseMessage, mooseError
+from .MooseException import MooseException
+from .eval_path import eval_path
+from .sqa_check import sqa_check, check_requirement
+from .AutoPropertyMixin import AutoPropertyMixin, Property, addProperty
+from . import parallel
 
 try:
     from hit_load import hit_load, HitNode, hit_parse
@@ -25,19 +25,19 @@ except:
     pass
 
 try:
-    from MooseDataFrame import MooseDataFrame
-    from PostprocessorReader import PostprocessorReader
-    from VectorPostprocessorReader import VectorPostprocessorReader
+    from .MooseDataFrame import MooseDataFrame
+    from .PostprocessorReader import PostprocessorReader
+    from .VectorPostprocessorReader import VectorPostprocessorReader
 except:
     pass
 
 try:
-    from ImageDiffer import ImageDiffer
+    from .ImageDiffer import ImageDiffer
 except:
     pass
 
 try:
     import clang.cindex
-    from MooseSourceParser import MooseSourceParser
+    from .MooseSourceParser import MooseSourceParser
 except:
     pass

--- a/python/mooseutils/hit_load.py
+++ b/python/mooseutils/hit_load.py
@@ -8,9 +8,10 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 """Wrapper for hit parser."""
+from __future__ import print_function
 import os
 import hit
-import message
+from . import message
 
 # The 'HitNode' object is used within the TestHarness, which should operate without any
 # special python libraries. However, the 'anytree' package is used by various utilities within the
@@ -230,5 +231,5 @@ def hit_parse(root, hit_node, filename):
 if __name__ == '__main__':
     filename = '../../test/tests/kernels/simple_diffusion/simple_diffusion.i'
     root = hit_load(filename)
-    print root
-    print root.render()
+    print(root)
+    print(root.render())

--- a/python/mooseutils/message.py
+++ b/python/mooseutils/message.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 import traceback
 from mooseutils import colorText
@@ -94,7 +95,7 @@ def mooseMessage(*args, **kwargs):
     # Print the message to screen
     if color:
         message = colorText(message, color)
-    print message
+    print(message)
     # Show the traceback
     if trace and MOOSE_USE_QT5:
         traceback.print_stack()

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -17,7 +17,10 @@ import subprocess
 import time
 import cProfile as profile
 import pstats
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 def colorText(string, color, **kwargs):
     """
@@ -378,7 +381,7 @@ def run_profile(function, *args, **kwargs):
     start = time.time()
     out = pr.runcall(function, *args, **kwargs)
     print('Total Time:', time.time() - start)
-    s = StringIO.StringIO()
+    s = StringIO()
     ps = pstats.Stats(pr, stream=s).sort_stats('tottime')
     ps.print_stats()
     print(s.getvalue())

--- a/python/mooseutils/sqa_check.py
+++ b/python/mooseutils/sqa_check.py
@@ -8,10 +8,11 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 import subprocess
-from hit_load import hit_load
-from mooseutils import git_root_dir
+from .hit_load import hit_load
+from .mooseutils import git_root_dir
 
 def check_requirement(filename):
     """Check spec file for requirement documentation."""
@@ -31,8 +32,8 @@ def check_requirement(filename):
             messages.append("    'issues' parameter is missing in '{}' block.".format(child.name))
 
     if messages:
-        print 'ERROR in {}'.format(filename)
-        print '\n'.join(messages) + '\n'
+        print('ERROR in {}'.format(filename))
+        print('\n'.join(messages) + '\n')
         return 1
     return 0
 

--- a/python/peacock/Execute/ConsoleOutputViewerPlugin.py
+++ b/python/peacock/Execute/ConsoleOutputViewerPlugin.py
@@ -9,7 +9,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from peacock.base.Plugin import Plugin
-from TerminalTextEdit import TerminalTextEdit
+from .TerminalTextEdit import TerminalTextEdit
 
 class ConsoleOutputViewerPlugin(TerminalTextEdit, Plugin):
     """

--- a/python/peacock/Execute/ExecuteRunnerPlugin.py
+++ b/python/peacock/Execute/ExecuteRunnerPlugin.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import QWidget, QMessageBox
 from PyQt5.QtCore import pyqtSignal
 from peacock.base.Plugin import Plugin
 from peacock.utils import WidgetUtils
-from JobRunner import JobRunner
+from .JobRunner import JobRunner
 import mooseutils
 import time
 import math

--- a/python/peacock/Execute/ExecuteTabPlugin.py
+++ b/python/peacock/Execute/ExecuteTabPlugin.py
@@ -13,9 +13,9 @@ from peacock.base.TabPlugin import TabPlugin
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
 from PyQt5.QtCore import pyqtSignal
 from peacock.utils import ExeFinder
-from ExecuteOptionsPlugin import ExecuteOptionsPlugin
-from ExecuteRunnerPlugin import ExecuteRunnerPlugin
-from ConsoleOutputViewerPlugin import ConsoleOutputViewerPlugin
+from .ExecuteOptionsPlugin import ExecuteOptionsPlugin
+from .ExecuteRunnerPlugin import ExecuteRunnerPlugin
+from .ConsoleOutputViewerPlugin import ConsoleOutputViewerPlugin
 from peacock.Input.ExecutableInfo import ExecutableInfo
 import os
 

--- a/python/peacock/ExodusViewer/ExodusPluginManager.py
+++ b/python/peacock/ExodusViewer/ExodusPluginManager.py
@@ -11,7 +11,7 @@ import re
 from PyQt5 import QtWidgets
 import peacock
 import mooseutils
-from plugins.ExodusPlugin import ExodusPlugin
+from .plugins.ExodusPlugin import ExodusPlugin
 
 class ExodusPluginManager(QtWidgets.QWidget, peacock.base.PluginManager):
 

--- a/python/peacock/ExodusViewer/ExodusViewer.py
+++ b/python/peacock/ExodusViewer/ExodusViewer.py
@@ -9,19 +9,19 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 import peacock
-from ExodusPluginManager import ExodusPluginManager
-from plugins.VTKWindowPlugin import VTKWindowPlugin
-from plugins.FilePlugin import FilePlugin
-from plugins.GoldDiffPlugin import GoldDiffPlugin
-from plugins.ColorbarPlugin import ColorbarPlugin
-from plugins.MeshPlugin import MeshPlugin
-from plugins.BackgroundPlugin import BackgroundPlugin
-from plugins.ClipPlugin import ClipPlugin
-from plugins.ContourPlugin import ContourPlugin
-from plugins.OutputPlugin import OutputPlugin
-from plugins.CameraPlugin import CameraPlugin
-from plugins.MediaControlPlugin import MediaControlPlugin
-from plugins.BlockPlugin import BlockPlugin
+from .ExodusPluginManager import ExodusPluginManager
+from .plugins.VTKWindowPlugin import VTKWindowPlugin
+from .plugins.FilePlugin import FilePlugin
+from .plugins.GoldDiffPlugin import GoldDiffPlugin
+from .plugins.ColorbarPlugin import ColorbarPlugin
+from .plugins.MeshPlugin import MeshPlugin
+from .plugins.BackgroundPlugin import BackgroundPlugin
+from .plugins.ClipPlugin import ClipPlugin
+from .plugins.ContourPlugin import ContourPlugin
+from .plugins.OutputPlugin import OutputPlugin
+from .plugins.CameraPlugin import CameraPlugin
+from .plugins.MediaControlPlugin import MediaControlPlugin
+from .plugins.BlockPlugin import BlockPlugin
 
 class ExodusViewer(peacock.base.ViewerBase):
     """

--- a/python/peacock/ExodusViewer/plugins/BackgroundPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/BackgroundPlugin.py
@@ -9,7 +9,7 @@
 
 import sys
 from PyQt5 import QtCore, QtGui, QtWidgets
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class BackgroundPlugin(QtWidgets.QWidget, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/BlockPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/BlockPlugin.py
@@ -10,8 +10,8 @@
 from PyQt5 import QtCore, QtWidgets
 import sys
 import chigger
-from ExodusPlugin import ExodusPlugin
-from BlockSelectorWidget import BlockSelectorWidget
+from .ExodusPlugin import ExodusPlugin
+from .BlockSelectorWidget import BlockSelectorWidget
 
 class BlockPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/CameraPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/CameraPlugin.py
@@ -10,7 +10,7 @@
 import sys
 import math
 from PyQt5 import QtCore, QtWidgets
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class CameraPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/ClipPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/ClipPlugin.py
@@ -10,7 +10,7 @@
 import sys
 from PyQt5 import QtCore, QtWidgets
 import chigger
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class ClipPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/ColorbarPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/ColorbarPlugin.py
@@ -12,7 +12,7 @@ import os
 import sys
 from PyQt5 import QtCore, QtWidgets, QtGui
 import glob
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class ColorbarPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/ContourPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/ContourPlugin.py
@@ -11,7 +11,7 @@ import re
 import sys
 from PyQt5 import QtCore, QtWidgets
 import chigger
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class ContourPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/FilePlugin.py
+++ b/python/peacock/ExodusViewer/plugins/FilePlugin.py
@@ -12,7 +12,7 @@ import sys
 import glob
 from PyQt5 import QtCore, QtWidgets
 import peacock
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 from peacock.ExodusViewer.plugins.ExodusFilterProxyModel import ExodusFilterProxyModel
 
 class ExodusComboBox(QtWidgets.QComboBox):

--- a/python/peacock/ExodusViewer/plugins/GoldDiffPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/GoldDiffPlugin.py
@@ -10,8 +10,8 @@
 import subprocess
 import os
 from PyQt5 import QtCore, QtWidgets
-from ExodusPlugin import ExodusPlugin
-from VTKWindowPlugin import VTKWindowPlugin
+from .ExodusPlugin import ExodusPlugin
+from .VTKWindowPlugin import VTKWindowPlugin
 import mooseutils
 
 class ExternalVTKWindowPlugin(VTKWindowPlugin):

--- a/python/peacock/ExodusViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/MediaControlPlugin.py
@@ -9,7 +9,7 @@
 
 import sys
 from PyQt5 import QtWidgets, QtCore
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 import mooseutils
 import peacock
 

--- a/python/peacock/ExodusViewer/plugins/MeshPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/MeshPlugin.py
@@ -10,7 +10,7 @@
 import sys
 from PyQt5 import QtCore, QtWidgets
 import chigger
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class MeshPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/ExodusViewer/plugins/OutputPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/OutputPlugin.py
@@ -12,7 +12,7 @@ import types
 import vtk
 
 from PyQt5 import QtWidgets, QtCore
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 from peacock.utils.TextSubWindow import TextSubWindow
 

--- a/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
+++ b/python/peacock/ExodusViewer/plugins/VTKWindowPlugin.py
@@ -14,7 +14,7 @@ import vtk
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 import chigger
 import mooseutils
-from ExodusPlugin import ExodusPlugin
+from .ExodusPlugin import ExodusPlugin
 
 class RetinaQVTKRenderWindowInteractor(QVTKRenderWindowInteractor):
     """

--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -11,10 +11,10 @@
 from PyQt5.QtWidgets import QWidget, QSplitter, QMessageBox
 from PyQt5.QtCore import Qt, pyqtSignal
 from peacock.utils import WidgetUtils
-from CommentEditor import CommentEditor
-from ParamsTable import ParamsTable
-from ParamsByGroup import ParamsByGroup
-from ParamsByType import ParamsByType
+from .CommentEditor import CommentEditor
+from .ParamsTable import ParamsTable
+from .ParamsByGroup import ParamsByGroup
+from .ParamsByType import ParamsByType
 from peacock.base.MooseWidget import MooseWidget
 
 class BlockEditor(QWidget, MooseWidget):

--- a/python/peacock/Input/BlockEditor.py
+++ b/python/peacock/Input/BlockEditor.py
@@ -11,11 +11,11 @@
 from PyQt5.QtWidgets import QWidget, QSplitter, QMessageBox
 from PyQt5.QtCore import Qt, pyqtSignal
 from peacock.utils import WidgetUtils
+from peacock.base.MooseWidget import MooseWidget
 from .CommentEditor import CommentEditor
 from .ParamsTable import ParamsTable
 from .ParamsByGroup import ParamsByGroup
 from .ParamsByType import ParamsByType
-from peacock.base.MooseWidget import MooseWidget
 
 class BlockEditor(QWidget, MooseWidget):
     """

--- a/python/peacock/Input/BlockHighlighterPlugin.py
+++ b/python/peacock/Input/BlockHighlighterPlugin.py
@@ -10,7 +10,7 @@
 from PyQt5 import QtCore, QtWidgets
 import chigger
 from peacock.ExodusViewer.plugins.ExodusPlugin import ExodusPlugin
-from MeshBlockSelectorWidget import MeshBlockSelectorWidget
+from .MeshBlockSelectorWidget import MeshBlockSelectorWidget
 
 class BlockHighlighterPlugin(QtWidgets.QGroupBox, ExodusPlugin):
     """

--- a/python/peacock/Input/BlockInfo.py
+++ b/python/peacock/Input/BlockInfo.py
@@ -9,9 +9,12 @@
 
 import os
 import copy
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import mooseutils
-from ParameterInfo import ParameterInfo
+from .ParameterInfo import ParameterInfo
 
 class BlockInfo(object):
     """
@@ -362,7 +365,7 @@ class BlockInfo(object):
         Return:
             str: The dump of this block.
         """
-        o = cStringIO.StringIO()
+        o = StringIO()
         i_str = sep*indent
         o.write("%sPath: %s\n" % (i_str, self.path))
         indent += 1

--- a/python/peacock/Input/BlockTree.py
+++ b/python/peacock/Input/BlockTree.py
@@ -13,7 +13,10 @@ from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtCore import Qt, pyqtSignal
 from peacock.utils import WidgetUtils
 from peacock.base.MooseWidget import MooseWidget
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class BlockTree(QTreeWidget, MooseWidget):
     """
@@ -388,7 +391,7 @@ class BlockTree(QTreeWidget, MooseWidget):
         Return:
             str: A display of the current QTreeWidget
         """
-        output = cStringIO.StringIO()
+        output = StringIO()
         for i in range(self.root_item.childCount()):
             child = self.root_item.child(i)
             self._dumpItem(output, child)

--- a/python/peacock/Input/ExecutableInfo.py
+++ b/python/peacock/Input/ExecutableInfo.py
@@ -8,12 +8,15 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from JsonData import JsonData
+from .JsonData import JsonData
 from peacock.utils.FileCache import FileCache
 import os
-import cStringIO
-from BlockInfo import BlockInfo
-from ParameterInfo import ParameterInfo
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+from .BlockInfo import BlockInfo
+from .ParameterInfo import ParameterInfo
 
 class ExecutableInfo(object):
     """
@@ -183,7 +186,7 @@ class ExecutableInfo(object):
                 self._dumpNode(output, entry.children[c], level+1, prefix, only_hard=only_hard)
 
     def dumpDefaultTree(self, hard_only=False):
-        output = cStringIO.StringIO()
+        output = StringIO()
         for c in sorted(self.path_map.keys()):
             if c == "/":
                 continue

--- a/python/peacock/Input/ExecutableInfo.py
+++ b/python/peacock/Input/ExecutableInfo.py
@@ -8,13 +8,13 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from .JsonData import JsonData
-from peacock.utils.FileCache import FileCache
 import os
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
+from peacock.utils.FileCache import FileCache
+from .JsonData import JsonData
 from .BlockInfo import BlockInfo
 from .ParameterInfo import ParameterInfo
 

--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -10,13 +10,13 @@
 
 from PyQt5.QtWidgets import QWidget, QSizePolicy
 from PyQt5.QtCore import Qt, pyqtSignal
-from BlockTree import BlockTree
-from BlockEditor import BlockEditor
+from .BlockTree import BlockTree
+from .BlockEditor import BlockEditor
 from peacock.utils import WidgetUtils
 from peacock.base.MooseWidget import MooseWidget
 import mooseutils
-from InputTree import InputTree
-from ExecutableInfo import ExecutableInfo
+from .InputTree import InputTree
+from .ExecutableInfo import ExecutableInfo
 import os
 
 class InputFileEditor(QWidget, MooseWidget):

--- a/python/peacock/Input/InputFileEditor.py
+++ b/python/peacock/Input/InputFileEditor.py
@@ -8,16 +8,16 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+import os
 from PyQt5.QtWidgets import QWidget, QSizePolicy
 from PyQt5.QtCore import Qt, pyqtSignal
-from .BlockTree import BlockTree
-from .BlockEditor import BlockEditor
 from peacock.utils import WidgetUtils
 from peacock.base.MooseWidget import MooseWidget
 import mooseutils
+from .BlockTree import BlockTree
+from .BlockEditor import BlockEditor
 from .InputTree import InputTree
 from .ExecutableInfo import ExecutableInfo
-import os
 
 class InputFileEditor(QWidget, MooseWidget):
     """

--- a/python/peacock/Input/InputFileEditorPlugin.py
+++ b/python/peacock/Input/InputFileEditorPlugin.py
@@ -13,8 +13,8 @@ from PyQt5 import QtCore
 from peacock.utils import WidgetUtils
 from peacock.base.Plugin import Plugin
 from peacock.utils.RecentlyUsedMenu import RecentlyUsedMenu
-from CheckInputWidget import CheckInputWidget
-from InputFileEditor import InputFileEditor
+from .CheckInputWidget import CheckInputWidget
+from .InputFileEditor import InputFileEditor
 
 class InputFileEditorPlugin(InputFileEditor, Plugin):
     """

--- a/python/peacock/Input/InputFileEditorWithMesh.py
+++ b/python/peacock/Input/InputFileEditorWithMesh.py
@@ -8,17 +8,17 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import os
-from plugins import MeshViewerPlugin
-from plugins import MeshCameraPlugin
-from peacock.ExodusViewer.plugins.BackgroundPlugin import BackgroundPlugin
-from BlockHighlighterPlugin import BlockHighlighterPlugin
-from peacock.base.PluginManager import PluginManager
-from peacock.base.TabPlugin import TabPlugin
 from PyQt5.QtWidgets import QMessageBox, QWidget, QVBoxLayout, QHBoxLayout
 from PyQt5.QtCore import pyqtSignal
-from InputFileEditorPlugin import InputFileEditorPlugin
-import BCHighlighter
-import TimeStepEstimate
+from peacock.ExodusViewer.plugins.BackgroundPlugin import BackgroundPlugin
+from peacock.base.PluginManager import PluginManager
+from peacock.base.TabPlugin import TabPlugin
+from .plugins import MeshViewerPlugin
+from .plugins import MeshCameraPlugin
+from .BlockHighlighterPlugin import BlockHighlighterPlugin
+from .InputFileEditorPlugin import InputFileEditorPlugin
+from . import BCHighlighter
+from . import TimeStepEstimate
 
 class InputFileEditorWithMesh(QWidget, PluginManager, TabPlugin):
     """

--- a/python/peacock/Input/InputTree.py
+++ b/python/peacock/Input/InputTree.py
@@ -8,9 +8,9 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from InputFile import InputFile
+from .InputFile import InputFile
 import mooseutils
-import InputTreeWriter
+from . import InputTreeWriter
 import os
 import hit
 

--- a/python/peacock/Input/InputTree.py
+++ b/python/peacock/Input/InputTree.py
@@ -8,11 +8,11 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from .InputFile import InputFile
-import mooseutils
-from . import InputTreeWriter
 import os
 import hit
+import mooseutils
+from .InputFile import InputFile
+from . import InputTreeWriter
 
 class InputTree(object):
     """

--- a/python/peacock/Input/ParamsByGroup.py
+++ b/python/peacock/Input/ParamsByGroup.py
@@ -10,7 +10,7 @@
 from PyQt5.QtWidgets import QTabWidget
 from PyQt5.QtCore import pyqtSignal
 from peacock.base.MooseWidget import MooseWidget
-from ParamsTable import ParamsTable
+from .ParamsTable import ParamsTable
 
 def tabSort(val):
     """

--- a/python/peacock/Input/ParamsByType.py
+++ b/python/peacock/Input/ParamsByType.py
@@ -11,7 +11,7 @@ from PyQt5.QtWidgets import QWidget, QComboBox, QStackedWidget
 from PyQt5.QtCore import pyqtSignal
 from peacock.base.MooseWidget import MooseWidget
 from peacock.utils import WidgetUtils
-from ParamsByGroup import ParamsByGroup
+from .ParamsByGroup import ParamsByGroup
 
 class ParamsByType(QWidget, MooseWidget):
     """

--- a/python/peacock/Input/ParamsTable.py
+++ b/python/peacock/Input/ParamsTable.py
@@ -11,7 +11,7 @@ from PyQt5 import QtWidgets
 from PyQt5.QtGui import QColor, QBrush
 from PyQt5.QtCore import pyqtSignal, Qt
 from peacock.base.MooseWidget import MooseWidget
-from ParameterInfo import ParameterInfo
+from .ParameterInfo import ParameterInfo
 import os
 
 class EditingDelegate(QtWidgets.QStyledItemDelegate):

--- a/python/peacock/Input/ParamsTable.py
+++ b/python/peacock/Input/ParamsTable.py
@@ -7,12 +7,12 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+import os
 from PyQt5 import QtWidgets
 from PyQt5.QtGui import QColor, QBrush
 from PyQt5.QtCore import pyqtSignal, Qt
 from peacock.base.MooseWidget import MooseWidget
 from .ParameterInfo import ParameterInfo
-import os
 
 class EditingDelegate(QtWidgets.QStyledItemDelegate):
     """

--- a/python/peacock/Input/plugins/__init__.py
+++ b/python/peacock/Input/plugins/__init__.py
@@ -7,5 +7,5 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from MeshViewerPlugin import MeshViewerPlugin
-from MeshCameraPlugin import MeshCameraPlugin
+from .MeshViewerPlugin import MeshViewerPlugin
+from .MeshCameraPlugin import MeshCameraPlugin

--- a/python/peacock/PostprocessorViewer/PostprocessorViewer.py
+++ b/python/peacock/PostprocessorViewer/PostprocessorViewer.py
@@ -13,14 +13,14 @@ from PyQt5 import QtWidgets
 import peacock
 import mooseutils
 
-from PostprocessorPluginManager import PostprocessorPluginManager
-from PostprocessorDataWidget import PostprocessorDataWidget
+from .PostprocessorPluginManager import PostprocessorPluginManager
+from .PostprocessorDataWidget import PostprocessorDataWidget
 
-from plugins.FigurePlugin import FigurePlugin
-from plugins.PostprocessorSelectPlugin import PostprocessorSelectPlugin
-from plugins.AxesSettingsPlugin import AxesSettingsPlugin
-from plugins.AxisTabsPlugin import AxisTabsPlugin
-from plugins.OutputPlugin import OutputPlugin
+from .plugins.FigurePlugin import FigurePlugin
+from .plugins.PostprocessorSelectPlugin import PostprocessorSelectPlugin
+from .plugins.AxesSettingsPlugin import AxesSettingsPlugin
+from .plugins.AxisTabsPlugin import AxisTabsPlugin
+from .plugins.OutputPlugin import OutputPlugin
 
 
 class PostprocessorViewer(peacock.base.ViewerBase):

--- a/python/peacock/PostprocessorViewer/VectorPostprocessorViewer.py
+++ b/python/peacock/PostprocessorViewer/VectorPostprocessorViewer.py
@@ -12,13 +12,13 @@ from PyQt5 import QtWidgets
 
 import mooseutils
 import peacock
-from PostprocessorViewer import PostprocessorViewer
-from plugins.FigurePlugin import FigurePlugin
-from plugins.MediaControlPlugin import MediaControlPlugin
-from plugins.PostprocessorSelectPlugin import PostprocessorSelectPlugin
-from plugins.AxesSettingsPlugin import AxesSettingsPlugin
-from plugins.AxisTabsPlugin import AxisTabsPlugin
-from plugins.OutputPlugin import OutputPlugin
+from .PostprocessorViewer import PostprocessorViewer
+from .plugins.FigurePlugin import FigurePlugin
+from .plugins.MediaControlPlugin import MediaControlPlugin
+from .plugins.PostprocessorSelectPlugin import PostprocessorSelectPlugin
+from .plugins.AxesSettingsPlugin import AxesSettingsPlugin
+from .plugins.AxisTabsPlugin import AxisTabsPlugin
+from .plugins.OutputPlugin import OutputPlugin
 
 
 class VectorPostprocessorViewer(PostprocessorViewer):

--- a/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
@@ -9,7 +9,7 @@
 
 import sys
 from PyQt5 import QtCore, QtWidgets
-from PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorPlugin import PostprocessorPlugin
 import peacock
 
 class AxesSettingsPlugin(QtWidgets.QGroupBox, PostprocessorPlugin):

--- a/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
@@ -9,8 +9,8 @@
 
 import sys
 from PyQt5 import QtCore, QtWidgets
-from .PostprocessorPlugin import PostprocessorPlugin
 import peacock
+from .PostprocessorPlugin import PostprocessorPlugin
 
 class AxesSettingsPlugin(QtWidgets.QGroupBox, PostprocessorPlugin):
     """

--- a/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
@@ -9,9 +9,9 @@
 
 import sys
 from PyQt5 import QtCore, QtWidgets
-from PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorPlugin import PostprocessorPlugin
 import mooseutils
-from AxisSettingsWidget import AxisSettingsWidget
+from .AxisSettingsWidget import AxisSettingsWidget
 
 class AxisTabsPlugin(QtWidgets.QTabWidget, PostprocessorPlugin):
 

--- a/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
@@ -9,8 +9,8 @@
 
 import sys
 from PyQt5 import QtCore, QtWidgets
-from .PostprocessorPlugin import PostprocessorPlugin
 import mooseutils
+from .PostprocessorPlugin import PostprocessorPlugin
 from .AxisSettingsWidget import AxisSettingsWidget
 
 class AxisTabsPlugin(QtWidgets.QTabWidget, PostprocessorPlugin):

--- a/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from PyQt5 import QtCore, QtWidgets
 
-from PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorPlugin import PostprocessorPlugin
 
 class FigurePlugin(QtWidgets.QWidget, PostprocessorPlugin):
     """

--- a/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
@@ -9,7 +9,7 @@
 
 import collections
 from PyQt5 import QtCore, QtWidgets
-from LineSettingsWidget import LineSettingsWidget
+from .LineSettingsWidget import LineSettingsWidget
 import peacock
 import mooseutils
 

--- a/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
@@ -9,9 +9,9 @@
 
 import collections
 from PyQt5 import QtCore, QtWidgets
-from .LineSettingsWidget import LineSettingsWidget
 import peacock
 import mooseutils
+from .LineSettingsWidget import LineSettingsWidget
 
 
 class LineGroupWidget(peacock.base.MooseWidget, QtWidgets.QGroupBox):

--- a/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
@@ -11,7 +11,7 @@
 import sys
 import bisect
 from PyQt5 import QtWidgets, QtCore
-from PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorPlugin import PostprocessorPlugin
 import mooseutils
 import peacock
 

--- a/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
@@ -11,9 +11,9 @@
 import sys
 import bisect
 from PyQt5 import QtWidgets, QtCore
-from .PostprocessorPlugin import PostprocessorPlugin
 import mooseutils
 import peacock
+from .PostprocessorPlugin import PostprocessorPlugin
 
 class MediaControlPlugin(QtWidgets.QGroupBox, peacock.base.MediaControlWidgetBase, PostprocessorPlugin):
     """

--- a/python/peacock/PostprocessorViewer/plugins/OutputPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/OutputPlugin.py
@@ -9,8 +9,8 @@
 
 import peacock
 from PyQt5 import QtWidgets
-from PostprocessorPlugin import PostprocessorPlugin
-from PostprocessorTableWidget import PostprocessorTableWidget
+from .PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorTableWidget import PostprocessorTableWidget
 from peacock.utils import WidgetUtils
 import mooseutils
 

--- a/python/peacock/PostprocessorViewer/plugins/OutputPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/OutputPlugin.py
@@ -9,10 +9,10 @@
 
 import peacock
 from PyQt5 import QtWidgets
-from .PostprocessorPlugin import PostprocessorPlugin
-from .PostprocessorTableWidget import PostprocessorTableWidget
 from peacock.utils import WidgetUtils
 import mooseutils
+from .PostprocessorPlugin import PostprocessorPlugin
+from .PostprocessorTableWidget import PostprocessorTableWidget
 
 class OutputPlugin(peacock.base.OutputWidgetBase, PostprocessorPlugin):
     """

--- a/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
@@ -14,8 +14,8 @@ import matplotlib.pyplot as plt
 import itertools
 
 from PyQt5 import QtCore, QtWidgets
-from PostprocessorPlugin import PostprocessorPlugin
-from LineGroupWidget import LineGroupWidget
+from .PostprocessorPlugin import PostprocessorPlugin
+from .LineGroupWidget import LineGroupWidget
 
 import mooseutils
 

--- a/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
@@ -14,10 +14,9 @@ import matplotlib.pyplot as plt
 import itertools
 
 from PyQt5 import QtCore, QtWidgets
+import mooseutils
 from .PostprocessorPlugin import PostprocessorPlugin
 from .LineGroupWidget import LineGroupWidget
-
-import mooseutils
 
 class PostprocessorSelectPlugin(QtWidgets.QWidget, PostprocessorPlugin):
     """

--- a/python/peacock/PythonConsoleWidget.py
+++ b/python/peacock/PythonConsoleWidget.py
@@ -11,7 +11,10 @@ from code import InteractiveConsole
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QEvent, Qt, QSettings
 from PyQt5.QtWidgets import QWidget, QPlainTextEdit, QSizePolicy
 import sys
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 from peacock.utils import WidgetUtils
 from peacock.base import MooseWidget
 

--- a/python/peacock/base/Plugin.py
+++ b/python/peacock/base/Plugin.py
@@ -8,9 +8,9 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtWidgets
-from MooseWidget import MooseWidget
+from .MooseWidget import MooseWidget
 import mooseutils
-from Preferences import Preferences
+from .Preferences import Preferences
 
 class Plugin(MooseWidget):
     """

--- a/python/peacock/base/Plugin.py
+++ b/python/peacock/base/Plugin.py
@@ -8,8 +8,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtWidgets
-from .MooseWidget import MooseWidget
 import mooseutils
+from .MooseWidget import MooseWidget
 from .Preferences import Preferences
 
 class Plugin(MooseWidget):

--- a/python/peacock/base/PluginManager.py
+++ b/python/peacock/base/PluginManager.py
@@ -9,10 +9,10 @@
 
 import collections
 from PyQt5 import QtWidgets
-from MooseWidget import MooseWidget
-from Plugin import Plugin
+from .MooseWidget import MooseWidget
+from .Plugin import Plugin
 import mooseutils
-from PreferenceWidget import PreferenceWidget
+from .PreferenceWidget import PreferenceWidget
 
 class PluginManager(MooseWidget):
     """

--- a/python/peacock/base/PluginManager.py
+++ b/python/peacock/base/PluginManager.py
@@ -9,9 +9,9 @@
 
 import collections
 from PyQt5 import QtWidgets
+import mooseutils
 from .MooseWidget import MooseWidget
 from .Plugin import Plugin
-import mooseutils
 from .PreferenceWidget import PreferenceWidget
 
 class PluginManager(MooseWidget):

--- a/python/peacock/base/TabPlugin.py
+++ b/python/peacock/base/TabPlugin.py
@@ -7,7 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from Plugin import Plugin
+from .Plugin import Plugin
 class TabPlugin(Plugin):
     def __init__(self):
         super(TabPlugin, self).__init__()

--- a/python/peacock/base/TabPluginManager.py
+++ b/python/peacock/base/TabPluginManager.py
@@ -9,9 +9,9 @@
 
 import argparse
 from PyQt5 import QtWidgets
-from PluginManager import PluginManager
-from TabPlugin import TabPlugin
-from TabbedPreferences import TabbedPreferences
+from .PluginManager import PluginManager
+from .TabPlugin import TabPlugin
+from .TabbedPreferences import TabbedPreferences
 
 class TabPluginManager(QtWidgets.QTabWidget, PluginManager):
     """

--- a/python/peacock/base/ViewerBase.py
+++ b/python/peacock/base/ViewerBase.py
@@ -8,8 +8,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtWidgets
-from TabPlugin import TabPlugin
-from ViewerCornerWidget import ViewerCornerWidget
+from .TabPlugin import TabPlugin
+from .ViewerCornerWidget import ViewerCornerWidget
 import mooseutils
 
 class ViewerBase(QtWidgets.QTabWidget, TabPlugin):

--- a/python/peacock/base/ViewerBase.py
+++ b/python/peacock/base/ViewerBase.py
@@ -8,9 +8,9 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtWidgets
+import mooseutils
 from .TabPlugin import TabPlugin
 from .ViewerCornerWidget import ViewerCornerWidget
-import mooseutils
 
 class ViewerBase(QtWidgets.QTabWidget, TabPlugin):
     """

--- a/python/peacock/base/ViewerCornerWidget.py
+++ b/python/peacock/base/ViewerCornerWidget.py
@@ -8,7 +8,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtCore, QtWidgets
-from MooseWidget import MooseWidget
+from .MooseWidget import MooseWidget
 from peacock.utils import WidgetUtils
 
 class ViewerCornerWidget(QtWidgets.QWidget, MooseWidget):

--- a/python/peacock/base/ViewerCornerWidget.py
+++ b/python/peacock/base/ViewerCornerWidget.py
@@ -8,8 +8,8 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5 import QtCore, QtWidgets
-from .MooseWidget import MooseWidget
 from peacock.utils import WidgetUtils
+from .MooseWidget import MooseWidget
 
 class ViewerCornerWidget(QtWidgets.QWidget, MooseWidget):
     """

--- a/python/peacock/base/__init__.py
+++ b/python/peacock/base/__init__.py
@@ -7,10 +7,10 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-from MooseWidget import MooseWidget
-from Plugin import Plugin
-from PluginManager import PluginManager
-from MediaControlWidgetBase import MediaControlWidgetBase
-from OutputWidgetBase import OutputWidgetBase
-from ViewerBase import ViewerBase
-from PeacockCollapsibleWidget import PeacockCollapsibleWidget
+from .MooseWidget import MooseWidget
+from .Plugin import Plugin
+from .PluginManager import PluginManager
+from .MediaControlWidgetBase import MediaControlWidgetBase
+from .OutputWidgetBase import OutputWidgetBase
+from .ViewerBase import ViewerBase
+from .PeacockCollapsibleWidget import PeacockCollapsibleWidget

--- a/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
+++ b/python/peacock/tests/input_tab/ParameterInfo/test_ParameterInfo.py
@@ -10,7 +10,10 @@
 
 from peacock.utils import Testing
 from peacock.Input.ParameterInfo import ParameterInfo
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from PyQt5 import QtWidgets
 
 class Tests(Testing.PeacockTester):
@@ -72,7 +75,7 @@ class Tests(Testing.PeacockTester):
 
     def testDump(self):
         p = ParameterInfo(None, "p0")
-        o = cStringIO.StringIO()
+        o = StringIO()
         p.dump(o)
         val = o.getvalue()
         self.assertIn("Name", val)

--- a/python/peacock/utils/FileCache.py
+++ b/python/peacock/utils/FileCache.py
@@ -8,7 +8,11 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from PyQt5.QtCore import QSettings, QStandardPaths
-import os, cPickle
+import os
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import uuid
 
 class FileCache(object):
@@ -76,7 +80,7 @@ class FileCache(object):
 
         try:
             with open(self.path_data["pickle_path"], "r") as f:
-                data = cPickle.load(f)
+                data = pickle.load(f)
                 return data
         except:
             return None
@@ -118,7 +122,7 @@ class FileCache(object):
         filename = uuid.uuid4().hex
         full_path = os.path.join(cache_dir, filename)
         with open(full_path, "w") as f:
-            cPickle.dump(obj, f, protocol=cPickle.HIGHEST_PROTOCOL)
+            pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
         self.path_data = {"ctime": self.stat.st_ctime,
                 "size": self.stat.st_size,
                 "pickle_path": full_path,

--- a/python/peacock/utils/WidgetUtils.py
+++ b/python/peacock/utils/WidgetUtils.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from __future__ import print_function
 import os
 from mooseutils import message
 from PyQt5 import QtWidgets, QtGui
@@ -114,7 +115,7 @@ def dumpQObjectTree(qobject, level=0):
     """
 
     if level == 0:
-        print '+ ' + qobject.objectName() + ' (' + str(type(qobject)) + ')'
+        print('+ ' + qobject.objectName() + ' (' + str(type(qobject)) + ')')
 
     children = qobject.children()
     n = len(children)
@@ -122,13 +123,13 @@ def dumpQObjectTree(qobject, level=0):
         child = children[i]
 
         if i == 0:
-            print '|  '*(level+1)
+            print('|  '*(level+1))
             prefix = '|  '*(level) + '+--'
         else:
-            print '|  '*(level+2)
+            print('|  '*(level+2))
             prefix = '|  '*(level+1)
 
-        print prefix + '+ ' + child.objectName() + ' (' + str(type(child)) + ')'
+        print(prefix + '+ ' + child.objectName() + ' (' + str(type(child)) + ')')
         dumpQObjectTree(child, level+1)
 
 def createIcon(name):


### PR DESCRIPTION
Python3 is the primary Python that I use in my workflow so I figured I would take a crack at adding Py3 compatibility to peacock.  This PR doesn't give full Py3 compatibility, but it gets a lot of the grunt work out of the way.  Mostly this just switches to the new formats for relative imports and print functions.

Beyond this, some more detailed work is needed.  In particular, some Qt objects are used as dictionary keys, but they aren't hashable in Py3.  Not sure if I'm motivated enough to tackle that stuff so I'll PR this work to give the next person a good start.

Refs #11100