### PR TITLE
Allow PorousFlowBrine to use a given water userobject

### DIFF
--- a/modules/porous_flow/examples/reservoir_model/field_model.i
+++ b/modules/porous_flow/examples/reservoir_model/field_model.i
@@ -12,140 +12,146 @@
 []
 
 [Variables]
-  [./porepressure]
+  [porepressure]
     initial_condition = 20e6
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 50
-  [../]
-  [./xnacl]
+  []
+  [xnacl]
     initial_condition = 0.1
-  [../]
-  [./porosity]
+  []
+  [porosity]
     family = MONOMIAL
     order = CONSTANT
     initial_from_file_var = poro
-  [../]
-  [./permx_md]
+  []
+  [permx_md]
     family = MONOMIAL
     order = CONSTANT
     initial_from_file_var = permX
-  [../]
-  [./permy_md]
+  []
+  [permy_md]
     family = MONOMIAL
     order = CONSTANT
     initial_from_file_var = permY
-  [../]
-  [./permz_md]
+  []
+  [permz_md]
     family = MONOMIAL
     order = CONSTANT
     initial_from_file_var = permZ
-  [../]
-  [./permx]
+  []
+  [permx]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./permy]
+  []
+  [permy]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./permz]
+  []
+  [permz]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./permx]
+  [permx]
     type = ParsedAux
     variable = permx
     args = permx_md
     function = '9.869233e-16*permx_md'
     execute_on = initial
-  [../]
-  [./permy]
+  []
+  [permy]
     type = ParsedAux
     variable = permy
     args = permy_md
     function = '9.869233e-16*permy_md'
     execute_on = initial
-  [../]
-  [./permz]
+  []
+  [permz]
     type = ParsedAux
     variable = permz
     args = permz_md
     function = '9.869233e-16*permz_md'
     execute_on = initial
-  [../]
+  []
 []
 
 [Kernels]
-  [./mass0]
+  [mass0]
     type = PorousFlowMassTimeDerivative
     variable = porepressure
-  [../]
-  [./flux0]
+  []
+  [flux0]
     type = PorousFlowFullySaturatedDarcyFlow
     variable = porepressure
-  [../]
+  []
 []
 
 [UserObjects]
-  [./dictator]
+  [dictator]
     type = PorousFlowDictator
     porous_flow_vars = porepressure
     number_fluid_phases = 1
     number_fluid_components = 1
-  [../]
+  []
 []
 
 [Modules]
-  [./FluidProperties]
-    [./brine]
-      type = BrineFluidProperties
-    [../]
-  [../]
+  [FluidProperties]
+    [water]
+      type = Water97FluidProperties
+    []
+    [watertab]
+      type = TabulatedFluidProperties
+      fp = water
+      save_file = false
+    []
+  []
 []
 
 [Materials]
-  [./temperature]
+  [temperature]
     type = PorousFlowTemperature
     temperature = temperature
-  [../]
-  [./ps]
+  []
+  [ps]
     type = PorousFlow1PhaseFullySaturated
     porepressure = porepressure
-  [../]
-  [./massfrac]
+  []
+  [massfrac]
     type = PorousFlowMassFraction
-  [../]
-  [./brine]
+  []
+  [brine]
     type = PorousFlowBrine
     compute_enthalpy = false
     compute_internal_energy = false
     xnacl = xnacl
     phase = 0
-  [../]
-  [./porosity]
+    water_fp = watertab
+  []
+  [porosity]
     type = PorousFlowPorosityConst
     porosity = porosity
-  [../]
-  [./permeability]
+  []
+  [permeability]
     type = PorousFlowPermeabilityConstFromVar
     perm_xx = permx
     perm_yy = permy
     perm_zz = permz
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/porous_flow/examples/reservoir_model/regular_grid.i
+++ b/modules/porous_flow/examples/reservoir_model/regular_grid.i
@@ -22,129 +22,135 @@
 []
 
 [Variables]
-  [./porepressure]
+  [porepressure]
     initial_condition = 20e6
-  [../]
+  []
 []
 
 [Functions]
-  [./perm_md_fcn]
+  [perm_md_fcn]
     type = PiecewiseMultilinear
     data_file = spe10_case1.data
-  [../]
+  []
 []
 
 [BCs]
-  [./top]
+  [top]
     type = PresetBC
     variable = porepressure
     value = 20e6
     boundary = top
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 50
-  [../]
-  [./xnacl]
+  []
+  [xnacl]
     initial_condition = 0.1
-  [../]
-  [./porosity]
+  []
+  [porosity]
     family = MONOMIAL
     order = CONSTANT
     initial_condition = 0.2
-  [../]
-  [./perm_md]
+  []
+  [perm_md]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./perm]
+  []
+  [perm]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [Kernels]
-  [./mass0]
+  [mass0]
     type = PorousFlowMassTimeDerivative
     variable = porepressure
-  [../]
-  [./flux0]
+  []
+  [flux0]
     type = PorousFlowFullySaturatedDarcyFlow
     variable = porepressure
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./perm_md]
+  [perm_md]
     type = FunctionAux
     function = perm_md_fcn
     variable = perm_md
     execute_on = initial
-  [../]
-  [./perm]
+  []
+  [perm]
     type = ParsedAux
     variable = perm
     args = perm_md
     function = '9.869233e-16*perm_md'
     execute_on = initial
-  [../]
+  []
 []
 
 [UserObjects]
-  [./dictator]
+  [dictator]
     type = PorousFlowDictator
     porous_flow_vars = porepressure
     number_fluid_phases = 1
     number_fluid_components = 1
-  [../]
+  []
 []
 
 [Modules]
-  [./FluidProperties]
-    [./brine]
-      type = BrineFluidProperties
-    [../]
-  [../]
+  [FluidProperties]
+    [water]
+      type = Water97FluidProperties
+    []
+    [watertab]
+      type = TabulatedFluidProperties
+      fp = water
+      save_file = false
+    []
+  []
 []
 
 [Materials]
-  [./temperature]
+  [temperature]
     type = PorousFlowTemperature
     temperature = temperature
-  [../]
-  [./ps]
+  []
+  [ps]
     type = PorousFlow1PhaseFullySaturated
     porepressure = porepressure
-  [../]
-  [./massfrac]
+  []
+  [massfrac]
     type = PorousFlowMassFraction
-  [../]
-  [./brine]
+  []
+  [brine]
     type = PorousFlowBrine
     compute_enthalpy = false
     compute_internal_energy = false
     xnacl = xnacl
     phase = 0
-  [../]
-  [./porosity]
+    water_fp = watertab
+  []
+  [porosity]
     type = PorousFlowPorosityConst
     porosity = porosity
-  [../]
-  [./permeability]
+  []
+  [permeability]
     type = PorousFlowPermeabilityConstFromVar
     perm_xx = perm
     perm_yy = perm
     perm_zz = perm
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -154,10 +160,10 @@
   nl_abs_tol = 1e-12
   nl_rel_tol = 1e-06
   steady_state_detection = true
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     dt = 1e2
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/porous_flow/include/materials/PorousFlowBrine.h
+++ b/modules/porous_flow/include/materials/PorousFlowBrine.h
@@ -75,13 +75,12 @@ protected:
   /// Derivative of fluid enthalpy wrt temperature at the qps or nodes
   MaterialProperty<Real> * const _denthalpy_dT;
 
-  /// Brine Fluid properties UserObject
+  /// Brine fluid properties UserObject
   const BrineFluidProperties * _brine_fp;
 
-  /// Water Fluid properties UserObject
+  /// Water fluid properties UserObject
   const SinglePhaseFluidProperties * _water_fp;
 
   /// NaCl mass fraction at the qps or nodes
   const VariableValue & _xnacl;
 };
-

--- a/modules/porous_flow/test/tests/fluids/brine1_tabulated.i
+++ b/modules/porous_flow/test/tests/fluids/brine1_tabulated.i
@@ -1,0 +1,119 @@
+# Test the density and viscosity calculated by the brine material using a
+# TabulatedFluidProperties userobject for water
+# Pressure 20 MPa
+# Temperature 50C
+# xnacl = 0.1047 (equivalent to 2.0 molality)
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[GlobalParams]
+  PorousFlowDictator = dictator
+[]
+
+[UserObjects]
+  [dictator]
+    type = PorousFlowDictator
+    porous_flow_vars = 'pp'
+    number_fluid_phases = 1
+    number_fluid_components = 1
+  []
+[]
+
+[Variables]
+  [pp]
+    initial_condition = 20e6
+  []
+[]
+
+[Kernels]
+  [dummy]
+    type = Diffusion
+    variable = pp
+  []
+[]
+
+[AuxVariables]
+  [temp]
+    initial_condition = 50
+  []
+  [xnacl]
+    initial_condition = 0.1047
+  []
+[]
+
+[Modules]
+  [FluidProperties]
+    [water]
+      type = Water97FluidProperties
+    []
+    [watertab]
+      type = TabulatedFluidProperties
+      fp = water
+      save_file = false
+    []
+  []
+[]
+
+[Materials]
+  [temperature]
+    type = PorousFlowTemperature
+    temperature = temp
+  []
+  [ppss]
+    type = PorousFlow1PhaseFullySaturated
+    porepressure = pp
+  []
+  [brine]
+    type = PorousFlowBrine
+    water_fp = watertab
+    temperature_unit = Celsius
+    xnacl = 0.1047
+    phase = 0
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = Newton
+[]
+
+[Postprocessors]
+  [pressure]
+    type = ElementIntegralVariablePostprocessor
+    variable = pp
+  []
+  [temperature]
+    type = ElementIntegralVariablePostprocessor
+    variable = temp
+  []
+  [xnacl]
+    type = ElementIntegralVariablePostprocessor
+    variable = xnacl
+  []
+  [density]
+    type = ElementIntegralMaterialProperty
+    mat_prop = 'PorousFlow_fluid_phase_density_qp0'
+  []
+  [viscosity]
+    type = ElementIntegralMaterialProperty
+    mat_prop = 'PorousFlow_viscosity_qp0'
+  []
+  [enthalpy]
+    type = ElementIntegralMaterialProperty
+    mat_prop = 'PorousFlow_fluid_phase_enthalpy_qp0'
+  []
+  [internal_energy]
+    type = ElementIntegralMaterialProperty
+    mat_prop = 'PorousFlow_fluid_phase_internal_energy_qp0'
+  []
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+  file_base = brine1
+  csv = true
+[]

--- a/modules/porous_flow/test/tests/fluids/tests
+++ b/modules/porous_flow/test/tests/fluids/tests
@@ -39,6 +39,17 @@
     issues = "#11716"
     design = 'PorousFlowBrine.md'
   [../]
+  [./brine1_tab]
+    type = 'CSVDiff'
+    input = 'brine1_tabulated.i'
+    csvdiff = 'brine1.csv'
+    rel_err = 1.0E-5
+    threading = '!pthreads'
+    prereq = 'brine1'
+    requirement = "PorousFlow shall be able to use a given UserObject for water properties"
+    issues = "#11716 #13882"
+    design = 'PorousFlowBrine.md'
+  [../]
   [./co2]
     type = 'CSVDiff'
     input = 'co2.i'


### PR DESCRIPTION
This allows PorousFlowBrine to use a tabulated version of
the water fluid properties to speed up the calculations.

Closes #13882
