### PR TITLE
Fixups for 14124

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6239,22 +6239,7 @@ FEProblemBase::needBoundaryMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
 bool
 FEProblemBase::needInterfaceMaterialOnSide(BoundaryID bnd_id, THREAD_ID tid)
 {
-  if (_bnd_mat_side_cache[tid].find(bnd_id) == _bnd_mat_side_cache[tid].end())
-  {
-    _bnd_mat_side_cache[tid][bnd_id] = false;
-
-    if (_nl->needInterfaceMaterialOnSide(bnd_id, tid))
-      _bnd_mat_side_cache[tid][bnd_id] = true;
-    else if (theWarehouse()
-                 .query()
-                 .condition<AttribThread>(tid)
-                 .condition<AttribInterfaces>(Interfaces::InterfaceUserObject)
-                 .condition<AttribBoundaries>(bnd_id)
-                 .count() > 0)
-      _bnd_mat_side_cache[tid][bnd_id] = true;
-  }
-
-  return _bnd_mat_side_cache[tid][bnd_id];
+  return _residual_interface_materials.hasActiveBoundaryObjects(bnd_id, tid);
 }
 
 bool

--- a/test/tests/materials/interface_material/tests
+++ b/test/tests/materials/interface_material/tests
@@ -16,6 +16,7 @@
     requirement = 'The system shall be able to grab face and neighboring face variable values and material properties in a single material object that lives on an interface when the mesh is split'
     mesh_mode = 'REPLICATED'
     recover = false
+    method = '!dbg' # issue 12033
   []
   [jump_split_stateful]
     type = Exodiff
@@ -26,5 +27,6 @@
     requirement = 'The system shall be able to calculate stateful material properties in an interface material object'
     mesh_mode = 'REPLICATED'
     recover = false
+    method = '!dbg' # issue 12033
   []
 []


### PR DESCRIPTION
When run in parallel in debug mode these split mesh tests
fail assertions in libMesh, specifically some node_touched
assertions. BreakMeshByBlockGenerator needs to be made more
robust in the future

Refs #14124 #12033

