### PR TITLE
Explicitly set skip_find_neighbors=false

### DIFF
--- a/framework/src/mesh/ConcentricCircleMesh.C
+++ b/framework/src/mesh/ConcentricCircleMesh.C
@@ -440,8 +440,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 3);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -453,8 +453,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -479,8 +479,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -492,8 +492,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
@@ -527,8 +527,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 3);
       MeshTools::Modification::change_boundary_id(mesh, 6, 4);
       MeshTools::Modification::change_boundary_id(mesh, 7, 1);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -540,8 +540,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -575,8 +575,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(mesh, 7, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -588,8 +588,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
-      mesh.prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -616,8 +616,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       MeshTools::Modification::change_boundary_id(portion_two, 6, 3);
       MeshTools::Modification::change_boundary_id(portion_two, 7, 4);
-      mesh.prepare_for_use(false);
-      portion_two.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      portion_two.prepare_for_use(false, false);
       // 'top_half'
       mesh.stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
 
@@ -631,8 +631,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_bottom, 5, 3);
       MeshTools::Modification::change_boundary_id(portion_bottom, 6, 4);
       MeshTools::Modification::change_boundary_id(portion_bottom, 7, 1);
-      mesh.prepare_for_use(false);
-      portion_bottom.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      portion_bottom.prepare_for_use(false, false);
       // 'full'
       mesh.stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
 
@@ -648,15 +648,15 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_two, 2, 1);
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       // 'top half'
-      mesh.prepare_for_use(false);
-      portion_two.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      portion_two.prepare_for_use(false, false);
       mesh.stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
-      mesh.prepare_for_use(false);
-      portion_bottom.prepare_for_use(false);
+      mesh.prepare_for_use(false, false);
+      portion_bottom.prepare_for_use(false, false);
       mesh.stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
       MeshTools::Modification::change_boundary_id(mesh, 3, 1);
       mesh.get_boundary_info().sideset_name(1) = "outer";
@@ -666,5 +666,5 @@ ConcentricCircleMesh::buildMesh()
   }
   if (_portion != "top_half" && _portion != "right_half" && _portion != "left_half" &&
       _portion != "bottom_half" && _portion != "full")
-    mesh.prepare_for_use(false);
+    mesh.prepare_for_use(false, false);
 }

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -74,7 +74,7 @@ FileMesh::buildMesh()
     // file.
     bool skip_partitioning_later = getMesh().skip_partitioning();
     getMesh().skip_partitioning(true);
-    getMesh().prepare_for_use();
+    getMesh().prepare_for_use(false, false);
     getMesh().skip_partitioning(skip_partitioning_later);
   }
   else // not reading Nemesis files
@@ -92,7 +92,7 @@ FileMesh::buildMesh()
       _exreader->read(_file_name);
 
       getMesh().allow_renumbering(false);
-      getMesh().prepare_for_use();
+      getMesh().prepare_for_use(false, false);
     }
     else
     {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -365,7 +365,7 @@ MooseMesh::prepare(bool force)
     {
       CONSOLE_TIMED_PRINT("Preparing for use");
 
-      getMesh().prepare_for_use();
+      getMesh().prepare_for_use(false, false);
     }
   }
   else
@@ -375,7 +375,7 @@ MooseMesh::prepare(bool force)
     // Call prepare_for_use() and DO NOT allow renumbering
     getMesh().allow_renumbering(false);
     if (force || _needs_prepare_for_use)
-      getMesh().prepare_for_use();
+      getMesh().prepare_for_use(false, false);
   }
 
   // Collect (local) subdomain IDs

--- a/framework/src/mesh/RinglebMesh.C
+++ b/framework/src/mesh/RinglebMesh.C
@@ -210,7 +210,7 @@ RinglebMesh::buildMesh()
   }
 
   /// Find neighbors, etc.
-  mesh.prepare_for_use();
+  mesh.prepare_for_use(false, false);
 
   /// Create the triangular elements if required by the user
   if (_triangles)

--- a/framework/src/mesh/SpiralAnnularMesh.C
+++ b/framework/src/mesh/SpiralAnnularMesh.C
@@ -237,7 +237,7 @@ SpiralAnnularMesh::buildMesh()
   mesh.boundary_info->sideset_name(_exterior_bid) = "exterior";
 
   // Find neighbors, etc.
-  mesh.prepare_for_use();
+  mesh.prepare_for_use(false, false);
 
   if (_use_tri6)
   {

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -107,7 +107,7 @@ TiledMesh::buildMesh()
     {
       ExodusII_IO ex(*this);
       ex.read(mesh_file);
-      serial_mesh->prepare_for_use();
+      serial_mesh->prepare_for_use(false, false);
     }
     else
       serial_mesh->read(mesh_file);

--- a/framework/src/meshgenerators/AnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/AnnularMeshGenerator.C
@@ -242,7 +242,7 @@ AnnularMeshGenerator::generate()
     }
   }
 
-  mesh->prepare_for_use(false);
+  mesh->prepare_for_use(false, false);
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -750,8 +750,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 3);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -763,8 +763,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -789,8 +789,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -802,8 +802,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
@@ -837,8 +837,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 3);
       MeshTools::Modification::change_boundary_id(*mesh, 6, 4);
       MeshTools::Modification::change_boundary_id(*mesh, 7, 1);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -850,8 +850,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -885,8 +885,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(*mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 7, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -898,8 +898,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
-      mesh->prepare_for_use(false);
-      other_mesh.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      other_mesh.prepare_for_use(false, false);
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -926,8 +926,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       MeshTools::Modification::change_boundary_id(portion_two, 6, 3);
       MeshTools::Modification::change_boundary_id(portion_two, 7, 4);
-      mesh->prepare_for_use(false);
-      portion_two.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      portion_two.prepare_for_use(false, false);
       // 'top_half'
       mesh->stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
 
@@ -941,8 +941,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_bottom, 5, 3);
       MeshTools::Modification::change_boundary_id(portion_bottom, 6, 4);
       MeshTools::Modification::change_boundary_id(portion_bottom, 7, 1);
-      mesh->prepare_for_use(false);
-      portion_bottom.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      portion_bottom.prepare_for_use(false, false);
       // 'full'
       mesh->stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
 
@@ -958,15 +958,15 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_two, 2, 1);
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       // 'top half'
-      mesh->prepare_for_use(false);
-      portion_two.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      portion_two.prepare_for_use(false, false);
       mesh->stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(*mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
-      mesh->prepare_for_use(false);
-      portion_bottom.prepare_for_use(false);
+      mesh->prepare_for_use(false, false);
+      portion_bottom.prepare_for_use(false, false);
       mesh->stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 1);
       mesh->get_boundary_info().sideset_name(1) = "outer";
@@ -977,7 +977,7 @@ ConcentricCircleMeshGenerator::generate()
 
   if (_portion != "top_half" && _portion != "right_half" && _portion != "left_half" &&
       _portion != "bottom_half" && _portion != "full")
-    mesh->prepare_for_use(false);
+    mesh->prepare_for_use(false, false);
 
   // Laplace smoothing
   LaplaceMeshSmoother lms(*mesh);

--- a/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
+++ b/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
@@ -225,7 +225,7 @@ ElementDeletionGeneratorBase::generate()
    * Action that we need to re-prepare the mesh.
    */
   mesh->contract();
-  mesh->prepare_for_use();
+  mesh->prepare_for_use(false, false);
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/PatchMeshGenerator.C
+++ b/framework/src/meshgenerators/PatchMeshGenerator.C
@@ -251,7 +251,7 @@ PatchMeshGenerator::generate()
     boundary_info.nodeset_name(107) = "top_front_left";
   }
 
-  mesh->prepare_for_use();
+  mesh->prepare_for_use(false, false);
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/RinglebMeshGenerator.C
+++ b/framework/src/meshgenerators/RinglebMeshGenerator.C
@@ -206,7 +206,7 @@ RinglebMeshGenerator::generate()
   }
 
   /// Find neighbors, etc.
-  mesh->prepare_for_use();
+  mesh->prepare_for_use(false, false);
 
   /// Create the triangular elements if required by the user
   if (_triangles)

--- a/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
@@ -233,7 +233,7 @@ SpiralAnnularMeshGenerator::generate()
   mesh->boundary_info->sideset_name(_exterior_bid) = "exterior";
 
   // Find neighbors, etc.
-  mesh->prepare_for_use();
+  mesh->prepare_for_use(false, false);
 
   if (_use_tri6)
   {

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -242,12 +242,15 @@ SolutionUserObject::readExodusII()
   if (dynamic_cast<DistributedMesh *>(_mesh.get()))
   {
     _mesh->allow_renumbering(true);
-    _mesh->prepare_for_use(/*false*/);
+    _mesh->prepare_for_use(false, false);
   }
   else
   {
     _mesh->allow_renumbering(false);
-    _mesh->prepare_for_use(/*true*/);
+    // Don't worry, calling prepare_for_use with skip_renumber_nodes_and_elements = false is a
+    // no-op. It doesn't do anything. However, if true is passed you'll get a deprecation warning.
+    // So we pass false even though it's now what we mean
+    _mesh->prepare_for_use(false, false);
   }
 
   // Create EquationSystems object for solution

--- a/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
+++ b/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
@@ -176,7 +176,7 @@ PatchSidesetGenerator::generate()
   }
 
   // partition the boundary mesh
-  boundary_mesh->prepare_for_use();
+  boundary_mesh->prepare_for_use(false, false);
   MooseMesh::setPartitioner(*boundary_mesh, _partitioner_name, false, _pars, *this);
   boundary_mesh->partition(_n_patches);
 

--- a/modules/peridynamics/src/mesh/PeridynamicsMesh.C
+++ b/modules/peridynamics/src/mesh/PeridynamicsMesh.C
@@ -114,7 +114,7 @@ PeridynamicsMesh::buildMesh()
   if (!hasMeshBase())
     _mesh = _app.getMeshGeneratorMesh();
 
-  _mesh->prepare_for_use(/*skip_renumber =*/true);
+  _mesh->prepare_for_use(/*skip_renumber =*/true, /*skip_find_neighbors=*/false);
 }
 
 unsigned int

--- a/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
+++ b/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
@@ -87,7 +87,7 @@ SphereSurfaceMeshGenerator::generate()
 
   // we need to prepare distributed meshes before using refinement
   if (!mesh->is_replicated())
-    mesh->prepare_for_use(/*skip_renumber =*/false);
+    mesh->prepare_for_use(/*skip_renumber =*/false, /*skip_find_neighbors=*/false);
 
   // Now we have the beginnings of a sphere.
   // Add some more elements by doing uniform refinements and

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -240,7 +240,7 @@ XFEM::updateHeal()
     //    _mesh->contract();
     _mesh->allow_renumbering(false);
     _mesh->skip_partitioning(true);
-    _mesh->prepare_for_use();
+    _mesh->prepare_for_use(false, false);
     //    _mesh->prepare_for_use(true,true); //doing this preserves the numbering, but generates
     //    warning
 
@@ -251,7 +251,7 @@ XFEM::updateHeal()
       MeshCommunication().make_nodes_parallel_consistent(*_displaced_mesh);
       _displaced_mesh->allow_renumbering(false);
       _displaced_mesh->skip_partitioning(true);
-      _displaced_mesh->prepare_for_use();
+      _displaced_mesh->prepare_for_use(false, false);
       //      _displaced_mesh->prepare_for_use(true,true);
     }
   }
@@ -290,7 +290,7 @@ XFEM::update(Real time, NonlinearSystemBase & nl, AuxiliarySystem & aux)
     //    _mesh->contract();
     _mesh->allow_renumbering(false);
     _mesh->skip_partitioning(true);
-    _mesh->prepare_for_use();
+    _mesh->prepare_for_use(false, false);
     //    _mesh->prepare_for_use(true,true); //doing this preserves the numbering, but generates
     //    warning
 
@@ -298,7 +298,7 @@ XFEM::update(Real time, NonlinearSystemBase & nl, AuxiliarySystem & aux)
     {
       _displaced_mesh->allow_renumbering(false);
       _displaced_mesh->skip_partitioning(true);
-      _displaced_mesh->prepare_for_use();
+      _displaced_mesh->prepare_for_use(false, false);
       //      _displaced_mesh->prepare_for_use(true,true);
     }
   }


### PR DESCRIPTION
libmesh/libmesh#2473 will hopefully add an `allow_find_neighbors`
API that has the same structure as `allow_renumbering`. However,
in order for it to to be backwards compatible, existing users of `prepare_for_use` need to
explicitly state whether they want to `find_neighbors` or not. This is temporary
and will be removed upon the next libmesh update (assuming libmesh/libmesh#2473
gets in)
