### PR TITLE
Update tutorial to use ADMaterialProperty in consumers

### DIFF
--- a/tutorials/darcy_thermo_mech/step03_darcy_material/include/kernels/DarcyPressure.h
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/include/kernels/DarcyPressure.h
@@ -35,8 +35,16 @@ protected:
   /// ADKernelGrad objects must override precomputeQpResidual
   virtual ADRealVectorValue precomputeQpResidual() override;
 
-  /// References to be set from Material system
+  // References to be set from Material system
+
+  /// The permeability. Note that this is declared as a \p MaterialProperty. This means that if
+  /// calculation of this property in the producing \p Material depends on non-linear variables, the
+  /// derivative information will be lost here in the consumer and the non-linear solve will suffer
   const MaterialProperty<Real> & _permeability;
+
+  /// The viscosity. This is declared as an \p ADMaterialProperty, meaning any derivative
+  /// information coming from the producing \p Material will be preserved and the integrity of the
+  /// non-linear solve will be likewise preserved
   const ADMaterialProperty(Real) & _viscosity;
 
   usingKernelGradMembers;


### PR DESCRIPTION
This was reported by a user [here](https://groups.google.com/d/msgid/moose-users/0333b708-98b0-4023-b1bc-81a49deb837c%40googlegroups.com?utm_medium=email&utm_source=footer)

We happen to know here that the producer of the `_permeability` is not using any non-linear variables in its calculation, but we want to teach our users that in their AD consumer objects they should (almost) always use `ADMaterialProperty`. It is consistent with our modular philosophy because who knows if sometime in the future we want to change the `_permeability` to be calculated based on non-linear variables.
