### PR TITLE
Fix --failed-tests, Unittests

### DIFF
--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -298,8 +298,8 @@ class Job(object):
     def createStatus(self):
         return self.job_status.createStatus()
 
-    def previousTesterStatus(self, options, previous_results=None):
-        return self.__tester.previousTesterStatus(options, previous_results)
+    def previousTesterStatus(self, options, previous_storage=None):
+        return self.__tester.previousTesterStatus(options, previous_storage)
 
     def getStatusMessage(self):
         return self.__job_message

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -260,10 +260,10 @@ class RunApp(Tester):
 
             if reason != '':
                 self.setStatus(self.fail, str(reason))
-                reason += "\n\nExit Code: " + str(self.exit_code)
+                return "\n\nExit Code: " + str(self.exit_code)
 
         # Return anything extra here that we want to tack onto the Output for when it gets printed later
-        return reason
+        return ''
 
     def processResults(self, moose_dir, options, output):
         """

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -254,16 +254,16 @@ class RunApp(Tester):
             elif self.exit_code != 0 and specs['should_crash'] == False:
                 # Let's look at the error code to see if we can perhaps further split this out later with a post exam
                 reason = 'CRASH'
-                return "\n\nExit Code: " + str(self.exit_code)
             # Valgrind runs
             elif self.exit_code == 0 and self.shouldExecute() and options.valgrind_mode != '' and 'ERROR SUMMARY: 0 errors' not in output:
                 reason = 'MEMORY ERROR'
 
             if reason != '':
-                self.setStatus(self.fail, reason)
+                self.setStatus(self.fail, str(reason))
+                reason += "\n\nExit Code: " + str(self.exit_code)
 
         # Return anything extra here that we want to tack onto the Output for when it gets printed later
-        return ''
+        return reason
 
     def processResults(self, moose_dir, options, output):
         """

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -154,15 +154,15 @@ class Tester(MooseObject):
 
     # Return a tuple (status, message, caveats) for this tester as found
     # in the .previous_test_results.json file (or supplied json object)
-    def previousTesterStatus(self, options, previous_results=None):
-        if not previous_results:
-            previous_results = options.results_storage
+    def previousTesterStatus(self, options, previous_storage=None):
+        if not previous_storage:
+            previous_storage = options.results_storage
 
-        status_exists = previous_results.get(self.getTestDir(), {}).get(self.getTestName(), None)
+        status_exists = previous_storage.get(self.getTestDir(), {}).get(self.getTestName(), None)
         status = (self.test_status.createStatus(), '', '')
         if status_exists:
-            status = (self.test_status.createStatus(status_exists['STATUS'].encode('ascii', 'ignore')),
-                      status_exists['STATUS_MESSAGE'].encode('ascii', 'ignore'),
+            status = (self.test_status.createStatus(str(status_exists['STATUS'])),
+                      str(status_exists['STATUS_MESSAGE']),
                       status_exists['CAVEATS'])
         return (status)
 

--- a/python/TestHarness/tests/test_FailedTests.py
+++ b/python/TestHarness/tests/test_FailedTests.py
@@ -22,7 +22,7 @@ class TestHarnessTester(TestHarnessTestCase):
 
         e = cm.exception
 
-        self.assertNotIn(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
+        self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
         self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.always_bad.*?FAILED \(CODE 1\)')
 
         with self.assertRaises(subprocess.CalledProcessError) as cm:
@@ -30,5 +30,8 @@ class TestHarnessTester(TestHarnessTestCase):
 
         e = cm.exception
 
-        self.assertNotIn(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
+        # Verify the passing test is not present
+        self.assertNotRegex(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
+
+        # Verify the caveat represents a previous result
         self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.always_bad.*?\[PREVIOUS RESULTS: CODE 1\] FAILED \(CODE 1\)')

--- a/python/TestHarness/tests/test_FailedTests.py
+++ b/python/TestHarness/tests/test_FailedTests.py
@@ -1,0 +1,34 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testFailedTests(self):
+        """
+        In order to test for failed tests, we need to run run_tests twice. Once
+        to create a json file containing previous results, and again to only run
+        the test which that has failed.
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'always_bad', '--results-file', 'failed-unittest')
+
+        e = cm.exception
+
+        self.assertNotIn(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
+        self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.always_bad.*?FAILED \(CODE 1\)')
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '--failed-tests', '--results-file', 'failed-unittest')
+
+        e = cm.exception
+
+        self.assertNotIn(e.output.decode('utf-8'), r'tests/test_harness.always_ok.*?OK')
+        self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.always_bad.*?\[PREVIOUS RESULTS: CODE 1\] FAILED \(CODE 1\)')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -188,4 +188,10 @@
     requirement = "TestHarness shall detect and report unreadable output in executed commands"
     issues = '#14370'
   [../]
+  [./failed_tests]
+    type = PythonUnitTest
+    input = test_FailedTests.py
+    requirement = "TestHarness shall run only tests which previously has failed"
+    issues = '#14512'
+  [../]
 []

--- a/test/tests/test_harness/always_bad
+++ b/test/tests/test_harness/always_bad
@@ -1,0 +1,10 @@
+[Tests]
+  [./always_ok]
+    type = RunApp
+    input = good.i
+  [../]
+  [./always_bad]
+    type = RunCommand
+    command = "false"
+  [../]
+[]


### PR DESCRIPTION
Create unittest for --failed-tests. While doing so,
discovered a rather nasty bug:

Fix the potential for unittests to fail, and not reporting
it. We were returning error codes, but not setting the
status of the test

Allow TestHarness to use a different naming convention for
.previous_test_results.json. This was necessary to prevent
the many-failing-tests in unittests from clobbering the
results file during the crucial --failed-tests test.

Jeez... fix all the dumb naming conventions of results_file,
results_storage... was overly confusing with similarly named
variables. results_file is a file object. results_storage is
json object.

Closes #14512 #14575