### PR TITLE
Allow convergence on zeroth nl iteration for ReferenceResidualProblem

### DIFF
--- a/framework/src/problems/ReferenceResidualProblem.C
+++ b/framework/src/problems/ReferenceResidualProblem.C
@@ -423,7 +423,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
     oss << "Failed to converge, function norm is NaN\n";
     reason = MooseNonlinearConvergenceReason::DIVERGED_FNORM_NAN;
   }
-  else if (fnorm < abstol && (it || !force_iteration))
+  else if (fnorm < abstol && !force_iteration)
   {
     oss << "Converged due to function norm " << fnorm << " < " << abstol << std::endl;
     reason = MooseNonlinearConvergenceReason::CONVERGED_FNORM_ABS;
@@ -435,7 +435,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
     reason = MooseNonlinearConvergenceReason::DIVERGED_FUNCTION_COUNT;
   }
 
-  if (it && reason == MooseNonlinearConvergenceReason::ITERATING)
+  if (reason == MooseNonlinearConvergenceReason::ITERATING)
   {
     if (checkConvergenceIndividVars(fnorm, abstol, rtol, ref_resid))
     {

--- a/modules/combined/test/tests/reference_residual/reference_residual.cmp
+++ b/modules/combined/test/tests/reference_residual/reference_residual.cmp
@@ -3,7 +3,6 @@ COORDINATES absolute 1.e-6
 TIME STEPS relative 1.e-6 floor 0.0
 
 GLOBAL VARIABLES relative 1.e-6 floor 1.e-10
-	nonlinear_its relative 0.5 #Timestep 1: 5 iters, timestep 2: 1  This allows large variation in the 1st step, but not in the 2nd
 	ref_resid_t    # min:               0 @ t1	max:    0.0030935922 @ t3
 	ref_resid_x    # min:               0 @ t1	max:    0.0061990214 @ t2
 	ref_resid_y    # min:               0 @ t1	max:     0.032165928 @ t3

--- a/modules/combined/test/tests/reference_residual/tests
+++ b/modules/combined/test/tests/reference_residual/tests
@@ -23,6 +23,7 @@
   [../]
   [./test_scaling]
     type = 'Exodiff'
+    custom_cmp = 'reference_residual.cmp'
     input = 'reference_residual.i'
     exodiff = 'reference_residual_out.e'
     cli_args = 'Variables/disp_x/scaling=2


### PR DESCRIPTION
I don't understand why the original author made it so that
convergence could not be achieved on the zeroth nl iteration.
This removes once of the principal advantages that I see of
ReferenceResidualProblem in that it can recognize essentially
that we've achieved a steady-state condition and/or that it
doesn't make any sense to keep iterating because the variables
are converged with respect to reference quantities.