### PR TITLE
Added hitArgCmp() to close #13518

### DIFF
--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -191,3 +191,13 @@ CommandLine::search(const std::string & option_name, T & argument)
   }
   mooseError("Unrecognized option name");
 }
+
+enum HitCmpResult
+{
+	GLOBAL,
+	MAIN,
+	MATCH,
+	WRONG
+};
+
+HitCmpResult hitArgCmp(std::string arg, std::string appname, int appnum);

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -120,8 +120,8 @@ public:
   {
     GLOBAL,
     MAIN,
-    MATCH,
-    WRONG
+    MULTIAPP_MATCH,
+    MULTIAPP_WRONG
   };
 
   static HitCmpResult

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -192,7 +192,7 @@ CommandLine::search(const std::string & option_name, T & argument)
   mooseError("Unrecognized option name");
 }
 
-enum HitCmpResult
+enum class HitCmpResult
 {
 	GLOBAL,
 	MAIN,

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -118,10 +118,10 @@ public:
 
   enum class HitCmpResult
   {
-	GLOBAL,
-	MAIN,
-	MATCH,
-	WRONG
+    GLOBAL,
+    MAIN,
+    MATCH,
+    WRONG
   };
 
   static HitCmpResult hitArgComparison(const std::string & arg, const std::string & appname, int appnum);

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -124,6 +124,12 @@ public:
     MULTIAPP_WRONG
   };
 
+  /**
+   * Determines whether the given arg string follows the pattern for a Hit parameter that is
+   * applicable either: globally to all master and multiapp subapps, only to the main/master app,
+   * only to the specified multiapp/subapp (via appname and appnum), or to another different
+   * multiapp/subapp.
+   */
   static HitCmpResult
   hitArgComparison(const std::string & arg, const std::string & appname, int appnum);
 

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -124,7 +124,8 @@ public:
     WRONG
   };
 
-  static HitCmpResult hitArgComparison(const std::string & arg, const std::string & appname, int appnum);
+  static HitCmpResult
+  hitArgComparison(const std::string & arg, const std::string & appname, int appnum);
 
 protected:
   /**

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -200,4 +200,4 @@ enum class HitCmpResult
 	WRONG
 };
 
-HitCmpResult hitArgCmp(std::string arg, std::string appname, int appnum);
+HitCmpResult hitArgCmp(const std::string & arg, const std::string & appname, int appnum);

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -200,4 +200,4 @@ enum class HitCmpResult
 	WRONG
 };
 
-HitCmpResult hitArgCmp(const std::string & arg, const std::string & appname, int appnum);
+HitCmpResult hitArgComparison(const std::string & arg, const std::string & appname, int appnum);

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -116,6 +116,16 @@ public:
     return unused;
   }
 
+  enum class HitCmpResult
+  {
+	GLOBAL,
+	MAIN,
+	MATCH,
+	WRONG
+  };
+
+  static HitCmpResult hitArgComparison(const std::string & arg, const std::string & appname, int appnum);
+
 protected:
   /**
    * Used to set the argument value, allows specialization
@@ -191,13 +201,3 @@ CommandLine::search(const std::string & option_name, T & argument)
   }
   mooseError("Unrecognized option name");
 }
-
-enum class HitCmpResult
-{
-	GLOBAL,
-	MAIN,
-	MATCH,
-	WRONG
-};
-
-HitCmpResult hitArgComparison(const std::string & arg, const std::string & appname, int appnum);

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -236,7 +236,7 @@ CommandLine::setArgument<std::string>(std::stringstream & stream, std::string & 
   argument = stream.str();
 }
 
-HitCmpResult hitArgCmp(std::string arg, std::string app_name, int app_num)
+HitCmpResult hitArgCmp(const std::string & arg, const std::string & app_name, int app_num)
 {
   int arg_num = -1;
   std::string arg_name;

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -75,7 +75,8 @@ CommandLine::initForMultiApp(const std::string & subapp_full_name)
   // an erase is needed to actually remove the items
   auto new_end =
       std::remove_if(_argv.begin(), _argv.end(), [&sub_name, sub_num](const std::string & arg) {
-        return CommandLine::hitArgComparison(arg, sub_name, sub_num) == CommandLine::HitCmpResult::WRONG;
+        return CommandLine::hitArgComparison(arg, sub_name, sub_num) ==
+               CommandLine::HitCmpResult::WRONG;
       });
   _argv.erase(new_end, _argv.end());
 
@@ -236,7 +237,7 @@ CommandLine::setArgument<std::string>(std::stringstream & stream, std::string & 
   argument = stream.str();
 }
 
-CommandLine::HitCmpResult 
+CommandLine::HitCmpResult
 CommandLine::hitArgComparison(const std::string & arg, const std::string & app_name, int app_num)
 {
   int arg_num = -1;
@@ -247,6 +248,7 @@ CommandLine::hitArgComparison(const std::string & arg, const std::string & app_n
   if (pos == std::string::npos)
     return CommandLine::HitCmpResult::MAIN;
   pcrecpp::RE("(\\S*?)(\\d*):").PartialMatch(arg, &arg_name, &arg_num);
-  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num)) return CommandLine::HitCmpResult::MATCH;
+  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num))
+    return CommandLine::HitCmpResult::MATCH;
   return CommandLine::HitCmpResult::WRONG;
 }

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -75,7 +75,7 @@ CommandLine::initForMultiApp(const std::string & subapp_full_name)
   // an erase is needed to actually remove the items
   auto new_end =
       std::remove_if(_argv.begin(), _argv.end(), [&sub_name, sub_num](const std::string & arg) {
-        return hitArgCmp(arg, sub_name, sub_num) == HitCmpResult::WRONG;
+        return hitArgComparison(arg, sub_name, sub_num) == HitCmpResult::WRONG;
       });
   _argv.erase(new_end, _argv.end());
 
@@ -236,7 +236,7 @@ CommandLine::setArgument<std::string>(std::stringstream & stream, std::string & 
   argument = stream.str();
 }
 
-HitCmpResult hitArgCmp(const std::string & arg, const std::string & app_name, int app_num)
+HitCmpResult hitArgComparison(const std::string & arg, const std::string & app_name, int app_num)
 {
   int arg_num = -1;
   std::string arg_name;

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -75,7 +75,7 @@ CommandLine::initForMultiApp(const std::string & subapp_full_name)
   // an erase is needed to actually remove the items
   auto new_end =
       std::remove_if(_argv.begin(), _argv.end(), [&sub_name, sub_num](const std::string & arg) {
-        return hitArgCmp(arg, sub_name, sub_num) == WRONG;
+        return hitArgCmp(arg, sub_name, sub_num) == HitCmpResult::WRONG;
       });
   _argv.erase(new_end, _argv.end());
 
@@ -242,10 +242,10 @@ HitCmpResult hitArgCmp(std::string arg, std::string app_name, int app_num)
   std::string arg_name;
   auto pos = arg.find(":", 0);
   if (pos == 0)
-    return GLOBAL;
+    return HitCmpResult::GLOBAL;
   if (pos == std::string::npos)
-    return MAIN;
+    return HitCmpResult::MAIN;
   pcrecpp::RE("(\\S*?)(\\d*):").PartialMatch(arg, &arg_name, &arg_num);
-  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num)) return MATCH;
-  return WRONG;
+  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num)) return HitCmpResult::MATCH;
+  return HitCmpResult::WRONG;
 }

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -75,7 +75,7 @@ CommandLine::initForMultiApp(const std::string & subapp_full_name)
   // an erase is needed to actually remove the items
   auto new_end =
       std::remove_if(_argv.begin(), _argv.end(), [&sub_name, sub_num](const std::string & arg) {
-        return hitArgComparison(arg, sub_name, sub_num) == HitCmpResult::WRONG;
+        return CommandLine::hitArgComparison(arg, sub_name, sub_num) == CommandLine::HitCmpResult::WRONG;
       });
   _argv.erase(new_end, _argv.end());
 
@@ -236,16 +236,17 @@ CommandLine::setArgument<std::string>(std::stringstream & stream, std::string & 
   argument = stream.str();
 }
 
-HitCmpResult hitArgComparison(const std::string & arg, const std::string & app_name, int app_num)
+CommandLine::HitCmpResult 
+CommandLine::hitArgComparison(const std::string & arg, const std::string & app_name, int app_num)
 {
   int arg_num = -1;
   std::string arg_name;
   auto pos = arg.find(":", 0);
   if (pos == 0)
-    return HitCmpResult::GLOBAL;
+    return CommandLine::HitCmpResult::GLOBAL;
   if (pos == std::string::npos)
-    return HitCmpResult::MAIN;
+    return CommandLine::HitCmpResult::MAIN;
   pcrecpp::RE("(\\S*?)(\\d*):").PartialMatch(arg, &arg_name, &arg_num);
-  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num)) return HitCmpResult::MATCH;
-  return HitCmpResult::WRONG;
+  if (app_name == arg_name && (arg_num == -1 || arg_num == app_num)) return CommandLine::HitCmpResult::MATCH;
+  return CommandLine::HitCmpResult::WRONG;
 }

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -434,13 +434,13 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
           .FullMatch(appname, &name, &num);
       switch (hitArgCmp(arg, name, num))
       {
-        case GLOBAL:
-        case MATCH:
+        case HitCmpResult::GLOBAL:
+        case HitCmpResult::MATCH:
           break;
-        case WRONG:
+        case HitCmpResult::WRONG:
           _app.commandLine()->markHitParam(i);
           continue;
-        case MAIN:
+        case HitCmpResult::MAIN:
           continue;
       }
       auto pos = arg.find(":", 0);

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -432,7 +432,7 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
                   "(\\d+)" // math the multiapp number
                   )
           .FullMatch(appname, &name, &num);
-      switch (hitArgCmp(arg, name, num))
+      switch (hitArgComparison(arg, name, num))
       {
         case HitCmpResult::GLOBAL:
         case HitCmpResult::MATCH:

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -427,22 +427,23 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
     else if (appname != "main") // app we are loading is a multiapp subapp
     {
       std::string name;
-      std::string num;
+      int num;
       pcrecpp::RE("(.*?)"  // Match the multiapp name
                   "(\\d+)" // math the multiapp number
                   )
           .FullMatch(appname, &name, &num);
-      auto pos = arg.find(":", 0);
-      if (pos == 0)
-        ; // cli param is ":" prefixed meaning global for all main+subapps
-      else if (pos == std::string::npos) // param is for main app - skip
-        continue;
-      else if (arg.substr(0, pos) != appname &&
-               arg.substr(0, pos) != name) // param is for different multiapp - skip
+      switch (hitArgCmp(arg, name, num))
       {
-        _app.commandLine()->markHitParam(i);
-        continue;
+        case GLOBAL:
+        case MATCH:
+          break;
+        case WRONG:
+          _app.commandLine()->markHitParam(i);
+          continue;
+        case MAIN:
+          continue;
       }
+      auto pos = arg.find(":", 0);
       arg = arg.substr(pos + 1, arg.size() - pos - 1); // trim off subapp name prefix
     }
 

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -432,15 +432,15 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
                   "(\\d+)" // math the multiapp number
                   )
           .FullMatch(appname, &name, &num);
-      switch (hitArgComparison(arg, name, num))
+      switch (CommandLine::hitArgComparison(arg, name, num))
       {
-        case HitCmpResult::GLOBAL:
-        case HitCmpResult::MATCH:
+        case CommandLine::HitCmpResult::GLOBAL:
+        case CommandLine::HitCmpResult::MATCH:
           break;
-        case HitCmpResult::WRONG:
+        case CommandLine::HitCmpResult::WRONG:
           _app.commandLine()->markHitParam(i);
           continue;
-        case HitCmpResult::MAIN:
+        case CommandLine::HitCmpResult::MAIN:
           continue;
       }
       auto pos = arg.find(":", 0);


### PR DESCRIPTION
Pulled out the shared code between CommandLine::initForMultiApp and Parser::hitCLIFilter. I think this has made it more simple to read, at least. Please tell me if my understanding of the issue wasn't right. I am also not sure what the proper way to include new code like this is, so I just went with the simplest thing I could think of.
