### PR TITLE
Removing IsParamValid usage after intialization in dynamic inertial force computations

### DIFF
--- a/modules/tensor_mechanics/include/kernels/InertialForce.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForce.h
@@ -34,8 +34,12 @@ private:
   const VariableValue * _u_old;
   const VariableValue * _vel_old;
   const VariableValue * _accel_old;
+  const bool _has_beta;
+  const bool _has_gamma;
   const Real _beta;
   const Real _gamma;
+  const bool _has_velocity;
+  const bool _has_acceleration;
   const MaterialProperty<Real> & _eta;
   const Real _alpha;
 

--- a/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
@@ -33,6 +33,15 @@ protected:
   virtual Real computeQpResidual() override { return 0.0; };
 
 private:
+  /// Booleans for validity of params
+  const bool _has_beta;
+  const bool _has_gamma;
+  const bool _has_velocities;
+  const bool _has_rot_velocities;
+  const bool _has_accelerations;
+  const bool _has_rot_accelerations;
+  const bool _has_Ix;
+  
   /// Density of the beam
   const MaterialProperty<Real> & _density;
 

--- a/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
@@ -41,7 +41,7 @@ private:
   const bool _has_accelerations;
   const bool _has_rot_accelerations;
   const bool _has_Ix;
-  
+
   /// Density of the beam
   const MaterialProperty<Real> & _density;
 

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalBeamStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalBeamStrain.h
@@ -39,6 +39,9 @@ protected:
   /// Computes the rotation matrix at time t. For small rotation scenarios, the rotation matrix at time t is same as the intiial rotation matrix
   virtual void computeRotation();
 
+  /// Booleans for validity of params
+  const bool _has_Ix;
+
   /// Number of coupled rotational variables
   unsigned int _nrot;
 

--- a/modules/tensor_mechanics/include/nodalkernels/NodalGravity.h
+++ b/modules/tensor_mechanics/include/nodalkernels/NodalGravity.h
@@ -34,6 +34,10 @@ public:
 protected:
   virtual Real computeQpResidual() override;
 
+  /// Booleans for validity of params
+  const bool _has_mass;
+  const bool _has_nodal_mass_file;
+
   /// Mass associated with the node
   const Real _mass;
 

--- a/modules/tensor_mechanics/include/nodalkernels/NodalRotationalInertia.h
+++ b/modules/tensor_mechanics/include/nodalkernels/NodalRotationalInertia.h
@@ -40,6 +40,14 @@ protected:
 
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
+  /// Booleans for validity of params
+  const bool _has_beta;
+  const bool _has_gamma;
+  const bool _has_rot_velocities;
+  const bool _has_rot_accelerations;
+  const bool _has_x_orientation;
+  const bool _has_y_orientation;
+
   /// Auxiliary system object
   AuxiliarySystem * _aux_sys;
 

--- a/modules/tensor_mechanics/include/nodalkernels/NodalTranslationalInertia.h
+++ b/modules/tensor_mechanics/include/nodalkernels/NodalTranslationalInertia.h
@@ -36,6 +36,14 @@ protected:
 
   virtual Real computeQpJacobian() override;
 
+  /// Booleans for validity of params
+  const bool _has_mass;
+  const bool _has_beta;
+  const bool _has_gamma;
+  const bool _has_velocity;
+  const bool _has_acceleration;
+  const bool _has_nodal_mass_file;
+
   /// Mass associated with the node
   const Real _mass;
 

--- a/modules/tensor_mechanics/src/kernels/InertialForce.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForce.C
@@ -53,15 +53,13 @@ InertialForce::InertialForce(const InputParameters & parameters)
     _eta(getMaterialProperty<Real>("eta")),
     _alpha(getParam<Real>("alpha"))
 {
-  if (_has_beta && _has_gamma && _has_velocity &&
-      _has_acceleration)
+  if (_has_beta && _has_gamma && _has_velocity && _has_acceleration)
   {
     _vel_old = &coupledValueOld("velocity");
     _accel_old = &coupledValueOld("acceleration");
     _u_old = &valueOld();
   }
-  else if (!_has_beta && !_has_gamma && !_has_velocity &&
-           !_has_acceleration)
+  else if (!_has_beta && !_has_gamma && !_has_velocity && !_has_acceleration)
   {
     _u_dot = &(_var.uDot());
     _u_dotdot = &(_var.uDotDot());

--- a/modules/tensor_mechanics/src/kernels/InertialForce.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForce.C
@@ -44,20 +44,24 @@ validParams<InertialForce>()
 InertialForce::InertialForce(const InputParameters & parameters)
   : TimeKernel(parameters),
     _density(getMaterialProperty<Real>("density")),
-    _beta(isParamValid("beta") ? getParam<Real>("beta") : 0.1),
-    _gamma(isParamValid("gamma") ? getParam<Real>("gamma") : 0.1),
+    _has_beta(isParamValid("beta")),
+    _has_gamma(isParamValid("gamma")),
+    _beta(_has_beta ? getParam<Real>("beta") : 0.1),
+    _gamma(_has_gamma ? getParam<Real>("gamma") : 0.1),
+    _has_velocity(isParamValid("velocity")),
+    _has_acceleration(isParamValid("acceleration")),
     _eta(getMaterialProperty<Real>("eta")),
     _alpha(getParam<Real>("alpha"))
 {
-  if (isParamValid("beta") && isParamValid("gamma") && isParamValid("velocity") &&
-      isParamValid("acceleration"))
+  if (_has_beta && _has_gamma && _has_velocity &&
+      _has_acceleration)
   {
     _vel_old = &coupledValueOld("velocity");
     _accel_old = &coupledValueOld("acceleration");
     _u_old = &valueOld();
   }
-  else if (!isParamValid("beta") && !isParamValid("gamma") && !isParamValid("velocity") &&
-           !isParamValid("acceleration"))
+  else if (!_has_beta && !_has_gamma && !_has_velocity &&
+           !_has_acceleration)
   {
     _u_dot = &(_var.uDot());
     _u_dotdot = &(_var.uDotDot());
@@ -75,7 +79,7 @@ InertialForce::computeQpResidual()
 {
   if (_dt == 0)
     return 0;
-  else if (isParamValid("beta"))
+  else if (_has_beta)
   {
     Real accel = 1. / _beta *
                  (((_u[_qp] - (*_u_old)[_qp]) / (_dt * _dt)) - (*_vel_old)[_qp] / _dt -
@@ -95,7 +99,7 @@ InertialForce::computeQpJacobian()
 {
   if (_dt == 0)
     return 0;
-  else if (isParamValid("beta"))
+  else if (_has_beta)
     return _test[_i][_qp] * _density[_qp] / (_beta * _dt * _dt) * _phi[_j][_qp] +
            _eta[_qp] * (1 + _alpha) * _test[_i][_qp] * _density[_qp] * _gamma / _beta / _dt *
                _phi[_j][_qp];

--- a/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
@@ -107,8 +107,7 @@ InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
     mooseError("InertialForceBeam: The number of variables supplied in 'displacements' and "
                "'rotations' must match.");
 
-  if (_has_beta && _has_gamma && _has_velocities &&
-      _has_accelerations && _has_rot_velocities &&
+  if (_has_beta && _has_gamma && _has_velocities && _has_accelerations && _has_rot_velocities &&
       _has_rot_accelerations)
   {
     if ((coupledComponents("velocities") != _ndisp) ||
@@ -136,9 +135,8 @@ InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
       _rot_accel_num[i] = rot_accel_variable->number();
     }
   }
-  else if (!_has_beta && !_has_gamma && !_has_velocities &&
-           !_has_accelerations && !_has_rot_velocities &&
-           !_has_rot_accelerations)
+  else if (!_has_beta && !_has_gamma && !_has_velocities && !_has_accelerations &&
+           !_has_rot_velocities && !_has_rot_accelerations)
   {
     _du_dot_du = &coupledDotDu("displacements", 0);
     _du_dotdot_du = &coupledDotDotDu("displacements", 0);

--- a/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
@@ -70,6 +70,13 @@ validParams<InertialForceBeam>()
 
 InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
   : TimeKernel(parameters),
+    _has_beta(isParamValid("beta")),
+    _has_gamma(isParamValid("gamma")),
+    _has_velocities(isParamValid("velocities")),
+    _has_rot_velocities(isParamValid("rotational_velocities")),
+    _has_accelerations(isParamValid("accelerations")),
+    _has_rot_accelerations(isParamValid("rotational_accelerations")),
+    _has_Ix(isParamValid("Ix")),
     _density(getMaterialProperty<Real>("density")),
     _nrot(coupledComponents("rotations")),
     _ndisp(coupledComponents("displacements")),
@@ -82,11 +89,11 @@ InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
     _area(coupledValue("area")),
     _Ay(coupledValue("Ay")),
     _Az(coupledValue("Az")),
-    _Ix(isParamValid("Ix") ? coupledValue("Ix") : _zero),
+    _Ix(_has_Ix ? coupledValue("Ix") : _zero),
     _Iy(coupledValue("Iy")),
     _Iz(coupledValue("Iz")),
-    _beta(isParamValid("beta") ? getParam<Real>("beta") : 0.1),
-    _gamma(isParamValid("gamma") ? getParam<Real>("gamma") : 0.1),
+    _beta(_has_beta ? getParam<Real>("beta") : 0.1),
+    _gamma(_has_gamma ? getParam<Real>("gamma") : 0.1),
     _eta(getMaterialProperty<Real>("eta")),
     _alpha(getParam<Real>("alpha")),
     _original_local_config(getMaterialPropertyByName<RankTwoTensor>("initial_rotation")),
@@ -100,9 +107,9 @@ InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
     mooseError("InertialForceBeam: The number of variables supplied in 'displacements' and "
                "'rotations' must match.");
 
-  if (isParamValid("beta") && isParamValid("gamma") && isParamValid("velocities") &&
-      isParamValid("accelerations") && isParamValid("rotational_velocities") &&
-      isParamValid("rotational_accelerations"))
+  if (_has_beta && _has_gamma && _has_velocities &&
+      _has_accelerations && _has_rot_velocities &&
+      _has_rot_accelerations)
   {
     if ((coupledComponents("velocities") != _ndisp) ||
         (coupledComponents("accelerations") != _ndisp) ||
@@ -129,9 +136,9 @@ InertialForceBeam::InertialForceBeam(const InputParameters & parameters)
       _rot_accel_num[i] = rot_accel_variable->number();
     }
   }
-  else if (!isParamValid("beta") && !isParamValid("gamma") && !isParamValid("velocities") &&
-           !isParamValid("accelerations") && !isParamValid("rotational_velocities") &&
-           !isParamValid("rotational_accelerations"))
+  else if (!_has_beta && !_has_gamma && !_has_velocities &&
+           !_has_accelerations && !_has_rot_velocities &&
+           !_has_rot_accelerations)
   {
     _du_dot_du = &coupledDotDu("displacements", 0);
     _du_dotdot_du = &coupledDotDotDu("displacements", 0);
@@ -170,7 +177,7 @@ InertialForceBeam::computeResidual()
     // Fetch the solution for the two end nodes at time t
     NonlinearSystemBase & nonlinear_sys = _fe_problem.getNonlinearSystemBase();
 
-    if (isParamValid("beta"))
+    if (_has_beta)
     {
       const NumericVector<Number> & sol = *nonlinear_sys.currentSolution();
       const NumericVector<Number> & sol_old = nonlinear_sys.solutionOld();
@@ -305,7 +312,7 @@ InertialForceBeam::computeResidual()
       if (_component > 2)
       {
         Real I = _Iy[0] + _Iz[0];
-        if (isParamValid("Ix") && (i == 0))
+        if (_has_Ix && (i == 0))
           I = _Ix[0];
         if (i == 1)
           I = _Iz[0];
@@ -425,7 +432,7 @@ InertialForceBeam::computeJacobian()
   mooseAssert(_beta > 0.0, "InertialForceBeam: Beta parameter should be positive.");
 
   Real factor = 0.0;
-  if (isParamValid("beta"))
+  if (_has_beta)
     factor = 1.0 / (_beta * _dt * _dt) + _eta[0] * (1.0 + _alpha) * _gamma / _beta / _dt;
   else
     factor = (*_du_dotdot_du)[0] + _eta[0] * (1.0 + _alpha) * (*_du_dot_du)[0];
@@ -440,7 +447,7 @@ InertialForceBeam::computeJacobian()
       else if (_component > 2)
       {
         RankTwoTensor I;
-        if (isParamValid("Ix"))
+        if (_has_Ix)
           I(0, 0) = _Ix[0];
         else
           I(0, 0) = _Iy[0] + _Iz[0];
@@ -477,7 +484,7 @@ InertialForceBeam::computeOffDiagJacobian(MooseVariableFEBase & jvar)
   mooseAssert(_beta > 0.0, "InertialForceBeam: Beta parameter should be positive.");
 
   Real factor = 0.0;
-  if (isParamValid("beta"))
+  if (_has_beta)
     factor = 1.0 / (_beta * _dt * _dt) + _eta[0] * (1.0 + _alpha) * _gamma / _beta / _dt;
   else
     factor = (*_du_dotdot_du)[0] + _eta[0] * (1.0 + _alpha) * (*_du_dot_du)[0];
@@ -552,7 +559,7 @@ InertialForceBeam::computeOffDiagJacobian(MooseVariableFEBase & jvar)
           else if (_component > 2 && coupled_component > 2)
           {
             RankTwoTensor I;
-            if (isParamValid("Ix"))
+            if (_has_Ix)
               I(0, 0) = _Ix[0];
             else
               I(0, 0) = _Iy[0] + _Iz[0];

--- a/modules/tensor_mechanics/src/materials/ComputeIncrementalBeamStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIncrementalBeamStrain.C
@@ -59,6 +59,7 @@ validParams<ComputeIncrementalBeamStrain>()
 
 ComputeIncrementalBeamStrain::ComputeIncrementalBeamStrain(const InputParameters & parameters)
   : Material(parameters),
+    _has_Ix(isParamValid("Ix")),
     _nrot(coupledComponents("rotations")),
     _ndisp(coupledComponents("displacements")),
     _rot_num(_nrot),
@@ -68,7 +69,7 @@ ComputeIncrementalBeamStrain::ComputeIncrementalBeamStrain(const InputParameters
     _Az(coupledValue("Az")),
     _Iy(coupledValue("Iy")),
     _Iz(coupledValue("Iz")),
-    _Ix(isParamValid("Ix") ? coupledValue("Ix") : _zero),
+    _Ix(_has_Ix ? coupledValue("Ix") : _zero),
     _original_length(declareProperty<Real>("original_length")),
     _total_rotation(declareProperty<RankTwoTensor>("total_rotation")),
     _total_disp_strain(declareProperty<RealVectorValue>("total_disp_strain")),
@@ -220,7 +221,7 @@ void
 ComputeIncrementalBeamStrain::computeQpStrain()
 {
   Real Ix = _Ix[_qp];
-  if (!isParamValid("Ix"))
+  if (!_has_Ix)
     Ix = _Iy[_qp] + _Iz[_qp];
 
   // Rotate the gradient of displacements and rotations at t+delta t from global coordinate
@@ -328,7 +329,7 @@ ComputeIncrementalBeamStrain::computeStiffnessMatrix()
   const Real Iy_avg = (_Iy[0] + _Iy[1]) / 2.0;
   const Real Iz_avg = (_Iz[0] + _Iz[1]) / 2.0;
   Real Ix_avg = (_Ix[0] + _Ix[1]) / 2.0;
-  if (!isParamValid("Ix"))
+  if (!_has_Ix)
     Ix_avg = Iy_avg + Iz_avg;
 
   // K = |K11 K12|

--- a/modules/tensor_mechanics/src/nodalkernels/NodalGravity.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalGravity.C
@@ -43,17 +43,19 @@ validParams<NodalGravity>()
 
 NodalGravity::NodalGravity(const InputParameters & parameters)
   : NodalKernel(parameters),
-    _mass(isParamValid("mass") ? getParam<Real>("mass") : 0.0),
+    _has_mass(isParamValid("mass")),
+    _has_nodal_mass_file(isParamValid("nodal_mass_file")),
+    _mass(_has_mass ? getParam<Real>("mass") : 0.0),
     _alpha(getParam<Real>("alpha")),
     _gravity_value(getParam<Real>("gravity_value")),
     _function(getFunction("function"))
 {
-  if (!isParamValid("nodal_mass_file") && !isParamValid("mass"))
+  if (!_has_nodal_mass_file && !_has_mass)
     mooseError("NodalGravity: Please provide either mass or nodal_mass_file as input.");
-  else if (isParamValid("nodal_mass_file") && isParamValid("mass"))
+  else if (_has_nodal_mass_file && _has_mass)
     mooseError("NodalGravity: Please provide either mass or nodal_mass_file as input, not both.");
 
-  if (isParamValid("nodal_mass_file"))
+  if (_has_nodal_mass_file)
   {
     MooseUtils::DelimitedFileReader nodal_mass_file(getParam<FileName>("nodal_mass_file"));
     nodal_mass_file.setHeaderFlag(MooseUtils::DelimitedFileReader::HeaderFlag::OFF);
@@ -102,7 +104,7 @@ Real
 NodalGravity::computeQpResidual()
 {
   Real mass = 0.0;
-  if (isParamValid("mass"))
+  if (_has_mass)
     mass = _mass;
   else
   {

--- a/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
@@ -91,8 +91,7 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
     _rot_vel_old_value(_nrot),
     _rot_accel_value(_nrot)
 {
-  if (_has_beta && _has_gamma && _has_rot_velocities &&
-      _has_rot_accelerations)
+  if (_has_beta && _has_gamma && _has_rot_velocities && _has_rot_accelerations)
   {
     _aux_sys = &(_fe_problem.getAuxiliarySystem());
     if (coupledComponents("rotational_velocities") != _nrot ||
@@ -117,8 +116,7 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
       _rot_variables[i] = coupled("rotations", i);
     }
   }
-  else if (!_has_beta && !_has_gamma &&
-           !_has_rot_velocities && !_has_rot_accelerations)
+  else if (!_has_beta && !_has_gamma && !_has_rot_velocities && !_has_rot_accelerations)
   {
     for (unsigned int i = 0; i < _nrot; ++i)
     {

--- a/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalRotationalInertia.C
@@ -67,6 +67,12 @@ validParams<NodalRotationalInertia>()
 
 NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameters)
   : TimeNodalKernel(parameters),
+    _has_beta(isParamValid("beta")),
+    _has_gamma(isParamValid("gamma")),
+    _has_rot_velocities(isParamValid("rotational_velocities")),
+    _has_rot_accelerations(isParamValid("rotational_accelerations")),
+    _has_x_orientation(isParamValid("x_orientation")),
+    _has_y_orientation(isParamValid("y_orientation")),
     _nrot(coupledComponents("rotations")),
     _rot(_nrot),
     _rot_old(_nrot),
@@ -76,8 +82,8 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
     _rot_accel(_nrot),
     _rot_vel(_nrot),
     _rot_vel_old(_nrot),
-    _beta(isParamValid("beta") ? getParam<Real>("beta") : 0.1),
-    _gamma(isParamValid("gamma") ? getParam<Real>("gamma") : 0.1),
+    _beta(_has_beta ? getParam<Real>("beta") : 0.1),
+    _gamma(_has_gamma ? getParam<Real>("gamma") : 0.1),
     _eta(getParam<Real>("eta")),
     _alpha(getParam<Real>("alpha")),
     _component(getParam<unsigned int>("component")),
@@ -85,8 +91,8 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
     _rot_vel_old_value(_nrot),
     _rot_accel_value(_nrot)
 {
-  if (isParamValid("beta") && isParamValid("gamma") && isParamValid("rotational_velocities") &&
-      isParamValid("rotational_accelerations"))
+  if (_has_beta && _has_gamma && _has_rot_velocities &&
+      _has_rot_accelerations)
   {
     _aux_sys = &(_fe_problem.getAuxiliarySystem());
     if (coupledComponents("rotational_velocities") != _nrot ||
@@ -111,8 +117,8 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
       _rot_variables[i] = coupled("rotations", i);
     }
   }
-  else if (!isParamValid("beta") && !isParamValid("gamma") &&
-           !isParamValid("rotational_velocities") && !isParamValid("rotational_accelerations"))
+  else if (!_has_beta && !_has_gamma &&
+           !_has_rot_velocities && !_has_rot_accelerations)
   {
     for (unsigned int i = 0; i < _nrot; ++i)
     {
@@ -152,7 +158,7 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
 
   if (det1 < 1e-6 || det2 < 1e-6 || det3 < 1e-6)
     mooseError("NodalRotationalInertia: The moment of inertia tensor should be positive definite.");
-  if (isParamValid("x_orientation") && isParamValid("y_orientation"))
+  if (_has_x_orientation && _has_y_orientation)
   {
     const RealGradient x_orientation = getParam<RealGradient>("x_orientation");
     const RealGradient y_orientation = getParam<RealGradient>("y_orientation");
@@ -188,8 +194,8 @@ NodalRotationalInertia::NodalRotationalInertia(const InputParameters & parameter
     RankTwoTensor global_inertia = orientation.transpose() * _inertia * orientation;
     _inertia = global_inertia;
   }
-  else if ((isParamValid("x_orientation") && !isParamValid("y_orientation")) ||
-           (!isParamValid("x_orientation") && isParamValid("y_orientation")))
+  else if ((_has_x_orientation && !_has_y_orientation) ||
+           (!_has_x_orientation && _has_y_orientation))
     mooseError("NodalRotationalInertia: Both x_orientation and y_orientation should be provided if "
                "x_orientation or "
                "y_orientation is different from global x or y direction, respectively.");
@@ -202,7 +208,7 @@ NodalRotationalInertia::computeQpResidual()
     return 0;
   else
   {
-    if (isParamValid("beta"))
+    if (_has_beta)
     {
       mooseAssert(_beta > 0.0, "NodalRotationalInertia: Beta parameter should be positive.");
 
@@ -251,7 +257,7 @@ NodalRotationalInertia::computeQpJacobian()
     return 0.0;
   else
   {
-    if (isParamValid("beta"))
+    if (_has_beta)
       return _inertia(_component, _component) / (_beta * _dt * _dt) +
              _eta * (1.0 + _alpha) * _inertia(_component, _component) * _gamma / _beta / _dt;
     else
@@ -282,7 +288,7 @@ NodalRotationalInertia::computeQpOffDiagJacobian(unsigned int jvar)
     return 0.0;
   else if (rot_coupled)
   {
-    if (isParamValid("beta"))
+    if (_has_beta)
       return _inertia(_component, coupled_component) / (_beta * _dt * _dt) +
              _eta * (1.0 + _alpha) * _inertia(_component, coupled_component) * _gamma / _beta / _dt;
     else

--- a/modules/tensor_mechanics/src/nodalkernels/NodalTranslationalInertia.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalTranslationalInertia.C
@@ -64,8 +64,7 @@ NodalTranslationalInertia::NodalTranslationalInertia(const InputParameters & par
     _eta(getParam<Real>("eta")),
     _alpha(getParam<Real>("alpha"))
 {
-  if (_has_beta && _has_gamma && _has_velocity &&
-      _has_acceleration)
+  if (_has_beta && _has_gamma && _has_velocity && _has_acceleration)
   {
     _u_old = &(_var.dofValuesOld());
     _aux_sys = &(_fe_problem.getAuxiliarySystem());
@@ -75,8 +74,7 @@ NodalTranslationalInertia::NodalTranslationalInertia(const InputParameters & par
     MooseVariable * accel_variable = getVar("acceleration", 0);
     _accel_num = accel_variable->number();
   }
-  else if (!_has_beta && !_has_gamma && !_has_velocity &&
-           !_has_acceleration)
+  else if (!_has_beta && !_has_gamma && !_has_velocity && !_has_acceleration)
   {
     _vel = &(_var.dofValuesDot());
     _vel_old = &(_var.dofValuesDotOld());

--- a/modules/tensor_mechanics/src/nodalkernels/NodalTranslationalInertia.C
+++ b/modules/tensor_mechanics/src/nodalkernels/NodalTranslationalInertia.C
@@ -52,14 +52,20 @@ validParams<NodalTranslationalInertia>()
 
 NodalTranslationalInertia::NodalTranslationalInertia(const InputParameters & parameters)
   : TimeNodalKernel(parameters),
-    _mass(isParamValid("mass") ? getParam<Real>("mass") : 0.0),
-    _beta(isParamValid("beta") ? getParam<Real>("beta") : 0.1),
-    _gamma(isParamValid("gamma") ? getParam<Real>("gamma") : 0.1),
+    _has_mass(isParamValid("mass")),
+    _has_beta(isParamValid("beta")),
+    _has_gamma(isParamValid("gamma")),
+    _has_velocity(isParamValid("velocity")),
+    _has_acceleration(isParamValid("acceleration")),
+    _has_nodal_mass_file(isParamValid("nodal_mass_file")),
+    _mass(_has_mass ? getParam<Real>("mass") : 0.0),
+    _beta(_has_beta ? getParam<Real>("beta") : 0.1),
+    _gamma(_has_gamma ? getParam<Real>("gamma") : 0.1),
     _eta(getParam<Real>("eta")),
     _alpha(getParam<Real>("alpha"))
 {
-  if (isParamValid("beta") && isParamValid("gamma") && isParamValid("velocity") &&
-      isParamValid("acceleration"))
+  if (_has_beta && _has_gamma && _has_velocity &&
+      _has_acceleration)
   {
     _u_old = &(_var.dofValuesOld());
     _aux_sys = &(_fe_problem.getAuxiliarySystem());
@@ -69,8 +75,8 @@ NodalTranslationalInertia::NodalTranslationalInertia(const InputParameters & par
     MooseVariable * accel_variable = getVar("acceleration", 0);
     _accel_num = accel_variable->number();
   }
-  else if (!isParamValid("beta") && !isParamValid("gamma") && !isParamValid("velocity") &&
-           !isParamValid("acceleration"))
+  else if (!_has_beta && !_has_gamma && !_has_velocity &&
+           !_has_acceleration)
   {
     _vel = &(_var.dofValuesDot());
     _vel_old = &(_var.dofValuesDotOld());
@@ -82,14 +88,14 @@ NodalTranslationalInertia::NodalTranslationalInertia(const InputParameters & par
     mooseError("NodalTranslationalInertia: Either all or none of `beta`, `gamma`, `velocity` and "
                "`acceleration` should be provided as input.");
 
-  if (!isParamValid("nodal_mass_file") && !isParamValid("mass"))
+  if (!_has_nodal_mass_file && !_has_mass)
     mooseError(
         "NodalTranslationalInertia: Please provide either mass or nodal_mass_file as input.");
-  else if (isParamValid("nodal_mass_file") && isParamValid("mass"))
+  else if (_has_nodal_mass_file && _has_mass)
     mooseError("NodalTranslationalInertia: Please provide either mass or nodal_mass_file as input, "
                "not both.");
 
-  if (isParamValid("nodal_mass_file"))
+  if (_has_nodal_mass_file)
   {
     MooseUtils::DelimitedFileReader nodal_mass_file(getParam<FileName>("nodal_mass_file"));
     nodal_mass_file.setHeaderFlag(MooseUtils::DelimitedFileReader::HeaderFlag::OFF);
@@ -142,7 +148,7 @@ NodalTranslationalInertia::computeQpResidual()
   else
   {
     Real mass = 0.0;
-    if (isParamValid("mass"))
+    if (_has_mass)
       mass = _mass;
     else
     {
@@ -153,7 +159,7 @@ NodalTranslationalInertia::computeQpResidual()
                    "_node_id_to_mass map.");
     }
 
-    if (isParamValid("beta"))
+    if (_has_beta)
     {
       mooseAssert(_beta > 0.0, "NodalTranslationalInertia: Beta parameter should be positive.");
       const NumericVector<Number> & aux_sol_old = _aux_sys->solutionOld();
@@ -184,7 +190,7 @@ NodalTranslationalInertia::computeQpJacobian()
   else
   {
     Real mass = 0.0;
-    if (isParamValid("mass"))
+    if (_has_mass)
       mass = _mass;
     else
     {
@@ -195,7 +201,7 @@ NodalTranslationalInertia::computeQpJacobian()
                    "_node_id_to_mass map.");
     }
 
-    if (isParamValid("beta"))
+    if (_has_beta)
       return mass / (_beta * _dt * _dt) + _eta * (1 + _alpha) * mass * _gamma / _beta / _dt;
     else
       return mass * (*_du_dotdot_du)[_qp] + _eta * (1.0 + _alpha) * mass * (*_du_dot_du)[_qp];


### PR DESCRIPTION
Changed the usage of isParamValid function to a boolean class variable that is initialized accordingly. This closes #13290 