### PR TITLE
Add include directives for missing libMesh headers

### DIFF
--- a/framework/include/constraints/AutomaticMortarGeneration.h
+++ b/framework/include/constraints/AutomaticMortarGeneration.h
@@ -17,7 +17,7 @@
 #include "libmesh/id_types.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/elem.h"
-#include "libmesh/mesh.h"
+#include "libmesh/replicated_mesh.h"
 
 // C++ includes
 #include <set>

--- a/framework/src/base/Registry.C
+++ b/framework/src/base/Registry.C
@@ -12,6 +12,7 @@
 #include "Factory.h"
 #include "ActionFactory.h"
 
+#include "libmesh/auto_ptr.h"
 #include "libmesh/libmesh_common.h"
 
 static Registry &

--- a/framework/src/utils/MooseADWrapper.C
+++ b/framework/src/utils/MooseADWrapper.C
@@ -9,6 +9,8 @@
 
 #include "MooseADWrapper.h"
 
+#include "libmesh/auto_ptr.h"
+
 MooseADWrapper<Real>::MooseADWrapper(bool use_ad) : _use_ad(use_ad), _val(), _dual_number(nullptr)
 {
   if (_use_ad)

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -14,6 +14,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/parallel.h"
 
 namespace MooseMeshUtils
 {

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -18,6 +18,9 @@
 // don't want to expose to EVERY file in MOOSE...
 #include "VariadicTable.h"
 
+// libMesh Includes
+#include "libmesh/auto_ptr.h"
+
 // System Includes
 #include <chrono>
 

--- a/framework/src/utils/RankMap.C
+++ b/framework/src/utils/RankMap.C
@@ -11,6 +11,8 @@
 
 #include "PerfGraphInterface.h"
 
+#include "libmesh/parallel.h"
+
 RankMap::RankMap(const Parallel::Communicator & comm, PerfGraph & perf_graph)
   : ParallelObject(comm),
     PerfGraphInterface(perf_graph, "RankMap"),

--- a/modules/functional_expansion_tools/src/series/Cartesian.C
+++ b/modules/functional_expansion_tools/src/series/Cartesian.C
@@ -10,6 +10,8 @@
 #include "Cartesian.h"
 #include "Legendre.h"
 
+#include "libmesh/auto_ptr.h"
+
 Cartesian::Cartesian(const std::string & who_is_using_me)
   : CompositeSeriesBasisInterface(who_is_using_me)
 {

--- a/modules/functional_expansion_tools/src/series/CylindricalDuo.C
+++ b/modules/functional_expansion_tools/src/series/CylindricalDuo.C
@@ -11,6 +11,8 @@
 #include "Legendre.h"
 #include "Zernike.h"
 
+#include "libmesh/auto_ptr.h"
+
 CylindricalDuo::CylindricalDuo(const std::string & who_is_using_me)
   : CompositeSeriesBasisInterface(who_is_using_me)
 {

--- a/modules/stochastic_tools/src/distributions/BoostLognormalDistribution.C
+++ b/modules/stochastic_tools/src/distributions/BoostLognormalDistribution.C
@@ -9,6 +9,8 @@
 
 #include "BoostLognormalDistribution.h"
 
+#include "libmesh/auto_ptr.h"
+
 registerMooseObject("StochasticToolsApp", BoostLognormalDistribution);
 
 template <>

--- a/modules/stochastic_tools/src/distributions/BoostNormalDistribution.C
+++ b/modules/stochastic_tools/src/distributions/BoostNormalDistribution.C
@@ -9,6 +9,8 @@
 
 #include "BoostNormalDistribution.h"
 
+#include "libmesh/auto_ptr.h"
+
 registerMooseObject("StochasticToolsApp", BoostNormalDistribution);
 
 template <>

--- a/modules/stochastic_tools/src/distributions/BoostWeibullDistribution.C
+++ b/modules/stochastic_tools/src/distributions/BoostWeibullDistribution.C
@@ -9,6 +9,8 @@
 
 #include "BoostWeibullDistribution.h"
 
+#include "libmesh/auto_ptr.h"
+
 registerMooseObject("StochasticToolsApp", BoostWeibullDistribution);
 
 template <>


### PR DESCRIPTION
There are a few libMesh headers which MOOSE files are using but not directly including, for which I'd like to remove the (unnecessary) indirect inclusions soon.  There's also another case of mesh.h being used to pull in replicated_mesh.h, which doesn't happen in --enable-parmesh libMesh builds.

Closes #8730 again for now, although the dependency reduction is all happening on the libMesh side this time.