### PR TITLE
Guard for out of index access in PatternedMeshGenerator

### DIFF
--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -61,6 +61,14 @@ PatternedMeshGenerator::PatternedMeshGenerator(const InputParameters & parameter
     _y_width(getParam<Real>("y_width")),
     _z_width(getParam<Real>("z_width"))
 {
+  for (MooseIndex(_pattern) i = 0; i < _pattern.size(); ++i)
+    for (MooseIndex(_pattern[i]) j = 0; j < _pattern[i].size(); ++j)
+      if (_pattern[i][j] >= _input_names.size())
+        paramError("pattern",
+                   "Index " + Moose::stringify(_pattern[i][j]) +
+                       " is larger than the the maximum possible index, which is determined by the "
+                       "number of MeshGenerators provided in inputs");
+
   _mesh_ptrs.reserve(_input_names.size());
   for (auto & input_name : _input_names)
     _mesh_ptrs.push_back(&getMeshByName(input_name));


### PR DESCRIPTION
Closes #14029.

I also realize now that there's very little checking on the `input` and `inputs` parameter for most of the `MeshGenerators`.