### PR TITLE
Add touch command for rpm to fix yum issues

### DIFF
--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -6,6 +6,9 @@ if [ -f $PT_REPO ]; then
   sed -i 's|^enabled=0|enabled=1|g' $PT_REPO
 fi
 
+# Needed for subsequent yum installs to work
+touch /var/lib/rpm/*
+
 # Update package lists
 yum update -y
 


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Per [this CentOS 8 issue](https://github.com/CentOS/sig-cloud-instance-images/issues/151#issuecomment-542851657), the workaround for this is to have the command
```
touch /var/lib/rpm/*
```
run before doing things with the Yum package manager is invoked in the base image.  I really don't know why this works, but I've verified that it does.  Closes #14907.
