### PR TITLE
chigger: allow to overwrite previously rendered movie

### DIFF
--- a/python/chigger/utils/__init__.py
+++ b/python/chigger/utils/__init__.py
@@ -146,7 +146,7 @@ def animate(pattern, output, delay=20, restart_delay=500, loop=True):
     subprocess.call(cmd)
 
 def img2mov(pattern, output, ffmpeg='ffmpeg', duration=60, framerate=None, bitrate='10M',
-            num_threads=1, quality=1, dry_run=False, output_framerate_increase=0):
+            num_threads=1, quality=1, dry_run=False, output_framerate_increase=0, overwrite=False):
     """
     Use ffmpeg to convert a series of images to a movie.
 
@@ -179,6 +179,8 @@ def img2mov(pattern, output, ffmpeg='ffmpeg', duration=60, framerate=None, bitra
     cmd += ['-q:v', str(quality)]
     cmd += ['-threads', str(num_threads)]
     cmd += ['-framerate', str(framerate + output_framerate_increase)]
+    if overwrite:
+        cmd += ['-y']
     cmd += [output]
 
     c = ' '.join(cmd)


### PR DESCRIPTION
Adding option to allow to overwrite a previously rendered movie.
When scripting movie rendering, we may not want to wait for user
to answer the question if the existing movie file should be
overwritten - ffmpeg does that.

This is simply accomplished by passing '-y' flag to ffmpeg which
will cause that all questions asked by ffmepeg will be answered by
'yes'.

Closes #13924

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
