### PR TITLE
TimedPrint Enhancements

### DIFF
--- a/framework/include/base/Adaptivity.h
+++ b/framework/include/base/Adaptivity.h
@@ -19,6 +19,8 @@
 #include "MooseTypes.h"
 #include "PerfGraphInterface.h"
 
+#include "libmesh/parallel_object.h"
+
 // libMesh
 #include "libmesh/mesh_refinement.h"
 
@@ -43,7 +45,9 @@ class ErrorEstimator;
  * Takes care of everything related to mesh adaptivity
  *
  */
-class Adaptivity : public ConsoleStreamInterface, public PerfGraphInterface
+class Adaptivity : public ConsoleStreamInterface,
+                   public PerfGraphInterface,
+                   public libMesh::ParallelObject
 {
 public:
   Adaptivity(FEProblemBase & subproblem);
@@ -336,4 +340,3 @@ Adaptivity::setParam(const std::string & param_name, const T & param_value)
     mooseError("Invalid Param in adaptivity object");
 }
 #endif // LIBMESH_ENABLE_AMR
-

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -680,6 +680,9 @@ public:
    */
   bool defaultAutomaticScaling() const { return _automatic_automatic_scaling; }
 
+  // Return the communicator for this application
+  const std::shared_ptr<Parallel::Communicator> getCommunicator() const { return _comm; }
+
 protected:
   /**
    * Whether or not this MooseApp has cached a Backup to use for restart / recovery

--- a/framework/include/outputs/ConsoleStream.h
+++ b/framework/include/outputs/ConsoleStream.h
@@ -58,6 +58,8 @@ public:
    */
   void unsetf(std::ios_base::fmtflags mask) const;
 
+  std::streampos tellp() const { return _oss.tellp(); }
+
 private:
   /// Reference to the OutputWarhouse that contains the Console output objects
   OutputWarehouse & _output_warehouse;

--- a/framework/include/utils/TimedPrint.h
+++ b/framework/include/utils/TimedPrint.h
@@ -12,6 +12,8 @@
 #include "ConsoleStream.h"
 #include "StreamArguments.h"
 
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
+
 #include <atomic>
 #include <chrono>
 #include <iostream>
@@ -25,8 +27,13 @@
 #endif
 
 #define CONSOLE_TIMED_PRINT(...)                                                                   \
-  TimedPrint tpc(                                                                                  \
-      _console, std::chrono::duration<double>(1), std::chrono::duration<double>(1), __VA_ARGS__);
+  std::unique_ptr<TimedPrint> tpc =                                                                \
+      _communicator.rank() == 0                                                                    \
+          ? libmesh_make_unique<TimedPrint>(_console,                                              \
+                                            std::chrono::duration<double>(1),                      \
+                                            std::chrono::duration<double>(1),                      \
+                                            __VA_ARGS__)                                           \
+          : nullptr;
 
 /**
  * Object to print a message after enough time has passed.

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -83,11 +83,13 @@ SetupMeshCompleteAction::act()
      */
     if (_app.setFileRestart() == false && _app.isRecovering() == false)
     {
+      TIME_SECTION(_uniform_refine_timer);
+
+      auto & _communicator = *_app.getCommunicator();
+      CONSOLE_TIMED_PRINT("Uniformly refining mesh");
+
       if (_mesh->uniformRefineLevel())
       {
-        TIME_SECTION(_uniform_refine_timer);
-        CONSOLE_TIMED_PRINT("Uniformly refining mesh");
-
         Adaptivity::uniformRefine(_mesh.get());
 
         if (_displaced_mesh)

--- a/framework/src/base/Adaptivity.C
+++ b/framework/src/base/Adaptivity.C
@@ -31,6 +31,7 @@
 Adaptivity::Adaptivity(FEProblemBase & subproblem)
   : ConsoleStreamInterface(subproblem.getMooseApp()),
     PerfGraphInterface(subproblem.getMooseApp().perfGraph(), "Adaptivity"),
+    ParallelObject(subproblem.getMooseApp()),
     _subproblem(subproblem),
     _mesh(_subproblem.mesh()),
     _mesh_refinement_on(false),


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

In addition to only printing on the first rank this PR "enhances" the screen output of TimedPrint.
Namely, we now get wrapping for very long timers so that they don't go off the screen indefinitely.
Next, when activated, timing information is printed out to the right when the task is finished (column aligned)
Finally, color is added to highlight the time (can't see that in this sample, but it's there)
```

Uniformly refining mesh ....................................................               [ 53.18 s]
Initializing equation system .............................................................
.............................................                                              [107.88 s]
Caching mesh information .........                                                         [ 10.36 s]

Framework Information:
MOOSE Version:           git commit eb31e4bc56 on 2019-06-24
LibMesh Version:         82a1cfa7e84f28c361a0ee7b59dcc99c67e11425
PETSc Version:           3.10.5
Current Time:            Mon Jun 24 16:19:45 2019
Executable Timestamp:    Mon Jun 24 12:52:30 2019

Parallelism:
  Num Processors:          1
  Num Threads:             1

Mesh: 
  Parallel Type:           replicated
  Mesh Dimension:          2
  Spatial Dimension:       2
  Nodes:                   
    Total:                 6558721
    Local:                 6558721
  Elems:                   
    Total:                 6553600
    Local:                 6553600
  Num Subdomains:          1
  Num Partitions:          1

Nonlinear System:
  Num DOFs:                6558721
  Num Local DOFs:          6558721
  Variables:               "u" 
  Finite Element Types:    "LAGRANGE" 
  Approximation Orders:    "FIRST" 

Execution Information:
  Executioner:             Steady
  Solver Mode:             Preconditioned JFNK
  PETSc Preconditioner:    hypre boomeramg 

Caching mesh information ......                                                            [  7.18 s]
Projecting initial condition .........                                                     [ 10.20 s]
Outputing exodus ....................                                                      [ 21.36 s]
Computing initial residual ............................                                    [ 29.24 s]
 0 Nonlinear |R| = 5.060632e+01
      0 Linear |R| = 5.060632e+01
      1 Linear |R| = 2.119692e+00
      2 Linear |R| = 1.200934e-01
```