### PR TITLE
Avoid temporary vectors and maps during KT stabilisation

### DIFF
--- a/modules/porous_flow/include/userobjects/AdvectiveFluxCalculatorBase.h
+++ b/modules/porous_flow/include/userobjects/AdvectiveFluxCalculatorBase.h
@@ -283,4 +283,45 @@ protected:
    * @param[in] node_i nodal id
    */
   void zeroedConnection(std::map<dof_id_type, Real> & the_map, dof_id_type node_i) const;
+
+  /// Vectors used in finalize()
+  std::vector<std::vector<Real>> _dij;
+  /// dDij_dKij[i][j] = d(D[i][j])/d(K[i][j]) for i!=j
+  std::vector<std::vector<Real>> _dDij_dKij;
+  /// dDij_dKji[i][j] = d(D[i][j])/d(K[j][i]) for i!=j
+  std::vector<std::vector<Real>> _dDij_dKji;
+  /// dDii_dKij[i][j] = d(D[i][i])/d(K[i][j])
+  std::vector<std::vector<Real>> _dDii_dKij;
+  /// dDii_dKji[i][j] = d(D[i][i])/d(K[j][i])
+  std::vector<std::vector<Real>> _dDii_dKji;
+
+  std::vector<std::vector<Real>> _lij;
+  std::vector<Real> _rP;
+  std::vector<Real> _rM;
+
+  /// drP[i][j] = d(rP[i])/d(u[j]). Here j indexes the j^th node connected to i
+  std::vector<std::vector<Real>> _drP;
+  /// drM[i][j] = d(rM[i])/d(u[j]). Here j indexes the j^th node connected to i
+  std::vector<std::vector<Real>> _drM;
+  /// drP_dk[i][j] = d(rP[i])/d(K[i][j]).  Here j indexes the j^th node connected to i
+  std::vector<std::vector<Real>> _drP_dk;
+  /// drM_dk[i][j] = d(rM[i])/d(K[i][j]).  Here j indexes the j^th node connected to i
+  std::vector<std::vector<Real>> _drM_dk;
+
+  /// fa[sequential_i][j]  sequential_j is the j^th connection to sequential_i
+  std::vector<std::vector<Real>> _fa;
+  /// dfa[sequential_i][j][global_k] = d(fa[sequential_i][j])/du[global_k].
+  /// Here global_k can be a neighbor to sequential_i or a neighbour to
+  /// sequential_j (sequential_j is the j^th connection to sequential_i)
+  std::vector<std::vector<std::map<dof_id_type, Real>>> _dfa;
+  /// dFij_dKik[sequential_i][j][k] =
+  /// d(fa[sequential_i][j])/d(K[sequential_i][k]).  Here j denotes
+  /// the j^th connection to sequential_i, while k denotes the k^th
+  /// connection to sequential_i
+  std::vector<std::vector<std::vector<Real>>> _dFij_dKik;
+  /// dFij_dKjk[sequential_i][j][k] =
+  /// d(fa[sequential_i][j])/d(K[sequential_j][k]).  Here sequential_j is
+  /// the j^th connection to sequential_i, and k denotes the k^th connection
+  /// to sequential_j (this will include sequential_i itself)
+  std::vector<std::vector<std::vector<Real>>> _dFij_dKjk;
 };

--- a/modules/porous_flow/src/userobjects/PorousFlowAdvectiveFluxCalculatorBase.C
+++ b/modules/porous_flow/src/userobjects/PorousFlowAdvectiveFluxCalculatorBase.C
@@ -180,7 +180,7 @@ PorousFlowAdvectiveFluxCalculatorBase::initialize()
   _du_dvar_computed_by_thread.assign(num_nodes, false);
   for (dof_id_type sequential_i = 0; sequential_i < num_nodes; ++sequential_i)
   {
-    const std::vector<dof_id_type> con_i =
+    const std::vector<dof_id_type> & con_i =
         _connections.globalConnectionsToSequentialID(sequential_i);
     const std::size_t num_con_i = con_i.size();
     for (unsigned j = 0; j < num_con_i; ++j)
@@ -219,7 +219,7 @@ PorousFlowAdvectiveFluxCalculatorBase::threadJoin(const UserObject & uo)
   const std::size_t num_nodes = _connections.numNodes();
   for (dof_id_type sequential_i = 0; sequential_i < num_nodes; ++sequential_i)
   {
-    const std::vector<dof_id_type> con_i =
+    const std::vector<dof_id_type> & con_i =
         _connections.globalConnectionsToSequentialID(sequential_i);
     const std::size_t num_con_i = con_i.size();
     for (unsigned j = 0; j < num_con_i; ++j)
@@ -261,7 +261,7 @@ PorousFlowAdvectiveFluxCalculatorBase::finalize()
     const dof_id_type sequential_i = _connections.sequentialID(node_i);
     _dflux_out_dvars[sequential_i].clear();
 
-    const std::map<dof_id_type, Real> dflux_out_du =
+    const std::map<dof_id_type, Real> & dflux_out_du =
         AdvectiveFluxCalculatorBase::getdFluxOutdu(node_i);
     for (const auto & node_du : dflux_out_du)
     {
@@ -275,18 +275,18 @@ PorousFlowAdvectiveFluxCalculatorBase::finalize()
     // _dflux_out_dvars is now sized correctly, because getdFluxOutdu(i) contains all nodes
     // connected to i and all nodes connected to nodes connected to i.  The
     // getdFluxOutdKij contains no extra nodes, so just += the dflux/dK terms
-    const std::vector<std::vector<Real>> dflux_out_dKjk =
+    const std::vector<std::vector<Real>> & dflux_out_dKjk =
         AdvectiveFluxCalculatorBase::getdFluxOutdKjk(node_i);
-    const std::vector<dof_id_type> con_i = _connections.globalConnectionsToGlobalID(node_i);
+    const std::vector<dof_id_type> & con_i = _connections.globalConnectionsToGlobalID(node_i);
     for (std::size_t index_j = 0; index_j < con_i.size(); ++index_j)
     {
       const dof_id_type node_j = con_i[index_j];
-      const std::vector<dof_id_type> con_j = _connections.globalConnectionsToGlobalID(node_j);
+      const std::vector<dof_id_type> & con_j = _connections.globalConnectionsToGlobalID(node_j);
       for (std::size_t index_k = 0; index_k < con_j.size(); ++index_k)
       {
         const dof_id_type node_k = con_j[index_k];
         const Real dflux_out_dK_jk = dflux_out_dKjk[index_j][index_k];
-        const std::map<dof_id_type, std::vector<Real>> dkj_dvarl = getdK_dvar(node_j, node_k);
+        const std::map<dof_id_type, std::vector<Real>> & dkj_dvarl = getdK_dvar(node_j, node_k);
         for (const auto & nodel_deriv : dkj_dvarl)
         {
           const dof_id_type l = nodel_deriv.first;


### PR DESCRIPTION
Creating and destroying the vectors and maps was slowing
numerical stabilisation.

Here are some test timing before and after this PR. 

| test  | before | after | speedup |
| ------------- | ------------- | ------------- | ------------- |
| `flux_limited_TVD_advection/fltvd_3D.i` | 36.763 | 21.703 | 1.69 |
| `flux_limited_TVD_pflow/pffltvd_3D.i` | 41.762 | 17.89 | 2.33 |
| `flux_limited_TVD_pflow/pffltvd_2D_trimesh.i` | 520.612 | 377.17 | 1.38 |

Refs #13857
