### PR TITLE
Mark definition dump tests heavy for valigrind to avoid timeout

### DIFF
--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -214,7 +214,7 @@
     requirement = 'The system shall be able to dump a subset of input file (HIT) syntax.'
   [../]
 
-  [./definition_existsin_test]
+  [./definition_exists_in_test]
     type = 'RunApp'
     input = 'IGNORED'
     expect_out = 'ExistsIn=\[\s*?EXTRA:"all"\s*?EXTRA:"none"\s*?"../../../../../Outputs/["*"]/decl"\s*?\]'
@@ -225,6 +225,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ExistsIn'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'HEAVY'
   [../]
 
   [./definition_childatleastone_test]
@@ -238,6 +239,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ChildAtLeastOne'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_valenum_test]
@@ -251,6 +253,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ValEnums'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_active_parameter_test]
@@ -264,6 +267,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check active parameter'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_normal_sub_test]
@@ -277,6 +281,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check normal_sub'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_type_sub_test]
@@ -290,6 +295,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check type_sub'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_default_type_test]
@@ -303,6 +309,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check default type'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_minvalinc_inputdefault_test]
@@ -316,6 +323,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check MinValInc'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_expressions_are_okay_test]
@@ -329,6 +337,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ExpressionsAreOkay'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_block_type_maxoccurs_nolimit_test]
@@ -342,6 +351,7 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Block type MaxOccurs NoLimit'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_functionname_type_maxoccurs_nolimit_test]
@@ -355,6 +365,7 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check FunctionName type MaxOccurs NoLimit'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 
   [./definition_array_type_minoccurs_zero_test]
@@ -368,5 +379,6 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Array type MinOccurs zero'
     design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_exists_in_test"
   [../]
 []


### PR DESCRIPTION
(refs #14578)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
