### PR TITLE
Enumerate fix for c++17, c++14, c++11 usage

### DIFF
--- a/framework/include/utils/Enumerate.h
+++ b/framework/include/utils/Enumerate.h
@@ -110,11 +110,16 @@ struct _enumerate_iterator
 
   bool operator!=(const _enumerate_iterator & other) const { return iter != other.iter; }
 
-#if __cplusplus > 201402L
-  std::pair<index_type &, reference> operator*() { return {index, *iter}; }
-#else
+  /**
+   * When MOOSE moves to C++17, we'll switch the return type of the dereference operator and the
+   * corresponding calling code. This is what
+   * we'll use instead.
+   *
+   *  #if __cplusplus > 201402L
+   *    std::pair<index_type &, reference> operator*() { return {index, *iter}; }
+   *  #endif
+   */
   _enumerate_struct<iterator> operator*() { return _enumerate_struct<iterator>(index, iter); }
-#endif
 
 private:
   index_type index;
@@ -142,4 +147,3 @@ private:
   index_type initial;
 };
 }
-


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

If somebody currently compiles MOOSE with -std=c++17, they will
get errors from use of enumerate. This is because the utility changes
the return type of enumerate conditionally based on the compiler standard
in use, which is a really poor idea. This PR makes the interface a little
less nice but consistently returns a tuple of the index and the aribtrary
type. The c++17 structured binding use is unchanged and very nice looking.
The c++14 and below usage however requires us to dig out the types with
the std::get<>() calls, which is not quite as nice. At least we'll
be ready to move forward on syntax when the time comes and now we can
compile under different standards without issue.