### PR TITLE
Use AD in porous flow fluid state classes

### DIFF
--- a/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/BrineFluidProperties.h
@@ -68,6 +68,7 @@ public:
   Real molarMassH2O() const;
 
   virtual Real rho_from_p_T_X(Real pressure, Real temperature, Real xnacl) const override;
+  using MultiComponentFluidProperties::rho_from_p_T_X;
 
   FPDualReal rho_from_p_T_X(const FPDualReal & pressure,
                             const FPDualReal & temperature,
@@ -82,6 +83,7 @@ public:
                               Real & drho_dx) const override;
 
   virtual Real mu_from_p_T_X(Real pressure, Real temperature, Real xnacl) const override;
+  using MultiComponentFluidProperties::mu_from_p_T_X;
 
   virtual void mu_from_p_T_X(Real pressure,
                              Real temperature,
@@ -96,6 +98,7 @@ public:
                           const FPDualReal & xnacl) const;
 
   virtual Real h_from_p_T_X(Real pressure, Real temperature, Real xnacl) const override;
+  using MultiComponentFluidProperties::h_from_p_T_X;
 
   virtual void h_from_p_T_X(Real pressure,
                             Real temperature,
@@ -162,6 +165,7 @@ public:
   Real henryConstant(Real temperature, const std::vector<Real> & coeffs) const;
   void
   henryConstant(Real temperature, const std::vector<Real> & coeffs, Real & Kh, Real & dKh_dT) const;
+  DualReal henryConstant(const DualReal & temperature, const std::vector<Real> & coeffs) const;
 
   /// Fluid component numbers for water and NaCl
   static const unsigned int WATER = 0;

--- a/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SinglePhaseFluidProperties.h
@@ -310,6 +310,8 @@ public:
                                Real & mu,
                                Real & dmu_dp,
                                Real & dmu_dT) const;
+  virtual void
+  rho_mu_from_p_T(const DualReal & p, const DualReal & T, DualReal & rho, DualReal & mu) const;
 
   virtual void rho_e_from_p_T(Real p,
                               Real T,

--- a/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/Water97FluidProperties.h
@@ -255,6 +255,7 @@ public:
   Real henryConstant(Real temperature, const std::vector<Real> & coeffs) const;
   void
   henryConstant(Real temperature, const std::vector<Real> & coeffs, Real & Kh, Real & dKh_dT) const;
+  DualReal henryConstant(const DualReal & temperature, const std::vector<Real> & coeffs) const;
 
 protected:
   /**
@@ -1336,4 +1337,3 @@ protected:
 };
 
 #pragma GCC diagnostic pop
-

--- a/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/BrineFluidProperties.C
@@ -515,3 +515,17 @@ BrineFluidProperties::henryConstant(Real temperature,
 {
   _water97_fp->henryConstant(temperature, coeffs, Kh, dKh_dT);
 }
+
+DualReal
+BrineFluidProperties::henryConstant(const DualReal & temperature,
+                                    const std::vector<Real> & coeffs) const
+{
+  Real Kh, dKh_dT;
+  henryConstant(temperature.value(), coeffs, Kh, dKh_dT);
+
+  DualReal henry = Kh;
+  for (std::size_t i = 0; i < temperature.derivatives().size(); ++i)
+    henry.derivatives()[i] = temperature.derivatives()[i] * dKh_dT;
+
+  return henry;
+}

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -273,6 +273,16 @@ SinglePhaseFluidProperties::rho_mu_from_p_T(Real p,
   mu_from_p_T(p, T, mu, dmu_dp, dmu_dT);
 }
 
+void
+SinglePhaseFluidProperties::rho_mu_from_p_T(const DualReal & p,
+                                            const DualReal & T,
+                                            DualReal & rho,
+                                            DualReal & mu) const
+{
+  rho = rho_from_p_T(p, T);
+  mu = mu_from_p_T(p, T);
+}
+
 Real SinglePhaseFluidProperties::e_spndl_from_v(Real) const
 {
   mooseError(name(), ": ", __PRETTY_FUNCTION__, " not implemented.");

--- a/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/Water97FluidProperties.C
@@ -1930,3 +1930,19 @@ Water97FluidProperties::henryConstant(Real temperature,
   Kh = p * std::exp(lnkh);
   dKh_dT = (p * dlnkh_dT + dp_dT) * std::exp(lnkh);
 }
+
+DualReal
+Water97FluidProperties::henryConstant(const DualReal & temperature,
+                                      const std::vector<Real> & coeffs) const
+{
+  const Real T = temperature.value();
+  Real Kh_real = 0.0;
+  Real dKh_dT_real = 0.0;
+  henryConstant(T, coeffs, Kh_real, dKh_dT_real);
+
+  DualReal Kh = Kh_real;
+  for (size_t i = 0; i < temperature.derivatives().size(); ++i)
+    Kh.derivatives()[i] = temperature.derivatives()[i] * dKh_dT_real;
+
+  return Kh;
+}

--- a/modules/porous_flow/include/materials/PorousFlowFluidState.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidState.h
@@ -139,5 +139,12 @@ protected:
   std::vector<FluidStateProperties> _fsp;
   /// Capillary pressure UserObject
   const PorousFlowCapillaryPressure & _pc;
+  /// Index of derivative wrt pressure
+  const unsigned int _pidx;
+  /// Index of derivative wrt temperature
+  const unsigned int _Tidx;
+  /// Index of derivative wrt total mass fraction Z
+  const unsigned int _Zidx;
+  /// Index of derivative wrt salt mass fraction X
+  const unsigned int _Xidx;
 };
-

--- a/modules/porous_flow/include/materials/PorousFlowFluidStateSingleComponent.h
+++ b/modules/porous_flow/include/materials/PorousFlowFluidStateSingleComponent.h
@@ -107,7 +107,7 @@ protected:
   /// Flag to indicate whether to calculate stateful properties
   bool _is_initqp;
   /// FluidStateProperties data structure
-  std::vector<FluidStatePropertiesAD> _fsp;
+  std::vector<FluidStateProperties> _fsp;
   /// FluidStatePhaseEnum
   FluidStatePhaseEnum _phase_state;
   /// Capillary pressure UserObject

--- a/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowBrineCO2.h
@@ -63,7 +63,7 @@ public:
                                         std::vector<FluidStateProperties> & fsp) const override;
 
   /**
-   * Mole fractions of CO2 in brine and water vapor in CO2 at equilibrium.
+   * Mole fractions of CO2 in brine and water vapor in CO2 at equilibrium
    *
    * In the low temperature regime (T <= 99C), the mole fractions are calculated directly,
    * while in the elevated temperature regime (T >= 109C), they are calculated iteratively.
@@ -74,25 +74,13 @@ public:
    * @param temperature phase temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
    * @param[out] xco2 mole fraction of CO2 in liquid
-   * @param[out] dxco2_dp derivative of mole fraction of CO2 in liquid wrt pressure
-   * @param[out] dxco2_dT derivative of mole fraction of CO2 in liqiud wrt temperature
-   * @param[out] dxco2_dX derivative of mole fraction of CO2 in liqiud wrt salt mass fraction
-   * @param[out] yh2o mass fraction of mole in gas
-   * @param[out] dyh2og_dp derivative of mole fraction of H2O in gas wrt pressure
-   * @param[out] dyh2o_dT derivative of mole fraction of H2O in gas wrt temperature
-   * @param[out] dyh2o_dX derivative of mole fraction of H2O in gas wrt salt mass fraction
+   * @param[out] yh2o mole fraction of H2O in gas
    */
-  void equilibriumMoleFractions(Real pressure,
-                                Real temperature,
-                                Real Xnacl,
-                                Real & xco2,
-                                Real & dxco2_dp,
-                                Real & dxco2_dT,
-                                Real & dxco2_dX,
-                                Real & yh2o,
-                                Real & dyh2o_dp,
-                                Real & dyh2o_dT,
-                                Real & dyh2o_dX) const;
+  void equilibriumMoleFractions(const DualReal & pressure,
+                                const DualReal & temperature,
+                                const DualReal & Xnacl,
+                                DualReal & xco2,
+                                DualReal & yh2o) const;
 
   /**
    * Mass fractions of CO2 in brine and water vapor in CO2 at equilibrium
@@ -101,25 +89,13 @@ public:
    * @param temperature phase temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
    * @param[out] Xco2 mass fraction of CO2 in liquid (kg/kg)
-   * @param[out] dXco2_dp derivative of mass fraction of CO2 in liquid wrt pressure
-   * @param[out] dXco2_dT derivative of mass fraction of CO2 in liqiud wrt temperature
-   * @param[out] dXco2_dX derivative of mass fraction of CO2 in liqiud wrt salt mass fraction
    * @param[out] Yh2o mass fraction of H2O in gas (kg/kg)
-   * @param[out] dYh2og_dp derivative of mass fraction of H2O in gas wrt pressure
-   * @param[out] dYh2o_dT derivative of mass fraction of H2O in gas wrt temperature
-   * @param[out] dYh2o_dX derivative of mass fraction of H2O in gas wrt salt mass fraction
    */
-  void equilibriumMassFractions(Real pressure,
-                                Real temperature,
-                                Real Xnacl,
-                                Real & Xco2,
-                                Real & dXco2_dp,
-                                Real & dXco2_dT,
-                                Real & dXco2_dX,
-                                Real & Yh2o,
-                                Real & dYh2o_dp,
-                                Real & dYh2o_dT,
-                                Real & dYh2o_dX) const;
+  void equilibriumMassFractions(const DualReal & pressure,
+                                const DualReal & temperature,
+                                const DualReal & Xnacl,
+                                DualReal & Xco2,
+                                DualReal & Yh2o) const;
 
   /**
    * Mass fractions of CO2 and H2O in both phases, as well as derivatives wrt
@@ -130,12 +106,12 @@ public:
    * @param Xnacl NaCl mass fraction (kg/kg)
    * @param Z total mass fraction of CO2 component
    * @param[out] PhaseStateEnum current phase state
-   * @param[out] FluidStateMassFractions data structure
+   * @param[out] FluidStateProperties data structure
    */
-  void massFractions(Real pressure,
-                     Real temperature,
-                     Real Xnacl,
-                     Real Z,
+  void massFractions(const DualReal & pressure,
+                     const DualReal & temperature,
+                     const DualReal & Xnacl,
+                     const DualReal & Z,
                      FluidStatePhaseEnum & phase_state,
                      std::vector<FluidStateProperties> & fsp) const;
 
@@ -144,10 +120,11 @@ public:
    *
    * @param pressure gas pressure (Pa)
    * @param temperature temperature (K)
-   * @param[out] FluidStateDensity data structure
+   * @param[out] FluidStateProperties data structure
    */
-  void
-  gasProperties(Real pressure, Real temperature, std::vector<FluidStateProperties> & fsp) const;
+  void gasProperties(const DualReal & pressure,
+                     const DualReal & temperature,
+                     std::vector<FluidStateProperties> & fsp) const;
 
   /**
    * Thermophysical properties of the liquid state
@@ -155,26 +132,44 @@ public:
    * @param pressure liquid pressure (Pa)
    * @param temperature temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
-   * @param[out] FluidStateDensity data structure
+   * @param[out] FluidStateProperties data structure
    */
-  void liquidProperties(Real pressure,
-                        Real temperature,
-                        Real Xnacl,
+  void liquidProperties(const DualReal & pressure,
+                        const DualReal & temperature,
+                        const DualReal & Xnacl,
                         std::vector<FluidStateProperties> & fsp) const;
 
   /**
-   * Gas and liquid saturations for the two-phase region
+   * Gas saturation in the two-phase region
    *
    * @param pressure gas pressure (Pa)
    * @param temperature phase temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
    * @param Z total mass fraction of CO2 component
-   * @param[out] FluidStateSaturation data structure
+   * @param FluidStateProperties data structure
+   * @return gas saturation (-)
    */
-  void saturationTwoPhase(Real pressure,
-                          Real temperature,
-                          Real Xnacl,
-                          Real Z,
+  DualReal saturation(const DualReal & pressure,
+                      const DualReal & temperature,
+                      const DualReal & Xnacl,
+                      const DualReal & Z,
+                      std::vector<FluidStateProperties> & fsp) const;
+
+  /**
+   * Gas and liquid properties in the two-phase region
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature phase temperature (K)
+   * @param Xnacl NaCl mass fraction (kg/kg)
+   * @param Z total mass fraction of NCG component
+   * @param qp quadpoint for capillary presssure
+   * @param[out] FluidStateProperties data structure
+   */
+  void twoPhaseProperties(const DualReal & pressure,
+                          const DualReal & temperature,
+                          const DualReal & Xnacl,
+                          const DualReal & Z,
+                          unsigned int qp,
                           std::vector<FluidStateProperties> & fsp) const;
 
   /**
@@ -184,26 +179,14 @@ public:
    * @param pressure gas pressure (Pa)
    * @param temperature temperature (K)
    * @param co2_density CO2 density (kg/m^3)
-   * @param dco2_density_dp derivative of CO2 density wrt pressure
-   * @param dco2_density_dT derivative of CO2 density wrt temperature
    * @param[out] fco2 fugacity coefficient for CO2
-   * @param[out] dfco2_dp derivative of fugacity coefficient wrt pressure
-   * @param[out] dfco2_dT derivative of fugacity coefficient wrt temperature
    * @param[out] fh2o fugacity coefficient for H2O
-   * @param[out] dfh2o_dp derivative of fugacity coefficient wrt pressure
-   * @param[out] dfh2o_dT derivative of fugacity coefficient wrt temperature
    */
-  void fugacityCoefficientsLowTemp(Real pressure,
-                                   Real temperature,
-                                   Real co2_density,
-                                   Real dco2_density_dp,
-                                   Real dco2_density_dT,
-                                   Real & fco2,
-                                   Real & dfco2_dp,
-                                   Real & dfco2_dT,
-                                   Real & fh2o,
-                                   Real & dfh2o_dp,
-                                   Real & dfh2o_dT) const;
+  void fugacityCoefficientsLowTemp(const DualReal & pressure,
+                                   const DualReal & temperature,
+                                   const DualReal & co2_density,
+                                   DualReal & fco2,
+                                   DualReal & fh2o) const;
 
   ///@{
   /**
@@ -216,37 +199,27 @@ public:
    * @param xco2 mole fraction of CO2 in liquid phase (-)
    * @param yh2o mole fraction of H2O in gas phase (-)
    * @param[out] fco2 fugacity coefficient for CO2
-   * @param[out] dfco2_dp derivative of fugacity coefficient wrt pressure
-   * @param[out] dfco2_dT derivative of fugacity coefficient wrt temperature
    * @param[out] fh2o fugacity coefficient for H2O
-   * @param[out] dfh2o_dp derivative of fugacity coefficient wrt pressure
-   * @param[out] dfh2o_dT derivative of fugacity coefficient wrt temperature
    */
-  void fugacityCoefficientsHighTemp(Real pressure,
-                                    Real temperature,
-                                    Real co2_density,
-                                    Real xco2,
-                                    Real yh2o,
-                                    Real & fco2,
-                                    Real & fh2o) const;
+  void fugacityCoefficientsHighTemp(const DualReal & pressure,
+                                    const DualReal & temperature,
+                                    const DualReal & co2_density,
+                                    const DualReal & xco2,
+                                    const DualReal & yh2o,
+                                    DualReal & fco2,
+                                    DualReal & fh2o) const;
 
-  void fugacityCoefficientsHighTemp(Real pressure,
-                                    Real temperature,
-                                    Real co2_density,
-                                    Real xco2,
-                                    Real yh2o,
-                                    Real & fco2,
-                                    Real & dfco2_dp,
-                                    Real & dfco2_dT,
-                                    Real & fh2o,
-                                    Real & dfh2o_dp,
-                                    Real & dfh2o_dT) const;
+  DualReal fugacityCoefficientH2OHighTemp(const DualReal & pressure,
+                                          const DualReal & temperature,
+                                          const DualReal & co2_density,
+                                          const DualReal & xco2,
+                                          const DualReal & yh2o) const;
 
-  Real fugacityCoefficientH2OHighTemp(
-      Real pressure, Real temperature, Real co2_density, Real xco2, Real yh2o) const;
-
-  Real fugacityCoefficientCO2HighTemp(
-      Real pressure, Real temperature, Real co2_density, Real xco2, Real yh2o) const;
+  DualReal fugacityCoefficientCO2HighTemp(const DualReal & pressure,
+                                          const DualReal & temperature,
+                                          const DualReal & co2_density,
+                                          const DualReal & xco2,
+                                          const DualReal & yh2o) const;
   ///@}
 
   /**
@@ -257,7 +230,7 @@ public:
    * @param xco2 mole fraction of CO2 in liquid phase (-)
    * @return activity coefficient
    */
-  Real activityCoefficientH2O(Real temperature, Real xco2) const;
+  DualReal activityCoefficientH2O(const DualReal & temperature, const DualReal & xco2) const;
 
   /**
    * Activity coefficient of CO2
@@ -267,7 +240,7 @@ public:
    * @param xco2 mole fraction of CO2 in liquid phase (-)
    * @return activity coefficient
    */
-  Real activityCoefficientCO2(Real temperature, Real xco2) const;
+  DualReal activityCoefficientCO2(const DualReal & temperature, const DualReal & xco2) const;
 
   /**
    * Activity coefficient for CO2 in brine. From Duan and Sun, An improved model calculating
@@ -281,18 +254,11 @@ public:
    * @param pressure phase pressure (Pa)
    * @param temperature phase temperature (K)
    * @param Xnacl salt mass fraction (kg/kg)
-   * @param[out] gamma activity coefficient for CO2 in brine
-   * @param[out] dgamma_dp derivative of activity coefficient wrt pressure
-   * @param[out] dgamma_dT derivative of activity coefficient wrt temperature
-   * @param[out] dgamma_dX derivative of activity coefficient wrt salt mass fraction
+   * @return activity coefficient for CO2 in brine
    */
-  void activityCoefficient(Real pressure,
-                           Real temperature,
-                           Real Xnacl,
-                           Real & gamma,
-                           Real & dgamma_dp,
-                           Real & dgamma_dT,
-                           Real & dgamma_dX) const;
+  DualReal activityCoefficient(const DualReal & pressure,
+                               const DualReal & temperature,
+                               const DualReal & Xnacl) const;
 
   /**
    * Activity coefficient for CO2 in brine used in the elevated temperature formulation.
@@ -303,12 +269,9 @@ public:
    *
    * @param temperature phase temperature (K)
    * @param Xnacl salt mass fraction (kg/kg)
-   * @param[out] gamma activity coefficient for CO2 in brine
-   * @param[out] dgamma_dT derivative of activity coefficient wrt temperature
-   * @param[out] dgamma_dX derivative of activity coefficient wrt salt mass fraction
+   * @return activity coefficient for CO2 in brine
    */
-  void activityCoefficientHighTemp(
-      Real temperature, Real Xnacl, Real & gamma, Real & dgamma_dT, Real & dgamma_dX) const;
+  DualReal activityCoefficientHighTemp(const DualReal & temperature, const DualReal & Xnacl) const;
 
   /**
    * Equilibrium constant for H2O
@@ -318,10 +281,9 @@ public:
    * the two formulations
    *
    * @param temperature temperature (K)
-   * @param[out] kh2o equilibrium constant for H2O
-   * @param[out] dkh2o_dT derivative of equilibrium constant wrt temperature
+   * @return equilibrium constant for H2O
    */
-  void equilibriumConstantH2O(Real temperature, Real & kh2o, Real & dkh2o_dT) const;
+  DualReal equilibriumConstantH2O(const DualReal & temperature) const;
 
   /**
    * Equilibrium constant for CO2
@@ -331,21 +293,18 @@ public:
    * the two formulations
    *
    * @param temperature temperature (K)
-   * @param[out] kco2 equilibrium constant for CO2
-   * @param[out] dkco2_dT derivative of equilibrium constant wrt temperature
+   * @return equilibrium constant for CO2
    */
-  void equilibriumConstantCO2(Real temperature, Real & kco2, Real & dkco2_dT) const;
+  DualReal equilibriumConstantCO2(const DualReal & temperature) const;
 
   /**
    * Partial density of dissolved CO2
    * From Garcia, Density of aqueous solutions of CO2, LBNL-49023 (2001)
    *
    * @param temperature fluid temperature (K)
-   * @param[out] partial molar density (kg/m^3)
-   * @param[out] derivative of partial molar density wrt temperature
+   * @return partial molar density (kg/m^3)
    */
-  void
-  partialDensityCO2(Real temperature, Real & partial_density, Real & dpartial_density_dT) const;
+  DualReal partialDensityCO2(const DualReal & temperature) const;
 
   virtual Real totalMassFraction(
       Real pressure, Real temperature, Real Xnacl, Real saturation, unsigned int qp) const override;
@@ -363,11 +322,9 @@ public:
    *
    * @param temperature fluid temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
-   * @param[out] Kh Henry's constant (Pa)
-   * @param[out] dKh_dT derivative of Henry's constant wrt temperature
-   * @param[out] dKh_dx derivative of Henry's constant wrt salt mass fraction
+   * @return Henry's constant (Pa)
    */
-  void henryConstant(Real temperature, Real Xnacl, Real & Kh, Real & dKh_dT, Real & dKh_dx) const;
+  DualReal henryConstant(const DualReal & temperature, const DualReal & Xnacl) const;
 
   /**
    * Enthalpy of dissolution of gas phase CO2 in brine calculated using Henry's constant
@@ -379,12 +336,9 @@ public:
    *
    * @param temperature fluid temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
-   * @param[out] hdis enthalpy of dissolution (J/kg)
-   * @param[out] dhdis_dT derivative of enthalpy of dissolution wrt temperature
-   * @param[out] dhdis_dx derivative of enthalpy of dissolution wrt salt mass fraction
+   * @return enthalpy of dissolution (J/kg)
    */
-  void enthalpyOfDissolutionGas(
-      Real temperature, Real Xnacl, Real & hdis, Real & dhdis_dT, Real & dhdis_dx) const;
+  DualReal enthalpyOfDissolutionGas(const DualReal & temperature, const DualReal & Xnacl) const;
 
   /**
    * Enthalpy of dissolution of CO2 in brine calculated using linear fit to model of
@@ -397,10 +351,9 @@ public:
    * Note: as the effect of salt mass fraction is small, it is not included in this function.
    *
    * @param temperature fluid temperature (K)
-   * @param[out] hdis enthalpy of dissolution (J/kg)
-   * @param[out] dhdis_dT derivative of enthalpy of dissolution wrt temperature
+   * @return enthalpy of dissolution (J/kg)
    */
-  void enthalpyOfDissolution(Real temperature, Real & hdis, Real & dhdis_dT) const;
+  DualReal enthalpyOfDissolution(const DualReal & temperature) const;
 
   /**
    * Mole fractions of CO2 in brine and water vapor in CO2 at equilibrium in the low
@@ -410,25 +363,13 @@ public:
    * @param temperature phase temperature (K)
    * @param Xnacl NaCl mass fraction (kg/kg)
    * @param[out] xco2 mole fraction of CO2 in liquid
-   * @param[out] dxco2_dp derivative of mole fraction of CO2 in liquid wrt pressure
-   * @param[out] dxco2_dT derivative of mole fraction of CO2 in liqiud wrt temperature
-   * @param[out] dxco2_dX derivative of mole fraction of CO2 in liqiud wrt salt mass fraction
    * @param[out] yh2o mass fraction of mole in gas
-   * @param[out] dyh2og_dp derivative of mole fraction of H2O in gas wrt pressure
-   * @param[out] dyh2o_dT derivative of mole fraction of H2O in gas wrt temperature
-   * @param[out] dyh2o_dX derivative of mole fraction of H2O in gas wrt salt mass fraction
    */
-  void equilibriumMoleFractionsLowTemp(Real pressure,
-                                       Real temperature,
-                                       Real Xnacl,
-                                       Real & xco2,
-                                       Real & dxco2_dp,
-                                       Real & dxco2_dT,
-                                       Real & dxco2_dX,
-                                       Real & yh2o,
-                                       Real & dyh2o_dp,
-                                       Real & dyh2o_dT,
-                                       Real & dyh2o_dX) const;
+  void equilibriumMoleFractionsLowTemp(const DualReal & pressure,
+                                       const DualReal & temperature,
+                                       const DualReal & Xnacl,
+                                       DualReal & xco2,
+                                       DualReal & yh2o) const;
 
   /**
    * Function to solve for yh2o and xco2 iteratively in the elevated temperature regime (T > 100C)
@@ -503,17 +444,11 @@ protected:
                       Real & dB_dT,
                       Real & dB_dX) const;
 
-  void funcABLowTemp(Real pressure,
-                     Real temperature,
-                     Real co2_density,
-                     Real dco2_density_dp,
-                     Real dco2_density_dT,
-                     Real & A,
-                     Real & dA_dp,
-                     Real & dA_dT,
-                     Real & B,
-                     Real & dB_dp,
-                     Real & dB_dT) const;
+  void funcABLowTemp(const DualReal & pressure,
+                     const DualReal & temperature,
+                     const DualReal & co2_density,
+                     DualReal & A,
+                     DualReal & B) const;
   ///@}
 
   /// Salt component index

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
@@ -22,71 +22,11 @@ enum class FluidStatePhaseEnum
   TWOPHASE
 };
 
-/// Data structure to pass calculated thermophysical properties
+/// AD data structure to pass calculated thermophysical properties
 struct FluidStateProperties
 {
   FluidStateProperties(){};
   FluidStateProperties(unsigned int n)
-    : pressure(0.0),
-      saturation(0.0),
-      density(0.0),
-      viscosity(1.0), // to guard against division by zero
-      enthalpy(0.0),
-      mass_fraction(n, 0.0),
-      dsaturation_dp(0.0),
-      dsaturation_dT(0.0),
-      dsaturation_dZ(0.0),
-      dsaturation_dX(0.0),
-      ddensity_dp(0.0),
-      ddensity_dT(0.0),
-      ddensity_dZ(0.0),
-      ddensity_dX(0.0),
-      dviscosity_dp(0.0),
-      dviscosity_dT(0.0),
-      dviscosity_dZ(0.0),
-      dviscosity_dX(0.0),
-      denthalpy_dp(0.0),
-      denthalpy_dT(0.0),
-      denthalpy_dZ(0.0),
-      denthalpy_dX(0.0),
-      dmass_fraction_dp(n, 0.0),
-      dmass_fraction_dT(n, 0.0),
-      dmass_fraction_dZ(n, 0.0),
-      dmass_fraction_dX(n, 0.0){};
-
-  Real pressure;
-  Real saturation;
-  Real density;
-  Real viscosity;
-  Real enthalpy;
-  std::vector<Real> mass_fraction;
-  Real dsaturation_dp;
-  Real dsaturation_dT;
-  Real dsaturation_dZ;
-  Real dsaturation_dX;
-  Real ddensity_dp;
-  Real ddensity_dT;
-  Real ddensity_dZ;
-  Real ddensity_dX;
-  Real dviscosity_dp;
-  Real dviscosity_dT;
-  Real dviscosity_dZ;
-  Real dviscosity_dX;
-  Real denthalpy_dp;
-  Real denthalpy_dT;
-  Real denthalpy_dZ;
-  Real denthalpy_dX;
-  std::vector<Real> dmass_fraction_dp;
-  std::vector<Real> dmass_fraction_dT;
-  std::vector<Real> dmass_fraction_dZ;
-  std::vector<Real> dmass_fraction_dX;
-};
-
-/// AD Data structure to pass calculated thermophysical properties
-struct FluidStatePropertiesAD
-{
-  FluidStatePropertiesAD(){};
-  FluidStatePropertiesAD(unsigned int n)
     : pressure(0.0),
       temperature(0, 0),
       saturation(0.0),
@@ -173,7 +113,6 @@ public:
    * @param[out] fsp FluidStateProperties data structure with all data initialized to 0
    */
   void clearFluidStateProperties(std::vector<FluidStateProperties> & fsp) const;
-  void clearFluidStateProperties(std::vector<FluidStatePropertiesAD> & fsp) const;
 
 protected:
   /// Number of phases
@@ -197,4 +136,3 @@ protected:
   /// Capillary pressure UserObject
   const PorousFlowCapillaryPressure & _pc;
 };
-

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateFlash.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateFlash.h
@@ -72,6 +72,7 @@ public:
    * @return vapor mass fraction
    */
   Real vaporMassFraction(Real Z0, Real K0, Real K1) const;
+  DualReal vaporMassFraction(const DualReal & Z0, const DualReal & K0, const DualReal & K1) const;
   Real vaporMassFraction(std::vector<Real> & Zi, std::vector<Real> & Ki) const;
 
 protected:
@@ -80,4 +81,3 @@ protected:
   /// Tolerance for Newton-Raphson iterations
   const Real _nr_tol;
 };
-

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateMultiComponentBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateMultiComponentBase.h
@@ -66,4 +66,19 @@ public:
    */
   virtual Real totalMassFraction(
       Real pressure, Real temperature, Real Xnacl, Real saturation, unsigned int qp) const = 0;
+
+  unsigned int getPressureIndex() const { return _pidx; };
+  unsigned int getTemperatureIndex() const { return _Tidx; };
+  unsigned int getZIndex() const { return _Zidx; };
+  unsigned int getXIndex() const { return _Xidx; };
+
+protected:
+  /// Index of derivative wrt pressure
+  const unsigned int _pidx;
+  /// Index of derivative wrt total mass fraction Z
+  const unsigned int _Zidx;
+  /// Index of derivative wrt temperature
+  const unsigned int _Tidx;
+  /// Index of derivative wrt salt mass fraction X
+  const unsigned int _Xidx;
 };

--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateSingleComponentBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateSingleComponentBase.h
@@ -39,7 +39,7 @@ public:
                                         Real enthalpy,
                                         unsigned int qp,
                                         FluidStatePhaseEnum & phase_state,
-                                        std::vector<FluidStatePropertiesAD> & fsp) const = 0;
+                                        std::vector<FluidStateProperties> & fsp) const = 0;
 
   unsigned int getPressureIndex() const { return _pidx; };
   unsigned int getEnthalpyIndex() const { return _hidx; };

--- a/modules/porous_flow/include/userobjects/PorousFlowWaterNCG.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowWaterNCG.h
@@ -49,70 +49,110 @@ public:
    * law (for water).
    *
    * @param pressure phase pressure (Pa)
-   * @param temperature phase temperature (C)
+   * @param temperature phase temperature (K)
    * @param[out] Xncg mass fraction of NCG in liquid (kg/kg)
-   * @param[out] dXncg_dp derivative of mass fraction of NCG in liquid wrt pressure
-   * @param[out] dXncg_dT derivative of mass fraction of NCG in liqiud wrt temperature
    * @param[out] Yh2o mass fraction of H2O in gas (kg/kg)
-   * @param[out] dYh2o_dp derivative of mass fraction of NCG in gas wrt pressure
-   * @param[out] dYh2o_dT derivative of mass fraction of NCG in gas wrt temperature
    */
-  void equilibriumMassFractions(Real pressure,
-                                Real temperature,
-                                Real & Xncg,
-                                Real & dXncg_dp,
-                                Real & dXncg_dT,
-                                Real & Yh2o,
-                                Real & dYh2o_dp,
-                                Real & dYh2o_dT) const;
+  void equilibriumMassFractions(const DualReal & pressure,
+                                const DualReal & temperature,
+                                DualReal & Xncg,
+                                DualReal & Yh2o) const;
 
   /**
    * Mass fractions of NCG and H2O in both phases, as well as derivatives wrt
    * PorousFlow variables. Values depend on the phase state (liquid, gas or two phase)
    *
    * @param pressure phase pressure (Pa)
-   * @param temperature phase temperature (C)
+   * @param temperature phase temperature (K)
    * @param Z total mass fraction of NCG component
    * @param[out] PhaseStateEnum current phase state
    * @param[out] FluidStateMassFractions data structure
    */
-  void massFractions(Real pressure,
-                     Real temperature,
-                     Real Z,
+  void massFractions(const DualReal & pressure,
+                     const DualReal & temperature,
+                     const DualReal & Z,
                      FluidStatePhaseEnum & phase_state,
                      std::vector<FluidStateProperties> & fsp) const;
 
   /**
-   * Gas density
+   * Gas properties - density, viscosity and enthalpy
    *
    * @param pressure gas pressure (Pa)
-   * @param temperature temperature (C)
-   * @param[out] FluidStateDensity data structure
+   * @param temperature temperature (K)
+   * @param[out] FluidStateProperties data structure
    */
-  void
-  gasProperties(Real pressure, Real temperature, std::vector<FluidStateProperties> & fsp) const;
-
+  void gasProperties(const DualReal & pressure,
+                     const DualReal & temperature,
+                     std::vector<FluidStateProperties> & fsp) const;
   /**
-   * Liquid density
+   * Liquid properties - density, viscosity and enthalpy
+   * Note: The pressure here is the liquid pressure. In this class, enthalpy includes a
+   * contribution due to the enthalpy of dissolution of the NCG into the liquid phase. As
+   * a result, the derivatives can include a dependence on the capillary pressure, so this
+   * method should be called after the saturation is calculated for the two phase case
+   * ie: after calling saturation(). For the single phase liquid case, it is ok to
+   * call this method by itself, as gas saturation is initialized to zero.
    *
    * @param pressure liquid pressure (Pa)
-   * @param temperature temperature (C)
-   * @param[out] FluidStateDensity data structure
+   * @param temperature temperature (K)
+   * @param[out] FluidStateProperties data structure
    */
-  void
-  liquidProperties(Real pressure, Real temperature, std::vector<FluidStateProperties> & fsp) const;
+  void liquidProperties(const DualReal & pressure,
+                        const DualReal & temperature,
+                        std::vector<FluidStateProperties> & fsp) const;
 
   /**
-   * Gas and liquid saturation in the two-phase region
+   * Density of the liquid phase
+   * Note: The pressure here is the gas pressure. As a result, the liquid pressure can
+   * include a dependence on saturation due to the capillary pressure, so this
+   * method should be called after the saturation is calculated for the two phase case
+   * ie: after calling saturation(). For the single phase liquid case, it is ok to
+   * call this method by itself, as gas saturation is initialized to zero.
    *
    * @param pressure gas pressure (Pa)
-   * @param temperature phase temperature (C)
-   * @param Z total mass fraction of NCG component
-   * @param[out] FluidStateSaturation data structure
+   * @param temperature temperature (K)
+   * @return liquid density (kg/m^3)
    */
-  void saturationTwoPhase(Real pressure,
-                          Real temperature,
-                          Real Z,
+  DualReal liquidDensity(const DualReal & pressure, const DualReal & temperature) const;
+
+  /**
+   * Density of the gas phase
+   *
+   * @param pressure pressure (Pa)
+   * @param temperature temperature (K)
+   * @return gas density (kg/m^3)
+   */
+  DualReal gasDensity(const DualReal & pressure,
+                      const DualReal & temperature,
+                      std::vector<FluidStateProperties> & fsp) const;
+
+  /**
+   * Gas saturation in the two-phase region
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature phase temperature (K)
+   * @param Z total mass fraction of NCG component
+   * @param[out] FluidStateProperties data structure
+   * @return gas saturation (-)
+   */
+  DualReal saturation(const DualReal & pressure,
+                      const DualReal & temperature,
+                      const DualReal & Z,
+                      std::vector<FluidStateProperties> & fsp) const;
+
+  /**
+   * Gas and liquid properties in the two-phase region
+   *
+   * @param pressure gas pressure (Pa)
+   * @param temperature phase temperature (K)
+   * @param Z total mass fraction of NCG component
+   * @param qp quadpoint for capillary pressure
+   * @param[out] FluidStateProperties data structure
+   */
+  void twoPhaseProperties(const DualReal & pressure,
+                          const DualReal & temperature,
+                          const DualReal & Z,
+                          unsigned int qp,
                           std::vector<FluidStateProperties> & fsp) const;
 
   /**
@@ -121,10 +161,9 @@ public:
    * in water from the freezing to the near critical point, J. Phys. Chem. 63 (1959)
    *
    * @param temperature fluid temperature (K)
-   * @param[out] hdis enthalpy of dissolution (J/kg)
-   * @param[out] dhdis_dT derivative of enthalpy of dissolution wrt temperature
+   * @return enthalpy of dissolution (J/kg)
    */
-  void enthalpyOfDissolution(Real temperature, Real & hdis, Real & dhdis_dT) const;
+  DualReal enthalpyOfDissolution(const DualReal & temperature) const;
 
   virtual Real totalMassFraction(
       Real pressure, Real temperature, Real Xnacl, Real saturation, unsigned int qp) const override;
@@ -135,7 +174,7 @@ protected:
    * @param xmol mole fraction
    * @return mass fraction
    */
-  Real moleFractionToMassFraction(Real xmol) const;
+  DualReal moleFractionToMassFraction(const DualReal & xmol) const;
 
   /**
    * Check that the temperature is between the triple and critical values
@@ -144,7 +183,9 @@ protected:
   void checkVariables(Real temperature) const;
 
   /// Fluid properties UserObject for water
-  const Water97FluidProperties & _water_fp;
+  const SinglePhaseFluidProperties & _water_fp;
+  /// Fluid properties UserObject for water (used to access Henry's law)
+  const Water97FluidProperties & _water97_fp;
   /// Fluid properties UserObject for the NCG
   const SinglePhaseFluidProperties & _ncg_fp;
   /// Molar mass of water (kg/mol)
@@ -158,4 +199,3 @@ protected:
   /// Henry's coefficients for the NCG
   const std::vector<Real> _ncg_henry;
 };
-

--- a/modules/porous_flow/include/userobjects/PorousFlowWaterVapor.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowWaterVapor.h
@@ -34,7 +34,7 @@ public:
                                 Real enthalpy,
                                 unsigned int qp,
                                 FluidStatePhaseEnum & phase_state,
-                                std::vector<FluidStatePropertiesAD> & fsp) const override;
+                                std::vector<FluidStateProperties> & fsp) const override;
 
 protected:
   /// Fluid properties UserObject for water

--- a/modules/porous_flow/src/materials/PorousFlowFluidStateSingleComponent.C
+++ b/modules/porous_flow/src/materials/PorousFlowFluidStateSingleComponent.C
@@ -132,7 +132,7 @@ PorousFlowFluidStateSingleComponent::PorousFlowFluidStateSingleComponent(
                "correct");
 
   // Set the size of the FluidStateProperties vector
-  _fsp.resize(_num_phases, FluidStatePropertiesAD(_num_components));
+  _fsp.resize(_num_phases, FluidStateProperties(_num_components));
 }
 
 void
@@ -236,13 +236,11 @@ PorousFlowFluidStateSingleComponent::computeQpProperties()
     const Real dp = 1.0e-2;
     const Real dh = 1.0e-2;
 
-    std::vector<FluidStatePropertiesAD> fsp_dp(_num_phases,
-                                               FluidStatePropertiesAD(_num_components));
+    std::vector<FluidStateProperties> fsp_dp(_num_phases, FluidStateProperties(_num_components));
     _fs.thermophysicalProperties(
         _liquid_porepressure[_qp] + dp, _enthalpy[_qp], _qp, _phase_state, fsp_dp);
 
-    std::vector<FluidStatePropertiesAD> fsp_dh(_num_phases,
-                                               FluidStatePropertiesAD(_num_components));
+    std::vector<FluidStateProperties> fsp_dh(_num_phases, FluidStateProperties(_num_components));
     _fs.thermophysicalProperties(
         _liquid_porepressure[_qp], _enthalpy[_qp] + dh, _qp, _phase_state, fsp_dh);
 

--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -100,11 +100,21 @@ PorousFlowBrineCO2::thermophysicalProperties(Real pressure,
   // Check whether the input temperature is within the region of validity
   checkVariables(pressure, temperature);
 
+  // AD versions of primary variables
+  DualReal p = pressure;
+  p.derivatives()[_pidx] = 1.0;
+  DualReal T = temperature;
+  T.derivatives()[_Tidx] = 1.0;
+  DualReal Zco2 = Z;
+  Zco2.derivatives()[_Zidx] = 1.0;
+  DualReal X = Xnacl;
+  X.derivatives()[_Xidx] = 1.0;
+
   // Clear all of the FluidStateProperties data
   clearFluidStateProperties(fsp);
 
   FluidStatePhaseEnum phase_state;
-  massFractions(pressure, temperature, Xnacl, Z, phase_state, fsp);
+  massFractions(p, T, X, Zco2, phase_state, fsp);
 
   switch (phase_state)
   {
@@ -114,7 +124,7 @@ PorousFlowBrineCO2::thermophysicalProperties(Real pressure,
       gas.saturation = 1.0;
 
       // Calculate gas properties
-      gasProperties(pressure, temperature, fsp);
+      gasProperties(p, T, fsp);
 
       break;
     }
@@ -122,23 +132,16 @@ PorousFlowBrineCO2::thermophysicalProperties(Real pressure,
     case FluidStatePhaseEnum::LIQUID:
     {
       // Calculate the liquid properties
-      Real liquid_pressure = pressure - _pc.capillaryPressure(1.0, qp);
-      liquidProperties(liquid_pressure, temperature, Xnacl, fsp);
+      const DualReal liquid_pressure = p - _pc.capillaryPressure(1.0, qp);
+      liquidProperties(liquid_pressure, T, X, fsp);
 
       break;
     }
 
     case FluidStatePhaseEnum::TWOPHASE:
     {
-      // Calculate the gas properties
-      gasProperties(pressure, temperature, fsp);
-
-      // Calculate the saturation
-      saturationTwoPhase(pressure, temperature, Xnacl, Z, fsp);
-
-      // Calculate the liquid properties
-      Real liquid_pressure = pressure - _pc.capillaryPressure(1.0 - gas.saturation, qp);
-      liquidProperties(liquid_pressure, temperature, Xnacl, fsp);
+      // Calculate the gas and liquid properties in the two phase region
+      twoPhaseProperties(p, T, X, Zco2, qp, fsp);
 
       break;
     }
@@ -146,30 +149,26 @@ PorousFlowBrineCO2::thermophysicalProperties(Real pressure,
 
   // Liquid saturations can now be set
   liquid.saturation = 1.0 - gas.saturation;
-  liquid.dsaturation_dp = -gas.dsaturation_dp;
-  liquid.dsaturation_dT = -gas.dsaturation_dT;
-  liquid.dsaturation_dX = -gas.dsaturation_dX;
-  liquid.dsaturation_dZ = -gas.dsaturation_dZ;
 
   // Save pressures to FluidStateProperties object
-  gas.pressure = pressure;
-  liquid.pressure = pressure - _pc.capillaryPressure(liquid.saturation, qp);
+  gas.pressure = p;
+  liquid.pressure = p - _pc.capillaryPressure(liquid.saturation, qp);
 }
 
 void
-PorousFlowBrineCO2::massFractions(Real pressure,
-                                  Real temperature,
-                                  Real Xnacl,
-                                  Real Z,
+PorousFlowBrineCO2::massFractions(const DualReal & pressure,
+                                  const DualReal & temperature,
+                                  const DualReal & Xnacl,
+                                  const DualReal & Z,
                                   FluidStatePhaseEnum & phase_state,
                                   std::vector<FluidStateProperties> & fsp) const
 {
   FluidStateProperties & liquid = fsp[_aqueous_phase_number];
   FluidStateProperties & gas = fsp[_gas_phase_number];
 
-  Real Xco2 = 0.0, dXco2_dp = 0.0, dXco2_dT = 0.0, dXco2_dX = 0.0;
-  Real Yh2o = 0.0, dYh2o_dp = 0.0, dYh2o_dT = 0.0, dYh2o_dX = 0.0;
-  Real Yco2 = 0.0, dYco2_dp = 0.0, dYco2_dT = 0.0, dYco2_dX = 0.0;
+  DualReal Xco2 = 0.0;
+  DualReal Yh2o = 0.0;
+  DualReal Yco2 = 0.0;
 
   // If the amount of CO2 is less than the smallest solubility, then all CO2 will
   // be dissolved, and the equilibrium mass fractions do not need to be computed
@@ -179,32 +178,18 @@ PorousFlowBrineCO2::massFractions(Real pressure,
   else
   {
     // Equilibrium mass fraction of CO2 in liquid and H2O in gas phases
-    equilibriumMassFractions(pressure,
-                             temperature,
-                             Xnacl,
-                             Xco2,
-                             dXco2_dp,
-                             dXco2_dT,
-                             dXco2_dX,
-                             Yh2o,
-                             dYh2o_dp,
-                             dYh2o_dT,
-                             dYh2o_dX);
+    equilibriumMassFractions(pressure, temperature, Xnacl, Xco2, Yh2o);
 
     Yco2 = 1.0 - Yh2o;
-    dYco2_dp = -dYh2o_dp;
-    dYco2_dT = -dYh2o_dT;
-    dYco2_dX = -dYh2o_dX;
 
     // Determine which phases are present based on the value of z
-    phaseState(Z, Xco2, Yco2, phase_state);
+    phaseState(Z.value(), Xco2.value(), Yco2.value(), phase_state);
   }
 
   // The equilibrium mass fractions calculated above are only correct in the two phase
   // state. If only liquid or gas phases are present, the mass fractions are given by
   // the total mass fraction z
-  Real Xh2o = 0.0;
-  Real dXco2_dZ = 0.0, dYco2_dZ = 0.0;
+  DualReal Xh2o = 0.0;
 
   switch (phase_state)
   {
@@ -214,13 +199,13 @@ PorousFlowBrineCO2::massFractions(Real pressure,
       Yco2 = 0.0;
       Xh2o = 1.0 - Z;
       Yh2o = 0.0;
-      dXco2_dp = 0.0;
-      dXco2_dT = 0.0;
-      dXco2_dX = 0.0;
-      dXco2_dZ = 1.0;
-      dYco2_dp = 0.0;
-      dYco2_dT = 0.0;
-      dYco2_dX = 0.0;
+      Xco2.derivatives()[_pidx] = 0.0;
+      Xco2.derivatives()[_Tidx] = 0.0;
+      Xco2.derivatives()[_Xidx] = 0.0;
+      Xco2.derivatives()[_Zidx] = 1.0;
+      Yco2.derivatives()[_pidx] = 0.0;
+      Yco2.derivatives()[_Tidx] = 0.0;
+      Yco2.derivatives()[_Xidx] = 0.0;
       break;
     }
 
@@ -229,13 +214,13 @@ PorousFlowBrineCO2::massFractions(Real pressure,
       Xco2 = 0.0;
       Yco2 = Z;
       Yh2o = 1.0 - Z;
-      dXco2_dp = 0.0;
-      dXco2_dT = 0.0;
-      dXco2_dX = 0.0;
-      dYco2_dZ = 1.0;
-      dYco2_dp = 0.0;
-      dYco2_dT = 0.0;
-      dYco2_dX = 0.0;
+      Xco2.derivatives()[_pidx] = 0.0;
+      Xco2.derivatives()[_Tidx] = 0.0;
+      Xco2.derivatives()[_Xidx] = 0.0;
+      Yco2.derivatives()[_pidx] = 0.0;
+      Yco2.derivatives()[_Tidx] = 0.0;
+      Yco2.derivatives()[_Xidx] = 0.0;
+      Yco2.derivatives()[_Zidx] = 1.0;
       break;
     }
 
@@ -253,434 +238,209 @@ PorousFlowBrineCO2::massFractions(Real pressure,
   liquid.mass_fraction[_salt_component] = Xnacl;
   gas.mass_fraction[_aqueous_fluid_component] = Yh2o;
   gas.mass_fraction[_gas_fluid_component] = Yco2;
-
-  // Save the derivatives wrt PorousFlow variables
-  liquid.dmass_fraction_dp[_aqueous_fluid_component] = -dXco2_dp;
-  liquid.dmass_fraction_dp[_gas_fluid_component] = dXco2_dp;
-  liquid.dmass_fraction_dT[_aqueous_fluid_component] = -dXco2_dT;
-  liquid.dmass_fraction_dT[_gas_fluid_component] = dXco2_dT;
-  liquid.dmass_fraction_dX[_aqueous_fluid_component] = -dXco2_dX;
-  liquid.dmass_fraction_dX[_gas_fluid_component] = dXco2_dX;
-  liquid.dmass_fraction_dX[_salt_component] = 1.0;
-  liquid.dmass_fraction_dZ[_aqueous_fluid_component] = -dXco2_dZ;
-  liquid.dmass_fraction_dZ[_gas_fluid_component] = dXco2_dZ;
-
-  gas.dmass_fraction_dp[_aqueous_fluid_component] = -dYco2_dp;
-  gas.dmass_fraction_dp[_gas_fluid_component] = dYco2_dp;
-  gas.dmass_fraction_dT[_aqueous_fluid_component] = -dYco2_dT;
-  gas.dmass_fraction_dT[_gas_fluid_component] = dYco2_dT;
-  gas.dmass_fraction_dX[_aqueous_fluid_component] = -dYco2_dX;
-  gas.dmass_fraction_dX[_gas_fluid_component] = dYco2_dX;
-  gas.dmass_fraction_dZ[_aqueous_fluid_component] = -dYco2_dZ;
-  gas.dmass_fraction_dZ[_gas_fluid_component] = dYco2_dZ;
 }
 
 void
-PorousFlowBrineCO2::gasProperties(Real pressure,
-                                  Real temperature,
+PorousFlowBrineCO2::gasProperties(const DualReal & pressure,
+                                  const DualReal & temperature,
                                   std::vector<FluidStateProperties> & fsp) const
 {
   FluidStateProperties & gas = fsp[_gas_phase_number];
 
   // Gas density, viscosity and enthalpy are approximated with pure CO2 - no correction due
   // to the small amount of water vapor is made
-  Real co2_density, dco2_density_dp, dco2_density_dT;
-  Real co2_viscosity, dco2_viscosity_dp, dco2_viscosity_dT;
-  Real co2_enthalpy, dco2_enthalpy_dp, dco2_enthalpy_dT;
-  _co2_fp.rho_mu_from_p_T(pressure,
-                          temperature,
-                          co2_density,
-                          dco2_density_dp,
-                          dco2_density_dT,
-                          co2_viscosity,
-                          dco2_viscosity_dp,
-                          dco2_viscosity_dT);
+  DualReal co2_density, co2_viscosity;
+  _co2_fp.rho_mu_from_p_T(pressure, temperature, co2_density, co2_viscosity);
 
-  _co2_fp.h_from_p_T(pressure, temperature, co2_enthalpy, dco2_enthalpy_dp, dco2_enthalpy_dT);
+  DualReal co2_enthalpy = _co2_fp.h_from_p_T(pressure, temperature);
 
   // Save the values to the FluidStateProperties object. Note that derivatives wrt z are 0
   gas.density = co2_density;
-  gas.ddensity_dp = dco2_density_dp;
-  gas.ddensity_dT = dco2_density_dT;
-  gas.ddensity_dZ = 0.0;
-
   gas.viscosity = co2_viscosity;
-  gas.dviscosity_dp = dco2_viscosity_dp;
-  gas.dviscosity_dT = dco2_viscosity_dT;
-  gas.dviscosity_dZ = 0.0;
-
   gas.enthalpy = co2_enthalpy;
-  gas.denthalpy_dp = dco2_enthalpy_dp;
-  gas.denthalpy_dT = dco2_enthalpy_dT;
-  gas.denthalpy_dZ = 0.0;
 }
 
 void
-PorousFlowBrineCO2::liquidProperties(Real pressure,
-                                     Real temperature,
-                                     Real Xnacl,
+PorousFlowBrineCO2::liquidProperties(const DualReal & pressure,
+                                     const DualReal & temperature,
+                                     const DualReal & Xnacl,
                                      std::vector<FluidStateProperties> & fsp) const
 {
   FluidStateProperties & liquid = fsp[_aqueous_phase_number];
 
   // The liquid density includes the density increase due to dissolved CO2
-  Real brine_density, dbrine_density_dp, dbrine_density_dT, dbrine_density_dX;
-  _brine_fp.rho_from_p_T_X(pressure,
-                           temperature,
-                           Xnacl,
-                           brine_density,
-                           dbrine_density_dp,
-                           dbrine_density_dT,
-                           dbrine_density_dX);
+  const DualReal brine_density = _brine_fp.rho_from_p_T_X(pressure, temperature, Xnacl);
 
   // Mass fraction of CO2 in liquid phase
-  const Real Xco2 = liquid.mass_fraction[_gas_fluid_component];
-  const Real dXco2_dp = liquid.dmass_fraction_dp[_gas_fluid_component];
-  const Real dXco2_dT = liquid.dmass_fraction_dT[_gas_fluid_component];
-  const Real dXco2_dZ = liquid.dmass_fraction_dZ[_gas_fluid_component];
-  const Real dXco2_dX = liquid.dmass_fraction_dX[_gas_fluid_component];
+  const DualReal Xco2 = liquid.mass_fraction[_gas_fluid_component];
 
   // The liquid density
-  Real co2_partial_density, dco2_partial_density_dT;
-  partialDensityCO2(temperature, co2_partial_density, dco2_partial_density_dT);
+  const DualReal co2_partial_density = partialDensityCO2(temperature);
 
-  const Real liquid_density = 1.0 / (Xco2 / co2_partial_density + (1.0 - Xco2) / brine_density);
-
-  const Real dliquid_density_dp =
-      (dXco2_dp / brine_density + (1.0 - Xco2) * dbrine_density_dp / brine_density / brine_density -
-       dXco2_dp / co2_partial_density) *
-      liquid_density * liquid_density;
-
-  const Real dliquid_density_dT =
-      (dXco2_dT / brine_density + (1.0 - Xco2) * dbrine_density_dT / brine_density / brine_density -
-       dXco2_dT / co2_partial_density +
-       Xco2 * dco2_partial_density_dT / co2_partial_density / co2_partial_density) *
-      liquid_density * liquid_density;
-
-  const Real dliquid_density_dZ =
-      (dXco2_dZ / brine_density - dXco2_dZ / co2_partial_density) * liquid_density * liquid_density;
-
-  const Real dliquid_density_dX =
-      (dXco2_dX / brine_density + (1.0 - Xco2) * dbrine_density_dX / brine_density / brine_density -
-       dXco2_dX / co2_partial_density) *
-      liquid_density * liquid_density;
+  const DualReal liquid_density = 1.0 / (Xco2 / co2_partial_density + (1.0 - Xco2) / brine_density);
 
   // Assume that liquid viscosity is just the brine viscosity
-  Real liquid_viscosity, dliquid_viscosity_dp, dliquid_viscosity_dT, dliquid_viscosity_dX;
-  _brine_fp.mu_from_p_T_X(pressure,
-                          temperature,
-                          Xnacl,
-                          liquid_viscosity,
-                          dliquid_viscosity_dp,
-                          dliquid_viscosity_dT,
-                          dliquid_viscosity_dX);
+  const DualReal liquid_viscosity = _brine_fp.mu_from_p_T_X(pressure, temperature, Xnacl);
 
   // Liquid enthalpy (including contribution due to the enthalpy of dissolution)
-  Real brine_enthalpy, dbrine_enthalpy_dp, dbrine_enthalpy_dT, dbrine_enthalpy_dX;
-  _brine_fp.h_from_p_T_X(pressure,
-                         temperature,
-                         Xnacl,
-                         brine_enthalpy,
-                         dbrine_enthalpy_dp,
-                         dbrine_enthalpy_dT,
-                         dbrine_enthalpy_dX);
+  const DualReal brine_enthalpy = _brine_fp.h_from_p_T_X(pressure, temperature, Xnacl);
 
   // Enthalpy of CO2
-  Real co2_enthalpy, dco2_enthalpy_dp, dco2_enthalpy_dT;
-  _co2_fp.h_from_p_T(pressure, temperature, co2_enthalpy, dco2_enthalpy_dp, dco2_enthalpy_dT);
+  const DualReal co2_enthalpy = _co2_fp.h_from_p_T(pressure, temperature);
 
   // Enthalpy of dissolution
-  Real hdis, dhdis_dT;
-  enthalpyOfDissolution(temperature, hdis, dhdis_dT);
+  const DualReal hdis = enthalpyOfDissolution(temperature);
 
-  const Real liquid_enthalpy = (1.0 - Xco2) * brine_enthalpy + Xco2 * (co2_enthalpy + hdis);
-  const Real dliquid_enthalpy_dp = (1.0 - Xco2) * dbrine_enthalpy_dp + Xco2 * dco2_enthalpy_dp +
-                                   dXco2_dp * (co2_enthalpy + hdis - brine_enthalpy);
-  const Real dliquid_enthalpy_dT = (1.0 - Xco2) * dbrine_enthalpy_dT +
-                                   Xco2 * (dco2_enthalpy_dT + dhdis_dT) +
-                                   dXco2_dT * (co2_enthalpy + hdis - brine_enthalpy);
-  const Real dliquid_enthalpy_dZ = dXco2_dZ * (co2_enthalpy + hdis - brine_enthalpy);
-  const Real dliquid_enthalpy_dX =
-      (1.0 - Xco2) * dbrine_enthalpy_dX + dXco2_dX * (co2_enthalpy + hdis - brine_enthalpy);
+  const DualReal liquid_enthalpy = (1.0 - Xco2) * brine_enthalpy + Xco2 * (co2_enthalpy + hdis);
 
   // Save the values to the FluidStateProperties object
   liquid.density = liquid_density;
-  liquid.ddensity_dp = dliquid_density_dp;
-  liquid.ddensity_dT = dliquid_density_dT;
-  liquid.ddensity_dZ = dliquid_density_dZ;
-  liquid.ddensity_dX = dliquid_density_dX;
-
   liquid.viscosity = liquid_viscosity;
-  liquid.dviscosity_dp = dliquid_viscosity_dp;
-  liquid.dviscosity_dT = dliquid_viscosity_dT;
-  liquid.dviscosity_dZ = 0.0;
-  liquid.dviscosity_dX = dliquid_viscosity_dX;
-
   liquid.enthalpy = liquid_enthalpy;
-  liquid.denthalpy_dp = dliquid_enthalpy_dp;
-  liquid.denthalpy_dT = dliquid_enthalpy_dT;
-  liquid.denthalpy_dZ = dliquid_enthalpy_dZ;
-  liquid.denthalpy_dX = dliquid_enthalpy_dX;
 }
 
-void
-PorousFlowBrineCO2::saturationTwoPhase(Real pressure,
-                                       Real temperature,
-                                       Real Xnacl,
-                                       Real Z,
-                                       std::vector<FluidStateProperties> & fsp) const
+DualReal
+PorousFlowBrineCO2::saturation(const DualReal & pressure,
+                               const DualReal & temperature,
+                               const DualReal & Xnacl,
+                               const DualReal & Z,
+                               std::vector<FluidStateProperties> & fsp) const
 {
-  FluidStateProperties & liquid = fsp[_aqueous_phase_number];
-  FluidStateProperties & gas = fsp[_gas_phase_number];
+  auto & gas = fsp[_gas_phase_number];
+  auto & liquid = fsp[_aqueous_fluid_component];
+
+  // Approximate liquid density as saturation isn't known yet, by using the gas
+  // pressure rather than the liquid pressure. This does result in a small error
+  // in the calculated saturation, but this is below the error associated with
+  // the correlations. A more accurate saturation could be found iteraviely,
+  // at the cost of increased computational expense
+
+  // Gas density
+  const DualReal gas_density = _co2_fp.rho_from_p_T(pressure, temperature);
 
   // Approximate liquid density as saturation isn't known yet
-  Real brine_density, dbrine_density_dp, dbrine_density_dT, dbrine_density_dX;
-  _brine_fp.rho_from_p_T_X(pressure,
-                           temperature,
-                           Xnacl,
-                           brine_density,
-                           dbrine_density_dp,
-                           dbrine_density_dT,
-                           dbrine_density_dX);
+  const DualReal brine_density = _brine_fp.rho_from_p_T_X(pressure, temperature, Xnacl);
 
   // Mass fraction of CO2 in liquid phase
-  const Real Xco2 = liquid.mass_fraction[_gas_fluid_component];
-  const Real dXco2_dp = liquid.dmass_fraction_dp[_gas_fluid_component];
-  const Real dXco2_dT = liquid.dmass_fraction_dT[_gas_fluid_component];
-  const Real dXco2_dX = liquid.dmass_fraction_dX[_gas_fluid_component];
+  const DualReal Xco2 = liquid.mass_fraction[_gas_fluid_component];
 
   // The liquid density
-  Real co2_partial_density, dco2_partial_density_dT;
-  partialDensityCO2(temperature, co2_partial_density, dco2_partial_density_dT);
+  const DualReal co2_partial_density = partialDensityCO2(temperature);
 
-  const Real liquid_density = 1.0 / (Xco2 / co2_partial_density + (1.0 - Xco2) / brine_density);
+  const DualReal liquid_density = 1.0 / (Xco2 / co2_partial_density + (1.0 - Xco2) / brine_density);
 
-  const Real dliquid_density_dp =
-      (dXco2_dp / brine_density + (1.0 - Xco2) * dbrine_density_dp / brine_density / brine_density -
-       dXco2_dp / co2_partial_density) *
-      liquid_density * liquid_density;
-
-  const Real dliquid_density_dT =
-      (dXco2_dT / brine_density + (1.0 - Xco2) * dbrine_density_dT / brine_density / brine_density -
-       dXco2_dT / co2_partial_density +
-       Xco2 * dco2_partial_density_dT / co2_partial_density / co2_partial_density) *
-      liquid_density * liquid_density;
-
-  const Real dliquid_density_dX =
-      (dXco2_dX / brine_density + (1.0 - Xco2) * dbrine_density_dX / brine_density / brine_density -
-       dXco2_dX / co2_partial_density) *
-      liquid_density * liquid_density;
-
-  const Real Yco2 = gas.mass_fraction[_gas_fluid_component];
-  const Real dYco2_dp = gas.dmass_fraction_dp[_gas_fluid_component];
-  const Real dYco2_dT = gas.dmass_fraction_dT[_gas_fluid_component];
-  const Real dYco2_dX = gas.dmass_fraction_dX[_gas_fluid_component];
+  const DualReal Yco2 = gas.mass_fraction[_gas_fluid_component];
 
   // Set mass equilibrium constants used in the calculation of vapor mass fraction
-  const Real K0 = Yco2 / Xco2;
-  const Real K1 = (1.0 - Yco2) / (1.0 - Xco2);
-  const Real vapor_mass_fraction = vaporMassFraction(Z, K0, K1);
+  const DualReal K0 = Yco2 / Xco2;
+  const DualReal K1 = (1.0 - Yco2) / (1.0 - Xco2);
+  const DualReal vapor_mass_fraction = vaporMassFraction(Z, K0, K1);
 
   // The gas saturation in the two phase case
-  gas.saturation = vapor_mass_fraction * liquid_density /
-                   (gas.density + vapor_mass_fraction * (liquid_density - gas.density));
+  const DualReal saturation = vapor_mass_fraction * liquid_density /
+                              (gas_density + vapor_mass_fraction * (liquid_density - gas_density));
 
-  const Real dv_dZ = (K1 - K0) / ((K0 - 1.0) * (K1 - 1.0));
-  const Real denominator = (gas.density + vapor_mass_fraction * (liquid_density - gas.density)) *
-                           (gas.density + vapor_mass_fraction * (liquid_density - gas.density));
-
-  const Real ds_dZ = gas.density * liquid_density * dv_dZ / denominator;
-
-  const Real dK0_dp = (Xco2 * dYco2_dp - Yco2 * dXco2_dp) / Xco2 / Xco2;
-  const Real dK0_dT = (Xco2 * dYco2_dT - Yco2 * dXco2_dT) / Xco2 / Xco2;
-  const Real dK0_dX = (Xco2 * dYco2_dX - Yco2 * dXco2_dX) / Xco2 / Xco2;
-
-  const Real dK1_dp =
-      ((1.0 - Yco2) * dXco2_dp - (1.0 - Xco2) * dYco2_dp) / (1.0 - Xco2) / (1.0 - Xco2);
-  const Real dK1_dT =
-      ((1.0 - Yco2) * dXco2_dT - (1.0 - Xco2) * dYco2_dT) / (1.0 - Xco2) / (1.0 - Xco2);
-  const Real dK1_dX =
-      ((1.0 - Yco2) * dXco2_dX - (1.0 - Xco2) * dYco2_dX) / (1.0 - Xco2) / (1.0 - Xco2);
-
-  const Real dv_dp =
-      Z * dK1_dp / (K1 - 1.0) / (K1 - 1.0) + (1.0 - Z) * dK0_dp / (K0 - 1.0) / (K0 - 1.0);
-
-  Real ds_dp = gas.density * liquid_density * dv_dp +
-               vapor_mass_fraction * (1.0 - vapor_mass_fraction) *
-                   (gas.density * dliquid_density_dp - gas.ddensity_dp * liquid_density);
-  ds_dp /= denominator;
-
-  const Real dv_dT =
-      Z * dK1_dT / (K1 - 1.0) / (K1 - 1.0) + (1.0 - Z) * dK0_dT / (K0 - 1.0) / (K0 - 1.0);
-
-  Real ds_dT = gas.density * liquid_density * dv_dT +
-               vapor_mass_fraction * (1.0 - vapor_mass_fraction) *
-                   (gas.density * dliquid_density_dT - gas.ddensity_dT * liquid_density);
-  ds_dT /= denominator;
-
-  const Real dv_dX =
-      Z * dK1_dX / (K1 - 1.0) / (K1 - 1.0) + (1.0 - Z) * dK0_dX / (K0 - 1.0) / (K0 - 1.0);
-
-  Real ds_dX = gas.density * liquid_density * dv_dX + vapor_mass_fraction *
-                                                          (1.0 - vapor_mass_fraction) *
-                                                          (gas.density * dliquid_density_dX);
-  ds_dX /= denominator;
-
-  gas.dsaturation_dp = ds_dp;
-  gas.dsaturation_dT = ds_dT;
-  gas.dsaturation_dZ = ds_dZ;
-  gas.dsaturation_dX = ds_dX;
+  return saturation;
 }
 
 void
-PorousFlowBrineCO2::equilibriumMassFractions(Real pressure,
-                                             Real temperature,
-                                             Real Xnacl,
-                                             Real & Xco2,
-                                             Real & dXco2_dp,
-                                             Real & dXco2_dT,
-                                             Real & dXco2_dX,
-                                             Real & Yh2o,
-                                             Real & dYh2o_dp,
-                                             Real & dYh2o_dT,
-                                             Real & dYh2o_dX) const
+PorousFlowBrineCO2::twoPhaseProperties(const DualReal & pressure,
+                                       const DualReal & temperature,
+                                       const DualReal & Xnacl,
+                                       const DualReal & Z,
+                                       unsigned int qp,
+                                       std::vector<FluidStateProperties> & fsp) const
 {
-  Real co2_density, dco2_density_dp, dco2_density_dT;
-  _co2_fp.rho_from_p_T(pressure, temperature, co2_density, dco2_density_dp, dco2_density_dT);
+  auto & gas = fsp[_gas_phase_number];
+
+  // Calculate all of the gas phase properties, as these don't depend on saturation
+  gasProperties(pressure, temperature, fsp);
+
+  // The gas saturation in the two phase case
+  gas.saturation = saturation(pressure, temperature, Xnacl, Z, fsp);
+
+  // The liquid pressure and properties can now be calculated
+  const DualReal liquid_pressure = pressure - _pc.capillaryPressure(1.0 - gas.saturation, qp);
+  liquidProperties(liquid_pressure, temperature, Xnacl, fsp);
+}
+
+void
+PorousFlowBrineCO2::equilibriumMassFractions(const DualReal & pressure,
+                                             const DualReal & temperature,
+                                             const DualReal & Xnacl,
+                                             DualReal & Xco2,
+                                             DualReal & Yh2o) const
+{
+  const DualReal co2_density = _co2_fp.rho_from_p_T(pressure, temperature);
 
   // Mole fractions at equilibrium
-  Real xco2, dxco2_dp, dxco2_dT, dxco2_dX, yh2o, dyh2o_dp, dyh2o_dT, dyh2o_dX;
-  equilibriumMoleFractions(pressure,
-                           temperature,
-                           Xnacl,
-                           xco2,
-                           dxco2_dp,
-                           dxco2_dT,
-                           dxco2_dX,
-                           yh2o,
-                           dyh2o_dp,
-                           dyh2o_dT,
-                           dyh2o_dX);
+  DualReal xco2, yh2o;
+  equilibriumMoleFractions(pressure, temperature, Xnacl, xco2, yh2o);
 
   // The mass fraction of H2O in gas (assume no salt in gas phase) and derivatives
   // wrt p, T, and X
   Yh2o = yh2o * _Mh2o / (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2);
-  dYh2o_dp = _Mco2 * _Mh2o * dyh2o_dp / (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2) /
-             (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2);
-  dYh2o_dT = _Mco2 * _Mh2o * dyh2o_dT / (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2) /
-             (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2);
-  dYh2o_dX = dyh2o_dX * _Mh2o * _Mco2 / (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2) /
-             (yh2o * _Mh2o + (1.0 - yh2o) * _Mco2);
 
   // NaCl molality (mol/kg)
-  const Real mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
-  const Real dmnacl_dX = 1.0 / (1.0 - Xnacl) / (1.0 - Xnacl) / _Mnacl;
+  const DualReal mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
 
   // The molality of CO2 in 1kg of H2O
-  const Real mco2 = xco2 * (2.0 * mnacl + _invMh2o) / (1.0 - xco2);
+  const DualReal mco2 = xco2 * (2.0 * mnacl + _invMh2o) / (1.0 - xco2);
   // The mass fraction of CO2 in brine is then
-  const Real denominator = (1.0 + mnacl * _Mnacl + mco2 * _Mco2);
+  const DualReal denominator = (1.0 + mnacl * _Mnacl + mco2 * _Mco2);
   Xco2 = mco2 * _Mco2 / denominator;
-
-  // Derivatives of Xco2 wrt p, T and X
-  const Real denominator2 = denominator * denominator;
-  const Real dmco2_dp = dxco2_dp * (2.0 * mnacl + _invMh2o) / (1.0 - xco2) / (1.0 - xco2);
-  dXco2_dp = (1.0 + mnacl * _Mnacl) * _Mco2 * dmco2_dp / denominator2;
-
-  const Real dmco2_dT = dxco2_dT * (2.0 * mnacl + _invMh2o) / (1.0 - xco2) / (1.0 - xco2);
-  dXco2_dT = (1.0 + mnacl * _Mnacl) * _Mco2 * dmco2_dT / denominator2;
-
-  const Real dmco2_dX =
-      (dxco2_dX * (2.0 * mnacl + _invMh2o) + 2.0 * (1.0 - xco2) * xco2 * dmnacl_dX) / (1.0 - xco2) /
-      (1.0 - xco2);
-  dXco2_dX = _Mco2 * ((1.0 + mnacl * _Mnacl) * dmco2_dX - dmnacl_dX * mco2 * _Mnacl) / denominator2;
 }
 
 void
-PorousFlowBrineCO2::fugacityCoefficientsLowTemp(Real pressure,
-                                                Real temperature,
-                                                Real co2_density,
-                                                Real dco2_density_dp,
-                                                Real dco2_density_dT,
-                                                Real & fco2,
-                                                Real & dfco2_dp,
-                                                Real & dfco2_dT,
-                                                Real & fh2o,
-                                                Real & dfh2o_dp,
-                                                Real & dfh2o_dT) const
+PorousFlowBrineCO2::fugacityCoefficientsLowTemp(const DualReal & pressure,
+                                                const DualReal & temperature,
+                                                const DualReal & co2_density,
+                                                DualReal & fco2,
+                                                DualReal & fh2o) const
 {
-  if (temperature > 373.15)
+  if (temperature.value() > 373.15)
     mooseError(name(),
                ": fugacityCoefficientsLowTemp() is not valid for T > 373.15K. Use "
                "fugacityCoefficientsHighTemp() instead");
 
   // Need pressure in bar
-  const Real pbar = pressure * 1.0e-5;
+  const DualReal pbar = pressure * 1.0e-5;
 
   // Molar volume in cm^3/mol
-  const Real V = _Mco2 / co2_density * 1.0e6;
-  const Real dV_dp = -V / co2_density * dco2_density_dp;
-  const Real dV_dT = -V / co2_density * dco2_density_dT;
+  const DualReal V = _Mco2 / co2_density * 1.0e6;
 
   // Redlich-Kwong parameters
-  const Real aCO2 = 7.54e7 - 4.13e4 * temperature;
-  const Real daCO2_dT = -4.13e4;
+  const DualReal aCO2 = 7.54e7 - 4.13e4 * temperature;
   const Real bCO2 = 27.8;
   const Real aCO2H2O = 7.89e7;
   const Real bH2O = 18.18;
 
-  const Real t15 = std::pow(temperature, 1.5);
+  const DualReal t15 = std::pow(temperature, 1.5);
 
   // The fugacity coefficients for H2O and CO2
-  auto lnPhi = [V, aCO2, bCO2, t15, this](Real a, Real b) {
+  auto lnPhi = [V, aCO2, bCO2, t15, this](DualReal a, DualReal b) {
     return std::log(V / (V - bCO2)) + b / (V - bCO2) -
            2.0 * a / (_Rbar * t15 * bCO2) * std::log((V + bCO2) / V) +
            aCO2 * b / (_Rbar * t15 * bCO2 * bCO2) * (std::log((V + bCO2) / V) - bCO2 / (V + bCO2));
   };
 
-  const Real lnPhiH2O = lnPhi(aCO2H2O, bH2O) - std::log(pbar * V / (_Rbar * temperature));
-  const Real lnPhiCO2 = lnPhi(aCO2, bCO2) - std::log(pbar * V / (_Rbar * temperature));
+  const DualReal lnPhiH2O = lnPhi(aCO2H2O, bH2O) - std::log(pbar * V / (_Rbar * temperature));
+  const DualReal lnPhiCO2 = lnPhi(aCO2, bCO2) - std::log(pbar * V / (_Rbar * temperature));
 
   fh2o = std::exp(lnPhiH2O);
   fco2 = std::exp(lnPhiCO2);
-
-  // The derivative of the fugacity coefficients wrt pressure
-  auto dlnPhi_dV = [V, aCO2, bCO2, t15, this](Real a, Real b) {
-    return (bCO2 * bCO2 - (bCO2 + b) * V) / V / (V - bCO2) / (V - bCO2) +
-           (2.0 * a * (V + bCO2) - aCO2 * b) / (_Rbar * t15 * V * (V + bCO2) * (V + bCO2));
-  };
-
-  dfh2o_dp = (dlnPhi_dV(aCO2H2O, bH2O) * dV_dp - 1.0e-5 / pbar - dV_dp / V) * fh2o;
-  dfco2_dp = (dlnPhi_dV(aCO2, bCO2) * dV_dp - 1.0e-5 / pbar - dV_dp / V) * fco2;
-
-  // The derivative of the fugacity coefficient wrt temperature
-  auto dlnPhi_dT = [V, aCO2, daCO2_dT, bCO2, t15, temperature, this](Real a, Real b, Real da_dT) {
-    return (3.0 * bCO2 * a * std::log((V + bCO2) / V) +
-            1.5 * aCO2 * b * (bCO2 / (V + bCO2) - std::log((V + bCO2) / V)) -
-            (2.0 * da_dT * bCO2 * std::log((V + bCO2) / V) -
-             daCO2_dT * b * (std::log((V + bCO2) / V) - bCO2 / (V + bCO2))) *
-                temperature) /
-           (temperature * t15 * _Rbar * bCO2 * bCO2);
-  };
-
-  dfh2o_dT = (dlnPhi_dT(aCO2H2O, bH2O, 0) + dlnPhi_dV(aCO2H2O, bH2O) * dV_dT - dV_dT / V +
-              1.0 / temperature) *
-             fh2o;
-  dfco2_dT = (dlnPhi_dT(aCO2, bCO2, daCO2_dT) + dlnPhi_dV(aCO2, bCO2) * dV_dT - dV_dT / V +
-              1.0 / temperature) *
-             fco2;
 }
 
 void
-PorousFlowBrineCO2::fugacityCoefficientsHighTemp(Real pressure,
-                                                 Real temperature,
-                                                 Real co2_density,
-                                                 Real xco2,
-                                                 Real yh2o,
-                                                 Real & fco2,
-                                                 Real & fh2o) const
+PorousFlowBrineCO2::fugacityCoefficientsHighTemp(const DualReal & pressure,
+                                                 const DualReal & temperature,
+                                                 const DualReal & co2_density,
+                                                 const DualReal & xco2,
+                                                 const DualReal & yh2o,
+                                                 DualReal & fco2,
+                                                 DualReal & fh2o) const
 {
-  if (temperature <= 373.15)
+  if (temperature.value() <= 373.15)
     mooseError(name(),
                ": fugacityCoefficientsHighTemp() is not valid for T <= 373.15K. Use "
                "fugacityCoefficientsLowTemp() instead");
@@ -689,80 +449,45 @@ PorousFlowBrineCO2::fugacityCoefficientsHighTemp(Real pressure,
   fco2 = fugacityCoefficientCO2HighTemp(pressure, temperature, co2_density, xco2, yh2o);
 }
 
-void
-PorousFlowBrineCO2::fugacityCoefficientsHighTemp(Real pressure,
-                                                 Real temperature,
-                                                 Real co2_density,
-                                                 Real xco2,
-                                                 Real yh2o,
-                                                 Real & fco2,
-                                                 Real & dfco2_dp,
-                                                 Real & dfco2_dT,
-                                                 Real & fh2o,
-                                                 Real & dfh2o_dp,
-                                                 Real & dfh2o_dT) const
-{
-  if (temperature <= 373.15)
-    mooseError(name(),
-               ": fugacityCoefficientsHighTemp() is not valid for T <= 373.15K. Use "
-               "fugacityCoefficientsLowTemp() instead");
-
-  fh2o = fugacityCoefficientH2OHighTemp(pressure, temperature, co2_density, xco2, yh2o);
-  fco2 = fugacityCoefficientCO2HighTemp(pressure, temperature, co2_density, xco2, yh2o);
-
-  // Derivatives by finite difference
-  const Real dp = 1.0e-2;
-  const Real dT = 1.0e-4;
-
-  Real fh2o2 = fugacityCoefficientH2OHighTemp(pressure + dp, temperature, co2_density, xco2, yh2o);
-  Real fco22 = fugacityCoefficientCO2HighTemp(pressure + dp, temperature, xco2, co2_density, yh2o);
-
-  dfh2o_dp = (fh2o2 - fh2o) / dp;
-  dfco2_dp = (fco22 - fco2) / dp;
-
-  fh2o2 = fugacityCoefficientH2OHighTemp(pressure, temperature + dT, co2_density, xco2, yh2o);
-  fco22 = fugacityCoefficientCO2HighTemp(pressure, temperature + dT, co2_density, xco2, yh2o);
-
-  dfh2o_dT = (fh2o2 - fh2o) / dT;
-  dfco2_dT = (fco22 - fco2) / dT;
-}
-
-Real
-PorousFlowBrineCO2::fugacityCoefficientH2OHighTemp(
-    Real pressure, Real temperature, Real co2_density, Real xco2, Real yh2o) const
+DualReal
+PorousFlowBrineCO2::fugacityCoefficientH2OHighTemp(const DualReal & pressure,
+                                                   const DualReal & temperature,
+                                                   const DualReal & co2_density,
+                                                   const DualReal & xco2,
+                                                   const DualReal & yh2o) const
 {
   // Need pressure in bar
-  const Real pbar = pressure * 1.0e-5;
+  const DualReal pbar = pressure * 1.0e-5;
   // Molar volume in cm^3/mol
-  const Real V = _Mco2 / co2_density * 1.0e6;
+  const DualReal V = _Mco2 / co2_density * 1.0e6;
 
   // Redlich-Kwong parameters
-  const Real yco2 = 1.0 - yh2o;
-  const Real xh2o = 1.0 - xco2;
+  const DualReal yco2 = 1.0 - yh2o;
+  const DualReal xh2o = 1.0 - xco2;
 
-  const Real aCO2 = 8.008e7 - 4.984e4 * temperature;
-  const Real aH2O = 1.337e8 - 1.4e4 * temperature;
+  const DualReal aCO2 = 8.008e7 - 4.984e4 * temperature;
+  const DualReal aH2O = 1.337e8 - 1.4e4 * temperature;
   const Real bCO2 = 28.25;
   const Real bH2O = 15.7;
-  const Real KH2OCO2 = 1.427e-2 - 4.037e-4 * temperature;
-  const Real KCO2H2O = 0.4228 - 7.422e-4 * temperature;
-  const Real kH2OCO2 = KH2OCO2 * yh2o + KCO2H2O * yco2;
-  const Real kCO2H2O = KCO2H2O * yh2o + KH2OCO2 * yco2;
+  const DualReal KH2OCO2 = 1.427e-2 - 4.037e-4 * temperature;
+  const DualReal KCO2H2O = 0.4228 - 7.422e-4 * temperature;
+  const DualReal kH2OCO2 = KH2OCO2 * yh2o + KCO2H2O * yco2;
+  const DualReal kCO2H2O = KCO2H2O * yh2o + KH2OCO2 * yco2;
 
-  const Real aH2OCO2 = std::sqrt(aCO2 * aH2O) * (1.0 - kH2OCO2);
-  const Real aCO2H2O = std::sqrt(aCO2 * aH2O) * (1.0 - kCO2H2O);
+  const DualReal aH2OCO2 = std::sqrt(aCO2 * aH2O) * (1.0 - kH2OCO2);
+  const DualReal aCO2H2O = std::sqrt(aCO2 * aH2O) * (1.0 - kCO2H2O);
 
-  const Real amix = yh2o * yh2o * aH2O + yh2o * yco2 * (aH2OCO2 + aCO2H2O) + yco2 * yco2 * aCO2;
-  const Real bmix = yh2o * bH2O + yco2 * bCO2;
+  const DualReal amix = yh2o * yh2o * aH2O + yh2o * yco2 * (aH2OCO2 + aCO2H2O) + yco2 * yco2 * aCO2;
+  const DualReal bmix = yh2o * bH2O + yco2 * bCO2;
 
-  const Real t15 = std::pow(temperature, 1.5);
+  const DualReal t15 = std::pow(temperature, 1.5);
 
-  Real lnPhiH2O = bH2O / bmix * (pbar * V / (_Rbar * temperature) - 1.0) -
-                  std::log(pbar * (V - bmix) / (_Rbar * temperature));
-  Real term3 = (2.0 * yh2o * aH2O + yco2 * (aH2OCO2 + aCO2H2O) -
-                yh2o * yco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O) * (yh2o - yco2) +
-                xh2o * xco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O)) /
-               amix;
+  DualReal lnPhiH2O = bH2O / bmix * (pbar * V / (_Rbar * temperature) - 1.0) -
+                      std::log(pbar * (V - bmix) / (_Rbar * temperature));
+  DualReal term3 = (2.0 * yh2o * aH2O + yco2 * (aH2OCO2 + aCO2H2O) -
+                    yh2o * yco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O) * (yh2o - yco2) +
+                    xh2o * xco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O)) /
+                   amix;
   term3 -= bH2O / bmix;
   term3 *= amix / (bmix * _Rbar * t15) * std::log(V / (V + bmix));
   lnPhiH2O += term3;
@@ -770,276 +495,216 @@ PorousFlowBrineCO2::fugacityCoefficientH2OHighTemp(
   return std::exp(lnPhiH2O);
 }
 
-Real
-PorousFlowBrineCO2::fugacityCoefficientCO2HighTemp(
-    Real pressure, Real temperature, Real co2_density, Real xco2, Real yh2o) const
+DualReal
+PorousFlowBrineCO2::fugacityCoefficientCO2HighTemp(const DualReal & pressure,
+                                                   const DualReal & temperature,
+                                                   const DualReal & co2_density,
+                                                   const DualReal & xco2,
+                                                   const DualReal & yh2o) const
 {
   // Need pressure in bar
-  const Real pbar = pressure * 1.0e-5;
+  const DualReal pbar = pressure * 1.0e-5;
   // Molar volume in cm^3/mol
-  const Real V = _Mco2 / co2_density * 1.0e6;
+  const DualReal V = _Mco2 / co2_density * 1.0e6;
 
   // Redlich-Kwong parameters
-  const Real yco2 = 1.0 - yh2o;
-  const Real xh2o = 1.0 - xco2;
+  const DualReal yco2 = 1.0 - yh2o;
+  const DualReal xh2o = 1.0 - xco2;
 
-  const Real aCO2 = 8.008e7 - 4.984e4 * temperature;
-  const Real aH2O = 1.337e8 - 1.4e4 * temperature;
+  const DualReal aCO2 = 8.008e7 - 4.984e4 * temperature;
+  const DualReal aH2O = 1.337e8 - 1.4e4 * temperature;
   const Real bCO2 = 28.25;
   const Real bH2O = 15.7;
-  const Real KH2OCO2 = 1.427e-2 - 4.037e-4 * temperature;
-  const Real KCO2H2O = 0.4228 - 7.422e-4 * temperature;
-  const Real kH2OCO2 = KH2OCO2 * yh2o + KCO2H2O * yco2;
-  const Real kCO2H2O = KCO2H2O * yh2o + KH2OCO2 * yco2;
+  const DualReal KH2OCO2 = 1.427e-2 - 4.037e-4 * temperature;
+  const DualReal KCO2H2O = 0.4228 - 7.422e-4 * temperature;
+  const DualReal kH2OCO2 = KH2OCO2 * yh2o + KCO2H2O * yco2;
+  const DualReal kCO2H2O = KCO2H2O * yh2o + KH2OCO2 * yco2;
 
-  const Real aH2OCO2 = std::sqrt(aCO2 * aH2O) * (1.0 - kH2OCO2);
-  const Real aCO2H2O = std::sqrt(aCO2 * aH2O) * (1.0 - kCO2H2O);
+  const DualReal aH2OCO2 = std::sqrt(aCO2 * aH2O) * (1.0 - kH2OCO2);
+  const DualReal aCO2H2O = std::sqrt(aCO2 * aH2O) * (1.0 - kCO2H2O);
 
-  const Real amix = yh2o * yh2o * aH2O + yh2o * yco2 * (aH2OCO2 + aCO2H2O) + yco2 * yco2 * aCO2;
-  const Real bmix = yh2o * bH2O + yco2 * bCO2;
+  const DualReal amix = yh2o * yh2o * aH2O + yh2o * yco2 * (aH2OCO2 + aCO2H2O) + yco2 * yco2 * aCO2;
+  const DualReal bmix = yh2o * bH2O + yco2 * bCO2;
 
-  const Real t15 = std::pow(temperature, 1.5);
+  const DualReal t15 = std::pow(temperature, 1.5);
 
-  Real lnPhiCO2 = bCO2 / bmix * (pbar * V / (_Rbar * temperature) - 1.0) -
-                  std::log(pbar * (V - bmix) / (_Rbar * temperature));
+  DualReal lnPhiCO2 = bCO2 / bmix * (pbar * V / (_Rbar * temperature) - 1.0) -
+                      std::log(pbar * (V - bmix) / (_Rbar * temperature));
 
-  Real term3 = (2.0 * yco2 * aCO2 + yh2o * (aH2OCO2 + aCO2H2O) -
-                yh2o * yco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O) * (yh2o - yco2) +
-                xh2o * xco2 * std::sqrt(aH2O * aCO2) * (kCO2H2O - kH2OCO2)) /
-               amix;
+  DualReal term3 = (2.0 * yco2 * aCO2 + yh2o * (aH2OCO2 + aCO2H2O) -
+                    yh2o * yco2 * std::sqrt(aH2O * aCO2) * (kH2OCO2 - kCO2H2O) * (yh2o - yco2) +
+                    xh2o * xco2 * std::sqrt(aH2O * aCO2) * (kCO2H2O - kH2OCO2)) /
+                   amix;
 
   lnPhiCO2 += (term3 - bCO2 / bmix) * amix / (bmix * _Rbar * t15) * std::log(V / (V + bmix));
 
   return std::exp(lnPhiCO2);
 }
 
-Real
-PorousFlowBrineCO2::activityCoefficientH2O(Real temperature, Real xco2) const
+DualReal
+PorousFlowBrineCO2::activityCoefficientH2O(const DualReal & temperature,
+                                           const DualReal & xco2) const
 {
-  if (temperature <= 373.15)
+  if (temperature.value() <= 373.15)
     return 1.0;
   else
   {
-    const Real Tref = temperature - 373.15;
-    const Real xh2o = 1.0 - xco2;
-    const Real Am = -3.084e-2 * Tref + 1.927e-5 * Tref * Tref;
+    const DualReal Tref = temperature - 373.15;
+    const DualReal xh2o = 1.0 - xco2;
+    const DualReal Am = -3.084e-2 * Tref + 1.927e-5 * Tref * Tref;
 
     return std::exp((Am - 2.0 * Am * xh2o) * xco2 * xco2);
   }
 }
 
-Real
-PorousFlowBrineCO2::activityCoefficientCO2(Real temperature, Real xco2) const
+DualReal
+PorousFlowBrineCO2::activityCoefficientCO2(const DualReal & temperature,
+                                           const DualReal & xco2) const
 {
-  if (temperature <= 373.15)
+  if (temperature.value() <= 373.15)
     return 1.0;
   else
   {
-    const Real Tref = temperature - 373.15;
-    const Real xh2o = 1.0 - xco2;
-    const Real Am = -3.084e-2 * Tref + 1.927e-5 * Tref * Tref;
+    const DualReal Tref = temperature - 373.15;
+    const DualReal xh2o = 1.0 - xco2;
+    const DualReal Am = -3.084e-2 * Tref + 1.927e-5 * Tref * Tref;
 
     return std::exp(2.0 * Am * xco2 * xh2o * xh2o);
   }
 }
 
-void
-PorousFlowBrineCO2::activityCoefficient(Real pressure,
-                                        Real temperature,
-                                        Real Xnacl,
-                                        Real & gamma,
-                                        Real & dgamma_dp,
-                                        Real & dgamma_dT,
-                                        Real & dgamma_dX) const
+DualReal
+PorousFlowBrineCO2::activityCoefficient(const DualReal & pressure,
+                                        const DualReal & temperature,
+                                        const DualReal & Xnacl) const
 {
   // Need pressure in bar
-  const Real pbar = pressure * 1.0e-5;
+  const DualReal pbar = pressure * 1.0e-5;
   // Need NaCl molality (mol/kg)
-  const Real mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
-  const Real dmnacl_dX = 1.0 / (1.0 - Xnacl) / (1.0 - Xnacl) / _Mnacl;
+  const DualReal mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
 
-  const Real lambda = -0.411370585 + 6.07632013e-4 * temperature + 97.5347708 / temperature -
-                      0.0237622469 * pbar / temperature +
-                      0.0170656236 * pbar / (630.0 - temperature) +
-                      1.41335834e-5 * temperature * std::log(pbar);
+  const DualReal lambda = -0.411370585 + 6.07632013e-4 * temperature + 97.5347708 / temperature -
+                          0.0237622469 * pbar / temperature +
+                          0.0170656236 * pbar / (630.0 - temperature) +
+                          1.41335834e-5 * temperature * std::log(pbar);
 
-  const Real xi = 3.36389723e-4 - 1.9829898e-5 * temperature + 2.12220830e-3 * pbar / temperature -
-                  5.24873303e-3 * pbar / (630.0 - temperature);
+  const DualReal xi = 3.36389723e-4 - 1.9829898e-5 * temperature +
+                      2.12220830e-3 * pbar / temperature -
+                      5.24873303e-3 * pbar / (630.0 - temperature);
 
-  gamma = std::exp(2.0 * lambda * mnacl + xi * mnacl * mnacl);
-
-  // Derivative wrt pressure
-  const Real dlambda_dp = -0.0237622469 / temperature + 0.0170656236 / (630.0 - temperature) +
-                          1.41335834e-5 * temperature / pbar;
-  const Real dxi_dp = 2.12220830e-3 / temperature - 5.24873303e-3 / (630.0 - temperature);
-  dgamma_dp = (2.0 * mnacl * dlambda_dp + mnacl * mnacl * dxi_dp) * gamma * 1.0e-5;
-
-  // Derivative wrt temperature
-  const Real dlambda_dT = 6.07632013e-4 - 97.5347708 / temperature / temperature +
-                          0.0237622469 * pbar / temperature / temperature +
-                          0.0170656236 * pbar / (630.0 - temperature) / (630.0 - temperature) +
-                          1.41335834e-5 * std::log(pbar);
-  const Real dxi_dT = -1.9829898e-5 - 2.12220830e-3 * pbar / temperature / temperature -
-                      5.24873303e-3 * pbar / (630.0 - temperature) / (630.0 - temperature);
-  dgamma_dT = (2.0 * mnacl * dlambda_dT + mnacl * mnacl * dxi_dT) * gamma;
-
-  // Derivative wrt salt mass fraction
-  dgamma_dX = (2.0 * lambda * dmnacl_dX + 2.0 * xi * mnacl * dmnacl_dX) * gamma;
+  return std::exp(2.0 * lambda * mnacl + xi * mnacl * mnacl);
 }
 
-void
-PorousFlowBrineCO2::activityCoefficientHighTemp(
-    Real temperature, Real Xnacl, Real & gamma, Real & dgamma_dT, Real & dgamma_dX) const
+DualReal
+PorousFlowBrineCO2::activityCoefficientHighTemp(const DualReal & temperature,
+                                                const DualReal & Xnacl) const
 {
   // Need NaCl molality (mol/kg)
-  const Real mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
-  const Real dmnacl_dX = 1.0 / (1.0 - Xnacl) / (1.0 - Xnacl) / _Mnacl;
+  const DualReal mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
 
-  const Real T2 = temperature * temperature;
-  const Real T3 = temperature * T2;
+  const DualReal T2 = temperature * temperature;
+  const DualReal T3 = temperature * T2;
 
-  const Real lambda = 2.217e-4 * temperature + 1.074 / temperature + 2648.0 / T2;
-  const Real xi = 1.3e-5 * temperature - 20.12 / temperature + 5259.0 / T2;
+  const DualReal lambda = 2.217e-4 * temperature + 1.074 / temperature + 2648.0 / T2;
+  const DualReal xi = 1.3e-5 * temperature - 20.12 / temperature + 5259.0 / T2;
 
-  gamma = (1.0 - mnacl / _invMh2o) * std::exp(2.0 * lambda * mnacl + xi * mnacl * mnacl);
-
-  // Derivative wrt temperature
-  const Real dlambda_dT = 2.217e-4 - 1.074 / T2 - 5296.0 / T3;
-  const Real dxi_dT = 1.3e-5 + 20.12 / T2 - 10518.0 / T3;
-  dgamma_dT = (2.0 * mnacl * dlambda_dT + mnacl * mnacl * dxi_dT) * gamma;
-
-  // Derivative wrt salt mass fraction
-  dgamma_dX = (2.0 * lambda * dmnacl_dX + 2.0 * xi * mnacl * dmnacl_dX) * gamma -
-              dmnacl_dX / _invMh2o * std::exp(2.0 * lambda * mnacl + xi * mnacl * mnacl);
+  return (1.0 - mnacl / _invMh2o) * std::exp(2.0 * lambda * mnacl + xi * mnacl * mnacl);
 }
 
-void
-PorousFlowBrineCO2::equilibriumConstantH2O(Real temperature, Real & kh2o, Real & dkh2o_dT) const
+DualReal
+PorousFlowBrineCO2::equilibriumConstantH2O(const DualReal & temperature) const
 {
   // Uses temperature in Celsius
-  const Real Tc = temperature - _T_c2k;
-  const Real Tc2 = Tc * Tc;
-  const Real Tc3 = Tc2 * Tc;
-  const Real Tc4 = Tc3 * Tc;
+  const DualReal Tc = temperature - _T_c2k;
+  const DualReal Tc2 = Tc * Tc;
+  const DualReal Tc3 = Tc2 * Tc;
+  const DualReal Tc4 = Tc3 * Tc;
 
-  Real logK0H2O, dlogK0H2O;
+  DualReal logK0H2O;
 
   if (Tc <= 99.0)
-  {
     logK0H2O = -2.209 + 3.097e-2 * Tc - 1.098e-4 * Tc2 + 2.048e-7 * Tc3;
-    dlogK0H2O = 3.097e-2 - 2.196e-4 * Tc + 6.144e-7 * Tc2;
-  }
+
   else if (Tc > 99.0 && Tc < 109.0)
   {
-    const Real Tint = (Tc - 99.0) / 10.0;
-    const Real Tint2 = Tint * Tint;
+    const DualReal Tint = (Tc - 99.0) / 10.0;
+    const DualReal Tint2 = Tint * Tint;
     logK0H2O = -0.0204026 + 0.0152513 * Tint + 0.417565 * Tint2 - 0.278636 * Tint * Tint2;
-    dlogK0H2O = 0.0152513 + 0.83513 * Tint - 0.835908 * Tint2;
-  }
-  else // 109 <= Tc <= 300
-  {
-    logK0H2O = -2.1077 + 2.8127e-2 * Tc - 8.4298e-5 * Tc2 + 1.4969e-7 * Tc3 - 1.1812e-10 * Tc4;
-    dlogK0H2O = 2.8127e-2 - 1.68596e-4 * Tc + 4.4907e-7 * Tc2 - 4.7248e-10 * Tc3;
   }
 
-  kh2o = std::pow(10.0, logK0H2O);
-  dkh2o_dT = std::log(10.0) * dlogK0H2O * kh2o;
+  else // 109 <= Tc <= 300
+    logK0H2O = -2.1077 + 2.8127e-2 * Tc - 8.4298e-5 * Tc2 + 1.4969e-7 * Tc3 - 1.1812e-10 * Tc4;
+
+  return std::pow(10.0, logK0H2O);
 }
 
-void
-PorousFlowBrineCO2::equilibriumConstantCO2(Real temperature, Real & kco2, Real & dkco2_dT) const
+DualReal
+PorousFlowBrineCO2::equilibriumConstantCO2(const DualReal & temperature) const
 {
   // Uses temperature in Celsius
-  const Real Tc = temperature - _T_c2k;
-  const Real Tc2 = Tc * Tc;
-  const Real Tc3 = Tc2 * Tc;
+  const DualReal Tc = temperature - _T_c2k;
+  const DualReal Tc2 = Tc * Tc;
+  const DualReal Tc3 = Tc2 * Tc;
 
-  Real logK0CO2, dlogK0CO2;
+  DualReal logK0CO2;
 
   if (Tc <= 99.0)
-  {
     logK0CO2 = 1.189 + 1.304e-2 * Tc - 5.446e-5 * Tc2;
-    dlogK0CO2 = 1.304e-2 - 1.0892e-4 * Tc;
-  }
+
   else if (Tc > 99.0 && Tc < 109.0)
   {
-    const Real Tint = (Tc - 99.0) / 10.0;
-    const Real Tint2 = Tint * Tint;
+    const DualReal Tint = (Tc - 99.0) / 10.0;
+    const DualReal Tint2 = Tint * Tint;
     logK0CO2 = 1.9462 + 2.25692e-2 * Tint - 9.49577e-3 * Tint2 - 6.77721e-3 * Tint * Tint2;
-    dlogK0CO2 = 2.25692e-2 - 1.899154e-2 * Tint + 2.033163e-2 * Tint2;
-  }
-  else // 109 <= Tc <= 300
-  {
-    logK0CO2 = 1.668 + 3.992e-3 * Tc - 1.156e-5 * Tc2 + 1.593e-9 * Tc3;
-    dlogK0CO2 = 3.992e-3 - 2.312e-5 * Tc + 4.779e-9 * Tc2;
   }
 
-  kco2 = std::pow(10.0, logK0CO2);
-  dkco2_dT = std::log(10.0) * dlogK0CO2 * kco2;
+  else // 109 <= Tc <= 300
+    logK0CO2 = 1.668 + 3.992e-3 * Tc - 1.156e-5 * Tc2 + 1.593e-9 * Tc3;
+
+  return std::pow(10.0, logK0CO2);
 }
 
 void
-PorousFlowBrineCO2::equilibriumMoleFractions(Real pressure,
-                                             Real temperature,
-                                             Real Xnacl,
-                                             Real & xco2,
-                                             Real & dxco2_dp,
-                                             Real & dxco2_dT,
-                                             Real & dxco2_dX,
-                                             Real & yh2o,
-                                             Real & dyh2o_dp,
-                                             Real & dyh2o_dT,
-                                             Real & dyh2o_dX) const
+PorousFlowBrineCO2::equilibriumMoleFractions(const DualReal & pressure,
+                                             const DualReal & temperature,
+                                             const DualReal & Xnacl,
+                                             DualReal & xco2,
+                                             DualReal & yh2o) const
 {
   // CO2 density and derivatives wrt pressure and temperature
-  Real co2_density, dco2_density_dp, dco2_density_dT;
-  _co2_fp.rho_from_p_T(pressure, temperature, co2_density, dco2_density_dp, dco2_density_dT);
+  const DualReal co2_density = _co2_fp.rho_from_p_T(pressure, temperature);
 
-  if (temperature <= _Tlower)
+  if (temperature.value() <= _Tlower)
   {
-    equilibriumMoleFractionsLowTemp(pressure,
-                                    temperature,
-                                    Xnacl,
-                                    xco2,
-                                    dxco2_dp,
-                                    dxco2_dT,
-                                    dxco2_dX,
-                                    yh2o,
-                                    dyh2o_dp,
-                                    dyh2o_dT,
-                                    dyh2o_dX);
+    equilibriumMoleFractionsLowTemp(pressure, temperature, Xnacl, xco2, yh2o);
   }
-  else if (temperature > _Tlower && temperature < _Tupper)
+  else if (temperature.value() > _Tlower && temperature.value() < _Tupper)
   {
     // Cubic polynomial in this regime
-    const Real Tint = (temperature - _Tlower) / 10.0;
+    const Real Tint = (temperature.value() - _Tlower) / 10.0;
 
     // Equilibrium mole fractions and derivatives at the lower temperature
-    Real xco2_lower, dxco2_dT_lower, yh2o_lower, dyh2o_dT_lower;
-    equilibriumMoleFractionsLowTemp(pressure,
-                                    _Tlower,
-                                    Xnacl,
-                                    xco2_lower,
-                                    dxco2_dp,
-                                    dxco2_dT_lower,
-                                    dxco2_dX,
-                                    yh2o_lower,
-                                    dyh2o_dp,
-                                    dyh2o_dT_lower,
-                                    dyh2o_dX);
+    DualReal Tlower = _Tlower;
+    Tlower.derivatives()[_Tidx] = 1.0;
+
+    DualReal xco2_lower, yh2o_lower;
+    equilibriumMoleFractionsLowTemp(pressure, Tlower, Xnacl, xco2_lower, yh2o_lower);
+
+    const Real dxco2_dT_lower = xco2_lower.derivatives()[_Tidx];
+    const Real dyh2o_dT_lower = yh2o_lower.derivatives()[_Tidx];
 
     // Equilibrium mole fractions and derivatives at the upper temperature
     Real xco2_upper, yh2o_upper;
-    Real co2_density_upper = _co2_fp.rho_from_p_T(pressure, _Tupper);
+    Real co2_density_upper = _co2_fp.rho_from_p_T(pressure.value(), _Tupper);
 
     solveEquilibriumMoleFractionHighTemp(
-        pressure, _Tupper, Xnacl, co2_density_upper, xco2_upper, yh2o_upper);
+        pressure.value(), _Tupper, Xnacl.value(), co2_density_upper, xco2_upper, yh2o_upper);
 
     Real A, dA_dp, dA_dT, B, dB_dp, dB_dT, dB_dX;
-    funcABHighTemp(pressure,
+    funcABHighTemp(pressure.value(),
                    _Tupper,
-                   Xnacl,
-                   co2_density,
+                   Xnacl.value(),
+                   co2_density_upper,
                    xco2_upper,
                    yh2o_upper,
                    A,
@@ -1055,25 +720,37 @@ PorousFlowBrineCO2::equilibriumMoleFractions(Real pressure,
     const Real dxco2_dT_upper = dB_dT * (1.0 - yh2o_upper) - B * dyh2o_dT_upper;
 
     // The mole fractions in this regime are then found by interpolation
-    Real dxco2_dT, dyh2o_dT;
+    Real xco2r, yh2or, dxco2_dT, dyh2o_dT;
     smoothCubicInterpolation(
-        Tint, xco2_lower, dxco2_dT_lower, xco2_upper, dxco2_dT_upper, xco2, dxco2_dT);
+        Tint, xco2_lower.value(), dxco2_dT_lower, xco2_upper, dxco2_dT_upper, xco2r, dxco2_dT);
     smoothCubicInterpolation(
-        Tint, yh2o_lower, dyh2o_dT_lower, yh2o_upper, dyh2o_dT_upper, yh2o, dyh2o_dT);
+        Tint, yh2o_lower.value(), dyh2o_dT_lower, yh2o_upper, dyh2o_dT_upper, yh2or, dyh2o_dT);
+
+    xco2 = xco2r;
+    xco2.derivatives()[_pidx] = xco2_lower.derivatives()[_pidx];
+    xco2.derivatives()[_Tidx] = dxco2_dT;
+    xco2.derivatives()[_Xidx] = xco2_lower.derivatives()[_Xidx];
+
+    yh2o = yh2or;
+    yh2o.derivatives()[_pidx] = yh2o_lower.derivatives()[_pidx];
+    yh2o.derivatives()[_Tidx] = dyh2o_dT;
+    yh2o.derivatives()[_Xidx] = yh2o_lower.derivatives()[_Xidx];
   }
   else
   {
     // Equilibrium mole fractions solved using iteration in this regime
-    solveEquilibriumMoleFractionHighTemp(pressure, temperature, Xnacl, co2_density, xco2, yh2o);
+    Real xco2r, yh2or;
+    solveEquilibriumMoleFractionHighTemp(
+        pressure.value(), temperature.value(), Xnacl.value(), co2_density.value(), xco2r, yh2or);
 
-    // Can use these in funcABHighTemp() to get derivatives analyticall rather than by iteration
+    // Can use these in funcABHighTemp() to get derivatives analytically rather than by iteration
     Real A, dA_dp, dA_dT, B, dB_dp, dB_dT, dB_dX;
-    funcABHighTemp(pressure,
-                   temperature,
-                   Xnacl,
-                   co2_density,
-                   xco2,
-                   yh2o,
+    funcABHighTemp(pressure.value(),
+                   temperature.value(),
+                   Xnacl.value(),
+                   co2_density.value(),
+                   xco2r,
+                   yh2or,
                    A,
                    dA_dp,
                    dA_dT,
@@ -1082,172 +759,102 @@ PorousFlowBrineCO2::equilibriumMoleFractions(Real pressure,
                    dB_dT,
                    dB_dX);
 
-    dyh2o_dp = ((1.0 - B) * dA_dp + (A - 1.0) * A * dB_dp) / (1.0 - A * B) / (1.0 - A * B);
-    dxco2_dp = dB_dp * (1.0 - yh2o) - B * dyh2o_dp;
+    const Real dyh2o_dp =
+        ((1.0 - B) * dA_dp + (A - 1.0) * A * dB_dp) / (1.0 - A * B) / (1.0 - A * B);
+    const Real dxco2_dp = dB_dp * (1.0 - yh2or) - B * dyh2o_dp;
 
-    dyh2o_dT = ((1.0 - B) * dA_dT + (A - 1.0) * A * dB_dT) / (1.0 - A * B) / (1.0 - A * B);
-    dxco2_dT = dB_dT * (1.0 - yh2o) - B * dyh2o_dT;
+    const Real dyh2o_dT =
+        ((1.0 - B) * dA_dT + (A - 1.0) * A * dB_dT) / (1.0 - A * B) / (1.0 - A * B);
+    const Real dxco2_dT = dB_dT * (1.0 - yh2or) - B * dyh2o_dT;
 
-    dyh2o_dX = ((A - 1.0) * A * dB_dX) / (1.0 - A * B) / (1.0 - A * B);
-    dxco2_dX = dB_dX * (1.0 - yh2o) - B * dyh2o_dX;
+    const Real dyh2o_dX = ((A - 1.0) * A * dB_dX) / (1.0 - A * B) / (1.0 - A * B);
+    const Real dxco2_dX = dB_dX * (1.0 - yh2or) - B * dyh2o_dX;
+
+    xco2 = xco2r;
+    xco2.derivatives()[_pidx] = dxco2_dp;
+    xco2.derivatives()[_Tidx] = dxco2_dT;
+    xco2.derivatives()[_Xidx] = dxco2_dX;
+
+    yh2o = yh2or;
+    yh2o.derivatives()[_pidx] = dyh2o_dp;
+    yh2o.derivatives()[_Tidx] = dyh2o_dT;
+    yh2o.derivatives()[_Xidx] = dyh2o_dX;
   }
 }
 
 void
-PorousFlowBrineCO2::equilibriumMoleFractionsLowTemp(Real pressure,
-                                                    Real temperature,
-                                                    Real Xnacl,
-                                                    Real & xco2,
-                                                    Real & dxco2_dp,
-                                                    Real & dxco2_dT,
-                                                    Real & dxco2_dX,
-                                                    Real & yh2o,
-                                                    Real & dyh2o_dp,
-                                                    Real & dyh2o_dT,
-                                                    Real & dyh2o_dX) const
+PorousFlowBrineCO2::equilibriumMoleFractionsLowTemp(const DualReal & pressure,
+                                                    const DualReal & temperature,
+                                                    const DualReal & Xnacl,
+                                                    DualReal & xco2,
+                                                    DualReal & yh2o) const
 {
-  if (temperature > 373.15)
+  if (temperature.value() > 373.15)
     mooseError(name(),
                ": equilibriumMoleFractionsLowTemp() is not valid for T > 373.15K. Use "
                "equilibriumMoleFractions() instead");
 
   // CO2 density and derivatives wrt pressure and temperature
-  Real co2_density, dco2_density_dp, dco2_density_dT;
-  _co2_fp.rho_from_p_T(pressure, temperature, co2_density, dco2_density_dp, dco2_density_dT);
+  const DualReal co2_density = _co2_fp.rho_from_p_T(pressure, temperature);
 
   // Assume infinite dilution (yh20 = 0 and xco2 = 0) in low temperature regime
-  Real A, dA_dp, dA_dT, B, dB_dp, dB_dT;
-  funcABLowTemp(pressure,
-                temperature,
-                co2_density,
-                dco2_density_dp,
-                dco2_density_dT,
-                A,
-                dA_dp,
-                dA_dT,
-                B,
-                dB_dp,
-                dB_dT);
+  DualReal A, B;
+  funcABLowTemp(pressure, temperature, co2_density, A, B);
 
   // As the activity coefficient for CO2 in brine used in this regime isn't a 'true'
   // activity coefficient, we instead calculate the molality of CO2 in water, then
   // correct it for brine, and then calculate the mole fractions.
   // The mole fraction in pure water is
-  const Real yh2ow = (1.0 - B) / (1.0 / A - B);
-  const Real xco2w = B * (1.0 - yh2ow);
+  const DualReal yh2ow = (1.0 - B) / (1.0 / A - B);
+  const DualReal xco2w = B * (1.0 - yh2ow);
 
   // Molality of CO2 in pure water
-  const Real mco2w = xco2w * _invMh2o / (1.0 - xco2w);
+  const DualReal mco2w = xco2w * _invMh2o / (1.0 - xco2w);
   // Molality of CO2 in brine is then calculated using gamma
-  Real gamma, dgamma_dp, dgamma_dT, dgamma_dX;
-  activityCoefficient(pressure, temperature, Xnacl, gamma, dgamma_dp, dgamma_dT, dgamma_dX);
-  const Real mco2 = mco2w / gamma;
+  const DualReal gamma = activityCoefficient(pressure, temperature, Xnacl);
+  const DualReal mco2 = mco2w / gamma;
 
   // Need NaCl molality (mol/kg)
-  const Real mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
-  const Real dmnacl_dX = 1.0 / (1.0 - Xnacl) / (1.0 - Xnacl) / _Mnacl;
+  const DualReal mnacl = Xnacl / (1.0 - Xnacl) / _Mnacl;
 
   // Mole fractions of CO2 and H2O in liquid and gas phases
-  const Real total_moles = 2.0 * mnacl + _invMh2o + mco2;
+  const DualReal total_moles = 2.0 * mnacl + _invMh2o + mco2;
   xco2 = mco2 / total_moles;
   yh2o = A * (1.0 - xco2 - 2.0 * mnacl / total_moles);
-
-  // The derivatives of the mole fractions wrt pressure
-  const Real dyh2ow_dp =
-      ((1.0 - B) * dA_dp + (A - 1.0) * A * dB_dp) / (1.0 - A * B) / (1.0 - A * B);
-  const Real dxco2w_dp = dB_dp * (1.0 - yh2ow) - B * dyh2ow_dp;
-
-  const Real dmco2w_dp = _invMh2o * dxco2w_dp / (1.0 - xco2w) / (1.0 - xco2w);
-  const Real dmco2_dp = dmco2w_dp / gamma - mco2w * dgamma_dp / gamma / gamma;
-  dxco2_dp = (2.0 * mnacl + _invMh2o) * dmco2_dp / total_moles / total_moles;
-
-  dyh2o_dp = (1.0 - xco2 - 2.0 * mnacl / total_moles) * dA_dp - A * dxco2_dp +
-             2.0 * A * mnacl * dmco2_dp / total_moles / total_moles;
-
-  // The derivatives of the mole fractions wrt temperature
-  const Real dyh2ow_dT =
-      ((1.0 - B) * dA_dT + (A - 1.0) * A * dB_dT) / (1.0 - A * B) / (1.0 - A * B);
-  const Real dxco2w_dT = dB_dT * (1.0 - yh2ow) - B * dyh2ow_dT;
-
-  const Real dmco2w_dT = _invMh2o * dxco2w_dT / (1.0 - xco2w) / (1.0 - xco2w);
-  const Real dmco2_dT = dmco2w_dT / gamma - mco2w * dgamma_dT / gamma / gamma;
-  dxco2_dT = (2.0 * mnacl + _invMh2o) * dmco2_dT / total_moles / total_moles;
-
-  dyh2o_dT = (1.0 - xco2 - 2.0 * mnacl / total_moles) * dA_dT - A * dxco2_dT +
-             2.0 * A * mnacl * dmco2_dT / total_moles / total_moles;
-
-  // The derivatives of the mole fractions wrt salt mass fraction
-  const Real dmco2_dX = -mco2w * dgamma_dX / gamma / gamma;
-  dxco2_dX =
-      ((2.0 * mnacl + _invMh2o) * dmco2_dX - 2.0 * mco2 * dmnacl_dX) / total_moles / total_moles;
-  dyh2o_dX =
-      A * (2.0 * (mnacl * dmco2_dX - (mco2 + _invMh2o) * dmnacl_dX) / total_moles / total_moles -
-           dxco2_dX);
 }
 
 void
-PorousFlowBrineCO2::funcABLowTemp(Real pressure,
-                                  Real temperature,
-                                  Real co2_density,
-                                  Real dco2_density_dp,
-                                  Real dco2_density_dT,
-                                  Real & A,
-                                  Real & dA_dp,
-                                  Real & dA_dT,
-                                  Real & B,
-                                  Real & dB_dp,
-                                  Real & dB_dT) const
+PorousFlowBrineCO2::funcABLowTemp(const DualReal & pressure,
+                                  const DualReal & temperature,
+                                  const DualReal & co2_density,
+                                  DualReal & A,
+                                  DualReal & B) const
 {
-  if (temperature > 373.15)
+  if (temperature.value() > 373.15)
     mooseError(name(),
                ": funcABLowTemp() is not valid for T > 373.15K. Use funcABHighTemp() instead");
 
   // Pressure in bar
-  const Real pbar = pressure * 1.0e-5;
+  const DualReal pbar = pressure * 1.0e-5;
 
   // Reference pressure and partial molar volumes
   const Real pref = 1.0;
   const Real vCO2 = 32.6;
   const Real vH2O = 18.1;
 
-  const Real delta_pbar = pbar - pref;
-  const Real Rt = _Rbar * temperature;
+  const DualReal delta_pbar = pbar - pref;
+  const DualReal Rt = _Rbar * temperature;
 
   // Equilibrium constants
-  Real K0H2O, dK0H2O_dT, K0CO2, dK0CO2_dT;
-  equilibriumConstantH2O(temperature, K0H2O, dK0H2O_dT);
-  equilibriumConstantCO2(temperature, K0CO2, dK0CO2_dT);
+  const DualReal K0H2O = equilibriumConstantH2O(temperature);
+  const DualReal K0CO2 = equilibriumConstantCO2(temperature);
 
   // Fugacity coefficients
-  Real phiH2O, dphiH2O_dp, dphiH2O_dT;
-  Real phiCO2, dphiCO2_dp, dphiCO2_dT;
-  fugacityCoefficientsLowTemp(pressure,
-                              temperature,
-                              co2_density,
-                              dco2_density_dp,
-                              dco2_density_dT,
-                              phiCO2,
-                              dphiCO2_dp,
-                              dphiCO2_dT,
-                              phiH2O,
-                              dphiH2O_dp,
-                              dphiH2O_dT);
+  DualReal phiH2O, phiCO2;
+  fugacityCoefficientsLowTemp(pressure, temperature, co2_density, phiCO2, phiH2O);
 
   A = K0H2O / (phiH2O * pbar) * std::exp(delta_pbar * vH2O / Rt);
   B = phiCO2 * pbar / (_invMh2o * K0CO2) * std::exp(-delta_pbar * vCO2 / Rt);
-
-  dA_dp = (-1.0e-5 / pbar + 1.0e-5 * vH2O / Rt - dphiH2O_dp / phiH2O) * A;
-
-  dB_dp = (1.0e-5 * phiCO2 + pbar * dphiCO2_dp - 1.0e-5 * vCO2 * pbar * phiCO2 / Rt) *
-          std::exp(-delta_pbar * vCO2 / Rt) / (_invMh2o * K0CO2);
-
-  dA_dT =
-      (dK0H2O_dT - dphiH2O_dT * K0H2O / phiH2O - delta_pbar * vH2O * K0H2O / (Rt * temperature)) *
-      std::exp(delta_pbar * vH2O / Rt) / (pbar * phiH2O);
-
-  dB_dT = (-pbar * phiCO2 * dK0CO2_dT / K0CO2 + pbar * dphiCO2_dT +
-           delta_pbar * vCO2 * pbar * phiCO2 / (Rt * temperature)) *
-          std::exp(-delta_pbar * vCO2 / Rt) / (_invMh2o * K0CO2);
 }
 
 void
@@ -1279,24 +886,33 @@ PorousFlowBrineCO2::funcABHighTemp(Real pressure,
   const Real Rt = _Rbar * temperature;
 
   // Equilibrium constants
-  Real K0H2O, dK0H2O_dT, K0CO2, dK0CO2_dT;
-  equilibriumConstantH2O(temperature, K0H2O, dK0H2O_dT);
-  equilibriumConstantCO2(temperature, K0CO2, dK0CO2_dT);
+  // Use dummy DualReal temperature as derivatives aren't required
+  const DualReal T = temperature;
+  Real K0H2O = equilibriumConstantH2O(T).value();
+  Real K0CO2 = equilibriumConstantCO2(T).value();
 
   // Fugacity coefficients
-  Real phiH2O, phiCO2;
-  fugacityCoefficientsHighTemp(pressure, temperature, co2_density, xco2, yh2o, phiCO2, phiH2O);
+  // Use dummy DualReal variables as derivatives aren't required
+  const DualReal p = pressure;
+  const DualReal rhoco2 = co2_density;
+  const DualReal x = xco2;
+  const DualReal y = yh2o;
+
+  DualReal phiH2O, phiCO2;
+  fugacityCoefficientsHighTemp(p, T, rhoco2, x, y, phiCO2, phiH2O);
 
   // Activity coefficients
-  const Real gammaH2O = activityCoefficientH2O(temperature, xco2);
-  const Real gammaCO2 = activityCoefficientCO2(temperature, xco2);
+  const Real gammaH2O = activityCoefficientH2O(T, x).value();
+  const Real gammaCO2 = activityCoefficientCO2(T, x).value();
 
   // Activity coefficient for CO2 in brine
-  Real gamma, dgamma_dT, dgamma_dX;
-  activityCoefficientHighTemp(temperature, Xnacl, gamma, dgamma_dT, dgamma_dX);
+  // Use dummy DualReal Xnacl as derivatives aren't required
+  const DualReal X = Xnacl;
+  const Real gamma = activityCoefficientHighTemp(T, X).value();
 
-  A = K0H2O * gammaH2O / (phiH2O * pbar) * std::exp(delta_pbar * vH2O / Rt);
-  B = phiCO2 * pbar / (_invMh2o * K0CO2 * gamma * gammaCO2) * std::exp(-delta_pbar * vCO2 / Rt);
+  A = K0H2O * gammaH2O / (phiH2O.value() * pbar) * std::exp(delta_pbar * vH2O / Rt);
+  B = phiCO2.value() * pbar / (_invMh2o * K0CO2 * gamma * gammaCO2) *
+      std::exp(-delta_pbar * vCO2 / Rt);
 }
 
 void
@@ -1400,19 +1016,15 @@ PorousFlowBrineCO2::solveEquilibriumMoleFractionHighTemp(
   xco2 = x;
 }
 
-void
-PorousFlowBrineCO2::partialDensityCO2(Real temperature,
-                                      Real & partial_density,
-                                      Real & dpartial_density_dT) const
+DualReal
+PorousFlowBrineCO2::partialDensityCO2(const DualReal & temperature) const
 {
   // This correlation uses temperature in C
-  const Real Tc = temperature - _T_c2k;
+  const DualReal Tc = temperature - _T_c2k;
   // The parial molar volume
-  const Real V = 37.51 - 9.585e-2 * Tc + 8.74e-4 * Tc * Tc - 5.044e-7 * Tc * Tc * Tc;
-  const Real dV_dT = -9.585e-2 + 1.748e-3 * Tc - 1.5132e-6 * Tc * Tc;
+  const DualReal V = 37.51 - 9.585e-2 * Tc + 8.74e-4 * Tc * Tc - 5.044e-7 * Tc * Tc * Tc;
 
-  partial_density = 1.0e6 * _Mco2 / V;
-  dpartial_density_dT = -1.0e6 * _Mco2 * dV_dT / V / V;
+  return 1.0e6 * _Mco2 / V;
 }
 
 Real
@@ -1422,27 +1034,22 @@ PorousFlowBrineCO2::totalMassFraction(
   // Check whether the input pressure and temperature are within the region of validity
   checkVariables(pressure, temperature);
 
+  // As we do not require derivatives, we can simply ignore their initialisation
+  const DualReal p = pressure;
+  const DualReal T = temperature;
+  const DualReal X = Xnacl;
+
   // FluidStateProperties data structure
   std::vector<FluidStateProperties> fsp(_num_phases, FluidStateProperties(_num_components));
   FluidStateProperties & liquid = fsp[_aqueous_phase_number];
   FluidStateProperties & gas = fsp[_gas_phase_number];
 
   // Calculate equilibrium mass fractions in the two-phase state
-  Real Xco2, dXco2_dp, dXco2_dT, dXco2_dX, Yh2o, dYh2o_dp, dYh2o_dT, dYh2o_dX;
-  equilibriumMassFractions(pressure,
-                           temperature,
-                           Xnacl,
-                           Xco2,
-                           dXco2_dp,
-                           dXco2_dT,
-                           dXco2_dX,
-                           Yh2o,
-                           dYh2o_dp,
-                           dYh2o_dT,
-                           dYh2o_dX);
+  DualReal Xco2, Yh2o;
+  equilibriumMassFractions(p, T, X, Xco2, Yh2o);
 
   // Save the mass fractions in the FluidStateMassFractions object
-  const Real Yco2 = 1.0 - Yh2o;
+  const DualReal Yco2 = 1.0 - Yh2o;
   liquid.mass_fraction[_aqueous_fluid_component] = 1.0 - Xco2;
   liquid.mass_fraction[_gas_fluid_component] = Xco2;
   gas.mass_fraction[_aqueous_fluid_component] = Yh2o;
@@ -1452,82 +1059,81 @@ PorousFlowBrineCO2::totalMassFraction(
   gasProperties(pressure, temperature, fsp);
 
   // Liquid properties
-  const Real liquid_saturation = 1.0 - saturation;
-  const Real liquid_pressure = pressure - _pc.capillaryPressure(liquid_saturation, qp);
-  liquidProperties(liquid_pressure, temperature, Xnacl, fsp);
+  const DualReal liquid_saturation = 1.0 - saturation;
+  const DualReal liquid_pressure = p - _pc.capillaryPressure(liquid_saturation, qp);
+  liquidProperties(liquid_pressure, T, X, fsp);
 
   // The total mass fraction of ncg (z) can now be calculated
-  const Real Z = (saturation * gas.density * Yco2 + liquid_saturation * liquid.density * Xco2) /
-                 (saturation * gas.density + liquid_saturation * liquid.density);
+  const DualReal Z = (saturation * gas.density * Yco2 + liquid_saturation * liquid.density * Xco2) /
+                     (saturation * gas.density + liquid_saturation * liquid.density);
 
-  return Z;
+  return Z.value();
 }
 
-void
-PorousFlowBrineCO2::henryConstant(
-    Real temperature, Real Xnacl, Real & Kh, Real & dKh_dT, Real & dKh_dX) const
+DualReal
+PorousFlowBrineCO2::henryConstant(const DualReal & temperature, const DualReal & Xnacl) const
 {
   // Henry's constant for dissolution in water
-  Real Kh_h2o, dKh_h2o_dT;
-  _brine_fp.henryConstant(temperature, _co2_henry, Kh_h2o, dKh_h2o_dT);
+  const DualReal Kh_h2o = _brine_fp.henryConstant(temperature, _co2_henry);
 
   // The correction to salt is obtained through the salting out coefficient
   const std::vector<Real> b{1.19784e-1, -7.17823e-4, 4.93854e-6, -1.03826e-8, 1.08233e-11};
 
   // Need temperature in Celsius
-  const Real Tc = temperature - _T_c2k;
+  const DualReal Tc = temperature - _T_c2k;
 
-  Real kb = 0.0;
+  DualReal kb = 0.0;
   for (unsigned int i = 0; i < b.size(); ++i)
-    kb += b[i] * MathUtils::pow(Tc, i);
-
-  Real dkb_dT = 0.0;
-  for (unsigned int i = 1; i < b.size(); ++i)
-    dkb_dT += i * b[i] * MathUtils::pow(Tc, i - 1);
+    kb += b[i] * std::pow(Tc, i);
 
   // Need salt mass fraction in molality
-  const Real xmol = Xnacl / (1.0 - Xnacl) / _Mnacl;
-  const Real dxmol_dX = 1.0 / (1.0 - Xnacl) / (1.0 - Xnacl) / _Mnacl;
+  const DualReal xmol = Xnacl / (1.0 - Xnacl) / _Mnacl;
+
   // Henry's constant and its derivative wrt temperature and salt mass fraction
-  Kh = Kh_h2o * std::pow(10.0, xmol * kb);
-  dKh_dT = (xmol * std::log(10.0) * dkb_dT + dKh_h2o_dT / Kh_h2o) * Kh;
-  dKh_dX = std::log(10.0) * kb * dxmol_dX * Kh;
+  return Kh_h2o * std::pow(10.0, xmol * kb);
 }
 
-void
-PorousFlowBrineCO2::enthalpyOfDissolutionGas(
-    Real temperature, Real Xnacl, Real & hdis, Real & dhdis_dT, Real & dhdis_dX) const
+DualReal
+PorousFlowBrineCO2::enthalpyOfDissolutionGas(const DualReal & temperature,
+                                             const DualReal & Xnacl) const
 {
   // Henry's constant
-  Real Kh, dKh_dT, dKh_dX;
-  henryConstant(temperature, Xnacl, Kh, dKh_dT, dKh_dX);
+  const DualReal Kh = henryConstant(temperature, Xnacl);
 
-  hdis = -_R * temperature * temperature * dKh_dT / Kh / _Mco2;
+  DualReal hdis = -_R * temperature * temperature * Kh.derivatives()[_Tidx] / Kh / _Mco2;
 
   // Derivative of enthalpy of dissolution wrt temperature and xnacl requires the second
   // derivatives of Henry's constant. For simplicity, approximate these numerically
-  const Real dT = temperature * 1.0e-8;
-  const Real T2 = temperature + dT;
-  henryConstant(T2, Xnacl, Kh, dKh_dT, dKh_dX);
+  const Real dT = temperature.value() * 1.0e-8;
+  const DualReal T2 = temperature + dT;
+  const DualReal Kh2 = henryConstant(T2, Xnacl);
 
-  dhdis_dT = (-_R * T2 * T2 * dKh_dT / Kh / _Mco2 - hdis) / dT;
+  const Real dhdis_dT =
+      (-_R * T2 * T2 * Kh2.derivatives()[_Tidx] / Kh2 / _Mco2 - hdis).value() / dT;
 
-  const Real dX = Xnacl * 1.0e-8;
-  const Real X2 = Xnacl + dX;
-  henryConstant(temperature, X2, Kh, dKh_dT, dKh_dX);
+  const Real dX = Xnacl.value() * 1.0e-8;
+  const DualReal X2 = Xnacl + dX;
+  const DualReal Kh3 = henryConstant(temperature, X2);
 
-  dhdis_dX = (-_R * temperature * temperature * dKh_dT / Kh / _Mco2 - hdis) / dX;
+  const Real dhdis_dX =
+      (-_R * temperature * temperature * Kh3.derivatives()[_Tidx] / Kh3 / _Mco2 - hdis).value() /
+      dX;
+
+  for (std::size_t i = 0; i < temperature.derivatives().size(); ++i)
+    hdis.derivatives()[i] =
+        temperature.derivatives()[i] * dhdis_dT + Xnacl.derivatives()[i] * dhdis_dX;
+
+  return hdis;
 }
 
-void
-PorousFlowBrineCO2::enthalpyOfDissolution(Real temperature, Real & hdis, Real & dhdis_dT) const
+DualReal
+PorousFlowBrineCO2::enthalpyOfDissolution(const DualReal & temperature) const
 {
   // Linear fit to model of Duan and Sun (2003) (in kJ/mol)
-  const Real delta_h = -58.3533 + 0.134519 * temperature;
+  const DualReal delta_h = -58.3533 + 0.134519 * temperature;
 
   // Convert to J/kg
-  hdis = delta_h * 1000.0 / _Mco2;
-  dhdis_dT = 134.519 / _Mco2;
+  return delta_h * 1000.0 / _Mco2;
 }
 
 void

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
@@ -40,9 +40,3 @@ PorousFlowFluidStateBase::clearFluidStateProperties(std::vector<FluidStateProper
 {
   std::fill(fsp.begin(), fsp.end(), FluidStateProperties(_num_components));
 }
-
-void
-PorousFlowFluidStateBase::clearFluidStateProperties(std::vector<FluidStatePropertiesAD> & fsp) const
-{
-  std::fill(fsp.begin(), fsp.end(), FluidStatePropertiesAD(_num_components));
-}

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateFlash.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateFlash.C
@@ -83,6 +83,14 @@ PorousFlowFluidStateFlash::vaporMassFraction(Real Z0, Real K0, Real K1) const
   return (Z0 * (K1 - K0) - (K1 - 1.0)) / ((K0 - 1.0) * (K1 - 1.0));
 }
 
+DualReal
+PorousFlowFluidStateFlash::vaporMassFraction(const DualReal & Z0,
+                                             const DualReal & K0,
+                                             const DualReal & K1) const
+{
+  return (Z0 * (K1 - K0) - (K1 - 1.0)) / ((K0 - 1.0) * (K1 - 1.0));
+}
+
 Real
 PorousFlowFluidStateFlash::vaporMassFraction(std::vector<Real> & Zi, std::vector<Real> & Ki) const
 {

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateMultiComponentBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateMultiComponentBase.C
@@ -20,7 +20,7 @@ validParams<PorousFlowFluidStateMultiComponentBase>()
 
 PorousFlowFluidStateMultiComponentBase::PorousFlowFluidStateMultiComponentBase(
     const InputParameters & parameters)
-  : PorousFlowFluidStateFlash(parameters)
+  : PorousFlowFluidStateFlash(parameters), _pidx(0), _Zidx(1), _Tidx(2), _Xidx(3)
 {
 }
 

--- a/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
@@ -28,7 +28,8 @@ validParams<PorousFlowWaterNCG>()
 
 PorousFlowWaterNCG::PorousFlowWaterNCG(const InputParameters & parameters)
   : PorousFlowFluidStateMultiComponentBase(parameters),
-    _water_fp(getUserObject<Water97FluidProperties>("water_fp")),
+    _water_fp(getUserObject<SinglePhaseFluidProperties>("water_fp")),
+    _water97_fp(getUserObject<Water97FluidProperties>("water_fp")),
     _ncg_fp(getUserObject<SinglePhaseFluidProperties>("gas_fp")),
     _Mh2o(_water_fp.molarMass()),
     _Mncg(_ncg_fp.molarMass()),
@@ -79,11 +80,19 @@ PorousFlowWaterNCG::thermophysicalProperties(Real pressure,
   // Check whether the input temperature is within the region of validity
   checkVariables(temperature);
 
+  // AD versions of primary variables
+  DualReal p = pressure;
+  p.derivatives()[_pidx] = 1.0;
+  DualReal T = temperature;
+  T.derivatives()[_Tidx] = 1.0;
+  DualReal Zncg = Z;
+  Zncg.derivatives()[_Zidx] = 1.0;
+
   // Clear all of the FluidStateProperties data
   clearFluidStateProperties(fsp);
 
   FluidStatePhaseEnum phase_state;
-  massFractions(pressure, temperature, Z, phase_state, fsp);
+  massFractions(p, T, Zncg, phase_state, fsp);
 
   switch (phase_state)
   {
@@ -93,7 +102,7 @@ PorousFlowWaterNCG::thermophysicalProperties(Real pressure,
       gas.saturation = 1.0;
 
       // Calculate gas properties
-      gasProperties(pressure, temperature, fsp);
+      gasProperties(p, T, fsp);
 
       break;
     }
@@ -101,23 +110,16 @@ PorousFlowWaterNCG::thermophysicalProperties(Real pressure,
     case FluidStatePhaseEnum::LIQUID:
     {
       // Calculate the liquid properties
-      Real liquid_pressure = pressure - _pc.capillaryPressure(1.0, qp);
-      liquidProperties(liquid_pressure, temperature, fsp);
+      const DualReal liquid_pressure = p - _pc.capillaryPressure(1.0, qp);
+      liquidProperties(liquid_pressure, T, fsp);
 
       break;
     }
 
     case FluidStatePhaseEnum::TWOPHASE:
     {
-      // Calculate the gas properties
-      gasProperties(pressure, temperature, fsp);
-
-      // Calculate the saturation
-      saturationTwoPhase(pressure, temperature, Z, fsp);
-
-      // Calculate the liquid properties
-      Real liquid_pressure = pressure - _pc.capillaryPressure(1.0 - gas.saturation, qp);
-      liquidProperties(liquid_pressure, temperature, fsp);
+      // Calculate the gas and liquid properties in the two phase region
+      twoPhaseProperties(p, T, Zncg, qp, fsp);
 
       break;
     }
@@ -125,19 +127,16 @@ PorousFlowWaterNCG::thermophysicalProperties(Real pressure,
 
   // Liquid saturations can now be set
   liquid.saturation = 1.0 - gas.saturation;
-  liquid.dsaturation_dp = -gas.dsaturation_dp;
-  liquid.dsaturation_dT = -gas.dsaturation_dT;
-  liquid.dsaturation_dZ = -gas.dsaturation_dZ;
 
   // Save pressures to FluidStateProperties object
-  gas.pressure = pressure;
-  liquid.pressure = pressure - _pc.capillaryPressure(liquid.saturation, qp);
+  gas.pressure = p;
+  liquid.pressure = p - _pc.capillaryPressure(liquid.saturation, qp);
 }
 
 void
-PorousFlowWaterNCG::massFractions(Real pressure,
-                                  Real temperature,
-                                  Real Z,
+PorousFlowWaterNCG::massFractions(const DualReal & pressure,
+                                  const DualReal & temperature,
+                                  const DualReal & Z,
                                   FluidStatePhaseEnum & phase_state,
                                   std::vector<FluidStateProperties> & fsp) const
 {
@@ -145,22 +144,18 @@ PorousFlowWaterNCG::massFractions(Real pressure,
   FluidStateProperties & gas = fsp[_gas_phase_number];
 
   // Equilibrium mass fraction of NCG in liquid and H2O in gas phases
-  Real Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT;
-  equilibriumMassFractions(
-      pressure, temperature, Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT);
+  DualReal Xncg, Yh2o;
+  equilibriumMassFractions(pressure, temperature, Xncg, Yh2o);
 
-  Real Yncg = 1.0 - Yh2o;
-  Real dYncg_dp = -dYh2o_dp;
-  Real dYncg_dT = -dYh2o_dT;
+  DualReal Yncg = 1.0 - Yh2o;
 
   // Determine which phases are present based on the value of Z
-  phaseState(Z, Xncg, Yncg, phase_state);
+  phaseState(Z.value(), Xncg.value(), Yncg.value(), phase_state);
 
   // The equilibrium mass fractions calculated above are only correct in the two phase
   // state. If only liquid or gas phases are present, the mass fractions are given by
   // the total mass fraction Z.
-  Real Xh2o = 0.0;
-  Real dXncg_dZ = 0.0, dYncg_dZ = 0.0;
+  DualReal Xh2o = 0.0;
 
   switch (phase_state)
   {
@@ -170,11 +165,9 @@ PorousFlowWaterNCG::massFractions(Real pressure,
       Yncg = 0.0;
       Xh2o = 1.0 - Z;
       Yh2o = 0.0;
-      dXncg_dp = 0.0;
-      dXncg_dT = 0.0;
-      dXncg_dZ = 1.0;
-      dYncg_dp = 0.0;
-      dYncg_dT = 0.0;
+      Xncg.derivatives()[_pidx] = 0.0;
+      Xncg.derivatives()[_Tidx] = 0.0;
+      Xncg.derivatives()[_Zidx] = 1.0;
       break;
     }
 
@@ -183,11 +176,9 @@ PorousFlowWaterNCG::massFractions(Real pressure,
       Xncg = 0.0;
       Yncg = Z;
       Yh2o = 1.0 - Z;
-      dXncg_dp = 0.0;
-      dXncg_dT = 0.0;
-      dYncg_dZ = 1.0;
-      dYncg_dp = 0.0;
-      dYncg_dT = 0.0;
+      Yncg.derivatives()[_pidx] = 0.0;
+      Yncg.derivatives()[_Tidx] = 0.0;
+      Yncg.derivatives()[_Zidx] = 1.0;
       break;
     }
 
@@ -204,136 +195,47 @@ PorousFlowWaterNCG::massFractions(Real pressure,
   liquid.mass_fraction[_gas_fluid_component] = Xncg;
   gas.mass_fraction[_aqueous_fluid_component] = Yh2o;
   gas.mass_fraction[_gas_fluid_component] = Yncg;
-
-  // Save the derivatives wrt PorousFlow variables
-  liquid.dmass_fraction_dp[_aqueous_fluid_component] = -dXncg_dp;
-  liquid.dmass_fraction_dp[_gas_fluid_component] = dXncg_dp;
-  liquid.dmass_fraction_dT[_aqueous_fluid_component] = -dXncg_dT;
-  liquid.dmass_fraction_dT[_gas_fluid_component] = dXncg_dT;
-  liquid.dmass_fraction_dZ[_aqueous_fluid_component] = -dXncg_dZ;
-  liquid.dmass_fraction_dZ[_gas_fluid_component] = dXncg_dZ;
-
-  gas.dmass_fraction_dp[_aqueous_fluid_component] = -dYncg_dp;
-  gas.dmass_fraction_dp[_gas_fluid_component] = dYncg_dp;
-  gas.dmass_fraction_dT[_aqueous_fluid_component] = -dYncg_dT;
-  gas.dmass_fraction_dT[_gas_fluid_component] = dYncg_dT;
-  gas.dmass_fraction_dZ[_aqueous_fluid_component] = -dYncg_dZ;
-  gas.dmass_fraction_dZ[_gas_fluid_component] = dYncg_dZ;
 }
 
 void
-PorousFlowWaterNCG::gasProperties(Real pressure,
-                                  Real temperature,
+PorousFlowWaterNCG::gasProperties(const DualReal & pressure,
+                                  const DualReal & temperature,
                                   std::vector<FluidStateProperties> & fsp) const
 {
   FluidStateProperties & liquid = fsp[_aqueous_phase_number];
   FluidStateProperties & gas = fsp[_gas_phase_number];
 
-  Real psat, dpsat_dT;
-  _water_fp.vaporPressure(temperature, psat, dpsat_dT);
+  const DualReal psat = _water_fp.vaporPressure(temperature);
 
-  const Real Yncg = gas.mass_fraction[_gas_fluid_component];
-  const Real dYncg_dp = gas.dmass_fraction_dp[_gas_fluid_component];
-  const Real dYncg_dT = gas.dmass_fraction_dT[_gas_fluid_component];
-  const Real dYncg_dZ = gas.dmass_fraction_dZ[_gas_fluid_component];
-
-  const Real Xncg = liquid.mass_fraction[_gas_fluid_component];
-  const Real dXncg_dp = liquid.dmass_fraction_dp[_gas_fluid_component];
-  const Real dXncg_dT = liquid.dmass_fraction_dT[_gas_fluid_component];
-  const Real dXncg_dZ = liquid.dmass_fraction_dZ[_gas_fluid_component];
-
-  // Note: take derivative wrt (Yncg * p) etc, hence the dp0
-  Real ncg_density, dncg_density_dp0, dncg_density_dT;
-  Real ncg_viscosity, dncg_viscosity_dp0, dncg_viscosity_dT;
-  Real ncg_enthalpy, dncg_enthalpy_dp0, dncg_enthalpy_dT;
-  Real vapor_density, dvapor_density_dp0, dvapor_density_dT;
-  Real vapor_viscosity, dvapor_viscosity_dp0, dvapor_viscosity_dT;
-  Real vapor_enthalpy, dvapor_enthalpy_dp0, dvapor_enthalpy_dT;
+  const DualReal Yncg = gas.mass_fraction[_gas_fluid_component];
+  const DualReal Xncg = liquid.mass_fraction[_gas_fluid_component];
 
   // NCG density, viscosity and enthalpy calculated using partial pressure
   // Yncg * gas_poreressure (Dalton's law)
-  _ncg_fp.rho_mu_from_p_T(Yncg * pressure,
-                          temperature,
-                          ncg_density,
-                          dncg_density_dp0,
-                          dncg_density_dT,
-                          ncg_viscosity,
-                          dncg_viscosity_dp0,
-                          dncg_viscosity_dT);
-
-  _ncg_fp.h_from_p_T(
-      Yncg * pressure, temperature, ncg_enthalpy, dncg_enthalpy_dp0, dncg_enthalpy_dT);
+  DualReal ncg_density, ncg_viscosity;
+  _ncg_fp.rho_mu_from_p_T(Yncg * pressure, temperature, ncg_density, ncg_viscosity);
+  DualReal ncg_enthalpy = _ncg_fp.h_from_p_T(Yncg * pressure, temperature);
 
   // Vapor density, viscosity and enthalpy calculated using partial pressure
   // X1 * psat (Raoult's law)
-  _water_fp.rho_mu_from_p_T((1.0 - Xncg) * psat,
-                            temperature,
-                            vapor_density,
-                            dvapor_density_dp0,
-                            dvapor_density_dT,
-                            vapor_viscosity,
-                            dvapor_viscosity_dp0,
-                            dvapor_viscosity_dT);
+  DualReal vapor_density, vapor_viscosity;
 
-  _water_fp.h_from_p_T(
-      (1.0 - Xncg) * psat, temperature, vapor_enthalpy, dvapor_enthalpy_dp0, dvapor_enthalpy_dT);
-
-  // Derivative wrt Z by the chain rule
-  Real dncg_density_dZ = dYncg_dZ * pressure * dncg_density_dp0;
-  Real dvapor_density_dZ = -dXncg_dZ * psat * dvapor_density_dp0;
-  Real dncg_viscosity_dZ = dYncg_dZ * pressure * dncg_viscosity_dp0;
-  Real dvapor_viscosity_dZ = -dXncg_dZ * psat * dvapor_viscosity_dp0;
-  Real dncg_enthalpy_dZ = dYncg_dZ * pressure * dncg_enthalpy_dp0;
-  Real dvapor_enthalpy_dZ = -dXncg_dZ * psat * dvapor_enthalpy_dp0;
-
-  // The derivatives wrt pressure and temperature above also depend on the derivative
-  // of the pressure variable using the chain rule
-  Real dncg_density_dp = (Yncg + dYncg_dp * pressure) * dncg_density_dp0;
-  dncg_density_dT += dYncg_dT * pressure * dncg_density_dp0;
-
-  Real dvapor_density_dp = -dXncg_dp * psat * dvapor_density_dp0;
-  dvapor_density_dT += ((1.0 - Xncg) * dpsat_dT - dXncg_dT * psat) * dvapor_density_dp0;
-
-  Real dncg_viscosity_dp = (Yncg + dYncg_dp * pressure) * dncg_viscosity_dp0;
-  dncg_viscosity_dT += dYncg_dT * pressure * dncg_viscosity_dp0;
-
-  Real dvapor_viscosity_dp = -dXncg_dp * psat * dvapor_viscosity_dp0;
-  dvapor_viscosity_dT += ((1.0 - Xncg) * dpsat_dT - dXncg_dT * psat) * dvapor_viscosity_dp0;
-
-  Real dncg_enthalpy_dp = (Yncg + dYncg_dp * pressure) * dncg_enthalpy_dp0;
-  dncg_enthalpy_dT += dYncg_dT * pressure * dncg_enthalpy_dp0;
-
-  Real dvapor_enthalpy_dp = -dXncg_dp * psat * dvapor_enthalpy_dp0;
-  dvapor_enthalpy_dT += ((1.0 - Xncg) * dpsat_dT - dXncg_dT * psat) * dvapor_enthalpy_dp0;
+  _water_fp.rho_mu_from_p_T((1.0 - Xncg) * psat, temperature, vapor_density, vapor_viscosity);
+  DualReal vapor_enthalpy = _water_fp.h_from_p_T((1.0 - Xncg) * psat, temperature);
 
   // Density is just the sum of individual component densities
   gas.density = ncg_density + vapor_density;
-  gas.ddensity_dp = dncg_density_dp + dvapor_density_dp;
-  gas.ddensity_dT = dncg_density_dT + dvapor_density_dT;
-  gas.ddensity_dZ = dncg_density_dZ + dvapor_density_dZ;
 
   // Viscosity of the gas phase is a weighted sum of the individual viscosities
   gas.viscosity = Yncg * ncg_viscosity + (1.0 - Yncg) * vapor_viscosity;
-  gas.dviscosity_dp = dYncg_dp * (ncg_viscosity - vapor_viscosity) + Yncg * dncg_viscosity_dp +
-                      (1.0 - Yncg) * dvapor_viscosity_dp;
-  gas.dviscosity_dT = dYncg_dT * (ncg_viscosity - vapor_viscosity) + Yncg * dncg_viscosity_dT +
-                      (1.0 - Yncg) * dvapor_viscosity_dT;
-  gas.dviscosity_dZ = dYncg_dZ * (ncg_viscosity - vapor_viscosity) + Yncg * dncg_viscosity_dZ +
-                      (1.0 - Yncg) * dvapor_viscosity_dZ;
 
   // Enthalpy of the gas phase is a weighted sum of the individual enthalpies
   gas.enthalpy = Yncg * ncg_enthalpy + (1.0 - Yncg) * vapor_enthalpy;
-  gas.denthalpy_dp = dYncg_dp * (ncg_enthalpy - vapor_enthalpy) + Yncg * dncg_enthalpy_dp +
-                     (1.0 - Yncg) * dvapor_enthalpy_dp;
-  gas.denthalpy_dT = dYncg_dT * (ncg_enthalpy - vapor_enthalpy) + Yncg * dncg_enthalpy_dT +
-                     (1.0 - Yncg) * dvapor_enthalpy_dT;
-  gas.denthalpy_dZ = dYncg_dZ * (ncg_enthalpy - vapor_enthalpy) + Yncg * dncg_enthalpy_dZ +
-                     (1.0 - Yncg) * dvapor_enthalpy_dZ;
 }
 
 void
-PorousFlowWaterNCG::liquidProperties(Real pressure,
-                                     Real temperature,
+PorousFlowWaterNCG::liquidProperties(const DualReal & pressure,
+                                     const DualReal & temperature,
                                      std::vector<FluidStateProperties> & fsp) const
 {
   FluidStateProperties & liquid = fsp[_aqueous_phase_number];
@@ -342,175 +244,128 @@ PorousFlowWaterNCG::liquidProperties(Real pressure,
   // liquid region, assuming they are not affected by the presence of dissolved
   // NCG. Note: the (small) contribution due to derivative of capillary pressure
   // wrt pressure (using the chain rule) is not implemented.
-  Real liquid_density, dliquid_density_dp, dliquid_density_dT;
-  Real liquid_viscosity, dliquid_viscosity_dp, dliquid_viscosity_dT;
-  _water_fp.rho_mu_from_p_T(pressure,
-                            temperature,
-                            liquid_density,
-                            dliquid_density_dp,
-                            dliquid_density_dT,
-                            liquid_viscosity,
-                            dliquid_viscosity_dp,
-                            dliquid_viscosity_dT);
+  DualReal liquid_density, liquid_viscosity;
+  _water_fp.rho_mu_from_p_T(pressure, temperature, liquid_density, liquid_viscosity);
 
   liquid.density = liquid_density;
-  liquid.ddensity_dp = dliquid_density_dp;
-  liquid.ddensity_dT = dliquid_density_dT;
-  liquid.ddensity_dZ = 0.0;
-
   liquid.viscosity = liquid_viscosity;
-  liquid.dviscosity_dp = dliquid_viscosity_dp;
-  liquid.dviscosity_dT = dliquid_viscosity_dT;
-  liquid.dviscosity_dZ = 0.0;
 
   // Enthalpy does include a contribution due to the enthalpy of dissolution
-  Real hdis, dhdis_dT;
-  enthalpyOfDissolution(temperature, hdis, dhdis_dT);
+  const DualReal hdis = enthalpyOfDissolution(temperature);
 
-  Real water_enthalpy, dwater_enthalpy_dp, dwater_enthalpy_dT;
-  _water_fp.h_from_p_T(
-      pressure, temperature, water_enthalpy, dwater_enthalpy_dp, dwater_enthalpy_dT);
+  const DualReal water_enthalpy = _water_fp.h_from_p_T(pressure, temperature);
+  const DualReal ncg_enthalpy = _ncg_fp.h_from_p_T(pressure, temperature);
 
-  // Enthalpy of gaseous CO2
-  Real ncg_enthalpy, dncg_enthalpy_dp, dncg_enthalpy_dT;
-  _ncg_fp.h_from_p_T(pressure, temperature, ncg_enthalpy, dncg_enthalpy_dp, dncg_enthalpy_dT);
-
-  const Real Xncg = liquid.mass_fraction[_gas_fluid_component];
-  const Real dXncg_dp = liquid.dmass_fraction_dp[_gas_fluid_component];
-  const Real dXncg_dT = liquid.dmass_fraction_dT[_gas_fluid_component];
-  const Real dXncg_dZ = liquid.dmass_fraction_dZ[_gas_fluid_component];
-
+  const DualReal Xncg = liquid.mass_fraction[_gas_fluid_component];
   liquid.enthalpy = (1.0 - Xncg) * water_enthalpy + Xncg * (ncg_enthalpy + hdis);
-  liquid.denthalpy_dp = (1.0 - Xncg) * dwater_enthalpy_dp - dXncg_dp * water_enthalpy +
-                        Xncg * dncg_enthalpy_dp + dXncg_dp * (ncg_enthalpy + hdis);
-  liquid.denthalpy_dT = (1.0 - Xncg) * dwater_enthalpy_dT - dXncg_dT * water_enthalpy +
-                        Xncg * dncg_enthalpy_dT + dXncg_dT * (ncg_enthalpy + hdis) +
-                        Xncg * dhdis_dT;
-  liquid.denthalpy_dZ = dXncg_dZ * (ncg_enthalpy + hdis - water_enthalpy);
 }
 
-void
-PorousFlowWaterNCG::saturationTwoPhase(Real pressure,
-                                       Real temperature,
-                                       Real Z,
-                                       std::vector<FluidStateProperties> & fsp) const
+DualReal
+PorousFlowWaterNCG::liquidDensity(const DualReal & pressure, const DualReal & temperature) const
 {
-  FluidStateProperties & liquid = fsp[_aqueous_phase_number];
-  FluidStateProperties & gas = fsp[_gas_phase_number];
+  return _water_fp.rho_from_p_T(pressure, temperature);
+}
 
-  // Mass fractions
-  const Real Xncg = liquid.mass_fraction[_gas_fluid_component];
-  const Real dXncg_dp = liquid.dmass_fraction_dp[_gas_fluid_component];
-  const Real dXncg_dT = liquid.dmass_fraction_dT[_gas_fluid_component];
+DualReal
+PorousFlowWaterNCG::gasDensity(const DualReal & pressure,
+                               const DualReal & temperature,
+                               std::vector<FluidStateProperties> & fsp) const
+{
+  auto & liquid = fsp[_aqueous_phase_number];
+  auto & gas = fsp[_gas_phase_number];
 
-  const Real Yncg = gas.mass_fraction[_gas_fluid_component];
-  const Real dYncg_dp = gas.dmass_fraction_dp[_gas_fluid_component];
-  const Real dYncg_dT = gas.dmass_fraction_dT[_gas_fluid_component];
+  DualReal psat = _water_fp.vaporPressure(temperature);
 
-  // Calculate the vapor mass fraction
-  const Real K0 = Yncg / Xncg;
-  const Real K1 = (1.0 - Yncg) / (1.0 - Xncg);
-  const Real vapor_mass_fraction = vaporMassFraction(Z, K0, K1);
+  const DualReal Yncg = gas.mass_fraction[_gas_fluid_component];
+  const DualReal Xncg = liquid.mass_fraction[_gas_fluid_component];
 
-  // Liquid density is a function of gas saturation through the capillary pressure
-  // curve, so approximate liquid pressure as gas pressure
-  const Real liquid_pressure = pressure;
+  DualReal ncg_density = _ncg_fp.rho_from_p_T(Yncg * pressure, temperature);
+  DualReal vapor_density = _water_fp.rho_from_p_T((1.0 - Xncg) * psat, temperature);
 
-  Real liquid_density, liquid_ddensity_dp, liquid_ddensity_dT;
-  _water_fp.rho_from_p_T(
-      liquid_pressure, temperature, liquid_density, liquid_ddensity_dp, liquid_ddensity_dT);
+  // Density is just the sum of individual component densities
+  return ncg_density + vapor_density;
+}
+
+DualReal
+PorousFlowWaterNCG::saturation(const DualReal & pressure,
+                               const DualReal & temperature,
+                               const DualReal & Z,
+                               std::vector<FluidStateProperties> & fsp) const
+{
+  auto & gas = fsp[_gas_phase_number];
+  auto & liquid = fsp[_aqueous_fluid_component];
+
+  // Approximate liquid density as saturation isn't known yet, by using the gas
+  // pressure rather than the liquid pressure. This does result in a small error
+  // in the calculated saturation, but this is below the error associated with
+  // the correlations. A more accurate saturation could be found iteraviely,
+  // at the cost of increased computational expense
+
+  // The gas and liquid densities
+  const DualReal gas_density = gasDensity(pressure, temperature, fsp);
+  const DualReal liquid_density = liquidDensity(pressure, temperature);
+
+  // Set mass equilibrium constants used in the calculation of vapor mass fraction
+  const DualReal Xncg = liquid.mass_fraction[_gas_fluid_component];
+  const DualReal Yncg = gas.mass_fraction[_gas_fluid_component];
+
+  const DualReal K0 = Yncg / Xncg;
+  const DualReal K1 = (1.0 - Yncg) / (1.0 - Xncg);
+  const DualReal vapor_mass_fraction = vaporMassFraction(Z, K0, K1);
 
   // The gas saturation in the two phase case
-  gas.saturation = vapor_mass_fraction * liquid_density /
-                   (gas.density + vapor_mass_fraction * (liquid_density - gas.density));
+  const DualReal saturation = vapor_mass_fraction * liquid_density /
+                              (gas_density + vapor_mass_fraction * (liquid_density - gas_density));
 
-  const Real dv_dZ = (K1 - K0) / ((K0 - 1.0) * (K1 - 1.0));
-  const Real denominator = (gas.density + vapor_mass_fraction * (liquid_density - gas.density)) *
-                           (gas.density + vapor_mass_fraction * (liquid_density - gas.density));
-
-  const Real ds_dZ = gas.density * liquid_density * dv_dZ / denominator;
-
-  const Real dK0_dp = (Xncg * dYncg_dp - Yncg * dXncg_dp) / Xncg / Xncg;
-  const Real dK0_dT = (Xncg * dYncg_dT - Yncg * dXncg_dT) / Xncg / Xncg;
-
-  const Real dK1_dp =
-      ((1.0 - Yncg) * dXncg_dp - (1.0 - Xncg) * dYncg_dp) / (1.0 - Xncg) / (1.0 - Xncg);
-  const Real dK1_dT =
-      ((1.0 - Yncg) * dXncg_dT - (1.0 - Xncg) * dYncg_dT) / (1.0 - Xncg) / (1.0 - Xncg);
-
-  const Real dv_dp =
-      Z * dK1_dp / (K1 - 1.0) / (K1 - 1.0) + (1.0 - Z) * dK0_dp / (K0 - 1.0) / (K0 - 1.0);
-
-  Real ds_dp = gas.density * liquid_density * dv_dp +
-               vapor_mass_fraction * (1.0 - vapor_mass_fraction) *
-                   (gas.density * liquid_ddensity_dp - gas.ddensity_dp * liquid_density);
-  ds_dp /= denominator;
-
-  const Real dv_dT =
-      Z * dK1_dT / (K1 - 1.0) / (K1 - 1.0) + (1.0 - Z) * dK0_dT / (K0 - 1.0) / (K0 - 1.0);
-
-  Real ds_dT = gas.density * liquid_density * dv_dT +
-               vapor_mass_fraction * (1.0 - vapor_mass_fraction) *
-                   (gas.density * liquid_ddensity_dT - gas.ddensity_dT * liquid_density);
-  ds_dT /= denominator;
-
-  gas.dsaturation_dp = ds_dp;
-  gas.dsaturation_dT = ds_dT;
-  gas.dsaturation_dZ = ds_dZ;
+  return saturation;
 }
 
 void
-PorousFlowWaterNCG::equilibriumMassFractions(Real pressure,
-                                             Real temperature,
-                                             Real & Xncg,
-                                             Real & dXncg_dp,
-                                             Real & dXncg_dT,
-                                             Real & Yh2o,
-                                             Real & dYh2o_dp,
-                                             Real & dYh2o_dT) const
+PorousFlowWaterNCG::twoPhaseProperties(const DualReal & pressure,
+                                       const DualReal & temperature,
+                                       const DualReal & Z,
+                                       unsigned int qp,
+                                       std::vector<FluidStateProperties> & fsp) const
+{
+  auto & gas = fsp[_gas_phase_number];
+
+  // Calculate all of the gas phase properties, as these don't depend on saturation
+  gasProperties(pressure, temperature, fsp);
+
+  // The gas saturation in the two phase case
+  gas.saturation = saturation(pressure, temperature, Z, fsp);
+
+  // The liquid pressure and properties can now be calculated
+  const DualReal liquid_pressure = pressure - _pc.capillaryPressure(1.0 - gas.saturation, qp);
+  liquidProperties(liquid_pressure, temperature, fsp);
+}
+
+void
+PorousFlowWaterNCG::equilibriumMassFractions(const DualReal & pressure,
+                                             const DualReal & temperature,
+                                             DualReal & Xncg,
+                                             DualReal & Yh2o) const
 {
   // Equilibrium constants for each component (Henry's law for the NCG
   // component, and Raoult's law for water).
-  Real Kh, dKh_dT, psat, dpsat_dT;
-  _water_fp.henryConstant(temperature, _ncg_henry, Kh, dKh_dT);
-  _water_fp.vaporPressure(temperature, psat, dpsat_dT);
-  const Real Kncg = Kh / pressure;
-  const Real Kh2o = psat / pressure;
+  const DualReal Kh = _water97_fp.henryConstant(temperature, _ncg_henry);
+  const DualReal psat = _water_fp.vaporPressure(temperature);
+
+  const DualReal Kncg = Kh / pressure;
+  const DualReal Kh2o = psat / pressure;
 
   // The mole fractions for the NCG component in the two component
   // case can be expressed in terms of the equilibrium constants only
-  const Real xncg = (1.0 - Kh2o) / (Kncg - Kh2o);
-  const Real yncg = Kncg * xncg;
+  const DualReal xncg = (1.0 - Kh2o) / (Kncg - Kh2o);
+  const DualReal yncg = Kncg * xncg;
 
   // Convert mole fractions to mass fractions
   Xncg = moleFractionToMassFraction(xncg);
   Yh2o = 1.0 - moleFractionToMassFraction(yncg);
-
-  // Derivatives of mass fractions wrt PorousFlow variables
-  const Real dKncg_dp = -Kh / pressure / pressure;
-  const Real dKncg_dT = dKh_dT / pressure;
-
-  const Real dKh2o_dp = -psat / pressure / pressure;
-  const Real dKh2o_dT = dpsat_dT / pressure;
-
-  Real dxncg_dp = ((Kh2o - 1.0) * dKncg_dp + (1 - Kncg) * dKh2o_dp) / (Kncg - Kh2o) / (Kncg - Kh2o);
-  Real dyncg_dp = xncg * dKncg_dp + Kncg * dxncg_dp;
-  Real dxncg_dT = ((Kh2o - 1.0) * dKncg_dT + (1 - Kncg) * dKh2o_dT) / (Kncg - Kh2o) / (Kncg - Kh2o);
-  Real dyncg_dT = xncg * dKncg_dT + Kncg * dxncg_dT;
-
-  Real dXncg_dxncg =
-      _Mncg * _Mh2o / (xncg * _Mncg + (1.0 - xncg) * _Mh2o) / (xncg * _Mncg + (1.0 - xncg) * _Mh2o);
-  Real dYncg_dyncg =
-      _Mncg * _Mh2o / (yncg * _Mncg + (1.0 - yncg) * _Mh2o) / (yncg * _Mncg + (1.0 - yncg) * _Mh2o);
-
-  dXncg_dp = dXncg_dxncg * dxncg_dp;
-  dXncg_dT = dXncg_dxncg * dxncg_dT;
-  dYh2o_dp = -dYncg_dyncg * dyncg_dp;
-  dYh2o_dT = -dYncg_dyncg * dyncg_dT;
 }
 
-Real
-PorousFlowWaterNCG::moleFractionToMassFraction(Real xmol) const
+DualReal
+PorousFlowWaterNCG::moleFractionToMassFraction(const DualReal & xmol) const
 {
   return xmol * _Mncg / (xmol * _Mncg + (1.0 - xmol) * _Mh2o);
 }
@@ -525,22 +380,27 @@ PorousFlowWaterNCG::checkVariables(Real temperature) const
                    " is outside range 273.16 K <= T <= 647.096 K");
 }
 
-void
-PorousFlowWaterNCG::enthalpyOfDissolution(Real temperature, Real & hdis, Real & dhdis_dT) const
+DualReal
+PorousFlowWaterNCG::enthalpyOfDissolution(const DualReal & temperature) const
 {
   // Henry's constant
-  Real Kh, dKh_dT;
-  _water_fp.henryConstant(temperature, _ncg_henry, Kh, dKh_dT);
+  const DualReal Kh = _water97_fp.henryConstant(temperature, _ncg_henry);
 
-  hdis = -_R * temperature * temperature * dKh_dT / Kh / _Mncg;
+  DualReal hdis = -_R * temperature * temperature * Kh.derivatives()[_Tidx] / Kh / _Mncg;
 
   // Derivative of enthalpy of dissolution wrt temperature requires the second derivative of
   // Henry's constant wrt temperature. For simplicity, approximate this numerically
-  const Real dT = temperature * 1.0e-8;
-  const Real t2 = temperature + dT;
-  _water_fp.henryConstant(t2, _ncg_henry, Kh, dKh_dT);
+  const Real dT = temperature.value() * 1.0e-8;
+  const DualReal t2 = temperature + dT;
+  const DualReal Kh2 = _water97_fp.henryConstant(t2, _ncg_henry);
 
-  dhdis_dT = (-_R * t2 * t2 * dKh_dT / Kh / _Mncg - hdis) / dT;
+  const Real dhdis_dT =
+      (-_R * t2 * t2 * Kh2.derivatives()[_Tidx] / Kh2 / _Mncg - hdis).value() / dT;
+
+  for (std::size_t i = 0; i < temperature.derivatives().size(); ++i)
+    hdis.derivatives()[i] = temperature.derivatives()[i] * dhdis_dT;
+
+  return hdis;
 }
 
 Real
@@ -550,34 +410,37 @@ PorousFlowWaterNCG::totalMassFraction(
   // Check whether the input temperature is within the region of validity
   checkVariables(temperature);
 
+  // As we do not require derivatives, we can simply ignore their initialisation
+  const DualReal p = pressure;
+  const DualReal T = temperature;
+
   // FluidStateProperties data structure
   std::vector<FluidStateProperties> fsp(_num_phases, FluidStateProperties(_num_components));
-  FluidStateProperties & liquid = fsp[_aqueous_phase_number];
-  FluidStateProperties & gas = fsp[_gas_phase_number];
+  auto & liquid = fsp[_aqueous_phase_number];
+  auto & gas = fsp[_gas_phase_number];
 
   // Calculate equilibrium mass fractions in the two-phase state
-  Real Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT;
-  equilibriumMassFractions(
-      pressure, temperature, Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT);
+  DualReal Xncg, Yh2o;
+  equilibriumMassFractions(p, T, Xncg, Yh2o);
 
-  // Save the mass fractions in the FluidStateMassFractions object
-  const Real Yncg = 1.0 - Yh2o;
+  // Save the mass fractions in the FluidStateMassFractions object to calculate gas density
+  const DualReal Yncg = 1.0 - Yh2o;
   liquid.mass_fraction[_aqueous_fluid_component] = 1.0 - Xncg;
   liquid.mass_fraction[_gas_fluid_component] = Xncg;
   gas.mass_fraction[_aqueous_fluid_component] = Yh2o;
   gas.mass_fraction[_gas_fluid_component] = Yncg;
 
-  // Gas properties
-  gasProperties(pressure, temperature, fsp);
+  // Gas density
+  const Real gas_density = gasDensity(p, T, fsp).value();
 
-  // Liquid properties
-  const Real liquid_saturation = 1.0 - saturation;
-  const Real liquid_pressure = pressure - _pc.capillaryPressure(liquid_saturation, qp);
-  liquidProperties(liquid_pressure, temperature, fsp);
+  // Liquid density
+  const DualReal liquid_pressure = p - _pc.capillaryPressure(1.0 - saturation, qp);
+  const Real liquid_density = liquidDensity(liquid_pressure, T).value();
 
   // The total mass fraction of ncg (Z) can now be calculated
-  const Real Z = (saturation * gas.density * Yncg + liquid_saturation * liquid.density * Xncg) /
-                 (saturation * gas.density + liquid_saturation * liquid.density);
+  const Real Z = (saturation * gas_density * Yncg.value() +
+                  (1.0 - saturation) * liquid_density * Xncg.value()) /
+                 (saturation * gas_density + (1.0 - saturation) * liquid_density);
 
   return Z;
 }

--- a/modules/porous_flow/src/userobjects/PorousFlowWaterVapor.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowWaterVapor.C
@@ -67,10 +67,10 @@ PorousFlowWaterVapor::thermophysicalProperties(Real pressure,
                                                Real enthalpy,
                                                unsigned int qp,
                                                FluidStatePhaseEnum & phase_state,
-                                               std::vector<FluidStatePropertiesAD> & fsp) const
+                                               std::vector<FluidStateProperties> & fsp) const
 {
-  FluidStatePropertiesAD & liquid = fsp[_aqueous_phase_number];
-  FluidStatePropertiesAD & gas = fsp[_gas_phase_number];
+  FluidStateProperties & liquid = fsp[_aqueous_phase_number];
+  FluidStateProperties & gas = fsp[_gas_phase_number];
 
   // AD versions of primary variables
   DualReal p = pressure;

--- a/unit/include/PorousFlowBrineCO2Test.h
+++ b/unit/include/PorousFlowBrineCO2Test.h
@@ -27,7 +27,7 @@ protected:
   {
     InputParameters pc_params = _factory.getValidParams("PorousFlowCapillaryPressureVG");
     pc_params.set<Real>("m") = 0.5;
-    pc_params.set<Real>("alpha") = 0.1;
+    pc_params.set<Real>("alpha") = 1.0e-4;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
     _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
@@ -41,19 +41,29 @@ protected:
 
     InputParameters co2_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "co2_fp", co2_params);
-    _co2_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("co2_fp");
+    _co2_fp = &_fe_problem->getUserObjectTempl<SinglePhaseFluidProperties>("co2_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowBrineCO2");
     uo_params.set<UserObjectName>("brine_fp") = "brine_fp";
     uo_params.set<UserObjectName>("co2_fp") = "co2_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
-    _fe_problem->addUserObject("PorousFlowBrineCO2", "fp", uo_params);
-    _fp = &_fe_problem->getUserObjectTempl<PorousFlowBrineCO2>("fp");
+    _fe_problem->addUserObject("PorousFlowBrineCO2", "fs", uo_params);
+    _fs = &_fe_problem->getUserObjectTempl<PorousFlowBrineCO2>("fs");
+
+    // Indices for derivatives
+    _pidx = _fs->getPressureIndex();
+    _Tidx = _fs->getTemperatureIndex();
+    _Zidx = _fs->getZIndex();
+    _Xidx = _fs->getXIndex();
   }
 
   const PorousFlowCapillaryPressureVG * _pc;
-  const PorousFlowBrineCO2 * _fp;
+  const PorousFlowBrineCO2 * _fs;
   const BrineFluidProperties * _brine_fp;
   const Water97FluidProperties * _water_fp;
-  const CO2FluidProperties * _co2_fp;
+  const SinglePhaseFluidProperties * _co2_fp;
+  unsigned int _pidx;
+  unsigned int _Tidx;
+  unsigned int _Zidx;
+  unsigned int _Xidx;
 };

--- a/unit/include/PorousFlowWaterNCGTest.h
+++ b/unit/include/PorousFlowWaterNCGTest.h
@@ -25,28 +25,36 @@ protected:
   {
     InputParameters pc_params = _factory.getValidParams("PorousFlowCapillaryPressureVG");
     pc_params.set<Real>("m") = 0.5;
-    pc_params.set<Real>("alpha") = 0.1;
+    pc_params.set<Real>("alpha") = 1.0e-4;
     _fe_problem->addUserObject("PorousFlowCapillaryPressureVG", "pc", pc_params);
     _pc = &_fe_problem->getUserObjectTempl<PorousFlowCapillaryPressureVG>("pc");
 
     InputParameters water_params = _factory.getValidParams("Water97FluidProperties");
     _fe_problem->addUserObject("Water97FluidProperties", "water_fp", water_params);
-    _water_fp = &_fe_problem->getUserObjectTempl<Water97FluidProperties>("water_fp");
+    _water_fp = &_fe_problem->getUserObjectTempl<SinglePhaseFluidProperties>("water_fp");
 
     InputParameters ncg_params = _factory.getValidParams("CO2FluidProperties");
     _fe_problem->addUserObject("CO2FluidProperties", "ncg_fp", ncg_params);
-    _ncg_fp = &_fe_problem->getUserObjectTempl<CO2FluidProperties>("ncg_fp");
+    _ncg_fp = &_fe_problem->getUserObjectTempl<SinglePhaseFluidProperties>("ncg_fp");
 
     InputParameters uo_params = _factory.getValidParams("PorousFlowWaterNCG");
     uo_params.set<UserObjectName>("water_fp") = "water_fp";
     uo_params.set<UserObjectName>("gas_fp") = "ncg_fp";
     uo_params.set<UserObjectName>("capillary_pressure") = "pc";
-    _fe_problem->addUserObject("PorousFlowWaterNCG", "fp", uo_params);
-    _fp = &_fe_problem->getUserObjectTempl<PorousFlowWaterNCG>("fp");
+    _fe_problem->addUserObject("PorousFlowWaterNCG", "fs", uo_params);
+    _fs = &_fe_problem->getUserObjectTempl<PorousFlowWaterNCG>("fs");
+
+    // Indices for derivatives
+    _pidx = _fs->getPressureIndex();
+    _Tidx = _fs->getTemperatureIndex();
+    _Zidx = _fs->getZIndex();
   }
 
   const PorousFlowCapillaryPressureVG * _pc;
-  const PorousFlowWaterNCG * _fp;
-  const Water97FluidProperties * _water_fp;
-  const CO2FluidProperties * _ncg_fp;
+  const PorousFlowWaterNCG * _fs;
+  const SinglePhaseFluidProperties * _water_fp;
+  const SinglePhaseFluidProperties * _ncg_fp;
+  unsigned int _pidx;
+  unsigned int _Tidx;
+  unsigned int _Zidx;
 };

--- a/unit/src/PorousFlowBrineCO2Test.C
+++ b/unit/src/PorousFlowBrineCO2Test.C
@@ -13,20 +13,20 @@
 /**
  * Verify that the correct name is supplied
  */
-TEST_F(PorousFlowBrineCO2Test, name) { EXPECT_EQ("brine-co2", _fp->fluidStateName()); }
+TEST_F(PorousFlowBrineCO2Test, name) { EXPECT_EQ("brine-co2", _fs->fluidStateName()); }
 
 /**
  * Verify that the correct values for the fluid phase and component indices are supplied
  */
 TEST_F(PorousFlowBrineCO2Test, indices)
 {
-  EXPECT_EQ(2, _fp->numPhases());
-  EXPECT_EQ(3, _fp->numComponents());
-  EXPECT_EQ(0, _fp->aqueousPhaseIndex());
-  EXPECT_EQ(1, _fp->gasPhaseIndex());
-  EXPECT_EQ(0, _fp->aqueousComponentIndex());
-  EXPECT_EQ(1, _fp->gasComponentIndex());
-  EXPECT_EQ(2, _fp->saltComponentIndex());
+  EXPECT_EQ(2, _fs->numPhases());
+  EXPECT_EQ(3, _fs->numComponents());
+  EXPECT_EQ(0, _fs->aqueousPhaseIndex());
+  EXPECT_EQ(1, _fs->gasPhaseIndex());
+  EXPECT_EQ(0, _fs->aqueousComponentIndex());
+  EXPECT_EQ(1, _fs->gasComponentIndex());
+  EXPECT_EQ(2, _fs->saltComponentIndex());
 }
 
 /*
@@ -34,41 +34,42 @@ TEST_F(PorousFlowBrineCO2Test, indices)
  */
 TEST_F(PorousFlowBrineCO2Test, equilibriumConstants)
 {
-  Real T = 350.0;
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
   const Real dT = 1.0e-6;
 
-  Real K0H2O, dK0H2O_dT, K0CO2, dK0CO2_dT;
-  _fp->equilibriumConstantH2O(T, K0H2O, dK0H2O_dT);
-  _fp->equilibriumConstantCO2(T, K0CO2, dK0CO2_dT);
+  DualReal K0H2O = _fs->equilibriumConstantH2O(T);
+  DualReal K0CO2 = _fs->equilibriumConstantCO2(T);
 
-  ABS_TEST(K0H2O, 0.412597711705, 1.0e-10);
-  ABS_TEST(K0CO2, 74.0435888596, 1.0e-10);
+  ABS_TEST(K0H2O.value(), 0.412597711705, 1.0e-10);
+  ABS_TEST(K0CO2.value(), 74.0435888596, 1.0e-10);
 
-  Real K0H2O_2, dK0H2O_2_dT, K0CO2_2, dK0CO2_2_dT;
-  _fp->equilibriumConstantH2O(T + dT, K0H2O_2, dK0H2O_2_dT);
-  _fp->equilibriumConstantCO2(T + dT, K0CO2_2, dK0CO2_2_dT);
+  Real K0H2O_2 = _fs->equilibriumConstantH2O(T + dT).value();
+  Real K0CO2_2 = _fs->equilibriumConstantCO2(T + dT).value();
 
-  Real dK0H2O_dT_fd = (K0H2O_2 - K0H2O) / dT;
-  Real dK0CO2_dT_fd = (K0CO2_2 - K0CO2) / dT;
-  REL_TEST(dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
-  REL_TEST(dK0CO2_dT, dK0CO2_dT_fd, 1.0e-6);
+  Real dK0H2O_dT_fd = (K0H2O_2 - K0H2O.value()) / dT;
+  Real dK0CO2_dT_fd = (K0CO2_2 - K0CO2.value()) / dT;
+  REL_TEST(K0H2O.derivatives()[_Tidx], dK0H2O_dT_fd, 1.0e-6);
+  REL_TEST(K0CO2.derivatives()[_Tidx], dK0CO2_dT_fd, 1.0e-6);
 
   // Test the high temperature formulation
   T = 450.0;
+  T.derivatives()[_Tidx] = 1.0;
 
-  _fp->equilibriumConstantH2O(T, K0H2O, dK0H2O_dT);
-  _fp->equilibriumConstantCO2(T, K0CO2, dK0CO2_dT);
+  K0H2O = _fs->equilibriumConstantH2O(T);
+  K0CO2 = _fs->equilibriumConstantCO2(T);
 
-  ABS_TEST(K0H2O, 8.75944517916, 1.0e-10);
-  ABS_TEST(K0CO2, 105.013867434, 1.0e-10);
+  ABS_TEST(K0H2O.value(), 8.75944517916, 1.0e-10);
+  ABS_TEST(K0CO2.value(), 105.013867434, 1.0e-10);
 
-  _fp->equilibriumConstantH2O(T + dT, K0H2O_2, dK0H2O_2_dT);
-  _fp->equilibriumConstantCO2(T + dT, K0CO2_2, dK0CO2_2_dT);
+  K0H2O_2 = _fs->equilibriumConstantH2O(T + dT).value();
+  K0CO2_2 = _fs->equilibriumConstantCO2(T + dT).value();
 
-  dK0H2O_dT_fd = (K0H2O_2 - K0H2O) / dT;
-  dK0CO2_dT_fd = (K0CO2_2 - K0CO2) / dT;
-  REL_TEST(dK0H2O_dT, dK0H2O_dT_fd, 1.0e-6);
-  REL_TEST(dK0CO2_dT, dK0CO2_dT_fd, 1.0e-5);
+  dK0H2O_dT_fd = (K0H2O_2 - K0H2O.value()) / dT;
+  dK0CO2_dT_fd = (K0CO2_2 - K0CO2.value()) / dT;
+  REL_TEST(K0H2O.derivatives()[_Tidx], dK0H2O_dT_fd, 1.0e-6);
+  REL_TEST(K0CO2.derivatives()[_Tidx], dK0CO2_dT_fd, 1.0e-6);
 }
 
 /*
@@ -77,72 +78,66 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumConstants)
 TEST_F(PorousFlowBrineCO2Test, fugacityCoefficients)
 {
   // Test the low temperature formulation
-  Real p = 40.0e6;
-  Real T = 350.0;
-  Real Xnacl = 0.0;
-  Real co2_density, dco2_density_dp, dco2_density_dT;
-  _co2_fp->rho_from_p_T(p, T, co2_density, dco2_density_dp, dco2_density_dT);
+  DualReal p = 40.0e6;
+  p.derivatives()[_pidx] = 1.0;
 
-  Real phiH2O, dphiH2O_dp, dphiH2O_dT;
-  Real phiCO2, dphiCO2_dp, dphiCO2_dT;
-  _fp->fugacityCoefficientsLowTemp(p,
-                                   T,
-                                   co2_density,
-                                   dco2_density_dp,
-                                   dco2_density_dT,
-                                   phiCO2,
-                                   dphiCO2_dp,
-                                   dphiCO2_dT,
-                                   phiH2O,
-                                   dphiH2O_dp,
-                                   dphiH2O_dT);
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
 
-  ABS_TEST(phiCO2, 0.401939178735, 1.0e-8);
-  ABS_TEST(phiH2O, 0.0898968578757, 1.0e-8);
+  DualReal Xnacl = 0.0;
+  Xnacl.derivatives()[_Xidx] = 1.0;
+
+  DualReal co2_density = _co2_fp->rho_from_p_T(p, T);
+
+  DualReal phiH2O, phiCO2;
+  _fs->fugacityCoefficientsLowTemp(p, T, co2_density, phiCO2, phiH2O);
+
+  ABS_TEST(phiCO2.value(), 0.401939178735, 1.0e-8);
+  ABS_TEST(phiH2O.value(), 0.0898968578757, 1.0e-8);
 
   // Test the high temperature formulation
   T = 423.15;
 
-  Real xco2, yh2o;
+  DualReal xco2, yh2o;
   co2_density = _co2_fp->rho_from_p_T(p, T);
 
-  _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
-  phiH2O = _fp->fugacityCoefficientH2OHighTemp(p, T, co2_density, xco2, yh2o);
-  phiCO2 = _fp->fugacityCoefficientCO2HighTemp(p, T, co2_density, xco2, yh2o);
+  _fs->solveEquilibriumMoleFractionHighTemp(
+      p.value(), T.value(), Xnacl.value(), co2_density.value(), xco2.value(), yh2o.value());
+  phiH2O = _fs->fugacityCoefficientH2OHighTemp(p, T, co2_density, xco2, yh2o);
+  phiCO2 = _fs->fugacityCoefficientCO2HighTemp(p, T, co2_density, xco2, yh2o);
 
-  ABS_TEST(phiH2O, 0.156303437579, 1.0e-8);
-  ABS_TEST(phiCO2, 0.641936639599, 1.0e-8);
+  ABS_TEST(phiH2O.value(), 0.156303437579, 1.0e-8);
+  ABS_TEST(phiCO2.value(), 0.641936639599, 1.0e-8);
 
   // Test that the same results are returned in fugacityCoefficientsHighTemp()
-  Real phiCO2_2, phiH2O_2;
-  _fp->fugacityCoefficientsHighTemp(p, T, co2_density, xco2, yh2o, phiCO2_2, phiH2O_2);
+  DualReal phiCO2_2, phiH2O_2;
+  _fs->fugacityCoefficientsHighTemp(p, T, co2_density, xco2, yh2o, phiCO2_2, phiH2O_2);
 
   ABS_TEST(phiH2O, phiH2O_2, 1.0e-12);
   ABS_TEST(phiCO2, phiCO2_2, 1.0e-12);
 }
 
 /*
- * Verify calculation of the H2O and CO2 activity coefficients and their derivative
- * wrt temperature
+ * Verify calculation of the H2O and CO2 activity coefficients
  */
 TEST_F(PorousFlowBrineCO2Test, activityCoefficients)
 {
-  const Real xco2 = 0.01;
-  Real T = 350.0;
+  DualReal xco2 = 0.01;
+  DualReal T = 350.0;
 
-  Real gammaH2O = _fp->activityCoefficientH2O(T, xco2);
-  Real gammaCO2 = _fp->activityCoefficientCO2(T, xco2);
+  DualReal gammaH2O = _fs->activityCoefficientH2O(T, xco2);
+  DualReal gammaCO2 = _fs->activityCoefficientCO2(T, xco2);
 
-  ABS_TEST(gammaH2O, 1.0, 1.0e-10);
-  ABS_TEST(gammaCO2, 1.0, 1.0e-10);
+  ABS_TEST(gammaH2O.value(), 1.0, 1.0e-10);
+  ABS_TEST(gammaCO2.value(), 1.0, 1.0e-10);
 
   T = 450.0;
 
-  gammaH2O = _fp->activityCoefficientH2O(T, xco2);
-  gammaCO2 = _fp->activityCoefficientCO2(T, xco2);
+  gammaH2O = _fs->activityCoefficientH2O(T, xco2);
+  gammaCO2 = _fs->activityCoefficientCO2(T, xco2);
 
-  ABS_TEST(gammaH2O, 1.00022113664, 1.0e-10);
-  ABS_TEST(gammaCO2, 0.956736800255, 1.0e-10);
+  ABS_TEST(gammaH2O.value(), 1.00022113664, 1.0e-10);
+  ABS_TEST(gammaCO2.value(), 0.956736800255, 1.0e-10);
 }
 
 /*
@@ -151,56 +146,62 @@ TEST_F(PorousFlowBrineCO2Test, activityCoefficients)
  */
 TEST_F(PorousFlowBrineCO2Test, activityCoefficientCO2Brine)
 {
-  const Real p = 10.0e6;
-  Real T = 350.0;
-  Real Xnacl = 0.1;
+  DualReal p = 10.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
+
   const Real dp = 1.0e-1;
   const Real dT = 1.0e-6;
   const Real dx = 1.0e-8;
 
   // Low temperature regime
-  Real gamma, dgamma_dp, dgamma_dT, dgamma_dX;
-  _fp->activityCoefficient(p, T, Xnacl, gamma, dgamma_dp, dgamma_dT, dgamma_dX);
-  ABS_TEST(gamma, 1.43276649338, 1.0e-8);
+  DualReal gamma = _fs->activityCoefficient(p, T, Xnacl);
+  ABS_TEST(gamma.value(), 1.43276649338, 1.0e-8);
 
-  Real gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX;
-  _fp->activityCoefficient(p + dp, T, Xnacl, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
+  DualReal gamma_2 = _fs->activityCoefficient(p + dp, T, Xnacl);
 
-  Real dgamma_dp_fd = (gamma_2 - gamma) / dp;
-  REL_TEST(dgamma_dp, dgamma_dp_fd, 1.0e-6);
+  Real dgamma_dp_fd = (gamma_2.value() - gamma.value()) / dp;
+  REL_TEST(gamma.derivatives()[_pidx], dgamma_dp_fd, 1.0e-6);
 
-  _fp->activityCoefficient(p, T + dT, Xnacl, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
+  gamma_2 = _fs->activityCoefficient(p, T + dT, Xnacl);
 
-  Real dgamma_dT_fd = (gamma_2 - gamma) / dT;
-  REL_TEST(dgamma_dT, dgamma_dT_fd, 1.0e-6);
+  Real dgamma_dT_fd = (gamma_2.value() - gamma.value()) / dT;
+  REL_TEST(gamma.derivatives()[_Tidx], dgamma_dT_fd, 1.0e-6);
 
-  _fp->activityCoefficient(p, T, Xnacl + dx, gamma_2, dgamma_2_dp, dgamma_2_dT, dgamma_2_dX);
+  gamma_2 = _fs->activityCoefficient(p, T, Xnacl + dx);
 
-  Real dgamma_dX_fd = (gamma_2 - gamma) / dx;
-  REL_TEST(dgamma_dX, dgamma_dX_fd, 1.0e-6);
+  Real dgamma_dX_fd = (gamma_2.value() - gamma.value()) / dx;
+  REL_TEST(gamma.derivatives()[_Xidx], dgamma_dX_fd, 1.0e-6);
 
   // High temperature regime
   T = 523.15;
-  _fp->activityCoefficientHighTemp(T, Xnacl, gamma, dgamma_dT, dgamma_dX);
-  ABS_TEST(gamma, 1.50047006243, 1.0e-8);
+  T.derivatives()[_Tidx] = 1.0;
 
-  _fp->activityCoefficientHighTemp(T + dT, Xnacl, gamma_2, dgamma_2_dT, dgamma_2_dX);
-  dgamma_dT_fd = (gamma_2 - gamma) / dT;
-  REL_TEST(dgamma_dT, dgamma_dT_fd, 1.0e-6);
+  gamma = _fs->activityCoefficientHighTemp(T, Xnacl);
+  ABS_TEST(gamma.value(), 1.50047006243, 1.0e-8);
 
-  _fp->activityCoefficientHighTemp(T, Xnacl + dx, gamma_2, dgamma_2_dT, dgamma_2_dX);
-  dgamma_dX_fd = (gamma_2 - gamma) / dx;
-  REL_TEST(dgamma_dX, dgamma_dX_fd, 1.0e-6);
+  gamma_2 = _fs->activityCoefficientHighTemp(T + dT, Xnacl);
+  dgamma_dT_fd = (gamma_2.value() - gamma.value()) / dT;
+  REL_TEST(gamma.derivatives()[_Tidx], dgamma_dT_fd, 1.0e-6);
+
+  gamma_2 = _fs->activityCoefficientHighTemp(T, Xnacl + dx);
+  dgamma_dX_fd = (gamma_2.value() - gamma.value()) / dx;
+  REL_TEST(gamma.derivatives()[_Xidx], dgamma_dX_fd, 1.0e-6);
 
   // Check that both formulations return gamma = 1 for Xnacl = 0
   Xnacl = 0.0;
   T = 350.0;
-  _fp->activityCoefficient(p, T, Xnacl, gamma, dgamma_dp, dgamma_dT, dgamma_dX);
-  ABS_TEST(gamma, 1.0, 1.0e-12);
+  gamma = _fs->activityCoefficient(p, T, Xnacl);
+  ABS_TEST(gamma.value(), 1.0, 1.0e-12);
 
   T = 523.15;
-  _fp->activityCoefficientHighTemp(T, Xnacl, gamma, dgamma_dT, dgamma_dX);
-  ABS_TEST(gamma, 1.0, 1.0e-12);
+  gamma = _fs->activityCoefficientHighTemp(T, Xnacl);
+  ABS_TEST(gamma.value(), 1.0, 1.0e-12);
 }
 
 /*
@@ -208,18 +209,18 @@ TEST_F(PorousFlowBrineCO2Test, activityCoefficientCO2Brine)
  */
 TEST_F(PorousFlowBrineCO2Test, partialDensity)
 {
-  const Real T = 473.15;
+  DualReal T = 473.15;
+  T.derivatives()[_Tidx] = 1.0;
+
   const Real dT = 1.0e-6;
 
-  Real partial_density, dpartial_density_dT;
-  _fp->partialDensityCO2(T, partial_density, dpartial_density_dT);
-  ABS_TEST(partial_density, 893.332, 1.0e-3);
+  DualReal partial_density = _fs->partialDensityCO2(T);
+  ABS_TEST(partial_density.value(), 893.332, 1.0e-3);
 
-  Real partial_density_2, dpartial_density_2_dT;
-  _fp->partialDensityCO2(T + dT, partial_density_2, dpartial_density_2_dT);
+  DualReal partial_density_2 = _fs->partialDensityCO2(T + dT);
 
-  Real dpartial_density_dT_fd = (partial_density_2 - partial_density) / dT;
-  REL_TEST(dpartial_density_dT, dpartial_density_dT_fd, 1.0e-6);
+  Real dpartial_density_dT_fd = (partial_density_2.value() - partial_density.value()) / dT;
+  REL_TEST(partial_density.derivatives()[_Tidx], dpartial_density_dT_fd, 1.0e-6);
 }
 
 /*
@@ -228,68 +229,67 @@ TEST_F(PorousFlowBrineCO2Test, partialDensity)
 TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
 {
   // Low temperature regime
-  Real p = 1.0e6;
-  Real T = 350.0;
-  const Real Xnacl = 0.1;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
+
   const Real dp = 1.0e-2;
   const Real dT = 1.0e-6;
   const Real dx = 1.0e-8;
 
-  Real X, dX_dp, dX_dT, dX_dX, Y, dY_dp, dY_dT, dY_dX;
-  Real X1, dX1_dp, dX1_dT, dX1_dX, Y1, dY1_dp, dY1_dT, dY1_dX;
-  Real X2, dX2_dp, dX2_dT, dX2_dX, Y2, dY2_dp, dY2_dT, dY2_dX;
-  _fp->equilibriumMassFractions(p, T, Xnacl, X, dX_dp, dX_dT, dX_dX, Y, dY_dp, dY_dT, dY_dX);
+  DualReal X, Y;
+  _fs->equilibriumMassFractions(p, T, Xnacl, X, Y);
 
-  ABS_TEST(X, 0.0035573020148, 1.0e-10);
-  ABS_TEST(Y, 0.0171977397214, 1.0e-10);
+  ABS_TEST(X.value(), 0.0035573020148, 1.0e-10);
+  ABS_TEST(Y.value(), 0.0171977397214, 1.0e-10);
 
   // Derivative wrt pressure
-  _fp->equilibriumMassFractions(
-      p - dp, T, Xnacl, X1, dX1_dp, dX1_dT, dX1_dX, Y1, dY1_dp, dY1_dT, dY1_dX);
-  _fp->equilibriumMassFractions(
-      p + dp, T, Xnacl, X2, dX2_dp, dX2_dT, dX2_dX, Y2, dY2_dp, dY2_dT, dY2_dX);
+  DualReal X1, Y1, X2, Y2;
+  _fs->equilibriumMassFractions(p - dp, T, Xnacl, X1, Y1);
+  _fs->equilibriumMassFractions(p + dp, T, Xnacl, X2, Y2);
 
-  Real dX_dp_fd = (X2 - X1) / (2.0 * dp);
-  Real dY_dp_fd = (Y2 - Y1) / (2.0 * dp);
+  Real dX_dp_fd = (X2.value() - X1.value()) / (2.0 * dp);
+  Real dY_dp_fd = (Y2.value() - Y1.value()) / (2.0 * dp);
 
-  REL_TEST(dX_dp, dX_dp_fd, 1.0e-6);
-  REL_TEST(dY_dp, dY_dp_fd, 1.0e-6);
+  REL_TEST(X.derivatives()[_pidx], dX_dp_fd, 1.0e-6);
+  REL_TEST(Y.derivatives()[_pidx], dY_dp_fd, 1.0e-6);
 
   // Derivative wrt temperature
-  _fp->equilibriumMassFractions(
-      p, T - dT, Xnacl, X1, dX1_dp, dX1_dT, dX1_dX, Y1, dY1_dp, dY1_dT, dY1_dX);
-  _fp->equilibriumMassFractions(
-      p, T + dT, Xnacl, X2, dX2_dp, dX2_dT, dX2_dX, Y2, dY2_dp, dY2_dT, dY2_dX);
+  _fs->equilibriumMassFractions(p, T - dT, Xnacl, X1, Y1);
+  _fs->equilibriumMassFractions(p, T + dT, Xnacl, X2, Y2);
 
-  Real dX_dT_fd = (X2 - X1) / (2.0 * dT);
-  Real dY_dT_fd = (Y2 - Y1) / (2.0 * dT);
+  Real dX_dT_fd = (X2.value() - X1.value()) / (2.0 * dT);
+  Real dY_dT_fd = (Y2.value() - Y1.value()) / (2.0 * dT);
 
-  REL_TEST(dX_dT, dX_dT_fd, 1.0e-5);
-  REL_TEST(dY_dT, dY_dT_fd, 1.0e-5);
+  REL_TEST(X.derivatives()[_Tidx], dX_dT_fd, 1.0e-6);
+  REL_TEST(Y.derivatives()[_Tidx], dY_dT_fd, 1.0e-6);
 
   // Derivative wrt salt mass fraction
-  _fp->equilibriumMassFractions(
-      p, T, Xnacl - dx, X1, dX1_dp, dX1_dT, dX1_dX, Y1, dY1_dp, dY1_dT, dY1_dX);
-  _fp->equilibriumMassFractions(
-      p, T, Xnacl + dx, X2, dX2_dp, dX2_dT, dX2_dX, Y2, dY2_dp, dY2_dT, dY2_dX);
+  _fs->equilibriumMassFractions(p, T, Xnacl - dx, X1, Y1);
+  _fs->equilibriumMassFractions(p, T, Xnacl + dx, X2, Y2);
 
-  Real dX_dX_fd = (X2 - X1) / (2.0 * dx);
-  Real dY_dX_fd = (Y2 - Y1) / (2.0 * dx);
+  Real dX_dX_fd = (X2.value() - X1.value()) / (2.0 * dx);
+  Real dY_dX_fd = (Y2.value() - Y1).value() / (2.0 * dx);
 
-  REL_TEST(dX_dX, dX_dX_fd, 1.0e-6);
-  REL_TEST(dY_dX, dY_dX_fd, 1.0e-6);
+  REL_TEST(X.derivatives()[_Xidx], dX_dX_fd, 1.0e-6);
+  REL_TEST(Y.derivatives()[_Xidx], dY_dX_fd, 1.0e-6);
 
   // High temperature regime
   p = 10.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
   T = 525.15;
+  T.derivatives()[_Tidx] = 1.0;
 
-  Real x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX;
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
+  _fs->equilibriumMassFractions(p, T, Xnacl, X, Y);
 
-  _fp->equilibriumMassFractions(p, T, Xnacl, X, dX_dp, dX_dT, dX_dX, Y, dY_dp, dY_dT, dY_dX);
-
-  ABS_TEST(X, 0.016299479086, 1.0e-10);
-  ABS_TEST(Y, 0.249471400766, 1.0e-10);
+  ABS_TEST(X.value(), 0.016299479086, 1.0e-10);
+  ABS_TEST(Y.value(), 0.249471400766, 1.0e-10);
 }
 
 /*
@@ -298,56 +298,55 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMassFraction)
  */
 TEST_F(PorousFlowBrineCO2Test, MassFraction)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
-  const Real Xnacl = 0.1;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
 
   FluidStatePhaseEnum phase_state;
-  const unsigned int np = _fp->numPhases();
-  const unsigned int nc = _fp->numComponents();
+  const unsigned int np = _fs->numPhases();
+  const unsigned int nc = _fs->numComponents();
   std::vector<FluidStateProperties> fsp(np, FluidStateProperties(nc));
 
   // Liquid region
-  Real Z = 0.0001;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  DualReal Z = 0.0001;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::LIQUID);
 
   // Verfify mass fraction values
-  Real Xco2 = fsp[0].mass_fraction[1];
-  Real Yco2 = fsp[1].mass_fraction[1];
-  Real Xh2o = fsp[0].mass_fraction[0];
-  Real Yh2o = fsp[1].mass_fraction[0];
-  Real Xnacl2 = fsp[0].mass_fraction[2];
-  ABS_TEST(Xco2, Z, 1.0e-8);
-  ABS_TEST(Yco2, 0.0, 1.0e-8);
-  ABS_TEST(Xh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST(Yh2o, 0.0, 1.0e-8);
-  ABS_TEST(Xnacl2, Xnacl, 1.0e-8);
+  DualReal Xco2 = fsp[0].mass_fraction[1];
+  DualReal Yco2 = fsp[1].mass_fraction[1];
+  DualReal Xh2o = fsp[0].mass_fraction[0];
+  DualReal Yh2o = fsp[1].mass_fraction[0];
+  DualReal Xnacl2 = fsp[0].mass_fraction[2];
+  ABS_TEST(Xco2.value(), Z.value(), 1.0e-8);
+  ABS_TEST(Yco2.value(), 0.0, 1.0e-8);
+  ABS_TEST(Xh2o.value(), 1.0 - Z.value(), 1.0e-8);
+  ABS_TEST(Yh2o.value(), 0.0, 1.0e-8);
+  ABS_TEST(Xnacl2.value(), Xnacl.value(), 1.0e-8);
 
   // Verify derivatives
-  Real dXco2_dp = fsp[0].dmass_fraction_dp[1];
-  Real dXco2_dT = fsp[0].dmass_fraction_dT[1];
-  Real dXco2_dX = fsp[0].dmass_fraction_dX[1];
-  Real dXco2_dZ = fsp[0].dmass_fraction_dZ[1];
-  Real dYco2_dp = fsp[1].dmass_fraction_dp[1];
-  Real dYco2_dT = fsp[1].dmass_fraction_dT[1];
-  Real dYco2_dX = fsp[1].dmass_fraction_dX[1];
-  Real dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
-  Real dXnacl_dX = fsp[0].dmass_fraction_dX[2];
-
-  ABS_TEST(dXco2_dp, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dT, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dX, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dZ, 1.0, 1.0e-8);
-  ABS_TEST(dYco2_dp, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dT, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST(dXnacl_dX, 1.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_pidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Tidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Xidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Zidx], 1.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_pidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Tidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Xidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Zidx], 0.0, 1.0e-8);
+  ABS_TEST(Xnacl.derivatives()[_Xidx], 1.0, 1.0e-8);
 
   // Gas region
   Z = 0.995;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::GAS);
 
   // Verfify mass fraction values
@@ -355,56 +354,39 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   Yco2 = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  Real Ynacl = fsp[1].mass_fraction[2];
-  ABS_TEST(Xco2, 0.0, 1.0e-8);
-  ABS_TEST(Yco2, Z, 1.0e-8);
-  ABS_TEST(Xh2o, 0.0, 1.0e-8);
-  ABS_TEST(Yh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST(Ynacl, 0.0, 1.0e-8);
+  DualReal Ynacl = fsp[1].mass_fraction[2];
+  ABS_TEST(Xco2.value(), 0.0, 1.0e-8);
+  ABS_TEST(Yco2.value(), Z.value(), 1.0e-8);
+  ABS_TEST(Xh2o.value(), 0.0, 1.0e-8);
+  ABS_TEST(Yh2o.value(), 1.0 - Z.value(), 1.0e-8);
+  ABS_TEST(Ynacl.value(), 0.0, 1.0e-8);
 
   // Verify derivatives
-  dXco2_dp = fsp[0].dmass_fraction_dp[1];
-  dXco2_dT = fsp[0].dmass_fraction_dT[1];
-  dXco2_dX = fsp[0].dmass_fraction_dX[1];
-  dXco2_dZ = fsp[0].dmass_fraction_dZ[1];
-  dYco2_dp = fsp[1].dmass_fraction_dp[1];
-  dYco2_dT = fsp[1].dmass_fraction_dT[1];
-  dYco2_dX = fsp[1].dmass_fraction_dX[1];
-  dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
-  Real dYnacl_dX = fsp[1].dmass_fraction_dX[2];
-  ABS_TEST(dXco2_dp, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dT, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dX, 0.0, 1.0e-8);
-  ABS_TEST(dXco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dp, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dT, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
-  ABS_TEST(dYnacl_dX, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dX, 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_pidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Tidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Xidx], 0.0, 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Zidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_pidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Tidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Xidx], 0.0, 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Zidx], 1.0, 1.0e-8);
+  ABS_TEST(Ynacl.derivatives()[_Xidx], 0.0, 1.0e-8);
 
   // Two phase region. In this region, the mass fractions and derivatives can
   // be verified using the equilibrium mass fraction derivatives that have
   // been verified above
   Z = 0.45;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
   // Equilibrium mass fractions and derivatives
-  Real Xco2_eq, dXco2_dp_eq, dXco2_dT_eq, dXco2_dX_eq, Yh2o_eq, dYh2o_dp_eq, dYh2o_dT_eq,
-      dYh2o_dX_eq;
-  _fp->equilibriumMassFractions(p,
-                                T,
-                                Xnacl,
-                                Xco2_eq,
-                                dXco2_dp_eq,
-                                dXco2_dT_eq,
-                                dXco2_dX_eq,
-                                Yh2o_eq,
-                                dYh2o_dp_eq,
-                                dYh2o_dT_eq,
-                                dYh2o_dX_eq);
+  DualReal Xco2_eq, Yh2o_eq;
+  _fs->equilibriumMassFractions(p, T, Xnacl, Xco2_eq, Yh2o_eq);
 
-  // Verfify mass fraction values
+  // Verfify mass fraction values - comparing DualReals verifies that derivatives
+  // are also identical
   Xco2 = fsp[0].mass_fraction[1];
   Yco2 = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
@@ -414,36 +396,17 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
   ABS_TEST(Xh2o, 1.0 - Xco2_eq, 1.0e-8);
   ABS_TEST(Yh2o, Yh2o_eq, 1.0e-8);
 
-  // Verify derivatives wrt p, T
-  dXco2_dp = fsp[0].dmass_fraction_dp[1];
-  dXco2_dT = fsp[0].dmass_fraction_dT[1];
-  dXco2_dX = fsp[0].dmass_fraction_dX[1];
-  dXco2_dZ = fsp[0].dmass_fraction_dZ[1];
-  dYco2_dp = fsp[1].dmass_fraction_dp[1];
-  dYco2_dT = fsp[1].dmass_fraction_dT[1];
-  dYco2_dX = fsp[1].dmass_fraction_dX[1];
-  dYco2_dZ = fsp[1].dmass_fraction_dZ[1];
-
-  ABS_TEST(dXco2_dp, dXco2_dp_eq, 1.0e-8);
-  ABS_TEST(dXco2_dT, dXco2_dT_eq, 1.0e-8);
-  ABS_TEST(dXco2_dX, dXco2_dX_eq, 1.0e-8);
-  ABS_TEST(dXco2_dZ, 0.0, 1.0e-8);
-  ABS_TEST(dYco2_dp, -dYh2o_dp_eq, 1.0e-8);
-  ABS_TEST(dYco2_dT, -dYh2o_dT_eq, 1.0e-8);
-  ABS_TEST(dYco2_dX, -dYh2o_dX_eq, 1.0e-8);
-  ABS_TEST(dYco2_dZ, 0.0, 1.0e-8);
-
   // Use finite differences to verify derivative wrt Z is unaffected by Z
   const Real dZ = 1.0e-8;
-  _fp->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
-  Real Xco21 = fsp[0].mass_fraction[1];
-  Real Yco21 = fsp[1].mass_fraction[1];
-  _fp->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
-  Real Xco22 = fsp[0].mass_fraction[1];
-  Real Yco22 = fsp[1].mass_fraction[1];
+  _fs->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
+  DualReal Xco21 = fsp[0].mass_fraction[1];
+  DualReal Yco21 = fsp[1].mass_fraction[1];
+  _fs->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
+  DualReal Xco22 = fsp[0].mass_fraction[1];
+  DualReal Yco22 = fsp[1].mass_fraction[1];
 
-  ABS_TEST(dXco2_dZ, (Xco21 - Xco22) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST(dYco2_dZ, (Yco21 - Yco22) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(Xco2.derivatives()[_Zidx], (Xco21.value() - Xco22.value()) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(Yco2.derivatives()[_Zidx], (Yco21.value() - Yco22.value()) / (2.0 * dZ), 1.0e-8);
 }
 
 /*
@@ -453,92 +416,89 @@ TEST_F(PorousFlowBrineCO2Test, MassFraction)
  */
 TEST_F(PorousFlowBrineCO2Test, gasProperties)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
-  const Real Xnacl = 0.1;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
 
   FluidStatePhaseEnum phase_state;
-  const unsigned int np = _fp->numPhases();
-  const unsigned int nc = _fp->numComponents();
+  const unsigned int np = _fs->numPhases();
+  const unsigned int nc = _fs->numComponents();
   std::vector<FluidStateProperties> fsp(np, FluidStateProperties(nc));
 
   // Gas region
-  Real Z = 0.995;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  DualReal Z = 0.995;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::GAS);
 
   // Verify fluid density, viscosity and enthalpy
-  _fp->gasProperties(p, T, fsp);
-  Real gas_density = fsp[1].density;
-  Real gas_viscosity = fsp[1].viscosity;
-  Real gas_enthalpy = fsp[1].enthalpy;
+  _fs->gasProperties(p, T, fsp);
+  DualReal gas_density = fsp[1].density;
+  DualReal gas_viscosity = fsp[1].viscosity;
+  DualReal gas_enthalpy = fsp[1].enthalpy;
 
-  Real density = _co2_fp->rho_from_p_T(p, T);
-  Real viscosity = _co2_fp->mu_from_p_T(p, T);
-  Real enthalpy = _co2_fp->h_from_p_T(p, T);
+  Real density = _co2_fp->rho_from_p_T(p.value(), T.value());
+  Real viscosity = _co2_fp->mu_from_p_T(p.value(), T.value());
+  Real enthalpy = _co2_fp->h_from_p_T(p.value(), T.value());
 
-  ABS_TEST(gas_density, density, 1.0e-8);
-  ABS_TEST(gas_viscosity, viscosity, 1.0e-8);
-  ABS_TEST(gas_enthalpy, enthalpy, 1.0e-8);
+  ABS_TEST(gas_density.value(), density, 1.0e-8);
+  ABS_TEST(gas_viscosity.value(), viscosity, 1.0e-8);
+  ABS_TEST(gas_enthalpy.value(), enthalpy, 1.0e-8);
 
   // Verify derivatives
-  Real ddensity_dp = fsp[1].ddensity_dp;
-  Real ddensity_dT = fsp[1].ddensity_dT;
-  Real ddensity_dZ = fsp[1].ddensity_dZ;
-  Real dviscosity_dp = fsp[1].dviscosity_dp;
-  Real dviscosity_dT = fsp[1].dviscosity_dT;
-  Real dviscosity_dZ = fsp[1].dviscosity_dZ;
-  Real denthalpy_dp = fsp[1].denthalpy_dp;
-  Real denthalpy_dT = fsp[1].denthalpy_dT;
-  Real denthalpy_dZ = fsp[1].denthalpy_dZ;
-
   const Real dp = 1.0e-1;
-  _fp->gasProperties(p + dp, T, fsp);
-  Real rho1 = fsp[1].density;
-  Real mu1 = fsp[1].viscosity;
-  Real h1 = fsp[1].enthalpy;
+  _fs->gasProperties(p + dp, T, fsp);
+  Real rho1 = fsp[1].density.value();
+  Real mu1 = fsp[1].viscosity.value();
+  Real h1 = fsp[1].enthalpy.value();
 
-  _fp->gasProperties(p - dp, T, fsp);
-  Real rho2 = fsp[1].density;
-  Real mu2 = fsp[1].viscosity;
-  Real h2 = fsp[1].enthalpy;
+  _fs->gasProperties(p - dp, T, fsp);
+  Real rho2 = fsp[1].density.value();
+  Real mu2 = fsp[1].viscosity.value();
+  Real h2 = fsp[1].enthalpy.value();
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(gas_density.derivatives()[_pidx], (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(gas_viscosity.derivatives()[_pidx], (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(gas_enthalpy.derivatives()[_pidx], (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   const Real dT = 1.0e-3;
-  _fp->gasProperties(p, T + dT, fsp);
-  rho1 = fsp[1].density;
-  mu1 = fsp[1].viscosity;
-  h1 = fsp[1].enthalpy;
+  _fs->gasProperties(p, T + dT, fsp);
+  rho1 = fsp[1].density.value();
+  mu1 = fsp[1].viscosity.value();
+  h1 = fsp[1].enthalpy.value();
 
-  _fp->gasProperties(p, T - dT, fsp);
-  rho2 = fsp[1].density;
-  mu2 = fsp[1].viscosity;
-  h2 = fsp[1].enthalpy;
+  _fs->gasProperties(p, T - dT, fsp);
+  rho2 = fsp[1].density.value();
+  mu2 = fsp[1].viscosity.value();
+  h2 = fsp[1].enthalpy.value();
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(gas_density.derivatives()[_Tidx], (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(gas_viscosity.derivatives()[_Tidx], (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(gas_enthalpy.derivatives()[_Tidx], (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Note: mass fraction changes with Z
   const Real dZ = 1.0e-8;
-  _fp->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  rho1 = fsp[1].density;
-  mu1 = fsp[1].viscosity;
-  h1 = fsp[1].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
+  rho1 = fsp[1].density.value();
+  mu1 = fsp[1].viscosity.value();
+  h1 = fsp[1].enthalpy.value();
 
-  _fp->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  rho2 = fsp[1].density;
-  mu2 = fsp[1].viscosity;
-  h2 = fsp[1].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
+  rho2 = fsp[1].density.value();
+  mu2 = fsp[1].viscosity.value();
+  h2 = fsp[1].enthalpy.value();
 
-  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(gas_density.derivatives()[_Zidx], (rho1 - rho2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(gas_viscosity.derivatives()[_Zidx], (mu1 - mu2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(gas_enthalpy.derivatives()[_Zidx], (h1 - h2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -546,314 +506,288 @@ TEST_F(PorousFlowBrineCO2Test, gasProperties)
  */
 TEST_F(PorousFlowBrineCO2Test, liquidProperties)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
-  const Real Xnacl = 0.1;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
 
   FluidStatePhaseEnum phase_state;
-  const unsigned int np = _fp->numPhases();
-  const unsigned int nc = _fp->numComponents();
+  const unsigned int np = _fs->numPhases();
+  const unsigned int nc = _fs->numComponents();
   std::vector<FluidStateProperties> fsp(np, FluidStateProperties(nc));
 
   // Liquid region
-  Real Z = 0.0001;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  DualReal Z = 0.0001;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::LIQUID);
 
   // Verify fluid density and viscosity
-  _fp->liquidProperties(p, T, Xnacl, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
 
-  Real liquid_density = fsp[0].density;
-  Real liquid_viscosity = fsp[0].viscosity;
-  Real liquid_enthalpy = fsp[0].enthalpy;
+  DualReal liquid_density = fsp[0].density;
+  DualReal liquid_viscosity = fsp[0].viscosity;
+  DualReal liquid_enthalpy = fsp[0].enthalpy;
 
-  Real co2_partial_density, dco2_partial_density_dT;
-  _fp->partialDensityCO2(T, co2_partial_density, dco2_partial_density_dT);
-  Real brine_density = _brine_fp->rho_from_p_T_X(p, T, Xnacl);
+  Real co2_partial_density = _fs->partialDensityCO2(T).value();
+  Real brine_density = _brine_fp->rho_from_p_T_X(p.value(), T.value(), Xnacl.value());
 
-  Real density = 1.0 / (Z / co2_partial_density + (1.0 - Z) / brine_density);
+  Real density = 1.0 / (Z.value() / co2_partial_density + (1.0 - Z.value()) / brine_density);
 
-  Real viscosity = _brine_fp->mu_from_p_T_X(p, T, Xnacl);
+  Real viscosity = _brine_fp->mu_from_p_T_X(p.value(), T.value(), Xnacl.value());
 
-  Real brine_enthalpy = _brine_fp->h_from_p_T_X(p, T, Xnacl);
-  Real hdis, dhdis_dT;
-  _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  Real co2_enthalpy = _co2_fp->h_from_p_T(p, T);
-  Real enthalpy = (1.0 - Z) * brine_enthalpy + Z * (co2_enthalpy + hdis);
+  Real brine_enthalpy = _brine_fp->h_from_p_T_X(p.value(), T.value(), Xnacl.value());
+  Real hdis = _fs->enthalpyOfDissolution(T).value();
+  Real co2_enthalpy = _co2_fp->h_from_p_T(p.value(), T.value());
+  Real enthalpy = (1.0 - Z.value()) * brine_enthalpy + Z.value() * (co2_enthalpy + hdis);
 
-  ABS_TEST(liquid_density, density, 1.0e-12);
-  ABS_TEST(liquid_viscosity, viscosity, 1.0e-12);
-  ABS_TEST(liquid_enthalpy, enthalpy, 1.0e-12);
+  ABS_TEST(liquid_density.value(), density, 1.0e-12);
+  ABS_TEST(liquid_viscosity.value(), viscosity, 1.0e-12);
+  ABS_TEST(liquid_enthalpy.value(), enthalpy, 1.0e-12);
 
-  // Verify fluid density and viscosity derivatives
-  Real ddensity_dp = fsp[0].ddensity_dp;
-  Real ddensity_dT = fsp[0].ddensity_dT;
-  Real ddensity_dZ = fsp[0].ddensity_dZ;
-  Real ddensity_dX = fsp[0].ddensity_dX;
-  Real dviscosity_dp = fsp[0].dviscosity_dp;
-  Real dviscosity_dT = fsp[0].dviscosity_dT;
-  Real dviscosity_dZ = fsp[0].dviscosity_dZ;
-  Real dviscosity_dX = fsp[0].dviscosity_dX;
-  Real denthalpy_dp = fsp[0].denthalpy_dp;
-  Real denthalpy_dT = fsp[0].denthalpy_dT;
-  Real denthalpy_dZ = fsp[0].denthalpy_dZ;
-  Real denthalpy_dX = fsp[0].denthalpy_dX;
-
+  // Verify derivatives
   // Derivatives wrt pressure
   const Real dp = 1.0;
-  _fp->liquidProperties(p + dp, T, Xnacl, fsp);
-  Real rho1 = fsp[0].density;
-  Real mu1 = fsp[0].viscosity;
-  Real h1 = fsp[0].enthalpy;
+  _fs->liquidProperties(p + dp, T, Xnacl, fsp);
+  Real rho1 = fsp[0].density.value();
+  Real mu1 = fsp[0].viscosity.value();
+  Real h1 = fsp[0].enthalpy.value();
 
-  _fp->liquidProperties(p - dp, T, Xnacl, fsp);
-  Real rho2 = fsp[0].density;
-  Real mu2 = fsp[0].viscosity;
-  Real h2 = fsp[0].enthalpy;
+  _fs->liquidProperties(p - dp, T, Xnacl, fsp);
+  Real rho2 = fsp[0].density.value();
+  Real mu2 = fsp[0].viscosity.value();
+  Real h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(liquid_density.derivatives()[_pidx], (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_pidx], (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_pidx], (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   // Derivatives wrt temperature
   const Real dT = 1.0e-4;
-  _fp->liquidProperties(p, T + dT, Xnacl, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->liquidProperties(p, T + dT, Xnacl, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->liquidProperties(p, T - dT, Xnacl, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->liquidProperties(p, T - dT, Xnacl, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_density.derivatives()[_Tidx], (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_Tidx], (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_Tidx], (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Derivatives wrt Xnacl
   const Real dx = 1.0e-8;
-  _fp->liquidProperties(p, T, Xnacl + dx, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->liquidProperties(p, T, Xnacl + dx, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->liquidProperties(p, T, Xnacl - dx, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->liquidProperties(p, T, Xnacl - dx, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
-  REL_TEST(dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
-  REL_TEST(denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_density.derivatives()[_Xidx], (rho1 - rho2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_Xidx], (mu1 - mu2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_Xidx], (h1 - h2) / (2.0 * dx), 1.0e-6);
 
   // Derivatives wrt Z
   const Real dZ = 1.0e-8;
-  _fp->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(liquid_density.derivatives()[_Zidx], (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(liquid_viscosity.derivatives()[_Zidx], (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_Zidx], (h1 - h2) / (2.0 * dZ), 1.0e-6);
 
   // Two-phase region
   Z = 0.045;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
   // Verify fluid density and viscosity derivatives
-  _fp->liquidProperties(p, T, Xnacl, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
 
-  ddensity_dp = fsp[0].ddensity_dp;
-  ddensity_dT = fsp[0].ddensity_dT;
-  ddensity_dX = fsp[0].ddensity_dX;
-  ddensity_dZ = fsp[0].ddensity_dZ;
-  dviscosity_dp = fsp[0].dviscosity_dp;
-  dviscosity_dT = fsp[0].dviscosity_dT;
-  dviscosity_dX = fsp[0].dviscosity_dX;
-  dviscosity_dZ = fsp[0].dviscosity_dZ;
-  denthalpy_dp = fsp[0].denthalpy_dp;
-  denthalpy_dT = fsp[0].denthalpy_dT;
-  denthalpy_dZ = fsp[0].denthalpy_dZ;
-  denthalpy_dX = fsp[0].denthalpy_dX;
+  liquid_density = fsp[0].density;
+  liquid_viscosity = fsp[0].viscosity;
+  liquid_enthalpy = fsp[0].enthalpy;
 
   // Derivatives wrt pressure
-  _fp->massFractions(p + dp, T, Xnacl, Z, phase_state, fsp);
-  _fp->liquidProperties(p + dp, T, Xnacl, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->massFractions(p + dp, T, Xnacl, Z, phase_state, fsp);
+  _fs->liquidProperties(p + dp, T, Xnacl, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->massFractions(p - dp, T, Xnacl, Z, phase_state, fsp);
-  _fp->liquidProperties(p - dp, T, Xnacl, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->massFractions(p - dp, T, Xnacl, Z, phase_state, fsp);
+  _fs->liquidProperties(p - dp, T, Xnacl, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-4);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-4);
+  REL_TEST(liquid_density.derivatives()[_pidx], (rho1 - rho2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_pidx], (mu1 - mu2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_pidx], (h1 - h2) / (2.0 * dp), 1.0e-6);
 
   // Derivatives wrt temperature
-  _fp->massFractions(p, T + dT, Xnacl, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T + dT, Xnacl, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->massFractions(p, T + dT, Xnacl, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T + dT, Xnacl, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->massFractions(p, T - dT, Xnacl, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T - dT, Xnacl, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->massFractions(p, T - dT, Xnacl, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T - dT, Xnacl, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_density.derivatives()[_Tidx], (rho1 - rho2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_Tidx], (mu1 - mu2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_Tidx], (h1 - h2) / (2.0 * dT), 1.0e-6);
 
   // Derivatives wrt Xnacl
-  _fp->massFractions(p, T, Xnacl + dx, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl + dx, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl + dx, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl + dx, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->massFractions(p, T, Xnacl - dx, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl - dx, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl - dx, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl - dx, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  REL_TEST(ddensity_dX, (rho1 - rho2) / (2.0 * dx), 1.0e-6);
-  REL_TEST(dviscosity_dX, (mu1 - mu2) / (2.0 * dx), 1.0e-6);
-  REL_TEST(denthalpy_dX, (h1 - h2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_density.derivatives()[_Xidx], (rho1 - rho2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_viscosity.derivatives()[_Xidx], (mu1 - mu2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(liquid_enthalpy.derivatives()[_Xidx], (h1 - h2) / (2.0 * dx), 1.0e-6);
 
   // Derivatives wrt Z
-  _fp->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl, fsp);
-  rho1 = fsp[0].density;
-  mu1 = fsp[0].viscosity;
-  h1 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z + dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
+  rho1 = fsp[0].density.value();
+  mu1 = fsp[0].viscosity.value();
+  h1 = fsp[0].enthalpy.value();
 
-  _fp->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, Xnacl, fsp);
-  rho2 = fsp[0].density;
-  mu2 = fsp[0].viscosity;
-  h2 = fsp[0].enthalpy;
+  _fs->massFractions(p, T, Xnacl, Z - dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, Xnacl, fsp);
+  rho2 = fsp[0].density.value();
+  mu2 = fsp[0].viscosity.value();
+  h2 = fsp[0].enthalpy.value();
 
-  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(liquid_density.derivatives()[_Zidx], (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(liquid_viscosity.derivatives()[_Zidx], (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(liquid_enthalpy.derivatives()[_Zidx], (h1 - h2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
  * Verify calculation of gas saturation and derivatives in the two-phase region
  */
-TEST_F(PorousFlowBrineCO2Test, saturationTwoPhase)
+TEST_F(PorousFlowBrineCO2Test, saturation)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
-  const Real Xnacl = 0.1;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
 
   FluidStatePhaseEnum phase_state;
-  const unsigned int np = _fp->numPhases();
-  const unsigned int nc = _fp->numComponents();
+  const unsigned int np = _fs->numPhases();
+  const unsigned int nc = _fs->numComponents();
   std::vector<FluidStateProperties> fsp(np, FluidStateProperties(nc));
 
   // In the two-phase region, the mass fractions are the equilibrium values, so
   // a temporary value of Z can be used (as long as it corresponds to the two-phase
   // region)
-  Real Z = 0.45;
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  DualReal Z = 0.45;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
   // Calculate Z that gives a saturation of 0.25
-  Real gas_saturation = 0.25;
-  Real liquid_pressure = p + _pc->capillaryPressure(1.0 - gas_saturation);
+  DualReal gas_saturation = 0.25;
+  DualReal liquid_pressure = p - _pc->capillaryPressure(1.0 - gas_saturation);
+
   // Calculate gas density and liquid density
-  _fp->gasProperties(p, T, fsp);
-  _fp->liquidProperties(liquid_pressure, T, Xnacl, fsp);
+  _fs->gasProperties(p, T, fsp);
+  _fs->liquidProperties(liquid_pressure, T, Xnacl, fsp);
 
   // The mass fraction that corresponds to a gas_saturation = 0.25
-  Z = (gas_saturation * fsp[1].density * fsp[1].mass_fraction[1] +
-       (1.0 - gas_saturation) * fsp[0].density * fsp[0].mass_fraction[1]) /
-      (gas_saturation * fsp[1].density + (1.0 - gas_saturation) * fsp[0].density);
+  DualReal Zc = (gas_saturation * fsp[1].density * fsp[1].mass_fraction[1] +
+                 (1.0 - gas_saturation) * fsp[0].density * fsp[0].mass_fraction[1]) /
+                (gas_saturation * fsp[1].density + (1.0 - gas_saturation) * fsp[0].density);
 
   // Calculate the gas saturation and derivatives
-  _fp->saturationTwoPhase(p, T, Xnacl, Z, fsp);
+  DualReal saturation = _fs->saturation(p, T, Xnacl, Zc, fsp);
+  ABS_TEST(saturation.value(), gas_saturation.value(), 1.0e-6);
 
-  ABS_TEST(fsp[1].saturation, gas_saturation, 1.0e-8);
+  // Test the derivatives of gas saturation
+  gas_saturation = _fs->saturation(p, T, Xnacl, Z, fsp);
 
-  // Test the derivatives
   const Real dp = 1.0e-1;
-  gas_saturation = fsp[1].saturation;
-  Real dgas_saturation_dp = fsp[1].dsaturation_dp;
-  Real dgas_saturation_dT = fsp[1].dsaturation_dT;
-  Real dgas_saturation_dX = fsp[1].dsaturation_dX;
-  Real dgas_saturation_dZ = fsp[1].dsaturation_dZ;
 
   // Derivative wrt pressure
-  _fp->massFractions(p + dp, T, Xnacl, Z, phase_state, fsp);
-  _fp->gasProperties(p + dp, T, fsp);
-  _fp->saturationTwoPhase(p + dp, T, Xnacl, Z, fsp);
-  Real gsat1 = fsp[1].saturation;
+  _fs->massFractions(p + dp, T, Xnacl, Z, phase_state, fsp);
+  Real gsat1 = _fs->saturation(p + dp, T, Xnacl, Z, fsp).value();
 
-  _fp->massFractions(p - dp, T, Xnacl, Z, phase_state, fsp);
-  _fp->gasProperties(p - dp, T, fsp);
-  _fp->saturationTwoPhase(p - dp, T, Xnacl, Z, fsp);
-  Real gsat2 = fsp[1].saturation;
+  _fs->massFractions(p - dp, T, Xnacl, Z, phase_state, fsp);
+  Real gsat2 = _fs->saturation(p - dp, T, Xnacl, Z, fsp).value();
 
-  REL_TEST(dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(gas_saturation.derivatives()[_pidx], (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
 
   // Derivative wrt temperature
   const Real dT = 1.0e-4;
-  _fp->massFractions(p, T + dT, Xnacl, Z, phase_state, fsp);
-  _fp->gasProperties(p, T + dT, fsp);
-  _fp->saturationTwoPhase(p, T + dT, Xnacl, Z, fsp);
-  gsat1 = fsp[1].saturation;
+  _fs->massFractions(p, T + dT, Xnacl, Z, phase_state, fsp);
+  gsat1 = _fs->saturation(p, T + dT, Xnacl, Z, fsp).value();
 
-  _fp->massFractions(p, T - dT, Xnacl, Z, phase_state, fsp);
-  _fp->gasProperties(p, T - dT, fsp);
-  _fp->saturationTwoPhase(p, T - dT, Xnacl, Z, fsp);
-  gsat2 = fsp[1].saturation;
+  _fs->massFractions(p, T - dT, Xnacl, Z, phase_state, fsp);
+  gsat2 = _fs->saturation(p, T - dT, Xnacl, Z, fsp).value();
 
-  REL_TEST(dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(gas_saturation.derivatives()[_Tidx], (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
 
   // Derivative wrt Xnacl
   const Real dx = 1.0e-8;
-  _fp->massFractions(p, T, Xnacl + dx, Z, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  _fp->saturationTwoPhase(p, T, Xnacl + dx, Z, fsp);
-  gsat1 = fsp[1].saturation;
+  _fs->massFractions(p, T, Xnacl + dx, Z, phase_state, fsp);
+  gsat1 = _fs->saturation(p, T, Xnacl + dx, Z, fsp).value();
 
-  _fp->massFractions(p, T, Xnacl - dx, Z, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  _fp->saturationTwoPhase(p, T, Xnacl - dx, Z, fsp);
-  gsat2 = fsp[1].saturation;
+  _fs->massFractions(p, T, Xnacl - dx, Z, phase_state, fsp);
+  gsat2 = _fs->saturation(p, T, Xnacl - dx, Z, fsp).value();
 
-  REL_TEST(dgas_saturation_dX, (gsat1 - gsat2) / (2.0 * dx), 1.0e-6);
+  REL_TEST(gas_saturation.derivatives()[_Xidx], (gsat1 - gsat2) / (2.0 * dx), 1.0e-6);
 
   // Derivative wrt Z
   const Real dZ = 1.0e-8;
 
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  _fp->saturationTwoPhase(p, T, Xnacl, Z + dZ, fsp);
-  gsat1 = fsp[1].saturation;
+  _fs->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  gsat1 = _fs->saturation(p, T, Xnacl, Z + dZ, fsp).value();
 
-  _fp->saturationTwoPhase(p, T, Xnacl, Z - dZ, fsp);
-  gsat2 = fsp[1].saturation;
+  gsat2 = _fs->saturation(p, T, Xnacl, Z - dZ, fsp).value();
 
-  REL_TEST(dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(gas_saturation.derivatives()[_Zidx], (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
 }
 
 /*
@@ -867,22 +801,23 @@ TEST_F(PorousFlowBrineCO2Test, totalMassFraction)
   const Real s = 0.2;
   const unsigned qp = 0;
 
-  Real Z = _fp->totalMassFraction(p, T, Xnacl, s, qp);
+  Real Z = _fs->totalMassFraction(p, T, Xnacl, s, qp);
 
   // Test that the saturation calculated in this fluid state using Z is equal to s
   FluidStatePhaseEnum phase_state;
-  const unsigned int np = _fp->numPhases();
-  const unsigned int nc = _fp->numComponents();
+  const unsigned int np = _fs->numPhases();
+  const unsigned int nc = _fs->numComponents();
   std::vector<FluidStateProperties> fsp(np, FluidStateProperties(nc));
 
-  _fp->massFractions(p, T, Xnacl, Z, phase_state, fsp);
+  DualReal pressure = p;
+  DualReal temperature = T;
+  DualReal z = Z;
+  DualReal x = Xnacl;
+  _fs->massFractions(pressure, temperature, x, z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
-  _fp->gasProperties(p, T, fsp);
-  Real liquid_pressure = p + _pc->capillaryPressure(1.0 - s);
-  _fp->liquidProperties(liquid_pressure, T, Xnacl, fsp);
-  _fp->saturationTwoPhase(p, T, Xnacl, Z, fsp);
-  ABS_TEST(fsp[1].saturation, s, 1.0e-8);
+  DualReal gas_saturation = _fs->saturation(pressure, temperature, x, z, fsp);
+  ABS_TEST(gas_saturation, s, 1.0e-6);
 }
 
 /*
@@ -893,33 +828,37 @@ TEST_F(PorousFlowBrineCO2Test, totalMassFraction)
  */
 TEST_F(PorousFlowBrineCO2Test, henryConstant)
 {
-  Real T = 373.15;
-  Real Xnacl = 0.1;
+  DualReal T = 373.15;
+  T.derivatives()[_Tidx] = 1.0;
 
-  Real Kh, dKh_dT, dKh_dX;
-  _fp->henryConstant(T, Xnacl, Kh, dKh_dT, dKh_dX);
-  REL_TEST(Kh, 7.46559e+08, 1.0e-3);
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
+
+  DualReal Kh = _fs->henryConstant(T, Xnacl);
+  REL_TEST(Kh.value(), 7.46559e+08, 1.0e-3);
 
   T = 473.15;
-  Xnacl = 0.2;
+  T.derivatives()[_Tidx] = 1.0;
 
-  _fp->henryConstant(T, Xnacl, Kh, dKh_dT, dKh_dX);
-  REL_TEST(Kh, 1.66069e+09, 1.0e-3);
+  Xnacl = 0.2;
+  Xnacl.derivatives()[_Xidx] = 1.0;
+
+  Kh = _fs->henryConstant(T, Xnacl);
+  REL_TEST(Kh.value(), 1.66069e+09, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
-  Real Kh2, dKh2_dT, dKh2_dX;
-  _fp->henryConstant(T + dT, Xnacl, Kh, dKh_dT, dKh_dX);
-  _fp->henryConstant(T - dT, Xnacl, Kh2, dKh2_dT, dKh2_dX);
+  DualReal Kh1 = _fs->henryConstant(T + dT, Xnacl);
+  DualReal Kh2 = _fs->henryConstant(T - dT, Xnacl);
 
-  REL_TEST(dKh_dT, (Kh - Kh2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(Kh.derivatives()[_Tidx], (Kh1.value() - Kh2.value()) / (2.0 * dT), 1.0e-6);
 
   // Test the derivative wrt Xnacl
   const Real dx = 1.0e-8;
-  _fp->henryConstant(T, Xnacl + dx, Kh, dKh_dT, dKh_dX);
-  _fp->henryConstant(T, Xnacl - dx, Kh2, dKh2_dT, dKh2_dX);
+  Kh1 = _fs->henryConstant(T, Xnacl + dx);
+  Kh2 = _fs->henryConstant(T, Xnacl - dx);
 
-  REL_TEST(dKh_dX, (Kh - Kh2) / (2.0 * dx), 1.0e-5);
+  REL_TEST(Kh.derivatives()[_Xidx], (Kh1.value() - Kh2.value()) / (2.0 * dx), 1.0e-6);
 }
 
 /*
@@ -930,35 +869,37 @@ TEST_F(PorousFlowBrineCO2Test, henryConstant)
 TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolutionGas)
 {
   // T = 50C
-  Real T = 323.15;
-  Real Xnacl = 0.1;
+  DualReal T = 323.15;
+  T.derivatives()[_Tidx] = 1.0;
+
+  DualReal Xnacl = 0.1;
+  Xnacl.derivatives()[_Xidx] = 1.0;
 
   // Enthalpy of dissolution of CO2 in brine
-  Real hdis, dhdis_dT, dhdis_dX;
-  _fp->enthalpyOfDissolutionGas(T, Xnacl, hdis, dhdis_dT, dhdis_dX);
+  DualReal hdis = _fs->enthalpyOfDissolutionGas(T, Xnacl);
   REL_TEST(hdis, -3.20130e5, 1.0e-3);
 
   // T = 350C
   T = 623.15;
+  T.derivatives()[_Tidx] = 1.0;
 
   // Enthalpy of dissolution of CO2 in brine
-  _fp->enthalpyOfDissolutionGas(T, Xnacl, hdis, dhdis_dT, dhdis_dX);
+  hdis = _fs->enthalpyOfDissolutionGas(T, Xnacl);
   REL_TEST(hdis, 9.83813e+05, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
-  Real hdis1, dhdis1_dT, dhdis1_dX, hdis2, dhdis2_dT, dhdis2_dX;
-  _fp->enthalpyOfDissolutionGas(T + dT, Xnacl, hdis1, dhdis1_dT, dhdis1_dX);
-  _fp->enthalpyOfDissolutionGas(T - dT, Xnacl, hdis2, dhdis2_dT, dhdis2_dX);
+  Real hdis1 = _fs->enthalpyOfDissolutionGas(T + dT, Xnacl).value();
+  Real hdis2 = _fs->enthalpyOfDissolutionGas(T - dT, Xnacl).value();
 
-  REL_TEST(dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(hdis.derivatives()[_Tidx], (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
 
   // Test the derivative wrt salt mass fraction
   const Real dx = 1.0e-8;
-  _fp->enthalpyOfDissolutionGas(T, Xnacl + dx, hdis1, dhdis1_dT, dhdis1_dX);
-  _fp->enthalpyOfDissolutionGas(T, Xnacl - dx, hdis2, dhdis2_dT, dhdis2_dX);
+  hdis1 = _fs->enthalpyOfDissolutionGas(T, Xnacl + dx).value();
+  hdis2 = _fs->enthalpyOfDissolutionGas(T, Xnacl - dx).value();
 
-  REL_TEST(dhdis_dX, (hdis1 - hdis2) / (2.0 * dx), 1.0e-5);
+  REL_TEST(hdis.derivatives()[_Xidx], (hdis1 - hdis2) / (2.0 * dx), 1.0e-5);
 }
 
 /*
@@ -970,27 +911,27 @@ TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolutionGas)
 TEST_F(PorousFlowBrineCO2Test, enthalpyOfDissolution)
 {
   // T = 50C
-  Real T = 323.15;
+  DualReal T = 323.15;
+  T.derivatives()[_Tidx] = 1.0;
 
   // Enthalpy of dissolution of CO2 in water
-  Real hdis, dhdis_dT;
-  _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST(hdis, -3.38185e5, 1.0e-3);
+  DualReal hdis = _fs->enthalpyOfDissolution(T);
+  REL_TEST(hdis.value(), -3.38185e5, 1.0e-3);
 
   // T = 350C
   T = 623.15;
+  T.derivatives()[_Tidx] = 1.0;
 
   // Enthalpy of dissolution of CO2 in water
-  _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST(hdis, 5.78787e5, 1.0e-3);
+  hdis = _fs->enthalpyOfDissolution(T);
+  REL_TEST(hdis.value(), 5.78787e5, 1.0e-3);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
-  Real hdis1, dhdis1_dT, hdis2, dhdis2_dT;
-  _fp->enthalpyOfDissolution(T + dT, hdis1, dhdis1_dT);
-  _fp->enthalpyOfDissolution(T - dT, hdis2, dhdis2_dT);
+  Real hdis1 = _fs->enthalpyOfDissolution(T + dT).value();
+  Real hdis2 = _fs->enthalpyOfDissolution(T - dT).value();
 
-  REL_TEST(dhdis_dT, (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(hdis.derivatives()[_Tidx], (hdis1 - hdis2) / (2.0 * dT), 1.0e-5);
 }
 
 /**
@@ -1005,7 +946,7 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
 
   Real yh2o, xco2;
   Real co2_density = _co2_fp->rho_from_p_T(p, T);
-  _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
+  _fs->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
   ABS_TEST(yh2o, 0.161429743509, 1.0e-10);
   ABS_TEST(xco2, 0.0236966821858, 1.0e-10);
 
@@ -1014,7 +955,7 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
   T = 423.15;
   Xnacl = 0.105;
 
-  _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
+  _fs->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
   ABS_TEST(yh2o, 0.0468197608955, 1.0e-10);
   ABS_TEST(xco2, 0.0236644599437, 1.0e-10);
 
@@ -1023,7 +964,7 @@ TEST_F(PorousFlowBrineCO2Test, solveEquilibriumMoleFractionHighTemp)
   Xnacl = 0.189;
 
   co2_density = _co2_fp->rho_from_p_T(p, T);
-  _fp->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
+  _fs->solveEquilibriumMoleFractionHighTemp(p, T, Xnacl, co2_density, xco2, yh2o);
   ABS_TEST(yh2o, 0.253292728991, 1.0e-10);
   ABS_TEST(xco2, 0.0168344513321, 1.0e-10);
 }
@@ -1035,37 +976,37 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMoleFractions)
 {
   // Test pure water (Xnacl = 0)
   // Low temperature regime
-  Real p = 20.0e6;
-  Real T = 323.15;
-  Real Xnacl = 0.0;
+  DualReal p = 20.0e6;
+  DualReal T = 323.15;
+  DualReal Xnacl = 0.0;
 
-  Real x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX;
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.0069638270001, 1.0e-8);
-  ABS_TEST(x, 0.0236535616524, 1.0e-8);
+  DualReal x, y;
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.0069638270001, 1.0e-8);
+  ABS_TEST(x.value(), 0.0236535616524, 1.0e-8);
 
   // Intermediate temperature regime
   T = 373.15;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.0194363768549, 1.0e-8);
-  ABS_TEST(x, 0.0201950146387, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.0194394631944, 1.0e-8);
+  ABS_TEST(x.value(), 0.020195776139, 1.0e-8);
 
   // High temperature regime
   p = 30.0e6;
   T = 523.15;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.286117195565, 1.0e-8);
-  ABS_TEST(x, 0.0409622051253, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.286117195565, 1.0e-8);
+  ABS_TEST(x.value(), 0.0409622051253, 1.0e-8);
 
   // High temperature regime with low pressure
   p = 1.0e6;
   T = 523.15;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 1.0, 1.0e-8);
-  ABS_TEST(x, 0.0, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 1.0, 1.0e-8);
+  ABS_TEST(x.value(), 0.0, 1.0e-8);
 
   // Test brine (Xnacl = 0.1)
   // Low temperature regime
@@ -1073,22 +1014,22 @@ TEST_F(PorousFlowBrineCO2Test, equilibriumMoleFractions)
   T = 323.15;
   Xnacl = 0.1;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.00657324876094, 1.0e-8);
-  ABS_TEST(x, 0.0152851601478, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.00657324876094, 1.0e-8);
+  ABS_TEST(x.value(), 0.0152851601478, 1.0e-8);
 
   // Intermediate temperature regime
   T = 373.15;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.0183105237286, 1.0e-8);
-  ABS_TEST(x, 0.013264842448, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.01831360857, 1.0e-8);
+  ABS_TEST(x.value(), 0.0132653916293, 1.0e-8);
 
   // High temperature regime
   p = 30.0e6;
   T = 523.15;
 
-  _fp->equilibriumMoleFractions(p, T, Xnacl, x, dx_dp, dx_dT, dx_dX, y, dy_dp, dy_dT, dy_dX);
-  ABS_TEST(y, 0.270258924237, 1.0e-8);
-  ABS_TEST(x, 0.0246589135776, 1.0e-8);
+  _fs->equilibriumMoleFractions(p, T, Xnacl, x, y);
+  ABS_TEST(y.value(), 0.270258924237, 1.0e-8);
+  ABS_TEST(x.value(), 0.0246589135776, 1.0e-8);
 }

--- a/unit/src/PorousFlowWaterNCGTest.C
+++ b/unit/src/PorousFlowWaterNCGTest.C
@@ -13,42 +13,41 @@
 /**
  * Verify that the correct name is supplied
  */
-TEST_F(PorousFlowWaterNCGTest, name) { EXPECT_EQ("water-ncg", _fp->fluidStateName()); }
+TEST_F(PorousFlowWaterNCGTest, name) { EXPECT_EQ("water-ncg", _fs->fluidStateName()); }
 
 /*
  * Verify calculation of equilibrium mass fraction and derivatives
  */
 TEST_F(PorousFlowWaterNCGTest, equilibriumMassFraction)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
-  const Real dp = 1.0e-2;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  const Real dp = 1.0e-1;
   const Real dT = 1.0e-6;
-  Real Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT;
-  Real Xncg1, dXncg1_dp, dXncg1_dT, Yh2o1, dYh2o1_dp, dYh2o1_dT;
-  Real Xncg2, dXncg2_dp, dXncg2_dT, Yh2o2, dYh2o2_dp, dYh2o2_dT;
-  _fp->equilibriumMassFractions(p, T, Xncg, dXncg_dp, dXncg_dT, Yh2o, dYh2o_dp, dYh2o_dT);
-  _fp->equilibriumMassFractions(
-      p - dp, T, Xncg1, dXncg1_dp, dXncg1_dT, Yh2o1, dYh2o1_dp, dYh2o1_dT);
-  _fp->equilibriumMassFractions(
-      p + dp, T, Xncg2, dXncg2_dp, dXncg2_dT, Yh2o2, dYh2o2_dp, dYh2o2_dT);
 
-  Real dXncg_dp_fd = (Xncg2 - Xncg1) / (2.0 * dp);
-  Real dYh2o_dp_fd = (Yh2o2 - Yh2o1) / (2.0 * dp);
+  DualReal Xncg, Yh2o, Xncg1, Yh2o1, Xncg2, Yh2o2;
+  _fs->equilibriumMassFractions(p, T, Xncg, Yh2o);
+  _fs->equilibriumMassFractions(p - dp, T, Xncg1, Yh2o1);
+  _fs->equilibriumMassFractions(p + dp, T, Xncg2, Yh2o2);
 
-  REL_TEST(dXncg_dp, dXncg_dp_fd, 1.0e-6);
-  REL_TEST(dYh2o_dp, dYh2o_dp_fd, 1.0e-6);
+  Real dXncg_dp_fd = (Xncg2.value() - Xncg1.value()) / (2.0 * dp);
+  Real dYh2o_dp_fd = (Yh2o2.value() - Yh2o1.value()) / (2.0 * dp);
 
-  _fp->equilibriumMassFractions(
-      p, T - dT, Xncg1, dXncg1_dp, dXncg1_dT, Yh2o1, dYh2o1_dp, dYh2o1_dT);
-  _fp->equilibriumMassFractions(
-      p, T + dT, Xncg2, dXncg2_dp, dXncg2_dT, Yh2o2, dYh2o2_dp, dYh2o2_dT);
+  REL_TEST(Xncg.derivatives()[_pidx], dXncg_dp_fd, 1.0e-8);
+  REL_TEST(Yh2o.derivatives()[_pidx], dYh2o_dp_fd, 1.0e-7);
 
-  Real dXncg_dT_fd = (Xncg2 - Xncg1) / (2.0 * dT);
-  Real dYh2o_dT_fd = (Yh2o2 - Yh2o1) / (2.0 * dT);
+  _fs->equilibriumMassFractions(p, T - dT, Xncg1, Yh2o1);
+  _fs->equilibriumMassFractions(p, T + dT, Xncg2, Yh2o2);
 
-  REL_TEST(dXncg_dT, dXncg_dT_fd, 1.0e-6);
-  REL_TEST(dYh2o_dT, dYh2o_dT_fd, 1.0e-6);
+  Real dXncg_dT_fd = (Xncg2.value() - Xncg1.value()) / (2.0 * dT);
+  Real dYh2o_dT_fd = (Yh2o2.value() - Yh2o1.value()) / (2.0 * dT);
+
+  REL_TEST(Xncg.derivatives()[_Tidx], dXncg_dT_fd, 1.0e-7);
+  REL_TEST(Yh2o.derivatives()[_Tidx], dYh2o_dT_fd, 1.0e-7);
 }
 
 /*
@@ -57,43 +56,51 @@ TEST_F(PorousFlowWaterNCGTest, equilibriumMassFraction)
  */
 TEST_F(PorousFlowWaterNCGTest, MassFraction)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
   FluidStatePhaseEnum phase_state;
   std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
 
   // Liquid region
-  Real Z = 0.0001;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  DualReal Z = 0.0001;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::LIQUID);
 
   // Verfify mass fraction values
-  Real Xncg = fsp[0].mass_fraction[1];
-  Real Yncg = fsp[1].mass_fraction[1];
-  Real Xh2o = fsp[0].mass_fraction[0];
-  Real Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST(Xncg, Z, 1.0e-8);
-  ABS_TEST(Yncg, 0.0, 1.0e-8);
-  ABS_TEST(Xh2o, 1.0 - Z, 1.0e-8);
-  ABS_TEST(Yh2o, 0.0, 1.0e-8);
+  DualReal Xncg = fsp[0].mass_fraction[1];
+  DualReal Yncg = fsp[1].mass_fraction[1];
+  DualReal Xh2o = fsp[0].mass_fraction[0];
+  DualReal Yh2o = fsp[1].mass_fraction[0];
+  ABS_TEST(Xncg.value(), Z.value(), 1.0e-12);
+  ABS_TEST(Yncg.value(), 0.0, 1.0e-12);
+  ABS_TEST(Xh2o.value(), 1.0 - Z.value(), 1.0e-12);
+  ABS_TEST(Yh2o.value(), 0.0, 1.0e-12);
 
   // Verify derivatives
-  Real dXncg_dp = fsp[0].dmass_fraction_dp[1];
-  Real dXncg_dT = fsp[0].dmass_fraction_dT[1];
-  Real dXncg_dZ = fsp[0].dmass_fraction_dZ[1];
-  Real dYncg_dp = fsp[1].dmass_fraction_dp[1];
-  Real dYncg_dT = fsp[1].dmass_fraction_dT[1];
-  Real dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST(dXncg_dp, 0.0, 1.0e-8);
-  ABS_TEST(dXncg_dT, 0.0, 1.0e-8);
-  ABS_TEST(dXncg_dZ, 1.0, 1.0e-8);
-  ABS_TEST(dYncg_dp, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dT, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dZ, 0.0, 1.0e-8);
+  Real dXncg_dp = Xncg.derivatives()[_pidx];
+  Real dXncg_dT = Xncg.derivatives()[_Tidx];
+  Real dXncg_dZ = Xncg.derivatives()[_Zidx];
+  Real dYncg_dp = Yncg.derivatives()[_pidx];
+  Real dYncg_dT = Yncg.derivatives()[_Tidx];
+  Real dYncg_dZ = Yncg.derivatives()[_Zidx];
+  ABS_TEST(dXncg_dp, 0.0, 1.0e-12);
+  ABS_TEST(dXncg_dT, 0.0, 1.0e-12);
+  ABS_TEST(dXncg_dZ, 1.0, 1.0e-12);
+  ABS_TEST(dYncg_dp, 0.0, 1.0e-12);
+  ABS_TEST(dYncg_dT, 0.0, 1.0e-12);
+  ABS_TEST(dYncg_dZ, 0.0, 1.0e-12);
 
   // Gas region
   Z = 0.995;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::GAS);
 
   // Verfify mass fraction values
@@ -101,72 +108,102 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
   Yncg = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST(Xncg, 0.0, 1.0e-8);
-  ABS_TEST(Yncg, Z, 1.0e-8);
-  ABS_TEST(Xh2o, 0.0, 1.0e-8);
-  ABS_TEST(Yh2o, 1.0 - Z, 1.0e-8);
+  ABS_TEST(Xncg.value(), 0.0, 1.0e-12);
+  ABS_TEST(Yncg.value(), Z.value(), 1.0e-12);
+  ABS_TEST(Xh2o.value(), 0.0, 1.0e-12);
+  ABS_TEST(Yh2o.value(), 1.0 - Z.value(), 1.0e-12);
 
   // Verify derivatives
-  dXncg_dp = fsp[0].dmass_fraction_dp[1];
-  dXncg_dT = fsp[0].dmass_fraction_dT[1];
-  dXncg_dZ = fsp[0].dmass_fraction_dZ[1];
-  dYncg_dp = fsp[1].dmass_fraction_dp[1];
-  dYncg_dT = fsp[1].dmass_fraction_dT[1];
-  dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST(dXncg_dp, 0.0, 1.0e-8);
-  ABS_TEST(dXncg_dT, 0.0, 1.0e-8);
-  ABS_TEST(dXncg_dZ, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dp, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dT, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dZ, 1.0, 1.0e-8);
+  dXncg_dp = Xncg.derivatives()[_pidx];
+  dXncg_dT = Xncg.derivatives()[_Tidx];
+  dXncg_dZ = Xncg.derivatives()[_Zidx];
+  dYncg_dp = Yncg.derivatives()[_pidx];
+  dYncg_dT = Yncg.derivatives()[_Tidx];
+  dYncg_dZ = Yncg.derivatives()[_Zidx];
+  ABS_TEST(dXncg_dp, 0.0, 1.0e-12);
+  ABS_TEST(dXncg_dT, 0.0, 1.0e-12);
+  ABS_TEST(dXncg_dZ, 0.0, 1.0e-12);
+  ABS_TEST(dYncg_dp, 0.0, 1.0e-12);
+  ABS_TEST(dYncg_dT, 0.0, 1.0e-12);
+  ABS_TEST(dYncg_dZ, 1.0, 1.0e-12);
 
   // Two phase region. In this region, the mass fractions and derivatives can
   //  be verified using the equilibrium mass fraction derivatives that have
   // been verified above
   Z = 0.45;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
   // Equilibrium mass fractions and derivatives
-  Real Xncg_eq, dXncg_dp_eq, dXncg_dT_eq, Yh2o_eq, dYh2o_dp_eq, dYh2o_dT_eq;
-  _fp->equilibriumMassFractions(
-      p, T, Xncg_eq, dXncg_dp_eq, dXncg_dT_eq, Yh2o_eq, dYh2o_dp_eq, dYh2o_dT_eq);
+  DualReal Xncg_eq, Yh2o_eq;
+  _fs->equilibriumMassFractions(p, T, Xncg_eq, Yh2o_eq);
 
   // Verfify mass fraction values
   Xncg = fsp[0].mass_fraction[1];
   Yncg = fsp[1].mass_fraction[1];
   Xh2o = fsp[0].mass_fraction[0];
   Yh2o = fsp[1].mass_fraction[0];
-  ABS_TEST(Xncg, Xncg_eq, 1.0e-8);
-  ABS_TEST(Yncg, 1.0 - Yh2o_eq, 1.0e-8);
-  ABS_TEST(Xh2o, 1.0 - Xncg_eq, 1.0e-8);
-  ABS_TEST(Yh2o, Yh2o_eq, 1.0e-8);
+  ABS_TEST(Xncg, Xncg_eq, 1.0e-12);
+  ABS_TEST(Yncg, 1.0 - Yh2o_eq, 1.0e-12);
+  ABS_TEST(Xh2o, 1.0 - Xncg_eq, 1.0e-12);
+  ABS_TEST(Yh2o, Yh2o_eq, 1.0e-12);
 
   // Verify derivatives wrt p and T
-  dXncg_dp = fsp[0].dmass_fraction_dp[1];
-  dXncg_dT = fsp[0].dmass_fraction_dT[1];
-  dXncg_dZ = fsp[0].dmass_fraction_dZ[1];
-  dYncg_dp = fsp[1].dmass_fraction_dp[1];
-  dYncg_dT = fsp[1].dmass_fraction_dT[1];
-  dYncg_dZ = fsp[1].dmass_fraction_dZ[1];
-  ABS_TEST(dXncg_dp, dXncg_dp_eq, 1.0e-8);
-  ABS_TEST(dXncg_dT, dXncg_dT_eq, 1.0e-8);
+  dXncg_dp = Xncg.derivatives()[_pidx];
+  dXncg_dT = Xncg.derivatives()[_Tidx];
+  dXncg_dZ = Xncg.derivatives()[_Zidx];
+  dYncg_dp = Yncg.derivatives()[_pidx];
+  dYncg_dT = Yncg.derivatives()[_Tidx];
+  dYncg_dZ = Yncg.derivatives()[_Zidx];
+  ABS_TEST(dXncg_dp, Xncg_eq.derivatives()[_pidx], 1.0e-8);
+  ABS_TEST(dXncg_dT, Xncg_eq.derivatives()[_Tidx], 1.0e-8);
   ABS_TEST(dXncg_dZ, 0.0, 1.0e-8);
-  ABS_TEST(dYncg_dp, -dYh2o_dp_eq, 1.0e-8);
-  ABS_TEST(dYncg_dT, -dYh2o_dT_eq, 1.0e-8);
+  ABS_TEST(dYncg_dp, -Yh2o_eq.derivatives()[_pidx], 1.0e-8);
+  ABS_TEST(dYncg_dT, -Yh2o_eq.derivatives()[_Tidx], 1.0e-8);
   ABS_TEST(dYncg_dZ, 0.0, 1.0e-8);
 
   // Use finite differences to verify derivative wrt Z is unaffected by Z
   const Real dZ = 1.0e-8;
-  _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
-  Real Xncg1 = fsp[0].mass_fraction[1];
-  Real Yncg1 = fsp[1].mass_fraction[1];
-  _fp->massFractions(p, T, Z - dZ, phase_state, fsp);
-  Real Xncg2 = fsp[0].mass_fraction[1];
-  Real Yncg2 = fsp[1].mass_fraction[1];
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  DualReal Xncg1 = fsp[0].mass_fraction[1];
+  DualReal Yncg1 = fsp[1].mass_fraction[1];
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  DualReal Xncg2 = fsp[0].mass_fraction[1];
+  DualReal Yncg2 = fsp[1].mass_fraction[1];
 
-  ABS_TEST(dXncg_dZ, (Xncg1 - Xncg2) / (2.0 * dZ), 1.0e-8);
-  ABS_TEST(dYncg_dZ, (Yncg1 - Yncg2) / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dXncg_dZ, (Xncg1 - Xncg2).value() / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dYncg_dZ, (Yncg1 - Yncg2).value() / (2.0 * dZ), 1.0e-8);
+}
+
+/*
+ * Verify calculation of gas density and derivatives
+ */
+TEST_F(PorousFlowWaterNCGTest, gasDensity)
+{
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  FluidStatePhaseEnum phase_state;
+  std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
+
+  // Gas region
+  DualReal Z = 0.995;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
+  EXPECT_EQ(phase_state, FluidStatePhaseEnum::GAS);
+
+  const DualReal gas_density = _fs->gasDensity(p, T, fsp);
+
+  const DualReal density =
+      _ncg_fp->rho_from_p_T(Z * p, T) + _water_fp->rho_from_p_T(_water_fp->vaporPressure(T), T);
+
+  ABS_TEST(gas_density, density, 1.0e-12);
 }
 
 /*
@@ -174,156 +211,184 @@ TEST_F(PorousFlowWaterNCGTest, MassFraction)
  */
 TEST_F(PorousFlowWaterNCGTest, gasProperties)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
   FluidStatePhaseEnum phase_state;
   std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
 
   // Gas region
-  Real Z = 0.995;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  DualReal Z = 0.995;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::GAS);
 
   // Verify fluid density, viscosity and enthalpy
-  _fp->gasProperties(p, T, fsp);
-  Real gas_density = fsp[1].density;
-  Real gas_viscosity = fsp[1].viscosity;
-  Real gas_enthalpy = fsp[1].enthalpy;
+  _fs->gasProperties(p, T, fsp);
+  DualReal gas_density = fsp[1].density;
+  DualReal gas_viscosity = fsp[1].viscosity;
+  DualReal gas_enthalpy = fsp[1].enthalpy;
 
-  Real density =
+  DualReal density =
       _ncg_fp->rho_from_p_T(Z * p, T) + _water_fp->rho_from_p_T(_water_fp->vaporPressure(T), T);
-  Real viscosity = Z * _ncg_fp->mu_from_p_T(Z * p, T) +
-                   (1.0 - Z) * _water_fp->mu_from_p_T(_water_fp->vaporPressure(T), T);
-  Real enthalpy = Z * _ncg_fp->h_from_p_T(Z * p, T) +
-                  (1.0 - Z) * _water_fp->h_from_p_T(_water_fp->vaporPressure(T), T);
+  DualReal viscosity = Z * _ncg_fp->mu_from_p_T(Z * p, T) +
+                       (1.0 - Z) * _water_fp->mu_from_p_T(_water_fp->vaporPressure(T), T);
+  DualReal enthalpy = Z * _ncg_fp->h_from_p_T(Z * p, T) +
+                      (1.0 - Z) * _water_fp->h_from_p_T(_water_fp->vaporPressure(T), T);
 
-  ABS_TEST(gas_density, density, 1.0e-8);
-  ABS_TEST(gas_viscosity, viscosity, 1.0e-8);
-  ABS_TEST(gas_enthalpy, enthalpy, 1.0e-8);
+  ABS_TEST(gas_density, density, 1.0e-10);
+  ABS_TEST(gas_viscosity, viscosity, 1.0e-10);
+  ABS_TEST(gas_enthalpy, enthalpy, 1.0e-10);
 
   // Verify derivatives
-  Real ddensity_dp = fsp[1].ddensity_dp;
-  Real ddensity_dT = fsp[1].ddensity_dT;
-  Real ddensity_dZ = fsp[1].ddensity_dZ;
-  Real dviscosity_dp = fsp[1].dviscosity_dp;
-  Real dviscosity_dT = fsp[1].dviscosity_dT;
-  Real dviscosity_dZ = fsp[1].dviscosity_dZ;
-  Real denthalpy_dp = fsp[1].denthalpy_dp;
-  Real denthalpy_dT = fsp[1].denthalpy_dT;
-  Real denthalpy_dZ = fsp[1].denthalpy_dZ;
+  Real ddensity_dp = gas_density.derivatives()[_pidx];
+  Real ddensity_dT = gas_density.derivatives()[_Tidx];
+  Real ddensity_dZ = gas_density.derivatives()[_Zidx];
+  Real dviscosity_dp = gas_viscosity.derivatives()[_pidx];
+  Real dviscosity_dT = gas_viscosity.derivatives()[_Tidx];
+  Real dviscosity_dZ = gas_viscosity.derivatives()[_Zidx];
+  Real denthalpy_dp = gas_enthalpy.derivatives()[_pidx];
+  Real denthalpy_dT = gas_enthalpy.derivatives()[_Tidx];
+  Real denthalpy_dZ = gas_enthalpy.derivatives()[_Zidx];
 
   const Real dp = 1.0e-1;
-  _fp->gasProperties(p + dp, T, fsp);
-  Real rho1 = fsp[1].density;
-  Real mu1 = fsp[1].viscosity;
-  Real h1 = fsp[1].enthalpy;
+  _fs->gasProperties(p + dp, T, fsp);
+  DualReal rho1 = fsp[1].density;
+  DualReal mu1 = fsp[1].viscosity;
+  DualReal h1 = fsp[1].enthalpy;
 
-  _fp->gasProperties(p - dp, T, fsp);
-  Real rho2 = fsp[1].density;
-  Real mu2 = fsp[1].viscosity;
-  Real h2 = fsp[1].enthalpy;
+  _fs->gasProperties(p - dp, T, fsp);
+  DualReal rho2 = fsp[1].density;
+  DualReal mu2 = fsp[1].viscosity;
+  DualReal h2 = fsp[1].enthalpy;
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(ddensity_dp, (rho1 - rho2).value() / (2.0 * dp), 1.0e-7);
+  REL_TEST(dviscosity_dp, (mu1 - mu2).value() / (2.0 * dp), 1.0e-7);
+  REL_TEST(denthalpy_dp, (h1 - h2).value() / (2.0 * dp), 5.0e-7);
 
   const Real dT = 1.0e-3;
-  _fp->gasProperties(p, T + dT, fsp);
+  _fs->gasProperties(p, T + dT, fsp);
   rho1 = fsp[1].density;
   mu1 = fsp[1].viscosity;
   h1 = fsp[1].enthalpy;
 
-  _fp->gasProperties(p, T - dT, fsp);
+  _fs->gasProperties(p, T - dT, fsp);
   rho2 = fsp[1].density;
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2).value() / (2.0 * dT), 1.0e-7);
+  REL_TEST(dviscosity_dT, (mu1 - mu2).value() / (2.0 * dT), 1.0e-8);
+  REL_TEST(denthalpy_dT, (h1 - h2).value() / (2.0 * dT), 1.0e-8);
 
   // Note: mass fraction changes with Z
   const Real dZ = 1.0e-8;
-  _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
   rho1 = fsp[1].density;
   mu1 = fsp[1].viscosity;
   h1 = fsp[1].enthalpy;
 
-  _fp->massFractions(p, T, Z - dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
   rho2 = fsp[1].density;
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST(dviscosity_dZ, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(ddensity_dZ, (rho1 - rho2).value() / (2.0 * dZ), 1.0e-8);
+  REL_TEST(dviscosity_dZ, (mu1 - mu2).value() / (2.0 * dZ), 1.0e-8);
+  REL_TEST(denthalpy_dZ, (h1 - h2).value() / (2.0 * dZ), 1.0e-8);
 
   // Check derivatives in the two phase region as well. Note that the mass fractions
   // vary with pressure and temperature in this region
   Z = 0.45;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
-  _fp->gasProperties(p, T, fsp);
-  ddensity_dp = fsp[1].ddensity_dp;
-  ddensity_dT = fsp[1].ddensity_dT;
-  ddensity_dZ = fsp[1].ddensity_dZ;
-  dviscosity_dp = fsp[1].dviscosity_dp;
-  dviscosity_dT = fsp[1].dviscosity_dT;
-  dviscosity_dZ = fsp[1].dviscosity_dZ;
-  denthalpy_dp = fsp[1].denthalpy_dp;
-  denthalpy_dT = fsp[1].denthalpy_dT;
-  denthalpy_dZ = fsp[1].denthalpy_dZ;
+  _fs->gasProperties(p, T, fsp);
+  gas_density = fsp[1].density;
+  gas_viscosity = fsp[1].viscosity;
+  gas_enthalpy = fsp[1].enthalpy;
+  ddensity_dp = gas_density.derivatives()[_pidx];
+  ddensity_dT = gas_density.derivatives()[_Tidx];
+  ddensity_dZ = gas_density.derivatives()[_Zidx];
+  dviscosity_dp = gas_viscosity.derivatives()[_pidx];
+  dviscosity_dT = gas_viscosity.derivatives()[_Tidx];
+  dviscosity_dZ = gas_viscosity.derivatives()[_Zidx];
+  denthalpy_dp = gas_enthalpy.derivatives()[_pidx];
+  denthalpy_dT = gas_enthalpy.derivatives()[_Tidx];
+  denthalpy_dZ = gas_enthalpy.derivatives()[_Zidx];
 
-  _fp->massFractions(p + dp, T, Z, phase_state, fsp);
-  _fp->gasProperties(p + dp, T, fsp);
+  _fs->massFractions(p + dp, T, Z, phase_state, fsp);
+  _fs->gasProperties(p + dp, T, fsp);
   rho1 = fsp[1].density;
   mu1 = fsp[1].viscosity;
   h1 = fsp[1].enthalpy;
 
-  _fp->massFractions(p - dp, T, Z, phase_state, fsp);
-  _fp->gasProperties(p - dp, T, fsp);
+  _fs->massFractions(p - dp, T, Z, phase_state, fsp);
+  _fs->gasProperties(p - dp, T, fsp);
   rho2 = fsp[1].density;
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-6);
+  REL_TEST(ddensity_dp, (rho1 - rho2).value() / (2.0 * dp), 1.0e-7);
+  REL_TEST(dviscosity_dp, (mu1 - mu2).value() / (2.0 * dp), 1.0e-7);
+  REL_TEST(denthalpy_dp, (h1 - h2).value() / (2.0 * dp), 1.0e-7);
 
-  _fp->massFractions(p, T + dT, Z, phase_state, fsp);
-  _fp->gasProperties(p, T + dT, fsp);
+  _fs->massFractions(p, T + dT, Z, phase_state, fsp);
+  _fs->gasProperties(p, T + dT, fsp);
   rho1 = fsp[1].density;
   mu1 = fsp[1].viscosity;
   h1 = fsp[1].enthalpy;
 
-  _fp->massFractions(p, T - dT, Z, phase_state, fsp);
-  _fp->gasProperties(p, T - dT, fsp);
+  _fs->massFractions(p, T - dT, Z, phase_state, fsp);
+  _fs->gasProperties(p, T - dT, fsp);
   rho2 = fsp[1].density;
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-6);
+  REL_TEST(ddensity_dT, (rho1 - rho2).value() / (2.0 * dT), 1.0e-7);
+  REL_TEST(dviscosity_dT, (mu1 - mu2).value() / (2.0 * dT), 1.0e-8);
+  REL_TEST(denthalpy_dT, (h1 - h2).value() / (2.0 * dT), 1.0e-8);
 
-  _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
   rho1 = fsp[1].density;
   mu1 = fsp[1].viscosity;
   h1 = fsp[1].enthalpy;
 
-  _fp->massFractions(p, T, Z - dZ, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  _fs->gasProperties(p, T, fsp);
   rho2 = fsp[1].density;
   mu2 = fsp[1].viscosity;
   h2 = fsp[1].enthalpy;
 
-  ABS_TEST(ddensity_dZ, (rho1 - rho2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dZ), 1.0e-6);
-  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  ABS_TEST(ddensity_dZ, (rho1 - rho2).value() / (2.0 * dZ), 1.0e-8);
+  ABS_TEST(dviscosity_dT, (mu1 - mu2).value() / (2.0 * dZ), 1.0e-7);
+  ABS_TEST(denthalpy_dZ, (h1 - h2).value() / (2.0 * dZ), 1.0e-8);
+}
+
+/*
+ * Verify calculation of liquid density and derivatives
+ */
+TEST_F(PorousFlowWaterNCGTest, liquidDensity)
+{
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  const DualReal liquid_density = _fs->liquidDensity(p, T);
+
+  const DualReal density = _water_fp->rho_from_p_T(p, T);
+  ABS_TEST(liquid_density, density, 1.0e-12);
 }
 
 /*
@@ -334,80 +399,88 @@ TEST_F(PorousFlowWaterNCGTest, gasProperties)
  */
 TEST_F(PorousFlowWaterNCGTest, liquidProperties)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  FluidStatePhaseEnum phase_state;
   std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
 
   // Verify fluid density and viscosity
-  _fp->liquidProperties(p, T, fsp);
-  Real liquid_density = fsp[0].density;
-  Real liquid_viscosity = fsp[0].viscosity;
-  Real density = _water_fp->rho_from_p_T(p, T);
-  Real viscosity = _water_fp->mu_from_p_T(p, T);
+  _fs->liquidProperties(p, T, fsp);
+  DualReal liquid_density = fsp[0].density;
+  DualReal liquid_viscosity = fsp[0].viscosity;
+  DualReal liquid_enthalpy = fsp[0].enthalpy;
+
+  DualReal density = _water_fp->rho_from_p_T(p, T);
+  DualReal viscosity = _water_fp->mu_from_p_T(p, T);
+  DualReal enthalpy = _water_fp->h_from_p_T(p, T);
 
   ABS_TEST(liquid_density, density, 1.0e-12);
   ABS_TEST(liquid_viscosity, viscosity, 1.0e-12);
+  ABS_TEST(liquid_enthalpy, enthalpy, 1.0e-12);
 
   // Verify derivatives
-  Real ddensity_dp = fsp[0].ddensity_dp;
-  Real ddensity_dT = fsp[0].ddensity_dT;
-  Real ddensity_dZ = fsp[0].ddensity_dZ;
-  Real dviscosity_dp = fsp[0].dviscosity_dp;
-  Real dviscosity_dT = fsp[0].dviscosity_dT;
-  Real dviscosity_dZ = fsp[0].dviscosity_dZ;
-  Real denthalpy_dp = fsp[0].denthalpy_dp;
-  Real denthalpy_dT = fsp[0].denthalpy_dT;
-  Real denthalpy_dZ = fsp[0].denthalpy_dZ;
+  Real ddensity_dp = liquid_density.derivatives()[_pidx];
+  Real ddensity_dT = liquid_density.derivatives()[_Tidx];
+  Real ddensity_dZ = liquid_density.derivatives()[_Zidx];
+  Real dviscosity_dp = liquid_viscosity.derivatives()[_pidx];
+  Real dviscosity_dT = liquid_viscosity.derivatives()[_Tidx];
+  Real dviscosity_dZ = liquid_viscosity.derivatives()[_Zidx];
+  Real denthalpy_dp = liquid_enthalpy.derivatives()[_pidx];
+  Real denthalpy_dT = liquid_enthalpy.derivatives()[_Tidx];
+  Real denthalpy_dZ = liquid_enthalpy.derivatives()[_Zidx];
 
-  const Real dp = 1.0;
-  _fp->liquidProperties(p + dp, T, fsp);
-  Real rho1 = fsp[0].density;
-  Real mu1 = fsp[0].viscosity;
-  Real h1 = fsp[0].enthalpy;
+  const Real dp = 10.0;
+  _fs->liquidProperties(p + dp, T, fsp);
+  DualReal rho1 = fsp[0].density;
+  DualReal mu1 = fsp[0].viscosity;
+  DualReal h1 = fsp[0].enthalpy;
 
-  _fp->liquidProperties(p - dp, T, fsp);
-  Real rho2 = fsp[0].density;
-  Real mu2 = fsp[0].viscosity;
-  Real h2 = fsp[0].enthalpy;
+  _fs->liquidProperties(p - dp, T, fsp);
+  DualReal rho2 = fsp[0].density;
+  DualReal mu2 = fsp[0].viscosity;
+  DualReal h2 = fsp[0].enthalpy;
 
-  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-6);
-  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-5);
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(ddensity_dp, (rho1 - rho2) / (2.0 * dp), 1.0e-8);
+  REL_TEST(dviscosity_dp, (mu1 - mu2) / (2.0 * dp), 1.0e-8);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-8);
 
   const Real dT = 1.0e-4;
-  _fp->liquidProperties(p, T + dT, fsp);
+  _fs->liquidProperties(p, T + dT, fsp);
   rho1 = fsp[0].density;
   mu1 = fsp[0].viscosity;
   h1 = fsp[0].enthalpy;
 
-  _fp->liquidProperties(p, T - dT, fsp);
+  _fs->liquidProperties(p, T - dT, fsp);
   rho2 = fsp[0].density;
   mu2 = fsp[0].viscosity;
   h2 = fsp[0].enthalpy;
 
-  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-6);
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(ddensity_dT, (rho1 - rho2) / (2.0 * dT), 1.0e-8);
+  REL_TEST(dviscosity_dT, (mu1 - mu2) / (2.0 * dT), 1.0e-8);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-8);
 
-  Real Z = 0.0001;
+  DualReal Z = 0.0001;
+  Z.derivatives()[_Zidx] = 1.0;
+
   const Real dZ = 1.0e-8;
-  FluidStatePhaseEnum phase_state;
 
-  _fp->massFractions(p, T, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
-  denthalpy_dp = fsp[0].denthalpy_dp;
-  denthalpy_dT = fsp[0].denthalpy_dT;
-  denthalpy_dZ = fsp[0].denthalpy_dZ;
+  _fs->massFractions(p, T, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
+  denthalpy_dZ = fsp[0].enthalpy.derivatives()[_Zidx];
 
-  _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
   h1 = fsp[0].enthalpy;
 
-  _fp->massFractions(p, T, Z - dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-8);
 
   // Density and viscosity don't depend on Z, so derivatives should be 0
   ABS_TEST(ddensity_dZ, 0.0, 1.0e-12);
@@ -416,50 +489,55 @@ TEST_F(PorousFlowWaterNCGTest, liquidProperties)
   // Check enthalpy calculations in the two phase region as well. Note that the mass fractions
   // vary with pressure and temperature in this region
   Z = 0.45;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
-  denthalpy_dp = fsp[0].denthalpy_dp;
-  denthalpy_dT = fsp[0].denthalpy_dT;
-  denthalpy_dZ = fsp[0].denthalpy_dZ;
+  Z.derivatives()[_Zidx] = 1.0;
 
-  _fp->massFractions(p + dp, T, Z, phase_state, fsp);
-  _fp->liquidProperties(p + dp, T, fsp);
+  _fs->massFractions(p, T, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
+  denthalpy_dp = fsp[0].enthalpy.derivatives()[_pidx];
+  denthalpy_dT = fsp[0].enthalpy.derivatives()[_Tidx];
+  denthalpy_dZ = fsp[0].enthalpy.derivatives()[_Zidx];
+
+  _fs->massFractions(p + dp, T, Z, phase_state, fsp);
+  _fs->liquidProperties(p + dp, T, fsp);
   h1 = fsp[0].enthalpy;
 
-  _fp->massFractions(p - dp, T, Z, phase_state, fsp);
-  _fp->liquidProperties(p - dp, T, fsp);
+  _fs->massFractions(p - dp, T, Z, phase_state, fsp);
+  _fs->liquidProperties(p - dp, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-5);
+  REL_TEST(denthalpy_dp, (h1 - h2) / (2.0 * dp), 1.0e-8);
 
-  _fp->massFractions(p, T + dT, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T + dT, fsp);
+  _fs->massFractions(p, T + dT, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T + dT, fsp);
   h1 = fsp[0].enthalpy;
 
-  _fp->massFractions(p, T - dT, Z, phase_state, fsp);
-  _fp->liquidProperties(p, T - dT, fsp);
+  _fs->massFractions(p, T - dT, Z, phase_state, fsp);
+  _fs->liquidProperties(p, T - dT, fsp);
   h2 = fsp[0].enthalpy;
 
-  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(denthalpy_dT, (h1 - h2) / (2.0 * dT), 1.0e-8);
 
-  _fp->massFractions(p, T, Z + dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
   h1 = fsp[0].enthalpy;
 
-  _fp->massFractions(p, T, Z - dZ, phase_state, fsp);
-  _fp->liquidProperties(p, T, fsp);
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  _fs->liquidProperties(p, T, fsp);
   h2 = fsp[0].enthalpy;
 
-  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-5);
+  ABS_TEST(denthalpy_dZ, (h1 - h2) / (2.0 * dZ), 1.0e-8);
 }
 
 /*
  * Verify calculation of gas saturation and derivatives in the two-phase region
  */
-TEST_F(PorousFlowWaterNCGTest, twoPhase)
+TEST_F(PorousFlowWaterNCGTest, saturation)
 {
-  const Real p = 1.0e6;
-  const Real T = 350.0;
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
 
   FluidStatePhaseEnum phase_state;
   std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
@@ -467,72 +545,119 @@ TEST_F(PorousFlowWaterNCGTest, twoPhase)
   // In the two-phase region, the mass fractions are the equilibrium values, so
   // a temporary value of Z can be used (as long as it corresponds to the two-phase
   // region)
-  Real Z = 0.45;
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  DualReal Z = 0.45;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
   // Calculate Z that gives a saturation of 0.25
-  Real gas_saturation = 0.25;
-  Real liquid_pressure = p + _pc->capillaryPressure(1.0 - gas_saturation);
+  DualReal target_gas_saturation = 0.25;
+  fsp[1].saturation = target_gas_saturation;
+
   // Calculate gas density and liquid density
-  _fp->gasProperties(p, T, fsp);
-  _fp->liquidProperties(liquid_pressure, T, fsp);
+  _fs->gasProperties(p, T, fsp);
+  _fs->liquidProperties(p, T, fsp);
 
   // The mass fraction that corresponds to a gas_saturation = 0.25
-  Z = (gas_saturation * fsp[1].density * fsp[1].mass_fraction[1] +
-       (1.0 - gas_saturation) * fsp[0].density * fsp[0].mass_fraction[1]) /
-      (gas_saturation * fsp[1].density + (1.0 - gas_saturation) * fsp[0].density);
+  DualReal Zc =
+      (target_gas_saturation * fsp[1].density * fsp[1].mass_fraction[1] +
+       (1.0 - target_gas_saturation) * fsp[0].density * fsp[0].mass_fraction[1]) /
+      (target_gas_saturation * fsp[1].density + (1.0 - target_gas_saturation) * fsp[0].density);
 
   // Calculate the gas saturation and derivatives
-  _fp->saturationTwoPhase(p, T, Z, fsp);
+  DualReal gas_saturation = _fs->saturation(p, T, Zc, fsp);
 
-  ABS_TEST(fsp[1].saturation, gas_saturation, 1.0e-8);
+  REL_TEST(gas_saturation, target_gas_saturation, 1.0e-6);
 
-  // Test the derivatives
+  // Test the derivatives of gas saturation
+  gas_saturation = _fs->saturation(p, T, Z, fsp);
   const Real dp = 1.0e-1;
-  gas_saturation = fsp[1].saturation;
-  Real dgas_saturation_dp = fsp[1].dsaturation_dp;
-  Real dgas_saturation_dT = fsp[1].dsaturation_dT;
-  Real dgas_saturation_dZ = fsp[1].dsaturation_dZ;
 
-  _fp->massFractions(p + dp, T, Z, phase_state, fsp);
-  _fp->gasProperties(p + dp, T, fsp);
-  _fp->saturationTwoPhase(p + dp, T, Z, fsp);
-  Real gsat1 = fsp[1].saturation;
+  Real dgas_saturation_dp = gas_saturation.derivatives()[_pidx];
+  Real dgas_saturation_dT = gas_saturation.derivatives()[_Tidx];
+  Real dgas_saturation_dZ = gas_saturation.derivatives()[_Zidx];
 
-  _fp->massFractions(p - dp, T, Z, phase_state, fsp);
-  _fp->gasProperties(p - dp, T, fsp);
-  _fp->saturationTwoPhase(p - dp, T, Z, fsp);
-  Real gsat2 = fsp[1].saturation;
+  _fs->massFractions(p + dp, T, Z, phase_state, fsp);
+  DualReal gsat1 = _fs->saturation(p + dp, T, Z, fsp);
 
-  REL_TEST(dgas_saturation_dp, (gsat1 - gsat2) / (2.0 * dp), 1.0e-6);
+  _fs->massFractions(p - dp, T, Z, phase_state, fsp);
+  DualReal gsat2 = _fs->saturation(p - dp, T, Z, fsp);
 
-  // Derivative wrt T
+  REL_TEST(dgas_saturation_dp, (gsat1 - gsat2).value() / (2.0 * dp), 1.0e-7);
+
   const Real dT = 1.0e-4;
-  _fp->massFractions(p, T + dT, Z, phase_state, fsp);
-  _fp->gasProperties(p, T + dT, fsp);
-  _fp->saturationTwoPhase(p, T + dT, Z, fsp);
-  gsat1 = fsp[1].saturation;
 
-  _fp->massFractions(p, T - dT, Z, phase_state, fsp);
-  _fp->gasProperties(p, T - dT, fsp);
-  _fp->saturationTwoPhase(p, T - dT, Z, fsp);
-  gsat2 = fsp[1].saturation;
+  _fs->massFractions(p, T + dT, Z, phase_state, fsp);
+  gsat1 = _fs->saturation(p, T + dT, Z, fsp);
 
-  REL_TEST(dgas_saturation_dT, (gsat1 - gsat2) / (2.0 * dT), 1.0e-6);
+  _fs->massFractions(p, T - dT, Z, phase_state, fsp);
+  gsat2 = _fs->saturation(p, T - dT, Z, fsp);
 
-  // Derivative wrt Z
+  REL_TEST(dgas_saturation_dT, (gsat1 - gsat2).value() / (2.0 * dT), 1.0e-7);
+
   const Real dZ = 1.0e-8;
 
-  _fp->massFractions(p, T, Z, phase_state, fsp);
-  _fp->gasProperties(p, T, fsp);
-  _fp->saturationTwoPhase(p, T, Z + dZ, fsp);
-  gsat1 = fsp[1].saturation;
+  _fs->massFractions(p, T, Z + dZ, phase_state, fsp);
+  gsat1 = _fs->saturation(p, T, Z + dZ, fsp);
 
-  _fp->saturationTwoPhase(p, T, Z - dZ, fsp);
-  gsat2 = fsp[1].saturation;
+  _fs->massFractions(p, T, Z - dZ, phase_state, fsp);
+  gsat2 = _fs->saturation(p, T, Z - dZ, fsp);
 
-  REL_TEST(dgas_saturation_dZ, (gsat1 - gsat2) / (2.0 * dZ), 1.0e-6);
+  REL_TEST(dgas_saturation_dZ, (gsat1 - gsat2).value() / (2.0 * dZ), 1.0e-7);
+}
+
+/*
+ * Verify calculation of gas saturation and derivatives in the two-phase region
+ */
+TEST_F(PorousFlowWaterNCGTest, twoPhase)
+{
+  DualReal p = 1.0e6;
+  p.derivatives()[_pidx] = 1.0;
+
+  DualReal T = 350.0;
+  T.derivatives()[_Tidx] = 1.0;
+
+  FluidStatePhaseEnum phase_state;
+  std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
+
+  DualReal Z = 0.45;
+  Z.derivatives()[_Zidx] = 1.0;
+
+  // Dummy qp value that isn't needed to test this
+  const unsigned int qp = 0;
+
+  _fs->massFractions(p, T, Z, phase_state, fsp);
+  EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
+
+  _fs->twoPhaseProperties(p, T, Z, qp, fsp);
+  DualReal liquid_density = fsp[0].density;
+  DualReal liquid_viscosity = fsp[0].viscosity;
+  DualReal liquid_enthalpy = fsp[0].enthalpy;
+  DualReal gas_saturation = fsp[1].saturation;
+  DualReal gas_density = fsp[1].density;
+  DualReal gas_viscosity = fsp[1].viscosity;
+  DualReal gas_enthalpy = fsp[1].enthalpy;
+
+  // As all the values are provided by the gasProperties(), liquidProperties() and
+  // saturation(), we can simply compare the DualReal results are the same (really
+  // only need to make sure that liquid properties are calculated correctly given the saturation)
+  std::vector<FluidStateProperties> fsp2(2, FluidStateProperties(2));
+
+  _fs->massFractions(p, T, Z, phase_state, fsp2);
+  _fs->gasProperties(p, T, fsp2);
+  fsp2[1].saturation = _fs->saturation(p, T, Z, fsp2);
+
+  const DualReal pliq = p - _pc->capillaryPressure(1.0 - fsp2[1].saturation, qp);
+  _fs->liquidProperties(pliq, T, fsp2);
+
+  ABS_TEST(gas_density, fsp2[1].density, 1.0e-12);
+  ABS_TEST(gas_viscosity, fsp2[1].viscosity, 1.0e-12);
+  ABS_TEST(gas_enthalpy, fsp2[1].enthalpy, 1.0e-12);
+
+  ABS_TEST(liquid_density, fsp2[0].density, 1.0e-12);
+  ABS_TEST(liquid_viscosity, fsp2[0].viscosity, 1.0e-12);
+  ABS_TEST(liquid_enthalpy, fsp2[0].enthalpy, 1.0e-12);
 }
 
 /*
@@ -546,20 +671,20 @@ TEST_F(PorousFlowWaterNCGTest, totalMassFraction)
   const Real Xnacl = 0.1;
   const unsigned qp = 0;
 
-  Real Z = _fp->totalMassFraction(p, T, Xnacl, s, qp);
+  Real Z = _fs->totalMassFraction(p, T, Xnacl, s, qp);
 
   // Test that the saturation calculated in this fluid state using Z is equal to s
   FluidStatePhaseEnum phase_state;
   std::vector<FluidStateProperties> fsp(2, FluidStateProperties(2));
 
-  _fp->massFractions(p, T, Z, phase_state, fsp);
+  DualReal pressure = p;
+  DualReal temperature = T;
+  DualReal z = Z;
+  _fs->massFractions(pressure, temperature, z, phase_state, fsp);
   EXPECT_EQ(phase_state, FluidStatePhaseEnum::TWOPHASE);
 
-  _fp->gasProperties(p, T, fsp);
-  Real liquid_pressure = p + _pc->capillaryPressure(1.0 - s);
-  _fp->liquidProperties(liquid_pressure, T, fsp);
-  _fp->saturationTwoPhase(p, T, Z, fsp);
-  ABS_TEST(fsp[1].saturation, s, 1.0e-8);
+  DualReal gas_saturation = _fs->saturation(pressure, temperature, z, fsp);
+  REL_TEST(gas_saturation, s, 1.0e-5);
 }
 
 /*
@@ -570,25 +695,25 @@ TEST_F(PorousFlowWaterNCGTest, totalMassFraction)
 TEST_F(PorousFlowWaterNCGTest, enthalpyOfDissolution)
 {
   // T = 50C
-  Real T = 323.15;
+  DualReal T = 323.15;
+  T.derivatives()[_Tidx] = 1.0;
 
   // Enthalpy of dissolution of NCG in water
-  Real hdis, dhdis_dT;
-  _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST(hdis, -3.45731e5, 1.0e-3);
+  DualReal hdis = _fs->enthalpyOfDissolution(T);
+  REL_TEST(hdis.value(), -3.45731e5, 1.0e-5);
 
   // T = 350C
   T = 623.15;
+  T.derivatives()[2] = 1.0;
 
   // Enthalpy of dissolution of NCG in water
-  _fp->enthalpyOfDissolution(T, hdis, dhdis_dT);
-  REL_TEST(hdis, 1.23423e+06, 1.0e-3);
+  hdis = _fs->enthalpyOfDissolution(T);
+  REL_TEST(hdis.value(), 1.23423e+06, 1.0e-5);
 
   // Test the derivative wrt temperature
   const Real dT = 1.0e-4;
-  Real hdis2, dhdis2_dT;
-  _fp->enthalpyOfDissolution(T + dT, hdis, dhdis_dT);
-  _fp->enthalpyOfDissolution(T - dT, hdis2, dhdis2_dT);
+  DualReal hdis2 = _fs->enthalpyOfDissolution(T + dT);
+  DualReal hdis3 = _fs->enthalpyOfDissolution(T - dT);
 
-  REL_TEST(dhdis_dT, (hdis - hdis2) / (2.0 * dT), 1.0e-5);
+  REL_TEST(hdis.derivatives()[_Tidx], (hdis2 - hdis3) / (2.0 * dT), 1.0e-6);
 }

--- a/unit/src/PorousFlowWaterVaporTest.C
+++ b/unit/src/PorousFlowWaterVaporTest.C
@@ -18,7 +18,7 @@ TEST_F(PorousFlowWaterVaporTest, name) { EXPECT_EQ("water-vapor", _fp->fluidStat
 TEST_F(PorousFlowWaterVaporTest, properties)
 {
   FluidStatePhaseEnum phase_state;
-  std::vector<FluidStatePropertiesAD> fsp(2, FluidStatePropertiesAD(1));
+  std::vector<FluidStateProperties> fsp(2, FluidStateProperties(1));
 
   // Single phase liquid region
   Real p = 1.0e6;


### PR DESCRIPTION
Replace hand-coded derivatives with AD versions.

- removes ~400 lines from PorousFlowBrineCO2
- removes ~150 lines from PorousFlowWaterNCG
- More than half this PR is updating the unit tests (could tighten some derivative tolerances too)

This should hopefully make future development of similar classes much easier as coding the derivatives was tricky and error-prone.

Closes #13853