### PR TITLE
retrieve file_base from correct params object

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1035,7 +1035,7 @@ MooseApp::getCheckpointDirectories() const
     if (moose_object_action->getParamTempl<std::string>("type") == "Checkpoint")
     {
       if (params.isParamValid("file_base"))
-        checkpoint_dirs.push_back(common->getParamTempl<std::string>("file_base") + "_cp");
+        checkpoint_dirs.push_back(params.get<std::string>("file_base") + "_cp");
       else
       {
         std::ostringstream oss;


### PR DESCRIPTION
User reported an error on the list
(https://groups.google.com/d/msg/moose-users/ceaLhidSrro/NGkiZv0fCAAJ)
where MOOSE aborted with ~"param retrieved before being set".  This
was occuring because we were retrieving the file_base parameter from the
incorrect object when starting up via a checkpoint file via --recover.

Fixes #14159.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
