### PR TITLE
Limit parallel testing for adaptive cycles test

### DIFF
--- a/test/tests/mesh/adapt/tests
+++ b/test/tests/mesh/adapt/tests
@@ -52,6 +52,7 @@
     input = 'adapt_test_cycles.i'
     exodiff = 'out_cycles.e out_cycles.e-s002'
     group = 'adaptive'
+    max_parallel = 8 # Test shows small diffs as the proc count increases
 
     requirement = 'The system shall support multiple adaptive steps per solve.'
     issues = '#830'


### PR DESCRIPTION
Note: This test was previously restricted to a single core. It does run
in parallel but the double mesh adaptivity makes it a little more
numerically unstable at higher core counts.

refs #13384

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
