### PR TITLE
Prune before image remove.  Fixes #14023.

### DIFF
--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -65,8 +65,8 @@ pipeline {
                 docker push $DOCKER_COMMIT_TAG
                 
                 # Clean up artifacts from the build
-                docker rmi $DOCKER_TAG $DOCKER_COMMIT_TAG
                 docker system prune -f
+                docker rmi -f $DOCKER_TAG $DOCKER_COMMIT_TAG
                 '''
             }
         }


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Sorry for the recent PR spam.  Jenkins needs to prune Docker, _then_ delete the image.  I failed to account for stopped containers depending on the image when I tested Docker cleanup.  Closes #14023.
