### PR TITLE
Update package manager installs to Python 3.

### DIFF
--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -2,7 +2,6 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-
 # Update package lists
 apt-get update -y
 
@@ -22,8 +21,8 @@ apt-get install -y \
   libcurl4-gnutls-dev \
   zlib1g-dev \
   libhwloc-dev \
-  python \
-  python-dev \
+  python3 \
+  python3-dev \
   cmake \
   curl \
   bison \
@@ -32,3 +31,6 @@ apt-get install -y \
 
 # Clear cache
 rm -rf /var/lib/apt/lists/*
+
+# Set Python 3 as the default interpreter
+update-alternatives --install /usr/bin/python python /usr/bin/python3 10

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Enable powertools if present
+PT_REPO=/etc/yum.repos.d/CentOS-PowerTools.repo
+if [ -f $PT_REPO ]; then
+  sed -i 's|^enabled=0|enabled=1|g' $PT_REPO
+fi
+
 # Update package lists
 yum update -y
 
@@ -17,7 +23,9 @@ yum install -y \
   blas-devel \
   lapack-devel \
   libX11-devel \
-  python-devel \
+  python3-devel \
+  python3 \
+  diffutils \
   wget \
   which \
   boost-devel \
@@ -28,3 +36,6 @@ yum install -y \
 # Clear cache
 yum clean all
 rm -rf /var/cache/yum/
+
+# Make symbolic link for invoking Python
+ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
* Changed package installs to Python 3 for `apt` and `yum`
* Set default Python interpreter to 3 via
  * `update-alternatives` for `apt`
  * Symbolic link for `yum`
* Tests run as they should for both distros, so closes #14656 
