### PR TITLE
Remove deprecated postprocessor_dtlim parameter

### DIFF
--- a/framework/src/timesteppers/IterationAdaptiveDT.C
+++ b/framework/src/timesteppers/IterationAdaptiveDT.C
@@ -33,11 +33,6 @@ validParams<IterationAdaptiveDT>()
                             "to determine target linear iterations and "
                             "window for adaptive timestepping (default = "
                             "25)");
-  params.addDeprecatedParam<PostprocessorName>("postprocessor_dtlim",
-                                               "If specified, the postprocessor value "
-                                               "is used as an upper limit for the "
-                                               "current time step length",
-                                               "Use 'timestep_limiting_postprocessor' instead");
   params.addParam<PostprocessorName>("timestep_limiting_postprocessor",
                                      "If specified, the postprocessor value "
                                      "is used as an upper limit for the "
@@ -97,8 +92,6 @@ IterationAdaptiveDT::IterationAdaptiveDT(const InputParameters & parameters)
     _adaptive_timestepping(false),
     _pps_value(isParamValid("timestep_limiting_postprocessor")
                    ? &getPostprocessorValue("timestep_limiting_postprocessor")
-                   : isParamValid("postprocessor_dtlim")
-                         ? &getPostprocessorValue("postprocessor_dtlim")
                          : nullptr),
     _timestep_limiting_function(nullptr),
     _piecewise_timestep_limiting_function(nullptr),


### PR DESCRIPTION
 ref #13250

This was deprecated 4 months ago, and should be removed now.