### PR TITLE
Serialize All Tests

### DIFF
--- a/framework/doc/content/source/parser/Parser.md
+++ b/framework/doc/content/source/parser/Parser.md
@@ -5,7 +5,7 @@ and constructing the necessary [Actions](Action.md) that ultimately execute to b
 up the objects which compose a complete MOOSE based simulation. It is important to note
 that +this+ object is not responsible for the raw file-base I/O. The underlying
 structure of the MOOSE input file is dictated by HIT and information on the format
-can be found [here](input_syntax optional=True). The parser abstraction expects
+can be found [here](/application_usage/input_syntax.md optional=True). The parser abstraction expects
 information to be organized into a hierarchy of blocks with zero or more children
 at each level. All of the name/value pairs at each level are used to construct
 one or more complete objects.

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -359,6 +359,7 @@ class TestHarness:
         relative_hitpath = os.path.join(*params['hit_path'].split(os.sep)[2:])  # Trim root node "[Tests]"
         formatted_name = relative_path + '.' + relative_hitpath
 
+        params['spec_file'] = filename
         params['test_name'] = formatted_name
         params['test_dir'] = test_dir
         params['relative_path'] = relative_path

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -44,6 +44,8 @@ class Tester(MooseObject):
         params.addParam('tags',      [], "A list of strings")
         params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions. "
                                                  "If 'max_buffer_size' is not set, the default value of 'None' triggers a reasonable value (e.g. 100 kB)")
+        params.addParam('parallel_scheduling', False, "Allow all tests in test spec file to run in parallel (still follows prereq rules). Note: while rather unorthodox, "
+                                                      "setting parallel_scheduling to true in one test, will enable all tests in this spec file to be treated as such.")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -44,8 +44,7 @@ class Tester(MooseObject):
         params.addParam('tags',      [], "A list of strings")
         params.addParam('max_buffer_size', None, "Bytes allowed in stdout/stderr before it is subjected to being trimmed. Set to -1 to ignore output size restrictions. "
                                                  "If 'max_buffer_size' is not set, the default value of 'None' triggers a reasonable value (e.g. 100 kB)")
-        params.addParam('parallel_scheduling', False, "Allow all tests in test spec file to run in parallel (still follows prereq rules). Note: while rather unorthodox, "
-                                                      "setting parallel_scheduling to true in one test, will enable all tests in this spec file to be treated as such.")
+        params.addParam('parallel_scheduling', False, "Allow all tests in test spec file to run in parallel (adheres to prereq rules).")
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -1,6 +1,8 @@
 [Tests]
     design = 'TestHarness.md'
     issues = '#427'
+    parallel_scheduling = True
+
   [./long_running]
     type = PythonUnitTest
     input = test_LongRunning.py

--- a/test/tests/geomsearch/2d_moving_penetration/tests
+++ b/test/tests/geomsearch/2d_moving_penetration/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = ''
+  issues = '#852'
   design = 'source/auxkernels/PenetrationAux.md'
 
   [./pl_test1]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -1,5 +1,7 @@
 [Tests]
   design = 'Problem/index.md'
+  parallel_scheduling = True
+
   [./steady_no_converge]
     type = 'RunApp'
     input = 'steady_no_converge.i'

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -1,4 +1,6 @@
 [Tests]
+  parallel_scheduling = True
+
   [./nemesis_out_test]
     type = 'CheckFiles'
     input = 'output_test_nemesis.i'

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -1,6 +1,4 @@
 [Tests]
-  parallel_scheduling = True
-
   [./nemesis_out_test]
     type = 'CheckFiles'
     input = 'output_test_nemesis.i'

--- a/test/tests/test_harness/output_clobber_simple
+++ b/test/tests/test_harness/output_clobber_simple
@@ -1,4 +1,7 @@
 [Tests]
+  # Enable the parallel scheduler so this unitteset fails
+  parallel_scheduling = True
+
 [./testA]
   type = RunApp
   input = output_csv_and_exodus.i


### PR DESCRIPTION
The JobDAG class releases only one job at a time, unless otherwise
specified in the spec file, by the param: parallel_scheduling.

This effectively sandboxes all tests in the spec file.

There are now three modes of operation controlling the behavior of our
Scheduler:

1. By default, multiple tests within a test spec file will be run
serially. The Scheduler however, will launch multiple test spec files
simultaneously.

2. Multiple tests are run in parallel, if specified to do so by the
parallel_scheduling parameter:

```
[Tests]
  parallel_scheduling = True

  [some_test]
  [../]
  [another_test]
    prereq = some_test
  [../]
[]
```

3. If `--pedantic-checks` is enabled (which it is for all testing on
Civet), only those tests which fall in category 2, are verified for
race conditions.

In all scenarios, prereq is still honored. But as you can see by
category 1, you may wish to avoid using it, unless you really need it.

When a pedantic test is actually run, you will see [pedantic check] added to that test's list of caveats.

Closes #14745 #14739