### PR TITLE
 add fluid props functions that calculate derivatives as DualNumbers 

### DIFF
--- a/modules/fluid_properties/include/userobjects/FlibeFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/FlibeFluidProperties.h
@@ -12,6 +12,8 @@ InputParameters validParams<FlibeFluidProperties>();
  */
 class FlibeFluidProperties : public SinglePhaseFluidProperties
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 public:
   FlibeFluidProperties(const InputParameters & parameters);
 
@@ -287,3 +289,4 @@ protected:
   /// derivative of pressure with respect to temperature at constant specific volume
   const Real _dp_dT_at_constant_v;
 };
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/FlinakFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/FlinakFluidProperties.h
@@ -12,6 +12,8 @@ InputParameters validParams<FlinakFluidProperties>();
  */
 class FlinakFluidProperties : public SinglePhaseFluidProperties
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 public:
   FlinakFluidProperties(const InputParameters & parameters);
 
@@ -298,3 +300,4 @@ protected:
   /// derivative of pressure with respect to temperature at constant specific volume
   const Real _dp_dT_at_constant_v;
 };
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/HeliumFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HeliumFluidProperties.h
@@ -42,6 +42,12 @@ public:
    */
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
 
+  void p_from_v_e(const DualReal & v,
+                  const DualReal & e,
+                  DualReal & p,
+                  DualReal & dp_dv,
+                  DualReal & dp_de) const override;
+
   /**
    * Temperature from specific volume and specific internal energy
    *
@@ -62,6 +68,12 @@ public:
    */
   virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
 
+  void T_from_v_e(const DualReal & v,
+                  const DualReal & e,
+                  DualReal & T,
+                  DualReal & dT_dv,
+                  DualReal & dT_de) const override;
+
   using SinglePhaseFluidProperties::c_from_v_e;
 
   /**
@@ -72,6 +84,7 @@ public:
    * @return speed of sound (m/s)
    */
   virtual Real c_from_v_e(Real v, Real e) const override;
+  virtual void c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real & dc_de) const override;
 
   /**
    * Isobaric specific heat from specific volume and specific internal energy
@@ -167,6 +180,11 @@ public:
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
 
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
   /**
    * Specific internal energy from pressure and temperature
    *

--- a/modules/fluid_properties/include/userobjects/HeliumFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HeliumFluidProperties.h
@@ -12,6 +12,8 @@ InputParameters validParams<HeliumFluidProperties>();
  */
 class HeliumFluidProperties : public SinglePhaseFluidProperties
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 public:
   HeliumFluidProperties(const InputParameters & parameters);
 
@@ -320,3 +322,4 @@ protected:
   /// specific heat at constant pressure
   const Real _cp;
 };
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -31,8 +31,18 @@ public:
 
   virtual Real p_from_v_e(Real v, Real e) const override;
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
+  virtual void p_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & p,
+                          DualReal & dp_dv,
+                          DualReal & dp_de) const override;
   virtual Real T_from_v_e(Real v, Real e) const override;
   virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
+  virtual void T_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & T,
+                          DualReal & dT_dv,
+                          DualReal & dT_de) const override;
   virtual Real c_from_v_e(Real v, Real e) const override;
   virtual void c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real & dc_de) const override;
   virtual Real cp_from_v_e(Real v, Real e) const override;
@@ -55,6 +65,11 @@ public:
   virtual Real rho_from_p_T(Real p, Real T) const override;
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
   virtual Real e_from_p_rho(Real p, Real rho) const override;
   virtual void
   e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -31,6 +31,20 @@ InputParameters validParams<SinglePhaseFluidProperties>();
     val = want##_from_##prop1##_##prop2(prop1, prop2);                                             \
   }                                                                                                \
                                                                                                    \
+  virtual void want##_from_##prop1##_##prop2(const DualReal & prop1,                               \
+                                             const DualReal & prop2,                               \
+                                             DualReal & val,                                       \
+                                             DualReal & d##want##d1,                               \
+                                             DualReal & d##want##d2) const                         \
+  {                                                                                                \
+    fluidPropError(name(), ": ", __PRETTY_FUNCTION__, " derivative derivatives not implemented."); \
+    Real dummy, tmp1, tmp2;                                                                        \
+    val = want##_from_##prop1##_##prop2(prop1, prop2);                                             \
+    want##_from_##prop1##_##prop2(prop1.value(), prop2.value(), dummy, tmp1, tmp2);                \
+    d##want##d1 = tmp1;                                                                            \
+    d##want##d2 = tmp2;                                                                            \
+  }                                                                                                \
+                                                                                                   \
   FPDualReal want##_from_##prop1##_##prop2(const FPDualReal & p1, const FPDualReal & p2) const     \
   {                                                                                                \
     Real x = 0;                                                                                    \

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -556,7 +556,7 @@ private:
   void fluidPropError(Args... args) const
   {
     if (_allow_imperfect_jacobians)
-      mooseWarning(std::forward<Args>(args)...);
+      mooseDoOnce(mooseWarning(std::forward<Args>(args)...));
     else
       mooseError(std::forward<Args>(args)...);
   }

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -95,6 +95,15 @@ IdealGasFluidProperties::p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real
   dp_de = (_gamma - 1.0) / v;
 }
 
+void
+IdealGasFluidProperties::p_from_v_e(
+    const DualReal & v, const DualReal & e, DualReal & p, DualReal & dp_dv, DualReal & dp_de) const
+{
+  p = SinglePhaseFluidProperties::p_from_v_e(v, e);
+  dp_dv = -(_gamma - 1.0) * e / v / v;
+  dp_de = (_gamma - 1.0) / v;
+}
+
 Real
 IdealGasFluidProperties::T_from_v_e(Real /*v*/, Real e) const
 {
@@ -105,6 +114,15 @@ void
 IdealGasFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const
 {
   T = T_from_v_e(v, e);
+  dT_dv = 0.0;
+  dT_de = 1.0 / _cv;
+}
+
+void
+IdealGasFluidProperties::T_from_v_e(
+    const DualReal & v, const DualReal & e, DualReal & T, DualReal & dT_dv, DualReal & dT_de) const
+{
+  T = SinglePhaseFluidProperties::T_from_v_e(v, e);
   dT_dv = 0.0;
   dT_de = 1.0 / _cv;
 }
@@ -303,6 +321,18 @@ Real
 IdealGasFluidProperties::rho_from_p_T(Real p, Real T) const
 {
   return p * _molar_mass / (_R * T);
+}
+
+void
+IdealGasFluidProperties::rho_from_p_T(const DualReal & p,
+                                      const DualReal & T,
+                                      DualReal & rho,
+                                      DualReal & drho_dp,
+                                      DualReal & drho_dT) const
+{
+  rho = SinglePhaseFluidProperties::rho_from_p_T(p, T);
+  drho_dp = _molar_mass / (_R * T);
+  drho_dT = -p * _molar_mass / (_R * T * T);
 }
 
 void

--- a/modules/fluid_properties/test/include/userobjects/NaNInterfaceTestFluidProperties.h
+++ b/modules/fluid_properties/test/include/userobjects/NaNInterfaceTestFluidProperties.h
@@ -22,10 +22,12 @@ InputParameters validParams<NaNInterfaceTestFluidProperties>();
  */
 class NaNInterfaceTestFluidProperties : public SinglePhaseFluidProperties, public NaNInterface
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 public:
   NaNInterfaceTestFluidProperties(const InputParameters & parameters);
 
   virtual Real p_from_v_e(Real v, Real e) const override;
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
 };
-
+#pragma GCC diagnostic pop


### PR DESCRIPTION
This gives us the derivatives of fluid prop w.r.t. fluid prop contain AD
derivatives w.r.t. the dofs.  This enables better/improved pronghorn
jacobians.  Also implement derivatives for sound speed in helium.

ref #12898