### PR TITLE
Add Mention of CentOS/yum Support for Docker Builds

### DIFF
--- a/modules/doc/content/getting_started/installation/docker.md
+++ b/modules/doc/content/getting_started/installation/docker.md
@@ -9,10 +9,16 @@
 
 ## Obtaining MOOSE and Running Tests
 
-Images of MOOSE are currently hosted on Docker Hub in the repository [herter4171/ubuntu-moose](https://cloud.docker.com/u/herter4171/repository/docker/herter4171/ubuntu-moose).  The tag "latest" is kept current with the master branch of the repository, and the other tags are commit hashes to be used by codes with MOOSE as a submodule.  Since the Docker image already has the framework compiled, it is possible to go from no extant, local copy of MOOSE to running the tests with a single command.
+Images of MOOSE are currently hosted on Docker Hub in the repository [herter4171/ubuntu-moose](https://hub.docker.com/r/herter4171/ubuntu-moose) and [herter4171/centos-moose](https://hub.docker.com/r/herter4171/centos-moose) for Ubuntu 18.04 and CentOS 7, respectively.  The tag "latest" is kept current with the master branch of the repository, and the other tags are commit hashes to be used by codes with MOOSE as a Git submodule.  Since the Docker image already has the framework compiled, it is possible to go from no extant, local copy of MOOSE to running the tests with a single command.
 
 ```bash
 docker run -ti herter4171/ubuntu-moose:latest /bin/bash -c 'cd test; ./run_tests'
+```
+
+As one might expect, the same procedure applies for running a CentOS image. 
+
+```bash
+docker run -ti herter4171/centos-moose:latest /bin/bash -c 'cd test; ./run_tests'
 ```
 
 ## Extending the Image With MOOSE Apps


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Added the following:
* Updated Ubuntu link to not require Docker Hub login
* Added link to CentOS images on Docker Hub
* Included an example command for running CentOS images

Closes #14344.