### PR TITLE
Fixing up incorrect branch names for contributing pages

### DIFF
--- a/modules/doc/content/framework_development/contributing.md
+++ b/modules/doc/content/framework_development/contributing.md
@@ -45,7 +45,7 @@ git remote add upstream git@github.com:idaholab/moose.git
 
 Create a branch for your work:
 
-```bash 
+```bash
 git checkout -b branch_name upstream/devel
 ```
 
@@ -96,7 +96,7 @@ GitHub utilizes Pull Requests (PRs) to allow you to submit changes stored in you
 
 In addition: [our own slides](https://mooseframework.org/static/media/uploads/docs/moose_github.pdf) are a great way to learn about the process of submitting a PR for the MOOSE project.
 
-The main thing to remember when issuing a PR for MOOSE is that all PRs should be specified to go to the `devel` branch.
+The main thing to remember when issuing a PR for MOOSE is that all PRs should be specified to go to the `next` branch.
 
 ## What Now?
 

--- a/modules/doc/content/framework_development/patch_to_code.md
+++ b/modules/doc/content/framework_development/patch_to_code.md
@@ -6,7 +6,7 @@ MOOSE uses an extensive set of automated processes and peer review to take in co
 
 ## 1. It begins with a Pull Request
 
-[Contributors](framework_development/contributing.md) submit code to MOOSE by pushing their modifications to their [Fork](https://help.github.com/articles/fork-a-repo) of the MOOSE repository.  Then, a Contributor will submit a Pull Request (PR) to pull their modifications from their Fork into the `devel` branch in the main MOOSE repository.
+[Contributors](framework_development/contributing.md) submit code to MOOSE by pushing their modifications to their [Fork](https://help.github.com/articles/fork-a-repo) of the MOOSE repository.  Then, a Contributor will submit a Pull Request (PR) to pull their modifications from their Fork into the `next` branch in the main MOOSE repository.
 
 ## 2. Testing At Every Turn
 
@@ -50,7 +50,7 @@ If there are more features that need to be added to your code before it's accept
 
 ## 5. Merging
 
-At the point where a MOOSE developer believes your code is fit for inclusion in MOOSE they will "merge" your code into the `devel` branch in the main MOOSE repository.  That act of merging automatically kicks off a set of processes:
+At the point where a MOOSE developer believes your code is fit for inclusion in MOOSE they will "merge" your code into the `next` branch in the main MOOSE repository.  That act of merging automatically kicks off a set of processes:
 
 1.  [CIVET](http://civet.inl.gov) is signaled and more testing is done across multiple platforms.
 2.  If #1 passes then the code change is automatically merged into the `master` branch in the main MOOSE repo (that is our "stable" branch).


### PR DESCRIPTION
refs #13916

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
