### PR TITLE
Remove unnecessary code to improve performance

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1045,7 +1045,25 @@ MooseMesh::getBoundaryIDs(const std::vector<BoundaryName> & boundary_name,
   const std::map<BoundaryID, std::string> & sideset_map = boundary_info.get_sideset_name_map();
   const std::map<BoundaryID, std::string> & nodeset_map = boundary_info.get_nodeset_name_map();
 
+  BoundaryID max_boundary_local_id = 0;
+  /* It is required to generate a new ID for a given name. It is used often in mesh modifiers such
+   * as SideSetsBetweenSubdomains. Then we need to check the current boundary ids since they are
+   * changing during "mesh modify()", and figure out the right max boundary ID. Most of mesh
+   * modifiers are running in serial, and we won't involve a global communication.
+   */
+  if (generate_unknown)
+  {
+    const std::set<BoundaryID> & local_bids = getMesh().get_boundary_info().get_boundary_ids();
+    max_boundary_local_id = local_bids.empty() ? 0 : *(local_bids.rbegin());
+    /* We should not hit this often */
+    if (!getMesh().is_serial())
+      _communicator.max(max_boundary_local_id);
+  }
+
   BoundaryID max_boundary_id = _mesh_boundary_ids.empty() ? 0 : *(_mesh_boundary_ids.rbegin());
+
+  max_boundary_id =
+      max_boundary_id > max_boundary_local_id ? max_boundary_id : max_boundary_local_id;
 
   std::vector<BoundaryID> ids(boundary_name.size());
   for (unsigned int i = 0; i < boundary_name.size(); i++)

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1045,14 +1045,7 @@ MooseMesh::getBoundaryIDs(const std::vector<BoundaryName> & boundary_name,
   const std::map<BoundaryID, std::string> & sideset_map = boundary_info.get_sideset_name_map();
   const std::map<BoundaryID, std::string> & nodeset_map = boundary_info.get_nodeset_name_map();
 
-  std::set<BoundaryID> boundary_ids = boundary_info.get_boundary_ids();
-
-  // On a distributed mesh we may have boundary ids that only exist on
-  // other processors.
-  if (!this->getMesh().is_replicated())
-    _communicator.set_union(boundary_ids);
-
-  BoundaryID max_boundary_id = boundary_ids.empty() ? 0 : *(boundary_ids.rbegin());
+  BoundaryID max_boundary_id = _mesh_boundary_ids.empty() ? 0 : *(_mesh_boundary_ids.rbegin());
 
   std::vector<BoundaryID> ids(boundary_name.size());
   for (unsigned int i = 0; i < boundary_name.size(); i++)


### PR DESCRIPTION
In MooseMesh.C, getBoundaryIDs, we try to collect all boundary IDs together, which involves
one global communication. It is expensive and unnecessary since _mesh_bounary_ids already has the same information.

Closes #13715

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
