### PR TITLE
Remove the default parmetis partitioner when using distributed mesh

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2031,11 +2031,6 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
                  "running with a DistributedMesh");
 
     mesh = libmesh_make_unique<DistributedMesh>(_communicator, dim);
-    if (_partitioner_name != "default" && _partitioner_name != "parmetis")
-    {
-      _partitioner_name = "parmetis";
-      _partitioner_overridden = true;
-    }
   }
   else
   {


### PR DESCRIPTION
Supposedly any partitioner should be fine. Let's see how much the damage is.
