### PR TITLE
Describe how to cite MOOSE

### DIFF
--- a/modules/doc/config.yml
+++ b/modules/doc/config.yml
@@ -35,6 +35,7 @@ Extensions:
             Documentation: documentation.menu.md
             Help: help.menu.md
             News: newsletter/index.md
+            Citing MOOSE: citing.md
     MooseDocs.extensions.bibtex:
         duplicates:
             - kim_phase-field_1999 # referenced in both Tensor Mechanics and Phase Field

--- a/modules/doc/content/citing.md
+++ b/modules/doc/content/citing.md
@@ -1,5 +1,7 @@
 # Citing MOOSE
 
+## Framework
+
 If you use MOOSE for your publication, please cite the following:
 
 ```
@@ -26,6 +28,10 @@ If you use MOOSE for your publication, please cite the following:
   publisher={Elsevier}
 }
 ```
+
+## Modules
+
+### Navier-Stokes
 
 If you use the incompressible portion of the Navier Stokes module, please cite:
 

--- a/modules/doc/content/citing.md
+++ b/modules/doc/content/citing.md
@@ -1,0 +1,43 @@
+# Citing MOOSE
+
+If you use MOOSE for your publication, please cite the following:
+
+```
+@Misc{moose-web-page,
+  author = {Brian Alger and David Andr{\v{s}} and Robert W. Carlsen and Derek R.
+            Gaston and Fande Kong and Alexander D. Lindsay and Jason M. Miller and
+            Cody J. Permann and John W. Peterson and Andrew E. Slaughter and Roy Stogner},
+  title = {{MOOSE} {W}eb page},
+  url = {https://mooseframework.org},
+  howpublished = {\url{https://mooseframework.org}},
+  year = {2019}
+}
+
+@article{gaston2015physics,
+  title = {Physics-based multiscale coupling for full core nuclear reactor simulation},
+  author = {Derek R. Gaston and Cody J. Permann and John W. Peterson and
+            Andrew E. Slaughter and David Andr{\v{s}} and Yaqi Wang and Michael
+            P. Short and Danielle M. Perez and Michael R. Tonks and Javier
+            Ortensi and Ling Zou and Richard C. Martineau},
+  journal={Annals of Nuclear Energy},
+  volume={84},
+  pages={45--54},
+  year={2015},
+  publisher={Elsevier}
+}
+```
+
+If you use the incompressible portion of the Navier Stokes module, please cite:
+
+```
+@article{peterson2018overview,
+  title = {Overview of the incompressible Navier--Stokes simulation capabilities
+           in the MOOSE framework},
+  author = {John W. Peterson and Alexander D. Lindsay and Fande Kong},
+  journal = {Advances in Engineering Software},
+  volume = {119},
+  pages = {68--92},
+  year = {2018},
+  publisher = {Elsevier}
+}
+```


### PR DESCRIPTION
This is modeled after the [PETSc citation approach](https://www.mcs.anl.gov/petsc/documentation/referencing.html) where they say to cite their web-site, which makes it easy to include all the team members, their user manual (which we don't have), and an article. The article can be updated when we create our new "definitive" MOOSE paper.