### PR TITLE
Check for working MPI

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -130,6 +130,9 @@ class TestHarness:
         checks['submodules'] = util.getInitializedSubmodules(self.run_tests_dir)
         checks['exe_objects'] = None # This gets calculated on demand
         checks['registered_apps'] = None # This gets extracted on demand
+        checks['mpi_command'] = util.getTestHarnessOption('mpi_command')
+        checks['force_mpi'] = util.getTestHarnessOption('force_mpi')
+        checks['mpi_works'] = util.checkMPI(checks)
 
         # The TestHarness doesn't strictly require the existence of libMesh in order to run. Here we allow the user
         # to select whether they want to probe for libMesh configuration options.

--- a/python/TestHarness/tests/test_ValidMPI.py
+++ b/python/TestHarness/tests/test_ValidMPI.py
@@ -1,0 +1,23 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import subprocess, os
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testValidMPI(self):
+        """
+        Test for a failing mpiexec
+        """
+        # Kill two birds with one stone. Verify the TestHarness obeys the environment variable MOOSE_MPI_COMMAND,
+        # while setting that command to a binary which always returns a non-zero exit code (`false`).
+        os.environ['MOOSE_MPI_COMMAND'] = 'false'
+
+        output = self.runTests('-i', 'always_ok', '-p2', '--no-color')
+        self.assertRegexpMatches(output, 'tests/test_harness.always_ok.*? \[MPI CHECK FAILED\] SKIP')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -182,4 +182,10 @@
     requirement = "TestHarness shall detect and report race conditions that exist in the supplied tests"
     issues = '#13186'
   [../]
+  [./valid_mpi]
+    type = PythonUnitTest
+    input = test_ValidMPI.py
+    requirement = "TestHarness shall detect the inability to use the MPI currently available"
+    issues = '#6171'
+  [../]
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -148,6 +148,10 @@ LIBMESH_OPTIONS = {
                    },
 }
 
+TESTHARNESS_OPTIONS = {
+    'mpi_command' : os.getenv('MOOSE_MPI_COMMAND', 'mpiexec'),
+    'force_mpi'   : 'MOOSE_MPI_COMMAND' in os.environ,
+}
 
 ## Run a command and return the output, or ERROR: + output if retcode != 0
 def runCommand(cmd, cwd=None):
@@ -158,7 +162,6 @@ def runCommand(cmd, cwd=None):
     if (p.returncode != 0):
         output = 'ERROR: ' + output
     return output
-
 
 ## method to return current character count with given results_dictionary
 def resultCharacterCount(results_dict):
@@ -348,7 +351,6 @@ def runExecutable(libmesh_dir, location, bin, args):
         exit(1)
 
     return runCommand(libmesh_exe + " " + args).rstrip()
-
 
 def getCompilers(libmesh_dir):
     # Supported compilers are GCC, INTEL or ALL
@@ -717,3 +719,10 @@ def trimOutput(job, options):
                                                    "#"*80,
                                                    "#"*80,
                                                    output[-second_part:])
+
+def getTestHarnessOption(option):
+    if option in TESTHARNESS_OPTIONS:
+        return TESTHARNESS_OPTIONS[option]
+
+def checkMPI(checks):
+    return 'ERROR' not in runCommand(checks['mpi_command'] + " -n 2 true")


### PR DESCRIPTION
Instead of crashing tests, skip them when MPI has failed in an
obvious way _not_ responsible by the TestHarness.

We will test mpiexec (or what ever MOOSE_MPI_COMMAND is currently set as) by running `true` in parallel, and analyzing the results.

Closes #6171

