### PR TITLE
WIP: substepping attempts in ADLAROMANCE base class

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADLAROMANCEStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/ADLAROMANCEStressUpdateBase.h
@@ -222,8 +222,14 @@ protected:
   /// Flag to optinoally allow model extrapolation to zero stress
   const bool _extrapolate_stress;
 
-  /// Flag to output verbose infromation
+  /// Flag to output verbose information
   const bool _verbose;
+
+  /**
+   * Threshold measure for allowable distance from an estimated yield surface
+   * Used to estimate the number of substeps to apply
+   */
+  const Real _yield_surface_distance_threshold;
 
   ///@{Material properties for mobile (glissile) dislocation densities (1/m^2)
   ADMaterialProperty(Real) & _mobile_dislocations;

--- a/modules/tensor_mechanics/test/tests/rom_stress_update/3d_withsubsteppping.i
+++ b/modules/tensor_mechanics/test/tests/rom_stress_update/3d_withsubsteppping.i
@@ -1,0 +1,123 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 2
+  ny = 2
+  nz = 2
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[AuxVariables]
+  [./temperature]
+    initial_condition = 900.0
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'vonmises_stress'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./symmy]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0
+  [../]
+  [./symmx]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0
+  [../]
+  [./symmz]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = back
+    value = 0
+  [../]
+  [./pressure_x]
+    type = ADPressure
+    variable = disp_x
+    component = 0
+    boundary = right
+    constant = 1.0e5
+  [../]
+  [./pressure_y]
+    type = ADPressure
+    variable = disp_y
+    component = 1
+    boundary = top
+    constant = -1.0e5
+  [../]
+  [./pressure_z]
+    type = ADPressure
+    variable = disp_z
+    component = 2
+    boundary = front
+    constant = -1.0e5
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 3.30e11
+    poissons_ratio = 0.3
+  [../]
+  [./stress]
+    type = ADComputeMultipleInelasticStress
+    inelastic_models = rom_stress_prediction
+  [../]
+  [./rom_stress_prediction]
+    type = SS316HLAROMANCEStressUpdateTest
+    temperature = temperature
+    initial_mobile_dislocation_density = 6.0e12
+    initial_immobile_dislocation_density = 4.4e11
+    outputs = all
+    yield_surface_distance_threshold = 0.0012
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'NEWTON'
+
+  nl_abs_tol = 1e-12
+  automatic_scaling = true
+  compute_scaling_once = false
+
+  num_steps = 5
+[]
+
+[Postprocessors]
+  [./effective_strain_avg]
+    type = ElementAverageValue
+    variable = effective_creep_strain
+  [../]
+  [./temperature]
+    type = ElementAverageValue
+    variable = temperature
+  [../]
+  [./mobile_dislocations]
+    type = ElementAverageValue
+    variable = mobile_dislocations
+  [../]
+  [./immobile_disloactions]
+    type = ElementAverageValue
+    variable = immobile_dislocations
+  [../]
+[]
+
+[Outputs]
+  csv = true
+[]


### PR DESCRIPTION
First step introduction of sub-stepping into just the ADLAROMANCE model, around the call to the specific ROM constitutive model. This WIP demonstrates a couple of issues I'd like to ask for feedback on, @bwspenc :

  1. The effective inelastic strain calculated by the substepping is off by a fairly large amount from effective inelastic strain calculated without substepping. I've compared the cases with 3d.i and the new 3d_withsubstepping.i, which apply a constant 0.2MPa for the simulation. At each timestep, the relative error between the no substepping and with substepping cases is 0.0549e-2. This error is larger than I'd like to see, if possible; is there a better implementation to reduce this error?

  2.  The ROM depends on internal state variables (here mobile and immobile dislocations, but other radial return classes update material properties like the hardening variable in ADIsotropicPlasticity). What's a good way to handle the need to update these state variables within the substeps (e.g. a flag or a substep time increment to pass down)?


Refs #14757