### PR TITLE
More control over codesigning

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -382,9 +382,14 @@ endif
 # Codesign command (OS X Only)
 codesign :=
 ifneq (,$(findstring darwin,$(libmesh_HOST)))
-	get_task_allow_entitlement := $(FRAMEWORK_DIR)/build_support/get_task_allow.plist
-	codesign := codesign -s - --entitlements $(get_task_allow_entitlement) $(app_EXEC)
+  ifneq (x$(MOOSE_NO_CODESIGN), x)
+    codesign :=
+  else
+    get_task_allow_entitlement := $(FRAMEWORK_DIR)/build_support/get_task_allow.plist
+    codesign := codesign -s - --entitlements $(get_task_allow_entitlement) $(app_EXEC)
+  endif
 endif
+
 $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend_test_libs) $(ADDITIONAL_DEPEND_LIBS)
 	@echo "Linking Executable "$@"..."
 	@$(libmesh_LIBTOOL) --tag=CXX $(LIBTOOLFLAGS) --mode=link --quiet \

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -382,9 +382,7 @@ endif
 # Codesign command (OS X Only)
 codesign :=
 ifneq (,$(findstring darwin,$(libmesh_HOST)))
-  ifneq (x$(MOOSE_NO_CODESIGN), x)
-    codesign :=
-  else
+  ifeq (x$(MOOSE_NO_CODESIGN), x)
     get_task_allow_entitlement := $(FRAMEWORK_DIR)/build_support/get_task_allow.plist
     codesign := codesign -s - --entitlements $(get_task_allow_entitlement) $(app_EXEC)
   endif


### PR DESCRIPTION
Allow more control when not to perform codesigning on Darwin machines.

Closes #14445 
