### PR TITLE
add missing thread lock to prevent race condition

### DIFF
--- a/framework/src/loops/ComputeInitialConditionThread.C
+++ b/framework/src/loops/ComputeInitialConditionThread.C
@@ -97,7 +97,11 @@ ComputeInitialConditionThread::operator()(const ConstElemRange & range)
       vec.clear();
 
       // Now that all dofs are set for this variable, solemnize the solution.
-      var->insert(var->sys().solution());
+      // Lock the new_vector since it is shared among threads.
+      {
+        Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+        var->insert(var->sys().solution());
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes a bug added by #14469 where I moved a function call outside
of an existing lock but still in a threaded region.  This PR fixes that
nonsense.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
