### PR TITLE
Add liblzma-dev to pre-reqs

### DIFF
--- a/modules/doc/content/getting_started/installation/centos_pre_req.md
+++ b/modules/doc/content/getting_started/installation/centos_pre_req.md
@@ -14,7 +14,8 @@ sudo -E yum install gcc \
   tcl-devel \
   libX11-devel \
   git \
-  zlib-devel
+  zlib-devel \
+  xz-devel
 ```
 
 Download and install one our redistributable packages according to your version of CentOS

--- a/modules/doc/content/getting_started/installation/fedora_pre_req.md
+++ b/modules/doc/content/getting_started/installation/fedora_pre_req.md
@@ -16,7 +16,8 @@ sudo -E dnf install gcc \
   m4 \
   blas-devel \
   lapack-devel \
-  git
+  git \
+  xz-devel
 ```
 
 Download and install one our redistributable packages according to your version of Fedora.

--- a/modules/doc/content/getting_started/installation/mint_pre_req.md
+++ b/modules/doc/content/getting_started/installation/mint_pre_req.md
@@ -19,7 +19,8 @@ sudo apt-get install build-essential \
   libhwloc-dev \
   libxml2-dev \
   libpng-dev \
-  pkg-config
+  pkg-config \
+  liblzma-dev
 ```
 
 Download and install one of our redistributable packages according to your version of Mint. Mint is a spinoff of Ubuntu. But the versions do not necessarly match (each Mint release is based on Ubuntu's LTS release schedule): [https://en.wikipedia.org/wiki/Linux_Mint_version_history](https://en.wikipedia.org/wiki/Linux_Mint_version_history).

--- a/modules/doc/content/getting_started/installation/opensuse_pre_req.md
+++ b/modules/doc/content/getting_started/installation/opensuse_pre_req.md
@@ -12,7 +12,8 @@ sudo -E zypper install gcc-c++ \
   freeglut-devel \
   tcl-devel \
   m4 \
-  git
+  git \
+  xz-devel
 ```
 
 Download and install one our redistributable packages according to your version of OpenSUSE.

--- a/modules/doc/content/getting_started/installation/ubuntu_pre_req.md
+++ b/modules/doc/content/getting_started/installation/ubuntu_pre_req.md
@@ -19,7 +19,8 @@ sudo apt-get install build-essential \
   libhwloc-dev \
   libxml2-dev \
   libpng-dev \
-  pkg-config
+  pkg-config \
+  liblzma-dev
 ```
 
 Download and install one of our redistributable packages according to your version of Ubuntu.


### PR DESCRIPTION
Add the missing liblzma-dev pre-req to Debian-like Getting Started
pages.

Closes #14362
