### PR TITLE
Reduce AD temp var memory thrashing (e.g. memcpy, memset)

### DIFF
--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -115,6 +115,9 @@ protected:
   /// The current shape functions
   const ADTemplateVariablePhiValue & _phi;
 
+  ADResidual _r;
+  std::vector<DualReal> _residuals;
+
   /// The current gradient of the shape functions
   const typename VariablePhiGradientType<T, compute_stage>::type & _grad_phi;
 };


### PR DESCRIPTION
Also hoist redundanc calcs out of inner loop.
5-10+% speedup on stabilized compressible euler pronghorn runs.

ref #10256

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
