### PR TITLE
Added base_name parameter to Density material class. Made all module base_name patterns constant.

### DIFF
--- a/modules/heat_conduction/include/materials/ElectricalConductivity.h
+++ b/modules/heat_conduction/include/materials/ElectricalConductivity.h
@@ -37,7 +37,7 @@ private:
   const Real _ref_temp;
   const VariableValue & _T;
 
-  std::string _base_name;
+  const std::string _base_name;
   MaterialProperty<Real> & _electric_conductivity;
   MaterialProperty<Real> & _delectric_conductivity_dT;
 };

--- a/modules/heat_conduction/include/materials/SemiconductorLinearConductivity.h
+++ b/modules/heat_conduction/include/materials/SemiconductorLinearConductivity.h
@@ -40,7 +40,7 @@ private:
   const Real _sh_coeff_B;
   const VariableValue & _T;
 
-  std::string _base_name;
+  const std::string _base_name;
   MaterialProperty<Real> & _electric_conductivity;
   MaterialProperty<Real> & _delectric_conductivity_dT;
 };

--- a/modules/misc/include/materials/Density.h
+++ b/modules/misc/include/materials/Density.h
@@ -28,7 +28,7 @@ protected:
   std::vector<const VariableGradient *> _grad_disp;
   const VariableValue & _disp_r;
 
-  std::string _base_name;
+  const std::string _base_name;
   const Real _orig_density;
   MaterialProperty<Real> & _density;
 };

--- a/modules/misc/include/materials/Density.h
+++ b/modules/misc/include/materials/Density.h
@@ -28,6 +28,7 @@ protected:
   std::vector<const VariableGradient *> _grad_disp;
   const VariableValue & _disp_r;
 
+  std::string _base_name;
   const Real _orig_density;
   MaterialProperty<Real> & _density;
 };

--- a/modules/misc/src/materials/Density.C
+++ b/modules/misc/src/materials/Density.C
@@ -26,6 +26,10 @@ validParams<Density>()
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");
 
+  params.addParam<std::string>("base_name",
+                               "Optional parameter that allows the user to define "
+                               "multiple material systems on the same block, "
+                               "e.g. for multiple phases");
   params.addRequiredParam<Real>("density", "Density");
   params.addClassDescription("Creates density material property");
 
@@ -37,8 +41,9 @@ Density::Density(const InputParameters & parameters)
     _is_coupled(true),
     _disp_r(isCoupled("displacements") ? coupledValue("displacements", 0)
                                        : (isCoupled("disp_r") ? coupledValue("disp_r") : _zero)),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _orig_density(getParam<Real>("density")),
-    _density(declareProperty<Real>("density"))
+    _density(declareProperty<Real>(_base_name + "density"))
 {
   // new parameter scheme
   if (isCoupled("displacements"))

--- a/modules/phase_field/include/action/PolycrystalElasticDrivingForceAction.h
+++ b/modules/phase_field/include/action/PolycrystalElasticDrivingForceAction.h
@@ -34,7 +34,7 @@ private:
 
   /// Base name for the order parameters
   std::string _var_name_base;
-  std::string _base_name;
+  const std::string _base_name;
   std::string _elasticity_tensor_name;
 };
 

--- a/modules/phase_field/include/kernels/ACInterfaceStress.h
+++ b/modules/phase_field/include/kernels/ACInterfaceStress.h
@@ -41,7 +41,7 @@ protected:
   const MaterialProperty<Real> & _L;
 
   ///@{ Strain base name and property
-  std::string _base_name;
+  const std::string _base_name;
   const MaterialProperty<RankTwoTensor> & _strain;
   ///@}
 

--- a/modules/phase_field/include/kernels/GrainRigidBodyMotionBase.h
+++ b/modules/phase_field/include/kernels/GrainRigidBodyMotionBase.h
@@ -56,7 +56,7 @@ protected:
   std::vector<const VariableGradient *> _grad_vals;
 
   /// base name specifying type of force density material
-  std::string _base_name;
+  const std::string _base_name;
 
   /// getting userobject for calculating grain forces and torques
   const GrainForceAndTorqueInterface & _grain_force_torque;

--- a/modules/phase_field/include/materials/ElasticEnergyMaterial.h
+++ b/modules/phase_field/include/materials/ElasticEnergyMaterial.h
@@ -38,7 +38,7 @@ protected:
   virtual Real computeDF(unsigned int i_var) override;
   virtual Real computeD2F(unsigned int i_var, unsigned int j_var) override;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   /// Stress tensor
   const MaterialProperty<RankTwoTensor> & _stress;

--- a/modules/phase_field/include/materials/ForceDensityMaterial.h
+++ b/modules/phase_field/include/materials/ForceDensityMaterial.h
@@ -50,7 +50,7 @@ private:
   std::vector<RealGradient> _sum_grad_etas;
 
   /// type of force density material
-  std::string _base_name;
+  const std::string _base_name;
 
   /// force density material
   MaterialProperty<std::vector<RealGradient>> & _dF;

--- a/modules/phase_field/include/materials/GrainAdvectionVelocity.h
+++ b/modules/phase_field/include/materials/GrainAdvectionVelocity.h
@@ -53,7 +53,7 @@ private:
   const unsigned int _op_num;
 
   /// type of force density material
-  std::string _base_name;
+  const std::string _base_name;
 
   /// Material storing advection velocities of grains
   MaterialProperty<std::vector<RealGradient>> & _velocity_advection;

--- a/modules/tensor_mechanics/include/auxkernels/ElasticEnergyAux.h
+++ b/modules/tensor_mechanics/include/auxkernels/ElasticEnergyAux.h
@@ -27,7 +27,7 @@ public:
 protected:
   virtual Real computeValue();
 
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankTwoTensor> & _stress;
   const MaterialProperty<RankTwoTensor> & _elastic_strain;

--- a/modules/tensor_mechanics/include/kernels/GeneralizedPlaneStrainOffDiag.h
+++ b/modules/tensor_mechanics/include/kernels/GeneralizedPlaneStrainOffDiag.h
@@ -44,7 +44,7 @@ protected:
   virtual void computeDispOffDiagJacobianScalar(unsigned int component, unsigned int jvar);
   virtual void computeTempOffDiagJacobianScalar(unsigned int jvar);
 
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankFourTensor> & _Jacobian_mult;
   const std::vector<MaterialPropertyName> _eigenstrain_names;

--- a/modules/tensor_mechanics/include/kernels/PhaseFieldFractureMechanicsOffDiag.h
+++ b/modules/tensor_mechanics/include/kernels/PhaseFieldFractureMechanicsOffDiag.h
@@ -36,7 +36,7 @@ protected:
 
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  std::string _base_name;
+  const std::string _base_name;
   const unsigned int _component;
 
   const bool _c_coupled;

--- a/modules/tensor_mechanics/include/kernels/PlasticHeatEnergy.h
+++ b/modules/tensor_mechanics/include/kernels/PlasticHeatEnergy.h
@@ -36,7 +36,7 @@ protected:
   Real _coeff;
 
   /// optional parameter that allows multiple mechanics models to be defined
-  std::string _base_name;
+  const std::string _base_name;
 
   /// stress * plastic_strain_rate
   const MaterialProperty<Real> & _plastic_heat;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
@@ -45,7 +45,7 @@ protected:
   virtual void computeAverageGradientTest();
   virtual void computeAverageGradientPhi();
 
-  std::string _base_name;
+  const std::string _base_name;
   bool _use_finite_deform_jacobian;
 
   const MaterialProperty<RankTwoTensor> & _stress;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
@@ -31,7 +31,7 @@ protected:
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
   using Kernel::computeOffDiagJacobian;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<Real> & _axial_stress;
   const MaterialProperty<Real> & _e_over_l;

--- a/modules/tensor_mechanics/include/kernels/WeakPlaneStress.h
+++ b/modules/tensor_mechanics/include/kernels/WeakPlaneStress.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankTwoTensor> & _stress;
   const MaterialProperty<RankFourTensor> & _Jacobian_mult;

--- a/modules/tensor_mechanics/include/materials/ADComputeEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeEigenstrainBase.h
@@ -45,7 +45,7 @@ protected:
   virtual void computeQpEigenstrain() = 0;
 
   ///Base name prepended to material property name
-  std::string _base_name;
+  const std::string _base_name;
 
   ///Material property name for the eigenstrain tensor
   std::string _eigenstrain_name;

--- a/modules/tensor_mechanics/include/materials/ADComputeElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeElasticityTensorBase.h
@@ -43,7 +43,7 @@ protected:
   virtual void computeQpProperties();
   virtual void computeQpElasticityTensor() = 0;
 
-  std::string _base_name;
+  const std::string _base_name;
   std::string _elasticity_tensor_name;
 
   ADMaterialProperty(RankFourTensor) & _elasticity_tensor;

--- a/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
@@ -55,7 +55,7 @@ protected:
   std::vector<const ADVariableValue *> _disp;
   std::vector<const ADVariableGradient *> _grad_disp;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   ADMaterialProperty(RankTwoTensor) & _mechanical_strain;
   ADMaterialProperty(RankTwoTensor) & _total_strain;

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrainBase.h
@@ -36,7 +36,7 @@ protected:
   virtual void computeQpEigenstrain() = 0;
 
   ///Base name prepended to material property name
-  std::string _base_name;
+  const std::string _base_name;
 
   ///Material property name for the eigenstrain tensor
   std::string _eigenstrain_name;

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTensorBase.h
@@ -32,7 +32,7 @@ protected:
   virtual void computeQpProperties();
   virtual void computeQpElasticityTensor() = 0;
 
-  std::string _base_name;
+  const std::string _base_name;
   std::string _elasticity_tensor_name;
 
   MaterialProperty<RankFourTensor> & _elasticity_tensor;

--- a/modules/tensor_mechanics/include/materials/ComputeExtraStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeExtraStressBase.h
@@ -30,7 +30,7 @@ protected:
   virtual void computeQpProperties();
   virtual void computeQpExtraStress() = 0;
 
-  std::string _base_name;
+  const std::string _base_name;
   std::string _extra_stress_name;
 
   MaterialProperty<RankTwoTensor> & _extra_stress;

--- a/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeGlobalStrain.h
@@ -35,7 +35,7 @@ protected:
   virtual void initQpStatefulProperties();
 
   ///Base name prepended to material property name
-  std::string _base_name;
+  const std::string _base_name;
   const VariableValue & _scalar_global_strain;
   MaterialProperty<RankTwoTensor> & _global_strain;
 

--- a/modules/tensor_mechanics/include/materials/ComputePlasticHeatEnergy.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlasticHeatEnergy.h
@@ -32,7 +32,7 @@ protected:
   virtual void computeQpProperties() override;
 
   /// optional parameter that allows multiple mechanics materials to be defined
-  std::string _base_name;
+  const std::string _base_name;
 
   /// plastic strain
   const MaterialProperty<RankTwoTensor> & _plastic_strain;

--- a/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeStrainBase.h
@@ -39,7 +39,7 @@ protected:
   std::vector<const VariableValue *> _disp;
   std::vector<const VariableGradient *> _grad_disp;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   MaterialProperty<RankTwoTensor> & _mechanical_strain;
 

--- a/modules/tensor_mechanics/include/materials/EshelbyTensor.h
+++ b/modules/tensor_mechanics/include/materials/EshelbyTensor.h
@@ -33,7 +33,7 @@ public:
   virtual void computeQpProperties() override;
 
 protected:
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<Real> & _sed;
   MaterialProperty<RankTwoTensor> & _eshelby_tensor;

--- a/modules/tensor_mechanics/include/materials/MultiPhaseStressMaterial.h
+++ b/modules/tensor_mechanics/include/materials/MultiPhaseStressMaterial.h
@@ -50,7 +50,7 @@ protected:
   std::vector<const MaterialProperty<RankFourTensor> *> _dphase_stress_dstrain;
 
   // global material properties
-  std::string _base_name;
+  const std::string _base_name;
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankFourTensor> & _dstress_dstrain;
 };

--- a/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
+++ b/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
@@ -34,7 +34,7 @@ public:
   virtual void computeQpProperties() override;
 
 protected:
-  std::string _base_name;
+  const std::string _base_name;
 
   /// Whether the material model is a total or incremental model
   bool _incremental;

--- a/modules/tensor_mechanics/include/materials/ThermalFractureIntegral.h
+++ b/modules/tensor_mechanics/include/materials/ThermalFractureIntegral.h
@@ -33,7 +33,7 @@ public:
   virtual void computeQpProperties() override;
 
 protected:
-  std::string _base_name;
+  const std::string _base_name;
   const std::vector<MaterialPropertyName> _eigenstrain_names;
   std::vector<const MaterialProperty<RankTwoTensor> *> _deigenstrain_dT;
   MaterialProperty<RankTwoTensor> & _total_deigenstrain_dT;

--- a/modules/tensor_mechanics/include/materials/TwoPhaseStressMaterial.h
+++ b/modules/tensor_mechanics/include/materials/TwoPhaseStressMaterial.h
@@ -50,7 +50,7 @@ protected:
   const MaterialProperty<RankFourTensor> & _dstress_dstrain_B;
 
   // global material properties
-  std::string _base_name;
+  const std::string _base_name;
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankFourTensor> & _dstress_dstrain;
 

--- a/modules/tensor_mechanics/include/userobjects/GeneralizedPlaneStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GeneralizedPlaneStrainUserObject.h
@@ -38,7 +38,7 @@ public:
   virtual Real returnJacobian(unsigned int scalar_var_id = 0) const;
 
 protected:
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankFourTensor> & _Cijkl;
   const MaterialProperty<RankTwoTensor> & _stress;

--- a/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GlobalStrainUserObject.h
@@ -39,7 +39,7 @@ public:
   virtual void computeAdditionalStress(){};
 
 protected:
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankFourTensor> & _dstress_dstrain;
   const MaterialProperty<RankTwoTensor> & _stress;

--- a/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
+++ b/modules/tensor_mechanics/include/userobjects/HEVPFlowRateUOBase.h
@@ -35,7 +35,7 @@ public:
 
 protected:
   std::string _strength_prop_name;
-  std::string _base_name;
+  const std::string _base_name;
   const MaterialProperty<Real> & _strength;
   std::string _pk2_prop_name;
   const MaterialProperty<RankTwoTensor> & _pk2;

--- a/modules/xfem/include/kernels/CrackTipEnrichmentStressDivergenceTensors.h
+++ b/modules/xfem/include/kernels/CrackTipEnrichmentStressDivergenceTensors.h
@@ -37,7 +37,7 @@ protected:
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  std::string _base_name;
+  const std::string _base_name;
 
   const MaterialProperty<RankTwoTensor> & _stress;
   const MaterialProperty<RankFourTensor> & _Jacobian_mult;

--- a/modules/xfem/include/materials/LevelSetBiMaterialBase.h
+++ b/modules/xfem/include/materials/LevelSetBiMaterialBase.h
@@ -42,7 +42,7 @@ protected:
   virtual void assignQpPropertiesForLevelSetPositive() = 0;
 
   /// global material properties
-  std::string _base_name;
+  const std::string _base_name;
 
   /// Property name
   std::string _prop_name;


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

refs #13600 
Added the base_name optional parameter to the Density material class to be able to use Density in BiMaterial simulations.