### PR TITLE
TimedPrint patch for Valgrind and min compiler failures

### DIFF
--- a/framework/include/utils/StreamArguments.h
+++ b/framework/include/utils/StreamArguments.h
@@ -12,13 +12,13 @@
 /***
  * Streams all of the given arguments into the given stream
  */
-
 template <class StreamType>
 void
 streamArguments(StreamType &)
 {
 }
 
+// Recursive parameter pack expansion
 template <class StreamType, typename T, typename... Args>
 void
 streamArguments(StreamType & ss, T && val, Args &&... args)
@@ -26,3 +26,21 @@ streamArguments(StreamType & ss, T && val, Args &&... args)
   ss << val;
   streamArguments(ss, std::forward<Args>(args)...);
 }
+
+// Base case for Tuple expansion recursive method
+template <std::size_t I = 0, class StreamType, typename... Args>
+inline typename std::enable_if<I == sizeof...(Args), void>::type
+streamArguments(StreamType & /*ss*/, std::tuple<Args...> /*args*/)
+{
+}
+
+// Recursive method for tuple expansion
+// clang-format off
+template <std::size_t I = 0, class StreamType, typename... Args>
+inline typename std::enable_if<I < sizeof...(Args), void>::type
+streamArguments(StreamType & ss, std::tuple<Args...> args)
+{
+  ss << std::get<I>(args);
+  streamArguments<I + 1, StreamType, Args...>(ss, args);
+}
+// clang-format on

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -180,7 +180,8 @@ Console::Console(const InputParameters & parameters)
     _old_nonlinear_norm(std::numeric_limits<Real>::max()),
     _print_mesh_changed_info(getParam<bool>("print_mesh_changed_info")),
     _system_info_flags(getParam<MultiMooseEnum>("system_info")),
-    _allow_changing_sysinfo_flag(true)
+    _allow_changing_sysinfo_flag(true),
+    _last_message_ended_in_newline(true)
 {
   // Apply the special common console flags (print_...)
   ActionWarehouse & awh = _app.actionWarehouse();

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -921,8 +921,6 @@ NonlinearSystemBase::enforceNodalConstraintsJacobian()
 void
 NonlinearSystemBase::setConstraintSlaveValues(NumericVector<Number> & solution, bool displaced)
 {
-  CONSOLE_TIMED_PRINT("Setting constraint slave values for ", name())
-
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
@@ -2217,8 +2215,6 @@ NonlinearSystemBase::computeScalarKernelsJacobians(const std::set<TagID> & tags)
 void
 NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
 {
-  CONSOLE_TIMED_PRINT("Computing jacobian");
-
   // Make matrix ready to use
   activeAllMatrixTags();
 
@@ -2596,8 +2592,6 @@ NonlinearSystemBase::computeJacobianBlocks(std::vector<JacobianBlock *> & blocks
                                            const std::set<TagID> & tags)
 {
   TIME_SECTION(_compute_jacobian_blocks_timer);
-  CONSOLE_TIMED_PRINT("Computing jacobian");
-
   FloatingPointExceptionGuard fpe_guard(_app);
 
   for (unsigned int i = 0; i < blocks.size(); i++)
@@ -2731,8 +2725,6 @@ NonlinearSystemBase::computeDamping(const NumericVector<Number> & solution,
   if (_element_dampers.hasActiveObjects())
   {
     TIME_SECTION(_compute_dampers_timer);
-    CONSOLE_TIMED_PRINT("Computing damping");
-
     has_active_dampers = true;
     *_increment_vec = update;
     ComputeElemDampingThread cid(_fe_problem);


### PR DESCRIPTION
GCC 4.8.4 has a bug where you can't capture a parameter pack in a lambda. Additionally there was a new member that wasn't initialized in the ctor.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
