### PR TITLE
Added the ability to print automatic scaling factors

### DIFF
--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -113,6 +113,12 @@ public:
   /// Augmented Picard convergence check that to be called by PicardSolve and can be overridden by derived executioners
   virtual bool augmentedPicardConvergenceCheck() const { return false; }
 
+  /**
+   * Get the verbose output flag
+   * @return The verbose output flag
+   */
+  bool & verbose() { return _verbose; }
+
 protected:
   /**
    * Adds a postprocessor to report a Real class attribute
@@ -131,5 +137,7 @@ protected:
 
   // Restart
   std::string _restart_file_base;
-};
 
+  /// True if printing out additional information
+  bool _verbose;
+};

--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -117,7 +117,7 @@ public:
    * Get the verbose output flag
    * @return The verbose output flag
    */
-  bool & verbose() { return _verbose; }
+  const bool & verbose() const { return _verbose; }
 
 protected:
   /**
@@ -139,5 +139,5 @@ protected:
   std::string _restart_file_base;
 
   /// True if printing out additional information
-  bool _verbose;
+  const bool & _verbose;
 };

--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -172,12 +172,6 @@ public:
   Real & timestepTol() { return _timestep_tolerance; }
 
   /**
-   * Get the verbose output flag
-   * @return The verbose output flag
-   */
-  bool & verbose() { return _verbose; }
-
-  /**
    * Is the current step at a sync point (sync times, time interval, target time, etc)?
    * @return Bool indicataing whether we are at a sync point
    */
@@ -254,9 +248,6 @@ protected:
   Real & _target_time;
   bool _use_multiapp_dt;
 
-  ///should detailed diagnostic output be printed
-  bool _verbose;
-
   Real _solution_change_norm;
 
   /// The difference of current and old solutions
@@ -266,4 +257,3 @@ protected:
 
   PerfID _final_timer;
 };
-

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -630,6 +630,12 @@ public:
 
   virtual TagID systemMatrixTag() override { return _Ke_system_tag; }
 
+  /**
+   * Sets the verbose flag
+   * @param[in] verbose   Verbose flag
+   */
+  void setVerboseFlag(const bool & verbose) { _verbose = verbose; }
+
 public:
   FEProblemBase & _fe_problem;
   System & _sys;
@@ -641,9 +647,6 @@ public:
   std::vector<unsigned int> _current_l_its;
   unsigned int _current_nl_its;
   bool _compute_initial_residual_before_preset_bcs;
-
-  /// True if printing out additional information
-  bool _verbose;
 
 protected:
   /**
@@ -694,6 +697,9 @@ protected:
   void mortarJacobianConstraints(bool displaced);
 
 protected:
+  /// True if printing out additional information
+  bool _verbose;
+
   /// solution vector from nonlinear solver
   const NumericVector<Number> * _current_solution;
   /// ghosted form of the residual

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -642,6 +642,9 @@ public:
   unsigned int _current_nl_its;
   bool _compute_initial_residual_before_preset_bcs;
 
+  /// True if printing out additional information
+  bool _verbose;
+
 protected:
   /**
    * Compute the residual for a given tag

--- a/framework/include/timesteppers/TimeStepper.h
+++ b/framework/include/timesteppers/TimeStepper.h
@@ -133,7 +133,7 @@ protected:
   Real & _timestep_tolerance;
 
   ///should detailed diagnostic output be printed
-  bool & _verbose;
+  const bool & _verbose;
 
   /// Whether or not the previous solve converged.
   bool _converged;
@@ -148,4 +148,3 @@ private:
   /// Size of the current time step as computed by the Stepper.  Note that the actual dt that was taken might be smaller if the Executioner constrained it.
   Real & _current_dt;
 };
-

--- a/framework/src/executioners/Executioner.C
+++ b/framework/src/executioners/Executioner.C
@@ -51,7 +51,8 @@ Executioner::Executioner(const InputParameters & parameters)
         "_fe_problem_base", "This might happen if you don't have a mesh")),
     _feproblem_solve(this),
     _picard_solve(this),
-    _restart_file_base(getParam<FileNameNoExtension>("restart_file_base"))
+    _restart_file_base(getParam<FileNameNoExtension>("restart_file_base")),
+    _verbose(getParam<bool>("verbose"))
 {
   if (!_restart_file_base.empty())
     _fe_problem.setRestartFile(_restart_file_base);

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -78,6 +78,7 @@ validParams<FEProblemSolve>()
       "Whether the scaling factors should only be computed once at the beginning of the simulation "
       "through an extra Jacobian evaluation. If this is set to false, then the scaling factors "
       "will be computed during an extra Jacobian evaluation at the beginning of every time step.");
+  params.addParam<bool>("verbose", false, "Set to true to print additional information");
 
   params.addParamNamesToGroup("l_tol l_abs_tol l_abs_step_tol l_max_its nl_max_its nl_max_funcs "
                               "nl_abs_tol nl_rel_tol nl_abs_step_tol nl_rel_step_tol "
@@ -125,6 +126,8 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
 
   _nl._compute_initial_residual_before_preset_bcs =
       getParam<bool>("compute_initial_residual_before_preset_bcs");
+
+  _nl._verbose = getParam<bool>("verbose");
 
   _problem.setSNESMFReuseBase(getParam<bool>("snesmf_reuse_base"),
                               _pars.isParamSetByUser("snesmf_reuse_base"));

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -127,7 +127,7 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
   _nl._compute_initial_residual_before_preset_bcs =
       getParam<bool>("compute_initial_residual_before_preset_bcs");
 
-  _nl._verbose = getParam<bool>("verbose");
+  _nl.setVerboseFlag(getParam<bool>("verbose"));
 
   _problem.setSNESMFReuseBase(getParam<bool>("snesmf_reuse_base"),
                               _pars.isParamSetByUser("snesmf_reuse_base"));

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -124,7 +124,6 @@ validParams<Transient>()
 
   params.addParamNamesToGroup("time_periods time_period_starts time_period_ends", "Time Periods");
 
-  params.addParam<bool>("verbose", false, "Print detailed diagnostics on timestep calculation");
   return params;
 }
 
@@ -159,7 +158,6 @@ Transient::Transient(const InputParameters & parameters)
     _timestep_tolerance(getParam<Real>("timestep_tolerance")),
     _target_time(declareRecoverableData<Real>("target_time", -1)),
     _use_multiapp_dt(getParam<bool>("use_multiapp_dt")),
-    _verbose(getParam<bool>("verbose")),
     _sln_diff(_nl.addVector("sln_diff", false, PARALLEL)),
     _final_timer(registerTimedSection("final", 1))
 {

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -113,6 +113,7 @@ NonlinearSystemBase::NonlinearSystemBase(FEProblemBase & fe_problem,
     _initial_residual_after_preset_bcs(0.),
     _current_nl_its(0),
     _compute_initial_residual_before_preset_bcs(true),
+    _verbose(false),
     _current_solution(NULL),
     _residual_ghosted(NULL),
     _serialized_solution(*NumericVector<Number>::build(_communicator).release()),
@@ -3252,6 +3253,24 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     for (auto & scaling_factor : inverse_scaling_factors)
       if (scaling_factor < std::numeric_limits<Real>::epsilon())
         scaling_factor = 1;
+
+    if (_verbose)
+    {
+      _console << "Automatic scaling factors:\n";
+      for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
+      {
+        auto & field_variable = *field_variables[i];
+        _console << "  " << field_variable.name() << ": " << 1.0 / inverse_scaling_factors[i]
+                 << "\n";
+      }
+      for (MooseIndex(scalar_variables) i = 0; i < scalar_variables.size(); ++i)
+      {
+        auto & scalar_variable = *scalar_variables[i];
+        _console << "  " << scalar_variable.name() << ": "
+                 << 1.0 / inverse_scaling_factors[offset + i] << "\n";
+      }
+      _console << "\n\n";
+    }
 
     // Now set the scaling factors for the variables
     applyScalingFactors(inverse_scaling_factors);

--- a/test/tests/executioners/executioner/tests
+++ b/test/tests/executioners/executioner/tests
@@ -31,4 +31,23 @@
     group = 'requirements'
     requirement = "MOOSE shall be capable of solving a transient diffusion problem."
   [../]
+
+  [./test_print_automatic_scaling_factors_true]
+    type = 'RunApp'
+    input = 'steady.i'
+    cli_args = "Executioner/automatic_scaling=true Executioner/verbose=true Outputs/exodus=false"
+    expect_out = "Automatic scaling factors:
+  u: 0.175781"
+    petsc_version = '>=3.9.0'
+    requirement = "MOOSE shall print automatic scaling factors if specified."
+  [../]
+
+  [./test_print_automatic_scaling_factors_false]
+    type = 'RunApp'
+    input = 'steady.i'
+    cli_args = "Executioner/automatic_scaling=true Outputs/exodus=false"
+    absent_out = "Automatic scaling factors:"
+    petsc_version = '>=3.9.0'
+    requirement = "MOOSE shall not print automatic scaling factors if not specified."
+  [../]
 []


### PR DESCRIPTION
The parameter "verbose" was moved from Transient to
FEProblemSolve so that Executioner can use it. This
then gets passed to NonlinearSystemBase.

Closes #13795

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
