### PR TITLE
An empty PR to check recipe: modules parallel petsc submodule

### DIFF
--- a/test/tests/partitioners/petsc_partitioner/petsc_partitioner.i
+++ b/test/tests/partitioners/petsc_partitioner/petsc_partitioner.i
@@ -12,6 +12,7 @@
   uniform_refine = 1
 []
 
+
 [Variables]
   [u]
   []


### PR DESCRIPTION
I wish we had a right to check recipe before it gets in

Refs #0000

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
