### PR TITLE
Serialize write for MooseDocs

### DIFF
--- a/python/MooseDocs/base/executioners.py
+++ b/python/MooseDocs/base/executioners.py
@@ -324,7 +324,7 @@ class ParallelQueue(Executioner):
                   "Rendering")
 
         # WRITE
-        self._run(nodes, None, self._write_target, num_threads,
+        self._run(nodes, None, self._write_target, 1,
                   lambda n: -self._page_result[n.uid].count,
                   "Writing")
 


### PR DESCRIPTION
The documentation seems to be hanging on write on the test machines, this is just a quick attempt to fix it.

(refs #14606)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
