### PR TITLE
PorousFlow heavy tests max_time

### DIFF
--- a/modules/porous_flow/examples/coal_mining/tests
+++ b/modules/porous_flow/examples/coal_mining/tests
@@ -2,10 +2,14 @@
   [./coarse]
     type = CSVDiff
     heavy = true
+    max_time = 1000
     input = 'coarse_with_fluid.i'
     csvdiff = 'coarse_with_fluid_out.csv'
     cli_args = 'Executioner/end_time=0.014706'
     superlu = true
     threading = '!pthreads'
+    requirement = 'PorousFlow shall be able to simulate caving coupled with fluid flow associated with underground coal mining'
+    design = 'porous_flow/coal_mining.md'
+    issues = '#14148'
   [../]
 []

--- a/modules/porous_flow/examples/flow_through_fractured_media/tests
+++ b/modules/porous_flow/examples/flow_through_fractured_media/tests
@@ -12,6 +12,7 @@
   [./coarse_3D]
     type = CSVDiff
     heavy = true
+    max_time = 1000
     input = 'coarse_3D.i'
     csvdiff = 'coarse_3D_csv_xmass_0021.csv'
     abs_zero = 1E-7

--- a/modules/porous_flow/examples/thm_example/tests
+++ b/modules/porous_flow/examples/thm_example/tests
@@ -6,6 +6,7 @@
     cli_args = 'Mesh/nx=50 Mesh/bias_x=1.2 Executioner/end_time=100'
     abs_zero = 1E-4
     heavy = true
+    max_time = 1000
     threading = '!pthreads'
     issues = '#11110'
     design = 'thm_example.md'

--- a/modules/porous_flow/test/tests/fluidstate/tests
+++ b/modules/porous_flow/test/tests/fluidstate/tests
@@ -78,6 +78,7 @@
     input = 'theis_brineco2.i'
     csvdiff = "theis_brineco2_csvout.csv theis_brineco2_csvout_line_0028.csv"
     heavy = true
+    max_time = 1000
     threading = '!pthreads'
     requirement = 'PorousFlow shall evolve a gas phase as CO2 is added to a liquid brine phase'
     design = 'PorousFlowBrineCO2.md'

--- a/modules/porous_flow/test/tests/flux_limited_TVD_advection/tests
+++ b/modules/porous_flow/test/tests/flux_limited_TVD_advection/tests
@@ -157,6 +157,7 @@
     csvdiff = 'fltvd_2D_trimesh_out_tracer_0101.csv'
     heavy = true
     abs_zero = 1.0E-5
+    max_time = 1000
     issues = '#12370 #12118 #10426'
     design = 'porous_flow/numerical_diffusion.md porous_flow/kt_worked.md'
     requirement = 'PorousFlow shall implement Kuzmin-Turek stabilization in 2D when using triangular mesh elements'
@@ -166,6 +167,7 @@
     input = 'fltvd_2D_trimesh.i'
     csvdiff = 'fltvd_2D_trimesh_out_tracer_0101.csv'
     heavy = true
+    max_time = 1000
     min_threads = 3
     max_threads = 3
     prereq = 'fltvd_2D_trimesh'

--- a/modules/porous_flow/test/tests/infiltration_and_drainage/tests
+++ b/modules/porous_flow/test/tests/infiltration_and_drainage/tests
@@ -30,7 +30,7 @@
     rel_err = 1E-5
     use_old_floor = True
     heavy = true
-    max_time = 1000
+    max_time = 2000
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model 2-phase drainage and agree with the analytic solution'
     issues = '#13155'


### PR DESCRIPTION
max_time has been increased in 6 PorousFlow heavy tests to allow them to not timeout on my macbook air when run in debug mode

Fixes #14148

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
