### PR TITLE
Fix Catch on Sierra

### DIFF
--- a/framework/src/functions/MooseParsedFunctionWrapper.C
+++ b/framework/src/functions/MooseParsedFunctionWrapper.C
@@ -126,7 +126,7 @@ MooseParsedFunctionWrapper::initialize()
       {
         val = MooseUtils::convert<Real>(_vals_input[i], true);
       }
-      catch (std::exception & e)
+      catch (const std::invalid_argument & e)
       {
         mooseError("'No postprocessor, scalar variable, or function with the name '",
                    _vals_input[i],


### PR DESCRIPTION
try/catch isn't working on our old build box - just catch the right type instead.

refs #14169

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
