### PR TITLE
Adding fp_type into base fluid property classes

### DIFF
--- a/modules/fluid_properties/src/userobjects/HEMFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/HEMFluidProperties.C
@@ -15,6 +15,8 @@ InputParameters
 validParams<HEMFluidProperties>()
 {
   InputParameters params = validParams<FluidProperties>();
+  params.addCustomTypeParam<std::string>(
+      "fp_type", "hem-fp", "FPType", "Type of the fluid property object");
   return params;
 }
 

--- a/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SinglePhaseFluidProperties.C
@@ -14,6 +14,8 @@ InputParameters
 validParams<SinglePhaseFluidProperties>()
 {
   InputParameters params = validParams<FluidProperties>();
+  params.addCustomTypeParam<std::string>(
+      "fp_type", "single-phase-fp", "FPType", "Type of the fluid property object");
   return params;
 }
 

--- a/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseFluidProperties.C
@@ -15,7 +15,8 @@ InputParameters
 validParams<TwoPhaseFluidProperties>()
 {
   InputParameters params = validParams<FluidProperties>();
-
+  params.addCustomTypeParam<std::string>(
+      "fp_type", "two-phase-fp", "FPType", "Type of the fluid property object");
   params.addParam<UserObjectName>("fp_liquid",
                                   "Liquid single-phase fluid properties user object name");
   params.addParam<UserObjectName>("fp_vapor",

--- a/modules/fluid_properties/src/userobjects/TwoPhaseNCGFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseNCGFluidProperties.C
@@ -14,6 +14,8 @@ InputParameters
 validParams<TwoPhaseNCGFluidProperties>()
 {
   InputParameters params = validParams<TwoPhaseFluidProperties>();
+  params.addCustomTypeParam<std::string>(
+      "fp_type", "two-phase-ncg-fp", "FPType", "Type of the fluid property object");
   params.addParam<UserObjectName>("fp_2phase",
                                   "Name of fluid properties user object(s) for two-phase model");
   return params;


### PR DESCRIPTION
Each base class gains a 'fp_type' parameter to help GUI determine
the type of the fluid property class.

Closes #13983

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
