### PR TITLE
FE prerequests

### DIFF
--- a/framework/src/geomsearch/FindContactPoint.C
+++ b/framework/src/geomsearch/FindContactPoint.C
@@ -74,9 +74,11 @@ findContactPoint(PenetrationInfo & p_info,
     p_info._closest_point_ref =
         master_elem->master_point(master_elem->get_node_index(nearest_node));
     std::vector<Point> elem_points = {p_info._closest_point_ref};
-    fe_elem->reinit(master_elem, &elem_points);
 
     const std::vector<RealGradient> & elem_dxyz_dxi = fe_elem->get_dxyzdxi();
+
+    fe_elem->reinit(master_elem, &elem_points);
+
     p_info._normal = elem_dxyz_dxi[0];
     if (nearest_node->id() == master_elem->node_id(0))
       p_info._normal *= -1.0;

--- a/framework/src/meshgenerators/ParsedGenerateSideset.C
+++ b/framework/src/meshgenerators/ParsedGenerateSideset.C
@@ -120,8 +120,8 @@ ParsedGenerateSideset::generate()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       // check normal if requested
       if (_check_normal && std::abs(1.0 - _normal * normals[0]) > _variance)

--- a/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
+++ b/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
@@ -127,8 +127,9 @@ SideSetsAroundSubdomainGenerator::generate()
       {
         if (_using_normal)
         {
+          const std::vector<Point> & normals = _fe_face->get_normals();
           _fe_face->reinit(elem, side);
-          face_normal = _fe_face->get_normals()[0];
+          face_normal = normals[0];
           add_to_bdy = (_normal * face_normal >= 1.0 - _normal_tol);
         }
 
@@ -184,8 +185,9 @@ SideSetsAroundSubdomainGenerator::generate()
         {
           if (_using_normal)
           {
+            const std::vector<Point> & normals = _fe_face->get_normals();
             _fe_face->reinit(elem, side);
-            face_normal = _fe_face->get_normals()[0];
+            face_normal = normals[0];
             add_to_bdy = (_normal * face_normal >= 1.0 - _normal_tol);
           }
 

--- a/framework/src/meshgenerators/SideSetsFromPointsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromPointsGenerator.C
@@ -89,8 +89,8 @@ SideSetsFromPointsGenerator::generate()
       {
         // This is the side that we want to paint our sideset with
         // First get the normal
-        _fe_face->reinit(elem, side);
         const std::vector<Point> & normals = _fe_face->get_normals();
+        _fe_face->reinit(elem, side);
 
         flood(elem, normals[0], boundary_ids[i], *mesh);
       }

--- a/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
+++ b/framework/src/meshmodifiers/AddAllSideSetsByNormals.C
@@ -69,8 +69,8 @@ AddAllSideSetsByNormals::modify()
       if (elem->neighbor_ptr(side))
         continue;
 
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       {
         // See if we've seen this normal before (linear search)

--- a/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
+++ b/framework/src/meshmodifiers/SideSetsAroundSubdomain.C
@@ -116,8 +116,9 @@ SideSetsAroundSubdomain::modify()
       {
         if (_using_normal)
         {
+          const std::vector<Point> & normals = _fe_face->get_normals();
           _fe_face->reinit(elem, side);
-          face_normal = _fe_face->get_normals()[0];
+          face_normal = normals[0];
           add_to_bdy = (_normal * face_normal >= 1.0 - _normal_tol);
         }
 
@@ -173,8 +174,9 @@ SideSetsAroundSubdomain::modify()
         {
           if (_using_normal)
           {
+            const std::vector<Point> & normals = _fe_face->get_normals();
             _fe_face->reinit(elem, side);
-            face_normal = _fe_face->get_normals()[0];
+            face_normal = normals[0];
             add_to_bdy = (_normal * face_normal >= 1.0 - _normal_tol);
           }
 

--- a/framework/src/meshmodifiers/SideSetsFromNormals.C
+++ b/framework/src/meshmodifiers/SideSetsFromNormals.C
@@ -80,8 +80,8 @@ SideSetsFromNormals::modify()
       if (elem->neighbor_ptr(side))
         continue;
 
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       for (unsigned int i = 0; i < boundary_ids.size(); ++i)
       {

--- a/framework/src/meshmodifiers/SideSetsFromPoints.C
+++ b/framework/src/meshmodifiers/SideSetsFromPoints.C
@@ -83,8 +83,8 @@ SideSetsFromPoints::modify()
       {
         // This is the side that we want to paint our sideset with
         // First get the normal
-        _fe_face->reinit(elem, side);
         const std::vector<Point> & normals = _fe_face->get_normals();
+        _fe_face->reinit(elem, side);
 
         flood(elem, normals[0], boundary_ids[i]);
       }


### PR DESCRIPTION
Closes #14811, and fixes 8 other objects that had similar failures to prerequest FE data.

This should be a performance improvement for those classes, and should improve compatibility with --disable-deprecated builds of libMesh post https://github.com/libMesh/libmesh/pull/2464