### PR TITLE
Error out in MooseVariableData::computeAD if derivatives too small

### DIFF
--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -1330,6 +1330,16 @@ MooseVariableData<OutputType>::computeAD(const unsigned int num_dofs, const unsi
   mooseAssert(_var.kind() == Moose::VarKindType::VAR_AUXILIARY || ad_offset || !_var_num,
               "Either this is the zeroth variable or we should have an offset");
 
+#ifndef MOOSE_SPARSE_AD
+  if (ad_offset + num_dofs > MOOSE_AD_MAX_DOFS_PER_ELEM)
+    mooseError("Current number of dofs per element ",
+               ad_offset + num_dofs,
+               " is greater than AD_MAX_DOFS_PER_ELEM of ",
+               MOOSE_AD_MAX_DOFS_PER_ELEM,
+               ". You can run `configure --with-derivative-size=<n>` to request a larger "
+               "derivative container.");
+#endif
+
   for (unsigned int qp = 0; qp < nqp; qp++)
   {
     if (_need_ad_u)

--- a/test/tests/kernels/ad_max_dofs_per_elem_error/ad_max_dofs_per_elem.i
+++ b/test/tests/kernels/ad_max_dofs_per_elem_error/ad_max_dofs_per_elem.i
@@ -1,0 +1,44 @@
+[Mesh]
+  type = GeneratedMesh
+  elem_type = HEX27
+  dim = 3
+[]
+
+[Variables]
+  [u]
+    order = SECOND
+  []
+  [v]
+    order = SECOND
+  []
+[]
+
+[Kernels]
+  [u_diff]
+    type = ADDiffusion
+    variable = u
+  []
+  [v_diff]
+    type = ADDiffusion
+    variable = v
+  []
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/kernels/ad_max_dofs_per_elem_error/tests
+++ b/test/tests/kernels/ad_max_dofs_per_elem_error/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [ad_max_dofs_per_elem_error]
+    type = RunException
+    input = 'ad_max_dofs_per_elem.i'
+    expect_err = 'Current number of dofs per element [0-9]+ is greater than AD_MAX_DOFS_PER_ELEM'
+    issues = '#5658'
+    design = 'DualReal.md'
+    requirement = 'The system will error and tell the user if they use derivative storage that is too small'
+  []
+[]


### PR DESCRIPTION
This error message was removed in #13963 but I think it should be added back since NumberArray is still an option (in fact it is the default) for derivative storage.

