### PR TITLE
improve some error messages

### DIFF
--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -14,6 +14,7 @@
 #include "ConsoleStreamInterface.h"
 #include "Registry.h"
 #include "MemberTemplateMacros.h"
+#include "MooseUtils.h"
 
 #include "libmesh/parallel_object.h"
 
@@ -29,6 +30,14 @@ InputParameters validParams<MooseObject>();
 
 // needed to avoid #include cycle with MooseApp and MooseObject
 [[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
+
+/**
+ * Generates a canonical paramError prefix for param-related error/warning/info messages.
+ *
+ * Use this for building custom messages when the default paramError isn't
+ * quite what you need.
+ */
+std::string paramErrorPrefix(const InputParameters & params, const std::string & param);
 
 // helper macro to explicitly instantiate AD classes
 #define adBaseClass(X)                                                                             \
@@ -105,13 +114,7 @@ public:
    * back to the normal behavior of mooseError - only printing a message using the given args.
    */
   template <typename... Args>
-  [[noreturn]] void paramError(const std::string & param, Args... args) const
-  {
-    auto prefix = param + ": ";
-    if (!_pars.inputLocation(param).empty())
-      prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
-    mooseError(prefix, args...);
-  }
+  [[noreturn]] void paramError(const std::string & param, Args... args) const;
 
   /**
    * Emits a warning prefixed with the file and line number of the given param (from the input
@@ -120,13 +123,7 @@ public:
    * back to the normal behavior of mooseWarning - only printing a message using the given args.
    */
   template <typename... Args>
-  void paramWarning(const std::string & param, Args... args) const
-  {
-    auto prefix = param + ": ";
-    if (!_pars.inputLocation(param).empty())
-      prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
-    mooseWarning(prefix, args...);
-  }
+  void paramWarning(const std::string & param, Args... args) const;
 
   /**
    * Emits an informational message prefixed with the file and line number of the given param
@@ -136,13 +133,7 @@ public:
    * the given args.
    */
   template <typename... Args>
-  void paramInfo(const std::string & param, Args... args) const
-  {
-    auto prefix = param + ": ";
-    if (!_pars.inputLocation(param).empty())
-      prefix = _pars.inputLocation(param) + ": (" + _pars.paramFullpath(param) + "):\n";
-    mooseInfo(prefix, args...);
-  }
+  void paramInfo(const std::string & param, Args... args) const;
 
   template <typename... Args>
   [[noreturn]] void mooseError(Args &&... args) const
@@ -186,6 +177,28 @@ protected:
 
   /// Reference to the "enable" InputParaemters, used by Controls for toggling on/off MooseObjects
   const bool & _enabled;
+
+private:
+  template <typename... Args>
+  std::string paramErrorMsg(const std::string & param, Args... args) const
+  {
+    auto prefix = paramErrorPrefix(_pars, param);
+    std::ostringstream oss;
+    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
+    std::string msg = oss.str();
+
+    // Wrap error message to a separate line from prefix if it is about to
+    // blow past 100 chars.  But only wrap if the prefix is long enough (12
+    // chars) for the wrap to buy us much extra length.
+    if ((prefix.size() > 12 && msg.size() + prefix.size() > 99) ||
+        msg.find("\n") != std::string::npos)
+    {
+      if (prefix.size() > 0 && prefix[prefix.size() - 1] != ':')
+        prefix += ":";
+      return prefix + "\n    " + MooseUtils::replaceAll(msg, "\n", "\n    ");
+    }
+    return prefix + " " + msg;
+  }
 };
 
 template <typename T>
@@ -193,4 +206,25 @@ const T &
 MooseObject::getParamTempl(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+}
+
+template <typename... Args>
+[[noreturn]] void
+MooseObject::paramError(const std::string & param, Args... args) const
+{
+  mooseError(paramErrorMsg(param, std::forward<Args>(args)...));
+}
+
+template <typename... Args>
+void
+MooseObject::paramWarning(const std::string & param, Args... args) const
+{
+  mooseWarning(paramErrorMsg(param, std::forward<Args>(args)...));
+}
+
+template <typename... Args>
+void
+MooseObject::paramInfo(const std::string & param, Args... args) const
+{
+  mooseInfo(paramErrorMsg(param, std::forward<Args>(args)...));
 }

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -56,6 +56,9 @@ MetaPhysicL::DualNumber<T, D> abs(MetaPhysicL::DualNumber<T, D> && in);
 namespace MooseUtils
 {
 
+/// Replaces all occurences of from in str with to and returns the result.
+std::string replaceAll(std::string str, const std::string & from, const std::string & to);
+
 /**
  * Replaces "LATEST" placeholders with the latest checkpoint file name.  If base_only is true, then
  * only return the base-name of the checkpoint directory - otherwise, a full mesh

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -20,6 +20,15 @@ class SystemBase;
 class AuxiliarySystem;
 class Transient;
 
+std::string
+paramErrorPrefix(const InputParameters & params, const std::string & param)
+{
+  auto prefix = param + ":";
+  if (!params.inputLocation(param).empty())
+    prefix = params.inputLocation(param) + ": (" + params.paramFullpath(param) + ")";
+  return prefix;
+}
+
 template <>
 InputParameters
 validParams<MooseObject>()

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -214,17 +214,17 @@ MaterialPropertyInterface::checkBlockAndBoundaryCompatibility(std::shared_ptr<Ma
   if (!discrete->hasBlocks(_mi_block_ids))
   {
     std::ostringstream oss;
-    oss << "The Material object '" << discrete->name()
-        << "' is defined on blocks that are incompatible with the retrieving object '" << _mi_name
-        << "':\n";
-    oss << "  " << discrete->name();
+    oss << "Incompatible material and object blocks:";
+
+    oss << "\n    " << paramErrorPrefix(discrete->parameters(), "block")
+        << " material defined on blocks ";
     for (const auto & sbd_id : discrete->blockIDs())
-      oss << " " << sbd_id;
-    oss << "\n";
-    oss << "  " << _mi_name;
+      oss << sbd_id << ", ";
+
+    oss << "\n    " << paramErrorPrefix(_mi_params, "block") << " object needs material on blocks ";
     for (const auto & block_id : _mi_block_ids)
-      oss << " " << block_id;
-    oss << "\n";
+      oss << block_id << ", ";
+
     mooseError(oss.str());
   }
 
@@ -232,17 +232,18 @@ MaterialPropertyInterface::checkBlockAndBoundaryCompatibility(std::shared_ptr<Ma
   if (!discrete->hasBoundary(_mi_boundary_ids))
   {
     std::ostringstream oss;
-    oss << "The Material object '" << discrete->name()
-        << "' is defined on boundaries that are incompatible with the retrieving object '"
-        << _mi_name << "':\n";
-    oss << "  " << discrete->name();
+    oss << "Incompatible material and object boundaries:";
+
+    oss << "\n    " << paramErrorPrefix(discrete->parameters(), "boundary")
+        << " material defined on boundaries ";
     for (const auto & bnd_id : discrete->boundaryIDs())
-      oss << " " << bnd_id;
-    oss << "\n";
-    oss << "  " << _mi_name;
+      oss << bnd_id << ", ";
+
+    oss << "\n    " << paramErrorPrefix(_mi_params, "boundary")
+        << " object needs material on boundaries ";
     for (const auto & bnd_id : _mi_boundary_ids)
-      oss << " " << bnd_id;
-    oss << "\n";
+      oss << bnd_id << ", ";
+
     mooseError(oss.str());
   }
 }
@@ -252,6 +253,7 @@ MaterialPropertyInterface::getMaterialByName(const std::string & name, bool no_w
 {
   std::shared_ptr<Material> discrete =
       _mi_feproblem.getMaterial(name, _material_data_type, _mi_tid, no_warn);
+
   checkBlockAndBoundaryCompatibility(discrete);
   return *discrete;
 }
@@ -286,6 +288,6 @@ void
 MaterialPropertyInterface::checkExecutionStage()
 {
   if (_mi_feproblem.startedInitialSetup())
-    mooseError("Material properties must be retrieved during object construction to ensure correct "
-               "problem integrity validation.");
+    mooseError("Material properties must be retrieved during object construction. This is a code "
+               "problem.");
 }

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -482,9 +482,15 @@ void
 Parser::parse(const std::string & input_filename)
 {
   // Save the filename
-  char abspath[PATH_MAX + 1];
-  realpath(input_filename.c_str(), abspath);
-  _input_filename = std::string(abspath);
+  _input_filename = input_filename;
+  std::string use_rel_paths_str =
+      std::getenv("MOOSE_RELATIVE_FILEPATHS") ? std::getenv("MOOSE_RELATIVE_FILEPATHS") : "false";
+  if (use_rel_paths_str == "0" || use_rel_paths_str == "false")
+  {
+    char abspath[PATH_MAX + 1];
+    realpath(input_filename.c_str(), abspath);
+    _input_filename = std::string(abspath);
+  }
 
   // vector for initializing active blocks
   std::vector<std::string> all = {"__all__"};

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -42,6 +42,18 @@ namespace MooseUtils
 {
 
 std::string
+replaceAll(std::string str, const std::string & from, const std::string & to)
+{
+  size_t start_pos = 0;
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+  {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
+  }
+  return str;
+}
+
+std::string
 convertLatestCheckpoint(std::string orig, bool base_only)
 {
   auto slash_pos = orig.find_last_of("/");

--- a/test/tests/materials/discrete/tests
+++ b/test/tests/materials/discrete/tests
@@ -56,8 +56,9 @@
       # Test error message when blocks are incompatible
       type = RunException
       input = recompute_block_error.i
-      expect_err = "The Material object 'recompute_props' is defined on blocks that are incompatible "
-                   "with the retrieving object 'newton':\n\s*recompute_props\s0\n\s*newton\s0\s10"
+      expect_err = "Incompatible material and object blocks:\s*"
+                   ".*recompute_block_error.i:.* \(Materials/recompute_props/block\) material defined on blocks 0"
+                   ".*recompute_block_error.i:.* \(Materials/newton/block\) object needs material on blocks 0, 10"
 
       detail = 'on compatible blocks, and'
     []
@@ -66,9 +67,9 @@
       # Test error message when boundary are incompatible
       type = RunException
       input = recompute_boundary_error.i
-      expect_err = "The Material object 'recompute_props' is defined on boundaries that are "
-                   "incompatible with the retrieving object "
-                   "'newton':\n\s*recompute_props\s3\n\s*newton\s1\s3"
+      expect_err = "Incompatible material and object boundaries:\s*"
+                   ".*recompute_boundary_error.i:.* \(Materials/recompute_props/boundary\) material defined on boundaries 3,"
+                   ".*recompute_boundary_error.i:.* \(Materials/newton/boundary\) object needs material on boundaries 1, 3,"
 
       detail = 'on compatible boundaries.'
     []


### PR DESCRIPTION
Improves [bla]Restrictable error messages.  Also allows users to set environment var `MOOSE_RELATIVE_FILEPATHS` to cause error message filepaths to be relative instead of absolute if desired.  Also factor out paramError prefix-generating logic into its own
function to allow custom-built errors to still use the same prefix/convention as paramError.

Before:

```
The Material object 'recompute_props' is defined on blocks that are incompatible with the retrieving object 'newton':
  recompute_props 0
  newton 0 10
```

After:

```
Incompatible material and object blocks:
    /path/to/input/file.i:51: (Materials/recompute_props/block) material defined on blocks 0, 
    /path/to/input/file.i:62: (Materials/newton/block) object needs material on blocks 0, 10,
```

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
