### PR TITLE
Faux PolycrystalVoronoi

### DIFF
--- a/modules/phase_field/doc/content/source/userobjects/FauxPolycrystalVoronoi.md
+++ b/modules/phase_field/doc/content/source/userobjects/FauxPolycrystalVoronoi.md
@@ -1,0 +1,16 @@
+# FauxPolycrystalVoronoi
+
+This is a special case of [PolycrystalVoronoi](PolycrystalVoronoi.md) when
+the number of grains equal to the number of order parameters. In this case,
+expensive [FeatureFloodCount](postprocessors/FeatureFloodCount.md) is avoided.
+
+
+## Description and Syntax
+
+!syntax description /Postprocessors/FauxPolycrystalVoronoi
+
+!syntax parameters /Postprocessors/FauxPolycrystalVoronoi
+
+!syntax inputs /Postprocessors/FauxPolycrystalVoronoi
+
+!syntax children /Postprocessors/FauxPolycrystalVoronoi

--- a/modules/phase_field/include/userobjects/FauxPolycrystalVoronoi.h
+++ b/modules/phase_field/include/userobjects/FauxPolycrystalVoronoi.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "PolycrystalVoronoi.h"
+
+// Forward Declarations
+class FauxPolycrystalVoronoi;
+
+class FauxPolycrystalVoronoi : public PolycrystalVoronoi
+{
+public:
+  static InputParameters validParams();
+
+  FauxPolycrystalVoronoi(const InputParameters & parameters);
+
+  /**
+   * We override all these functions to avoid calling FeatureFloodCount
+   * We know here is a one-to-one mapping between grain and variable
+   */
+  virtual void initialSetup() override;
+  virtual void initialize() override {}
+  virtual void execute() override;
+  virtual void finalize() override;
+};

--- a/modules/phase_field/include/userobjects/PolycrystalVoronoi.h
+++ b/modules/phase_field/include/userobjects/PolycrystalVoronoi.h
@@ -60,4 +60,3 @@ private:
                      const Point & cntr,
                      const unsigned int dim) const;
 };
-

--- a/modules/phase_field/src/userobjects/FauxPolycrystalVoronoi.C
+++ b/modules/phase_field/src/userobjects/FauxPolycrystalVoronoi.C
@@ -1,0 +1,69 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "FauxPolycrystalVoronoi.h"
+#include "IndirectSort.h"
+#include "MooseRandom.h"
+#include "MooseMesh.h"
+#include "MooseVariable.h"
+#include "NonlinearSystemBase.h"
+#include "DelimitedFileReader.h"
+
+registerMooseObject("PhaseFieldApp", FauxPolycrystalVoronoi);
+
+InputParameters
+FauxPolycrystalVoronoi::validParams()
+{
+  InputParameters params = PolycrystalVoronoi::validParams();
+  params.addClassDescription("Random Voronoi tessellation polycrystal when the number of order "
+                             "parameters equal to the number of grains");
+  return params;
+}
+
+FauxPolycrystalVoronoi::FauxPolycrystalVoronoi(const InputParameters & parameters)
+  : PolycrystalVoronoi(parameters)
+{
+  if (_grain_num != _op_num)
+    paramError("op_num", "The number of order parameters has to equal to the number of grains");
+}
+
+void
+FauxPolycrystalVoronoi::initialSetup()
+{
+  /**
+   * For polycrystal ICs we need to assume that each of the variables has the same periodicity.
+   * Since BCs are handled elsewhere in the system, we'll have to check this case explicitly.
+   */
+  if (_op_num < 1)
+    mooseError("No coupled variables found");
+
+  for (unsigned int dim = 0; dim < _dim; ++dim)
+  {
+    bool first_variable_value = _mesh.isTranslatedPeriodic(_vars[0]->number(), dim);
+
+    for (unsigned int i = 1; i < _vars.size(); ++i)
+      if (_mesh.isTranslatedPeriodic(_vars[i]->number(), dim) != first_variable_value)
+        mooseError("Coupled polycrystal variables differ in periodicity");
+  }
+}
+
+void
+FauxPolycrystalVoronoi::execute()
+{
+  precomputeGrainStructure();
+}
+
+void
+FauxPolycrystalVoronoi::finalize()
+{
+  _grain_to_op.resize(_grain_num);
+
+  for (auto grain = decltype(_grain_num)(0); grain < _grain_num; grain++)
+    _grain_to_op[grain] = grain;
+}

--- a/modules/phase_field/test/tests/grain_growth/tests
+++ b/modules/phase_field/test/tests/grain_growth/tests
@@ -92,6 +92,18 @@
     issues = '#8810'
   [../]
 
+  [./faux_voronoi]
+    type = 'Exodiff'
+    input = 'voronoi.i'
+    exodiff = 'voronoi_out.e'
+    prereq = 'voronoi'
+    requirement = 'The system shall support a faux voronoi tesselation grain structure IC without using FeatureFloodCount when
+                  the number of grains equal to the number of order parameters'
+    design = 'FauxPolycrystalVoronoi.md'
+    cli_args ='UserObjects/voronoi/type=PolycrystalVoronoi'
+    issues = '#14697'
+  [../]
+
   [./voronoi_columnar_3D]
     type = 'Exodiff'
     input = 'voronoi_columnar_3D.i'


### PR DESCRIPTION
When the number of grains equal to the number of order parameters, a faux PolycrystalVoronoi
is useful for avoiding calling unnecessary FeatureFloodCount

Close #14697

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
