### PR TITLE
Contact documentation

### DIFF
--- a/modules/contact/doc/content/modules/contact/MortarPerformance.md
+++ b/modules/contact/doc/content/modules/contact/MortarPerformance.md
@@ -1,0 +1,201 @@
+# Mortar-Based Mechanical Contact Performance
+
+Results of performance studies on the mortar-based contact approach are shown here.
+
+### Frictionless contact algorithm comparison id=frictionless_table
+
+| Constraint | Displacement | NCP function | Time (arbitrary units) | Time steps | Nonlinear iterations |
+| ---------- | ------------ | ------------ | ---------------------- | ---------- | -------------------- |
+| Nodal | Mortar | Min | 4.164 | 40 | 104 |
+| Nodal | Mortar | FB | 5.020 | 40 | 135 |
+| Nodal | Nodal | Min | 3.124 | 41 | 104 |
+| Nodal | Nodal | FB | 4.014 | 41 | 149 |
+| Mortar | Mortar | Min | 4.461 | 40 | 106 |
+| Mortar | Mortar | FB | 5.577 | 40 | 136 |
+| Nodal | Nodal | RANFS | 2.700 | 40 | 99 |
+
+The first column denotes the discretization algorithm used for applying the
+frictionless contact constraints. Nodal denotes use of a `NodeFaceConstraint`;
+`Mortar` denotes use of a `MortarConstraint`. The second column denotes the
+discretization used for applying the contact forces to the displacement
+residuals. The third column denotes the type of non-linear complimentarity
+problem (NCP) function used to ensure that the contact constraints are
+satisfied. Min indicates the canonical min function (see
+[std::min](https://en.cppreference.com/w/cpp/algorithm/min)); FB represents the
+Fischer-Burmeister function. `RANFS` denotes the Reduced Active Nonlinear
+Function Set scheme in which no Lagrange Multipliers are used, and instead the
+non-linear residual equations at the slave nodes are replaced with the gap
+function. The fourth column in the table is the simulation time in
+arbitrary units (since timings will be different across machines). The fifth
+column is the number of time steps required to reach the simulation end
+time. The final, sixth column is the cumulative number of non-linear iterations
+taken during the simulation (note that this does not include any non-linear
+iterations from failed time steps).
+
+Notes:
+
+- Clearly having mortar mesh generation slows the simulation down, which is not surprising
+- The min NCP function is undeniably better for solving normal contact
+- For the pure nodal algorithms, the time step that did not converge featured classic ping-ponging behavior:
+
+```
+ 5 Nonlinear |R| = 4.007951e-04
+    |residual|_2 of individual variables:
+                  disp_x:    0.000399808
+                  disp_y:    2.75599e-05
+                  normal_lm: 5.52166e-06
+
+
+The number of nodes in contact is 11
+
+      0 Linear |R| = 4.007951e-04
+      1 Linear |R| = 1.287307e-04
+      2 Linear |R| = 8.423398e-06
+      3 Linear |R| = 1.046825e-07
+      4 Linear |R| = 8.017310e-09
+      5 Linear |R| = 3.053040e-10
+  Linear solve converged due to CONVERGED_RTOL iterations 5
+ 6 Nonlinear |R| = 4.432193e-04
+    |residual|_2 of individual variables:
+                  disp_x:    0.000396694
+                  disp_y:    0.00019545
+                  normal_lm: 2.96013e-05
+
+
+The number of nodes in contact is 11
+
+      0 Linear |R| = 4.432193e-04
+      1 Linear |R| = 1.355935e-04
+      2 Linear |R| = 1.216010e-05
+      3 Linear |R| = 6.386952e-07
+      4 Linear |R| = 2.235594e-08
+      5 Linear |R| = 2.884193e-10
+  Linear solve converged due to CONVERGED_RTOL iterations 5
+ 7 Nonlinear |R| = 4.008045e-04
+    |residual|_2 of individual variables:
+                  disp_x:    0.000399816
+                  disp_y:    2.76329e-05
+                  normal_lm: 5.29313e-06
+
+
+The number of nodes in contact is 11
+
+      0 Linear |R| = 4.008045e-04
+      1 Linear |R| = 1.287272e-04
+      2 Linear |R| = 8.423081e-06
+      3 Linear |R| = 1.047782e-07
+      4 Linear |R| = 8.054781e-09
+      5 Linear |R| = 3.046073e-10
+  Linear solve converged due to CONVERGED_RTOL iterations 5
+ 8 Nonlinear |R| = 4.432194e-04
+```
+
+### Frictional contact algorithm comparison id=frictional_table
+
+| LM normal | LM tangential | Displacement | NCP function normal | NCP function tangential | Time (arbitrary units) | Time steps | Nonlinear iterations | CLI PETSc options |
+| --------- | ------------  | ------------ | ------------------- | ----------------------- | ---------------------- | ---------- | -------------------- | --- |
+| Mortar | Mortar | Mortar | FB | FB | 8.241 | 40 | 175 | None |
+| Mortar | Mortar | Mortar | Min | FB | 7.928 | 40 | 159 | None |
+| Nodal | Mortar | Mortar | Min | FB | 7.459 | 40 | 152 | None |
+| Mortar | Mortar | Mortar | Min | Min | 11.237 | 41 | 234 | None |
+| Nodal | Nodal | Mortar | Min | Min | 39.409 | 55 | 275 | `-snes_ksp_ew 0` |
+| Nodal | Nodal | Mortar | FB | FB | NA | NA | NA | None |
+
+Notes:
+
+- NA: solve did not converge
+- Timings run on a different machine than the frictionless cases
+- The most performant case uses a `NodeFaceConstraint` discretization for
+  enforcing the normal contact conditions and `MortarConstraint` discretizations
+  for enforcement of the Coulomb frictional constraints and application of
+  forces to the displacement residuals. Interestingly, this performant case uses
+  different NCP functions for normal and tangential constraints: `std::min` for
+  the former and Fischer-Burmeister for the latter. This performant case is used
+  for comparison with the node-face penalty algorithm, shown below:
+
+### NCP-LM-Mortar vs Penalty-NodeFace
+
+The table below compares the timing and solver performance of
+[NCP-LM-Mortar](/in_and_out/constraint/frictional_lm.i) and
+[Penalty-NodeFace](/in_and_out/constraint/frictional_04_penalty.i) algorithms. NCP-LM refers to use of an
+NCP function for contact constraint enforcement on a lagrange multiplier. The
+"Mortar" designation denotes that a mortar discretization is used for enforcing
+the tangential Coulomb friction conditions and applying contact forces to the
+displacement residuals.
+
+| Algorithm | Time (arb. units) | Time steps to end time | Cumulative non-linear iterations |
+| --- | --- | --- | --- |
+| NCP-LM-Mortar | 13.901 | 151 | 476 |
+| Penalty-NodeFace | 20.711 | 151 | 938 |
+
+There's a cost associated with generation of the mortar segment mesh that
+partially offsets the fact that the mortar case takes nearly half the non-linear
+iterations of the penalty case.
+
+## Petsc options for contact
+
+Recommended PETSc options for use with mortar based frictional contact are:
+
+```puppet
+[Executioner]
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_ksp_ew'
+  petsc_options_iname = '-pc_type -mat_mffd_err -pc_factor_shift_type -pc_factor_shift_amount'
+  petsc_options_value = 'lu       1e-5          NONZERO               1e-15'
+[]
+```
+
+Using Eisenstat-Walker is advantageous for frictional contact because time is
+not wasted in the linear solve in early non-linear iterations while the contact
+set and stick/slip conditions are being resolved. Later in the non-linear solve
+when the set of constraints has been resolved, more linear iterations will be
+used as the non-linear solver moves through the quadratic basin. Experience has
+shown that a choice of 1e-5 for the matrix free finite differencing parameter
+works well for many problems. However, the user may want to experiment with
+values anywhere between 1e-8 and 1e-4 depending on their multi-physics. A
+very small non-zero shift is used to avoid zero pivots during the LU
+decomposition. This may be extraneous in many cases. Note that the Jacobian
+entries for mortar based contact are accurate and complete enough that
+incomplete factorization may be used in serial or as a sub-block solver for
+block jacobi or additive schwarz in parallel. This may be necessary for large
+problems where lu does not scale.
+
+The recommended PETSc options for use with `NodeFaceConstraint` based contact are shown below :
+
+```puppet
+[Executioner]
+  ...
+  petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap
+                        -ksp_gmres_restart'
+  petsc_options_value = 'asm lu 20 101'
+  ...
+[../]
+```
+
+## Scaling effects
+
+The effects of scaling on non-linear solve convergence are shown below for
+different kinds of contact formulations. The results are based on the input files for
+[RANFS](/ranfs-and-scaling/bouncing-block-ranfs.i),
+[kinematic](/bouncing-block-kinematic.i), and
+[tangential penalty](/bouncing-block-tan-pen.i),
+running with two processes.
+
+| Scheme | Cumulative nonlinear iterations | Cumulative linear iterations | Initial condition number | Variable Scaling Factor |
+| - | - | - | - | - |
+| SMP PJFNK RANFS no scaling AMG | 68 | 510 | 9e3 | 1 |
+| SMP PJFNK RANFS residual auto-scaling AMG | 65 | 391 | 1e2 | 1.1e-2 |
+| SMP PJFNK RANFS Jacobian auto-scaling AMG | 66 | 372 | 4e1 | 4.1e-4 |
+| SMP PJFNK Kinematic no scaling AMG | 58 | 305 | 9e3 | 1 |
+| SMP PJFNK Kinematic residual auto-scaling AMG | 58 | 305 | 1e2 | 1.1e-2 |
+| SMP PJFNK Kinematic Jacobian auto-scaling AMG | 58 | 305 | 4e1 | 4.1e-4 |
+| SMP PJFNK Tangential Penalty no scaling AMG | 65 | 400 | 9e3 | 1 |
+| SMP PJFNK Tangential Penalty residual auto-scaling AMG | 65 | 400 | 1e2 | 1.1e-2 |
+| SMP PJFNK Tangential Penalty Jacobian auto-scaling AMG | 65 | 400 | 4e1 | 4.1e-4 |
+| FD PJFNK RANFS jacobian auto-scaling LU | 54 | 70 | 4e1 | 4.1e-4 |
+| FD PJFNK Kinematic jacobian auto-scaling LU | 62 | 95 | 4e1 | 4.1e-4 |
+
+Important takeaways:
+
+- The solve efficiency of kinematic and tangential penalty formulations is independent of scaling (within the window of this problem)
+- Because RANFS constraint residuals/Jacobians are of gap magnitude, the RANFS solve really does perform better when the internal physics is scaled to be on the same order of magnitude
+- There are some bugs with the RANFS Jacobian functions because RANFS takes more nonlinear and linear iterations than kinematic, but with a FD Jacobian RANFS takes significantly less nonlinear and linear iterations than kinematic

--- a/modules/contact/doc/content/modules/contact/index.md
+++ b/modules/contact/doc/content/modules/contact/index.md
@@ -19,283 +19,35 @@ t_N g = 0.
 \end{equation*}
 
 
-That is, the penetration distance (typically referred to as the gap $g$ in the contact literature) of one of the body into another must not be positive; the contact force $t_N$ opposing penetration must be positive in the normal direction; and either the penetration distance or the contact force must be zero at all times.
-
-In the MOOSE Contact Module, these contact constraints are enforced through the use of node/face constraints. This is accomplished in a manner similar to that detailed by [!cite](heinstein_algorithm_1999). First, a geometric search determines which slave nodes have penetrated master faces. For those nodes, the internal force computed by the divergence of stress is moved to the appropriate master face at the point of contact. Those forces are distributed to master nodes by employing the finite element shape functions. Additionally, the slave nodes are constrained to remain on the master faces, preventing penetration. The module currently supports frictionless, frictional, and glued contact.
+That is, the penetration distance (typically referred to as the gap $g$ in the contact literature) of one of the body into another must not be positive; the contact force $t_N$ opposing penetration must be positive in the normal direction; and either the penetration distance or the contact force must be zero at all times.  In the MOOSE Contact Module, these contact constraints are enforced through the use of either node/face constraints or by using a mortar method. 
 
 [](---)
 
-## Procedure for using mechanical contact
+## Node/Face Mechanical Contact
 
-In the contact module there are currently two systems to choose from mechanical contact : Dirac and Constraint.  The Constraint system is recommended for all problems, as the Dirac system will be removed in the future.
-The contact block in the MOOSE input file looks like this :
-
-```puppet
-[Contact]
-  [./contact]
-    disp_x = <variable>
-    disp_y = <variable>
-    disp_z = <variable>
-    formulation = <string> (DEFAULT)
-    friction_coefficient = <real> (0)
-    master = <string>
-    model = <string> (frictionless)
-    normal_smoothing_distance = <real>
-    normal_smoothing_method = <string> (edge_based)
-    order = <string> (FIRST)
-    penalty = <real> (1e8)
-    normalize_penalty = <bool> (false)
-    slave = <string>
-    system = <string> (Dirac)
-    tangential_tolerance = <real>
-    tension_release = <real> (0)
-  [../]
-[]
-```
-
-The parameters descriptions are :
-
-- `disp_x` (+Required+) Variable name for displacement variable in x direction. Typically `disp_x`.
-- `disp_y` Variable name for displacement variable in y direction. Typically `disp_y`.
-- `disp_z` Variable name for displacement variable in z direction. Typically `disp_z`
-- `formulation` Select either `DEFAULT`, `KINEMATIC`, or `PENALTY`. `DEFAULT` is `KINEMATIC`.
-- `friction_coefficient` The friction coefficient.
-- `master` (+Required+) The boundary ID for the master surface.
-- `model` Select either `frictionless`, `glued`, or `coulomb`.
-- `normal_smoothing_distance` Distance from face edge in parametric coordinates over which to smooth the contact normal. $0.1$ is a reasonable value.
-- `normal_smoothing_method` Select either `edge_based` or `nodal_normal_based`. If `nodal_normal_based`, must also have a `NodalNormals` block.
-- `order` The order of the variable. Typical values are `FIRST` and `SECOND`.
-- `penalty` The penalty stiffness value to be used in the constraint.
-- `normalize_penalty` Whether to normalize the penalty stiffness by the nodal area of the slave node.
-- `slave` (+Required+) The boundary ID for the slave surface.
-- `system` The system to use for constraint enforcement. Options are Dirac `DiracKernel` or `Constraint`. The default is `Dirac`.
-- `tangential_tolerance` Tangential distance to extend edges of contact surfaces.
-- `tension_release` Tension release threshold. A node will not be released if its tensile load is below this value. If negative, no tension release will occur.
-
-
-It is good practice to make the surface with the coarser mesh to be the master surface.
-
-The robustness and accuracy of the mechanical contact algorithm is strongly dependent on the penalty parameter. If the parameter is too small, inaccurate solutions are more likely. If the parameter is too large, the solver may struggle.
-
-The `DEFAULT` option uses an enforcement algorithm that moves the internal forces at a slave node to Thu master face. The distance between the slave node and the master face is penalized, The `PENALTY` algorithm is the traditional penalty enforcement technique.
+Contact constraints can be enforced through the use of node/face constraints in a manner similar to that detailed by [!cite](heinstein_algorithm_1999)). In this approach, first, a geometric search determines which slave nodes have penetrated master faces. For those nodes, the internal force computed by the divergence of stress is moved to the appropriate master face at the point of contact. Those forces are distributed to master nodes by employing the finite element shape functions. Additionally, the slave nodes are constrained to remain on the master faces, preventing penetration. The module currently supports frictionless, frictional, and glued contact.
 
 [](---)
 
 ## Mortar-Based Mechanical Contact
 
-The [mortar constraint system](Constraints/index.md) provides an alternative
-discretization technique for solving mechanical contact. Some results are summarized below.
+Models specific for mechanical contact enforcement have been developed based on the MOOSE 
+[mortar constraint system](Constraints/index.md), and provide an alternative
+discretization technique for solving mechanical contact. Results of performance studies
+using this approach are summarized in [MortarPerformance](modules/contact/MortarPerformance.md). 
 
- The `contact/test/tests/bouncing-block-contact` directory provides a series of
-input files testing different algorithms for solving both normal and tangential
-frictional contact. Mortar contact can also be specified using the `Contact` block
-similar to pure node-face discretization contact. For normal mortar contact:
+[](---)
 
-!listing test/tests/mechanical-small-problem/frictionless-nodal-lm-mortar-disp-action.i block=Contact
+## `Contact` Syntax Block
 
-For normal and tangential (frictional) mortar contact:
+Setting up a model to use contact enforcement in MOOSE requires the creation of
+multiple types of MOOSE objects. Using the top-level
+[Contact](/Contact/index.md) syntax block, which streamlines the process of
+setting up these objects, is highly recommended, and supports most available types of contact.
+The following input file example shows the basic usage of the `Contact` block:
 
-!listing test/tests/bouncing-block-contact/frictional-nodal-min-normal-lm-mortar-fb-tangential-lm-mortar-action.i block=Contact
-
-
-### Frictionless contact algorithm comparison id=frictionless_table
-
-| Constraint | Displacement | NCP function | Time (arbitrary units) | Time steps | Nonlinear iterations |
-| ---------- | ------------ | ------------ | ---------------------- | ---------- | -------------------- |
-| Nodal | Mortar | Min | 4.164 | 40 | 104 |
-| Nodal | Mortar | FB | 5.020 | 40 | 135 |
-| Nodal | Nodal | Min | 3.124 | 41 | 104 |
-| Nodal | Nodal | FB | 4.014 | 41 | 149 |
-| Mortar | Mortar | Min | 4.461 | 40 | 106 |
-| Mortar | Mortar | FB | 5.577 | 40 | 136 |
-| Nodal | Nodal | RANFS | 2.700 | 40 | 99 |
-
-The first column denotes the discretization algorithm used for applying the
-frictionless contact constraints. Nodal denotes use of a `NodeFaceConstraint`;
-`Mortar` denotes use of a `MortarConstraint`. The second column denotes the
-discretization used for applying the contact forces to the displacement
-residuals. The third column denotes the type of non-linear complimentarity
-problem (NCP) function used to ensure that the contact constraints are
-satisfied. Min indicates the canonical min function (see
-[std::min](https://en.cppreference.com/w/cpp/algorithm/min)); FB represents the
-Fischer-Burmeister function. `RANFS` denotes the Reduced Active Nonlinear
-Function Set scheme in which no Lagrange Multipliers are used, and instead the
-non-linear residual equations at the slave nodes are replaced with the gap
-function. The fourth column in the table is the simulation time in
-arbitrary units (since timings will be different across machines). The fifth
-column is the number of time steps required to reach the simulation end
-time. The final, sixth column is the cumulative number of non-linear iterations
-taken during the simulation (note that this does not include any non-linear
-iterations from failed time steps).
-
-Notes:
-
-- Clearly having mortar mesh generation slows the simulation down, which is not surprising
-- The min NCP function is undeniably better for solving normal contact
-- For the pure nodal algorithms, the time step that did not converge featured classic ping-ponging behavior:
-
-```
- 5 Nonlinear |R| = 4.007951e-04
-    |residual|_2 of individual variables:
-                  disp_x:    0.000399808
-                  disp_y:    2.75599e-05
-                  normal_lm: 5.52166e-06
-
-
-The number of nodes in contact is 11
-
-      0 Linear |R| = 4.007951e-04
-      1 Linear |R| = 1.287307e-04
-      2 Linear |R| = 8.423398e-06
-      3 Linear |R| = 1.046825e-07
-      4 Linear |R| = 8.017310e-09
-      5 Linear |R| = 3.053040e-10
-  Linear solve converged due to CONVERGED_RTOL iterations 5
- 6 Nonlinear |R| = 4.432193e-04
-    |residual|_2 of individual variables:
-                  disp_x:    0.000396694
-                  disp_y:    0.00019545
-                  normal_lm: 2.96013e-05
-
-
-The number of nodes in contact is 11
-
-      0 Linear |R| = 4.432193e-04
-      1 Linear |R| = 1.355935e-04
-      2 Linear |R| = 1.216010e-05
-      3 Linear |R| = 6.386952e-07
-      4 Linear |R| = 2.235594e-08
-      5 Linear |R| = 2.884193e-10
-  Linear solve converged due to CONVERGED_RTOL iterations 5
- 7 Nonlinear |R| = 4.008045e-04
-    |residual|_2 of individual variables:
-                  disp_x:    0.000399816
-                  disp_y:    2.76329e-05
-                  normal_lm: 5.29313e-06
-
-
-The number of nodes in contact is 11
-
-      0 Linear |R| = 4.008045e-04
-      1 Linear |R| = 1.287272e-04
-      2 Linear |R| = 8.423081e-06
-      3 Linear |R| = 1.047782e-07
-      4 Linear |R| = 8.054781e-09
-      5 Linear |R| = 3.046073e-10
-  Linear solve converged due to CONVERGED_RTOL iterations 5
- 8 Nonlinear |R| = 4.432194e-04
-```
-
-### Frictional contact algorithm comparison id=frictional_table
-
-| LM normal | LM tangential | Displacement | NCP function normal | NCP function tangential | Time (arbitrary units) | Time steps | Nonlinear iterations | CLI PETSc options |
-| --------- | ------------  | ------------ | ------------------- | ----------------------- | ---------------------- | ---------- | -------------------- | --- |
-| Mortar | Mortar | Mortar | FB | FB | 8.241 | 40 | 175 | None |
-| Mortar | Mortar | Mortar | Min | FB | 7.928 | 40 | 159 | None |
-| Nodal | Mortar | Mortar | Min | FB | 7.459 | 40 | 152 | None |
-| Mortar | Mortar | Mortar | Min | Min | 11.237 | 41 | 234 | None |
-| Nodal | Nodal | Mortar | Min | Min | 39.409 | 55 | 275 | `-snes_ksp_ew 0` |
-| Nodal | Nodal | Mortar | FB | FB | NA | NA | NA | None |
-
-Notes:
-
-- NA: solve did not converge
-- Timings run on a different machine than the frictionless cases
-- The most performant case uses a `NodeFaceConstraint` discretization for
-  enforcing the normal contact conditions and `MortarConstraint` discretizations
-  for enforcement of the Coulomb frictional constraints and application of
-  forces to the displacement residuals. Interestingly, this performant case uses
-  different NCP functions for normal and tangential constraints: `std::min` for
-  the former and Fischer-Burmeister for the latter. This performant case is used
-  for comparison with the node-face penalty algorithm, shown below:
-
-### NCP-LM-Mortar vs Penalty-NodeFace
-
-The table below compares the timing and solver performance of
-[NCP-LM-Mortar](/in_and_out/constraint/frictional_lm.i) and
-[Penalty-NodeFace](/in_and_out/constraint/frictional_04_penalty.i) algorithms. NCP-LM refers to use of an
-NCP function for contact constraint enforcement on a lagrange multiplier. The
-"Mortar" designation denotes that a mortar discretization is used for enforcing
-the tangential Coulomb friction conditions and applying contact forces to the
-displacement residuals.
-
-| Algorithm | Time (arb. units) | Time steps to end time | Cumulative non-linear iterations |
-| --- | --- | --- | --- |
-| NCP-LM-Mortar | 13.901 | 151 | 476 |
-| Penalty-NodeFace | 20.711 | 151 | 938 |
-
-There's a cost associated with generation of the mortar segment mesh that
-partially offsets the fact that the mortar case takes nearly half the non-linear
-iterations of the penalty case.
-
-## Petsc options for contact
-
-Recommended PETSc options for use with mortar based frictional contact are:
-
-```puppet
-[Executioner]
-  petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_ksp_ew'
-  petsc_options_iname = '-pc_type -mat_mffd_err -pc_factor_shift_type -pc_factor_shift_amount'
-  petsc_options_value = 'lu       1e-5          NONZERO               1e-15'
-[]
-```
-
-Using Eisenstat-Walker is advantageous for frictional contact because time is
-not wasted in the linear solve in early non-linear iterations while the contact
-set and stick/slip conditions are being resolved. Later in the non-linear solve
-when the set of constraints has been resolved, more linear iterations will be
-used as the non-linear solver moves through the quadratic basin. Experience has
-shown that a choice of 1e-5 for the matrix free finite differencing parameter
-works well for many problems. However, the user may want to experiment with
-values anywhere between 1e-8 and 1e-4 depending on their multi-physics. A
-very small non-zero shift is used to avoid zero pivots during the LU
-decomposition. This may be extraneous in many cases. Note that the Jacobian
-entries for mortar based contact are accurate and complete enough that
-incomplete factorization may be used in serial or as a sub-block solver for
-block jacobi or additive schwarz in parallel. This may be necessary for large
-problems where lu does not scale.
-
-The recommended PETSc options for use with `NodeFaceConstraint` based contact are shown below :
-
-```puppet
-[Executioner]
-  ...
-  petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap
-                        -ksp_gmres_restart'
-  petsc_options_value = 'asm lu 20 101'
-  ...
-[../]
-```
+!listing test/tests/sliding_block/sliding/constraint/frictionless_kinematic.i block=Contact
 
 ## Objects, Actions, and Syntax
 
 !syntax complete groups=ContactApp level=3
-
-## Scaling effects
-
-The effects of scaling on non-linear solve convergence are shown below for
-different kinds of contact formulations. The results are based on the input files for
-[RANFS](/ranfs-and-scaling/bouncing-block-ranfs.i),
-[kinematic](/bouncing-block-kinematic.i), and
-[tangential penalty](/bouncing-block-tan-pen.i),
-running with two processes.
-
-| Scheme | Cumulative nonlinear iterations | Cumulative linear iterations | Initial condition number | Variable Scaling Factor |
-| - | - | - | - | - |
-| SMP PJFNK RANFS no scaling AMG | 68 | 510 | 9e3 | 1 |
-| SMP PJFNK RANFS residual auto-scaling AMG | 65 | 391 | 1e2 | 1.1e-2 |
-| SMP PJFNK RANFS Jacobian auto-scaling AMG | 66 | 372 | 4e1 | 4.1e-4 |
-| SMP PJFNK Kinematic no scaling AMG | 58 | 305 | 9e3 | 1 |
-| SMP PJFNK Kinematic residual auto-scaling AMG | 58 | 305 | 1e2 | 1.1e-2 |
-| SMP PJFNK Kinematic Jacobian auto-scaling AMG | 58 | 305 | 4e1 | 4.1e-4 |
-| SMP PJFNK Tangential Penalty no scaling AMG | 65 | 400 | 9e3 | 1 |
-| SMP PJFNK Tangential Penalty residual auto-scaling AMG | 65 | 400 | 1e2 | 1.1e-2 |
-| SMP PJFNK Tangential Penalty Jacobian auto-scaling AMG | 65 | 400 | 4e1 | 4.1e-4 |
-| FD PJFNK RANFS jacobian auto-scaling LU | 54 | 70 | 4e1 | 4.1e-4 |
-| FD PJFNK Kinematic jacobian auto-scaling LU | 62 | 95 | 4e1 | 4.1e-4 |
-
-Important takeaways:
-
-- The solve efficiency of kinematic and tangential penalty formulations is independent of scaling (within the window of this problem)
-- Because RANFS constraint residuals/Jacobians are of gap magnitude, the RANFS solve really does perform better when the internal physics is scaled to be on the same order of magnitude
-- There are some bugs with the RANFS Jacobian functions because RANFS takes more nonlinear and linear iterations than kinematic, but with a FD Jacobian RANFS takes significantly less nonlinear and linear iterations than kinematic

--- a/modules/contact/doc/content/source/actions/ContactAction.md
+++ b/modules/contact/doc/content/source/actions/ContactAction.md
@@ -1,30 +1,9 @@
 # Contact Action
 
+!syntax description /Contact/ContactAction
+
 ## Description
 
-`ContactAction` can be used to specify mechanical normal and tangential contact using several possible
-models:
-- frictionless
-- glued
-- coulomb (frictional)
-and formulations:
-- kinematic
-- penalty (normal and tangential)
-- augmented lagrange
-- mortar (normal with/without tangential)
-
-## Example Input syntax id=example
-
-For normal mortar contact:
-
-!listing test/tests/mechanical-small-problem/frictionless-nodal-lm-mortar-disp-action.i block=Contact
-
-For normal and tangential (frictional) mortar contact:
-
-!listing test/tests/bouncing-block-contact/frictional-nodal-min-normal-lm-mortar-fb-tangential-lm-mortar-action.i block=Contact
-
-!syntax parameters /Contact/ContactAction
-
-!syntax inputs /Contact/ContactAction
-
-!syntax children /Contact/ContactAction
+ContactAction is a MOOSE action that constructs objects needed for mechanical contact enforcement. This
+is invoked by including the [Contact](syntax/Contact/index.md) block at the top level in a MOOSE input file.
+See the page documenting the syntax for that block for a description, example usage, and parameters.

--- a/modules/contact/doc/content/source/constraints/MechanicalContactConstraint.md
+++ b/modules/contact/doc/content/source/constraints/MechanicalContactConstraint.md
@@ -1,4 +1,6 @@
-# Mechanical Contact Constraint
+# MechanicalContactConstraint
+
+!syntax description /Constraints/MechanicalContactConstraint
 
 ## Description
 

--- a/modules/contact/doc/content/source/dampers/ContactSlipDamper.md
+++ b/modules/contact/doc/content/source/dampers/ContactSlipDamper.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This damper minimizes the oscillations that are inherent in the solution of frictional contact problems by limiting the change in contact state from one nonlinear iteration to the next. This is designed specifically to work with node/face mechanical contact enforced using [MechanicalContactConstraint](/Constraints/MechanicalContactConstraint.md).
+This damper minimizes the oscillations that are inherent in the solution of frictional contact problems by limiting the change in contact state from one nonlinear iteration to the next. This is designed specifically to work with node/face mechanical contact enforced using [MechanicalContactConstraint](/constraints/MechanicalContactConstraint.md).
 
 This damper specifically addresses reversals in the slip direction from one nonlinear iteration to the next. If a node that is in contact slips farther than it should during a given nonlinear iteration, the resulting residual will cause that node to slip back in the opposite direction in the next nonlinear iteration. If that slip in the opposite direction in this next nonlinear iteration is large enough that it causes the node to slip past the original contact point, it can be extremely difficult to obtain a converged solution because the node keeps slipping back and forth past that original contact point during each nonlinear iteration.
 

--- a/modules/contact/doc/content/source/dampers/ContactSlipDamper.md
+++ b/modules/contact/doc/content/source/dampers/ContactSlipDamper.md
@@ -1,1 +1,31 @@
-!template load file=stubs/moose_object.md.template name=ContactSlipDamper syntax=/Dampers/ContactSlipDamper
+# ContactSlipDamper
+
+!syntax description /Dampers/ContactSlipDamper
+
+## Description
+
+This damper minimizes the oscillations that are inherent in the solution of frictional contact problems by limiting the change in contact state from one nonlinear iteration to the next. This is designed specifically to work with node/face mechanical contact enforced using [MechanicalContactConstraint](/Constraints/MechanicalContactConstraint.md).
+
+This damper specifically addresses reversals in the slip direction from one nonlinear iteration to the next. If a node that is in contact slips farther than it should during a given nonlinear iteration, the resulting residual will cause that node to slip back in the opposite direction in the next nonlinear iteration. If that slip in the opposite direction in this next nonlinear iteration is large enough that it causes the node to slip past the original contact point, it can be extremely difficult to obtain a converged solution because the node keeps slipping back and forth past that original contact point during each nonlinear iteration.
+
+This damper mitigates this problem by scaling back the nonlinear solution update to limit the amount of slip experienced by nodes that are slipping in a direction opposite to the slip direction in the previous nonlinear iteration. For each node in this situation, a scale factor that would bring the node back to its original position is computed, and the minimum value for all such nodes is taken as the overall scale factor. For a simulation with many nodes in contact, this can result initially in small damping factors, but over the course of iterations as the converged solution is approached, the damping factor will typically increase.
+
+The following optional parameters can be used to adjust the behavior of this damper:
+
+- `min_damping_factor` sets a minimum value for the damping. Setting this to a number larger than 0 can permit some amount of excess slip reversals to avoid having the solution getting stuck with extremely small damping factors.
+- `max_iterative_slip` allows the damper to also limit the amount of slip that can occur during a nonlinear iteration, in addition to limiting slip reversals. This is prescribed in the length units of the model.
+- `damping_threshold_factor` affects the slip reversal limiting behavior of this damper when the magnitude of the slip is small. If the amount of slip is small, the node is likely actually in a sticking state, and simply moving within the limits permitted by the penalty factor. This factor specifies the threshold slip, computed as a multiplier on the limit imposed by the penalty factor, at which the damper will start to limit slip reversals. Setting it to larger numbers will make this damper have less effect on nodes will small amounts of slip.
+
+In addition to limiting the nonlinear solution step, this damper also prints out some useful diagnostic information to the output stream, including statistics on the numbers of nodes in various contact states.
+
+Finally, it should be noted that although this damper is primarily intended to be used with frictional contact, it can be useful for frictionless contact because of its ability to limit the maximum amount of slip.
+
+## Example Input Syntax
+
+!listing test/tests/frictional/sliding_elastic_blocks_2d/sliding_elastic_blocks_2d.i block=Dampers
+
+!syntax parameters /Dampers/ContactSlipDamper
+
+!syntax inputs /Dampers/ContactSlipDamper
+
+!syntax children /Dampers/ContactSlipDamper

--- a/modules/contact/include/actions/ContactAction.h
+++ b/modules/contact/include/actions/ContactAction.h
@@ -52,6 +52,7 @@ public:
 
   using Action::addRelationshipManagers;
   virtual void addRelationshipManagers(Moose::RelationshipManagerType input_rm_type) override;
+
   /**
    * Get contact model
    * @return enum
@@ -72,7 +73,10 @@ public:
    * @return enum
    */
   static MooseEnum getSmoothingEnum();
-
+  /**
+   * Define parameters used by multiple contact objects
+   * @return InputParameters object populated with common parameters
+   */
   static InputParameters commonParameters();
 
 protected:

--- a/modules/contact/include/auxkernels/ContactPressureAux.h
+++ b/modules/contact/include/auxkernels/ContactPressureAux.h
@@ -14,6 +14,9 @@
 class NodalArea;
 class PenetrationLocator;
 
+/**
+ * Computes the contact pressure from the contact force and nodal area
+ */
 class ContactPressureAux : public AuxKernel
 {
 public:
@@ -24,9 +27,12 @@ public:
   virtual ~ContactPressureAux();
 
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
+  /// AuxVariable containing the nodal area
   const VariableValue & _nodal_area;
+
+  /// Reference to the PenetrationLocator object
   const PenetrationLocator & _penetration_locator;
 };
 

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -107,6 +107,8 @@ ContactAction::validParams()
   params.addParam<Real>(
       "tangential_lm_scaling", 1., "Scaling factor to apply to the tangential LM variable");
 
+  params.addClassDescription("Sets up all objects needed for mechanical contact enforcement");
+
   return params;
 }
 

--- a/modules/contact/src/auxkernels/ContactPressureAux.C
+++ b/modules/contact/src/auxkernels/ContactPressureAux.C
@@ -27,6 +27,9 @@ ContactPressureAux::validParams()
   params.set<ExecFlagEnum>("execute_on") = EXEC_NONLINEAR;
   MooseEnum orders("FIRST SECOND THIRD FOURTH", "FIRST");
   params.addParam<MooseEnum>("order", orders, "The finite element order: " + orders.getRawNames());
+
+  params.addClassDescription("Computes the contact pressure from the contact force and nodal area");
+
   return params;
 }
 

--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -103,6 +103,12 @@ MechanicalContactConstraint::validParams()
                         "The tolerance of the frictional force for augmented Lagrangian method.");
   params.addParam<bool>(
       "print_contact_nodes", false, "Whether to print the number of nodes in contact.");
+
+  params.addClassDescription("Apply non-penetration constraints on the mechanical deformation "
+                             "using a node on face, master/slave algorithm, and multiple options "
+                             "for the physical behavior on the interface and the mathematical "
+                             "formulation for constraint enforcement");
+
   return params;
 }
 

--- a/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
+++ b/modules/contact/src/constraints/RANFSNormalMechanicalContact.C
@@ -34,9 +34,6 @@ RANFSNormalMechanicalContact::validParams()
   params.addRequiredCoupledVar(
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");
-  params.addClassDescription("Applies the Reduced Active Nonlinear Function Set scheme in which "
-                             "the slave node's non-linear residual function is replaced by the "
-                             "zero penetration constraint equation when the constraint is active");
   params.addParam<bool>(
       "ping_pong_protection",
       false,
@@ -46,6 +43,9 @@ RANFSNormalMechanicalContact::validParams()
   params.addParam<Real>(
       "normal_smoothing_distance",
       "Distance from edge in parametric coordinates over which to smooth contact normal");
+  params.addClassDescription("Applies the Reduced Active Nonlinear Function Set scheme in which "
+                             "the slave node's non-linear residual function is replaced by the "
+                             "zero penetration constraint equation when the constraint is active");
   return params;
 }
 

--- a/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
+++ b/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
@@ -35,11 +35,6 @@ TangentialNodalLMMechanicalContact::validParams()
   params.addParam<MooseEnum>(
       "ncp_function_type", ncp_function_type, "The type of NCP function to use");
 
-  params.addClassDescription("Implements the KKT conditions for frictional Coulomb contact using "
-                             "an NCP function. Requires that either the relative tangential "
-                             "velocity is zero or the tangential stress is equal to the friction "
-                             "coefficient times the normal contact pressure.");
-
   params.addRequiredParam<Real>("mu", "The friction coefficient for the Coulomb friction law");
 
   params.addParam<Real>(
@@ -47,6 +42,11 @@ TangentialNodalLMMechanicalContact::validParams()
       10,
       "The smoothing parameter for the function used to approximate std::abs. The approximating "
       "function is courtesy of https://math.stackexchange.com/a/1115033/408963");
+
+  params.addClassDescription("Implements the KKT conditions for frictional Coulomb contact using "
+                             "an NCP function. Requires that either the relative tangential "
+                             "velocity is zero or the tangential stress is equal to the friction "
+                             "coefficient times the normal contact pressure.");
   return params;
 }
 

--- a/modules/contact/src/dampers/ContactSlipDamper.C
+++ b/modules/contact/src/dampers/ContactSlipDamper.C
@@ -34,12 +34,13 @@ ContactSlipDamper::validParams()
                                     "Minimum permissible value for damping factor");
   params.addParam<Real>("damping_threshold_factor",
                         1.0e3,
-                        "If previous iterations's slip is below "
-                        "the slip tolerance, only damp a slip "
-                        "reversal if the slip magnitude is "
-                        "greater than than this factor times "
-                        "the old slip.");
+                        "If previous iterations's slip is below the slip tolerance, "
+                        "only damp a slip reversal if the slip magnitude is greater "
+                        "than than this factor times the old slip.");
   params.addParam<bool>("debug_output", false, "Output detailed debugging information");
+  params.addClassDescription(
+      "Damp the iterative solution to minimize oscillations in frictional contact "
+      "constriants between nonlinear iterations");
   return params;
 }
 

--- a/modules/contact/src/problems/AugmentedLagrangianContactProblem.C
+++ b/modules/contact/src/problems/AugmentedLagrangianContactProblem.C
@@ -36,6 +36,7 @@ AugmentedLagrangianContactProblem::validParams()
   params.addParam<int>("maximum_lagrangian_update_iterations",
                        100,
                        "Maximum number of update Lagrangian Multiplier iterations per step");
+  params.addClassDescription("Manages nested solution for augmented Lagrange contact");
   return params;
 }
 

--- a/modules/contact/src/splits/ContactSplit.C
+++ b/modules/contact/src/splits/ContactSplit.C
@@ -34,10 +34,11 @@ ContactSplit::validParams()
   params.addParam<std::vector<int>>(
       "uncontact_displaced",
       "List of indicators whether displaced mesh is used to define excluded contact");
-  // Right now, we consider this as a required parameter.
-  // After some tests from BISON, we will set a default value for this parameter.
   params.addRequiredParam<bool>("include_all_contact_nodes",
                                 "Whether to include all nodes on the contact surfaces");
+  params.addClassDescription("Split-based preconditioner that partitions the domain into DOFs "
+                             "directly involved in contact (on contact surfaces) and those "
+                             "that are not");
   return params;
 }
 

--- a/modules/contact/src/userobject/NodalArea.C
+++ b/modules/contact/src/userobject/NodalArea.C
@@ -25,6 +25,7 @@ NodalArea::validParams()
 {
   InputParameters params = SideIntegralVariableUserObject::validParams();
   params.set<ExecFlagEnum>("execute_on") = EXEC_LINEAR;
+  params.addClassDescription("Compute the tributary area for nodes on a surface");
   return params;
 }
 

--- a/modules/xfem/doc/content/source/actions/XFEMAction.md
+++ b/modules/xfem/doc/content/source/actions/XFEMAction.md
@@ -1,7 +1,9 @@
-# XFEM Action
+# XFEMAction
 
-## Overview
+!syntax description /XFEM/XFEMAction
 
-The XFEM Action takes in parameters that generally apply to how one wants to use XFEM and provides
-these to XFEM. See the description, example use, and parameters on the
-[XFEM Action syntax](syntax/XFEM/index.md) page.
+## Description
+
+XFEMAction is a MOOSE action that constructs objects needed for using XFEM. This is invoked by including
+the [XFEM](syntax/XFEM/index.md) block at the top level in a MOOSE input file. See the page documenting
+the syntax for that block for a description, example usage, and parameters.

--- a/modules/xfem/doc/content/syntax/XFEM/index.md
+++ b/modules/xfem/doc/content/syntax/XFEM/index.md
@@ -1,11 +1,10 @@
-# XFEM Action System
+# XFEM
 
-!syntax description /XFEM/XFEMAction
+## Description
 
-## Overview
-
-The `XFEM` block must be supplied to run any MOOSE simulations using XFEM. It provides general
-solution parameters to XFEM. Including this block in the input file serves several functions:
+The `XFEM` block must be supplied to run any MOOSE simulations using XFEM. The [XFEMAction](/actions/XFEMAction.md)
+is associated with this block and performs the key model setup tasks.  The `XFEM` input syntax block provides an interface
+to specify parameters related to XFEM. Including this block in the input file serves several functions:
 
 - Causes an algorithm to be run at defined intervals to split the mesh based on a set of evolving defined interfaces.
 - Causes a modified quadrature rule to be used to correctly integrate elements split by these interfaces.
@@ -18,7 +17,7 @@ solution parameters to XFEM. Including this block in the input file serves sever
   - Optional: Setup of near tip enrichment parameters.
   - Optional: Allow users to control the amount of debugging information printed during a simulation.
 
-## Constructed MooseObjects
+## Constructed Objects
 
 Three of the above user-settable parameters pass parameters to the XFEM object for use in setting up
 relevant options: the `qrule` variable, incremental crack growth, and `debug_output_level`. The


### PR DESCRIPTION
ref #14813 
This PR adds classDescriptions for multiple classes related to contact, adds documentation for the ContactDamper class, and does a major reorganization of the top-level contact module documentation and documentation of the Contact syntax block and action to make them more consistent with that for other modules.
Also, I used the XFEM documentation as a starting point for this, and did some minor cleanup of that as well.
