### PR TITLE
Fix PATH issue in translator test

### DIFF
--- a/python/MooseDocs/test/base/test_translator.py
+++ b/python/MooseDocs/test/base/test_translator.py
@@ -22,7 +22,7 @@ class TestTranslator(unittest.TestCase):
 
     def setUp(self):
         command.CommandExtension.EXTENSION_COMMANDS.clear()
-        config = os.path.join('MooseDocs', 'test', 'config.yml')
+        config = os.path.join('..', 'config.yml')
         self.translator, _ = common.load_config(config)
         self.translator.init()
 


### PR DESCRIPTION
Not knowing much how MooseDocs testing works, it would seem the
current path is not correct when the test begins (CWD is in the
test directory, not MOOSE_DIR/python).

The proper method I think, would be to use the ABS path to the
config.yaml file. However, I am not sure how to obtain that within
the unittest (MOOSE_DIR/python/MooseDocs/test/config.yaml).

Closes #14588 
