### PR TITLE
TimedPrint improvements and GrainTracker error improvement

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -818,7 +818,6 @@ FEProblemBase::initialSetup()
     if (n && !_app.isUltimateMaster() && _app.isRestarting())
       mooseError("Cannot perform initial adaptivity during restart on sub-apps of a MultiApp!");
 
-    CONSOLE_TIMED_PRINT("Adapting initial mesh");
     initialAdaptMesh();
   }
 
@@ -5560,7 +5559,7 @@ FEProblemBase::initialAdaptMesh()
 
     for (unsigned int i = 0; i < n; i++)
     {
-      _console << "Initial adaptivity step " << i + 1 << " of " << n << std::endl;
+      CONSOLE_TIMED_PRINT("Initial adaptivity step ", i + 1, " of ", n);
       computeIndicators();
       computeMarkers();
 
@@ -5599,7 +5598,7 @@ FEProblemBase::adaptMesh()
 
   for (unsigned int i = 0; i < cycles_per_step; ++i)
   {
-    _console << "Adaptivity step " << i + 1 << " of " << cycles_per_step << '\n';
+    CONSOLE_TIMED_PRINT("Adaptivity step ", i + 1, " of ", cycles_per_step);
 
     // Markers were already computed once by Executioner
     if (_adaptivity.getRecomputeMarkersFlag() && i > 0)

--- a/framework/src/utils/TimedPrint.C
+++ b/framework/src/utils/TimedPrint.C
@@ -1,0 +1,13 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TimedPrint.h"
+
+// Singleton TimedPrint object
+TimedPrint * TimedPrint::_active_instance = nullptr;

--- a/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
+++ b/modules/phase_field/src/vectorpostprocessors/FeatureVolumeVectorPostprocessor.C
@@ -39,6 +39,8 @@ validParams<FeatureVolumeVectorPostprocessor>()
                              "of a \"FeatureFloodCount\" or derived object (e.g. individual "
                              "feature volumes)");
 
+  params.suppressParameter<bool>("contains_complete_history");
+
   return params;
 }
 


### PR DESCRIPTION
This PR improves console output of a typical GrainTracker run by adding the singleton pattern to the TimedPrint object. Also, I'm suppressing a parameter that shouldn't be used in the FeatureVolumeVectorPostprocessor.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
