### PR TITLE
Adding template specialization of mooseSetToZero for std::vector<Real>

### DIFF
--- a/framework/include/utils/MathUtils.h
+++ b/framework/include/utils/MathUtils.h
@@ -221,4 +221,13 @@ mooseSetToZero(T *&)
 {
   mooseError("mooseSetToZero does not accept pointers");
 }
+
+template <>
+inline void
+mooseSetToZero(std::vector<Real> & vec)
+{
+  for (auto & v : vec)
+    v = 0.;
+}
+
 } // namespace MathUtils


### PR DESCRIPTION
This specialization is required when users specify derivatives via
`declarePropertyDerivative<std::vector<Real>>("a", "x")` and want to use
them via `getMaterialPropertyDerivative<std::vector<Real>>("a", "x")`

Closes #14267

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
