### PR TITLE
fix line numbering for exploded HIT syntax

### DIFF
--- a/framework/contrib/hit/parse.cc
+++ b/framework/contrib/hit/parse.cc
@@ -369,7 +369,9 @@ Comment::render(int indent, const std::string & indent_text, int /*maxlen*/)
 Node *
 Comment::clone()
 {
-  return new Comment(_text, _isinline);
+  auto n = new Comment(_text, _isinline);
+  n->tokens() = tokens();
+  return n;
 }
 
 Section::Section(const std::string & path) : Node(NodeType::Section), _path(pathNorm(path)) {}
@@ -496,7 +498,9 @@ Field::render(int indent, const std::string & indent_text, int maxlen)
 Node *
 Field::clone()
 {
-  return new Field(_field, _kind, _val);
+  auto n = new Field(_field, _kind, _val);
+  n->tokens() = tokens();
+  return n;
 }
 
 Field::Kind
@@ -994,6 +998,7 @@ explode(Node * n)
         if (n->parent())
           n->parent()->addChild(newsec);
         newsec->addChild(newnode);
+        newsec->tokens() = n->tokens();
       }
       auto newroot = explode(newnode);
       delete n;

--- a/unit/src/HitTests.C
+++ b/unit/src/HitTests.C
@@ -101,6 +101,7 @@ TEST(HitTests, LineNumbers)
   LineCase cases[] = {
       {"[hello] foo='bar'\n\n\n boo='far'\n\n[]", {1, 1, 4}},
       {"[hello]\n  foo='bar'\n[]\n[goodbye]\n  boo=42\n[]", {1, 2, 4, 5}},
+      {"[hello/bar]\n  foo=42\n[]", {1, 1, 2}},
       {"[hello]\n\n # comment\n foo='bar' 'baz' # another comment\n\nboo=42[]", {1, 3, 4, 4, 6}}};
 
   for (size_t i = 0; i < sizeof(cases) / sizeof(LineCase); i++)
@@ -109,6 +110,7 @@ TEST(HitTests, LineNumbers)
     try
     {
       std::unique_ptr<hit::Node> root(hit::parse("TESTCASE", test.input));
+      hit::explode(root.get());
       LineWalker w(i, test.line_nums);
       root->walk(&w, hit::NodeType::All);
     }


### PR DESCRIPTION
Previously, when using the "/" separator syntax in HIT, line
number+token metadata wasn't being propogated correctly to the generated
nodes in the syntax tree.  This caused wrong ("0") line numbers to be
reported in some cases (e.g. see the added unit test).

This was discovered by andrew with work on #14103.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
