### PR TITLE
Include auto_ptr.h directly

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -20,6 +20,7 @@
 #include "RankFourTensor.h"
 #include "MooseADWrapper.h"
 
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/parallel.h"
 #include "libmesh/parameters.h"
 


### PR DESCRIPTION
This will fix things when libMesh removes an indirect auto_ptr.h inclusion that MOOSE was inadvertently relying on.

There should be no effect beforehand.

This closes #8730 for now.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
