### PR TITLE
Fix use of deprecated methods

### DIFF
--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -89,6 +89,8 @@ BreakMeshByBlockGenerator::generate()
             // assign the newly added node to current_elem
             Node * new_node = nullptr;
 
+            std::vector<boundary_id_type> node_boundary_ids;
+
             for (unsigned int node_id = 0; node_id < current_elem->n_nodes(); ++node_id)
               if (current_elem->node_id(node_id) ==
                   current_node->id()) // if current node == node on element
@@ -99,8 +101,7 @@ BreakMeshByBlockGenerator::generate()
                 mesh->add_node(new_node);
 
                 // Add boundary info to the new node
-                std::vector<boundary_id_type> node_boundary_ids =
-                    mesh->boundary_info->boundary_ids(current_node);
+                mesh->boundary_info->boundary_ids(current_node, node_boundary_ids);
                 mesh->boundary_info->add_node(new_node, node_boundary_ids);
 
                 multiplicity_counter--; // node created, update multiplicity counter

--- a/framework/src/meshmodifiers/BreakMeshByBlock.C
+++ b/framework/src/meshmodifiers/BreakMeshByBlock.C
@@ -83,6 +83,8 @@ BreakMeshByBlock::modify()
             // assign the newly added node to current_elem
             Node * new_node = nullptr;
 
+            std::vector<boundary_id_type> node_boundary_ids;
+
             for (unsigned int node_id = 0; node_id < current_elem->n_nodes(); ++node_id)
               if (current_elem->node_id(node_id) ==
                   current_node->id()) // if current node == node on element
@@ -93,8 +95,7 @@ BreakMeshByBlock::modify()
                 mesh.add_node(new_node);
 
                 // Add boundary info to the new node
-                std::vector<boundary_id_type> node_boundary_ids =
-                    mesh.boundary_info->boundary_ids(current_node);
+                mesh.boundary_info->boundary_ids(current_node, node_boundary_ids);
                 mesh.boundary_info->add_node(new_node, node_boundary_ids);
 
                 multiplicity_counter--; // node created, update multiplicity counter

--- a/modules/contact/src/MechanicalContactConstraint.C
+++ b/modules/contact/src/MechanicalContactConstraint.C
@@ -582,8 +582,8 @@ MechanicalContactConstraint::computeContactForce(PenetrationInfo * pinfo, bool u
               (pinfo->_incremental_slip * pinfo->_normal) * pinfo->_normal;
 
           // Magnitude of tangential predictor force
-          const Real tan_mag(contact_force_tangential.size());
-          const Real tangential_inc_slip_mag = tangential_inc_slip.size();
+          const Real tan_mag(contact_force_tangential.norm());
+          const Real tangential_inc_slip_mag = tangential_inc_slip.norm();
           const Real slip_tol = capacity / penalty;
           pinfo->_slip_tol = slip_tol;
 

--- a/modules/level_set/src/functions/LevelSetOlssonBubble.C
+++ b/modules/level_set/src/functions/LevelSetOlssonBubble.C
@@ -36,14 +36,14 @@ LevelSetOlssonBubble::LevelSetOlssonBubble(const InputParameters & parameters)
 Real
 LevelSetOlssonBubble::value(Real /*t*/, const Point & p) const
 {
-  const Real x = ((p - _center).size() - _radius) / _epsilon;
+  const Real x = ((p - _center).norm() - _radius) / _epsilon;
   return 1.0 / (1 + std::exp(x));
 }
 
 RealGradient
 LevelSetOlssonBubble::gradient(Real /*t*/, const Point & p) const
 {
-  Real norm = (p - _center).size();
+  Real norm = (p - _center).norm();
   Real g = (norm - _radius) / _epsilon;
   RealGradient output;
 

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -20,7 +20,7 @@
 #include <set>
 #include <vector>
 
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h"
 #include "libmesh/periodic_boundaries.h"
 
 // External includes
@@ -162,7 +162,7 @@ public:
     FeatureData(std::size_t var_index,
                 Status status,
                 unsigned int id = invalid_id,
-                std::vector<MeshTools::BoundingBox> bboxes = {MeshTools::BoundingBox()})
+                std::vector<BoundingBox> bboxes = {BoundingBox()})
       : _var_index(var_index),
         _id(id),
         _bboxes(bboxes), // Assume at least one bounding box
@@ -185,7 +185,7 @@ public:
      * given a Point, Elem or BBox parameter.
      */
     void updateBBoxExtremes(MeshBase & mesh);
-    void updateBBoxExtremes(MeshTools::BoundingBox & bbox, const MeshTools::BoundingBox & rhs_bbox);
+    void updateBBoxExtremes(BoundingBox & bbox, const BoundingBox & rhs_bbox);
     ///@}
 
     /**
@@ -288,7 +288,7 @@ public:
 
     /// The vector of bounding boxes completely enclosing this feature
     /// (multiple used with periodic constraints)
-    std::vector<MeshTools::BoundingBox> _bboxes;
+    std::vector<BoundingBox> _bboxes;
 
     /// Original processor/local ids
     std::list<std::pair<processor_id_type, unsigned int>> _orig_ids;
@@ -783,12 +783,12 @@ private:
 template <>
 void dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void * context);
 template <>
-void dataStore(std::ostream & stream, MeshTools::BoundingBox & bbox, void * context);
+void dataStore(std::ostream & stream, BoundingBox & bbox, void * context);
 
 template <>
 void dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, void * context);
 template <>
-void dataLoad(std::istream & stream, MeshTools::BoundingBox & bbox, void * context);
+void dataLoad(std::istream & stream, BoundingBox & bbox, void * context);
 
 template <>
 struct enable_bitmask_operators<FeatureFloodCount::Status>

--- a/modules/phase_field/include/postprocessors/GrainTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainTracker.h
@@ -12,7 +12,7 @@
 #include "FeatureFloodCount.h"
 #include "GrainTrackerInterface.h"
 
-#include "libmesh/mesh_tools.h"
+#include "libmesh/bounding_box.h"
 
 class GrainTracker;
 class PolycrystalUserObjectBase;
@@ -156,15 +156,15 @@ protected:
    * This method returns the minimum periodic distance between two vectors of bounding boxes. If the
    * bounding boxes overlap the result is always -1.0.
    */
-  Real boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1,
-                              std::vector<MeshTools::BoundingBox> & bboxes2) const;
+  Real boundingRegionDistance(std::vector<BoundingBox> & bboxes1,
+                              std::vector<BoundingBox> & bboxes2) const;
 
   /**
    * This method returns the minimum periodic distance between the centroids of two vectors of
    * bounding boxes.
    */
-  Real centroidRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1,
-                              std::vector<MeshTools::BoundingBox> & bboxes2) const;
+  Real centroidRegionDistance(std::vector<BoundingBox> & bboxes1,
+                              std::vector<BoundingBox> & bboxes2) const;
 
   /**
    * Retrieve the next unique grain number if a new grain is detected during trackGrains. This

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1902,8 +1902,7 @@ FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshBase & mesh)
 }
 
 void
-FeatureFloodCount::FeatureData::updateBBoxExtremes(BoundingBox & bbox,
-                                                   const BoundingBox & rhs_bbox)
+FeatureFloodCount::FeatureData::updateBBoxExtremes(BoundingBox & bbox, const BoundingBox & rhs_bbox)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1046,7 +1046,7 @@ FeatureFloodCount::prepareDataForTransfer()
       else
       {
         for (auto & halo_id : feature._halo_ids)
-          updateBBoxExtremesHelper(feature._bboxes[0], mesh.node(halo_id));
+          updateBBoxExtremesHelper(feature._bboxes[0], mesh.point(halo_id));
       }
 
       mooseAssert(!feature._local_ids.empty(), "local entity ids cannot be empty");
@@ -1822,9 +1822,9 @@ FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshBase & mesh)
 {
   // First update the primary bounding box (all topologically connected)
   for (auto & halo_id : _halo_ids)
-    updateBBoxExtremesHelper(_bboxes[0], *mesh.elem(halo_id));
+    updateBBoxExtremesHelper(_bboxes[0], mesh.elem_ref(halo_id));
   for (auto & ghost_id : _ghosted_ids)
-    updateBBoxExtremesHelper(_bboxes[0], *mesh.elem(ghost_id));
+    updateBBoxExtremesHelper(_bboxes[0], mesh.elem_ref(ghost_id));
 
   // Remove all of the IDs that are in the primary region
   std::list<dof_id_type> disjoint_elem_id_list;

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -52,7 +52,7 @@ dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void 
 
 template <>
 void
-dataStore(std::ostream & stream, MeshTools::BoundingBox & bbox, void * context)
+dataStore(std::ostream & stream, BoundingBox & bbox, void * context)
 {
   storeHelper(stream, bbox.min(), context);
   storeHelper(stream, bbox.max(), context);
@@ -83,15 +83,15 @@ dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, void *
 
 template <>
 void
-dataLoad(std::istream & stream, MeshTools::BoundingBox & bbox, void * context)
+dataLoad(std::istream & stream, BoundingBox & bbox, void * context)
 {
   loadHelper(stream, bbox.min(), context);
   loadHelper(stream, bbox.max(), context);
 }
 
 // Utility routines
-void updateBBoxExtremesHelper(MeshTools::BoundingBox & bbox, const Point & node);
-void updateBBoxExtremesHelper(MeshTools::BoundingBox & bbox, const Elem & elem);
+void updateBBoxExtremesHelper(BoundingBox & bbox, const Point & node);
+void updateBBoxExtremesHelper(BoundingBox & bbox, const Elem & elem);
 bool areElemListsMergeable(const std::list<dof_id_type> & elem_list1,
                            const std::list<dof_id_type> & elem_list2,
                            MeshBase & mesh);
@@ -1902,8 +1902,8 @@ FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshBase & mesh)
 }
 
 void
-FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshTools::BoundingBox & bbox,
-                                                   const MeshTools::BoundingBox & rhs_bbox)
+FeatureFloodCount::FeatureData::updateBBoxExtremes(BoundingBox & bbox,
+                                                   const BoundingBox & rhs_bbox)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {
@@ -2201,7 +2201,7 @@ operator<<(std::ostream & out, const FeatureFloodCount::FeatureData & feature)
  *****************************************************************************************
  */
 void
-updateBBoxExtremesHelper(MeshTools::BoundingBox & bbox, const Point & node)
+updateBBoxExtremesHelper(BoundingBox & bbox, const Point & node)
 {
   for (unsigned int i = 0; i < LIBMESH_DIM; ++i)
   {
@@ -2211,7 +2211,7 @@ updateBBoxExtremesHelper(MeshTools::BoundingBox & bbox, const Point & node)
 }
 
 void
-updateBBoxExtremesHelper(MeshTools::BoundingBox & bbox, const Elem & elem)
+updateBBoxExtremesHelper(BoundingBox & bbox, const Elem & elem)
 {
   for (MooseIndex(elem.n_nodes()) node_n = 0; node_n < elem.n_nodes(); ++node_n)
     updateBBoxExtremesHelper(bbox, *(elem.node_ptr(node_n)));

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -1446,7 +1446,7 @@ GrainTracker::swapSolutionValues(FeatureData & grain,
   {
     if (_is_elemental)
     {
-      Elem * elem = mesh.query_elem(entity);
+      Elem * elem = mesh.query_elem_ptr(entity);
       if (!elem)
         continue;
 

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -1717,8 +1717,8 @@ GrainTracker::communicateHaloMap()
 }
 
 Real
-GrainTracker::centroidRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1,
-                                     std::vector<MeshTools::BoundingBox> & bboxes2) const
+GrainTracker::centroidRegionDistance(std::vector<BoundingBox> & bboxes1,
+                                     std::vector<BoundingBox> & bboxes2) const
 {
   /**
    * Find the minimum centroid distance between any to pieces of the grains.
@@ -1744,8 +1744,8 @@ GrainTracker::centroidRegionDistance(std::vector<MeshTools::BoundingBox> & bboxe
 }
 
 Real
-GrainTracker::boundingRegionDistance(std::vector<MeshTools::BoundingBox> & bboxes1,
-                                     std::vector<MeshTools::BoundingBox> & bboxes2) const
+GrainTracker::boundingRegionDistance(std::vector<BoundingBox> & bboxes1,
+                                     std::vector<BoundingBox> & bboxes2) const
 {
   /**
    * The region that each grain covers is represented by a bounding box large enough to encompassing

--- a/modules/phase_field/src/userobjects/EBSDReader.C
+++ b/modules/phase_field/src/userobjects/EBSDReader.C
@@ -374,7 +374,7 @@ EBSDReader::buildNodeWeightMaps()
         unsigned int elem_id = (node_to_elem_pair->second)[ne];
 
         // Retrieve EBSD grain number for the current element index
-        const Elem * elem = mesh.elem(elem_id);
+        const Elem * elem = mesh.elem_ptr(elem_id);
         const EBSDReader::EBSDPointData & d = getData(elem->centroid());
 
         // get the (global) grain ID for the EBSD feature ID

--- a/modules/porous_flow/src/functions/MovingPlanarFront.C
+++ b/modules/porous_flow/src/functions/MovingPlanarFront.C
@@ -67,9 +67,9 @@ MovingPlanarFront::MovingPlanarFront(const InputParameters & parameters)
     _deactivation_time(getParam<Real>("deactivation_time")),
     _front_normal(_end_posn - _start_posn)
 {
-  if (_front_normal.size() == 0)
+  if (_front_normal.norm() == 0)
     mooseError("MovingPlanarFront: start_posn and end_posn must be different points");
-  _front_normal /= _front_normal.size();
+  _front_normal /= _front_normal.norm();
 }
 
 Real

--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -114,7 +114,7 @@ PorousFlowMaterial::nearestQP(unsigned nodenum) const
   Real smallest_dist = std::numeric_limits<Real>::max();
   for (unsigned qp = 1; qp < _qrule->n_points(); ++qp)
   {
-    const Real this_dist = (_current_elem->point(nodenum) - _q_point[qp]).size();
+    const Real this_dist = (_current_elem->point(nodenum) - _q_point[qp]).norm();
     if (this_dist < smallest_dist)
     {
       nearest_qp = qp;

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -1153,6 +1153,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
   // Add new elements
   std::map<unsigned int, std::vector<const Elem *>> temporary_parent_children_map;
 
+  std::vector<boundary_id_type> parent_boundary_ids;
+
   for (unsigned int i = 0; i < new_elements.size(); ++i)
   {
     unsigned int parent_id = new_elements[i]->getParent()->id();
@@ -1239,9 +1241,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       }
 
       Node * parent_node = parent_elem->node_ptr(j);
-      std::vector<boundary_id_type> parent_node_boundary_ids =
-          _mesh->boundary_info->boundary_ids(parent_node);
-      _mesh->boundary_info->add_node(libmesh_node, parent_node_boundary_ids);
+      _mesh->boundary_info->boundary_ids(parent_node, parent_boundary_ids);
+      _mesh->boundary_info->add_node(libmesh_node, parent_boundary_ids);
 
       if (_displaced_mesh)
       {
@@ -1257,9 +1258,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
         libmesh_elem2->set_node(j) = libmesh_node;
 
         parent_node = parent_elem2->node_ptr(j);
-        parent_node_boundary_ids.clear();
-        parent_node_boundary_ids = _displaced_mesh->boundary_info->boundary_ids(parent_node);
-        _displaced_mesh->boundary_info->add_node(libmesh_node, parent_node_boundary_ids);
+        _displaced_mesh->boundary_info->boundary_ids(parent_node, parent_boundary_ids);
+        _displaced_mesh->boundary_info->add_node(libmesh_node, parent_boundary_ids);
       }
     }
 
@@ -1277,10 +1277,9 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       (*_material_data)[0]->copy(*libmesh_elem, *parent_elem, 0);
       for (unsigned int side = 0; side < parent_elem->n_sides(); ++side)
       {
-        std::vector<boundary_id_type> parent_elem_boundary_ids =
-            _mesh->boundary_info->boundary_ids(parent_elem, side);
-        std::vector<boundary_id_type>::iterator it_bd = parent_elem_boundary_ids.begin();
-        for (; it_bd != parent_elem_boundary_ids.end(); ++it_bd)
+        _mesh->boundary_info->boundary_ids(parent_elem, side, parent_boundary_ids);
+        std::vector<boundary_id_type>::iterator it_bd = parent_boundary_ids.begin();
+        for (; it_bd != parent_boundary_ids.end(); ++it_bd)
         {
           if (_fe_problem->needBoundaryMaterialOnSide(*it_bd, 0))
             (*_bnd_material_data)[0]->copy(*libmesh_elem, *parent_elem, side);
@@ -1355,36 +1354,32 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     unsigned int n_sides = parent_elem->n_sides();
     for (unsigned int side = 0; side < n_sides; ++side)
     {
-      std::vector<boundary_id_type> parent_elem_boundary_ids =
-          _mesh->boundary_info->boundary_ids(parent_elem, side);
-      _mesh->boundary_info->add_side(libmesh_elem, side, parent_elem_boundary_ids);
+      _mesh->boundary_info->boundary_ids(parent_elem, side, parent_boundary_ids);
+      _mesh->boundary_info->add_side(libmesh_elem, side, parent_boundary_ids);
     }
     if (_displaced_mesh)
     {
       n_sides = parent_elem2->n_sides();
       for (unsigned int side = 0; side < n_sides; ++side)
       {
-        std::vector<boundary_id_type> parent_elem_boundary_ids =
-            _displaced_mesh->boundary_info->boundary_ids(parent_elem2, side);
-        _displaced_mesh->boundary_info->add_side(libmesh_elem2, side, parent_elem_boundary_ids);
+        _displaced_mesh->boundary_info->boundary_ids(parent_elem2, side, parent_boundary_ids);
+        _displaced_mesh->boundary_info->add_side(libmesh_elem2, side, parent_boundary_ids);
       }
     }
 
     unsigned int n_edges = parent_elem->n_edges();
     for (unsigned int edge = 0; edge < n_edges; ++edge)
     {
-      std::vector<boundary_id_type> parent_elem_boundary_ids =
-          _mesh->boundary_info->edge_boundary_ids(parent_elem, edge);
-      _mesh->boundary_info->add_edge(libmesh_elem, edge, parent_elem_boundary_ids);
+      _mesh->boundary_info->edge_boundary_ids(parent_elem, edge, parent_boundary_ids);
+      _mesh->boundary_info->add_edge(libmesh_elem, edge, parent_boundary_ids);
     }
     if (_displaced_mesh)
     {
       n_edges = parent_elem2->n_edges();
       for (unsigned int edge = 0; edge < n_edges; ++edge)
       {
-        std::vector<boundary_id_type> parent_elem_boundary_ids =
-            _displaced_mesh->boundary_info->edge_boundary_ids(parent_elem2, edge);
-        _displaced_mesh->boundary_info->add_edge(libmesh_elem2, edge, parent_elem_boundary_ids);
+        _displaced_mesh->boundary_info->edge_boundary_ids(parent_elem2, edge, parent_boundary_ids);
+        _displaced_mesh->boundary_info->add_edge(libmesh_elem2, edge, parent_boundary_ids);
       }
     }
   }

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -111,7 +111,7 @@ XFEM::getCrackTipOrigin(std::map<unsigned int, const Elem *> & elem_id_crack_tip
 void
 XFEM::addStateMarkedElem(unsigned int elem_id, RealVectorValue & normal)
 {
-  Elem * elem = _mesh->elem(elem_id);
+  Elem * elem = _mesh->elem_ptr(elem_id);
   std::map<const Elem *, RealVectorValue>::iterator mit;
   mit = _state_marked_elems.find(elem);
   if (mit != _state_marked_elems.end())
@@ -123,7 +123,7 @@ void
 XFEM::addStateMarkedElem(unsigned int elem_id, RealVectorValue & normal, unsigned int marked_side)
 {
   addStateMarkedElem(elem_id, normal);
-  Elem * elem = _mesh->elem(elem_id);
+  Elem * elem = _mesh->elem_ptr(elem_id);
   std::map<const Elem *, unsigned int>::iterator mit;
   mit = _state_marked_elem_sides.find(elem);
   if (mit != _state_marked_elem_sides.end())
@@ -138,7 +138,7 @@ void
 XFEM::addStateMarkedFrag(unsigned int elem_id, RealVectorValue & normal)
 {
   addStateMarkedElem(elem_id, normal);
-  Elem * elem = _mesh->elem(elem_id);
+  Elem * elem = _mesh->elem_ptr(elem_id);
   std::set<const Elem *>::iterator mit;
   mit = _state_marked_frags.find(elem);
   if (mit != _state_marked_frags.end())
@@ -163,7 +163,7 @@ XFEM::addGeomMarkedElem2D(const unsigned int elem_id,
                           const Xfem::GeomMarkedElemInfo2D geom_info,
                           const unsigned int interface_id)
 {
-  Elem * elem = _mesh->elem(elem_id);
+  Elem * elem = _mesh->elem_ptr(elem_id);
   _geom_marked_elems_2d[elem].push_back(geom_info);
   _geom_marker_id_elems[interface_id].insert(elem_id);
 }
@@ -173,7 +173,7 @@ XFEM::addGeomMarkedElem3D(const unsigned int elem_id,
                           const Xfem::GeomMarkedElemInfo3D geom_info,
                           const unsigned int interface_id)
 {
-  Elem * elem = _mesh->elem(elem_id);
+  Elem * elem = _mesh->elem_ptr(elem_id);
   _geom_marked_elems_3d[elem].push_back(geom_info);
   _geom_marker_id_elems[interface_id].insert(elem_id);
 }
@@ -203,7 +203,7 @@ XFEM::storeCrackTipOriginAndDirection()
       Point direction(0, 0, 0);
 
       std::map<unique_id_type, XFEMCutElem *>::const_iterator it;
-      it = _cut_elem_map.find(_mesh->elem(cts_id)->unique_id());
+      it = _cut_elem_map.find(_mesh->elem_ptr(cts_id)->unique_id());
       if (it != _cut_elem_map.end())
       {
         const XFEMCutElem * xfce = it->second;
@@ -217,7 +217,7 @@ XFEM::storeCrackTipOriginAndDirection()
       std::vector<Point> tip_data;
       tip_data.push_back(origin);
       tip_data.push_back(direction);
-      const Elem * elem = _mesh->elem((*sit)->id());
+      const Elem * elem = _mesh->elem_ptr((*sit)->id());
       _elem_crack_origin_direction_map.insert(
           std::pair<const Elem *, std::vector<Point>>(elem, tip_data));
     }
@@ -964,8 +964,8 @@ XFEM::healMesh()
 
         if (_displaced_mesh)
         {
-          Elem * elem1_displaced = _displaced_mesh->elem(it.first->id());
-          Elem * elem2_displaced = _displaced_mesh->elem(it.second->id());
+          Elem * elem1_displaced = _displaced_mesh->elem_ptr(it.first->id());
+          Elem * elem2_displaced = _displaced_mesh->elem_ptr(it.second->id());
 
           std::map<unique_id_type, XFEMCutElem *>::iterator cemit =
               _cut_elem_map.find(elem1_displaced->unique_id());
@@ -1160,7 +1160,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     unsigned int parent_id = new_elements[i]->getParent()->id();
     unsigned int efa_child_id = new_elements[i]->id();
 
-    Elem * parent_elem = _mesh->elem(parent_id);
+    Elem * parent_elem = _mesh->elem_ptr(parent_id);
     Elem * libmesh_elem = Elem::build(parent_elem->type()).release();
 
     for (unsigned int m = 0; m < _geometric_cuts.size(); ++m)
@@ -1182,7 +1182,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     Elem * libmesh_elem2 = NULL;
     if (_displaced_mesh)
     {
-      parent_elem2 = _displaced_mesh->elem(parent_id);
+      parent_elem2 = _displaced_mesh->elem_ptr(parent_id);
       libmesh_elem2 = Elem::build(parent_elem2->type()).release();
 
       for (unsigned int m = 0; m < _geometric_cuts.size(); ++m)
@@ -1387,7 +1387,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
   // delete elements
   for (std::size_t i = 0; i < delete_elements.size(); ++i)
   {
-    Elem * elem_to_delete = _mesh->elem(delete_elements[i]->id());
+    Elem * elem_to_delete = _mesh->elem_ptr(delete_elements[i]->id());
 
     // delete the XFEMCutElem object for any elements that are to be deleted
     std::map<unique_id_type, XFEMCutElem *>::iterator cemit =
@@ -1407,7 +1407,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
 
     if (_displaced_mesh)
     {
-      Elem * elem_to_delete2 = _displaced_mesh->elem(delete_elements[i]->id());
+      Elem * elem_to_delete2 = _displaced_mesh->elem_ptr(delete_elements[i]->id());
       elem_to_delete2->nullify_neighbors();
       _displaced_mesh->boundary_info->remove(elem_to_delete2);
       _displaced_mesh->delete_elem(elem_to_delete2);
@@ -1438,8 +1438,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     {
       for (auto & se : _sibling_elems[_geometric_cuts[i]->getInterfaceID()])
       {
-        Elem * elem = _displaced_mesh->elem(se.first->id());
-        Elem * elem_pair = _displaced_mesh->elem(se.second->id());
+        Elem * elem = _displaced_mesh->elem_ptr(se.first->id());
+        Elem * elem_pair = _displaced_mesh->elem_ptr(se.second->id());
         _sibling_displaced_elems[_geometric_cuts[i]->getInterfaceID()].push_back(
             std::make_pair(elem, elem_pair));
       }
@@ -1464,7 +1464,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       if (eit != efa_id_to_new_elem.end())
         crack_tip_elem = eit->second;
       else
-        crack_tip_elem = _mesh->elem(eid);
+        crack_tip_elem = _mesh->elem_ptr(eid);
       _crack_tip_elems.insert(crack_tip_elem);
 
       // Store the crack tip elements which are going to be healed

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -1816,7 +1816,7 @@ XFEM::getXFEMqRuleOnLine(std::vector<Point> & intersection_points,
   quad_wts.resize(num_qpoints);
   quad_pts.resize(num_qpoints);
 
-  Real integ_jacobian = pow((p1 - p2).size_sq(), 0.5) * 0.5;
+  Real integ_jacobian = pow((p1 - p2).norm_sq(), 0.5) * 0.5;
 
   quad_wts[0] = 1.0 * integ_jacobian;
   quad_wts[1] = 1.0 * integ_jacobian;


### PR DESCRIPTION
This replaces all remaining deprecated libMesh method calls with newer APIs.  It also reduces header dependencies in BoundingBox cases (where the newer API was intended to make that possible) and improves performance slightly in boundary_ids cases (where the newer API was intended to make *that* possible).

Refs #8730 

Closes #13921

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
