### PR TITLE
Simplify Makefiles for modules

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -263,13 +263,22 @@ LIBRARY_SUFFIX :=
 # Instantiate a new suffix rule for the module loader
 $(eval $(call CXX_RULE_TEMPLATE,_with$(app_LIB_SUFFIX)))
 
-ifeq ($(BUILD_EXEC),yes)
-  all:: $(app_EXEC)
+# If this is a matching module then build the exec, otherwise fall back and use the variable
+ifneq (, $(SAVED_APPLICATION_NAME))
+  ifeq ($(SAVED_APPLICATION_NAME),$(APPLICATION_NAME))
+    all:: $(app_EXEC)
+  else
+    all:: $(app_LIB)
+  endif
 else
-  all:: $(app_LIB)
-endif
+  ifeq ($(BUILD_EXEC),yes)
+    all:: $(app_EXEC)
+  else
+    all:: $(app_LIB)
+  endif
 
-BUILD_EXEC :=
+  BUILD_EXEC :=
+endif
 
 app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
 # Use wildcard in case the files don't exist

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -264,8 +264,8 @@ LIBRARY_SUFFIX :=
 $(eval $(call CXX_RULE_TEMPLATE,_with$(app_LIB_SUFFIX)))
 
 # If this is a matching module then build the exec, otherwise fall back and use the variable
-ifneq (, $(SAVED_APPLICATION_NAME))
-  ifeq ($(SAVED_APPLICATION_NAME),$(APPLICATION_NAME))
+ifneq (,$(MODULE_NAME))
+  ifeq ($(MODULE_NAME),$(APPLICATION_NAME))
     all:: $(app_EXEC)
   else
     all:: $(app_LIB)

--- a/modules/chemical_reactions/Makefile
+++ b/modules/chemical_reactions/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/chemical_reactions
-APPLICATION_NAME   := chemical_reactions
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := chemical_reactions
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/chemical_reactions/Makefile
+++ b/modules/chemical_reactions/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := chemical_reactions
+MODULE_NAME := chemical_reactions
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/contact/Makefile
+++ b/modules/contact/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/contact
-APPLICATION_NAME   := contact
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := contact
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/contact/Makefile
+++ b/modules/contact/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := contact
+MODULE_NAME := contact
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/external_petsc_solver/Makefile
+++ b/modules/external_petsc_solver/Makefile
@@ -11,18 +11,16 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/external_petsc_solver
-APPLICATION_NAME   := external_petsc_solver
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := external_petsc_solver
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/external_petsc_solver/Makefile
+++ b/modules/external_petsc_solver/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := external_petsc_solver
+MODULE_NAME := external_petsc_solver
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/fluid_properties/Makefile
+++ b/modules/fluid_properties/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_NAME   := fluid_properties
-APPLICATION_DIR    := $(MODULE_DIR)/$(APPLICATION_NAME)
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := fluid_properties
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/fluid_properties/Makefile
+++ b/modules/fluid_properties/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := fluid_properties
+MODULE_NAME := fluid_properties
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/functional_expansion_tools/Makefile
+++ b/modules/functional_expansion_tools/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := functional_expansion_tools
+MODULE_NAME := functional_expansion_tools
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/functional_expansion_tools/Makefile
+++ b/modules/functional_expansion_tools/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_NAME   := functional_expansion_tools
-APPLICATION_DIR    := $(MODULE_DIR)/$(APPLICATION_NAME)
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := functional_expansion_tools
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/heat_conduction
-APPLICATION_NAME   := heat_conduction
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := heat_conduction
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/heat_conduction/Makefile
+++ b/modules/heat_conduction/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := heat_conduction
+MODULE_NAME := heat_conduction
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/level_set/Makefile
+++ b/modules/level_set/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/level_set
-APPLICATION_NAME   := level_set
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := level_set
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/level_set/Makefile
+++ b/modules/level_set/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := level_set
+MODULE_NAME := level_set
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/misc/Makefile
+++ b/modules/misc/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := misc
+MODULE_NAME := misc
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/misc/Makefile
+++ b/modules/misc/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/misc
-APPLICATION_NAME   := misc
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := misc
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/modules.mk
+++ b/modules/modules.mk
@@ -1,19 +1,16 @@
-###############################################################################
-############################ COMMON MODULES ###################################
-###############################################################################
+################################################################################
+############################ COMMON MODULES ####################################
+################################################################################
 
-# When building an individual module, you should define APPLICATION_NAME to the
-# module you want to build before including this file. When doing that, there
-# is no need to duplicate the dependencies in the individual module's Makefile.
-# However, since APPLICATION_NAME gets redefined several times if multiple
-# modules are being built we need to save it off to keep track when we need
-# to build the exec for it or not.
+# When building an individual module, you should define MODULE_NAME (lower case)
+# to the module you want to build before including this file. When doing that,
+# there is no need to duplicate the dependencies in the individual module's
+# Makefile.
 
-SAVED_APPLICATION_NAME := $(APPLICATION_NAME)
-ifneq (, $(SAVED_APPLICATION_NAME))
-  # Exec will automatically be built for the given APPLICATION_NAME
+ifneq (,$(MODULE_NAME))
+  # Exec will automatically be built for the given MODULE_NAME
   SKIP_LOADER := yes
-  UC_APP = $(shell echo $(SAVED_APPLICATION_NAME) | tr a-z A-Z)
+  UC_APP = $(shell echo $(MODULE_NAME) | tr a-z A-Z)
   $(eval $(UC_APP):=yes)
 endif
 
@@ -65,9 +62,9 @@ endif
 # The master list of all moose modules
 MODULE_NAMES := "chemical_reactions contact fluid_properties functional_expansion_tools heat_conduction level_set misc navier_stokes phase_field porous_flow rdg richards solid_mechanics stochastic_tools tensor_mechanics xfem external_petsc_solver"
 
-###############################################################################
-########################## MODULE REGISTRATION ################################
-###############################################################################
+################################################################################
+########################## MODULE REGISTRATION #################################
+################################################################################
 GEN_REVISION  := no
 
 ifeq ($(CHEMICAL_REACTIONS),yes)

--- a/modules/modules.mk
+++ b/modules/modules.mk
@@ -2,9 +2,25 @@
 ############################ COMMON MODULES ###################################
 ###############################################################################
 
+# When building an individual module, you should define APPLICATION_NAME to the
+# module you want to build before including this file. When doing that, there
+# is no need to duplicate the dependencies in the individual module's Makefile.
+# However, since APPLICATION_NAME gets redefined several times if multiple
+# modules are being built we need to save it off to keep track when we need
+# to build the exec for it or not.
+
+SAVED_APPLICATION_NAME := $(APPLICATION_NAME)
+ifneq (, $(SAVED_APPLICATION_NAME))
+  # Exec will automatically be built for the given APPLICATION_NAME
+  SKIP_LOADER := yes
+  UC_APP = $(shell echo $(SAVED_APPLICATION_NAME) | tr a-z A-Z)
+  $(eval $(UC_APP):=yes)
+endif
+
 ifeq ($(ALL_MODULES),yes)
         CHEMICAL_REACTIONS          := yes
         CONTACT                     := yes
+        EXTERNAL_PETSC_SOLVER       := yes
         FLUID_PROPERTIES            := yes
         FUNCTIONAL_EXPANSION_TOOLS  := yes
         HEAT_CONDUCTION             := yes
@@ -19,7 +35,6 @@ ifeq ($(ALL_MODULES),yes)
         STOCHASTIC_TOOLS            := yes
         TENSOR_MECHANICS            := yes
         XFEM                        := yes
-        EXTERNAL_PETSC_SOLVER       := yes
 endif
 
 ifeq ($(XFEM),yes)
@@ -104,6 +119,13 @@ ifeq ($(MISC),yes)
   include $(FRAMEWORK_DIR)/app.mk
 endif
 
+ifeq ($(RDG),yes)
+  APPLICATION_DIR    := $(MOOSE_DIR)/modules/rdg
+  APPLICATION_NAME   := rdg
+  SUFFIX             := rdg
+  include $(FRAMEWORK_DIR)/app.mk
+endif
+
 ifeq ($(NAVIER_STOKES),yes)
   APPLICATION_DIR    := $(MOOSE_DIR)/modules/navier_stokes
   APPLICATION_NAME   := navier_stokes
@@ -138,13 +160,6 @@ ifeq ($(POROUS_FLOW),yes)
 
   DEPEND_MODULES     := tensor_mechanics fluid_properties chemical_reactions rdg
   SUFFIX             := pflow
-  include $(FRAMEWORK_DIR)/app.mk
-endif
-
-ifeq ($(RDG),yes)
-  APPLICATION_DIR    := $(MOOSE_DIR)/modules/rdg
-  APPLICATION_NAME   := rdg
-  SUFFIX             := rdg
   include $(FRAMEWORK_DIR)/app.mk
 endif
 

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := navier_stokes
+MODULE_NAME := navier_stokes
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/navier_stokes/Makefile
+++ b/modules/navier_stokes/Makefile
@@ -18,17 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-FLUID_PROPERTIES := yes
-HEAT_CONDUCTION  := yes
-SKIP_LOADER      := yes
+# Module
+APPLICATION_NAME := navier_stokes
 include $(MODULE_DIR)/modules.mk
-
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/navier_stokes
-APPLICATION_NAME   := navier_stokes
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := phase_field
+MODULE_NAME := phase_field
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/phase_field/Makefile
+++ b/modules/phase_field/Makefile
@@ -18,17 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dependency on tensor_mechanics
-TENSOR_MECHANICS := yes
-SKIP_LOADER      := yes
+# Module
+APPLICATION_NAME := phase_field
 include $(MODULE_DIR)/modules.mk
-
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/phase_field
-APPLICATION_NAME   := phase_field
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/porous_flow/Makefile
+++ b/modules/porous_flow/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := porous_flow
+MODULE_NAME := porous_flow
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/porous_flow/Makefile
+++ b/modules/porous_flow/Makefile
@@ -18,20 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dependency on tensor_mechanics and fluid_properties and chemical_reactions and RDG
-TENSOR_MECHANICS := yes
-FLUID_PROPERTIES := yes
-CHEMICAL_REACTIONS := yes
-RDG := yes
-SKIP_LOADER      := yes
+# Module
+APPLICATION_NAME := porous_flow
 include $(MODULE_DIR)/modules.mk
-
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/porous_flow
-APPLICATION_NAME   := porous_flow
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/rdg/Makefile
+++ b/modules/rdg/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := rdg
+MODULE_NAME := rdg
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/rdg/Makefile
+++ b/modules/rdg/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/rdg
-APPLICATION_NAME   := rdg
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := rdg
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/richards/Makefile
+++ b/modules/richards/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := richards
+MODULE_NAME := richards
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/richards/Makefile
+++ b/modules/richards/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/richards
-APPLICATION_NAME   := richards
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := richards
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/solid_mechanics/Makefile
+++ b/modules/solid_mechanics/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := solid_mechanics
+MODULE_NAME := solid_mechanics
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/solid_mechanics/Makefile
+++ b/modules/solid_mechanics/Makefile
@@ -18,17 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-#dependency on tensor_mechanics
-TENSOR_MECHANICS   := yes
-SKIP_LOADER        := yes
+# Module
+APPLICATION_NAME := solid_mechanics
 include $(MODULE_DIR)/modules.mk
-
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/solid_mechanics
-APPLICATION_NAME   := solid_mechanics
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/stochastic_tools/Makefile
+++ b/modules/stochastic_tools/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := stochastic_tools
+MODULE_NAME := stochastic_tools
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/stochastic_tools/Makefile
+++ b/modules/stochastic_tools/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/stochastic_tools
-APPLICATION_NAME   := stochastic_tools
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := stochastic_tools
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/tensor_mechanics/Makefile
+++ b/modules/tensor_mechanics/Makefile
@@ -18,12 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/tensor_mechanics
-APPLICATION_NAME   := tensor_mechanics
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+APPLICATION_NAME := tensor_mechanics
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/tensor_mechanics/Makefile
+++ b/modules/tensor_mechanics/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := tensor_mechanics
+MODULE_NAME := tensor_mechanics
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/modules/xfem/Makefile
+++ b/modules/xfem/Makefile
@@ -18,18 +18,9 @@ ADDITIONAL_CPPFLAGS += -Wall -Wextra
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-#dependency on solid_mechanics
-SOLID_MECHANICS    := yes
-SKIP_LOADER        := yes
+# Module
+APPLICATION_NAME := xfem
 include $(MODULE_DIR)/modules.mk
-
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/xfem
-APPLICATION_NAME   := xfem
-BUILD_EXEC         := yes
-DEPEND_MODULES     := solid_mechanics
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################
 # Additional special case targets should be added here

--- a/modules/xfem/Makefile
+++ b/modules/xfem/Makefile
@@ -19,7 +19,7 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 # Module
-APPLICATION_NAME := xfem
+MODULE_NAME := xfem
 include $(MODULE_DIR)/modules.mk
 
 ###############################################################################

--- a/stork/Makefile.app
+++ b/stork/Makefile.app
@@ -24,22 +24,25 @@ include $(FRAMEWORK_DIR)/moose.mk
 # yes as needed.  Or set ALL_MODULES to yes to turn on everything (overrides
 # other set variables).
 
-ALL_MODULES         := no
+ALL_MODULES                 := no
 
-CHEMICAL_REACTIONS  := no
-CONTACT             := no
-FLUID_PROPERTIES    := no
-HEAT_CONDUCTION     := no
-MISC                := no
-NAVIER_STOKES       := no
-PHASE_FIELD         := no
-RDG                 := no
-RICHARDS            := no
-SOLID_MECHANICS     := no
-STOCHASTIC_TOOLS    := no
-TENSOR_MECHANICS    := no
-XFEM                := no
-POROUS_FLOW         := no
+CHEMICAL_REACTIONS          := no
+CONTACT                     := no
+EXTERNAL_PETSC_SOLVER       := no
+FLUID_PROPERTIES            := no
+FUNCTIONAL_EXPANSION_TOOLS  := no
+HEAT_CONDUCTION             := no
+LEVEL_SET                   := no
+MISC                        := no
+NAVIER_STOKES               := no
+PHASE_FIELD                 := no
+POROUS_FLOW                 := no
+RDG                         := no
+RICHARDS                    := no
+SOLID_MECHANICS             := no
+STOCHASTIC_TOOLS            := no
+TENSOR_MECHANICS            := no
+XFEM                        := no
 
 include $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################

--- a/stork/Makefile.module
+++ b/stork/Makefile.module
@@ -11,18 +11,16 @@
 MODULE_DIR         ?= $(shell dirname `pwd`)
 MOOSE_DIR          ?= $(shell dirname $(MODULE_DIR))
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
+ADDITIONAL_CPPFLAGS += -Wall -Wextra
 ###############################################################################
 
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
-# dep apps
-APPLICATION_DIR    := $(MODULE_DIR)/stork
-APPLICATION_NAME   := stork
-BUILD_EXEC         := yes
-GEN_REVISION       := no
-include            $(FRAMEWORK_DIR)/app.mk
+# Module
+MODULE_NAME := stork
+include $(MODULE_DIR)/modules.mk
 
 ###############################################################################
 # Additional special case targets should be added here


### PR DESCRIPTION
No more specifying dependencies at the Makefile level
Fixes missing deps in the libraries when building individual modules

This will also fix the failures in the new Parallel Modules test:
https://civet.inl.gov/job/330190/

closes #13341

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
