### PR TITLE
if GPERF_DIR is set, compile in support for profiling

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -42,6 +42,11 @@ ifneq (x$(MOOSE_NO_PERF_GRAPH), x)
   libmesh_CXXFLAGS += -DMOOSE_NO_PERF_GRAPH
 endif
 
+ifneq ($(GPERF_DIR), )
+    libmesh_CXXFLAGS += -DHAVE_GPERFTOOLS -I$(GPERF_DIR)/include
+    libmesh_LDFLAGS += -L$(GPERF_DIR)/lib -ltcmalloc_and_profiler
+endif
+
 # Make.common used to provide an obj-suffix which was related to the
 # machine in question (from config.guess, i.e. @host@ in
 # contrib/utils/Make.common.in) and the $(METHOD).
@@ -87,6 +92,7 @@ all:
 header_symlinks:
 
 unity_files:
+
 
 #
 # C++ rules

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -974,6 +974,8 @@ private:
   /// longer accessible
   bool _popped_final_mesh_generator;
 
+  bool _profiling = false;
+
   // Allow FEProblemBase to set the recover/restart state, so make it a friend
   friend class FEProblemBase;
   friend class Restartable;


### PR DESCRIPTION
Set GPERF_DIR to the install path/prefix where gperftools is
installed (i.e. so $GPERF_DIR/lib/libprofiler.[so/dylib] exists) and
rebuild MOOSE - you will probably need to do a clean build.
Setting MOOSE_PARALLEL_PROFILE=filebase in the environment will cause
MOOSE to write out a profile for each mpi proc named
"filebase[rank].prof".

fixes #14210

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
