### PR TITLE
Full specialization before possible implicit instantiations

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "MooseArray.h"
 #include "MooseTypes.h"
 
-#include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/fe_type.h"

--- a/framework/include/interfaces/TaggingInterface.h
+++ b/framework/include/interfaces/TaggingInterface.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "MooseTypes.h"
 #include "MultiMooseEnum.h"
 
 #include "libmesh/dense_vector.h"
-#include "libmesh/dense_matrix.h"
 
 // Forward declarations
 class InputParameters;

--- a/framework/include/samplers/Sampler.h
+++ b/framework/include/samplers/Sampler.h
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include "libmesh/dense_matrix.h"
-
-// MOOSE includes
+#include "DenseMatrix.h"
 #include "MooseObject.h"
 #include "MooseRandom.h"
 #include "SetupInterface.h"

--- a/framework/include/utils/ColumnMajorMatrix.h
+++ b/framework/include/utils/ColumnMajorMatrix.h
@@ -9,13 +9,12 @@
 
 #pragma once
 
-// MOOSE includes
+#include "DenseMatrix.h"
 #include "Moose.h" // using namespace libMesh
 #include "MooseError.h"
 #include "DualReal.h"
 
 #include "libmesh/type_tensor.h"
-#include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 
 // C++ includes

--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "MooseError.h"
 #include "DualReal.h"
 #include "RankTwoTensor.h"
@@ -18,7 +19,6 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
-#include "libmesh/dense_matrix.h"
 
 #include "DualRealOps.h"
 

--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 // Moose
+#include "DenseMatrix.h"
 #include "FindContactPoint.h"
 #include "LineSegment.h"
 #include "PenetrationInfo.h"
@@ -18,7 +19,6 @@
 #include "libmesh/elem.h"
 #include "libmesh/plane.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/vector_value.h"

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -7,6 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "DenseMatrix.h"
 #include "MooseConfig.h"
 #include "MooseADWrapper.h"
 #include "DataIO.h"
@@ -16,7 +17,6 @@
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/dense_matrix.h"
 #include "libmesh/elem.h"
 
 #include "DualRealOps.h"

--- a/framework/src/utils/DenseMatrixDualReal.C
+++ b/framework/src/utils/DenseMatrixDualReal.C
@@ -7,6 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "DenseMatrix.h"
 #include "DualReal.h"
 #include "MooseError.h"
 

--- a/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
+++ b/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
@@ -9,9 +9,8 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "FeatureFloodCount.h"
-
-#include "libmesh/dense_matrix.h"
 
 // Forward Declarations
 class PolycrystalUserObjectBase;

--- a/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
+++ b/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
@@ -7,13 +7,12 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "DenseMatrix.h"
 #include "PolycrystalUserObjectBase.h"
 #include "NonlinearSystemBase.h"
 #include "MooseMesh.h"
 #include "MooseVariable.h"
 #include "TimedPrint.h"
-
-#include "libmesh/dense_matrix.h"
 
 #include <vector>
 #include <map>

--- a/modules/solid_mechanics/include/materials/AnisotropicElasticityTensor.h
+++ b/modules/solid_mechanics/include/materials/AnisotropicElasticityTensor.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "ElasticityTensor.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/vector_value.h"
-#include "libmesh/dense_matrix.h"
 #include "libmesh/mesh.h"
 
 /**
@@ -88,4 +88,3 @@ protected:
 
   virtual void calculateEntries(unsigned int qp);
 };
-

--- a/modules/tensor_mechanics/include/materials/ADComputeFiniteShellStrain.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeFiniteShellStrain.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "ADComputeIncrementalShellStrain.h"
-#include "libmesh/dense_matrix.h"
 
 #define usingComputeFiniteShellStrainMembers usingComputeIncrementalShellStrainMembers
 

--- a/modules/tensor_mechanics/include/materials/ADComputeIncrementalShellStrain.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeIncrementalShellStrain.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "ADMaterial.h"
-#include "libmesh/dense_matrix.h"
 
 #define usingComputeIncrementalShellStrainMembers                                                  \
   usingMaterialMembers;                                                                            \

--- a/modules/tensor_mechanics/include/materials/ComputeReducedOrderEigenstrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeReducedOrderEigenstrain.h
@@ -8,11 +8,11 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #pragma once
+#include "DenseMatrix.h"
 #include "ComputeEigenstrainBase.h"
 #include "RankTwoTensor.h"
 
 // libmesh includes
-#include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 
 class Assembly;

--- a/test/include/materials/TypesMaterial.h
+++ b/test/include/materials/TypesMaterial.h
@@ -9,9 +9,8 @@
 
 #pragma once
 
+#include "DenseMatrix.h"
 #include "Material.h"
-// libMesh
-#include "libmesh/dense_matrix.h"
 
 /**
  * Material for testing different types of material properties

--- a/test/src/materials/TypesMaterial.C
+++ b/test/src/materials/TypesMaterial.C
@@ -7,8 +7,8 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "DenseMatrix.h"
 #include "TypesMaterial.h"
-#include "libmesh/dense_matrix.h"
 
 registerMooseObject("MooseTestApp", TypesMaterial);
 


### PR DESCRIPTION
In any translation unit where DenseMatrix<DualReal>::DenseMatrix
might be implicitly instantiated we have to make sure that the full
specialization has been declared before that happens, otherwise
we risk the primary template being used.

Refs idaholab/conda-moose#38

