### PR TITLE
Test harness fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ config.status
 *MooseConfig.h
 *MooseConfig.h.tmp
 conf_vars.mk
+
+# GPerf performance
+*.prof

--- a/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSamplePostprocessorTransfer.C
@@ -83,6 +83,7 @@ MultiAppVariableValueSamplePostprocessorTransfer::execute()
 
           if (elem && elem->processor_id() == from_mesh.processor_id())
           {
+            from_sub_problem.setCurrentSubdomainID(elem, 0);
             from_sub_problem.reinitElemPhys(elem, point_vec, 0);
 
             mooseAssert(from_var.sln().size() == 1, "No values in u!");

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -39,11 +39,6 @@ class RunParallel(Scheduler):
         if job.isFinished():
             return
 
-        # If we are doing recover tests
-        if self.options.enable_recover and tester.specs.isValid('skip_checks') and tester.specs['skip_checks']:
-            self.setSuccessfulMessage(tester)
-            return
-
         # Allow derived proccessResults to process the output and set a failing status (if it failed)
         job_output = job.getOutput()
         output = tester.processResults(tester.getMooseDir(), self.options, job_output)

--- a/python/TestHarness/tests/test_Recover.py
+++ b/python/TestHarness/tests/test_Recover.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+import subprocess
 from TestHarnessTestCase import TestHarnessTestCase
 
 class TestHarnessTester(TestHarnessTestCase):
@@ -23,3 +24,14 @@ class TestHarnessTester(TestHarnessTestCase):
         self.assertIn('2 passed', output)
         self.assertIn('0 skipped', output)
         self.assertIn('0 failed', output)
+
+    def testRecoverPart1Fail(self):
+        """
+        Test that --recover still checks status on Part1 tests
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+             self.runTests('-i', 'exception_transient', '--recover').decode('utf-8')
+
+        e = cm.exception
+        output = e.output.decode('utf-8')
+        self.assertRegexpMatches(output, r'test_harness.*?part1.*?FAILED \(CRASH\)')

--- a/test/include/kernels/ExceptionKernel.h
+++ b/test/include/kernels/ExceptionKernel.h
@@ -39,6 +39,9 @@ protected:
   // Determine whether we should throw an exception or just trigger an error (abort)
   const bool _should_throw;
 
+  // Determine the type of exception to throw (something not normally caught versus normally caught)
+  const bool _throw_std_exception;
+
   // The rank to isolate the exception to if valid
   const processor_id_type _rank;
 
@@ -51,4 +54,3 @@ protected:
   /// Function which returns true if it's time to throw
   bool time_to_throw() const;
 };
-

--- a/test/src/kernels/ExceptionKernel.C
+++ b/test/src/kernels/ExceptionKernel.C
@@ -36,6 +36,11 @@ validParams<ExceptionKernel>()
   params.addParam<MooseEnum>("when", when, "When to throw the exception");
   params.addParam<bool>(
       "should_throw", true, "Toggle between throwing an exception or triggering an error");
+  params.addParam<bool>("throw_std_exception",
+                        false,
+                        "A standard exception won't be caught by MOOSE's exception handling. This "
+                        "can be useful for checking other failure modes.");
+
   params.addParam<processor_id_type>(
       "rank", DofObject::invalid_processor_id, "Isolate an exception to a particular rank");
   return params;
@@ -45,6 +50,7 @@ ExceptionKernel::ExceptionKernel(const InputParameters & parameters)
   : Kernel(parameters),
     _when(static_cast<WhenType>((int)getParam<MooseEnum>("when"))),
     _should_throw(getParam<bool>("should_throw")),
+    _throw_std_exception(getParam<bool>("throw_std_exception")),
     _rank(getParam<processor_id_type>("rank"))
 {
 }
@@ -70,7 +76,12 @@ ExceptionKernel::computeQpResidual()
     _res_has_thrown = true;
 
     if (_should_throw)
-      throw MooseException("MooseException thrown during residual calculation");
+    {
+      if (_throw_std_exception)
+        throw std::exception();
+      else
+        throw MooseException("MooseException thrown during residual calculation");
+    }
     else
       mooseError("Intentional error triggered during residual calculation");
   }

--- a/test/tests/test_harness/exception_transient
+++ b/test/tests/test_harness/exception_transient
@@ -1,0 +1,6 @@
+[Tests]
+  [./exception_transient]
+    type = RunApp
+    input = exception_transient.i
+  [../]
+[]

--- a/test/tests/test_harness/exception_transient.i
+++ b/test/tests/test_harness/exception_transient.i
@@ -1,0 +1,59 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./exception]
+    type = ExceptionKernel
+    variable = u
+    when = residual
+
+    # This exception won't be caught and will crash the simulation
+    throw_std_exception = true
+  [../]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./time_deriv]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 2
+    value = 1
+  [../]
+  [./right2]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 0.01
+  dtmin = 0.005
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
The TestHarness was passing all Part1 tests that were automatically created as part of the recover testing. This lead to an odd bug when the Part1 was failing hard but we weren't seeing it because it was always passing. Generally this wasn't a huge issue because Part2 would always fail if Part1 failed.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
