### PR TITLE
Fix argument skipping logic in Parser::hitCLIFilter

### DIFF
--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -407,16 +407,16 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
     else if (arg.find("=", 0) != std::string::npos)
       afterDoubleDash = true;
 
+    // skip over args that don't look like or are before hit parameters
+    if (!afterDoubleDash)
+      continue;
     // skip arguments with no equals sign
     if (arg.find("=", 0) == std::string::npos)
       continue;
     // skip cli flags (i.e. start with dash)
-    else if (arg.find("-", 0) == 0)
+    if (arg.find("-", 0) == 0)
       continue;
-    // skip over args that don't look like or are before hit parameters
-    else if (!afterDoubleDash)
-      continue;
-    else if (appname == "main")
+    if (appname == "main")
     {
       auto pos = arg.find(":", 0);
       if (pos == 0) // trim leading colon
@@ -424,7 +424,7 @@ Parser::hitCLIFilter(std::string appname, const std::vector<std::string> & argv)
       else if (pos != std::string::npos && pos < arg.find("=", 0)) // param is for non-main subapp
         continue;
     }
-    else if (appname != "main") // app we are loading is a multiapp subapp
+    else // app we are loading is a multiapp subapp
     {
       std::string name;
       std::string num;


### PR DESCRIPTION
`if (!afterDoubleDash)` would never evaluate true if it's running after `if (arg.find("=", 0) == std::string::npos)`. If arg doesn't contain an "=", then `if (arg.find("=", 0) == std::string::npos)` continues. If it does, then `else if (arg.find("=", 0) != std::string::npos)` will set afterDoubleDash to true.
I also cleaned up all of the unnecessary else ifs while I was at it.
