### PR TITLE
PorousFlowFluidMass: Get variable corresponding to correct thread ID

### DIFF
--- a/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowFluidMass.C
@@ -60,7 +60,11 @@ PorousFlowFluidMass::PorousFlowFluidMass(const InputParameters & parameters)
         getMaterialProperty<std::vector<std::vector<Real>>>("PorousFlow_mass_frac_nodal")),
     _saturation_threshold(getParam<Real>("saturation_threshold")),
     _var(getParam<unsigned>("kernel_variable_number") < _dictator.numVariables()
-             ? _dictator.getCoupledStandardMooseVars()[getParam<unsigned>("kernel_variable_number")]
+             ? &_fe_problem.getStandardVariable(
+                   _tid,
+                   _dictator
+                       .getCoupledStandardMooseVars()[getParam<unsigned>("kernel_variable_number")]
+                       ->name())
              : nullptr)
 {
   const unsigned int num_phases = _dictator.numPhases();


### PR DESCRIPTION
The PorousFlowFluidMass postprocessor was getting its _var member from the PorousFlowDictator GeneralUserObject. Through the logic in UserObjectInterface::getUserObject, this returns the thread 0 copy of the PorousFlowDictator. This thread 0 copy also has thread 0 copies of the variables through the Coupleable interface. If the thread 0 has not reinitialized its variables before the thread 1 copy of PorousFlowFluidMass runs its execute routine, then the value of _var->phi() will be garbage. Hence we must ensure that we are getting a pointer to the correct thread copy of _var.

@WilkAndy @cpgr You guys should make sure that you are getting the correct thread copy of `MooseVariable` members in other threaded UserObjects and Postprocessors.

Refs #14151

