### PR TITLE
Force parallel DiagonalMatrix even for single element cases

### DIFF
--- a/framework/include/systems/NonlinearSystem.h
+++ b/framework/include/systems/NonlinearSystem.h
@@ -106,4 +106,7 @@ private:
   void setupColoringFiniteDifferencedPreconditioner();
 
   bool _use_coloring_finite_difference;
+
+  /// Whether we've initialized the automatic scaling data structures
+  bool _auto_scaling_initd;
 };


### PR DESCRIPTION
BISON has a single element automatic scaling test case. In the guts of `PetscVector`, if `n_local == n_global` then the parallel type is set to `SERIAL`. In the single element case, one proc gets all the dofs and sets its vector type to `SERIAL` while the other sets it to `PARALLEL` which leads to a hang when the `PARALLEL` proc tries to communicate with the `SERIAL` proc. So here we force parallel.
