### PR TITLE
Improvements to PatchSidesetGenerator

### DIFF
--- a/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
+++ b/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
@@ -22,7 +22,16 @@
 #include "libmesh/hilbert_sfc_partitioner.h"
 #include "libmesh/morton_sfc_partitioner.h"
 #include "libmesh/enum_elem_type.h"
+
+// libmesh elem types
+#include "libmesh/edge_edge2.h"
+#include "libmesh/edge_edge3.h"
+#include "libmesh/edge_edge4.h"
+#include "libmesh/face_tri3.h"
+#include "libmesh/face_tri6.h"
 #include "libmesh/face_quad4.h"
+#include "libmesh/face_quad8.h"
+#include "libmesh/face_quad9.h"
 
 #include <set>
 #include <limits>
@@ -75,8 +84,7 @@ PatchSidesetGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
-  if (_mesh->isDistributedMesh())
-    mooseWarning("Distributed mesh may not work yet, because communication is not done.");
+  _mesh->errorIfDistributedMesh("PatchSidesetGenerator");
 
   // Get a reference to our BoundaryInfo object for later use
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
@@ -228,8 +236,22 @@ PatchSidesetGenerator::boundaryElementHelper(MeshBase & mesh, libMesh::ElemType 
 {
   switch (type)
   {
+    case 0:
+      return mesh.add_elem(new libMesh::Edge2);
+    case 1:
+      return mesh.add_elem(new libMesh::Edge3);
+    case 2:
+      return mesh.add_elem(new libMesh::Edge4);
+    case 3:
+      return mesh.add_elem(new libMesh::Tri3);
+    case 4:
+      return mesh.add_elem(new libMesh::Tri6);
     case 5:
       return mesh.add_elem(new libMesh::Quad4);
+    case 6:
+      return mesh.add_elem(new libMesh::Quad8);
+    case 7:
+      return mesh.add_elem(new libMesh::Quad9);
     default:
       mooseError("Unsupported element type (libMesh elem_type enum): ", type);
   }

--- a/modules/heat_conduction/test/tests/generate_radiation_patch/tests
+++ b/modules/heat_conduction/test/tests/generate_radiation_patch/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'generate_radiation_patch.i'
     exodiff = 'generate_radiation_patch_in.e'
-    requirement = "Moose shall be able to divide a sideset into patches for more accurate radiative transfer modeling."
+    requirement = "The system shall be able to divide a sideset into patches for more accurate radiative transfer modeling."
     design = 'source/meshgenerators/PatchSidesetGenerator.md'
     cli_args = '--mesh-only'
     issues = "#14000"
@@ -13,7 +13,7 @@
     type = 'Exodiff'
     input = 'generate_radiation_patch.i'
     exodiff = 'generate_radiation_patch_linear.e'
-    requirement = "Moose shall be able to use linear partitioner for subdividing sidesets into patches."
+    requirement = "The system shall be able to use linear partitioner for subdividing sidesets into patches."
     design = 'source/meshgenerators/PatchSidesetGenerator.md'
     cli_args = 'Mesh/patch/partitioner=linear --mesh-only generate_radiation_patch_linear.e'
     issues = "#14000"
@@ -23,7 +23,7 @@
     type = 'Exodiff'
     input = 'generate_radiation_patch.i'
     exodiff = 'generate_radiation_patch_centroid.e'
-    requirement = "Moose shall be able to use centroid partitioner for subdividing sidesets into patches."
+    requirement = "The system shall be able to use centroid partitioner for subdividing sidesets into patches."
     design = 'source/meshgenerators/PatchSidesetGenerator.md'
     cli_args = 'Mesh/patch/partitioner=centroid Mesh/patch/centroid_partitioner_direction=x --mesh-only generate_radiation_patch_centroid.e'
     issues = "#14000"
@@ -33,7 +33,7 @@
     type = RunException
     input = 'generate_radiation_patch.i'
     expect_err = "If using the centroid partitioner you _must_ specify centroid_partitioner_direction!"
-    requirement = "Moose shall error when centroid partitioner is used but centroid_partitioner_direction is not provided."
+    requirement = "The system shall error when centroid partitioner is used but centroid_partitioner_direction is not provided."
     design = 'source/meshgenerators/PatchSidesetGenerator.md'
     cli_args = 'Mesh/patch/partitioner=centroid --mesh-only generate_radiation_patch_centroid.e'
     issues = "#14000"


### PR DESCRIPTION
closes #14000.

Support more element types, error out with distributed mesh, and NQA consistent wording in `tests`. 
