### PR TITLE
More careful MeshGenerator checks

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -243,8 +243,6 @@ protected:
   ActionFactory & _action_factory;
   /// Pointers to the actual parsed input file blocks
   std::map<std::string, std::list<Action *>> _action_blocks;
-  /// Action blocks that have been requested
-  std::map<std::string, std::vector<Action *>> _requested_action_blocks;
   /// The container that holds the sorted action names from the DependencyResolver
   std::vector<std::string> _ordered_names;
   /// Use to store the current list of unsatisfied dependencies

--- a/modules/tensor_mechanics/test/tests/beam/dynamic/tests
+++ b/modules/tensor_mechanics/test/tests/beam/dynamic/tests
@@ -131,7 +131,7 @@
                   " a consistent mass/inertia matrix in the presence of Rayleigh"
                   " damping and numerical damping in the form of Hilber-Hughes-Taylor (HHT) time integration."
     design = "C0TimoshenkoBeam.md LineElementMaster/index.md"
-    rel_err = 7e-6
+    rel_err = 2e-5
   [../]
   [./dyn_euler_added_mass_inertia_damping_action]
     type = 'Exodiff'


### PR DESCRIPTION
When checking for whether we should set the MooseMesh type to
MeshGeneratorMesh, we need to be more careful about checking
which `Actions` have triggered the `add_mesh_generator` task.
If it is a custom action, they may not always be adding
mesh generators depending on user input, so we need to have
more careful checks when both setting up the mesh and when
setting the `MeshBase`.
