### PR TITLE
Mortar variables setup

### DIFF
--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -172,6 +172,7 @@ addActionTypes(Syntax & syntax)
   registerTask("add_aux_variable", false);
   registerTask("add_external_aux_variables", true);
   registerTask("add_variable", false);
+  registerTask("add_mortar_variable", false);
 
   registerTask("execute_mesh_modifiers", false);
   registerTask("execute_mesh_generators", true);
@@ -270,6 +271,7 @@ addActionTypes(Syntax & syntax)
                            "(init_displaced_problem)"
                            "(add_aux_variable, add_variable, add_elemental_field_variable,"
                            " add_external_aux_variables)"
+                           "(add_mortar_variable)"
                            "(setup_variable_complete)"
                            "(setup_quadrature)"
                            "(add_function)"

--- a/modules/combined/test/tests/contact/horizontal_blocks_mortar_TM.i
+++ b/modules/combined/test/tests/contact/horizontal_blocks_mortar_TM.i
@@ -1,0 +1,206 @@
+offset = 0.01
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+  volumetric_locking_correction = true
+[]
+
+[Mesh]
+  [./left_block]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = -1.0
+    xmax = 0.0
+    ymin = -0.5
+    ymax = 0.5
+    nx = 1
+    ny = 1
+    elem_type = QUAD4
+  [../]
+  [./left_block_sidesets]
+    type = RenameBoundaryGenerator
+    input = left_block
+    old_boundary_id = '0 1 2 3'
+    new_boundary_name = 'lb_bottom lb_right lb_top lb_left'
+  [../]
+  [./left_block_id]
+    type = SubdomainIDGenerator
+    input = left_block_sidesets
+    subdomain_id = 1
+  [../]
+
+  [./right_block]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0.0
+    xmax = 1.0
+    ymin = -0.6
+    ymax = 0.6
+    nx = 1
+    ny = 1
+    elem_type = QUAD4
+  [../]
+  [./right_block_id]
+    type = SubdomainIDGenerator
+    input = right_block
+    subdomain_id = 2
+  [../]
+
+  [./combined]
+    type = MeshCollectionGenerator
+    inputs = 'left_block_id right_block_id'
+  [../]
+  [./block_rename]
+    type = RenameBlockGenerator
+    input = combined
+    old_block_id = '1 2'
+    new_block_name = 'left_block right_block'
+  [../]
+  [./right_block_sidesets]
+    type = SideSetsFromPointsGenerator
+    input = block_rename
+    points = '0.5  -0.6  0
+              1.0   0    0
+              0.5  0.6   0
+              0     0    0'
+    new_boundary = 'rb_bottom rb_right rb_top rb_left'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    incremental = true
+    add_variables = true
+    block = '1 2'
+  [../]
+[]
+
+[Functions]
+  [./horizontal_movement]
+    type = ParsedFunction
+    value = t/10.0
+  [../]
+[]
+
+[BCs]
+  [./push_x]
+    type = FunctionDirichletBC
+    preset = true
+    variable = disp_x
+    boundary = lb_left
+    function = horizontal_movement
+  [../]
+  [./fix_x]
+    type = DirichletBC
+    preset = true
+    variable = disp_x
+    boundary = rb_right
+    value = 0.0
+  [../]
+  [./fix_y]
+    type = DirichletBC
+    preset = true
+    variable = disp_y
+    boundary = rb_right
+    value = 0.0
+  [../]
+  [./fix_y_offset]
+    type = DirichletBC
+    preset = true
+    variable = disp_y
+    boundary = lb_left
+    value = ${offset}
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor_left]
+    type = ComputeIsotropicElasticityTensor
+    block = left_block
+    youngs_modulus = 1.0e6
+    poissons_ratio = 0.3
+  [../]
+  [./stress_left]
+    type = ComputeFiniteStrainElasticStress
+    block = 1
+  [../]
+
+  [./elasticity_tensor_right]
+    type = ComputeIsotropicElasticityTensor
+    block = right_block
+    youngs_modulus = 1.0e6
+    poissons_ratio = 0.3
+  [../]
+  [./stress_right]
+    type = ComputeFiniteStrainElasticStress
+    block = right_block
+  [../]
+[]
+
+[Contact]
+  [./leftright]
+    disp_x = disp_x
+    disp_y = disp_y
+
+    mesh = right_block_sidesets
+    slave = lb_right
+    master = rb_left
+
+    model = frictionless
+    formulation = mortar
+    system = constraint
+
+    friction_coefficient = 0.0
+
+    normal_smoothing_distance = 0.1
+
+    penalty = 1e+8
+    normalize_penalty = true
+  [../]
+[]
+
+[ICs]
+  [./disp_x]
+    type = ConstantIC
+    block = left_block
+    variable = disp_x
+    value = -${offset}
+  [../]
+  [./disp_y]
+    block = left_block
+    variable = disp_y
+    value = ${offset}
+    type = ConstantIC
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-pc_type -mat_mffd_err -pc_factor_shift_type -pc_factor_shift_amount -snes_max_it'
+  petsc_options_value = 'lu       1e-5          NONZERO               1e-15                   20'
+
+  dt = 0.1
+  dtmin = 0.1
+  end_time = 0.1
+
+  l_tol = 1e-4
+  l_max_its = 100
+
+  nl_rel_tol = 1e-10
+  nl_abs_tol = 1e-6
+  nl_max_its = 100
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/combined/test/tests/contact/tests
+++ b/modules/combined/test/tests/contact/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#3418'
+  issues = '#3418 #14630'
   design = 'syntax/Contact/index.md MechanicalContactConstraint.md'
   [./pressureAugLag]
     type = 'Exodiff'
@@ -17,7 +17,7 @@
     exodiff = 'pressurePenalty_out.e'
     custom_cmp = 'pressure.exodiff'
     max_parallel = 1
-    requirement = 'The contact system shall reproduce contact pressure results among various formulation types. Penalty.'    
+    requirement = 'The contact system shall reproduce contact pressure results among various formulation types. Penalty.'
   [../]
 
   [./pressurePenalty_mechanical_constraint]
@@ -79,5 +79,10 @@
     petsc_version = '>=3.5.0'
     requirement = 'The contact system shall enforce and release contact conditions. 8 elements.'
 
+  [../]
+
+  [./horizontal_blocks_mortar_TM]
+    type = 'RunApp'
+    input = horizontal_blocks_mortar_TM.i
   [../]
 []

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -24,7 +24,9 @@ registerMooseAction("ContactApp", ContactAction, "add_aux_variable");
 registerMooseAction("ContactApp", ContactAction, "add_constraint"); // for mortar constraint
 registerMooseAction("ContactApp", ContactAction, "add_dirac_kernel");
 registerMooseAction("ContactApp", ContactAction, "add_mesh_generator"); // for mortar subdomains
-registerMooseAction("ContactApp", ContactAction, "add_variable"); // for mortar lagrange multiplier
+registerMooseAction("ContactApp",
+                    ContactAction,
+                    "add_mortar_variable"); // for mortar lagrange multiplier
 registerMooseAction("ContactApp", ContactAction, "output_penetration_info_vars");
 
 template <>
@@ -209,7 +211,7 @@ ContactAction::addMortarContact()
     }
   }
 
-  if (_current_task == "add_variable")
+  if (_current_task == "add_mortar_variable")
   {
     // Add the lagrange multiplier on the slave subdomain.
     const auto addLagrangeMultiplier =


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

- Issue description:
In the. add_variables task the contact action requires the displacement variables to be already set up to infer the order of the Mortar variables. However moose can't guarantee the action execution order within a given moose task. #14630 

- Development:
Created a new task, add_mortar_variable, in the mortar action to ensure that the Lagrange multipliers are created after the displacement variables being setup



