### PR TITLE
Support older Python namedtuple

### DIFF
--- a/python/TestHarness/StatusSystem.py
+++ b/python/TestHarness/StatusSystem.py
@@ -115,7 +115,7 @@ class StatusSystem(object):
         return self.__status
 
     def isValid(self, status):
-        original = set(self.no_status.__dict__.keys())
-        altered = set(status.__dict__.keys())
+        original = set(self.no_status._asdict().keys())
+        altered = set(status._asdict().keys())
         if not original.difference(altered) or status in self.__all_statuses:
             return True


### PR DESCRIPTION
Use _asdict method instead of __dict to obtain the namedtuple
dictionary.

Beacuse this method appears to return the same results, it is
unclear how long the _asdict method will be supported in later
Python versions.

Closes #13475
