### PR TITLE
Initialize QP in nodal BCs

### DIFF
--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -43,8 +43,9 @@ protected:
   /// current node being processed
   const Node * const & _current_node;
 
-  /// Quadrature point index
-  unsigned int _qp;
+  /// Pseudo-"quadrature point" index (Always zero for the current node)
+  const unsigned int _qp = 0;
+
   /// Value of the unknown variable this BC is acting on
   const VariableValue & _u;
 
@@ -62,4 +63,3 @@ protected:
    */
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 };
-

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -80,7 +80,6 @@ NodalBC::computeResidual()
 {
   if (_var.isNodalDefined())
   {
-    _qp = 0;
     Real res = computeQpResidual();
 
     for (auto tag_id : _vector_tags)
@@ -105,7 +104,6 @@ NodalBC::computeJacobian()
   // all the assembly is done.
   if (_var.isNodalDefined())
   {
-    _qp = 0;
     Real cached_val = 0.;
     cached_val = computeQpJacobian();
 
@@ -132,7 +130,6 @@ NodalBC::computeOffDiagJacobian(unsigned int jvar)
     computeJacobian();
   else
   {
-    _qp = 0;
     Real cached_val = 0.0;
     cached_val = computeQpOffDiagJacobian(jvar);
 

--- a/framework/src/bcs/NodalNormalBC.C
+++ b/framework/src/bcs/NodalNormalBC.C
@@ -33,7 +33,6 @@ NodalNormalBC::NodalNormalBC(const InputParameters & parameters)
 void
 NodalNormalBC::computeResidual()
 {
-  _qp = 0;
   _normal = Point(_nx[_qp], _ny[_qp], _nz[_qp]);
   computeQpResidual();
 }

--- a/framework/src/bcs/PresetNodalBC.C
+++ b/framework/src/bcs/PresetNodalBC.C
@@ -28,7 +28,6 @@ void
 PresetNodalBC::computeValue(NumericVector<Number> & current_solution)
 {
   const dof_id_type & dof_idx = _var.nodalDofIndex();
-  _qp = 0;
   current_solution.set(dof_idx, computeQpValue());
 }
 


### PR DESCRIPTION
Right now it's possible to pick up garbage from the member variable
_qp in NodalBC. This is because it's not initialized in the ctor.
User code may execute routines (shouldApply) before hitting
computational code that may access that member.

refs #14027

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
