### PR TITLE
Update mooseframework.inl.gov/civet

### DIFF
--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -45,11 +45,11 @@ conda_vtk: 8.2
 pip_pylint: 1.6.5
 pip_livereload: 2.5.1
 moose_packages:
-    osx10.15: moose-environment_osx-catalina_20191115_x86_64.pkg
-    osx10.14: moose-environment_osx-mojave_20191115_x86_64.pkg
-    osx10.13: moose-environment_osx-highsierra_20191105_x86_64.pkg
-    ubuntu16: moose-environment_ubuntu-16.04_20191115_x86_64.deb
-    ubuntu18: moose-environment_ubuntu-18.04_20191115_x86_64.deb
-    opensuse15: moose-environment_opensuse-15.0_20191115_x86_64.rpm
-    fedora31: moose-environment_fedora-31_20191115_x86_64.rpm
-    centos8: moose-environment_centos-8.0.1905_20191115_x86_64.rpm
+    osx10.15: moose-environment_osx-catalina_20191125_x86_64.pkg
+    osx10.14: moose-environment_osx-mojave_20191125_x86_64.pkg
+    osx10.13: moose-environment_osx-highsierra_20191125_x86_64.pkg
+    ubuntu16: moose-environment_ubuntu-16.04_20191125_x86_64.deb
+    ubuntu18: moose-environment_ubuntu-18.04_20191125_x86_64.deb
+    opensuse15: moose-environment_opensuse-15.0_20191125_x86_64.rpm
+    fedora31: moose-environment_fedora-31_20191125_x86_64.rpm
+    centos8: moose-environment_centos-8.0.1905_20191125_x86_64.rpm

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -45,11 +45,11 @@ conda_vtk: 8.2
 pip_pylint: 1.6.5
 pip_livereload: 2.5.1
 moose_packages:
-    osx10.15: moose-environment_osx-catalina_20191104_x86_64.pkg
-    osx10.14: moose-environment_osx-mojave_20191104_x86_64.pkg
+    osx10.15: moose-environment_osx-catalina_20191115_x86_64.pkg
+    osx10.14: moose-environment_osx-mojave_20191115_x86_64.pkg
     osx10.13: moose-environment_osx-highsierra_20191105_x86_64.pkg
-    ubuntu16: moose-environment_ubuntu-16.04_20191104_x86_64.deb
-    ubuntu18: moose-environment_ubuntu-18.04_20191104_x86_64.deb
-    opensuse15: moose-environment_opensuse-15.0_20191104_x86_64.rpm
-    fedora30: moose-environment_fedora-30_20191104_x86_64.rpm
-    centos7: moose-environment_centos-7.7.1908_20191104_x86_64.rpm
+    ubuntu16: moose-environment_ubuntu-16.04_20191115_x86_64.deb
+    ubuntu18: moose-environment_ubuntu-18.04_20191115_x86_64.deb
+    opensuse15: moose-environment_opensuse-15.0_20191115_x86_64.rpm
+    fedora31: moose-environment_fedora-31_20191115_x86_64.rpm
+    centos8: moose-environment_centos-8.0.1905_20191115_x86_64.rpm

--- a/modules/doc/content/getting_started/installation/centos_pre_req.md
+++ b/modules/doc/content/getting_started/installation/centos_pre_req.md
@@ -20,7 +20,7 @@ sudo -E yum install gcc \
 
 Download and install one our redistributable packages according to your version of CentOS
 
-- CentOS 7: [!package!name arch=centos7]
+- CentOS 8: [!package!name arch=centos8]
 
 Once downloaded, the package can be installed via the rpm utility:
 

--- a/modules/doc/content/getting_started/installation/fedora_pre_req.md
+++ b/modules/doc/content/getting_started/installation/fedora_pre_req.md
@@ -22,7 +22,7 @@ sudo -E dnf install gcc \
 
 Download and install one our redistributable packages according to your version of Fedora.
 
-- Fedora: [!package!name arch=fedora30]
+- Fedora 31: [!package!name arch=fedora31]
 
 Once downloaded, the package can be installed via the rpm utility:
 

--- a/modules/doc/content/getting_started/installation/manual_petsc.md
+++ b/modules/doc/content/getting_started/installation/manual_petsc.md
@@ -15,33 +15,36 @@ cd $STACK_SRC/petsc-__PETSC_DEFAULT__
 
 ./configure \
 --prefix=$PACKAGES_DIR/petsc-__PETSC_DEFAULT__ \
---download-hypre=1 \
---with-debugging=no \
---with-shared-libraries=1 \
---download-fblaslapack=1 \
---download-metis=1 \
---download-parmetis=1 \
---download-superlu_dist=1 \
---download-mumps=1 \
---download-scalapack=1 \
---with-cxx-dialect=C++11 \
---download-slepc \
+--with-debugging=0 \
+--with-ssl=0 \
+--with-pic=1 \
+--with-openmp=1 \
 --with-mpi=1 \
+--with-shared-libraries=1 \
 --with-cxx-dialect=C++11 \
 --with-fortran-bindings=0 \
 --with-sowing=0 \
-PETSC_DIR=`pwd`
+--download-hypre=1 \
+--download-fblaslapack=1 \
+--download-metis=1 \
+--download-ptscotch=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-scalapack=1 \
+--download-mumps=1 \
+--download-slepc=1 \
+PETSC_DIR=`pwd` PETSC_ARCH=linux-opt
 !package-end!
 
 Once configure is done, we build PETSc
 
 !package code
-make PETSC_DIR=$STACK_SRC/petsc-__PETSC_DEFAULT__ PETSC_ARCH=arch-linux2-c-opt all
+make PETSC_DIR=$STACK_SRC/petsc-__PETSC_DEFAULT__ PETSC_ARCH=linux-opt all
 
 Everything good so far? PETSc should be asking to run more make commands
 
 !package code
-make PETSC_DIR=$STACK_SRC/petsc-__PETSC_DEFAULT__ PETSC_ARCH=arch-linux2-c-opt install
+make PETSC_DIR=$STACK_SRC/petsc-__PETSC_DEFAULT__ PETSC_ARCH=linux-opt install
 
 And now after the install, we can run some built-in tests
 
@@ -51,7 +54,7 @@ make PETSC_DIR=$PACKAGES_DIR/petsc-__PETSC_DEFAULT__ PETSC_ARCH="" test
 Running the tests should produce some output like the following:
 
 !package code
-[moose@centos-7 petsc-__PETSC_DEFAULT__]$ make PETSC_DIR=$PACKAGES_DIR/petsc-__PETSC_DEFAULT__ PETSC_ARCH="" test
+[moose@centos-8 petsc-__PETSC_DEFAULT__]$ make PETSC_DIR=$PACKAGES_DIR/petsc-__PETSC_DEFAULT__ PETSC_ARCH="" test
 Running test examples to verify correct installation
 Using PETSC_DIR=/opt/moose/petsc-__PETSC_DEFAULT__ and PETSC_ARCH=
 C/C++ example src/snes/examples/tutorials/ex19 run successfully with 1 MPI process

--- a/package_version
+++ b/package_version
@@ -1,4 +1,4 @@
 # moose-environment package version (https://github.com/idaholab/package_builder)
-# https://github.com/idaholab/package_builder/pull/213
-repo-hash:6f3c438e838564d48bf591191986ef747f50c8e1
+# https://github.com/idaholab/package_builder/pull/216
+repo-hash:6b624b2769e9d3f5b9a03749d3b351d76e5d6607
 

--- a/package_version
+++ b/package_version
@@ -1,4 +1,4 @@
 # moose-environment package version (https://github.com/idaholab/package_builder)
-# https://github.com/idaholab/package_builder/pull/216
-repo-hash:6b624b2769e9d3f5b9a03749d3b351d76e5d6607
+# https://github.com/idaholab/package_builder/pull/217
+repo-hash:7af64c8a0de933a801d096655b79fb957ecc10b1
 


### PR DESCRIPTION
Instruct MOOSE PR's to use latest package.
Changes:

- Iceream has been updated
- MOOSE_PROMPT (for sh, bash, and zsh)
- AUTO_JUMP has been updated (for zsh compatibility)
- CCACHE module correct CC/CXX environment variable
- GCC module correct CC/CXX environment variable
- Cleanup miniconda, use miniconda to install Gnuplot
- Cleanup seacas tools (remove temporary build directories)

Documentation Changes:
-  Remove CentOS 7.x in favor of CentOS 8
-  Remove Fedora 30 in favor of Fedora 31
- Group like arguments for PETSc configure
- Set PETSC_ARCH during configure so we are not guessing
