### PR TITLE
Ensure that neighbor is init'd before interface stateful props

### DIFF
--- a/test/src/materials/InterfaceValueMaterial.C
+++ b/test/src/materials/InterfaceValueMaterial.C
@@ -93,6 +93,7 @@ InterfaceValueMaterial::InterfaceValueMaterial(const InputParameters & parameter
 void
 InterfaceValueMaterial::computeQpProperties()
 {
+  mooseAssert(_neighbor_elem, "Neighbor elem is NULL!");
   mooseAssert(_mp_master[_qp] == _var_master[_qp],
               "the material property and variable values on the master side do not coincide.");
   mooseAssert(_mp_slave[_qp] == _var_slave[_qp],
@@ -118,6 +119,7 @@ InterfaceValueMaterial::computeQpProperties()
 void
 InterfaceValueMaterial::initQpStatefulProperties()
 {
+  mooseAssert(_neighbor_elem, "Neighbor elem is NULL!");
   _interface_value[_qp] = 0;
   _interface_value_2[_qp] = 0;
 }


### PR DESCRIPTION
Previously we had not reinit'd the neighbor before calling
InterfaceMaterial::initStatefulProperties, leading to a nullptr
in _neighbor_elem. Thanks to @arovinelli for catching this

Closes #14770

