### PR TITLE
Set execute_on for TagVector(Matrix)Aux to timestep end

### DIFF
--- a/framework/src/auxkernels/TagMatrixAux.C
+++ b/framework/src/auxkernels/TagMatrixAux.C
@@ -20,6 +20,7 @@ TagMatrixAux::validParams()
   params.addParam<std::string>("matrix_tag", "TagName", "Tag Name this Aux works on");
   params.addRequiredCoupledVar("v",
                                "The coupled variable whose components are coupled to AuxVariable");
+  params.set<ExecFlagEnum>("execute_on", true) = {EXEC_TIMESTEP_END};
 
   params.addClassDescription("Couple the diag of a tag matrix, and return its nodal value");
   return params;
@@ -30,6 +31,9 @@ TagMatrixAux::TagMatrixAux(const InputParameters & parameters)
     _tag_id(_subproblem.getMatrixTagID(getParam<std::string>("matrix_tag"))),
     _v(coupledMatrixTagValue("v", _tag_id))
 {
+  auto & execute_on = getParam<ExecFlagEnum>("execute_on");
+  if (execute_on.size() != 1 || !execute_on.contains(EXEC_TIMESTEP_END))
+    mooseError("execute_on for TagMatrixAux must be set to EXEC_TIMESTEP_END");
 }
 
 Real

--- a/framework/src/auxkernels/TagVectorAux.C
+++ b/framework/src/auxkernels/TagVectorAux.C
@@ -21,6 +21,7 @@ TagVectorAux::validParams()
   params.addParam<std::string>("vector_tag", "TagName", "Tag Name this Aux works on");
   params.addRequiredCoupledVar("v",
                                "The coupled variable whose components are coupled to AuxVariable");
+  params.set<ExecFlagEnum>("execute_on", true) = {EXEC_TIMESTEP_END};
 
   params.addClassDescription("Couple a tag vector, and return its nodal value");
   return params;
@@ -31,6 +32,9 @@ TagVectorAux::TagVectorAux(const InputParameters & parameters)
     _tag_id(_subproblem.getVectorTagID(getParam<std::string>("vector_tag"))),
     _v(coupledVectorTagValue("v", _tag_id))
 {
+  auto & execute_on = getParam<ExecFlagEnum>("execute_on");
+  if (execute_on.size() != 1 || !execute_on.contains(EXEC_TIMESTEP_END))
+    mooseError("execute_on for TagVectorAux must be set to EXEC_TIMESTEP_END");
 }
 
 Real

--- a/test/tests/tag/2d_diffusion_tag_matrix.i
+++ b/test/tests/tag/2d_diffusion_tag_matrix.i
@@ -35,7 +35,6 @@
     variable = tag_variable1
     v = u
     matrix_tag = mat_tag1
-    execute_on = timestep_end
   [../]
 
   [./TagMatrixAux2]
@@ -43,7 +42,6 @@
     variable = tag_variable2
     v = u
     matrix_tag = mat_tag2
-    execute_on = timestep_end
   [../]
 []
 

--- a/test/tests/tag/2d_diffusion_tag_vector.i
+++ b/test/tests/tag/2d_diffusion_tag_vector.i
@@ -35,7 +35,6 @@
     variable = tag_variable1
     v = u
     vector_tag = vec_tag1
-    execute_on = timestep_end
   [../]
 
   [./TagVectorAux2]
@@ -43,7 +42,6 @@
     variable = tag_variable2
     v = u
     vector_tag = vec_tag2
-    execute_on = timestep_end
   [../]
 []
 


### PR DESCRIPTION
These aux computations rely on the nonlinear variables already
being evaluated so we have a dependency issue if we allow these
things to be evaluated on linear or potentially other execute
stages. AFAIK the only real use case for these computing objects
is for "visualizing" reference quantities akin to save-in values.

Closes #14427

