### PR TITLE
Skip tensor rotations for isotropic plasticity models 

### DIFF
--- a/modules/tensor_mechanics/include/materials/CappedDruckerPragerStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedDruckerPragerStressUpdate.h
@@ -69,6 +69,8 @@ public:
    */
   bool requiresIsotropicTensor() override { return true; }
 
+  bool isIsotropic() override { return true; };
+
 protected:
   /// Hardening model for cohesion, friction and dilation angles
   const TensorMechanicsPlasticDruckerPrager & _dp;

--- a/modules/tensor_mechanics/include/materials/CappedMohrCoulombStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/CappedMohrCoulombStressUpdate.h
@@ -33,6 +33,8 @@ public:
    */
   bool requiresIsotropicTensor() override { return true; }
 
+  bool isIsotropic() override { return true; };
+
 protected:
   /// Hardening model for tensile strength
   const TensorMechanicsHardeningModel & _tensile_strength;

--- a/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
+++ b/modules/tensor_mechanics/include/materials/ComputeMultipleInelasticStress.h
@@ -179,6 +179,9 @@ protected:
   /// is the elasticity tensor guaranteed to be isotropic?
   bool _is_elasticity_tensor_guaranteed_isotropic;
 
+  /// are all inelastic models inherently isotropic? (not the case for e.g. weak plane plasticity models)
+  bool _all_models_isotropic;
+
   /// Pointer to the damage model
   DamageBase * _damage_model;
 

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -82,6 +82,11 @@ public:
    */
   bool requiresIsotropicTensor() override { return true; }
 
+  /**
+   * Radial return mapped models should be isotropic by default!
+   */
+  bool isIsotropic() override { return true; };
+
 protected:
   virtual void initQpStatefulProperties() override;
 

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -106,6 +106,11 @@ public:
    */
   virtual bool requiresIsotropicTensor() = 0;
 
+  /**
+   * Is the implmented model isotropic? The safe default is 'false'.
+   */
+  virtual bool isIsotropic() { return false; };
+
   virtual Real computeTimeStepLimit();
 
   virtual TangentCalculationMethod getTangentCalculationMethod()


### PR DESCRIPTION
This should save a significant amount of compute time for all radial return based models that do not use an elastic approximation to the tangent operator.

Closes #14495