### PR TITLE
Only include permeability derivatives when required

### DIFF
--- a/modules/porous_flow/include/bcs/PorousFlowSink.h
+++ b/modules/porous_flow/include/bcs/PorousFlowSink.h
@@ -151,4 +151,7 @@ protected:
 
   /// d(multiplier)/d(Porous flow variable pvar)
   virtual Real dmultiplier_dvar(unsigned int pvar) const;
+
+  /// Flag to check whether permeabiity derivatives are non-zero
+  const bool _perm_derivs;
 };

--- a/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
@@ -131,6 +131,9 @@ protected:
   /// Gravity. Defaults to 9.81 m/s^2
   const RealVectorValue _gravity;
 
+  /// Flag to check whether permeabiity derivatives are non-zero
+  const bool _perm_derivs;
+
   /**
    * If the number of upwind-downwind swaps is less than this amount then
    * full upwinding is used.  Otherwise the fallback scheme is employed
@@ -203,4 +206,3 @@ protected:
    */
   void harmonicMean(JacRes res_or_jac, unsigned int ph, unsigned int pvar);
 };
-

--- a/modules/porous_flow/include/kernels/PorousFlowDispersiveFlux.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDispersiveFlux.h
@@ -123,5 +123,7 @@ protected:
 
   /// Transverse dispersivity for each phase
   const std::vector<Real> _disp_trans;
-};
 
+  /// Flag to check whether permeabiity derivatives are non-zero
+  const bool _perm_derivs;
+};

--- a/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowFullySaturatedDarcyBase.h
@@ -84,5 +84,7 @@ protected:
 
   /// Gravity pointing downwards
   const RealVectorValue _gravity;
-};
 
+  /// Flag to check whether permeabiity derivatives are non-zero
+  const bool _perm_derivs;
+};

--- a/modules/porous_flow/include/userobjects/PorousFlowAdvectiveFluxCalculatorBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowAdvectiveFluxCalculatorBase.h
@@ -156,4 +156,7 @@ protected:
    * 1]][_triples_to_send[proc_id][i + 2]][:] to processor proc_id
    */
   std::map<processor_id_type, std::vector<dof_id_type>> _triples_to_send;
+
+  /// Flag to check whether permeabiity derivatives are non-zero
+  const bool _perm_derivs;
 };

--- a/modules/porous_flow/include/userobjects/PorousFlowDictator.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowDictator.h
@@ -148,6 +148,18 @@ public:
    */
   FEType feType() const;
 
+  /**
+   * Check if the simulation includes derivatives of permeability
+   * Note: when the permeability is constant, expensive tensor calculations
+   * can be ignored in Jacobian calculations
+   */
+  bool usePermDerivs() const { return _perm_derivs; };
+
+  /**
+   * Set the _perm_derivs flag
+   */
+  void usePermDerivs(bool flag) const { _perm_derivs = flag; };
+
 protected:
   /// Number of PorousFlow variables
   const unsigned int _num_variables;
@@ -167,6 +179,9 @@ protected:
   /// Aqueous phase number
   const unsigned int _aqueous_phase_number;
 
+  /// Indicates whether the simulation includes derivatives of permeability
+  mutable bool _perm_derivs;
+
 private:
   /// Whether the porous_flow_vars all have the same fe_type
   bool _consistent_fe_type;
@@ -180,4 +195,3 @@ private:
   /// _pf_var_num[i] = the porous flow variable corresponding to moose variable i
   std::vector<unsigned int> _pf_var_num;
 };
-

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityExponential.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityExponential.C
@@ -69,6 +69,9 @@ PorousFlowPermeabilityExponential::PorousFlowPermeabilityExponential(
       _BB = _B;
       break;
   }
+
+  // Make sure that derivatives are included in the Jacobian calculations
+  _dictator.usePermDerivs(true);
 }
 
 void

--- a/modules/porous_flow/src/materials/PorousFlowPermeabilityKozenyCarman.C
+++ b/modules/porous_flow/src/materials/PorousFlowPermeabilityKozenyCarman.C
@@ -85,6 +85,9 @@ PorousFlowPermeabilityKozenyCarman::PorousFlowPermeabilityKozenyCarman(
       _A = _k0 * std::pow(1.0 - _phi0, _m) / std::pow(_phi0, _n);
       break;
   }
+
+  // Make sure that derivatives are included in the Jacobian calculations
+  _dictator.usePermDerivs(true);
 }
 
 void

--- a/modules/porous_flow/src/userobjects/PorousFlowDictator.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowDictator.C
@@ -89,6 +89,10 @@ PorousFlowDictator::PorousFlowDictator(const InputParameters & parameters)
   if ((_num_phases > 0) && (_aqueous_phase_number >= _num_phases))
     mooseError("PorousflowDictator: The aqueous phase number must be less than the number of fluid "
                "phases.  The Dictator does not appreciate jokes.");
+
+  // Don't include permeabiity derivatives in the Jacobian by default (overwrite using
+  // usePermDerivs()) when necessary in permeabiity material classes
+  _perm_derivs = false;
 }
 
 unsigned int


### PR DESCRIPTION
These calculations can be expensive, so should only
be done when the permeability is not constant.

Refs #13857
