### PR TITLE
Restore stream settings after TimedPrint/PerfGraph

### DIFF
--- a/framework/include/outputs/ConsoleStream.h
+++ b/framework/include/outputs/ConsoleStream.h
@@ -60,6 +60,26 @@ public:
 
   std::streampos tellp() const { return _oss.tellp(); }
 
+  /**
+   * Return the current precision
+   */
+  std::streamsize precision() const;
+
+  /**
+   * Set the precision and return the old precision
+   */
+  std::streamsize precision(std::streamsize new_precision) const;
+
+  /**
+   * Return the current flags
+   */
+  std::ios_base::fmtflags flags() const;
+
+  /**
+   * Set the flags and return the old flags
+   */
+  std::ios_base::fmtflags flags(std::ios_base::fmtflags new_flags) const;
+
 private:
   /// Reference to the OutputWarhouse that contains the Console output objects
   OutputWarehouse & _output_warehouse;

--- a/framework/include/utils/TimedPrint.h
+++ b/framework/include/utils/TimedPrint.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <thread>
 #include <future>
+#include <ios>
 
 #if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 9) && !defined(__INTEL_COMPILER) &&  \
     !defined(__clang__)
@@ -115,9 +116,16 @@ public:
         auto end = std::chrono::steady_clock::now();
         std::chrono::duration<double> duration = end - start;
 
+        auto original_precision = out.precision();
+        auto original_flags = out.flags();
+
         out << std::setw(WRAP_LENGTH - offset) << ' ' << " [" << COLOR_YELLOW << std::setw(6)
             << std::fixed << std::setprecision(2) << duration.count() << " s" << COLOR_DEFAULT
             << ']';
+
+        // Restore the original stream state
+        out.precision(original_precision);
+        out.flags(original_flags);
       }
 
       out << std::endl;

--- a/framework/include/utils/VariadicTable.h
+++ b/framework/include/utils/VariadicTable.h
@@ -221,6 +221,9 @@ protected:
   {
     auto & val = std::get<I>(t);
 
+    auto original_precision = stream.precision();
+    auto original_flags = stream.flags();
+
     // Set the precision
     if (!_precision.empty())
     {
@@ -249,12 +252,13 @@ protected:
     stream << std::string(_cell_padding, ' ') << std::setw(_column_sizes[I])
            << justify<decltype(val)>(0) << val << std::string(_cell_padding, ' ') << "|";
 
-    // Unset the format
+    // Restore the format
     if (!_column_format.empty())
-    {
-      // Because "stream << std::defaultfloat;" won't compile with old GCC or Clang
-      stream.unsetf(std::ios_base::floatfield);
-    }
+      stream.flags(original_flags);
+
+    // Restore the precision
+    if (!_precision.empty())
+      stream.precision(original_precision);
 
     // Recursive call to print the next item
     print_each(std::forward<TupleType>(t), stream, std::integral_constant<size_t, I + 1>());

--- a/framework/src/outputs/ConsoleStream.C
+++ b/framework/src/outputs/ConsoleStream.C
@@ -35,3 +35,27 @@ ConsoleStream::unsetf(std::ios_base::fmtflags mask) const
 {
   _oss.unsetf(mask);
 }
+
+std::streamsize
+ConsoleStream::precision() const
+{
+  return _oss.precision();
+}
+
+std::streamsize
+ConsoleStream::precision(std::streamsize new_precision) const
+{
+  return _oss.precision(new_precision);
+}
+
+std::ios_base::fmtflags
+ConsoleStream::flags() const
+{
+  return _oss.flags();
+}
+
+std::ios_base::fmtflags
+ConsoleStream::flags(std::ios_base::fmtflags new_flags) const
+{
+  return _oss.flags(new_flags);
+}

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -71,6 +71,7 @@
 #include "ADPresetNodalBC.h"
 #include "Moose.h"
 #include "TimedPrint.h"
+#include "ConsoleStream.h"
 
 // libMesh
 #include "libmesh/nonlinear_solver.h"
@@ -88,6 +89,8 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/default_coupling.h"
+
+#include <ios>
 
 // PETSc
 #ifdef LIBMESH_HAVE_PETSC
@@ -3265,6 +3268,11 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
     if (_verbose)
     {
       _console << "Automatic scaling factors:\n";
+      auto original_flags = _console.flags();
+      auto original_precision = _console.precision();
+      _console.unsetf(std::ios_base::floatfield);
+      _console.precision(6);
+
       for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
       {
         auto & field_variable = *field_variables[i];
@@ -3278,6 +3286,10 @@ NonlinearSystemBase::computeScalingJacobian(NonlinearImplicitSystem & sys)
                  << 1.0 / inverse_scaling_factors[offset + i] << "\n";
       }
       _console << "\n\n";
+
+      // restore state
+      _console.flags(original_flags);
+      _console.precision(original_precision);
     }
 
     // Now set the scaling factors for the variables

--- a/test/tests/executioners/executioner/tests
+++ b/test/tests/executioners/executioner/tests
@@ -1,12 +1,12 @@
 [Tests]
   design = 'syntax/Executioner/index.md'
-  issues = ''
   [./test_steady_adapt]
     type = 'Exodiff'
     input = 'steady-adapt.i'
     exodiff = 'out_steady_adapt.e-s004'
     group = 'adaptive'
     requirement = "MOOSE shall support adaptive solves for steady-state execution."
+    issues = '#1405'
   [../]
 
   [./test_steady_state_check]
@@ -14,6 +14,7 @@
     input = 'steady_state_check_test.i'
     exodiff = 'out_ss_check.e'
     requirement = "MOOSE shall be able to detect steady state conditions during execution."
+    issues = '#1927'
   [../]
 
   [./test_steady]
@@ -22,6 +23,7 @@
     exodiff = 'out_steady.e'
     abs_zero = 1e-9
     requirement = "MOOSE shall be capable of solving a steady state diffusion problem."
+    issues = '#1405'
   [../]
 
   [./test_transient]
@@ -30,17 +32,18 @@
     exodiff = 'out_transient.e'
     group = 'requirements'
     requirement = "MOOSE shall be capable of solving a transient diffusion problem."
+    issues = '#1405'
   [../]
 
   [./test_print_automatic_scaling_factors_true]
     type = 'RunApp'
     input = 'steady.i'
     cli_args = "Executioner/automatic_scaling=true Executioner/verbose=true Outputs/exodus=false"
-    expect_out = "Automatic scaling factors:
-  u: 0.175781"
+    expect_out = "Automatic scaling factors:\s+u: 0\.175781"
     petsc_version = '>=3.9.0'
     max_parallel = 4
     requirement = "MOOSE shall print automatic scaling factors if specified."
+    issues = '#13795'
   [../]
 
   [./test_print_automatic_scaling_factors_false]
@@ -51,5 +54,6 @@
     petsc_version = '>=3.9.0'
     max_parallel = 4
     requirement = "MOOSE shall not print automatic scaling factors if not specified."
+    issues = '#13795'
   [../]
 []


### PR DESCRIPTION
This bit us in the test added from #13798. If we generate output
from TimedPrint (e.g. if mesh building or equation systems initing
takes **enough time**), then we set the precision to 2, and then
this impacts unwary users who attempt to use the console and
expect default precision (e.g. 6).