### PR TITLE
Reduce number of DualNumber operations for undisplaced problems

### DIFF
--- a/framework/include/bcs/ADIntegratedBC.h
+++ b/framework/include/bcs/ADIntegratedBC.h
@@ -60,6 +60,9 @@ protected:
 
   /// The AD version of coord
   const MooseArray<typename Moose::RealType<compute_stage>::type> & _ad_coord;
+
+  /// Whether this object is acting on the displaced mesh
+  const bool _use_displaced_mesh;
 };
 
 template <ComputeStage compute_stage>

--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -27,9 +27,12 @@
   using ADKernelTempl<type, compute_stage>::_u;                                                    \
   using ADKernelTempl<type, compute_stage>::_var;                                                  \
   using ADKernelTempl<type, compute_stage>::_grad_test;                                            \
+  using ADKernelTempl<type, compute_stage>::_regular_grad_test;                                    \
   using ADKernelTempl<type, compute_stage>::_grad_u;                                               \
   using ADKernelTempl<type, compute_stage>::_ad_JxW;                                               \
+  using ADKernelTempl<type, compute_stage>::_JxW;                                                  \
   using ADKernelTempl<type, compute_stage>::_ad_coord;                                             \
+  using ADKernelTempl<type, compute_stage>::_coord;                                                \
   using ADKernelTempl<type, compute_stage>::_local_re;                                             \
   using ADKernelTempl<type, compute_stage>::_local_ke;                                             \
   using ADKernelTempl<type, compute_stage>::_qrule;                                                \
@@ -45,6 +48,8 @@
   using ADKernelTempl<type, compute_stage>::_dt;                                                   \
   using ADKernelTempl<type, compute_stage>::_phi;                                                  \
   using ADKernelTempl<type, compute_stage>::_grad_phi;                                             \
+  using ADKernelTempl<type, compute_stage>::_regular_grad_phi;                                     \
+  using ADKernelTempl<type, compute_stage>::_use_displaced_mesh;                                   \
   using ADKernelTempl<type, compute_stage>::precalculateResidual;                                  \
   using ADKernelTempl<type, compute_stage>::prepareVectorTag;                                      \
   using ADKernelTempl<type, compute_stage>::prepareMatrixTag;                                      \
@@ -107,6 +112,9 @@ protected:
   /// gradient of the test function
   const typename VariableTestGradientType<T, compute_stage>::type & _grad_test;
 
+  // gradient of the test function without possible displacement derivatives
+  const typename OutputTools<T>::VariableTestGradient & _regular_grad_test;
+
   /// Holds the solution at current quadrature points
   const ADTemplateVariableValue & _u;
 
@@ -130,4 +138,10 @@ protected:
 
   /// The current gradient of the shape functions
   const typename VariablePhiGradientType<T, compute_stage>::type & _grad_phi;
+
+  /// The current gradient of the shape functions without possible displacement derivatives
+  const typename OutputTools<T>::VariablePhiGradient & _regular_grad_phi;
+
+  /// Whether this object is acting on the displaced mesh
+  const bool _use_displaced_mesh;
 };

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -32,13 +32,16 @@ ADKernelTempl<T, compute_stage>::ADKernelTempl(const InputParameters & parameter
     _var(*this->mooseVariable()),
     _test(_var.phi()),
     _grad_test(_var.template adGradPhi<compute_stage>()),
+    _regular_grad_test(_var.gradPhi()),
     _u(_var.template adSln<compute_stage>()),
     _grad_u(_var.template adGradSln<compute_stage>()),
     _ad_JxW(_assembly.adJxW<compute_stage>()),
     _ad_coord(_assembly.adCoordTransformation<compute_stage>()),
     _ad_q_point(_assembly.template adQPoints<compute_stage>()),
     _phi(_assembly.phi(_var)),
-    _grad_phi(_assembly.template adGradPhi<T, compute_stage>(_var))
+    _grad_phi(_assembly.template adGradPhi<T, compute_stage>(_var)),
+    _regular_grad_phi(_assembly.gradPhi(_var)),
+    _use_displaced_mesh(getParam<bool>("use_displaced_mesh"))
 {
   addMooseVariableDependency(this->mooseVariable());
   _save_in.resize(_save_in_strings.size());
@@ -83,6 +86,12 @@ ADKernelTempl<T, compute_stage>::ADKernelTempl(const InputParameters & parameter
   }
 
   _has_diag_save_in = _diag_save_in.size() > 0;
+
+  if (_use_displaced_mesh && _displacements.empty())
+    mooseError("ADKernel ",
+               name(),
+               "has been asked to act on the displaced mesh, but no displacements have been "
+               "coupled in. Your Jacobian will be wrong without that coupling");
 }
 
 template <typename T, ComputeStage compute_stage>
@@ -92,9 +101,15 @@ ADKernelTempl<T, compute_stage>::computeResidual()
   prepareVectorTag(_assembly, _var.number());
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-    for (_i = 0; _i < _test.size(); _i++)
-      _local_re(_i) += _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual();
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+      for (_i = 0; _i < _test.size(); _i++)
+        _local_re(_i) += _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual();
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+      for (_i = 0; _i < _test.size(); _i++)
+        _local_re(_i) += _JxW[_qp] * _coord[_qp] * computeQpResidual();
 
   accumulateTaggedLocalResidual();
 
@@ -127,15 +142,23 @@ ADKernelTempl<T, compute_stage>::computeJacobian()
   size_t ad_offset = _var.number() * _sys.getMaxVarNDofsPerElem();
 
   precalculateResidual();
-  for (_i = 0; _i < _test.size(); _i++)
-  {
-    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-    {
-      DualReal residual = _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual();
-      for (_j = 0; _j < _var.phiSize(); _j++)
-        _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
-    }
-  }
+
+  if (_use_displaced_mesh)
+    for (_i = 0; _i < _test.size(); _i++)
+      for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+      {
+        DualReal residual = _ad_JxW[_qp] * _ad_coord[_qp] * computeQpResidual();
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
+  else
+    for (_i = 0; _i < _test.size(); _i++)
+      for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+      {
+        DualReal residual = _JxW[_qp] * _coord[_qp] * computeQpResidual();
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
 
   accumulateTaggedLocalMatrix();
 
@@ -173,13 +196,18 @@ ADKernelTempl<T, compute_stage>::computeADOffDiagJacobian()
     r = 0;
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    _r = _ad_JxW[_qp];
-    _r *= _ad_coord[_qp];
-    for (_i = 0; _i < _test.size(); _i++)
-      _residuals[_i] += _r * computeQpResidual();
-  }
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      _r = _ad_JxW[_qp];
+      _r *= _ad_coord[_qp];
+      for (_i = 0; _i < _test.size(); _i++)
+        _residuals[_i] += _r * computeQpResidual();
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+      for (_i = 0; _i < _test.size(); _i++)
+        _residuals[_i] += _JxW[_qp] * _coord[_qp] * computeQpResidual();
 
   auto & ce = _assembly.couplingEntries();
   for (const auto & it : ce)

--- a/framework/src/kernels/ADKernelGrad.C
+++ b/framework/src/kernels/ADKernelGrad.C
@@ -32,12 +32,21 @@ ADKernelGradTempl<T, compute_stage>::computeResidual()
 
   precalculateResidual();
   const unsigned int n_test = _grad_test.size();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < n_test; _i++) // target for auto vectorization
-      _local_re(_i) += MathUtils::dotProduct(value, _grad_test[_i][_qp]);
-  }
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += MathUtils::dotProduct(value, _grad_test[_i][_qp]);
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += MathUtils::dotProduct(value, _regular_grad_test[_i][_qp]);
+    }
 
   accumulateTaggedLocalResidual();
 
@@ -70,17 +79,32 @@ ADKernelGradTempl<T, compute_stage>::computeJacobian()
   size_t ad_offset = _var.number() * _sys.getMaxVarNDofsPerElem();
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    // This will also compute the derivative with respect to all dofs
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _grad_test.size(); _i++)
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      const auto residual = MathUtils::dotProduct(value, _grad_test[_i][_qp]);
-      for (_j = 0; _j < _var.phiSize(); _j++)
-        _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+      {
+        const auto residual = MathUtils::dotProduct(value, _grad_test[_i][_qp]);
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
     }
-  }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+      {
+        const auto residual = MathUtils::dotProduct(value, _regular_grad_test[_i][_qp]);
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
+    }
+
   accumulateTaggedLocalMatrix();
 
   if (_has_diag_save_in)
@@ -115,12 +139,20 @@ ADKernelGradTempl<T, compute_stage>::computeADOffDiagJacobian()
   std::vector<DualReal> residuals(_grad_test.size(), 0);
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _grad_test.size(); _i++)
-      residuals[_i] += MathUtils::dotProduct(value, _grad_test[_i][_qp]);
-  }
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+        residuals[_i] += MathUtils::dotProduct(value, _grad_test[_i][_qp]);
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+        residuals[_i] += MathUtils::dotProduct(value, _regular_grad_test[_i][_qp]);
+    }
 
   auto & ce = _assembly.couplingEntries();
   for (const auto & it : ce)

--- a/framework/src/kernels/ADKernelStabilized.C
+++ b/framework/src/kernels/ADKernelStabilized.C
@@ -33,12 +33,21 @@ ADKernelStabilizedTempl<T, compute_stage>::computeResidual()
 
   precalculateResidual();
   const unsigned int n_test = _grad_test.size();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < n_test; _i++) // target for auto vectorization
-      _local_re(_i) += _grad_test[_i][_qp] * computeQpStabilization() * value;
-  }
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += _grad_test[_i][_qp] * computeQpStabilization() * value;
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpStrongResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += _regular_grad_test[_i][_qp] * computeQpStabilization() * value;
+    }
 
   accumulateTaggedLocalResidual();
 
@@ -71,17 +80,32 @@ ADKernelStabilizedTempl<T, compute_stage>::computeJacobian()
   size_t ad_offset = _var.number() * _sys.getMaxVarNDofsPerElem();
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    // This will also compute the derivative with respect to all dofs
-    const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _grad_test.size(); _i++)
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      const auto residual = _grad_test[_i][_qp] * computeQpStabilization() * value;
-      for (_j = 0; _j < _var.phiSize(); _j++)
-        _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+      {
+        const auto residual = _grad_test[_i][_qp] * computeQpStabilization() * value;
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
     }
-  }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpStrongResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+      {
+        const auto residual = _regular_grad_test[_i][_qp] * computeQpStabilization() * value;
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
+    }
+
   accumulateTaggedLocalMatrix();
 
   if (_has_diag_save_in)
@@ -116,12 +140,21 @@ ADKernelStabilizedTempl<T, compute_stage>::computeADOffDiagJacobian()
   std::vector<DualReal> residuals(_grad_test.size(), 0);
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _grad_test.size(); _i++)
-      residuals[_i] += _grad_test[_i][_qp] * computeQpStabilization() * value;
-  }
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpStrongResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+        residuals[_i] += _grad_test[_i][_qp] * computeQpStabilization() * value;
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpStrongResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _grad_test.size(); _i++)
+        residuals[_i] += _regular_grad_test[_i][_qp] * computeQpStabilization() * value;
+    }
 
   auto & ce = _assembly.couplingEntries();
   for (const auto & it : ce)

--- a/framework/src/kernels/ADKernelValue.C
+++ b/framework/src/kernels/ADKernelValue.C
@@ -31,12 +31,21 @@ ADKernelValueTempl<T, compute_stage>::computeResidual()
 
   precalculateResidual();
   const unsigned int n_test = _test.size();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < n_test; _i++) // target for auto vectorization
-      _local_re(_i) += value * _test[_i][_qp];
-  }
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += value * _test[_i][_qp];
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < n_test; _i++) // target for auto vectorization
+        _local_re(_i) += value * _test[_i][_qp];
+    }
 
   accumulateTaggedLocalResidual();
 
@@ -69,17 +78,32 @@ ADKernelValueTempl<T, compute_stage>::computeJacobian()
   size_t ad_offset = _var.number() * _sys.getMaxVarNDofsPerElem();
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    // This will also compute the derivative with respect to all dofs
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _test.size(); _i++)
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      const auto residual = value * _test[_i][_qp];
-      for (_j = 0; _j < _var.phiSize(); _j++)
-        _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _test.size(); _i++)
+      {
+        const auto residual = value * _test[_i][_qp];
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
     }
-  }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      // This will also compute the derivative with respect to all dofs
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _test.size(); _i++)
+      {
+        const auto residual = value * _test[_i][_qp];
+        for (_j = 0; _j < _var.phiSize(); _j++)
+          _local_ke(_i, _j) += residual.derivatives()[ad_offset + _j];
+      }
+    }
+
   accumulateTaggedLocalMatrix();
 
   if (_has_diag_save_in)
@@ -114,12 +138,21 @@ ADKernelValueTempl<T, compute_stage>::computeADOffDiagJacobian()
   std::vector<DualReal> residuals(_test.size(), 0);
 
   precalculateResidual();
-  for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-  {
-    const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
-    for (_i = 0; _i < _test.size(); _i++)
-      residuals[_i] += value * _test[_i][_qp];
-  }
+
+  if (_use_displaced_mesh)
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _ad_JxW[_qp] * _ad_coord[_qp];
+      for (_i = 0; _i < _test.size(); _i++)
+        residuals[_i] += value * _test[_i][_qp];
+    }
+  else
+    for (_qp = 0; _qp < _qrule->n_points(); _qp++)
+    {
+      const auto value = precomputeQpResidual() * _JxW[_qp] * _coord[_qp];
+      for (_i = 0; _i < _test.size(); _i++)
+        residuals[_i] += value * _test[_i][_qp];
+    }
 
   auto & ce = _assembly.couplingEntries();
   for (const auto & it : ce)


### PR DESCRIPTION
Use regular versions of _JxW, _coord, and _grad_test where
appropriate. One sad thing is that if a user inherits from
ordinary ADKernel and uses _grad_test then they will be
performing a bunch of unnecessary DualNumber operations
if they are computing on the undisplaced, but I think it's
better to be correct than to be fast. I tried to think of
clean solutions for making it so that _grad_test is always
the right thing, but that would require template arguments
whether in the class or in the method in order to make it work

Closes #13027
