### PR TITLE
Update SQA templates to optionally explicitly define the dependencies

### DIFF
--- a/framework/doc/content/templates/sqa/app_rtm.md.template
+++ b/framework/doc/content/templates/sqa/app_rtm.md.template
@@ -12,7 +12,7 @@ documentation and associated test case.
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](RTM) for {{app}} is dependent upon the following documents.
 
-!sqa dependencies suffix=rtm
+!sqa dependencies suffix=rtm category={{category}}
 
 ## Requirements
 

--- a/framework/doc/content/templates/sqa/app_sdd.md.template
+++ b/framework/doc/content/templates/sqa/app_sdd.md.template
@@ -12,7 +12,7 @@ describes the architecture of the system and all of its parts.
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](SDD) for {{app}} is dependent upon the following documents.
 
-!sqa dependencies suffix=sdd
+!sqa dependencies suffix=sdd category={{category}}
 
 ## Requirements Cross Reference
 

--- a/framework/doc/content/templates/sqa/app_srs.md.template
+++ b/framework/doc/content/templates/sqa/app_srs.md.template
@@ -12,7 +12,7 @@ describe the expected interactions that the software shall provide.
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](SRS) for {{app}} is dependent upon the following documents.
 
-!sqa dependencies suffix=srs
+!sqa dependencies suffix=srs category={{category}}
 
 ## Requirements
 

--- a/framework/doc/content/templates/sqa/app_stp.md.template
+++ b/framework/doc/content/templates/sqa/app_stp.md.template
@@ -11,4 +11,4 @@ The [!ac](STP) details the objectives, resources, and processes utilized for tes
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](STP) for {{app}} is dependent upon the following documents.
 
-!sqa dependencies suffix=stp
+!sqa dependencies suffix=stp category={{category}}

--- a/framework/doc/content/templates/sqa/app_vvr.md.template
+++ b/framework/doc/content/templates/sqa/app_vvr.md.template
@@ -11,7 +11,7 @@ The [!ac](VVR) for {{app}} provides evidence that {{app}} fullfills its intended
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](VVR) for {{app}} is dependent upon the following documents.
 
-!sqa dependencies suffix=vvr
+!sqa dependencies suffix=vvr category={{category}}
 
 ## Verification
 

--- a/modules/contact/doc/sqa_contact.yml
+++ b/modules/contact/doc/sqa_contact.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/contact/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/fluid_properties/doc/sqa_fluid_properties.yml
+++ b/modules/fluid_properties/doc/sqa_fluid_properties.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/fluid_properties/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/heat_conduction/doc/sqa_heat_conduction.yml
+++ b/modules/heat_conduction/doc/sqa_heat_conduction.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/heat_conduction/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/misc/doc/sqa_misc.yml
+++ b/modules/misc/doc/sqa_misc.yml
@@ -1,4 +1,6 @@
 directories:
     - ${MOOSE_DIR}/modules/misc/test/tests
+dependencies:
+    - framework
 specs:
     - tests

--- a/modules/phase_field/doc/sqa_phase_field.yml
+++ b/modules/phase_field/doc/sqa_phase_field.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/phase_field/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/stochastic_tools/doc/sqa_stochastic_tools.yml
+++ b/modules/stochastic_tools/doc/sqa_stochastic_tools.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/stochastic_tools/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/tensor_mechanics/doc/sqa_tensor_mechanics.yml
+++ b/modules/tensor_mechanics/doc/sqa_tensor_mechanics.yml
@@ -2,3 +2,5 @@ directories:
     - ${MOOSE_DIR}/modules/tensor_mechanics/test/tests
 specs:
     - tests
+dependencies:
+    - framework

--- a/modules/xfem/doc/sqa_xfem.yml
+++ b/modules/xfem/doc/sqa_xfem.yml
@@ -1,4 +1,7 @@
 directories:
     - ${MOOSE_DIR}/modules/xfem/test/tests
+dependencies:
+    - framework
+    - tensor_mechanics
 specs:
     - tests

--- a/python/MooseDocs/test/extensions/test_sqa.py
+++ b/python/MooseDocs/test/extensions/test_sqa.py
@@ -324,16 +324,13 @@ class TestSQADependencies(MooseDocsTestCase):
                                                   specs=['demo'])))
 
     def testCommand(self):
-        text = u"!sqa dependencies suffix=foo"
+        text = u"!sqa dependencies suffix=foo category=Demo"
         ast = self.tokenize(text)
 
         self.assertSize(ast, 1)
-        self.assertToken(ast(0), 'UnorderedList', size=2)
+        self.assertToken(ast(0), 'UnorderedList', size=1)
         self.assertToken(ast(0)(0), 'ListItem', size=1)
         self.assertToken(ast(0)(0)(0), 'AutoLink', page=u'sqa/Demo2_foo.md', optional=True, warning=True)
-        self.assertToken(ast(0), 'UnorderedList', size=2)
-        self.assertToken(ast(0)(1), 'ListItem', size=1)
-        self.assertToken(ast(0)(1)(0), 'AutoLink', page=u'sqa/Demo_foo.md', optional=True, warning=True)
 
 class TestSQADocument(MooseDocsTestCase):
     EXTENSIONS = [core, command, floats, autolink, heading, sqa]


### PR DESCRIPTION
This is necessary for applications, otherwise all of the documents depend on all the others

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
