### PR TITLE
Update moose-environment package

### DIFF
--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -45,11 +45,11 @@ conda_vtk: 7.1.0
 pip_pylint: 1.6.5
 pip_livereload: 2.5.1
 moose_packages:
-    osx10.14: moose-environment_osx-mojave_20190430_x86_64.pkg
-    osx10.13: moose-environment_osx-highsierra_20190430_x86_64.pkg
-    osx10.12: moose-environment_osx-sierra_20190430_x86_64.pkg
-    ubuntu16: moose-environment_ubuntu-16.04_20190430_x86_64.deb
-    ubuntu18: moose-environment_ubuntu-18.04_20190430_x86_64.deb
-    opensuse15: moose-environment_opensuse-15.0_20190430_x86_64.rpm
-    fedora28: moose-environment_fedora-28_20190430_x86_64.rpm
-    centos7: moose-environment_centos-7.6.1810_20190430_x86_64.rpm
+    osx10.14: moose-environment_osx-mojave_20190509_x86_64.pkg
+    osx10.13: moose-environment_osx-highsierra_20190509_x86_64.pkg
+    osx10.12: moose-environment_osx-sierra_20190509_x86_64.pkg
+    ubuntu16: moose-environment_ubuntu-16.04_20190509_x86_64.deb
+    ubuntu18: moose-environment_ubuntu-18.04_20190509_x86_64.deb
+    opensuse15: moose-environment_opensuse-15.0_20190509_x86_64.rpm
+    fedora28: moose-environment_fedora-28_20190509_x86_64.rpm
+    centos7: moose-environment_centos-7.6.1810_20190509_x86_64.rpm

--- a/modules/doc/content/getting_started/installation/bash_profile.md
+++ b/modules/doc/content/getting_started/installation/bash_profile.md
@@ -1,0 +1,19 @@
+Follow the on-screen instructions. Those instructions will ask you to close any opened terminal windows, and open a new one.
+
+Next, in a new terminal window, load the moose-dev-gcc module:
+
+```bash
+module load moose-dev-gcc
+```
+
+For bash users (the default shell for most users), if you wish to have the moose-dev-gcc module loaded automatically with each new terminal session, copy and paste the following (which will append the necessary module load command to the end of your bash_profile):
+
+```bash
+echo "module load moose-dev-gcc" >> ~/.bash_profile
+```
+
++If you do not perform the above echo command, you must remember to execute: `module load moose-dev-gcc` each time you wish to perform *any* MOOSE related development.+
+
+!alert! note title=Multiple Users
+Each user of the machine wishing to use the moose-environment must also perform the above bash_profile modification.
+!alert-end!

--- a/modules/doc/content/getting_started/installation/centos.md
+++ b/modules/doc/content/getting_started/installation/centos.md
@@ -4,6 +4,6 @@
 
 !include getting_started/installation/centos_pre_req.md
 
-!include getting_started/installation/post_package_install.md
+!include getting_started/installation/bash_profile.md
 
 !include getting_started/installation/install_moose.md

--- a/modules/doc/content/getting_started/installation/fedora.md
+++ b/modules/doc/content/getting_started/installation/fedora.md
@@ -4,6 +4,6 @@
 
 !include getting_started/installation/fedora_pre_req.md
 
-!include getting_started/installation/post_package_install.md
+!include getting_started/installation/bash_profile.md
 
 !include getting_started/installation/install_moose.md

--- a/modules/doc/content/getting_started/installation/mint.md
+++ b/modules/doc/content/getting_started/installation/mint.md
@@ -4,6 +4,6 @@
 
 !include getting_started/installation/mint_pre_req.md
 
-!include getting_started/installation/post_package_install.md
+!include getting_started/installation/bash_profile.md
 
 !include getting_started/installation/install_moose.md

--- a/modules/doc/content/getting_started/installation/opensuse.md
+++ b/modules/doc/content/getting_started/installation/opensuse.md
@@ -4,6 +4,6 @@
 
 !include getting_started/installation/opensuse_pre_req.md
 
-!include getting_started/installation/post_package_install.md
+!include getting_started/installation/bash_profile.md
 
 !include getting_started/installation/install_moose.md

--- a/modules/doc/content/getting_started/installation/post_package_install.md
+++ b/modules/doc/content/getting_started/installation/post_package_install.md
@@ -4,31 +4,6 @@ Internal INL users may obtain the latest redistributable packages from the follo
 [https://rod.inl.gov/moose/](https://rod.inl.gov/moose/)
 !alert-end!
 
-!alert warning title=Close Open Terminals
+!alert warning title=Close Open Terminals After Package Installation
 If you have any opened terminals at this point, you must close and re-open them to use the MOOSE
 environment. The following instructions will ultimately fail if you do not.
-
-
-With your terminal windows now closed... open one. -By closing and opening a terminal window, you
-re-source the environment profiles the installer modified (or created).
-
-You should now have access to MOOSE's module environment. Modules allow users to simplify the
-managing of their running environment. If you and your system are already using modules, you will
-find our modules prepended to your already available list.
-
-While the moose-environment package allows for many different modules to be available, the modules
-all of us use (and is thouroughly tested against) are the following:
-
-On Linux machines:
-
-```bash
-  module load moose-dev-gcc
-```
-
-On Macintosh machines:
-
-```bash
-  module load moose-dev-clang
-```
-
-Load one of these modules pertinent to your operating system now, and continue on to Obtaining and Building MOOSE below.

--- a/modules/doc/content/getting_started/installation/ubuntu.md
+++ b/modules/doc/content/getting_started/installation/ubuntu.md
@@ -4,6 +4,6 @@
 
 !include getting_started/installation/ubuntu_pre_req.md
 
-!include getting_started/installation/post_package_install.md
+!include getting_started/installation/bash_profile.md
 
 !include getting_started/installation/install_moose.md

--- a/package_version
+++ b/package_version
@@ -1,3 +1,3 @@
 # moose-environment package version (https://github.com/idaholab/package_builder)
-# https://github.com/idaholab/package_builder/pull/198
-repo-hash:68b130eadb09ec50c57b87f39947ab9dceedc735
+# https://github.com/idaholab/package_builder/pull/199
+repo-hash:1b239077c1c4e35a82abcfe0c921d0390a260ecb


### PR DESCRIPTION
This update reverts back to the previous way the moose environment becomes available
for Macintosh users.

Linux users must now append: "module load moose-dev-gcc" to their bash profile instead
of the: "source /opt/moose/environments/moose_profile"

Closes #13408