### PR TITLE
Remove duplicate bibtex entry from phase field module

### DIFF
--- a/modules/phase_field/doc/content/bib/phase_field.bib
+++ b/modules/phase_field/doc/content/bib/phase_field.bib
@@ -13,22 +13,6 @@
   year = {2010},
 }
 
-@article{kim_phase-field_1999,
-  title = {Phase-field model for binary alloys},
-  volume = {60},
-  url = {http://link.aps.org/doi/10.1103/PhysRevE.60.7186},
-  doi = {10.1103/PhysRevE.60.7186},
-  abstract = {We present a phase-field model ({PFM}) for solidification in binary alloys, which is found from the phase-field model for a pure material by direct comparison of the variables for a pure material solidification and alloy solidification. The model appears to be equivalent with the Wheeler-Boettinger-{McFadden} ({WBM}) model [A.A. Wheeler, W. J. Boettinger, and G. B. {McFadden}, Phys. Rev. A 45, 7424 (1992)], but has a different definition of the free energy density for interfacial region. An extra potential originated from the free energy density definition in the {WBM} model disappears in this model. At a dilute solution limit, the model is reduced to the Tiaden et al. model [Physica D 115, 73 (1998)] for a binary alloy. A relationship between the phase-field mobility and the interface kinetics coefficient is derived at a thin-interface limit condition under an assumption of negligible diffusivity in the solid phase. For a dilute alloy, a steady-state solution of the concentration profile across the diffuse interface is obtained as a function of the interface velocity and the resultant partition coefficient is compared with the previous solute trapping model. For one dimensional steady-state solidification, where the classical sharp-interface model is exactly soluble, we perform numerical simulations of the phase-field model: At low interface velocity, the simulated results from the thin-interface {PFM} are in excellent agreement with the exact solutions. As the partition coefficient becomes close to unit at high interface velocities, whereas, the sharp-interface {PFM} yields the correct answer.},
-  number = {6},
-  urldate = {2014-03-31},
-  journal = {Physical Review E},
-  author = {Kim, Seong Gyoon and Kim, Won Tae and Suzuki, Toshio},
-  month = dec,
-  year = {1999},
-  pages = {7186--7197},
-  annote = {This is the {KKS} model paper},
-  file = {Kim et al. - 1999 - Phase-field model for binary alloys.html:/Users/schwd/Library/Application Support/Firefox/Profiles/i2j5gt6k.default/zotero/storage/IQMMGVCR/Kim et al. - 1999 - Phase-field model for binary alloys.html:text/html;Kim et al. - 1999 - Phase-field model for binary alloys.pdf:/Users/schwd/Library/Application Support/Firefox/Profiles/i2j5gt6k.default/zotero/storage/R6VMMT2S/Kim et al. - 1999 - Phase-field model for binary alloys.pdf:application/pdf}
-}
 
 @article{Nest98,
   title = {Anisotropic multi-phase-field model: Interfaces and junctions},


### PR DESCRIPTION
Bibtex entry is already included in the tensor mechanics module and the duplicate creates a warning

Closes #13389
