### PR TITLE
Add algebraic ghosting to all EquationSystems

### DIFF
--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -21,6 +21,7 @@ namespace libMesh
 template <typename>
 class VectorValue;
 typedef VectorValue<Real> RealVectorValue;
+class GhostingFunctor;
 }
 
 class MooseMesh;
@@ -649,6 +650,11 @@ public:
    * The coupling matrix defining what blocks exist in the preconditioning matrix
    */
   virtual const CouplingMatrix * couplingMatrix() const = 0;
+
+  /**
+   * Add an algebraic ghosting functor to this problem's DofMaps
+   */
+  void addAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool to_mesh = true);
 
 protected:
   /**

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1943,18 +1943,13 @@ MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType rm_type)
             rm->setDofMap(dof_map);
           }
           // If this rm is algebraic AND coupling, then in the case of the non-linear system there
-          // is no reason to add it to the DofMap twice. In the case of the aux system, it actually
-          // would be disastrous to add this rm because it's going to set a coupling matrix based on
-          // the non-linear system. So we don't add this rm to either system here if its also a
-          // coupling functor
+          // is no reason to add it to the DofMap twice. In the case of any other system, it
+          // actually would be disastrous to add this rm because it's going to set a coupling matrix
+          // based on the non-linear system. So we don't add this rm at all here if its also
+          // a coupling functor
           else if (rm_type == Moose::RelationshipManagerType::ALGEBRAIC &&
                    !rm->isType(Moose::RelationshipManagerType::COUPLING))
-          {
-            problem.getDisplacedProblem()->nlSys().dofMap().add_algebraic_ghosting_functor(
-                *rm, /*to_mesh = */ false);
-            problem.getDisplacedProblem()->auxSys().dofMap().add_algebraic_ghosting_functor(
-                *rm, /*to_mesh = */ false);
-          }
+            problem.getDisplacedProblem()->addAlgebraicGhostingFunctor(*rm, /*to_mesh = */ false);
         }
         else // undisplaced
         {
@@ -1965,18 +1960,13 @@ MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType rm_type)
             rm->setDofMap(dof_map);
           }
           // If this rm is algebraic AND coupling, then in the case of the non-linear system there
-          // is no reason to add it to the DofMap twice. In the case of the aux system, it actually
-          // would be disastrous to add this rm because it's going to set a coupling matrix based on
-          // the non-linear system. So we don't add this rm to either system here if its also a
-          // coupling functor
+          // is no reason to add it to the DofMap twice. In the case of any other system, it
+          // actually would be disastrous to add this rm because it's going to set a coupling matrix
+          // based on the non-linear system. So we don't add this rm at all here if its also
+          // a coupling functor
           else if (rm_type == Moose::RelationshipManagerType::ALGEBRAIC &&
                    !rm->isType(Moose::RelationshipManagerType::COUPLING))
-          {
-            problem.getNonlinearSystemBase().dofMap().add_algebraic_ghosting_functor(
-                *rm, /*to_mesh = */ false);
-            problem.getAuxiliarySystem().dofMap().add_algebraic_ghosting_functor(
-                *rm, /*to_mesh = */ false);
-          }
+            problem.addAlgebraicGhostingFunctor(*rm, /*to_mesh = */ false);
         }
       }
     }

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -18,6 +18,10 @@
 #include "SystemBase.h"
 #include "Assembly.h"
 
+#include "libmesh/equation_systems.h"
+#include "libmesh/system.h"
+#include "libmesh/dof_map.h"
+
 defineLegacyParams(SubProblem);
 
 InputParameters
@@ -763,4 +767,14 @@ void
 SubProblem::reinitMortarElem(const Elem * elem, THREAD_ID tid)
 {
   assembly(tid).reinitMortarElem(elem);
+}
+
+void
+SubProblem::addAlgebraicGhostingFunctor(GhostingFunctor & algebraic_gf, bool to_mesh)
+{
+  EquationSystems & eq = es();
+  auto n_sys = eq.n_systems();
+
+  for (MooseIndex(n_sys) i = 0; i < n_sys; ++i)
+    eq.get_system(i).get_dof_map().add_algebraic_ghosting_functor(algebraic_gf, to_mesh);
 }

--- a/test/include/problems/MooseTestProblem.h
+++ b/test/include/problems/MooseTestProblem.h
@@ -11,6 +11,8 @@
 
 #include "FEProblem.h"
 
+class AuxiliarySystem;
+
 /**
  * FEProblemBase derived class for customization of callbacks. In this instance we only print out
  * something in the c-tor and d-tor, so we know the class was build and used properly.
@@ -22,4 +24,7 @@ public:
 
   MooseTestProblem(const InputParameters & params);
   virtual ~MooseTestProblem();
+
+private:
+  std::shared_ptr<AuxiliarySystem> _test_aux;
 };

--- a/test/include/userobjects/AllSystemsEvaluable.h
+++ b/test/include/userobjects/AllSystemsEvaluable.h
@@ -1,0 +1,27 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralUserObject.h"
+
+// Forward Declarations
+class InputParameters;
+class AllSystemsEvaluable : public GeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  AllSystemsEvaluable(const InputParameters & parameters);
+
+  void initialize() override {}
+  void finalize() override {}
+
+  void execute() override;
+};

--- a/test/src/problems/MooseTestProblem.C
+++ b/test/src/problems/MooseTestProblem.C
@@ -8,6 +8,10 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "MooseTestProblem.h"
+#include "AuxiliarySystem.h"
+
+#include "libmesh/system.h"
+#include "libmesh/fe_type.h"
 
 registerMooseObject("MooseTestApp", MooseTestProblem);
 
@@ -23,6 +27,9 @@ MooseTestProblem::MooseTestProblem(const InputParameters & params) : FEProblem(p
   _console << "Hello, I am your FEProblemBase-derived class with coordinate type "
            << getParam<MultiMooseEnum>("coord_type") << " and my name is '" << this->name() << "'"
            << std::endl;
+
+  _test_aux = std::make_shared<AuxiliarySystem>(*this, "aux1");
+  _test_aux->system().add_variable("dummy", FEType());
 }
 
 MooseTestProblem::~MooseTestProblem() { _console << "Goodbye!" << std::endl; }

--- a/test/src/userobjects/AllSystemsEvaluable.C
+++ b/test/src/userobjects/AllSystemsEvaluable.C
@@ -1,0 +1,63 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "AllSystemsEvaluable.h"
+#include "SubProblem.h"
+#include "MooseMesh.h"
+
+#include "libmesh/mesh_base.h"
+#include "libmesh/elem.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/system.h"
+#include "libmesh/dof_map.h"
+#include "libmesh/numeric_vector.h"
+
+registerMooseObject("MooseTestApp", AllSystemsEvaluable);
+
+InputParameters
+AllSystemsEvaluable::validParams()
+{
+  auto params = GeneralUserObject::validParams();
+  params.addRelationshipManager("ElementSideNeighborLayers",
+                                Moose::RelationshipManagerType::GEOMETRIC |
+                                    Moose::RelationshipManagerType::ALGEBRAIC);
+  return params;
+}
+
+AllSystemsEvaluable::AllSystemsEvaluable(const InputParameters & parameters)
+  : GeneralUserObject(parameters)
+{
+}
+
+void
+AllSystemsEvaluable::execute()
+{
+  const MeshBase & mesh = _subproblem.mesh().getMesh();
+  const EquationSystems & eq = _subproblem.es();
+  auto n_sys = eq.n_systems();
+  std::vector<dof_id_type> dof_indices;
+  std::vector<Number> values;
+
+  for (const auto & elem : mesh.active_local_element_ptr_range())
+    for (const auto & neighbor : elem->neighbor_ptr_range())
+      // Are we non-local?
+      if (neighbor && neighbor->processor_id() != this->processor_id())
+        for (MooseIndex(n_sys) sys_num = 0; sys_num < n_sys; ++sys_num)
+        {
+          const System & system = eq.get_system(sys_num);
+          const DofMap & dof_map = system.get_dof_map();
+
+          auto n_vars = dof_map.n_variables();
+          for (MooseIndex(n_vars) var_num = 0; var_num < n_vars; ++var_num)
+          {
+            dof_map.dof_indices(neighbor, dof_indices, var_num);
+            system.current_local_solution->get(dof_indices, values);
+          }
+        }
+}

--- a/test/tests/relationship_managers/evaluable/all-systems-evaluable.i
+++ b/test/tests/relationship_managers/evaluable/all-systems-evaluable.i
@@ -1,0 +1,32 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 5
+  ny = 5
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[UserObjects]
+  [all_sys]
+    type = AllSystemsEvaluable
+    execute_on = 'initial'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = true
+[]
+
+[Problem]
+  type = MooseTestProblem
+  solve = false
+  kernel_coverage_check = false
+[]

--- a/test/tests/relationship_managers/evaluable/tests
+++ b/test/tests/relationship_managers/evaluable/tests
@@ -54,4 +54,9 @@
 
     requirement = "MOOSE shall ghost additional neighboring elements surrounding a partition when running in parallel with DistributedMesh with 3D"
   [../]
+  [all_systems_evaluable]
+    type = 'RunApp'
+    input = all-systems-evaluable.i
+    min_parallel = 2
+  []
 []


### PR DESCRIPTION
If an algebraic ghosting functor is requested by an object, we
add that functor to all Systems held by EquationSystems instead
of manually adding to the nonlinear System and auxiliary System.
This covers cases where users have more than the two traditional
Systems.

Closes #14536
