### PR TITLE
Change default of emissivities to be consistent w/ BISON

### DIFF
--- a/modules/combined/test/tests/exception/ad.i
+++ b/modules/combined/test/tests/exception/ad.i
@@ -71,6 +71,8 @@
     variable = temp
     master = outer_interior
     slave = inner_surface
+    emissivity_master = 0
+    emissivity_slave = 0
     quadrature = true
   [../]
 []

--- a/modules/combined/test/tests/exception/nonad.i
+++ b/modules/combined/test/tests/exception/nonad.i
@@ -70,6 +70,8 @@
     variable = temp
     master = outer_interior
     slave = inner_surface
+    emissivity_master = 0
+    emissivity_slave = 0
     quadrature = true
   [../]
 []

--- a/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex.i
+++ b/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex.i
@@ -39,6 +39,8 @@
     variable = temp
     master = 2
     slave = 3
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex_sm.i
+++ b/modules/combined/test/tests/gap_heat_transfer_convex/gap_heat_transfer_convex_sm.i
@@ -36,6 +36,8 @@
     variable = temp
     master = 2
     slave = 3
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D.i
@@ -119,6 +119,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = CYLINDER

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_xz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_xz.i
@@ -79,6 +79,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = CYLINDER

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_yz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl2D_yz.i
@@ -79,6 +79,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = CYLINDER

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/cyl3D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/cyl3D.i
@@ -117,6 +117,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = CYLINDER

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_it_plot_test.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_it_plot_test.i
@@ -47,6 +47,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rspherical.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rspherical.i
@@ -54,6 +54,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_rz_test.i
@@ -71,12 +71,16 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
   [./thermal_contact2]
     type = GapHeatTransfer
     variable = temp2
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_geometry_type = PLATE
     appended_property_name = 2
   [../]

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_test.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/gap_heat_transfer_htonly_test.i
@@ -51,12 +51,16 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
   [./awesomium_contact]
     type = GapHeatTransfer
     variable = awesomium
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 10
     appended_property_name = _awesomium
   [../]

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xy.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xy.i
@@ -45,6 +45,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/planar_xz.i
@@ -52,6 +52,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/planar_yz.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/planar_yz.i
@@ -52,6 +52,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
   [../]
 []
 

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/sphere2DRZ.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/sphere2DRZ.i
@@ -122,6 +122,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = SPHERE

--- a/modules/combined/test/tests/gap_heat_transfer_htonly/sphere3D.i
+++ b/modules/combined/test/tests/gap_heat_transfer_htonly/sphere3D.i
@@ -116,6 +116,8 @@
     variable = temp
     master = 3
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1
     quadrature = true
     gap_geometry_type = SPHERE

--- a/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
+++ b/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
@@ -58,6 +58,8 @@
     variable = temp
     master = 4
     slave = 5
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 1e4
     quadrature = true
   [../]

--- a/modules/combined/test/tests/gap_heat_transfer_radiation/gap_heat_transfer_radiation_test.i
+++ b/modules/combined/test/tests/gap_heat_transfer_radiation/gap_heat_transfer_radiation_test.i
@@ -92,7 +92,6 @@
     variable = temp
     master = 3
     slave = 2
-
     gap_conductivity = 0.09187557
     emissivity_master = 0.5
     emissivity_slave = 0.5

--- a/modules/combined/test/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact.i
+++ b/modules/combined/test/tests/generalized_plane_strain_tm_contact/generalized_plane_strain_tm_contact.i
@@ -209,6 +209,8 @@
     type = GapHeatTransfer
     master = 8
     slave = 2
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     tangential_tolerance = .1
     normal_smoothing_distance = .1

--- a/modules/heat_conduction/src/materials/GapConductance.C
+++ b/modules/heat_conduction/src/materials/GapConductance.C
@@ -86,11 +86,11 @@ GapConductance::actionParameters()
   params.addParam<RealVectorValue>("sphere_origin", "Origin for sphere geometry");
 
   params.addRangeCheckedParam<Real>("emissivity_master",
-                                    0.0,
+                                    1,
                                     "emissivity_master>=0 & emissivity_master<=1",
                                     "The emissivity of the master surface");
   params.addRangeCheckedParam<Real>("emissivity_slave",
-                                    0.0,
+                                    1,
                                     "emissivity_slave>=0 & emissivity_slave<=1",
                                     "The emissivity of the slave surface");
   params.addDeprecatedParam<Real>("emissivity_1",

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/gap_conductivity_property.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/gap_conductivity_property.i
@@ -50,6 +50,8 @@
     slave = leftright
     quadrature = true
     master = rightleft
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     type = GapHeatTransfer
     gap_conductivity = 3.0

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/moving.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/moving.i
@@ -62,6 +62,8 @@
     slave = leftright
     quadrature = true
     master = rightleft
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     type = GapHeatTransfer
   [../]
@@ -107,4 +109,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/nonmatching.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/nonmatching.i
@@ -31,6 +31,8 @@
 
 [ThermalContact]
   [./left_to_right]
+    emissivity_master = 0
+    emissivity_slave = 0
     slave = leftright
     quadrature = true
     master = rightleft

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfect.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfect.i
@@ -34,6 +34,8 @@
     slave = leftright
     quadrature = true
     master = rightleft
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     type = GapHeatTransfer
   [../]

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfectQ8.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfectQ8.i
@@ -38,6 +38,8 @@
     slave = leftright
     quadrature = true
     master = rightleft
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     type = GapHeatTransfer
   [../]

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfectQ9.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/perfectQ9.i
@@ -38,6 +38,8 @@
     slave = leftright
     quadrature = true
     master = rightleft
+    emissivity_master = 0
+    emissivity_slave = 0
     variable = temp
     type = GapHeatTransfer
   [../]

--- a/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/second_order.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/2d_quadrature_gap_heat_transfer/second_order.i
@@ -33,6 +33,8 @@
 
 [ThermalContact]
   [./left_to_right]
+    emissivity_master = 0
+    emissivity_slave = 0
     slave = leftright
     quadrature = true
     master = rightleft
@@ -79,4 +81,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/moving.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/moving.i
@@ -65,6 +65,8 @@
     variable = temp
     master = rightleft
     slave = leftright
+    emissivity_master = 0
+    emissivity_slave = 0
     quadrature = true
   [../]
 []

--- a/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/nonmatching.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/nonmatching.i
@@ -35,6 +35,8 @@
     quadrature = true
     master = rightleft
     variable = temp
+    emissivity_master = 0
+    emissivity_slave = 0
     type = GapHeatTransfer
   [../]
 []
@@ -76,4 +78,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/second.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/3d_quadrature_gap_heat_transfer/second.i
@@ -37,6 +37,8 @@
     quadrature = true
     master = rightleft
     variable = temp
+    emissivity_master = 0
+    emissivity_slave = 0
     type = GapHeatTransfer
     order = SECOND
   [../]
@@ -79,4 +81,3 @@
 [Outputs]
   exodus = true
 []
-

--- a/modules/heat_conduction/test/tests/heat_conduction/min_gap/min_gap.i
+++ b/modules/heat_conduction/test/tests/heat_conduction/min_gap/min_gap.i
@@ -139,6 +139,8 @@
     variable = temp
     min_gap = 1
     min_gap_order = 1
+    emissivity_master = 0
+    emissivity_slave = 0
     type = GapHeatTransfer
   [../]
 []

--- a/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_annulus_thermal_contact.i
+++ b/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_annulus_thermal_contact.i
@@ -47,6 +47,8 @@
     variable = temp
     master = 2
     slave = 3
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 0.5
   [../]
 []

--- a/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_gap_thermal_contact.i
+++ b/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_gap_thermal_contact.i
@@ -48,6 +48,8 @@
     variable = temp
     master = 2
     slave = 3
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductivity = 0.5
   [../]
 []

--- a/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_gap_thermal_contact_constant_conductance.i
+++ b/modules/heat_conduction/test/tests/meshed_gap_thermal_contact/meshed_gap_thermal_contact_constant_conductance.i
@@ -48,6 +48,8 @@
     variable = temp
     master = 2
     slave = 3
+    emissivity_master = 0
+    emissivity_slave = 0
     gap_conductance = 2.5
   [../]
 []

--- a/modules/heat_conduction/test/tests/recover/ad_recover.i
+++ b/modules/heat_conduction/test/tests/recover/ad_recover.i
@@ -44,6 +44,8 @@
     variable = temp
     master = 5
     slave = 10
+    emissivity_master = 0
+    emissivity_slave = 0
     quadrature = true
   [../]
 []

--- a/modules/heat_conduction/test/tests/recover/recover.i
+++ b/modules/heat_conduction/test/tests/recover/recover.i
@@ -44,6 +44,8 @@
     variable = temp
     master = 5
     slave = 10
+    emissivity_master = 0
+    emissivity_slave = 0
     quadrature = true
   [../]
 []


### PR DESCRIPTION
The recent naming changes in emissivities cause a conflict of defaults between BISON `GapConductanceLWR` and heat conduction `GapConductance` materials. BISON's default is 1, while the module's default is 0. This needs to be consistent. I opted to retain BISON's default
because more users may use their models. 