### PR TITLE
Fixes for breakages caused by #13670

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1076,6 +1076,12 @@ public:
   virtual void computeResidualTag(const NumericVector<Number> & soln,
                                   NumericVector<Number> & residual,
                                   TagID tag);
+  /**
+   * Form a residual vector for a given tag and "residual" tag
+   */
+  virtual void computeResidualType(const NumericVector<Number> & soln,
+                                   NumericVector<Number> & residual,
+                                   TagID tag);
 
   /**
    * Form a residual vector for a set of tags. It should not be called directly

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4588,6 +4588,37 @@ FEProblemBase::computeResidualInternal(const NumericVector<Number> & soln,
 }
 
 void
+FEProblemBase::computeResidualType(const NumericVector<Number> & soln,
+                                   NumericVector<Number> & residual,
+                                   TagID tag)
+{
+  TIME_SECTION(_compute_residual_type_timer);
+
+  try
+  {
+    _nl->setSolution(soln);
+
+    _nl->associateVectorToTag(residual, _nl->residualVectorTag());
+
+    computeResidualTags({tag, _nl->residualVectorTag()});
+
+    _nl->disassociateVectorFromTag(residual, _nl->residualVectorTag());
+  }
+  catch (MooseException & e)
+  {
+    // If a MooseException propagates all the way to here, it means
+    // that it was thrown from a MOOSE system where we do not
+    // (currently) properly support the throwing of exceptions, and
+    // therefore we have no choice but to error out.  It may be
+    // *possible* to handle exceptions from other systems, but in the
+    // meantime, we don't want to silently swallow any unhandled
+    // exceptions here.
+    mooseError("An unhandled MooseException was raised during residual computation.  Please "
+               "contact the MOOSE team for assistance.");
+  }
+}
+
+void
 FEProblemBase::computeTransientImplicitResidual(Real time,
                                                 const NumericVector<Number> & u,
                                                 const NumericVector<Number> & udot,

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3261,7 +3261,7 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     petsc_matrix.reset_preallocation();
 
 #else
-    mooseWarning("Automatic scaling requires a PETSc version of 3.8.0 or greater, so no automatic "
+    mooseWarning("Automatic scaling requires a PETSc version of 3.9.0 or greater, so no automatic "
                  "scaling is going to be performed");
 #endif
   }

--- a/test/tests/dgkernels/2d_diffusion_dg/tests
+++ b/test/tests/dgkernels/2d_diffusion_dg/tests
@@ -23,5 +23,6 @@
     requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
     issues = '#12601'
     design = 'FEProblemSolve.md'
+    allow_warnings = True # for PETSc versions < 3.9
   []
 []

--- a/test/tests/interfacekernels/2d_interface/tests
+++ b/test/tests/interfacekernels/2d_interface/tests
@@ -64,5 +64,6 @@
     requirement = 'We shall not do any mallocs in MatSetValues because of automatic scaling'
     issues = '#12601'
     design = 'FEProblemSolve.md'
+    allow_warnings = True # for PETSc versions < 3.9
   []
 []

--- a/test/tests/kernels/bad_scaling_scalar_kernels/tests
+++ b/test/tests/kernels/bad_scaling_scalar_kernels/tests
@@ -17,6 +17,7 @@
     cli_args = 'Executioner/automatic_scaling=true'
     max_parallel = 1 # no parallel svd
     requirement = 'We shall be able to show that with automatic scaling, this system is non-singular'
+    petsc_version = '>=3.9.0'
   []
   [auto-scaled-field-scalar-system-parallel]
     type = Exodiff
@@ -26,5 +27,6 @@
     prereq = auto-scaled-field-scalar-system
     requirement = 'We shall be able to show that with automatic scaling we can run this problem successfully in parallel'
     max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
+    petsc_version = '>=3.9.0'
   []
 []

--- a/test/tests/kernels/simple_transient_diffusion/tests
+++ b/test/tests/kernels/simple_transient_diffusion/tests
@@ -29,6 +29,7 @@
     requirement = "We shall be able to solve an initially poorly scaled problem by using MOOSE's automatic scaling feature"
     cli_args = 'Executioner/automatic_scaling=true'
     max_parallel = 1 # no parallel svd preconditioner
+    petsc_version = '>=3.9.0'
   []
   [automatic-scaling-done-once-parallel-preconditioner]
     type = Exodiff
@@ -40,6 +41,7 @@
     cli_args = 'Executioner/automatic_scaling=true -pc_type hypre -pc_hypre_type boomeramg'
     prereq = 'automatic-scaling-done-once'
     max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
+    petsc_version = '>=3.9.0'
   []
   [cant-solve-large-transient-changes]
     type = RunException
@@ -51,6 +53,7 @@
     requirement = 'We shall not be able to solve a problem where the physics has large changes over time if we only scale once'
     cli_args = "Executioner/automatic_scaling=true Materials/active='function' Executioner/num_steps=10 BCs/right/function='ramp' Outputs/exodus=false"
     max_parallel = 1 # no parallel svd preconditioner
+    petsc_version = '>=3.9.0'
   []
   [automatic-scaling-done-per-time-step]
     type = Exodiff
@@ -62,6 +65,7 @@
     requirement = 'We shall be able to solve a problem where the physics has large changes over time if we scale on every time step'
     cli_args = "Executioner/automatic_scaling=true Executioner/compute_scaling_once=false Materials/active='function' Executioner/num_steps=10 BCs/right/function='ramp' Outputs/file_base=transient"
     max_parallel = 1 # no parallel svd preconditioner
+    petsc_version = '>=3.9.0'
   []
   [automatic-scaling-done-per-time-step-parallel-preconditioner]
     type = Exodiff
@@ -74,6 +78,7 @@
     cli_args = "Executioner/automatic_scaling=true Executioner/compute_scaling_once=false Materials/active='function' Executioner/num_steps=10 BCs/right/function='ramp' Outputs/file_base=transient -pc_type hypre -pc_hypre_type boomeramg"
     prereq = 'automatic-scaling-done-per-time-step'
     max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
+    petsc_version = '>=3.9.0'
   []
   [auto-scaling-cant-have-zero-local-dofs]
     type = RunException
@@ -84,5 +89,6 @@
     requirement = 'We shall error out when trying to do automatic scaling and we have any process with zero dofs'
     design = 'FEProblemSolve.md'
     expect_err = "MOOSE doesn't currently support automatic scaling when there are any processes owning zero dofs"
+    petsc_version = '>=3.9.0'
   []
 []

--- a/test/tests/outputs/console/tests
+++ b/test/tests/outputs/console/tests
@@ -132,7 +132,7 @@
     # Test the used of MooseObject::_console method
     type = RunApp
     input = 'moose_console.i'
-    expect_out = 'ConsoleMessageKernel::timestepSetup - time = 0\.4; t_step = 4'
+    expect_out = 'ConsoleMessageKernel::timestepSetup - time = 0\.4[0-9]*; t_step = 4'
     cli_args = 'Outputs/exodus=false'
 
     requirement = 'The system shall support writing to a buffered console object from every MooseObject-derived object.'


### PR DESCRIPTION
- Add back computeResidualType
- Generalize regex for periodically failing _console test
- Don't run MatResetPreallocation tests on a PETSc older than 3.9.0