### PR TITLE
 Update to use new SLEPc URL

### DIFF
--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -95,7 +95,8 @@ if [ -z "$go_fast" ]; then
       --download-superlu_dist=1 \
       --download-mumps=1 \
       --download-scalapack=1 \
-      --download-slepc \
+      --download-slepc=git://https://gitlab.com/slepc/slepc.git \
+      --download-slepc-commit= 59ff81b \
       --with-mpi=1 \
       --with-cxx-dialect=C++11 \
       --with-fortran-bindings=0 \


### PR DESCRIPTION
SLEPc is moved to gitlab now: https://gitlab.com/slepc/slepc

Closes #14501

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
