### PR TITLE
Disable fortran bindings and sowing cuz we don't need that shiz

### DIFF
--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -94,6 +94,8 @@ if [ -z "$go_fast" ]; then
       --F90FLAGS='-fPIC -fopenmp' \
       --F77FLAGS='-fPIC -fopenmp' \
       --with-cxx-dialect=C++11 \
+      --with-fortran-bindings=0 \
+      --with-sowing=0 \
       $* \
 
    make all


### PR DESCRIPTION
This allows the update_and_rebuild_petsc.sh script to be run with icecream
loaded.

Refs #12578

