### PR TITLE
Make are_queued_jobs_finished Python3 Compatible

### DIFF
--- a/scripts/are_queued_jobs_finished.py
+++ b/scripts/are_queued_jobs_finished.py
@@ -20,7 +20,7 @@ class Jobs:
             raise Exception('File does not exist: %s' % (json_file))
 
     def yieldJobsResultPath(self):
-        for k, v in self.__job_data.iteritems():
+        for k, v in self.__job_data.items():
             yield k, v
 
 def hasExited(meta):


### PR DESCRIPTION
This is just a simple replace for a removed dict method in python3

Refs #14714
