### PR TITLE
Add conda instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,0 +1,34 @@
+# Anaconda MOOSE Environment
+
+Our preferred method for obtaining libraries necessary for MOOSE based Application development, is through Anaconda. Follow these instructions to create an environment on your machine using Anaconda.
+
+!include getting_started/minimum_requirements.md
+
+## Prerequisites
+
+- [Install Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
+- Configure Conda to work with conda-forge, and our Idaholab channel:
+
+  ```bash
+  conda config --add channels conda-forge idaholab
+  ```
+
+- Install the moose-env package from Idaholab:
+
+  ```bash
+  conda create --name moose moose-env
+  ```
+
+- Activate the moose environment:
+
+  ```bash
+  conda activate moose
+  ```
+
+  Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again. You have successfully activated the environment when you see the name of this environment prefixed within your prompt:
+
+  ```pre
+  (moose) [x86_64-apple-darwin13]
+  ```
+
+!include getting_started/installation/install_moose.md

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,6 +1,6 @@
-# Anaconda MOOSE Environment
+# Conda MOOSE Environment
 
-Our preferred method for obtaining libraries necessary for MOOSE based Application development, is through Anaconda. Follow these instructions to create an environment on your machine using Anaconda.
+Our preferred method for obtaining libraries necessary for MOOSE based Application development, is through Conda. Follow these instructions to create an environment on your machine using Conda. At this time, a Conda install via Windows is not supported.
 
 !include getting_started/minimum_requirements.md
 
@@ -8,9 +8,10 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
 !include installation/remove_moose_environment.md
 
-## Install Miniconda id=installminiconda
+## Install Conda id=installconda
 
-- [Install Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
+- [Install Miniconda or Anaconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (we recommend Miniconda)
+
 - Configure Conda to work with conda-forge, and our Idaholab channel:
 
   ```bash
@@ -18,7 +19,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
   conda config --add channels idaholab
   ```
 
-- Install the moose-env package from Idaholab:
+- Install the moose-env package from Idaholab and name your environment 'moose':
 
   ```bash
   conda create --name moose moose-env
@@ -30,16 +31,14 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
   conda activate moose
   ```
 
-  Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again. You have successfully activated the environment when you see the name of this environment prefixed within your prompt:
+  Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again.
 
-  ```bash
-  (moose) [x86_64-apple-darwin13]
-  ```
+  You will have successfully activated the moose environment when you see 'moose' within your prompt.
 
 If you close, and then re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for every terminal you open. If you wish to make this automatic, you can append `conda activate moose` to your bash or zsh profile.
 
 !alert note title= sudo is not necessary
-If you find yourself using `sudo` for any of the above conda commands... you shouldn't be. Miniconda should be installed to your home directory. Therefore you should already have write access. Try and figure out +why+ you don't have permissions before forcing a conda command with `sudo`.
+If you find yourself using `sudo` for any of the above conda commands... you shouldn't be. Conda should be installed to your home directory. Therefore you should already have write access. Try and figure out +why+ you don't have permissions before forcing a conda command with `sudo`.
 
 !include getting_started/installation/clone_moose.md
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -2,7 +2,7 @@
 
 Our preferred method for obtaining libraries necessary for MOOSE based Application development, is through Conda. Follow these instructions to create an environment on your machine using Conda. At this time, a Conda install via Windows is not supported.
 
-!include getting_started/minimum_requirements.md
+!include sqa/minimum_requirements.md
 
 ## Prerequisites
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -25,7 +25,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
   conda create --name moose moose-env
   ```
 
-- Activate the moose environment:
+- Activate the moose environment +(do this for any new terminal opened)+:
 
   ```bash
   conda activate moose

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -37,8 +37,15 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
 If you close, and then re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for every terminal you open. If you wish to make this automatic, you can append `conda activate moose` to your bash or zsh profile.
 
+The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
+
+```bash
+conda activate moose
+conda update --all
+```
+
 !alert note title= sudo is not necessary
-If you find yourself using `sudo` for any of the above conda commands... you shouldn't be. Conda should be installed to your home directory. Therefore you should already have write access. Try and figure out +why+ you don't have permissions before forcing a conda command with `sudo`.
+If you find yourself applying the use of `sudo` for any of the above conda commands... something's not right. The most common reason for needing sudo, is due to an improper installation. Conda *should* be installed to your home directory, and without any use of `sudo`.
 
 !include getting_started/installation/clone_moose.md
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -6,11 +6,16 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
 ## Prerequisites
 
+!include installation/remove_moose_environment.md
+
+## Install Miniconda id=installminiconda
+
 - [Install Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
 - Configure Conda to work with conda-forge, and our Idaholab channel:
 
   ```bash
-  conda config --add channels conda-forge idaholab
+  conda config --add channels conda-forge
+  conda config --add channels idaholab
   ```
 
 - Install the moose-env package from Idaholab:
@@ -27,8 +32,19 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
   Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again. You have successfully activated the environment when you see the name of this environment prefixed within your prompt:
 
-  ```pre
+  ```bash
   (moose) [x86_64-apple-darwin13]
   ```
 
-!include getting_started/installation/install_moose.md
+If you close, and then re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for every terminal you open. If you wish to make this automatic, you can append `conda activate moose` to your bash or zsh profile.
+
+!alert note title= sudo is not necessary
+If you find yourself using `sudo` for any of the above conda commands... you shouldn't be. Miniconda should be installed to your home directory. Therefore you should already have write access. Try and figure out +why+ you don't have permissions before forcing a conda command with `sudo`.
+
+!include getting_started/installation/clone_moose.md
+
+!include getting_started/installation/test_moose.md
+
+!include getting_started/installation/update_moose.md
+
+Head back over to the [getting_started/index.md] page to continue your tour of MOOSE.

--- a/modules/doc/content/getting_started/installation/remove_moose_environment.md
+++ b/modules/doc/content/getting_started/installation/remove_moose_environment.md
@@ -1,10 +1,10 @@
 ### Transitional step for pre-existing users
 
-For those of you who have previously installed the moose-environment package, you should remove it. +If you are a first time MOOSE user, please skip down to [Install Miniconda](conda.md#installminiconda).+
+For those of you who have previously installed the moose-environment package, you should remove it. +If you are a first time MOOSE user, please skip down to [Install Conda](conda.md#installconda).+ Removal of the moose-envirnment package, is only needed to be performed once.
 
 - Using Conda, it is no longer neccessary to have /opt/moose present on your machine. Depending on the type of machine you have, please do the following:
 
-  | OS | Command |
+  | Operating System | Command |
   | :- | -: |
   | CentOS | `sudo yum remove moose-environment` |
   | Fedora | `sudo dnf remove moose-environment` |

--- a/modules/doc/content/getting_started/installation/remove_moose_environment.md
+++ b/modules/doc/content/getting_started/installation/remove_moose_environment.md
@@ -1,0 +1,16 @@
+### Transitional step for pre-existing users
+
+For those of you who have previously installed the moose-environment package, you should remove it. +If you are a first time MOOSE user, please skip down to [Install Miniconda](conda.md#installminiconda).+
+
+- Using Conda, it is no longer neccessary to have /opt/moose present on your machine. Depending on the type of machine you have, please do the following:
+
+  | OS | Command |
+  | :- | -: |
+  | CentOS | `sudo yum remove moose-environment` |
+  | Fedora | `sudo dnf remove moose-environment` |
+  | OpenSUSE | `sudo zypper remove moose-environment` |
+  | Debian (Ubuntu, Mint) | `sudo dpkg -r moose-environment` |
+  | Macintosh | `sudo rm -rf /opt/moose` |
+
+  !alert warning title= sudo is dangerous
+  Be especially carful with the above commands! Verify +twice+ that what you have entered in your terminal is what the instructions are asking you to do.

--- a/modules/doc/content/getting_started/installation/test_moose.md
+++ b/modules/doc/content/getting_started/installation/test_moose.md
@@ -1,7 +1,5 @@
 ## Compile and Test MOOSE
 
-After libMesh has compiled the next step is to compile and test MOOSE.
-
 ```bash
 cd ~/projects/moose/test
 make -j 4


### PR DESCRIPTION
Begin adding instructions for using MOOSE with Anaconda.

The resulting link will be:
```pre
-site address-/getting_started/installation/conda.html
```
_At this time, we do not want a link to these instructions._

Refs #14515
