### PR TITLE
Minor SONDefinitionFormatter enhancements

### DIFF
--- a/framework/src/outputs/formatters/SONDefinitionFormatter.C
+++ b/framework/src/outputs/formatters/SONDefinitionFormatter.C
@@ -108,8 +108,8 @@ SONDefinitionFormatter::addBlock(const std::string & block_name,
   // add MinOccurs : optional because nothing available to specify block requirement
   addLine("MinOccurs=0");
 
-  // add MaxOccurs : if a StarBlock then no limit / otherwise maximum one occurrence
-  addLine(is_starblock ? "MaxOccurs=NoLimit" : "MaxOccurs=1");
+  // add MaxOccurs : NoLimit because more than one block of the same name is allowed
+  addLine("MaxOccurs=NoLimit");
 
   // ensure block has one string declarator node and if this is not a StarBlock then
   // also ensure that the block [./declarator] is the expected block_decl from above
@@ -246,7 +246,8 @@ SONDefinitionFormatter::addParameters(const JsonVal & params)
     std::string cpp_type = param["cpp_type"].asString();
     std::string basic_type = param["basic_type"].asString();
     bool is_array = false;
-    if (cpp_type == "FunctionExpression" || basic_type.compare(0, 6, "Array:") == 0)
+    if (cpp_type == "FunctionExpression" || cpp_type == "FunctionName" ||
+        basic_type.compare(0, 6, "Array:") == 0)
       is_array = true;
     pcrecpp::RE(".+<([A-Za-z0-9_' ':]*)>.*").GlobalReplace("\\1", &cpp_type);
     pcrecpp::RE("(Array:)*(.*)").GlobalReplace("\\2", &basic_type);
@@ -292,7 +293,7 @@ SONDefinitionFormatter::addParameters(const JsonVal & params)
     _level++;
 
     // *** MinOccurs / MaxOccurs of parameter's value
-    addLine("MinOccurs=1");
+    addLine(is_array ? "MinOccurs=0" : "MinOccurs=1");
     addLine(is_array ? "MaxOccurs=NoLimit" : "MaxOccurs=1");
 
     // *** ValType of parameter's value

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -330,4 +330,43 @@
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ExpressionsAreOkay'
     design = 'SONDefinitionFormatter.md'
   [../]
+
+  [./definition_block_type_maxoccurs_nolimit_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'AuxVariables\'{.*?InputTmpl=MooseBlock.*?InputName="AuxVariables".*?InputType=normal_top.*?InputDefault="AuxVariables".*?MinOccurs=0.*?MaxOccurs=NoLimit.*?decl{.*?ValEnums=\[ "AuxVariables" \]'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#14277'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Block type MaxOccurs NoLimit'
+    design = 'SONDefinitionFormatter.md'
+  [../]
+
+  [./definition_functionname_type_maxoccurs_nolimit_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'x_forcing_func\'{.*?\'value\'{.*?MaxOccurs=NoLimit.*?}.*?} % end parameter x_forcing_func'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#14277'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check FunctionName type MaxOccurs NoLimit'
+    design = 'SONDefinitionFormatter.md'
+  [../]
+
+  [./definition_array_type_minoccurs_zero_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'active\'{.*?\'value\'{.*?MinOccurs=0.*?}.*?} % end parameter active'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#14277'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Array type MinOccurs zero'
+    design = 'SONDefinitionFormatter.md'
+  [../]
 []


### PR DESCRIPTION
 - Allowed blocks to occur more than a single time per input
 - Allowed single-quoted array syntax for cpp_type FunctionName
 - Allowed array type to have zero values inside the quotes

closes #14277

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
