### PR TITLE
Do not use numpy

### DIFF
--- a/python/TestHarness/testers/CSVValidationTester.py
+++ b/python/TestHarness/testers/CSVValidationTester.py
@@ -13,7 +13,7 @@ from mooseutils.csvdiff import CSVTools
 from mooseutils import colorText
 import os
 import math
-import numpy as np
+import statistics
 
 def diff_files(gold_file, out_file, err_type='relative'):
     """
@@ -82,8 +82,8 @@ def diff_files(gold_file, out_file, err_type='relative'):
                 diff = val2 - val1
             a.append(diff)
 
-    mean = np.mean(a)
-    std = np.std(a)
+    mean = statistics.mean(a)
+    std = statistics.stdev(a)
     return (mean, std)
 
 


### PR DESCRIPTION
Use `statistics` module instead of `numpy` - as long as users have python 3.4,
the module is available. `numpy` may not be installed.

Refs #14511

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
