### PR TITLE
Make benchmark.py Python3 usable

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -18,7 +18,7 @@ import tempfile
 import threading
 import resource
 
-from .Tester import Tester
+from TestHarness.testers.Tester import Tester
 
 def process_timeout(proc, timeout_sec):
   kill_proc = lambda p: p.kill()

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -389,6 +389,6 @@ def git_revision(dir='.'):
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         raise RuntimeError('failed to retrieve git revision')
-    commit = stdout.strip().split(' ')[0]
-    date = int(stdout.strip().split(' ')[1])
+    commit = str(stdout).strip().split(' ')[0]
+    date = int(str(stdout).strip().split(' ')[1])
     return commit, date

--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -18,7 +18,7 @@ import tempfile
 import threading
 import resource
 
-from Tester import Tester
+from .Tester import Tester
 
 def process_timeout(proc, timeout_sec):
   kill_proc = lambda p: p.kill()

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -31,7 +31,7 @@ os.environ['MOOSE_DIR'] = MOOSE_DIR
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 
-from TestHarness.testers.bench import *
+from TestHarness.testers.bench import DB
 import hit
 
 def find_moose_python():
@@ -326,4 +326,3 @@ def read_benchmarks(benchlist):
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -31,7 +31,7 @@ os.environ['MOOSE_DIR'] = MOOSE_DIR
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
 os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + os.path.join(MOOSE_DIR, 'python')
 
-from TestHarness.testers.bench import DB
+from TestHarness.testers.bench import *
 import hit
 
 def find_moose_python():

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -15,7 +15,7 @@ import os
 import os.path
 import sys
 import collections
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 
 # this is a hack to prevent matplotlib from trying to do interactive plot crap with e.g. Qt on
 # remote machines.  See:
@@ -211,8 +211,8 @@ def buildpage(fname, plotnames, db, psig, lastn=60, method='opt', baseurl='https
 
             t1 = datetime.datetime.fromtimestamp(t1).strftime(tformat)
             t2 = datetime.datetime.fromtimestamp(t2).strftime(tformat)
-            link1 = urlparse.urljoin(baseurl, rev1)
-            link2 = urlparse.urljoin(baseurl, rev2)
+            link1 = urljoin(baseurl, rev1)
+            link2 = urljoin(baseurl, rev2)
             c = Comp(rev1, rev2, t1, t2, link1, link2, s)
             comparisons.append(c)
 
@@ -225,8 +225,8 @@ def buildpage(fname, plotnames, db, psig, lastn=60, method='opt', baseurl='https
             s += '\n' + BenchComp.footer()
 
             t2 = datetime.datetime.fromtimestamp(t2).strftime(tformat)
-            link1 = urlparse.urljoin(baseurl, rev1)
-            link2 = urlparse.urljoin(baseurl, rev2)
+            link1 = urljoin(baseurl, rev1)
+            link2 = urljoin(baseurl, rev2)
             c = Comp(rev1, rev2, t1, t2, link1, link2, s)
             refcomparisons.append(c)
 
@@ -284,7 +284,7 @@ def plot(revisions, benchmarks, subdir='.', baseurl='https://github.com/idaholab
     ax = fig.axes[0]
     labels = ax.get_xticklabels()
     for label in labels:
-        label.set_url(urlparse.urljoin(baseurl, label.get_text()))
+        label.set_url(urljoin(baseurl, label.get_text()))
 
     legend = ax.legend(loc='upper right')
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -15,7 +15,7 @@ import os
 import os.path
 import sys
 import collections
-import urlparse
+from urllib.parse import urlparse
 
 # this is a hack to prevent matplotlib from trying to do interactive plot crap with e.g. Qt on
 # remote machines.  See:


### PR DESCRIPTION
There may be more issues with this. For now, fix the obvious.
urlparse is no longer avialable using pip. It is a built-in in
python3, under the urllib module.

Closes #14613
