### PR TITLE
Reimplement the coupling between scalar out-of-plane strain with disps

### DIFF
--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -2187,6 +2187,8 @@ NonlinearSystemBase::computeScalarKernelsJacobians(const std::set<TagID> & tags)
 
     _fe_problem.reinitScalars(/*tid=*/0);
 
+    _fe_problem.reinitOffDiagScalars(/*_tid*/ 0);
+
     bool have_scalar_contributions = false;
     for (const auto & kernel : scalars)
     {

--- a/modules/tensor_mechanics/src/kernels/GeneralizedPlaneStrainOffDiag.C
+++ b/modules/tensor_mechanics/src/kernels/GeneralizedPlaneStrainOffDiag.C
@@ -118,8 +118,7 @@ GeneralizedPlaneStrainOffDiag::computeDispOffDiagJacobianScalar(unsigned int com
   if (jvar == _scalar_out_of_plane_strain_var)
   {
     DenseMatrix<Number> & ken = _assembly.jacobianBlock(_var.number(), jvar);
-    DenseMatrix<Number> kne(ken.n(), ken.m());
-    kne.zero();
+    DenseMatrix<Number> & kne = _assembly.jacobianBlock(jvar, _var.number());
     MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
 
     // Set appropriate components for scalar kernels, including in the cases where a planar model is
@@ -146,13 +145,6 @@ GeneralizedPlaneStrainOffDiag::computeDispOffDiagJacobianScalar(unsigned int com
                                              component) *
                          _grad_test[_i][_qp](component);
         }
-
-    unsigned int nnodes = _current_elem->n_nodes();
-    std::vector<dof_id_type> ivdofs(nnodes);
-    for (unsigned int i = 0; i < nnodes; ++i)
-      ivdofs[i] = _current_elem->node_ptr(i)->dof_number(_sys.number(), _var.number(), 0);
-
-    _assembly.cacheJacobianBlock(kne, jv.dofIndices(), ivdofs, jv.scalingFactor());
   }
 }
 

--- a/modules/tensor_mechanics/src/kernels/GeneralizedPlaneStrainOffDiag.C
+++ b/modules/tensor_mechanics/src/kernels/GeneralizedPlaneStrainOffDiag.C
@@ -118,7 +118,8 @@ GeneralizedPlaneStrainOffDiag::computeDispOffDiagJacobianScalar(unsigned int com
   if (jvar == _scalar_out_of_plane_strain_var)
   {
     DenseMatrix<Number> & ken = _assembly.jacobianBlock(_var.number(), jvar);
-    DenseMatrix<Number> & kne = _assembly.jacobianBlock(jvar, _var.number());
+    DenseMatrix<Number> kne(ken.n(), ken.m());
+    kne.zero();
     MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
 
     // Set appropriate components for scalar kernels, including in the cases where a planar model is
@@ -145,6 +146,13 @@ GeneralizedPlaneStrainOffDiag::computeDispOffDiagJacobianScalar(unsigned int com
                                              component) *
                          _grad_test[_i][_qp](component);
         }
+
+    unsigned int nnodes = _current_elem->n_nodes();
+    std::vector<dof_id_type> ivdofs(nnodes);
+    for (unsigned int i = 0; i < nnodes; ++i)
+      ivdofs[i] = _current_elem->node_ptr(i)->dof_number(_sys.number(), _var.number(), 0);
+
+    _assembly.cacheJacobianBlock(kne, jv.dofIndices(), ivdofs, jv.scalingFactor());
   }
 }
 

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_finite.i
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_finite.i
@@ -96,6 +96,13 @@
   [../]
 []
 
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
 [Executioner]
   type = Transient
 

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_increment.i
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_increment.i
@@ -96,6 +96,13 @@
   [../]
 []
 
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
 [Executioner]
   type = Transient
 

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_small.i
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/generalized_plane_strain_small.i
@@ -100,6 +100,13 @@
   [../]
 []
 
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
 [Executioner]
   type = Transient
 


### PR DESCRIPTION
Use cacheJacobianBlock() rather than reference to jacobianBlock() to avoid element matrix constraint failure.

Ref #13656 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
