### PR TITLE
Disable volumetric_locking_correction for face materials

### DIFF
--- a/framework/include/materials/ADMaterial.h
+++ b/framework/include/materials/ADMaterial.h
@@ -32,6 +32,7 @@
   using ADMaterial<compute_stage>::_fe_problem;                                                    \
   using ADMaterial<compute_stage>::_assembly;                                                      \
   using ADMaterial<compute_stage>::_mesh;                                                          \
+  using ADMaterial<compute_stage>::isBoundaryMaterial;                                             \
   using ADMaterial<compute_stage>::copyDualNumbersToValues;                                        \
   using ADMaterial<compute_stage>::_displacements
 

--- a/modules/tensor_mechanics/include/materials/ADComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeFiniteStrain.h
@@ -31,7 +31,7 @@ class ADComputeFiniteStrain : public ADComputeIncrementalStrainBase<compute_stag
 public:
   ADComputeFiniteStrain(const InputParameters & parameters);
 
-  virtual void computeProperties();
+  void computeProperties() override;
 
   static MooseEnum decompositionType();
 

--- a/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeFiniteStrain.h
@@ -24,7 +24,7 @@ class ComputeFiniteStrain : public ComputeIncrementalStrainBase
 public:
   ComputeFiniteStrain(const InputParameters & parameters);
 
-  virtual void computeProperties();
+  void computeProperties() override;
 
   static MooseEnum decompositionType();
 

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -50,7 +50,7 @@ protected:
 
   const MaterialProperty<RankTwoTensor> * _global_strain;
 
-  bool _volumetric_locking_correction;
+  const bool _volumetric_locking_correction;
   const Real & _current_elem_volume;
 };
 

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
@@ -127,12 +127,7 @@ ADComputeFiniteStrain<compute_stage>::computeQpIncrements(ADRankTwoTensor & tota
     case DecompMethod::TaylorExpansion:
     {
       // inverse of _Fhat
-      ADRankTwoTensor invFhat;
-      static const RankTwoTensor zero;
-      if (_Fhat[_qp] == zero)
-        invFhat.zero();
-      else
-        invFhat = _Fhat[_qp].inverse();
+      const ADRankTwoTensor invFhat = _Fhat[_qp].inverse();
 
       // A = I - _Fhat^-1
       ADRankTwoTensor A(RankTwoTensorType<compute_stage>::type::initIdentity);
@@ -211,7 +206,7 @@ ADComputeFiniteStrain<compute_stage>::computeQpIncrements(ADRankTwoTensor & tota
       N3.vectorOuterProduct(e_vector.column(2), e_vector.column(2));
 
       const auto Uhat = N1 * lambda1 + N2 * lambda2 + N3 * lambda3;
-      ADRankTwoTensor invUhat(Uhat.inverse());
+      const ADRankTwoTensor invUhat(Uhat.inverse());
 
       rotation_increment = _Fhat[_qp] * invUhat;
 

--- a/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
@@ -46,7 +46,8 @@ ADComputeStrainBase<compute_stage>::ADComputeStrainBase(const InputParameters & 
     _global_strain(isParamValid("global_strain")
                        ? &adGetADMaterialProperty<RankTwoTensor>(_base_name + "global_strain")
                        : nullptr),
-    _volumetric_locking_correction(adGetParam<bool>("volumetric_locking_correction")),
+    _volumetric_locking_correction(adGetParam<bool>("volumetric_locking_correction") &&
+                                   !this->isBoundaryMaterial()),
     _current_elem_volume(_assembly.elemVolume())
 {
   for (unsigned int i = 0; i < _eigenstrains.size(); ++i)

--- a/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeFiniteStrain.C
@@ -141,12 +141,7 @@ ComputeFiniteStrain::computeQpIncrements(RankTwoTensor & total_strain_increment,
     case DecompMethod::TaylorExpansion:
     {
       // inverse of _Fhat
-      RankTwoTensor invFhat;
-      static const RankTwoTensor zero;
-      if (_Fhat[_qp] == zero)
-        invFhat.zero();
-      else
-        invFhat = _Fhat[_qp].inverse();
+      const RankTwoTensor invFhat = _Fhat[_qp].inverse();
 
       // A = I - _Fhat^-1
       RankTwoTensor A(RankTwoTensor::initIdentity);
@@ -222,8 +217,8 @@ ComputeFiniteStrain::computeQpIncrements(RankTwoTensor & total_strain_increment,
       N2.vectorOuterProduct(e_vector.column(1), e_vector.column(1));
       N3.vectorOuterProduct(e_vector.column(2), e_vector.column(2));
 
-      RankTwoTensor Uhat = N1 * lambda1 + N2 * lambda2 + N3 * lambda3;
-      RankTwoTensor invUhat(Uhat.inverse());
+      const RankTwoTensor Uhat = N1 * lambda1 + N2 * lambda2 + N3 * lambda3;
+      const RankTwoTensor invUhat(Uhat.inverse());
 
       rotation_increment = _Fhat[_qp] * invUhat;
 

--- a/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeStrainBase.C
@@ -47,7 +47,8 @@ ComputeStrainBase::ComputeStrainBase(const InputParameters & parameters)
     _global_strain(isParamValid("global_strain")
                        ? &getMaterialProperty<RankTwoTensor>(_base_name + "global_strain")
                        : nullptr),
-    _volumetric_locking_correction(getParam<bool>("volumetric_locking_correction")),
+    _volumetric_locking_correction(getParam<bool>("volumetric_locking_correction") &&
+                                   !isBoundaryMaterial()),
     _current_elem_volume(_assembly.elemVolume())
 {
   for (unsigned int i = 0; i < _eigenstrains.size(); ++i)


### PR DESCRIPTION
 closes #13420

_Fhat was zero because of a multiplication by _coord in the process
of the volumetric locking correction calculation. _coord can sometimes
be zero for all qps in face elements.

I can't see any reason why we would want to use the volumetric locking
correction for face materials, so this can be addressed by simply
disabling it in this case.

Because this prevents _Fhat from being zero, there's no need for the
checks for it being zero, so I removed them.