### PR TITLE
fix suffix for mint package

### DIFF
--- a/modules/doc/content/getting_started/installation/mint_pre_req.md
+++ b/modules/doc/content/getting_started/installation/mint_pre_req.md
@@ -31,5 +31,5 @@ Download and install one of our redistributable packages according to your versi
 Once downloaded, the package can be installed via the dpkg utility:
 
 ```bash
-sudo dpkg -i moose-environment_ubuntu-*.rpm
+sudo dpkg -i moose-environment_ubuntu-*.deb
 ```


### PR DESCRIPTION
Just changed the suffix in the documentation to match the file that gets downloaded.

I checked the other Linux package pages and they are fine.

closes #14912