### PR TITLE
Detect that MooseMesh::setMeshBase was already called

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -873,6 +873,11 @@ public:
    */
   bool needsRemoteElemDeletion() const { return _need_delete; }
 
+  /**
+   * Whether mesh base object was constructed or not
+   */
+  bool hasMeshBase() const { return _mesh.get() != nullptr; }
+
 protected:
   /// Deprecated (DO NOT USE)
   std::vector<std::unique_ptr<GhostingFunctor>> _ghosting_functors;

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -254,7 +254,7 @@ SetupMeshAction::act()
 
   else if (_current_task == "set_mesh_base")
   {
-    if (!_app.masterMesh())
+    if (!_app.masterMesh() && !_mesh->hasMeshBase())
       _mesh->setMeshBase(_mesh->buildMeshBaseObject());
   }
 


### PR DESCRIPTION
New API that reports if setMeshBase was already called. This is used to prevent multiple calls to setMeshBase which can have detrimental effect on problem setup.  This is needed for the component system used in THM.

Closes #14084
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
