### PR TITLE
Remove redundant initialize() in StochasticResults 

### DIFF
--- a/modules/stochastic_tools/src/transfers/SamplerPostprocessorTransfer.C
+++ b/modules/stochastic_tools/src/transfers/SamplerPostprocessorTransfer.C
@@ -96,6 +96,7 @@ SamplerPostprocessorTransfer::finalizeFromMultiapp()
   // Update VPP
   if (processor_id() == 0)
   {
+    _results->initialize();
     const dof_id_type n = _sampler->getTotalNumberOfRows();
     for (MooseIndex(n) i = 0; i < n; i++)
     {
@@ -127,6 +128,9 @@ SamplerPostprocessorTransfer::execute()
 
   // Sum the PP values from all ranks
   _communicator.sum(_local_values);
+
+  // Initialize VPP
+  _results->initialize();
 
   // Update VPP
   for (unsigned int i = 0; i < n; i++)

--- a/modules/stochastic_tools/src/vectorpostprocessors/StochasticResults.C
+++ b/modules/stochastic_tools/src/vectorpostprocessors/StochasticResults.C
@@ -46,7 +46,6 @@ StochasticResults::initialize()
 VectorPostprocessorValue &
 StochasticResults::getVectorPostprocessorValueByGroup(unsigned int group)
 {
-  StochasticResults::initialize();
   if (group >= _sample_vectors.size())
     mooseError("The supplied sample index ", group, " does not exist.");
   return *_sample_vectors[group];


### PR DESCRIPTION
close ref #13555

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
