### PR TITLE
Update the RankMap to use the new Communicator split_by_type

### DIFF
--- a/framework/src/utils/RankMap.C
+++ b/framework/src/utils/RankMap.C
@@ -19,24 +19,18 @@ RankMap::RankMap(const Parallel::Communicator & comm, PerfGraph & perf_graph)
   TIME_SECTION(_construct_timer);
 
   auto num_procs = n_processors();
-
   _rank_to_hardware_id.resize(num_procs);
+
+  Parallel::Communicator shmem_comm;
+  _communicator.split_by_type(MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, shmem_comm);
 
   // This will be the world rank of the root process
   // from the shared memory communicator we're getting ready to create
   // Each process on the same node will end up with the same world_rank
-  processor_id_type world_rank = 0;
-
-#ifdef LIBMESH_HAVE_MPI
-  // Create a split communicator among shared memory ranks
-  MPI_Comm shmem_raw_comm;
-  MPI_Comm_split_type(_communicator.get(), MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &shmem_raw_comm);
-  Parallel::Communicator shmem_comm(shmem_raw_comm);
+  processor_id_type world_rank = processor_id();
 
   // Broadcast the world rank of the sub group root to all processes within this communicator
-  world_rank = processor_id();
   shmem_comm.broadcast(world_rank, 0);
-#endif
 
   // Send the info to everyone
   std::vector<processor_id_type> world_ranks(num_procs);
@@ -71,7 +65,4 @@ RankMap::RankMap(const Parallel::Communicator & comm, PerfGraph & perf_graph)
     // Side-effect insertion utilized
     _hardware_id_to_ranks[current_id].emplace_back(pid);
   }
-
-  // Free up the memory
-  MPI_Comm_free(&shmem_raw_comm);
 }


### PR DESCRIPTION
Drop raw MPI in favor of using Communicator routines.
libMesh/libmesh#2129



<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
