### PR TITLE
Fixed PetscJacobianTester for PETSc-3.8.x or older

### DIFF
--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -52,7 +52,7 @@ class PetscJacobianTester(RunApp):
 
         if map(int, util.getPetscVersion(self.libmesh_dir).split(".")) < [3, 9]:
             self.old_petsc = True
-            self.specs['cli_args'].append('-snes_type test')
+            self.specs['cli_args'].extend(['-snes_type test', '-snes_mf_operator 0'])
         else:
             self.old_petsc = False
             self.specs['cli_args'].extend(['-snes_test_jacobian', '-snes_force_iteration'])


### PR DESCRIPTION
We should not use the Jacobian-free method when testing Jacobian matrices

Closes #13284

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
