### PR TITLE
Error out only when >1 (p)threads are used 

### DIFF
--- a/framework/src/userobject/ThreadedGeneralUserObject.C
+++ b/framework/src/userobject/ThreadedGeneralUserObject.C
@@ -13,9 +13,10 @@ ThreadedGeneralUserObject::ThreadedGeneralUserObject(const InputParameters & par
   : GeneralUserObject(parameters)
 {
 #if !defined(LIBMESH_HAVE_OPENMP) && !defined(LIBMESH_HAVE_TBB_API)
-  mooseError(name(),
-             ": You cannot use threaded general user objects with pthreads. To enable this "
-             "functionality configure libMesh with OpenMP or TBB.");
+  if (libMesh::n_threads() > 1)
+    mooseError(name(),
+               ": You cannot use threaded general user objects with pthreads. To enable this "
+               "functionality configure libMesh with OpenMP or TBB.");
 #endif
 }
 


### PR DESCRIPTION
Closes #14266

(Closes the issue because the remaining complaints are *won't fix*. Bottom line is *use OpenMP*, it works better!)