### PR TITLE
Convert DynamicStressDivergenceTensors to AD

### DIFF
--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -31,9 +31,11 @@ InputParameters validParams<MaterialPropertyInterface>();
 #define adGetADMaterialProperty this->template getADMaterialProperty
 #define adGetMaterialProperty this->template getMaterialProperty
 #define adGetMaterialPropertyOld this->template getMaterialPropertyOld
+#define adGetMaterialPropertyOlder this->template getMaterialPropertyOlder
 #define adGetADMaterialPropertyByName this->template getADMaterialPropertyByName
 #define adGetMaterialPropertyByName this->template getMaterialPropertyByName
 #define adGetMaterialPropertyOldByName this->template getMaterialPropertyOldByName
+#define adGetMaterialPropertyOlderByName this->template getMaterialPropertyOlderByName
 #define adHasMaterialProperty this->template hasMaterialProperty
 #define adHasMaterialPropertyByName this->template hasMaterialPropertyByName
 
@@ -536,4 +538,3 @@ MaterialPropertyInterface::getZeroMaterialProperty(const std::string & /*prop_na
 
   return zero;
 }
-

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADDynamicStressDivergenceTensors.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADDynamicStressDivergenceTensors.md
@@ -1,0 +1,13 @@
+# ADDynamicStressDivergenceTensors
+
+!syntax description /Kernels/ADDynamicStressDivergenceTensors
+
+## Description
+
+This class computes the stress divergence and the stiffness proportional Rayleigh damping for structural dynamics problems. Each ADDynamicStressDivergenceTensors input block computes force in one direction. So, a separate ADDynamicStressDivergenceTensors input block should be set up for each coordinate direction. The [DynamicTensorMechanics](/DynamicTensorMechanicsAction.md) action automatically sets up the ADDynamicStressDivergenceTensors input block in all coordinate direction. More information about the residual calculation and usage can be found at [Dynamics](Dynamics.md).
+
+!syntax parameters /Kernels/ADDynamicStressDivergenceTensors
+
+!syntax inputs /Kernels/ADDynamicStressDivergenceTensors
+
+!syntax children /Kernels/ADDynamicStressDivergenceTensors

--- a/modules/tensor_mechanics/doc/content/source/kernels/ADDynamicStressDivergenceTensors.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/ADDynamicStressDivergenceTensors.md
@@ -4,7 +4,12 @@
 
 ## Description
 
-This class computes the stress divergence and the stiffness proportional Rayleigh damping for structural dynamics problems. Each ADDynamicStressDivergenceTensors input block computes force in one direction. So, a separate ADDynamicStressDivergenceTensors input block should be set up for each coordinate direction. The [DynamicTensorMechanics](/DynamicTensorMechanicsAction.md) action automatically sets up the ADDynamicStressDivergenceTensors input block in all coordinate direction. More information about the residual calculation and usage can be found at [Dynamics](Dynamics.md).
+This class computes the stress divergence and the stiffness proportional Rayleigh damping for  
+structural dynamics problems. Each ADDynamicStressDivergenceTensors input block computes force in  
+one direction. So, a separate ADDynamicStressDivergenceTensors input block should be set up for  
+each coordinate direction. The [DynamicTensorMechanics](/DynamicTensorMechanicsAction.md) action  
+automatically sets up the ADDynamicStressDivergenceTensors input block in all coordinate directions.  
+More information about the residual calculation and usage can be found at [Dynamics](Dynamics.md).
 
 !syntax parameters /Kernels/ADDynamicStressDivergenceTensors
 

--- a/modules/tensor_mechanics/include/kernels/ADDynamicStressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/ADDynamicStressDivergenceTensors.h
@@ -1,0 +1,44 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ADStressDivergenceTensors.h"
+
+// Forward Declarations
+template <ComputeStage>
+class ADDynamicStressDivergenceTensors;
+
+declareADValidParams(ADDynamicStressDivergenceTensors);
+
+/**
+ * ADDynamicStressDivergenceTensors is the automatic
+ * differentiation version of DynamicStressDivergenceTensors.
+ * This kernel derives from ADStressDivergenceTensors and
+ * adds stress related Rayleigh and HHT time integration terms.
+ */
+template <ComputeStage compute_stage>
+class ADDynamicStressDivergenceTensors : public ADStressDivergenceTensors<compute_stage>
+{
+public:
+  ADDynamicStressDivergenceTensors(const InputParameters & parameters);
+
+protected:
+  ADResidual computeQpResidual();
+
+  const MaterialProperty<RankTwoTensor> & _stress_older;
+  const MaterialProperty<RankTwoTensor> & _stress_old;
+
+  // Rayleigh damping parameter _zeta and HHT time integration parameter _alpha
+  const MaterialProperty<Real> & _zeta;
+  const Real _alpha;
+  const bool _static_initialization;
+
+  usingStressDivergenceTensorsMembers;
+};

--- a/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/DynamicTensorMechanicsAction.C
@@ -44,8 +44,6 @@ validParams<DynamicTensorMechanicsAction>()
 DynamicTensorMechanicsAction::DynamicTensorMechanicsAction(const InputParameters & params)
   : TensorMechanicsAction(params)
 {
-  if (_use_ad)
-    paramError("use_ad", "AD not setup for use with DynamicTensorMechanicsAction");
 }
 
 std::string

--- a/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
@@ -16,7 +16,7 @@ defineADValidParams(
     ADDynamicStressDivergenceTensors,
     ADStressDivergenceTensors,
     params.addClassDescription(
-        "Residual due to stress related Rayleigh damping and HHT time integration terms ");
+        "Residual due to stress related Rayleigh damping and HHT time integration terms");
     params.addParam<MaterialPropertyName>("zeta",
                                           0.0,
                                           "Name of material property or a constant real "
@@ -60,12 +60,12 @@ ADDynamicStressDivergenceTensors<compute_stage>::computeQpResidual()
    *_alpha*_zeta/dt Div sigma_older
    */
 
-  ADResidual residual = 0.0;
+  ADResidual residual;
   if (_static_initialization && _t == _dt)
   {
     // If static inialization is true, then in the first step residual is only Ku which is
     // stress.grad(test).
-    residual += _stress[_qp].row(_component) * _grad_test[_i][_qp];
+    residual = _stress[_qp].row(_component) * _grad_test[_i][_qp];
 
     if (_volumetric_locking_correction)
       residual +=
@@ -73,7 +73,7 @@ ADDynamicStressDivergenceTensors<compute_stage>::computeQpResidual()
   }
   else if (_dt > 0)
   {
-    residual +=
+    residual =
         _stress[_qp].row(_component) * _grad_test[_i][_qp] *
             (1.0 + _alpha + (1.0 + _alpha) * _zeta[_qp] / _dt) -
         (_alpha + (1.0 + 2.0 * _alpha) * _zeta[_qp] / _dt) * _stress_old[_qp].row(_component) *
@@ -86,6 +86,8 @@ ADDynamicStressDivergenceTensors<compute_stage>::computeQpResidual()
                    (_alpha * _zeta[_qp] / _dt) * _stress_older[_qp].trace()) /
                   3.0 * (_avg_grad_test[_i] - _grad_test[_i][_qp](_component));
   }
+  else
+    residual = 0.0;
 
   return residual;
 }

--- a/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
@@ -1,0 +1,91 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADDynamicStressDivergenceTensors.h"
+#include "ElasticityTensorTools.h"
+
+registerADMooseObject("TensorMechanicsApp", ADDynamicStressDivergenceTensors);
+
+defineADValidParams(
+    ADDynamicStressDivergenceTensors,
+    ADStressDivergenceTensors,
+    params.addClassDescription(
+        "Residual due to stress related Rayleigh damping and HHT time integration terms ");
+    params.addParam<MaterialPropertyName>("zeta",
+                                          0.0,
+                                          "Name of material property or a constant real "
+                                          "number defining the zeta parameter for the "
+                                          "Rayleigh damping.");
+    params.addParam<Real>("alpha", 0, "alpha parameter for HHT time integration");
+    params.addParam<bool>("static_initialization",
+                          false,
+                          "Set to true to get the system to "
+                          "equillibrium under gravity by running a "
+                          "quasi-static analysis (by solving Ku = F) "
+                          "in the first time step"););
+
+template <ComputeStage compute_stage>
+ADDynamicStressDivergenceTensors<compute_stage>::ADDynamicStressDivergenceTensors(
+    const InputParameters & parameters)
+  : ADStressDivergenceTensors<compute_stage>(parameters),
+    _stress_older(adGetMaterialPropertyOlder<RankTwoTensor>(_base_name + "stress")),
+    _stress_old(adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
+    _zeta(adGetMaterialProperty<Real>("zeta")),
+    _alpha(adGetParam<Real>("alpha")),
+    _static_initialization(adGetParam<bool>("static_initialization"))
+{
+}
+
+template <ComputeStage compute_stage>
+ADResidual
+ADDynamicStressDivergenceTensors<compute_stage>::computeQpResidual()
+{
+  /**
+   *This kernel needs to be used only if either Rayleigh damping or numerical damping through HHT
+   *time integration scheme needs to be added to the problem thorugh the stiffness dependent damping
+   * parameter _zeta or HHT parameter _alpha, respectively.
+   *
+   * The residual of _zeta*K*[(1+_alpha)vel-_alpha vel_old]+ alpha K [ u - uold] + K u is required
+   * = _zeta*[(1+_alpha)d/dt (Div sigma)-alpha d/dt(Div sigma_old)] +alpha [Div sigma - Div
+   *sigma_old]+ Div sigma
+   * = _zeta*[(1+alpha)(Div sigma - Div sigma_old)/dt - alpha (Div sigma_old - Div sigma_older)/dt]
+   *   + alpha [Div sigma - Div sigma_old] +Div sigma
+   * = [(1+_alpha)*_zeta/dt +_alpha+1]* Div sigma - [(1+2_alpha)*_zeta/dt + _alpha] Div sigma_old +
+   *_alpha*_zeta/dt Div sigma_older
+   */
+
+  ADResidual residual = 0.0;
+  if (_static_initialization && _t == _dt)
+  {
+    // If static inialization is true, then in the first step residual is only Ku which is
+    // stress.grad(test).
+    residual += _stress[_qp].row(_component) * _grad_test[_i][_qp];
+
+    if (_volumetric_locking_correction)
+      residual +=
+          _stress[_qp].trace() / 3.0 * (_avg_grad_test[_i] - _grad_test[_i][_qp](_component));
+  }
+  else if (_dt > 0)
+  {
+    residual +=
+        _stress[_qp].row(_component) * _grad_test[_i][_qp] *
+            (1.0 + _alpha + (1.0 + _alpha) * _zeta[_qp] / _dt) -
+        (_alpha + (1.0 + 2.0 * _alpha) * _zeta[_qp] / _dt) * _stress_old[_qp].row(_component) *
+            _grad_test[_i][_qp] +
+        (_alpha * _zeta[_qp] / _dt) * _stress_older[_qp].row(_component) * _grad_test[_i][_qp];
+
+    if (_volumetric_locking_correction)
+      residual += (_stress[_qp].trace() * (1.0 + _alpha + (1.0 + _alpha) * _zeta[_qp] / _dt) -
+                   (_alpha + (1.0 + 2.0 * _alpha) * _zeta[_qp] / _dt) * _stress_old[_qp].trace() +
+                   (_alpha * _zeta[_qp] / _dt) * _stress_older[_qp].trace()) /
+                  3.0 * (_avg_grad_test[_i] - _grad_test[_i][_qp](_component));
+  }
+
+  return residual;
+}

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
@@ -60,3 +60,6 @@ ADComputeFiniteStrainElasticStress<compute_stage>::computeQpStress()
   // Assign value for elastic strain, which is equal to the mechanical strain
   _elastic_strain[_qp] = _mechanical_strain[_qp];
 }
+
+// explicit instantiation is required for AD base classes
+adBaseClass(ADComputeFiniteStrainElasticStress);

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/tests
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/tests
@@ -6,7 +6,6 @@
     input = 'wave_hht.i'
     exodiff = 'wave_hht_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
                    " in a linear elastic material with numerical damping resulting"
@@ -17,7 +16,6 @@
     input = 'wave_newmark.i'
     exodiff = 'wave_newmark_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
                    " in a linear elastic material with no numerical or structural"
@@ -28,7 +26,6 @@
     input = 'wave_rayleigh_hht.i'
     exodiff = 'wave_rayleigh_hht_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
                    " in a linear elastic material with both Rayleigh damping and"
@@ -39,7 +36,6 @@
     input = 'wave_rayleigh_hht_AD.i'
     exodiff = 'wave_rayleigh_hht_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
                    " in a linear elastic material with both Rayleigh damping and"
@@ -50,21 +46,18 @@
   [./rayleigh_hht_ad_jac]
     type = 'PetscJacobianTester'
     input = 'wave_rayleigh_hht_AD.i'
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly compute the Jacobian"
                  " for 1D wave propagation in a linear elastic material with"
                  " both Rayleigh damping and numerical damping resulting from"
                  " Hilber-Hughes-Taylor (HHT) time integration when automatic"
                  " differentiation is used."
-    prereq = "rayleigh_hht_ad"
   [../]
   [./rayleigh_hht_ti]
     type = 'Exodiff'
     input = 'wave_rayleigh_hht_ti.i'
     exodiff = 'wave_rayleigh_hht_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     allow_warnings = True
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
@@ -73,14 +66,13 @@
                    " when using the velocity and acceleration computed using the Newmark-Beta time"
                    " integrator."
     issues = "#12185"
-    prereq = "rayleigh_hht_ad_jac"
+    prereq = "rayleigh_hht_ad"
   [../]
   [./rayleigh_newmark]
     type = 'Exodiff'
     input = 'wave_rayleigh_newmark.i'
     exodiff = 'wave_rayleigh_newmark_out.e'
     abs_zero = 1e-09
-    compiler = 'GCC CLANG'
 
     requirement = "The mechanics system shall correctly predict 1D wave propagation"
                    " in a linear elastic material with Rayleigh damping."

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/tests
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/tests
@@ -34,6 +34,31 @@
                    " in a linear elastic material with both Rayleigh damping and"
                    " numerical damping resulting from Hilber-Hughes-Taylor (HHT) time integration."
   [../]
+  [./rayleigh_hht_ad]
+    type = 'Exodiff'
+    input = 'wave_rayleigh_hht_AD.i'
+    exodiff = 'wave_rayleigh_hht_out.e'
+    abs_zero = 1e-09
+    compiler = 'GCC CLANG'
+
+    requirement = "The mechanics system shall correctly predict 1D wave propagation"
+                   " in a linear elastic material with both Rayleigh damping and"
+                   " numerical damping resulting from Hilber-Hughes-Taylor (HHT)"
+                   " time integration when automatic differentiation is used."
+    prereq = "rayleigh_hht"
+  [../]
+  [./rayleigh_hht_ad_jac]
+    type = 'PetscJacobianTester'
+    input = 'wave_rayleigh_hht_AD.i'
+    compiler = 'GCC CLANG'
+
+    requirement = "The mechanics system shall correctly compute the Jacobian"
+                 " for 1D wave propagation in a linear elastic material with"
+                 " both Rayleigh damping and numerical damping resulting from"
+                 " Hilber-Hughes-Taylor (HHT) time integration when automatic"
+                 " differentiation is used."
+    prereq = "rayleigh_hht_ad"
+  [../]
   [./rayleigh_hht_ti]
     type = 'Exodiff'
     input = 'wave_rayleigh_hht_ti.i'
@@ -48,7 +73,7 @@
                    " when using the velocity and acceleration computed using the Newmark-Beta time"
                    " integrator."
     issues = "#12185"
-    prereq = "rayleigh_hht"
+    prereq = "rayleigh_hht_ad_jac"
   [../]
   [./rayleigh_newmark]
     type = 'Exodiff'

--- a/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_hht_AD.i
+++ b/modules/tensor_mechanics/test/tests/dynamics/wave_1D/wave_rayleigh_hht_AD.i
@@ -1,0 +1,318 @@
+# Wave propogation in 1D using HHT time integration in the presence of Rayleigh damping
+#
+# The test is for an 1D bar element of length 4m  fixed on one end
+# with a sinusoidal pulse dirichlet boundary condition applied to the other end.
+# alpha, beta and gamma are HHT  time integration parameters
+# eta and zeta are mass dependent and stiffness dependent Rayleigh damping
+# coefficients, respectively.
+# The equation of motion in terms of matrices is:
+#
+# M*accel + (eta*M+zeta*K)*((1+alpha)*vel-alpha*vel_old)
+# +(1+alpha)*K*disp-alpha*K*disp_old = 0
+#
+# Here M is the mass matrix, K is the stiffness matrix
+#
+# The displacement at the first, second, third and fourth node at t = 0.1 are
+# -7.787499960311491942e-02, 1.955566679096475483e-02 and -4.634888180231294501e-03, respectively.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 4
+  nz = 1
+  xmin = 0.0
+  xmax = 0.1
+  ymin = 0.0
+  ymax = 4.0
+  zmin = 0.0
+  zmax = 0.1
+[]
+
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+[]
+
+[AuxVariables]
+  [./vel_x]
+  [../]
+  [./accel_x]
+  [../]
+  [./vel_y]
+  [../]
+  [./accel_y]
+  [../]
+  [./vel_z]
+  [../]
+  [./accel_z]
+  [../]
+[]
+
+[Kernels]
+  [./DynamicTensorMechanics]
+    displacements = 'disp_x disp_y disp_z'
+    alpha = -0.3
+    zeta = 0.1
+    use_automatic_differentiation = true
+  [../]
+  [./inertia_x]
+    type = InertialForce
+    variable = disp_x
+    velocity = vel_x
+    acceleration = accel_x
+    beta = 0.422
+    gamma = 0.8
+    eta=0.1
+    alpha = -0.3
+  [../]
+  [./inertia_y]
+    type = InertialForce
+    variable = disp_y
+    velocity = vel_y
+    acceleration = accel_y
+    beta = 0.422
+    gamma = 0.8
+    eta=0.1
+    alpha = -0.3
+  [../]
+  [./inertia_z]
+    type = InertialForce
+    variable = disp_z
+    velocity = vel_z
+    acceleration = accel_z
+    beta = 0.422
+    gamma = 0.8
+    eta = 0.1
+    alpha = -0.3
+  [../]
+
+[]
+
+[AuxKernels]
+  [./accel_x]
+    type = NewmarkAccelAux
+    variable = accel_x
+    displacement = disp_x
+    velocity = vel_x
+    beta = 0.422
+    execute_on = timestep_end
+  [../]
+  [./vel_x]
+    type = NewmarkVelAux
+    variable = vel_x
+    acceleration = accel_x
+    gamma = 0.8
+    execute_on = timestep_end
+  [../]
+  [./accel_y]
+    type = NewmarkAccelAux
+    variable = accel_y
+    displacement = disp_y
+    velocity = vel_y
+    beta = 0.422
+    execute_on = timestep_end
+  [../]
+  [./vel_y]
+    type = NewmarkVelAux
+    variable = vel_y
+    acceleration = accel_y
+    gamma = 0.8
+    execute_on = timestep_end
+  [../]
+  [./accel_z]
+    type = NewmarkAccelAux
+    variable = accel_z
+    displacement = disp_z
+    velocity = vel_z
+    beta = 0.422
+    execute_on = timestep_end
+  [../]
+  [./vel_z]
+    type = NewmarkVelAux
+    variable = vel_z
+    acceleration = accel_z
+    gamma = 0.8
+    execute_on = timestep_end
+  [../]
+[]
+
+
+[BCs]
+  [./top_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = top
+    value=0.0
+  [../]
+  [./top_x]
+   type = DirichletBC
+    variable = disp_x
+    boundary = top
+    value=0.0
+  [../]
+  [./top_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = top
+    value=0.0
+  [../]
+  [./right_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = right
+    value=0.0
+  [../]
+  [./right_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = right
+    value=0.0
+  [../]
+  [./left_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value=0.0
+  [../]
+  [./left_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = left
+    value=0.0
+  [../]
+  [./front_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = front
+    value=0.0
+  [../]
+  [./front_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = front
+    value=0.0
+  [../]
+  [./back_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = back
+    value=0.0
+  [../]
+  [./back_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = back
+    value=0.0
+  [../]
+  [./bottom_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = bottom
+    value=0.0
+  [../]
+  [./bottom_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = bottom
+    value=0.0
+  [../]
+  [./bottom_y]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = bottom
+    function = displacement_bc
+  [../]
+[]
+
+[Materials]
+  [./Elasticity_tensor]
+    type = ComputeElasticityTensor
+    block = 0
+    fill_method = symmetric_isotropic
+    C_ijkl = '1 0'
+  [../]
+
+  [./strain]
+    type = ADComputeSmallStrain
+    block = 0
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+
+  [./stress]
+    type = ADComputeLinearElasticStress
+    block = 0
+  [../]
+
+  [./density]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'density'
+    prop_values = '1'
+  [../]
+
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'NEWTON'
+  start_time = 0
+  end_time = 6.0
+  l_tol = 1e-12
+  nl_rel_tol = 1e-12
+  dt = 0.1
+[]
+
+
+[Functions]
+  [./displacement_bc]
+    type = PiecewiseLinear
+    data_file = 'sine_wave.csv'
+    format = columns
+  [../]
+
+[]
+
+[Postprocessors]
+  [./_dt]
+    type = TimestepSize
+  [../]
+  [./disp_1]
+    type = NodalVariableValue
+    nodeid = 1
+    variable = disp_y
+  [../]
+  [./disp_2]
+    type = NodalVariableValue
+    nodeid = 3
+    variable = disp_y
+  [../]
+  [./disp_3]
+    type = NodalVariableValue
+    nodeid = 10
+    variable = disp_y
+  [../]
+  [./disp_4]
+    type = NodalVariableValue
+    nodeid = 14
+    variable = disp_y
+  [../]
+[]
+
+[Outputs]
+  file_base = 'wave_rayleigh_hht_out'
+  exodus = true
+  perf_graph = true
+[]


### PR DESCRIPTION
- Converts DynamicStressDivergenceTensors to AD. 
- Converting InertialForce to AD requires some more work because functions such as adUDotDot, adDuDotDu etc have to be added and I am not sure if any changes are required in the time integrators. So InertialForce is not converted in this PR.
- ADComputeFiniteStrainElasticStress serves as the parent class for one of the materials in MASTODON, so a line is added to the end of the ADComputeFiniteStrainElasticStress to enable this. 

refs #12650
