### PR TITLE
Add missing packages to Getting Started

### DIFF
--- a/modules/doc/content/getting_started/installation/mint_pre_req.md
+++ b/modules/doc/content/getting_started/installation/mint_pre_req.md
@@ -17,7 +17,9 @@ sudo apt-get install build-essential \
   libcurl4-gnutls-dev \
   zlib1g-dev \
   libhwloc-dev \
-  libxml2-dev
+  libxml2-dev \
+  libpng-dev \
+  pkg-config
 ```
 
 Download and install one of our redistributable packages according to your version of Mint. Mint is a spinoff of Ubuntu. But the versions do not necessarly match (each Mint release is based on Ubuntu's LTS release schedule): [https://en.wikipedia.org/wiki/Linux_Mint_version_history](https://en.wikipedia.org/wiki/Linux_Mint_version_history).

--- a/modules/doc/content/getting_started/installation/ubuntu_pre_req.md
+++ b/modules/doc/content/getting_started/installation/ubuntu_pre_req.md
@@ -17,7 +17,9 @@ sudo apt-get install build-essential \
   libcurl4-gnutls-dev \
   zlib1g-dev \
   libhwloc-dev \
-  libxml2-dev
+  libxml2-dev \
+  libpng-dev \
+  pkg-config
 ```
 
 Download and install one of our redistributable packages according to your version of Ubuntu.


### PR DESCRIPTION
Add libpng-dev and pkg-config to our Getting Started pages.

Closes #14074

