### PR TITLE
Also need to resize ad_q_points

### DIFF
--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -601,8 +601,6 @@ Assembly::reinitFE(const Elem * elem)
   {
     auto n_qp = _current_qrule->n_points();
     resizeADMappingObjects(n_qp, dim);
-    if (_calculate_xyz)
-      _ad_q_points.resize(n_qp);
     if (_displaced)
     {
       const auto & qw = _current_qrule->get_weights();
@@ -776,6 +774,8 @@ Assembly::resizeADMappingObjects(unsigned int n_qp, unsigned int dim)
 
   _ad_jac.resize(n_qp);
   _ad_JxW.resize(n_qp);
+  if (_calculate_xyz)
+    _ad_q_points.resize(n_qp);
 }
 
 void

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/gold/qnnl_ad.e
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/gold/qnnl_ad.e
@@ -1,0 +1,1 @@
+quadrature_nearest_node_locator_out.e

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/qnnl_ad.cmp
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/qnnl_ad.cmp
@@ -1,0 +1,9 @@
+COORDINATES absolute 1.e-6
+
+TIME STEPS relative 1.e-6 floor 0.0
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	u
+
+ELEMENT VARIABLES relative 1.e-6 floor 0.0
+	distance

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/qnnl_ad.i
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/qnnl_ad.i
@@ -1,0 +1,76 @@
+[Mesh]
+  file = 2dcontact_collide.e
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./distance]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [disp_x][]
+  [disp_y][]
+[]
+
+[Kernels]
+  [./diff]
+    type = ADDiffusion
+    variable = u
+    use_displaced_mesh = true
+  [../]
+[]
+
+[AuxKernels]
+  [./distance]
+    type = NearestNodeDistanceAux
+    variable = distance
+    boundary = 2
+    paired_boundary = 3
+  [../]
+[]
+
+[BCs]
+  [./block1_left]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+  [./block1_right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+  [./block2_left]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 0
+  [../]
+  [./block2_right]
+    type = DirichletBC
+    variable = u
+    boundary = 4
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  solve_type = 'PJFNK'
+
+[]
+
+[Outputs]
+  exodus = true
+  file_base = qnnl_ad
+[]

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/tests
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/tests
@@ -15,5 +15,6 @@
     requirement = 'Volumetric AD assembly data shall be properly sized when reinitializing faces'
     group = 'geometric'
     issues = '#5658'
+    custom_cmp = 'qnnl_ad.cmp'
   []
 []

--- a/test/tests/geomsearch/quadrature_nearest_node_locator/tests
+++ b/test/tests/geomsearch/quadrature_nearest_node_locator/tests
@@ -1,5 +1,4 @@
 [Tests]
-  issues = ''
   design = 'source/auxkernels/NearestNodeDistanceAux.md'
   [./qnnl]
     type = 'Exodiff'
@@ -7,5 +6,14 @@
     exodiff = 'quadrature_nearest_node_locator_out.e'
     group = 'geometric'
     requirement = "The NearestNodeDistanceAux object shall compute the shortest distance between nodes on two overlapping boundaries using a constant monomial auxiliary variable."
+    issues = '#1462'
   [../]
+  [qnnl_ad]
+    type = 'Exodiff'
+    input = 'qnnl_ad.i'
+    exodiff = 'qnnl_ad.e'
+    requirement = 'Volumetric AD assembly data shall be properly sized when reinitializing faces'
+    group = 'geometric'
+    issues = '#5658'
+  []
 []


### PR DESCRIPTION
Bug reported by @tophmatthews: We would have an out-of-bounds access in `_ad_q_points` if we had the following:

- An `ADKernel` operating on a displaced mesh
- A `NearestNodeLocator` operating on quadrature points

This PR fixes the issue and adds a corresponding test.
