### PR TITLE
Wrapup defaulted vec of pps

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -76,6 +76,10 @@ public:
    */
   virtual void set_attributes(const std::string & name, bool inserted_only) override;
 
+  /// This functions is called in set as a 'callback' to avoid code duplication
+  template <typename T>
+  void setHelper(const std::string & name);
+
   /**
    * Returns a writable reference to the named parameters.  Note: This is not a virtual
    * function! Use caution when comparing to the parent class implementation
@@ -971,6 +975,12 @@ private:
   friend class Parser;
 };
 
+template <typename T>
+void
+InputParameters::setHelper(const std::string & /*name*/)
+{
+}
+
 // Template and inline function implementations
 template <typename T>
 T &
@@ -986,6 +996,8 @@ InputParameters::set(const std::string & name, bool quiet_mode)
 
   if (quiet_mode)
     _params[name]._set_by_add_param = true;
+
+  setHelper<T>(name);
 
   return cast_ptr<Parameter<T> *>(_values[name])->set();
 }
@@ -1498,8 +1510,7 @@ void InputParameters::setParamHelper<MaterialPropertyName, int>(const std::strin
                                                                 MaterialPropertyName & l_value,
                                                                 const int & r_value);
 template <>
-std::vector<PostprocessorName> &
-InputParameters::set<std::vector<PostprocessorName>>(const std::string & name, bool quiet_mode);
+void InputParameters::setHelper<std::vector<PostprocessorName>>(const std::string & name);
 
 template <typename T>
 const T &

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1032,23 +1032,10 @@ InputParameters::setParamHelper<MaterialPropertyName, int>(const std::string & /
 }
 
 template <>
-std::vector<PostprocessorName> &
-InputParameters::set<std::vector<PostprocessorName>>(const std::string & name, bool quiet_mode)
+void
+InputParameters::setHelper<std::vector<PostprocessorName>>(const std::string & name)
 {
-  checkParamName(name);
-  checkConsistentType<std::vector<PostprocessorName>>(name);
-
-  if (!this->have_parameter<std::vector<PostprocessorName>>(name))
-    _values[name] = new Parameter<std::vector<PostprocessorName>>;
-
-  set_attributes(name, false);
-
-  if (quiet_mode)
-    _params[name]._set_by_add_param = true;
-
   _params[name]._vector_of_postprocessors = true;
-
-  return cast_ptr<Parameter<std::vector<PostprocessorName>> *>(_values[name])->set();
 }
 
 template <>

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -663,13 +663,32 @@ InputParameters::setDefaultPostprocessorValue(const std::string & name,
                                               const PostprocessorValue & value,
                                               unsigned int index)
 {
-  _params[name]._default_postprocessor_val[index] = value;
-  _params[name]._have_default_postprocessor_val[index] = true;
+  if (_params.at(name)._default_postprocessor_val.size() <= index)
+    mooseError("Attempting to access _default_postprocessor_val with index ",
+               index,
+               " but size is ",
+               _params.at(name)._default_postprocessor_val.size());
+  if (_params.at(name)._have_default_postprocessor_val.size() <= index)
+    mooseError("Attempting to access _have_default_postprocessor_val with index ",
+               index,
+               " but size is ",
+               _params.at(name)._have_default_postprocessor_val.size(),
+               ". This can be caused by trying to assign default postprocessor values "
+               "programmatically (by using set method).");
+  _params.at(name)._default_postprocessor_val[index] = value;
+  _params.at(name)._have_default_postprocessor_val[index] = true;
 }
 
 bool
 InputParameters::hasDefaultPostprocessorValue(const std::string & name, unsigned int index) const
 {
+  if (_params.at(name)._have_default_postprocessor_val.size() <= index)
+    mooseError("Attempting to access _have_default_postprocessor_val with index ",
+               index,
+               " but size is ",
+               _params.at(name)._have_default_postprocessor_val.size(),
+               ". This can be caused by trying to assign default postprocessor values "
+               "programmatically (by using set method).");
   return _params.count(name) > 0 && _params.at(name)._have_default_postprocessor_val[index];
 }
 

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -259,3 +259,32 @@ TEST(InputParameters, makeParamRequired)
         << "failed with unexpected error: " << msg;
   }
 }
+
+TEST(InputParameters, setPPandVofPP)
+{
+  // programmatically set default value of PPName parameter
+  InputParameters p1 = emptyInputParameters();
+  p1.addParam<std::vector<PostprocessorName>>("pp_name", "testing");
+  p1.set<std::vector<PostprocessorName>>("pp_name") = {"first", "second", "third"};
+
+  // check if we have a vector of pps
+  EXPECT_TRUE(!p1.isSinglePostprocessor("pp_name")) << "Failed to detect vector of PPs";
+
+  // check what happens if default value is requested
+  /*
+  try
+  {
+    p1.hasDefaultPostprocessorValue("pp_name", 2);
+    FAIL() << "failed to error on supression of nonexisting parameter";
+  }
+  catch (const std::exception & e)
+  {
+    std::string msg(e.what());
+    ASSERT_TRUE(msg.find("Attempting to access _have_default_postprocessor_val") !=
+  std::string::npos)
+        << "failed with unexpected error: " << msg;
+  }
+  */
+
+  // EXPECT_EQ(p1.getDefaultPostprocessorValue("pp_name"), 1);
+}


### PR DESCRIPTION
@permcody I want to address your comments about defaulted vectors of PPs in this PR.

The first commit should remove unwanted code duplication. 

The second commit shows that you cannot set PPs to default values programmatically. 
Do we want this capability? 

How would I set parameters by the parser in unit tests?
