### PR TITLE
Display when GhostingFunctors are active

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -211,7 +211,10 @@ public:
   // this context.  Since full support for unique_ptr is not quite
   // available yet, we've implemented it as a std::shared_ptr.
   std::shared_ptr<MooseMesh> & mesh() { return _mesh; }
+  const std::shared_ptr<MooseMesh> & getMesh() const { return _mesh; }
+
   std::shared_ptr<MooseMesh> & displacedMesh() { return _displaced_mesh; }
+  const std::shared_ptr<MooseMesh> & getDisplacedMesh() const { return _displaced_mesh; }
 
   std::shared_ptr<FEProblemBase> & problemBase() { return _problem; }
   std::shared_ptr<FEProblem> problem();
@@ -283,4 +286,3 @@ private:
 
   const std::list<Action *> _empty_action_list;
 };
-

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1811,5 +1811,26 @@ MooseApp::getRelationshipManagerInfo() const
     info_strings.emplace_back(std::make_pair(Moose::stringify(rm->getType()), oss.str()));
   }
 
+  // List the libMesh GhostingFunctors - Not that in libMesh all of the algebraic and coupling
+  // Ghosting Functors are also attached to the mesh. This should catch them all.
+  const auto & mesh = _action_warehouse.getMesh();
+  if (mesh)
+  {
+    std::unordered_map<std::string, unsigned int> counts;
+
+    for (auto & gf : as_range(mesh->getMesh().ghosting_functors_begin(),
+                              mesh->getMesh().ghosting_functors_end()))
+    {
+      const auto * gf_ptr = dynamic_cast<const RelationshipManager *>(gf);
+      if (!gf_ptr)
+        // Count how many occurances of the same Ghosting Functor types we are encountering
+        counts[demangle(typeid(*gf).name())]++;
+    }
+
+    for (const auto pair : counts)
+      info_strings.emplace_back(std::make_pair(
+          "Default", pair.first + (pair.second > 1 ? " x " + std::to_string(pair.second) : "")));
+  }
+
   return info_strings;
 }

--- a/test/tests/relationship_managers/default_ghosting/default_ghosting.i
+++ b/test/tests/relationship_managers/default_ghosting/default_ghosting.i
@@ -1,0 +1,49 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]
+
+# Show that we can enable and see that libmesh Ghosting Functors are active
+[Problem]
+  default_ghosting = true
+[]

--- a/test/tests/relationship_managers/default_ghosting/tests
+++ b/test/tests/relationship_managers/default_ghosting/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [./test]
+    type = 'RunApp'
+    input = 'default_ghosting.i'
+    expect_out = "Default:\s+libMesh::"
+
+    requirement = 'The system shall indicate when libMesh Ghosting Functors are in use.'
+    design = "relationship_managers.md"
+    issues = '#13206'
+  [../]
+[]


### PR DESCRIPTION
refs #13206

This will show you when libMesh has ghosting functors that aren't added by MOOSE.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
