### PR TITLE
Skip CIVET tests to avoid network traffic

### DIFF
--- a/python/MooseDocs/test/extensions/test_civet.py
+++ b/python/MooseDocs/test/extensions/test_civet.py
@@ -16,6 +16,7 @@ from MooseDocs.tree import pages
 from MooseDocs import base
 logging.basicConfig()
 
+@unittest.skip("Disabled to avoid excessive network access")
 class CivetTestCase(MooseDocsTestCase):
     def assertURL(self, node):
         url = node['url']


### PR DESCRIPTION
Restore the skipping of CIVET test that is causing problems due to network limitations.

see https://github.com/aeslaughter/moose/commit/6b844817011c624c4ab2e63db9f4a173963ab8da
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
