### PR TITLE
Add profiling documentation

### DIFF
--- a/modules/doc/content/application_development/index.md
+++ b/modules/doc/content/application_development/index.md
@@ -29,3 +29,5 @@ These documentation pages are meant to be used by developers who are developing 
 [RelationshipManagers](/relationship_managers.md) - Telling MOOSE about extra geomatric or algebraic information needed in parallel
 
 [Moose-Wrapped Apps](/moose_wrapped_apps.md) - Coupling external codes to MOOSE
+
+[Profiling](/profiling.md) - How to profile your application in order to determine what functions are hogging compute time.

--- a/modules/doc/content/application_development/profiling.md
+++ b/modules/doc/content/application_development/profiling.md
@@ -1,0 +1,42 @@
+# Profiling MOOSE code
+
+## MacOS
+
+Follow the steps below to get profiling information for your application:
+
+- Download the full Xcode distribution (iprofiler is not included with the Xcode command line tools distribution).
+- Compile MOOSE and your application in `oprof` mode.
+- Run your application through the profiler:
+
+### Newer versions of MacOS (Mojave):
+
+```
+instruments -t Time\ Profiler ./mooseapp-oprof -i input.i
+```
+
+This will create a directory `instrumentscli[0-9]+.trace`, where `[0-9]+`
+denotes a number, which you can open using
+
+```
+open instrumentscli[0-9]+.trace
+```
+
+The Instruments application will open in a new window with the profile.
+
+### Older versions of MacOS (Sierra)
+
+```
+iprofiler -timeprofiler -T 10m ./mooseapp-oprof -i input.i
+```
+
+This will create a directory `mooseapp-oprof.dtps` which you can open using
+
+```
+open mooseapp-oprof.dtps
+```
+
+The Instruments application will open in a new window with the profile.
+
+## Linux
+
+Profiling on Linux can be done using [gperftools](https://github.com/gperftools/gperftools).


### PR DESCRIPTION
Mostly just a copy from our old wiki, but it updates the commands needed for profiling on Mojave (different from Sierra). Also mentions `gperftools` for Linux.