### PR TITLE
Modify Conda install instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -24,7 +24,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 - Install the moose and moose-tools package from mooseframework.org, and name your environment 'moose':
 
   ```bash
-  conda create --name moose moose moose-tools
+  conda create --name moose moose-libmesh moose-tools
   ```
 
 - Activate the moose environment +(do this for any new terminal opened)+:

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -10,7 +10,9 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
 ## Install Conda id=installconda
 
-- [Install Miniconda or Anaconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (we recommend Miniconda)
+- [Install Miniconda or Anaconda for Python 3.x](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (we recommend Miniconda)
+
+  - +Catalina Users:+ It is recommended you +do not+ choose the pkg installation technique. Please download the 'bash' or 'command line' variant, as there appears to be issues installing the pkg version on Zsh enabled machines.
 
 - Configure Conda to work with conda-forge, and our Idaholab channel:
 
@@ -19,10 +21,10 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
   conda config --add channels https://mooseframework.org/conda/moose
   ```
 
-- Install the moose-env package from Idaholab and name your environment 'moose':
+- Install the moose and moose-tools package from mooseframework.org, and name your environment 'moose':
 
   ```bash
-  conda create --name moose moose-env
+  conda create --name moose moose moose-tools
   ```
 
 - Activate the moose environment +(do this for any new terminal opened)+:
@@ -35,7 +37,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
   You will have successfully activated the moose environment when you see 'moose' within your prompt.
 
-If you close, and then re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for every terminal you open. If you wish to make this automatic, you can append `conda activate moose` to your bash or zsh profile.
+If you close, and re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for each terminal you open. If you wish to make this automatic, you may append `conda activate moose` within your bash or zsh profile.
 
 The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
 
@@ -51,6 +53,13 @@ If you find yourself applying the use of `sudo` for any of the above conda comma
 
 !include getting_started/installation/test_moose.md
 
-!include getting_started/installation/update_moose.md
-
 Head back over to the [getting_started/index.md] page to continue your tour of MOOSE.
+
+## Uninstall Conda MOOSE Environment
+
+If you wish to remove the moose environment at any time, you may do so using the following commands:
+
+```bash
+conda deactivate   # if 'moose' was currently activated
+conda remove --name moose --all
+```


### PR DESCRIPTION
With the recent change to our conda package naming conventions, modify
the instructions to match.

Remove the bit about updating MOOSE (that is displayed when user continues
with the instructions).

Add a note about Catalina and Zsh conda installation issues.

Closes #14681