### PR TITLE
Avoid constructing a new FluidStateProperties while clearing

### DIFF
--- a/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
+++ b/modules/porous_flow/include/userobjects/PorousFlowFluidStateBase.h
@@ -135,4 +135,6 @@ protected:
   const Real _T_c2k;
   /// Capillary pressure UserObject
   const PorousFlowCapillaryPressure & _pc;
+  /// Empty FluidStateProperties object
+  FluidStateProperties _empty_fsp;
 };

--- a/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowBrineCO2.C
@@ -78,6 +78,8 @@ PorousFlowBrineCO2::PorousFlowBrineCO2(const InputParameters & parameters)
     paramError("salt_component",
                "The value provided is larger than the possible number of fluid components",
                _num_components);
+
+  _empty_fsp = FluidStateProperties(_num_components);
 }
 
 std::string

--- a/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowFluidStateBase.C
@@ -38,5 +38,5 @@ PorousFlowFluidStateBase::PorousFlowFluidStateBase(const InputParameters & param
 void
 PorousFlowFluidStateBase::clearFluidStateProperties(std::vector<FluidStateProperties> & fsp) const
 {
-  std::fill(fsp.begin(), fsp.end(), FluidStateProperties(_num_components));
+  std::fill(fsp.begin(), fsp.end(), _empty_fsp);
 }

--- a/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowWaterNCG.C
@@ -58,6 +58,8 @@ PorousFlowWaterNCG::PorousFlowWaterNCG(const InputParameters & parameters)
     paramError("liquid_fluid_component",
                "This value is larger than the possible number of fluid components",
                _num_components);
+
+  _empty_fsp = FluidStateProperties(_num_components);
 }
 
 std::string

--- a/modules/porous_flow/src/userobjects/PorousFlowWaterVapor.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowWaterVapor.C
@@ -54,6 +54,8 @@ PorousFlowWaterVapor::PorousFlowWaterVapor(const InputParameters & parameters)
     paramError("liquid_fluid_component",
                "This value is larger than the possible number of fluid components",
                _num_components);
+
+  _empty_fsp = FluidStateProperties(_num_components);
 }
 
 std::string


### PR DESCRIPTION
So clearing this vector by constructing a new object was the second most expensive function in these classes, taking up to 2% of the wall time... this makes it negligible now.

Refs #13857

