### PR TITLE
ADify Tensor helper functions

### DIFF
--- a/modules/tensor_mechanics/include/utils/ElasticityTensorTools.h
+++ b/modules/tensor_mechanics/include/utils/ElasticityTensorTools.h
@@ -66,9 +66,9 @@ momentJacobianWC(const RankFourTensor & r4t, unsigned int i, unsigned int k, Rea
  * Get the shear modulus for an isotropic elasticity tensor
  * param elasticity_tensor the tensor (must be isotropic, but not checked for efficiency)
  */
-template <class T>
-auto
-getIsotropicShearModulus(const T & elasticity_tensor) -> decltype(elasticity_tensor(0, 1, 0, 1))
+template <typename T>
+T
+getIsotropicShearModulus(const RankFourTensorTempl<T> & elasticity_tensor)
 {
   return elasticity_tensor(0, 1, 0, 1);
 }
@@ -77,18 +77,46 @@ getIsotropicShearModulus(const T & elasticity_tensor) -> decltype(elasticity_ten
  * Get the bulk modulus for an isotropic elasticity tensor
  * param elasticity_tensor the tensor (must be isotropic, but not checked for efficiency)
  */
-Real getIsotropicBulkModulus(const RankFourTensor & elasticity_tensor);
+template <typename T>
+T
+getIsotropicBulkModulus(const RankFourTensorTempl<T> & elasticity_tensor)
+{
+  const T shear_modulus = getIsotropicShearModulus(elasticity_tensor);
+  // dilatational modulus is defined as lambda plus two mu
+  const T dilatational_modulus = elasticity_tensor(0, 0, 0, 0);
+  const T lambda = dilatational_modulus - 2.0 * shear_modulus;
+  const T bulk_modulus = lambda + 2.0 * shear_modulus / 3.0;
+  return bulk_modulus;
+}
 
 /**
  * Get the Young's modulus for an isotropic elasticity tensor
  * param elasticity_tensor the tensor (must be isotropic, but not checked for efficiency)
  */
-Real getIsotropicYoungsModulus(const RankFourTensor & elasticity_tensor);
+template <typename T>
+T
+getIsotropicYoungsModulus(const RankFourTensorTempl<T> & elasticity_tensor)
+{
+  const T shear_modulus = getIsotropicShearModulus(elasticity_tensor);
+  // dilatational modulus is defined as lambda plus two mu
+  const T dilatational_modulus = elasticity_tensor(0, 0, 0, 0);
+  const T lambda = dilatational_modulus - 2.0 * shear_modulus;
+  const T youngs_modulus =
+      shear_modulus * (3.0 * lambda + 2.0 * shear_modulus) / (lambda + shear_modulus);
+  return youngs_modulus;
+}
 
 /**
  * Get the Poisson's modulus for an isotropic elasticity tensor
  * param elasticity_tensor the tensor (must be isotropic, but not checked for efficiency)
  */
-Real getIsotropicPoissonsRatio(const RankFourTensor & elasticity_tensor);
+template <typename T>
+T
+getIsotropicPoissonsRatio(const RankFourTensorTempl<T> & elasticity_tensor)
+{
+  const T poissons_ratio = elasticity_tensor(1, 1, 0, 0) /
+                           (elasticity_tensor(1, 1, 1, 1) + elasticity_tensor(1, 1, 0, 0));
+  return poissons_ratio;
 }
 
+}

--- a/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
+++ b/modules/tensor_mechanics/src/utils/ElasticityTensorTools.C
@@ -114,34 +114,4 @@ momentJacobianWC(const RankFourTensor & r4t, unsigned int i, unsigned int k, Rea
   return test * phi * sum;
 }
 
-Real
-getIsotropicBulkModulus(const RankFourTensor & elasticity_tensor)
-{
-  const Real shear_modulus = getIsotropicShearModulus(elasticity_tensor);
-  // dilatational modulus is defined as lambda plus two mu
-  const Real dilatational_modulus = elasticity_tensor(0, 0, 0, 0);
-  const Real lambda = dilatational_modulus - 2.0 * shear_modulus;
-  const Real bulk_modulus = lambda + 2.0 * shear_modulus / 3.0;
-  return bulk_modulus;
-}
-
-Real
-getIsotropicYoungsModulus(const RankFourTensor & elasticity_tensor)
-{
-  const Real shear_modulus = getIsotropicShearModulus(elasticity_tensor);
-  // dilatational modulus is defined as lambda plus two mu
-  const Real dilatational_modulus = elasticity_tensor(0, 0, 0, 0);
-  const Real lambda = dilatational_modulus - 2.0 * shear_modulus;
-  const Real youngs_modulus =
-      shear_modulus * (3.0 * lambda + 2.0 * shear_modulus) / (lambda + shear_modulus);
-  return youngs_modulus;
-}
-
-Real
-getIsotropicPoissonsRatio(const RankFourTensor & elasticity_tensor)
-{
-  const Real poissons_ratio = elasticity_tensor(1, 1, 0, 0) /
-                              (elasticity_tensor(1, 1, 1, 1) + elasticity_tensor(1, 1, 0, 0));
-  return poissons_ratio;
-}
 }


### PR DESCRIPTION
Templated scalar property extraction helpers for RankFourTensors. The decltype solution was overly complicated. The new version restricts the function arguments to RankFourTensor and DualRankFourTensor.

Closes #13927 