### PR TITLE
Improve error message in DependencyResolver during insert

### DIFF
--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -229,8 +229,14 @@ DependencyResolver<T>::insertDependency(const T & key, const T & value)
 
   if (dependsOn(value, key))
   {
+    decltype(_depends) depends_copy(_depends);
+
+    // Insert the breaking dependency here so it will reflect properly in the exception
+    depends_copy.insert(k);
+
     throw CyclicDependencyException<T>(
-        "DependencyResolver: attempt to insert dependency will result in cyclic graph", _depends);
+        "DependencyResolver: attempt to insert dependency will result in cyclic graph",
+        depends_copy);
   }
   _depends.insert(k);
   if (std::find(_ordering_vector.begin(), _ordering_vector.end(), key) == _ordering_vector.end())


### PR DESCRIPTION
~~Here we are trying to deal with systems that don't seem to want to catch exceptions by the right type. This is probably the wrong long-term solution but a reasonable workaround for a non-essential code path that will keep things working.~~

BTW - The first commit in this PR I do want to keep. I noticed that the error messages weren't making any sense when they print out the list of bad items. It's because the item that created the dependency wasn't in the list! This commit simply corrects that oversight.

UPDATE: We are ONLY keeping the first commit now....

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
