### PR TITLE
Control access to Assembly::JxWNeighbor

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -12,6 +12,7 @@
 #include "DenseMatrix.h"
 #include "MooseArray.h"
 #include "MooseTypes.h"
+#include "MoosePassKey.h"
 
 #include "libmesh/dense_vector.h"
 #include "libmesh/enum_quadrature_type.h"
@@ -54,6 +55,7 @@ typedef MooseVariableFE<RealVectorValue> VectorMooseVariable;
 typedef MooseVariableFE<RealEigenVector> ArrayMooseVariable;
 class XFEMInterface;
 class SubProblem;
+class NodeFaceConstraint;
 
 /**
  * Keeps track of stuff related to assembling
@@ -402,7 +404,10 @@ public:
    * Returns the reference to the transformed jacobian weights on a current face
    * @return A _reference_.  Make sure to store this as a reference!
    */
-  const MooseArray<Real> & JxWNeighbor() const { return _current_JxW_neighbor; }
+  const MooseArray<Real> & JxWNeighbor(Moose::PassKey<NodeFaceConstraint>) const
+  {
+    return _current_JxW_neighbor;
+  }
 
   /**
    * Returns the reference to the current quadrature points being used on the neighbor face

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -274,6 +274,9 @@ protected:
    */
   bool _overwrite_slave_residual;
 
+  /// JxW on the master face
+  const MooseArray<Real> & _master_JxW;
+
   /// Whether the slave residual has been computed
   bool _slave_residual_computed;
 

--- a/framework/include/utils/MoosePassKey.h
+++ b/framework/include/utils/MoosePassKey.h
@@ -1,0 +1,21 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+namespace Moose
+{
+template <typename T>
+class PassKey
+{
+  friend T;
+  PassKey() {}
+  PassKey(const PassKey &) {}
+};
+}

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -85,7 +85,8 @@ NodeFaceConstraint::NodeFaceConstraint(const InputParameters & parameters)
     _dof_map(_sys.dofMap()),
     _node_to_elem_map(_mesh.nodeToElemMap()),
 
-    _overwrite_slave_residual(true)
+    _overwrite_slave_residual(true),
+    _master_JxW(_assembly.JxWNeighbor({}))
 {
   addMooseVariableDependency(&_var);
 


### PR DESCRIPTION
Use the PassKey pattern to protect access of JxWNeighbor. This API
was developed for NodeFaceConstraints but users may be tempted to
incorrectly use this for things like DGKernels or InterfaceKernrels.
So using PassKey we can limit this to be accessible to
NodeFaceConstraint.

Closes #14870

