### PR TITLE
PorousFlowHeatEnergy uses _tid

### DIFF
--- a/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
+++ b/modules/porous_flow/src/postprocessors/PorousFlowHeatEnergy.C
@@ -59,7 +59,11 @@ PorousFlowHeatEnergy::PorousFlowHeatEnergy(const InputParameters & parameters)
                                        "PorousFlow_fluid_phase_internal_energy_nodal")
                                  : nullptr),
     _var(getParam<unsigned>("kernel_variable_number") < _dictator.numVariables()
-             ? _dictator.getCoupledStandardMooseVars()[getParam<unsigned>("kernel_variable_number")]
+             ? &_fe_problem.getStandardVariable(
+                   _tid,
+                   _dictator
+                       .getCoupledStandardMooseVars()[getParam<unsigned>("kernel_variable_number")]
+                       ->name())
              : nullptr)
 {
   if (!_phase_index.empty())


### PR DESCRIPTION
Similar to PR #14161

Refs #14151

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
