### PR TITLE
Make GriddedData more robust

### DIFF
--- a/framework/include/utils/GriddedData.h
+++ b/framework/include/utils/GriddedData.h
@@ -13,7 +13,6 @@
 
 using namespace libMesh;
 
-// C++ includes
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -83,13 +82,52 @@ private:
   std::vector<Real> _fcn;
   std::vector<unsigned int> _step;
 
+  /**
+   * parse the file_name extracting information.
+   * Here is an example file:
+   * # this is a comment line at start of file
+   * AXIS Y
+   * -1.5 0
+   * # there is no reason why the x axis can't be second
+   * AXIS X
+   * 1 2 3
+   * # This example has a 3D grid, but the 3rd direction is time
+   * AXIS T
+   * 0 199
+   * # now some data
+   * DATA
+   * # following for x=1, t=0
+   * 1 2
+   * # following for x=2, t=0
+   * 2 3
+   * # following for x=3, t=0
+   * 2 3
+   * # following for x=1, t=199
+   * 89 900
+   * # following for x=2, t=199, and x=3, t=199
+   * 1 -3 -5 -6.898
+   * # end of file
+   */
   void parse(unsigned int & dim,
              std::vector<int> & axes,
              std::vector<std::vector<Real>> & grid,
              std::vector<Real> & f,
              std::vector<unsigned int> & step,
              std::string file_name);
+
+  /**
+   * Extracts the next line from file_stream that is:
+   *  - not empty
+   *  - does not start with #
+   * Returns true if such a line was found,
+   * otherwise returns false
+   */
   bool getSignificantLine(std::ifstream & file_stream, std::string & line);
+
+  /**
+   * Splits an input_string using space as the separator
+   * Converts the resulting items to Real, and adds these
+   * to the end of output_vec
+   */
   void splitToRealVec(const std::string & input_string, std::vector<Real> & output_vec);
 };
-

--- a/framework/src/utils/GriddedData.C
+++ b/framework/src/utils/GriddedData.C
@@ -8,11 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "GriddedData.h"
-
-// MOOSE includes
 #include "MooseError.h"
-
-// C++ includes
+#include "MooseUtils.h"
 #include <fstream>
 
 /**
@@ -60,25 +57,12 @@ GriddedData::GriddedData(std::string file_name)
   parse(_dim, _axes, _grid, _fcn, _step, file_name);
 }
 
-/**
- * Returns the dimensionality of the grid.
- * This may have nothing to do with the dimensionality of
- * the simulation.  Eg, a 2D grid with axes (Y,Z) (so dim=2)
- * be used in a 3D simulation
- */
 unsigned int
 GriddedData::getDim()
 {
   return _dim;
 }
 
-/**
- * Yields axes information.
- * If axes[i] == 0 then the i_th axis in the grid data corresponds to the x axis in the simulation
- * If axes[i] == 1 then the i_th axis in the grid data corresponds to the y axis in the simulation
- * If axes[i] == 2 then the i_th axis in the grid data corresponds to the z axis in the simulation
- * If axes[i] == 3 then the i_th axis in the grid data corresponds to the time in the simulation
- */
 void
 GriddedData::getAxes(std::vector<int> & axes)
 {
@@ -87,10 +71,6 @@ GriddedData::getAxes(std::vector<int> & axes)
     axes[i] = _axes[i];
 }
 
-/**
- * Yields the grid.
- * grid[i] = a vector of Reals that define the i_th axis of the grid
- */
 void
 GriddedData::getGrid(std::vector<std::vector<Real>> & grid)
 {
@@ -103,9 +83,6 @@ GriddedData::getGrid(std::vector<std::vector<Real>> & grid)
   }
 }
 
-/**
- * Yields the values defined at the grid points
- */
 void
 GriddedData::getFcn(std::vector<Real> & fcn)
 {
@@ -114,11 +91,6 @@ GriddedData::getFcn(std::vector<Real> & fcn)
     fcn[i] = _fcn[i];
 }
 
-/**
- * Evaluates the function at a given grid point
- * for instance evaluateFcn({n,m}) = value at (grid[0][n], grid[1][m]), for a function defined on a
- * 2D grid
- */
 Real
 GriddedData::evaluateFcn(const std::vector<unsigned int> & ijk)
 {
@@ -137,32 +109,6 @@ GriddedData::evaluateFcn(const std::vector<unsigned int> & ijk)
   return _fcn[index];
 }
 
-/**
- * parse the file_name extracting information.
- * Here is an example file:
- * # this is a comment line at start of file
- * AXIS Y
- * -1.5 0
- * # there is no reason why the x axis can't be second
- * AXIS X
- * 1 2 3
- * # This example has a 3D grid, but the 3rd direction is time
- * AXIS T
- * 0 199
- * # now some data
- * DATA
- * # following for x=1, t=0
- * 1 2
- * # following for x=2, t=0
- * 2 3
- * # following for x=3, t=0
- * 2 3
- * # following for x=1, t=199
- * 89 900
- * # following for x=2, t=199, and x=3, t=199
- * 1 -3 -5 -6.898
- * # end of file
- */
 void
 GriddedData::parse(unsigned int & dim,
                    std::vector<int> & axes,
@@ -262,17 +208,10 @@ GriddedData::parse(unsigned int & dim,
                " function values were read from file");
 }
 
-/**
- * Extracts the next line from file_stream that is:
- *  - not empty
- *  - does not start with #
- * Returns true if such a line was found,
- * otherwise returns false
- */
 bool
 GriddedData::getSignificantLine(std::ifstream & file_stream, std::string & line)
 {
-  while (getline(file_stream, line))
+  while (std::getline(file_stream, line))
   {
     if (line.size() == 0) // empty line: read next line from file
       continue;
@@ -285,21 +224,15 @@ GriddedData::getSignificantLine(std::ifstream & file_stream, std::string & line)
   return false;
 }
 
-/**
- * Splits an input_string using space as the separator
- * Converts the resulting items to Real, and adds these
- * to the end of output_vec
- */
 void
 GriddedData::splitToRealVec(const std::string & input_string, std::vector<Real> & output_vec)
 {
-  std::istringstream linestream(input_string);
-  std::string item;
-  while (getline(linestream, item, ' '))
-  {
-    std::istringstream i(item);
-    Real d;
-    i >> d;
-    output_vec.push_back(d);
-  }
+  std::vector<Real> values;
+  bool status = MooseUtils::tokenizeAndConvert<Real>(input_string, values, " ");
+
+  if (!status)
+    mooseError("GriddedData: Failed to convert string into Real when reading line ", input_string);
+
+  for (auto val : values)
+    output_vec.push_back(val);
 }

--- a/unit/data/gridded/empty_axis.txt
+++ b/unit/data/gridded/empty_axis.txt
@@ -1,0 +1,4 @@
+# This file is missing axes data for AXIS Y
+AXIS X
+-1.0  0.0 2.0
+AXIS Y

--- a/unit/data/gridded/fourd.txt
+++ b/unit/data/gridded/fourd.txt
@@ -1,0 +1,13 @@
+AXIS X
+0 1
+AXIS Y
+0 1
+AXIS Z
+0 1
+# Time points
+AXIS T
+3 7
+# function values
+DATA
+1 2 3 4 5 6 7 8
+8 7 6 5 4 3 2 1

--- a/unit/data/gridded/missing_data.txt
+++ b/unit/data/gridded/missing_data.txt
@@ -1,0 +1,12 @@
+# Some data values are missing
+AXIS X
+-1.0  0.0 2.0
+AXIS Y
+ -1.0 2.0   3.0
+DATA
+-4.0
+-2.0
+2.0
+5.0
+7.0
+11.0

--- a/unit/data/gridded/no_axes.txt
+++ b/unit/data/gridded/no_axes.txt
@@ -1,0 +1,11 @@
+# This file has no axes specified
+DATA
+-4.0
+-2.0
+2.0
+5.0
+7.0
+11.0
+8.0
+10.0
+14.0

--- a/unit/data/gridded/twod.txt
+++ b/unit/data/gridded/twod.txt
@@ -1,0 +1,15 @@
+# This is the function 1 + 2x + 3y
+# Note: this file has extra spaces in data
+AXIS X
+-1.0  0.0 2.0
+AXIS Y
+ -1.0 2.0   3.0
+DATA
+-4.0
+    -2.0
+2.0
+5.0
+7.0
+11.0
+8.0
+10.0 14.0

--- a/unit/src/GriddedDataTest.C
+++ b/unit/src/GriddedDataTest.C
@@ -1,0 +1,116 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "GriddedData.h"
+#include "MooseException.h"
+
+TEST(GriddedData, 2D)
+{
+  GriddedData gridded_data("data/gridded/twod.txt");
+
+  // Test dimension
+  EXPECT_EQ(gridded_data.getDim(), 2);
+
+  // Test axes
+  std::vector<int> axes;
+  gridded_data.getAxes(axes);
+
+  std::vector<int> axes_gold{{0, 1}};
+  EXPECT_EQ(axes, axes_gold);
+
+  // Test grid (AXES points in file)
+  std::vector<std::vector<Real>> grid;
+  gridded_data.getGrid(grid);
+
+  std::vector<std::vector<Real>> grid_gold{{{-1.0, 0.0, 2.0}, {-1.0, 2.0, 3.0}}};
+  EXPECT_EQ(grid, grid_gold);
+
+  // Test function values (DATA values in file)
+  std::vector<Real> fcn;
+  gridded_data.getFcn(fcn);
+
+  std::vector<Real> fcn_gold{{-4.0, -2.0, 2.0, 5.0, 7.0, 11.0, 8.0, 10.0, 14.0}};
+  EXPECT_EQ(fcn, fcn_gold);
+}
+
+TEST(GriddedData, 4D)
+{
+  GriddedData gridded_data("data/gridded/fourd.txt");
+
+  // Test dimension
+  EXPECT_EQ(gridded_data.getDim(), 4);
+
+  // Test axes
+  std::vector<int> axes;
+  gridded_data.getAxes(axes);
+
+  std::vector<int> axes_gold{{0, 1, 2, 3}};
+  EXPECT_EQ(axes, axes_gold);
+
+  // Test grid (AXES points in file)
+  std::vector<std::vector<Real>> grid;
+  gridded_data.getGrid(grid);
+
+  std::vector<std::vector<Real>> grid_gold{{{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {3.0, 7.0}}};
+  EXPECT_EQ(grid, grid_gold);
+
+  // Test function values (DATA values in file)
+  std::vector<Real> fcn;
+  gridded_data.getFcn(fcn);
+
+  std::vector<Real> fcn_gold{
+      {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0}};
+  EXPECT_EQ(fcn, fcn_gold);
+}
+
+TEST(GriddedData, noAxes)
+{
+  try
+  {
+    GriddedData gridded_data("data/gridded/no_axes.txt");
+    FAIL();
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what()).find("No valid AXIS lines found by GriddedData");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+}
+
+TEST(GriddedData, emptyAxis)
+{
+  try
+  {
+    GriddedData gridded_data("data/gridded/empty_axis.txt");
+    FAIL();
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what()).find("Axis 1 in your GriddedData has zero size");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+}
+
+TEST(GriddedData, missingData)
+{
+  try
+  {
+    GriddedData gridded_data("data/gridded/missing_data.txt");
+    FAIL();
+  }
+  catch (const std::exception & err)
+  {
+    std::size_t pos = std::string(err.what())
+                          .find("According to AXIS statements in GriddedData, number of data "
+                                "points is 9 but 6 function values were read from file");
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+}


### PR DESCRIPTION
Using `MooseUtils::tokenizeAndConvert` to do the splitting makes GriddedData robust to multiple spaces.

Closes #13740 
