### PR TITLE
Update PETSc submodule to the latest maint (3.12.4+)

### DIFF
--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -250,6 +250,10 @@ PetscExternalPartitioner::partitionGraph(const Parallel::Communicator & comm,
 
   ierr = MatPartitioningCreate(comm.get(), &part);
   CHKERRABORT(comm.get(), ierr);
+#if !PETSC_VERSION_LESS_THAN(3, 12, 3)
+  ierr = MatPartitioningSetUseEdgeWeights(part, PETSC_TRUE);
+  CHKERRABORT(comm.get(), ierr);
+#endif
   ierr = MatPartitioningSetAdjacency(part, dual);
   CHKERRABORT(comm.get(), ierr);
 


### PR DESCRIPTION
The last PETSc maint has a fix for Conda: skip sysroot libs. 

Closes #14938
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->