### PR TITLE
Add escape character to MooseDocs

### DIFF
--- a/modules/doc/content/python/MooseDocs/extensions/core.md
+++ b/modules/doc/content/python/MooseDocs/extensions/core.md
@@ -310,8 +310,36 @@ When rendering HTML, MooseDocs converts the following punctuation to the correct
 table below lists the conversions that are performed.
 
 | MooseDocs | HTML |
-| - | - |
+| :- | :- |
 | `--` | `&ndash` |
 | `---` | `&mdash` |
 
 [markdown]: https://en.wikipedia.org/wiki/Markdown
+
+### Line Breaks
+
+Line breaks can be forced by using `\\` within the text followed by a space or the end of a line,
+as in [break].
+
+!devel! example id=break caption=Example line break.
+This sentence has a\\ line break. And so does\\
+this.
+!devel-end!
+
+### Escape Characters
+
+In some cases the use of characters such as a bracket of exclamation are needed in a context that
+is recognized as special markdown syntax. In this case, the character should be escaped, using the
+`\` character, as in the following examples.
+
+| MooseDocs | HTML |
+| :-        | :-   |
+| `\!`      | \!   |
+| `\[`      | \[   |
+| `\]`      | \]   |
+| `\@`      | \@   |
+| `\^`      | \^   |
+| `\*`      | \*   |
+| `\+`      | \+   |
+| `\~`      | \~   |
+| `\-`      | \-   |

--- a/python/MooseDocs/extensions/core.py
+++ b/python/MooseDocs/extensions/core.py
@@ -80,6 +80,7 @@ class CoreExtension(components.Extension):
         reader.addBlock(EndOfFileBlock())
 
         # Inline tokenize components
+        reader.addInline(EscapeCharacter())
         reader.addInline(FormatInline())
         reader.addInline(LinkInline())
         reader.addInline(ShortcutLinkInline())
@@ -372,6 +373,14 @@ class FormatInline(components.TokenComponent):
             return Strikethrough(parent)
         elif tok == '`':
             return Monospace(parent, content=info['inline'], recursive=False)
+
+class EscapeCharacter(components.TokenComponent):
+    RE = re.compile(r'\\(?P<char>[\[\]!])',
+                    flags=re.MULTILINE|re.DOTALL)
+
+    def createToken(self, parent, info, page):
+        Punctuation(parent, content=info['char'])
+        return parent
 
 ####################################################################################################
 # Rendering.

--- a/python/MooseDocs/extensions/core.py
+++ b/python/MooseDocs/extensions/core.py
@@ -375,7 +375,7 @@ class FormatInline(components.TokenComponent):
             return Monospace(parent, content=info['inline'], recursive=False)
 
 class EscapeCharacter(components.TokenComponent):
-    RE = re.compile(r'\\(?P<char>[\[\]!])',
+    RE = re.compile(r'\\(?P<char>\[|\]|!|\@|\^|\=|\*|\+|~|-)',
                     flags=re.MULTILINE|re.DOTALL)
 
     def createToken(self, parent, info, page):

--- a/python/MooseDocs/test/extensions/test_core.py
+++ b/python/MooseDocs/test/extensions/test_core.py
@@ -41,6 +41,22 @@ class TestCore(MooseDocsTestCase):
                          after_begin='\n', before_end='\n', escape=False)
         self.assertLatexString(tex(0)(0), 'int x = 0;', escape=False)
 
+    def testLineBreak(self):
+        text = r'Break\\ this'
+        ast = self.tokenize(text)
+        self.assertToken(ast(0), 'Paragraph', size=3)
+        self.assertToken(ast(0)(0), 'Word', content='Break')
+        self.assertToken(ast(0)(1), 'LineBreak')
+        self.assertToken(ast(0)(2), 'Word', content='this')
+
+        text = r'''Break\\
+this'''
+        ast = self.tokenize(text)
+        self.assertToken(ast(0), 'Paragraph', size=3)
+        self.assertToken(ast(0)(0), 'Word', content='Break')
+        self.assertToken(ast(0)(1), 'LineBreak')
+        self.assertToken(ast(0)(2), 'Word', content='this')
+
     def testEscapeCharacter(self):
         text = "No \[link\] and no \!\! comment"
         ast = self.tokenize(text)
@@ -59,6 +75,16 @@ class TestCore(MooseDocsTestCase):
         self.assertToken(ast(0)(11), 'Punctuation', content='!')
         self.assertToken(ast(0)(12), 'Space', count=1)
         self.assertToken(ast(0)(13), 'Word', content='comment')
+
+        for c in ['!', '[', ']', '@', '^', '*', '+', '~', '-']:
+            text = r'foo \{} bar'.format(c)
+            ast = self.tokenize(text)
+            self.assertToken(ast(0), 'Paragraph', size=5)
+            self.assertToken(ast(0)(0), 'Word', content='foo')
+            self.assertToken(ast(0)(1), 'Space', count=1)
+            self.assertToken(ast(0)(2), 'Punctuation', content=c)
+            self.assertToken(ast(0)(3), 'Space', count=1)
+            self.assertToken(ast(0)(4), 'Word', content='bar')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/MooseDocs/test/extensions/test_core.py
+++ b/python/MooseDocs/test/extensions/test_core.py
@@ -41,5 +41,24 @@ class TestCore(MooseDocsTestCase):
                          after_begin='\n', before_end='\n', escape=False)
         self.assertLatexString(tex(0)(0), 'int x = 0;', escape=False)
 
+    def testEscapeCharacter(self):
+        text = "No \[link\] and no \!\! comment"
+        ast = self.tokenize(text)
+        self.assertToken(ast(0), 'Paragraph', size=14)
+        self.assertToken(ast(0)(0), 'Word', content='No')
+        self.assertToken(ast(0)(1), 'Space', count=1)
+        self.assertToken(ast(0)(2), 'Punctuation', content='[')
+        self.assertToken(ast(0)(3), 'Word', content='link')
+        self.assertToken(ast(0)(4), 'Punctuation', content=']')
+        self.assertToken(ast(0)(5), 'Space', count=1)
+        self.assertToken(ast(0)(6), 'Word', content='and')
+        self.assertToken(ast(0)(7), 'Space', count=1)
+        self.assertToken(ast(0)(8), 'Word', content='no')
+        self.assertToken(ast(0)(9), 'Space', count=1)
+        self.assertToken(ast(0)(10), 'Punctuation', content='!')
+        self.assertToken(ast(0)(11), 'Punctuation', content='!')
+        self.assertToken(ast(0)(12), 'Space', count=1)
+        self.assertToken(ast(0)(13), 'Word', content='comment')
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
