### PR TITLE
Test for non-unicode characters in output

### DIFF
--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -62,7 +62,7 @@ class RunPBS(QueueManager):
                 output_file = job_data.json_data.get(job_data.job_dir, {}).get(job_data.plugin, {}).get('QSUB_OUTPUT', "")
                 if os.path.exists(output_file):
                     with open(output_file, 'r') as f:
-                        output_string = util.readOutput(f, None)
+                        output_string = util.readOutput(f, None, job.getTester())
                     job_data.jobs.getJobs()[0].setOutput(output_string)
 
                 # Add a caveat to each job, explaining that one of the jobs caused a TestHarness exception

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -320,7 +320,7 @@ class Tester(MooseObject):
         self.errfile.flush()
 
         # store the contents of output, and close the file
-        self.joined_out = util.readOutput(self.outfile, self.errfile)
+        self.joined_out = util.readOutput(self.outfile, self.errfile, self)
         self.outfile.close()
         self.errfile.close()
 

--- a/python/TestHarness/tests/test_UnreadableOutput.py
+++ b/python/TestHarness/tests/test_UnreadableOutput.py
@@ -13,7 +13,7 @@ from TestHarnessTestCase import TestHarnessTestCase
 class TestHarnessTester(TestHarnessTestCase):
     def testUnreadableOutput(self):
         """
-        Test for bad output supplied be executed commands
+        Test for bad output supplied by executed commands
         """
 
         with self.assertRaises(subprocess.CalledProcessError) as cm:

--- a/python/TestHarness/tests/test_UnreadableOutput.py
+++ b/python/TestHarness/tests/test_UnreadableOutput.py
@@ -1,0 +1,22 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testUnreadableOutput(self):
+        """
+        Test for bad output supplied be executed commands
+        """
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'non_unicode')
+        e = cm.exception
+        self.assertIn('non-unicode characters in output', e.output.decode('utf-8'))

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -182,4 +182,10 @@
     requirement = "TestHarness shall detect and report race conditions that exist in the supplied tests"
     issues = '#13186'
   [../]
+  [./unreadable_output]
+    type = PythonUnitTest
+    input = test_UnreadableOutput.py
+    requirement = "TestHarness shall detect and report unreadable output in executed commands"
+    issues = '#14370'
+  [../]
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -709,18 +709,24 @@ def getOutputFromFiles(tester, options):
     for file_path in output_files:
         with open(file_path, 'r+b') as f:
             file_output += "#"*80 + "\nOutput from " + file_path \
-                           + "\n" + "#"*80 + "\n" + readOutput(f, None)
+                           + "\n" + "#"*80 + "\n" + readOutput(f, None, tester)
     return file_output
 
 # Read stdout and stderr file objects, append error and return the string
-def readOutput(stdout, stderr):
+def readOutput(stdout, stderr, tester):
     output = ''
-    if stdout:
-        stdout.seek(0)
-        output += stdout.read().decode('utf-8')
-    if stderr:
-        stderr.seek(0)
-        output += stderr.read().decode('utf-8')
+    try:
+        if stdout:
+            stdout.seek(0)
+            output += stdout.read().decode('utf-8')
+        if stderr:
+            stderr.seek(0)
+            output += stderr.read().decode('utf-8')
+    except UnicodeDecodeError:
+        tester.setStatus(tester.fail, 'non-unicode characters in output')
+    except:
+        tester.setStatus(tester.fail, 'error while attempting to read output files')
+
     return output
 
 # Trimming routines for job output

--- a/test/tests/test_harness/non_unicode
+++ b/test/tests/test_harness/non_unicode
@@ -1,0 +1,6 @@
+[Tests]
+  [./non_unicode]
+    type = RunCommand
+    command = 'echo b\'A\xC4B\xE8C\''
+  [../]
+[]

--- a/test/tests/test_harness/non_unicode
+++ b/test/tests/test_harness/non_unicode
@@ -1,6 +1,6 @@
 [Tests]
   [./non_unicode]
     type = RunCommand
-    command = 'echo b\'A\xC4B\xE8C\''
+    command = "cat gold/good_exodiff_out.e"
   [../]
 []


### PR DESCRIPTION
Fail the test properly when non-unicode characters are present in
stdout/stderr output.

Create unittest to verify functionality.

Closes #14370
