### PR TITLE
Re-factor mesh meta data as generic 'extra' data that apps can create

### DIFF
--- a/framework/include/interfaces/MeshMetaDataInterface.h
+++ b/framework/include/interfaces/MeshMetaDataInterface.h
@@ -28,9 +28,6 @@ class MeshGenerator;
 class MeshMetaDataInterface
 {
 public:
-  /// The suffix appended when writing the restartable data file.
-  static constexpr auto FILE_SUFFIX = "_mesh";
-
   /// The system name used when initializing the Restartable interface
   static constexpr auto SYSTEM = "MeshMetaData";
 

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -106,8 +106,8 @@ MeshGenerator::declareMeshProperty(const std::string & data_name)
   // return that one instead. We might refactor this to have the app create the RestartableData
   // at a later date.
   auto data_ptr = libmesh_make_unique<RestartableData<T>>(full_name, nullptr);
-  auto & restartable_data_ref = static_cast<RestartableData<T> &>(
-      _app.registerRestartableData(full_name, std::move(data_ptr), 0, true, false));
+  auto & restartable_data_ref = static_cast<RestartableData<T> &>(_app.registerRestartableData(
+      full_name, std::move(data_ptr), 0, false, MooseApp::MESH_META_DATA));
 
   return restartable_data_ref.get();
 }

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -37,7 +37,7 @@ struct CheckpointFileNames
   std::string restart;
 
   /// Filename for restartable data filename
-  std::string restart_mesh_meta_data;
+  std::vector<std::string> restart_meta_data;
 };
 
 /**
@@ -97,9 +97,6 @@ private:
 
   /// Reference to the restartable data
   const RestartableDataMaps & _restartable_data;
-
-  /// Reference to the mesh meta data
-  const RestartableDataMap & _mesh_meta_data;
 
   /// RestrableData input/output interface
   RestartableDataIO _restartable_data_io;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -196,6 +196,7 @@ typedef unsigned int MooseObjectID;
 typedef unsigned int THREAD_ID;
 typedef unsigned int TagID;
 typedef unsigned int PerfID;
+using RestartableDataMapName = std::string; // see MooseApp.h
 
 typedef StoredRange<std::vector<dof_id_type>::iterator, dof_id_type> NodeIdRange;
 typedef StoredRange<std::vector<const Elem *>::iterator, const Elem *> ConstElemPointerRange;

--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -165,7 +165,7 @@ addActionTypes(Syntax & syntax)
   registerTask("dynamic_object_registration", false);
   registerTask("common_output", true);
   registerTask("setup_recover_file_base", true);
-  registerTask("recover_mesh_meta_data", true);
+  registerTask("recover_meta_data", true);
 
   registerTask("add_bounds_vectors", false);
   registerTask("add_periodic_bc", false);
@@ -245,7 +245,7 @@ addActionTypes(Syntax & syntax)
                            "(setup_mesh)"
                            "(add_mesh_generator)"
                            "(execute_mesh_generators)"
-                           "(recover_mesh_meta_data)"
+                           "(recover_meta_data)"
                            "(set_mesh_base)"
                            "(check_copy_nodal_vars)"
                            "(add_partitioner)"

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1169,9 +1169,9 @@ MooseApp::registerRestartableData(const std::string & name,
     mooseError(
         "The meta data storage for '", metaname, "' is not threaded, so the tid must be zero.");
 
-  if (!metaname.empty())
-    mooseAssert(_restartable_meta_data.find(metaname) != _restartable_meta_data.end(),
-                "The desired meta data name does not exist: " + metaname);
+  mooseAssert(metaname.empty() ||
+                  _restartable_meta_data.find(metaname) != _restartable_meta_data.end(),
+              "The desired meta data name does not exist: " + metaname);
 
   // Select the data store for saving this piece of restartable data (mesh or everything else)
   auto & data_ref =

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -444,6 +444,12 @@ MooseApp::MooseApp(InputParameters parameters)
 
   if (_master_displaced_mesh && !_master_mesh)
     mooseError("_master_mesh should have been set when _master_displaced_mesh is set");
+
+  // Data specifically associated with the mesh (meta-data) that will read from the restart
+  // file early during the simulation setup so that they are available to Actions and other objects
+  // that need them during the setup process. Most of the restartable data isn't made available
+  // until all objects have been created and all Actions have been executed (i.e. initialSetup).
+  registerRestartableDataMapName(MooseApp::MESH_META_DATA, "mesh");
 }
 
 void
@@ -1156,11 +1162,20 @@ RestartableDataValue &
 MooseApp::registerRestartableData(const std::string & name,
                                   std::unique_ptr<RestartableDataValue> data,
                                   THREAD_ID tid,
-                                  bool mesh_meta_data,
-                                  bool read_only)
+                                  bool read_only,
+                                  const RestartableDataMapName & metaname)
 {
+  if (!metaname.empty() && tid != 0)
+    mooseError(
+        "The meta data storage for '", metaname, "' is not threaded, so the tid must be zero.");
+
+  if (!metaname.empty())
+    mooseAssert(_restartable_meta_data.find(metaname) != _restartable_meta_data.end(),
+                "The desired meta data name does not exist: " + metaname);
+
   // Select the data store for saving this piece of restartable data (mesh or everything else)
-  auto & data_ref = mesh_meta_data ? _mesh_meta_data_map : _restartable_data[tid];
+  auto & data_ref =
+      metaname.empty() ? _restartable_data[tid] : _restartable_meta_data[metaname].first;
 
   auto insert_pair = data_ref.emplace(name, RestartableDataValuePair(std::move(data), !read_only));
 
@@ -2041,21 +2056,53 @@ MooseApp::meshReinitForRMs()
 }
 
 void
-MooseApp::checkMeshMetaDataIntegrity() const
+MooseApp::checkMetaDataIntegrity() const
 {
-  std::vector<std::string> not_declared;
-
-  for (const auto & pair : _mesh_meta_data_map)
-    if (!pair.second.declared)
-      not_declared.push_back(pair.first);
-
-  if (!not_declared.empty())
+  for (auto map_iter = _restartable_meta_data.begin(); map_iter != _restartable_meta_data.end();
+       ++map_iter)
   {
-    std::ostringstream oss;
-    std::copy(
-        not_declared.begin(), not_declared.end(), infix_ostream_iterator<std::string>(oss, ", "));
+    const RestartableDataMapName & name = map_iter->first;
+    const RestartableDataMap & meta_data = map_iter->second.first;
 
-    mooseError("The following Mesh meta-data properties were retrieved but never declared: ",
-               oss.str());
+    std::vector<std::string> not_declared;
+
+    for (const auto & pair : meta_data)
+      if (!pair.second.declared)
+        not_declared.push_back(pair.first);
+
+    if (!not_declared.empty())
+    {
+      std::ostringstream oss;
+      std::copy(
+          not_declared.begin(), not_declared.end(), infix_ostream_iterator<std::string>(oss, ", "));
+
+      mooseError("The following '",
+                 name,
+                 "' meta-data properties were retrieved but never declared: ",
+                 oss.str());
+    }
   }
+}
+
+const RestartableDataMapName MooseApp::MESH_META_DATA = "MeshMetaData";
+
+const RestartableDataMap &
+MooseApp::getRestartableDataMap(const RestartableDataMapName & name) const
+{
+  auto iter = _restartable_meta_data.find(name);
+  if (iter == _restartable_meta_data.end())
+    mooseError("Unable to find RestartableDataMap object for the supplied name '",
+               name,
+               "', did you call registerRestartableDataMapName in the application constructor?");
+  return iter->second.first;
+}
+
+void
+MooseApp::registerRestartableDataMapName(const RestartableDataMapName & name, std::string suffix)
+{
+  if (suffix.empty())
+    std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::tolower);
+  suffix.insert(0, "_");
+  _restartable_meta_data.emplace(
+      std::make_pair(name, std::make_pair(RestartableDataMap(), suffix)));
 }

--- a/framework/src/interfaces/MeshMetaDataInterface.C
+++ b/framework/src/interfaces/MeshMetaDataInterface.C
@@ -23,5 +23,6 @@ RestartableDataValue &
 MeshMetaDataInterface::registerMetaDataOnApp(const std::string & name,
                                              std::unique_ptr<RestartableDataValue> data)
 {
-  return _meta_data_app.registerRestartableData(name, std::move(data), 0, true, true);
+  return _meta_data_app.registerRestartableData(
+      name, std::move(data), 0, true, MooseApp::MESH_META_DATA);
 }

--- a/framework/src/restart/Restartable.C
+++ b/framework/src/restart/Restartable.C
@@ -49,7 +49,7 @@ Restartable::registerRestartableDataOnApp(const std::string & name,
                                           std::unique_ptr<RestartableDataValue> data,
                                           THREAD_ID tid)
 {
-  return _restartable_app.registerRestartableData(name, std::move(data), tid, false, false);
+  return _restartable_app.registerRestartableData(name, std::move(data), tid, false);
 }
 
 void

--- a/modules/stochastic_tools/include/userobject/SurrogateModel.h
+++ b/modules/stochastic_tools/include/userobject/SurrogateModel.h
@@ -46,7 +46,7 @@ public:
 protected:
   /// Sampler from which the parameters were perturbed
   Sampler * _sampler;
-  /// Vector postprocessor of the results from peturbing the model with _sampler
+  /// Vector postprocessor of the results from perturbing the model with _sampler
   const VectorPostprocessorValue & _values;
   /// Total number of parameters/dimensions
   unsigned int _ndim;

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -22,6 +22,13 @@ InputParameters
 MooseTestApp::validParams()
 {
   InputParameters params = MooseApp::validParams();
+
+  // Flag for testing MooseApp::getRestartableDataMap error message
+  params.addCommandLineParam<bool>("test_getRestartableDataMap_error",
+                                   "--test_getRestartableDataMap_error",
+                                   false,
+                                   "Call getRestartableDataMap with a bad name.");
+
   /* MooseTestApp is special because it will have its own
    * binary and we want the default to allow test objects.
    */
@@ -42,6 +49,9 @@ MooseTestApp::MooseTestApp(const InputParameters & parameters) : MooseApp(parame
 {
   MooseTestApp::registerAll(
       _factory, _action_factory, _syntax, !getParam<bool>("disallow_test_objects"));
+
+  if (getParam<bool>("test_getRestartableDataMap_error"))
+    getRestartableDataMap("slaughter");
 }
 
 MooseTestApp::~MooseTestApp() {}

--- a/test/tests/meshgenerators/meta_data_store/tests
+++ b/test/tests/meshgenerators/meta_data_store/tests
@@ -20,8 +20,17 @@
     input = 'mesh_meta_data_store.i'
 
     cli_args = 'AutoLineSamplerTest/test_request_invalid_property=true'
-    expect_err = 'The following Mesh meta-data properties were retrieved but never declared: \S+'
+    expect_err = "The following 'MeshMetaData' meta-data properties were retrieved but never declared: \S+"
 
     requirement = 'The system shall issue an error when mesh meta-data properties are requested but never declared.'
+  []
+
+  [get_meta_data_error_check]
+    type = RunException
+    input = 'mesh_meta_data_store.i'
+    cli_args = '--test_getRestartableDataMap_error'
+
+    expect_err = "Unable to find RestartableDataMap object for the supplied name"
+    requirement = "The system shall error if a invalid identifier is supplied when attempting to retrieve a restart meta data object."
   []
 []


### PR DESCRIPTION
This is just a first step. In the end this new storage container will automatically be written to the checkpoint, regardless of the name. The filename suffix will be included or inferred from the 
registerRestartableDataMapName.

An Enum cannot be used for the map because the StochasticToolsApp needs to add an item that the MOOSE knows nothing about, and it shouldn't.

(refs #14785)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
