### PR TITLE
Remove henryConstant from SinglePhaseFluidProperties

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -151,6 +151,18 @@ public:
    */
   Real haliteSolubility(Real temperature) const;
 
+  /**
+   * IAPWS formulation of Henry's law constant for dissolution in water
+   * (implemented in water FluidProperties userobject)
+   * @param T fluid temperature (K)
+   * @param coeffs Henry's constant coefficients of gas
+   * @param[out] Kh Henry's constant
+   * @param[out] dKh_dT derivative of Kh wrt temperature
+   */
+  Real henryConstant(Real temperature, const std::vector<Real> & coeffs) const;
+  void
+  henryConstant(Real temperature, const std::vector<Real> & coeffs, Real & Kh, Real & dKh_dT) const;
+
   /// Fluid component numbers for water and NaCl
   static const unsigned int WATER = 0;
   static const unsigned int NACL = 1;
@@ -173,6 +185,8 @@ protected:
   Real massFractionToMoleFraction(Real xnacl) const;
   FPDualReal massFractionToMoleFraction(const FPDualReal & xnacl) const;
 
+  /// Water97FluidProperties UserObject (for Henry's law)
+  const Water97FluidProperties * _water97_fp;
   /// Water97FluidProperties UserObject
   const SinglePhaseFluidProperties * _water_fp;
   /// NaClFluidProperties UserObject

--- a/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/CO2FluidProperties.h
@@ -145,9 +145,7 @@ public:
 
   virtual Real p_from_rho_T(Real density, Real temperature) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
+  virtual std::vector<Real> henryCoefficients() const override;
 
   /**
    * Partial density of dissolved CO2

--- a/modules/fluid_properties/include/userobjects/HydrogenFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/HydrogenFluidProperties.h
@@ -81,9 +81,7 @@ public:
   virtual void
   k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
+  virtual std::vector<Real> henryCoefficients() const override;
 
   virtual Real criticalPressure() const override;
 

--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -113,9 +113,6 @@ public:
 
   virtual Real pp_sat_from_p_T(Real /*p*/, Real /*T*/) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
-
   // Methods used by Navier-Stokes module
   virtual Real gamma() const { return _gamma; };
   virtual Real cv() const { return _cv; };
@@ -140,8 +137,6 @@ protected:
   Real _T_c;
   Real _rho_c;
   Real _e_c;
-  /// Henry constant
-  const Real _henry_constant;
 };
 
 #pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/MethaneFluidProperties.h
@@ -54,9 +54,7 @@ public:
   virtual void
   k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
+  virtual std::vector<Real> henryCoefficients() const override;
 
   virtual Real criticalPressure() const override;
 

--- a/modules/fluid_properties/include/userobjects/NitrogenFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/NitrogenFluidProperties.h
@@ -77,9 +77,7 @@ public:
   virtual void
   k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
+  virtual std::vector<Real> henryCoefficients() const override;
 
   virtual Real criticalPressure() const override;
 

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -39,13 +39,10 @@ public:
   SimpleFluidProperties(const InputParameters & parameters);
   virtual ~SimpleFluidProperties();
 
-  /// Fluid name
   virtual std::string fluidName() const override;
 
-  /// Molar mass (kg/mol)
   virtual Real molarMass() const override;
 
-  /// Thermal expansion coefficient (1/K)
   virtual Real beta_from_p_T(Real pressure, Real temperature) const override;
 
   virtual void beta_from_p_T(Real pressure,
@@ -54,40 +51,30 @@ public:
                              Real & dbeta_dp,
                              Real & dbeta_dT) const override;
 
-  /// Isobaric specific heat capacity (J/kg/K)
   virtual Real cp_from_p_T(Real pressure, Real temperature) const override;
 
   virtual void cp_from_p_T(
       Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
 
-  /// Isochoric specific heat capacity (J/kg/K)
   virtual Real cv_from_p_T(Real pressure, Real temperature) const override;
 
-  /// Speed of sound (m/s)
   virtual Real c_from_p_T(Real pressure, Real temperature) const override;
 
-  /// Thermal conductivity (W/m/K)
   virtual Real k_from_p_T(Real pressure, Real temperature) const override;
 
-  /// Thermal conductivity and its derivatives wrt pressure and temperature
   virtual void
   k_from_p_T(Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  /// Specific entropy (J/kg/K)
   virtual Real s_from_p_T(Real pressure, Real temperature) const override;
   virtual void s_from_p_T(Real p, Real T, Real & s, Real & ds_dp, Real & ds_dT) const override;
 
-  /// Density from pressure and temperature (kg/m^3)
   virtual Real rho_from_p_T(Real pressure, Real temperature) const override;
 
-  /// Density from pressure and temperature and its derivatives wrt pressure and temperature
   virtual void rho_from_p_T(
       Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
 
-  /// Internal energy from pressure and temperature (J/kg)
   virtual Real e_from_p_T(Real pressure, Real temperature) const override;
 
-  /// Internal energy and its derivatives wrt pressure and temperature
   virtual void
   e_from_p_T(Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const override;
 
@@ -96,18 +83,10 @@ public:
   virtual void mu_from_p_T(
       Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const override;
 
-  /// Specific enthalpy (J/kg)
   virtual Real h_from_p_T(Real p, Real T) const override;
 
-  /// Specific enthalpy and its derivatives
   virtual void
   h_from_p_T(Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const override;
-
-  /// Henry's law constant for dissolution in water
-  virtual Real henryConstant(Real temperature) const override;
-
-  /// Henry's law constant for dissolution in water and derivative wrt temperature
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
 
 protected:
   /// molar mass
@@ -137,12 +116,8 @@ protected:
   /// density at zero pressure and temperature
   const Real _density0;
 
-  /// Henry constant
-  const Real _henry_constant;
-
   /// Porepressure coefficient: enthalpy = internal_energy + porepressure / density * _pp_coeff
   const Real _pp_coeff;
 };
 
 #pragma GCC diagnostic pop
-

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -262,15 +262,6 @@ public:
   virtual void v_e_spndl_from_T(Real T, Real & v, Real & e) const;
 
   /**
-   * Henry's law constant for dissolution in water and derivative wrt temperature
-   * @param T fluid temperature (K)
-   * @param[out] Kh Henry's constant
-   * @param[out] dKh_dT derivative of Kh wrt temperature
-   */
-  virtual Real henryConstant(Real T) const;
-  virtual void henryConstant(Real T, Real & Kh, Real & dKh_dT) const;
-
-  /**
    * Vapor pressure. Used to delineate liquid and gas phases.
    * Valid for temperatures between the triple point temperature
    * and the critical temperature
@@ -295,6 +286,12 @@ public:
   virtual Real vaporTemperature(Real p) const;
   virtual void vaporTemperature(Real p, Real & Tsat, Real & dTsat_dp) const;
   DualReal vaporTemperature(const DualReal & p) const;
+
+  /**
+   * Henry's law coefficients for dissolution in water
+   * @return Henry's constant coefficients
+   */
+  virtual std::vector<Real> henryCoefficients() const;
 
   /**
    * Combined methods. These methods are particularly useful for the PorousFlow
@@ -322,16 +319,6 @@ public:
                               Real & e,
                               Real & de_dp,
                               Real & de_dT) const;
-
-protected:
-  /**
-   * IAPWS formulation of Henry's law constant for dissolution in water
-   * From Guidelines on the Henry's constant and vapour
-   * liquid distribution constant for gases in H20 and D20 at high
-   * temperatures, IAPWS (2004)
-   */
-  virtual Real henryConstantIAPWS(Real T, Real A, Real B, Real C) const;
-  virtual void henryConstantIAPWS(Real T, Real & Kh, Real & dKh_dT, Real A, Real B, Real C) const;
 
 private:
   template <typename... Args>

--- a/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/TabulatedFluidProperties.h
@@ -138,9 +138,7 @@ public:
 
   virtual void s_from_p_T(Real p, Real T, Real & s, Real & ds_dp, Real & ds_dT) const override;
 
-  virtual Real henryConstant(Real temperature) const override;
-
-  virtual void henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const override;
+  virtual std::vector<Real> henryCoefficients() const override;
 
   virtual Real vaporPressure(Real temperature) const override;
 

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -242,6 +242,20 @@ public:
    */
   Real b3ab(Real pressure) const;
 
+  /**
+   * IAPWS formulation of Henry's law constant for dissolution in water
+   * From Guidelines on the Henry's constant and vapour
+   * liquid distribution constant for gases in H20 and D20 at high
+   * temperatures, IAPWS (2004)
+   * @param T fluid temperature (K)
+   * @param coeffs Henry's constant coefficients of gas
+   * @param[out] Kh Henry's constant
+   * @param[out] dKh_dT derivative of Kh wrt temperature
+   */
+  Real henryConstant(Real temperature, const std::vector<Real> & coeffs) const;
+  void
+  henryConstant(Real temperature, const std::vector<Real> & coeffs, Real & Kh, Real & dKh_dT) const;
+
 protected:
   /**
    * Gibbs free energy in Region 1 - single phase liquid region

--- a/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/CO2FluidProperties.C
@@ -633,16 +633,10 @@ CO2FluidProperties::partialDensity(Real temperature) const
   return 1.0e6 * _Mco2 / V;
 }
 
-Real
-CO2FluidProperties::henryConstant(Real temperature) const
+std::vector<Real>
+CO2FluidProperties::henryCoefficients() const
 {
-  return henryConstantIAPWS(temperature, -8.55445, 4.01195, 9.52345);
-}
-
-void
-CO2FluidProperties::henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const
-{
-  henryConstantIAPWS(temperature, Kh, dKh_dT, -8.55445, 4.01195, 9.52345);
+  return {-8.55445, 4.01195, 9.52345};
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/HydrogenFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/HydrogenFluidProperties.C
@@ -268,16 +268,10 @@ HydrogenFluidProperties::k_from_p_T(
   dk_dT = (this->k_from_p_T(pressure, temperature + Teps) - k) / Teps;
 }
 
-Real
-HydrogenFluidProperties::henryConstant(Real temperature) const
+std::vector<Real>
+HydrogenFluidProperties::henryCoefficients() const
 {
-  return henryConstantIAPWS(temperature, -4.73284, 6.08954, 6.06066);
-}
-
-void
-HydrogenFluidProperties::henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const
-{
-  henryConstantIAPWS(temperature, Kh, dKh_dT, -4.73284, 6.08954, 6.06066);
+  return {-4.73284, 6.08954, 6.06066};
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -39,7 +39,6 @@ validParams<IdealGasFluidProperties>()
       1.005e3,
       "Constant specific heat capacity at constant pressure (J/kg/K)",
       "The parameter 'cp' is now computed from the provided values for 'gamma' and 'molar_mass'.");
-  params.addParam<Real>("henry_constant", 0.0, "Henry constant for dissolution in water");
 
   params.addClassDescription("Fluid properties for an ideal gas");
 
@@ -57,8 +56,7 @@ IdealGasFluidProperties::IdealGasFluidProperties(const InputParameters & paramet
     _molar_mass(getParam<Real>("molar_mass")),
     _T_c(getParam<Real>("T_c")),
     _rho_c(getParam<Real>("rho_c")),
-    _e_c(getParam<Real>("e_c")),
-    _henry_constant(getParam<Real>("henry_constant"))
+    _e_c(getParam<Real>("e_c"))
 {
   // If R is provided, calculate molar mass using this
   if (parameters.isParamSetByUser("R"))
@@ -593,13 +591,4 @@ Real IdealGasFluidProperties::pp_sat_from_p_T(Real /*p*/, Real /*T*/) const
 {
   mooseError(
       name(), ": ", __PRETTY_FUNCTION__, " not implemented. Use a real fluid property class!");
-}
-
-Real IdealGasFluidProperties::henryConstant(Real /*T*/) const { return _henry_constant; }
-
-void
-IdealGasFluidProperties::henryConstant(Real /*T*/, Real & Kh, Real & dKh_dT) const
-{
-  Kh = _henry_constant;
-  dKh_dT = 0.0;
 }

--- a/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/MethaneFluidProperties.C
@@ -165,16 +165,10 @@ MethaneFluidProperties::vaporPressure(Real, Real &, Real &) const
   mooseError(name(), ": vaporPressure() is not implemented");
 }
 
-Real
-MethaneFluidProperties::henryConstant(Real temperature) const
+std::vector<Real>
+MethaneFluidProperties::henryCoefficients() const
 {
-  return henryConstantIAPWS(temperature, -10.44708, 4.66491, 12.12986);
-}
-
-void
-MethaneFluidProperties::henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const
-{
-  henryConstantIAPWS(temperature, Kh, dKh_dT, -10.44708, 4.66491, 12.12986);
+  return {-10.44708, 4.66491, 12.12986};
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/NitrogenFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/NitrogenFluidProperties.C
@@ -238,16 +238,10 @@ NitrogenFluidProperties::k_from_p_T(
   dk_dT = (this->k_from_p_T(pressure, temperature + Teps) - k) / Teps;
 }
 
-Real
-NitrogenFluidProperties::henryConstant(Real temperature) const
+std::vector<Real>
+NitrogenFluidProperties::henryCoefficients() const
 {
-  return henryConstantIAPWS(temperature, -9.67578, 4.72162, 11.70585);
-}
-
-void
-NitrogenFluidProperties::henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const
-{
-  henryConstantIAPWS(temperature, Kh, dKh_dT, -9.67578, 4.72162, 11.70585);
+  return {-9.67578, 4.72162, 11.70585};
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SimpleFluidProperties.C
@@ -29,7 +29,6 @@ validParams<SimpleFluidProperties>()
   params.addParam<Real>("specific_entropy", 300.0, "Constant specific entropy (J/kg/K)");
   params.addParam<Real>("viscosity", 1.0E-3, "Constant dynamic viscosity (Pa.s)");
   params.addParam<Real>("density0", 1000.0, "Density at zero pressure and zero temperature");
-  params.addParam<Real>("henry_constant", 0.0, "Henry constant for dissolution in water");
   params.addParam<Real>("porepressure_coefficient",
                         1.0,
                         "The enthalpy is internal_energy + P / density * "
@@ -50,7 +49,6 @@ SimpleFluidProperties::SimpleFluidProperties(const InputParameters & parameters)
     _specific_entropy(getParam<Real>("specific_entropy")),
     _viscosity(getParam<Real>("viscosity")),
     _density0(getParam<Real>("density0")),
-    _henry_constant(getParam<Real>("henry_constant")),
     _pp_coeff(getParam<Real>("porepressure_coefficient"))
 {
 }
@@ -195,13 +193,4 @@ SimpleFluidProperties::h_from_p_T(
 
   dh_dp = _pp_coeff / density - _pp_coeff * pressure * ddensity_dp / density / density;
   dh_dT = _cv - _pp_coeff * pressure * ddensity_dT / density / density;
-}
-
-Real SimpleFluidProperties::henryConstant(Real /*temperature*/) const { return _henry_constant; }
-
-void
-SimpleFluidProperties::henryConstant(Real /*temperature*/, Real & Kh, Real & dKh_dT) const
-{
-  Kh = _henry_constant;
-  dKh_dT = 0.0;
 }

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -172,77 +172,13 @@ SinglePhaseFluidProperties::gamma_from_p_T(
   gamma = gamma_from_p_T(p, T);
 }
 
-Real
-SinglePhaseFluidProperties::henryConstantIAPWS(Real T, Real A, Real B, Real C) const
-{
-  const Real Tr = T / 647.096;
-  const Real tau = 1.0 - Tr;
-
-  const Real lnkh =
-      A / Tr + B * std::pow(tau, 0.355) / Tr + C * std::pow(Tr, -0.41) * std::exp(tau);
-
-  // The vapor pressure used in this formulation
-  const std::vector<Real> a{
-      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-  const std::vector<Real> b{1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-  Real sum = 0.0;
-
-  for (std::size_t i = 0; i < a.size(); ++i)
-    sum += a[i] * std::pow(tau, b[i]);
-
-  return 22.064e6 * std::exp(sum / Tr) * std::exp(lnkh);
-}
-
-void
-SinglePhaseFluidProperties::henryConstantIAPWS(
-    Real T, Real & Kh, Real & dKh_dT, Real A, Real B, Real C) const
-{
-  const Real pc = 22.064e6;
-  const Real Tc = 647.096;
-
-  const Real Tr = T / Tc;
-  const Real tau = 1.0 - Tr;
-
-  const Real lnkh =
-      A / Tr + B * std::pow(tau, 0.355) / Tr + C * std::pow(Tr, -0.41) * std::exp(tau);
-  const Real dlnkh_dT =
-      (-A / Tr / Tr - B * std::pow(tau, 0.355) / Tr / Tr - 0.355 * B * std::pow(tau, -0.645) / Tr -
-       0.41 * C * std::pow(Tr, -1.41) * std::exp(tau) - C * std::pow(Tr, -0.41) * std::exp(tau)) /
-      Tc;
-
-  // The vapor pressure used in this formulation
-  const std::vector<Real> a{
-      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-  const std::vector<Real> b{1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-  Real sum = 0.0;
-  Real dsum = 0.0;
-
-  for (std::size_t i = 0; i < a.size(); ++i)
-  {
-    sum += a[i] * std::pow(tau, b[i]);
-    dsum += a[i] * b[i] * std::pow(tau, b[i] - 1.0);
-  }
-
-  const Real p = pc * std::exp(sum / Tr);
-  const Real dp_dT = -p / Tc / Tr * (sum / Tr + dsum);
-
-  // Henry's constant and its derivative wrt temperature
-  Kh = p * std::exp(lnkh);
-  dKh_dT = (p * dlnkh_dT + dp_dT) * std::exp(lnkh);
-}
-
-Real SinglePhaseFluidProperties::henryConstant(Real) const
-{
-  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
-}
-
-void
-SinglePhaseFluidProperties::henryConstant(Real, Real &, Real &) const
-{
-  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
-}
-
 Real SinglePhaseFluidProperties::vaporPressure(Real) const
+{
+  mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
+}
+
+std::vector<Real>
+SinglePhaseFluidProperties::henryCoefficients() const
 {
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");
 }

--- a/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TabulatedFluidProperties.C
@@ -490,16 +490,10 @@ TabulatedFluidProperties::s_from_p_T(Real p, Real T, Real & s, Real & ds_dp, Rea
   SinglePhaseFluidProperties::s_from_p_T(p, T, s, ds_dp, ds_dT);
 }
 
-Real
-TabulatedFluidProperties::henryConstant(Real temperature) const
+std::vector<Real>
+TabulatedFluidProperties::henryCoefficients() const
 {
-  return _fp.henryConstant(temperature);
-}
-
-void
-TabulatedFluidProperties::henryConstant(Real temperature, Real & Kh, Real & dKh_dT) const
-{
-  _fp.henryConstant(temperature, Kh, dKh_dT);
+  return _fp.henryCoefficients();
 }
 
 Real

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -1861,3 +1861,72 @@ Water97FluidProperties::temperature_from_ph3b(const FPDualReal & pressure,
 
   return sum * 860.0;
 }
+
+Real
+Water97FluidProperties::henryConstant(Real temperature, const std::vector<Real> & coeffs) const
+{
+  const Real A = coeffs[0];
+  const Real B = coeffs[1];
+  const Real C = coeffs[2];
+
+  const Real Tr = temperature / 647.096;
+  const Real tau = 1.0 - Tr;
+
+  const Real lnkh =
+      A / Tr + B * std::pow(tau, 0.355) / Tr + C * std::pow(Tr, -0.41) * std::exp(tau);
+
+  // The vapor pressure used in this formulation
+  const std::vector<Real> a{
+      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+  const std::vector<Real> b{1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+  Real sum = 0.0;
+
+  for (std::size_t i = 0; i < a.size(); ++i)
+    sum += a[i] * std::pow(tau, b[i]);
+
+  return 22.064e6 * std::exp(sum / Tr) * std::exp(lnkh);
+}
+
+void
+Water97FluidProperties::henryConstant(Real temperature,
+                                      const std::vector<Real> & coeffs,
+                                      Real & Kh,
+                                      Real & dKh_dT) const
+{
+  const Real A = coeffs[0];
+  const Real B = coeffs[1];
+  const Real C = coeffs[2];
+
+  const Real pc = 22.064e6;
+  const Real Tc = 647.096;
+
+  const Real Tr = temperature / Tc;
+  const Real tau = 1.0 - Tr;
+
+  const Real lnkh =
+      A / Tr + B * std::pow(tau, 0.355) / Tr + C * std::pow(Tr, -0.41) * std::exp(tau);
+  const Real dlnkh_dT =
+      (-A / Tr / Tr - B * std::pow(tau, 0.355) / Tr / Tr - 0.355 * B * std::pow(tau, -0.645) / Tr -
+       0.41 * C * std::pow(Tr, -1.41) * std::exp(tau) - C * std::pow(Tr, -0.41) * std::exp(tau)) /
+      Tc;
+
+  // The vapor pressure used in this formulation
+  const std::vector<Real> a{
+      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+  const std::vector<Real> b{1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+  Real sum = 0.0;
+  Real dsum = 0.0;
+
+  for (std::size_t i = 0; i < a.size(); ++i)
+  {
+    sum += a[i] * std::pow(tau, b[i]);
+    dsum += a[i] * b[i] * std::pow(tau, b[i] - 1.0);
+  }
+
+  const Real p = pc * std::exp(sum / Tr);
+  const Real dp_dT = -p / Tc / Tr * (sum / Tr + dsum);
+
+  // Henry's constant and its derivative wrt temperature
+  Kh = p * std::exp(lnkh);
+  dKh_dT = (p * dlnkh_dT + dp_dT) * std::exp(lnkh);
+}

--- a/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
@@ -13,6 +13,7 @@
 
 class BrineFluidProperties;
 class SinglePhaseFluidProperties;
+class Water97FluidProperties;
 class PorousFlowBrineCO2;
 
 template <>
@@ -521,8 +522,6 @@ protected:
   const BrineFluidProperties & _brine_fp;
   /// Fluid properties UserObject for the CO2
   const SinglePhaseFluidProperties & _co2_fp;
-  /// Fluid properties UserObject for H20
-  const SinglePhaseFluidProperties & _water_fp;
   /// Molar mass of water (kg/mol)
   const Real _Mh2o;
   /// Inverse of molar mass of H2O (mol/kg)
@@ -540,5 +539,6 @@ protected:
   /// Minimum Z - below this value all CO2 will be dissolved. This reduces the
   /// computational burden when small values of Z are present
   const Real _Zmin;
+  /// Henry's coefficeients for CO2
+  const std::vector<Real> _co2_henry;
 };
-

--- a/modules/porous_flow/include/userobjects/PorousFlowWaterNCG.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowWaterNCG.h
@@ -12,6 +12,7 @@
 #include "PorousFlowFluidStateMultiComponentBase.h"
 
 class SinglePhaseFluidProperties;
+class Water97FluidProperties;
 class PorousFlowWaterNCG;
 
 template <>
@@ -143,7 +144,7 @@ protected:
   void checkVariables(Real temperature) const;
 
   /// Fluid properties UserObject for water
-  const SinglePhaseFluidProperties & _water_fp;
+  const Water97FluidProperties & _water_fp;
   /// Fluid properties UserObject for the NCG
   const SinglePhaseFluidProperties & _ncg_fp;
   /// Molar mass of water (kg/mol)
@@ -154,5 +155,7 @@ protected:
   const Real _water_triple_temperature;
   /// Critical temperature of water (K)
   const Real _water_critical_temperature;
+  /// Henry's coefficients for the NCG
+  const std::vector<Real> _ncg_henry;
 };
 

--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -32,7 +32,6 @@ PorousFlowBrineCO2::PorousFlowBrineCO2(const InputParameters & parameters)
     _salt_component(getParam<unsigned int>("salt_component")),
     _brine_fp(getUserObject<BrineFluidProperties>("brine_fp")),
     _co2_fp(getUserObject<SinglePhaseFluidProperties>("co2_fp")),
-    _water_fp(_brine_fp.getComponent(BrineFluidProperties::WATER)),
     _Mh2o(_brine_fp.molarMassH2O()),
     _invMh2o(1.0 / _Mh2o),
     _Mco2(_co2_fp.molarMass()),
@@ -40,7 +39,8 @@ PorousFlowBrineCO2::PorousFlowBrineCO2(const InputParameters & parameters)
     _Rbar(_R * 10.0),
     _Tlower(372.15),
     _Tupper(382.15),
-    _Zmin(1.0e-4)
+    _Zmin(1.0e-4),
+    _co2_henry(_co2_fp.henryCoefficients())
 {
   // Check that the correct FluidProperties UserObjects have been provided
   if (_co2_fp.fluidName() != "co2")
@@ -1469,7 +1469,7 @@ PorousFlowBrineCO2::henryConstant(
 {
   // Henry's constant for dissolution in water
   Real Kh_h2o, dKh_h2o_dT;
-  _co2_fp.henryConstant(temperature, Kh_h2o, dKh_h2o_dT);
+  _brine_fp.henryConstant(temperature, _co2_henry, Kh_h2o, dKh_h2o_dT);
 
   // The correction to salt is obtained through the salting out coefficient
   const std::vector<Real> b{1.19784e-1, -7.17823e-4, 4.93854e-6, -1.03826e-8, 1.08233e-11};

--- a/unit/src/CO2FluidPropertiesTest.C
+++ b/unit/src/CO2FluidPropertiesTest.C
@@ -117,18 +117,18 @@ TEST_F(CO2FluidPropertiesTest, partialDensity)
 }
 
 /**
- * Verify calculation of Henry's constant using data from
+ * Verify that the coefficients for Henry's constant are correct using
  * Guidelines on the Henry's constant and vapour liquid distribution constant
  * for gases in H20 and D20 at high temperatures, IAPWS (2004).
  */
 TEST_F(CO2FluidPropertiesTest, henry)
 {
   const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> hc = _fp->henryCoefficients();
 
-  REL_TEST(_fp->henryConstant(300.0), 173.63e6, tol);
-  REL_TEST(_fp->henryConstant(400.0), 579.84e6, tol);
-  REL_TEST(_fp->henryConstant(500.0), 520.79e6, tol);
-  REL_TEST(_fp->henryConstant(600.0), 259.53e6, tol);
+  REL_TEST(hc[0], -8.55445, tol);
+  REL_TEST(hc[1], 4.01195, tol);
+  REL_TEST(hc[2], 9.52345, tol);
 }
 
 /**
@@ -267,14 +267,6 @@ TEST_F(CO2FluidPropertiesTest, derivatives)
   dmu_dT_fd = (_fp->mu_from_p_T(p, T + dT) - _fp->mu_from_p_T(p, T - dT)) / (2.0 * dT);
 
   REL_TEST(dmu_dT, dmu_dT_fd, tol);
-
-  // Henry's constant
-
-  Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
-  Real Kh = 0.0, dKh_dT = 0.0;
-  _fp->henryConstant(T, Kh, dKh_dT);
-  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_CONSISTENCY);
-  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
 }
 
 /**

--- a/unit/src/HydrogenFluidPropertiesTest.C
+++ b/unit/src/HydrogenFluidPropertiesTest.C
@@ -56,18 +56,18 @@ TEST_F(HydrogenFluidPropertiesTest, vapor)
 }
 
 /**
- * Verify calculation of Henry's constant using data from
+ * Verify that the coefficients for Henry's constant are correct using
  * Guidelines on the Henry's constant and vapour liquid distribution constant
  * for gases in H20 and D20 at high temperatures, IAPWS (2004).
  */
 TEST_F(HydrogenFluidPropertiesTest, henry)
 {
   const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> hc = _fp->henryCoefficients();
 
-  REL_TEST(_fp->henryConstant(300.0), 7.17211e9, tol);
-  REL_TEST(_fp->henryConstant(400.0), 6.33697e9, tol);
-  REL_TEST(_fp->henryConstant(500.0), 2.86137e9, tol);
-  REL_TEST(_fp->henryConstant(600.0), 8.31271e8, tol);
+  REL_TEST(hc[0], -4.73284, tol);
+  REL_TEST(hc[1], 6.08954, tol);
+  REL_TEST(hc[2], 6.06066, tol);
 }
 
 /**
@@ -201,13 +201,6 @@ TEST_F(HydrogenFluidPropertiesTest, derivatives)
   dmu_dT_fd = (_fp->mu_from_p_T(p, T + dT) - _fp->mu_from_p_T(p, T - dT)) / (2.0 * dT);
 
   REL_TEST(dmu_dT, dmu_dT_fd, tol);
-
-  // Henry's constant
-  Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
-  Real Kh = 0.0, dKh_dT = 0.0;
-  _fp->henryConstant(T, Kh, dKh_dT);
-  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_CONSISTENCY);
-  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
 }
 
 /**

--- a/unit/src/IdealGasFluidPropertiesTest.C
+++ b/unit/src/IdealGasFluidPropertiesTest.C
@@ -108,7 +108,6 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
   const Real thermal_conductivity = 0.02568;
   const Real entropy = 1767.24985689;
   const Real viscosity = 18.23e-6;
-  Real henry = 0.0;
   const Real R = 8.3144598;
 
   const Real tol = REL_TOL_CONSISTENCY;
@@ -129,17 +128,12 @@ TEST_F(IdealGasFluidPropertiesTest, testAll)
   REL_TEST(_fp_pT->mu_from_p_T(p, T), viscosity, tol);
   REL_TEST(_fp_pT->mu_from_p_T(p, T), viscosity, tol);
   REL_TEST(_fp_pT->h_from_p_T(p, T), cp * T, tol);
-  ABS_TEST(_fp_pT->henryConstant(T), henry, tol);
 
   DERIV_TEST(_fp_pT->rho_from_p_T, p, T, REL_TOL_DERIVATIVE);
   DERIV_TEST(_fp_pT->mu_from_p_T, p, T, REL_TOL_DERIVATIVE);
   DERIV_TEST(_fp_pT->e_from_p_T, p, T, REL_TOL_DERIVATIVE);
   DERIV_TEST(_fp_pT->h_from_p_T, p, T, REL_TOL_DERIVATIVE);
   DERIV_TEST(_fp_pT->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
-
-  Real dhenry_dT;
-  _fp_pT->henryConstant(T, henry, dhenry_dT);
-  ABS_TEST(dhenry_dT, 0.0, tol);
 }
 
 /**

--- a/unit/src/MethaneFluidPropertiesTest.C
+++ b/unit/src/MethaneFluidPropertiesTest.C
@@ -43,16 +43,18 @@ TEST_F(MethaneFluidPropertiesTest, molarMass)
 }
 
 /**
- * Verify calculation of Henry's constant using data from
+ * Verify that the coefficients for Henry's constant are correct using
  * Guidelines on the Henry's constant and vapour liquid distribution constant
  * for gases in H20 and D20 at high temperatures, IAPWS (2004).
  */
 TEST_F(MethaneFluidPropertiesTest, henry)
 {
-  REL_TEST(_fp->henryConstant(300.0), 4069.0e6, REL_TOL_EXTERNAL_VALUE);
-  REL_TEST(_fp->henryConstant(400.0), 6017.1e6, REL_TOL_EXTERNAL_VALUE);
-  REL_TEST(_fp->henryConstant(500.0), 2812.9e6, REL_TOL_EXTERNAL_VALUE);
-  REL_TEST(_fp->henryConstant(600.0), 801.8e6, REL_TOL_EXTERNAL_VALUE);
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> hc = _fp->henryCoefficients();
+
+  REL_TEST(hc[0], -10.44708, tol);
+  REL_TEST(hc[1], 4.66491, tol);
+  REL_TEST(hc[2], 12.1298, tol);
 }
 
 /**
@@ -124,16 +126,6 @@ TEST_F(MethaneFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->e_from_p_T, p, T, tol);
   DERIV_TEST(_fp->h_from_p_T, p, T, tol);
   DERIV_TEST(_fp->k_from_p_T, p, T, tol);
-
-  // Henry's constant
-  T = 350.0;
-  const Real dT = 1.0e-4;
-
-  Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
-  Real Kh = 0.0, dKh_dT = 0.0;
-  _fp->henryConstant(T, Kh, dKh_dT);
-  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_SAVED_VALUE);
-  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
 }
 
 /**

--- a/unit/src/NitrogenFluidPropertiesTest.C
+++ b/unit/src/NitrogenFluidPropertiesTest.C
@@ -67,18 +67,18 @@ TEST_F(NitrogenFluidPropertiesTest, vapor)
 }
 
 /**
- * Verify calculation of Henry's constant using data from
+ * Verify that the coefficients for Henry's constant are correct using
  * Guidelines on the Henry's constant and vapour liquid distribution constant
  * for gases in H20 and D20 at high temperatures, IAPWS (2004).
  */
 TEST_F(NitrogenFluidPropertiesTest, henry)
 {
   const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> hc = _fp->henryCoefficients();
 
-  REL_TEST(_fp->henryConstant(300.0), 8.77231e9, tol);
-  REL_TEST(_fp->henryConstant(400.0), 1.0495e10, tol);
-  REL_TEST(_fp->henryConstant(500.0), 4.41143e9, tol);
-  REL_TEST(_fp->henryConstant(600.0), 1.17904e9, tol);
+  REL_TEST(hc[0], -9.67578, tol);
+  REL_TEST(hc[1], 4.72162, tol);
+  REL_TEST(hc[2], 11.70585, tol);
 }
 
 /**
@@ -213,13 +213,6 @@ TEST_F(NitrogenFluidPropertiesTest, derivatives)
   dmu_dT_fd = (_fp->mu_from_p_T(p, T + dT) - _fp->mu_from_p_T(p, T - dT)) / (2.0 * dT);
 
   REL_TEST(dmu_dT, dmu_dT_fd, tol);
-
-  // Henry's constant
-  const Real dKh_dT_fd = (_fp->henryConstant(T + dT) - _fp->henryConstant(T - dT)) / (2.0 * dT);
-  Real Kh = 0.0, dKh_dT = 0.0;
-  _fp->henryConstant(T, Kh, dKh_dT);
-  REL_TEST(Kh, _fp->henryConstant(T), REL_TOL_CONSISTENCY);
-  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
 }
 
 /**

--- a/unit/src/SimpleFluidPropertiesTest.C
+++ b/unit/src/SimpleFluidPropertiesTest.C
@@ -36,7 +36,6 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   const Real entropy = 300.0;
   const Real visc = 1.0E-3;
   const Real density0 = 1000.0;
-  const Real henry = 0.0;
   const Real pp_coef = 0.0;
 
   const Real tol = REL_TOL_CONSISTENCY;
@@ -57,7 +56,6 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
   ABS_TEST(_fp->h_from_p_T(p, T), cv * T + p / _fp->rho_from_p_T(p, T), tol);
   ABS_TEST(_fp2->h_from_p_T(p, T), cv * T + p * pp_coef / _fp2->rho_from_p_T(p, T), tol);
-  ABS_TEST(_fp->henryConstant(T), henry, tol);
 
   p = 1.0E7;
   T = 300.0;
@@ -74,7 +72,6 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
   ABS_TEST(_fp->h_from_p_T(p, T), cv * T + p / _fp->rho_from_p_T(p, T), tol);
   ABS_TEST(_fp2->h_from_p_T(p, T), cv * T + p * pp_coef / _fp2->rho_from_p_T(p, T), tol);
-  ABS_TEST(_fp->henryConstant(T), henry, tol);
 }
 
 /**
@@ -104,10 +101,6 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->h_from_p_T, p, T, tol);
   DERIV_TEST(_fp->k_from_p_T, p, T, tol);
   DERIV_TEST(_fp->cp_from_p_T, p, T, tol);
-
-  Real henry, dhenry_dT;
-  _fp->henryConstant(T, henry, dhenry_dT);
-  ABS_TEST(dhenry_dT, 0.0, tol);
 }
 
 /**

--- a/unit/src/TabulatedFluidPropertiesTest.C
+++ b/unit/src/TabulatedFluidPropertiesTest.C
@@ -190,7 +190,9 @@ TEST_F(TabulatedFluidPropertiesTest, passthrough)
   ABS_TEST(_tab_fp->cp_from_p_T(p, T), _co2_fp->cp_from_p_T(p, T), tol);
   ABS_TEST(_tab_fp->cv_from_p_T(p, T), _co2_fp->cv_from_p_T(p, T), tol);
   ABS_TEST(_tab_fp->s_from_p_T(p, T), _co2_fp->s_from_p_T(p, T), tol);
-  ABS_TEST(_tab_fp->henryConstant(T), _co2_fp->henryConstant(T), tol);
+  ABS_TEST(_tab_fp->henryCoefficients()[0], _co2_fp->henryCoefficients()[0], tol);
+  ABS_TEST(_tab_fp->henryCoefficients()[1], _co2_fp->henryCoefficients()[1], tol);
+  ABS_TEST(_tab_fp->henryCoefficients()[2], _co2_fp->henryCoefficients()[2], tol);
 
   // Use a temperature less than the critical point
   T = 300.0;

--- a/unit/src/Water97FluidPropertiesTest.C
+++ b/unit/src/Water97FluidPropertiesTest.C
@@ -647,3 +647,33 @@ TEST_F(Water97FluidPropertiesTest, combined)
   ABS_TEST(de_dp, de2_dp, tol);
   ABS_TEST(de_dT, de2_dT, tol);
 }
+
+/**
+ * Verify calculation of Henry's constant using data from
+ * Guidelines on the Henry's constant and vapour liquid distribution constant
+ * for gases in H20 and D20 at high temperatures, IAPWS (2004).
+ */
+TEST_F(Water97FluidPropertiesTest, henry)
+{
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+
+  // CO2 constants
+  const std::vector<Real> co2{-8.55445, 4.01195, 9.52345};
+  REL_TEST(_fp->henryConstant(300.0, co2), 173.63e6, tol);
+  REL_TEST(_fp->henryConstant(500.0, co2), 520.79e6, tol);
+
+  // CH4 constants
+  const std::vector<Real> ch4{-10.44708, 4.66491, 12.1298};
+  REL_TEST(_fp->henryConstant(400.0, ch4), 6017.1e6, REL_TOL_EXTERNAL_VALUE);
+  REL_TEST(_fp->henryConstant(600.0, ch4), 801.8e6, REL_TOL_EXTERNAL_VALUE);
+
+  // Test derivative of Henry's constant wrt temperature
+  const Real dT = 1.0e-4;
+  const Real dKh_dT_fd =
+      (_fp->henryConstant(500.0 + dT, co2) - _fp->henryConstant(500.0 - dT, co2)) / (2.0 * dT);
+
+  Real Kh = 0.0, dKh_dT = 0.0;
+  _fp->henryConstant(500.0, co2, Kh, dKh_dT);
+  REL_TEST(Kh, _fp->henryConstant(500.0, co2), REL_TOL_CONSISTENCY);
+  REL_TEST(dKh_dT_fd, dKh_dT, REL_TOL_DERIVATIVE);
+}


### PR DESCRIPTION
The Henry's constant formulation is only applicable for dissolution
in water, so it should belong there. Only the coefficients for each
gas should be in their individual classes.

Closes #13835