### PR TITLE
fix material property AD bugs

### DIFF
--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -174,7 +174,7 @@ public:
    * copy the value portion (not the derivatives) of the DualNumber<Real> version of the material
    * property to the Real version for the specified quadrature point
    */
-  void copyDualNumberToValue(const unsigned int i) override { _value[i].copyDualNumberToValue(); }
+  void copyDualNumberToValue(const unsigned int i) override { _value[i].synchronizeToVal(); }
 
   void markAD(bool use_ad) override;
 
@@ -206,8 +206,6 @@ inline void
 MaterialProperty<T>::markAD(bool use_ad)
 {
   _use_ad = use_ad;
-  for (auto && moose_wrapper : _value)
-    moose_wrapper.markAD(use_ad);
 }
 
 template <typename T>
@@ -233,7 +231,7 @@ MaterialProperty<T>::resize(int n)
     _value.erase(_value.end() + diff, _value.end());
   else
     for (decltype(diff) i = 0; i < diff; ++i)
-      _value.emplace_back(MooseADWrapper<T>(_use_ad));
+      _value.emplace_back(MooseADWrapper<T>());
 }
 
 template <typename T>

--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -32,142 +32,189 @@ void dataStore(std::ostream & stream, MooseADWrapper<T> & dn_wrapper, void * con
 template <typename T>
 void dataLoad(std::istream & stream, MooseADWrapper<T> & dn_wrapper, void * context);
 
-template <typename T>
-class MooseADWrapper
+template <typename T, typename S>
+class MooseADWrapperBase
 {
 public:
-  MooseADWrapper(bool = false) : _val(), _dual_number(nullptr) {}
-  MooseADWrapper(MooseADWrapper<T> &&) = default;
+  typedef S DNType;
 
-  MooseADWrapper<T> & operator=(const MooseADWrapper<T> & rhs)
-  {
-    _val = rhs._val;
-    return *this;
-  }
-  MooseADWrapper<T> & operator=(MooseADWrapper<T> &&) = default;
-
-  typedef T DNType;
+  MooseADWrapperBase() : _val() {}
+  MooseADWrapperBase(MooseADWrapperBase<T, S> &&) = default;
+  virtual ~MooseADWrapperBase() = default;
 
   /**
    * Returns the value for any case where a MaterialProperty is requested as a regular (non-AD)
    * property
    */
-  const T & value() const { return _val; }
+  const T & value() const
+  {
+    synchronizeToVal();
+    return _val;
+  }
 
   /**
    * Returns the value for any case where a MaterialProperty is declared as a regular (non-AD)
    * property (used only during material calculations)
    */
-  T & value() { return _val; }
+  T & value()
+  {
+    synchronizeToVal();
+    _dual_is_dirty = true;
+    return _val;
+  }
+
+  MooseADWrapperBase<T, S> & operator=(const MooseADWrapperBase<T, S> & rhs)
+  {
+    _val = rhs._val;
+    if (_dual_number && rhs._dual_number)
+      *_dual_number = *rhs._dual_number;
+    else if (_dual_number)
+      copyValueToDualNumber();
+    return *this;
+  }
+
+  MooseADWrapperBase<T, S> & operator=(MooseADWrapperBase<T, S> &&) = default;
 
   /**
    * Returns the dual number for any case where a MaterialProperty is requested as a AD property
    */
-  const T & dn(bool requested_by_user = true) const
+  virtual const DNType & dn(bool = true) const
   {
-    if (requested_by_user)
-      mooseError("Type ",
-                 typeid(T).name(),
-                 " does not currently support automatic differentiation. Consider using a regular "
-                 "material property (declareProperty, getMaterialProperty) instead.");
-    return _val;
+    synchronizeToDual();
+    return *_dual_number;
   }
 
   /**
    * Returns the value for any case where a MaterialProperty is declared as an AD property (used
    * only during material calculations)
    */
-  T & dn(bool requested_by_user = true)
+  virtual DNType & dn(bool = true)
+  {
+    synchronizeToDual();
+    _val_is_dirty = true;
+    return *_dual_number;
+  }
+
+  void synchronizeToVal() const
+  {
+    mooseAssert(!(_dual_is_dirty && _val_is_dirty),
+                "dual/non-dual material property synchronization is broken");
+    if (!_val_is_dirty)
+      return;
+
+    if (!_dual_number)
+      initializeDual();
+    if (_dual_number)
+      copyDualNumberToValue();
+    _val_is_dirty = false;
+  }
+
+  void synchronizeToDual() const
+  {
+    mooseAssert(!(_dual_is_dirty && _val_is_dirty),
+                "dual/non-dual material property synchronization is broken");
+    if (!_dual_is_dirty)
+      return;
+
+    if (!_dual_number)
+      initializeDual();
+    if (_dual_number)
+      copyValueToDualNumber();
+    _dual_is_dirty = false;
+  }
+
+protected:
+  virtual void initializeDual() const = 0;
+  virtual void copyDualNumberToValue() const = 0;
+  virtual void copyValueToDualNumber() const = 0;
+
+  mutable T _val;
+  mutable std::unique_ptr<DNType> _dual_number = nullptr;
+
+private:
+  mutable bool _dual_is_dirty = true;
+  mutable bool _val_is_dirty = false;
+};
+
+template <typename T>
+class MooseADWrapper : public MooseADWrapperBase<T, T>
+{
+public:
+  MooseADWrapper() = default;
+  MooseADWrapper(MooseADWrapper<T> &&) = default;
+  MooseADWrapper<T> & operator=(const MooseADWrapper<T> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+  virtual const T & dn(bool requested_by_user = true) const override
   {
     if (requested_by_user)
       mooseError("Type ",
                  typeid(T).name(),
                  " does not currently support automatic differentiation. Consider using a regular "
                  "material property (declareProperty, getMaterialProperty) instead.");
-    return _val;
+    return MooseADWrapperBase<T, T>::dn();
   }
 
   /**
-   * Used during Jacobian calculations in case a property was declared as AD but a consuming object
-   * has requested it as a regular property
+   * Returns the value for any case where a MaterialProperty is declared as an AD property (used
+   * only during material calculations)
    */
-  void copyDualNumberToValue() {}
+  virtual T & dn(bool requested_by_user = true) override
+  {
+    if (requested_by_user)
+      mooseError("Type ",
+                 typeid(T).name(),
+                 " does not currently support automatic differentiation. Consider using a regular "
+                 "material property (declareProperty, getMaterialProperty) instead.");
+    return MooseADWrapperBase<T, T>::dn();
+  }
 
-  /**
-   * Mark a change in whether to use AD or not. This is relevant during stateful material
-   * calculations. E.g. when a current property becomes old we call markAD(false) and when we swap
-   * an old material property to the current property (see MaterialPropertyStorage::shift) we call
-   * markAD(true)
-   */
-  void markAD(bool /*use_ad*/) {}
+protected:
+  virtual void copyDualNumberToValue() const override { this->_val = *(this->_dual_number); }
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
+  virtual void initializeDual() const override {}
 
 private:
-  T _val;
-  mutable std::unique_ptr<T> _dual_number;
   friend void dataStore<T>(std::ostream &, MooseADWrapper<T> &, void *);
   friend void dataLoad<T>(std::istream &, MooseADWrapper<T> &, void *);
 };
 
 template <>
-class MooseADWrapper<Real>
+class MooseADWrapper<Real> : public MooseADWrapperBase<Real, DualReal>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<Real> &&) = default;
+  MooseADWrapper<Real> & operator=(const MooseADWrapper<Real> &) = default;
+  virtual ~MooseADWrapper() = default;
 
-  typedef DualReal DNType;
-
-  const Real & value() const { return _val; }
-
-  Real & value() { return _val; }
-
-  const DualReal & dn(bool = true) const;
-
-  DualReal & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<Real> & operator=(const MooseADWrapper<Real> &);
-  MooseADWrapper<Real> & operator=(MooseADWrapper<Real> &&) = default;
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
 
 private:
-  bool _use_ad;
-  Real _val;
-  mutable std::unique_ptr<DualReal> _dual_number;
   friend void dataStore<Real>(std::ostream &, MooseADWrapper<Real> &, void *);
   friend void dataLoad<Real>(std::istream &, MooseADWrapper<Real> &, void *);
 };
 
 template <>
 class MooseADWrapper<VectorValue<Real>>
+  : public MooseADWrapperBase<VectorValue<Real>, VectorValue<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<VectorValue<Real>> &&) = default;
+  MooseADWrapper<VectorValue<Real>> &
+  operator=(const MooseADWrapper<VectorValue<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
 
-  typedef VectorValue<DualReal> DNType;
-
-  const VectorValue<Real> & value() const { return _val; }
-
-  VectorValue<Real> & value() { return _val; }
-
-  const VectorValue<DualReal> & dn(bool = true) const;
-
-  VectorValue<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<VectorValue<Real>> & operator=(const MooseADWrapper<VectorValue<Real>> &);
-  MooseADWrapper<VectorValue<Real>> & operator=(MooseADWrapper<VectorValue<Real>> &&) = default;
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
 
 private:
-  bool _use_ad;
-  VectorValue<Real> _val;
-  mutable std::unique_ptr<VectorValue<DualReal>> _dual_number;
   friend void
   dataStore<VectorValue<Real>>(std::ostream &, MooseADWrapper<VectorValue<Real>> &, void *);
   friend void
@@ -176,32 +223,21 @@ private:
 
 template <>
 class MooseADWrapper<TensorValue<Real>>
+  : public MooseADWrapperBase<TensorValue<Real>, TensorValue<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<TensorValue<Real>> &&) = default;
+  MooseADWrapper<TensorValue<Real>> &
+  operator=(const MooseADWrapper<TensorValue<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
 
-  typedef TensorValue<DualReal> DNType;
-
-  const TensorValue<Real> & value() const { return _val; }
-
-  TensorValue<Real> & value() { return _val; }
-
-  const TensorValue<DualReal> & dn(bool = true) const;
-
-  TensorValue<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<TensorValue<Real>> & operator=(const MooseADWrapper<TensorValue<Real>> &);
-  MooseADWrapper<TensorValue<Real>> & operator=(MooseADWrapper<TensorValue<Real>> &&) = default;
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
 
 private:
-  bool _use_ad;
-  TensorValue<Real> _val;
-  mutable std::unique_ptr<TensorValue<DualReal>> _dual_number;
   friend void
   dataStore<TensorValue<Real>>(std::ostream &, MooseADWrapper<TensorValue<Real>> &, void *);
   friend void
@@ -210,34 +246,21 @@ private:
 
 template <>
 class MooseADWrapper<RankTwoTensorTempl<Real>>
+  : public MooseADWrapperBase<RankTwoTensorTempl<Real>, RankTwoTensorTempl<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<RankTwoTensorTempl<Real>> &&) = default;
-
-  typedef RankTwoTensorTempl<DualReal> DNType;
-
-  const RankTwoTensorTempl<Real> & value() const { return _val; }
-
-  RankTwoTensorTempl<Real> & value() { return _val; }
-
-  const RankTwoTensorTempl<DualReal> & dn(bool = true) const;
-
-  RankTwoTensorTempl<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
   MooseADWrapper<RankTwoTensorTempl<Real>> &
-  operator=(const MooseADWrapper<RankTwoTensorTempl<Real>> &);
-  MooseADWrapper<RankTwoTensorTempl<Real>> &
-  operator=(MooseADWrapper<RankTwoTensorTempl<Real>> &&) = default;
+  operator=(const MooseADWrapper<RankTwoTensorTempl<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
 
 private:
-  bool _use_ad;
-  RankTwoTensorTempl<Real> _val;
-  mutable std::unique_ptr<RankTwoTensorTempl<DualReal>> _dual_number;
   friend void dataStore<RankTwoTensorTempl<Real>>(std::ostream &,
                                                   MooseADWrapper<RankTwoTensorTempl<Real>> &,
                                                   void *);
@@ -248,34 +271,24 @@ private:
 
 template <>
 class MooseADWrapper<RankThreeTensorTempl<Real>>
+  : public MooseADWrapperBase<RankThreeTensorTempl<Real>, RankThreeTensorTempl<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<RankThreeTensorTempl<Real>> &&) = default;
-
-  typedef RankThreeTensorTempl<DualReal> DNType;
-
-  const RankThreeTensorTempl<Real> & value() const { return _val; }
-
-  RankThreeTensorTempl<Real> & value() { return _val; }
-
-  const RankThreeTensorTempl<DualReal> & dn(bool = true) const;
-
-  RankThreeTensorTempl<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
   MooseADWrapper<RankThreeTensorTempl<Real>> &
-  operator=(const MooseADWrapper<RankThreeTensorTempl<Real>> &);
-  MooseADWrapper<RankThreeTensorTempl<Real>> &
-  operator=(MooseADWrapper<RankThreeTensorTempl<Real>> &&) = default;
+  operator=(const MooseADWrapper<RankThreeTensorTempl<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override
+  {
+    *(this->_dual_number) = RankThreeTensorTempl<DualReal>(this->_val);
+  }
 
 private:
-  bool _use_ad;
-  RankThreeTensorTempl<Real> _val;
-  mutable std::unique_ptr<RankThreeTensorTempl<DualReal>> _dual_number;
   friend void dataStore<RankThreeTensorTempl<Real>>(std::ostream &,
                                                     MooseADWrapper<RankThreeTensorTempl<Real>> &,
                                                     void *);
@@ -286,34 +299,21 @@ private:
 
 template <>
 class MooseADWrapper<RankFourTensorTempl<Real>>
+  : public MooseADWrapperBase<RankFourTensorTempl<Real>, RankFourTensorTempl<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<RankFourTensorTempl<Real>> &&) = default;
-
-  typedef RankFourTensorTempl<DualReal> DNType;
-
-  const RankFourTensorTempl<Real> & value() const { return _val; }
-
-  RankFourTensorTempl<Real> & value() { return _val; }
-
-  const RankFourTensorTempl<DualReal> & dn(bool = true) const;
-
-  RankFourTensorTempl<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
   MooseADWrapper<RankFourTensorTempl<Real>> &
-  operator=(const MooseADWrapper<RankFourTensorTempl<Real>> &);
-  MooseADWrapper<RankFourTensorTempl<Real>> &
-  operator=(MooseADWrapper<RankFourTensorTempl<Real>> &&) = default;
+  operator=(const MooseADWrapper<RankFourTensorTempl<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override { *(this->_dual_number) = this->_val; }
 
 private:
-  bool _use_ad;
-  RankFourTensorTempl<Real> _val;
-  mutable std::unique_ptr<RankFourTensorTempl<DualReal>> _dual_number;
   friend void dataStore<RankFourTensorTempl<Real>>(std::ostream &,
                                                    MooseADWrapper<RankFourTensorTempl<Real>> &,
                                                    void *);
@@ -324,32 +324,21 @@ private:
 
 template <>
 class MooseADWrapper<DenseVector<Real>>
+  : public MooseADWrapperBase<DenseVector<Real>, DenseVector<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<DenseVector<Real>> &&) = default;
+  MooseADWrapper<DenseVector<Real>> &
+  operator=(const MooseADWrapper<DenseVector<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
 
-  typedef DenseVector<DualReal> DNType;
-
-  const DenseVector<Real> & value() const { return _val; }
-
-  DenseVector<Real> & value() { return _val; }
-
-  const DenseVector<DualReal> & dn(bool = true) const;
-
-  DenseVector<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<DenseVector<Real>> & operator=(const MooseADWrapper<DenseVector<Real>> &);
-  MooseADWrapper<DenseVector<Real>> & operator=(MooseADWrapper<DenseVector<Real>> &&) = default;
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override;
 
 private:
-  bool _use_ad;
-  DenseVector<Real> _val;
-  mutable std::unique_ptr<DenseVector<DualReal>> _dual_number;
   friend void
   dataStore<DenseVector<Real>>(std::ostream &, MooseADWrapper<DenseVector<Real>> &, void *);
   friend void
@@ -358,32 +347,21 @@ private:
 
 template <>
 class MooseADWrapper<DenseMatrix<Real>>
+  : public MooseADWrapperBase<DenseMatrix<Real>, DenseMatrix<DualReal>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<DenseMatrix<Real>> &&) = default;
+  MooseADWrapper<DenseMatrix<Real>> &
+  operator=(const MooseADWrapper<DenseMatrix<Real>> &) = default;
+  virtual ~MooseADWrapper() = default;
 
-  typedef DenseMatrix<DualReal> DNType;
-
-  const DenseMatrix<Real> & value() const { return _val; }
-
-  DenseMatrix<Real> & value() { return _val; }
-
-  const DenseMatrix<DualReal> & dn(bool = true) const;
-
-  DenseMatrix<DualReal> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<DenseMatrix<Real>> & operator=(const MooseADWrapper<DenseMatrix<Real>> &);
-  MooseADWrapper<DenseMatrix<Real>> & operator=(MooseADWrapper<DenseMatrix<Real>> &&) = default;
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override;
 
 private:
-  bool _use_ad;
-  DenseMatrix<Real> _val;
-  mutable std::unique_ptr<DenseMatrix<DualReal>> _dual_number;
   friend void
   dataStore<DenseMatrix<Real>>(std::ostream &, MooseADWrapper<DenseMatrix<Real>> &, void *);
   friend void
@@ -391,73 +369,47 @@ private:
 };
 
 template <>
-class MooseADWrapper<std::vector<DenseMatrix<Real>>>
-{
-public:
-  MooseADWrapper(bool use_ad = false);
-  MooseADWrapper(MooseADWrapper<std::vector<DenseMatrix<Real>>> &&) = default;
-
-  typedef std::vector<DenseMatrix<DualReal>> DNType;
-
-  const std::vector<DenseMatrix<Real>> & value() const { return _val; }
-
-  std::vector<DenseMatrix<Real>> & value() { return _val; }
-
-  const std::vector<DenseMatrix<DualReal>> & dn(bool = true) const;
-
-  std::vector<DenseMatrix<DualReal>> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
-  MooseADWrapper<std::vector<DenseMatrix<Real>>> &
-  operator=(const MooseADWrapper<std::vector<DenseMatrix<Real>>> &);
-  MooseADWrapper<std::vector<DenseMatrix<Real>>> &
-  operator=(MooseADWrapper<std::vector<DenseMatrix<Real>>> &&) = default;
-
-private:
-  bool _use_ad;
-  std::vector<DenseMatrix<Real>> _val;
-  mutable std::unique_ptr<std::vector<DenseMatrix<DualReal>>> _dual_number;
-  friend void dataStore<std::vector<DenseMatrix<Real>>>(
-      std::ostream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
-  friend void dataLoad<std::vector<DenseMatrix<Real>>>(
-      std::istream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
-};
-
-template <>
 class MooseADWrapper<std::vector<DenseVector<Real>>>
+  : public MooseADWrapperBase<std::vector<DenseVector<Real>>, std::vector<DenseVector<DualReal>>>
 {
 public:
-  MooseADWrapper(bool use_ad = false);
+  MooseADWrapper() = default;
   MooseADWrapper(MooseADWrapper<std::vector<DenseVector<Real>>> &&) = default;
-
-  typedef std::vector<DenseVector<DualReal>> DNType;
-
-  const std::vector<DenseVector<Real>> & value() const { return _val; }
-
-  std::vector<DenseVector<Real>> & value() { return _val; }
-
-  const std::vector<DenseVector<DualReal>> & dn(bool = true) const;
-
-  std::vector<DenseVector<DualReal>> & dn(bool = true);
-
-  void copyDualNumberToValue();
-
-  void markAD(bool use_ad);
-
   MooseADWrapper<std::vector<DenseVector<Real>>> &
-  operator=(const MooseADWrapper<std::vector<DenseVector<Real>>> &);
-  MooseADWrapper<std::vector<DenseVector<Real>>> &
-  operator=(MooseADWrapper<std::vector<DenseVector<Real>>> &&) = default;
+  operator=(const MooseADWrapper<std::vector<DenseVector<Real>>> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override;
 
 private:
-  bool _use_ad;
-  std::vector<DenseVector<Real>> _val;
-  mutable std::unique_ptr<std::vector<DenseVector<DualReal>>> _dual_number;
   friend void dataStore<std::vector<DenseVector<Real>>>(
       std::ostream &, MooseADWrapper<std::vector<DenseVector<Real>>> &, void *);
   friend void dataLoad<std::vector<DenseVector<Real>>>(
       std::istream &, MooseADWrapper<std::vector<DenseVector<Real>>> &, void *);
+};
+
+template <>
+class MooseADWrapper<std::vector<DenseMatrix<Real>>>
+  : public MooseADWrapperBase<std::vector<DenseMatrix<Real>>, std::vector<DenseMatrix<DualReal>>>
+{
+public:
+  MooseADWrapper() = default;
+  MooseADWrapper(MooseADWrapper<std::vector<DenseMatrix<Real>>> &&) = default;
+  MooseADWrapper<std::vector<DenseMatrix<Real>>> &
+  operator=(const MooseADWrapper<std::vector<DenseMatrix<Real>>> &) = default;
+  virtual ~MooseADWrapper() = default;
+
+protected:
+  virtual void initializeDual() const override;
+  virtual void copyDualNumberToValue() const override;
+  virtual void copyValueToDualNumber() const override;
+
+private:
+  friend void dataStore<std::vector<DenseMatrix<Real>>>(
+      std::ostream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
+  friend void dataLoad<std::vector<DenseMatrix<Real>>>(
+      std::istream &, MooseADWrapper<std::vector<DenseMatrix<Real>>> &, void *);
 };

--- a/framework/src/utils/MooseADWrapper.C
+++ b/framework/src/utils/MooseADWrapper.C
@@ -11,134 +11,39 @@
 
 #include "libmesh/auto_ptr.h"
 
-MooseADWrapper<Real>::MooseADWrapper(bool use_ad) : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<DualReal>();
-}
-
-const DualReal &
-MooseADWrapper<Real>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<DualReal>(_val);
-  else if (!_use_ad)
-    _dual_number->value() = _val;
-  return *_dual_number;
-}
-
-DualReal &
-MooseADWrapper<Real>::dn(bool)
-{
-  return *_dual_number;
-}
-
 void
-MooseADWrapper<Real>::copyDualNumberToValue()
+MooseADWrapper<Real>::copyDualNumberToValue() const
 {
   _val = _dual_number->value();
 }
 
 void
-MooseADWrapper<Real>::markAD(bool use_ad)
+MooseADWrapper<Real>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<DualReal>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<Real> &
-MooseADWrapper<Real>::operator=(const MooseADWrapper<Real> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-MooseADWrapper<VectorValue<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<VectorValue<DualReal>>();
-}
-
-const VectorValue<DualReal> &
-MooseADWrapper<VectorValue<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<VectorValue<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
-      (*_dual_number)(i).value() = _val(i);
-  return *_dual_number;
-}
-
-VectorValue<DualReal> &
-MooseADWrapper<VectorValue<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<DualReal>(_val);
 }
 
 void
-MooseADWrapper<VectorValue<Real>>::copyDualNumberToValue()
+MooseADWrapper<VectorValue<Real>>::initializeDual() const
+{
+  _dual_number = libmesh_make_unique<VectorValue<DualReal>>(_val);
+}
+
+void
+MooseADWrapper<VectorValue<Real>>::copyDualNumberToValue() const
 {
   for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
     _val(i) = (*_dual_number)(i).value();
 }
 
 void
-MooseADWrapper<VectorValue<Real>>::markAD(bool use_ad)
+MooseADWrapper<TensorValue<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<VectorValue<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<VectorValue<Real>> &
-MooseADWrapper<VectorValue<Real>>::operator=(const MooseADWrapper<VectorValue<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-MooseADWrapper<TensorValue<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<TensorValue<DualReal>>();
-}
-
-const TensorValue<DualReal> &
-MooseADWrapper<TensorValue<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<TensorValue<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
-      for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
-        (*_dual_number)(i, j).value() = _val(i, j);
-  return *_dual_number;
-}
-
-TensorValue<DualReal> &
-MooseADWrapper<TensorValue<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<TensorValue<DualReal>>(_val);
 }
 
 void
-MooseADWrapper<TensorValue<Real>>::copyDualNumberToValue()
+MooseADWrapper<TensorValue<Real>>::copyDualNumberToValue() const
 {
   for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
     for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -146,53 +51,13 @@ MooseADWrapper<TensorValue<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<TensorValue<Real>>::markAD(bool use_ad)
+MooseADWrapper<RankTwoTensorTempl<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<TensorValue<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<TensorValue<Real>> &
-MooseADWrapper<TensorValue<Real>>::operator=(const MooseADWrapper<TensorValue<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-MooseADWrapper<RankTwoTensorTempl<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>();
-}
-
-const RankTwoTensorTempl<DualReal> &
-MooseADWrapper<RankTwoTensorTempl<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
-      for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
-        (*_dual_number)(i, j).value() = _val(i, j);
-  return *_dual_number;
-}
-
-RankTwoTensorTempl<DualReal> &
-MooseADWrapper<RankTwoTensorTempl<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>(_val);
 }
 
 void
-MooseADWrapper<RankTwoTensorTempl<Real>>::copyDualNumberToValue()
+MooseADWrapper<RankTwoTensorTempl<Real>>::copyDualNumberToValue() const
 {
   for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
     for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -200,56 +65,13 @@ MooseADWrapper<RankTwoTensorTempl<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<RankTwoTensorTempl<Real>>::markAD(bool use_ad)
+MooseADWrapper<RankThreeTensorTempl<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<RankTwoTensorTempl<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<RankTwoTensorTempl<Real>> &
-MooseADWrapper<RankTwoTensorTempl<Real>>::
-operator=(const MooseADWrapper<RankTwoTensorTempl<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-// RankThreeTensor
-MooseADWrapper<RankThreeTensorTempl<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<RankThreeTensorTempl<DualReal>>();
-}
-
-const RankThreeTensorTempl<DualReal> &
-MooseADWrapper<RankThreeTensorTempl<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<RankThreeTensorTempl<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
-      for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
-        for (std::size_t k = 0; k < LIBMESH_DIM; ++k)
-          (*_dual_number)(i, j, k).value() = _val(i, j, k);
-  return *_dual_number;
-}
-
-RankThreeTensorTempl<DualReal> &
-MooseADWrapper<RankThreeTensorTempl<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<RankThreeTensorTempl<DualReal>>(_val);
 }
 
 void
-MooseADWrapper<RankThreeTensorTempl<Real>>::copyDualNumberToValue()
+MooseADWrapper<RankThreeTensorTempl<Real>>::copyDualNumberToValue() const
 {
   for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
     for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -258,57 +80,13 @@ MooseADWrapper<RankThreeTensorTempl<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<RankThreeTensorTempl<Real>>::markAD(bool use_ad)
+MooseADWrapper<RankFourTensorTempl<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<RankThreeTensorTempl<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<RankThreeTensorTempl<Real>> &
-MooseADWrapper<RankThreeTensorTempl<Real>>::
-operator=(const MooseADWrapper<RankThreeTensorTempl<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-// RankFourTensor
-MooseADWrapper<RankFourTensorTempl<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>();
-}
-
-const RankFourTensorTempl<DualReal> &
-MooseADWrapper<RankFourTensorTempl<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
-      for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
-        for (std::size_t k = 0; k < LIBMESH_DIM; ++k)
-          for (std::size_t l = 0; l < LIBMESH_DIM; ++l)
-            (*_dual_number)(i, j, k, l).value() = _val(i, j, k, l);
-  return *_dual_number;
-}
-
-RankFourTensorTempl<DualReal> &
-MooseADWrapper<RankFourTensorTempl<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>(_val);
 }
 
 void
-MooseADWrapper<RankFourTensorTempl<Real>>::copyDualNumberToValue()
+MooseADWrapper<RankFourTensorTempl<Real>>::copyDualNumberToValue() const
 {
   for (std::size_t i = 0; i < LIBMESH_DIM; ++i)
     for (std::size_t j = 0; j < LIBMESH_DIM; ++j)
@@ -318,53 +96,21 @@ MooseADWrapper<RankFourTensorTempl<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<RankFourTensorTempl<Real>>::markAD(bool use_ad)
+MooseADWrapper<DenseVector<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<RankFourTensorTempl<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<RankFourTensorTempl<Real>> &
-MooseADWrapper<RankFourTensorTempl<Real>>::
-operator=(const MooseADWrapper<RankFourTensorTempl<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    *_dual_number = 0;
-  return *this;
-}
-
-MooseADWrapper<DenseVector<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<DenseVector<DualReal>>();
-}
-
-const DenseVector<DualReal> &
-MooseADWrapper<DenseVector<Real>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<DenseVector<DualReal>>(_val);
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < _dual_number->size(); ++i)
-      (*_dual_number)(i).value() = _val(i);
-  return *_dual_number;
-}
-
-DenseVector<DualReal> &
-MooseADWrapper<DenseVector<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<DenseVector<DualReal>>(_val.size());
 }
 
 void
-MooseADWrapper<DenseVector<Real>>::copyDualNumberToValue()
+MooseADWrapper<DenseVector<Real>>::copyValueToDualNumber() const
+{
+  _dual_number->resize(_val.size());
+  for (std::size_t i = 0; i < _dual_number->size(); ++i)
+    (*_dual_number)(i) = _val(i);
+}
+
+void
+MooseADWrapper<DenseVector<Real>>::copyDualNumberToValue() const
 {
   _val.resize(_dual_number->size());
   for (std::size_t i = 0; i < _dual_number->size(); ++i)
@@ -372,62 +118,24 @@ MooseADWrapper<DenseVector<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<DenseVector<Real>>::markAD(bool use_ad)
+MooseADWrapper<DenseMatrix<Real>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<DenseVector<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<DenseVector<Real>> &
-MooseADWrapper<DenseVector<Real>>::operator=(const MooseADWrapper<DenseVector<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    // I don't know why we do this, but other code does it - ask Alex.
-    for (size_t i = 0; i < _dual_number->size(); ++i)
-      (*_dual_number)(i) = 0;
-  return *this;
-}
-
-MooseADWrapper<DenseMatrix<Real>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>();
-}
-
-const DenseMatrix<DualReal> &
-MooseADWrapper<DenseMatrix<Real>>::dn(bool) const
-{
-  auto m = _val.m();
-  auto n = _val.n();
-  if (!_dual_number)
-  {
-    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>(m, n);
-    for (std::size_t i = 0; i < m; ++i)
-      for (std::size_t j = 0; j < n; ++j)
-        (*_dual_number)(i, j).value() = _val(i, j);
-  }
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < m; ++i)
-      for (std::size_t j = 0; j < n; ++j)
-        (*_dual_number)(i, j).value() = _val(i, j);
-  return *_dual_number;
-}
-
-DenseMatrix<DualReal> &
-MooseADWrapper<DenseMatrix<Real>>::dn(bool)
-{
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>(_val.m(), _val.n());
 }
 
 void
-MooseADWrapper<DenseMatrix<Real>>::copyDualNumberToValue()
+MooseADWrapper<DenseMatrix<Real>>::copyValueToDualNumber() const
+{
+  auto m = _val.m();
+  auto n = _val.n();
+  _dual_number->resize(m, n);
+  for (std::size_t i = 0; i < m; ++i)
+    for (std::size_t j = 0; j < n; ++j)
+      (*_dual_number)(i, j) = _val(i, j);
+}
+
+void
+MooseADWrapper<DenseMatrix<Real>>::copyDualNumberToValue() const
 {
   _val.resize(_dual_number->m(), _dual_number->n());
   for (std::size_t i = 0; i < _dual_number->m(); ++i)
@@ -436,150 +144,27 @@ MooseADWrapper<DenseMatrix<Real>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<DenseMatrix<Real>>::markAD(bool use_ad)
+MooseADWrapper<std::vector<DenseVector<Real>>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<DenseMatrix<DualReal>>();
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<DenseMatrix<Real>> &
-MooseADWrapper<DenseMatrix<Real>>::operator=(const MooseADWrapper<DenseMatrix<Real>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    // I don't know why we do this, but other code does it - ask Alex.
-    for (std::size_t i = 0; i < _dual_number->m(); ++i)
-      for (std::size_t j = 0; j < _dual_number->n(); ++j)
-        (*_dual_number)(i, j) = 0;
-  return *this;
-}
-
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>();
-}
-
-const std::vector<DenseMatrix<DualReal>> &
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::dn(bool) const
-{
-  if (!_dual_number)
-  {
-    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>(_val.size());
-    for (size_t h = 0; h < _val.size(); h++)
-    {
-      auto & val = _val[h];
-      (*_dual_number)[h].resize(val.m(), val.n());
-      for (std::size_t i = 0; i < val.m(); ++i)
-        for (std::size_t j = 0; j < val.n(); ++j)
-          (*_dual_number)[h](i, j).value() = val(i, j);
-    }
-  }
-  else if (!_use_ad)
-  {
-    assert(_dual_number.get());
-    assert(_dual_number->size() == _val.size());
-    for (size_t h = 0; h < _val.size(); h++)
-    {
-      auto & val = _val[h];
-      for (std::size_t i = 0; i < val.m(); ++i)
-        for (std::size_t j = 0; j < val.n(); ++j)
-          (*_dual_number)[h](i, j).value() = val(i, j);
-    }
-  }
-  assert(_dual_number.get());
-  return *_dual_number;
-}
-
-std::vector<DenseMatrix<DualReal>> &
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::dn(bool)
-{
-  assert(_dual_number.get());
-  return *_dual_number;
+  _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>(_val.size());
 }
 
 void
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::copyDualNumberToValue()
+MooseADWrapper<std::vector<DenseVector<Real>>>::copyValueToDualNumber() const
 {
-  assert(_dual_number.get());
-  _val.resize(_dual_number->size());
-  for (size_t h = 0; h < _dual_number->size(); h++)
+  _dual_number->resize(_val.size());
+  for (std::size_t i = 0; i < _dual_number->size(); ++i)
   {
-    auto & val = (*_dual_number)[h];
-    _val[h].resize(val.m(), val.n());
-    for (std::size_t i = 0; i < val.m(); ++i)
-      for (std::size_t j = 0; j < val.n(); ++j)
-        _val[h](i, j) = val(i, j).value();
+    auto & val = _val[i];
+    auto & dn = (*_dual_number)[i];
+    dn.resize(val.size());
+    for (std::size_t j = 0; j < val.size(); ++j)
+      dn(j) = val(j);
   }
 }
 
 void
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::markAD(bool use_ad)
-{
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_dual_number)
-    _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>(_val.size());
-  _use_ad = use_ad;
-}
-
-MooseADWrapper<std::vector<DenseMatrix<Real>>> &
-MooseADWrapper<std::vector<DenseMatrix<Real>>>::
-operator=(const MooseADWrapper<std::vector<DenseMatrix<Real>>> & rhs)
-{
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    // I don't know why we do this, but other code does it - ask Alex.
-    for (size_t h = 0; h < _dual_number->size(); h++)
-    {
-      auto & val = (*_dual_number)[h];
-      for (std::size_t i = 0; i < val.m(); ++i)
-        for (std::size_t j = 0; j < val.n(); ++j)
-          val(i, j) = 0;
-    }
-  return *this;
-}
-
-MooseADWrapper<std::vector<DenseVector<Real>>>::MooseADWrapper(bool use_ad)
-  : _use_ad(use_ad), _val(), _dual_number(nullptr)
-{
-  if (_use_ad)
-    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>();
-}
-
-const std::vector<DenseVector<DualReal>> &
-MooseADWrapper<std::vector<DenseVector<Real>>>::dn(bool) const
-{
-  if (!_dual_number)
-    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>(_val.size());
-  else if (!_use_ad)
-    for (std::size_t i = 0; i < _dual_number->size(); ++i)
-    {
-      auto & val = _val[i];
-      auto & dn = (*_dual_number)[i];
-      dn.resize(val.size());
-      for (std::size_t j = 0; j < val.size(); ++j)
-        dn(j).value() = val(j);
-    }
-  return *_dual_number;
-}
-
-std::vector<DenseVector<DualReal>> &
-MooseADWrapper<std::vector<DenseVector<Real>>>::dn(bool)
-{
-  return *_dual_number;
-}
-
-void
-MooseADWrapper<std::vector<DenseVector<Real>>>::copyDualNumberToValue()
+MooseADWrapper<std::vector<DenseVector<Real>>>::copyDualNumberToValue() const
 {
   _val.resize(_dual_number->size());
   for (std::size_t i = 0; i < _dual_number->size(); ++i)
@@ -591,26 +176,36 @@ MooseADWrapper<std::vector<DenseVector<Real>>>::copyDualNumberToValue()
 }
 
 void
-MooseADWrapper<std::vector<DenseVector<Real>>>::markAD(bool use_ad)
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::initializeDual() const
 {
-  if (!use_ad && _use_ad)
-    _dual_number = nullptr;
-  else if (use_ad && !_use_ad)
-    _dual_number = libmesh_make_unique<std::vector<DenseVector<DualReal>>>();
-  _use_ad = use_ad;
+  _dual_number = libmesh_make_unique<std::vector<DenseMatrix<DualReal>>>(_val.size());
 }
 
-MooseADWrapper<std::vector<DenseVector<Real>>> &
-MooseADWrapper<std::vector<DenseVector<Real>>>::
-operator=(const MooseADWrapper<std::vector<DenseVector<Real>>> & rhs)
+void
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::copyValueToDualNumber() const
 {
-  _val = rhs._val;
-  if (_dual_number && rhs._dual_number)
-    *_dual_number = *rhs._dual_number;
-  else if (_dual_number)
-    // I don't know why we do this, but other code does it - ask Alex.
-    for (std::size_t i = 0; i < _dual_number->size(); ++i)
-      for (std::size_t j = 0; j < (*_dual_number)[i].size(); ++j)
-        (*_dual_number)[i](j) = 0;
-  return *this;
+  _dual_number->resize(_val.size());
+  for (size_t h = 0; h < _val.size(); h++)
+  {
+    auto & val = _val[h];
+    (*_dual_number)[h].resize(val.m(), val.n());
+    for (std::size_t i = 0; i < val.m(); ++i)
+      for (std::size_t j = 0; j < val.n(); ++j)
+        (*_dual_number)[h](i, j) = val(i, j);
+  }
 }
+
+void
+MooseADWrapper<std::vector<DenseMatrix<Real>>>::copyDualNumberToValue() const
+{
+  _val.resize(_dual_number->size());
+  for (size_t h = 0; h < _dual_number->size(); h++)
+  {
+    auto & val = (*_dual_number)[h];
+    _val[h].resize(val.m(), val.n());
+    for (std::size_t i = 0; i < val.m(); ++i)
+      for (std::size_t j = 0; j < val.n(); ++j)
+        _val[h](i, j) = val(i, j).value();
+  }
+}
+


### PR DESCRIPTION
This refactors MooseADWrapper to be much more simple and robust.  It is
now much easier to add new types and much harder to do it incorrectly.
Basically, whenever a non-const version of the non-dual or dual number is
requested, the other (dual or non-dual respectively) is marked as
"dirty".  Then whenever a const version of a dirty value is requested,
it is automatically updated/synchronized from the other.

There was a nasty bug with automatic differentiation and material
properties caused by poor handling of this before.  It occured when all
of the following were true:

* multiple material objects provide the same property via block restriction
* one or more of the materials is a non-AD object
* one or more of the materials is an AD object
* we are not operating on the first non-linear iteration
* one or more objects retrieve that material property as an AD property.

There was a "race" of sorts to which object's declareProperty call ran
first.  If the AD object's declare ran first, then _use_ad was marked as
true in that object.  When the property was computed in the part of the
domain where the non-AD object operated, it was stored in the _value
parameter of a MooseADWrapper object. Then when another object that used
the property as an AD property (i.e. via getADMaterialProperty), this
would trigger a call to the MooseADWrapper dn() function that normally
had an if condition that would fire true to cause the wrapper's
_dual_number member to be synchronized to its _val member that had just
been calculated by the declarer.  But in this case, because of the
_use_ad race, this if condition was marked false, and the _dual_number
was not synchronized. This caused the property user to see an old
garbage value for the material property rather then the one that had
just been computed by the non-AD material object.

There may have been other similar bugs lurking - having to do with the
precarious, manual nature of managing/propogating the "_use_ad" state of
material properties correctly.  I profiled this on some AD-heavy
pronghorn problems and it seems to be no slower than the previous
implementation.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
