### PR TITLE
Vectors of mixed PPs and Reals

### DIFF
--- a/framework/include/interfaces/PostprocessorInterface.h
+++ b/framework/include/interfaces/PostprocessorInterface.h
@@ -35,6 +35,7 @@ public:
    * doco-normal-methods-begin
    * Retrieve the value of a Postprocessor or one of it's old or older values
    * @param name The name of the Postprocessor parameter (see below)
+   * @param index The index of the Postprocessor
    * @return A reference to the desired value
    *
    * The name required by this method is the name that is hard-coded into
@@ -44,9 +45,12 @@ public:
    *
    * see getPostprocessorValueByName getPostprocessorValueOldByName getPostprocessorValueOlderByName
    */
-  const PostprocessorValue & getPostprocessorValue(const std::string & name);
-  const PostprocessorValue & getPostprocessorValueOld(const std::string & name);
-  const PostprocessorValue & getPostprocessorValueOlder(const std::string & name);
+  const PostprocessorValue & getPostprocessorValue(const std::string & name,
+                                                   unsigned int index = 0);
+  const PostprocessorValue & getPostprocessorValueOld(const std::string & name,
+                                                      unsigned int index = 0);
+  const PostprocessorValue & getPostprocessorValueOlder(const std::string & name,
+                                                        unsigned int index = 0);
   // doco-normal-methods-end
 
   ///@}
@@ -81,11 +85,12 @@ public:
   /**
    * Determine if the Postprocessor exists
    * @param name The name of the Postprocessor parameter
+   * @param index The index of the Postprocessor
    * @return True if the Postprocessor exists
    *
    * @see hasPostprocessorByName getPostprocessorValue
    */
-  bool hasPostprocessor(const std::string & name) const;
+  bool hasPostprocessor(const std::string & name, unsigned int index = 0) const;
 
   /**
    * Determine if the Postprocessor exists
@@ -95,6 +100,22 @@ public:
    * @see hasPostprocessor getPostprocessorValueByName
    */
   bool hasPostprocessorByName(const PostprocessorName & name);
+
+  /**
+   * Returns number of Postprocessors coupled under parameter name
+   * @param name The name of the Postprocessor parameter
+   * @return Number of coupled post-processors, 1 if it's a single
+   *
+   */
+  unsigned int coupledPostprocessors(const std::string & name) const;
+
+  /**
+   * Checks if there is a single postprocessor coupled by parameter name
+   * @param name The name of the Postprocessor parameter
+   * @return Number of coupled post-processors, 1 if it's a single
+   *
+   */
+  bool singlePostprocessor(const std::string & name) const;
 
 private:
   /// PostprocessorInterface Parameters

--- a/framework/include/interfaces/PostprocessorInterface.h
+++ b/framework/include/interfaces/PostprocessorInterface.h
@@ -21,6 +21,12 @@ class InputParameters;
 class PostprocessorName;
 class MooseObject;
 
+#define usingPostprocessorInterfaceMembers                                                         \
+  using PostprocessorInterface::getPostprocessorValue;                                             \
+  using PostprocessorInterface::getPostprocessorValueOld;                                          \
+  using PostprocessorInterface::getPostprocessorValueOlder;                                        \
+  using PostprocessorInterface::coupledPostprocessors
+
 /**
  * Interface class for classes which interact with Postprocessors.
  * Provides the getPostprocessorValueXYZ() and related interfaces.

--- a/framework/include/postprocessors/LinearCombinationPostprocessor.h
+++ b/framework/include/postprocessors/LinearCombinationPostprocessor.h
@@ -38,8 +38,6 @@ public:
   virtual PostprocessorValue getValue() override;
 
 protected:
-  /// List of names of post-processors to include in linear combination
-  const std::vector<PostprocessorName> & _pp_names;
   /// Number of post-processors in linear combination
   const unsigned int _n_pp;
   /// List of linear combination coefficients for each post-processor value
@@ -50,4 +48,3 @@ protected:
   /// List of post-processor values
   std::vector<const PostprocessorValue *> _pp_values;
 };
-

--- a/framework/include/userobject/GeneralUserObject.h
+++ b/framework/include/userobject/GeneralUserObject.h
@@ -55,7 +55,8 @@ public:
   /**
    * Store dependency among same object types for proper execution order
    */
-  virtual const PostprocessorValue & getPostprocessorValue(const std::string & name);
+  virtual const PostprocessorValue & getPostprocessorValue(const std::string & name,
+                                                           unsigned int index = 0);
   virtual const PostprocessorValue & getPostprocessorValueByName(const PostprocessorName & name);
 
   virtual const VectorPostprocessorValue &
@@ -77,4 +78,3 @@ protected:
   std::set<std::string> _depend_vars;
   std::set<std::string> _supplied_vars;
 };
-

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -600,24 +600,28 @@ public:
    * Get the default value for a postprocessor added with addPostprocessor
    * @param name The name of the postprocessor
    * @param suppress_error If true, the error check is suppressed
+   * @param index The index in the default postprocessor vector
    * @return The default value for the postprocessor
    */
   const PostprocessorValue & getDefaultPostprocessorValue(const std::string & name,
-                                                          bool suppress_error = false) const;
+                                                          bool suppress_error = false,
+                                                          unsigned int index = 0) const;
 
   /**
    * Set the default value for a postprocessor added with addPostprocessor
    * @param name The name of the postprocessor
    * @value value The value of the postprocessor default to set
+   * @param index The index in the default postprocessor vector
    */
-  void setDefaultPostprocessorValue(const std::string & name, const PostprocessorValue & value);
+  void setDefaultPostprocessorValue(const std::string & name, const PostprocessorValue & value, unsigned int index = 0);
 
   /**
    * Returns true if a default PostprocessorValue is defined
    * @param name The name of the postprocessor
+   * @param index The index in the default postprocessor vector
    * @return True if a default value exists
    */
-  bool hasDefaultPostprocessorValue(const std::string & name) const;
+  bool hasDefaultPostprocessorValue(const std::string & name, unsigned int index = 0) const;
 
   // BEGIN APPLY PARAMETER METHODS
   /**
@@ -827,8 +831,8 @@ private:
     bool _have_coupled_default = false;
     /// The default value for optionally coupled variables
     std::vector<Real> _coupled_default = {0};
-    bool _have_default_postprocessor_val = false;
-    PostprocessorValue _default_postprocessor_val = 0;
+    std::vector<bool> _have_default_postprocessor_val = {false};
+    std::vector<PostprocessorValue> _default_postprocessor_val = {0};
     /// True if a parameters value was set by addParam, and not set again.
     bool _set_by_add_param = false;
     /// The reserved option names for a parameter

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -608,13 +608,6 @@ public:
                                                           unsigned int index = 0) const;
 
   /**
-   * Reserve space for default postprocessor values
-   * @param name The name of the postprocessor
-   * @param size Number of entries required in default p
-   */
-  void reserveDefaultPostprocessorValueStorage(const std::string & name, unsigned int size);
-
-  /**
    * Set the default value for a postprocessor added with addPostprocessor
    * @param name The name of the postprocessor
    * @value value The value of the postprocessor default to set
@@ -821,17 +814,6 @@ public:
     return !_params.find(pp_name)->second._vector_of_postprocessors;
   }
 
-  /**
-   * Setter for the _vector_of_postprocessors flag in parameters
-   *
-   * @param pp_name The name of the postprocessor parameter
-   * @param b value that _vector_of_postprocessors is set to
-   */
-  void setVectorOfPostprocessors(const std::string & pp_name, bool b)
-  {
-    _params[pp_name]._vector_of_postprocessors = b;
-  }
-
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
@@ -921,6 +903,24 @@ private:
   template <typename T, typename S>
   void setParamHelper(const std::string & name, T & l_value, const S & r_value);
 
+  /**
+   * Reserve space for default postprocessor values
+   * @param name The name of the postprocessor
+   * @param size Number of entries required in default p
+   */
+  void reserveDefaultPostprocessorValueStorage(const std::string & name, unsigned int size);
+
+  /**
+   * Setter for the _vector_of_postprocessors flag in parameters
+   *
+   * @param pp_name The name of the postprocessor parameter
+   * @param b value that _vector_of_postprocessors is set to
+   */
+  void setVectorOfPostprocessors(const std::string & pp_name, bool b)
+  {
+    _params[pp_name]._vector_of_postprocessors = b;
+  }
+
   /// original location of input block (i.e. filename,linenum) - used for nice error messages.
   std::string _block_location;
 
@@ -968,6 +968,7 @@ private:
   // These are the only objects allowed to _create_ InputParameters
   friend InputParameters emptyInputParameters();
   friend class InputParameterWarehouse;
+  friend class Parser;
 };
 
 // Template and inline function implementations

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -608,12 +608,21 @@ public:
                                                           unsigned int index = 0) const;
 
   /**
+   * Reserve space for default postprocessor values
+   * @param name The name of the postprocessor
+   * @param size Number of entries required in default p
+   */
+  void reserveDefaultPostprocessorValueStorage(const std::string & name, unsigned int size);
+
+  /**
    * Set the default value for a postprocessor added with addPostprocessor
    * @param name The name of the postprocessor
    * @value value The value of the postprocessor default to set
    * @param index The index in the default postprocessor vector
    */
-  void setDefaultPostprocessorValue(const std::string & name, const PostprocessorValue & value, unsigned int index = 0);
+  void setDefaultPostprocessorValue(const std::string & name,
+                                    const PostprocessorValue & value,
+                                    unsigned int index = 0);
 
   /**
    * Returns true if a default PostprocessorValue is defined
@@ -802,6 +811,27 @@ public:
    */
   bool shouldIgnore(const std::string & name);
 
+  /**
+   * Getter for the _vector_of_postprocessors flag in parameters
+   *
+   * @param pp_name The name of the postprocessor parameter
+   */
+  bool isSinglePostprocessor(const std::string & pp_name) const
+  {
+    return !_params.find(pp_name)->second._vector_of_postprocessors;
+  }
+
+  /**
+   * Setter for the _vector_of_postprocessors flag in parameters
+   *
+   * @param pp_name The name of the postprocessor parameter
+   * @param b value that _vector_of_postprocessors is set to
+   */
+  void setVectorOfPostprocessors(const std::string & pp_name, bool b)
+  {
+    _params[pp_name]._vector_of_postprocessors = b;
+  }
+
 private:
   // Private constructor so that InputParameters can only be created in certain places.
   InputParameters();
@@ -831,6 +861,8 @@ private:
     bool _have_coupled_default = false;
     /// The default value for optionally coupled variables
     std::vector<Real> _coupled_default = {0};
+    /// are pps provided as single pp or as vector of pps
+    bool _vector_of_postprocessors = false;
     std::vector<bool> _have_default_postprocessor_val = {false};
     std::vector<PostprocessorValue> _default_postprocessor_val = {0};
     /// True if a parameters value was set by addParam, and not set again.

--- a/framework/src/interfaces/PostprocessorInterface.C
+++ b/framework/src/interfaces/PostprocessorInterface.C
@@ -22,6 +22,11 @@ PostprocessorInterface::PostprocessorInterface(const MooseObject * moose_object)
 const PostprocessorValue &
 PostprocessorInterface::getPostprocessorValue(const std::string & name, unsigned int index)
 {
+  if (singlePostprocessor(name) && index > 0)
+    mooseError("Postprocessor requested with index ",
+               index,
+               " when only a single postprocessor is coupled.");
+
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
   if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
@@ -30,6 +35,17 @@ PostprocessorInterface::getPostprocessorValue(const std::string & name, unsigned
   {
     if (singlePostprocessor(name))
       return _pi_feproblem.getPostprocessorValue(_ppi_params.get<PostprocessorName>(name));
+
+    // check size of parameter array here
+    if (index >= _ppi_params.get<std::vector<PostprocessorName>>(name).size())
+      mooseError("Postprocessor requested with index ",
+                 index,
+                 " but parameter ",
+                 name,
+                 " has only ",
+                 _ppi_params.get<std::vector<PostprocessorName>>(name).size(),
+                 " entries.");
+
     return _pi_feproblem.getPostprocessorValue(
         _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
   }
@@ -38,6 +54,11 @@ PostprocessorInterface::getPostprocessorValue(const std::string & name, unsigned
 const PostprocessorValue &
 PostprocessorInterface::getPostprocessorValueOld(const std::string & name, unsigned int index)
 {
+  if (singlePostprocessor(name) && index > 0)
+    mooseError("Postprocessor requested with index ",
+               index,
+               " when only a single postprocessor is coupled.");
+
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
   if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
@@ -46,6 +67,17 @@ PostprocessorInterface::getPostprocessorValueOld(const std::string & name, unsig
   {
     if (singlePostprocessor(name))
       return _pi_feproblem.getPostprocessorValueOld(_ppi_params.get<PostprocessorName>(name));
+
+    // check size of parameter array here
+    if (index >= _ppi_params.get<std::vector<PostprocessorName>>(name).size())
+      mooseError("Postprocessor requested with index ",
+                 index,
+                 " but parameter ",
+                 name,
+                 " has only ",
+                 _ppi_params.get<std::vector<PostprocessorName>>(name).size(),
+                 " entries.");
+
     return _pi_feproblem.getPostprocessorValueOld(
         _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
   }
@@ -54,6 +86,11 @@ PostprocessorInterface::getPostprocessorValueOld(const std::string & name, unsig
 const PostprocessorValue &
 PostprocessorInterface::getPostprocessorValueOlder(const std::string & name, unsigned int index)
 {
+  if (singlePostprocessor(name) && index > 0)
+    mooseError("Postprocessor requested with index ",
+               index,
+               " when only a single postprocessor is coupled.");
+
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
   if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
@@ -62,6 +99,17 @@ PostprocessorInterface::getPostprocessorValueOlder(const std::string & name, uns
   {
     if (singlePostprocessor(name))
       return _pi_feproblem.getPostprocessorValueOlder(_ppi_params.get<PostprocessorName>(name));
+
+    // check size of parameter array here
+    if (index >= _ppi_params.get<std::vector<PostprocessorName>>(name).size())
+      mooseError("Postprocessor requested with index ",
+                 index,
+                 " but parameter ",
+                 name,
+                 " has only ",
+                 _ppi_params.get<std::vector<PostprocessorName>>(name).size(),
+                 " entries.");
+
     return _pi_feproblem.getPostprocessorValueOlder(
         _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
   }

--- a/framework/src/interfaces/PostprocessorInterface.C
+++ b/framework/src/interfaces/PostprocessorInterface.C
@@ -20,36 +20,51 @@ PostprocessorInterface::PostprocessorInterface(const MooseObject * moose_object)
 }
 
 const PostprocessorValue &
-PostprocessorInterface::getPostprocessorValue(const std::string & name)
+PostprocessorInterface::getPostprocessorValue(const std::string & name, unsigned int index)
 {
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
-  if (!hasPostprocessor(name) && _ppi_params.hasDefaultPostprocessorValue(name))
-    return _ppi_params.getDefaultPostprocessorValue(name);
+  if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
+    return _ppi_params.getDefaultPostprocessorValue(name, false, index);
   else
-    return _pi_feproblem.getPostprocessorValue(_ppi_params.get<PostprocessorName>(name));
+  {
+    if (singlePostprocessor(name))
+      return _pi_feproblem.getPostprocessorValue(_ppi_params.get<PostprocessorName>(name));
+    return _pi_feproblem.getPostprocessorValue(
+        _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
+  }
 }
 
 const PostprocessorValue &
-PostprocessorInterface::getPostprocessorValueOld(const std::string & name)
+PostprocessorInterface::getPostprocessorValueOld(const std::string & name, unsigned int index)
 {
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
-  if (!hasPostprocessor(name) && _ppi_params.hasDefaultPostprocessorValue(name))
-    return _ppi_params.getDefaultPostprocessorValue(name);
+  if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
+    return _ppi_params.getDefaultPostprocessorValue(name, false, index);
   else
-    return _pi_feproblem.getPostprocessorValueOld(_ppi_params.get<PostprocessorName>(name));
+  {
+    if (singlePostprocessor(name))
+      return _pi_feproblem.getPostprocessorValueOld(_ppi_params.get<PostprocessorName>(name));
+    return _pi_feproblem.getPostprocessorValueOld(
+        _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
+  }
 }
 
 const PostprocessorValue &
-PostprocessorInterface::getPostprocessorValueOlder(const std::string & name)
+PostprocessorInterface::getPostprocessorValueOlder(const std::string & name, unsigned int index)
 {
   // Return the default if the Postprocessor does not exist and a default does, otherwise
   // continue as usual
-  if (!hasPostprocessor(name) && _ppi_params.hasDefaultPostprocessorValue(name))
-    return _ppi_params.getDefaultPostprocessorValue(name);
+  if (!hasPostprocessor(name, index) && _ppi_params.hasDefaultPostprocessorValue(name, index))
+    return _ppi_params.getDefaultPostprocessorValue(name, false, index);
   else
-    return _pi_feproblem.getPostprocessorValueOlder(_ppi_params.get<PostprocessorName>(name));
+  {
+    if (singlePostprocessor(name))
+      return _pi_feproblem.getPostprocessorValueOlder(_ppi_params.get<PostprocessorName>(name));
+    return _pi_feproblem.getPostprocessorValueOlder(
+        _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
+  }
 }
 
 const PostprocessorValue &
@@ -71,9 +86,26 @@ PostprocessorInterface::getPostprocessorValueOlderByName(const PostprocessorName
 }
 
 bool
-PostprocessorInterface::hasPostprocessor(const std::string & name) const
+PostprocessorInterface::hasPostprocessor(const std::string & name, unsigned int index) const
 {
-  return _pi_feproblem.hasPostprocessor(_ppi_params.get<PostprocessorName>(name));
+  if (singlePostprocessor(name))
+    return _pi_feproblem.hasPostprocessor(_ppi_params.get<PostprocessorName>(name));
+  return _pi_feproblem.hasPostprocessor(
+      _ppi_params.get<std::vector<PostprocessorName>>(name)[index]);
+}
+
+unsigned int
+PostprocessorInterface::coupledPostprocessors(const std::string & name) const
+{
+  if (singlePostprocessor(name))
+    return 1;
+  return _ppi_params.get<std::vector<PostprocessorName>>(name).size();
+}
+
+bool
+PostprocessorInterface::singlePostprocessor(const std::string & name) const
+{
+  return _ppi_params.isSinglePostprocessor(name);
 }
 
 bool

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -961,7 +961,15 @@ Parser::setVectorParameter<Point, Point>(const std::string & full_name,
                                          InputParameters::Parameter<std::vector<Point>> * param,
                                          bool in_global,
                                          GlobalParamsAction * global_block);
-
+/*
+template <>
+void Parser::setVectorParameter<PostprocessorName, PostprocessorName>(
+    const std::string & full_name,
+    const std::string & short_name,
+    InputParameters::Parameter<std::vector<PostprocessorName>> * param,
+    bool in_global,
+    GlobalParamsAction * global_block);
+*/
 template <>
 void Parser::setVectorParameter<MooseEnum, MooseEnum>(
     const std::string & full_name,

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -961,7 +961,7 @@ Parser::setVectorParameter<Point, Point>(const std::string & full_name,
                                          InputParameters::Parameter<std::vector<Point>> * param,
                                          bool in_global,
                                          GlobalParamsAction * global_block);
-/*
+
 template <>
 void Parser::setVectorParameter<PostprocessorName, PostprocessorName>(
     const std::string & full_name,
@@ -969,7 +969,7 @@ void Parser::setVectorParameter<PostprocessorName, PostprocessorName>(
     InputParameters::Parameter<std::vector<PostprocessorName>> * param,
     bool in_global,
     GlobalParamsAction * global_block);
-*/
+
 template <>
 void Parser::setVectorParameter<MooseEnum, MooseEnum>(
     const std::string & full_name,
@@ -1221,7 +1221,7 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
       setvector(IndicatorName, string);
       setvector(MarkerName, string);
       setvector(MultiAppName, string);
-      setvector(PostprocessorName, string);
+      setvector(PostprocessorName, PostprocessorName);
       setvector(VectorPostprocessorName, string);
       setvector(OutputName, string);
       setvector(MaterialPropertyName, string);
@@ -1337,7 +1337,6 @@ Parser::setScalarParameter(const std::string & full_name,
                            bool in_global,
                            GlobalParamsAction * global_block)
 {
-
   try
   {
     param->set() = _root->param<Base>(full_name);
@@ -1943,6 +1942,39 @@ Parser::setVectorParameter<MooseEnum, MooseEnum>(
     global_block->setVectorParam<MooseEnum>(short_name).resize(vec.size(), enum_values[0]);
     for (unsigned int i = 0; i < vec.size(); ++i)
       global_block->setVectorParam<MooseEnum>(short_name)[i] = values[0];
+  }
+}
+
+template <>
+void
+Parser::setVectorParameter<PostprocessorName, PostprocessorName>(
+    const std::string & full_name,
+    const std::string & short_name,
+    InputParameters::Parameter<std::vector<PostprocessorName>> * param,
+    bool in_global,
+    GlobalParamsAction * global_block)
+{
+  std::vector<std::string> pps_names = _root->param<std::vector<std::string>>(full_name);
+  unsigned int n = pps_names.size();
+  param->set().resize(n);
+  _current_params->setVectorOfPostprocessors(short_name, true);
+  _current_params->reserveDefaultPostprocessorValueStorage(short_name, n);
+
+  for (unsigned int j = 0; j < n; ++j)
+  {
+    param->set()[j] = pps_names[j];
+    Real real_value = -std::numeric_limits<Real>::max();
+    std::istringstream ss(pps_names[j]);
+    if (ss >> real_value && ss.eof())
+      _current_params->setDefaultPostprocessorValue(short_name, real_value, j);
+  }
+
+  if (in_global)
+  {
+    global_block->remove(short_name);
+    global_block->setVectorParam<PostprocessorName>(short_name).resize(n, "");
+    for (unsigned int j = 0; j < n; ++j)
+      global_block->setVectorParam<PostprocessorName>(short_name)[j] = pps_names[j];
   }
 }
 

--- a/framework/src/postprocessors/LinearCombinationPostprocessor.C
+++ b/framework/src/postprocessors/LinearCombinationPostprocessor.C
@@ -28,8 +28,7 @@ LinearCombinationPostprocessor::validParams()
 
 LinearCombinationPostprocessor::LinearCombinationPostprocessor(const InputParameters & parameters)
   : GeneralPostprocessor(parameters),
-    _pp_names(getParam<std::vector<PostprocessorName>>("pp_names")),
-    _n_pp(_pp_names.size()),
+    _n_pp(coupledPostprocessors("pp_names")),
     _pp_coefs(getParam<std::vector<Real>>("pp_coefs")),
     _b_value(getParam<Real>("b"))
 {
@@ -38,7 +37,7 @@ LinearCombinationPostprocessor::LinearCombinationPostprocessor(const InputParame
 
   _pp_values.resize(_n_pp);
   for (unsigned int i = 0; i < _n_pp; i++)
-    _pp_values[i] = &getPostprocessorValueByName(_pp_names[i]);
+    _pp_values[i] = &getPostprocessorValue("pp_names", i);
 }
 
 void

--- a/framework/src/userobject/GeneralUserObject.C
+++ b/framework/src/userobject/GeneralUserObject.C
@@ -47,10 +47,15 @@ GeneralUserObject::getSuppliedItems()
 }
 
 const PostprocessorValue &
-GeneralUserObject::getPostprocessorValue(const std::string & name)
+GeneralUserObject::getPostprocessorValue(const std::string & name, unsigned int index)
 {
-  _depend_vars.insert(_pars.get<PostprocessorName>(name));
-  return PostprocessorInterface::getPostprocessorValue(name);
+  // is this a vector of pp names, we use the number of default entries
+  // to figure that out
+  if (_pars.isSinglePostprocessor(name))
+    _depend_vars.insert(_pars.get<PostprocessorName>(name));
+  else
+    _depend_vars.insert(_pars.get<std::vector<PostprocessorName>>(name)[index]);
+  return PostprocessorInterface::getPostprocessorValue(name, index);
 }
 
 const PostprocessorValue &

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -626,28 +626,31 @@ InputParameters::getGroupName(const std::string & param_name) const
 }
 
 const PostprocessorValue &
-InputParameters::getDefaultPostprocessorValue(const std::string & name, bool suppress_error) const
+InputParameters::getDefaultPostprocessorValue(const std::string & name,
+                                              bool suppress_error,
+                                              unsigned int index) const
 {
   // Check that a default exists, error if it does not
   auto it = _params.find(name);
-  if (!suppress_error && (it == _params.end() || !it->second._have_default_postprocessor_val))
+  if (!suppress_error && (it == _params.end() || !it->second._have_default_postprocessor_val[index]))
     mooseError("A default PostprcessorValue does not exist for the given name: ", name);
 
-  return it->second._default_postprocessor_val;
+  return it->second._default_postprocessor_val[index];
 }
 
 void
 InputParameters::setDefaultPostprocessorValue(const std::string & name,
-                                              const PostprocessorValue & value)
+                                              const PostprocessorValue & value,
+                                              unsigned int index)
 {
-  _params[name]._default_postprocessor_val = value;
-  _params[name]._have_default_postprocessor_val = true;
+  _params[name]._default_postprocessor_val[index] = value;
+  _params[name]._have_default_postprocessor_val[index] = true;
 }
 
 bool
-InputParameters::hasDefaultPostprocessorValue(const std::string & name) const
+InputParameters::hasDefaultPostprocessorValue(const std::string & name, unsigned int index) const
 {
-  return _params.count(name) > 0 && _params.at(name)._have_default_postprocessor_val;
+  return _params.count(name) > 0 && _params.at(name)._have_default_postprocessor_val[index];
 }
 
 void
@@ -927,8 +930,8 @@ InputParameters::setParamHelper<PostprocessorName, Real>(const std::string & nam
                                                          const Real & r_value)
 {
   // Store the default value
-  _params[name]._default_postprocessor_val = r_value;
-  _params[name]._have_default_postprocessor_val = true;
+  _params[name]._default_postprocessor_val[0] = r_value;
+  _params[name]._have_default_postprocessor_val[0] = true;
 
   // Assign the default value so that it appears in the dump
   std::ostringstream oss;
@@ -943,8 +946,8 @@ InputParameters::setParamHelper<PostprocessorName, int>(const std::string & name
                                                         const int & r_value)
 {
   // Store the default value
-  _params[name]._default_postprocessor_val = r_value;
-  _params[name]._have_default_postprocessor_val = true;
+  _params[name]._default_postprocessor_val[0] = r_value;
+  _params[name]._have_default_postprocessor_val[0] = true;
 
   // Assign the default value so that it appears in the dump
   std::ostringstream oss;

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -949,6 +949,10 @@ InputParameters::setParamHelper<PostprocessorName, Real>(const std::string & nam
                                                          PostprocessorName & l_value,
                                                          const Real & r_value)
 {
+  mooseAssert(_params[name]._default_postprocessor_val.size() == 1 &&
+                  _params[name]._have_default_postprocessor_val.size() == 1,
+              "Default postprocessor size is not equal to 1.");
+
   // Store the default value
   _params[name]._default_postprocessor_val[0] = r_value;
   _params[name]._have_default_postprocessor_val[0] = true;
@@ -965,6 +969,10 @@ InputParameters::setParamHelper<PostprocessorName, int>(const std::string & name
                                                         PostprocessorName & l_value,
                                                         const int & r_value)
 {
+  mooseAssert(_params[name]._default_postprocessor_val.size() == 1 &&
+                  _params[name]._have_default_postprocessor_val.size() == 1,
+              "Default postprocessor size is not equal to 1.");
+
   // Store the default value
   _params[name]._default_postprocessor_val[0] = r_value;
   _params[name]._have_default_postprocessor_val[0] = true;

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -632,10 +632,21 @@ InputParameters::getDefaultPostprocessorValue(const std::string & name,
 {
   // Check that a default exists, error if it does not
   auto it = _params.find(name);
-  if (!suppress_error && (it == _params.end() || !it->second._have_default_postprocessor_val[index]))
+  if (!suppress_error &&
+      (it == _params.end() || !it->second._have_default_postprocessor_val[index]))
     mooseError("A default PostprcessorValue does not exist for the given name: ", name);
 
   return it->second._default_postprocessor_val[index];
+}
+
+void
+InputParameters::reserveDefaultPostprocessorValueStorage(const std::string & name,
+                                                         unsigned int size)
+{
+  if (_params[name]._default_postprocessor_val.size() >= size)
+    return;
+  _params[name]._default_postprocessor_val.resize(size, 0);
+  _params[name]._have_default_postprocessor_val.resize(size, false);
 }
 
 void

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -636,6 +636,15 @@ InputParameters::getDefaultPostprocessorValue(const std::string & name,
       (it == _params.end() || !it->second._have_default_postprocessor_val[index]))
     mooseError("A default PostprcessorValue does not exist for the given name: ", name);
 
+  if (index >= it->second._default_postprocessor_val.size())
+    mooseError("Default postprocessor with parameter name ",
+               name,
+               " requested with index ",
+               index,
+               " but only ",
+               it->second._default_postprocessor_val.size(),
+               " exists.");
+
   return it->second._default_postprocessor_val[index];
 }
 

--- a/test/tests/postprocessors/linear_combination/gold/linear_combination_defaulted_pps.csv
+++ b/test/tests/postprocessors/linear_combination/gold/linear_combination_defaulted_pps.csv
@@ -1,0 +1,3 @@
+time,linear_combination
+0,0
+1,-111

--- a/test/tests/postprocessors/linear_combination/tests
+++ b/test/tests/postprocessors/linear_combination/tests
@@ -9,4 +9,13 @@
 
     requirement = 'The system shall support the ability to compute a linear combination of scalar values (Postprocessors).'
   [../]
+
+  [./linear_combination_defaulted_pps]
+    type = 'CSVDiff'
+    input = 'linear_combination.i'
+    csvdiff = 'linear_combination_defaulted_pps.csv'
+    cli_args = 'Outputs/file_base=linear_combination_defaulted_pps
+                Postprocessors/linear_combination/pp_names="pp1 120"'
+    requirement = 'The system shall allow a mix of postprocessor names and real numbers to be provided to PostprocessorName parameters.'
+  [../]
 []


### PR DESCRIPTION
Allow `std::vector<PostprocessorName>` to contain a mixture of actual `PostprocessorNames` and Reals.
