### PR TITLE
Properly restoring tester status methods

### DIFF
--- a/python/TestHarness/JobDAG.py
+++ b/python/TestHarness/JobDAG.py
@@ -124,8 +124,8 @@ class JobDAG(object):
             tester.addCaveats('previous results: {}'.format(status.status))
             job.setStatus(job.finished)
 
-        # This job was skipped (but not due to a failing dependency) or passed without having failing dependencies
-        elif (status == tester.skip and not tester.getPrereqs()) or status == tester.success:
+        # This job was skipped, passed or silent
+        elif status in job.job_status.getSuccessStatuses():
             tester.setStatus(tester.silent)
             job.setStatus(job.finished)
 

--- a/python/TestHarness/StatusSystem.py
+++ b/python/TestHarness/StatusSystem.py
@@ -87,6 +87,20 @@ class StatusSystem(object):
                       running,
                       finished]
 
+    __exit_nonzero_statuses = [fail,
+                               diff,
+                               deleted,
+                               error,
+                               timeout]
+
+    __exit_zero_statuses = [success,
+                            skip,
+                            silent]
+
+    __pending_statuses = [hold,
+                          queued,
+                          running]
+
     def __init__(self):
         self.__status = self.no_status
 
@@ -101,6 +115,22 @@ class StatusSystem(object):
         Return the status object.
         """
         return self.__status
+
+    def getAllStatuses(self):
+        """ return list of named tuples containing all status types """
+        return self.__all_statuses
+
+    def getFailingStatuses(self):
+        """ return list of named tuples containing failing status types """
+        return self.__exit_nonzero_statuses
+
+    def getSuccessStatuses(self):
+        """ return list of named tuples containing exit code zero status types """
+        return self.__exit_zero_statuses
+
+    def getPendingStatuses(self):
+        """ return list of named tuples containing pending status types """
+        return self.__pending_statuses
 
     def setStatus(self, status=no_status):
         """

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -712,7 +712,10 @@ class TestHarness:
                     self.options.results_storage = json.load(f)
 
                     # Adhere to previous input file syntax, or set the default
-                    self.options.input_file_name = self.options.results_storage.get('INPUT_FILE_NAME', 'tests')
+                    _input_file_name = 'tests'
+                    if self.options.input_file_name:
+                        _input_file_name = self.options.input_file_name
+                    self.options.input_file_name = self.options.results_storage.get('INPUT_FILE_NAME', _input_file_name)
 
                 except ValueError:
                     # This is a hidden file, controled by the TestHarness. So we probably shouldn't error
@@ -855,6 +858,9 @@ class TestHarness:
             sys.exit(1)
         if opts.queue_source_command and not os.path.exists(opts.queue_source_command):
             print('ERROR: pre-source supplied but path does not exist')
+            sys.exit(1)
+        if opts.failed_tests and not os.path.exists(self.results_storage):
+            print('ERROR: --failed-tests could not detect a previous run')
             sys.exit(1)
 
         # Flatten input_file_name from ['tests', 'speedtests'] to just tests if none supplied

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -267,6 +267,9 @@ class Job(object):
     def createStatus(self):
         return self.job_status.createStatus()
 
+    def previousTesterStatus(self, options, previous_results=None):
+        return self.__tester.previousTesterStatus(options, previous_results)
+
     def getStatusMessage(self):
         return self.__job_message
 
@@ -274,8 +277,8 @@ class Job(object):
     ### should now call job.isSomeStatus for the definitive answer.
     # the following are more job related...
     def isError(self):
-        _status = self.getStatus()
-        return _status == self.error or _status == self.timeout
+        return self.getStatus() in self.job_status.getFailingStatuses()
+
     def isSkip(self):
         _status = self.getStatus()
         return (_status == self.finished and self.__tester.isSkip()) \

--- a/python/contrib/dag/__init__.py
+++ b/python/contrib/dag/__init__.py
@@ -65,9 +65,6 @@ class DAG(object):
         if node_name not in graph:
             raise KeyError('node %s does not exist' % node_name)
 
-        # cache current graph before we delete a node
-        self.__cacheGraph()
-
         graph.pop(node_name)
 
         for node, edges in graph.iteritems():
@@ -105,9 +102,6 @@ class DAG(object):
         if not graph:
             graph = self.graph
 
-        # cache current graph before we delete an edge
-        self.__cacheGraph()
-
         if dep_node not in graph.get(ind_node, []):
             raise KeyError('this edge does not exist in graph')
         graph[ind_node].remove(dep_node)
@@ -116,9 +110,6 @@ class DAG(object):
         """ Change references to a task in existing edges. """
         if not graph:
             graph = self.graph
-
-        # cache current graph before we rename an edge
-        self.__cacheGraph()
 
         for node, edges in graph.items():
 
@@ -266,13 +257,9 @@ class DAG(object):
     # Added by the MOOSE group
     def getOriginalDAG(self):
         """
-        Returns a clone of the graph as it existed before any nodes
-        were deleted.
-
-        Adding nodes again later, will allow the original graph to
-        'reset' and grow.
+        Returns a clone of the graph as it existed before calling the first ind_nodes
         """
-        return self.__cacheGraph()
+        return self.__cacheGraph().graph
 
     # Added by the MOOSE group
     def clone(self):
@@ -304,8 +291,6 @@ class DAG(object):
     # Added by the MOOSE group
     def reverse_edges(self, graph=None):
         """ Reversed dependencies in current graph. """
-        # Create clone of original graph
-        self.__cacheGraph()
 
         new_graph = self.reverse_clone()
         self.graph = new_graph.graph
@@ -315,9 +300,6 @@ class DAG(object):
         """ Delete an edge from the graph. """
         if not graph:
             graph = self.graph
-
-        # cache current graph before we delete an edge
-        self.__cacheGraph()
 
         if dep_node not in graph.get(ind_node, []):
             return


### PR DESCRIPTION
This is work required to make a proper --failed-tests DAG operation

A more efficient skippedDependency checker

Modify the QueueManager to utilize the same status restoring as
--failed-tests techniques.

Closes #13424

