### PR TITLE
Fix links and modify help

### DIFF
--- a/modules/doc/content/getting_started/index.md
+++ b/modules/doc/content/getting_started/index.md
@@ -62,6 +62,8 @@ make -j4
 If your application is working correctly, you should see one passing test. This indicates that
 your application is ready to be further developed.
 
+!include getting_started/installation/update_moose.md
+
 !include getting_started/installation/post_moose_install.md
 
 !include getting_started/installation/installation_troubleshooting.md

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -16,7 +16,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
   ```bash
   conda config --add channels conda-forge
-  conda config --add channels idaholab
+  conda config --add channels https://mooseframework.org/conda/moose
   ```
 
 - Install the moose-env package from Idaholab and name your environment 'moose':

--- a/modules/doc/content/getting_started/installation/install_moose.md
+++ b/modules/doc/content/getting_started/installation/install_moose.md
@@ -6,6 +6,4 @@
 
 !include getting_started/installation/test_moose.md
 
-!include getting_started/installation/update_moose.md
-
 Head back over to the [getting_started/index.md] page to continue your tour of MOOSE.


### PR DESCRIPTION
Move 'Update MOOSE' instructions to main page, just after instructing
the user how to use Stork, and ./run_tests. As what was there before
made no sense (update moose and your app, before we actually showed
them how to make an app).

Modify the link to our conda channel.

Closes #14601 

