### PR TITLE
Added SQA requirements to tensor_mechanics test folders

### DIFF
--- a/modules/tensor_mechanics/test/tests/orthotropic_plasticity/tests
+++ b/modules/tensor_mechanics/test/tests/orthotropic_plasticity/tests
@@ -1,10 +1,15 @@
 [Tests]
+  design = 'TensorMechanicsPlasticOrthotropic.md'
+  issues = '#3832'
   [./test]
     type = 'CSVDiff'
     input = 'orthotropic.i'
     csvdiff = 'orthotropic_out.csv'
     rel_err = 1.0E-4
     abs_zero = 1.0E-4
+    requirement = 'Moose shall be capable of simulating materials that exhibit '
+                  'orthotropic plasticity with constant hardening and linear '
+                  'strain applied in the x and y directions.'
   [../]
 
   [./power_rule]
@@ -13,5 +18,8 @@
     csvdiff = 'powerRuleHardening_out.csv'
     rel_err = 1.0E-2
     abs_zero = 1.0E-2
+    requirement = 'Moose shall be capable of simulating materials that exhibit '
+                  'orthotropic plasticity with power rule hardening and linear '
+                  'strain applied in the x direction.'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/tests
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/tests
@@ -1,33 +1,50 @@
 [Tests]
+ issues = '#10972'
+ design = 'StrainEnergyDensity.md'
  [./incr_elas]
    type = 'CSVDiff'
    input = 'incr_model.i'
    csvdiff = 'incr_model_out.csv'
    rel_err = 1e-6
    abs_zero = 1e-8
+   requirements = 'Moose shall be capable of calculating strain energy density '
+                  'incrementally in materials with elastic stress and finite '
+                  'strain.'
  [../]
  [./incr_chk1]
    type = 'RunException'
    input = 'incr_model.i'
    cli_args = 'Materials/strain_energy_density/incremental=false'
    expect_err = 'StrainEnergyDensity: Specified incremental = false, but material model is incremental.'
+   requirements = 'Moose shall be capable of informing a user when they '
+                  'incorrectly choose not to use the incremental strain '
+                  'energy density formulation with an incremental material '
+                  'model.'
  [../]
  [./tot_elas]
    type = 'CSVDiff'
    input = 'tot_model.i'
    csvdiff = 'tot_model_out.csv'
    rel_err = 1e-6
+   requirements = 'Moose shall be capable of calculating strain energy density '
+                  'for materials with elastic stress and small strain.'
  [../]
  [./tot_chk1]
    type = 'RunException'
    input = 'tot_model.i'
    cli_args = 'Materials/strain_energy_density/incremental=true'
    expect_err = 'One or more Material Properties were not supplied on block'
+   requirements = 'Moose shall be capable of informing a user when they '
+                  'incorrectly choose to use the incremental strain energy '
+                  'density formulation in a material utilizing small strain.'
  [../]
  [./incr_elas_plas]
    type = 'CSVDiff'
    input = 'incr_model_elas_plas.i'
    csvdiff = 'incr_model_elas_plas_out.csv'
    rel_err = 1e-6
+   requirements = 'Moose shall be capable of calculating strain energy density '
+                  'incrementally in materials with inelastic stress and '
+                  'isotropic plasticity.'
  [../]
 []

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/tests
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/tests
@@ -7,44 +7,44 @@
    csvdiff = 'incr_model_out.csv'
    rel_err = 1e-6
    abs_zero = 1e-8
-   requirements = 'Moose shall be capable of calculating strain energy density '
-                  'incrementally in materials with elastic stress and finite '
-                  'strain.'
+   requirement = 'Moose shall be capable of calculating strain energy density '
+                 'incrementally in materials with elastic stress and finite '
+                 'strain.'
  [../]
  [./incr_chk1]
    type = 'RunException'
    input = 'incr_model.i'
    cli_args = 'Materials/strain_energy_density/incremental=false'
    expect_err = 'StrainEnergyDensity: Specified incremental = false, but material model is incremental.'
-   requirements = 'Moose shall be capable of informing a user when they '
-                  'incorrectly choose not to use the incremental strain '
-                  'energy density formulation with an incremental material '
-                  'model.'
+   requirement = 'Moose shall be capable of informing a user when they '
+                 'incorrectly choose not to use the incremental strain '
+                 'energy density formulation with an incremental material '
+                 'model.'
  [../]
  [./tot_elas]
    type = 'CSVDiff'
    input = 'tot_model.i'
    csvdiff = 'tot_model_out.csv'
    rel_err = 1e-6
-   requirements = 'Moose shall be capable of calculating strain energy density '
-                  'for materials with elastic stress and small strain.'
+   requirement = 'Moose shall be capable of calculating strain energy density '
+                 'for materials with elastic stress and small strain.'
  [../]
  [./tot_chk1]
    type = 'RunException'
    input = 'tot_model.i'
    cli_args = 'Materials/strain_energy_density/incremental=true'
    expect_err = 'One or more Material Properties were not supplied on block'
-   requirements = 'Moose shall be capable of informing a user when they '
-                  'incorrectly choose to use the incremental strain energy '
-                  'density formulation in a material utilizing small strain.'
+   requirement = 'Moose shall be capable of informing a user when they '
+                 'incorrectly choose to use the incremental strain energy '
+                 'density formulation in a material utilizing small strain.'
  [../]
  [./incr_elas_plas]
    type = 'CSVDiff'
    input = 'incr_model_elas_plas.i'
    csvdiff = 'incr_model_elas_plas_out.csv'
    rel_err = 1e-6
-   requirements = 'Moose shall be capable of calculating strain energy density '
-                  'incrementally in materials with inelastic stress and '
-                  'isotropic plasticity.'
+   requirement = 'Moose shall be capable of calculating strain energy density '
+                 'incrementally in materials with inelastic stress and '
+                 'isotropic plasticity.'
  [../]
 []


### PR DESCRIPTION
Added SQA requirement tags to tensor_mechanics test folders:
orthotropic plasticity
strain_energy_density

refs #13634 
