### PR TITLE
Salt properties Cp and Cv derivatives and missing AD functions

### DIFF
--- a/modules/fluid_properties/include/userobjects/FlibeFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/FlibeFluidProperties.h
@@ -52,6 +52,11 @@ public:
    * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
    */
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
+  virtual void p_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & p,
+                          DualReal & dp_dv,
+                          DualReal & dp_de) const override;
 
   /**
    * Temperature from specific volume and specific internal energy
@@ -72,8 +77,11 @@ public:
    * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
    */
   virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
-
-  using SinglePhaseFluidProperties::cp_from_v_e;
+  virtual void T_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & T,
+                          DualReal & dT_dv,
+                          DualReal & dT_de) const override;
 
   /**
    * Isobaric specific heat from specific volume and specific internal energy
@@ -84,7 +92,16 @@ public:
    */
   virtual Real cp_from_v_e(Real v, Real e) const override;
 
-  using SinglePhaseFluidProperties::cv_from_v_e;
+  /**
+   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cp     isobaric specific heat (J/kg.K)
+   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
+   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
+   */
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
 
   /**
    * Isochoric specific heat from specific volume and specific internal energy
@@ -94,6 +111,22 @@ public:
    * @return isochoric specific heat (J/kg.K)
    */
   virtual Real cv_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cv     isochoric specific heat (J/kg.K)
+   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
+   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
+   */
+  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+  virtual void cv_from_v_e(const DualReal & v,
+                           const DualReal & e,
+                           DualReal & cv,
+                           DualReal & dcv_dv,
+                           DualReal & dcv_de) const override;
 
   using SinglePhaseFluidProperties::mu_from_v_e;
 
@@ -137,6 +170,11 @@ public:
    */
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
 
   /**
    * Specific volume from pressure and temperature

--- a/modules/fluid_properties/include/userobjects/FlinakFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/FlinakFluidProperties.h
@@ -52,6 +52,11 @@ public:
    * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
    */
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
+  virtual void p_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & p,
+                          DualReal & dp_dv,
+                          DualReal & dp_de) const override;
 
   /**
    * Temperature from specific volume and specific internal energy
@@ -72,8 +77,11 @@ public:
    * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
    */
   virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
-
-  using SinglePhaseFluidProperties::cp_from_v_e;
+  virtual void T_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & T,
+                          DualReal & dT_dv,
+                          DualReal & dT_de) const override;
 
   /**
    * Isobaric specific heat from specific volume and specific internal energy
@@ -84,7 +92,16 @@ public:
    */
   virtual Real cp_from_v_e(Real v, Real e) const override;
 
-  using SinglePhaseFluidProperties::cv_from_v_e;
+  /**
+   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cp     isobaric specific heat (J/kg.K)
+   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
+   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
+   */
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
 
   /**
    * Isochoric specific heat from specific volume and specific internal energy
@@ -94,6 +111,22 @@ public:
    * @return isochoric specific heat (J/kg.K)
    */
   virtual Real cv_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cv     isochoric specific heat (J/kg.K)
+   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
+   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
+   */
+  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+  virtual void cv_from_v_e(const DualReal & v,
+                           const DualReal & e,
+                           DualReal & cv,
+                           DualReal & dcv_dv,
+                           DualReal & dcv_de) const override;
 
   using SinglePhaseFluidProperties::mu_from_v_e;
 
@@ -137,6 +170,11 @@ public:
    */
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & pressure,
+                            const DualReal & temperature,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
 
   /**
    * Specific volume from pressure and temperature

--- a/modules/fluid_properties/src/userobjects/FlibeFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/FlibeFluidProperties.C
@@ -72,6 +72,24 @@ FlibeFluidProperties::p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & 
   dp_dv = -dp_de * de_dv_at_constant_p;
 }
 
+void
+FlibeFluidProperties::p_from_v_e(
+    const DualReal & v, const DualReal & e, DualReal & p, DualReal & dp_dv, DualReal & dp_de) const
+{
+  p = SinglePhaseFluidProperties::p_from_v_e(v, e);
+
+  // chain rule, (dp_de)_v = (dp_dT)_v * (dT_de)_v
+  DualReal T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
+  dp_de = _dp_dT_at_constant_v * dT_de;
+
+  // cyclic relation, (dP_dv)_e = - (dp_de)_v * (de_dv)_p
+  auto cp = SinglePhaseFluidProperties::cp_from_v_e(v, e);
+  auto dT_dv_at_constant_p = -1.0 / (_drho_dT * v * v);
+  auto de_dv_at_constant_p = cp * dT_dv_at_constant_p - p;
+  dp_dv = -dp_de * de_dv_at_constant_p;
+}
+
 Real
 FlibeFluidProperties::T_from_v_e(Real v, Real e) const
 {
@@ -108,7 +126,32 @@ FlibeFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & 
   dT_dv = -dT_de * de_dv_at_constant_T;
 }
 
+void
+FlibeFluidProperties::T_from_v_e(
+    const DualReal & v, const DualReal & e, DualReal & T, DualReal & dT_dv, DualReal & dT_de) const
+{
+  T = SinglePhaseFluidProperties::T_from_v_e(v, e);
+
+  // reciprocity relation based on the definition of cv
+  auto cv = SinglePhaseFluidProperties::cv_from_v_e(v, e);
+  dT_de = 1.0 / cv;
+
+  // cyclic relation, (dT_dv)_e = -(dT_de)_v * (de_dv)_T
+  auto p = SinglePhaseFluidProperties::p_from_v_e(v, e);
+  auto dp_dv_at_constant_T = -1.0 / (_drho_dp * v * v);
+  auto de_dv_at_constant_T = -(p + v * dp_dv_at_constant_T);
+  dT_dv = -dT_de * de_dv_at_constant_T;
+}
+
 Real FlibeFluidProperties::cp_from_v_e(Real /*v*/, Real /*e*/) const { return _cp; }
+
+void
+FlibeFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
+{
+  cp = cp_from_v_e(v, e);
+  dcp_dv = 0.0;
+  dcp_de = 0.0;
+}
 
 Real
 FlibeFluidProperties::cv_from_v_e(Real v, Real e) const
@@ -116,6 +159,26 @@ FlibeFluidProperties::cv_from_v_e(Real v, Real e) const
   // definition of Cv by replacing e by h + p * v
   Real cp = cp_from_v_e(v, e);
   return cp - _dp_dT_at_constant_v * v;
+}
+
+void
+FlibeFluidProperties::cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const
+{
+  cv = cv_from_v_e(v, e);
+  dcv_dv = -_dp_dT_at_constant_v;
+  dcv_de = 0.0;
+}
+
+void
+FlibeFluidProperties::cv_from_v_e(const DualReal & v,
+                                  const DualReal & e,
+                                  DualReal & cv,
+                                  DualReal & dcv_dv,
+                                  DualReal & dcv_de) const
+{
+  cv = SinglePhaseFluidProperties::cv_from_v_e(v, e);
+  dcv_dv = -_dp_dT_at_constant_v;
+  dcv_de = 0.0;
 }
 
 Real
@@ -143,6 +206,18 @@ FlibeFluidProperties::rho_from_p_T(
     Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
   rho = rho_from_p_T(pressure, temperature);
+  drho_dp = _drho_dp;
+  drho_dT = _drho_dT;
+}
+
+void
+FlibeFluidProperties::rho_from_p_T(const DualReal & pressure,
+                                   const DualReal & temperature,
+                                   DualReal & rho,
+                                   DualReal & drho_dp,
+                                   DualReal & drho_dT) const
+{
+  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
   drho_dp = _drho_dp;
   drho_dT = _drho_dT;
 }

--- a/unit/src/FlibeFluidPropertiesTest.C
+++ b/unit/src/FlibeFluidPropertiesTest.C
@@ -67,10 +67,11 @@ TEST_F(FlibeFluidPropertiesTest, isobaricSpecificHeat)
   REL_TEST(_fp->cp_from_v_e(v, e), 2416.0, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_p_T(p, T), 2416.0, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**
- * Test that the isochoric specific heat is correctly computed.
+ * Test that the isochoric specific heat and its derivatives are correctly computed.
  */
 TEST_F(FlibeFluidPropertiesTest, isochoricSpecificHeat)
 {
@@ -80,6 +81,7 @@ TEST_F(FlibeFluidPropertiesTest, isochoricSpecificHeat)
   const Real v = 1. / _fp->rho_from_p_T(p, T);
 
   REL_TEST(_fp->cv_from_v_e(v, e), 1.0219369260016974e+03, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cv_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**

--- a/unit/src/FlinakFluidPropertiesTest.C
+++ b/unit/src/FlinakFluidPropertiesTest.C
@@ -67,10 +67,11 @@ TEST_F(FlinakFluidPropertiesTest, isobaricSpecificHeat)
   REL_TEST(_fp->cp_from_v_e(v, e), 2010.0, REL_TOL_SAVED_VALUE);
   REL_TEST(_fp->cp_from_p_T(p, T), 2010.0, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->cp_from_p_T, p, T, REL_TOL_DERIVATIVE);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**
- * Test that the isochoric specific heat is correctly computed.
+ * Test that the isochoric specific heat and its derivatives are correctly computed.
  */
 TEST_F(FlinakFluidPropertiesTest, isochoricSpecificHeat)
 {
@@ -80,6 +81,7 @@ TEST_F(FlinakFluidPropertiesTest, isochoricSpecificHeat)
   const Real v = 1. / _fp->rho_from_p_T(p, T);
 
   REL_TEST(_fp->cv_from_v_e(v, e), 45.55316141330309, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cv_from_v_e, v, e, REL_TOL_DERIVATIVE);
 }
 
 /**


### PR DESCRIPTION
Adds `Cp` and `Cv` derivatives with respect to `v` and `e` to flibe and flinak fluid properties, as well as `DualReal` versions of the `p_from_v_e`, `T_from_v_e`, and `rho_from_p_T` functions.

Refs #14565 

