### PR TITLE
Add IdealRealGasMixtureFluidProperties::c_from_v_e

### DIFF
--- a/modules/fluid_properties/include/userobjects/GeneralVaporMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/GeneralVaporMixtureFluidProperties.h
@@ -59,6 +59,14 @@ public:
                           Real & dT_dv,
                           Real & dT_de,
                           std::vector<Real> & dT_dx) const override;
+  virtual Real c_from_v_e(Real v, Real e, const std::vector<Real> & x) const override;
+  virtual void c_from_v_e(Real v,
+                          Real e,
+                          const std::vector<Real> & x,
+                          Real & c,
+                          Real & dc_dv,
+                          Real & dc_de,
+                          std::vector<Real> & dc_dx) const override;
   virtual Real rho_from_p_T(Real p, Real T, const std::vector<Real> & x) const override;
   virtual void rho_from_p_T(Real p,
                             Real T,
@@ -184,4 +192,3 @@ protected:
   /// Current guess for temperature (in case guess is chosen to be changed)
   mutable Real _T_guess;
 };
-

--- a/modules/fluid_properties/include/userobjects/IdealRealGasMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealRealGasMixtureFluidProperties.h
@@ -94,6 +94,35 @@ public:
                           std::vector<Real> & dT_dx) const override;
 
   /**
+   * Speed of sound from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume
+   * @param[in] e   specific internal energy
+   * @param[in] x   vapor mass fraction values
+   * @return        speed of sound
+   */
+  virtual Real c_from_v_e(Real v, Real e, const std::vector<Real> & x) const override;
+
+  /**
+   * Speed of sound and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume
+   * @param[in] e   specific internal energy
+   * @param[in] x   vapor mass fraction values
+   * @param[out] c       Speed of sound
+   * @param[out] dc_dv   derivative of temperature w.r.t. specific volume
+   * @param[out] dc_de   derivative of temperature w.r.t. specific internal energy
+   * @param[out] dc_dx   derivative of temperature w.r.t. vapor mass fraction values
+   */
+  virtual void c_from_v_e(Real v,
+                          Real e,
+                          const std::vector<Real> & x,
+                          Real & c,
+                          Real & dc_dv,
+                          Real & dc_de,
+                          std::vector<Real> & dc_dx) const override;
+
+  /**
    * Density from pressure and temperature
    *
    * @param[in] p   pressure
@@ -464,4 +493,3 @@ protected:
   /// maximum temperature of all components
   const Real _T_mix_max;
 };
-

--- a/modules/fluid_properties/include/userobjects/VaporMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/VaporMixtureFluidProperties.h
@@ -92,6 +92,35 @@ public:
                           std::vector<Real> & dT_dx) const = 0;
 
   /**
+   * Speed of sound from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume
+   * @param[in] e   specific internal energy
+   * @param[in] x   vapor mass fraction values
+   * @return        speed of sound
+   */
+  virtual Real c_from_v_e(Real v, Real e, const std::vector<Real> & x) const = 0;
+
+  /**
+   * Speed of sound and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume
+   * @param[in] e   specific internal energy
+   * @param[in] x   vapor mass fraction values
+   * @param[out] c       Speed of sound
+   * @param[out] dc_dv   derivative of temperature w.r.t. specific volume
+   * @param[out] dc_de   derivative of temperature w.r.t. specific internal energy
+   * @param[out] dc_dx   derivative of temperature w.r.t. vapor mass fraction values
+   */
+  virtual void c_from_v_e(Real v,
+                          Real e,
+                          const std::vector<Real> & x,
+                          Real & c,
+                          Real & dc_dv,
+                          Real & dc_de,
+                          std::vector<Real> & dc_dx) const = 0;
+
+  /**
    * Density from pressure and temperature
    *
    * @param[in] p   pressure
@@ -231,4 +260,3 @@ public:
    */
   Real primaryMassFraction(const std::vector<Real> & x) const;
 };
-

--- a/modules/fluid_properties/src/userobjects/GeneralVaporMixtureFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/GeneralVaporMixtureFluidProperties.C
@@ -123,6 +123,26 @@ GeneralVaporMixtureFluidProperties::rho_from_p_T(Real p, Real T, const std::vect
   return 1.0 / v_from_p_T(p, T, x);
 }
 
+Real
+GeneralVaporMixtureFluidProperties::c_from_v_e(Real /*v*/,
+                                               Real /*e*/,
+                                               const std::vector<Real> & /*x*/) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " is not implemented.");
+}
+
+void
+GeneralVaporMixtureFluidProperties::c_from_v_e(Real /*v*/,
+                                               Real /*e*/,
+                                               const std::vector<Real> & /*x*/,
+                                               Real & /*c*/,
+                                               Real & /*dc_dv*/,
+                                               Real & /*dc_de*/,
+                                               std::vector<Real> & /*dc_dx*/) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " is not implemented.");
+}
+
 void
 GeneralVaporMixtureFluidProperties::rho_from_p_T(Real p,
                                                  Real T,


### PR DESCRIPTION
Adds c_from_v_e(Real v, Real e) and derivatives to
VaporMixtureFluidProperties and the derived class
IdealRealGasMixtureFluidProperties.

Closes #13523
