### PR TITLE
Small modules and stork documentation fixes

### DIFF
--- a/modules/doc/config.yml
+++ b/modules/doc/config.yml
@@ -38,6 +38,7 @@ Extensions:
     MooseDocs.extensions.bibtex:
         duplicates:
             - kim_phase-field_1999 # referenced in both Tensor Mechanics and Phase Field
+            - hales15homogenization # referenced in both Tensor Mechanics and Heat Conduction
     MooseDocs.extensions.katex:
         macros:
             \pf: "\\frac{\\partial #1}{\\partial #2}"

--- a/modules/tensor_mechanics/doc/config.yml
+++ b/modules/tensor_mechanics/doc/config.yml
@@ -30,6 +30,3 @@ Extensions:
         categories:
             framework: !include framework/doc/sqa_framework.yml
             tensor_mechanics: !include modules/tensor_mechanics/doc/sqa_tensor_mechanics.yml
-    MooseDocs.extensions.bibtex:
-        duplicates:
-            - hales15homogenization

--- a/stork/doc/config.yml.app
+++ b/stork/doc/config.yml.app
@@ -17,5 +17,8 @@ Extensions:
         name: Stork
     MooseDocs.extensions.appsyntax:
         executable: ${ROOT_DIR}
+        hide:
+            framework: !include ${MOOSE_DIR}/framework/doc/hidden.yml
+        remove: !include ${MOOSE_DIR}/framework/doc/remove.yml
         includes:
             - include

--- a/stork/doc/config.yml.module
+++ b/stork/doc/config.yml.module
@@ -11,7 +11,8 @@ Extensions:
         home: /modules/stork
     MooseDocs.extensions.appsyntax:
         executable: ${MOOSE_DIR}/modules/stork
-        hide: !include framework/doc/hidden.yml
+        hide:
+            framework: !include framework/doc/hidden.yml
         remove: !include framework/doc/remove.yml
         includes:
             - framework/include


### PR DESCRIPTION
Fixes up a couple small things noticed while reviewing #14790:

-   Moves bibtex extension duplicate for hales15homogenization from tensor mechanics config.yml to MOOSE doc config.yml. This removes a warning related to duplicate bibtex entries during the full MooseDocs build.

-  Modifies stork module config.yml template to better follow conventions for hidden appsyntax.

- Fixes stork app config.yml template to allow MooseDocs to build in a brand new app without throwing errors and warnings specifically related to hidden and removed framework syntax pages.

Refs #13947 and #14786 
