### PR TITLE
Manually --enable-glibcxx-debugging in libmesh

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -145,6 +145,7 @@ if [ -z "$go_fast" ]; then
                                    --enable-silent-rules \
                                    --enable-unique-id \
                                    --disable-warnings \
+                                   --enable-glibcxx-debugging \
                                    --with-thread-model=openmp \
                                    --disable-maintainer-mode \
                                    --enable-petsc-hypre-required \


### PR DESCRIPTION
Closes #13935.

This should be a no-op with the current libMesh and should future-proof MOOSE's debugging options against libMesh --disable-glibcxx-debugging becoming the default behavior later.