### PR TITLE
Adding a unit test

### DIFF
--- a/framework/include/utils/InputParameterWarehouse.h
+++ b/framework/include/utils/InputParameterWarehouse.h
@@ -178,6 +178,7 @@ private:
   FRIEND_TEST(InputParameterWarehouse, getControllableItems);
   FRIEND_TEST(InputParameterWarehouse, getControllableParameter);
   FRIEND_TEST(InputParameterWarehouse, getControllableParameterValues);
+  FRIEND_TEST(InputParameterWarehouse, emptyControllableParameterValues);
   FRIEND_TEST(InputParameterWarehouse, addControllableParameterConnection);
   FRIEND_TEST(InputParameterWarehouse, addControllableParameterAlias);
 };
@@ -190,4 +191,3 @@ InputParameterWarehouse::getControllableParameterValues(
   ControllableParameter param = getControllableParameter(input);
   return param.get<T>();
 }
-

--- a/unit/src/InputParameterWarehouseTest.C
+++ b/unit/src/InputParameterWarehouseTest.C
@@ -114,6 +114,22 @@ TEST(InputParameterWarehouse, getControllableParameterValues)
   EXPECT_EQ(values, std::vector<int>(1, 2011));
 }
 
+TEST(InputParameterWarehouse, emptyControllableParameterValues)
+{
+  InputParameters in_params = emptyInputParameters();
+  in_params.addPrivateParam<std::string>("_moose_base", "Base");
+  in_params.addParam<int>("control", 2011, "");
+  in_params.declareControllable("control");
+
+  InputParameterWarehouse wh;
+  wh.addInputParameters("Object", in_params);
+
+  MooseObjectParameterName name("Base", "Object", "asdf");
+  std::vector<int> values = wh.getControllableParameterValues<int>(name);
+
+  ASSERT_TRUE(values.empty());
+}
+
 TEST(InputParameterWarehouse, addControllableParameterConnection)
 {
   // One-to-one


### PR DESCRIPTION
Test that getControllableParameterValues() returns an empty vector when
specified MooseObjectParameterName does not exist.

Refs #10533

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
