### PR TITLE
Extended the ability of the output testers to match more literals

### DIFF
--- a/python/TestHarness/testers/FileTester.py
+++ b/python/TestHarness/testers/FileTester.py
@@ -26,8 +26,11 @@ class FileTester(RunApp):
         RunApp.__init__(self, name, params)
 
     def prepare(self, options):
-        if self.specs['delete_output_before_running'] == True:
+        if self.specs['delete_output_before_running']:
             util.deleteFilesAndFolders(self.specs['test_dir'], self.getOutputFiles(), self.specs['delete_output_folders'])
 
     def processResults(self, moose_dir, options, output):
-        return RunApp.testFileOutput(self, moose_dir, options, output)
+        output += self.testFileOutput(moose_dir, options, output)
+        self.testExitCodes(moose_dir, options, output)
+
+        return output

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -20,7 +20,7 @@ class RunApp(Tester):
         params.addParam('test_name',          "The name of the test - populated automatically")
         params.addParam('input_switch', '-i', "The default switch used for indicating an input to the executable")
         params.addParam('errors',             ['ERROR', 'command not found', 'erminate called after throwing an instance of'], "The error messages to detect a failed run")
-        params.addParam('expect_out',         "A regular expression that must occur in the input in order for the test to be considered passing.")
+        params.addParam('expect_out',         "A regular expression or literal string that must occur in the input in order for the test to be considered passing (see match_literal).")
         params.addParam('match_literal', False, "Treat expect_out as a string not a regular expression.")
         params.addParam('absent_out',         "A regular expression that must be *absent* from the output for the test to pass.")
         params.addParam('should_crash', False, "Inidicates that the test is expected to crash or otherwise terminate early")
@@ -193,27 +193,57 @@ class RunApp(Tester):
     def testFileOutput(self, moose_dir, options, output):
         """ Set a failure status for expressions found in output """
         reason = ''
+        errors = ''
         specs = self.specs
-        if specs.isValid('expect_out'):
-            mode = ""
-            if specs['match_literal']:
-                have_expected_out = util.checkOutputForLiteral(output, specs['expect_out'])
-                mode = 'literal'
-            else:
-                have_expected_out = util.checkOutputForPattern(output, specs['expect_out'])
-                mode = 'pattern'
 
-            if (not have_expected_out):
-                reason = 'EXPECTED OUTPUT MISSING'
-                output += "#"*80 + "\n\nUnable to match the following " + mode + " against the program's output:\n\n" + specs['expect_out'] + "\n"
+        params_and_msgs = {'expect_err':
+                              {'error_missing': True,
+                               'modes': ['ALL'],
+                               'reason': "EXPECTED ERROR MISSING",
+                               'message': "Unable to match the following {} against the program's output:"},
+                           'expect_assert':
+                              {'error_missing': True,
+                               'modes': ['dbg', 'devel'],
+                               'reason': "EXPECTED ASSERT MISSING",
+                               'message': "Unable to match the following {} against the program's output:"},
+                           'expect_out':
+                               {'error_missing': True,
+                                'modes': ['ALL'],
+                                'reason': "EXPECTED OUTPUT MISSING",
+                                'message': "Unable to match the following {} against the program's output:"},
+                           'absent_out':
+                               {'error_missing': False,
+                                'modes': ['ALL'],
+                                'reason': "OUTPUT NOT ABSENT",
+                                'message': "Matched the following {}, which we did NOT expect:"}
+                           }
 
-        if reason == '' and specs.isValid('absent_out'):
-            have_absent_out = util.checkOutputForPattern(output, specs['absent_out'])
-            if (have_absent_out):
-                reason = 'OUTPUT NOT ABSENT'
-                output += "#"*80 + "\n\nMatched the following pattern, which we did NOT expect:\n\n" + specs['absent_out'] + "\n"
+        for param,attr in params_and_msgs.iteritems():
+            if specs.isValid(param) and (options.method in attr['modes'] or attr['modes'] == ['ALL']):
+                match_type = ""
+                if specs['match_literal']:
+                    have_expected_out = util.checkOutputForLiteral(output, specs[param])
+                    match_type = 'literal'
+                else:
+                    have_expected_out = util.checkOutputForPattern(output, specs[param])
+                    match_type = 'pattern'
 
-        if reason == '':
+                # Exclusive OR test
+                if attr['error_missing'] ^ have_expected_out:
+                    reason = attr['reason']
+                    errors += "#"*80 + "\n\n" + attr['message'].format(match_type) + "\n\n" + specs[param] + "\n"
+                    break
+
+        if reason != '':
+            self.setStatus(self.fail, reason)
+
+        return errors
+
+    def testExitCodes(self, moose_dir, options, output):
+        # Don't do anything if we already have a status set
+        reason = ''
+        if self.isNoStatus():
+            specs = self.specs
             # We won't pay attention to the ERROR strings if EXPECT_ERR is set (from the derived class)
             # since a message to standard error might actually be a real error.  This case should be handled
             # in the derived class.
@@ -227,10 +257,8 @@ class RunApp(Tester):
             elif self.exit_code == 0 and self.shouldExecute() and options.valgrind_mode != '' and 'ERROR SUMMARY: 0 errors' not in output:
                 reason = 'MEMORY ERROR'
 
-        if reason != '':
-            self.setStatus(self.fail, reason)
-
-        return output
+            if reason != '':
+                self.setStatus(self.fail, reason)
 
     def processResults(self, moose_dir, options, output):
         """
@@ -246,4 +274,7 @@ class RunApp(Tester):
         # TODO: because RunParallel is now setting every successful status message,
                 refactor testFileOutput and processResults.
         """
-        return self.testFileOutput(moose_dir, options, output)
+        output += self.testFileOutput(moose_dir, options, output)
+        self.testExitCodes(moose_dir, options, output)
+
+        return output

--- a/python/TestHarness/testers/VTKDiff.py
+++ b/python/TestHarness/testers/VTKDiff.py
@@ -33,7 +33,8 @@ class VTKDiff(RunApp):
             util.deleteFilesAndFolders(self.specs['test_dir'], self.specs['vtkdiff'])
 
     def processResults(self, moose_dir, options, output):
-        RunApp.testFileOutput(self, moose_dir, options, output)
+        output += self.testFileOutput(moose_dir, options, output)
+        self.testExitCodes(moose_dir, options, output)
 
         # Skip
         specs = self.specs

--- a/python/TestHarness/tests/test_Expect.py
+++ b/python/TestHarness/tests/test_Expect.py
@@ -19,9 +19,13 @@ class TestHarnessTester(TestHarnessTestCase):
             self.runTests('-i', 'expect')
 
         e = cm.exception
-        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_err.*?FAILED \(EXPECTED ERROR MISSING\)')
-        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_out.*?FAILED \(EXPECTED OUTPUT MISSING\)')
-        self.assertRegexpMatches(e.output, r'test_harness\.absent_out.*?FAILED \(OUTPUT NOT ABSENT\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_err_pattern.*?FAILED \(EXPECTED ERROR MISSING\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_out_pattern.*?FAILED \(EXPECTED OUTPUT MISSING\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.absent_out_pattern.*?FAILED \(OUTPUT NOT ABSENT\)')
+
+        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_err_literal.*?FAILED \(EXPECTED ERROR MISSING\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.no_expect_out_literal.*?FAILED \(EXPECTED OUTPUT MISSING\)')
+        self.assertRegexpMatches(e.output, r'test_harness\.absent_out_literal.*?FAILED \(OUTPUT NOT ABSENT\)')
 
 
     def testExpectMissing(self):

--- a/test/tests/test_harness/expect
+++ b/test/tests/test_harness/expect
@@ -1,19 +1,40 @@
 [Tests]
-  [./no_expect_err]
+  [./no_expect_err_pattern]
+    type = RunException
+    input = bad_kernel.i
+    expect_err = 'Wrong Error \w+'
+  [../]
+
+  [./no_expect_err_literal]
     type = RunException
     input = bad_kernel.i
     expect_err = 'Wrong Error'
+    match_literal = true
   [../]
 
-  [./no_expect_out]
+  [./no_expect_out_pattern]
     type = RunApp
     input = good.i
-    expect_out = 'Wrong Error'
+    expect_out = 'Wrong Output \w+'
   [../]
 
-  [./absent_out]
+  [./no_expect_out_literal]
+    type = RunApp
+    input = good.i
+    expect_out = 'Wrong Output'
+    match_literal = true
+  [../]
+
+  [./absent_out_pattern]
+    type = RunApp
+    input = good.i
+    absent_out = '\w+ Converged!'
+  [../]
+
+  [./absent_out_literal]
     type = RunApp
     input = good.i
     absent_out = 'Solve Converged!'
+    match_literal = true
   [../]
 []


### PR DESCRIPTION
This makes each of the "expect" type string matching tests all work with literals or regular expressions.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
