### PR TITLE
Consistent interface for member template functions

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -13,6 +13,7 @@
 #include "ConsoleStreamInterface.h"
 #include "Registry.h"
 #include "PerfGraphInterface.h"
+#include "MemberTemplateMacros.h"
 
 #include <string>
 #include <ostream>
@@ -99,7 +100,7 @@ public:
    * @return The value of the parameter
    */
   template <typename T>
-  const T & getParam(const std::string & name) const;
+  const T & getParamTempl(const std::string & name) const;
   ///@}
 
   /**
@@ -123,7 +124,8 @@ public:
    * back to the normal behavior of mooseError - only printing a message using the given args.
    */
   template <typename... Args>
-  [[noreturn]] void paramError(const std::string & param, Args... args) {
+  [[noreturn]] void paramError(const std::string & param, Args... args)
+  {
     auto prefix = param + ": ";
     if (!_pars.inputLocation(param).empty())
       prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
@@ -221,8 +223,7 @@ protected:
 
 template <typename T>
 const T &
-Action::getParam(const std::string & name) const
+Action::getParamTempl(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
 }
-

--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -106,7 +106,7 @@ public:
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOlderTempl(const std::string & name);
 
   template <typename T>
   const T & getUserObjectTempl(const std::string & name);
@@ -276,7 +276,7 @@ AuxKernelTempl<ComputeValueType>::getMaterialPropertyOldTempl(const std::string 
 template <typename ComputeValueType>
 template <typename T>
 const MaterialProperty<T> &
-AuxKernelTempl<ComputeValueType>::getMaterialPropertyOlder(const std::string & name)
+AuxKernelTempl<ComputeValueType>::getMaterialPropertyOlderTempl(const std::string & name)
 {
   if (isNodal())
     mooseError("Nodal AuxKernel '",
@@ -287,7 +287,7 @@ AuxKernelTempl<ComputeValueType>::getMaterialPropertyOlder(const std::string & n
                _var.name(),
                "'.");
 
-  return MaterialPropertyInterface::getMaterialPropertyOlder<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyOlderTempl<T>(name);
 }
 
 template <typename ComputeValueType>

--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -27,6 +27,7 @@
 #include "MeshChangedInterface.h"
 #include "VectorPostprocessorInterface.h"
 #include "MooseVariableInterface.h"
+#include "MemberTemplateMacros.h"
 
 // forward declarations
 template <typename ComputeValueType>
@@ -101,16 +102,16 @@ public:
    * Override functions from MaterialPropertyInterface for error checking
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
 
   template <typename T>
-  const T & getUserObject(const std::string & name);
+  const T & getUserObjectTempl(const std::string & name);
   template <typename T>
-  const T & getUserObjectByName(const UserObjectName & name);
+  const T & getUserObjectByNameTempl(const UserObjectName & name);
 
   const UserObject & getUserObjectBase(const std::string & name);
 
@@ -241,7 +242,7 @@ protected:
 template <typename ComputeValueType>
 template <typename T>
 const MaterialProperty<T> &
-AuxKernelTempl<ComputeValueType>::getMaterialProperty(const std::string & name)
+AuxKernelTempl<ComputeValueType>::getMaterialPropertyTempl(const std::string & name)
 {
   if (isNodal())
     mooseError("Nodal AuxKernel '",
@@ -252,13 +253,13 @@ AuxKernelTempl<ComputeValueType>::getMaterialProperty(const std::string & name)
                _var.name(),
                "'.");
 
-  return MaterialPropertyInterface::getMaterialProperty<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyTempl<T>(name);
 }
 
 template <typename ComputeValueType>
 template <typename T>
 const MaterialProperty<T> &
-AuxKernelTempl<ComputeValueType>::getMaterialPropertyOld(const std::string & name)
+AuxKernelTempl<ComputeValueType>::getMaterialPropertyOldTempl(const std::string & name)
 {
   if (isNodal())
     mooseError("Nodal AuxKernel '",
@@ -269,7 +270,7 @@ AuxKernelTempl<ComputeValueType>::getMaterialPropertyOld(const std::string & nam
                _var.name(),
                "'.");
 
-  return MaterialPropertyInterface::getMaterialPropertyOld<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyOldTempl<T>(name);
 }
 
 template <typename ComputeValueType>
@@ -292,17 +293,17 @@ AuxKernelTempl<ComputeValueType>::getMaterialPropertyOlder(const std::string & n
 template <typename ComputeValueType>
 template <typename T>
 const T &
-AuxKernelTempl<ComputeValueType>::getUserObject(const std::string & name)
+AuxKernelTempl<ComputeValueType>::getUserObjectTempl(const std::string & name)
 {
   _depend_uo.insert(_pars.get<UserObjectName>(name));
-  return UserObjectInterface::getUserObject<T>(name);
+  return UserObjectInterface::getUserObjectTempl<T>(name);
 }
 
 template <typename ComputeValueType>
 template <typename T>
 const T &
-AuxKernelTempl<ComputeValueType>::getUserObjectByName(const UserObjectName & name)
+AuxKernelTempl<ComputeValueType>::getUserObjectByNameTempl(const UserObjectName & name)
 {
   _depend_uo.insert(name);
-  return UserObjectInterface::getUserObjectByName<T>(name);
+  return UserObjectInterface::getUserObjectByNameTempl<T>(name);
 }

--- a/framework/include/auxkernels/MaterialStdVectorAuxBase.h
+++ b/framework/include/auxkernels/MaterialStdVectorAuxBase.h
@@ -42,7 +42,7 @@ protected:
 template <typename T>
 MaterialStdVectorAuxBase<T>::MaterialStdVectorAuxBase(const InputParameters & parameters)
   : MaterialAuxBase<std::vector<T>>(parameters),
-    _index(this->template getParam<unsigned int>("index"))
+    _index(this->template getParamTempl<unsigned int>("index"))
 {
 }
 
@@ -52,9 +52,6 @@ MaterialStdVectorAuxBase<T>::computeValue()
 {
   mooseAssert(_prop[_qp].size() > _index,
               "MaterialStdVectorRealGradientAux: You chose to extract component "
-                  << _index
-                  << " but your Material property only has size "
-                  << _prop[_qp].size());
+                  << _index << " but your Material property only has size " << _prop[_qp].size());
   return MaterialAuxBase<std::vector<T>>::computeValue();
 }
-

--- a/framework/include/auxkernels/NodalPatchRecovery.h
+++ b/framework/include/auxkernels/NodalPatchRecovery.h
@@ -61,7 +61,7 @@ public:
    * all qps on the current element
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOlderTempl(const std::string & name);
 
 protected:
   /**
@@ -159,7 +159,7 @@ NodalPatchRecovery::getMaterialPropertyOldTempl(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-NodalPatchRecovery::getMaterialPropertyOlder(const std::string & name)
+NodalPatchRecovery::getMaterialPropertyOlderTempl(const std::string & name)
 {
-  return MaterialPropertyInterface::getMaterialPropertyOlder<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyOlderTempl<T>(name);
 }

--- a/framework/include/auxkernels/NodalPatchRecovery.h
+++ b/framework/include/auxkernels/NodalPatchRecovery.h
@@ -41,7 +41,7 @@ public:
    * element
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyTempl(const std::string & name);
   /**
    * This function overrides the one implemented in AuxKernel.C to suppress warnings when retrieving
    * material properties
@@ -51,7 +51,7 @@ public:
    * at all qps on the current element
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   /**
    * This function overrides the one implemented in AuxKernel.C to suppress warnings when retrieving
    * material properties
@@ -145,16 +145,16 @@ private:
 
 template <typename T>
 const MaterialProperty<T> &
-NodalPatchRecovery::getMaterialProperty(const std::string & name)
+NodalPatchRecovery::getMaterialPropertyTempl(const std::string & name)
 {
-  return MaterialPropertyInterface::getMaterialProperty<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyTempl<T>(name);
 }
 
 template <typename T>
 const MaterialProperty<T> &
-NodalPatchRecovery::getMaterialPropertyOld(const std::string & name)
+NodalPatchRecovery::getMaterialPropertyOldTempl(const std::string & name)
 {
-  return MaterialPropertyInterface::getMaterialPropertyOld<T>(name);
+  return MaterialPropertyInterface::getMaterialPropertyOldTempl<T>(name);
 }
 
 template <typename T>
@@ -163,4 +163,3 @@ NodalPatchRecovery::getMaterialPropertyOlder(const std::string & name)
 {
   return MaterialPropertyInterface::getMaterialPropertyOlder<T>(name);
 }
-

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -21,6 +21,7 @@
 #include "PerfGraph.h"
 #include "TheWarehouse.h"
 #include "RankMap.h"
+#include "MemberTemplateMacros.h"
 
 #include "libmesh/parallel_object.h"
 #include "libmesh/mesh_base.h"
@@ -110,10 +111,10 @@ public:
    * @return The value of the parameter
    */
   template <typename T>
-  const T & getParam(const std::string & name);
+  const T & getParamTempl(const std::string & name);
 
   template <typename T>
-  const T & getParam(const std::string & name) const;
+  const T & getParamTempl(const std::string & name) const;
   ///@}
 
   inline bool isParamValid(const std::string & name) const { return _pars.isParamValid(name); }
@@ -940,14 +941,14 @@ private:
 
 template <typename T>
 const T &
-MooseApp::getParam(const std::string & name)
+MooseApp::getParamTempl(const std::string & name)
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
 }
 
 template <typename T>
 const T &
-MooseApp::getParam(const std::string & name) const
+MooseApp::getParamTempl(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
 }

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -13,6 +13,7 @@
 #include "InputParameters.h"
 #include "ConsoleStreamInterface.h"
 #include "Registry.h"
+#include "MemberTemplateMacros.h"
 
 #include "libmesh/parallel_object.h"
 
@@ -33,8 +34,6 @@ InputParameters validParams<MooseObject>();
 #define adBaseClass(X)                                                                             \
   template class X<RESIDUAL>;                                                                      \
   template class X<JACOBIAN>
-
-#define adGetParam this->template getParam
 
 /**
  * Every object that can be built by the factory should be derived from this class.
@@ -70,7 +69,7 @@ public:
    * @return The value of the parameter
    */
   template <typename T>
-  const T & getParam(const std::string & name) const;
+  const T & getParamTempl(const std::string & name) const;
 
   /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
@@ -105,7 +104,8 @@ public:
    * back to the normal behavior of mooseError - only printing a message using the given args.
    */
   template <typename... Args>
-  [[noreturn]] void paramError(const std::string & param, Args... args) {
+  [[noreturn]] void paramError(const std::string & param, Args... args)
+  {
     auto prefix = param + ": ";
     if (!_pars.inputLocation(param).empty())
       prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
@@ -144,7 +144,8 @@ public:
   }
 
   template <typename... Args>
-  [[noreturn]] void mooseError(Args &&... args) const {
+  [[noreturn]] void mooseError(Args &&... args) const
+  {
     std::ostringstream oss;
     moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
     std::string msg = oss.str();
@@ -188,8 +189,7 @@ protected:
 
 template <typename T>
 const T &
-MooseObject::getParam(const std::string & name) const
+MooseObject::getParamTempl(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
 }
-

--- a/framework/include/ics/InitialConditionBase.h
+++ b/framework/include/ics/InitialConditionBase.h
@@ -18,6 +18,7 @@
 #include "DependencyResolverInterface.h"
 #include "BoundaryRestrictable.h"
 #include "MooseTypes.h"
+#include "MemberTemplateMacros.h"
 
 // forward declarations
 class InitialConditionBase;
@@ -92,12 +93,12 @@ public:
    * reimplements the getUserObject method from UserObjectInterface
    */
   template <typename T2>
-  const T2 & getUserObject(const std::string & name);
+  const T2 & getUserObjectTempl(const std::string & name);
   /**
    * reimplements the getUserObjectByName method from UserObjectInterface
    */
   template <typename T2>
-  const T2 & getUserObjectByName(const UserObjectName & name);
+  const T2 & getUserObjectByNameTempl(const UserObjectName & name);
 
   /**
    * reimplements the getUserObjectBase method from UserObjectInterface
@@ -122,19 +123,18 @@ protected:
 
 template <typename T>
 const T &
-InitialConditionBase::getUserObject(const std::string & name)
+InitialConditionBase::getUserObjectTempl(const std::string & name)
 {
   if (!_ignore_uo_dependency)
     _depend_uo.insert(_pars.get<UserObjectName>(name));
-  return UserObjectInterface::getUserObject<T>(name);
+  return UserObjectInterface::getUserObjectTempl<T>(name);
 }
 
 template <typename T>
 const T &
-InitialConditionBase::getUserObjectByName(const UserObjectName & name)
+InitialConditionBase::getUserObjectByNameTempl(const UserObjectName & name)
 {
   if (!_ignore_uo_dependency)
     _depend_uo.insert(name);
-  return UserObjectInterface::getUserObjectByName<T>(name);
+  return UserObjectInterface::getUserObjectByNameTempl<T>(name);
 }
-

--- a/framework/include/loops/ComputeUserObjectsThread.h
+++ b/framework/include/loops/ComputeUserObjectsThread.h
@@ -106,11 +106,10 @@ groupUserObjects(TheWarehouse & w,
     if (ic_deps.count(obj->name()) > 0)
       w.update(obj, AttribPreIC(w, true));
 
-    if ((obj->isParamValid("force_preaux") && obj->template getParam<bool>("force_preaux")) ||
+    if ((obj->isParamValid("force_preaux") && obj->template getParamTempl<bool>("force_preaux")) ||
         aux_deps.count(obj->name()) > 0 || ic_deps.count(obj->name()) > 0)
       w.update(obj, AttribPreAux(w, true));
     else
       w.update(obj, AttribPreAux(w, false));
   }
 }
-

--- a/framework/include/materials/ADMaterial.h
+++ b/framework/include/materials/ADMaterial.h
@@ -55,16 +55,15 @@ public:
    * declare the ad property named "prop_name"
    */
   template <typename T>
-  ADMaterialPropertyObject<T> & declareADProperty(const std::string & prop_name);
+  ADMaterialPropertyObject<T> & declareADPropertyTempl(const std::string & prop_name);
 };
 
 template <ComputeStage compute_stage>
 template <typename T>
 ADMaterialPropertyObject<T> &
-ADMaterial<compute_stage>::declareADProperty(const std::string & prop_name)
+ADMaterial<compute_stage>::declareADPropertyTempl(const std::string & prop_name)
 {
   _fe_problem.usingADMatProps(true);
   registerPropName(prop_name, false, Material::CURRENT, compute_stage == JACOBIAN);
-  return _material_data->declareADProperty<T>(prop_name);
+  return _material_data->declareADPropertyTempl<T>(prop_name);
 }
-

--- a/framework/include/materials/CompositeTensorBase.h
+++ b/framework/include/materials/CompositeTensorBase.h
@@ -80,8 +80,8 @@ protected:
 template <class T, class U>
 CompositeTensorBase<T, U>::CompositeTensorBase(const InputParameters & parameters)
   : DerivativeMaterialInterface<U>(parameters),
-    _tensor_names(this->template getParam<std::vector<MaterialPropertyName>>("tensors")),
-    _weight_names(this->template getParam<std::vector<MaterialPropertyName>>("weights")),
+    _tensor_names(this->template getParamTempl<std::vector<MaterialPropertyName>>("tensors")),
+    _weight_names(this->template getParamTempl<std::vector<MaterialPropertyName>>("weights")),
     _num_args(this->DerivativeMaterialInterface<U>::coupledComponents("args")),
     _num_comp(_tensor_names.size()),
     _dM(_num_args),
@@ -129,8 +129,8 @@ CompositeTensorBase<T, U>::initializeDerivativeProperties(const std::string name
   // setup input components and its derivatives
   for (unsigned int i = 0; i < _num_comp; ++i)
   {
-    _tensors[i] = &this->template getMaterialPropertyByName<T>(_tensor_names[i]);
-    _weights[i] = &this->template getMaterialPropertyByName<Real>(_weight_names[i]);
+    _tensors[i] = &this->template getMaterialPropertyByNameTempl<T>(_tensor_names[i]);
+    _weights[i] = &this->template getMaterialPropertyByNameTempl<Real>(_weight_names[i]);
 
     _dtensors[i].resize(_num_args);
     _dweights[i].resize(_num_args);
@@ -196,4 +196,3 @@ CompositeTensorBase<T, U>::computeQpTensorProperties(MaterialProperty<T> & M,
     }
   }
 }
-

--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -179,7 +179,7 @@ DerivativeMaterialInterface<T>::haveMaterialProperty(const std::string & prop_na
   return ((bnd && bnd->boundaryRestricted() &&
            bnd->template hasBoundaryMaterialProperty<U>(prop_name)) ||
           (blk && blk->template hasBlockMaterialProperty<U>(prop_name)) ||
-          (this->template hasMaterialProperty<U>(prop_name)));
+          (hasMaterialProperty<U>(prop_name)));
 }
 
 template <class T>
@@ -207,7 +207,7 @@ DerivativeMaterialInterface<T>::getDefaultMaterialPropertyByName(const std::stri
 {
   // if found return the requested property
   if (haveMaterialProperty<U>(prop_name))
-    return this->template getMaterialPropertyByName<U>(prop_name);
+    return getMaterialPropertyByName<U>(prop_name);
 
   return this->template getZeroMaterialProperty<U>(prop_name);
 }
@@ -218,7 +218,7 @@ MaterialProperty<U> &
 DerivativeMaterialInterface<T>::declarePropertyDerivative(const std::string & base,
                                                           const std::vector<VariableName> & c)
 {
-  return this->template declareProperty<U>(derivativePropertyName(base, c));
+  return declareProperty<U>(derivativePropertyName(base, c));
 }
 
 template <class T>
@@ -230,10 +230,10 @@ DerivativeMaterialInterface<T>::declarePropertyDerivative(const std::string & ba
                                                           const VariableName & c3)
 {
   if (c3 != "")
-    return this->template declareProperty<U>(derivativePropertyNameThird(base, c1, c2, c3));
+    return declareProperty<U>(derivativePropertyNameThird(base, c1, c2, c3));
   if (c2 != "")
-    return this->template declareProperty<U>(derivativePropertyNameSecond(base, c1, c2));
-  return this->template declareProperty<U>(derivativePropertyNameFirst(base, c1));
+    return declareProperty<U>(derivativePropertyNameSecond(base, c1, c2));
+  return declareProperty<U>(derivativePropertyNameFirst(base, c1));
 }
 
 template <class T>
@@ -426,7 +426,7 @@ void
 DerivativeMaterialInterface<T>::validateDerivativeMaterialPropertyBase(const std::string & base)
 {
   // resolve the input parameter name base to the actual material property name
-  const MaterialPropertyName prop_name = this->template getParam<MaterialPropertyName>(base);
+  const MaterialPropertyName prop_name = getParam<MaterialPropertyName>(base);
 
   // check if the material property does not exist on the blocks of the current object,
   // and check if it is not a plain number in the input file
@@ -456,4 +456,3 @@ DerivativeMaterialInterface<T>::isNotObjectVariable(const VariableName & name)
   // This interface is not templated on a class derived from either Kernel or BC
   return true;
 }
-

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -99,11 +99,11 @@ public:
    * to getting it by name
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  const ADMaterialPropertyObject<T> & getADMaterialProperty(const std::string & name);
+  const ADMaterialPropertyObject<T> & getADMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
   ///@}
@@ -113,11 +113,12 @@ public:
    * Retrieve the property named "name"
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyByNameTempl(const std::string & prop_name);
   template <typename T>
-  const ADMaterialPropertyObject<T> & getADMaterialPropertyByName(const std::string & prop_name);
+  const ADMaterialPropertyObject<T> &
+  getADMaterialPropertyByNameTempl(const std::string & prop_name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOldByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyOldByNameTempl(const std::string & prop_name);
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name);
   ///@}
@@ -127,7 +128,7 @@ public:
    * Declare the property named "name"
    */
   template <typename T>
-  MaterialProperty<T> & declareProperty(const std::string & prop_name);
+  MaterialProperty<T> & declarePropertyTempl(const std::string & prop_name);
   template <typename T>
   MaterialProperty<T> & declarePropertyOld(const std::string & prop_name);
   template <typename T>
@@ -308,7 +309,7 @@ private:
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialProperty(const std::string & name)
+Material::getMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid imput parameter key
   std::string prop_name = deducePropertyName(name);
@@ -323,7 +324,7 @@ Material::getMaterialProperty(const std::string & name)
 
 template <typename T>
 const ADMaterialPropertyObject<T> &
-Material::getADMaterialProperty(const std::string & name)
+Material::getADMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid imput parameter key
   std::string prop_name = deducePropertyName(name);
@@ -338,7 +339,7 @@ Material::getADMaterialProperty(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialPropertyOld(const std::string & name)
+Material::getMaterialPropertyOldTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid imput parameter key
   std::string prop_name = deducePropertyName(name);
@@ -368,34 +369,34 @@ Material::getMaterialPropertyOlder(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialPropertyByName(const std::string & prop_name)
+Material::getMaterialPropertyByNameTempl(const std::string & prop_name)
 {
   checkExecutionStage();
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the
   // same memory)
   _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::CURRENT);
-  return MaterialPropertyInterface::getMaterialPropertyByName<T>(prop_name);
+  return MaterialPropertyInterface::getMaterialPropertyByNameTempl<T>(prop_name);
 }
 
 template <typename T>
 const ADMaterialPropertyObject<T> &
-Material::getADMaterialPropertyByName(const std::string & prop_name)
+Material::getADMaterialPropertyByNameTempl(const std::string & prop_name)
 {
   checkExecutionStage();
   // The property may not exist yet, so declare it (declare/getADMaterialProperty are referencing
   // the same memory)
   _requested_props.insert(prop_name);
   registerPropName(prop_name, true, Material::CURRENT);
-  return MaterialPropertyInterface::getADMaterialPropertyByName<T>(prop_name);
+  return MaterialPropertyInterface::getADMaterialPropertyByNameTempl<T>(prop_name);
 }
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialPropertyOldByName(const std::string & prop_name)
+Material::getMaterialPropertyOldByNameTempl(const std::string & prop_name)
 {
   registerPropName(prop_name, true, Material::OLD);
-  return MaterialPropertyInterface::getMaterialPropertyOldByName<T>(prop_name);
+  return MaterialPropertyInterface::getMaterialPropertyOldByNameTempl<T>(prop_name);
 }
 
 template <typename T>
@@ -408,10 +409,10 @@ Material::getMaterialPropertyOlderByName(const std::string & prop_name)
 
 template <typename T>
 MaterialProperty<T> &
-Material::declareProperty(const std::string & prop_name)
+Material::declarePropertyTempl(const std::string & prop_name)
 {
   registerPropName(prop_name, false, Material::CURRENT);
-  return _material_data->declareProperty<T>(prop_name);
+  return _material_data->declarePropertyTempl<T>(prop_name);
 }
 
 template <typename T>
@@ -465,4 +466,3 @@ Material::getZeroMaterialProperty(const std::string & prop_name)
 
   return preload_with_zero;
 }
-

--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -105,7 +105,7 @@ public:
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOlderTempl(const std::string & name);
   ///@}
 
   ///@{
@@ -120,7 +120,7 @@ public:
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyOldByNameTempl(const std::string & prop_name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyOlderByNameTempl(const std::string & prop_name);
   ///@}
 
   ///@{
@@ -354,7 +354,7 @@ Material::getMaterialPropertyOldTempl(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialPropertyOlder(const std::string & name)
+Material::getMaterialPropertyOlderTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid imput parameter key
   std::string prop_name = deducePropertyName(name);
@@ -401,10 +401,10 @@ Material::getMaterialPropertyOldByNameTempl(const std::string & prop_name)
 
 template <typename T>
 const MaterialProperty<T> &
-Material::getMaterialPropertyOlderByName(const std::string & prop_name)
+Material::getMaterialPropertyOlderByNameTempl(const std::string & prop_name)
 {
   registerPropName(prop_name, true, Material::OLDER);
-  return MaterialPropertyInterface::getMaterialPropertyOlderByName<T>(prop_name);
+  return MaterialPropertyInterface::getMaterialPropertyOlderByNameTempl<T>(prop_name);
 }
 
 template <typename T>

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -53,7 +53,7 @@ public:
    * will result in a single identical reference returned every time.
    */
   template <typename T>
-  MaterialProperty<T> & declareProperty(const std::string & prop_name);
+  MaterialProperty<T> & declarePropertyTempl(const std::string & prop_name);
 
   /**
    * Declare the Real valued property prop_name.
@@ -74,7 +74,7 @@ public:
    * will result in a single identical reference returned every time.
    */
   template <typename T>
-  ADMaterialPropertyObject<T> & declareADProperty(const std::string & prop_name);
+  ADMaterialPropertyObject<T> & declareADPropertyTempl(const std::string & prop_name);
 
   /// copy material properties from one element to another
   void copy(const Elem & elem_to, const Elem & elem_from, unsigned int side);
@@ -220,14 +220,14 @@ MaterialData::resizeProps(unsigned int size, bool declared_ad)
 
 template <typename T>
 MaterialProperty<T> &
-MaterialData::declareProperty(const std::string & prop_name)
+MaterialData::declarePropertyTempl(const std::string & prop_name)
 {
   return declareHelper<T>(_props, prop_name, _storage.addProperty(prop_name));
 }
 
 template <typename T>
 ADMaterialPropertyObject<T> &
-MaterialData::declareADProperty(const std::string & prop_name)
+MaterialData::declareADPropertyTempl(const std::string & prop_name)
 {
   return declareADHelper<T>(_props, prop_name, _storage.addProperty(prop_name));
 }
@@ -309,4 +309,3 @@ MaterialData::getPropertyOlder(const std::string & name)
 {
   return declareHelper<T>(_props_older, name, _storage.addPropertyOlder(name));
 }
-

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -26,18 +26,53 @@ InputParameters validParams();
 template <>
 InputParameters validParams<MaterialPropertyInterface>();
 
-#define adDeclareADProperty this->template declareADProperty
-#define adDeclareProperty this->template declareProperty
-#define adGetADMaterialProperty this->template getADMaterialProperty
-#define adGetMaterialProperty this->template getMaterialProperty
-#define adGetMaterialPropertyOld this->template getMaterialPropertyOld
-#define adGetMaterialPropertyOlder this->template getMaterialPropertyOlder
-#define adGetADMaterialPropertyByName this->template getADMaterialPropertyByName
-#define adGetMaterialPropertyByName this->template getMaterialPropertyByName
-#define adGetMaterialPropertyOldByName this->template getMaterialPropertyOldByName
-#define adGetMaterialPropertyOlderByName this->template getMaterialPropertyOlderByName
-#define adHasMaterialProperty this->template hasMaterialProperty
-#define adHasMaterialPropertyByName this->template hasMaterialPropertyByName
+#define adDeclareADProperty                                                                        \
+  _Pragma("GCC warning \"adDeclareADProperty is deprecated. Simply use declareADProperty\"") this  \
+      ->template declareADPropertyTempl
+#define adDeclareProperty                                                                          \
+  _Pragma("GCC warning \"adDeclareProperty is deprecated. Simply use declareProperty\"") this      \
+      ->template declarePropertyTempl
+
+// clang-format off
+#define adGetADMaterialProperty \
+  _Pragma( \
+      "GCC warning \"adGetADMaterialProperty is deprecated. Simply use getADMaterialProperty\"") \
+  this->template getADMaterialPropertyTempl
+#define adGetADMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adGetADMaterialPropertyByName is deprecated. Simply use getADMaterialPropertyByName\"") \
+  this->template getADMaterialPropertyByNameTempl
+#define adGetMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyByName is deprecated. Simply use getMaterialPropertyByName\"") \
+  this->template getMaterialPropertyByNameTempl
+#define adGetMaterialPropertyOldByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOldByName is deprecated. Simply use getMaterialPropertyOldByName\"") \
+  this->template getMaterialPropertyOldByNameTempl
+#define adGetMaterialPropertyOlderByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOlderByName is deprecated. Simply use getMaterialPropertyOlderByName\"") \
+  this->template getMaterialPropertyOlderByNameTempl
+#define adHasMaterialProperty \
+  _Pragma( \
+      "GCC warning \"adHasMaterialProperty is deprecated. Simply use hasMaterialProperty\"") \
+  this->template hasMaterialPropertyTempl
+#define adHasMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adHasMaterialPropertyByName is deprecated. Simply use hasMaterialPropertyByName\"") \
+  this->template hasMaterialPropertyByNameTempl
+// clang-format on
+
+#define declareADProperty this->template declareADPropertyTempl
+#define declareProperty this->template declarePropertyTempl
+#define getADMaterialProperty this->template getADMaterialPropertyTempl
+#define getADMaterialPropertyByName this->template getADMaterialPropertyByNameTempl
+#define getMaterialPropertyByName this->template getMaterialPropertyByNameTempl
+#define getMaterialPropertyOldByName this->template getMaterialPropertyOldByNameTempl
+#define getMaterialPropertyOlderByName this->template getMaterialPropertyOlderByNameTempl
+#define hasMaterialProperty this->template hasMaterialPropertyTempl
+#define hasMaterialPropertyByName this->template hasMaterialPropertyByNameTempl
 
 /**
  * \class MaterialPropertyInterface
@@ -66,13 +101,13 @@ public:
    * @return Reference to the desired material property
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  const ADMaterialPropertyObject<T> & getADMaterialProperty(const std::string & name);
+  const ADMaterialPropertyObject<T> & getADMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOldTempl(const std::string & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOlderTempl(const std::string & name);
   ///@}
 
   ///@{
@@ -83,14 +118,15 @@ public:
    * @return Reference to the material property with the name 'name'
    */
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyByName(const MaterialPropertyName & name);
+  const MaterialProperty<T> & getMaterialPropertyByNameTempl(const MaterialPropertyName & name);
   template <typename T>
   const ADMaterialPropertyObject<T> &
-  getADMaterialPropertyByName(const MaterialPropertyName & name);
+  getADMaterialPropertyByNameTempl(const MaterialPropertyName & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOldByName(const MaterialPropertyName & name);
+  const MaterialProperty<T> & getMaterialPropertyOldByNameTempl(const MaterialPropertyName & name);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlderByName(const MaterialPropertyName & name);
+  const MaterialProperty<T> &
+  getMaterialPropertyOlderByNameTempl(const MaterialPropertyName & name);
   ///@}
 
   /**
@@ -172,9 +208,9 @@ public:
    * @return true if the property exists, otherwise false
    */
   template <typename T>
-  bool hasMaterialProperty(const std::string & name);
+  bool hasMaterialPropertyTempl(const std::string & name);
   template <typename T>
-  bool hasMaterialPropertyByName(const std::string & name);
+  bool hasMaterialPropertyByNameTempl(const std::string & name);
   ///@}
 
   /**
@@ -313,7 +349,7 @@ mooseSetToZero(T *&)
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialProperty(const std::string & name)
+MaterialPropertyInterface::getMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
@@ -328,7 +364,7 @@ MaterialPropertyInterface::getMaterialProperty(const std::string & name)
 
 template <typename T>
 const ADMaterialPropertyObject<T> &
-MaterialPropertyInterface::getADMaterialProperty(const std::string & name)
+MaterialPropertyInterface::getADMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
@@ -343,7 +379,7 @@ MaterialPropertyInterface::getADMaterialProperty(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialPropertyOld(const std::string & name)
+MaterialPropertyInterface::getMaterialPropertyOldTempl(const std::string & name)
 {
   if (!_stateful_allowed)
     mooseError("Stateful material properties not allowed for this object."
@@ -364,7 +400,7 @@ MaterialPropertyInterface::getMaterialPropertyOld(const std::string & name)
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialPropertyOlder(const std::string & name)
+MaterialPropertyInterface::getMaterialPropertyOlderTempl(const std::string & name)
 {
   if (!_stateful_allowed)
     mooseError("Stateful material properties not allowed for this object."
@@ -414,7 +450,7 @@ MaterialPropertyInterface::defaultADMaterialProperty<RealVectorValue>(const std:
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialPropertyByName(const MaterialPropertyName & name)
+MaterialPropertyInterface::getMaterialPropertyByNameTempl(const MaterialPropertyName & name)
 {
   checkExecutionStage();
   checkMaterialProperty(name);
@@ -432,7 +468,7 @@ MaterialPropertyInterface::getMaterialPropertyByName(const MaterialPropertyName 
 
 template <typename T>
 const ADMaterialPropertyObject<T> &
-MaterialPropertyInterface::getADMaterialPropertyByName(const MaterialPropertyName & name)
+MaterialPropertyInterface::getADMaterialPropertyByNameTempl(const MaterialPropertyName & name)
 {
   _mi_feproblem.usingADMatProps(true);
 
@@ -452,7 +488,7 @@ MaterialPropertyInterface::getADMaterialPropertyByName(const MaterialPropertyNam
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialPropertyOldByName(const MaterialPropertyName & name)
+MaterialPropertyInterface::getMaterialPropertyOldByNameTempl(const MaterialPropertyName & name)
 {
   if (!_stateful_allowed)
     mooseError("Stateful material properties not allowed for this object."
@@ -470,7 +506,7 @@ MaterialPropertyInterface::getMaterialPropertyOldByName(const MaterialPropertyNa
 
 template <typename T>
 const MaterialProperty<T> &
-MaterialPropertyInterface::getMaterialPropertyOlderByName(const MaterialPropertyName & name)
+MaterialPropertyInterface::getMaterialPropertyOlderByNameTempl(const MaterialPropertyName & name)
 {
   if (!_stateful_allowed)
     mooseError("Stateful material properties not allowed for this object."
@@ -505,7 +541,7 @@ MaterialPropertyInterface::getBlockMaterialProperty(const MaterialPropertyName &
 
 template <typename T>
 bool
-MaterialPropertyInterface::hasMaterialProperty(const std::string & name)
+MaterialPropertyInterface::hasMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
@@ -514,7 +550,7 @@ MaterialPropertyInterface::hasMaterialProperty(const std::string & name)
 
 template <typename T>
 bool
-MaterialPropertyInterface::hasMaterialPropertyByName(const std::string & name)
+MaterialPropertyInterface::hasMaterialPropertyByNameTempl(const std::string & name)
 {
   return _material_data->haveProperty<T>(name);
 }

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -14,6 +14,7 @@
 #include "FEProblemBase.h"
 #include "MooseTypes.h"
 #include "MaterialData.h"
+#include "MemberTemplateMacros.h"
 
 // Forward declarations
 class InputParameters;
@@ -25,54 +26,6 @@ InputParameters validParams();
 
 template <>
 InputParameters validParams<MaterialPropertyInterface>();
-
-#define adDeclareADProperty                                                                        \
-  _Pragma("GCC warning \"adDeclareADProperty is deprecated. Simply use declareADProperty\"") this  \
-      ->template declareADPropertyTempl
-#define adDeclareProperty                                                                          \
-  _Pragma("GCC warning \"adDeclareProperty is deprecated. Simply use declareProperty\"") this      \
-      ->template declarePropertyTempl
-
-// clang-format off
-#define adGetADMaterialProperty \
-  _Pragma( \
-      "GCC warning \"adGetADMaterialProperty is deprecated. Simply use getADMaterialProperty\"") \
-  this->template getADMaterialPropertyTempl
-#define adGetADMaterialPropertyByName \
-  _Pragma( \
-      "GCC warning \"adGetADMaterialPropertyByName is deprecated. Simply use getADMaterialPropertyByName\"") \
-  this->template getADMaterialPropertyByNameTempl
-#define adGetMaterialPropertyByName \
-  _Pragma( \
-      "GCC warning \"adGetMaterialPropertyByName is deprecated. Simply use getMaterialPropertyByName\"") \
-  this->template getMaterialPropertyByNameTempl
-#define adGetMaterialPropertyOldByName \
-  _Pragma( \
-      "GCC warning \"adGetMaterialPropertyOldByName is deprecated. Simply use getMaterialPropertyOldByName\"") \
-  this->template getMaterialPropertyOldByNameTempl
-#define adGetMaterialPropertyOlderByName \
-  _Pragma( \
-      "GCC warning \"adGetMaterialPropertyOlderByName is deprecated. Simply use getMaterialPropertyOlderByName\"") \
-  this->template getMaterialPropertyOlderByNameTempl
-#define adHasMaterialProperty \
-  _Pragma( \
-      "GCC warning \"adHasMaterialProperty is deprecated. Simply use hasMaterialProperty\"") \
-  this->template hasMaterialPropertyTempl
-#define adHasMaterialPropertyByName \
-  _Pragma( \
-      "GCC warning \"adHasMaterialPropertyByName is deprecated. Simply use hasMaterialPropertyByName\"") \
-  this->template hasMaterialPropertyByNameTempl
-// clang-format on
-
-#define declareADProperty this->template declareADPropertyTempl
-#define declareProperty this->template declarePropertyTempl
-#define getADMaterialProperty this->template getADMaterialPropertyTempl
-#define getADMaterialPropertyByName this->template getADMaterialPropertyByNameTempl
-#define getMaterialPropertyByName this->template getMaterialPropertyByNameTempl
-#define getMaterialPropertyOldByName this->template getMaterialPropertyOldByNameTempl
-#define getMaterialPropertyOlderByName this->template getMaterialPropertyOlderByNameTempl
-#define hasMaterialProperty this->template hasMaterialPropertyTempl
-#define hasMaterialPropertyByName this->template hasMaterialPropertyByNameTempl
 
 /**
  * \class MaterialPropertyInterface

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -18,8 +18,19 @@ class TwoMaterialPropertyInterface;
 template <>
 InputParameters validParams<TwoMaterialPropertyInterface>();
 
-#define adGetNeighborMaterialProperty this->template getNeighborMaterialProperty
-#define adGetNeighborADMaterialProperty this->template getNeighborADMaterialProperty
+// clang-format off
+#define adGetNeighborMaterialProperty \
+  _Pragma( \
+    "GCC warning \"adGetNeighborMaterialProperty is deprecated. Simply use getNeighborMaterialProperty\"") \
+  this->template getNeighborMaterialPropertyTempl
+#define adGetNeighborADMaterialProperty \
+  _Pragma( \
+    "GCC warning \"adGetNeighborADMaterialProperty is deprecated. Simply use getNeighborADMaterialProperty\"") \
+  this->template getNeighborADMaterialPropertyTempl
+// clang-format on
+
+#define getNeighborMaterialProperty this->template getNeighborMaterialPropertyTempl
+#define getNeighborADMaterialProperty this->template getNeighborADMaterialPropertyTempl
 
 class TwoMaterialPropertyInterface : public MaterialPropertyInterface
 {
@@ -32,13 +43,13 @@ public:
    * Retrieve the property named "name"
    */
   template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getNeighborMaterialPropertyTempl(const std::string & name);
 
   /**
    * Retrieve the ADMaterialProperty named "name"
    */
   template <typename T>
-  const ADMaterialPropertyObject<T> & getNeighborADMaterialProperty(const std::string & name);
+  const ADMaterialPropertyObject<T> & getNeighborADMaterialPropertyTempl(const std::string & name);
 
   template <typename T>
   const MaterialProperty<T> & getNeighborMaterialPropertyOld(const std::string & name);
@@ -52,7 +63,7 @@ protected:
 
 template <typename T>
 const MaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborMaterialProperty(const std::string & name)
+TwoMaterialPropertyInterface::getNeighborMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
@@ -67,7 +78,7 @@ TwoMaterialPropertyInterface::getNeighborMaterialProperty(const std::string & na
 
 template <typename T>
 const ADMaterialPropertyObject<T> &
-TwoMaterialPropertyInterface::getNeighborADMaterialProperty(const std::string & name)
+TwoMaterialPropertyInterface::getNeighborADMaterialPropertyTempl(const std::string & name)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
@@ -109,4 +120,3 @@ TwoMaterialPropertyInterface::getNeighborMaterialPropertyOlder(const std::string
   else
     return _neighbor_material_data->getPropertyOlder<T>(prop_name);
 }
-

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "MaterialPropertyInterface.h"
+#include "MemberTemplateMacros.h"
 
 // Forward Declarations
 class MaterialData;
@@ -17,20 +18,6 @@ class TwoMaterialPropertyInterface;
 
 template <>
 InputParameters validParams<TwoMaterialPropertyInterface>();
-
-// clang-format off
-#define adGetNeighborMaterialProperty \
-  _Pragma( \
-    "GCC warning \"adGetNeighborMaterialProperty is deprecated. Simply use getNeighborMaterialProperty\"") \
-  this->template getNeighborMaterialPropertyTempl
-#define adGetNeighborADMaterialProperty \
-  _Pragma( \
-    "GCC warning \"adGetNeighborADMaterialProperty is deprecated. Simply use getNeighborADMaterialProperty\"") \
-  this->template getNeighborADMaterialPropertyTempl
-// clang-format on
-
-#define getNeighborMaterialProperty this->template getNeighborMaterialPropertyTempl
-#define getNeighborADMaterialProperty this->template getNeighborADMaterialPropertyTempl
 
 class TwoMaterialPropertyInterface : public MaterialPropertyInterface
 {

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -727,7 +727,7 @@ public:
    * @return Const reference to the user object
    */
   template <class T>
-  T & getUserObject(const std::string & name, unsigned int tid = 0) const
+  T & getUserObjectTempl(const std::string & name, unsigned int tid = 0) const
   {
     std::vector<T *> objs;
     theWarehouse().query().condition<AttribThread>(tid).condition<AttribName>(name).queryInto(objs);

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -12,15 +12,7 @@
 // MOOSE includes
 #include "MooseTypes.h"
 #include "RestartableData.h"
-
-// clang-format off
-#define adDeclareRestartableData \
-  _Pragma( \
-    "GCC warning \"adDeclareRestartableData is deprecated. Simply use declareRestartableData\"") \
-  this->template declareRestartableDataTempl
-// clang-format on
-
-#define declareRestartableData this->template declareRestartableDataTempl
+#include "MemberTemplateMacros.h"
 
 // Forward declarations
 class PostprocessorData;

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -13,9 +13,12 @@
 #include "MooseTypes.h"
 #include "RestartableData.h"
 
-#define adDeclareRestartableData                                                                   \
-  _Pragma("GCC warning \"adDeclareRestartableData is deprecated. Simply use "                      \
-          "declareRestartableData\"") this->template declareRestartableDataTempl
+// clang-format off
+#define adDeclareRestartableData \
+  _Pragma( \
+    "GCC warning \"adDeclareRestartableData is deprecated. Simply use declareRestartableData\"") \
+  this->template declareRestartableDataTempl
+// clang-format on
 
 #define declareRestartableData this->template declareRestartableDataTempl
 

--- a/framework/include/restart/Restartable.h
+++ b/framework/include/restart/Restartable.h
@@ -13,7 +13,11 @@
 #include "MooseTypes.h"
 #include "RestartableData.h"
 
-#define adDeclareRestartableData this->template declareRestartableData
+#define adDeclareRestartableData                                                                   \
+  _Pragma("GCC warning \"adDeclareRestartableData is deprecated. Simply use "                      \
+          "declareRestartableData\"") this->template declareRestartableDataTempl
+
+#define declareRestartableData this->template declareRestartableDataTempl
 
 // Forward declarations
 class PostprocessorData;
@@ -75,7 +79,7 @@ protected:
    * @param data_name The name of the data (usually just use the same name as the member variable)
    */
   template <typename T>
-  T & declareRestartableData(std::string data_name);
+  T & declareRestartableDataTempl(std::string data_name);
 
   /**
    * Declare a piece of data as "restartable" and initialize it.
@@ -88,7 +92,7 @@ protected:
    * @param init_value The initial value of the data
    */
   template <typename T>
-  T & declareRestartableData(std::string data_name, const T & init_value);
+  T & declareRestartableDataTempl(std::string data_name, const T & init_value);
 
   /**
    * Declare a piece of data as "restartable".
@@ -200,14 +204,14 @@ private:
 
 template <typename T>
 T &
-Restartable::declareRestartableData(std::string data_name)
+Restartable::declareRestartableDataTempl(std::string data_name)
 {
   return declareRestartableDataWithContext<T>(data_name, nullptr);
 }
 
 template <typename T>
 T &
-Restartable::declareRestartableData(std::string data_name, const T & init_value)
+Restartable::declareRestartableDataTempl(std::string data_name, const T & init_value)
 {
   return declareRestartableDataWithContext<T>(data_name, init_value, nullptr);
 }
@@ -286,4 +290,3 @@ Restartable::declareRecoverableData(std::string data_name, const T & init_value)
 
   return declareRestartableDataWithContext<T>(data_name, init_value, nullptr);
 }
-

--- a/framework/include/userobject/NearestPointBase.h
+++ b/framework/include/userobject/NearestPointBase.h
@@ -134,11 +134,11 @@ NearestPointBase<UserObjectType, BaseType>::fillPoints()
 
   if (isParamValid("points"))
   {
-    _points = this->template getParam<std::vector<Point>>("points");
+    _points = this->template getParamTempl<std::vector<Point>>("points");
   }
   else if (isParamValid("points_file"))
   {
-    const FileName & points_file = this->template getParam<FileName>("points_file");
+    const FileName & points_file = this->template getParamTempl<FileName>("points_file");
     std::vector<Real> points_vec;
 
     if (processor_id() == 0)
@@ -238,4 +238,3 @@ NearestPointBase<UserObjectType, BaseType>::nearestUserObject(const Point & p) c
 
   return _user_objects[closest];
 }
-

--- a/framework/include/userobject/ShapeUserObject.h
+++ b/framework/include/userobject/ShapeUserObject.h
@@ -101,7 +101,7 @@ ShapeUserObject<T>::ShapeUserObject(const InputParameters & parameters, ShapeTyp
     _phi(type == ShapeType::Element ? this->_assembly.phi() : this->_assembly.phiFace()),
     _grad_phi(type == ShapeType::Element ? this->_assembly.gradPhi()
                                          : this->_assembly.gradPhiFace()),
-    _compute_jacobians(MooseObject::getParam<bool>("compute_jacobians"))
+    _compute_jacobians(MooseObject::getParamTempl<bool>("compute_jacobians"))
 {
   mooseWarning("Jacobian calculation in UserObjects is an experimental capability with a "
                "potentially unstable interface.");
@@ -142,4 +142,3 @@ ShapeUserObject<T>::executeJacobianWrapper(unsigned int jvar,
     executeJacobian(jvar);
   }
 }
-

--- a/framework/include/userobject/UserObjectInterface.h
+++ b/framework/include/userobject/UserObjectInterface.h
@@ -12,16 +12,12 @@
 // MOOSE includes
 #include "FEProblemBase.h"
 #include "MooseTypes.h"
+#include "MemberTemplateMacros.h"
 
 // Forward declarations
 class InputParameters;
 class UserObject;
 
-// Template member functions can't be introduced through using declarations
-#define adGetUserObject this->template getUserObject
-#define adGetUserObjectByName this->template getUserObjectByName
-
-// But non-templates can be!
 #define usingUserObjectInterfaceMembers                                                            \
   using UserObjectInterface::getUserObjectBase;                                                    \
   using UserObjectInterface::getUserObjectBaseByName
@@ -46,7 +42,7 @@ public:
    * @return The user object with name associated with the parameter 'name'
    */
   template <class T>
-  const T & getUserObject(const std::string & name);
+  const T & getUserObjectTempl(const std::string & name);
 
   /**
    * Get an user object with a given name
@@ -54,7 +50,7 @@ public:
    * @return The user object with the name
    */
   template <class T>
-  const T & getUserObjectByName(const std::string & name);
+  const T & getUserObjectByNameTempl(const std::string & name);
 
   /**
    * Get an user object with a given parameter name
@@ -86,16 +82,16 @@ private:
 
 template <class T>
 const T &
-UserObjectInterface::getUserObject(const std::string & name)
+UserObjectInterface::getUserObjectTempl(const std::string & name)
 {
   unsigned int tid = needThreadedCopy(getUserObjectBase(name)) ? _uoi_tid : 0;
-  return _uoi_feproblem.getUserObject<T>(_uoi_params.get<UserObjectName>(name), tid);
+  return _uoi_feproblem.getUserObjectTempl<T>(_uoi_params.get<UserObjectName>(name), tid);
 }
 
 template <class T>
 const T &
-UserObjectInterface::getUserObjectByName(const std::string & name)
+UserObjectInterface::getUserObjectByNameTempl(const std::string & name)
 {
   unsigned int tid = needThreadedCopy(getUserObjectBaseByName(name)) ? _uoi_tid : 0;
-  return _uoi_feproblem.getUserObject<T>(name, tid);
+  return _uoi_feproblem.getUserObjectTempl<T>(name, tid);
 }

--- a/framework/include/utils/DerivativeKernelInterface.h
+++ b/framework/include/utils/DerivativeKernelInterface.h
@@ -33,7 +33,7 @@ template <class T>
 DerivativeKernelInterface<T>::DerivativeKernelInterface(const InputParameters & parameters)
   : DerivativeMaterialInterface<T>(parameters),
     _nvar(this->_coupled_moose_vars.size()),
-    _F_name(this->template getParam<std::string>("f_name"))
+    _F_name(this->template getParamTempl<std::string>("f_name"))
 {
 }
 
@@ -46,4 +46,3 @@ DerivativeKernelInterface<T>::validParams()
       "f_name", "Base name of the free energy function F defined in a DerivativeParsedMaterial");
   return params;
 }
-

--- a/framework/include/utils/MemberTemplateMacros.h
+++ b/framework/include/utils/MemberTemplateMacros.h
@@ -9,24 +9,33 @@
 
 #pragma once
 
-// This file is for member template functions that are defined in multiple classes
+// MooseObject
 
 #define adGetParam                                                                                 \
   _Pragma("GCC warning \"adGetParam is deprecated. Simply use getParam\"") this                    \
       ->template getParamTempl
+
 #define getParam this->template getParamTempl
+
+// UserObjectInterface
 
 #define adGetUserObject                                                                            \
   _Pragma("GCC warning \"adGetUserObject is deprecated. Simply use getUserObject\"") this          \
       ->template getUserObjectTempl
+#define adGetUserObjectByName                                                                      \
+  _Pragma(                                                                                         \
+      "GCC warning \"adGetUserObjectByName is deprecated. Simply use getUserObjectByName\"") this  \
+      ->template getUserObjectByNameTempl
+
+#define getUserObjectByName this->template getUserObjectByNameTempl
 #define getUserObject this->template getUserObjectTempl
+
+// MaterialPropertyInterface
 
 #define adGetMaterialProperty                                                                      \
   _Pragma(                                                                                         \
       "GCC warning \"adGetMaterialProperty is deprecated. Simply use getMaterialProperty\"") this  \
       ->template getMaterialPropertyTempl
-#define getMaterialProperty this->template getMaterialPropertyTempl
-
 // clang-format off
 #define adGetMaterialPropertyOld \
   _Pragma( \
@@ -36,12 +45,78 @@
   _Pragma( \
       "GCC warning \"adGetMaterialPropertyOlder is deprecated. Simply use getMaterialPropertyOlder\"") \
   this->template getMaterialPropertyOlderTempl
+#define adGetADMaterialProperty \
+  _Pragma( \
+      "GCC warning \"adGetADMaterialProperty is deprecated. Simply use getADMaterialProperty\"") \
+  this->template getADMaterialPropertyTempl
+#define adGetADMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adGetADMaterialPropertyByName is deprecated. Simply use getADMaterialPropertyByName\"") \
+  this->template getADMaterialPropertyByNameTempl
+#define adGetMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyByName is deprecated. Simply use getMaterialPropertyByName\"") \
+  this->template getMaterialPropertyByNameTempl
+#define adGetMaterialPropertyOldByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOldByName is deprecated. Simply use getMaterialPropertyOldByName\"") \
+  this->template getMaterialPropertyOldByNameTempl
+#define adGetMaterialPropertyOlderByName \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOlderByName is deprecated. Simply use getMaterialPropertyOlderByName\"") \
+  this->template getMaterialPropertyOlderByNameTempl
+#define adHasMaterialProperty \
+  _Pragma( \
+      "GCC warning \"adHasMaterialProperty is deprecated. Simply use hasMaterialProperty\"") \
+  this->template hasMaterialPropertyTempl
+#define adHasMaterialPropertyByName \
+  _Pragma( \
+      "GCC warning \"adHasMaterialPropertyByName is deprecated. Simply use hasMaterialPropertyByName\"") \
+  this->template hasMaterialPropertyByNameTempl
 // clang-format on
+#define adDeclareADProperty                                                                        \
+  _Pragma("GCC warning \"adDeclareADProperty is deprecated. Simply use declareADProperty\"") this  \
+      ->template declareADPropertyTempl
+#define adDeclareProperty                                                                          \
+  _Pragma("GCC warning \"adDeclareProperty is deprecated. Simply use declareProperty\"") this      \
+      ->template declarePropertyTempl
+
+#define getMaterialProperty this->template getMaterialPropertyTempl
 #define getMaterialPropertyOld this->template getMaterialPropertyOldTempl
 #define getMaterialPropertyOlder this->template getMaterialPropertyOlderTempl
+#define declareADProperty this->template declareADPropertyTempl
+#define declareProperty this->template declarePropertyTempl
+#define getADMaterialProperty this->template getADMaterialPropertyTempl
+#define getADMaterialPropertyByName this->template getADMaterialPropertyByNameTempl
+#define getMaterialPropertyByName this->template getMaterialPropertyByNameTempl
+#define getMaterialPropertyOldByName this->template getMaterialPropertyOldByNameTempl
+#define getMaterialPropertyOlderByName this->template getMaterialPropertyOlderByNameTempl
+#define hasMaterialProperty this->template hasMaterialPropertyTempl
+#define hasMaterialPropertyByName this->template hasMaterialPropertyByNameTempl
 
-#define adGetUserObjectByName                                                                      \
-  _Pragma(                                                                                         \
-      "GCC warning \"adGetUserObjectByName is deprecated. Simply use getUserObjectByName\"") this  \
-      ->template getUserObjectByNameTempl
-#define getUserObjectByName this->template getUserObjectByNameTempl
+// TwoMaterialPropertyInterface
+
+// clang-format off
+#define adGetNeighborMaterialProperty \
+  _Pragma( \
+    "GCC warning \"adGetNeighborMaterialProperty is deprecated. Simply use getNeighborMaterialProperty\"") \
+  this->template getNeighborMaterialPropertyTempl
+#define adGetNeighborADMaterialProperty \
+  _Pragma( \
+    "GCC warning \"adGetNeighborADMaterialProperty is deprecated. Simply use getNeighborADMaterialProperty\"") \
+  this->template getNeighborADMaterialPropertyTempl
+// clang-format on
+
+#define getNeighborMaterialProperty this->template getNeighborMaterialPropertyTempl
+#define getNeighborADMaterialProperty this->template getNeighborADMaterialPropertyTempl
+
+// Restartable
+
+// clang-format off
+#define adDeclareRestartableData \
+  _Pragma( \
+    "GCC warning \"adDeclareRestartableData is deprecated. Simply use declareRestartableData\"") \
+  this->template declareRestartableDataTempl
+// clang-format on
+
+#define declareRestartableData this->template declareRestartableDataTempl

--- a/framework/include/utils/MemberTemplateMacros.h
+++ b/framework/include/utils/MemberTemplateMacros.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+// This file is for member template functions that are defined in multiple classes
+
+#define adGetParam                                                                                 \
+  _Pragma("GCC warning \"adGetParam is deprecated. Simply use getParam\"") this                    \
+      ->template getParamTempl
+#define getParam this->template getParamTempl
+
+#define adGetUserObject                                                                            \
+  _Pragma("GCC warning \"adGetUserObject is deprecated. Simply use getUserObject\"") this          \
+      ->template getUserObjectTempl
+#define getUserObject this->template getUserObjectTempl
+
+#define adGetMaterialProperty                                                                      \
+  _Pragma(                                                                                         \
+      "GCC warning \"adGetMaterialProperty is deprecated. Simply use getMaterialProperty\"") this  \
+      ->template getMaterialPropertyTempl
+#define getMaterialProperty this->template getMaterialPropertyTempl
+
+// clang-format off
+#define adGetMaterialPropertyOld \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOld is deprecated. Simply use getMaterialPropertyOld\"") \
+  this->template getMaterialPropertyOldTempl
+#define adGetMaterialPropertyOlder \
+  _Pragma( \
+      "GCC warning \"adGetMaterialPropertyOlder is deprecated. Simply use getMaterialPropertyOlder\"") \
+  this->template getMaterialPropertyOlderTempl
+// clang-format on
+#define getMaterialPropertyOld this->template getMaterialPropertyOldTempl
+#define getMaterialPropertyOlder this->template getMaterialPropertyOlderTempl
+
+#define adGetUserObjectByName                                                                      \
+  _Pragma(                                                                                         \
+      "GCC warning \"adGetUserObjectByName is deprecated. Simply use getUserObjectByName\"") this  \
+      ->template getUserObjectByNameTempl
+#define getUserObjectByName this->template getUserObjectByNameTempl

--- a/framework/src/actions/CheckOutputAction.C
+++ b/framework/src/actions/CheckOutputAction.C
@@ -93,7 +93,7 @@ CheckOutputAction::checkConsoleOutput()
   std::vector<Console *> console_ptrs = _app.getOutputWarehouse().getOutputs<Console>();
   unsigned int num_screen_outputs = 0;
   for (const auto & console : console_ptrs)
-    if (console->getParam<bool>("output_screen"))
+    if (console->getParamTempl<bool>("output_screen"))
       num_screen_outputs++;
 
   if (num_screen_outputs > 1)
@@ -112,7 +112,7 @@ CheckOutputAction::checkPerfLogOutput()
   bool has_console = false;
   std::vector<Console *> ptrs = _app.getOutputWarehouse().getOutputs<Console>();
   for (const auto & console : ptrs)
-    if (console->getParam<bool>("output_screen"))
+    if (console->getParamTempl<bool>("output_screen"))
     {
       has_console = true;
       break;

--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -187,12 +187,12 @@ CommonOutputAction::act()
   if (getParam<bool>("dofmap"))
     create("DOFMap");
 
-  if (getParam<bool>("controls") || _app.getParam<bool>("show_controls"))
+  if (getParam<bool>("controls") || _app.getParamTempl<bool>("show_controls"))
     create("ControlOutput");
 
-  if (!_app.getParam<bool>("no_timing") &&
+  if (!_app.getParamTempl<bool>("no_timing") &&
       (getParam<bool>("perf_graph") || getParam<bool>("print_perf_log") ||
-       _app.getParam<bool>("timing")))
+       _app.getParamTempl<bool>("timing")))
     create("PerfGraphOutput");
 
   if (!getParam<bool>("color"))

--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -114,7 +114,7 @@ MaterialOutputAction::act()
 
     // Extract the property names that will actually be output
     std::vector<std::string> output_properties =
-        mat->getParam<std::vector<std::string>>("output_properties");
+        mat->getParamTempl<std::vector<std::string>>("output_properties");
 
     // Append the properties listed in the Outputs block
     if (outputs_has_properties)

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -112,7 +112,7 @@ SetupMeshAction::setupMesh(MooseMesh * mesh)
   unsigned int level = getParam<unsigned int>("uniform_refine");
 
   // Did they specify extra refinement levels on the command-line?
-  level += _app.getParam<unsigned int>("refinements");
+  level += _app.getParamTempl<unsigned int>("refinements");
 
   mesh->setUniformRefineLevel(level);
 #endif // LIBMESH_ENABLE_AMR

--- a/framework/src/base/Attributes.C
+++ b/framework/src/base/Attributes.C
@@ -213,7 +213,7 @@ AttribBoundaries::isEqual(const Attribute & other) const
 void
 AttribThread::initFrom(const MooseObject * obj)
 {
-  _val = obj->getParam<THREAD_ID>("_tid");
+  _val = obj->getParamTempl<THREAD_ID>("_tid");
 }
 bool
 AttribThread::isMatch(const Attribute & other) const

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -998,7 +998,7 @@ MooseApp::getCheckpointDirectories() const
   // If file_base is set in CommonOutputAction, add this file to the list of potential checkpoint
   // files
   if (common->isParamValid("file_base"))
-    checkpoint_dirs.push_back(common->getParam<std::string>("file_base") + "_cp");
+    checkpoint_dirs.push_back(common->getParamTempl<std::string>("file_base") + "_cp");
   // Case for normal application or master in a Multiapp setting
   else if (getOutputFileBase().empty())
     checkpoint_dirs.push_back(FileOutput::getOutputFileBase(*this, "_out_cp"));
@@ -1018,10 +1018,10 @@ MooseApp::getCheckpointDirectories() const
     const InputParameters & params = moose_object_action->getObjectParams();
 
     // Loop through the actions and add the necessary directories to the list to check
-    if (moose_object_action->getParam<std::string>("type") == "Checkpoint")
+    if (moose_object_action->getParamTempl<std::string>("type") == "Checkpoint")
     {
       if (params.isParamValid("file_base"))
-        checkpoint_dirs.push_back(common->getParam<std::string>("file_base") + "_cp");
+        checkpoint_dirs.push_back(common->getParamTempl<std::string>("file_base") + "_cp");
       else
       {
         std::ostringstream oss;

--- a/framework/src/bcs/ADPresetBC.C
+++ b/framework/src/bcs/ADPresetBC.C
@@ -19,7 +19,7 @@ defineADValidParams(
 
 template <ComputeStage compute_stage>
 ADPresetBC<compute_stage>::ADPresetBC(const InputParameters & parameters)
-  : ADPresetNodalBC<compute_stage>(parameters), _value(adGetParam<Real>("value"))
+  : ADPresetNodalBC<compute_stage>(parameters), _value(getParam<Real>("value"))
 {
 }
 

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -38,10 +38,10 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object,
   // NodeFaceConstraint
   if (nfc)
   {
-    MooseMesh & mesh = nfc->getParam<FEProblemBase *>("_fe_problem_base")->mesh();
-    unsigned int slave = mesh.getBoundaryID(nfc->getParam<BoundaryName>("slave"));
+    MooseMesh & mesh = nfc->getParamTempl<FEProblemBase *>("_fe_problem_base")->mesh();
+    unsigned int slave = mesh.getBoundaryID(nfc->getParamTempl<BoundaryName>("slave"));
     bool displaced = nfc->parameters().have_parameter<bool>("use_displaced_mesh") &&
-                     nfc->getParam<bool>("use_displaced_mesh");
+                     nfc->getParamTempl<bool>("use_displaced_mesh");
 
     if (displaced)
       _displaced_node_face_constraints[slave].addObject(nfc);
@@ -52,11 +52,12 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object,
   // MortarConstraint
   else if (mc)
   {
-    MooseMesh & mesh = mc->getParam<FEProblemBase *>("_fe_problem_base")->mesh();
-    bool displaced = mc->getParam<bool>("use_displaced_mesh");
+    MooseMesh & mesh = mc->getParamTempl<FEProblemBase *>("_fe_problem_base")->mesh();
+    bool displaced = mc->getParamTempl<bool>("use_displaced_mesh");
 
-    auto slave_boundary_id = mesh.getBoundaryID(mc->getParam<BoundaryName>("slave_boundary"));
-    auto master_boundary_id = mesh.getBoundaryID(mc->getParam<BoundaryName>("master_boundary"));
+    auto slave_boundary_id = mesh.getBoundaryID(mc->getParamTempl<BoundaryName>("slave_boundary"));
+    auto master_boundary_id =
+        mesh.getBoundaryID(mc->getParamTempl<BoundaryName>("master_boundary"));
     auto key = std::make_pair(master_boundary_id, slave_boundary_id);
 
     if (displaced)
@@ -69,7 +70,7 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object,
   else if (ec)
   {
     bool displaced = ec->parameters().have_parameter<bool>("use_displaced_mesh") &&
-                     ec->getParam<bool>("use_displaced_mesh");
+                     ec->getParamTempl<bool>("use_displaced_mesh");
     const InterfaceID interface_id = ec->getInterfaceID();
 
     if (displaced)
@@ -81,11 +82,11 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object,
   // NodeElemConstraint
   else if (nec)
   {
-    MooseMesh & mesh = nec->getParam<FEProblemBase *>("_fe_problem_base")->mesh();
-    SubdomainID slave = mesh.getSubdomainID(nec->getParam<SubdomainName>("slave"));
-    SubdomainID master = mesh.getSubdomainID(nec->getParam<SubdomainName>("master"));
+    MooseMesh & mesh = nec->getParamTempl<FEProblemBase *>("_fe_problem_base")->mesh();
+    SubdomainID slave = mesh.getSubdomainID(nec->getParamTempl<SubdomainName>("slave"));
+    SubdomainID master = mesh.getSubdomainID(nec->getParamTempl<SubdomainName>("master"));
     bool displaced = nec->parameters().have_parameter<bool>("use_displaced_mesh") &&
-                     nec->getParam<bool>("use_displaced_mesh");
+                     nec->getParamTempl<bool>("use_displaced_mesh");
 
     if (displaced)
       _displaced_node_elem_constraints[std::make_pair(slave, master)].addObject(nec);

--- a/framework/src/constraints/EqualGradientConstraint.C
+++ b/framework/src/constraints/EqualGradientConstraint.C
@@ -23,7 +23,7 @@ defineADValidParams(
 
 template <ComputeStage compute_stage>
 EqualGradientConstraint<compute_stage>::EqualGradientConstraint(const InputParameters & parameters)
-  : ADMortarConstraint<compute_stage>(parameters), _component(adGetParam<unsigned int>("component"))
+  : ADMortarConstraint<compute_stage>(parameters), _component(getParam<unsigned int>("component"))
 {
 }
 

--- a/framework/src/controls/TimePeriod.C
+++ b/framework/src/controls/TimePeriod.C
@@ -43,7 +43,7 @@ TimePeriod::TimePeriod(const InputParameters & parameters) : ConditionalEnableCo
   if (isParamValid("start_time"))
     _start_time = getParam<std::vector<Real>>("start_time");
   else
-    _start_time = {_app.getExecutioner()->getParam<Real>("start_time")};
+    _start_time = {_app.getExecutioner()->getParamTempl<Real>("start_time")};
 
   // Set end time
   if (isParamValid("end_time"))

--- a/framework/src/dgkernels/ADDGDiffusion.C
+++ b/framework/src/dgkernels/ADDGDiffusion.C
@@ -29,10 +29,10 @@ defineADValidParams(ADDGDiffusion,
 template <ComputeStage compute_stage>
 ADDGDiffusion<compute_stage>::ADDGDiffusion(const InputParameters & parameters)
   : ADDGKernel<compute_stage>(parameters),
-    _epsilon(adGetParam<Real>("epsilon")),
-    _sigma(adGetParam<Real>("sigma")),
-    _diff(adGetADMaterialProperty<Real>("diff")),
-    _diff_neighbor(adGetNeighborADMaterialProperty<Real>("diff"))
+    _epsilon(getParam<Real>("epsilon")),
+    _sigma(getParam<Real>("sigma")),
+    _diff(getADMaterialProperty<Real>("diff")),
+    _diff_neighbor(getNeighborADMaterialProperty<Real>("diff"))
 {
 }
 

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -95,14 +95,16 @@ EigenExecutionerBase::init()
 
   // check when the postprocessors are evaluated
   const ExecFlagEnum & bx_exec =
-      _problem.getUserObject<UserObject>(getParam<PostprocessorName>("bx_norm")).getExecuteOnEnum();
+      _problem.getUserObjectTempl<UserObject>(getParam<PostprocessorName>("bx_norm"))
+          .getExecuteOnEnum();
   if (!bx_exec.contains(EXEC_LINEAR))
     mooseError("Postprocessor " + getParam<PostprocessorName>("bx_norm") +
                " requires execute_on = 'linear'");
 
   if (isParamValid("normalization"))
-    _norm_exec = _problem.getUserObject<UserObject>(getParam<PostprocessorName>("normalization"))
-                     .getExecuteOnEnum();
+    _norm_exec =
+        _problem.getUserObjectTempl<UserObject>(getParam<PostprocessorName>("normalization"))
+            .getExecuteOnEnum();
   else
     _norm_exec = bx_exec;
 
@@ -179,7 +181,8 @@ EigenExecutionerBase::inversePowerIteration(unsigned int min_iter,
   if (!xdiff.empty())
   {
     solution_diff = &getPostprocessorValueByName(xdiff);
-    const ExecFlagEnum & xdiff_exec = _problem.getUserObject<UserObject>(xdiff).getExecuteOnEnum();
+    const ExecFlagEnum & xdiff_exec =
+        _problem.getUserObjectTempl<UserObject>(xdiff).getExecuteOnEnum();
     if (!xdiff_exec.contains(EXEC_LINEAR))
       mooseError("Postprocessor " + xdiff + " requires execute_on = 'linear'");
   }

--- a/framework/src/functions/ImageFunction.C
+++ b/framework/src/functions/ImageFunction.C
@@ -33,7 +33,7 @@ ImageFunction::~ImageFunction() {}
 void
 ImageFunction::initialSetup()
 {
-  FEProblemBase * fe_problem = this->getParam<FEProblemBase *>("_fe_problem_base");
+  FEProblemBase * fe_problem = this->getParamTempl<FEProblemBase *>("_fe_problem_base");
   MooseMesh & mesh = fe_problem->mesh();
   setupImageSampler(mesh);
 }

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -39,15 +39,17 @@ validParams<BlockRestrictable>()
 
 // Standard constructor
 BlockRestrictable::BlockRestrictable(const MooseObject * moose_object)
-  : _blk_dual_restrictable(moose_object->getParam<bool>("_dual_restrictable")),
+  : _blk_dual_restrictable(moose_object->getParamTempl<bool>("_dual_restrictable")),
     _blk_feproblem(moose_object->isParamValid("_fe_problem_base")
-                       ? moose_object->getParam<FEProblemBase *>("_fe_problem_base")
+                       ? moose_object->getParamTempl<FEProblemBase *>("_fe_problem_base")
                        : NULL),
-    _blk_mesh(moose_object->isParamValid("_mesh") ? moose_object->getParam<MooseMesh *>("_mesh")
-                                                  : NULL),
+    _blk_mesh(moose_object->isParamValid("_mesh")
+                  ? moose_object->getParamTempl<MooseMesh *>("_mesh")
+                  : NULL),
     _boundary_ids(_empty_boundary_ids),
-    _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
-    _blk_name(moose_object->getParam<std::string>("_object_name"))
+    _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParamTempl<THREAD_ID>("_tid")
+                                                : 0),
+    _blk_name(moose_object->getParamTempl<std::string>("_object_name"))
 {
   initializeBlockRestrictable(moose_object);
 }
@@ -55,15 +57,17 @@ BlockRestrictable::BlockRestrictable(const MooseObject * moose_object)
 // Dual restricted constructor
 BlockRestrictable::BlockRestrictable(const MooseObject * moose_object,
                                      const std::set<BoundaryID> & boundary_ids)
-  : _blk_dual_restrictable(moose_object->getParam<bool>("_dual_restrictable")),
+  : _blk_dual_restrictable(moose_object->getParamTempl<bool>("_dual_restrictable")),
     _blk_feproblem(moose_object->isParamValid("_fe_problem_base")
-                       ? moose_object->getParam<FEProblemBase *>("_fe_problem_base")
+                       ? moose_object->getParamTempl<FEProblemBase *>("_fe_problem_base")
                        : NULL),
-    _blk_mesh(moose_object->isParamValid("_mesh") ? moose_object->getParam<MooseMesh *>("_mesh")
-                                                  : NULL),
+    _blk_mesh(moose_object->isParamValid("_mesh")
+                  ? moose_object->getParamTempl<MooseMesh *>("_mesh")
+                  : NULL),
     _boundary_ids(boundary_ids),
-    _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
-    _blk_name(moose_object->getParam<std::string>("_object_name"))
+    _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParamTempl<THREAD_ID>("_tid")
+                                                : 0),
+    _blk_name(moose_object->getParamTempl<std::string>("_object_name"))
 {
   initializeBlockRestrictable(moose_object);
 }
@@ -88,7 +92,7 @@ BlockRestrictable::initializeBlockRestrictable(const MooseObject * moose_object)
   if (moose_object->isParamValid("block"))
   {
     // Extract the blocks from the input
-    _blocks = moose_object->getParam<std::vector<SubdomainName>>("block");
+    _blocks = moose_object->getParamTempl<std::vector<SubdomainName>>("block");
 
     // Get the IDs from the supplied names
     std::vector<SubdomainID> vec_ids = _blk_mesh->getSubdomainIDs(_blocks);

--- a/framework/src/interfaces/BoundaryRestrictable.C
+++ b/framework/src/interfaces/BoundaryRestrictable.C
@@ -35,13 +35,15 @@ validParams<BoundaryRestrictable>()
 // Standard constructor
 BoundaryRestrictable::BoundaryRestrictable(const MooseObject * moose_object, bool nodal)
   : _bnd_feproblem(moose_object->isParamValid("_fe_problem_base")
-                       ? moose_object->getParam<FEProblemBase *>("_fe_problem_base")
+                       ? moose_object->getParamTempl<FEProblemBase *>("_fe_problem_base")
                        : NULL),
-    _bnd_mesh(moose_object->isParamValid("_mesh") ? moose_object->getParam<MooseMesh *>("_mesh")
-                                                  : NULL),
-    _bnd_dual_restrictable(moose_object->getParam<bool>("_dual_restrictable")),
+    _bnd_mesh(moose_object->isParamValid("_mesh")
+                  ? moose_object->getParamTempl<MooseMesh *>("_mesh")
+                  : NULL),
+    _bnd_dual_restrictable(moose_object->getParamTempl<bool>("_dual_restrictable")),
     _block_ids(_empty_block_ids),
-    _bnd_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
+    _bnd_tid(moose_object->isParamValid("_tid") ? moose_object->getParamTempl<THREAD_ID>("_tid")
+                                                : 0),
     _bnd_material_data(_bnd_feproblem->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA, _bnd_tid)),
     _bnd_nodal(nodal)
 {
@@ -53,13 +55,15 @@ BoundaryRestrictable::BoundaryRestrictable(const MooseObject * moose_object,
                                            const std::set<SubdomainID> & block_ids,
                                            bool nodal)
   : _bnd_feproblem(moose_object->isParamValid("_fe_problem_base")
-                       ? moose_object->getParam<FEProblemBase *>("_fe_problem_base")
+                       ? moose_object->getParamTempl<FEProblemBase *>("_fe_problem_base")
                        : NULL),
-    _bnd_mesh(moose_object->isParamValid("_mesh") ? moose_object->getParam<MooseMesh *>("_mesh")
-                                                  : NULL),
-    _bnd_dual_restrictable(moose_object->getParam<bool>("_dual_restrictable")),
+    _bnd_mesh(moose_object->isParamValid("_mesh")
+                  ? moose_object->getParamTempl<MooseMesh *>("_mesh")
+                  : NULL),
+    _bnd_dual_restrictable(moose_object->getParamTempl<bool>("_dual_restrictable")),
     _block_ids(block_ids),
-    _bnd_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
+    _bnd_tid(moose_object->isParamValid("_tid") ? moose_object->getParamTempl<THREAD_ID>("_tid")
+                                                : 0),
     _bnd_material_data(_bnd_feproblem->getMaterialData(Moose::BOUNDARY_MATERIAL_DATA, _bnd_tid)),
     _bnd_nodal(nodal)
 {
@@ -70,7 +74,7 @@ void
 BoundaryRestrictable::initializeBoundaryRestrictable(const MooseObject * moose_object)
 {
   // The name and id of the object
-  const std::string & name = moose_object->getParam<std::string>("_object_name");
+  const std::string & name = moose_object->getParamTempl<std::string>("_object_name");
 
   // If the mesh pointer is not defined, but FEProblemBase is, get it from there
   if (_bnd_feproblem != NULL && _bnd_mesh == NULL)
@@ -85,7 +89,7 @@ BoundaryRestrictable::initializeBoundaryRestrictable(const MooseObject * moose_o
   if (moose_object->isParamValid("boundary"))
   {
     // Extract the blocks from the input
-    _boundary_names = moose_object->getParam<std::vector<BoundaryName>>("boundary");
+    _boundary_names = moose_object->getParamTempl<std::vector<BoundaryName>>("boundary");
 
     // Get the IDs from the supplied names
     std::vector<BoundaryID> vec_ids = _bnd_mesh->getBoundaryIDs(_boundary_names, true);

--- a/framework/src/kernels/ADBodyForce.C
+++ b/framework/src/kernels/ADBodyForce.C
@@ -29,7 +29,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADBodyForce<compute_stage>::ADBodyForce(const InputParameters & parameters)
   : ADKernelValue<compute_stage>(parameters),
-    _scale(adGetParam<Real>("value")),
+    _scale(getParam<Real>("value")),
     _function(getFunction("function")),
     _postprocessor(getPostprocessorValue("postprocessor"))
 {

--- a/framework/src/kernels/ADKernelSUPG.C
+++ b/framework/src/kernels/ADKernelSUPG.C
@@ -25,7 +25,7 @@ defineADValidParams(ADVectorKernelSUPG, ADVectorKernel, PGParams;);
 template <typename T, ComputeStage compute_stage>
 ADKernelSUPGTempl<T, compute_stage>::ADKernelSUPGTempl(const InputParameters & parameters)
   : ADKernelStabilizedTempl<T, compute_stage>(parameters),
-    _tau(adGetADMaterialProperty<Real>("tau_name")),
+    _tau(getADMaterialProperty<Real>("tau_name")),
     _velocity(adCoupledVectorValue("velocity"))
 {
 }

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -52,7 +52,7 @@ EigenKernel::EigenKernel(const InputParameters & parameters)
   {
     EigenExecutionerBase * exec = dynamic_cast<EigenExecutionerBase *>(_app.getExecutioner());
     if (exec)
-      eigen_pp_name = exec->getParam<PostprocessorName>("bx_norm");
+      eigen_pp_name = exec->getParamTempl<PostprocessorName>("bx_norm");
   }
 
   // If the postprocessor name was not provided and an EigenExecutionerBase is not being used,

--- a/framework/src/materials/ADPiecewiseLinearInterpolationMaterial.C
+++ b/framework/src/materials/ADPiecewiseLinearInterpolationMaterial.C
@@ -36,10 +36,10 @@ template <ComputeStage compute_stage>
 ADPiecewiseLinearInterpolationMaterial<compute_stage>::ADPiecewiseLinearInterpolationMaterial(
     const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _prop_name(adGetParam<std::string>("property")),
+    _prop_name(getParam<std::string>("property")),
     _coupled_var(adCoupledValue("variable")),
-    _scale_factor(adGetParam<Real>("scale_factor")),
-    _property(adDeclareADProperty<Real>(_prop_name))
+    _scale_factor(getParam<Real>("scale_factor")),
+    _property(declareADProperty<Real>(_prop_name))
 {
   std::vector<Real> x;
   std::vector<Real> y;
@@ -52,12 +52,12 @@ ADPiecewiseLinearInterpolationMaterial<compute_stage>::ADPiecewiseLinearInterpol
     if (parameters.isParamValid("xy_data"))
       mooseError("In ", _name, ": Cannot specify 'x', 'y', and 'xy_data' together.");
 
-    x = adGetParam<std::vector<Real>>("x");
-    y = adGetParam<std::vector<Real>>("y");
+    x = getParam<std::vector<Real>>("x");
+    y = getParam<std::vector<Real>>("y");
   }
   else if (parameters.isParamValid("xy_data"))
   {
-    std::vector<Real> xy = adGetParam<std::vector<Real>>("xy_data");
+    std::vector<Real> xy = getParam<std::vector<Real>>("xy_data");
     unsigned int xy_size = xy.size();
     if (xy_size % 2 != 0)
       mooseError("In ", _name, ": Length of data provided in 'xy_data' must be a multiple of 2.");

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -192,13 +192,13 @@ Console::Console(const InputParameters & parameters)
   // Honor the 'print_linear_residuals' option, only if 'execute_on' has not been set by the user
   if (!parameters.isParamSetByUser("execute_on"))
   {
-    if (common_action->getParam<bool>("print_linear_residuals"))
+    if (common_action->getParamTempl<bool>("print_linear_residuals"))
       _execute_on.push_back("linear");
     else
       _execute_on.erase("linear");
   }
 
-  if (!_pars.isParamSetByUser("perf_log") && common_action->getParam<bool>("print_perf_log"))
+  if (!_pars.isParamSetByUser("perf_log") && common_action->getParamTempl<bool>("print_perf_log"))
   {
     _perf_log = true;
     _solve_log = true;
@@ -206,12 +206,12 @@ Console::Console(const InputParameters & parameters)
 
   // Append the common 'execute_on' to the setting for this object
   // This is unique to the Console object, all other objects inherit from the common options
-  const ExecFlagEnum & common_execute_on = common_action->getParam<ExecFlagEnum>("execute_on");
+  const ExecFlagEnum & common_execute_on = common_action->getParamTempl<ExecFlagEnum>("execute_on");
   for (auto & mme : common_execute_on)
     _execute_on.push_back(mme);
 
   // If --show-outputs is used, enable it
-  if (_app.getParam<bool>("show_outputs"))
+  if (_app.getParamTempl<bool>("show_outputs"))
     _system_info_flags.push_back("output");
 }
 
@@ -256,7 +256,7 @@ Console::initialSetup()
 
   // Enable verbose output if Executioner has it enabled
   if (_app.getExecutioner()->isParamValid("verbose") &&
-      _app.getExecutioner()->getParam<bool>("verbose"))
+      _app.getExecutioner()->getParamTempl<bool>("verbose"))
     _verbose = true;
 
   // Display a message to indicate the application is running (useful for MultiApps)

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -267,7 +267,7 @@ outputExecutionInformation(const MooseApp & app, FEProblemBase & problem)
   if (mpc)
   {
     oss << std::setw(console_field_width)
-        << "  MOOSE Preconditioner: " << mpc->getParam<std::string>("_type");
+        << "  MOOSE Preconditioner: " << mpc->getParamTempl<std::string>("_type");
     if (mpc->name() == "_moose_auto")
       oss << " (auto)";
     oss << '\n';

--- a/framework/src/outputs/PerfGraphOutput.C
+++ b/framework/src/outputs/PerfGraphOutput.C
@@ -68,7 +68,7 @@ PerfGraphOutput::shouldOutput(const ExecFlagType & type)
 void
 PerfGraphOutput::output(const ExecFlagType & /*type*/)
 {
-  if (!_app.getParam<bool>("no_timing"))
+  if (!_app.getParamTempl<bool>("no_timing"))
   {
     _app.perfGraph().print(_console, _level);
 

--- a/framework/src/postprocessors/ChangeOverTimePostprocessor.C
+++ b/framework/src/postprocessors/ChangeOverTimePostprocessor.C
@@ -44,7 +44,7 @@ ChangeOverTimePostprocessor::ChangeOverTimePostprocessor(const InputParameters &
   {
     // ensure dependent post-processor is executed on initial
     const PostprocessorName & pp_name = getParam<PostprocessorName>("postprocessor");
-    const UserObject & pp = _fe_problem.getUserObject<UserObject>(pp_name);
+    const UserObject & pp = _fe_problem.getUserObjectTempl<UserObject>(pp_name);
     if (!pp.getExecuteOnEnum().contains(EXEC_INITIAL))
       mooseError("When 'change_with_respect_to_initial' is specified to be true, 'execute_on' for "
                  "the dependent post-processor ('" +

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2378,7 +2378,7 @@ FEProblemBase::getMaterial(std::string name,
   }
 
   std::shared_ptr<Material> material = _all_materials[type].getActiveObject(name, tid);
-  if (!no_warn && material->getParam<bool>("compute") && type == Moose::BLOCK_MATERIAL_DATA)
+  if (!no_warn && material->getParamTempl<bool>("compute") && type == Moose::BLOCK_MATERIAL_DATA)
     mooseWarning("You are retrieving a Material object (",
                  material->name(),
                  "), but its compute flag is set to true. This indicates that MOOSE is "
@@ -2462,7 +2462,7 @@ FEProblemBase::addMaterialHelper(std::vector<MaterialWarehouse *> warehouses,
   {
     // Create the general Block/Boundary Material object
     std::shared_ptr<Material> material = _factory.create<Material>(mat_name, name, parameters, tid);
-    bool discrete = !material->getParam<bool>("compute");
+    bool discrete = !material->getParamTempl<bool>("compute");
 
     // If the object is boundary restricted do not create the neighbor and face objects
     if (material->boundaryRestricted())
@@ -3773,7 +3773,7 @@ FEProblemBase::addTransfer(const std::string & transfer_name,
   {
     ExecFlagEnum & exec_enum = parameters.set<ExecFlagEnum>("execute_on", true);
     std::shared_ptr<MultiApp> multiapp = getMultiApp(parameters.get<MultiAppName>("multi_app"));
-    exec_enum = multiapp->getParam<ExecFlagEnum>("execute_on");
+    exec_enum = multiapp->getParamTempl<ExecFlagEnum>("execute_on");
   }
 
   // Create the Transfer objects
@@ -5991,7 +5991,7 @@ FEProblemBase::addOutput(const std::string & object_type,
     exclude.push_back("execute_on");
 
     // --show-input should enable the display of the input file on the screen
-    if (_app.getParam<bool>("show_input") && parameters.get<bool>("output_screen"))
+    if (_app.getParamTempl<bool>("show_input") && parameters.get<bool>("output_screen"))
       parameters.set<ExecFlagEnum>("execute_input_on") = EXEC_INITIAL;
   }
 

--- a/modules/fluid_properties/src/interfaces/NaNInterface.C
+++ b/modules/fluid_properties/src/interfaces/NaNInterface.C
@@ -32,7 +32,7 @@ validParams<NaNInterface>()
 
 NaNInterface::NaNInterface(const MooseObject * moose_object)
   : _emit_on_nan(
-        moose_object->getParam<MooseEnum>("emit_on_nan").getEnum<NaNInterface::NaNMessage>())
+        moose_object->getParamTempl<MooseEnum>("emit_on_nan").getEnum<NaNInterface::NaNMessage>())
 {
   _moose_object = moose_object;
 }

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -37,7 +37,7 @@ BrineFluidProperties::BrineFluidProperties(const InputParameters & parameters)
       InputParameters params = _app.getFactory().getValidParams(class_name);
       _fe_problem.addUserObject(class_name, water_name, params);
     }
-    _water_fp = &_fe_problem.getUserObject<SinglePhaseFluidProperties>(water_name);
+    _water_fp = &_fe_problem.getUserObjectTempl<SinglePhaseFluidProperties>(water_name);
   }
 
   // SinglePhaseFluidPropertiesPT UserObject for NaCl
@@ -47,7 +47,7 @@ BrineFluidProperties::BrineFluidProperties(const InputParameters & parameters)
     InputParameters params = _app.getFactory().getValidParams(class_name);
     _fe_problem.addUserObject(class_name, nacl_name, params);
   }
-  _nacl_fp = &_fe_problem.getUserObject<SinglePhaseFluidProperties>(nacl_name);
+  _nacl_fp = &_fe_problem.getUserObjectTempl<SinglePhaseFluidProperties>(nacl_name);
 
   // Molar mass of NaCl and H20
   _Mnacl = _nacl_fp->molarMass();

--- a/modules/fluid_properties/test/src/userobjects/TestTwoPhaseNCGFluidProperties.C
+++ b/modules/fluid_properties/test/src/userobjects/TestTwoPhaseNCGFluidProperties.C
@@ -58,7 +58,7 @@ TestTwoPhaseNCGFluidProperties::TestTwoPhaseNCGFluidProperties(const InputParame
     params.set<UserObjectName>("fp_vapor") = "test_fp_vapor";
     _fe_problem.addUserObject(class_name, _2phase_name, params);
   }
-  _fp_2phase = &_fe_problem.getUserObject<TwoPhaseFluidProperties>(_2phase_name);
+  _fp_2phase = &_fe_problem.getUserObjectTempl<TwoPhaseFluidProperties>(_2phase_name);
 
   // create vapor mixture fluid properties
   if (_tid == 0)
@@ -70,5 +70,6 @@ TestTwoPhaseNCGFluidProperties::TestTwoPhaseNCGFluidProperties(const InputParame
         getParam<std::vector<UserObjectName>>("fp_ncgs");
     _fe_problem.addUserObject(class_name, _vapor_mixture_name, params);
   }
-  _fp_vapor_mixture = &_fe_problem.getUserObject<VaporMixtureFluidProperties>(_vapor_mixture_name);
+  _fp_vapor_mixture =
+      &_fe_problem.getUserObjectTempl<VaporMixtureFluidProperties>(_vapor_mixture_name);
 }

--- a/modules/functional_expansion_tools/include/userobject/FXIntegralBaseUserObject.h
+++ b/modules/functional_expansion_tools/include/userobject/FXIntegralBaseUserObject.h
@@ -62,11 +62,11 @@ public:
 
 protected:
   // Policy-based design requires us to specify which inherited members we are using
-  using IntegralBaseVariableUserObject::_JxW;
   using IntegralBaseVariableUserObject::_communicator;
   using IntegralBaseVariableUserObject::_console;
   using IntegralBaseVariableUserObject::_coord;
   using IntegralBaseVariableUserObject::_integral_value;
+  using IntegralBaseVariableUserObject::_JxW;
   using IntegralBaseVariableUserObject::_q_point;
   using IntegralBaseVariableUserObject::_qp;
   using IntegralBaseVariableUserObject::_variable;
@@ -116,9 +116,9 @@ FXIntegralBaseUserObject<IntegralBaseVariableUserObject>::FXIntegralBaseUserObje
   : IntegralBaseVariableUserObject(parameters),
     MutableCoefficientsInterface(this, parameters),
     _function_series(FunctionSeries::checkAndConvertFunction(
-        getFunction("function"), UserObject::getParam<std::string>("_moose_base"), name())),
-    _keep_history(UserObject::getParam<bool>("keep_history")),
-    _print_state(UserObject::getParam<bool>("print_state")),
+        getFunction("function"), UserObject::getParamTempl<std::string>("_moose_base"), name())),
+    _keep_history(UserObject::getParamTempl<bool>("keep_history")),
+    _print_state(UserObject::getParamTempl<bool>("print_state")),
     _standardized_function_volume(_function_series.getStandardizedFunctionVolume())
 {
   // Size the coefficient arrays
@@ -239,4 +239,3 @@ FXIntegralBaseUserObject<IntegralBaseVariableUserObject>::spatialValue(const Poi
 
   return _function_series.expand(_coefficients);
 }
-

--- a/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
+++ b/modules/functional_expansion_tools/src/transfers/MultiAppFXTransfer.C
@@ -115,7 +115,7 @@ MultiAppFXTransfer::scanProblemBaseForObject(FEProblemBase & base,
   else if (base.hasUserObject(object_name))
   {
     // Get the non-const qualified UserObject, otherwise we would use getUserObject()
-    auto & user_object = base.getUserObject<UserObject>(object_name);
+    auto & user_object = base.getUserObjectTempl<UserObject>(object_name);
     interface = dynamic_cast<MutableCoefficientsInterface *>(&user_object);
 
     // Check to see if the userObject is a subclass of MutableCoefficientsInterface
@@ -147,7 +147,7 @@ MultiAppFXTransfer::getMutableCoefficientsUserOject(FEProblemBase & base,
                                                     THREAD_ID thread)
 {
   // Get the non-const qualified UserObject, otherwise we would use getUserObject()
-  auto & user_object = base.getUserObject<UserObject>(object_name, thread);
+  auto & user_object = base.getUserObjectTempl<UserObject>(object_name, thread);
   return dynamic_cast<MutableCoefficientsInterface &>(user_object);
 }
 

--- a/modules/heat_conduction/src/constraints/GapConductanceConstraint.C
+++ b/modules/heat_conduction/src/constraints/GapConductanceConstraint.C
@@ -24,7 +24,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 GapConductanceConstraint<compute_stage>::GapConductanceConstraint(
     const InputParameters & parameters)
-  : ADMortarConstraint<compute_stage>(parameters), _k(adGetParam<Real>("k"))
+  : ADMortarConstraint<compute_stage>(parameters), _k(getParam<Real>("k"))
 {
 }
 

--- a/modules/heat_conduction/src/kernels/ADHeatConduction.C
+++ b/modules/heat_conduction/src/kernels/ADHeatConduction.C
@@ -22,7 +22,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADHeatConduction<compute_stage>::ADHeatConduction(const InputParameters & parameters)
   : ADDiffusion<compute_stage>(parameters),
-    _thermal_conductivity(adGetADMaterialProperty<Real>("thermal_conductivity"))
+    _thermal_conductivity(getADMaterialProperty<Real>("thermal_conductivity"))
 {
 }
 

--- a/modules/heat_conduction/src/kernels/ADHeatConductionTimeDerivative.C
+++ b/modules/heat_conduction/src/kernels/ADHeatConductionTimeDerivative.C
@@ -29,8 +29,8 @@ template <ComputeStage compute_stage>
 ADHeatConductionTimeDerivative<compute_stage>::ADHeatConductionTimeDerivative(
     const InputParameters & parameters)
   : ADTimeDerivative<compute_stage>(parameters),
-    _specific_heat(adGetADMaterialProperty<Real>("specific_heat")),
-    _density(adGetADMaterialProperty<Real>("density_name"))
+    _specific_heat(getADMaterialProperty<Real>("specific_heat")),
+    _density(getADMaterialProperty<Real>("density_name"))
 {
 }
 

--- a/modules/heat_conduction/src/kernels/ADMatHeatSource.C
+++ b/modules/heat_conduction/src/kernels/ADMatHeatSource.C
@@ -22,8 +22,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADMatHeatSource<compute_stage>::ADMatHeatSource(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
-    _scalar(adGetParam<Real>("scalar")),
-    _material_property(adGetADMaterialProperty<Real>("material_property"))
+    _scalar(getParam<Real>("scalar")),
+    _material_property(getADMaterialProperty<Real>("material_property"))
 {
 }
 

--- a/modules/heat_conduction/test/src/materials/ADThermalConductivityTest.C
+++ b/modules/heat_conduction/test/src/materials/ADThermalConductivityTest.C
@@ -22,7 +22,7 @@ template <ComputeStage compute_stage>
 ADThermalConductivityTest<compute_stage>::ADThermalConductivityTest(
     const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _diffusivity(adDeclareADProperty<Real>("thermal_conductivity")),
+    _diffusivity(declareADProperty<Real>("thermal_conductivity")),
     _temperature(adCoupledValue("temperature")),
     _c(adCoupledValue("c"))
 {

--- a/modules/misc/src/kernels/ADMatDiffusion.C
+++ b/modules/misc/src/kernels/ADMatDiffusion.C
@@ -20,8 +20,7 @@ defineADValidParams(ADMatDiffusion,
 
 template <ComputeStage compute_stage>
 ADMatDiffusion<compute_stage>::ADMatDiffusion(const InputParameters & parameters)
-  : ADDiffusion<compute_stage>(parameters),
-    _diffusivity(adGetADMaterialProperty<Real>("diffusivity"))
+  : ADDiffusion<compute_stage>(parameters), _diffusivity(getADMaterialProperty<Real>("diffusivity"))
 {
 }
 

--- a/modules/misc/src/kernels/ADThermoDiffusion.C
+++ b/modules/misc/src/kernels/ADThermoDiffusion.C
@@ -25,7 +25,7 @@ template <ComputeStage compute_stage>
 ADThermoDiffusion<compute_stage>::ADThermoDiffusion(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
     _grad_temp(adCoupledGradient("temperature")),
-    _soret_coeff(adGetADMaterialProperty<Real>("soret_coefficient"))
+    _soret_coeff(getADMaterialProperty<Real>("soret_coefficient"))
 {
 }
 

--- a/modules/misc/src/materials/ADDensity.C
+++ b/modules/misc/src/materials/ADDensity.C
@@ -23,8 +23,8 @@ ADDensity<compute_stage>::ADDensity(const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
     _coord_system(getBlockCoordSystem()),
     _disp_r(adCoupledValue("displacements", 0)),
-    _initial_density(adGetParam<Real>("density")),
-    _density(adDeclareADProperty<Real>("density"))
+    _initial_density(getParam<Real>("density")),
+    _density(declareADProperty<Real>("density"))
 {
   // get coupled gradients
   const unsigned int ndisp = coupledComponents("displacements");

--- a/modules/misc/test/src/materials/ADSoretCoeffTest.C
+++ b/modules/misc/test/src/materials/ADSoretCoeffTest.C
@@ -20,7 +20,7 @@ ADSoretCoeffTest<compute_stage>::ADSoretCoeffTest(const InputParameters & parame
   : ADMaterial<compute_stage>(parameters),
     _coupled_var(adCoupledValue("coupled_var")),
     _temp(adCoupledValue("temperature")),
-    _soret_coeff(adDeclareADProperty<Real>("soret_coefficient"))
+    _soret_coeff(declareADProperty<Real>("soret_coefficient"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMass.C
+++ b/modules/navier_stokes/src/kernels/INSADMass.C
@@ -22,7 +22,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 INSADMass<compute_stage>::INSADMass(const InputParameters & parameters)
   : ADKernelValue<compute_stage>(parameters),
-    _mass_strong_residual(adGetADMaterialProperty<Real>("mass_strong_residual"))
+    _mass_strong_residual(getADMaterialProperty<Real>("mass_strong_residual"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMassPSPG.C
+++ b/modules/navier_stokes/src/kernels/INSADMassPSPG.C
@@ -23,9 +23,9 @@ defineADValidParams(INSADMassPSPG,
 template <ComputeStage compute_stage>
 INSADMassPSPG<compute_stage>::INSADMassPSPG(const InputParameters & parameters)
   : ADKernelGrad<compute_stage>(parameters),
-    _rho(adGetADMaterialProperty<Real>("rho_name")),
-    _tau(adGetADMaterialProperty<Real>("tau")),
-    _momentum_strong_residual(adGetADMaterialProperty<RealVectorValue>("momentum_strong_residual"))
+    _rho(getADMaterialProperty<Real>("rho_name")),
+    _tau(getADMaterialProperty<Real>("tau")),
+    _momentum_strong_residual(getADMaterialProperty<RealVectorValue>("momentum_strong_residual"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMomentumAdvection.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumAdvection.C
@@ -20,7 +20,7 @@ template <ComputeStage compute_stage>
 INSADMomentumAdvection<compute_stage>::INSADMomentumAdvection(const InputParameters & parameters)
   : ADVectorKernelValue<compute_stage>(parameters),
     _convective_strong_residual(
-        adGetADMaterialProperty<RealVectorValue>("convective_strong_residual"))
+        getADMaterialProperty<RealVectorValue>("convective_strong_residual"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMomentumForces.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumForces.C
@@ -18,9 +18,9 @@ defineADValidParams(INSADMomentumForces,
 template <ComputeStage compute_stage>
 INSADMomentumForces<compute_stage>::INSADMomentumForces(const InputParameters & parameters)
   : ADVectorKernelValue<compute_stage>(parameters),
-    _gravity_strong_residual(adGetADMaterialProperty<RealVectorValue>("gravity_strong_residual")),
+    _gravity_strong_residual(getADMaterialProperty<RealVectorValue>("gravity_strong_residual")),
     _mms_function_strong_residual(
-        adGetADMaterialProperty<RealVectorValue>("mms_function_strong_residual"))
+        getADMaterialProperty<RealVectorValue>("mms_function_strong_residual"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMomentumPressure.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumPressure.C
@@ -23,7 +23,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 INSADMomentumPressure<compute_stage>::INSADMomentumPressure(const InputParameters & parameters)
   : ADVectorKernel<compute_stage>(parameters),
-    _integrate_p_by_parts(adGetParam<bool>("integrate_p_by_parts")),
+    _integrate_p_by_parts(getParam<bool>("integrate_p_by_parts")),
     _p(adCoupledValue("p")),
     _grad_p(adCoupledGradient("p"))
 {

--- a/modules/navier_stokes/src/kernels/INSADMomentumSUPG.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumSUPG.C
@@ -19,7 +19,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 INSADMomentumSUPG<compute_stage>::INSADMomentumSUPG(const InputParameters & parameters)
   : ADVectorKernelSUPG<compute_stage>(parameters),
-    _momentum_strong_residual(adGetADMaterialProperty<RealVectorValue>("momentum_strong_residual"))
+    _momentum_strong_residual(getADMaterialProperty<RealVectorValue>("momentum_strong_residual"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMomentumTimeDerivative.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumTimeDerivative.C
@@ -26,7 +26,7 @@ template <ComputeStage compute_stage>
 INSADMomentumTimeDerivative<compute_stage>::INSADMomentumTimeDerivative(
     const InputParameters & parameters)
   : ADVectorTimeKernelValue<compute_stage>(parameters),
-    _rho(adGetADMaterialProperty<Real>("rho_name"))
+    _rho(getADMaterialProperty<Real>("rho_name"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADMomentumViscous.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumViscous.C
@@ -21,7 +21,7 @@ defineADValidParams(
 
 template <ComputeStage compute_stage>
 INSADMomentumViscous<compute_stage>::INSADMomentumViscous(const InputParameters & parameters)
-  : ADVectorKernelGrad<compute_stage>(parameters), _mu(adGetADMaterialProperty<Real>("mu_name"))
+  : ADVectorKernelGrad<compute_stage>(parameters), _mu(getADMaterialProperty<Real>("mu_name"))
 {
 }
 

--- a/modules/navier_stokes/src/kernels/INSADTemperatureAdvection.C
+++ b/modules/navier_stokes/src/kernels/INSADTemperatureAdvection.C
@@ -26,8 +26,8 @@ template <ComputeStage compute_stage>
 INSADTemperatureAdvection<compute_stage>::INSADTemperatureAdvection(
     const InputParameters & parameters)
   : ADKernelValue<compute_stage>(parameters),
-    _rho(adGetADMaterialProperty<Real>("rho_name")),
-    _cp(adGetADMaterialProperty<Real>("cp_name")),
+    _rho(getADMaterialProperty<Real>("rho_name")),
+    _cp(getADMaterialProperty<Real>("cp_name")),
     _U(adCoupledVectorValue("velocity"))
 {
 }
@@ -59,8 +59,8 @@ template <ComputeStage compute_stage>
 INSADTemperatureAdvectionSUPG<compute_stage>::INSADTemperatureAdvectionSUPG(
     const InputParameters & parameters)
   : ADKernelSUPG<compute_stage>(parameters),
-    _rho(adGetADMaterialProperty<Real>("rho_name")),
-    _cp(adGetADMaterialProperty<Real>("cp_name")),
+    _rho(getADMaterialProperty<Real>("rho_name")),
+    _cp(getADMaterialProperty<Real>("cp_name")),
     _U(adCoupledVectorValue("velocity"))
 {
 }

--- a/modules/navier_stokes/src/materials/INSADMaterial.C
+++ b/modules/navier_stokes/src/materials/INSADMaterial.C
@@ -43,19 +43,18 @@ INSADMaterial<compute_stage>::INSADMaterial(const InputParameters & parameters)
     _velocity(adCoupledVectorValue("velocity")),
     _grad_velocity(adCoupledVectorGradient("velocity")),
     _grad_p(adCoupledGradient("pressure")),
-    _mu(adGetADMaterialProperty<Real>("mu_name")),
-    _rho(adGetADMaterialProperty<Real>("rho_name")),
-    _transient_term(adGetParam<bool>("transient_term")),
+    _mu(getADMaterialProperty<Real>("mu_name")),
+    _rho(getADMaterialProperty<Real>("rho_name")),
+    _transient_term(getParam<bool>("transient_term")),
     _velocity_dot(_transient_term ? &adCoupledVectorDot("velocity") : nullptr),
-    _integrate_p_by_parts(adGetParam<bool>("integrate_p_by_parts")),
-    _include_viscous_term_in_strong_form(adGetParam<bool>("include_viscous_term_in_strong_form")),
-    _mass_strong_residual(adDeclareADProperty<Real>("mass_strong_residual")),
-    _convective_strong_residual(adDeclareADProperty<RealVectorValue>("convective_strong_residual")),
-    _td_strong_residual(adDeclareADProperty<RealVectorValue>("td_strong_residual")),
-    _gravity_strong_residual(adDeclareADProperty<RealVectorValue>("gravity_strong_residual")),
-    _mms_function_strong_residual(
-        adDeclareProperty<RealVectorValue>("mms_function_strong_residual")),
-    _momentum_strong_residual(adDeclareADProperty<RealVectorValue>("momentum_strong_residual")),
+    _integrate_p_by_parts(getParam<bool>("integrate_p_by_parts")),
+    _include_viscous_term_in_strong_form(getParam<bool>("include_viscous_term_in_strong_form")),
+    _mass_strong_residual(declareADProperty<Real>("mass_strong_residual")),
+    _convective_strong_residual(declareADProperty<RealVectorValue>("convective_strong_residual")),
+    _td_strong_residual(declareADProperty<RealVectorValue>("td_strong_residual")),
+    _gravity_strong_residual(declareADProperty<RealVectorValue>("gravity_strong_residual")),
+    _mms_function_strong_residual(declareProperty<RealVectorValue>("mms_function_strong_residual")),
+    _momentum_strong_residual(declareADProperty<RealVectorValue>("momentum_strong_residual")),
     _x_vel_fn(getFunction("function_x")),
     _y_vel_fn(getFunction("function_y")),
     _z_vel_fn(getFunction("function_z"))
@@ -63,11 +62,11 @@ INSADMaterial<compute_stage>::INSADMaterial(const InputParameters & parameters)
   if (parameters.isParamSetByUser("gravity"))
   {
     _gravity_set = true;
-    _gravity = adGetParam<RealVectorValue>("gravity");
+    _gravity = getParam<RealVectorValue>("gravity");
   }
   else
     _gravity_set = false;
-  if (adGetParam<bool>("include_viscous_term_in_strong_form"))
+  if (getParam<bool>("include_viscous_term_in_strong_form"))
     mooseError("Sorry no TypeNTensor operations are currently implemented, so we cannot add the "
                "strong form contribution of the viscous term. Note that for linear elements, this "
                "introduces no error, and in general for bi-linear elements, the error is small");

--- a/modules/navier_stokes/src/materials/INSADTauMaterial.C
+++ b/modules/navier_stokes/src/materials/INSADTauMaterial.C
@@ -25,8 +25,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 INSADTauMaterial<compute_stage>::INSADTauMaterial(const InputParameters & parameters)
   : INSADMaterial<compute_stage>(parameters),
-    _alpha(adGetParam<Real>("alpha")),
-    _tau(adDeclareADProperty<Real>("tau"))
+    _alpha(getParam<Real>("alpha")),
+    _tau(declareADProperty<Real>("tau"))
 {
 }
 

--- a/modules/phase_field/include/kernels/ADAllenCahnBase.h
+++ b/modules/phase_field/include/kernels/ADAllenCahnBase.h
@@ -55,7 +55,7 @@ template <ComputeStage compute_stage, typename T>
 ADAllenCahnBase<compute_stage, T>::ADAllenCahnBase(const InputParameters & parameters)
   : ADKernelValue<compute_stage>(parameters),
     DerivativeMaterialPropertyNameInterface(),
-    _prop_L(adGetADMaterialProperty<T>("mob_name"))
+    _prop_L(getADMaterialProperty<T>("mob_name"))
 {
 }
 
@@ -65,4 +65,3 @@ ADAllenCahnBase<compute_stage, T>::precomputeQpResidual()
 {
   return _prop_L[_qp] * computeDFDOP();
 }
-

--- a/modules/phase_field/include/kernels/ADSplitCHWResBase.h
+++ b/modules/phase_field/include/kernels/ADSplitCHWResBase.h
@@ -46,8 +46,8 @@ protected:
 template <ComputeStage compute_stage, typename T>
 ADSplitCHWResBase<compute_stage, T>::ADSplitCHWResBase(const InputParameters & parameters)
   : ADKernelGrad<compute_stage>(parameters),
-    _mob_name(adGetParam<MaterialPropertyName>("mob_name")),
-    _mob(adGetADMaterialProperty<T>("mob_name"))
+    _mob_name(getParam<MaterialPropertyName>("mob_name")),
+    _mob(getADMaterialProperty<T>("mob_name"))
 {
 }
 
@@ -57,4 +57,3 @@ ADSplitCHWResBase<compute_stage, T>::precomputeQpResidual()
 {
   return _mob[_qp] * _grad_u[_qp];
 }
-

--- a/modules/phase_field/src/kernels/ADACInterface.C
+++ b/modules/phase_field/src/kernels/ADACInterface.C
@@ -27,12 +27,12 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADACInterface<compute_stage>::ADACInterface(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
-    _prop_L(adGetADMaterialProperty<Real>("mob_name")),
-    _name_L(adGetParam<MaterialPropertyName>("mob_name")),
-    _kappa(adGetADMaterialProperty<Real>("kappa_name")),
-    _variable_L(adGetParam<bool>("variable_L")),
+    _prop_L(getADMaterialProperty<Real>("mob_name")),
+    _name_L(getParam<MaterialPropertyName>("mob_name")),
+    _kappa(getADMaterialProperty<Real>("kappa_name")),
+    _variable_L(getParam<bool>("variable_L")),
     _dLdop(_variable_L
-               ? &adGetADMaterialProperty<Real>(derivativePropertyNameFirst(_name_L, _var.name()))
+               ? &getADMaterialProperty<Real>(derivativePropertyNameFirst(_name_L, _var.name()))
                : nullptr),
     _nvar(Coupleable::_coupled_standard_moose_vars.size()),
     _dLdarg(_nvar),
@@ -48,7 +48,7 @@ ADACInterface<compute_stage>::ADACInterface(const InputParameters & parameters)
         paramError("args",
                    "The kernel variable should not be specified in the coupled `args` parameter.");
 
-      _dLdarg[i] = &adGetADMaterialProperty<Real>(derivativePropertyNameFirst(_name_L, iname));
+      _dLdarg[i] = &getADMaterialProperty<Real>(derivativePropertyNameFirst(_name_L, iname));
       _gradarg[i] = &(ivar->adGradSln<compute_stage>());
     }
 }

--- a/modules/phase_field/src/kernels/ADAllenCahn.C
+++ b/modules/phase_field/src/kernels/ADAllenCahn.C
@@ -22,8 +22,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADAllenCahn<compute_stage>::ADAllenCahn(const InputParameters & parameters)
   : ADAllenCahnBase<compute_stage, Real>(parameters),
-    _f_name(adGetParam<MaterialPropertyName>("f_name")),
-    _dFdEta(adGetADMaterialProperty<Real>(this->derivativePropertyNameFirst(_f_name, _var.name())))
+    _f_name(getParam<MaterialPropertyName>("f_name")),
+    _dFdEta(getADMaterialProperty<Real>(this->derivativePropertyNameFirst(_f_name, _var.name())))
 {
 }
 

--- a/modules/phase_field/src/kernels/ADMatReaction.C
+++ b/modules/phase_field/src/kernels/ADMatReaction.C
@@ -26,7 +26,7 @@ template <ComputeStage compute_stage>
 ADMatReaction<compute_stage>::ADMatReaction(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
     _v(isCoupled("v") ? adCoupledValue("v") : _u),
-    _mob(adGetADMaterialProperty<Real>("mob_name"))
+    _mob(getADMaterialProperty<Real>("mob_name"))
 {
 }
 

--- a/modules/phase_field/src/kernels/ADSplitCHCRes.C
+++ b/modules/phase_field/src/kernels/ADSplitCHCRes.C
@@ -19,7 +19,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADSplitCHCRes<compute_stage>::ADSplitCHCRes(const InputParameters & parameters)
   : ADSplitCHBase<compute_stage>(parameters),
-    _kappa(adGetADMaterialProperty<Real>("kappa_name")),
+    _kappa(getADMaterialProperty<Real>("kappa_name")),
     _w(adCoupledValue("w"))
 {
 }

--- a/modules/phase_field/src/kernels/ADSplitCHParsed.C
+++ b/modules/phase_field/src/kernels/ADSplitCHParsed.C
@@ -23,8 +23,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADSplitCHParsed<compute_stage>::ADSplitCHParsed(const InputParameters & parameters)
   : ADSplitCHCRes<compute_stage>(parameters),
-    _f_name(adGetParam<MaterialPropertyName>("f_name")),
-    _dFdc(adGetADMaterialProperty<Real>(derivativePropertyNameFirst(_f_name, _var.name())))
+    _f_name(getParam<MaterialPropertyName>("f_name")),
+    _dFdc(getADMaterialProperty<Real>(derivativePropertyNameFirst(_f_name, _var.name())))
 {
 }
 

--- a/modules/phase_field/src/materials/ADMathFreeEnergy.C
+++ b/modules/phase_field/src/materials/ADMathFreeEnergy.C
@@ -23,10 +23,10 @@ template <ComputeStage compute_stage>
 ADMathFreeEnergy<compute_stage>::ADMathFreeEnergy(const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
     _c(adCoupledValue("c")),
-    _f_name(adGetParam<MaterialPropertyName>("f_name")),
-    _prop_F(adDeclareADProperty<Real>(_f_name)),
-    _prop_dFdc(adDeclareADProperty<Real>(
-        derivativePropertyNameFirst(_f_name, this->getVar("c", 0)->name())))
+    _f_name(getParam<MaterialPropertyName>("f_name")),
+    _prop_F(declareADProperty<Real>(_f_name)),
+    _prop_dFdc(
+        declareADProperty<Real>(derivativePropertyNameFirst(_f_name, this->getVar("c", 0)->name())))
 {
 }
 

--- a/modules/phase_field/test/src/materials/ADTestDerivativeFunction.C
+++ b/modules/phase_field/test/src/materials/ADTestDerivativeFunction.C
@@ -29,16 +29,16 @@ template <ComputeStage compute_stage>
 ADTestDerivativeFunction<compute_stage>::ADTestDerivativeFunction(
     const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _function(adGetParam<MooseEnum>("function").template getEnum<FunctionEnum>()),
+    _function(getParam<MooseEnum>("function").template getEnum<FunctionEnum>()),
     _op(coupledComponents("op")),
-    _f_name(adGetParam<MaterialPropertyName>("f_name")),
-    _prop_F(adDeclareADProperty<Real>(_f_name)),
+    _f_name(getParam<MaterialPropertyName>("f_name")),
+    _prop_F(declareADProperty<Real>(_f_name)),
     _prop_dFdop(coupledComponents("op"))
 {
   for (std::size_t i = 0; i < _op.size(); ++i)
   {
     _op[i] = &adCoupledValue("op", i);
-    _prop_dFdop[i] = &adDeclareADProperty<Real>(
+    _prop_dFdop[i] = &declareADProperty<Real>(
         derivativePropertyNameFirst(_f_name, this->getVar("op", i)->name()));
   }
 

--- a/modules/porous_flow/src/materials/PorousFlowBrine.C
+++ b/modules/porous_flow/src/materials/PorousFlowBrine.C
@@ -130,7 +130,7 @@ PorousFlowBrine::PorousFlowBrine(const InputParameters & parameters)
     InputParameters params = _app.getFactory().getValidParams(class_name);
     _fe_problem.addUserObject(class_name, brine_name, params);
   }
-  _brine_fp = &_fe_problem.getUserObject<BrineFluidProperties>(brine_name);
+  _brine_fp = &_fe_problem.getUserObjectTempl<BrineFluidProperties>(brine_name);
 
   // Water properties UserObject
   _water_fp = &_brine_fp->getComponent(BrineFluidProperties::WATER);

--- a/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
+++ b/modules/solid_mechanics/src/materials/AxisymmetricRZ.C
@@ -22,10 +22,10 @@ AxisymmetricRZ::AxisymmetricRZ(SolidModel & solid_model,
   : Element(solid_model, name, parameters),
     _disp_r(coupledValue("disp_r")),
     _disp_z(coupledValue("disp_z")),
-    _large_strain(solid_model.getParam<bool>("large_strain")),
+    _large_strain(solid_model.getParamTempl<bool>("large_strain")),
     _grad_disp_r(coupledGradient("disp_r")),
     _grad_disp_z(coupledGradient("disp_z")),
-    _volumetric_locking_correction(solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
 }
 
@@ -75,11 +75,13 @@ AxisymmetricRZ::computeStrain(const unsigned qp,
 
       if (_large_strain)
       {
-        volumetric_strain += 0.5 * (_grad_disp_r[qp_loop](0) * _grad_disp_r[qp_loop](0) +
-                                    _grad_disp_z[qp_loop](0) * _grad_disp_z[qp_loop](0)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_r[qp_loop](0) * _grad_disp_r[qp_loop](0) +
+                              _grad_disp_z[qp_loop](0) * _grad_disp_z[qp_loop](0)) /
                              dim * _solid_model.JxW(qp_loop) * _solid_model.q_point(qp_loop)(0);
-        volumetric_strain += 0.5 * (_grad_disp_r[qp_loop](1) * _grad_disp_r[qp_loop](1) +
-                                    _grad_disp_z[qp_loop](1) * _grad_disp_z[qp_loop](1)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_r[qp_loop](1) * _grad_disp_r[qp_loop](1) +
+                              _grad_disp_z[qp_loop](1) * _grad_disp_z[qp_loop](1)) /
                              dim * _solid_model.JxW(qp_loop) * _solid_model.q_point(qp_loop)(0);
       }
     }

--- a/modules/solid_mechanics/src/materials/Linear.C
+++ b/modules/solid_mechanics/src/materials/Linear.C
@@ -20,13 +20,13 @@ Linear::Linear(SolidModel & solid_model,
                const std::string & name,
                const InputParameters & parameters)
   : Element(solid_model, name, parameters),
-    _large_strain(solid_model.getParam<bool>("large_strain")),
+    _large_strain(solid_model.getParamTempl<bool>("large_strain")),
     _grad_disp_x(coupledGradient("disp_x")),
     _grad_disp_y(coupledGradient("disp_y")),
     _grad_disp_z(parameters.get<SubProblem *>("_subproblem")->mesh().dimension() == 3
                      ? coupledGradient("disp_z")
                      : _grad_zero),
-    _volumetric_locking_correction(solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
 }
 
@@ -81,17 +81,20 @@ Linear::computeStrain(const unsigned qp,
 
       if (_large_strain)
       {
-        volumetric_strain += 0.5 * (_grad_disp_x[qp_loop](0) * _grad_disp_x[qp_loop](0) +
-                                    _grad_disp_y[qp_loop](0) * _grad_disp_y[qp_loop](0) +
-                                    _grad_disp_z[qp_loop](0) * _grad_disp_z[qp_loop](0)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_x[qp_loop](0) * _grad_disp_x[qp_loop](0) +
+                              _grad_disp_y[qp_loop](0) * _grad_disp_y[qp_loop](0) +
+                              _grad_disp_z[qp_loop](0) * _grad_disp_z[qp_loop](0)) /
                              3.0 * _solid_model.JxW(qp_loop);
-        volumetric_strain += 0.5 * (_grad_disp_x[qp_loop](1) * _grad_disp_x[qp_loop](1) +
-                                    _grad_disp_y[qp_loop](1) * _grad_disp_y[qp_loop](1) +
-                                    _grad_disp_z[qp_loop](1) * _grad_disp_z[qp_loop](1)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_x[qp_loop](1) * _grad_disp_x[qp_loop](1) +
+                              _grad_disp_y[qp_loop](1) * _grad_disp_y[qp_loop](1) +
+                              _grad_disp_z[qp_loop](1) * _grad_disp_z[qp_loop](1)) /
                              3.0 * _solid_model.JxW(qp_loop);
-        volumetric_strain += 0.5 * (_grad_disp_x[qp_loop](2) * _grad_disp_x[qp_loop](2) +
-                                    _grad_disp_y[qp_loop](2) * _grad_disp_y[qp_loop](2) +
-                                    _grad_disp_z[qp_loop](2) * _grad_disp_z[qp_loop](2)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_x[qp_loop](2) * _grad_disp_x[qp_loop](2) +
+                              _grad_disp_y[qp_loop](2) * _grad_disp_y[qp_loop](2) +
+                              _grad_disp_z[qp_loop](2) * _grad_disp_z[qp_loop](2)) /
                              3.0 * _solid_model.JxW(qp_loop);
       }
     }

--- a/modules/solid_mechanics/src/materials/Nonlinear.C
+++ b/modules/solid_mechanics/src/materials/Nonlinear.C
@@ -26,7 +26,8 @@ Nonlinear::Nonlinear(SolidModel & solid_model,
     _Uhat(3, 3)
 {
 
-  std::string increment_calculation = solid_model.getParam<std::string>("increment_calculation");
+  std::string increment_calculation =
+      solid_model.getParamTempl<std::string>("increment_calculation");
   std::transform(increment_calculation.begin(),
                  increment_calculation.end(),
                  increment_calculation.begin(),

--- a/modules/solid_mechanics/src/materials/Nonlinear3D.C
+++ b/modules/solid_mechanics/src/materials/Nonlinear3D.C
@@ -27,7 +27,8 @@ Nonlinear3D::Nonlinear3D(SolidModel & solid_model,
     _grad_disp_x_old(coupledGradientOld("disp_x")),
     _grad_disp_y_old(coupledGradientOld("disp_y")),
     _grad_disp_z_old(coupledGradientOld("disp_z")),
-    _volumetric_locking_correction(_solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(
+        _solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
 }
 

--- a/modules/solid_mechanics/src/materials/NonlinearPlaneStrain.C
+++ b/modules/solid_mechanics/src/materials/NonlinearPlaneStrain.C
@@ -33,7 +33,8 @@ NonlinearPlaneStrain::NonlinearPlaneStrain(SolidModel & solid_model,
     _strain_zz_old(_have_strain_zz ? coupledValueOld("strain_zz") : _zero),
     _scalar_strain_zz_old(_have_scalar_strain_zz ? coupledScalarValueOld("scalar_strain_zz")
                                                  : _zero),
-    _volumetric_locking_correction(_solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(
+        _solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
 }
 

--- a/modules/solid_mechanics/src/materials/NonlinearRZ.C
+++ b/modules/solid_mechanics/src/materials/NonlinearRZ.C
@@ -27,7 +27,8 @@ NonlinearRZ::NonlinearRZ(SolidModel & solid_model,
     _grad_disp_z_old(coupledGradientOld("disp_z")),
     _disp_r(coupledValue("disp_r")),
     _disp_r_old(coupledValueOld("disp_r")),
-    _volumetric_locking_correction(_solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(
+        _solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
 }
 

--- a/modules/solid_mechanics/src/materials/PlaneStrain.C
+++ b/modules/solid_mechanics/src/materials/PlaneStrain.C
@@ -19,14 +19,14 @@ PlaneStrain::PlaneStrain(SolidModel & solid_model,
                          const InputParameters & parameters)
   : Element(solid_model, name, parameters),
     ScalarCoupleable(&solid_model),
-    _large_strain(solid_model.getParam<bool>("large_strain")),
+    _large_strain(solid_model.getParamTempl<bool>("large_strain")),
     _grad_disp_x(coupledGradient("disp_x")),
     _grad_disp_y(coupledGradient("disp_y")),
     _have_strain_zz(isCoupled("strain_zz")),
     _strain_zz(_have_strain_zz ? coupledValue("strain_zz") : _zero),
     _have_scalar_strain_zz(isCoupledScalar("scalar_strain_zz")),
     _scalar_strain_zz(_have_scalar_strain_zz ? coupledScalarValue("scalar_strain_zz") : _zero),
-    _volumetric_locking_correction(solid_model.getParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(solid_model.getParamTempl<bool>("volumetric_locking_correction"))
 {
   if (_have_strain_zz && _have_scalar_strain_zz)
     mooseError("Must define only one of strain_zz or scalar_strain_zz");
@@ -87,11 +87,13 @@ PlaneStrain::computeStrain(const unsigned qp,
 
       if (_large_strain)
       {
-        volumetric_strain += 0.5 * (_grad_disp_x[qp_loop](0) * _grad_disp_x[qp_loop](0) +
-                                    _grad_disp_y[qp_loop](0) * _grad_disp_y[qp_loop](0)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_x[qp_loop](0) * _grad_disp_x[qp_loop](0) +
+                              _grad_disp_y[qp_loop](0) * _grad_disp_y[qp_loop](0)) /
                              dim * _solid_model.JxW(qp_loop);
-        volumetric_strain += 0.5 * (_grad_disp_x[qp_loop](1) * _grad_disp_x[qp_loop](1) +
-                                    _grad_disp_y[qp_loop](1) * _grad_disp_y[qp_loop](1)) /
+        volumetric_strain += 0.5 *
+                             (_grad_disp_x[qp_loop](1) * _grad_disp_x[qp_loop](1) +
+                              _grad_disp_y[qp_loop](1) * _grad_disp_y[qp_loop](1)) /
                              dim * _solid_model.JxW(qp_loop);
       }
     }

--- a/modules/solid_mechanics/src/materials/SphericalR.C
+++ b/modules/solid_mechanics/src/materials/SphericalR.C
@@ -20,7 +20,7 @@ SphericalR::SphericalR(SolidModel & solid_model,
                        const InputParameters & parameters)
   : Element(solid_model, name, parameters),
     _disp_r(coupledValue("disp_r")),
-    _large_strain(solid_model.getParam<bool>("large_strain")),
+    _large_strain(solid_model.getParamTempl<bool>("large_strain")),
     _grad_disp_r(coupledGradient("disp_r"))
 {
 }

--- a/modules/stochastic_tools/src/controls/MultiAppCommandLineControl.C
+++ b/modules/stochastic_tools/src/controls/MultiAppCommandLineControl.C
@@ -45,7 +45,7 @@ MultiAppCommandLineControl::MultiAppCommandLineControl(const InputParameters & p
     _sampler(SamplerInterface::getSampler("sampler")),
     _param_names(getParam<std::vector<std::string>>("param_names"))
 {
-  if (!_sampler.getParam<ExecFlagEnum>("execute_on").contains(EXEC_PRE_MULTIAPP_SETUP))
+  if (!_sampler.getParamTempl<ExecFlagEnum>("execute_on").contains(EXEC_PRE_MULTIAPP_SETUP))
     _sampler.paramError(
         "execute_on",
         "The sampler object, '",
@@ -55,9 +55,9 @@ MultiAppCommandLineControl::MultiAppCommandLineControl(const InputParameters & p
         "' object, thus the 'execute_on' of the sampler must include 'PRE_MULTIAPP_SETUP'.");
 
   bool batch_reset = _multi_app->isParamValid("mode") &&
-                     (_multi_app->getParam<MooseEnum>("mode") == "batch-reset");
+                     (_multi_app->getParamTempl<MooseEnum>("mode") == "batch-reset");
   bool batch_restore = _multi_app->isParamValid("mode") &&
-                       (_multi_app->getParam<MooseEnum>("mode") == "batch-restore");
+                       (_multi_app->getParamTempl<MooseEnum>("mode") == "batch-restore");
   if (batch_reset)
     ; // Do not perform the App count test, because in batch mode there is only one
 

--- a/modules/stochastic_tools/src/transfers/SamplerPostprocessorTransfer.C
+++ b/modules/stochastic_tools/src/transfers/SamplerPostprocessorTransfer.C
@@ -58,7 +58,7 @@ SamplerPostprocessorTransfer::SamplerPostprocessorTransfer(const InputParameters
 void
 SamplerPostprocessorTransfer::initialSetup()
 {
-  auto & uo = _fe_problem.getUserObject<UserObject>(_master_vpp_name);
+  auto & uo = _fe_problem.getUserObjectTempl<UserObject>(_master_vpp_name);
   _results = dynamic_cast<StochasticResults *>(&uo);
 
   if (!_results)

--- a/modules/stochastic_tools/src/transfers/StochasticToolsTransfer.C
+++ b/modules/stochastic_tools/src/transfers/StochasticToolsTransfer.C
@@ -27,8 +27,8 @@ StochasticToolsTransfer::StochasticToolsTransfer(const InputParameters & paramet
   // running the execute flags must be removed. This is done automatically here, unless
   // 'execute_on' was modified by the user, which an error is produced.
   if (_multi_app->isParamValid("mode") &&
-      (_multi_app->getParam<MooseEnum>("mode") == "batch-reset" ||
-       _multi_app->getParam<MooseEnum>("mode") == "batch-restore"))
+      (_multi_app->getParamTempl<MooseEnum>("mode") == "batch-reset" ||
+       _multi_app->getParamTempl<MooseEnum>("mode") == "batch-restore"))
   {
     if (parameters.isParamSetByUser("execute_on"))
       paramError("execute_on",

--- a/modules/tensor_mechanics/src/bcs/ADPressure.C
+++ b/modules/tensor_mechanics/src/bcs/ADPressure.C
@@ -30,12 +30,12 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADPressure<compute_stage>::ADPressure(const InputParameters & parameters)
   : ADIntegratedBC<compute_stage>(parameters),
-    _component(adGetParam<unsigned int>("component")),
-    _constant(adGetParam<Real>("constant")),
+    _component(getParam<unsigned int>("component")),
+    _constant(getParam<Real>("constant")),
     _function(isParamValid("function") ? &this->getFunction("function") : nullptr),
     _postprocessor(isParamValid("postprocessor") ? &this->getPostprocessorValue("postprocessor")
                                                  : nullptr),
-    _alpha(adGetParam<Real>("alpha"))
+    _alpha(getParam<Real>("alpha"))
 {
 }
 

--- a/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/ADDynamicStressDivergenceTensors.C
@@ -34,11 +34,11 @@ template <ComputeStage compute_stage>
 ADDynamicStressDivergenceTensors<compute_stage>::ADDynamicStressDivergenceTensors(
     const InputParameters & parameters)
   : ADStressDivergenceTensors<compute_stage>(parameters),
-    _stress_older(adGetMaterialPropertyOlder<RankTwoTensor>(_base_name + "stress")),
-    _stress_old(adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
-    _zeta(adGetMaterialProperty<Real>("zeta")),
-    _alpha(adGetParam<Real>("alpha")),
-    _static_initialization(adGetParam<bool>("static_initialization"))
+    _stress_older(getMaterialPropertyOlder<RankTwoTensor>(_base_name + "stress")),
+    _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
+    _zeta(getMaterialProperty<Real>("zeta")),
+    _alpha(getParam<Real>("alpha")),
+    _static_initialization(getParam<bool>("static_initialization"))
 {
 }
 

--- a/modules/tensor_mechanics/src/kernels/ADGravity.C
+++ b/modules/tensor_mechanics/src/kernels/ADGravity.C
@@ -28,9 +28,9 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADGravity<compute_stage>::ADGravity(const InputParameters & parameters)
   : ADKernelValue<compute_stage>(parameters),
-    _density(adGetADMaterialProperty<Real>("density")),
-    _value(adGetParam<Real>("value")),
-    _alpha(adGetParam<Real>("alpha"))
+    _density(getADMaterialProperty<Real>("density")),
+    _value(getParam<Real>("value")),
+    _alpha(getParam<Real>("alpha"))
 {
 }
 

--- a/modules/tensor_mechanics/src/kernels/ADStressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/ADStressDivergenceTensors.C
@@ -34,13 +34,13 @@ template <ComputeStage compute_stage>
 ADStressDivergenceTensors<compute_stage>::ADStressDivergenceTensors(
     const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : ""),
-    _stress(adGetADMaterialProperty<RankTwoTensor>(_base_name + "stress")),
-    _component(adGetParam<unsigned int>("component")),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _stress(getADMaterialProperty<RankTwoTensor>(_base_name + "stress")),
+    _component(getParam<unsigned int>("component")),
     _ndisp(coupledComponents("displacements")),
     _disp_var(_ndisp),
     _avg_grad_test(),
-    _volumetric_locking_correction(adGetParam<bool>("volumetric_locking_correction"))
+    _volumetric_locking_correction(getParam<bool>("volumetric_locking_correction"))
 {
   for (unsigned int i = 0; i < _ndisp; ++i)
     // the next line should be _disp_var[i] = coupled("displacements", i);

--- a/modules/tensor_mechanics/src/materials/ADCompute2DFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DFiniteStrain.C
@@ -25,7 +25,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADCompute2DFiniteStrain<compute_stage>::ADCompute2DFiniteStrain(const InputParameters & parameters)
   : ADComputeFiniteStrain<compute_stage>(parameters),
-    _out_of_plane_direction(adGetParam<MooseEnum>("out_of_plane_direction"))
+    _out_of_plane_direction(getParam<MooseEnum>("out_of_plane_direction"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADCompute2DIncrementalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DIncrementalStrain.C
@@ -26,7 +26,7 @@ template <ComputeStage compute_stage>
 ADCompute2DIncrementalStrain<compute_stage>::ADCompute2DIncrementalStrain(
     const InputParameters & parameters)
   : ADComputeIncrementalSmallStrain<compute_stage>(parameters),
-    _out_of_plane_direction(adGetParam<MooseEnum>("out_of_plane_direction"))
+    _out_of_plane_direction(getParam<MooseEnum>("out_of_plane_direction"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADCompute2DSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DSmallStrain.C
@@ -23,7 +23,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADCompute2DSmallStrain<compute_stage>::ADCompute2DSmallStrain(const InputParameters & parameters)
   : ADComputeSmallStrain<compute_stage>(parameters),
-    _out_of_plane_direction(adGetParam<MooseEnum>("out_of_plane_direction"))
+    _out_of_plane_direction(getParam<MooseEnum>("out_of_plane_direction"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeEigenstrain.C
@@ -25,9 +25,9 @@ defineADValidParams(ADComputeEigenstrain,
 template <ComputeStage compute_stage>
 ADComputeEigenstrain<compute_stage>::ADComputeEigenstrain(const InputParameters & parameters)
   : ADComputeEigenstrainBase<compute_stage>(parameters),
-    _prefactor(adGetADMaterialProperty<Real>("prefactor"))
+    _prefactor(getADMaterialProperty<Real>("prefactor"))
 {
-  _eigen_base_tensor.fillFromInputVector(adGetParam<std::vector<Real>>("eigen_base"));
+  _eigen_base_tensor.fillFromInputVector(getParam<std::vector<Real>>("eigen_base"));
 }
 
 template <ComputeStage compute_stage>

--- a/modules/tensor_mechanics/src/materials/ADComputeEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeEigenstrainBase.C
@@ -33,10 +33,10 @@ template <ComputeStage compute_stage>
 ADComputeEigenstrainBase<compute_stage>::ADComputeEigenstrainBase(
     const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : ""),
-    _eigenstrain_name(_base_name + adGetParam<std::string>("eigenstrain_name")),
-    _eigenstrain(adDeclareADProperty<RankTwoTensor>(_eigenstrain_name)),
-    _step_zero(adDeclareRestartableData<bool>("step_zero", true))
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _eigenstrain_name(_base_name + getParam<std::string>("eigenstrain_name")),
+    _eigenstrain(declareADProperty<RankTwoTensor>(_eigenstrain_name)),
+    _step_zero(declareRestartableData<bool>("step_zero", true))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeElasticityTensorBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeElasticityTensorBase.C
@@ -25,9 +25,9 @@ ADComputeElasticityTensorBase<compute_stage>::ADComputeElasticityTensorBase(
     const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
     GuaranteeProvider(this),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : ""),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
-    _elasticity_tensor(adDeclareADProperty<RankFourTensor>(_elasticity_tensor_name)),
+    _elasticity_tensor(declareADProperty<RankFourTensor>(_elasticity_tensor_name)),
     _prefactor_function(isParamValid("elasticity_tensor_prefactor")
                             ? &getFunction("elasticity_tensor_prefactor")
                             : nullptr)

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
@@ -35,7 +35,7 @@ ADComputeFiniteStrain<compute_stage>::ADComputeFiniteStrain(const InputParameter
   : ADComputeIncrementalStrainBase<compute_stage>(parameters),
     _Fhat(_fe_problem.getMaxQps()),
     _decomposition_method(
-        adGetParam<MooseEnum>("decomposition_method").template getEnum<DecompMethod>())
+        getParam<MooseEnum>("decomposition_method").template getEnum<DecompMethod>())
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrainElasticStress.C
@@ -22,14 +22,12 @@ ADComputeFiniteStrainElasticStress<compute_stage>::ADComputeFiniteStrainElasticS
   : ADComputeStressBase<compute_stage>(parameters),
     GuaranteeConsumer(this),
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
-    _elasticity_tensor(adGetADMaterialProperty<RankFourTensor>(_elasticity_tensor_name)),
-    _strain_increment(
-        adGetADMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
+    _elasticity_tensor(getADMaterialProperty<RankFourTensor>(_elasticity_tensor_name)),
+    _strain_increment(getADMaterialPropertyByName<RankTwoTensor>(_base_name + "strain_increment")),
     _rotation_increment(
-        adGetADMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
-    _stress_old(adGetMaterialPropertyOldByName<RankTwoTensor>(_base_name + "stress")),
-    _elastic_strain_old(
-        adGetMaterialPropertyOldByName<RankTwoTensor>(_base_name + "elastic_strain"))
+        getADMaterialPropertyByName<RankTwoTensor>(_base_name + "rotation_increment")),
+    _stress_old(getMaterialPropertyOldByName<RankTwoTensor>(_base_name + "stress")),
+    _elastic_strain_old(getMaterialPropertyOldByName<RankTwoTensor>(_base_name + "elastic_strain"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeIncrementalStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeIncrementalStrainBase.C
@@ -17,16 +17,15 @@ ADComputeIncrementalStrainBase<compute_stage>::ADComputeIncrementalStrainBase(
     const InputParameters & parameters)
   : ADComputeStrainBase<compute_stage>(parameters),
     _grad_disp_old(3),
-    _strain_rate(adDeclareADProperty<RankTwoTensor>(_base_name + "strain_rate")),
-    _strain_increment(adDeclareADProperty<RankTwoTensor>(_base_name + "strain_increment")),
-    _rotation_increment(adDeclareADProperty<RankTwoTensor>(_base_name + "rotation_increment")),
-    _mechanical_strain_old(
-        adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "mechanical_strain")),
-    _total_strain_old(adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")),
+    _strain_rate(declareADProperty<RankTwoTensor>(_base_name + "strain_rate")),
+    _strain_increment(declareADProperty<RankTwoTensor>(_base_name + "strain_increment")),
+    _rotation_increment(declareADProperty<RankTwoTensor>(_base_name + "rotation_increment")),
+    _mechanical_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _total_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")),
     _eigenstrains_old(_eigenstrain_names.size())
 {
   for (unsigned int i = 0; i < _eigenstrains_old.size(); ++i)
-    _eigenstrains_old[i] = &adGetMaterialPropertyOld<RankTwoTensor>(_eigenstrain_names[i]);
+    _eigenstrains_old[i] = &getMaterialPropertyOld<RankTwoTensor>(_eigenstrain_names[i]);
 }
 
 template <ComputeStage compute_stage>

--- a/modules/tensor_mechanics/src/materials/ADComputeLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeLinearElasticStress.C
@@ -21,7 +21,7 @@ ADComputeLinearElasticStress<compute_stage>::ADComputeLinearElasticStress(
     const InputParameters & parameters)
   : ADComputeStressBase<compute_stage>(parameters),
     _elasticity_tensor_name(_base_name + "elasticity_tensor"),
-    _elasticity_tensor(adGetADMaterialProperty<RankFourTensor>(_elasticity_tensor_name))
+    _elasticity_tensor(getADMaterialProperty<RankFourTensor>(_elasticity_tensor_name))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
@@ -67,18 +67,17 @@ ADComputeMultipleInelasticStress<compute_stage>::ADComputeMultipleInelasticStres
     _max_iterations(parameters.get<unsigned int>("max_iterations")),
     _relative_tolerance(parameters.get<Real>("relative_tolerance")),
     _absolute_tolerance(parameters.get<Real>("absolute_tolerance")),
-    _internal_solve_full_iteration_history(
-        adGetParam<bool>("internal_solve_full_iteration_history")),
-    _perform_finite_strain_rotations(adGetParam<bool>("perform_finite_strain_rotations")),
-    _inelastic_strain(adDeclareADProperty<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
+    _internal_solve_full_iteration_history(getParam<bool>("internal_solve_full_iteration_history")),
+    _perform_finite_strain_rotations(getParam<bool>("perform_finite_strain_rotations")),
+    _inelastic_strain(declareADProperty<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
     _inelastic_strain_old(
-        adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
-    _num_models(adGetParam<std::vector<MaterialName>>("inelastic_models").size()),
+        getMaterialPropertyOld<RankTwoTensor>(_base_name + "combined_inelastic_strain")),
+    _num_models(getParam<std::vector<MaterialName>>("inelastic_models").size()),
     _inelastic_weights(isParamValid("combined_inelastic_strain_weights")
-                           ? adGetParam<std::vector<Real>>("combined_inelastic_strain_weights")
+                           ? getParam<std::vector<Real>>("combined_inelastic_strain_weights")
                            : std::vector<Real>(_num_models, true)),
-    _cycle_models(adGetParam<bool>("cycle_models")),
-    _matl_timestep_limit(adDeclareProperty<Real>("matl_timestep_limit"))
+    _cycle_models(getParam<bool>("cycle_models")),
+    _matl_timestep_limit(declareProperty<Real>("matl_timestep_limit"))
 {
   if (_inelastic_weights.size() != _num_models)
     paramError("combined_inelastic_strain_weights",
@@ -103,7 +102,7 @@ ADComputeMultipleInelasticStress<compute_stage>::initialSetup()
   _is_elasticity_tensor_guaranteed_isotropic =
       this->hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC);
 
-  std::vector<MaterialName> models = adGetParam<std::vector<MaterialName>>("inelastic_models");
+  std::vector<MaterialName> models = getParam<std::vector<MaterialName>>("inelastic_models");
 
   for (unsigned int i = 0; i < _num_models; ++i)
   {

--- a/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
@@ -38,28 +38,28 @@ ADComputeStrainBase<compute_stage>::ADComputeStrainBase(const InputParameters & 
     _ndisp(coupledComponents("displacements")),
     _disp(3),
     _grad_disp(3),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : ""),
-    _mechanical_strain(adDeclareADProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
-    _total_strain(adDeclareADProperty<RankTwoTensor>(_base_name + "total_strain")),
-    _eigenstrain_names(adGetParam<std::vector<MaterialPropertyName>>("eigenstrain_names")),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _mechanical_strain(declareADProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _total_strain(declareADProperty<RankTwoTensor>(_base_name + "total_strain")),
+    _eigenstrain_names(getParam<std::vector<MaterialPropertyName>>("eigenstrain_names")),
     _eigenstrains(_eigenstrain_names.size()),
     _global_strain(isParamValid("global_strain")
-                       ? &adGetADMaterialProperty<RankTwoTensor>(_base_name + "global_strain")
+                       ? &getADMaterialProperty<RankTwoTensor>(_base_name + "global_strain")
                        : nullptr),
-    _volumetric_locking_correction(adGetParam<bool>("volumetric_locking_correction") &&
+    _volumetric_locking_correction(getParam<bool>("volumetric_locking_correction") &&
                                    !this->isBoundaryMaterial()),
     _current_elem_volume(_assembly.elemVolume())
 {
   for (unsigned int i = 0; i < _eigenstrains.size(); ++i)
   {
     _eigenstrain_names[i] = _base_name + _eigenstrain_names[i];
-    _eigenstrains[i] = &adGetADMaterialProperty<RankTwoTensor>(_eigenstrain_names[i]);
+    _eigenstrains[i] = &getADMaterialProperty<RankTwoTensor>(_eigenstrain_names[i]);
   }
 
   if (_ndisp == 1 && _volumetric_locking_correction)
     paramError("volumetric_locking_correction", "has to be set to false for 1-D problems.");
 
-  if (adGetParam<bool>("use_displaced_mesh"))
+  if (getParam<bool>("use_displaced_mesh"))
     paramError("use_displaced_mesh", "The strain calculator needs to run on the undisplaced mesh.");
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStressBase.C
@@ -23,13 +23,13 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADComputeStressBase<compute_stage>::ADComputeStressBase(const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : ""),
-    _mechanical_strain(adGetADMaterialProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
-    _stress(adDeclareADProperty<RankTwoTensor>(_base_name + "stress")),
-    _elastic_strain(adDeclareADProperty<RankTwoTensor>(_base_name + "elastic_strain"))
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _mechanical_strain(getADMaterialProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _stress(declareADProperty<RankTwoTensor>(_base_name + "stress")),
+    _elastic_strain(declareADProperty<RankTwoTensor>(_base_name + "elastic_strain"))
 {
 
-  if (adGetParam<bool>("use_displaced_mesh"))
+  if (getParam<bool>("use_displaced_mesh"))
     mooseError("The stress calculator needs to run on the undisplaced mesh.");
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeThermalExpansionEigenstrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeThermalExpansionEigenstrain.C
@@ -22,7 +22,7 @@ template <ComputeStage compute_stage>
 ADComputeThermalExpansionEigenstrain<compute_stage>::ADComputeThermalExpansionEigenstrain(
     const InputParameters & parameters)
   : ADComputeThermalExpansionEigenstrainBase<compute_stage>(parameters),
-    _thermal_expansion_coeff(adGetParam<Real>("thermal_expansion_coeff"))
+    _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADComputeThermalExpansionEigenstrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeThermalExpansionEigenstrainBase.C
@@ -23,7 +23,7 @@ ADComputeThermalExpansionEigenstrainBase<compute_stage>::ADComputeThermalExpansi
     const InputParameters & parameters)
   : ADComputeEigenstrainBase<compute_stage>(parameters),
     _temperature(adCoupledValue("temperature")),
-    _deigenstrain_dT(adDeclareADProperty<RankTwoTensor>(
+    _deigenstrain_dT(declareADProperty<RankTwoTensor>(
         derivativePropertyNameFirst(_eigenstrain_name, this->getVar("temperature", 0)->name()))),
     _stress_free_temperature(adCoupledValue("stress_free_temperature"))
 {

--- a/modules/tensor_mechanics/src/materials/ADComputeVariableIsotropicElasticityTensor.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeVariableIsotropicElasticityTensor.C
@@ -26,8 +26,8 @@ template <ComputeStage compute_stage>
 ADComputeVariableIsotropicElasticityTensor<
     compute_stage>::ADComputeVariableIsotropicElasticityTensor(const InputParameters & parameters)
   : ADComputeElasticityTensorBase<compute_stage>(parameters),
-    _youngs_modulus(adGetADMaterialProperty<Real>("youngs_modulus")),
-    _poissons_ratio(adGetADMaterialProperty<Real>("poissons_ratio"))
+    _youngs_modulus(getADMaterialProperty<Real>("youngs_modulus")),
+    _poissons_ratio(getADMaterialProperty<Real>("poissons_ratio"))
 {
   // all tensors created by this class are always isotropic
   issueGuarantee(_elasticity_tensor_name, Guarantee::ISOTROPIC);

--- a/modules/tensor_mechanics/src/materials/ADIsotropicPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADIsotropicPlasticityStressUpdate.C
@@ -42,21 +42,21 @@ template <ComputeStage compute_stage>
 ADIsotropicPlasticityStressUpdate<compute_stage>::ADIsotropicPlasticityStressUpdate(
     const InputParameters & parameters)
   : ADRadialReturnStressUpdate<compute_stage>(parameters),
-    _plastic_prepend(adGetParam<std::string>("plastic_prepend")),
+    _plastic_prepend(getParam<std::string>("plastic_prepend")),
     _yield_stress_function(
         isParamValid("yield_stress_function") ? &getFunction("yield_stress_function") : NULL),
-    _yield_stress(adGetParam<Real>("yield_stress")),
-    _hardening_constant(adGetParam<Real>("hardening_constant")),
+    _yield_stress(getParam<Real>("yield_stress")),
+    _hardening_constant(getParam<Real>("hardening_constant")),
     _hardening_function(isParamValid("hardening_function") ? &getFunction("hardening_function")
                                                            : NULL),
     _yield_condition(-1.0), // set to a non-physical value to catch uninitalized yield condition
     _hardening_slope(0.0),
     _plastic_strain(
-        adDeclareADProperty<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain")),
+        declareADProperty<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain")),
     _plastic_strain_old(
-        adGetMaterialPropertyOld<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain")),
-    _hardening_variable(adDeclareADProperty<Real>(_base_name + "hardening_variable")),
-    _hardening_variable_old(adGetMaterialPropertyOld<Real>(_base_name + "hardening_variable")),
+        getMaterialPropertyOld<RankTwoTensor>(_base_name + _plastic_prepend + "plastic_strain")),
+    _hardening_variable(declareADProperty<Real>(_base_name + "hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>(_base_name + "hardening_variable")),
     _temperature(adCoupledValue("temperature"))
 {
   if (parameters.isParamSetByUser("yield_stress") && _yield_stress <= 0.0)

--- a/modules/tensor_mechanics/src/materials/ADPowerLawCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADPowerLawCreepStressUpdate.C
@@ -34,12 +34,12 @@ ADPowerLawCreepStressUpdate<compute_stage>::ADPowerLawCreepStressUpdate(
     const InputParameters & parameters)
   : ADRadialReturnCreepStressUpdateBase<compute_stage>(parameters),
     _temperature(isParamValid("temperature") ? &adCoupledValue("temperature") : nullptr),
-    _coefficient(adGetParam<Real>("coefficient")),
-    _n_exponent(adGetParam<Real>("n_exponent")),
-    _m_exponent(adGetParam<Real>("m_exponent")),
-    _activation_energy(adGetParam<Real>("activation_energy")),
-    _gas_constant(adGetParam<Real>("gas_constant")),
-    _start_time(adGetParam<Real>("start_time")),
+    _coefficient(getParam<Real>("coefficient")),
+    _n_exponent(getParam<Real>("n_exponent")),
+    _m_exponent(getParam<Real>("m_exponent")),
+    _activation_energy(getParam<Real>("activation_energy")),
+    _gas_constant(getParam<Real>("gas_constant")),
+    _start_time(getParam<Real>("start_time")),
     _exponential(1.0)
 {
   if (_start_time < this->_app.getStartTime() && (std::trunc(_m_exponent) != _m_exponent))

--- a/modules/tensor_mechanics/src/materials/ADRadialReturnCreepStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/ADRadialReturnCreepStressUpdateBase.C
@@ -19,8 +19,8 @@ template <ComputeStage compute_stage>
 ADRadialReturnCreepStressUpdateBase<compute_stage>::ADRadialReturnCreepStressUpdateBase(
     const InputParameters & parameters)
   : ADRadialReturnStressUpdate<compute_stage>(parameters),
-    _creep_strain(adDeclareADProperty<RankTwoTensor>(_base_name + "creep_strain")),
-    _creep_strain_old(adGetMaterialPropertyOld<RankTwoTensor>(_base_name + "creep_strain"))
+    _creep_strain(declareADProperty<RankTwoTensor>(_base_name + "creep_strain")),
+    _creep_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "creep_strain"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADRadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADRadialReturnStressUpdate.C
@@ -34,11 +34,11 @@ ADRadialReturnStressUpdate<compute_stage>::ADRadialReturnStressUpdate(
     const InputParameters & parameters)
   : ADStressUpdateBase<compute_stage>(parameters),
     ADSingleVariableReturnMappingSolution<compute_stage>(parameters),
-    _effective_inelastic_strain(adDeclareADProperty<Real>(
-        _base_name + adGetParam<std::string>("effective_inelastic_strain_name"))),
-    _effective_inelastic_strain_old(adGetMaterialPropertyOld<Real>(
-        _base_name + adGetParam<std::string>("effective_inelastic_strain_name"))),
-    _max_inelastic_increment(adGetParam<Real>("max_inelastic_increment"))
+    _effective_inelastic_strain(declareADProperty<Real>(
+        _base_name + getParam<std::string>("effective_inelastic_strain_name"))),
+    _effective_inelastic_strain_old(getMaterialPropertyOld<Real>(
+        _base_name + getParam<std::string>("effective_inelastic_strain_name"))),
+    _max_inelastic_increment(getParam<Real>("max_inelastic_increment"))
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ADStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/ADStressUpdateBase.C
@@ -33,7 +33,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADStressUpdateBase<compute_stage>::ADStressUpdateBase(const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _base_name(isParamValid("base_name") ? adGetParam<std::string>("base_name") + "_" : "")
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : "")
 {
 }
 

--- a/test/include/postprocessors/SetupInterfaceCount.h
+++ b/test/include/postprocessors/SetupInterfaceCount.h
@@ -83,9 +83,9 @@ private:
 template <class T>
 SetupInterfaceCount<T>::SetupInterfaceCount(const InputParameters & parameters)
   : T(parameters),
-    _count_type(T::template getParam<MooseEnum>("count_type")),
+    _count_type(T::template getParamTempl<MooseEnum>("count_type")),
     _execute(0),
-    _counts(T::template declareRestartableData<std::map<std::string, unsigned int>>("counts"))
+    _counts(T::template declareRestartableDataTempl<std::map<std::string, unsigned int>>("counts"))
 {
   // Initialize the count storage map
   const std::vector<std::string> & names = _count_type.getNames();
@@ -174,4 +174,3 @@ protected:
   virtual void threadJoin(const UserObject & uo) { threadJoinHelper(uo); }
   virtual void subdomainSetup() { subdomainSetupHelper(); }
 };
-

--- a/test/src/constraints/GapHeatConductanceTest.C
+++ b/test/src/constraints/GapHeatConductanceTest.C
@@ -21,7 +21,7 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 GapHeatConductanceTest<compute_stage>::GapHeatConductanceTest(const InputParameters & parameters)
   : ADMortarConstraint<compute_stage>(parameters),
-    _gap_conductance_constant(adGetParam<Real>("gap_conductance_constant"))
+    _gap_conductance_constant(getParam<Real>("gap_conductance_constant"))
 {
 }
 

--- a/test/src/constraints/MechanicalContactTest.C
+++ b/test/src/constraints/MechanicalContactTest.C
@@ -22,7 +22,7 @@ defineADValidParams(MechanicalContactTest,
 
 template <ComputeStage compute_stage>
 MechanicalContactTest<compute_stage>::MechanicalContactTest(const InputParameters & parameters)
-  : ADMortarConstraint<compute_stage>(parameters), _component(adGetParam<MooseEnum>("component"))
+  : ADMortarConstraint<compute_stage>(parameters), _component(getParam<MooseEnum>("component"))
 {
 }
 

--- a/test/src/dgkernels/ADDGConvection.C
+++ b/test/src/dgkernels/ADDGConvection.C
@@ -18,7 +18,7 @@ defineADValidParams(ADDGConvection,
 
 template <ComputeStage compute_stage>
 ADDGConvection<compute_stage>::ADDGConvection(const InputParameters & parameters)
-  : ADDGKernel<compute_stage>(parameters), _velocity(adGetParam<RealVectorValue>("velocity"))
+  : ADDGKernel<compute_stage>(parameters), _velocity(getParam<RealVectorValue>("velocity"))
 {
 }
 

--- a/test/src/kernels/ADConvectionPrecompute.C
+++ b/test/src/kernels/ADConvectionPrecompute.C
@@ -21,7 +21,7 @@ defineADValidParams(ADConvectionPrecompute,
 
 template <ComputeStage compute_stage>
 ADConvectionPrecompute<compute_stage>::ADConvectionPrecompute(const InputParameters & parameters)
-  : ADKernelValue<compute_stage>(parameters), _velocity(adGetParam<RealVectorValue>("velocity"))
+  : ADKernelValue<compute_stage>(parameters), _velocity(getParam<RealVectorValue>("velocity"))
 {
 }
 

--- a/test/src/kernels/ADCoupledConvection.C
+++ b/test/src/kernels/ADCoupledConvection.C
@@ -21,7 +21,7 @@ template <ComputeStage compute_stage>
 ADCoupledConvection<compute_stage>::ADCoupledConvection(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
     _velocity_vector(adCoupledGradient("velocity_vector")),
-    _scale(adGetParam<Real>("scale"))
+    _scale(getParam<Real>("scale"))
 {
 }
 

--- a/test/src/kernels/ADCoupledVectorConvection.C
+++ b/test/src/kernels/ADCoupledVectorConvection.C
@@ -21,7 +21,7 @@ template <ComputeStage compute_stage>
 ADCoupledVectorConvection<compute_stage>::ADCoupledVectorConvection(
     const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
-    _use_grad(adGetParam<bool>("use_grad_row")),
+    _use_grad(getParam<bool>("use_grad_row")),
     _velocity_vector(adCoupledVectorValue("velocity_vector")),
     _grad_velocity_vector(adCoupledVectorGradient("velocity_vector"))
 {

--- a/test/src/kernels/ADMatDiffusionTest.C
+++ b/test/src/kernels/ADMatDiffusionTest.C
@@ -32,11 +32,11 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADMatDiffusionTest<compute_stage>::ADMatDiffusionTest(const InputParameters & parameters)
   : ADKernel<compute_stage>(parameters),
-    _ad_diff_from_ad_prop(adGetADMaterialProperty<Real>("ad_mat_prop")),
-    _regular_diff_from_ad_prop(adGetMaterialProperty<Real>("ad_mat_prop")),
-    _ad_diff_from_regular_prop(adGetADMaterialProperty<Real>("regular_mat_prop")),
-    _regular_diff_from_regular_prop(adGetMaterialProperty<Real>("regular_mat_prop")),
-    _prop_to_use(adGetParam<MooseEnum>("prop_to_use"))
+    _ad_diff_from_ad_prop(getADMaterialProperty<Real>("ad_mat_prop")),
+    _regular_diff_from_ad_prop(getMaterialProperty<Real>("ad_mat_prop")),
+    _ad_diff_from_regular_prop(getADMaterialProperty<Real>("regular_mat_prop")),
+    _regular_diff_from_regular_prop(getMaterialProperty<Real>("regular_mat_prop")),
+    _prop_to_use(getParam<MooseEnum>("prop_to_use"))
 {
 }
 

--- a/test/src/materials/ADCoupledMaterial.C
+++ b/test/src/materials/ADCoupledMaterial.C
@@ -21,9 +21,8 @@ defineADValidParams(
 template <ComputeStage compute_stage>
 ADCoupledMaterial<compute_stage>::ADCoupledMaterial(const InputParameters & parameters)
   : ADMaterial<compute_stage>(parameters),
-    _ad_mat_prop(adDeclareADProperty<Real>(adGetParam<MaterialPropertyName>("ad_mat_prop"))),
-    _regular_mat_prop(
-        adDeclareProperty<Real>(adGetParam<MaterialPropertyName>("regular_mat_prop"))),
+    _ad_mat_prop(declareADProperty<Real>(getParam<MaterialPropertyName>("ad_mat_prop"))),
+    _regular_mat_prop(declareProperty<Real>(getParam<MaterialPropertyName>("regular_mat_prop"))),
     _coupled_var(adCoupledValue("coupled_var"))
 {
 }

--- a/test/src/materials/ADStatefulMaterial.C
+++ b/test/src/materials/ADStatefulMaterial.C
@@ -21,15 +21,15 @@ ADStatefulMaterial<compute_stage>::ADStatefulMaterial(const InputParameters & pa
   : ADMaterial<compute_stage>(parameters),
 
     // Get a parameter value for the diffusivity
-    _initial_diffusivity(adGetParam<Real>("initial_diffusivity")),
+    _initial_diffusivity(getParam<Real>("initial_diffusivity")),
 
     // Declare that this material is going to have a Real
     // valued property named "diffusivity" that Kernels can use.
-    _diffusivity(adDeclareADProperty<Real>("diffusivity")),
+    _diffusivity(declareADProperty<Real>("diffusivity")),
 
     // Retrieve/use an old value of diffusivity.
     // Note: this is _expensive_ - only do this if you REALLY need it!
-    _diffusivity_old(adGetMaterialPropertyOld<Real>("diffusivity")),
+    _diffusivity_old(getMaterialPropertyOld<Real>("diffusivity")),
     _u(adCoupledValue("u"))
 {
 }

--- a/unit/include/ADFluidPropsTest.h
+++ b/unit/include/ADFluidPropsTest.h
@@ -26,7 +26,7 @@ protected:
     uo_pars.set<Real>("gamma") = 1.41;
     uo_pars.set<bool>("allow_imperfect_jacobians") = allow_imperfect_jac;
     _fe_problem->addUserObject("IdealGasFluidProperties", name, uo_pars);
-    _fp = &_fe_problem->getUserObject<IdealGasFluidProperties>(name);
+    _fp = &_fe_problem->getUserObjectTempl<IdealGasFluidProperties>(name);
     return *_fp;
   }
 

--- a/unit/include/BrineFluidPropertiesTest.h
+++ b/unit/include/BrineFluidPropertiesTest.h
@@ -26,11 +26,10 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("BrineFluidProperties");
     _fe_problem->addUserObject("BrineFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<BrineFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<BrineFluidProperties>("fp");
     _water_fp = &_fp->getComponent(BrineFluidProperties::WATER);
   }
 
   const BrineFluidProperties * _fp;
   const SinglePhaseFluidProperties * _water_fp;
 };
-

--- a/unit/include/CO2FluidPropertiesTest.h
+++ b/unit/include/CO2FluidPropertiesTest.h
@@ -15,19 +15,15 @@
 class CO2FluidPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  CO2FluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  CO2FluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
   {
     InputParameters uo_pars = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<CO2FluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("fp");
   }
 
   const CO2FluidProperties * _fp;
 };
-

--- a/unit/include/FlibeFluidPropertiesTest.h
+++ b/unit/include/FlibeFluidPropertiesTest.h
@@ -22,7 +22,7 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("FlibeFluidProperties");
     _fe_problem->addUserObject("FlibeFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<FlibeFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<FlibeFluidProperties>("fp");
   }
 
   const FlibeFluidProperties * _fp;

--- a/unit/include/FlinakFluidPropertiesTest.h
+++ b/unit/include/FlinakFluidPropertiesTest.h
@@ -22,7 +22,7 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("FlinakFluidProperties");
     _fe_problem->addUserObject("FlinakFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<FlinakFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<FlinakFluidProperties>("fp");
   }
 
   const FlinakFluidProperties * _fp;

--- a/unit/include/HeliumFluidPropertiesTest.h
+++ b/unit/include/HeliumFluidPropertiesTest.h
@@ -22,7 +22,7 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("HeliumFluidProperties");
     _fe_problem->addUserObject("HeliumFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<HeliumFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<HeliumFluidProperties>("fp");
   }
 
   const HeliumFluidProperties * _fp;

--- a/unit/include/HydrogenFluidPropertiesTest.h
+++ b/unit/include/HydrogenFluidPropertiesTest.h
@@ -22,9 +22,8 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("HydrogenFluidProperties");
     _fe_problem->addUserObject("HydrogenFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<HydrogenFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<HydrogenFluidProperties>("fp");
   }
 
   const HydrogenFluidProperties * _fp;
 };
-

--- a/unit/include/IdealGasFluidPropertiesTest.h
+++ b/unit/include/IdealGasFluidPropertiesTest.h
@@ -24,14 +24,13 @@ protected:
     uo_pars.set<Real>("R") = 287.04;
     uo_pars.set<Real>("gamma") = 1.41;
     _fe_problem->addUserObject("IdealGasFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<IdealGasFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<IdealGasFluidProperties>("fp");
 
     InputParameters uo_pars_pT = _factory.getValidParams("IdealGasFluidProperties");
     _fe_problem->addUserObject("IdealGasFluidProperties", "fp_pT", uo_pars_pT);
-    _fp_pT = &_fe_problem->getUserObject<IdealGasFluidProperties>("fp_pT");
+    _fp_pT = &_fe_problem->getUserObjectTempl<IdealGasFluidProperties>("fp_pT");
   }
 
   const IdealGasFluidProperties * _fp;
   const IdealGasFluidProperties * _fp_pT;
 };
-

--- a/unit/include/IdealRealGasMixtureFluidPropertiesTest.h
+++ b/unit/include/IdealRealGasMixtureFluidPropertiesTest.h
@@ -45,7 +45,7 @@ protected:
       params.set<Real>("rho_c") = 322.;
       params.set<Real>("e_c") = 2015734.52419;
       _fe_problem->addUserObject(class_name, fp_steam_name, params);
-      _fp_steam = &_fe_problem->getUserObject<StiffenedGasFluidProperties>(fp_steam_name);
+      _fp_steam = &_fe_problem->getUserObjectTempl<StiffenedGasFluidProperties>(fp_steam_name);
     }
 
     // nitrogen
@@ -57,7 +57,7 @@ protected:
       params.set<Real>("mu") = 0.0000222084; // at 400 K and 1.e5 Pa
       params.set<Real>("k") = 0.032806168;   // at 400 K and 1.e5 Pa
       _fe_problem->addUserObject(class_name, fp_nitrogen_name, params);
-      _fp_nitrogen = &_fe_problem->getUserObject<IdealGasFluidProperties>(fp_nitrogen_name);
+      _fp_nitrogen = &_fe_problem->getUserObjectTempl<IdealGasFluidProperties>(fp_nitrogen_name);
     }
 
     // mixture
@@ -67,7 +67,7 @@ protected:
       params.set<UserObjectName>("fp_primary") = fp_steam_name;
       params.set<std::vector<UserObjectName>>("fp_secondary") = {fp_nitrogen_name};
       _fe_problem->addUserObject(class_name, fp_mix_name, params);
-      _fp_mix = &_fe_problem->getUserObject<IdealRealGasMixtureFluidProperties>(fp_mix_name);
+      _fp_mix = &_fe_problem->getUserObjectTempl<IdealRealGasMixtureFluidProperties>(fp_mix_name);
     }
   }
 
@@ -75,4 +75,3 @@ protected:
   const IdealGasFluidProperties * _fp_nitrogen;
   const IdealRealGasMixtureFluidProperties * _fp_mix;
 };
-

--- a/unit/include/MethaneFluidPropertiesTest.h
+++ b/unit/include/MethaneFluidPropertiesTest.h
@@ -15,19 +15,15 @@
 class MethaneFluidPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  MethaneFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  MethaneFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
   {
     InputParameters uo_pars = _factory.getValidParams("MethaneFluidProperties");
     _fe_problem->addUserObject("MethaneFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<MethaneFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<MethaneFluidProperties>("fp");
   }
 
   const MethaneFluidProperties * _fp;
 };
-

--- a/unit/include/NaClFluidPropertiesTest.h
+++ b/unit/include/NaClFluidPropertiesTest.h
@@ -15,19 +15,15 @@
 class NaClFluidPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  NaClFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  NaClFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
   {
     InputParameters uo_pars = _factory.getValidParams("NaClFluidProperties");
     _fe_problem->addUserObject("NaClFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<NaClFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<NaClFluidProperties>("fp");
   }
 
   const NaClFluidProperties * _fp;
 };
-

--- a/unit/include/NitrogenFluidPropertiesTest.h
+++ b/unit/include/NitrogenFluidPropertiesTest.h
@@ -22,9 +22,8 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("NitrogenFluidProperties");
     _fe_problem->addUserObject("NitrogenFluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<NitrogenFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<NitrogenFluidProperties>("fp");
   }
 
   const NitrogenFluidProperties * _fp;
 };
-

--- a/unit/include/PorousFlowBrineCO2Test.h
+++ b/unit/include/PorousFlowBrineCO2Test.h
@@ -29,26 +29,26 @@ protected:
     pc_params.set<Real>("m") = 0.5;
     pc_params.set<Real>("alpha") = 0.1;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters brine_params = _factory.getValidParams("BrineFluidProperties");
     _fe_problem->addUserObject("BrineFluidProperties", "brine_fp", brine_params);
-    _brine_fp = &_fe_problem->getUserObject<BrineFluidProperties>("brine_fp");
+    _brine_fp = &_fe_problem->getUserObjectTempl<BrineFluidProperties>("brine_fp");
 
     InputParameters water_params = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    _water_fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("water_fp");
 
     InputParameters co2_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_params);
-    _co2_fp = &_fe_problem->getUserObject<CO2FluidProperties>("co2_fp");
+    _co2_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("co2_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowBrineCO2");
     uo_params.set<UserObjectName>("brine_fp") = "brine_fp";
     uo_params.set<UserObjectName>("co2_fp") = "co2_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
     _fe_problem->addUserObject("PorousFlowBrineCO2", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowBrineCO2>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<PorousFlowBrineCO2>("fp");
   }
 
   const PorousFlowCapillaryPressureVG * _pc;
@@ -57,4 +57,3 @@ protected:
   const Water97FluidProperties * _water_fp;
   const CO2FluidProperties * _co2_fp;
 };
-

--- a/unit/include/PorousFlowDictatorTest.h
+++ b/unit/include/PorousFlowDictatorTest.h
@@ -49,7 +49,7 @@ protected:
     params.set<unsigned int>("number_aqueous_kinetic") = 6;
     params.set<unsigned int>("aqueous_phase_number") = 1;
     _fe_problem->addUserObject("PorousFlowDictator", "dictator_name", params);
-    _dictator = &_fe_problem->getUserObject<PorousFlowDictator>("dictator_name");
+    _dictator = &_fe_problem->getUserObjectTempl<PorousFlowDictator>("dictator_name");
 
     InputParameters params_no_fetype = _factory.getValidParams("PorousFlowDictator");
     params_no_fetype.set<std::vector<VariableName>>("porous_flow_vars") =
@@ -57,7 +57,8 @@ protected:
     params_no_fetype.set<unsigned>("number_fluid_phases") = 1;
     params_no_fetype.set<unsigned>("number_fluid_components") = 3;
     _fe_problem->addUserObject("PorousFlowDictator", "dictator_no_fetype", params_no_fetype);
-    _dictator_no_fetype = &_fe_problem->getUserObject<PorousFlowDictator>("dictator_no_fetype");
+    _dictator_no_fetype =
+        &_fe_problem->getUserObjectTempl<PorousFlowDictator>("dictator_no_fetype");
   }
 
   const FEType _linear_lagrange;
@@ -65,4 +66,3 @@ protected:
   const PorousFlowDictator * _dictator;
   const PorousFlowDictator * _dictator_no_fetype;
 };
-

--- a/unit/include/PorousFlowFluidStateFlashTest.h
+++ b/unit/include/PorousFlowFluidStateFlashTest.h
@@ -27,22 +27,22 @@ protected:
     pc_params.set<Real>("m") = 0.5;
     pc_params.set<Real>("alpha") = 0.1;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters water_params = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    _water_fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("water_fp");
 
     InputParameters ncg_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "ncg_fp", ncg_params);
-    _ncg_fp = &_fe_problem->getUserObject<CO2FluidProperties>("ncg_fp");
+    _ncg_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("ncg_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowWaterNCG");
     uo_params.set<UserObjectName>("water_fp") = "water_fp";
     uo_params.set<UserObjectName>("gas_fp") = "ncg_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
     _fe_problem->addUserObject("PorousFlowWaterNCG", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowWaterNCG>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<PorousFlowWaterNCG>("fp");
   }
 
   const PorousFlowCapillaryPressureVG * _pc;
@@ -50,4 +50,3 @@ protected:
   const Water97FluidProperties * _water_fp;
   const CO2FluidProperties * _ncg_fp;
 };
-

--- a/unit/include/PorousFlowWaterNCGTest.h
+++ b/unit/include/PorousFlowWaterNCGTest.h
@@ -18,10 +18,7 @@
 class PorousFlowWaterNCGTest : public MooseObjectUnitTest
 {
 public:
-  PorousFlowWaterNCGTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  PorousFlowWaterNCGTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
@@ -30,22 +27,22 @@ protected:
     pc_params.set<Real>("m") = 0.5;
     pc_params.set<Real>("alpha") = 0.1;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters water_params = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    _water_fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("water_fp");
 
     InputParameters ncg_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "ncg_fp", ncg_params);
-    _ncg_fp = &_fe_problem->getUserObject<CO2FluidProperties>("ncg_fp");
+    _ncg_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("ncg_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowWaterNCG");
     uo_params.set<UserObjectName>("water_fp") = "water_fp";
     uo_params.set<UserObjectName>("gas_fp") = "ncg_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
     _fe_problem->addUserObject("PorousFlowWaterNCG", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowWaterNCG>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<PorousFlowWaterNCG>("fp");
   }
 
   const PorousFlowCapillaryPressureVG * _pc;
@@ -53,4 +50,3 @@ protected:
   const Water97FluidProperties * _water_fp;
   const CO2FluidProperties * _ncg_fp;
 };
-

--- a/unit/include/PorousFlowWaterVaporTest.h
+++ b/unit/include/PorousFlowWaterVaporTest.h
@@ -27,17 +27,17 @@ protected:
     pc_params.set<Real>("alpha") = 1.0e-4;
     pc_params.set<Real>("pc_max") = 1.0e5;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
-    _pc = &_fe_problem->getUserObject<PorousFlowCapillaryPressureVG>("pc");
+    _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters water_params = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObject<Water97FluidProperties>("water_fp");
+    _water_fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("water_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowWaterVapor");
     uo_params.set<UserObjectName>("water_fp") = "water_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
     _fe_problem->addUserObject("PorousFlowWaterVapor", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<PorousFlowWaterVapor>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<PorousFlowWaterVapor>("fp");
   }
 
   const PorousFlowCapillaryPressureVG * _pc;

--- a/unit/include/SimpleFluidPropertiesTest.h
+++ b/unit/include/SimpleFluidPropertiesTest.h
@@ -15,25 +15,21 @@
 class SimpleFluidPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  SimpleFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  SimpleFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
   {
     InputParameters uo_params = _factory.getValidParams("SimpleFluidProperties");
     _fe_problem->addUserObject("SimpleFluidProperties", "fp", uo_params);
-    _fp = &_fe_problem->getUserObject<SimpleFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<SimpleFluidProperties>("fp");
 
     InputParameters uo2_params = _factory.getValidParams("SimpleFluidProperties");
     uo2_params.set<Real>("porepressure_coefficient") = 0.0;
     _fe_problem->addUserObject("SimpleFluidProperties", "fp2", uo2_params);
-    _fp2 = &_fe_problem->getUserObject<SimpleFluidProperties>("fp2");
+    _fp2 = &_fe_problem->getUserObjectTempl<SimpleFluidProperties>("fp2");
   }
 
   const SimpleFluidProperties * _fp;
   const SimpleFluidProperties * _fp2;
 };
-

--- a/unit/include/SodiumPropertiesTest.h
+++ b/unit/include/SodiumPropertiesTest.h
@@ -15,19 +15,15 @@
 class SodiumPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  SodiumPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  SodiumPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
   {
     InputParameters uo_pars = _factory.getValidParams("SodiumProperties");
     _fe_problem->addUserObject("SodiumProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<SodiumProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<SodiumProperties>("fp");
   }
 
   const SodiumProperties * _fp;
 };
-

--- a/unit/include/StiffenedGasFluidPropertiesTest.h
+++ b/unit/include/StiffenedGasFluidPropertiesTest.h
@@ -15,10 +15,7 @@
 class StiffenedGasFluidPropertiesTest : public MooseObjectUnitTest
 {
 public:
-  StiffenedGasFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp")
-  {
-    buildObjects();
-  }
+  StiffenedGasFluidPropertiesTest() : MooseObjectUnitTest("MooseUnitApp") { buildObjects(); }
 
 protected:
   void buildObjects()
@@ -31,9 +28,8 @@ protected:
     eos_pars.set<Real>("cv") = 1816;
     eos_pars.set<std::string>("_object_name") = "name3";
     _fe_problem->addUserObject("StiffenedGasFluidProperties", "fp", eos_pars);
-    _fp = &_fe_problem->getUserObject<StiffenedGasFluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<StiffenedGasFluidProperties>("fp");
   }
 
   const StiffenedGasFluidProperties * _fp;
 };
-

--- a/unit/include/TabulatedFluidPropertiesTest.h
+++ b/unit/include/TabulatedFluidPropertiesTest.h
@@ -26,13 +26,13 @@ protected:
   {
     InputParameters co2_uo_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_uo_params);
-    _co2_fp = &_fe_problem->getUserObject<CO2FluidProperties>("co2_fp");
+    _co2_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("co2_fp");
 
     InputParameters tab_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     tab_uo_params.set<UserObjectName>("fp") = "co2_fp";
     tab_uo_params.set<FileName>("fluid_property_file") = "data/csv/fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "tab_fp", tab_uo_params);
-    _tab_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_fp");
+    _tab_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("tab_fp");
 
     InputParameters tab_gen_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     tab_gen_uo_params.set<UserObjectName>("fp") = "co2_fp";
@@ -45,32 +45,32 @@ protected:
     MultiMooseEnum properties("density enthalpy internal_energy viscosity k cv cp entropy");
     tab_gen_uo_params.set<MultiMooseEnum>("interpolated_properties") = properties;
     _fe_problem->addUserObject("TabulatedFluidProperties", "tab_gen_fp", tab_gen_uo_params);
-    _tab_gen_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("tab_gen_fp");
+    _tab_gen_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("tab_gen_fp");
 
     InputParameters unordered_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unordered_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unordered_uo_params.set<FileName>("fluid_property_file") = "data/csv/unordered_fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "unordered_fp", unordered_uo_params);
-    _unordered_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unordered_fp");
+    _unordered_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("unordered_fp");
 
     InputParameters unequal_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unequal_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unequal_uo_params.set<FileName>("fluid_property_file") = "data/csv/unequal_fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "unequal_fp", unequal_uo_params);
-    _unequal_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unequal_fp");
+    _unequal_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("unequal_fp");
 
     InputParameters missing_col_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     missing_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     missing_col_uo_params.set<FileName>("fluid_property_file") =
         "data/csv/missing_col_fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "missing_col_fp", missing_col_uo_params);
-    _missing_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_col_fp");
+    _missing_col_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("missing_col_fp");
 
     InputParameters unknown_col_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     unknown_col_uo_params.set<UserObjectName>("fp") = "co2_fp";
     unknown_col_uo_params.set<FileName>("fluid_property_file") = "data/csv/unknown_fluid_props.csv";
     _fe_problem->addUserObject("TabulatedFluidProperties", "unknown_col_fp", unknown_col_uo_params);
-    _unknown_col_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("unknown_col_fp");
+    _unknown_col_fp = &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("unknown_col_fp");
 
     InputParameters missing_data_uo_params = _factory.getValidParams("TabulatedFluidProperties");
     missing_data_uo_params.set<UserObjectName>("fp") = "co2_fp";
@@ -78,7 +78,8 @@ protected:
         "data/csv/missing_data_fluid_props.csv";
     _fe_problem->addUserObject(
         "TabulatedFluidProperties", "missing_data_fp", missing_data_uo_params);
-    _missing_data_fp = &_fe_problem->getUserObject<TabulatedFluidProperties>("missing_data_fp");
+    _missing_data_fp =
+        &_fe_problem->getUserObjectTempl<TabulatedFluidProperties>("missing_data_fp");
   }
 
   void TearDown()
@@ -97,4 +98,3 @@ protected:
   const TabulatedFluidProperties * _unknown_col_fp;
   const TabulatedFluidProperties * _missing_data_fp;
 };
-

--- a/unit/include/Water97FluidPropertiesTest.h
+++ b/unit/include/Water97FluidPropertiesTest.h
@@ -23,14 +23,13 @@ protected:
   {
     InputParameters uo_pars = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "fp", uo_pars);
-    _fp = &_fe_problem->getUserObject<Water97FluidProperties>("fp");
+    _fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("fp");
 
     InputParameters ad_uo_pars = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "ad_fp", ad_uo_pars);
-    _ad_fp = &_fe_problem->getUserObject<SinglePhaseFluidProperties>("ad_fp");
+    _ad_fp = &_fe_problem->getUserObjectTempl<SinglePhaseFluidProperties>("ad_fp");
   }
 
   const Water97FluidProperties * _fp;
   const SinglePhaseFluidProperties * _ad_fp;
 };
-


### PR DESCRIPTION
We had added a lot of macros prefixed with ad in order to hide this->template
syntax from users. A more consistent interface is to rename the member template
functions and then give the macros the original name so that users experience
no disruption in the interface when moving from traditional
objects to AD.