### PR TITLE
Allow setting more font options

### DIFF
--- a/python/chigger/exodus/LabelExodusSource.py
+++ b/python/chigger/exodus/LabelExodusSource.py
@@ -33,6 +33,8 @@ class LabelExodusSource(base.ChiggerSource2D):
                 allow=['point', 'cell', 'variable'])
         opt.setDefault('justification', 'center')
         opt.setDefault('vertical_justification', 'middle')
+        opt.setDefault('italic', True)
+        opt.setDefault('bold', True)
         return opt
 
     def __init__(self, exodus_source, **kwargs):

--- a/python/chigger/utils/FontOptions.py
+++ b/python/chigger/utils/FontOptions.py
@@ -24,6 +24,9 @@ def get_options():
     opt.add('text_opacity', 1, "The text opacity.", vtype=float)
     opt.add('text', None, "The text to display.", vtype=str)
     opt.add('font_size', 24, "The text font size.", vtype=int)
+    opt.add('font_family', None, "The font family.", vtype=str)
+    opt.add('bold', False, "Enable/disable text bolding.", vtype=bool)
+    opt.add('italic', False, "Enable/disable text italic.", vtype=bool)
     return opt
 
 
@@ -53,5 +56,14 @@ def set_options(tprop, options):
     if options.isOptionValid('text_opacity'):
         tprop.SetOpacity(options['text_opacity'])
 
+    if options.isOptionValid('font_family'):
+        tprop.SetFontFamilyAsString(options['font_family'])
+
     if options.isOptionValid('font_size'):
         tprop.SetFontSize(options['font_size'])
+
+    if options.isOptionValid('bold'):
+        tprop.SetBold(options['bold'])
+
+    if options.isOptionValid('italic'):
+        tprop.SetItalic(options['italic'])


### PR DESCRIPTION
Allow users to set:
- bold type
- italic type
- font family ('Arial', 'Times' and 'Courier')

refs #8771

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
