### PR TITLE
Addition of SQA requirements to TM tests

### DIFF
--- a/modules/tensor_mechanics/test/tests/material_limit_time_step/creep/tests
+++ b/modules/tensor_mechanics/test/tests/material_limit_time_step/creep/tests
@@ -1,4 +1,5 @@
 [Tests]
+  design = 'MaterialTimeStepPostprocessor.md'
   [./test5a_lim]
     type = 'Exodiff'
     input = 'nafems_test5a_lim.i'
@@ -6,6 +7,8 @@
     rel_err = 1e-5
     abs_zero = 1e-8
     superlu = true
+    issues = '#8553'
+    requirement = 'The system shall compute a timestep size that is limited by a power law creep model and a specified maximum inelastic strain increment.'
   [../]
   [./test5a_lim_on_initial]
     type = 'CSVDiff'
@@ -17,5 +20,7 @@
     override_columns = '_dt'
     override_rel_err = '1e-5'
     override_abs_zero = '1e-8'
+    issues = '#10382'
+    requirement = 'The system shall not impose a limit on the time step during the initial evaluation when the creep limiting time step option is used.'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/temperature_dependent_hardening/tests
+++ b/modules/tensor_mechanics/test/tests/temperature_dependent_hardening/tests
@@ -3,5 +3,8 @@
     type = 'Exodiff'
     input = 'temp_dep_hardening.i'
     exodiff = 'temp_dep_hardening_out.e'
+    design = 'TemperatureDependentHardeningStressUpdate.md'
+    issues = '#7043'
+    requirement = 'The system shall compute the stress as a function of temperature and plastic strain from user-supplied hardening functions.'
   [../]
 []


### PR DESCRIPTION
 Refs #13634.

Directories covered in this PR include:
material_limit_time_step/creep/
temperature_dependent_hardening/

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
