### PR TITLE
Fix for vec of PPs with default values

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1497,6 +1497,9 @@ template <>
 void InputParameters::setParamHelper<MaterialPropertyName, int>(const std::string & /*name*/,
                                                                 MaterialPropertyName & l_value,
                                                                 const int & r_value);
+template <>
+std::vector<PostprocessorName> &
+InputParameters::set<std::vector<PostprocessorName>>(const std::string & name, bool quiet_mode);
 
 template <typename T>
 const T &

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1032,6 +1032,26 @@ InputParameters::setParamHelper<MaterialPropertyName, int>(const std::string & /
 }
 
 template <>
+std::vector<PostprocessorName> &
+InputParameters::set<std::vector<PostprocessorName>>(const std::string & name, bool quiet_mode)
+{
+  checkParamName(name);
+  checkConsistentType<std::vector<PostprocessorName>>(name);
+
+  if (!this->have_parameter<std::vector<PostprocessorName>>(name))
+    _values[name] = new Parameter<std::vector<PostprocessorName>>;
+
+  set_attributes(name, false);
+
+  if (quiet_mode)
+    _params[name]._set_by_add_param = true;
+
+  _params[name]._vector_of_postprocessors = true;
+
+  return cast_ptr<Parameter<std::vector<PostprocessorName>> *>(_values[name])->set();
+}
+
+template <>
 const MooseEnum &
 InputParameters::getParamHelper<MooseEnum>(const std::string & name,
                                            const InputParameters & pars,


### PR DESCRIPTION
@permcody This removed the errors I got. The bug only showed up when standard vectors of PPs were set by actions. 

However, this fix prevents actions from providing default values to `std::vector<PostprocessName>` parameters, because the default values
are never properly sized/set. 

Suggestions on how to fix that are welcome.  
