### PR TITLE
Adds sqa requirements for J2 isotropic plasticity and slip rate crystal plasticity

### DIFF
--- a/modules/tensor_mechanics/doc/content/bib/tensor_mechanics.bib
+++ b/modules/tensor_mechanics/doc/content/bib/tensor_mechanics.bib
@@ -375,4 +375,16 @@ author = "Jian-Ying Wu",
   Pages = {468--495},
   Title = {Aleatory uncertainty and scale effects in computational damage models for failure and fragmentation},
   Volume = {102},
-  Year = {2015}}
+  Year = {2015}
+}
+
+@article{kalidindi1992,
+  title={Crystallographic texture evolution in bulk deformation processing of FCC metals},
+  author={Kalidindi, Surya R and Bronkhorst, Curt A and Anand, Lallit},
+  journal={Journal of the Mechanics and Physics of Solids},
+  volume={40},
+  number={3},
+  pages={537--569},
+  year={1992},
+  publisher={Elsevier}
+}

--- a/modules/tensor_mechanics/doc/content/source/materials/FiniteStrainCPSlipRateRes.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/FiniteStrainCPSlipRateRes.md
@@ -1,13 +1,78 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# FiniteStrainCPSlipRateRes
-
-!alert construction title=Undocumented Class
-The FiniteStrainCPSlipRateRes has not been documented. The content contained on this page
-includes the basic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+# Finite Strain Crystal Plasticity Slip Rate Residual
 
 !syntax description /Materials/FiniteStrainCPSlipRateRes
+
+## Description
+
+!alert warning
+The `FiniteStrainCPSlipRateRes` model is maintained but not actively developed.
+Use of the [FiniteStrainUObasedCP](/FiniteStrainUObasedCP.md) crystal plasticity
+system is recommend instead.
+
+In `FiniteStrainCPSlipRateRes` the convergence of the crystal plasticity strain
+and stress response is determined with respect to the slip rate on each slip
+system of the crystal plasticity model. In contrast, in the material
+[FiniteStrainCrystalPLasticity](/FiniteStrainCrystalPlasticity.md) determines
+the crystal strain and stress response with response to the residual calculated
+by the second Piola-Kirchoff stress increment.
+
+### Constitutive Model Definition
+
+Constitutive models are used to calculate the plastic slip rate.
+In this crystal plasticity material the slip rate is modeled as a power law:
+\begin{equation}
+  \label{eqn:powerLawSlipRate}
+  \dot{\gamma}^{\alpha} = \dot{\gamma}_o \left| \frac{\tau^{\alpha}}{g^{\alpha}} \right|^{1/m} sign \left( \tau^{\alpha} \right)
+\end{equation}
+where $\dot{\gamma}_o$ is a reference slip rate, $\tau^{\alpha}$ is the applied
+shear stress on each slip system $\alpha$, $g^{\alpha}$ is the slip system
+strength, or resistance to slip, and $m$ is the strain rate sensitivity
+exponent. The strength of each slip system is solved with an iterative process
+as a function of the slip increment
+\begin{equation}
+  \label{eqn:slipStrengthEvolution}
+  g^{\alpha} =  g_o + \Delta \gamma^{\alpha} q^{\alpha \beta} h _o \left| 1 - \frac{g^{\alpha}}{g_{sat}}  \right|^a sign \left( 1 - \frac{g^{\alpha}}{g_{sat}} \right)
+\end{equation}
+where $q^{\alpha \beta}$ is a hardening coefficient matrix that accounts for the
+different in self and latent hardening, [eqn:selfLatentQMatrix], $h_o$
+is an initial hardening term, $g_{sat}$ is a constant saturated hardening value,
+and $a$ is the hardening exponent [!citep](kalidindi1992). The self and latent
+hardening of the crystal is defined for an FCC system as
+\begin{equation}
+  \label{eqn:selfLatentQMatrix}
+  q^{\alpha \beta} = \begin{Bmatrix}
+                       1.0 & q   & q   & q  \\
+                       q   & 1.0 & q   & q  \\
+                       q   & q   & 1.0 & q  \\
+                       q   & q   & q   & 1.0
+                     \end{Bmatrix}
+\end{equation}
+where $q$ is a constant value of latent hardening among non-coplanar slip
+systems. In [eqn:selfLatentQMatrix] the slip systems which share the
+same slip plane normal (e.g. $[\bar{1}11]$) are coplanar and grouped together
+with a latent hardening rate of unity [!citep](kalidindi1992). Each matrix entry in
+[eqn:selfLatentQMatrix] represents the interaction among two different
+coplanar slip system groups, that is a total of six slip systems
+[!citep](kalidindi1992).
+
+
+## Units Assumed in the Crystal Plasticity Materials
+
+The simulation domain for crystal plasticity models is resolved on the order of
+individual crystal grains, and, as such, the mesh size is small. Although MOOSE
+itself is dimension agnostic, the crystal plasticity models are implemented in
+the +mm-MPa-s unit system+. This dimension system choice impacts the
+input files in the following manner:
+
+- Mesh dimensions should be constructed in mm
+- Elastic constant values (e.g. Young's modulus and shear modulus) are entered in MPa
+- Initial slip system strength values are entered in MPa
+- Simulation times are given in s
+- Strain rates and displacement loading rates are given in 1/s and mm/s, respectively
+
+In physically based models, which maybe based on this class, initial densities
+of crystal defects (e.g. dislocations, point defects) should be given in
+1/mm$^2$ or 1/mm$^3$
 
 !syntax parameters /Materials/FiniteStrainCPSlipRateRes
 

--- a/modules/tensor_mechanics/doc/content/source/materials/FiniteStrainCrystalPlasticity.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/FiniteStrainCrystalPlasticity.md
@@ -1,13 +1,75 @@
-<!-- MOOSE Documentation Stub: Remove this when content is added. -->
-
-# FiniteStrainCrystalPlasticity
-
-!alert construction title=Undocumented Class
-The FiniteStrainCrystalPlasticity has not been documented. The content contained on this page
-includes the basic documentation associated with a MooseObject; however, what is contained is
-ultimately determined by what is necessary to make the documentation clear for users.
+# Finite Strain Crystal Plasticity
 
 !syntax description /Materials/FiniteStrainCrystalPlasticity
+
+## Description
+
+!alert warning
+The `FiniteStrainCrystalPlasticity` model is maintained but not actively
+developed. Use of the [FiniteStrainUObasedCP](/FiniteStrainUObasedCP.md) crystal
+plasticity system is recommend instead.
+
+Constitutive models are used to calculate the plastic slip rate.
+In this crystal plasticity material the slip rate is modeled as a power law:
+\begin{equation}
+  \label{eqn:powerLawSlipRate}
+  \dot{\gamma}^{\alpha} = \dot{\gamma}_o \left| \frac{\tau^{\alpha}}{g^{\alpha}} \right|^{1/m} sign \left( \tau^{\alpha} \right)
+\end{equation}
+where $\dot{\gamma}_o$ is a reference slip rate, $\tau^{\alpha}$ is the applied
+shear stress on each slip system $\alpha$, $g^{\alpha}$ is the slip system
+strength, or resistance to slip, and $m$ is the strain rate sensitivity
+exponent. The strength of each slip system is solved with an iterative process
+as a function of the slip increment
+\begin{equation}
+  \label{eqn:slipStrengthEvolution}
+  g^{\alpha} =  g_o + \Delta \gamma^{\alpha} q^{\alpha \beta} h _o \left| 1 - \frac{g^{\alpha}}{g_{sat}}  \right|^a sign \left( 1 - \frac{g^{\alpha}}{g_{sat}} \right)
+\end{equation}
+where $q^{\alpha \beta}$ is a hardening coefficient matrix that accounts for the
+different in self and latent hardening, [eqn:selfLatentQMatrix], $h_o$
+is an initial hardening term, $g_{sat}$ is a constant saturated hardening value,
+and $a$ is the hardening exponent [!citep](kalidindi1992). The self and latent
+hardening of the crystal is defined for an FCC system as
+\begin{equation}
+  \label{eqn:selfLatentQMatrix}
+  q^{\alpha \beta} = \begin{Bmatrix}
+                       1.0 & q   & q   & q  \\
+                       q   & 1.0 & q   & q  \\
+                       q   & q   & 1.0 & q  \\
+                       q   & q   & q   & 1.0
+                     \end{Bmatrix}
+\end{equation}
+where $q$ is a constant value of latent hardening among non-coplanar slip
+systems. In [eqn:selfLatentQMatrix] the slip systems which share the
+same slip plane normal (e.g. $[\bar{1}11]$) are coplanar and grouped together
+with a latent hardening rate of unity [!citep](kalidindi1992). Each matrix entry in
+[eqn:selfLatentQMatrix] represents the interaction among two different
+coplanar slip system groups, that is a total of six slip systems
+[!citep](kalidindi1992).
+
+In this class, the  crystal strain and stress response with response to the
+residual calculated by the second Piola-Kirchoff stress increment. In contrast,
+in [FiniteStrainCPSlipRateRes](FiniteStrainCPSlipRateRes.md) the convergence of
+the crystal plasticity strain and stress response is determined with respect to
+the slip rate on each slip system of the crystal plasticity model.
+
+## Units Assumed in the Crystal Plasticity Materials
+
+The simulation domain for crystal plasticity models is resolved on the order of
+individual crystal grains, and, as such, the mesh size is small. Although MOOSE
+itself is dimension agnostic, the crystal plasticity models are implemented in
+the +mm-MPa-s unit system+. This dimension system choice impacts the
+input files in the following manner:
+
+- Mesh dimensions should be constructed in mm
+- Elastic constant values (e.g. Young's modulus and shear modulus) are entered in MPa
+- Initial slip system strength values are entered in MPa
+- Simulation times are given in s
+- Strain rates and displacement loading rates are given in 1/s and mm/s, respectively
+
+In physically based models, which maybe based on this class, initial densities
+of crystal defects (e.g. dislocations, point defects) should be given in
+1/mm$^2$ or 1/mm$^3$
+
 
 !syntax parameters /Materials/FiniteStrainCrystalPlasticity
 

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/crysp.i
@@ -7,13 +7,10 @@
 
 [Variables]
   [./disp_x]
-    block = 0
   [../]
   [./disp_y]
-    block = 0
   [../]
   [./disp_z]
-    block = 0
   [../]
 []
 
@@ -21,22 +18,18 @@
   [./stress_zz]
     order = CONSTANT
     family = MONOMIAL
-    block = 0
   [../]
   [./fp_zz]
     order = CONSTANT
     family = MONOMIAL
-    block = 0
   [../]
   [./e_zz]
     order = CONSTANT
     family = MONOMIAL
-    block = 0
   [../]
   [./gss1]
     order = CONSTANT
     family = MONOMIAL
-    block = 0
   [../]
 []
 
@@ -62,7 +55,6 @@
     index_j = 2
     index_i = 2
     execute_on = timestep_end
-    block = 0
   [../]
   [./fp_zz]
     type = RankTwoAux
@@ -71,7 +63,6 @@
     index_j = 2
     index_i = 2
     execute_on = timestep_end
-    block = 0
   [../]
   [./e_zz]
     type = RankTwoAux
@@ -80,7 +71,6 @@
     index_j = 2
     index_i = 2
     execute_on = timestep_end
-    block = 0
   [../]
   [./gss1]
     type = MaterialStdVectorAux
@@ -88,7 +78,6 @@
     property = gss
     index = 0
     execute_on = timestep_end
-    block = 0
   [../]
 []
 
@@ -122,7 +111,6 @@
 [Materials]
   [./crysp]
     type = FiniteStrainCPSlipRateRes
-    block = 0
     gtol = 1e-2
     rtol = 1e-8
     abs_tol = 1e-15
@@ -137,13 +125,11 @@
   [../]
   [./elasticity_tensor]
     type = ComputeElasticityTensorCP
-    block = 0
     C_ijkl = '1.684e5 1.214e5 1.214e5 1.684e5 1.214e5 1.684e5 0.754e5 0.754e5 0.754e5'
     fill_method = symmetric9
   [../]
   [./strain]
     type = ComputeFiniteStrain
-    block = 0
     displacements = 'disp_x disp_y disp_z'
   [../]
 []
@@ -152,22 +138,18 @@
   [./stress_zz]
     type = ElementAverageValue
     variable = stress_zz
-    block = 'ANY_BLOCK_ID 0'
   [../]
   [./fp_zz]
     type = ElementAverageValue
     variable = fp_zz
-    block = 'ANY_BLOCK_ID 0'
   [../]
   [./e_zz]
     type = ElementAverageValue
     variable = e_zz
-    block = 'ANY_BLOCK_ID 0'
   [../]
   [./gss1]
     type = ElementAverageValue
     variable = gss1
-    block = 'ANY_BLOCK_ID 0'
   [../]
 []
 
@@ -180,8 +162,6 @@
 
 [Executioner]
   type = Transient
-
-  #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
 
   petsc_options_iname = '-pc_type'

--- a/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/tests
+++ b/modules/tensor_mechanics/test/tests/cp_slip_rate_integ/tests
@@ -1,8 +1,11 @@
 [Tests]
+  issues = '#5683 #6973'
+  design = 'FiniteStrainCPSlipRateRes.md'
   [./test_one_elem]
     type = 'Exodiff'
     input = 'crysp.i'
     exodiff = 'out.e'
+    requirement = 'The system shall compute the stress and strain response of a single crystal using the Kalidindi constitutive equation for hardening as a function of slip rate on each slip system.'
   [../]
   [./test_substep]
     type = 'Exodiff'
@@ -11,6 +14,8 @@
     allow_warnings = true
     max_time = 350
     valgrind = HEAVY
+    issues = '#5082 #5683'
+    requirement = 'The system shall compute the stress and strain response of a single crystal using the Kalidindi constitutive equation for hardening as a function of slip rate on each slip system with the substepping capability that reduces the intermediate time step size to aid with convergence within the crystal plasticity hardening model.'
   [../]
   [./test_with_linesearch]
     type = 'Exodiff'
@@ -19,5 +24,6 @@
     allow_warnings = true
     max_time = 350
     valgrind = HEAVY
+    requirement = 'The system shall compute the stress and strain response of a single crystal using the Kalidindi constitutive equation for hardening as a function of slip rate on each slip system with the bisection line search method within the crystal plasticity hardening model to aid with convergence.'
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/recompute_radial_return/tests
+++ b/modules/tensor_mechanics/test/tests/recompute_radial_return/tests
@@ -1,9 +1,12 @@
 [Tests]
+  issues = '#5481 #11239'
   [./isotropic_plasticity_incremental]
     type = Exodiff
     input = 'isotropic_plasticity_incremental_strain.i'
     exodiff = 'isotropic_plasticity_incremental_strain_out.e'
     compiler = 'CLANG GCC'
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall compute the J2 isotropic plasticity stress and plastic strain response under tensile loading within the small incremental strain formulation.'
   [../]
   [./isotropic_plasticity_incremental_base_name]
     type = Exodiff
@@ -14,6 +17,8 @@
     exodiff_opts = '-allow_name_mismatch'
     compiler = 'CLANG GCC'
     prereq = isotropic_plasticity_incremental
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall compute the J2 isotropic plasticity stress and plastic strain response under tensile loading within the small incremental strain formulation while prescribing a base name for the isotropic plasticity material properties.'
   [../]
   [./isotropic_plasticity_incremental_Bbar]
     type = Exodiff
@@ -22,12 +27,16 @@
     compiler = 'CLANG GCC'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'isotropic_plasticity_incremental_base_name'
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall compute the J2 isotropic plasticity stress and plastic strain response under tensile loading within the small incremental strain formulation and using the b-bar element volume correction.'
   [../]
   [./isotropic_plasticity_finite]
     type = Exodiff
     input = 'isotropic_plasticity_finite_strain.i'
     exodiff = 'isotropic_plasticity_finite_strain_out.e'
     compiler = 'CLANG GCC'
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall compute the J2 isotropic plasticity stress and plastic strain response under tensile loading within the finite incremental strain formulation.'
   [../]
   [./isotropic_plasticity_finite_Bbar]
     type = Exodiff
@@ -36,12 +45,16 @@
     compiler = 'CLANG GCC'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
     prereq = 'isotropic_plasticity_finite'
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall compute the J2 isotropic plasticity stress and plastic strain response under tensile loading within the finite incremental strain formulation and using the b-bar element volume correction.'
   [../]
   [./uniaxial_viscoplasticity]
     type = Exodiff
     input = 'uniaxial_viscoplasticity_incrementalstrain.i'
     exodiff = 'uniaxial_viscoplasticity_incrementalstrain_out.e'
     compiler = 'CLANG GCC'
+    design = 'HyperbolicViscoplasticityStressUpdate.md'
+    requirement = 'The system shall compute the hyperbolic visoplastic stress response for a time-dependent linear strain hardening plasticity model in a small incremental strain formulation in a manner equivalent to the ABAQUS result.'
   [../]
 
   [./isotropic_plasticity_error1]
@@ -53,6 +66,8 @@
                 Materials/elasticity_tensor/type=ComputeIsotropicElasticityTensor Materials/elasticity_tensor/youngs_modulus=2.1e5
                 Materials/elasticity_tensor/poissons_ratio=0.0'
     expect_err = 'Only the hardening_constant or only the hardening_function can be defined but not both'
+    design = 'IsotropicPlasticityStressUpdate.md'
+    requirement = 'The system shall only allow the calculation of a J2 isotropic plasticity stress response with only one but not both of a hardening function or hardening constant specified to define the evolving yield surface.'
   [../]
   [./isotropic_plasticity_error2]
     type = 'RunException'
@@ -62,6 +77,8 @@
                 Materials/elasticity_tensor/poissons_ratio=0.0'
     expect_err = 'Either hardening_constant or hardening_function must be defined'
     prereq = 'isotropic_plasticity_error1'
+    design = 'IsotropicPlasticityStressUpdate.md'
+    requirement = 'The system shall only calculate the J2 isotropic plasticity stress response when either a hardening function or a hardening constant is specified to define the evolving yield surface.'
   [../]
   [./isotropic_plasticity_error3]
     type = 'RunException'
@@ -71,6 +88,8 @@
                 Materials/elasticity_tensor/poissons_ratio=0.0'
     expect_err = 'Either yield_stress or yield_stress_function must be given'
     prereq = 'isotropic_plasticity_error2'
+    design = 'IsotropicPlasticityStressUpdate.md'
+    requirement = 'The system shall only calculate the J2 isotropic plasticity stress response when either a constant yield stress or a yield stress function is specified to define the initial yield surface.'
   [../]
   [./isotropic_plasticity_error4]
     type = 'RunException'
@@ -81,6 +100,8 @@
                 Materials/isotropic_plasticity/yield_stress=-5.0'
     expect_err = 'Yield stress must be greater than zero'
     prereq = 'isotropic_plasticity_error3'
+    design = 'IsotropicPlasticityStressUpdate.md'
+    requirement = 'The system shall return an error if a negative yield stress is supplied when calculating the J2 isotropic plasticity stress response.'
   [../]
   [./isotropic_plasticity_error5]
     type = 'RunException'
@@ -91,11 +112,15 @@
                 Materials/elasticity_tensor/C_ijkl="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21"'
     expect_err = 'Model isotropic_plasticity requires an isotropic elasticity tensor, but the one supplied is not guaranteed isotropic'
     prereq = 'isotropic_plasticity_error4'
+    design = 'IsotropicPlasticityStressUpdate.md'
+    requirement = 'The system shall return an error if anisotropic elasticity tensor is supplied when the J2 isotropic plasticity stress response calculation is requested.'
   [../]
   [./affine_plasticity]
     type = Exodiff
     input = 'affine_plasticity.i'
     exodiff = 'affine_plasticity_out.e'
     custom_cmp = 'affine_plasticity.exodiff'
+    design = 'IsotropicPlasticityStressUpdate.md ComputeMultipleInelasticStress.md'
+    requirement = 'The system shall calculate, with J2 isotropic plasticity, the transient stress eigenvalues with stationary eigenvectors verification test from K. Jamojjala, R. Brannon, A. Sadeghirad, J. Guilkey, Verification tests in solid mechanics, Engineering with Computers, Vol 31., p. 193-213.'
   [../]
 []


### PR DESCRIPTION
No design change information. 

In addition to sqa tags, adds documentation for older crystal plasticity classes, with warning that these classes are not actively developed and should be replaced with the user object based version.


Refs #13634 

