### PR TITLE
Deprecated all MeshModifiers

### DIFF
--- a/framework/include/meshgenerators/ExtraNodesetGenerator.h
+++ b/framework/include/meshgenerators/ExtraNodesetGenerator.h
@@ -17,9 +17,6 @@ class ExtraNodesetGenerator;
 template <>
 InputParameters validParams<ExtraNodesetGenerator>();
 
-/**
- *
- */
 class ExtraNodesetGenerator : public MeshGenerator
 {
 public:
@@ -30,4 +27,3 @@ public:
 protected:
   std::unique_ptr<MeshBase> & _input;
 };
-

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -20,7 +20,10 @@
 #include "libmesh/point_locator_base.h"
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", AddAllSideSetsByNormals);
+registerMooseObjectReplaced("MooseApp",
+                            AddAllSideSetsByNormals,
+                            "08/12/2019 00:00",
+                            AllSideSetsByNormalsGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/AddExtraNodeset.C
+++ b/framework/src/meshmodifiers/AddExtraNodeset.C
@@ -13,7 +13,7 @@
 #include "FEProblem.h"
 #include "ActionWarehouse.h"
 
-registerMooseObject("MooseApp", AddExtraNodeset);
+registerMooseObjectReplaced("MooseApp", AddExtraNodeset, "08/12/2019 00:00", ExtraNodesetGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -14,7 +14,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", AddSideSetsFromBoundingBox);
+registerMooseObjectReplaced("MooseApp",
+                            AddSideSetsFromBoundingBox,
+                            "08/12/2019 00:00",
+                            SideSetsFromBoundingBoxGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/AssignElementSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignElementSubdomainID.C
@@ -12,7 +12,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", AssignElementSubdomainID);
+registerMooseObjectReplaced("MooseApp",
+                            AssignElementSubdomainID,
+                            "08/12/2019 00:00",
+                            ElementSubdomainIDGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/AssignSubdomainID.C
+++ b/framework/src/meshmodifiers/AssignSubdomainID.C
@@ -12,7 +12,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", AssignSubdomainID);
+registerMooseObjectReplaced("MooseApp",
+                            AssignSubdomainID,
+                            "08/12/2019 00:00",
+                            SubdomainIDGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/BlockDeleter.C
+++ b/framework/src/meshmodifiers/BlockDeleter.C
@@ -12,7 +12,7 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", BlockDeleter);
+registerMooseObjectReplaced("MooseApp", BlockDeleter, "08/12/2019 00:00", BlockDeletionGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -12,7 +12,10 @@
 
 #include "libmesh/node.h"
 
-registerMooseObject("MooseApp", BoundingBoxNodeSet);
+registerMooseObjectReplaced("MooseApp",
+                            BoundingBoxNodeSet,
+                            "08/12/2019 00:00",
+                            BoundingBoxNodeSetGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
+++ b/framework/src/meshmodifiers/BreakBoundaryOnSubdomain.C
@@ -14,7 +14,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", BreakBoundaryOnSubdomain);
+registerMooseObjectReplaced("MooseApp",
+                            BreakBoundaryOnSubdomain,
+                            "08/12/2019 00:00",
+                            BreakBoundaryOnSubdomainGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/BreakMeshByBlock.C
+++ b/framework/src/meshmodifiers/BreakMeshByBlock.C
@@ -12,7 +12,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", BreakMeshByBlock);
+registerMooseObjectReplaced("MooseApp",
+                            BreakMeshByBlock,
+                            "08/12/2019 00:00",
+                            BreakMeshByBlockGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/ImageSubdomain.C
+++ b/framework/src/meshmodifiers/ImageSubdomain.C
@@ -16,7 +16,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", ImageSubdomain);
+registerMooseObjectReplaced("MooseApp",
+                            ImageSubdomain,
+                            "08/12/2019 00:00",
+                            ImageSubdomainGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/LowerDBlockFromSideset.C
+++ b/framework/src/meshmodifiers/LowerDBlockFromSideset.C
@@ -17,7 +17,10 @@
 
 #include <set>
 
-registerMooseObject("MooseApp", LowerDBlockFromSideset);
+registerMooseObjectReplaced("MooseApp",
+                            LowerDBlockFromSideset,
+                            "08/12/2019 00:00",
+                            LowerDBlockFromSidesetGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/MeshExtruder.C
+++ b/framework/src/meshmodifiers/MeshExtruder.C
@@ -15,7 +15,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/boundary_info.h"
 
-registerMooseObject("MooseApp", MeshExtruder);
+registerMooseObjectReplaced("MooseApp", MeshExtruder, "08/12/2019 00:00", MeshExtruderGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/MeshSideSet.C
+++ b/framework/src/meshmodifiers/MeshSideSet.C
@@ -13,7 +13,7 @@
 #include "libmesh/mesh_modification.h"
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", MeshSideSet);
+registerMooseObjectReplaced("MooseApp", MeshSideSet, "08/12/2019 00:00", MeshSideSetGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/OrientedSubdomainBoundingBox.C
+++ b/framework/src/meshmodifiers/OrientedSubdomainBoundingBox.C
@@ -12,7 +12,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", OrientedSubdomainBoundingBox);
+registerMooseObjectReplaced("MooseApp",
+                            OrientedSubdomainBoundingBox,
+                            "08/12/2019 00:00",
+                            OrientedSubdomainBoundingBoxGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/ParsedAddSideset.C
+++ b/framework/src/meshmodifiers/ParsedAddSideset.C
@@ -16,7 +16,10 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_base.h"
 
-registerMooseObject("MooseApp", ParsedAddSideset);
+registerMooseObjectReplaced("MooseApp",
+                            ParsedAddSideset,
+                            "08/12/2019 00:00",
+                            ParsedGenerateSideset);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/ParsedSubdomainMeshModifier.C
+++ b/framework/src/meshmodifiers/ParsedSubdomainMeshModifier.C
@@ -15,7 +15,10 @@
 #include "libmesh/fparser_ad.hh"
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", ParsedSubdomainMeshModifier);
+registerMooseObjectReplaced("MooseApp",
+                            ParsedSubdomainMeshModifier,
+                            "08/12/2019 00:00",
+                            ParsedSubdomainMeshGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/RenameBlock.C
+++ b/framework/src/meshmodifiers/RenameBlock.C
@@ -12,7 +12,7 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", RenameBlock);
+registerMooseObjectReplaced("MooseApp", RenameBlock, "08/12/2019 00:00", RenameBlockGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -16,7 +16,10 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/fe_base.h"
 
-registerMooseObject("MooseApp", SideSetsAroundSubdomain);
+registerMooseObjectReplaced("MooseApp",
+                            SideSetsAroundSubdomain,
+                            "08/12/2019 00:00",
+                            SideSetsAroundSubdomainGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
+++ b/framework/src/meshmodifiers/SideSetsBetweenSubdomains.C
@@ -14,7 +14,10 @@
 
 #include "libmesh/remote_elem.h"
 
-registerMooseObject("MooseApp", SideSetsBetweenSubdomains);
+registerMooseObjectReplaced("MooseApp",
+                            SideSetsBetweenSubdomains,
+                            "08/12/2019 00:00",
+                            SideSetsBetweenSubdomainGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -20,7 +20,10 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_base.h"
 
-registerMooseObject("MooseApp", SideSetsFromNormals);
+registerMooseObjectReplaced("MooseApp",
+                            SideSetsFromNormals,
+                            "08/12/2019 00:00",
+                            SideSetsFromNormalsGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -21,7 +21,10 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_base.h"
 
-registerMooseObject("MooseApp", SideSetsFromPoints);
+registerMooseObjectReplaced("MooseApp",
+                            SideSetsFromPoints,
+                            "08/12/2019 00:00",
+                            SideSetsFromPointsGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SmoothMesh.C
+++ b/framework/src/meshmodifiers/SmoothMesh.C
@@ -16,7 +16,7 @@
 #include "libmesh/mesh_smoother_laplace.h"
 #include "libmesh/unstructured_mesh.h"
 
-registerMooseObject("MooseApp", SmoothMesh);
+registerMooseObjectReplaced("MooseApp", SmoothMesh, "08/12/2019 00:00", SmoothMeshGeneraotr);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/SubdomainBoundingBox.C
+++ b/framework/src/meshmodifiers/SubdomainBoundingBox.C
@@ -13,7 +13,10 @@
 
 #include "libmesh/elem.h"
 
-registerMooseObject("MooseApp", SubdomainBoundingBox);
+registerMooseObjectReplaced("MooseApp",
+                            SubdomainBoundingBox,
+                            "08/12/2019 00:00",
+                            SubdomainBoundingBoxGenerator);
 
 template <>
 InputParameters

--- a/framework/src/meshmodifiers/Transform.C
+++ b/framework/src/meshmodifiers/Transform.C
@@ -12,7 +12,7 @@
 
 #include "libmesh/mesh_modification.h"
 
-registerMooseObject("MooseApp", Transform);
+registerMooseObjectReplaced("MooseApp", Transform, "08/12/2019 00:00", TransformGenerator);
 
 template <>
 InputParameters

--- a/test/tests/kernels/ad_transient_diffusion/ad_transient_vector_diffusion.i
+++ b/test/tests/kernels/ad_transient_diffusion/ad_transient_vector_diffusion.i
@@ -1,13 +1,17 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 10
+  type = MeshGeneratorMesh
 []
 
-[MeshModifiers]
+[MeshGenerators]
+  [./generator]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 10
+  [../]
   [./block]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = generator
     bottom_left = '0.4 0.4 -1'
     top_right = '0.6 0.6 1'
     block_id = 1

--- a/test/tests/kernels/ad_transient_diffusion/tests
+++ b/test/tests/kernels/ad_transient_diffusion/tests
@@ -30,7 +30,7 @@
   [./jac_ad_transient_vector_diffusion]
     type = 'PetscJacobianTester'
     input = 'ad_transient_vector_diffusion.i'
-    cli_args = 'Outputs/exodus=false Mesh/nx=3 Mesh/ny=3 Executioner/num_steps=3'
+    cli_args = 'Outputs/exodus=false MeshGenerators/generator/nx=3 MeshGenerators/generator/ny=3 Executioner/num_steps=3'
     run_sim = True
     ratio_tol = 1e-7
     difference_tol = 1e-6

--- a/test/tests/materials/discrete/recompute2.i
+++ b/test/tests/materials/discrete/recompute2.i
@@ -1,19 +1,22 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 1
+  type = MeshGeneratorMesh
 []
 
-[MeshModifiers]
-  [./left_domain]
-    type = SubdomainBoundingBox
+[MeshGenerators]
+  [generator]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 1
+  []
+  [left_domain]
+    type = SubdomainBoundingBoxGenerator
+    input = generator
     bottom_left = '0 0 0'
     top_right = '0.5 1 0'
     block_id = 10
-  [../]
+  []
 []
-
 
 [Variables]
   [./u]
@@ -45,7 +48,6 @@
 []
 
 [Materials]
-
   [./recompute_props]
     type = RecomputeMaterial
     block = 0

--- a/test/tests/mesh/mesh_only/output_dimension_override.i
+++ b/test/tests/mesh/mesh_only/output_dimension_override.i
@@ -5,11 +5,10 @@
     nx = 2
     ny = 2
   []
-[]
 
-[MeshModifiers]
   [rotate]
-    type = Transform
+    type = TransformGenerator
+    input = gmg
     transform = ROTATE
     vector_value = '0 90 0'
   []

--- a/test/tests/misc/block_user_object_check/block_check.i
+++ b/test/tests/misc/block_user_object_check/block_check.i
@@ -1,19 +1,24 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 5
+  type = MeshGeneratorMesh
 []
 
-[MeshModifiers]
+[MeshGenerators]
+  [./generator]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 5
+  [../]
   [./left_block]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = generator
     block_id = 1
     bottom_left = '0 0 0'
     top_right = '0.5 1 0'
   [../]
   [./right_block]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = left_block
     block_id = 2
     bottom_left = '0.5 0 0'
     top_right = '1 1 0'

--- a/test/tests/misc/block_user_object_check/coupled_check.i
+++ b/test/tests/misc/block_user_object_check/coupled_check.i
@@ -1,19 +1,24 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 5
+  type = MeshGeneratorMesh
 []
 
-[MeshModifiers]
+[MeshGenerators]
+  [./generator]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 5
+  [../]
   [./left_block]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = generator
     block_id = 1
     bottom_left = '0 0 0'
     top_right = '0.5 1 0'
   [../]
   [./right_block]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = left_block
     block_id = 2
     bottom_left = '0.5 0 0'
     top_right = '1 1 0'

--- a/test/tests/misc/subdomain_setup/mat_prop_block.i
+++ b/test/tests/misc/subdomain_setup/mat_prop_block.i
@@ -1,35 +1,42 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 2
-  ny = 2
+  type = MeshGeneratorMesh
 []
 
 [Debug]
   show_material_props = true
 []
 
-[MeshModifiers]
+[MeshGenerators]
+  [./generator]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    ny = 2
+  [../]
   [./subdomain1]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = generator
     bottom_left = '0 0 0'
     top_right = '0.5 0.5 0'
     block_id = 1
   [../]
   [./subdomain2]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = subdomain1
     bottom_left = '0.5 0 0'
     top_right = '1 0.5 0'
     block_id = 2
   [../]
   [./subdomain3]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = subdomain2
     bottom_left = '0 0.5 0'
     top_right = '0.5 1 0'
     block_id = 3
   [../]
   [./subdomain4]
-    type = SubdomainBoundingBox
+    type = SubdomainBoundingBoxGenerator
+    input = subdomain3
     bottom_left = '0.5 0.5 0'
     top_right = '1 1 0'
     block_id = 4


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

I started converting tests over. We have several dozen. It's a time consuming task that I don't have time for right now. Since we can't remove all tests (since we have several that are testing the MeshModifiers themselves, I'll leave it for now - bye bye green deprecated badge).
