### PR TITLE
AD wrapper types

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -380,11 +380,11 @@ dataStore(std::ostream & stream, DenseVector<T> & v, void * context)
   }
 }
 
-template <>
-void dataStore(std::ostream & stream, DenseMatrix<Real> & v, void * context);
-
 template <typename T>
 void dataStore(std::ostream & stream, TensorValue<T> & v, void * context);
+
+template <typename T>
+void dataStore(std::ostream & stream, DenseMatrix<T> & v, void * context);
 
 template <typename T>
 void dataStore(std::ostream & stream, VectorValue<T> & v, void * context);
@@ -627,11 +627,11 @@ dataLoad(std::istream & stream, DenseVector<T> & v, void * context)
   }
 }
 
-template <>
-void dataLoad(std::istream & stream, DenseMatrix<Real> & v, void * context);
-
 template <typename T>
 void dataLoad(std::istream & stream, TensorValue<T> & v, void * context);
+
+template <typename T>
+void dataLoad(std::istream & stream, DenseMatrix<T> & v, void * context);
 
 template <typename T>
 void dataLoad(std::istream & stream, VectorValue<T> & v, void * context);

--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -15,8 +15,10 @@
 #include "RankThreeTensor.h"
 #include "RankFourTensor.h"
 
+#include "libmesh/dense_vector.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
+#include "libmesh/dense_matrix.h"
 
 #include "metaphysicl/numberarray.h"
 #include "metaphysicl/dualnumber.h"
@@ -321,3 +323,142 @@ private:
                                                   void *);
 };
 
+template <>
+class MooseADWrapper<DenseVector<Real>>
+{
+public:
+  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper(MooseADWrapper<DenseVector<Real>> &&) = default;
+
+  typedef DenseVector<DualReal> DNType;
+
+  const DenseVector<Real> & value() const { return _val; }
+
+  DenseVector<Real> & value() { return _val; }
+
+  const DenseVector<DualReal> & dn(bool = true) const;
+
+  DenseVector<DualReal> & dn(bool = true);
+
+  void copyDualNumberToValue();
+
+  void markAD(bool use_ad);
+
+  MooseADWrapper<DenseVector<Real>> & operator=(const MooseADWrapper<DenseVector<Real>> &);
+  MooseADWrapper<DenseVector<Real>> & operator=(MooseADWrapper<DenseVector<Real>> &&) = default;
+
+private:
+  bool _use_ad;
+  DenseVector<Real> _val;
+  mutable std::unique_ptr<DenseVector<DualReal>> _dual_number;
+  friend void
+  dataStore<DenseVector<Real>>(std::ostream &, MooseADWrapper<DenseVector<Real>> &, void *);
+  friend void
+  dataLoad<DenseVector<Real>>(std::istream &, MooseADWrapper<DenseVector<Real>> &, void *);
+};
+
+template <>
+class MooseADWrapper<DenseMatrix<Real>>
+{
+public:
+  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper(MooseADWrapper<DenseMatrix<Real>> &&) = default;
+
+  typedef DenseMatrix<DualReal> DNType;
+
+  const DenseMatrix<Real> & value() const { return _val; }
+
+  DenseMatrix<Real> & value() { return _val; }
+
+  const DenseMatrix<DualReal> & dn(bool = true) const;
+
+  DenseMatrix<DualReal> & dn(bool = true);
+
+  void copyDualNumberToValue();
+
+  void markAD(bool use_ad);
+
+  MooseADWrapper<DenseMatrix<Real>> & operator=(const MooseADWrapper<DenseMatrix<Real>> &);
+  MooseADWrapper<DenseMatrix<Real>> & operator=(MooseADWrapper<DenseMatrix<Real>> &&) = default;
+
+private:
+  bool _use_ad;
+  DenseMatrix<Real> _val;
+  mutable std::unique_ptr<DenseMatrix<DualReal>> _dual_number;
+  friend void
+  dataStore<DenseMatrix<Real>>(std::ostream &, MooseADWrapper<DenseMatrix<Real>> &, void *);
+  friend void
+  dataLoad<DenseMatrix<Real>>(std::istream &, MooseADWrapper<DenseMatrix<Real>> &, void *);
+};
+
+template <>
+class MooseADWrapper<std::vector<DenseMatrix<Real>>>
+{
+public:
+  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper(MooseADWrapper<std::vector<DenseMatrix<Real>>> &&) = default;
+
+  typedef std::vector<DenseMatrix<DualReal>> DNType;
+
+  const std::vector<DenseMatrix<Real>> & value() const { return _val; }
+
+  std::vector<DenseMatrix<Real>> & value() { return _val; }
+
+  const std::vector<DenseMatrix<DualReal>> & dn(bool = true) const;
+
+  std::vector<DenseMatrix<DualReal>> & dn(bool = true);
+
+  void copyDualNumberToValue();
+
+  void markAD(bool use_ad);
+
+  MooseADWrapper<std::vector<DenseMatrix<Real>>> &
+  operator=(const MooseADWrapper<std::vector<DenseMatrix<Real>>> &);
+  MooseADWrapper<std::vector<DenseMatrix<Real>>> &
+  operator=(MooseADWrapper<std::vector<DenseMatrix<Real>>> &&) = default;
+
+private:
+  bool _use_ad;
+  std::vector<DenseMatrix<Real>> _val;
+  mutable std::unique_ptr<std::vector<DenseMatrix<DualReal>>> _dual_number;
+  friend void dataStore<std::vector<DenseMatrix<Real>>>(
+      std::ostream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
+  friend void dataLoad<std::vector<DenseMatrix<Real>>>(
+      std::istream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
+};
+
+template <>
+class MooseADWrapper<std::vector<DenseVector<Real>>>
+{
+public:
+  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper(MooseADWrapper<std::vector<DenseVector<Real>>> &&) = default;
+
+  typedef std::vector<DenseVector<DualReal>> DNType;
+
+  const std::vector<DenseVector<Real>> & value() const { return _val; }
+
+  std::vector<DenseVector<Real>> & value() { return _val; }
+
+  const std::vector<DenseVector<DualReal>> & dn(bool = true) const;
+
+  std::vector<DenseVector<DualReal>> & dn(bool = true);
+
+  void copyDualNumberToValue();
+
+  void markAD(bool use_ad);
+
+  MooseADWrapper<std::vector<DenseVector<Real>>> &
+  operator=(const MooseADWrapper<std::vector<DenseVector<Real>>> &);
+  MooseADWrapper<std::vector<DenseVector<Real>>> &
+  operator=(MooseADWrapper<std::vector<DenseVector<Real>>> &&) = default;
+
+private:
+  bool _use_ad;
+  std::vector<DenseVector<Real>> _val;
+  mutable std::unique_ptr<std::vector<DenseVector<DualReal>>> _dual_number;
+  friend void dataStore<std::vector<DenseVector<Real>>>(
+      std::ostream &, MooseADWrapper<std::vector<DenseVector<Real>>> &, void *);
+  friend void dataLoad<std::vector<DenseVector<Real>>>(
+      std::istream &, MooseADWrapper<std::vector<DenseVector<Real>>> &, void *);
+};

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -168,22 +168,6 @@ dataStore(std::ostream & stream, std::stringstream *& s, void * context)
   dataStore(stream, *s, context);
 }
 
-template <>
-void
-dataStore(std::ostream & stream, DenseMatrix<Real> & v, void * context)
-{
-  unsigned int m = v.m();
-  unsigned int n = v.n();
-  stream.write((char *)&m, sizeof(m));
-  stream.write((char *)&n, sizeof(n));
-  for (unsigned int i = 0; i < v.m(); i++)
-    for (unsigned int j = 0; j < v.n(); j++)
-    {
-      Real r = v(i, j);
-      dataStore(stream, r, context);
-    }
-}
-
 template <typename T>
 void
 dataStore(std::ostream & stream, TensorValue<T> & v, void * context)
@@ -198,6 +182,25 @@ dataStore(std::ostream & stream, TensorValue<T> & v, void * context)
 
 template void dataStore(std::ostream & stream, TensorValue<Real> & v, void * context);
 template void dataStore(std::ostream & stream, TensorValue<DualReal> & v, void * context);
+
+template <typename T>
+void
+dataStore(std::ostream & stream, DenseMatrix<T> & v, void * context)
+{
+  unsigned int m = v.m();
+  unsigned int n = v.n();
+  stream.write((char *)&m, sizeof(m));
+  stream.write((char *)&n, sizeof(n));
+  for (unsigned int i = 0; i < m; i++)
+    for (unsigned int j = 0; j < n; j++)
+    {
+      T r = v(i, j);
+      dataStore(stream, r, context);
+    }
+}
+
+template void dataStore(std::ostream & stream, DenseMatrix<Real> & v, void * context);
+template void dataStore(std::ostream & stream, DenseMatrix<DualReal> & v, void * context);
 
 template <typename T>
 void
@@ -375,23 +378,6 @@ dataLoad(std::istream & stream, std::stringstream *& s, void * context)
   dataLoad(stream, *s, context);
 }
 
-template <>
-void
-dataLoad(std::istream & stream, DenseMatrix<Real> & v, void * /*context*/)
-{
-  unsigned int nr = 0, nc = 0;
-  stream.read((char *)&nr, sizeof(nr));
-  stream.read((char *)&nc, sizeof(nc));
-  v.resize(nr, nc);
-  for (unsigned int i = 0; i < v.m(); i++)
-    for (unsigned int j = 0; j < v.n(); j++)
-    {
-      Real r = 0;
-      stream.read((char *)&r, sizeof(r));
-      v(i, j) = r;
-    }
-}
-
 template <typename T>
 void
 dataLoad(std::istream & stream, TensorValue<T> & v, void * context)
@@ -409,6 +395,26 @@ dataLoad(std::istream & stream, TensorValue<T> & v, void * context)
 
 template void dataLoad(std::istream & stream, TensorValue<Real> & v, void * context);
 template void dataLoad(std::istream & stream, TensorValue<DualReal> & v, void * context);
+
+template <typename T>
+void
+dataLoad(std::istream & stream, DenseMatrix<T> & v, void * context)
+{
+  unsigned int m = 0, n = 0;
+  stream.read((char *)&m, sizeof(m));
+  stream.read((char *)&n, sizeof(n));
+  v.resize(m, n);
+  for (unsigned int i = 0; i < m; i++)
+    for (unsigned int j = 0; j < n; j++)
+    {
+      T r = 0;
+      dataLoad(stream, r, context);
+      v(i, j) = r;
+    }
+}
+
+template void dataLoad(std::istream & stream, DenseMatrix<Real> & v, void * context);
+template void dataLoad(std::istream & stream, DenseMatrix<DualReal> & v, void * context);
 
 template <typename T>
 void

--- a/framework/src/utils/MooseADWrapper.C
+++ b/framework/src/utils/MooseADWrapper.C
@@ -336,3 +336,273 @@ operator=(const MooseADWrapper<RankFourTensorTempl<Real>> & rhs)
     *_dual_number = 0;
   return *this;
 }
+
+MooseADWrapper<DenseVector<Real>>::MooseADWrapper(bool use_ad)
+  : _use_ad(use_ad), _val(), _dual_number(nullptr)
+{
+  if (_use_ad)
+    _dual_number = libmesh_make_unique<DenseVector<DualReal>>();
+}
+
+const DenseVector<DualReal> &
+MooseADWrapper<DenseVector<Real>>::dn(bool) const
+{
+  if (!_dual_number)
+    _dual_number = libmesh_make_unique<DenseVector<DualReal>>(_val);
+  else if (!_use_ad)
+    for (std::size_t i = 0; i < _dual_number->size(); ++i)
+      (*_dual_number)(i).value() = _val(i);
+  return *_dual_number;
+}
+
+DenseVector<DualReal> &
+MooseADWrapper<DenseVector<Real>>::dn(bool)
+{
+  return *_dual_number;
+}
+
+void
+MooseADWrapper<DenseVector<Real>>::copyDualNumberToValue()
+{
+  for (std::size_t i = 0; i < _dual_number->size(); ++i)
+    _val(i) = (*_dual_number)(i).value();
+}
+
+void
+MooseADWrapper<DenseVector<Real>>::markAD(bool use_ad)
+{
+  if (!use_ad && _use_ad)
+    _dual_number = nullptr;
+  else if (use_ad && !_use_ad)
+    _dual_number = libmesh_make_unique<DenseVector<DualReal>>();
+  _use_ad = use_ad;
+}
+
+MooseADWrapper<DenseVector<Real>> &
+MooseADWrapper<DenseVector<Real>>::operator=(const MooseADWrapper<DenseVector<Real>> & rhs)
+{
+  _val = rhs._val;
+  if (_dual_number && rhs._dual_number)
+    *_dual_number = *rhs._dual_number;
+  else if (_dual_number)
+    // I don't know why we do this, but other code does it - ask Alex.
+    for (size_t i = 0; i < _dual_number->size(); ++i)
+      (*_dual_number)(i) = 0;
+  return *this;
+}
+
+MooseADWrapper<DenseMatrix<Real>>::MooseADWrapper(bool use_ad)
+  : _use_ad(use_ad), _val(), _dual_number(nullptr)
+{
+  if (_use_ad)
+    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>();
+}
+
+const DenseMatrix<DualReal> &
+MooseADWrapper<DenseMatrix<Real>>::dn(bool) const
+{
+  auto m = _val.m();
+  auto n = _val.n();
+  if (!_dual_number)
+  {
+    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>(m, n);
+    for (std::size_t i = 0; i < m; ++i)
+      for (std::size_t j = 0; j < n; ++j)
+        (*_dual_number)(i, j).value() = _val(i, j);
+  }
+  else if (!_use_ad)
+    for (std::size_t i = 0; i < m; ++i)
+      for (std::size_t j = 0; j < n; ++j)
+        (*_dual_number)(i, j).value() = _val(i, j);
+  return *_dual_number;
+}
+
+DenseMatrix<DualReal> &
+MooseADWrapper<DenseMatrix<Real>>::dn(bool)
+{
+  return *_dual_number;
+}
+
+void
+MooseADWrapper<DenseMatrix<Real>>::copyDualNumberToValue()
+{
+  for (std::size_t i = 0; i < _dual_number->m(); ++i)
+    for (std::size_t j = 0; j < _dual_number->n(); ++j)
+      _val(i, j) = (*_dual_number)(i, j).value();
+}
+
+void
+MooseADWrapper<DenseMatrix<Real>>::markAD(bool use_ad)
+{
+  if (!use_ad && _use_ad)
+    _dual_number = nullptr;
+  else if (use_ad && !_use_ad)
+    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>();
+  _use_ad = use_ad;
+}
+
+MooseADWrapper<DenseMatrix<Real>> &
+MooseADWrapper<DenseMatrix<Real>>::operator=(const MooseADWrapper<DenseMatrix<Real>> & rhs)
+{
+  _val = rhs._val;
+  if (_dual_number && rhs._dual_number)
+    *_dual_number = *rhs._dual_number;
+  else if (_dual_number)
+    // I don't know why we do this, but other code does it - ask Alex.
+    for (std::size_t i = 0; i < _dual_number->m(); ++i)
+      for (std::size_t j = 0; j < _dual_number->n(); ++j)
+        (*_dual_number)(i, j) = 0;
+  return *this;
+}
+
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::MooseADWrapper(bool use_ad)
+  : _use_ad(use_ad), _val(), _dual_number(nullptr)
+{
+  if (_use_ad)
+    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>();
+}
+
+const std::vector<DenseMatrix<DualReal>> &
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::dn(bool) const
+{
+  if (!_dual_number)
+  {
+    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>(_val.size());
+    for (size_t h = 0; h < _val.size(); h++)
+    {
+      auto & val = _val[h];
+      (*_dual_number)[h].resize(val.m(), val.n());
+      for (std::size_t i = 0; i < val.m(); ++i)
+        for (std::size_t j = 0; j < val.n(); ++j)
+          (*_dual_number)[h](i, j).value() = val(i, j);
+    }
+  }
+  else if (!_use_ad)
+  {
+    assert(_dual_number.get());
+    assert(_dual_number->size() == _val.size());
+    for (size_t h = 0; h < _val.size(); h++)
+    {
+      auto & val = _val[h];
+      for (std::size_t i = 0; i < val.m(); ++i)
+        for (std::size_t j = 0; j < val.n(); ++j)
+          (*_dual_number)[h](i, j).value() = val(i, j);
+    }
+  }
+  assert(_dual_number.get());
+  return *_dual_number;
+}
+
+std::vector<DenseMatrix<DualReal>> &
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::dn(bool)
+{
+  assert(_dual_number.get());
+  return *_dual_number;
+}
+
+void
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::copyDualNumberToValue()
+{
+  assert(_dual_number.get());
+  _val.resize(_dual_number->size());
+  for (size_t h = 0; h < _dual_number->size(); h++)
+  {
+    auto & val = (*_dual_number)[h];
+    _val[h].resize(val.m(), val.n());
+    for (std::size_t i = 0; i < val.m(); ++i)
+      for (std::size_t j = 0; j < val.n(); ++j)
+        _val[h](i, j) = val(i, j).value();
+  }
+}
+
+void
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::markAD(bool use_ad)
+{
+  if (!use_ad && _use_ad)
+    _dual_number = nullptr;
+  else if (use_ad && !_dual_number)
+    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>(_val.size());
+  _use_ad = use_ad;
+}
+
+MooseADWrapper<std::vector<DenseMatrix<Real>>> &
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::
+operator=(const MooseADWrapper<std::vector<DenseMatrix<Real>>> & rhs)
+{
+  _val = rhs._val;
+  if (_dual_number && rhs._dual_number)
+    *_dual_number = *rhs._dual_number;
+  else if (_dual_number)
+    // I don't know why we do this, but other code does it - ask Alex.
+    for (size_t h = 0; h < _dual_number->size(); h++)
+    {
+      auto & val = (*_dual_number)[h];
+      for (std::size_t i = 0; i < val.m(); ++i)
+        for (std::size_t j = 0; j < val.n(); ++j)
+          val(i, j) = 0;
+    }
+  return *this;
+}
+
+MooseADWrapper<std::vector<DenseVector<Real>>>::MooseADWrapper(bool use_ad)
+  : _use_ad(use_ad), _val(), _dual_number(nullptr)
+{
+  if (_use_ad)
+    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>();
+}
+
+const std::vector<DenseVector<DualReal>> &
+MooseADWrapper<std::vector<DenseVector<Real>>>::dn(bool) const
+{
+  if (!_dual_number)
+    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>(_val.size());
+  else if (!_use_ad)
+    for (std::size_t i = 0; i < _dual_number->size(); ++i)
+    {
+      auto & val = _val[i];
+      auto & dn = (*_dual_number)[i];
+      dn.resize(val.size());
+      for (std::size_t j = 0; j < val.size(); ++j)
+        dn(j).value() = val(j);
+    }
+  return *_dual_number;
+}
+
+std::vector<DenseVector<DualReal>> &
+MooseADWrapper<std::vector<DenseVector<Real>>>::dn(bool)
+{
+  return *_dual_number;
+}
+
+void
+MooseADWrapper<std::vector<DenseVector<Real>>>::copyDualNumberToValue()
+{
+  for (std::size_t i = 0; i < _dual_number->size(); ++i)
+    for (std::size_t j = 0; j < (*_dual_number)[i].size(); ++j)
+      _val[i](j) = (*_dual_number)[i](j).value();
+}
+
+void
+MooseADWrapper<std::vector<DenseVector<Real>>>::markAD(bool use_ad)
+{
+  if (!use_ad && _use_ad)
+    _dual_number = nullptr;
+  else if (use_ad && !_use_ad)
+    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>();
+  _use_ad = use_ad;
+}
+
+MooseADWrapper<std::vector<DenseVector<Real>>> &
+MooseADWrapper<std::vector<DenseVector<Real>>>::
+operator=(const MooseADWrapper<std::vector<DenseVector<Real>>> & rhs)
+{
+  _val = rhs._val;
+  if (_dual_number && rhs._dual_number)
+    *_dual_number = *rhs._dual_number;
+  else if (_dual_number)
+    // I don't know why we do this, but other code does it - ask Alex.
+    for (std::size_t i = 0; i < _dual_number->size(); ++i)
+      for (std::size_t j = 0; j < (*_dual_number)[i].size(); ++j)
+        (*_dual_number)[i](j) = 0;
+  return *this;
+}

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -38,6 +38,7 @@ public:
   virtual Real cp_from_v_e(Real v, Real e) const override;
   virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
   virtual Real cv_from_v_e(Real v, Real e) const override;
+  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
   virtual Real mu_from_v_e(Real v, Real e) const override;
   virtual Real k_from_v_e(Real v, Real e) const override;
   virtual Real s_from_v_e(Real v, Real e) const override;
@@ -75,6 +76,7 @@ public:
   virtual Real g_from_v_e(Real v, Real e) const override;
   virtual Real T_from_p_h(Real p, Real h) const override;
   virtual Real cv_from_p_T(Real p, Real T) const override;
+  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
   virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -221,6 +221,7 @@ public:
    * @param[in] T   temperature
    */
   virtual Real v_from_p_T(Real p, Real T) const;
+  virtual DualReal v_from_p_T(const DualReal & p, const DualReal & T) const;
 
   /**
    * Specific volume and its derivatives from pressure and temperature
@@ -278,6 +279,7 @@ public:
    */
   virtual Real e_from_p_T(Real p, Real T) const;
   virtual Real e(Real pressure, Real temperature) const;
+  DualReal e_from_p_T(const DualReal & p, const DualReal & T) const;
 
   /**
    * Internal energy and its derivatives from pressure and temperature

--- a/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/StiffenedGasFluidProperties.h
@@ -79,6 +79,7 @@ public:
   virtual Real criticalDensity() const override;
   virtual Real criticalInternalEnergy() const override;
   virtual Real cv_from_p_T(Real p, Real T) const override;
+  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const override;
   virtual Real cp_from_p_T(Real p, Real T) const override;
   virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
   virtual Real mu_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/utils/DimensionlessFlowNumbers.h
+++ b/modules/fluid_properties/include/utils/DimensionlessFlowNumbers.h
@@ -9,7 +9,12 @@
 
 #pragma once
 
+#include "DualReal.h"
+
+#include "metaphysicl/numberarray.h"
+#include "metaphysicl/dualnumber.h"
 #include "libmesh/libmesh_common.h"
+
 using namespace libMesh;
 
 namespace fp
@@ -25,6 +30,7 @@ namespace fp
  * @return Reynolds number
  */
 Real reynolds(Real rho, Real vel, Real L, Real mu);
+DualReal reynolds(DualReal rho, DualReal vel, DualReal L, DualReal mu);
 
 /**
  * Compute Prandtl number
@@ -35,6 +41,7 @@ Real reynolds(Real rho, Real vel, Real L, Real mu);
  * @return Prandtl number
  */
 Real prandtl(Real cp, Real mu, Real k);
+DualReal prandtl(DualReal cp, DualReal mu, DualReal k);
 
 /**
  * Compute Grashof number
@@ -49,6 +56,13 @@ Real prandtl(Real cp, Real mu, Real k);
  * @return Grashof number
  */
 Real grashof(Real beta, Real T_s, Real T_bulk, Real L, Real rho, Real mu, Real gravity_magnitude);
+DualReal grashof(DualReal beta,
+                 DualReal T_s,
+                 DualReal T_bulk,
+                 DualReal L,
+                 DualReal rho,
+                 DualReal mu,
+                 DualReal gravity_magnitude);
 
 /**
  * Compute Laplace number
@@ -60,6 +74,7 @@ Real grashof(Real beta, Real T_s, Real T_bulk, Real L, Real rho, Real mu, Real g
  * @return Laplace number
  */
 Real laplace(Real sigma, Real rho, Real L, Real mu);
+DualReal laplace(DualReal sigma, DualReal rho, DualReal L, DualReal mu);
 
 /**
  * Compute thermal diffusivity
@@ -70,6 +85,7 @@ Real laplace(Real sigma, Real rho, Real L, Real mu);
  * @return Thermal diffusivity
  */
 Real thermalDiffusivity(Real k, Real rho, Real cp);
+DualReal thermalDiffusivity(DualReal k, DualReal rho, DualReal cp);
 
 /**
  * Compute Peclet number
@@ -80,6 +96,7 @@ Real thermalDiffusivity(Real k, Real rho, Real cp);
  * @return Peclet number
  */
 Real peclet(Real vel, Real L, Real diffusivity);
+DualReal peclet(DualReal vel, DualReal L, DualReal diffusivity);
 
 } // namespace fp
 

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -147,6 +147,14 @@ IdealGasFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, R
 
 Real IdealGasFluidProperties::cv_from_v_e(Real, Real) const { return _cv; }
 
+void
+IdealGasFluidProperties::cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const
+{
+  cv = cv_from_v_e(v, e);
+  dcv_dv = 0.0;
+  dcv_de = 0.0;
+}
+
 Real IdealGasFluidProperties::gamma_from_v_e(Real, Real) const { return _gamma; }
 
 Real IdealGasFluidProperties::gamma_from_p_T(Real, Real) const { return _gamma; }
@@ -454,6 +462,14 @@ IdealGasFluidProperties::T_from_p_h(Real, Real h) const
 Real IdealGasFluidProperties::cv_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _cv;
+}
+
+void
+IdealGasFluidProperties::cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const
+{
+  cv = cv_from_p_T(p, T);
+  dcv_dp = 0.0;
+  dcv_dT = 0.0;
 }
 
 Real IdealGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -31,6 +31,22 @@ SinglePhaseFluidProperties::e_from_p_T(Real p, Real T) const
   return e_from_p_rho(p, rho);
 }
 
+DualReal
+SinglePhaseFluidProperties::e_from_p_T(const DualReal & p, const DualReal & T) const
+{
+  Real rawe = 0;
+  Real rawp = p.value();
+  Real rawT = T.value();
+  Real dedp = 0;
+  Real dedT = 0;
+  e_from_p_T(rawp, rawT, rawe, dedp, dedT);
+
+  DualReal result = rawe;
+  for (size_t i = 0; i < p.derivatives().size(); i++)
+    result.derivatives()[i] = p.derivatives()[i] * dedp + T.derivatives()[i] * dedT;
+  return result;
+}
+
 void
 SinglePhaseFluidProperties::e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const
 {
@@ -54,6 +70,22 @@ SinglePhaseFluidProperties::v_from_p_T(Real p, Real T) const
 {
   const Real rho = rho_from_p_T(p, T);
   return 1.0 / rho;
+}
+
+DualReal
+SinglePhaseFluidProperties::v_from_p_T(const DualReal & p, const DualReal & T) const
+{
+  Real rawv = 0;
+  Real rawp = p.value();
+  Real rawT = T.value();
+  Real dvdp = 0;
+  Real dvdT = 0;
+  v_from_p_T(rawp, rawT, rawv, dvdp, dvdT);
+
+  DualReal result = rawv;
+  for (size_t i = 0; i < p.derivatives().size(); i++)
+    result.derivatives()[i] = p.derivatives()[i] * dvdp + T.derivatives()[i] * dvdT;
+  return result;
 }
 
 void

--- a/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/StiffenedGasFluidProperties.C
@@ -457,6 +457,15 @@ Real StiffenedGasFluidProperties::cv_from_p_T(Real /* pressure */, Real /* tempe
   return _cv;
 }
 
+void
+StiffenedGasFluidProperties::cv_from_p_T(
+    Real pressure, Real temperature, Real & cv, Real & dcv_dp, Real & dcv_dT) const
+{
+  cv = cv_from_p_T(pressure, temperature);
+  dcv_dp = 0.0;
+  dcv_dT = 0.0;
+}
+
 Real StiffenedGasFluidProperties::cp_from_p_T(Real /* pressure */, Real /* temperature */) const
 {
   return _cp;

--- a/modules/fluid_properties/src/utils/DimensionlessFlowNumbers.C
+++ b/modules/fluid_properties/src/utils/DimensionlessFlowNumbers.C
@@ -18,8 +18,20 @@ reynolds(Real rho, Real vel, Real L, Real mu)
   return rho * std::fabs(vel) * L / mu;
 }
 
+DualReal
+reynolds(DualReal rho, DualReal vel, DualReal L, DualReal mu)
+{
+  return rho * std::fabs(vel) * L / mu;
+}
+
 Real
 prandtl(Real cp, Real mu, Real k)
+{
+  return cp * mu / k;
+}
+
+DualReal
+prandtl(DualReal cp, DualReal mu, DualReal k)
 {
   return cp * mu / k;
 }
@@ -31,8 +43,27 @@ grashof(Real beta, Real T_s, Real T_bulk, Real L, Real rho, Real mu, Real gravit
          (mu * mu);
 }
 
+DualReal
+grashof(DualReal beta,
+        DualReal T_s,
+        DualReal T_bulk,
+        DualReal L,
+        DualReal rho,
+        DualReal mu,
+        DualReal gravity_magnitude)
+{
+  return gravity_magnitude * beta * std::abs(T_s - T_bulk) * std::pow(L, 3) * (rho * rho) /
+         (mu * mu);
+}
+
 Real
 laplace(Real sigma, Real rho, Real L, Real mu)
+{
+  return sigma * rho * L / (mu * mu);
+}
+
+DualReal
+laplace(DualReal sigma, DualReal rho, DualReal L, DualReal mu)
 {
   return sigma * rho * L / (mu * mu);
 }
@@ -43,8 +74,20 @@ thermalDiffusivity(Real k, Real rho, Real cp)
   return k / (rho * cp);
 }
 
+DualReal
+thermalDiffusivity(DualReal k, DualReal rho, DualReal cp)
+{
+  return k / (rho * cp);
+}
+
 Real
 peclet(Real vel, Real L, Real diffusivity)
+{
+  return std::fabs(vel) * L / diffusivity;
+}
+
+DualReal
+peclet(DualReal vel, DualReal L, DualReal diffusivity)
 {
   return std::fabs(vel) * L / diffusivity;
 }

--- a/unit/src/ADTypesTest.C
+++ b/unit/src/ADTypesTest.C
@@ -1,0 +1,77 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "Moose.h"
+#include "ADMaterial.h"
+#include "DenseMatrix.h"
+
+#include "libmesh/dense_vector.h"
+#include "gtest_include.h"
+
+#include <vector>
+
+template <typename T, ComputeStage compute_stage>
+class MyMat
+{
+public:
+  ADMaterialProperty(T) prop;
+};
+
+#define testType(simpleT, dualT)                                                                   \
+  {                                                                                                \
+    MyMat<simpleT, RESIDUAL> mr;                                                                   \
+    auto & vals = mr.prop;                                                                         \
+    vals.resize(1);                                                                                \
+    EXPECT_EQ(typeid(vals[0]).name(), typeid(simpleT).name());                                     \
+                                                                                                   \
+    MyMat<simpleT, JACOBIAN> mj;                                                                   \
+    auto & valsjac = mj.prop;                                                                      \
+    valsjac.resize(1);                                                                             \
+    EXPECT_EQ(typeid(valsjac[0]).name(), typeid(dualT).name());                                    \
+  }
+
+TEST(ADTypesTest, vector_DenseMatrix_Real)
+{
+  testType(std::vector<DenseMatrix<Real>>, std::vector<DenseMatrix<DualReal>>);
+
+  std::vector<DenseMatrix<DualReal>> vm(2);
+  auto & m1 = vm[0];
+  auto & m2 = vm[1];
+  m1.resize(3, 3);
+  m2.resize(3, 3);
+  m1(0, 0) = 1;
+  m1(1, 1) = 2;
+  m1(2, 2) = 3;
+  m2(0, 0) = 1;
+  m2(1, 1) = 2;
+  m2(2, 2) = 3;
+  m1.right_multiply(m2);
+  EXPECT_EQ(1.0, m1(0, 0));
+  EXPECT_EQ(4.0, m1(1, 1));
+  EXPECT_EQ(9.0, m1(2, 2));
+}
+
+TEST(ADTypesTest, vector_DenseVector_Real)
+{
+  testType(std::vector<DenseVector<Real>>, std::vector<DenseVector<DualReal>>);
+
+  std::vector<DenseVector<DualReal>> vv(2);
+  auto & v1 = vv[0];
+  auto & v2 = vv[1];
+  v1.resize(3);
+  v2.resize(3);
+  v1(0) = 1;
+  v1(1) = 2;
+  v1(2) = 3;
+  v2(0) = 1;
+  v2(1) = 2;
+  v2(2) = 3;
+  auto val = v1.dot(v2);
+  EXPECT_EQ(14.0, val);
+}


### PR DESCRIPTION
Adds AD support for some data types and fluid properties functions that Pronghorn needs. This is still waiting on a DenseMatrix explicit instantiation PR and will fail until that gets in.
