### PR TITLE
SimplePredictor console output fix

### DIFF
--- a/framework/src/predictors/SimplePredictor.C
+++ b/framework/src/predictors/SimplePredictor.C
@@ -41,14 +41,7 @@ SimplePredictor::shouldApply()
 void
 SimplePredictor::apply(NumericVector<Number> & sln)
 {
-  // Save the original stream flags
-  std::ios_base::fmtflags out_flags = Moose::out.flags();
-
-  _console << "  Applying predictor with scale factor = " << std::fixed << std::setprecision(2)
-           << _scale << std::endl;
-
-  // Restore the flags
-  Moose::out.flags(out_flags);
+  _console << "  Applying predictor with scale factor = " << _scale << std::endl;
 
   Real dt_adjusted_scale_factor = _scale * _dt / _dt_old;
   if (dt_adjusted_scale_factor != 0.0)

--- a/test/tests/predictors/simple/predictor_reference_residual_test.i
+++ b/test/tests/predictors/simple/predictor_reference_residual_test.i
@@ -1,0 +1,56 @@
+# The purpose of this test is to ensure the SimplePredictor resets the std::precision
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 3
+  ny = 3
+[]
+
+[Problem]
+  type = ReferenceResidualProblem
+  solution_variables = 'u'
+  extra_tag_vectors = 'ref'
+  reference_vector = 'ref'
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[Kernels]
+  [./diff_u]
+    type = Diffusion
+    variable = u
+    extra_vector_tags = 'ref'
+  [../]
+[]
+
+[BCs]
+  [./bot]
+    type = PresetBC
+    variable = u
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./top]
+    type = FunctionPresetBC
+    variable = u
+    boundary = top
+    function = 't'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  start_time = 0.0
+  dt = 0.5
+  end_time = 1.0
+
+  [./Predictor]
+    type = SimplePredictor
+    scale = 1.0e-10
+  [../]
+[]

--- a/test/tests/predictors/simple/tests
+++ b/test/tests/predictors/simple/tests
@@ -10,6 +10,14 @@
     requirement = "The system shall include a means for predicting future solution based on previous "
                   "solutions."
   []
+  [output]
+    type = 'RunApp'
+    input = 'predictor_reference_residual_test.i'
+    expect_out = 'Applying predictor with scale factor = 1e-10'
+
+    requirement = "The system shall include a means for predicting future solution based on previous "
+                  "solutions and print the scale factor to the output stream."
+  []
 
   [skip]
     requirement = "The system shall support the ability to skip performing solution predictions"


### PR DESCRIPTION
Removed std::fixed and std::precision calls in SimplePredictor. They seem unnecessary, and limit the ability to see very small predictor numbers.

Closes #14099
