### PR TITLE
ReferenceResidualProblem behavior when solution_variables isn't provided

### DIFF
--- a/framework/include/problems/ReferenceResidualProblem.h
+++ b/framework/include/problems/ReferenceResidualProblem.h
@@ -43,13 +43,25 @@ public:
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
                             const PetscBool force_iteration,
-                            const Real ref_resid,
+                            const Real initial_residual_before_preset_bcs,
                             const Real div_threshold) override;
 
+  /**
+   * Check the convergence by comparing the norm of each variable separately against
+   * its reference variable's norm. Only consider the solution converged if all
+   * variables are converged individually using either a relative or absolute
+   * criterion.
+   * @param fnorm Function norm (norm of full residual vector)
+   * @param abstol Absolute convergence tolerance
+   * @param rtol Relative convergence tolerance
+   * @param initial_residual_before_preset_bcs Initial norm of full residual vector
+   *                                           before applying preset bcs
+   * @return true if all variables are converged
+   */
   bool checkConvergenceIndividVars(const Real fnorm,
                                    const Real abstol,
                                    const Real rtol,
-                                   const Real ref_resid);
+                                   const Real initial_residual_before_preset_bcs);
 
   /**
    * Add solution variables to ReferenceResidualProblem.

--- a/framework/src/problems/ReferenceResidualProblem.C
+++ b/framework/src/problems/ReferenceResidualProblem.C
@@ -55,7 +55,13 @@ ReferenceResidualProblem::ReferenceResidualProblem(const InputParameters & param
   : FEProblem(params), _use_group_variables(false), _reference_vector(nullptr)
 {
   if (params.isParamValid("solution_variables"))
+  {
+    if (params.isParamValid("reference_vector"))
+      mooseDeprecated("The `solution_variables` parameter is deprecated, has no effect when "
+                      "the tagging system is used, and will be removed on January 1, 2020. "
+                      "Please simply delete this parameter from your input file.");
     _soln_var_names = params.get<std::vector<std::string>>("solution_variables");
+  }
 
   if (params.isParamValid("reference_residual_variables") &&
       params.isParamValid("reference_vector"))
@@ -66,9 +72,10 @@ ReferenceResidualProblem::ReferenceResidualProblem(const InputParameters & param
 
   if (params.isParamValid("reference_residual_variables"))
   {
-    mooseDeprecated("The save-in method for composing reference residual quantities is deprecated "
-                    "and will be removed on Januay 1, 2020. Please use the tagging system instead; "
-                    "specifically, please assign a TagName to the `reference_vector` parameter");
+    mooseDeprecated(
+        "The save-in method for composing reference residual quantities is deprecated "
+        "and will be removed on January 1, 2020. Please use the tagging system instead; "
+        "specifically, please assign a TagName to the `reference_vector` parameter");
 
     _ref_resid_var_names = params.get<std::vector<std::string>>("reference_residual_variables");
 
@@ -84,8 +91,8 @@ ReferenceResidualProblem::ReferenceResidualProblem(const InputParameters & param
   else
     mooseInfo("Neither the `reference_residual_variables` nor `reference_vector` parameter is "
               "specified for `ReferenceResidualProblem`, which means that no reference "
-              "quantites are set. The only way to achieve convergence will be through "
-              "nl_abs_tol which is generally not recommended as an indicator for convergence.");
+              "quantites are set. Because of this, the standard technique of comparing the "
+              "norm of the full residual vector with its initial value will be used.");
 
   if (params.isParamValid("group_variables"))
   {
@@ -129,6 +136,32 @@ ReferenceResidualProblem::addGroupVariables(std::set<std::string> & group_vars)
 void
 ReferenceResidualProblem::initialSetup()
 {
+  NonlinearSystemBase & nonlinear_sys = getNonlinearSystemBase();
+  AuxiliarySystem & aux_sys = getAuxiliarySystem();
+  System & s = nonlinear_sys.system();
+  TransientExplicitSystem & as = aux_sys.sys();
+
+  if (_soln_var_names.size() == 0)
+  {
+    // If the user provides reference_vector, that implies that they want the
+    // individual variables compared against their reference quantities in the
+    // tag vector. The code depends on having _soln_var_names populated,
+    // so fill that out if they didn't specify solution_variables.
+    if (_reference_vector)
+    {
+      for (unsigned int var_num = 0; var_num < s.n_vars(); var_num++)
+        _soln_var_names.push_back(s.variable_name(var_num));
+    }
+    // If they didn't provide reference_vector, that implies that they
+    // want to skip the individual variable comparison, so leave it alone.
+  }
+  else if (_soln_var_names.size() != s.n_vars())
+    mooseError("In ReferenceResidualProblem, size of solution_variables (",
+               _soln_var_names.size(),
+               ") != number of variables in system (",
+               s.n_vars(),
+               ")");
+
   _variable_group_num_index.resize(_soln_var_names.size());
 
   unsigned int group_variable_num = 0;
@@ -168,18 +201,6 @@ ReferenceResidualProblem::initialSetup()
       mooseError(
           "A variable cannot be included in multiple groups in the 'group_variables' parameter.");
   }
-
-  NonlinearSystemBase & nonlinear_sys = getNonlinearSystemBase();
-  AuxiliarySystem & aux_sys = getAuxiliarySystem();
-  System & s = nonlinear_sys.system();
-  TransientExplicitSystem & as = aux_sys.sys();
-
-  if (_soln_var_names.size() > 0 && _soln_var_names.size() != s.n_vars())
-    mooseError("In ReferenceResidualProblem, size of solution_variables (",
-               _soln_var_names.size(),
-               ") != number of variables in system (",
-               s.n_vars(),
-               ")");
 
   _soln_vars.clear();
   for (unsigned int i = 0; i < _soln_var_names.size(); ++i)
@@ -384,7 +405,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
                                                     const PetscInt nfuncs,
                                                     const PetscInt max_funcs,
                                                     const PetscBool force_iteration,
-                                                    const Real ref_resid,
+                                                    const Real initial_residual_before_preset_bcs,
                                                     const Real /*div_threshold*/)
 {
   updateReferenceResidual();
@@ -438,7 +459,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
 
   if (reason == MooseNonlinearConvergenceReason::ITERATING)
   {
-    if (checkConvergenceIndividVars(fnorm, abstol, rtol, ref_resid))
+    if (checkConvergenceIndividVars(fnorm, abstol, rtol, initial_residual_before_preset_bcs))
     {
       if (_group_resid.size() > 0)
         oss << "Converged due to function norm "
@@ -450,9 +471,10 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
             << " (relative tolerance)" << std::endl;
       reason = MooseNonlinearConvergenceReason::CONVERGED_FNORM_RELATIVE;
     }
-    else if (it >= _accept_iters &&
-             checkConvergenceIndividVars(
-                 fnorm, abstol * _accept_mult, rtol * _accept_mult, ref_resid))
+    else if (it >= _accept_iters && checkConvergenceIndividVars(fnorm,
+                                                                abstol * _accept_mult,
+                                                                rtol * _accept_mult,
+                                                                initial_residual_before_preset_bcs))
     {
       if (_group_resid.size() > 0)
         oss << "Converged due to function norm "
@@ -486,7 +508,7 @@ bool
 ReferenceResidualProblem::checkConvergenceIndividVars(const Real fnorm,
                                                       const Real abstol,
                                                       const Real rtol,
-                                                      const Real ref_resid)
+                                                      const Real initial_residual_before_preset_bcs)
 {
   bool convergedRelative = true;
   if (_group_resid.size() > 0)
@@ -496,7 +518,7 @@ ReferenceResidualProblem::checkConvergenceIndividVars(const Real fnorm,
           ((_group_resid[i] < _group_ref_resid[i] * rtol) || (_group_resid[i] < abstol));
   }
 
-  else if (fnorm > ref_resid * rtol)
+  else if (fnorm > initial_residual_before_preset_bcs * rtol)
     convergedRelative = false;
 
   return convergedRelative;

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q4/hertz_cyl_half_1deg_template3.i
@@ -11,7 +11,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template1.i
@@ -10,7 +10,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/half_symm_q8/hertz_cyl_half_1deg_template3.i
@@ -10,7 +10,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q4/hertz_cyl_qsym_1deg_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
+++ b/modules/combined/test/tests/contact_verification/hertz_cyl/quart_symm_q8/hertz_cyl_qsym_1deg_template1.i
@@ -10,7 +10,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/overclosure_removal/overclosure.i
+++ b/modules/combined/test/tests/contact_verification/overclosure_removal/overclosure.i
@@ -16,7 +16,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 100

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_aug_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 100

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_mu_0_2_pen_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template1_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_1/brick1_template2_sm.i
@@ -9,7 +9,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 100

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_aug_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 100

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_mu_0_2_pen_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template1_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_2/brick2_template2_sm.i
@@ -9,7 +9,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_mu_0_2_pen_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template1_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_3/brick3_template2_sm.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_mu_0_2_pen_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template1_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/brick_4/brick4_template2_sm.i
@@ -10,7 +10,6 @@
 [Problem]
   type = AugmentedLagrangianContactProblem
   maximum_lagrangian_update_iterations = 200
-  solution_variables = 'disp_x disp_y disp_z'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_mu_0_2_pen_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template1_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_1/plane1_template2_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_mu_0_2_pen_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template1_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_2/plane2_template2_sm.i
@@ -8,7 +8,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_mu_0_2_pen_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template1_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_3/plane3_template2_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_mu_0_2_pen_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template1_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2_sm.i
+++ b/modules/combined/test/tests/contact_verification/patch_tests/plane_4/plane4_template2_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 200

--- a/modules/combined/test/tests/generalized_plane_strain_tm_contact/out_of_plane_pressure.i
+++ b/modules/combined/test/tests/generalized_plane_strain_tm_contact/out_of_plane_pressure.i
@@ -14,7 +14,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y scalar_strain_zz'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2d/ad_frictionless_fir/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2d/ad_frictionless_fir/finite_rr.i
@@ -74,7 +74,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2d/ad_frictionless_sec/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2d/ad_frictionless_sec/finite_rr.i
@@ -74,7 +74,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2d/frictionless_first/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2d/frictionless_first/finite_rr.i
@@ -74,7 +74,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2d/frictionless_second/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2d/frictionless_second/finite_rr.i
@@ -74,7 +74,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2drz/ad_frictionless_first/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2drz/ad_frictionless_first/finite_rr.i
@@ -78,7 +78,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2drz/ad_frictionless_second/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2drz/ad_frictionless_second/finite_rr.i
@@ -78,7 +78,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2drz/frictionless_first/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2drz/frictionless_first/finite_rr.i
@@ -78,7 +78,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/mortar_tm/2drz/frictionless_second/finite_rr.i
+++ b/modules/combined/test/tests/mortar_tm/2drz/frictionless_second/finite_rr.i
@@ -78,7 +78,6 @@ name = 'finite_rr'
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y frictionless_normal_lm'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/normalized_penalty/normalized_penalty.i
+++ b/modules/combined/test/tests/normalized_penalty/normalized_penalty.i
@@ -10,7 +10,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/normalized_penalty/normalized_penalty_Q8.i
+++ b/modules/combined/test/tests/normalized_penalty/normalized_penalty_Q8.i
@@ -11,7 +11,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/normalized_penalty/normalized_penalty_kin.i
+++ b/modules/combined/test/tests/normalized_penalty/normalized_penalty_kin.i
@@ -10,7 +10,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/normalized_penalty/normalized_penalty_kin_Q8.i
+++ b/modules/combined/test/tests/normalized_penalty/normalized_penalty_kin_Q8.i
@@ -11,7 +11,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/reference_residual/group_variables.i
+++ b/modules/combined/test/tests/reference_residual/group_variables.i
@@ -5,7 +5,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y scalar_strain_zz1 scalar_strain_zz2'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   group_variables = 'disp_x disp_y;

--- a/modules/combined/test/tests/reference_residual/reference_residual.i
+++ b/modules/combined/test/tests/reference_residual/reference_residual.i
@@ -12,7 +12,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z temp'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/reference_residual/reference_residual_perfgraph.i
+++ b/modules/combined/test/tests/reference_residual/reference_residual_perfgraph.i
@@ -12,7 +12,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z temp'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/reference_residual/reference_residual_sm.i
+++ b/modules/combined/test/tests/reference_residual/reference_residual_sm.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'disp_x disp_y disp_z temp'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/modules/combined/test/tests/sliding_block/sliding/constraint/frictional_02_aug.i
+++ b/modules/combined/test/tests/sliding_block/sliding/constraint/frictional_02_aug.i
@@ -207,7 +207,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 100

--- a/modules/combined/test/tests/sliding_block/sliding/constraint/frictionless_aug.i
+++ b/modules/combined/test/tests/sliding_block/sliding/constraint/frictionless_aug.i
@@ -199,7 +199,6 @@
 
 [Problem]
   type = AugmentedLagrangianContactProblem
-  solution_variables = 'disp_x disp_y'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
   maximum_lagrangian_update_iterations = 25

--- a/test/tests/predictors/simple/predictor_reference_residual_test.i
+++ b/test/tests/predictors/simple/predictor_reference_residual_test.i
@@ -9,7 +9,6 @@
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'u'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []

--- a/test/tests/problems/reference_residual_problem/reference_residual.i
+++ b/test/tests/problems/reference_residual_problem/reference_residual.i
@@ -8,7 +8,6 @@ coef=1
 
 [Problem]
   type = ReferenceResidualProblem
-  solution_variables = 'u v'
   extra_tag_vectors = 'ref'
   reference_vector = 'ref'
 []


### PR DESCRIPTION
closes #14334

Fix a crash when group_variables was specified without solution_variables

Make use of solution_variables with tagging system deprecated, and
remove from it from all tests.