### PR TITLE
Skip debug version of a few slow Polycrystal tests

### DIFF
--- a/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
+++ b/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
@@ -170,5 +170,8 @@ private:
   std::vector<unsigned int> _prealloc_tmp_grains;
 
   std::map<dof_id_type, std::vector<unsigned int>> _entity_to_grain_cache;
-};
 
+  /// Timers
+  const PerfID _execute_timer;
+  const PerfID _finalize_timer;
+};

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -17,6 +17,7 @@
 #include "Assembly.h"
 #include "FEProblem.h"
 #include "NonlinearSystem.h"
+#include "TimedPrint.h"
 
 #include "libmesh/dof_map.h"
 #include "libmesh/mesh_tools.h"
@@ -357,6 +358,7 @@ void
 FeatureFloodCount::execute()
 {
   TIME_SECTION(_execute_timer);
+  CONSOLE_TIMED_PRINT("Flooding Features");
 
   // Iterate only over boundaries if restricted
   if (_is_boundary_restricted)
@@ -679,6 +681,7 @@ void
 FeatureFloodCount::finalize()
 {
   TIME_SECTION(_finalize_timer);
+  CONSOLE_TIMED_PRINT("Finalizing Feature Identification");
 
   // Gather all information on processor zero and merge
   communicateAndMerge();

--- a/modules/phase_field/test/tests/MultiSmoothCircleIC/tests
+++ b/modules/phase_field/test/tests/MultiSmoothCircleIC/tests
@@ -17,6 +17,7 @@
     exodiff = 'multismoothcircleIC_normal_test_out.e'
     scale_refine = 1
     valgrind = 'HEAVY'
+    method = '!DBG' # Uses nodal feature flood count - probably should be revamped
     max_parallel = 1 # See #9886
     rel_err = 2e-5
     design = 'MultiSmoothCircleIC.md'

--- a/modules/phase_field/test/tests/initial_conditions/tests
+++ b/modules/phase_field/test/tests/initial_conditions/tests
@@ -157,6 +157,8 @@
       type = Exodiff
       input = HexPolycrystalIC.i
       exodiff = HexPolycrystalIC_out.e
+      # Testing optimal hex coloring with a backtracking algorithm
+      method = '!DBG'
 
       detail = 'hexagonal structure, and'
     []


### PR DESCRIPTION
These tests are fairly slow in debug mode and aren't easily shrunk. The code paths are well tested in several areas so skipping debug mode seems like a reasonable workaround.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
