### PR TITLE
Fixup validParams in Tensor Mechanics

### DIFF
--- a/modules/tensor_mechanics/include/bcs/DashpotBC.h
+++ b/modules/tensor_mechanics/include/bcs/DashpotBC.h
@@ -24,12 +24,12 @@ InputParameters validParams<DashpotBC>();
 class DashpotBC : public IntegratedBC
 {
 public:
+  static InputParameters validParams();
+
   /**
    * Factory constructor, takes parameters so that all derived classes can be built using the same
    * constructor.
    */
-  static InputParameters validParams();
-
   DashpotBC(const InputParameters & parameters);
 
 protected:

--- a/modules/tensor_mechanics/include/materials/ADPowerLawCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADPowerLawCreepStressUpdate.h
@@ -30,9 +30,9 @@ template <ComputeStage compute_stage>
 class ADPowerLawCreepStressUpdate : public ADRadialReturnCreepStressUpdateBase<compute_stage>
 {
 public:
-  ADPowerLawCreepStressUpdate<compute_stage>(const InputParameters & parameters);
-
   static InputParameters validParams();
+
+  ADPowerLawCreepStressUpdate<compute_stage>(const InputParameters & parameters);
 
 protected:
   virtual void computeStressInitialize(const ADReal & effective_trial_stress,

--- a/modules/tensor_mechanics/include/materials/LinearViscoelasticityBase.h
+++ b/modules/tensor_mechanics/include/materials/LinearViscoelasticityBase.h
@@ -95,6 +95,7 @@ public:
     /// theta automatically adjusted as a function of the time step and the viscosity
     Zienkiewicz,
   };
+
   static InputParameters validParams();
 
   LinearViscoelasticityBase(const InputParameters & parameters);

--- a/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/MultiParameterPlasticityStressUpdate.h
@@ -99,12 +99,12 @@ InputParameters validParams<MultiParameterPlasticityStressUpdate>();
 class MultiParameterPlasticityStressUpdate : public StressUpdateBase
 {
 public:
+  static InputParameters validParams();
+
   MultiParameterPlasticityStressUpdate(const InputParameters & parameters,
                                        unsigned num_sp,
                                        unsigned num_yf,
                                        unsigned num_intnl);
-
-  static InputParameters validParams();
 
 protected:
   virtual void initQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/materials/PlasticTruss.h
+++ b/modules/tensor_mechanics/include/materials/PlasticTruss.h
@@ -19,6 +19,8 @@ InputParameters validParams<PlasticTruss>();
 class PlasticTruss : public LinearElasticTruss
 {
 public:
+  static InputParameters validParams();
+
   PlasticTruss(const InputParameters & parameters);
 
 protected:

--- a/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/TwoParameterPlasticityStressUpdate.h
@@ -29,11 +29,11 @@ InputParameters validParams<TwoParameterPlasticityStressUpdate>();
 class TwoParameterPlasticityStressUpdate : public MultiParameterPlasticityStressUpdate
 {
 public:
+  static InputParameters validParams();
+
   TwoParameterPlasticityStressUpdate(const InputParameters & parameters,
                                      unsigned num_yf,
                                      unsigned num_intnl);
-
-  static InputParameters validParams();
 
 protected:
   /// Number of variables = 2 = (p, q)

--- a/modules/tensor_mechanics/include/utils/MultiPlasticityDebugger.h
+++ b/modules/tensor_mechanics/include/utils/MultiPlasticityDebugger.h
@@ -24,9 +24,9 @@ InputParameters validParams<MultiPlasticityDebugger>();
 class MultiPlasticityDebugger : public MultiPlasticityLinearSystem
 {
 public:
-  MultiPlasticityDebugger(const MooseObject * moose_object);
-
   static InputParameters validParams();
+
+  MultiPlasticityDebugger(const MooseObject * moose_object);
 
   /**
    * Outputs the debug parameters: _fspb_debug_stress, _fspd_debug_pm, etc

--- a/modules/tensor_mechanics/include/utils/MultiPlasticityLinearSystem.h
+++ b/modules/tensor_mechanics/include/utils/MultiPlasticityLinearSystem.h
@@ -124,9 +124,9 @@ InputParameters validParams<MultiPlasticityLinearSystem>();
 class MultiPlasticityLinearSystem : public MultiPlasticityRawComponentAssembler
 {
 public:
-  MultiPlasticityLinearSystem(const MooseObject * moose_object);
-
   static InputParameters validParams();
+
+  MultiPlasticityLinearSystem(const MooseObject * moose_object);
 
 protected:
   /// Tolerance on the minimum ratio of singular values before flow-directions are deemed linearly dependent

--- a/modules/tensor_mechanics/include/vectorpostprocessors/LineMaterialRankTwoSampler.h
+++ b/modules/tensor_mechanics/include/vectorpostprocessors/LineMaterialRankTwoSampler.h
@@ -25,13 +25,13 @@ InputParameters validParams<LineMaterialRankTwoSampler>();
 class LineMaterialRankTwoSampler : public LineMaterialSamplerBase<RankTwoTensor>
 {
 public:
+  static InputParameters validParams();
+
   /**
    * Class constructor
    * Sets up variables for output based on the properties to be output
    * @param parameters The input parameters
    */
-  static InputParameters validParams();
-
   LineMaterialRankTwoSampler(const InputParameters & parameters);
 
   /**

--- a/modules/tensor_mechanics/include/vectorpostprocessors/LineMaterialRankTwoScalarSampler.h
+++ b/modules/tensor_mechanics/include/vectorpostprocessors/LineMaterialRankTwoScalarSampler.h
@@ -26,13 +26,13 @@ InputParameters validParams<LineMaterialRankTwoScalarSampler>();
 class LineMaterialRankTwoScalarSampler : public LineMaterialSamplerBase<RankTwoTensor>
 {
 public:
+  static InputParameters validParams();
+
   /**
    * Class constructor
    * Sets up variables for output based on the properties to be output
    * @param parameters The input parameters
    */
-  static InputParameters validParams();
-
   LineMaterialRankTwoScalarSampler(const InputParameters & parameters);
 
   /**

--- a/modules/tensor_mechanics/src/materials/PlasticTruss.C
+++ b/modules/tensor_mechanics/src/materials/PlasticTruss.C
@@ -14,11 +14,12 @@
 
 registerMooseObject("TensorMechanicsApp", PlasticTruss);
 
-template <>
+defineLegacyParams(PlasticTruss);
+
 InputParameters
-validParams<PlasticTruss>()
+PlasticTruss::validParams()
 {
-  InputParameters params = validParams<LinearElasticTruss>();
+  InputParameters params = LinearElasticTruss::validParams();
   params.addClassDescription(
       "Computes the stress and strain for a truss element with plastic behavior defined by either "
       "linear hardening or a user-defined hardening function.");


### PR DESCRIPTION
- Moves location of static validParams declaration in several header files for consistency, and less confusion (when declaration was accidentally placed after comments regarding factory constructor).
- Updates a missed class (`PlasticTruss`) to the new static function.

@bwspenc This should address your comments from #14351 
