### PR TITLE
Removing deprecated parameters in eigenvalue executioners

### DIFF
--- a/framework/include/executioners/NonlinearEigen.h
+++ b/framework/include/executioners/NonlinearEigen.h
@@ -39,13 +39,6 @@ protected:
   const Real & _l_tol;
   const Real & _free_l_tol;
 
-  // We will delete these three parameters once Rattlesnake is updated.
-  // These parameters are used in PicardEigen.C
-  //  _eigen_solve.passRequiredParams(_rel_tol, _abs_tol, _pfactor, _eigenvalue);
-  Real _abs_tol;
-  Real _rel_tol;
-  Real _pfactor;
-
   bool _output_pi;
   bool _output_after_pi;
   bool _last_solve_converged;

--- a/framework/src/executioners/InversePowerMethod.C
+++ b/framework/src/executioners/InversePowerMethod.C
@@ -27,10 +27,6 @@ InversePowerMethod::validParams()
   params.addParam<Real>("sol_check_tol",
                         std::numeric_limits<Real>::max(),
                         "Convergence tolerance on |x-x_previous| when provided");
-  params.addDeprecatedParam<Real>("pfactor",
-                                  1e-2,
-                                  "Reduce residual norm per power iteration by this factor",
-                                  "Please use l_tol instead");
   params.set<Real>("l_tol", true) = 1e-2;
   params.addParam<bool>(
       "Chebyshev_acceleration_on", true, "If Chebyshev acceleration is turned on");
@@ -44,8 +40,7 @@ InversePowerMethod::InversePowerMethod(const InputParameters & parameters)
     _max_iter(getParam<unsigned int>("max_power_iterations")),
     _eig_check_tol(getParam<Real>("eig_check_tol")),
     _sol_check_tol(getParam<Real>("sol_check_tol")),
-    _l_tol(parameters.isParamSetByUser("l_tol") ? getParam<Real>("l_tol")
-                                                : getParam<Real>("pfactor")),
+    _l_tol(getParam<Real>("l_tol")),
     _cheb_on(getParam<bool>("Chebyshev_acceleration_on"))
 {
   if (_max_iter < _min_iter)
@@ -53,7 +48,7 @@ InversePowerMethod::InversePowerMethod(const InputParameters & parameters)
   if (_eig_check_tol < 0.0)
     mooseError("eig_check_tol<0!");
   if (_l_tol < 0.0)
-    mooseError("pfactor<0!");
+    paramError("l_tol", "l_tol<0!");
 }
 
 void

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -18,22 +18,8 @@ NonlinearEigen::validParams()
 {
   InputParameters params = EigenExecutionerBase::validParams();
   params.addParam<unsigned int>("free_power_iterations", 4, "The number of free power iterations");
-  params.addDeprecatedParam<Real>("source_abs_tol",
-                                  1e-06,
-                                  "Absolute tolernance on residual norm",
-                                  "Please use nl_abs_tol instead");
   params.set<Real>("nl_abs_tol", true) = 1.0e-06;
-  params.addDeprecatedParam<Real>(
-      "source_rel_tol",
-      1e-50,
-      "Relative tolernance on residual norm after free power iterations",
-      "Please use nl_rel_tol instead");
   params.set<Real>("nl_rel_tol", true) = 1e-50;
-  params.addDeprecatedParam<Real>(
-      "pfactor",
-      1e-2,
-      "The factor of residual to be reduced per free power iteration or per nonlinear step",
-      "Please use l_tol");
   params.set<Real>("l_tol", true) = 1e-2;
   params.addParam<Real>("free_l_tol", 1e-2, "Relative linear tolerance in free power iteration");
   params.addParam<bool>(
@@ -44,18 +30,12 @@ NonlinearEigen::validParams()
 NonlinearEigen::NonlinearEigen(const InputParameters & parameters)
   : EigenExecutionerBase(parameters),
     _free_iter(getParam<unsigned int>("free_power_iterations")),
-    _nl_abs_tol(parameters.isParamSetByUser("nl_abs_tol") ? getParam<Real>("nl_abs_tol")
-                                                          : getParam<Real>("source_abs_tol")),
-    _nl_rel_tol(parameters.isParamSetByUser("nl_rel_tol") ? getParam<Real>("nl_rel_tol")
-                                                          : getParam<Real>("source_rel_tol")),
-    _l_tol(parameters.isParamSetByUser("l_tol") ? getParam<Real>("l_tol")
-                                                : getParam<Real>("pfactor")),
-    _free_l_tol(parameters.isParamSetByUser("free_l_tol") ? getParam<Real>("free_l_tol")
-                                                          : getParam<Real>("pfactor")),
+    _nl_abs_tol(getParam<Real>("nl_abs_tol")),
+    _nl_rel_tol(getParam<Real>("nl_rel_tol")),
+    _l_tol(getParam<Real>("l_tol")),
+    _free_l_tol(getParam<Real>("free_l_tol")),
     _output_after_pi(getParam<bool>("output_after_power_iterations"))
 {
-  // Delete these silly codes once Rattlesnake is updated
-  _abs_tol = _nl_abs_tol, _rel_tol = _nl_rel_tol, _pfactor = _l_tol;
 }
 
 void


### PR DESCRIPTION
Removes deprecated parameters mentioned in  #14398
