### PR TITLE
Prevent hidden-virtual warning

### DIFF
--- a/framework/include/utils/JvarMapInterface.h
+++ b/framework/include/utils/JvarMapInterface.h
@@ -51,6 +51,7 @@ class JvarMapIntegratedBCInterface : public JvarMapInterfaceBase<T>
 public:
   JvarMapIntegratedBCInterface(const InputParameters & parameters);
   virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  using T::computeJacobianBlock;
 };
 
 /**
@@ -149,4 +150,3 @@ JvarMapIntegratedBCInterface<T>::computeJacobianBlock(MooseVariableFEBase & jvar
   // call the underlying class' off-diagonal Jacobian
   T::computeJacobianBlock(jvar);
 }
-


### PR DESCRIPTION
Prevents warnings (see https://civet.inl.gov/job/341082/) like:
```
/opt/civet/build_0/moltres/moose/framework/build/header_symlinks/IntegratedBC.h:40:16: error: 'virtual void IntegratedBC::computeJacobianBlock(unsigned int)' was hidden [-Werror=overloaded-virtual]
   virtual void computeJacobianBlock(unsigned jvar);
```
Refs #7761

