### PR TITLE
Move overzealous assert into nodal variable scope

### DIFF
--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -441,12 +441,13 @@ MooseVariableFE<OutputType>::getValue(const Elem * elem,
 {
   std::vector<dof_id_type> dof_indices;
   _dof_map.dof_indices(elem, dof_indices, _var_num);
-  mooseAssert(dof_indices.size() == phi.size(),
-              "The number of shapes does not match the number of dof indices on the elem");
 
   OutputType value = 0;
   if (isNodal())
   {
+    mooseAssert(dof_indices.size() == phi.size(),
+                "The number of shapes does not match the number of dof indices on the elem");
+
     for (unsigned int i = 0; i < dof_indices.size(); ++i)
     {
       // The zero index is because we only have one point that the phis are evaluated at


### PR DESCRIPTION
ref #14626 

An assert that was introduced the other day in a commit to address the referenced issue
was overzealous, and triggers failure in the BISON debug tests. This commit fixes that issue,
moving the assert to the correct place so that it only applies to nodal variables.
