### PR TITLE
Limit peacock/chigger tests to linux (for now)

### DIFF
--- a/python/chigger/tests/adapt/tests
+++ b/python/chigger/tests/adapt/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./adapt_steps]
+  [adapt_steps]
     type = ImageDiff
     command = adapt.py
     imagediff = 'adapt_0.png adapt_4.png adapt_9.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/annotations/tests
+++ b/python/chigger/tests/annotations/tests
@@ -1,49 +1,51 @@
 [Tests]
-  [./image]
+  [image]
     # Test displaying an image
     type = ImageDiff
     command = image_annotation.py
     imagediff = 'image_annotation.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
 
     display_required = true
-  [../]
+  []
 
-  [./logo]
+  [logo]
     # Test displaying logos
     type = ImageDiff
     command = logo_annotation.py
     imagediff = 'logo_annotation.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
 
     display_required = true
-  [../]
+  []
 
-  [./text]
+  [text]
     # Test displaying text
     type = ImageDiff
     command = text_annotation.py
     imagediff = 'text_annotation.png'
 
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./time]
+  [time]
     # Test displaying time with TimeAnnotation
     type = ImageDiff
     command = time_annotation.py
     imagediff = 'time_annotation.png'
 
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./time_change]
+  [time_change]
     # Test displaying changing time
     type = ImageDiff
     command = time_annotation_change.py
     imagediff = 'time_annotation_change_0.png time_annotation_change_9.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
 
     display_required = true
-  [../]
+  []
 []

--- a/python/chigger/tests/background/tests
+++ b/python/chigger/tests/background/tests
@@ -1,14 +1,16 @@
 [Tests]
-  [./solid]
+  [solid]
     type = ImageDiff
     command = background.py
     imagediff = background.png
     display_required = true
-  [../]
-  [./gradient]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [gradient]
     type = ImageDiff
     command = gradient.py
     imagediff = gradient.png
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/chigger/tests
+++ b/python/chigger/tests/chigger/tests
@@ -1,6 +1,8 @@
 [Tests]
-  [./command_line]
+  [command_line]
     type = PythonUnitTest
     input = test_chigger.py
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/clipping/tests
+++ b/python/chigger/tests/clipping/tests
@@ -1,50 +1,57 @@
 [Tests]
-  [./plane]
+  [plane]
     type = ImageDiff
     command = clip.py
     imagediff = 'clip.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./plane_elem_var]
+  [plane_elem_var]
     type = ImageDiff
     command = clip_elem.py
     imagediff = 'clip_elem.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./clip_z]
+  [clip_z]
     type = ImageDiff
     command = clip_z.py
     imagediff = 'clip_z.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./dual]
+  [dual]
     type = ImageDiff
     command = dual.py
     imagediff = dual.png
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./box]
+  [box]
     type = ImageDiff
     command = box_clip.py
     imagediff = 'box_clip.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./dynamic]
+  [dynamic]
     type = ImageDiff
     command = clip_change.py
     imagediff = 'clip_change0.png clip_change1.png clip_change2.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./multiple]
+  [multiple]
     type = ImageDiff
     command = multiple_clips.py
     imagediff = 'multiple_clips.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/color/tests
+++ b/python/chigger/tests/color/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = color.py
     imagediff = color.png
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/colorbar/tests
+++ b/python/chigger/tests/colorbar/tests
@@ -1,116 +1,121 @@
 [Tests]
   issues = '#8661'
   design = 'chigger/index.md'
-  [./standalone]
+  [standalone]
     type = ImageDiff
     command = colorbar.py
     imagediff = 'colorbar.png'
     requirement = "Chigger shall include a colorbar object that can be oriented vertically."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./standalone_horiz]
+  [standalone_horiz]
     type = ImageDiff
     command = colorbar_horiz.py
     imagediff = 'colorbar_horiz.png'
     requirement = "Chigger shall include a colorbar object that can be oriented horizontally."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./exdous_default]
+  [exdous_default]
     type = ImageDiff
     command = exodus_colorbar.py
     imagediff = 'exodus_colorbar.png'
     requirement = "Chigger shall include a colorbar object that captures range and colormap data from an Exodus result."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./left]
+  [left]
     type = ImageDiff
     command = colorbar_left.py
     imagediff = 'colorbar_left.png'
     requirement = "The chigger colorbar shall support placing the tick marks on the left-side of a vertical oriented colorbar."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./top]
+  [top]
     type = ImageDiff
     command = colorbar_top.py
     imagediff = 'colorbar_top.png'
     requirement = "The chigger colorbar shall support placing the tick marks on the top of a horizontal oriented colorbar."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./bottom]
+  [bottom]
     type = ImageDiff
     command = colorbar_bottom.py
     imagediff = 'colorbar_bottom.png'
     requirement = "The chigger colorbar shall support placing the tick marks on the bottom of a horizontal oriented colorbar."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./common]
+  [common]
     type = ImageDiff
     command = common_colorbar.py
     imagediff = 'common_colorbar.png'
     requirement = "Chigger shall include a colorbar object oriented vertically that captures range and colormap data from two Exodus results."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./common_horiz]
+  [common_horiz]
     type = ImageDiff
     command = common_colorbar_horiz.py
     imagediff = 'common_colorbar_horiz.png'
     requirement = "Chigger shall include a colorbar object oriented horizontally that captures range and colormap data from two Exodus results."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./dual]
+  [dual]
     type = ImageDiff
     command = dual_colorbar.py
     imagediff = 'dual_colorbar.png'
     requirement = "Chigger shall support vertical colorbars associated with Exodus results within a viewport."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./dual_horiz]
+  [dual_horiz]
     type = ImageDiff
     command = dual_colorbar_horiz.py
     imagediff = 'dual_colorbar_horiz.png'
     requirement = "Chigger shall support horizontal colorbars associated with Exodus results within a viewport."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./font]
+  [font]
     type = ImageDiff
     command = colorbar_font.py
     imagediff = 'colorbar_font.png'
     requirement = "The chigger colorbar shall support the ability to change the font size of the tick labels."
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./zero_range]
+  [zero_range]
     type = ImageDiff
     command = zero_range.py
     imagediff = 'zero_range.png'
     requirement = "The chigger colorbar shall handle range values that do not differ in value."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./precision_with_wrong_notation]
+  [precision_with_wrong_notation]
     type = RunApp
     command = precision_with_wrong_notation.py
     expect_out = "When using 'precision' option, 'notation' option has to be set to either 'scientific' or 'fixed'"
     match_literal = true
     requirement = "The chigger colorbar shall error when the 'notation' and 'precision' settings are incongruent."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/colormap/tests
+++ b/python/chigger/tests/colormap/tests
@@ -1,43 +1,43 @@
 [Tests]
-  [./matplotlib]
+  [matplotlib]
     # Tests that matplotlib colormaps are loaded
     type = ImageDiff
     command = colormap.py
     imagediff = colormap.png
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./number]
+  [number]
     # Test use of "number" for matplotlib colormaps
     type = ImageDiff
     command = colormap_number.py
     imagediff = colormap_number.png
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./reverse_matplotlib]
+  [reverse_matplotlib]
     type = ImageDiff
     command = reverse.py
     imagediff = reverse.png
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./reverse_xml]
+  [reverse_xml]
     type = ImageDiff
     command = reverse_xml.py
     imagediff = reverse_xml.png
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./reverse_default]
+  [reverse_default]
     type = ImageDiff
     command = reverse_default.py
     imagediff = reverse_default.png
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 []

--- a/python/chigger/tests/contours/tests
+++ b/python/chigger/tests/contours/tests
@@ -1,56 +1,63 @@
 [Tests]
-  [./default]
+  [default]
     # Test contour object with default settings
     type = ImageDiff
     command = default.py
     imagediff = 'default.png'
     allowed_linux = 0.97
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./blocks]
+  [blocks]
     # Subdomain restricted contours
     type = ImageDiff
     command = block.py
     imagediff = 'block.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./block_elem]
+  [block_elem]
     type = RunException
     command = block_elem.py
     expect_err = "ContourFilter currently only works with nodal variables."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./levels]
+  [levels]
     # Explicit levels
     type = ImageDiff
     command = levels.py
     imagediff = 'levels.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./combo]
+  [combo]
     # Volume and contour together
     type = ImageDiff
     command = combo.py
     imagediff = 'combo.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./inline]
+  [inline]
     type = ImageDiff
     command = inline.py
     imagediff = 'inline.png'
     allowed_linux = 0.97
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./inline_clip]
+  [inline_clip]
     type = ImageDiff
     command = inline_clip.py
     imagediff = 'inline_clip.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/displacement/tests
+++ b/python/chigger/tests/displacement/tests
@@ -1,22 +1,25 @@
 [Tests]
-  [./on]
+  [on]
     type = ImageDiff
     command = displacement.py
     imagediff = 'displacement_0.png displacement_1.png displacement_2.png displacement_3.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./off]
+  [off]
     type = ImageDiff
     command = displacement_off.py
     imagediff = 'displacement_off_3.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./magnitude]
+  [magnitude]
     type = ImageDiff
     command = displacement_mag.py
     imagediff = 'displacement_mag_0.png displacement_mag_1.png displacement_mag_2.png displacement_mag_3.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/edge/tests
+++ b/python/chigger/tests/edge/tests
@@ -1,10 +1,11 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = edge.py
     imagediff = 'edge.png'
     allowed_linux = 0.94
     allowed_darwin = 0.96
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/error/tests
+++ b/python/chigger/tests/error/tests
@@ -1,13 +1,17 @@
 [Tests]
-  [./warn_time_timestep]
+  [warn_time_timestep]
     type = RunApp
     command = time_timestep.py
     expect_out = "Both \'time\' \(1.0\) and \'timestep\' \(1\) are set, \'timestep\' is being used."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./result_given_file]
+  [result_given_file]
     type = RunException
     command = result_given_file.py
     expect_err = "The supplied object of type str is not supported, only ExodusReader and MultiAppExodusReader objects may be utilized."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/exodus/blocks/tests
+++ b/python/chigger/tests/exodus/blocks/tests
@@ -11,6 +11,7 @@
       display_required = true
 
       detail = "default settings;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [blocks]
       type = ImageDiff
@@ -19,6 +20,7 @@
       display_required = true
 
       detail = "defined subdomains;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [all_boundary]
       type = ImageDiff
@@ -28,6 +30,7 @@
       display_required = true
 
       detail = "all boundaries;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [boundary]
       type = ImageDiff
@@ -36,6 +39,7 @@
       display_required = true
 
       detail = "defined boundaries by name;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [boundary_numeric]
       type = ImageDiff
@@ -44,13 +48,14 @@
       display_required = true
 
       detail = "defined boundaries by number;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [nodesets]
       type = ImageDiff
       command = nodesets.py
       imagediff = 'nodesets.png'
       allowed_linux = 0.97
-      platform = LINUX
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
       display_required = true
 
       detail = "defined nodesets;"
@@ -60,7 +65,7 @@
       command = all_nodesets.py
       imagediff = 'all_nodesets.png'
       allowed_linux = 0.90
-      platform = LINUX
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
       display_required = true
 
       detail = "all nodesets;"
@@ -72,13 +77,14 @@
       display_required = true
 
       detail = "no geometric entities selected;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
     [combo]
       type = ImageDiff
       command = combo.py
       imagediff = 'combo.png'
       allowed_linux = 0.95
-      platform = LINUX
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
       display_required = true
 
       detail = "subdomains, boundaries, and nodesets specified; and"
@@ -90,6 +96,7 @@
       display_required = true
 
       detail = "data only defined on a subset of subdomains."
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
   []
 []

--- a/python/chigger/tests/exodus/labels/tests
+++ b/python/chigger/tests/exodus/labels/tests
@@ -1,27 +1,27 @@
 [Tests]
-  [./points]
+  [points]
     type = ImageDiff
     command = points.py
     imagediff = 'points.png'
     allowed_linux = 0.96
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./cells]
+  [cells]
     type = ImageDiff
     command = cells.py
     imagediff = 'cells.png'
     allowed_linux = 0.96
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./variable]
+  [variable]
     type = ImageDiff
     command = variable.py
     imagediff = 'variable.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 []

--- a/python/chigger/tests/exodus/tests
+++ b/python/chigger/tests/exodus/tests
@@ -1,6 +1,8 @@
 [Tests]
-  [./reader]
+  [reader]
     type = PythonUnitTest
     input = test_ExodusReader.py
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/field_data/tests
+++ b/python/chigger/tests/field_data/tests
@@ -1,28 +1,34 @@
 [Tests]
-  [./field_data]
+  [field_data]
     type = RunApp
     command = field_data.py
     expect_out = "13.960"
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./current_field_data]
+  [current_field_data]
     type = RunApp
     command = current_field_data.py
     expect_out = "0.0,\s14.\d+,\s14."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./plot_field_data]
+  [plot_field_data]
     type = ImageDiff
     command = plot_field_data.py
     imagediff = 'plot_field_data.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./plot_current_field_data]
+  [plot_current_field_data]
     type = ImageDiff
     command = plot_current_field_data.py
     imagediff = 'plot_current_field_data_0.png plot_current_field_data_4.png plot_current_field_data_9.png'
     allowed_linux = 0.95
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/geometric/base/tests
+++ b/python/chigger/tests/geometric/base/tests
@@ -1,22 +1,25 @@
 [Tests]
-  [./orientation]
+  [orientation]
     type = ImageDiff
     command = orientation.py
     imagediff = 'orientation.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./scale]
+  [scale]
     type = ImageDiff
     command = scale.py
     imagediff = 'scale.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./rotation]
+  [rotation]
     type = ImageDiff
     command = rotation.py
     imagediff = 'rotation.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/geometric/cube_source/tests
+++ b/python/chigger/tests/geometric/cube_source/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = cube_source.py
     imagediff = 'cube_source.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/geometric/cylinder_source/tests
+++ b/python/chigger/tests/geometric/cylinder_source/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = cylinder_source.py
     imagediff = 'cylinder_source.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/geometric/line_source/tests
+++ b/python/chigger/tests/geometric/line_source/tests
@@ -1,22 +1,25 @@
 [Tests]
-  [./line]
+  [line]
     type = ImageDiff
     command = line_source.py
     imagediff = 'line_source.png'
     allowed_darwin = 0.96
     display_required = true
-  [../]
-  [./line_data]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [line_data]
     type = ImageDiff
     command = line_source_data.py
     imagediff = 'line_source_data.png'
     allowed_darwin = 0.974
     display_required = true
-  [../]
-  [./line_data_tube]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [line_data_tube]
     type = ImageDiff
     command = line_source_data_tube.py
     imagediff = 'line_source_data_tube.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/geometric/plane_source/tests
+++ b/python/chigger/tests/geometric/plane_source/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = plane_source.py
     imagediff = 'plane_source.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/graphs/tests
+++ b/python/chigger/tests/graphs/tests
@@ -1,18 +1,20 @@
 [Tests]
-  [./dual]
+  [dual]
     type = ImageDiff
     command = dual.py
     imagediff = 'dual.png'
     allowed_darwin = 0.94
     allowed_linux = 0.96
     display_required = true
-  [../]
-  [./dualx]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [dualx]
     type = ImageDiff
     command = dualx.py
     imagediff = 'dualx.png'
     allowed_linux = 0.96
     allowed_darwin = 0.94
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/line/tests
+++ b/python/chigger/tests/line/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [./default]
+  [default]
     type = ImageDiff
     command = line.py
     imagediff = 'line.png'
@@ -9,9 +9,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./single_point]
+  [single_point]
     type = ImageDiff
     command = single_point.py
     imagediff = 'single_point.png'
@@ -21,9 +22,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./empty]
+  [empty]
     type = ImageDiff
     command = empty.py
     imagediff = 'empty.png'
@@ -32,9 +34,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./color]
+  [color]
     type = ImageDiff
     command = color.py
     imagediff = 'color.png'
@@ -43,9 +46,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./legend]
+  [legend]
     type = ImageDiff
     command = legend.py
     imagediff = 'legend.png'
@@ -55,9 +59,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./legend_viewport]
+  [legend_viewport]
     type = ImageDiff
     command = legend_viewport.py
     imagediff = 'legend_viewport.png'
@@ -67,9 +72,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./update]
+  [update]
     type = ImageDiff
     command = update.py
     imagediff = 'update_0.png update_1.png update_2.png update_3.png update_4.png update_5.png'
@@ -78,9 +84,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./secondary]
+  [secondary]
     type = ImageDiff
     command = secondary.py
     imagediff = 'secondary_initial.png secondary_0.png secondary_1.png secondary_2.png secondary_3.png'
@@ -90,9 +97,10 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./tracer]
+  [tracer]
     type = ImageDiff
     command = tracer.py
     imagediff = 'tracer_1.png tracer_3.png tracer_5.png'
@@ -102,5 +110,6 @@
     design = ''
     issues = '#7451'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/line_sample/tests
+++ b/python/chigger/tests/line_sample/tests
@@ -1,37 +1,38 @@
 [Tests]
-  [./default]
+  [default]
     type = ImageDiff
     command = line_sample_default.py
     imagediff = 'line_sample_default.png'
     allowed_linux = 0.95
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./line_sample]
+  [line_sample]
     type = ImageDiff
     command = line_sample.py
     imagediff = 'line_sample.png'
     expect_out = '0.049\d*\s0.400' # Test the the sampled values are present
     allowed_linux = 0.92
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./line_sample_elem]
+  [line_sample_elem]
     type = ImageDiff
     command = line_sample_elem.py
     imagediff = 'line_sample_elem.png'
     allowed_linux = 0.97
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./line_sample_error]
+  [line_sample_error]
     type = RunApp
     command = line_sample_error.py
     expect_out = "Unable to locate the variable, invalid_name, in the supplied source data."
     errors = "zzzzzzz" # Supress default error checking
-    platform = LINUX
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/mesh/tests
+++ b/python/chigger/tests/mesh/tests
@@ -1,10 +1,11 @@
 [Tests]
-  [./view_mesh]
+  [view_mesh]
     type = ImageDiff
     command = mesh.py
     imagediff = 'mesh.png'
     allowed_linux = 0.97
     allowed_darwin = 0.95
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/mesh_only/tests
+++ b/python/chigger/tests/mesh_only/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = mesh_only.py
     imagediff = 'mesh_only.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/multiapps/tests
+++ b/python/chigger/tests/multiapps/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./auto]
+  [auto]
     type = ImageDiff
     command = multiapp.py
     imagediff = 'multiapp.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/nemesis/tests
+++ b/python/chigger/tests/nemesis/tests
@@ -1,14 +1,16 @@
 [Tests]
-  [./nemesis]
+  [nemesis]
     type = ImageDiff
     command = nemesis.py
     imagediff = 'nemesis.png'
     display_required = true
-  [../]
-  [./explode]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [explode]
     type = ImageDiff
     command = explode.py
     imagediff = 'explode.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/new_files/tests
+++ b/python/chigger/tests/new_files/tests
@@ -1,22 +1,26 @@
 [Tests]
-  [./newfiles]
+  [newfiles]
     type = ImageDiff
     command = new_files.py
     imagediff = 'new_files_0.png new_files_1.png new_files_2.png new_files_3.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./newfiles_adapt]
+  [newfiles_adapt]
     type = ImageDiff
     command = new_files_adapt.py
     imagediff = 'new_files_adapt_0.png new_files_adapt_4.png new_files_adapt_8.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./old_files]
+  [old_files]
     type = RunApp
     command = old_files.py
     expect_out = "[0.0, 0.5, 1.0, 2.0, 3.5, 4.5]"
     match_literal = True
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/observers/tests
+++ b/python/chigger/tests/observers/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./timer]
+  [timer]
     type = RunApp
     command = timer.py
     expect_out = "count = 3"
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/offscreen/tests
+++ b/python/chigger/tests/offscreen/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./offscreen]
+  [offscreen]
     type = ImageDiff
     command = offscreen.py
     imagediff = 'offscreen.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 []

--- a/python/chigger/tests/options/tests
+++ b/python/chigger/tests/options/tests
@@ -1,50 +1,64 @@
 [Tests]
-  [./run]
+  [run]
     type = RunApp
     command = options.py
     cli_args = '--type=run'
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./bad_type]
+  [bad_type]
     type = RunApp
     command = options.py
     cli_args = '--type=bad-type'
     expect_out = "param must be of type int but str provided."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./bad_allow_type]
+  [bad_allow_type]
     type = RunApp
     command = options.py
     cli_args = '--type=bad-allow-type'
     expect_out = "The type provided, int, does not match the type of the allowed values, list."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./value_not_allowed]
+  [value_not_allowed]
     type = RunApp
     command = options.py
     cli_args = '--type=value-not-allowed'
     expect_out = "Attempting to set param to a value of 1 but only the following are allowed"
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./bad-arg-count]
+  [bad-arg-count]
     type = RunException
     command = options.py
     cli_args = '--type=bad-arg-count'
     expect_err = "Wrong number of arguments, must supply 2 or 3 input arguments."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./dump]
+  [dump]
     type = RunApp
     command = options.py
     cli_args = '--type=dump'
     expect_out = "Some parameter"
     skip = 'Needs terminaltables'
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 
-  [./duplicate]
+  [duplicate]
     type = RunApp
     command = options.py
     cli_args = '--type=duplicate'
     expect_out = "A parameter with the name param already exists."
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+    display_required = true
+  []
 []

--- a/python/chigger/tests/range/tests
+++ b/python/chigger/tests/range/tests
@@ -1,52 +1,52 @@
 [Tests]
-  [./none]
+  [none]
     type = ImageDiff
     command = none.py
     imagediff = 'none_0.png none_1.png'
     allowed_linux = 0.97
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./min]
+  [min]
     type = ImageDiff
     command = min.py
     imagediff = 'min_0.png min_4.png'
     allowed_linux = 0.97
     allowed_darwin = 0.97
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./max]
+  [max]
     type = ImageDiff
     command = max.py
     imagediff = 'max_0.png max_1.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./minmax]
+  [minmax]
     type = ImageDiff
     command = minmax.py
     imagediff = 'minmax_0.png minmax_1.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./range]
+  [range]
     type = ImageDiff
     command = range.py
     imagediff = 'range_0.png range_1.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./auto]
+  [auto]
     type = ImageDiff
     command = auto.py
     imagediff = 'auto_1.png auto_3.png auto_5.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 []

--- a/python/chigger/tests/result_group/tests
+++ b/python/chigger/tests/result_group/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./group]
+  [group]
     type = ImageDiff
     command = result_group.py
     imagediff = result_group.png
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/rotational_extrusion/tests
+++ b/python/chigger/tests/rotational_extrusion/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [./exodus]
+  [exodus]
     type = ImageDiff
     command = rotational_extrusion.py
     imagediff = rotational_extrusion.png
@@ -7,5 +7,6 @@
     issues = '#12128'
     requirement = "Chigger shall include the ability to rotate and extrude a 2D ExodusII result."
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/simple/tests
+++ b/python/chigger/tests/simple/tests
@@ -1,18 +1,19 @@
 [Tests]
-  [./simple]
+  [simple]
     # Most basic example
     type = ImageDiff
     command = simple.py
     imagediff = 'simple.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
+  []
 
-  [./simple_camera]
+  [simple_camera]
     # Use custom camera
     type = ImageDiff
     command = simple_camera.py
     imagediff = 'simple_camera.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/transform/tests
+++ b/python/chigger/tests/transform/tests
@@ -1,64 +1,71 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = scale.py
     imagediff = 'scale.png'
     display_required = true
-  [../]
-  [./test_2d]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [test_2d]
     type = ImageDiff
     command = scale_2d.py
     imagediff = 'scale_2d.png'
     display_required = true
-  [../]
-  [./rotate_none]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [rotate_none]
     type = ImageDiff
     command = rotate.py
     imagediff = 'rotate.png'
     display_required = true
-  [../]
-  [./rotate_x]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [rotate_x]
     type = ImageDiff
     command = rotate.py
     cli_args = '--rotate 90 0 0 --name rotate_x.png'
     imagediff = 'rotate_x.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
-  [./rotate_y]
+  []
+  [rotate_y]
     type = ImageDiff
     command = rotate.py
     cli_args = '--rotate 0 90 0 --name rotate_y.png'
     imagediff = 'rotate_y.png'
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     display_required = true
-  [../]
-  [./rotate_z]
+  []
+  [rotate_z]
     type = ImageDiff
     command = rotate.py
     cli_args = '--rotate 0 0 90 --name rotate_z.png'
     imagediff = 'rotate_z.png'
     display_required = true
-  [../]
-  [./translate_x]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [translate_x]
     type = ImageDiff
     command = translate.py
     cli_args = '--translate 2 0 0 --name translate_x.png'
     imagediff = 'translate_x.png'
     display_required = true
-  [../]
-  [./translate_y]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [translate_y]
     type = ImageDiff
     command = translate.py
     cli_args = '--translate 0 2 0 --name translate_y.png'
     imagediff = 'translate_y.png'
     display_required = true
-  [../]
-  [./translate_z_scale_and_rotate]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [translate_z_scale_and_rotate]
     type = ImageDiff
     command = translate.py
     cli_args = '--translate 0 0 2 --rotate 0 90 0 --scale 0.5 0.5 0.5 --name translate_z.png'
     imagediff = 'translate_z.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/tube/tests
+++ b/python/chigger/tests/tube/tests
@@ -1,9 +1,10 @@
 [Tests]
-  [./tube]
+  [tube]
     # Test creating 3D tube from 1D part
     type = ImageDiff
     command = tube.py
     imagediff = 'tube.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/utils/tests
+++ b/python/chigger/tests/utils/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./getActiveFilenames]
+  [getActiveFilenames]
     type = PythonUnitTest
     input = test_get_active_filenames.py
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/vector/tests
+++ b/python/chigger/tests/vector/tests
@@ -1,25 +1,28 @@
 [Tests]
-  [./magnitude]
+  [magnitude]
     type = ImageDiff
     command = vector_magnitude.py
     imagediff = 'vector_magnitude.png'
     allowed_linux = 0.975
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./x_component]
+  [x_component]
     type = ImageDiff
     command = vector_x.py
     imagediff = 'vector_x.png'
     allowed_linux = 0.965
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./y_component]
+  [y_component]
     type = ImageDiff
     command = vector_y.py
     imagediff = 'vector_y.png'
     allowed_linux = 0.965
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/viewports/tests
+++ b/python/chigger/tests/viewports/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./viewports]
+  [viewports]
     type = ImageDiff
     command = viewports.py
     imagediff = 'viewports.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/volume_extents/tests
+++ b/python/chigger/tests/volume_extents/tests
@@ -1,10 +1,11 @@
 [Tests]
-  [./test]
+  [test]
     type = ImageDiff
     command = extents.py
     imagediff = 'extents.png'
     allowed_darwin = 0.96
     allowed_linux = 0.96
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/window/tests
+++ b/python/chigger/tests/window/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./clear]
+  [clear]
     type = ImageDiff
     command = window_clear.py
     imagediff = 'window_clear.png'
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/wireframe/tests
+++ b/python/chigger/tests/wireframe/tests
@@ -1,19 +1,21 @@
 [Tests]
-  [./wireframe]
+  [wireframe]
     type = ImageDiff
     command = wireframe.py
     imagediff = 'wireframe.png'
     allowed_linux = 0.895
     allowed_darwin = 0.93
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./points]
+  [points]
     type = ImageDiff
     command = points.py
     imagediff = 'points.png'
     allowed_linux = 0.965
     allowed_darwin = 0.94
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/chigger/tests/writers/tests
+++ b/python/chigger/tests/writers/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./writers]
+  [writers]
     type = PythonUnitTest
     input = writers.py
     buffer = True
     display_required = true
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxesSettingsPlugin.py
@@ -168,6 +168,10 @@ def main(filenames):
     from .PostprocessorSelectPlugin import PostprocessorSelectPlugin
     import mooseutils
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (6.25, 6.25)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     widget = PostprocessorViewer(mooseutils.PostprocessorReader, timeout=None, plugins=[FigurePlugin, AxesSettingsPlugin, PostprocessorSelectPlugin])
     widget.onSetFilenames(filenames)
     control = widget.currentWidget().AxesSettingsPlugin

--- a/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/AxisTabsPlugin.py
@@ -96,6 +96,10 @@ def main(filenames):
     from .PostprocessorSelectPlugin import PostprocessorSelectPlugin
     import mooseutils
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (6.25, 6.25)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     widget = PostprocessorViewer(mooseutils.PostprocessorReader, timeout=None, plugins=[FigurePlugin, AxisTabsPlugin, PostprocessorSelectPlugin])
     widget.onSetFilenames(filenames)
     control = widget.currentWidget().AxisTabsPlugin

--- a/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/FigurePlugin.py
@@ -131,6 +131,10 @@ def main():
     from peacock.PostprocessorViewer.PostprocessorViewer import PostprocessorViewer
     import mooseutils
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (3.75, 3.75)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     widget = PostprocessorViewer(mooseutils.VectorPostprocessorReader, plugins=[FigurePlugin])
     widget.onSetFilenames([])
     widget.currentWidget().FigurePlugin.setFixedSize(QtCore.QSize(375, 375))

--- a/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineGroupWidget.py
@@ -338,6 +338,10 @@ def main(data, pp_class=mooseutils.VectorPostprocessorReader):
     import numpy as np
     import itertools
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (6.25, 6.25)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     # Create main widget
     widget = PostprocessorViewer(plugins=[FigurePlugin])
     widget.onSetFilenames(['empty_file'])

--- a/python/peacock/PostprocessorViewer/plugins/LineSettingsWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineSettingsWidget.py
@@ -305,6 +305,10 @@ def main(*args):
     from ..PostprocessorViewer import PostprocessorViewer
     from .FigurePlugin import FigurePlugin
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (3.75, 3.75)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     # Load the viewer
     widget = PostprocessorViewer(plugins=[FigurePlugin])
     widget.onSetFilenames(['empty_file'])

--- a/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/MediaControlPlugin.py
@@ -97,6 +97,11 @@ def main(filenames):
     from ..PostprocessorViewer import PostprocessorViewer
     from .FigurePlugin import FigurePlugin
     from .PostprocessorSelectPlugin import PostprocessorSelectPlugin
+
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (4., 4.)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     widget = PostprocessorViewer(mooseutils.VectorPostprocessorReader, plugins=[FigurePlugin, PostprocessorSelectPlugin, MediaControlPlugin])
     widget.onSetFilenames(filenames)
     widget.show()

--- a/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
+++ b/python/peacock/PostprocessorViewer/plugins/PostprocessorSelectPlugin.py
@@ -188,6 +188,10 @@ def main(filenames, reader=mooseutils.VectorPostprocessorReader):
     from ..PostprocessorViewer import PostprocessorViewer
     from .FigurePlugin import FigurePlugin
 
+    import matplotlib
+    matplotlib.rcParams["figure.figsize"] = (6.25, 6.25)
+    matplotlib.rcParams["figure.dpi"] = (100)
+
     widget = PostprocessorViewer(reader, timeout=None, plugins=[FigurePlugin, PostprocessorSelectPlugin])
     widget.onSetFilenames(filenames)
     control = widget.currentWidget().PostprocessorSelectPlugin

--- a/python/peacock/tests/base/tests
+++ b/python/peacock/tests/base/tests
@@ -1,12 +1,14 @@
 [Tests]
-  [./PluginManager]
+  [PluginManager]
     type = RunApp
     command = test_PluginManager.py
-    display_required = True
-  [../]
-  [./collapsible]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [collapsible]
     type = RunApp
     command = test_PeacockCollapsibleWidget.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/tests
+++ b/python/peacock/tests/execute_tab/ConsoleOutputViewerPlugin/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ConsoleOutputViewerPlugin]
+  [ConsoleOutputViewerPlugin]
     type = PythonUnitTest
     input = test_ConsoleOutputViewerPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/tests
+++ b/python/peacock/tests/execute_tab/ExecuteOptionsPlugin/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ExecuteOptionsPlugin]
+  [ExecuteOptionsPlugin]
     type = PythonUnitTest
     input = test_ExecuteOptionsPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/tests
+++ b/python/peacock/tests/execute_tab/ExecuteRunnerPlugin/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ExecuteRunnerPlugin]
+  [ExecuteRunnerPlugin]
     type = PythonUnitTest
     input = test_ExecuteRunnerPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/ExecuteTabPlugin/tests
+++ b/python/peacock/tests/execute_tab/ExecuteTabPlugin/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ExecuteTabPlugin]
+  [ExecuteTabPlugin]
     type = PythonUnitTest
     input = test_ExecuteTabPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/JobRunner/tests
+++ b/python/peacock/tests/execute_tab/JobRunner/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./JobRunner]
+  [JobRunner]
     type = PythonUnitTest
     input = test_JobRunner.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/execute_tab/TerminalTextEdit/tests
+++ b/python/peacock/tests/execute_tab/TerminalTextEdit/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./TerminalTextEdit]
+  [TerminalTextEdit]
     type = PythonUnitTest
     input = test_TerminalTextEdit.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/exodus_tab/tests
+++ b/python/peacock/tests/exodus_tab/tests
@@ -1,92 +1,107 @@
 [Tests]
-  [./VTKWindowPlugin]
+  [VTKWindowPlugin]
     type = PythonUnitTest
     input = test_VTKWindowPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./FilePlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [FilePlugin]
     type = PythonUnitTest
     input = test_FilePlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./GoldDiffPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [GoldDiffPlugin]
     type = PythonUnitTest
     input = test_GoldDiffPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./ColorbarPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ColorbarPlugin]
     type = PythonUnitTest
     input = test_ColorbarPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./BackgroundPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [BackgroundPlugin]
     type = PythonUnitTest
     input = test_BackgroundPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./ClipPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ClipPlugin]
     type = PythonUnitTest
     input = test_ClipPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./ContourPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ContourPlugin]
     type = PythonUnitTest
     input = test_ContourPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./BlockPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [BlockPlugin]
     type = PythonUnitTest
     input = test_BlockPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./MeshPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [MeshPlugin]
     type = PythonUnitTest
     input = test_MeshPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./MediaControlPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [MediaControlPlugin]
     type = PythonUnitTest
     input = test_MediaControlPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./CameraPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [CameraPlugin]
     type = PythonUnitTest
     input = test_CameraPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./OutputPlugin]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [OutputPlugin]
     type = PythonUnitTest
     input = test_OutputPlugin.py
     separate = True
-    display_required = True
-  [../]
-  [./ExodusPluginManager]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ExodusPluginManager]
     type = PythonUnitTest
     input = test_ExodusPluginManager.py
     separate = True
-    display_required = True
-  [../]
-  [./ExodusViewer]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ExodusViewer]
     type = PythonUnitTest
     input = test_ExodusViewer.py
     separate = True
-    display_required = True
-  [../]
-  [./ExodusViewer2]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ExodusViewer2]
     type = PythonUnitTest
     input = test_ExodusViewer2.py
     separate = True
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/BlockEditor/tests
+++ b/python/peacock/tests/input_tab/BlockEditor/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./BlockEditor]
+  [BlockEditor]
     type = PythonUnitTest
     input = test_BlockEditor.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/BlockInfo/tests
+++ b/python/peacock/tests/input_tab/BlockInfo/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./BlockInfo]
+  [BlockInfo]
     type = PythonUnitTest
     input = test_BlockInfo.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/BlockTree/tests
+++ b/python/peacock/tests/input_tab/BlockTree/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./BlockTree]
+  [BlockTree]
     type = PythonUnitTest
     input = test_BlockTree.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/CheckInputWidget/tests
+++ b/python/peacock/tests/input_tab/CheckInputWidget/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./CheckInputWidget]
+  [CheckInputWidget]
     type = PythonUnitTest
     input = test_CheckInputWidget.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/CommentEditor/tests
+++ b/python/peacock/tests/input_tab/CommentEditor/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./CommentEditor]
+  [CommentEditor]
     type = PythonUnitTest
     input = test_CommentEditor.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/ExecutableInfo/tests
+++ b/python/peacock/tests/input_tab/ExecutableInfo/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ExecutableInfo]
+  [ExecutableInfo]
     type = PythonUnitTest
     input = test_ExecutableInfo.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/InputFile/tests
+++ b/python/peacock/tests/input_tab/InputFile/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./InputFile]
+  [InputFile]
     type = PythonUnitTest
     input = test_InputFile.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/InputFileEditor/tests
+++ b/python/peacock/tests/input_tab/InputFileEditor/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./InputFileEditor]
+  [InputFileEditor]
     type = PythonUnitTest
     input = test_InputFileEditor.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/InputFileEditorPlugin/tests
+++ b/python/peacock/tests/input_tab/InputFileEditorPlugin/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./InputFileEditorPlugin]
+  [InputFileEditorPlugin]
     type = PythonUnitTest
     input = test_InputFileEditorPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/InputFileEditorWithMesh/tests
+++ b/python/peacock/tests/input_tab/InputFileEditorWithMesh/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./InputFileEditorWithMesh]
+  [InputFileEditorWithMesh]
     type = PythonUnitTest
     input = test_InputFileEditorWithMesh.py
     separate = True
-    display_required = True
-    platform = linux
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/InputTree/tests
+++ b/python/peacock/tests/input_tab/InputTree/tests
@@ -8,94 +8,105 @@
     [InputFileOnly]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testInputFileOnly
 
       detail = " the ability to read and display application input files;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testTransient]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testTransient
 
       detail = "support for input files with transient solves;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testLCF]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testLCF
       prereq = 'input/testTransient'
 
       detail = "support for input files with a linear combination function;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testFSP]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testFSP
       prereq = 'input/testLCF'
 
       detail = "support for input files with a field split preconditioner;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testSimpleDiffusion]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testSimpleDiffusion
       prereq = 'input/testFSP'
 
       detail = "the ability to read and write a complete input file;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testChangingInputFiles]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testChangingInputFiles
 
       detail = "the ability to change input files;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testTreeWithOnlyApp]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testTreeWithOnlyApp
 
       detail = "the ability to open without an input file;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testAddVectorPostprocessor]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testAddVectorPostprocessor
 
       detail = "the capability to add input file blocks graphically;"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testBlocks]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testBlocks
 
       detail = "supports the creation of input file blocks; and"
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
 
     [testIncompatible]
       type = PythonUnitTest
       input = test_InputTree.py
-      display_required = True
+      display_required = true
       test_case = Tests.testIncompatible
 
       detail = "handles incompatible parameter changes without failure."
+      platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     []
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 []

--- a/python/peacock/tests/input_tab/InputTreeWriter/tests
+++ b/python/peacock/tests/input_tab/InputTreeWriter/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./InputTreeWriter]
+  [InputTreeWriter]
     type = PythonUnitTest
     input = test_InputTreeWriter.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/JsonData/tests
+++ b/python/peacock/tests/input_tab/JsonData/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./JsonData]
+  [JsonData]
     type = PythonUnitTest
     input = test_JsonData.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/OutputNames/tests
+++ b/python/peacock/tests/input_tab/OutputNames/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./Outputnames]
+  [Outputnames]
     type = PythonUnitTest
     input = test_OutputNames.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/ParameterInfo/tests
+++ b/python/peacock/tests/input_tab/ParameterInfo/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ParameterInfo]
+  [ParameterInfo]
     type = PythonUnitTest
     input = test_ParameterInfo.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/ParamsByGroup/tests
+++ b/python/peacock/tests/input_tab/ParamsByGroup/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ParamsByGroup]
+  [ParamsByGroup]
     type = PythonUnitTest
     input = test_ParamsByGroup.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/ParamsByType/tests
+++ b/python/peacock/tests/input_tab/ParamsByType/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ParamsByType]
+  [ParamsByType]
     type = PythonUnitTest
     input = test_ParamsByType.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/ParamsTable/tests
+++ b/python/peacock/tests/input_tab/ParamsTable/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./ParamsTable]
+  [ParamsTable]
     type = PythonUnitTest
     input = test_ParamsTable.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/TimeStepEstimate/tests
+++ b/python/peacock/tests/input_tab/TimeStepEstimate/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./TimeStepEstimate]
+  [TimeStepEstimate]
     type = PythonUnitTest
     input = test_TimeStepEstimate.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/input_tab/plugins/tests
+++ b/python/peacock/tests/input_tab/plugins/tests
@@ -3,6 +3,6 @@
     type = PythonUnitTest
     input = test_MeshViewerPlugin.py
     display_required = true
-    platform = LINUX
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 []

--- a/python/peacock/tests/peacock_app/BasePeacockMainWindow/tests
+++ b/python/peacock/tests/peacock_app/BasePeacockMainWindow/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./BasePeacockMainWindow]
+  [BasePeacockMainWindow]
     type = PythonUnitTest
     input = test_BasePeacockMainWindow.py
-    display_required = True
+    display_required = true
     separate = True
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/CheckRequirements/tests
+++ b/python/peacock/tests/peacock_app/CheckRequirements/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./CheckRequirements]
+  [CheckRequirements]
     type = PythonUnitTest
     input = test_CheckRequirements.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/LogWidget/tests
+++ b/python/peacock/tests/peacock_app/LogWidget/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./LogWidget]
+  [LogWidget]
     type = PythonUnitTest
     input = test_LogWidget.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/PeacockApp/tests
+++ b/python/peacock/tests/peacock_app/PeacockApp/tests
@@ -4,122 +4,136 @@
   [PeacockApp]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testPeacockApp
     requirement = "The system shall include a graphical interface that opens without any input arguments."
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [PeacockAppWithExec]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testPeacockAppWithExe
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application executable."
     prereq = PeacockApp
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [PeacockAppWithInput]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testPeacockAppWithInput
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application input file."
     prereq = PeacockAppWithExec
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [Results]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testResults
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application Exodus result."
     prereq = PeacockAppWithInput
-    platform = linux
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [ResultsNoOption]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testResultsNoOption
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application Exodus result without using the '-r' flag."
     prereq = Results
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [Postprocessor]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testPostprocessor
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application CSV result."
     prereq = ResultsNoOption
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [PostprocessorNoOption]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testPostprocessorNoOption
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application CSV result without using the '-p' flag."
     prereq = Postprocessor
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [AllCommandLine]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testAllCommandLine
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application executable, input, Exodus, and CSV results."
     prereq = PostprocessorNoOption
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [OnlyInputFileWithExeInPath]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testOnlyInputFileWithExeInPath
     requirement = "The system shall include a graphical interface that opens with a MOOSE-based application input file without the '-i' flag."
     prereq = AllCommandLine
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [WrongExe]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testWrongExe
     requirement = "The system shall include a graphical interface that opens with an invalid MOOSE-based application executable."
     prereq = OnlyInputFileWithExeInPath
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [BadInput]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testBadInput
     requirement = "The system shall include a graphical interface that opens with an invalid MOOSE-based application input file."
     prereq = WrongExe
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [ClearSettings]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testClearSettings
     requirement = "The system shall include a graphical interface that includes the ability to clear stored settings."
     prereq = BadInput
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [BadMesh]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testBadMesh
     requirement = "The system shall include a graphical interface that opens a MOOSE-based application input file that includes an invalid mesh."
     prereq = ClearSettings
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [ExodusChangedFile]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testExodusChangedFile
     requirement = "The system shall include a graphical interface that includes the ability to change MOOSE-based application input files."
     prereq = BadMesh
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
   [ExodusExtentsReload]
     type = PythonUnitTest
     input = test_PeacockApp.py
-    display_required = True
+    display_required = true
     test_case = Tests.testExodusExtentsReload
     requirement = "The system shall include a graphical interface that includes the ability to visualize and reload Exodus result extents."
     prereq = ExodusChangedFile
     skip = '#11756'
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 []

--- a/python/peacock/tests/peacock_app/PeacockMainWindow/tests
+++ b/python/peacock/tests/peacock_app/PeacockMainWindow/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./PeacockMainWindow]
+  [PeacockMainWindow]
     type = PythonUnitTest
     input = test_PeacockMainWindow.py
-    display_required = True
+    display_required = true
     separate = True
-  [../]
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/PythonConsoleWidget/tests
+++ b/python/peacock/tests/peacock_app/PythonConsoleWidget/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./PythonConsoleWidget]
+  [PythonConsoleWidget]
     type = PythonUnitTest
     input = test_PythonConsoleWidget.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_add_variables_and_blocks/tests
+++ b/python/peacock/tests/peacock_app/check_add_variables_and_blocks/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./add_variable_and_block]
+  [add_variable_and_block]
     type = PythonUnitTest
     input = test_AddVariableAndBlock.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_change_input_file/tests
+++ b/python/peacock/tests/peacock_app/check_change_input_file/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./change_input]
+  [change_input]
     type = PythonUnitTest
     input = test_ChangeInputFile.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_exodus_state/tests
+++ b/python/peacock/tests/peacock_app/check_exodus_state/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = PythonUnitTest
     input = test_exodus_state.py
-    platform = "LINUX"
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     separate = True
     display_required = true
-  [../]
+  []
 []

--- a/python/peacock/tests/peacock_app/check_mesh/tests
+++ b/python/peacock/tests/peacock_app/check_mesh/tests
@@ -1,8 +1,8 @@
 [Tests]
-  [./CheckMesh]
+  [CheckMesh]
     type = PythonUnitTest
     input = test_check_mesh.py
-    display_required = True
-    platform = linux
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_postprocessor/tests
+++ b/python/peacock/tests/peacock_app/check_postprocessor/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./CheckPostprocessor]
+  [CheckPostprocessor]
     type = PythonUnitTest
     input = test_check_postprocessor.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_postprocessor_state/tests
+++ b/python/peacock/tests/peacock_app/check_postprocessor_state/tests
@@ -1,8 +1,9 @@
 [Tests]
-  [./test]
+  [test]
     type = PythonUnitTest
     input = test_postprocessor_state.py
-    platform = "DARWIN"
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
     separate = True
-  [../]
+    display_required = true
+  []
 []

--- a/python/peacock/tests/peacock_app/check_result/tests
+++ b/python/peacock/tests/peacock_app/check_result/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./CheckResult]
+  [CheckResult]
     type = PythonUnitTest
     input = test_check_result.py
     separate = True
-    display_required = True
-    platform = linux
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/check_vectorpostprocessor/tests
+++ b/python/peacock/tests/peacock_app/check_vectorpostprocessor/tests
@@ -1,7 +1,8 @@
 [Tests]
-  [./CheckVectorPostprocessor]
+  [CheckVectorPostprocessor]
     type = PythonUnitTest
     input = test_check_vectorpostprocessor.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/peacock_app/results_output/tests
+++ b/python/peacock/tests/peacock_app/results_output/tests
@@ -1,9 +1,9 @@
 [Tests]
-  [./CheckResultOutput]
+  [CheckResultOutput]
     type = PythonUnitTest
     input = test_results_output.py
     separate = True
-    display_required = True
-    platform = linux
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorPluginManager.py
@@ -44,6 +44,9 @@ class TestPostprocessorPluginManager(Testing.PeacockImageTestCase):
         """
         Creates the GUI containing the ArtistGroupWidget and the matplotlib figure axes.
         """
+        import matplotlib
+        matplotlib.rcParams["figure.figsize"] = (5., 5.)
+        matplotlib.rcParams["figure.dpi"] = (100)
 
         data = [PostprocessorDataWidget(mooseutils.PostprocessorReader('../input/white_elephant_jan_2016.csv'))]
         self._widget, self._window = main()

--- a/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_PostprocessorViewer.py
@@ -30,6 +30,10 @@ class TestPostprocessorViewer(Testing.PeacockImageTestCase):
         """
         Creates the GUI containing the ArtistGroupWidget and the matplotlib figure axes.
         """
+        import matplotlib
+        matplotlib.rcParams["figure.figsize"] = (6.4, 4.8)
+        matplotlib.rcParams["figure.dpi"] = (100)
+
         self._filename = "{}_test.csv".format(self.__class__.__name__)
         self._widget = PostprocessorViewer(reader=mooseutils.PostprocessorReader, timeout=None)
         self._widget.onSetFilenames([self._filename])

--- a/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
+++ b/python/peacock/tests/postprocessor_tab/test_VectorPostprocessorViewer.py
@@ -30,6 +30,10 @@ class TestVectorPostprocessorViewer(Testing.PeacockImageTestCase):
         """
         Creates the GUI containing the ArtistGroupWidget and the matplotlib figure axes.
         """
+        import matplotlib
+        matplotlib.rcParams["figure.figsize"] = (6.4, 4.8)
+        matplotlib.rcParams["figure.dpi"] = (100)
+
         self._filename = "{}_test_*.csv".format(self.__class__.__name__)
         self._widget = VectorPostprocessorViewer(timeout=None)
         self._widget.onSetFilenames([self._filename])

--- a/python/peacock/tests/postprocessor_tab/tests
+++ b/python/peacock/tests/postprocessor_tab/tests
@@ -1,89 +1,92 @@
 [Tests]
-  [./FigurePlugin]
+  [FigurePlugin]
     type = PythonUnitTest
     input = test_FigurePlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./LineSettingsWidget]
+  [LineSettingsWidget]
     type = PythonUnitTest
     input = test_LineSettingsWidget.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./LineGroupWidget_Postprocessor]
+  [LineGroupWidget_Postprocessor]
     type = PythonUnitTest
     input = test_LineGroupWidgetPostprocessor.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./LineGroupWidget_VectorPostprocessor]
+  [LineGroupWidget_VectorPostprocessor]
     type = PythonUnitTest
     input = test_LineGroupWidgetVectorPostprocessor.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./PostprocessorSelectPlugin_Postprocessor]
+  [PostprocessorSelectPlugin_Postprocessor]
     type = PythonUnitTest
     input = test_PostprocessorSelectPlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./PostprocessorSelectPlugin_VectorPostprocessor]
+  [PostprocessorSelectPlugin_VectorPostprocessor]
     type = PythonUnitTest
     input = test_VectorPostprocessorSelectPlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./AxesSettingsPlugin]
+  [AxesSettingsPlugin]
     type = PythonUnitTest
     input = test_AxesSettingsPlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./AxisTabsPlugin]
+  [AxisTabsPlugin]
     type = PythonUnitTest
     input = test_AxisTabsPlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./MediaControlPlugin]
+  [MediaControlPlugin]
     type = PythonUnitTest
     input = test_MediaControlPlugin.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./PostprocessorPluginManager]
+  [PostprocessorPluginManager]
     type = PythonUnitTest
     input = test_PostprocessorPluginManager.py
-    display_required = True
-    platform = "DARWIN" # images are a different size on linux #11734
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./PostprocessorViewer_Postprocessor]
+  [PostprocessorViewer_Postprocessor]
     type = PythonUnitTest
     input = test_PostprocessorViewer.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./PostprocessorViewer_VectorPostprocessor]
+  [PostprocessorViewer_VectorPostprocessor]
     type = PythonUnitTest
     input = test_VectorPostprocessorViewer.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 
-  [./Output]
+  [Output]
     type = PythonUnitTest
     input = test_OutputPlugin.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/peacock/tests/postprocessor_tab/tests
+++ b/python/peacock/tests/postprocessor_tab/tests
@@ -3,90 +3,77 @@
     type = PythonUnitTest
     input = test_FigurePlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [LineSettingsWidget]
     type = PythonUnitTest
     input = test_LineSettingsWidget.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [LineGroupWidget_Postprocessor]
     type = PythonUnitTest
     input = test_LineGroupWidgetPostprocessor.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [LineGroupWidget_VectorPostprocessor]
     type = PythonUnitTest
     input = test_LineGroupWidgetVectorPostprocessor.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [PostprocessorSelectPlugin_Postprocessor]
     type = PythonUnitTest
     input = test_PostprocessorSelectPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [PostprocessorSelectPlugin_VectorPostprocessor]
     type = PythonUnitTest
     input = test_VectorPostprocessorSelectPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [AxesSettingsPlugin]
     type = PythonUnitTest
     input = test_AxesSettingsPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [AxisTabsPlugin]
     type = PythonUnitTest
     input = test_AxisTabsPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [MediaControlPlugin]
     type = PythonUnitTest
     input = test_MediaControlPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [PostprocessorPluginManager]
     type = PythonUnitTest
     input = test_PostprocessorPluginManager.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [PostprocessorViewer_Postprocessor]
     type = PythonUnitTest
     input = test_PostprocessorViewer.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [PostprocessorViewer_VectorPostprocessor]
     type = PythonUnitTest
     input = test_VectorPostprocessorViewer.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 
   [Output]
     type = PythonUnitTest
     input = test_OutputPlugin.py
     display_required = true
-    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
   []
 []

--- a/python/peacock/tests/utils/tests
+++ b/python/peacock/tests/utils/tests
@@ -1,37 +1,44 @@
 [Tests]
-  [./ExeLauncher]
+  [ExeLauncher]
     type = PythonUnitTest
     input = test_ExeLauncher.py
-    display_required = True
-  [../]
-  [./RecentlyUsedMenu]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [RecentlyUsedMenu]
     type = PythonUnitTest
     input = test_RecentlyUsedMenu.py
-    display_required = True
-  [../]
-  [./ExeFinder]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [ExeFinder]
     type = PythonUnitTest
     input = test_ExeFinder.py
-    display_required = True
-  [../]
-  [./FileCache]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [FileCache]
     type = PythonUnitTest
     input = test_FileCache.py
-    display_required = True
-  [../]
-  [./TerminalUtils]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [TerminalUtils]
     type = PythonUnitTest
     input = test_TerminalUtils.py
-    display_required = True
-  [../]
-  [./Widgetutils]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [Widgetutils]
     type = PythonUnitTest
     input = test_WidgetUtils.py
-    display_required = True
-  [../]
-  [./loadstore]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
+  [loadstore]
     type = PythonUnitTest
     input = test_StoreLoadWidgetState.py
-    display_required = True
-  [../]
+    display_required = true
+    platform = LINUX # https://github.com/conda-forge/vtk-feedstock/issues/109
+  []
 []

--- a/python/pyhit/__init__.py
+++ b/python/pyhit/__init__.py
@@ -1,1 +1,1 @@
-from .pyhit import Node, load, parse
+from .pyhit import Node, load, write, parse

--- a/python/pyhit/pyhit.py
+++ b/python/pyhit/pyhit.py
@@ -303,7 +303,7 @@ def write(filename, root):
         root[Node]: The root node of the tree to write
     """
     with open(filename, 'w') as fid:
-        fid.write(root.render())
+        fid.write(root.render() + "\n")
 
 def parse(content, root=None, filename=''):
     """

--- a/python/pyhit/pyhit.py
+++ b/python/pyhit/pyhit.py
@@ -294,6 +294,17 @@ def load(filename, root=None):
 
     return parse(content, root, filename)
 
+def write(filename, root):
+    """
+    Write the supplied tree to the file.
+
+    Inputs:
+        filename[str]: The filename to open and parse
+        root[Node]: The root node of the tree to write
+    """
+    with open(filename, 'w') as fid:
+        fid.write(root.render())
+
 def parse(content, root=None, filename=''):
     """
     Parse a hit tree from a string.


### PR DESCRIPTION
There is currently a bug in VTK on conda when writing PNG files: https://github.com/conda-forge/vtk-feedstock/issues/109.

Eventually, part of restoring this should be to use offscreen, software rendering with osmesa. But, for now we need to get things working so conda work can continue.


<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
