### PR TITLE
TheWarehouse: add support for cached, parametrized queries

### DIFF
--- a/framework/include/base/Attributes.h
+++ b/framework/include/base/Attributes.h
@@ -319,4 +319,3 @@ private:
 
 #undef clonefunc
 #undef hashfunc
-

--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -18,6 +18,32 @@
 
 // C++ includes
 #include <cstdlib>
+#include <tuple>
+#include <type_traits>
+
+// these functions allow streaming tuples to ostreams
+template <size_t n, typename... T>
+typename std::enable_if<(n >= sizeof...(T))>::type
+print_tuple(std::ostream &, const std::tuple<T...> &)
+{
+}
+template <size_t n, typename... T>
+typename std::enable_if<(n < sizeof...(T))>::type
+print_tuple(std::ostream & os, const std::tuple<T...> & tup)
+{
+  if (n != 0)
+    os << ", ";
+  os << std::get<n>(tup);
+  print_tuple<n + 1>(os, tup);
+}
+template <typename... T>
+std::ostream &
+operator<<(std::ostream & os, const std::tuple<T...> & tup)
+{
+  os << "[";
+  print_tuple<0>(os, tup);
+  return os << "]";
+}
 
 /// Application abort macro. Uses MPI_Abort if available, std::abort otherwise
 #if defined(LIBMESH_HAVE_MPI)

--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -163,6 +163,8 @@ public:
     typedef std::tuple<KeyType<Attribs>...> KeyTuple;
     typedef std::tuple<AttribType<Attribs>...> AttribTuple;
 
+    QueryCache() {}
+
     /// Creates a new query operating on the given warehouse w.  You should generally use
     /// TheWarehouse::query() instead.
     QueryCache(TheWarehouse & w) : _w(&w)
@@ -199,6 +201,23 @@ public:
         _attribs.push_back(other._attribs[i]->clone());
       return *this;
     }
+
+    /// Copy constructor from another Query
+    template <typename T>
+    QueryCache & operator=(const T & q)
+    {
+      _attribs.clear();
+      _w = &q.warehouse();
+
+      addAttribs<0, Attribs...>();
+      _attribs.reserve(5);
+
+      for (auto & attrib : q.attributes())
+        _attribs.push_back(attrib->clone());
+
+      return *this;
+    }
+
     QueryCache(const QueryCache & other) : _w(other._w), _key_tup(other._key_tup)
     {
       // do NOT copy the cache.

--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -28,6 +28,24 @@ class TheWarehouse;
 /// must be registered with the warehouse (i.e. via TheWarehouse::registerAttribute) where they will
 /// be used *before* objects are added to that warehouse.  Specific Attribute instances cannot (and
 /// should not) generally be created before the class is registered with a warehouse.
+///
+/// In order to work with QueryCache objects, attribute classes should include
+/// a public typedef for a Key type, as well as a setFromKey function that
+/// takes this type as an argument:
+///
+/// @begincode
+/// class FooAttribute : public Attribute
+/// {
+/// public:
+///   typedef [type-for-foo] Key;
+///
+///   void
+///   setFrom(Key k)
+///   {
+///     // code to mutate/reinitialize FooAttribute using k
+///   }
+/// }
+/// @endcode
 class Attribute
 {
 public:
@@ -119,68 +137,166 @@ public:
 class TheWarehouse
 {
 public:
-  /// Query is a convenient way to construct and pass around (possible partially constructed)
-  /// warehouse queries.  The warehouse's "query()" function should generally be used to create
-  /// new Query objects rather than constructing them directly.  A Query object holds a list of
-  /// conditions used to filter/select objects from the warehouse.  When the query is
-  /// executed/run, results are filtered by "and"ing each condition together - i.e. only objects
-  /// that match *all* conditions are returned.
-  class Query
+  template <typename T>
+  using KeyType = typename T::Key;
+  template <typename T>
+  using AttribType = T *;
+
+  /// QueryCache is a convenient way to construct and pass around (possible
+  /// partially constructed) warehouse queries.  The warehouse's "query()" or
+  /// "queryCache(...)" functions should generally be used to create new Query
+  /// objects rather than constructing them directly.  A Query object holds a
+  /// list of persistent conditions used to filter/select objects from the
+  /// warehouse.  When the query is executed/run, results are filtered by
+  /// "and"ing each condition together - i.e. only objects that match *all*
+  /// conditions are returned.
+  ///
+  ///
+  /// Template arguments (i.e. Attribs) are used to specify parametrized query
+  /// conditions.  The passed template parameters should be the Attribute
+  /// classes you want to use for parameterization (i.e. the values that will
+  /// change from query to query).
+  template <typename... Attribs>
+  class QueryCache
   {
   public:
+    typedef std::tuple<KeyType<Attribs>...> KeyTuple;
+    typedef std::tuple<AttribType<Attribs>...> AttribTuple;
+
     /// Creates a new query operating on the given warehouse w.  You should generally use
     /// TheWarehouse::query() instead.
-    Query(TheWarehouse & w) : _w(&w) { _attribs.reserve(5); }
+    QueryCache(TheWarehouse & w) : _w(&w)
+    {
+      addAttribs<0, Attribs...>();
+      _attribs.reserve(5);
+    }
 
-    Query & operator=(const Query & other)
+    template <typename T>
+    QueryCache(const T & q) : _w(&q.warehouse())
+    {
+      addAttribs<0, Attribs...>();
+      _attribs.reserve(5);
+
+      for (auto & attrib : q.attributes())
+        _attribs.push_back(attrib->clone());
+    }
+
+    QueryCache & operator=(const QueryCache & other)
     {
       if (this == &other)
         return *this;
 
-      _w = other._w;
       _attribs.clear();
-      _attribs.reserve(other._attribs.size());
-      for (auto & attrib : other._attribs)
-        _attribs.push_back(attrib->clone());
+      _w = other._w;
+      // MUST have own pointers to attribs to avoid data races - don't copy _key_attribs.
+      // initialize parametrized attributes and tuple:
+      addAttribs<0, Attribs...>();
+      _key_tup = other._key_tup;
+      // do NOT copy the cache.
+
+      // only copy over non-parametrized attributes
+      for (size_t i = std::tuple_size<AttribTuple>::value; i < other._attribs.size(); i++)
+        _attribs.push_back(other._attribs[i]->clone());
       return *this;
     }
-    Query(const Query & other) : _w(other._w)
+    QueryCache(const QueryCache & other) : _w(other._w), _key_tup(other._key_tup)
     {
-      _attribs.reserve(other._attribs.size());
-      for (auto & attrib : other._attribs)
-        _attribs.push_back(attrib->clone());
+      // do NOT copy the cache.
+
+      // initialize parametrized attributes and tuple:
+      addAttribs<0, Attribs...>(); // MUST have own pointers to attribs to avoid data races.
+      for (size_t i = std::tuple_size<AttribTuple>::value; i < other._attribs.size(); i++)
+        _attribs.push_back(other._attribs[i]->clone());
     }
 
     /// Adds a new condition to the query.  The template parameter T is the Attribute class of
     /// interest and args are forwarded to T's constructor to build+add the attribute in-situ.
+    /// Conditions represent persistent query conditions that do not change
+    /// from query to query for a particular QueryCache instance.
     template <typename T, typename... Args>
-    Query & condition(Args &&... args)
+    QueryCache & condition(Args &&... args)
     {
       _attribs.emplace_back(new T(*_w, std::forward<Args>(args)...));
+      _cache.clear(); // invalidate cache if base query changes.
       return *this;
     }
 
     /// clone creates and returns an independent copy of the query in its current state.
-    Query clone() const { return Query(*this); }
+    QueryCache clone() const { return Query(*this); }
     /// count returns the number of results that match the query (this requires actually running
     /// the query).
     size_t count() { return _w->count(_attribs); }
 
-    /// attribs returns a copy of the constructed Attribute list for the query in its current state.
-    std::vector<std::unique_ptr<Attribute>> attributes() { return clone()._attribs; }
+    TheWarehouse & warehouse() const { return *_w; }
 
-    /// queryInto executes the query and stores the results in the given vector.  All results must
-    /// be castable to the templated type T.
-    template <typename T>
-    std::vector<T *> & queryInto(std::vector<T *> & results)
+    /// attribs returns a copy of the constructed Attribute list for the query in its current state.
+    std::vector<std::unique_ptr<Attribute>> attributes() const { return clone()._attribs; }
+
+    /// queryInto executes the query and stores the results in the given
+    /// vector.  For parametrized queries (i.e. QueryCaches created with more
+    /// than zero template arguments) args must contain one value for each
+    /// parametrized query attribute - the types of args should be equal to the
+    /// ::Key typedef specified for each corresponding parametrized attribute.
+    /// All results must be castable to the templated type T.
+    template <typename T, typename... Args>
+    std::vector<T *> & queryInto(std::vector<T *> & results, Args &&... args)
     {
+      std::lock_guard<std::mutex> lock(_cache_mutex);
+      setKeysInner<0, KeyType<Attribs>...>(args...);
+      // if (_cache.count(_key_tup) == 0)
+      //{
+      setAttribsInner<0, KeyType<Attribs>...>(args...);
+      _cache[_key_tup] = _w->queryID(_attribs);
+      //}
+      // return _w->queryInto(_cache[_key_tup], results);
       return _w->queryInto(_attribs, results);
     }
 
   private:
+    template <int Index, typename A, typename... As>
+    void addAttribs()
+    {
+      std::get<Index>(_attrib_tup) = new A(*_w);
+      _attribs.emplace_back(std::get<Index>(_attrib_tup));
+      addAttribs<Index + 1, As...>();
+    }
+    template <int Index>
+    void addAttribs()
+    {
+    }
+
+    template <int Index, typename K, typename... Args>
+    void setKeysInner(K & k, Args &... args)
+    {
+      std::get<Index>(_key_tup) = k;
+      setKeysInner<Index + 1, Args...>(args...);
+    }
+    template <int Index>
+    void setKeysInner()
+    {
+    }
+
+    template <int Index, typename K, typename... Args>
+    void setAttribsInner(K k, Args &... args)
+    {
+      std::get<Index>(_attrib_tup)->setFrom(k);
+      setAttribsInner<Index + 1, Args...>(args...);
+    }
+    template <int Index>
+    void setAttribsInner()
+    {
+    }
+
     TheWarehouse * _w = nullptr;
     std::vector<std::unique_ptr<Attribute>> _attribs;
+
+    KeyTuple _key_tup;
+    AttribTuple _attrib_tup;
+    std::map<KeyTuple, size_t> _cache;
+    std::mutex _cache_mutex;
   };
+
+  using Query = QueryCache<>;
 
   TheWarehouse();
   ~TheWarehouse();
@@ -254,7 +370,6 @@ public:
     return queryInto(queryID(conds), results);
   }
 
-private:
   size_t queryID(const std::vector<std::unique_ptr<Attribute>> & conds);
 
   template <typename T>
@@ -275,6 +390,7 @@ private:
     return results;
   }
 
+private:
   /// prepares a query and returns an associated query_id (i.e. for use with the query function).
   int prepare(std::vector<std::unique_ptr<Attribute>> conds);
 

--- a/framework/include/loops/ComputeUserObjectsThread.h
+++ b/framework/include/loops/ComputeUserObjectsThread.h
@@ -56,23 +56,17 @@ private:
   template <typename T>
   void querySubdomain(Interfaces iface, std::vector<T> & results)
   {
-    _query.clone()
-        .condition<AttribThread>(_tid)
-        .condition<AttribSubdomains>(_subdomain)
-        .condition<AttribInterfaces>(iface)
-        .queryInto(results);
+    _query_subdomain.queryInto(results, _tid, _subdomain, iface);
   }
   template <typename T>
   void queryBoundary(Interfaces iface, BoundaryID bnd, std::vector<T> & results)
   {
-    _query.clone()
-        .condition<AttribThread>(_tid)
-        .condition<AttribBoundaries>(bnd)
-        .condition<AttribInterfaces>(iface)
-        .queryInto(results);
+    _query_boundary.queryInto(results, _tid, std::make_tuple(bnd, false), iface);
   }
 
   const TheWarehouse::Query _query;
+  TheWarehouse::QueryCache<AttribThread, AttribSubdomains, AttribInterfaces> _query_subdomain;
+  TheWarehouse::QueryCache<AttribThread, AttribBoundaries, AttribInterfaces> _query_boundary;
   std::vector<InternalSideUserObject *> _internal_side_objs;
   std::vector<InterfaceUserObject *> _interface_user_objects;
   std::vector<ElementUserObject *> _element_objs;

--- a/framework/src/base/Attributes.C
+++ b/framework/src/base/Attributes.C
@@ -26,6 +26,38 @@
 #include "ShapeSideUserObject.h"
 #include "ShapeElementUserObject.h"
 
+std::ostream &
+operator<<(std::ostream & os, Interfaces & iface)
+{
+  os << "Interfaces(";
+  if (static_cast<bool>(iface & Interfaces::UserObject))
+    os << "|UserObject";
+  if (static_cast<bool>(iface & Interfaces::ElementUserObject))
+    os << "|ElementUserObject";
+  if (static_cast<bool>(iface & Interfaces::SideUserObject))
+    os << "|SideUserObject";
+  if (static_cast<bool>(iface & Interfaces::InternalSideUserObject))
+    os << "|InternalSideUserObject";
+  if (static_cast<bool>(iface & Interfaces::NodalUserObject))
+    os << "|NodalUserObject";
+  if (static_cast<bool>(iface & Interfaces::GeneralUserObject))
+    os << "|GeneralUserObject";
+  if (static_cast<bool>(iface & Interfaces::ThreadedGeneralUserObject))
+    os << "|ThreadedGeneralUserObject";
+  if (static_cast<bool>(iface & Interfaces::ShapeElementUserObject))
+    os << "|ShapeElementUserObject";
+  if (static_cast<bool>(iface & Interfaces::ShapeSideUserObject))
+    os << "|ShapeSideUserObject";
+  if (static_cast<bool>(iface & Interfaces::Postprocessor))
+    os << "|Postprocessor";
+  if (static_cast<bool>(iface & Interfaces::VectorPostprocessor))
+    os << "|VectorPostprocessor";
+  if (static_cast<bool>(iface & Interfaces::InterfaceUserObject))
+    os << "|InterfaceUserObject";
+  os << ")";
+  return os;
+}
+
 bool
 AttribTagBase::isMatch(const Attribute & other) const
 {

--- a/framework/src/loops/ComputeUserObjectsThread.C
+++ b/framework/src/loops/ComputeUserObjectsThread.C
@@ -25,13 +25,21 @@
 ComputeUserObjectsThread::ComputeUserObjectsThread(FEProblemBase & problem,
                                                    SystemBase & sys,
                                                    const TheWarehouse::Query & query)
-  : ThreadedElementLoop<ConstElemRange>(problem), _soln(*sys.currentSolution()), _query(query)
+  : ThreadedElementLoop<ConstElemRange>(problem),
+    _soln(*sys.currentSolution()),
+    _query(query),
+    _query_subdomain(_query),
+    _query_boundary(_query)
 {
 }
 
 // Splitting Constructor
 ComputeUserObjectsThread::ComputeUserObjectsThread(ComputeUserObjectsThread & x, Threads::split)
-  : ThreadedElementLoop<ConstElemRange>(x._fe_problem), _soln(x._soln), _query(x._query)
+  : ThreadedElementLoop<ConstElemRange>(x._fe_problem),
+    _soln(x._soln),
+    _query(x._query),
+    _query_subdomain(x._query_subdomain),
+    _query_boundary(x._query_boundary)
 {
 }
 


### PR DESCRIPTION
To have a parametrized query cache do this:

```c++
class YourClass
{
    // base_query might include query conditions for a particular system, etc.
    Foo(TheWarehouse::Query& base_query) : _cache(base_query) { }

    void aFunction()
    {
      auto curr_subdomain = ...;
      auto curr_thread = ...;
      _cache.queryInto(_results, curr_thread, curr_subdomain);
    }

    std::vector<FooObjects *> _results;
    TheWarehouse::QueryCache<AttribThread, AttribSubdomain> _cache;
    ...
```

@friedmud - see how this works for you performance-wise.  fixes #14260

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
