### PR TITLE
Add Getting Started Page for Use of Docker Image (Issue #13952)

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -11,7 +11,7 @@
 #
 # MOOSE_JOBS: Optional.  Sets number of cores for running make.
 # PETSC_REV: Commit hash of submodule petsc.
-# LIBMESH_REV: Commit hash of submodule libmesh. 
+# LIBMESH_REV: Commit hash of submodule libmesh.
 #-----------------------------------------------------------------------------#
 
 FROM ubuntu

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -11,7 +11,7 @@
 #
 # MOOSE_JOBS: Optional.  Sets number of cores for running make.
 # PETSC_REV: Commit hash of submodule petsc.
-# LIBMESH_REV: Commit hash of submodule libmesh.
+# LIBMESH_REV: Commit hash of submodule libmesh. 
 #-----------------------------------------------------------------------------#
 
 FROM ubuntu

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -45,7 +45,8 @@ python-dev \
 cmake \
 curl \
 bison \
-flex ; \
+flex \
+libboost-all-dev ; \
 rm -rf /var/lib/apt/lists/*
 
 #-----------------------------------------------------------------------------#

--- a/modules/doc/content/getting_started/index.md
+++ b/modules/doc/content/getting_started/index.md
@@ -18,6 +18,7 @@ your operating system/platform and follow the instructions:
   - [getting_started/installation/centos.md]
 
 - [getting_started/installation/windows10.md]
+- [getting_started/installation/docker.md]
 - Advanced Instructions:
 
   - [getting_started/installation/hpc_install_moose.md]

--- a/modules/doc/content/getting_started/installation/docker.md
+++ b/modules/doc/content/getting_started/installation/docker.md
@@ -8,6 +8,7 @@
 - Disk: 3 GB (image size)
 
 ## Obtaining MOOSE and Running Tests
+
 Images of MOOSE are currently hosted on Docker Hub in the repository [herter4171/ubuntu-moose](https://cloud.docker.com/u/herter4171/repository/docker/herter4171/ubuntu-moose).  The tag "latest" is kept current with the master branch of the repository, and the other tags are commit hashes to be used by codes with MOOSE as a submodule.  Since the Docker image already has the framework compiled, it is possible to go from no extant, local copy of MOOSE to running the tests with a single command.
 
 ```bash
@@ -15,6 +16,7 @@ docker run -ti herter4171/ubuntu-moose:latest /bin/bash -c 'cd test; ./run_tests
 ```
 
 ## Extending the Image With MOOSE Apps
+
 With the fully configured MOOSE framework in a Docker image, the next logical step is to extend this image with whichever MOOSE app is of interest.  For example, consider another open sourced INL code known as BLACKBEAR.  To build an image of BLACKBEAR, start by pasting the following in a new file with the name Dockerfile.    
 
 ```docker

--- a/modules/doc/content/getting_started/installation/docker.md
+++ b/modules/doc/content/getting_started/installation/docker.md
@@ -1,0 +1,45 @@
+# Docker
+
+## Minimum System Requirements
+
+- Some flavor of Linux or MacOS with Docker installed
+- Memory: 16 GBs (debug builds)
+- Processor: 64-bit x86
+- Disk: 3 GB (image size)
+
+## Obtaining MOOSE and Running Tests
+Images of MOOSE are currently hosted on Docker Hub in the repository [herter4171/ubuntu-moose](https://cloud.docker.com/u/herter4171/repository/docker/herter4171/ubuntu-moose).  The tag "latest" is kept current with the master branch of the repository, and the other tags are commit hashes to be used by codes with MOOSE as a submodule.  Since the Docker image already has the framework compiled, it is possible to go from no extant, local copy of MOOSE to running the tests with a single command.
+
+```bash
+docker run -ti herter4171/ubuntu-moose:latest /bin/bash -c 'cd test; ./run_tests'
+```
+
+## Extending the Image With MOOSE Apps
+With the fully configured MOOSE framework in a Docker image, the next logical step is to extend this image with whichever MOOSE app is of interest.  For example, consider another open sourced INL code known as BLACKBEAR.  To build an image of BLACKBEAR, start by pasting the following in a new file with the name Dockerfile.    
+
+```docker
+FROM herter4171/ubuntu-moose:latest
+  
+WORKDIR /opt
+
+RUN git clone -b master https://github.com/idaholab/blackbear.git ; \
+cd blackbear ; \
+git submodule update --init ; \
+make -j $(grep -c ^processor /proc/cpuinfo)
+
+WORKDIR /opt/blackbear
+```
+
+The first line of this file tells Docker to use MOOSE as a base image.  The tag "latest" is used, because BLACKBEAR does not have MOOSE as a submodule.  If it did, a commit hash would be used as the tag instead.  From here, the ```RUN``` instruction handles the cloning, submodule checkout, and building steps.  Last of all, to support end-use, the working directory is set to the root of the image's BLACKBEAR repository.  To build an image using this Dockerfile, run the following.
+
+```bash
+docker build -t blackbear .
+```
+
+After this, like before, the tests can be ran with a single command.
+
+```bash
+docker run -ti blackbear ./run_tests
+```
+
+Hopefully this tutorial has shed some light on some advantages of containerizing MOOSE (or any other large and complex code-base) for development and end-use applications.


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Adds a linked bullet "Docker" to the page Getting Started.  The Docker page itself covers how to obtain the framework, run tests in a container, and extend the image to contain a MOOSE app with BLACKBEAR as the working example.  For BLACKBEAR to compile with neml, Boost has to be installed from the get-go, so libboost-all-dev has been added to the Dockerfile.  This closes #13952.

I've tried to emulate existing markdown, and I've made sure everything looks alright in a markdown renderer.  Although I've built the docs, I'm not seeing any HTML files, so I'm not sure if I did it right or how the page looks in a browser.  Clarification on that would be helpful.
