### PR TITLE
Error unless realpath() succeeds

### DIFF
--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -488,7 +488,9 @@ Parser::parse(const std::string & input_filename)
   if (use_rel_paths_str == "0" || use_rel_paths_str == "false")
   {
     char abspath[PATH_MAX + 1];
-    realpath(input_filename.c_str(), abspath);
+    char * rval = realpath(input_filename.c_str(), abspath);
+    if (!rval)
+      mooseError("Failed to find realpath of ", input_filename.c_str());
     _input_filename = std::string(abspath);
   }
 


### PR DESCRIPTION
If it fails then the return buffer contents are undefined so it's not
safe to continue anyway.

This fixes compilation with -Werror for me.

Refs #1542