### PR TITLE
Adding additional Xcode installation instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/macos_mojave_pre_req.md
+++ b/modules/doc/content/getting_started/installation/macos_mojave_pre_req.md
@@ -12,7 +12,7 @@ The following, is required to be installed before you can begin using MOOSE.
 
   If by chance, `xcode-select --install` states you already have Xcode installed, your best bet is to continue on with the instructions.
 
-- +Xcode+. Using the App Store, search for and install Xcode.
+- +Xcode+. Using the App Store, search for and install Xcode. Once installed, you must open and run Xcode to finish the installation.
 
 - +Caveats+
 

--- a/modules/doc/content/getting_started/installation/macos_other_pre_req.md
+++ b/modules/doc/content/getting_started/installation/macos_other_pre_req.md
@@ -10,7 +10,7 @@ The following, is required to be installed before you can begin using MOOSE.
 
   If you do not have both Xcode and CLT installed, you will be presented with a dialog box allowing you to install CLT. There are two choices, 'Get Xcode' and 'Install'. Choose 'Install' to install CLT. We will need Xcode as well, but choosing 'Get Xcode' will send you to the App Store and will ultimately fail if you are not running the lastest version of Mac OS.
 
-- +Xcode+. Log into [Apple's Developer](https://developer.apple.com/downloads/more) website (iTunes account required) and obtain the appropriate version of Xcode pertaining to your version of Mac OS.
+- +Xcode+. Log into [Apple's Developer](https://developer.apple.com/downloads/more) website (iTunes account required) and obtain the appropriate version of Xcode pertaining to your version of Mac OS. Once downloaded, you will need to extract the Xcode-*.xip file, and move the Xcode.app to your /Applications folder. Once that is done, you must then open Xcode to complete the installation.
 
 - +Download and install [XQuartz](https://www.xquartz.org/)+
 


### PR DESCRIPTION
If we do not explain to our users to actuall _run_ Xcode after they
have downloaded it from the App Store, our instructions fail.

TODO: We might want to invest some time into screen shots when the
      App Store fails (or for older Mac OS versions which need to
      log into developer.apple.com).

Closes #13733
