### PR TITLE
RDG ElementLoopUserObject sets current subdomain

### DIFF
--- a/modules/rdg/include/userobjects/ElementLoopUserObject.h
+++ b/modules/rdg/include/userobjects/ElementLoopUserObject.h
@@ -70,6 +70,7 @@ public:
   virtual void finalize();
 
   virtual void pre();
+  virtual void preElement(const Elem * elem);
   virtual void onElement(const Elem * elem);
   virtual void onBoundary(const Elem * elem, unsigned int side, BoundaryID bnd_id);
   virtual void onInternalSide(const Elem * elem, unsigned int side);

--- a/modules/rdg/src/userobjects/ElementLoopUserObject.C
+++ b/modules/rdg/src/userobjects/ElementLoopUserObject.C
@@ -66,6 +66,12 @@ ElementLoopUserObject::initialize()
 }
 
 void
+ElementLoopUserObject::preElement(const Elem * elem)
+{
+  _fe_problem.setCurrentSubdomainID(elem, _tid);
+}
+
+void
 ElementLoopUserObject::execute()
 {
   ConstElemRange & elem_range = *_mesh.getActiveLocalElementRange();
@@ -83,6 +89,7 @@ ElementLoopUserObject::execute()
 
       const Elem * elem = *el;
       unsigned int cur_subdomain = elem->subdomain_id();
+      preElement(elem);
 
       _old_subdomain = _subdomain;
       _subdomain = cur_subdomain;


### PR DESCRIPTION
when looping over elements.

Fixes #12540

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
