### PR TITLE
Switch to search over match

### DIFF
--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -379,17 +379,17 @@ def getCompilers(libmesh_dir):
     if "distcc" in mpicxx_cmd or "ccache" in mpicxx_cmd:
         mpicxx_cmd = mpicxx_cmd.split()[-1]
 
-    # If mpi ic on the command, run -show to get the compiler
+    # If mpi is in the command, run -show to get the compiler
     if "mpi" in mpicxx_cmd:
-        raw_compiler = runCommand(mpicxx_cmd + " -show")
+        raw_compiler = runCommand(mpicxx_cmd + " -show").split()[0]
     else:
         raw_compiler = mpicxx_cmd
 
-    if re.match('icpc', raw_compiler) != None:
+    if re.search('icpc', raw_compiler) != None:
         compilers.add("INTEL")
-    elif re.match('[cg]\+\+', raw_compiler) != None:
+    elif re.search('(?<!clan)[cg]\+\+', raw_compiler) != None:
         compilers.add("GCC")
-    elif re.match('clang\+\+', raw_compiler) != None:
+    elif re.search('clang\+\+', raw_compiler) != None:
         compilers.add("CLANG")
 
     return compilers


### PR DESCRIPTION
According to https://docs.python.org/3/library/re.html#search-vs-match we should be using search
(match only works at the start of the string).

Conda compilers display a lot of 'text' before revealing the actual compiler name
at the _end_ of the string. In order to better support the previous method, split the
mpicxx --show command. This will aid in false positive detection.

Closes #14967

