### PR TITLE
App objects must depend on MooseConfig

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -46,6 +46,12 @@ SRC_DIRS    := $(APPLICATION_DIR)/src
 PLUGIN_DIR  := $(APPLICATION_DIR)/plugins
 
 excluded_srcfiles += main.C
+excluded_srcfile_paths += $(shell find $(SRC_DIRS) -name main.C)
+ifeq ($(LIBRARY_SUFFIX),yes)
+excluded_objects	    := $(patsubst %.C, %_with$(app_LIB_SUFFIX).$(obj-suffix), $(excluded_srcfile_paths))
+else
+excluded_objects	    := $(patsubst %.C, %.$(obj-suffix), $(excluded_srcfile_paths))
+endif
 
 find_excludes     := $(foreach i, $(excluded_srcfiles), -not -name $(i))
 srcfiles    := $(shell find $(SRC_DIRS) -regex "[^\#~]*\.C" $(find_excludes))
@@ -132,13 +138,13 @@ ifeq ($(MOOSE_HEADER_SYMLINKS),true)
 
 $(app_objects): $(moose_config_symlink)
 $(app_test_objects): $(moose_config_symlink)
-$(excluded_srcfiles): $(moose_config_symlink)
+$(excluded_objects): $(moose_config_symlink)
 
 else
 
 $(app_objects): $(moose_config)
 $(app_test_objects): $(moose_config)
-$(excluded_srcfiles): $(moose_config_symlink)
+$(excluded_objects): $(moose_config_symlink)
 
 endif
 

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -46,11 +46,11 @@ SRC_DIRS    := $(APPLICATION_DIR)/src
 PLUGIN_DIR  := $(APPLICATION_DIR)/plugins
 
 excluded_srcfiles += main.C
-excluded_srcfile_paths += $(shell find $(SRC_DIRS) -name main.C)
+relative_excluded_srcfiles := $(foreach i, $(excluded_srcfiles), $(shell find $(SRC_DIRS) -name $(i)))
 ifeq ($(LIBRARY_SUFFIX),yes)
-excluded_objects	    := $(patsubst %.C, %_with$(app_LIB_SUFFIX).$(obj-suffix), $(excluded_srcfile_paths))
+excluded_objects	    := $(patsubst %.C, %_with$(app_LIB_SUFFIX).$(obj-suffix), $(relative_excluded_srcfiles))
 else
-excluded_objects	    := $(patsubst %.C, %.$(obj-suffix), $(excluded_srcfile_paths))
+excluded_objects	    := $(patsubst %.C, %.$(obj-suffix), $(relative_excluded_srcfiles))
 endif
 
 find_excludes     := $(foreach i, $(excluded_srcfiles), -not -name $(i))

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -46,6 +46,7 @@ SRC_DIRS    := $(APPLICATION_DIR)/src
 PLUGIN_DIR  := $(APPLICATION_DIR)/plugins
 
 excluded_srcfiles += main.C
+
 find_excludes     := $(foreach i, $(excluded_srcfiles), -not -name $(i))
 srcfiles    := $(shell find $(SRC_DIRS) -regex "[^\#~]*\.C" $(find_excludes))
 
@@ -126,6 +127,20 @@ test_cobjects:= $(patsubst %.c, %.$(obj-suffix), $(test_csrcfiles))
 test_fobjects:= $(patsubst %.f, %.$(obj-suffix), $(test_fsrcfiles))
 test_f90objects:= $(patsubst %.f90, %.$(obj-suffix), $(test_f90srcfiles))
 app_test_objects := $(test_objects) $(test_cobjects) $(test_fobjects) $(test_f90objects)
+
+ifeq ($(MOOSE_HEADER_SYMLINKS),true)
+
+$(app_objects): $(moose_config_symlink)
+$(app_test_objects): $(moose_config_symlink)
+$(excluded_srcfiles): $(moose_config_symlink)
+
+else
+
+$(app_objects): $(moose_config)
+$(app_test_objects): $(moose_config)
+$(excluded_srcfiles): $(moose_config_symlink)
+
+endif
 
 # plugin files
 plugfiles   := $(shell find $(PLUGIN_DIR) -regex "[^\#~]*\.C" 2>/dev/null)


### PR DESCRIPTION
@cpgr reported this issue on the [mailing list](https://groups.google.com/d/msgid/moose-users/cd0f6915-3d9d-4430-8a70-1b6b0b8db844%40googlegroups.com?utm_medium=email&utm_source=footer). I was able to reproduce it if I took an existing MOOSE build, updated to `next`, and then executed `make` in an application directory as opposed to a framework directory.

The fix is to also make application objects depend on `MooseConfig.h`.
