### PR TITLE
Updating package version

### DIFF
--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -1,22 +1,22 @@
 minimum_gcc: 4.8.4
 minimum_clang: 3.4.0
 minimum_intel: 2017
-mpich: 3.2
-petsc_alt: 3.8.3
-slepc_alt: 3.8.2
-petsc_default: 3.9.4
-slepc_default: 3.9.2
+mpich: 3.3
+petsc_alt: 3.9.4
+slepc_alt: 3.9.2
+petsc_default: 3.10.5
+slepc_default: 3.10.0
 autoconf: 2.69
 automake: 1.16
 gcc: 8.3.0
-llvm: 6.0.1
-llvm_release: 60
+llvm: 8.0.0
+llvm_release: 80
 cmake: 3.9.4
 gnuplot: 4.6.5
-doxygen: 1.8.11
+doxygen: 1.8.14
 graphviz: 2.38.0
 lcov: 1.14
-miniconda: 4.5.11
+miniconda: 4.6.14
 vtk: 7.1.0
 tbb: 2018_U3
 cppunit: 1.12.1
@@ -45,11 +45,11 @@ conda_vtk: 7.1.0
 pip_pylint: 1.6.5
 pip_livereload: 2.5.1
 moose_packages:
-    osx10.14: moose-environment_osx-mojave_20190509_x86_64.pkg
-    osx10.13: moose-environment_osx-highsierra_20190509_x86_64.pkg
-    osx10.12: moose-environment_osx-sierra_20190509_x86_64.pkg
-    ubuntu16: moose-environment_ubuntu-16.04_20190509_x86_64.deb
-    ubuntu18: moose-environment_ubuntu-18.04_20190509_x86_64.deb
-    opensuse15: moose-environment_opensuse-15.0_20190509_x86_64.rpm
-    fedora28: moose-environment_fedora-28_20190509_x86_64.rpm
-    centos7: moose-environment_centos-7.6.1810_20190509_x86_64.rpm
+    osx10.14: moose-environment_osx-mojave_20190528_x86_64.pkg
+    osx10.13: moose-environment_osx-highsierra_20190528_x86_64.pkg
+    osx10.12: moose-environment_osx-sierra_20190528_x86_64.pkg
+    ubuntu16: moose-environment_ubuntu-16.04_20190528_x86_64.deb
+    ubuntu18: moose-environment_ubuntu-18.04_20190528_x86_64.deb
+    opensuse15: moose-environment_opensuse-15.0_20190528_x86_64.rpm
+    fedora28: moose-environment_fedora-28_20190528_x86_64.rpm
+    centos7: moose-environment_centos-7.6.1810_20190528_x86_64.rpm

--- a/modules/doc/content/getting_started/installation/manual_petsc.md
+++ b/modules/doc/content/getting_started/installation/manual_petsc.md
@@ -29,6 +29,7 @@ cd $STACK_SRC/petsc-__PETSC_DEFAULT__
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
+--with-cxx-dialect=C++11 \
 --CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
 --CFLAGS='-fPIC -fopenmp' \
 --CXXFLAGS='-fPIC -fopenmp' \

--- a/package_version
+++ b/package_version
@@ -1,3 +1,3 @@
 # moose-environment package version (https://github.com/idaholab/package_builder)
-# https://github.com/idaholab/package_builder/pull/200
-repo-hash:60dcb01a92664dfb6f2dba54d788651abea2e897
+# https://github.com/idaholab/package_builder/pull/203
+repo-hash:fa3273a763814f741e273c5d96d363b5cbfb2429


### PR DESCRIPTION
Update LLVM from 6.0.1 to 8.0.0
Update MPICH from 3.2 to 3.3
Update default PETSc to 3.10.5
Update alt PETSc to 3.9.4 (PETSc 3.8.3 is not buildable with LLVM 8)
Update Doxygen to 1.8.14

Closes #13482
