### PR TITLE
Sort status results by exit_code

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -472,7 +472,7 @@ class TestHarness:
                 timing = job.getTiming()
 
                 # Save these results for 'Final Test Result' summary
-                self.test_table.append( (job, status, timing) )
+                self.test_table.append( (job, exit_code, timing) )
 
                 self.postRun(job.specs, timing)
 
@@ -508,7 +508,7 @@ class TestHarness:
 
         if (self.options.verbose or (self.num_failed != 0 and not self.options.quiet)) and not self.options.dry_run:
             print('\n\nFinal Test Results:\n' + ('-' * (util.TERM_COLS)))
-            for (job, result, timing) in sorted(self.test_table, key=lambda x: x[1], reverse=True):
+            for (job, exit_code, timing) in sorted(self.test_table, key=lambda x: x[1]):
                 print(util.formatResult(job, self.options, caveats=True))
 
         time = clock() - self.start_time
@@ -551,6 +551,7 @@ class TestHarness:
             else:
                 summary += ', <b>%d failed</b>'
             if self.scheduler.maxFailures():
+                self.error_code = self.error_code | 0x80
                 summary += '\n<r>MAX FAILURES REACHED</r>'
 
             summary += fatal_error

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -314,7 +314,7 @@ class Job(object):
         Most of the time, we want to return a Tester status. As this class will have the most detail.
         """
         # Tester has no status, use a job status instead
-        if self.isNoStatus():
+        if self.isTimeout() or self.isNoStatus():
             return (self.getStatus().status,
                     self.getStatusMessage(),
                     self.getStatus().color,

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -178,7 +178,7 @@ def formatCase(format_key, message, formatted_results):
         formatted_results[format_key] = (message[0], message[1])
 
 def formatStatusMessage(job, status, message, options):
-    # If there is no unique status message, use the name of the status as the message
+    # If there is no message, use status as message
     if not message:
         message = status
 
@@ -189,7 +189,7 @@ def formatStatusMessage(job, status, message, options):
                 job.addCaveats(check)
 
     # Format the failed message to list a big fat FAILED in front of the status
-    elif job.isFail() or (job.isDeleted() and options.extra_info):
+    elif job.isFail():
         return 'FAILED (%s)' % (message)
 
     return message
@@ -204,7 +204,6 @@ def formatResult(job, options, result='', color=True, **kwargs):
     terminal_format = list(OrderedDict.fromkeys(list(TERM_FORMAT)))
     status, message, message_color, exit_code = job.getJointStatus()
 
-    # status = job.getStatus()
     color_opts = {'code' : options.code, 'colored' : options.colored}
 
     # container for every printable item
@@ -292,9 +291,8 @@ def formatResult(job, options, result='', color=True, **kwargs):
 
             # Do special coloring for first directory
             if format_rule == 'n' and options.color_first_directory:
-                tester = job.getTester()
-                formatted_results[format_rule] = (colorText(tester.specs['first_directory'], 'CYAN', **color_opts) +\
-                                         formatted_results[format_rule][0].replace(tester.specs['first_directory'], '', 1), 'CYAN') # Strip out first occurence only
+                formatted_results[format_rule] = (colorText(job.specs['first_directory'], 'CYAN', **color_opts) +\
+                                         formatted_results[format_rule][0].replace(job.specs['first_directory'], '', 1), 'CYAN') # Strip out first occurence only
 
     # join printable results in the order in which the user asked
     final_results = ' '.join([formatted_results[x][0] for x in terminal_format if formatted_results[x]])
@@ -705,13 +703,12 @@ def readOutput(stdout, stderr):
 # Trimming routines for job output
 def trimOutput(job, options):
     output = job.getOutput()
-    tester = job.getTester()
-    if ((tester.isFail() and options.no_trimmed_output_on_error)
-        or (tester.specs.isValid('max_buffer_size') and tester.specs['max_buffer_size'] == -1)
+    if ((job.isFail() and options.no_trimmed_output_on_error)
+        or (job.specs.isValid('max_buffer_size') and job.specs['max_buffer_size'] == -1)
         or options.no_trimmed_output):
         return output
-    elif tester.specs.isValid('max_buffer_size'):
-        max_size = tester.specs['max_buffer_size']
+    elif job.specs.isValid('max_buffer_size'):
+        max_size = job.specs['max_buffer_size']
     else:
         max_size = 100000
 


### PR DESCRIPTION
If there are failures, sort be exit_code. This will ensure any failing status
we create, will be listed after successful tests.

Clean up some of the status code.

Closes #13323
