### PR TITLE
Implements e_from_p_rho (including derivatives)

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealRealGasMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealRealGasMixtureFluidProperties.h
@@ -279,6 +279,35 @@ public:
                           std::vector<Real> & dv_dx) const;
 
   /**
+   * Specific internal energy from pressure and density
+   *
+   * @param[in] p   pressure
+   * @param[in] rho density
+   * @param[in] x   vapor mass fraction values
+   * @return        specific internal energy
+   */
+  virtual Real e_from_p_rho(Real p, Real rho, const std::vector<Real> & x) const override;
+
+  /**
+   * Specific internal energy and its derivatives from pressure and density
+   *
+   * @param[in] p   pressure
+   * @param[in] rho density
+   * @param[in] x   vapor mass fraction values
+   * @param[out] e       specific internal energy
+   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
+   * @param[out] de_drho derivative of specific internal energy w.r.t. density
+   * @param[out] de_dx   derivative of specific internal energy w.r.t. vapor mass fraction values
+   */
+  virtual void e_from_p_rho(Real p,
+                            Real rho,
+                            const std::vector<Real> & x,
+                            Real & e,
+                            Real & de_dp,
+                            Real & de_drho,
+                            std::vector<Real> & de_dx) const override;
+
+  /**
    * Pressure and temperature from specific volume and specific internal energy
    *
    * @param[in] v   specific volume
@@ -315,6 +344,35 @@ public:
                     Real & dT_dv,
                     Real & dT_de,
                     std::vector<Real> & dT_dx) const;
+
+  /**
+   * Temperature from pressure and specific volume
+   *
+   * @param[in] p   pressure
+   * @param[in] v   specific volume
+   * @param[in] x   vapor mass fraction values
+   * @return        temperature
+   */
+  Real T_from_p_v(Real p, Real v, const std::vector<Real> & x) const;
+
+  /**
+   * Temperature and its derivatives from pressure and specific volume
+   *
+   * @param[in] p   pressure
+   * @param[in] v   specific volume
+   * @param[in] x   vapor mass fraction values
+   * @param[out] T       temperature
+   * @param[out] dT_dp   derivative of temperature w.r.t. pressure
+   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
+   * @param[out] dT_dx   derivative of temperature w.r.t. vapor mass fraction values
+   */
+  void T_from_p_v(Real p,
+                  Real v,
+                  const std::vector<Real> & x,
+                  Real & T,
+                  Real & dT_dp,
+                  Real & dT_dv,
+                  std::vector<Real> & dT_dx) const;
 
   /**
    * Pressure from temperature and specific volume

--- a/modules/fluid_properties/include/userobjects/VaporMixtureFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/VaporMixtureFluidProperties.h
@@ -248,6 +248,35 @@ public:
   virtual Real k_from_p_T(Real p, Real T, const std::vector<Real> & x) const = 0;
 
   /**
+   * Specific internal energy from pressure and density
+   *
+   * @return        specific internal energy
+   * @param[in] p   pressure
+   * @param[in] rho density
+   * @param[in] x   vapor mass fraction values
+   */
+  virtual Real e_from_p_rho(Real p, Real rho, const std::vector<Real> & x) const = 0;
+
+  /**
+   * Specific internal energy and its derivatives from pressure and density
+   *
+   * @param[in] p   pressure
+   * @param[in] rho density
+   * @param[in] x   vapor mass fraction values
+   * @param[out] e       specific internal energy
+   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
+   * @param[out] de_drho derivative of specific internal energy w.r.t. density
+   * @param[out] de_dx   derivative of specific internal energy w.r.t. vapor mass fraction values
+   */
+  virtual void e_from_p_rho(Real p,
+                            Real rho,
+                            const std::vector<Real> & x,
+                            Real & e,
+                            Real & de_dp,
+                            Real & de_drho,
+                            std::vector<Real> & de_dx) const = 0;
+
+  /**
    * Computes the mass fraction of the primary vapor given mass fractions of the
    * secondary vapors.
    *

--- a/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
+++ b/unit/src/IdealRealGasMixtureFluidPropertiesTest.C
@@ -47,6 +47,14 @@ TEST_F(IdealRealGasMixtureFluidPropertiesTest, test)
   REL_TEST(p_mix, p, REL_TOL_CONSISTENCY);
   REL_TEST(T_mix, T, REL_TOL_CONSISTENCY);
 
+  // check T(p,v) and its derivatives
+  REL_TEST(T, _fp_mix->T_from_p_v(p, v_mix, x), REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->T_from_p_v, p, v_mix, x, REL_TOL_DERIVATIVE);
+
+  // check e(p,rho) and its derivatives
+  REL_TEST(e_mix, _fp_mix->e_from_p_rho(p, rho_mix, x), REL_TOL_CONSISTENCY);
+  VAPOR_MIX_DERIV_TEST(_fp_mix->e_from_p_rho, p, rho_mix, x, REL_TOL_DERIVATIVE);
+
   //////////////////////////////////////////////////////////////////////////////
   // note that the VAPOR_MIX_DERIV_TEST works for binary mixtures only (for now)
   //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This extension was requested for the implementation of BC with
prescribed outlet pressure for the mixture model implemented in
IdealRealGasMixtureFluidProperties.

Closes #14571
