### PR TITLE
Don't let automatic scaling destroy the sparsity pattern

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1076,12 +1076,7 @@ public:
   virtual void computeResidualTag(const NumericVector<Number> & soln,
                                   NumericVector<Number> & residual,
                                   TagID tag);
-  /**
-   * Form a residual vector for a given tag and "residual" tag
-   */
-  virtual void computeResidualType(const NumericVector<Number> & soln,
-                                   NumericVector<Number> & residual,
-                                   TagID tag);
+
   /**
    * Form a residual vector for a set of tags. It should not be called directly
    * by users.

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4588,37 +4588,6 @@ FEProblemBase::computeResidualInternal(const NumericVector<Number> & soln,
 }
 
 void
-FEProblemBase::computeResidualType(const NumericVector<Number> & soln,
-                                   NumericVector<Number> & residual,
-                                   TagID tag)
-{
-  TIME_SECTION(_compute_residual_type_timer);
-
-  try
-  {
-    _nl->setSolution(soln);
-
-    _nl->associateVectorToTag(residual, _nl->residualVectorTag());
-
-    computeResidualTags({tag, _nl->residualVectorTag()});
-
-    _nl->disassociateVectorFromTag(residual, _nl->residualVectorTag());
-  }
-  catch (MooseException & e)
-  {
-    // If a MooseException propagates all the way to here, it means
-    // that it was thrown from a MOOSE system where we do not
-    // (currently) properly support the throwing of exceptions, and
-    // therefore we have no choice but to error out.  It may be
-    // *possible* to handle exceptions from other systems, but in the
-    // meantime, we don't want to silently swallow any unhandled
-    // exceptions here.
-    mooseError("An unhandled MooseException was raised during residual computation.  Please "
-               "contact the MOOSE team for assistance.");
-  }
-}
-
-void
 FEProblemBase::computeTransientImplicitResidual(Real time,
                                                 const NumericVector<Number> & u,
                                                 const NumericVector<Number> & udot,

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3186,6 +3186,14 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     TIME_SECTION(_compute_scaling_jacobian_timer);
 
     auto & petsc_matrix = *static_cast<PetscMatrix<Real> *>(sys.matrix);
+
+    PetscInt m, n;
+    auto ierr = MatGetLocalSize(petsc_matrix.mat(), &m, &n);
+    LIBMESH_CHKERR(ierr);
+    if (!m)
+      mooseError("MOOSE doesn't currently support automatic scaling when there are any processes "
+                 "owning zero dofs. Check back soon :-)");
+
     _computing_initial_jacobian = true;
     _fe_problem.computeJacobianSys(sys, *_current_solution, *sys.matrix);
     _computing_initial_jacobian = false;
@@ -3253,7 +3261,7 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
       displaced_problem->systemBaseNonlinear().applyScalingFactors(inverse_scaling_factors);
 
     // Now it's essential that we reset the sparsity pattern of the matrix
-    auto ierr = MatResetPreallocation(petsc_matrix.mat());
+    ierr = MatResetPreallocation(petsc_matrix.mat());
     LIBMESH_CHKERR(ierr);
 
 #else

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3180,6 +3180,7 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
 
   if (dynamic_cast<PetscMatrix<Real> *>(sys.matrix))
   {
+#if !PETSC_VERSION_LESS_THAN(3, 9, 0)
     _console << "\nPerforming automatic scaling calculation\n\n";
 
     TIME_SECTION(_compute_scaling_jacobian_timer);
@@ -3254,6 +3255,11 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     // Now it's essential that we reset the sparsity pattern of the matrix
     auto ierr = MatResetPreallocation(petsc_matrix.mat());
     LIBMESH_CHKERR(ierr);
+
+#else
+    mooseWarning("Automatic scaling requires a PETSc version of 3.8.0 or greater, so no automatic "
+                 "scaling is going to be performed");
+#endif
   }
 
 #endif

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3250,6 +3250,11 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     applyScalingFactors(inverse_scaling_factors);
     if (auto displaced_problem = _fe_problem.getDisplacedProblem().get())
       displaced_problem->systemBaseNonlinear().applyScalingFactors(inverse_scaling_factors);
+
+    // Now it's essential that we reset the sparsity pattern of the matrix
+    auto ierr = MatResetPreallocation(petsc_matrix.mat());
+    LIBMESH_CHKERR(ierr);
   }
+
 #endif
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3187,10 +3187,7 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
 
     auto & petsc_matrix = *static_cast<PetscMatrix<Real> *>(sys.matrix);
 
-    PetscInt m, n;
-    auto ierr = MatGetLocalSize(petsc_matrix.mat(), &m, &n);
-    LIBMESH_CHKERR(ierr);
-    if (!m)
+    if (!petsc_matrix.local_m())
       mooseError("MOOSE doesn't currently support automatic scaling when there are any processes "
                  "owning zero dofs. Check back soon :-)");
 
@@ -3261,8 +3258,7 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
       displaced_problem->systemBaseNonlinear().applyScalingFactors(inverse_scaling_factors);
 
     // Now it's essential that we reset the sparsity pattern of the matrix
-    ierr = MatResetPreallocation(petsc_matrix.mat());
-    LIBMESH_CHKERR(ierr);
+    petsc_matrix.reset_preallocation();
 
 #else
     mooseWarning("Automatic scaling requires a PETSc version of 3.8.0 or greater, so no automatic "

--- a/framework/src/timeintegrators/CrankNicolson.C
+++ b/framework/src/timeintegrators/CrankNicolson.C
@@ -61,7 +61,7 @@ CrankNicolson::init()
   _du_dot_du = 0;
 
   // compute residual for the initial time step
-  // Note: we can not directly pass _residual_old in computeResidualType because
+  // Note: we can not directly pass _residual_old in computeResidualTag because
   //       the function will call postResidual, which will cause _residual_old
   //       to be added on top of itself prohibited by PETSc.
   //       Objects executed on initial have been executed by FEProblem,

--- a/test/tests/dgkernels/2d_diffusion_dg/tests
+++ b/test/tests/dgkernels/2d_diffusion_dg/tests
@@ -15,4 +15,13 @@
     issues = '#11766'
     design = 'DGKernels/index.md'
   [../]
+  [no_mallocs_during_scaling]
+    type = 'RunApp'
+    input = '2d_diffusion_dg_test.i'
+    cli_args = 'Executioner/automatic_scaling=true Outputs/exodus=false Outputs/csv=false -snes_view'
+    absent_out = 'MatSetValues calls =12'
+    requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
+    issues = '#12601'
+    design = 'failed_solves.md'
+  []
 []

--- a/test/tests/dgkernels/2d_diffusion_dg/tests
+++ b/test/tests/dgkernels/2d_diffusion_dg/tests
@@ -22,6 +22,6 @@
     absent_out = 'MatSetValues calls =12'
     requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
     issues = '#12601'
-    design = 'failed_solves.md'
+    design = 'FEProblemSolve.md'
   []
 []

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -55,4 +55,14 @@
     design = "InterfaceKernels/index.md"
     requirement = "The InterfaceKernel system shall support Vector Finite Elements in 2D."
     [../]
+
+  [no_mallocs_during_scaling]
+    type = 'RunApp'
+    input = 'coupled_value_coupled_flux.i'
+    cli_args = 'Executioner/automatic_scaling=true Outputs/exodus=false -snes_view'
+    absent_out = 'MatSetValues calls =11'
+    requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
+    issues = '#12601'
+    design = 'failed_solves.md'
+  []
 []

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -63,6 +63,6 @@
     absent_out = 'MatSetValues calls =11'
     requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
     issues = '#12601'
-    design = 'failed_solves.md'
+    design = 'FEProblemSolve.md'
   []
 []

--- a/test/tests/kernels/bad_scaling_scalar_kernels/tests
+++ b/test/tests/kernels/bad_scaling_scalar_kernels/tests
@@ -25,5 +25,6 @@
     cli_args = 'Executioner/automatic_scaling=true -pc_type hypre -pc_hypre_type boomeramg'
     prereq = auto-scaled-field-scalar-system
     requirement = 'We shall be able to show that with automatic scaling we can run this problem successfully in parallel'
+    max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
   []
 []

--- a/test/tests/kernels/simple_transient_diffusion/tests
+++ b/test/tests/kernels/simple_transient_diffusion/tests
@@ -82,7 +82,7 @@
     min_parallel = 3
     issues = '#12601'
     requirement = 'We shall error out when trying to do automatic scaling and we have any process with zero dofs'
-    design = 'failed_solves.md'
+    design = 'FEProblemSolve.md'
     expect_err = "MOOSE doesn't currently support automatic scaling when there are any processes owning zero dofs"
   []
 []

--- a/test/tests/kernels/simple_transient_diffusion/tests
+++ b/test/tests/kernels/simple_transient_diffusion/tests
@@ -75,4 +75,14 @@
     prereq = 'automatic-scaling-done-per-time-step'
     max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
   []
+  [auto-scaling-cant-have-zero-local-dofs]
+    type = RunException
+    input = ill_conditioned_simple_diffusion.i
+    cli_args = "Executioner/automatic_scaling=true Outputs/exodus=false"
+    min_parallel = 3
+    issues = '#12601'
+    requirement = 'We shall error out when trying to do automatic scaling and we have any process with zero dofs'
+    design = 'failed_solves.md'
+    expect_err = "MOOSE doesn't currently support automatic scaling when there are any processes owning zero dofs"
+  []
 []

--- a/test/tests/kernels/simple_transient_diffusion/tests
+++ b/test/tests/kernels/simple_transient_diffusion/tests
@@ -39,6 +39,7 @@
     requirement = "We shall be able to solve an initially poorly scaled problem by using MOOSE's automatic scaling feature in parallel"
     cli_args = 'Executioner/automatic_scaling=true -pc_type hypre -pc_hypre_type boomeramg'
     prereq = 'automatic-scaling-done-once'
+    max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
   []
   [cant-solve-large-transient-changes]
     type = RunException
@@ -72,5 +73,6 @@
     requirement = 'We shall be able to solve a problem where the physics has large changes over time if we scale on every time step in parallel'
     cli_args = "Executioner/automatic_scaling=true Executioner/compute_scaling_once=false Materials/active='function' Executioner/num_steps=10 BCs/right/function='ramp' Outputs/file_base=transient -pc_type hypre -pc_hypre_type boomeramg"
     prereq = 'automatic-scaling-done-per-time-step'
+    max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
   []
 []


### PR DESCRIPTION
We call through to only kernels during the automatic scaling
calculation. These kernels do not capture the sparsity pattern
needed for things like DGKernels and InterfaceKernels, so if
we don't tell PETSc to not change the sparsity pattern, it will
shrink the allocation (I believe). Then when we actually call
through to compute the real Jacobian, we have to do a bunch of
mallocs in MatSetValues which makes the simulation super slow.
To fix this, we use @fdkong MatResetPreallocation function.

This also deletes FEProblemBase::computeResidualType which was
not being used anywhere.

Refs #12601
