### PR TITLE
Do not evaluate nodal BCs for non-nodal variables

### DIFF
--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -162,7 +162,7 @@ public:
   bool isVector() const override;
   const Node * const & node() const { return _element_data->node(); }
   const dof_id_type & nodalDofIndex() const override { return _element_data->nodalDofIndex(); }
-  bool isNodalDefined() const;
+  virtual bool isNodalDefined() const override;
 
   const Node * const & nodeNeighbor() const { return _neighbor_data->node(); }
   const dof_id_type & nodalDofIndexNeighbor() const override

--- a/framework/include/variables/MooseVariableFEBase.h
+++ b/framework/include/variables/MooseVariableFEBase.h
@@ -69,6 +69,12 @@ public:
    */
   virtual bool isVector() const = 0;
 
+  /**
+   * Is this variable defined at nodes
+   * @return true if it the variable is defined at nodes, otherwise false
+   */
+  virtual bool isNodalDefined() const = 0;
+
   virtual const dof_id_type & nodalDofIndex() const = 0;
   virtual const dof_id_type & nodalDofIndexNeighbor() const = 0;
 

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -498,6 +498,13 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name,
   // NodalBCBase
   if (nbc)
   {
+    if (!nbc->variable().isNodal())
+      mooseError("Trying to use nodal boundary condition '",
+                 nbc->name(),
+                 "' on a non-nodal variable '",
+                 nbc->variable().name(),
+                 "'.");
+
     _nodal_bcs.addObject(nbc);
     _vars[tid].addBoundaryVars(boundary_ids, nbc->getCoupledVars());
 

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -378,11 +378,9 @@ SystemBase::reinitNode(const Node * /*node*/, THREAD_ID tid)
   const std::vector<MooseVariableFEBase *> & vars = _vars[tid].fieldVariables();
   for (const auto & var : vars)
   {
-    if (var->isNodal())
-    {
-      var->reinitNode();
+    var->reinitNode();
+    if (var->isNodalDefined())
       var->computeNodalValues();
-    }
   }
 }
 
@@ -392,11 +390,9 @@ SystemBase::reinitNodeFace(const Node * /*node*/, BoundaryID /*bnd_id*/, THREAD_
   const std::vector<MooseVariableFEBase *> & vars = _vars[tid].fieldVariables();
   for (const auto & var : vars)
   {
-    if (var->isNodal())
-    {
-      var->reinitNode();
+    var->reinitNode();
+    if (var->isNodalDefined())
       var->computeNodalValues();
-    }
   }
 }
 

--- a/test/tests/misc/check_error/nodal_bc_on_elemental_var.i
+++ b/test/tests/misc/check_error/nodal_bc_on_elemental_var.i
@@ -1,0 +1,35 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+ []
+
+[Variables]
+  [u]
+    family = MONOMIAL
+    order = CONSTANT
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [bcs]
+    type = DirichletBC
+    variable = u
+    boundary = 'left right'
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Transient
+  dt = 1
+  num_steps = 1
+  abort_on_solve_fail = true
+[]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -1039,4 +1039,14 @@
     design = 'Executioner/index.md'
     issues = '#11586'
   [../]
+
+  [./nodal_bc_on_elemental_var]
+    type = 'RunException'
+    input = 'nodal_bc_on_elemental_var.i'
+    expect_err = "Trying to use nodal boundary condition 'bcs' on a non-nodal variable 'u'"
+
+    requirement = 'The system shall report an error when nodal boundary condition is applied on a non-nodal variable.'
+    design = 'NonlinearSystem.md'
+    issues = '#14019'
+  [../]
 []


### PR DESCRIPTION
In SystemBase::reinitNode{Face}(), we checked if the variable was nodal
and if it was we called reinitNode() and then computed values.  This caused
that the internal state of MooseVariable was not updated, so when we got
into a nodal system and asked the variable if it was defined at nodes via
isNodalDefined() call, the answer was incorrect.

The SystemBase::reinitNode{Face}() needs to update the internal state of
MooseVariable first and then if the variable is defined at the node, we
compute its values and possibly evaluate the objects associated with the
variable.

Closes #14019

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
