### PR TITLE
Fix calling `update` on `ResultGroup` in chigger

### DIFF
--- a/python/chigger/RenderWindow.py
+++ b/python/chigger/RenderWindow.py
@@ -65,6 +65,7 @@ class RenderWindow(base.ChiggerObject):
         super(RenderWindow, self).__init__(**kwargs)
 
         self._results = [misc.ChiggerBackground()]
+        self._groups = []
         self.__active = None
 
         self.__watermark = annotations.ImageAnnotation(filename='chigger_white.png',
@@ -104,6 +105,7 @@ class RenderWindow(base.ChiggerObject):
             mooseutils.mooseDebug('RenderWindow.append {}'.format(type(result).__name__))
             if isinstance(result, base.ResultGroup):
                 self.append(*result.getResults())
+                self._groups.append(result)
             elif not isinstance(result, self.RESULT_TYPE):
                 n = result.__class__.__name__
                 t = self.RESULT_TYPE.__name__
@@ -228,6 +230,10 @@ class RenderWindow(base.ChiggerObject):
 
         # Setup the result objects
         n = self.__vtkwindow.GetNumberOfLayers()
+        for group in self._groups:
+            if group.needsUpdate():
+                group.update()
+
         for result in self._results:
             renderer = result.getVTKRenderer()
             if self.isOptionValid('antialiasing'):

--- a/python/chigger/base/ResultGroup.py
+++ b/python/chigger/base/ResultGroup.py
@@ -47,8 +47,7 @@ class ResultGroup(ChiggerResult):
         """
         Call update on all children.
         """
-        for result in self._results:
-            result.update(**kwargs)
+        pass
 
     def setOptions(self, *args, **kwargs):
         """

--- a/python/chigger/exodus/ExodusSource.py
+++ b/python/chigger/exodus/ExodusSource.py
@@ -89,7 +89,7 @@ class ExodusSource(base.ChiggerSource):
 
     def getVTKSource(self):
         """
-        Returns the vtkExtractBlock object used for pulling subdomsin/sideset/nodeset data from the
+        Returns the vtkExtractBlock object used for pulling subdomain/sideset/nodeset data from the
         reader. (override)
 
         Returns:


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

`update` was not called when `ResultGroup` was part of the visualization chain