### PR TITLE
Add libtirpc to CentOS instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/centos_pre_req.md
+++ b/modules/doc/content/getting_started/installation/centos_pre_req.md
@@ -15,7 +15,8 @@ sudo -E yum install gcc \
   libX11-devel \
   git \
   zlib-devel \
-  xz-devel
+  xz-devel \
+  libtirpc-devel
 ```
 
 Download and install one our redistributable packages according to your version of CentOS


### PR DESCRIPTION
Add libtirpc to CentOS pre-req Getting Started instructions.

Closes #14951

