### PR TITLE
Allow writing distributed checkpoint using --mesh-only

### DIFF
--- a/framework/doc/content/syntax/Mesh/index.md
+++ b/framework/doc/content/syntax/Mesh/index.md
@@ -60,6 +60,9 @@ Here are a couple of examples showing the usage of `--mesh-only`:
 
 # Will do the same but write out mesh_file.e
 ./myapp-opt -i input_file.i --mesh-only mesh_file.e
+
+# Run in parallel and write out parllel checkpoint format (which can be read as a split)
+mpiexec -n 3 ./myapp-opt -i input_file.i Mesh/parallel_type=distributed --mesh-only mesh_file.cpr
 ```
 
 ## Named Entity Support

--- a/framework/src/actions/MeshOnlyAction.C
+++ b/framework/src/actions/MeshOnlyAction.C
@@ -12,7 +12,10 @@
 #include "MooseApp.h"
 #include "MooseMesh.h"
 #include "Exodus.h"
+#include "TimedPrint.h"
+
 #include "libmesh/exodusII_io.h"
+#include "libmesh/checkpoint_io.h"
 
 registerMooseAction("MooseApp", MeshOnlyAction, "mesh_only");
 
@@ -68,7 +71,23 @@ MeshOnlyAction::act()
 
     Exodus::setOutputDimensionInExodusWriter(exio, *mesh_ptr);
 
+    TimedPrint tp(std ::cout,
+                  std::chrono::duration<double>(0.),
+                  std::chrono::duration<double>(1.),
+                  "Writing Exodus");
+
     exio.write(mesh_file);
+  }
+  else if (mesh_file.find(".cpr") + 4 == mesh_file.size())
+  {
+    TimedPrint tp(std ::cout,
+                  std::chrono::duration<double>(0.),
+                  std::chrono::duration<double>(1.),
+                  "Writing Checkpoint");
+
+    CheckpointIO io(mesh_ptr->getMesh(), true);
+
+    io.write(mesh_file);
   }
   else
   {

--- a/test/tests/mesh/mesh_only/tests
+++ b/test/tests/mesh/mesh_only/tests
@@ -44,4 +44,17 @@
     issues = '#12757'
     requirement = 'The system shall support overriding output dimension when necessary to store coordinates in higher planes'
   [../]
+
+  [./mesh_only_checkpoint]
+    type = 'CheckFiles'
+    input = 'mesh_only.i'
+    cli_args = 'Mesh/parallel_type=distributed --mesh-only 3d_chimney.cpr'
+    check_files = '3d_chimney.cpr/3/split-3-0.cpr 3d_chimney.cpr/3/split-3-1.cpr 3d_chimney.cpr/3/split-3-2.cpr'
+    min_parallel = 3
+    max_parallel = 3
+    recover = false
+    method = '!dbg'
+    issues = '#14312'
+    requirement = 'The system shall support writing parallel checkpoint files with --mesh-only'
+  [../]
 []


### PR DESCRIPTION
This is useful for parallel mesh generation and dealing with really large meshes.

closes #14312