### PR TITLE
Fixing up PNGOutputter issues

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -42,20 +42,6 @@ ifneq (x$(MOOSE_NO_PERF_GRAPH), x)
   libmesh_CXXFLAGS += -DMOOSE_NO_PERF_GRAPH
 endif
 
-#
-# libPNG Definition
-#
-png_LIB         :=
-ifneq (, $(shell which pkg-config 2>/dev/null))
-  RET_CODE := $(shell pkg-config --libs libpng 2>/dev/null 1>&2; echo $$?)
-
-  ifeq (0,$(RET_CODE))
-    png_LIB = $(shell pkg-config --libs libpng)
-    libmesh_CXXFLAGS += $(shell pkg-config --cflags-only-I libpng)
-    libmesh_CXXFLAGS += -DMOOSE_HAVE_LIBPNG
-  endif
-endif
-
 # Make.common used to provide an obj-suffix which was related to the
 # machine in question (from config.guess, i.e. @host@ in
 # contrib/utils/Make.common.in) and the $(METHOD).
@@ -69,6 +55,24 @@ ifeq ($(wildcard $(libmesh_LIBTOOL)),)
 endif
 libmesh_shared  := $(shell $(libmesh_LIBTOOL) --config | grep build_libtool_libs | cut -d'=' -f2)
 libmesh_static  := $(shell $(libmesh_LIBTOOL) --config | grep build_old_libs | cut -d'=' -f2)
+
+#
+# libPNG Definition
+#
+png_LIB         :=
+# There is a linking problem where we have undefined symbols in the png library on Linux
+# systems that we have not resolved. We won't attempt to use libpng with static
+ifneq ($(libmesh_static),yes)
+  ifneq (, $(shell which pkg-config 2>/dev/null))
+    RET_CODE := $(shell pkg-config --libs libpng 2>/dev/null 1>&2; echo $$?)
+
+    ifeq (0,$(RET_CODE))
+      png_LIB = $(shell pkg-config --libs libpng)
+      libmesh_CXXFLAGS += $(shell pkg-config --cflags-only-I libpng)
+      libmesh_CXXFLAGS += -DMOOSE_HAVE_LIBPNG
+    endif
+  endif
+endif
 
 # If $(libmesh_CXX) is an mpiXXX compiler script, use -show
 # to determine the base compiler

--- a/framework/include/outputs/png/PNGOutput.h
+++ b/framework/include/outputs/png/PNGOutput.h
@@ -55,16 +55,16 @@ protected:
   virtual void output(const ExecFlagType & type);
 
   // Variable to determine the size, or resolution, of the image.
-  unsigned int _resolution;
+  const unsigned int _resolution;
 
   // Way to specify color vs grayscale image creation.
-  MooseEnum _color;
+  const MooseEnum _color;
 
   // Indicates whether to make the background transparent.
-  bool _transparent_background;
+  const bool _transparent_background;
 
   // Controls transparency level for the general image.
-  Real _transparency;
+  const Real _transparency;
 
   /// Pointer the libMesh::MeshFunction object that the read data is stored
   std::unique_ptr<MeshFunction> _mesh_function;

--- a/framework/src/outputs/png/PNGOutput.C
+++ b/framework/src/outputs/png/PNGOutput.C
@@ -36,8 +36,8 @@ validParams<PNGOutput>()
   params.addRangeCheckedParam<Real>("transparency",
                                     1,
                                     "transparency>=0 & transparency<=1",
-                                    "Value is between 1 and 0"
-                                    "where 1 is completely opaque and 0 is completely transparent"
+                                    "Value is between 0 and 1"
+                                    "where 0 is completely transparent and 1 is completely opaque. "
                                     "Default transparency of the image is no transparency.");
 
   return params;
@@ -258,7 +258,6 @@ PNGOutput::output(const ExecFlagType & /*type*/)
 void
 PNGOutput::makePNG()
 {
-
   // Get the max and min of the BoundingBox
   Point maxPoint = _box.max();
   Point minPoint = _box.min();
@@ -280,7 +279,7 @@ PNGOutput::makePNG()
   Real width = dist_x * _resolution;
   Real height = dist_y * _resolution;
   // Allocate resources.
-  std::vector<png_byte> row((width * 4) + 1);
+  std::vector<png_byte> row((width + 1) * 4);
 
   // Check if we can open and write to the file.
   MooseUtils::checkFileWriteable(png_file.str());
@@ -324,7 +323,7 @@ PNGOutput::makePNG()
   for (Real y = maxPoint(1); y >= minPoint(1); y -= 1. / _resolution)
   {
     pt(1) = y;
-    int indx = 0;
+    unsigned int index = 0;
     for (Real x = minPoint(0); x <= maxPoint(0); x += 1. / _resolution)
     {
       pt(0) = x;
@@ -332,11 +331,11 @@ PNGOutput::makePNG()
 
       // Determine whether to create the PNG in color or grayscale
       if (_color)
-        setRGB(&row.data()[indx * 4], applyScale(dv(0)));
+        setRGB(&row.data()[index * 4], applyScale(dv(0)));
       else
-        row.data()[indx] = applyScale(dv(0)) * 255;
+        row.data()[index] = applyScale(dv(0)) * 255;
 
-      indx++;
+      index++;
     }
     png_write_row(pngp, row.data());
   }
@@ -348,7 +347,7 @@ PNGOutput::makePNG()
   if (infop != nullptr)
     png_free_data(pngp, infop, PNG_FREE_ALL, -1);
   if (pngp != nullptr)
-    png_destroy_write_struct(&pngp, (png_infopp) nullptr);
+    png_destroy_write_struct(&pngp, &infop);
 }
 
 #endif

--- a/test/tests/outputs/png/tests
+++ b/test/tests/outputs/png/tests
@@ -4,28 +4,34 @@
     issues = '#12846'
     design = 'PNGOutput.md'
 
+    # The PNGOutputter does not current work with static builds
+    # due to an unresolved linkage issue. There is currently no
+    # plans (ticket) to resolve this issue.
     [square_domain]
       type = 'CheckFiles'
       input = 'simple_transient_diffusion.i'
       check_files = 'simple_transient_diffusion_png_001.png'
-      
+      library_mode = 'DYNAMIC'
+
       detail = 'for 2D square images,'
     []
-    
+
     [adv_diff_reaction]
       type = 'CheckFiles'
       input = 'adv_diff_reaction_test.i'
       check_files = 'adv_diff_reaction_test_png_001.png'
       max_parallel = 1 # Test uses PETSc options that require a serial run
-      
+      library_mode = 'DYNAMIC'
+
       detail = 'arbitrary shapped domains,'
     []
     [wedge]
       type = 'CheckFiles'
       input = 'wedge.i'
       check_files = 'wedge_png_001.png'
-      
+      library_mode = 'DYNAMIC'
+
       detail = 'and complex shapes with periodic boudary conditions.'
     []
-  []  
+  []
 []


### PR DESCRIPTION
- PNGOutputter restricted to work in dynaimc linkage mode only
  due to unresolved linkage problem with the library in static mode
- Some constness added to member variables
- Memory issue fixed

refs #13646

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
