### PR TITLE
Cleaned up documentation of XFEM UserObjects

### DIFF
--- a/modules/xfem/doc/content/source/userobjects/CircleCutUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/CircleCutUserObject.md
@@ -2,6 +2,8 @@
 
 !syntax description /UserObjects/CircleCutUserObject
 
+## Overview
+
 The `CircleCutUserObject` defines the boundary of a circular cut for XFEM to
 make on a 3 dimensional mesh. The user enters three points in the cut_data
 parameter in x, y, and z coordinates: first the center point of the circle,
@@ -19,5 +21,3 @@ determine if a given point is inside the cut plane.
 !syntax inputs /UserObjects/CircleCutUserObject
 
 !syntax children /UserObjects/CircleCutUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/EllipseCutUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/EllipseCutUserObject.md
@@ -2,6 +2,8 @@
 
 !syntax description /UserObjects/EllipseCutUserObject
 
+## Overview
+
 The `EllipseCutUserObject` defines the boundary of an elliptical cut for XFEM
 to make on a 3 dimensional mesh. The user enters three points in the cut_data
 parameter in x, y, z coordinates: the center point of the ellipse (must be
@@ -14,12 +16,8 @@ logic to determine whether a given point is located inside the cut plane.
 
 !listing test/tests/solid_mechanics_basic/elliptical_crack.i block=UserObjects
 
-!syntax description /UserObjects/EllipseCutUserObject
-
 !syntax parameters /UserObjects/EllipseCutUserObject
 
 !syntax inputs /UserObjects/EllipseCutUserObject
 
 !syntax children /UserObjects/EllipseCutUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/LevelSetCutUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/LevelSetCutUserObject.md
@@ -1,7 +1,9 @@
 # LevelSetCutUserObject
+
 !syntax description /UserObjects/LevelSetCutUserObject
 
-## Description
+## Overview
+
 This userobject, `LevelSetCutUserObject` uses a level set field to cut the finite element mesh. The zero level set contour represents the interface.
 
 ## Example Input File Syntax
@@ -13,5 +15,3 @@ This userobject, `LevelSetCutUserObject` uses a level set field to cut the finit
 !syntax inputs /UserObjects/LevelSetCutUserObject
 
 !syntax children /UserObjects/LevelSetCutUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/LineSegmentCutSetUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/LineSegmentCutSetUserObject.md
@@ -2,6 +2,8 @@
 
 !syntax description /UserObjects/LineSegmentCutSetUserObject
 
+## Overview
+
 The `LineSegmentCutSetUserObject` defines a set of line segment cuts for XFEM
 to make on a 2 dimensional mesh. The cut_data parameter consists of $n$ entries
 each with a length of six Real values (the $n$ entries are not separate but
@@ -25,5 +27,3 @@ cut_data.
 !syntax inputs /UserObjects/LineSegmentCutSetUserObject
 
 !syntax children /UserObjects/LineSegmentCutSetUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/LineSegmentCutUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/LineSegmentCutUserObject.md
@@ -2,6 +2,8 @@
 
 !syntax description /UserObjects/LineSegmentCutUserObject
 
+## Overview
+
 The `LineSegmentCutUserObject` defines a line segment cut for XFEM to make on a
 2 dimensional mesh. The start and end points of the line segment are defined in
 cut_data as a vector of four Real values: start point x, start point y, end
@@ -24,5 +26,3 @@ to both start and end points.
 !syntax inputs /UserObjects/LineSegmentCutUserObject
 
 !syntax children /UserObjects/LineSegmentCutUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/MeshCut3DUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/MeshCut3DUserObject.md
@@ -2,9 +2,13 @@
 
 !syntax description /UserObjects/MeshCut3DUserObject
 
-## Description
+## Overview
 
 This class: (1) reads in a mesh describing the crack surface, (2) uses the mesh to do initial cutting of 3D elements, and (3) grows the mesh incrementally based on prescribed growth functions. Interfacing with the domain integral methods is needed to grow the surface mesh based on physically determined propagation directions and speeds.
+
+## Example Input Syntax
+
+!listing test/tests/solid_mechanics_basic/edge_crack_3d_propagation.i block=UserObjects
 
 !syntax parameters /UserObjects/MeshCut3DUserObject
 

--- a/modules/xfem/doc/content/source/userobjects/MovingLineSegmentCutSetUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/MovingLineSegmentCutSetUserObject.md
@@ -2,7 +2,7 @@
 
 !syntax description /UserObjects/MovingLineSegmentCutSetUserObject
 
-## Description
+## Overview
 
 The `MovingLineSegmentCutSetUserObject` is used to cut the mesh with a set of line segments. The points on those line segments move at a velocity that is given by `XFEMPhaseTransitionMovingInterfaceVelocity`.
 
@@ -15,5 +15,3 @@ The `MovingLineSegmentCutSetUserObject` is used to cut the mesh with a set of li
 !syntax inputs /UserObjects/MovingLineSegmentCutSetUserObject
 
 !syntax children /UserObjects/MovingLineSegmentCutSetUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/PointValueAtXFEMInterface.md
+++ b/modules/xfem/doc/content/source/userobjects/PointValueAtXFEMInterface.md
@@ -2,7 +2,7 @@
 
 !syntax description /UserObjects/PointValueAtXFEMInterface
 
-## Description
+## Overview
 
 The values of field variables on either side of a moving interface are often needed to define the interface velocity. These variables and their gradients might be discontinuous across the interface. The fact that the interface does not lie on the standard quadrature points makes it difficult to get the quantities on the interface using existing functions in MOOSE.
 
@@ -17,5 +17,3 @@ The values of field variables on either side of a moving interface are often nee
 !syntax inputs /UserObjects/PointValueAtXFEMInterface
 
 !syntax children /UserObjects/PointValueAtXFEMInterface
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/RectangleCutUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/RectangleCutUserObject.md
@@ -2,6 +2,8 @@
 
 !syntax description /UserObjects/RectangleCutUserObject
 
+## Overview
+
 The `RectangleCutUserObject` defines the boundary of a rectangular cut for XFEM
 to make on a 3 dimensional mesh. The cut_data parameter is a vector of length
 twelve that defines the x, y , and z Real values of the four vertices that form
@@ -18,5 +20,3 @@ the cut plane.
 !syntax inputs /UserObjects/RectangleCutUserObject
 
 !syntax children /UserObjects/RectangleCutUserObject
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/XFEMPhaseTransitionMovingInterfaceVelocity.md
+++ b/modules/xfem/doc/content/source/userobjects/XFEMPhaseTransitionMovingInterfaceVelocity.md
@@ -2,7 +2,7 @@
 
 !syntax description /UserObjects/XFEMPhaseTransitionMovingInterfaceVelocity
 
-## Description
+## Overview
 
 The `XFEMPhaseTransitionMovingInterfaceVelocity` calculates an interface velocity that is given as $v = \frac{[[ {D}\nabla {u}\cdot\text{n}]]}{[[ {u}]] + u_0}$. The current implementation only supports the case in which the interface is moving horizontally.
 
@@ -15,5 +15,3 @@ The `XFEMPhaseTransitionMovingInterfaceVelocity` calculates an interface velocit
 !syntax inputs /UserObjects/XFEMPhaseTransitionMovingInterfaceVelocity
 
 !syntax children /UserObjects/XFEMPhaseTransitionMovingInterfaceVelocity
-
-!bibtex bibliography

--- a/modules/xfem/doc/content/source/userobjects/XFEMRankTwoTensorMarkerUserObject.md
+++ b/modules/xfem/doc/content/source/userobjects/XFEMRankTwoTensorMarkerUserObject.md
@@ -2,13 +2,17 @@
 
 !syntax description /UserObjects/XFEMRankTwoTensorMarkerUserObject
 
-## Description
+## Overview
 
 This object is used to mark elements to be cut by XFEM based on a scalar extracted from a specified RankTwoTensor (used to store stresses and strains in TensorMechanics), such as a principal stress or a component of stress. All of the standard scalar types that can be extracted from RankTwoTensors are available. If the scalar exceeds a user-specified threshold, the crack extends into the current element. 
 
 The threshold is provided as a coupled variable. This can be specified as either a constant value or as the name of that variable. This is useful for introducing randomness in the strength, by using an AuxVariable that has been initialized with a random initial condition.
 
 The determination of whether an element cracks is based either on the maximum value of the scalar quantity at all of the quadrature points in an element, or on the average value. Cracks are allowed to propagate into new elements that exceed the criterion, or to initiate on specified boundaries.
+
+## Example Input File Syntax
+
+!listing test/tests/solid_mechanics_basic/crack_propagation_2d.i block=UserObjects/xfem_marker_uo
 
 !syntax parameters /UserObjects/XFEMRankTwoTensorMarkerUserObject
 


### PR DESCRIPTION
Cleaned up documentation of XFEM UserObjects including:

- Changed Description Section headings to Overview to maintain consistency with current documentation and reduce redundancy.
- Ensured consistency in Section headings for each class' documentation (some were missing)
- Added missing Example Input File Syntax listings
- Removed redundant References Sections

refs #10210