### PR TITLE
Catch throws from NearestNodeThread before point locator

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -443,7 +443,7 @@ public:
    * Note: DO NOT CALL THIS IN A THREADED REGION!  This is meant to be called just after a threaded
    * section.
    */
-  virtual void checkExceptionAndStopSolve();
+  virtual void checkExceptionAndStopSolve(bool print_message = true);
 
   virtual bool converged() override;
   virtual unsigned int nNonlinearIterations() const override;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4420,7 +4420,7 @@ FEProblemBase::setException(const std::string & message)
 }
 
 void
-FEProblemBase::checkExceptionAndStopSolve()
+FEProblemBase::checkExceptionAndStopSolve(bool print_message)
 {
   if (_skip_exception_check)
     return;
@@ -4438,7 +4438,7 @@ FEProblemBase::checkExceptionAndStopSolve()
     _communicator.broadcast(_exception_message, processor_id);
 
     // Print the message
-    if (_communicator.rank() == 0)
+    if (_communicator.rank() == 0 && print_message)
       Moose::err << _exception_message << std::endl;
 
     // Stop the solve -- this entails setting


### PR DESCRIPTION
Point locator does parallel operations so we have to make sure
we catch any exceptions and propagate them to all processes before
getting to the point locator.

This would be pretty hard to drum up a test for since we really are only
testing a very particular possible throw from `NearestNodeThread`
and generating that throw typically requires a previously bad linear solve
that puts the mesh displacements in a "bad place". So we could get
regressions in the future...