### PR TITLE
fix AD symmetricEigenvaluesEigenvectors dead loop

### DIFF
--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -419,16 +419,22 @@ public:
    *                                     0 a32 a33]
    * A DualReal instantiation is available to rotate dual numbers as well.
    */
-  RankTwoTensorTempl<T>
-  givensRotation(unsigned int row1, unsigned int row2, unsigned int col) const;
+  RankTwoTensorTempl<T> givensRotation(unsigned int row1,
+                                       unsigned int row2,
+                                       unsigned int col,
+                                       const Real eps = libMesh::TOLERANCE *
+                                                        libMesh::TOLERANCE) const;
 
   /// computes the Hessenberg form of this matrix A and its unitary transformation U such that A = U * H * U^T
-  void hessenberg(RankTwoTensorTempl<T> & H, RankTwoTensorTempl<T> & U) const;
+  void hessenberg(RankTwoTensorTempl<T> & H,
+                  RankTwoTensorTempl<T> & U,
+                  const Real eps = libMesh::TOLERANCE * libMesh::TOLERANCE) const;
 
   /// computes the QR factorization such that A = Q * R, where Q is the unitary matrix and R an upper triangular matrix
   void QR(RankTwoTensorTempl<T> & Q,
           RankTwoTensorTempl<T> & R,
-          unsigned int dim = RankTwoTensorTempl<T>::N) const;
+          unsigned int dim = RankTwoTensorTempl<T>::N,
+          const Real eps = libMesh::TOLERANCE * libMesh::TOLERANCE) const;
 
   /**
    * computes eigenvalues and eigenvectors, assuming tens is symmetric, and places them

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -433,7 +433,7 @@ public:
   /// computes the QR factorization such that A = Q * R, where Q is the unitary matrix and R an upper triangular matrix
   void QR(RankTwoTensorTempl<T> & Q,
           RankTwoTensorTempl<T> & R,
-          unsigned int dim = RankTwoTensorTempl<T>::N,
+          const unsigned int dim = RankTwoTensorTempl<T>::N,
           const Real eps = libMesh::TOLERANCE * libMesh::TOLERANCE) const;
 
   /**

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -419,9 +419,9 @@ public:
    *                                     0 a32 a33]
    * A DualReal instantiation is available to rotate dual numbers as well.
    */
-  RankTwoTensorTempl<T> givensRotation(unsigned int row1,
-                                       unsigned int row2,
-                                       unsigned int col,
+  RankTwoTensorTempl<T> givensRotation(const unsigned int row1,
+                                       const unsigned int row2,
+                                       const unsigned int col,
                                        const Real eps = libMesh::TOLERANCE *
                                                         libMesh::TOLERANCE) const;
 
@@ -433,6 +433,7 @@ public:
   /// computes the QR factorization such that A = Q * R, where Q is the unitary matrix and R an upper triangular matrix
   void QR(RankTwoTensorTempl<T> & Q,
           RankTwoTensorTempl<T> & R,
+          RankTwoTensorTempl<T> & U,
           const unsigned int dim = RankTwoTensorTempl<T>::N,
           const Real eps = libMesh::TOLERANCE * libMesh::TOLERANCE) const;
 

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1071,10 +1071,7 @@ RankTwoTensorTempl<DualReal>::symmetricEigenvaluesEigenvectors(
         mooseError("eigenvalue decomposition does not converge.");
       DualReal shift = D(m, m);
       if (MooseUtils::absoluteFuzzyEqual(shift.value(), 0.0))
-      {
-        shift = std::max(D(m, m), D(m - 1, m - 1));
-        shift = std::max(D(m - 1, m), shift);
-      }
+        shift = std::max(D(m - 1, m), D(m - 1, m - 1));
       D.addIa(-shift);
       D.QR(Q, R, m + 1);
       D = R * Q;

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1082,19 +1082,19 @@ RankTwoTensorTempl<DualReal>::QR(RankTwoTensorTempl<DualReal> & Q,
 
       if (i == 0 && b == 2)
       {
-        if (abs(R(a, 1)) > eps || abs(R(b, 1)) > eps)
+        if (std::abs(R(a, 1)) > eps || std::abs(R(b, 1)) > eps)
           j = 1;
-        else if (abs(R(b, 2)) > eps)
+        else if (std::abs(R(b, 2)) > eps)
           j = 2;
       }
       else if (i == 0 && b == 1 && dim == 2)
       {
-        if (abs(R(b, 1)) > eps)
+        if (std::abs(R(b, 1)) > eps)
           j = 1;
       }
       else if (i == 2)
       {
-        if (abs(R(b, 2)) > eps)
+        if (std::abs(R(b, 2)) > eps)
           j = 2;
       }
 

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1067,7 +1067,14 @@ RankTwoTensorTempl<DualReal>::symmetricEigenvaluesEigenvectors(
     do
     {
       iter++;
+      if (iter > 100)
+        mooseError("eigenvalue decomposition does not converge.");
       DualReal shift = D(m, m);
+      if (MooseUtils::absoluteFuzzyEqual(shift.value(), 0.0))
+      {
+        shift = std::max(D(m, m), D(m - 1, m - 1));
+        shift = std::max(D(m - 1, m), shift);
+      }
       D.addIa(-shift);
       D.QR(Q, R, m + 1);
       D = R * Q;

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1156,7 +1156,7 @@ RankTwoTensorTempl<DualReal>::symmetricEigenvaluesEigenvectors(
 
       D.addIa(-shift);
       D.QR(Q, R, U, m + 1, eps);
-      if (abs(R(m - 1, m - 1)) < eps)
+      if (std::abs(R(m - 1, m - 1)) < eps)
       {
         D.addIa(shift);
         shift = m == N - 1 ? R(0, 0) : R(N - 1, N - 1);

--- a/framework/src/utils/RankTwoTensor.C
+++ b/framework/src/utils/RankTwoTensor.C
@@ -1068,7 +1068,7 @@ RankTwoTensorTempl<DualReal>::symmetricEigenvaluesEigenvectors(
     {
       iter++;
       if (iter > 100)
-        mooseError("eigenvalue decomposition does not converge.");
+        mooseException("RankTwoTensor::symmetricEigenvaluesEigenvectors() is not converging.");
       DualReal shift = D(m, m);
       if (MooseUtils::absoluteFuzzyEqual(shift.value(), 0.0))
         shift = std::max(D(m - 1, m), D(m - 1, m - 1));

--- a/unit/src/RankTwoEigenRoutinesTest.C
+++ b/unit/src/RankTwoEigenRoutinesTest.C
@@ -142,10 +142,80 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   m(0, 2).derivatives()[0] = m(2, 0).derivatives()[0] = 2;
   m(0, 1).derivatives()[0] = m(1, 0).derivatives()[0] = -9;
 
-  // case of three distinct eigenvalues
+  // case of three nonzero eigenvalues
+  m(0, 0).value() = 39.8271858233381;
+  m(1, 1).value() = 20.5533974737178;
+  m(2, 2).value() = -2.38058329705591;
+  m(1, 2).value() = m(2, 1).value() = 4.30639905389877;
+  m(0, 2).value() = m(2, 0).value() = 8.41377713759714;
+  m(0, 1).value() = m(1, 0).value() = -4.30188957211253;
+
+  m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
+  D_ad.fillFromInputVector(eigvals);
+  m_ad = eigvecs * D_ad * eigvecs.transpose();
+
+  std::cout << "=====================\n";
+  m_ad.printDualReal(1);
+
+  // m_ad should be equal to m in values and dual numbers!
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
+
+  // case of two nonzero eigenvalues
+  m(0, 0).value() = 40.0251805997219;
+  m(1, 1).value() = 20.7441889367721;
+  m(2, 2).value() = 2.23063046350594;
+  m(1, 2).value() = m(2, 1).value() = 3.36843305247129;
+  m(0, 2).value() = m(2, 0).value() = 7.45826877165760;
+  m(0, 1).value() = m(1, 0).value() = -4.10752982045755;
+
+  m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
+  D_ad.fillFromInputVector(eigvals);
+  m_ad = eigvecs * D_ad * eigvecs.transpose();
+
+  std::cout << "=====================\n";
+  m_ad.printDualReal(1);
+
+  // m_ad should be equal to m in values and dual numbers!
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
+
+  // case of one nonzero eigenvalues
+  m(0, 0).value() = 39.7135173210679;
+  m(1, 1).value() = 1.09102616320067;
+  m(2, 2).value() = 1.19545651573143;
+  m(1, 2).value() = m(2, 1).value() = -1.14204830704822;
+  m(0, 2).value() = m(2, 0).value() = 6.89026726942313;
+  m(0, 1).value() = m(1, 0).value() = -6.58243772701330;
+
+  m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
+  D_ad.fillFromInputVector(eigvals);
+  m_ad = eigvecs * D_ad * eigvecs.transpose();
+
+  std::cout << "=====================\n";
+  m_ad.printDualReal(1);
+
+  // m_ad should be equal to m in values and dual numbers!
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      // FIXME: does not work yet
+      // EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
+
+  // case of diagonal matrix
   m(0, 0).value() = 42;
   m(1, 1).value() = 21;
-  m(2, 2).value() = -5;
+  m(2, 2).value() = 0;
   m(1, 2).value() = m(2, 1).value() = 0;
   m(0, 2).value() = m(2, 0).value() = 0;
   m(0, 1).value() = m(1, 0).value() = 0;
@@ -154,41 +224,41 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
+  std::cout << "=====================\n";
   m_ad.printDualReal(1);
 
   // m_ad should be equal to m in values and dual numbers!
-  // for (unsigned i = 0; i < 3; i++)
-  //   for (unsigned j = 0; j < 3; j++)
-  //   {
-  //     EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[1], m_ad(i, j).derivatives()[1], 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[2], m_ad(i, j).derivatives()[2], 0.0001);
-  //   }
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      // FIXME: does not work yet
+      // EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
 
-  // case of two repeated eigenvalues
-  m(0, 0).value() = 42;
-  m(1, 1).value() = 42;
-  m(2, 2).value() = 21;
+  // case of purely offdiagonal matrix
+  m(0, 0).value() = 0;
+  m(1, 1).value() = 0;
+  m(2, 2).value() = 0;
   m(1, 2).value() = m(2, 1).value() = 0;
   m(0, 2).value() = m(2, 0).value() = 0;
-  m(0, 1).value() = m(1, 0).value() = 0;
+  m(0, 1).value() = m(1, 0).value() = 5;
 
   m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
+  std::cout << "=====================\n";
   m_ad.printDualReal(1);
 
   // m_ad should be equal to m in values and dual numbers!
-  // for (unsigned i = 0; i < 3; i++)
-  //   for (unsigned j = 0; j < 3; j++)
-  //   {
-  //     EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[1], m_ad(i, j).derivatives()[1], 0.0001);
-  //     EXPECT_NEAR(m(i, j).derivatives()[2], m_ad(i, j).derivatives()[2], 0.0001);
-  //   }
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      // FIXME: does not work yet
+      // EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
 }
 
 TEST(RankTwoEigenRoutines, dsymmetricEigenvalues)

--- a/unit/src/RankTwoEigenRoutinesTest.C
+++ b/unit/src/RankTwoEigenRoutinesTest.C
@@ -68,20 +68,6 @@ TEST(RankTwoEigenRoutines, symmetricEigenvalues)
   EXPECT_NEAR(11.6597, eigvals[2], 0.0001);
 }
 
-TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_zero)
-{
-  // all zero eigenvalues
-  // m = [0, 0, 0
-  //      0, 0, 0
-  //      0, 0, 0]
-  // d1 = 0, v1 = [1, 0, 0]^T
-  // d2 = 0, v2 = [0, 1, 0]^T
-  // d3 = 0, v3 = [0, 0, 1]^T
-  std::vector<Real> eigvals_expect = {0, 0, 0};
-  RankTwoTensor eigvecs_expect(1, 0, 0, 0, 1, 0, 0, 0, 1);
-  testADSymmetricEigenvaluesEigenvectors(0, 0, 0, 0, 0, 0, eigvals_expect, eigvecs_expect);
-}
-
 TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_sorting)
 {
   // testing eigenvalue/eigenvector sorting
@@ -154,9 +140,6 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
-  std::cout << "=====================\n";
-  m_ad.printDualReal(1);
-
   // m_ad should be equal to m in values and dual numbers!
   for (unsigned i = 0; i < 3; i++)
     for (unsigned j = 0; j < 3; j++)
@@ -177,9 +160,6 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
-  std::cout << "=====================\n";
-  m_ad.printDualReal(1);
-
   // m_ad should be equal to m in values and dual numbers!
   for (unsigned i = 0; i < 3; i++)
     for (unsigned j = 0; j < 3; j++)
@@ -199,9 +179,6 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
-
-  std::cout << "=====================\n";
-  m_ad.printDualReal(1);
 
   // m_ad should be equal to m in values and dual numbers!
   for (unsigned i = 0; i < 3; i++)
@@ -224,16 +201,12 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
-  std::cout << "=====================\n";
-  m_ad.printDualReal(1);
-
   // m_ad should be equal to m in values and dual numbers!
   for (unsigned i = 0; i < 3; i++)
     for (unsigned j = 0; j < 3; j++)
     {
       EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
-      // FIXME: does not work yet
-      // EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
     }
 
   // case of purely offdiagonal matrix
@@ -248,8 +221,25 @@ TEST(RankTwoEigenRoutines, symmetricEigenvaluesEigenvectors_AD_consistency)
   D_ad.fillFromInputVector(eigvals);
   m_ad = eigvecs * D_ad * eigvecs.transpose();
 
-  std::cout << "=====================\n";
-  m_ad.printDualReal(1);
+  // m_ad should be equal to m in values and dual numbers!
+  for (unsigned i = 0; i < 3; i++)
+    for (unsigned j = 0; j < 3; j++)
+    {
+      EXPECT_NEAR(m(i, j).value(), m_ad(i, j).value(), 0.0001);
+      EXPECT_NEAR(m(i, j).derivatives()[0], m_ad(i, j).derivatives()[0], 0.0001);
+    }
+
+  // case of zero matrix
+  m(0, 0).value() = 0;
+  m(1, 1).value() = 0;
+  m(2, 2).value() = 0;
+  m(1, 2).value() = m(2, 1).value() = 0;
+  m(0, 2).value() = m(2, 0).value() = 0;
+  m(0, 1).value() = m(1, 0).value() = 0;
+
+  m.symmetricEigenvaluesEigenvectors(eigvals, eigvecs);
+  D_ad.fillFromInputVector(eigvals);
+  m_ad = eigvecs * D_ad * eigvecs.transpose();
 
   // m_ad should be equal to m in values and dual numbers!
   for (unsigned i = 0; i < 3; i++)

--- a/unit/src/RankTwoTensorTest.C
+++ b/unit/src/RankTwoTensorTest.C
@@ -552,8 +552,8 @@ TEST_F(RankTwoTensorTest, HessenbergTransformation)
 TEST_F(RankTwoTensorTest, QRFactorization)
 {
   RankTwoTensor a(1, 3, 4, 2, 5, 12, 3, 6, 1);
-  RankTwoTensor Q, R;
-  a.QR(Q, R);
+  RankTwoTensor Q, R, U;
+  a.QR(Q, R, U);
 
   EXPECT_NEAR(0.1961, std::abs(Q(0, 0)), 0.0001);
   EXPECT_NEAR(0.5883, std::abs(Q(1, 0)), 0.0001);


### PR DESCRIPTION
Kill the loop when it is not converging. Using an off-diagonal shift if diagonal entries are all zero.

refs #13652

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
