### PR TITLE
Update auto-scaling to use new DiagonalMatrix

### DIFF
--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -31,9 +31,6 @@ public:
 
   virtual SparseMatrix<Number> & addMatrix(TagID tag) override;
 
-  template <template <typename> class MatrixType>
-  SparseMatrix<Number> & addMatrix(TagID tag);
-
   virtual void solve() override;
 
   void init() override;
@@ -109,32 +106,4 @@ private:
   void setupColoringFiniteDifferencedPreconditioner();
 
   bool _use_coloring_finite_difference;
-
-  /// \p TagID for the scaling matrix
-  TagID _scaling_matrix_tag;
 };
-
-template <template <typename> class MatrixType>
-SparseMatrix<Number> &
-NonlinearSystem::addMatrix(TagID tag)
-{
-  if (!_subproblem.matrixTagExists(tag))
-    mooseError("Cannot add a tagged matrix with matrix_tag, ",
-               tag,
-               ", that tag does not exist in System ",
-               name());
-
-  if (hasMatrix(tag))
-    return getMatrix(tag);
-
-  auto matrix_name = _subproblem.matrixTagName(tag);
-
-  SparseMatrix<Number> * mat = &_transient_sys.add_matrix<MatrixType>(matrix_name);
-
-  if (_tagged_matrices.size() < tag + 1)
-    _tagged_matrices.resize(tag + 1);
-
-  _tagged_matrices[tag] = mat;
-
-  return *mat;
-}

--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -12,6 +12,11 @@
 #include "NonlinearSystemBase.h"
 #include "ComputeResidualFunctor.h"
 #include "ComputeFDResidualFunctor.h"
+#include "SubProblem.h"
+#include "MooseError.h"
+
+#include "libmesh/transient_system.h"
+#include "libmesh/nonlinear_implicit_system.h"
 
 /**
  * Nonlinear system to be solved
@@ -26,7 +31,12 @@ public:
 
   virtual SparseMatrix<Number> & addMatrix(TagID tag) override;
 
+  template <template <typename> class MatrixType>
+  SparseMatrix<Number> & addMatrix(TagID tag);
+
   virtual void solve() override;
+
+  void init() override;
 
   /**
    * Quit the current solve as soon as possible.
@@ -99,4 +109,32 @@ private:
   void setupColoringFiniteDifferencedPreconditioner();
 
   bool _use_coloring_finite_difference;
+
+  /// \p TagID for the scaling matrix
+  TagID _scaling_matrix_tag;
 };
+
+template <template <typename> class MatrixType>
+SparseMatrix<Number> &
+NonlinearSystem::addMatrix(TagID tag)
+{
+  if (!_subproblem.matrixTagExists(tag))
+    mooseError("Cannot add a tagged matrix with matrix_tag, ",
+               tag,
+               ", that tag does not exist in System ",
+               name());
+
+  if (hasMatrix(tag))
+    return getMatrix(tag);
+
+  auto matrix_name = _subproblem.matrixTagName(tag);
+
+  SparseMatrix<Number> * mat = &_transient_sys.add_matrix<MatrixType>(matrix_name);
+
+  if (_tagged_matrices.size() < tag + 1)
+    _tagged_matrices.resize(tag + 1);
+
+  _tagged_matrices[tag] = mat;
+
+  return *mat;
+}

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -913,8 +913,13 @@ protected:
   /// Flag used to indicate whether we have already computed the scaling Jacobian
   bool _computed_scaling;
 
-  /// A vector to be filled by the preconditioning matrix diagonal
-  NumericVector<Number> * _pmat_diagonal;
+  /// Whether to automatically scale the variables
+  bool _automatic_scaling;
+
+  /// Whether the scaling factors should only be computed once at the beginning of the simulation
+  /// through an extra Jacobian evaluation. If this is set to false, then the scaling factors will
+  /// be computed during an extra Jacobian evaluation at the beginning of every time step.
+  bool _compute_scaling_once;
 
 private:
   /// Functors for computing residuals from undisplaced mortar constraints
@@ -936,14 +941,6 @@ private:
   std::unordered_map<std::pair<BoundaryID, BoundaryID>,
                      ComputeMortarFunctor<ComputeStage::JACOBIAN>>
       _displaced_mortar_jacobian_functors;
-
-  /// Whether to automatically scale the variables
-  bool _automatic_scaling;
-
-  /// Whether the scaling factors should only be computed once at the beginning of the simulation
-  /// through an extra Jacobian evaluation. If this is set to false, then the scaling factors will
-  /// be computed during an extra Jacobian evaluation at the beginning of every time step.
-  bool _compute_scaling_once;
 
 #ifndef MOOSE_SPARSE_AD
   /// The required size of the derivative storage array

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -189,10 +189,6 @@ typedef subdomain_id_type SubdomainID;
 typedef unsigned int MooseObjectID;
 typedef unsigned int THREAD_ID;
 typedef unsigned int TagID;
-namespace Moose
-{
-extern const TagID INVALID_TAG_ID;
-}
 typedef unsigned int PerfID;
 
 typedef StoredRange<std::vector<dof_id_type>::iterator, dof_id_type> NodeIdRange;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -189,6 +189,10 @@ typedef subdomain_id_type SubdomainID;
 typedef unsigned int MooseObjectID;
 typedef unsigned int THREAD_ID;
 typedef unsigned int TagID;
+namespace Moose
+{
+extern const TagID INVALID_TAG_ID;
+}
 typedef unsigned int PerfID;
 
 typedef StoredRange<std::vector<dof_id_type>::iterator, dof_id_type> NodeIdRange;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4486,6 +4486,9 @@ FEProblemBase::init()
   if (solverParams()._type == Moose::ST_JFNK)
     _nl->turnOffJacobian();
 
+  _nl->init();
+  _aux->init();
+
   {
     TIME_SECTION(_eq_init_timer);
     CONSOLE_TIMED_PRINT("Initializing equation system")
@@ -4501,12 +4504,8 @@ FEProblemBase::init()
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); ++tid)
     _assembly[tid]->init(_cm.get());
 
-  _nl->init();
-
   if (_displaced_problem)
     _displaced_problem->init();
-
-  _aux->init();
 
   _initialized = true;
 }

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -18,11 +18,13 @@
 #include "ComputeFDResidualFunctor.h"
 #include "TimedPrint.h"
 #include "MooseVariableScalar.h"
+#include "MooseTypes.h"
 
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/petsc_matrix.h"
+#include "libmesh/diagonal_matrix.h"
 #include "libmesh/default_coupling.h"
 
 namespace Moose
@@ -93,7 +95,8 @@ NonlinearSystem::NonlinearSystem(FEProblemBase & fe_problem, const std::string &
     _transient_sys(fe_problem.es().get_system<TransientNonlinearImplicitSystem>(name)),
     _nl_residual_functor(_fe_problem),
     _fd_residual_functor(_fe_problem),
-    _use_coloring_finite_difference(false)
+    _use_coloring_finite_difference(false),
+    _scaling_matrix_tag(Moose::INVALID_TAG_ID)
 {
   nonlinearSolver()->residual_object = &_nl_residual_functor;
   nonlinearSolver()->jacobian = Moose::compute_jacobian;
@@ -115,6 +118,19 @@ NonlinearSystem::NonlinearSystem(FEProblemBase & fe_problem, const std::string &
 }
 
 NonlinearSystem::~NonlinearSystem() {}
+
+void
+NonlinearSystem::init()
+{
+  NonlinearSystemBase::init();
+
+  if (_automatic_scaling)
+  {
+    // Add diagonal matrix that will be used for computing scaling factors
+    _scaling_matrix_tag = _subproblem.addMatrixTag("scaling_matrix");
+    addMatrix<DiagonalMatrix>(_scaling_matrix_tag);
+  }
+}
 
 SparseMatrix<Number> &
 NonlinearSystem::addMatrix(TagID tag)
@@ -400,120 +416,99 @@ NonlinearSystem::converged()
 void
 NonlinearSystem::computeScalingJacobian()
 {
-#ifdef LIBMESH_HAVE_PETSC
-  if (dynamic_cast<PetscMatrix<Real> *>(_transient_sys.matrix))
+  _console << "\nPerforming automatic scaling calculation\n\n";
+
+  TIME_SECTION(_compute_scaling_jacobian_timer);
+
+  mooseAssert(_scaling_matrix_tag != Moose::INVALID_TAG_ID,
+              "The scaling matrix has not been created. There must have been an issue in "
+              "initialization of the NonlinearSystem");
+
+  auto & scaling_matrix = getMatrix(_scaling_matrix_tag);
+
+  _computing_scaling_jacobian = true;
+  _fe_problem.computeJacobianSys(_transient_sys, *_current_solution, scaling_matrix);
+  _computing_scaling_jacobian = false;
+
+  // container for repeated access of element global dof indices
+  std::vector<dof_id_type> dof_indices;
+
+  auto & field_variables = _vars[0].fieldVariables();
+  auto & scalar_variables = _vars[0].scalars();
+
+  std::vector<Real> inverse_scaling_factors(field_variables.size() + scalar_variables.size(), 0);
+  auto & dof_map = dofMap();
+
+  // Compute our scaling factors for the spatial field variables
+  for (const auto & elem : *mesh().getActiveLocalElementRange())
   {
-#if !PETSC_VERSION_LESS_THAN(3, 9, 0)
-    _console << "\nPerforming automatic scaling calculation\n\n";
-
-    TIME_SECTION(_compute_scaling_jacobian_timer);
-
-    auto & petsc_matrix = *static_cast<PetscMatrix<Real> *>(_transient_sys.matrix);
-
-    if (!petsc_matrix.local_m())
-      mooseError("MOOSE doesn't currently support automatic scaling when there are any processes "
-                 "owning zero dofs. Check back soon :-)");
-
-    _computing_scaling_jacobian = true;
-    _fe_problem.computeJacobianSys(_transient_sys, *_current_solution, *_transient_sys.matrix);
-    _computing_scaling_jacobian = false;
-
-    // container for repeated access of element global dof indices
-    std::vector<dof_id_type> dof_indices;
-
-    auto & field_variables = _vars[0].fieldVariables();
-    auto & scalar_variables = _vars[0].scalars();
-
-    std::vector<Real> inverse_scaling_factors(field_variables.size() + scalar_variables.size(), 0);
-    auto & dof_map = dofMap();
-
-    // limit dereferencing
-    auto & diagonal = *_pmat_diagonal;
-
-    // fill our diagonal vector
-    petsc_matrix.get_diagonal(diagonal);
-
-    // Compute our scaling factors for the spatial field variables
-    for (const auto & elem : *mesh().getActiveLocalElementRange())
+    for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
     {
-      for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
-      {
-        auto & field_variable = *field_variables[i];
-        dof_map.dof_indices(elem, dof_indices, field_variable.number());
-        for (auto dof_index : dof_indices)
-          if (dof_map.local_index(dof_index))
-          {
-            // For now we will use the diagonal for determining scaling
-            auto mat_value = diagonal(dof_index);
-            inverse_scaling_factors[i] = std::max(inverse_scaling_factors[i], std::abs(mat_value));
-          }
-      }
-    }
-
-    auto offset = field_variables.size();
-
-    // Compute scalar factors for scalar variables
-    for (MooseIndex(scalar_variables) i = 0; i < scalar_variables.size(); ++i)
-    {
-      auto & scalar_variable = *scalar_variables[i];
-      dof_map.SCALAR_dof_indices(dof_indices, scalar_variable.number());
+      auto & field_variable = *field_variables[i];
+      dof_map.dof_indices(elem, dof_indices, field_variable.number());
       for (auto dof_index : dof_indices)
         if (dof_map.local_index(dof_index))
         {
           // For now we will use the diagonal for determining scaling
-          auto mat_value = diagonal(dof_index);
-          inverse_scaling_factors[offset + i] =
-              std::max(inverse_scaling_factors[offset + i], std::abs(mat_value));
+          auto mat_value = scaling_matrix(dof_index, dof_index);
+          inverse_scaling_factors[i] = std::max(inverse_scaling_factors[i], std::abs(mat_value));
         }
     }
-
-    // Get the maximum value across processes
-    _communicator.max(inverse_scaling_factors);
-
-    // We have to make sure that our scaling values are not zero
-    for (auto & scaling_factor : inverse_scaling_factors)
-      if (scaling_factor < std::numeric_limits<Real>::epsilon())
-        scaling_factor = 1;
-
-    if (_verbose)
-    {
-      _console << "Automatic scaling factors:\n";
-      auto original_flags = _console.flags();
-      auto original_precision = _console.precision();
-      _console.unsetf(std::ios_base::floatfield);
-      _console.precision(6);
-
-      for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
-      {
-        auto & field_variable = *field_variables[i];
-        _console << "  " << field_variable.name() << ": " << 1.0 / inverse_scaling_factors[i]
-                 << "\n";
-      }
-      for (MooseIndex(scalar_variables) i = 0; i < scalar_variables.size(); ++i)
-      {
-        auto & scalar_variable = *scalar_variables[i];
-        _console << "  " << scalar_variable.name() << ": "
-                 << 1.0 / inverse_scaling_factors[offset + i] << "\n";
-      }
-      _console << "\n\n";
-
-      // restore state
-      _console.flags(original_flags);
-      _console.precision(original_precision);
-    }
-
-    // Now set the scaling factors for the variables
-    applyScalingFactors(inverse_scaling_factors);
-    if (auto displaced_problem = _fe_problem.getDisplacedProblem().get())
-      displaced_problem->systemBaseNonlinear().applyScalingFactors(inverse_scaling_factors);
-
-    // Now it's essential that we reset the sparsity pattern of the matrix
-    petsc_matrix.reset_preallocation();
-#endif
   }
-  else
-    mooseError(
-        "Automatic scaling has been requested but you are not using a PetscMatrix. Please contact "
-        "the MOOSE development team at moose-users@googlegroups.com if you encounter this error");
-#endif
+
+  auto offset = field_variables.size();
+
+  // Compute scalar factors for scalar variables
+  for (MooseIndex(scalar_variables) i = 0; i < scalar_variables.size(); ++i)
+  {
+    auto & scalar_variable = *scalar_variables[i];
+    dof_map.SCALAR_dof_indices(dof_indices, scalar_variable.number());
+    for (auto dof_index : dof_indices)
+      if (dof_map.local_index(dof_index))
+      {
+        // For now we will use the diagonal for determining scaling
+        auto mat_value = scaling_matrix(dof_index, dof_index);
+        inverse_scaling_factors[offset + i] =
+            std::max(inverse_scaling_factors[offset + i], std::abs(mat_value));
+      }
+  }
+
+  // Get the maximum value across processes
+  _communicator.max(inverse_scaling_factors);
+
+  // We have to make sure that our scaling values are not zero
+  for (auto & scaling_factor : inverse_scaling_factors)
+    if (scaling_factor < std::numeric_limits<Real>::epsilon())
+      scaling_factor = 1;
+
+  if (_verbose)
+  {
+    _console << "Automatic scaling factors:\n";
+    auto original_flags = _console.flags();
+    auto original_precision = _console.precision();
+    _console.unsetf(std::ios_base::floatfield);
+    _console.precision(6);
+
+    for (MooseIndex(field_variables) i = 0; i < field_variables.size(); ++i)
+    {
+      auto & field_variable = *field_variables[i];
+      _console << "  " << field_variable.name() << ": " << 1.0 / inverse_scaling_factors[i] << "\n";
+    }
+    for (MooseIndex(scalar_variables) i = 0; i < scalar_variables.size(); ++i)
+    {
+      auto & scalar_variable = *scalar_variables[i];
+      _console << "  " << scalar_variable.name() << ": "
+               << 1.0 / inverse_scaling_factors[offset + i] << "\n";
+    }
+    _console << "\n\n";
+
+    // restore state
+    _console.flags(original_flags);
+    _console.precision(original_precision);
+  }
+
+  // Now set the scaling factors for the variables
+  applyScalingFactors(inverse_scaling_factors);
+  if (auto displaced_problem = _fe_problem.getDisplacedProblem().get())
+    displaced_problem->systemBaseNonlinear().applyScalingFactors(inverse_scaling_factors);
 }

--- a/framework/src/utils/MooseTypes.C
+++ b/framework/src/utils/MooseTypes.C
@@ -9,6 +9,7 @@
 
 #include "MooseTypes.h"
 #include "libmesh/elem.h"
+#include "libmesh/libmesh.h"
 
 namespace Moose
 {
@@ -16,4 +17,5 @@ const SubdomainID ANY_BLOCK_ID = libMesh::Elem::invalid_subdomain_id - 1;
 const SubdomainID INVALID_BLOCK_ID = libMesh::Elem::invalid_subdomain_id;
 const BoundaryID ANY_BOUNDARY_ID = static_cast<BoundaryID>(-1);
 const BoundaryID INVALID_BOUNDARY_ID = libMesh::BoundaryInfo::invalid_id;
+const TagID INVALID_TAG_ID = libMesh::invalid_uint;
 }

--- a/framework/src/utils/MooseTypes.C
+++ b/framework/src/utils/MooseTypes.C
@@ -17,5 +17,4 @@ const SubdomainID ANY_BLOCK_ID = libMesh::Elem::invalid_subdomain_id - 1;
 const SubdomainID INVALID_BLOCK_ID = libMesh::Elem::invalid_subdomain_id;
 const BoundaryID ANY_BOUNDARY_ID = static_cast<BoundaryID>(-1);
 const BoundaryID INVALID_BOUNDARY_ID = libMesh::BoundaryInfo::invalid_id;
-const TagID INVALID_TAG_ID = libMesh::invalid_uint;
 }

--- a/test/tests/kernels/simple_transient_diffusion/tests
+++ b/test/tests/kernels/simple_transient_diffusion/tests
@@ -86,18 +86,5 @@
     requirement = 'We shall be able to solve a problem where the physics has large changes over time if we scale on every time step in parallel'
     cli_args = "Executioner/automatic_scaling=true Executioner/compute_scaling_once=false Materials/active='function' Executioner/num_steps=10 BCs/right/function='ramp' Outputs/file_base=transient -pc_type hypre -pc_hypre_type boomeramg"
     prereq = 'automatic-scaling-done-per-time-step'
-    max_parallel = 2 # Can't reset preallocation in PETSc when there are no dofs on a process
-    petsc_version = '>=3.9.0'
-  []
-  [auto-scaling-cant-have-zero-local-dofs]
-    type = RunException
-    input = ill_conditioned_simple_diffusion.i
-    cli_args = "Executioner/automatic_scaling=true Outputs/exodus=false"
-    min_parallel = 3
-    issues = '#12601'
-    requirement = 'We shall error out when trying to do automatic scaling and we have any process with zero dofs'
-    design = 'FEProblemSolve.md'
-    expect_err = "MOOSE doesn't currently support automatic scaling when there are any processes owning zero dofs"
-    petsc_version = '>=3.9.0'
   []
 []


### PR DESCRIPTION
One really nice thing that this does is avoid the need to reset the preallocation of the actual Jacobian matrix. This is actually a big problem when we didn't actually get the sparsity pattern of the matrix correct, e.g. when the preallocation itself is not correct.
