### PR TITLE
Fix inability to detect failed launch

### DIFF
--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -75,7 +75,7 @@ class RunPBS(QueueManager):
         template = {}
 
         # Launch script location
-        template['launch_script'] = os.path.join(job.getTestDir(), job.getTestNameShort() + '.qsub')
+        template['launch_script'] = os.path.join(job.getTestDir(), os.path.basename(job.getTestNameShort()) + '.qsub')
 
         # NCPUS
         template['mpi_procs'] = job.getMetaData().get('QUEUEING_NCPUS', 1)
@@ -87,7 +87,7 @@ class RunPBS(QueueManager):
         template['walltime'] = '{0:02d}'.format(hours) + ':' + '{0:02d}'.format(minutes) + ':00'
 
         # Job Name
-        template['job_name'] = job.getTestNameShort()
+        template['job_name'] = os.path.basename(job.getTestNameShort())
 
         # PBS Project group
         template['pbs_project'] = '#PBS -P %s' % (self.options.queue_project)
@@ -141,7 +141,6 @@ class RunPBS(QueueManager):
                 other_tester.setStatus(other_tester.fail, 'launch failure')
 
             # This is _only_ to make the failed message more useful
-            tester.specs['test_dir'] = ''
             tester.specs['command'] = command
             tester.setStatus(tester.fail, 'QSUB Group Failure')
             job.setOutput(launch_results)


### PR DESCRIPTION
Setting test_dir to null... what was that about? I can not pin down
why we were doing this. Regardless, making this a null string, left
the JSON table unable to store information on that particular test
group. The test_dir is what we were using as the key to said
information. By removing that line... it works as intended.

Fixed issue with the creation of the QSUB file. Spec files which
now include a nested naming block, the 'TestName' can no longer be
used as a valid path when determining paths to write files too.

Closes #13865
