### PR TITLE
Save needed image env vars to /etc/environment. Fixes #14448.

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -101,3 +101,10 @@ rm -rf libmesh/* libmesh/.* || true
 #-----------------------------------------------------------------------------#
 COPY . ${MOOSE_DIR}
 RUN cd test ; make -j ${MOOSE_JOBS}
+
+#-----------------------------------------------------------------------------#
+# Add needed env vars to /etc/environment
+#-----------------------------------------------------------------------------#
+RUN for CURR_VAR in $(env | grep 'CC\|CXX\|_DIR'); do \
+    echo "$CURR_VAR" >> /etc/environment ; \
+done


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Users logging into a MOOSE-based container via SSH stopped having all of the environment variables preset from the Docker build.  What I've added to the Dockerfile ensures that the following are set appropriately in `/etc/environment`.
* CC=mpicc
* CXX=mpicxx
* PETSC_DIR=/usr/local
* LIBMESH_DIR=/usr/local
* MOOSE_DIR=/opt/moose