### PR TITLE
Remove the deprecated MooseMesh::clone interface

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -95,11 +95,6 @@ public:
   };
 
   /**
-   * Clone method.  Allocates memory you are responsible to clean up.
-   */
-  virtual MooseMesh & clone() const;
-
-  /**
    * A safer version of the clone() method that hands back an
    * allocated object wrapped in a smart pointer. This makes it much
    * less likely that the caller will leak the memory in question.

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2016,12 +2016,6 @@ MooseMesh::getNormalByBoundaryID(BoundaryID id) const
   return (*_boundary_to_normal_map)[id];
 }
 
-MooseMesh &
-MooseMesh::clone() const
-{
-  mooseError("MooseMesh::clone() is no longer supported, use MooseMesh::safeClone() instead.");
-}
-
 std::unique_ptr<MeshBase>
 MooseMesh::buildMeshBaseObject(ParallelType override_type)
 {


### PR DESCRIPTION
closes #11515

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
