### PR TITLE
Anisotropic crack propagation along cleavage planes in crystalline materials

### DIFF
--- a/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_cleavage_plane.i
+++ b/modules/combined/test/tests/phase_field_fracture/crack2d_aniso_cleavage_plane.i
@@ -1,0 +1,198 @@
+#This input uses PhaseField-Nonconserved Action to add phase field fracture bulk rate kernels
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 20
+  ymax = 0.5
+[]
+
+[MeshModifiers]
+  [./noncrack]
+    type = BoundingBoxNodeSet
+    new_boundary = noncrack
+    bottom_left = '0.5 0 0'
+    top_right = '1 0 0'
+  [../]
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./c]
+    family = LAGRANGE
+    order = FIRST
+  [../]
+[]
+
+[Modules]
+  [./TensorMechanics]
+    [./Master]
+      [./All]
+        add_variables = true
+        strain = SMALL
+        additional_generate_output = 'strain_yy stress_yy'
+        planar_formulation = PLANE_STRAIN
+      [../]
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./ACbulk]
+    type = AllenCahn
+    variable = c
+    f_name = F
+  [../]
+  [./ACInterfaceBetaPenalty]
+    type = ACInterfaceBetaPenalty
+    variable = c
+    beta_penalty = 1
+    cleavage_plane_normal = '-0.707 0.707 0.0'
+  [../]
+  [./dcdt]
+    type = TimeDerivative
+    variable = c
+  [../]
+  [./solid_x]
+    type = PhaseFieldFractureMechanicsOffDiag
+    variable = disp_x
+    component = 0
+    c = c
+  [../]
+  [./solid_y]
+    type = PhaseFieldFractureMechanicsOffDiag
+    variable = disp_y
+    component = 1
+    c = c
+  [../]
+  [./off_disp]
+    type = AllenCahnElasticEnergyOffDiag
+    variable = c
+    displacements = 'disp_x disp_y'
+    mob_name = L
+  [../]
+[]
+
+[BCs]
+  [./ydisp]
+    type = FunctionPresetBC
+    variable = disp_y
+    boundary = top
+    function = 't'
+  [../]
+  [./yfix]
+    type = PresetBC
+    variable = disp_y
+    boundary = noncrack
+    value = 0
+  [../]
+  [./xfix]
+    type = PresetBC
+    variable = disp_x
+    boundary = right
+    value = 0
+  [../]
+[]
+
+[Materials]
+  [./pfbulkmat]
+    type = GenericConstantMaterial
+    prop_names = 'gc_prop l visco'
+    prop_values = '1e-3 0.05 1e-6'
+  [../]
+  [./elasticity_tensor]
+    type = ComputeElasticityTensor
+    C_ijkl = '127.0 70.8 70.8 127.0 70.8 127.0 73.55 73.55 73.55'
+    fill_method = symmetric9
+    euler_angle_1 = 30
+    euler_angle_2 = 0
+    euler_angle_3 = 0
+  [../]
+  [./define_mobility]
+    type = ParsedMaterial
+    material_property_names = 'gc_prop visco'
+    f_name = L
+    function = '1.0/(gc_prop * visco)'
+  [../]
+  [./define_kappa]
+    type = ParsedMaterial
+    material_property_names = 'gc_prop l'
+    f_name = kappa_op
+    function = 'gc_prop * l'
+  [../]
+  [./damage_stress]
+    type = ComputeLinearElasticPFFractureStress
+    c = c
+    E_name = 'elastic_energy'
+    D_name = 'degradation'
+    F_name = 'local_fracture_energy'
+    decomposition_type = stress_spectral
+    use_current_history_variable = true
+  [../]
+  [./degradation]
+    type = DerivativeParsedMaterial
+    f_name = degradation
+    args = 'c'
+    function = '(1.0-c)^2*(1.0 - eta) + eta'
+    constant_names       = 'eta'
+    constant_expressions = '1.0e-6'
+    derivative_order = 2
+  [../]
+  [./local_fracture_energy]
+    type = DerivativeParsedMaterial
+    f_name = local_fracture_energy
+    args = 'c'
+    material_property_names = 'gc_prop l'
+    function = 'c^2 * gc_prop / 2 / l'
+    derivative_order = 2
+  [../]
+  [./fracture_driving_energy]
+    type = DerivativeSumMaterial
+    args = c
+    sum_materials = 'elastic_energy local_fracture_energy'
+    derivative_order = 2
+    f_name = F
+  [../]
+[]
+
+[Postprocessors]
+  [./av_stress_yy]
+    type = ElementAverageValue
+    variable = stress_yy
+  [../]
+  [./av_strain_yy]
+    type = SideAverageValue
+    variable = disp_y
+    boundary = top
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_factor_mat_solving_package'
+  petsc_options_value = 'lu superlu_dist'
+
+  nl_rel_tol = 1e-8
+  l_tol = 1e-4
+  l_max_its = 100
+  nl_max_its = 10
+
+  dt = 5e-5
+  num_steps = 2
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/phase_field/doc/content/source/kernels/ACInterfaceBetaPenalty.md
+++ b/modules/phase_field/doc/content/source/kernels/ACInterfaceBetaPenalty.md
@@ -1,0 +1,42 @@
+# ACInterfaceBetaPenalty
+
+!syntax description /Kernels/ACInterfaceBetaPenalty
+
+Based on the ACInterface, this kernel implements an added term for
+anisotropic fracture along the cleavage plane. The added term is
+\begin{equation}
+\dfrac{\beta l_0}{2} \left( \bm{I} - \bm{n} \otimes \bm{n} \right) : \left( \nabla c \otimes \nabla c \right)
+\end{equation}
+
+Its weak form is
+
+\begin{equation}
+\left( - \beta l_0 \left( \nabla^2 c - \nabla c \otimes \nabla c : \nabla \nabla c \right) \right) \psi
+\end{equation}
+
+Simplified expression would be
+
+\begin{equation}
+\beta l_0 \left( - \psi \nabla^2 c + \psi \left( \bm{n} \otimes \bm{n} : \nabla \nabla c \right)
+\end{equation}
+
+where $\beta$ (`beta_penalty`) is the penalty parameter to prefer crack
+propagation along one cleavage plane as against other cleavage planes,
+$l_0$ is the characteristic length in phase field fracture model,
+$\bm{I}$ is the identity tensor,
+$\bm{n}$ (`cleavage_plane_normal`) is the normal to the weak cleavage plane
+$c$ is the phase field variable
+and $\psi$ is the test function.
+
+The expression for Jacobian would be
+
+\begin{equation}
+\beta l_0 \left( \nable \psi \cdot \nable \phi_j - \left( \bm{n} \cdot \nabla \psi \right) \left( \bm{n} \cdot \nabla \phi_j \right)
+\end{equation}
+
+
+!syntax parameters /Kernels/ACInterfaceBetaPenalty
+
+!syntax inputs /Kernels/ACInterfaceBetaPenalty
+
+!syntax children /Kernels/ACInterfaceBetaPenalty

--- a/modules/phase_field/include/kernels/ACInterfaceBetaPenalty.h
+++ b/modules/phase_field/include/kernels/ACInterfaceBetaPenalty.h
@@ -1,0 +1,85 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Kernel.h"
+#include "JvarMapInterface.h"
+#include "DerivativeMaterialInterface.h"
+
+class ACInterfaceBetaPenalty;
+
+template <>
+InputParameters validParams<ACInterfaceBetaPenalty>();
+
+/**
+ * Compute the Allen-Cahn interface term with the weak form residual
+ * \f$ \left( \kappa_i \nabla\eta_i, \nabla (L_i \psi) \right) \f$
+ */
+class ACInterfaceBetaPenalty : public DerivativeMaterialInterface<JvarMapKernelInterface<Kernel>>
+{
+public:
+  ACInterfaceBetaPenalty(const InputParameters & parameters);
+  virtual void initialSetup();
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+
+  RealGradient gradL();
+  RealGradient gradKappa();
+
+  /// the \f$ \nabla(L\psi) \f$ term
+  RealGradient nablaLPsi();
+
+  /// the \f$ \kappa\nabla(L\psi) \f$ term
+  RealGradient kappaNablaLPsi();
+
+  /// the Mcoupling term
+  Real betaNablaPsi();
+
+  /// Mobility
+  const MaterialProperty<Real> & _L;
+  /// Interfacial parameter
+  const MaterialProperty<Real> & _kappa;
+
+  /// flag set if L is a function of non-linear variables in args
+  const bool _variable_L;
+
+  /// @{ Mobility derivatives w.r.t. order parameter
+  const MaterialProperty<Real> & _dLdop;
+  const MaterialProperty<Real> & _d2Ldop2;
+  /// @}
+
+  /// kappa derivative w.r.t. order parameter
+  const MaterialProperty<Real> & _dkappadop;
+
+  /// number of coupled variables
+  const unsigned int _nvar;
+
+  /// @{ Mobility derivative w.r.t. other coupled variables
+  std::vector<const MaterialProperty<Real> *> _dLdarg;
+  std::vector<const MaterialProperty<Real> *> _d2Ldargdop;
+  std::vector<std::vector<const MaterialProperty<Real> *>> _d2Ldarg2;
+  /// @}
+
+  /// kappa derivative w.r.t. other coupled variables
+  std::vector<const MaterialProperty<Real> *> _dkappadarg;
+
+  /// Gradients for all coupled variables
+  std::vector<const VariableGradient *> _gradarg;
+
+private:
+  // penalty for damage on planes not normal to the favoured cleavage plane normal (Nguyen, 2017)
+  const Real _beta_penalty;
+
+  // normal to the favoured cleavage plane: M in (Nguyen, 2017)
+  const std::vector<Real> _cleavage_plane_normal;
+};

--- a/modules/phase_field/src/kernels/ACInterfaceBetaPenalty.C
+++ b/modules/phase_field/src/kernels/ACInterfaceBetaPenalty.C
@@ -1,0 +1,185 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ACInterfaceBetaPenalty.h"
+
+registerMooseObject("PhaseFieldApp", ACInterfaceBetaPenalty);
+
+template <>
+InputParameters
+validParams<ACInterfaceBetaPenalty>()
+{
+  InputParameters params = validParams<Kernel>();
+  params.addClassDescription("Gradient energy Allen-Cahn Kernel");
+  params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
+  params.addParam<MaterialPropertyName>("kappa_name", "kappa_op", "The kappa used with the kernel");
+  params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
+  params.addParam<bool>("variable_L",
+                        true,
+                        "The mobility is a function of any MOOSE variable (if "
+                        "this is set to false L must be constant over the "
+                        "entire domain!)");
+  params.addRequiredParam<Real>("beta_penalty","penalty for damage on planes not normal to z (Nguyen, 2017)");
+  params.addRequiredParam<std::vector<Real>>("cleavage_plane_normal","Normal to the favoured cleavage plane");
+  return params;
+}
+
+ACInterfaceBetaPenalty::ACInterfaceBetaPenalty(const InputParameters & parameters)
+  : DerivativeMaterialInterface<JvarMapKernelInterface<Kernel>>(parameters),
+    _L(getMaterialProperty<Real>("mob_name")),
+    _kappa(getMaterialProperty<Real>("kappa_name")),
+    _variable_L(getParam<bool>("variable_L")),
+    _dLdop(getMaterialPropertyDerivative<Real>("mob_name", _var.name())),
+    _d2Ldop2(getMaterialPropertyDerivative<Real>("mob_name", _var.name(), _var.name())),
+    _dkappadop(getMaterialPropertyDerivative<Real>("kappa_name", _var.name())),
+    _nvar(_coupled_moose_vars.size()),
+    _dLdarg(_nvar),
+    _d2Ldargdop(_nvar),
+    _d2Ldarg2(_nvar),
+    _dkappadarg(_nvar),
+    _gradarg(_nvar),
+    _beta_penalty(getParam<Real>("beta_penalty")),
+    _cleavage_plane_normal(getParam<std::vector<Real>>("cleavage_plane_normal"))
+{
+  // Get mobility and kappa derivatives and coupled variable gradients
+  for (unsigned int i = 0; i < _nvar; ++i)
+  {
+    MooseVariable * ivar = _coupled_standard_moose_vars[i];
+    const VariableName iname = ivar->name();
+    if (iname == _var.name())
+      paramError("args",
+                 "The kernel variable should not be specified in the coupled `args` parameter.");
+
+    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", iname);
+    _dkappadarg[i] = &getMaterialPropertyDerivative<Real>("kappa_name", iname);
+
+    _d2Ldargdop[i] = &getMaterialPropertyDerivative<Real>("mob_name", iname, _var.name());
+
+    _gradarg[i] = &(ivar->gradSln());
+
+    _d2Ldarg2[i].resize(_nvar);
+    for (unsigned int j = 0; j < _nvar; ++j)
+      _d2Ldarg2[i][j] =
+          &getMaterialPropertyDerivative<Real>("mob_name", iname, _coupled_moose_vars[j]->name());
+  }
+}
+
+void
+ACInterfaceBetaPenalty::initialSetup()
+{
+  validateCoupling<Real>("mob_name");
+  validateCoupling<Real>("kappa_name");
+}
+
+RealGradient
+ACInterfaceBetaPenalty::gradL()
+{
+  RealGradient g = _grad_u[_qp] * _dLdop[_qp];
+  for (unsigned int i = 0; i < _nvar; ++i)
+    g += (*_gradarg[i])[_qp] * (*_dLdarg[i])[_qp];
+  return g;
+}
+
+RealGradient
+ACInterfaceBetaPenalty::nablaLPsi()
+{
+  // sum is the product rule gradient \f$ \nabla (L\psi) \f$
+  RealGradient sum = _L[_qp] * _grad_test[_i][_qp];
+
+  if (_variable_L)
+    sum += gradL() * _test[_i][_qp];
+
+  return sum;
+}
+
+RealGradient
+ACInterfaceBetaPenalty::kappaNablaLPsi()
+{
+  return _kappa[_qp] * nablaLPsi();
+}
+
+Real
+ACInterfaceBetaPenalty::betaNablaPsi()
+{
+  Real ngradc;
+  ngradc = _grad_u[_qp](0) * _cleavage_plane_normal[0]
+         + _grad_u[_qp](1) * _cleavage_plane_normal[1]
+         + _grad_u[_qp](2) * _cleavage_plane_normal[2];
+
+  Real ngradpsi;
+  ngradpsi = _grad_test[_i][_qp](0) * _cleavage_plane_normal[0]
+           + _grad_test[_i][_qp](1) * _cleavage_plane_normal[1]
+           + _grad_test[_i][_qp](2) * _cleavage_plane_normal[2];
+
+  return _beta_penalty * _L[_qp] * _kappa[_qp] * ngradc * ngradpsi ;
+}
+
+Real
+ACInterfaceBetaPenalty::computeQpResidual()
+{
+  return (1+_beta_penalty) * _grad_u[_qp] * kappaNablaLPsi() - betaNablaPsi();
+}
+
+Real
+ACInterfaceBetaPenalty::computeQpJacobian()
+{
+  // dsum is the derivative \f$ \frac\partial{\partial \eta} \left( \nabla (L\psi) \right) \f$
+  RealGradient dsum =
+      (_dkappadop[_qp] * _L[_qp] + _kappa[_qp] * _dLdop[_qp]) * _phi[_j][_qp] * _grad_test[_i][_qp];
+
+  // compute the derivative of the gradient of the mobility
+  if (_variable_L)
+  {
+    RealGradient dgradL =
+        _grad_phi[_j][_qp] * _dLdop[_qp] + _grad_u[_qp] * _phi[_j][_qp] * _d2Ldop2[_qp];
+
+    for (unsigned int i = 0; i < _nvar; ++i)
+      dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[i])[_qp];
+
+    dsum += (_kappa[_qp] * dgradL + _dkappadop[_qp] * _phi[_j][_qp] * gradL()) * _test[_i][_qp];
+  }
+
+  Real ngradc;
+  ngradc = _grad_u[_qp](0) * _cleavage_plane_normal[0]
+         + _grad_u[_qp](1) * _cleavage_plane_normal[1]
+         + _grad_u[_qp](2) * _cleavage_plane_normal[2];
+
+  Real ngradphi;
+  ngradphi = _grad_phi[_j][_qp](0) * _cleavage_plane_normal[0]
+           + _grad_phi[_j][_qp](1) * _cleavage_plane_normal[1]
+           + _grad_phi[_j][_qp](2) * _cleavage_plane_normal[2];
+
+  return (1+_beta_penalty) * _grad_phi[_j][_qp] * kappaNablaLPsi() + _grad_u[_qp] * dsum
+          - _beta_penalty * _L[_qp] * _kappa[_qp] * ngradc * ngradphi;
+}
+
+Real
+ACInterfaceBetaPenalty::computeQpOffDiagJacobian(unsigned int jvar)
+{
+  // get the coupled variable jvar is referring to
+  const unsigned int cvar = mapJvarToCvar(jvar);
+
+  // dsum is the derivative \f$ \frac\partial{\partial \eta} \left( \nabla (L\psi) \right) \f$
+  RealGradient dsum = ((*_dkappadarg[cvar])[_qp] * _L[_qp] + _kappa[_qp] * (*_dLdarg[cvar])[_qp]) *
+                      _phi[_j][_qp] * _grad_test[_i][_qp];
+
+  // compute the derivative of the gradient of the mobility
+  if (_variable_L)
+  {
+    RealGradient dgradL = _grad_phi[_j][_qp] * (*_dLdarg[cvar])[_qp] +
+                          _grad_u[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[cvar])[_qp];
+
+    for (unsigned int i = 0; i < _nvar; ++i)
+      dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldarg2[cvar][i])[_qp];
+
+    dsum += (_kappa[_qp] * dgradL + _dkappadop[_qp] * _phi[_j][_qp] * gradL()) * _test[_i][_qp];
+  }
+
+  return _grad_u[_qp] * dsum;
+}


### PR DESCRIPTION
Enhancements - Considers anisotropic crack propagation along cleavage planes in crystalline materials
- Crack path is preferred along weak cleavage plane as compared to several other cleavage planes
- Can be used with the material anisotropic stiffness tensor

Issue # 14775

closes #14775

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
