### PR TITLE
Add MONOMIAL_VEC support to MOOSE

### DIFF
--- a/framework/include/auxkernels/VectorVariableComponentAux.h
+++ b/framework/include/auxkernels/VectorVariableComponentAux.h
@@ -36,10 +36,12 @@ protected:
   virtual Real computeValue() override;
 
 private:
-  /// Reference to the value of the coupled vector variable
-  const RealVectorValue & _vector_variable_value;
+  /// Pointer to nodal variable value
+  const RealVectorValue * _nodal_variable_value;
+
+  /// Pointer to elemental variable value
+  const VectorVariableValue * _elemental_variable_value;
 
   /// Desired component
-  int _component;
+  const int _component;
 };
-

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -2028,17 +2028,6 @@ Assembly::feADGradPhiFace<RealVectorValue>(FEType type) const
 }
 
 template <>
-inline void
-Assembly::computeGradPhiAD<RealVectorValue>(
-    const Elem *,
-    unsigned int,
-    typename VariableTestGradientType<RealVectorValue, ComputeStage::JACOBIAN>::type &,
-    FEGenericBase<RealVectorValue> *)
-{
-  mooseError("Not implemented");
-}
-
-template <>
 inline const MooseArray<typename Moose::RealType<ComputeStage::JACOBIAN>::type> &
 Assembly::adCurvatures<ComputeStage::JACOBIAN>() const
 {

--- a/framework/src/actions/AddAuxVariableAction.C
+++ b/framework/src/actions/AddAuxVariableAction.C
@@ -25,7 +25,7 @@ AddAuxVariableAction::AddAuxVariableAction(InputParameters params) : AddVariable
 MooseEnum
 AddAuxVariableAction::getAuxVariableFamilies()
 {
-  return MooseEnum("LAGRANGE MONOMIAL SCALAR LAGRANGE_VEC", "LAGRANGE", true);
+  return MooseEnum("LAGRANGE MONOMIAL SCALAR LAGRANGE_VEC MONOMIAL_VEC", "LAGRANGE", true);
 }
 
 MooseEnum

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -67,7 +67,7 @@ MooseEnum
 AddVariableAction::getNonlinearVariableFamilies()
 {
   return MooseEnum("LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
-                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC",
+                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC",
                    "LAGRANGE");
 }
 
@@ -200,7 +200,8 @@ AddVariableAction::determineType(const FEType & fe_type, unsigned int components
 {
   if (components > 1)
   {
-    if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE)
+    if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE ||
+        fe_type.family == MONOMIAL_VEC)
       mooseError("Vector finite element families do not currently have ArrayVariable support");
     else
       return "ArrayMooseVariable";
@@ -209,7 +210,8 @@ AddVariableAction::determineType(const FEType & fe_type, unsigned int components
     return "MooseVariableConstMonomial";
   else if (fe_type.family == SCALAR)
     return "MooseVariableScalar";
-  else if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE)
+  else if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE ||
+           fe_type.family == MONOMIAL_VEC)
     return "VectorMooseVariable";
   else
     return "MooseVariable";

--- a/framework/src/auxkernels/VectorVariableComponentAux.C
+++ b/framework/src/auxkernels/VectorVariableComponentAux.C
@@ -28,17 +28,18 @@ VectorVariableComponentAux::validParams()
 
 VectorVariableComponentAux::VectorVariableComponentAux(const InputParameters & parameters)
   : AuxKernel(parameters),
-    _vector_variable_value(coupledNodalValue<RealVectorValue>("vector_variable")),
+    _nodal_variable_value(_nodal ? &coupledNodalValue<RealVectorValue>("vector_variable")
+                                 : nullptr),
+    _elemental_variable_value(_nodal ? nullptr : &coupledVectorValue("vector_variable")),
     _component(getParam<MooseEnum>("component"))
 {
-  if (!isNodal())
-    mooseError(
-        "VectorVariableComponentAux is meant to be used with LAGRANGE_VEC variables and so the "
-        "auxiliary variable should be nodal");
 }
 
 Real
 VectorVariableComponentAux::computeValue()
 {
-  return _vector_variable_value(_component);
+  if (_nodal)
+    return (*_nodal_variable_value)(_component);
+  else
+    return (*_elemental_variable_value)[_qp](_component);
 }

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -714,9 +714,9 @@ Assembly::computeGradPhiAD(
       for (decltype(num_shapes) i = 0; i < num_shapes; ++i)
         for (unsigned qp = 0; qp < n_qp; ++qp)
         {
-          grad_phi[i][qp](0) = dphidxi[i][qp] * _ad_dxidx_map[qp];
-          grad_phi[i][qp](1) = dphidxi[i][qp] * _ad_dxidy_map[qp];
-          grad_phi[i][qp](2) = dphidxi[i][qp] * _ad_dxidz_map[qp];
+          grad_phi[i][qp].slice(0) = dphidxi[i][qp] * _ad_dxidx_map[qp];
+          grad_phi[i][qp].slice(1) = dphidxi[i][qp] * _ad_dxidy_map[qp];
+          grad_phi[i][qp].slice(2) = dphidxi[i][qp] * _ad_dxidz_map[qp];
         }
       break;
     }
@@ -726,11 +726,11 @@ Assembly::computeGradPhiAD(
       for (decltype(num_shapes) i = 0; i < num_shapes; ++i)
         for (unsigned qp = 0; qp < n_qp; ++qp)
         {
-          grad_phi[i][qp](0) =
+          grad_phi[i][qp].slice(0) =
               dphidxi[i][qp] * _ad_dxidx_map[qp] + dphideta[i][qp] * _ad_detadx_map[qp];
-          grad_phi[i][qp](1) =
+          grad_phi[i][qp].slice(1) =
               dphidxi[i][qp] * _ad_dxidy_map[qp] + dphideta[i][qp] * _ad_detady_map[qp];
-          grad_phi[i][qp](2) =
+          grad_phi[i][qp].slice(2) =
               dphidxi[i][qp] * _ad_dxidz_map[qp] + dphideta[i][qp] * _ad_detadz_map[qp];
         }
       break;
@@ -741,15 +741,15 @@ Assembly::computeGradPhiAD(
       for (decltype(num_shapes) i = 0; i < num_shapes; ++i)
         for (unsigned qp = 0; qp < n_qp; ++qp)
         {
-          grad_phi[i][qp](0) = dphidxi[i][qp] * _ad_dxidx_map[qp] +
-                               dphideta[i][qp] * _ad_detadx_map[qp] +
-                               dphidzeta[i][qp] * _ad_dzetadx_map[qp];
-          grad_phi[i][qp](1) = dphidxi[i][qp] * _ad_dxidy_map[qp] +
-                               dphideta[i][qp] * _ad_detady_map[qp] +
-                               dphidzeta[i][qp] * _ad_dzetady_map[qp];
-          grad_phi[i][qp](2) = dphidxi[i][qp] * _ad_dxidz_map[qp] +
-                               dphideta[i][qp] * _ad_detadz_map[qp] +
-                               dphidzeta[i][qp] * _ad_dzetadz_map[qp];
+          grad_phi[i][qp].slice(0) = dphidxi[i][qp] * _ad_dxidx_map[qp] +
+                                     dphideta[i][qp] * _ad_detadx_map[qp] +
+                                     dphidzeta[i][qp] * _ad_dzetadx_map[qp];
+          grad_phi[i][qp].slice(1) = dphidxi[i][qp] * _ad_dxidy_map[qp] +
+                                     dphideta[i][qp] * _ad_detady_map[qp] +
+                                     dphidzeta[i][qp] * _ad_dzetady_map[qp];
+          grad_phi[i][qp].slice(2) = dphidxi[i][qp] * _ad_dxidz_map[qp] +
+                                     dphideta[i][qp] * _ad_detadz_map[qp] +
+                                     dphidzeta[i][qp] * _ad_dzetadz_map[qp];
         }
       break;
     }

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -368,15 +368,15 @@ Assembly::buildVectorFE(FEType type) const
   if (!_vector_fe_shape_data[type])
     _vector_fe_shape_data[type] = new VectorFEShapeData;
 
+  // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
-  if (type.family == LAGRANGE_VEC)
+  if (type.family == LAGRANGE_VEC || type.family == MONOMIAL_VEC)
     min_dim = 0;
   else
     min_dim = 2;
 
-  // Build an FE object for this type for each dimension up to the dimension of the current mesh
-  // Note that NEDELEC_ONE elements can only be built for dimension > 2. The for loop logic should
-  // be modified for LAGRANGE_VEC
+  // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
+  // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe[dim][type])
@@ -400,16 +400,15 @@ Assembly::buildVectorFaceFE(FEType type) const
   if (!_vector_fe_shape_data_face[type])
     _vector_fe_shape_data_face[type] = new VectorFEShapeData;
 
+  // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
-  if (type.family == LAGRANGE_VEC)
+  if (type.family == LAGRANGE_VEC || type.family == MONOMIAL_VEC)
     min_dim = 0;
   else
     min_dim = 2;
 
-  // Build an VectorFE object for this type for each dimension up to the dimension of the current
-  // mesh
-  // Note that NEDELEC_ONE elements can only be built for dimension > 2. The for loop logic should
-  // be modified for LAGRANGE_VEC
+  // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
+  // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_face[dim][type])
@@ -429,16 +428,15 @@ Assembly::buildVectorNeighborFE(FEType type) const
   if (!_vector_fe_shape_data_neighbor[type])
     _vector_fe_shape_data_neighbor[type] = new VectorFEShapeData;
 
+  // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
-  if (type.family == LAGRANGE_VEC)
+  if (type.family == LAGRANGE_VEC || type.family == MONOMIAL_VEC)
     min_dim = 0;
   else
     min_dim = 2;
 
-  // Build an VectorFE object for this type for each dimension up to the dimension of the current
-  // mesh
-  // Note that NEDELEC_ONE elements can only be built for dimension > 2. The for loop logic should
-  // be modified for LAGRANGE_VEC
+  // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
+  // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_neighbor[dim][type])
@@ -458,16 +456,15 @@ Assembly::buildVectorFaceNeighborFE(FEType type) const
   if (!_vector_fe_shape_data_face_neighbor[type])
     _vector_fe_shape_data_face_neighbor[type] = new VectorFEShapeData;
 
+  // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
-  if (type.family == LAGRANGE_VEC)
+  if (type.family == LAGRANGE_VEC || type.family == MONOMIAL_VEC)
     min_dim = 0;
   else
     min_dim = 2;
 
-  // Build an VectorFE object for this type for each dimension up to the dimension of the current
-  // mesh
-  // Note that NEDELEC_ONE elements can only be built for dimension > 2. The for loop logic should
-  // be modified for LAGRANGE_VEC
+  // Build an FE object for this type for each dimension from the min_dim up to the dimension of the
+  // current mesh
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_face_neighbor[dim][type])

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -397,9 +397,10 @@ AdvancedOutput::initAvailableLists()
         if (var.count() > 1)
           vname = SubProblem::arrayVariableComponent(var_name, i);
 
-        if (type.order == CONSTANT)
+        if (type.order == CONSTANT && type.family != MONOMIAL_VEC)
           _execute_data["elemental"].available.insert(vname);
-        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC)
+        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC ||
+                 type.family == MONOMIAL_VEC)
         {
           switch (_es_ptr->get_mesh().spatial_dimension())
           {
@@ -477,7 +478,8 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
 
         if (type.order == CONSTANT)
           _execute_data["elemental"].show.insert(vname);
-        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC)
+        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC ||
+                 type.family == MONOMIAL_VEC)
         {
           switch (_es_ptr->get_mesh().spatial_dimension())
           {
@@ -526,7 +528,8 @@ AdvancedOutput::initShowHideLists(const std::vector<VariableName> & show,
 
         if (type.order == CONSTANT)
           _execute_data["elemental"].hide.insert(vname);
-        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC)
+        else if (type.family == NEDELEC_ONE || type.family == LAGRANGE_VEC ||
+                 type.family == MONOMIAL_VEC)
         {
           switch (_es_ptr->get_mesh().spatial_dimension())
           {

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1990,7 +1990,7 @@ FEProblemBase::addVariable(const std::string & var_name,
     var_type = "MooseVariableConstMonomial";
   else if (type.family == SCALAR)
     var_type = "MooseVariableScalar";
-  else if (type.family == LAGRANGE_VEC || type.family == NEDELEC_ONE)
+  else if (type.family == LAGRANGE_VEC || type.family == NEDELEC_ONE || type.family == MONOMIAL_VEC)
     var_type = "VectorMooseVariable";
   else
     var_type = "MooseVariable";
@@ -2272,7 +2272,7 @@ FEProblemBase::addAuxVariable(const std::string & var_name,
     var_type = "MooseVariableConstMonomial";
   else if (type.family == SCALAR)
     var_type = "MooseVariableScalar";
-  else if (type.family == LAGRANGE_VEC || type.family == NEDELEC_ONE)
+  else if (type.family == LAGRANGE_VEC || type.family == NEDELEC_ONE || type.family == MONOMIAL_VEC)
     var_type = "VectorMooseVariable";
   else
     var_type = "MooseVariable";

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -196,13 +196,22 @@ AuxiliarySystem::addVariable(const std::string & var_type,
 
   for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
   {
-    if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE)
+    if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE ||
+        fe_type.family == MONOMIAL_VEC)
     {
       VectorMooseVariable * var = _vars[tid].getFieldVariable<RealVectorValue>(name);
       if (var)
       {
-        _nodal_vars[tid].push_back(var);
-        _nodal_vec_vars[tid].push_back(var);
+        if (var->feType().family == LAGRANGE_VEC)
+        {
+          _nodal_vars[tid].push_back(var);
+          _nodal_vec_vars[tid].push_back(var);
+        }
+        else
+        {
+          _elem_vars[tid].push_back(var);
+          _elem_vec_vars[tid].push_back(var);
+        }
       }
     }
 
@@ -361,10 +370,10 @@ AuxiliarySystem::compute(ExecFlagType type)
 
   if (_vars[0].fieldVariables().size() > 0)
   {
-    computeNodalVars(type);
     computeNodalVecVars(type);
-    computeElementalVars(type);
+    computeNodalVars(type);
     computeElementalVecVars(type);
+    computeElementalVars(type);
 
     // compute time derivatives of nodal aux variables _after_ the values were updated
     if (_fe_problem.dt() > 0. && _time_integrator)

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -635,7 +635,8 @@ SystemBase::addVariable(const std::string & var_type,
 
   if (var_type == "ArrayMooseVariable")
   {
-    if (fe_type.family == NEDELEC_ONE || fe_type.family == LAGRANGE_VEC)
+    if (fe_type.family == NEDELEC_ONE || fe_type.family == LAGRANGE_VEC ||
+        fe_type.family == MONOMIAL_VEC)
       mooseError("Vector family type cannot be used in an array variable");
 
     // Turn off automatic variable group identification so that we can be sure that this variable

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -416,6 +416,8 @@ stringify(FEFamily f)
       return "LAGRANGE_VEC";
     case 42:
       return "NEDELEC_ONE";
+    case 43:
+      return "MONOMIAL_VEC";
     case 99:
       return "INVALID_FE";
     default:

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -47,7 +47,7 @@ MooseVariableBase::validParams()
                              "orders not listed here are allowed, depending on the family).");
 
   MooseEnum family("LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
-                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC",
+                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC",
                    "LAGRANGE");
   params.addParam<MooseEnum>(
       "family", family, "Specifies the family of FE shape functions to use for this variable.");

--- a/framework/src/variables/MooseVariableData.C
+++ b/framework/src/variables/MooseVariableData.C
@@ -95,7 +95,8 @@ MooseVariableData<OutputType>::MooseVariableData(const MooseVariableFE<OutputTyp
 {
   // FIXME: continuity of FE type seems equivalent with the definition of nodal variables.
   //        Continuity does not depend on the FE dimension, so we just pass in a valid dimension.
-  if (_fe_type.family == NEDELEC_ONE || _fe_type.family == LAGRANGE_VEC)
+  if (_fe_type.family == NEDELEC_ONE || _fe_type.family == LAGRANGE_VEC ||
+      _fe_type.family == MONOMIAL_VEC)
     _continuity = _assembly.getVectorFE(_fe_type, _sys.mesh().dimension())->get_continuity();
   else
     _continuity = _assembly.getFE(_fe_type, _sys.mesh().dimension())->get_continuity();

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/include/auxkernels/DarcyVelocity.h
@@ -15,7 +15,7 @@
  * Auxiliary kernel responsible for computing the Darcy velocity given
  * several fluid properties and the pressure gradient.
  */
-class DarcyVelocity : public AuxKernel
+class DarcyVelocity : public VectorAuxKernel
 {
 public:
   static InputParameters validParams();
@@ -28,10 +28,7 @@ protected:
    * every quadrature point.  For Nodal Auxiliary variables those quadrature
    * points coincide with the nodes.
    */
-  virtual Real computeValue() override;
-
-  /// Will hold 0, 1, or 2 corresponding to x, y, or z.
-  const int _component;
+  virtual RealVectorValue computeValue() override;
 
   /// The gradient of a coupled variable
   const VariableGradient & _pressure_gradient;

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/problems/step4.i
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/problems/step4.i
@@ -23,6 +23,10 @@
     order = CONSTANT
     family = MONOMIAL
   []
+  [velocity]
+    order = CONSTANT
+    family = MONOMIAL_VEC
+  []
 []
 
 [Kernels]
@@ -33,26 +37,32 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
+    variable = velocity
+    execute_on = timestep_end
+    pressure = pressure
+  []
+  [velocity_x]
+    type = VectorVariableComponentAux
     variable = velocity_x
     component = x
     execute_on = timestep_end
-    pressure = pressure
+    vector_variable = velocity
   []
   [velocity_y]
-    type = DarcyVelocity
+    type = VectorVariableComponentAux
     variable = velocity_y
     component = y
     execute_on = timestep_end
-    pressure = pressure
+    vector_variable = velocity
   []
   [velocity_z]
-    type = DarcyVelocity
+    type = VectorVariableComponentAux
     variable = velocity_z
     component = z
     execute_on = timestep_end
-    pressure = pressure
+    vector_variable = velocity
   []
 []
 

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/src/auxkernels/DarcyVelocity.C
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/src/auxkernels/DarcyVelocity.C
@@ -14,15 +14,7 @@ registerMooseObject("DarcyThermoMechApp", DarcyVelocity);
 InputParameters
 DarcyVelocity::validParams()
 {
-  InputParameters params = AuxKernel::validParams();
-
-  // Declare the options for a MooseEnum.
-  // These options will be presented to the user in Peacock and if something other than these
-  // options is in the input file an error will be printed
-  MooseEnum component("x y z");
-
-  // Use the MooseEnum to add a parameter called "component"
-  params.addRequiredParam<MooseEnum>("component", component, "The desired component of velocity.");
+  InputParameters params = VectorAuxKernel::validParams();
 
   // Add a "coupling paramater" to get a variable from the input file.
   params.addRequiredCoupledVar("pressure", "The pressure field.");
@@ -31,10 +23,7 @@ DarcyVelocity::validParams()
 }
 
 DarcyVelocity::DarcyVelocity(const InputParameters & parameters)
-  : AuxKernel(parameters),
-
-    // Automatically convert the MooseEnum to an integer
-    _component(getParam<MooseEnum>("component")),
+  : VectorAuxKernel(parameters),
 
     // Get the gradient of the variable
     _pressure_gradient(coupledGradient("pressure")),
@@ -49,11 +38,11 @@ DarcyVelocity::DarcyVelocity(const InputParameters & parameters)
 {
 }
 
-Real
+RealVectorValue
 DarcyVelocity::computeValue()
 {
   // Access the gradient of the pressure at this quadrature point, then pull out the "component" of
   // it requested (x, y or z). Note, that getting a particular component of a gradient is done using
   // the parenthesis operator.
-  return -(_permeability[_qp] / _viscosity[_qp]) * _pressure_gradient[_qp](_component);
+  return -(_permeability[_qp] / _viscosity[_qp]) * _pressure_gradient[_qp];
 }

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/tests
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/tests
@@ -6,12 +6,13 @@
     input = 'velocity_aux.i'
     exodiff = 'velocity_aux_out.e'
     requirement = "The Darcy-Thermomechanics tutorial shall include method for computing the velocity based pressure using Darcy equation."
+    custom_cmp = 'velocity_aux.cmp'
   []
   [nodal_error]
     type = 'RunException'
     input = 'velocity_aux.i'
     cli_args = "AuxVariables/velocity_x/order=FIRST AuxVariables/velocity_x/family=LAGRANGE"
-    expect_err = "velocity_x: nodal variables do not have gradients"
+    expect_err = "velocity_x: cannot couple elemental variables into nodal objects"
     requirement = "The Darcy-Thermomechanics tutorial object for computing velocity shall error if computed at nodes."
   []
 []

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,16 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               1 @ t2
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	pressure    # min:               0 @ t1,n1	max:            2000 @ t1,n9
+
+ELEMENT VARIABLES relative 1.e-6 floor 0.0
+	velocity_x  # min:               0 @ t1,b0,e1	max:    0.0021180451 @ t2,b0,e4
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.i
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.i
@@ -15,15 +15,25 @@
     order = CONSTANT
     family = MONOMIAL
   []
+  [velocity]
+    order = CONSTANT
+    family = MONOMIAL_VEC
+  []
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
+    variable = velocity
+    execute_on = timestep_end
+    pressure = pressure
+  []
+  [velocity_x]
+    type = VectorVariableComponentAux
     variable = velocity_x
     component = x
     execute_on = timestep_end
-    pressure = pressure
+    vector_variable = velocity
   []
 []
 

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6a_coupled.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6a_coupled.i
@@ -16,17 +16,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -51,24 +43,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
@@ -16,17 +16,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -51,24 +43,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7a_coarse.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7a_coarse.i
@@ -16,17 +16,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -51,24 +43,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7b_fine.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7b_fine.i
@@ -17,17 +17,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -52,24 +44,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7c_adapt.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7c_adapt.i
@@ -17,17 +17,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -52,24 +44,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7d_adapt_blocks.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7d_adapt_blocks.i
@@ -27,17 +27,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -62,24 +54,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/problems/step8.i
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/problems/step8.i
@@ -17,17 +17,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -52,24 +44,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
@@ -30,17 +30,9 @@
 []
 
 [AuxVariables]
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -77,24 +69,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step09_mechanics/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/problems/step10.i
@@ -23,17 +23,9 @@
   [k_eff]
     initial_condition = 15.0 # water at 20C
   []
-  [velocity_x]
+  [velocity]
     order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_y]
-    order = CONSTANT
-    family = MONOMIAL
-  []
-  [velocity_z]
-    order = CONSTANT
-    family = MONOMIAL
+    family = MONOMIAL_VEC
   []
 []
 
@@ -70,24 +62,9 @@
 []
 
 [AuxKernels]
-  [velocity_x]
+  [velocity]
     type = DarcyVelocity
-    variable = velocity_x
-    component = x
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_y]
-    type = DarcyVelocity
-    variable = velocity_y
-    component = y
-    execute_on = timestep_end
-    pressure = pressure
-  []
-  [velocity_z]
-    type = DarcyVelocity
-    variable = velocity_z
-    component = z
+    variable = velocity
     execute_on = timestep_end
     pressure = pressure
   []

--- a/tutorials/darcy_thermo_mech/step10_multiapps/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp

--- a/tutorials/darcy_thermo_mech/step11_action/src/actions/SetupDarcySimulation.C
+++ b/tutorials/darcy_thermo_mech/step11_action/src/actions/SetupDarcySimulation.C
@@ -42,11 +42,6 @@ SetupDarcySimulation::SetupDarcySimulation(InputParameters parameters)
 void
 SetupDarcySimulation::act()
 {
-  // Helper variables
-  const std::string vel_x = "velocity_x";
-  const std::string vel_y = "velocity_y";
-  const std::string vel_z = "velocity_z";
-
   // Actual names of input variables
   const std::string pressure = getParam<VariableName>("pressure");
   const std::string temperature = getParam<VariableName>("temperature");
@@ -54,10 +49,11 @@ SetupDarcySimulation::act()
   // Velocity AuxVariables
   if (_compute_velocity && _current_task == "add_aux_variable")
   {
-    FEType fe_type(CONSTANT, MONOMIAL);
-    _problem->addAuxVariable(vel_x, fe_type);
-    _problem->addAuxVariable(vel_y, fe_type);
-    _problem->addAuxVariable(vel_z, fe_type);
+    InputParameters var_params = _factory.getValidParams("VectorMooseVariable");
+    var_params.set<MooseEnum>("family") = "MONOMIAL_VEC";
+    var_params.set<MooseEnum>("order") = "CONSTANT";
+
+    _problem->addAuxVariable("VectorMooseVariable", "velocity", var_params);
   }
 
   // Velocity AuxKernels
@@ -67,17 +63,8 @@ SetupDarcySimulation::act()
     params.set<ExecFlagEnum>("execute_on") = EXEC_TIMESTEP_END;
     params.set<std::vector<VariableName>>("pressure") = {pressure};
 
-    params.set<MooseEnum>("component") = "x";
-    params.set<AuxVariableName>("variable") = vel_x;
-    _problem->addAuxKernel("DarcyVelocity", vel_x, params);
-
-    params.set<MooseEnum>("component") = "y";
-    params.set<AuxVariableName>("variable") = vel_y;
-    _problem->addAuxKernel("DarcyVelocity", vel_y, params);
-
-    params.set<MooseEnum>("component") = "z";
-    params.set<AuxVariableName>("variable") = vel_z;
-    _problem->addAuxKernel("DarcyVelocity", vel_z, params);
+    params.set<AuxVariableName>("variable") = "velocity";
+    _problem->addAuxKernel("DarcyVelocity", "velocity", params);
   }
 
   // Kernels

--- a/tutorials/darcy_thermo_mech/step11_action/tests/auxkernels/velocity_aux/velocity_aux.cmp
+++ b/tutorials/darcy_thermo_mech/step11_action/tests/auxkernels/velocity_aux/velocity_aux.cmp
@@ -1,0 +1,1 @@
+../../../../step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.cmp


### PR DESCRIPTION
Also update the darcy mechanics tutorial to use MONOMIAL_VEC for the velocity variable. The only thing I don't like right now is that we can't write MONOMIAL_VEC as elemental data in exodus. See libmesh/libmesh#2381 for the ticket
