### PR TITLE
Fix issue with parallel

### DIFF
--- a/modules/tensor_mechanics/src/postprocessors/CriticalTimeStep.C
+++ b/modules/tensor_mechanics/src/postprocessors/CriticalTimeStep.C
@@ -64,7 +64,7 @@ CriticalTimeStep::execute()
 void
 CriticalTimeStep::finalize()
 {
-  gatherSum(_critical_time);
+  gatherMin(_critical_time);
 }
 
 Real


### PR DESCRIPTION
The gatherSum operation was the wrong one to use and was giving incorrect results under mpiexec mode. This has been fixed now by using gatherMin instead.

Closes  #13975