### PR TITLE
No longer deletes latest tag.  Fixes #14031

### DIFF
--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                 
                 # Clean up artifacts from the build
                 docker system prune -f
-                docker rmi -f $DOCKER_TAG $DOCKER_COMMIT_TAG
+                docker rmi $DOCKER_COMMIT_TAG
                 '''
             }
         }


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Latest tag (stored in $DOCKER_TAG) is no longer removed, which allows use of the build cache for upstream dependencies in subsequent builds.  Closes #14031.
