### PR TITLE
Restricted auto scale factor printing test to 4 processes

### DIFF
--- a/test/tests/executioners/executioner/tests
+++ b/test/tests/executioners/executioner/tests
@@ -39,6 +39,7 @@
     expect_out = "Automatic scaling factors:
   u: 0.175781"
     petsc_version = '>=3.9.0'
+    max_parallel = 4
     requirement = "MOOSE shall print automatic scaling factors if specified."
   [../]
 
@@ -48,6 +49,7 @@
     cli_args = "Executioner/automatic_scaling=true Outputs/exodus=false"
     absent_out = "Automatic scaling factors:"
     petsc_version = '>=3.9.0'
+    max_parallel = 4
     requirement = "MOOSE shall not print automatic scaling factors if not specified."
   [../]
 []


### PR DESCRIPTION
Automatic scaling cannot currently handle processes with
zero dofs.

Refs #13795

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
