### PR TITLE
added AD compatible spectral decomposition for ranktwotensor

### DIFF
--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -400,8 +400,9 @@ public:
    * Dual numbers are permuted as well
    * P * A permutes rows and A * P^T permutes columns
    */
-  RankTwoTensorTempl<T> permutationTensor(std::vector<unsigned int> old_elements,
-                                          std::vector<unsigned int> new_elements) const;
+  RankTwoTensorTempl<T>
+  permutationTensor(const std::array<unsigned int, LIBMESH_DIM> & old_elements,
+                    const std::array<unsigned int, LIBMESH_DIM> & new_elements) const;
 
   /**
    * computes and returns the Givens rotation matrix R

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -433,7 +433,9 @@ public:
   void hessenberg(RankTwoTensorTempl<T> & H, RankTwoTensorTempl<T> & U) const;
 
   /// computes the QR factorization such that A = Q * R, where Q is the unitary matrix and R an upper triangular matrix
-  void QR(RankTwoTensorTempl<T> & Q, RankTwoTensorTempl<T> & R) const;
+  void QR(RankTwoTensorTempl<T> & Q,
+          RankTwoTensorTempl<T> & R,
+          unsigned int dim = RankTwoTensorTempl<T>::N) const;
 
   /**
    * computes eigenvalues and eigenvectors, assuming tens is symmetric, and places them

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -395,21 +395,13 @@ public:
 
   /**
    * computes and returns the permutation matrix P
-   * @param old_row is the original row numbering
-   * @param new_row is the permuted row numbering
+   * @param old_elements is the original row/column numbering
+   * @param new_elements is the permuted row/column numbering
    * Dual numbers are permuted as well
+   * P * A permutes rows and A * P^T permutes columns
    */
-  RankTwoTensorTempl<T> rowPermutationTensor(std::vector<unsigned int> old_row,
-                                             std::vector<unsigned int> new_row) const;
-
-  /**
-   * computes and returns the permutation matrix P
-   * @param old_col is the original column numbering
-   * @param new_col is the permuted column numbering
-   * Dual numbers are permuted as well
-   */
-  RankTwoTensorTempl<T> columnPermutationTensor(std::vector<unsigned int> old_col,
-                                                std::vector<unsigned int> new_col) const;
+  RankTwoTensorTempl<T> permutationTensor(std::vector<unsigned int> old_elements,
+                                          std::vector<unsigned int> new_elements) const;
 
   /**
    * computes and returns the Givens rotation matrix R

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -388,6 +388,30 @@ public:
   void symmetricEigenvalues(std::vector<T> & eigvals) const;
 
   /**
+   * computes and returns the Givens rotation matrix R
+   * @param row1 is the row number of the first component to rotate
+   * @param row2 is the row number of the second component to rotate
+   * @param col is the column number of the components to rotate
+   * consider a RankTwoTensor A = [ a11 a12 a13
+   *                                a21 a22 a23
+   *                                a31 a32 a33]
+   * and we want to rotate a21 and a31. Then row1 = 1, row2 = 2, col = 0.
+   * It retunrs the Givens rotation matrix R of this tensor A such that R * A rotates the second
+   * component to zero, i.e. R * A = [ a11 a12 a13
+   *                                     r a22 a23
+   *                                     0 a32 a33]
+   * A DualReal instantiation is available to rotate dual numbers as well.
+   */
+  RankTwoTensorTempl<T>
+  givensRotation(unsigned int row1, unsigned int row2, unsigned int col) const;
+
+  /// computes the Hessenberg form of this matrix A and its unitary transformation U such that A = U * H * U^T
+  void hessenberg(RankTwoTensorTempl<T> & H, RankTwoTensorTempl<T> & U) const;
+
+  /// computes the QR factorization such that A = Q * R, where Q is the unitary matrix and R an upper triangular matrix
+  void QR(RankTwoTensorTempl<T> & Q, RankTwoTensorTempl<T> & R) const;
+
+  /**
    * computes eigenvalues and eigenvectors, assuming tens is symmetric, and places them
    * in ascending order in eigvals.  eigvecs is a matrix with the first column
    * being the first eigenvector, the second column being the second, etc.

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -369,6 +369,12 @@ public:
   /// Print the rank two tensor
   void print(std::ostream & stm = Moose::out) const;
 
+  /// Print the Real part of the DualReal rank two tensor
+  void printReal(std::ostream & stm = Moose::out) const;
+
+  /// Print the Real part of the DualReal rank two tensor along with its first nDual dual numbers
+  void printDualReal(unsigned int nDual, std::ostream & stm = Moose::out) const;
+
   /// Add identity times a to _coords
   void addIa(const T & a);
 
@@ -386,6 +392,24 @@ public:
    * in ascending order in eigvals
    */
   void symmetricEigenvalues(std::vector<T> & eigvals) const;
+
+  /**
+   * computes and returns the permutation matrix P
+   * @param old_row is the original row numbering
+   * @param new_row is the permuted row numbering
+   * Dual numbers are permuted as well
+   */
+  RankTwoTensorTempl<T> rowPermutationTensor(std::vector<unsigned int> old_row,
+                                             std::vector<unsigned int> new_row) const;
+
+  /**
+   * computes and returns the permutation matrix P
+   * @param old_col is the original column numbering
+   * @param new_col is the permuted column numbering
+   * Dual numbers are permuted as well
+   */
+  RankTwoTensorTempl<T> columnPermutationTensor(std::vector<unsigned int> old_col,
+                                                std::vector<unsigned int> new_col) const;
 
   /**
    * computes and returns the Givens rotation matrix R

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -929,12 +929,10 @@ RankTwoTensorTempl<T>::symmetricEigenvaluesEigenvectors(std::vector<T> & eigvals
 
 template <typename T>
 RankTwoTensorTempl<T>
-RankTwoTensorTempl<T>::permutationTensor(std::vector<unsigned int> old_elements,
-                                         std::vector<unsigned int> new_elements) const
+RankTwoTensorTempl<T>::permutationTensor(
+    const std::array<unsigned int, LIBMESH_DIM> & old_elements,
+    const std::array<unsigned int, LIBMESH_DIM> & new_elements) const
 {
-  mooseAssert(N == old_elements.size() && N == new_elements.size(),
-              "permutationTensor: number of permuting elements should be equal to LIBMESH_DIM");
-
   RankTwoTensorTempl<T> P;
 
   for (unsigned int i = 0; i < N; ++i)

--- a/unit/src/RankTwoEigenRoutinesTest.C
+++ b/unit/src/RankTwoEigenRoutinesTest.C
@@ -124,95 +124,42 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_two_nonzero_eigvals)
   testADSymmetricEigenvaluesEigenvectors(0, 1, 2, 0, 0, 0, eigvals_expect, eigvecs_expect);
 }
 
-TEST(RankTwoEigenRoutines, hessenberg_dual_number_consistency)
-{
-  // consider a dual rank two tensor
-  // m = [1(1,2,3), 0(2,3,4), 0(1,3,5)
-  //      0(2,3,4), 2(-2,-5,1), 4(2,4,6)
-  //      0(1,3,5), 4(2,4,6), 3(2,1,4)]
-  NumberArray<50, Real> da11_dx;
-  da11_dx[0] = 1;
-  da11_dx[1] = 2;
-  da11_dx[2] = 3;
-  DualReal a11(1, da11_dx);
-  NumberArray<50, Real> da22_dx;
-  da22_dx[0] = -2;
-  da22_dx[1] = -5;
-  da22_dx[2] = 1;
-  DualReal a22(2, da22_dx);
-  NumberArray<50, Real> da33_dx;
-  da33_dx[0] = 2;
-  da33_dx[1] = 1;
-  da33_dx[2] = 4;
-  DualReal a33(3, da33_dx);
-  NumberArray<50, Real> da23_dx;
-  da23_dx[0] = 2;
-  da23_dx[1] = 4;
-  da23_dx[2] = 6;
-  DualReal a23(4, da23_dx);
-  NumberArray<50, Real> da13_dx;
-  da13_dx[0] = 1;
-  da13_dx[1] = 3;
-  da13_dx[2] = 5;
-  DualReal a13(0, da13_dx);
-  NumberArray<50, Real> da12_dx;
-  da12_dx[0] = 2;
-  da12_dx[1] = 3;
-  da12_dx[2] = 4;
-  DualReal a12(0, da12_dx);
-
-  DualRankTwoTensor m(a11, a22, a33, a23, a13, a12);
-  DualRankTwoTensor H, U;
-  m.hessenberg(H, U);
-  DualRankTwoTensor m_ad = U * H * U.transpose();
-
-  // m_ad should be equal to m in values and dual numbers!
-  for (unsigned i = 0; i < 3; i++)
-    for (unsigned j = 0; j < 3; j++)
-    {
-      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
-      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
-      EXPECT_NEAR(m(i, j).derivatives()[1], m_ad(i, j).derivatives()[1], 0.0001);
-      EXPECT_NEAR(m(i, j).derivatives()[2], m_ad(i, j).derivatives()[2], 0.0001);
-    }
-}
-
 TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_dual_number_consistency)
 {
   // consider a dual rank two tensor
-  // m = [1(1,2,3), 1(2,3,4), 2(1,3,5)
-  //      1(2,3,4), 2(-2,-5,1), 4(2,4,6)
-  //      2(1,3,5), 4(2,4,6), 3(2,1,4)]
+  // m = [241.6329(1,2,3),  96.7902(2,3,4),   -73.0700(1,3,5)
+  //       96.7902(2,3,4), 222.3506(-2,-5,1), 168.9006(2,4,6)
+  //      -73.0700(1,3,5), 168.9006(2,4,6),   236.0164(2,1,4)]
   NumberArray<50, Real> da11_dx;
   da11_dx[0] = 1;
   da11_dx[1] = 2;
   da11_dx[2] = 3;
-  DualReal a11(1, da11_dx);
+  DualReal a11(241.6329, da11_dx);
   NumberArray<50, Real> da22_dx;
   da22_dx[0] = -2;
   da22_dx[1] = -5;
   da22_dx[2] = 1;
-  DualReal a22(2, da22_dx);
+  DualReal a22(222.3506, da22_dx);
   NumberArray<50, Real> da33_dx;
   da33_dx[0] = 2;
   da33_dx[1] = 1;
   da33_dx[2] = 4;
-  DualReal a33(3, da33_dx);
+  DualReal a33(236.0164, da33_dx);
   NumberArray<50, Real> da23_dx;
   da23_dx[0] = 2;
   da23_dx[1] = 4;
   da23_dx[2] = 6;
-  DualReal a23(4, da23_dx);
+  DualReal a23(168.9006, da23_dx);
   NumberArray<50, Real> da13_dx;
   da13_dx[0] = 1;
   da13_dx[1] = 3;
   da13_dx[2] = 5;
-  DualReal a13(2, da13_dx);
+  DualReal a13(-73.07, da13_dx);
   NumberArray<50, Real> da12_dx;
   da12_dx[0] = 2;
   da12_dx[1] = 3;
   da12_dx[2] = 4;
-  DualReal a12(1, da12_dx);
+  DualReal a12(96.7902, da12_dx);
 
   DualRankTwoTensor m(a11, a22, a33, a23, a13, a12);
   DualRankTwoTensor eigvecs;

--- a/unit/src/RankTwoEigenRoutinesTest.C
+++ b/unit/src/RankTwoEigenRoutinesTest.C
@@ -124,26 +124,12 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_two_nonzero_eigvals)
   testADSymmetricEigenvaluesEigenvectors(0, 1, 2, 0, 0, 0, eigvals_expect, eigvecs_expect);
 }
 
-TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_one_nonzero_eigval)
-{
-  // one nonzero eigenvalue
-  // m = [0, 0, 0
-  //      0, 0, 0
-  //      0, 0, 1]
-  // d1 = 0, v1 = [1, 0, 0]^T
-  // d2 = 0, v2 = [0, 1, 0]^T
-  // d3 = 1, v3 = [0, 0, 1]^T
-  std::vector<Real> eigvals_expect = {0, 0, 1};
-  RankTwoTensor eigvecs_expect(1, 0, 0, 0, 1, 0, 0, 0, 1);
-  testADSymmetricEigenvaluesEigenvectors(0, 0, 1, 0, 0, 0, eigvals_expect, eigvecs_expect);
-}
-
 TEST(RankTwoEigenRoutines, hessenberg_dual_number_consistency)
 {
   // consider a dual rank two tensor
-  // m = [1(1,2,3), 1(2,3,4), 2(1,3,5)
-  //      1(2,3,4), 2(-2,-5,1), 4(2,4,6)
-  //      2(1,3,5), 4(2,4,6), 3(2,1,4)]
+  // m = [1(1,2,3), 0(2,3,4), 0(1,3,5)
+  //      0(2,3,4), 2(-2,-5,1), 4(2,4,6)
+  //      0(1,3,5), 4(2,4,6), 3(2,1,4)]
   NumberArray<50, Real> da11_dx;
   da11_dx[0] = 1;
   da11_dx[1] = 2;
@@ -168,12 +154,12 @@ TEST(RankTwoEigenRoutines, hessenberg_dual_number_consistency)
   da13_dx[0] = 1;
   da13_dx[1] = 3;
   da13_dx[2] = 5;
-  DualReal a13(2, da13_dx);
+  DualReal a13(0, da13_dx);
   NumberArray<50, Real> da12_dx;
   da12_dx[0] = 2;
   da12_dx[1] = 3;
   da12_dx[2] = 4;
-  DualReal a12(1, da12_dx);
+  DualReal a12(0, da12_dx);
 
   DualRankTwoTensor m(a11, a22, a33, a23, a13, a12);
   DualRankTwoTensor H, U;
@@ -241,10 +227,10 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_dual_number_consiste
   for (unsigned i = 0; i < 3; i++)
     for (unsigned j = 0; j < 3; j++)
     {
-      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.01);
-      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.01);
-      EXPECT_NEAR(m(i, j).derivatives()[1], m_ad(i, j).derivatives()[1], 0.01);
-      EXPECT_NEAR(m(i, j).derivatives()[2], m_ad(i, j).derivatives()[2], 0.01);
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[1], m_ad(i, j).derivatives()[1], 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[2], m_ad(i, j).derivatives()[2], 0.0001);
     }
 }
 

--- a/unit/src/RankTwoTensorTest.C
+++ b/unit/src/RankTwoTensorTest.C
@@ -521,3 +521,57 @@ TEST_F(RankTwoTensorTest, ErrorComputingEV)
     ASSERT_TRUE(pos != std::string::npos);
   }
 }
+
+TEST_F(RankTwoTensorTest, HessenbergTransformation)
+{
+  RankTwoTensor a(1, 3, 4, 2, 5, 12, 3, 6, 1);
+  RankTwoTensor H, U;
+  a.hessenberg(H, U);
+
+  EXPECT_NEAR(1.0, H(0, 0), 0.0001);
+  EXPECT_NEAR(5.0, H(1, 0), 0.0001);
+  EXPECT_NEAR(0.0, H(2, 0), 0.0001);
+  EXPECT_NEAR(3.6, H(0, 1), 0.0001);
+  EXPECT_NEAR(11.08, H(1, 1), 0.0001);
+  EXPECT_NEAR(-1.44, H(2, 1), 0.0001);
+  EXPECT_NEAR(0.2, H(0, 2), 0.0001);
+  EXPECT_NEAR(-7.44, H(1, 2), 0.0001);
+  EXPECT_NEAR(-5.08, H(2, 2), 0.0001);
+
+  EXPECT_NEAR(1.0, U(0, 0), 0.0001);
+  EXPECT_NEAR(0.0, U(1, 0), 0.0001);
+  EXPECT_NEAR(0.0, U(2, 0), 0.0001);
+  EXPECT_NEAR(0.0, U(0, 1), 0.0001);
+  EXPECT_NEAR(0.6, U(1, 1), 0.0001);
+  EXPECT_NEAR(0.8, U(2, 1), 0.0001);
+  EXPECT_NEAR(0.0, U(0, 2), 0.0001);
+  EXPECT_NEAR(-0.8, U(1, 2), 0.0001);
+  EXPECT_NEAR(0.6, U(2, 2), 0.0001);
+}
+
+TEST_F(RankTwoTensorTest, QRFactorization)
+{
+  RankTwoTensor a(1, 3, 4, 2, 5, 12, 3, 6, 1);
+  RankTwoTensor Q, R;
+  a.QR(Q, R);
+
+  EXPECT_NEAR(0.1961, std::abs(Q(0, 0)), 0.0001);
+  EXPECT_NEAR(0.5883, std::abs(Q(1, 0)), 0.0001);
+  EXPECT_NEAR(0.7845, std::abs(Q(2, 0)), 0.0001);
+  EXPECT_NEAR(0.1543, std::abs(Q(0, 1)), 0.0001);
+  EXPECT_NEAR(0.7715, std::abs(Q(1, 1)), 0.0001);
+  EXPECT_NEAR(0.6172, std::abs(Q(2, 1)), 0.0001);
+  EXPECT_NEAR(0.9684, std::abs(Q(0, 2)), 0.0001);
+  EXPECT_NEAR(0.2421, std::abs(Q(1, 2)), 0.0001);
+  EXPECT_NEAR(0.0605, std::abs(Q(2, 2)), 0.0001);
+
+  EXPECT_NEAR(5.099, std::abs(R(0, 0)), 0.0001);
+  EXPECT_NEAR(0.0, std::abs(R(1, 0)), 0.0001);
+  EXPECT_NEAR(0.0, std::abs(R(2, 0)), 0.0001);
+  EXPECT_NEAR(12.7475, std::abs(R(0, 1)), 0.0001);
+  EXPECT_NEAR(3.2404, std::abs(R(1, 1)), 0.0001);
+  EXPECT_NEAR(0.0, std::abs(R(2, 1)), 0.0001);
+  EXPECT_NEAR(4.9029, std::abs(R(0, 2)), 0.0001);
+  EXPECT_NEAR(4.4748, std::abs(R(1, 2)), 0.0001);
+  EXPECT_NEAR(1.392, std::abs(R(2, 2)), 0.0001);
+}


### PR DESCRIPTION
derived an algorithm from EISPACK to solve eigenvalue decomposition of a ranktwotensor by using a tridiagonal reduction and a QL decomposition

refs #13191

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
