### PR TITLE
fix compile time warning

### DIFF
--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1040,7 +1040,7 @@ RankTwoTensorTempl<DualReal>::QR(RankTwoTensorTempl<DualReal> & Q,
       {
         unsigned int c = 3 - a - b;
         if (!MooseUtils::absoluteFuzzyEqual(R(c, i).value(), 0.0))
-          P = this->permutationTensor({a, b, c}, {c, b, a});
+          P = this->permutationTensor({{a, b, c}}, {{c, b, a}});
       }
 
       Q = Q * P.transpose();


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
The old compiler complains about single brace initializers {a,b,c}.

ref #13511