### PR TITLE
Improved error has caused the expected pattern to fail 

### DIFF
--- a/test/tests/materials/material/tests
+++ b/test/tests/materials/material/tests
@@ -66,7 +66,7 @@
   [mat_cyclic_dep_error_test]
     type = 'RunException'
     input = 'mat_cyclic_coupling.i'
-    expect_err = 'Cyclic dependency detected in object ordering:\nmat2 -> mat1'
+    expect_err = 'Cyclic dependency detected in object ordering:\nmat\d -> mat\d'
 
     requirement = "The system shall error if material property calculations result in a cyclic "
                   "dependency."


### PR DESCRIPTION
By adding in all the objects in the cyclic loop we sometimes get them out in a different order. I'm changing the expected pattern to handle different orderings.

refs #14467

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
