### PR TITLE
Deprecate Navier-Stokes duplicated aux kernels

### DIFF
--- a/modules/navier_stokes/include/actions/AddNavierStokesKernelsAction.h
+++ b/modules/navier_stokes/include/actions/AddNavierStokesKernelsAction.h
@@ -58,7 +58,7 @@ protected:
   // Helper functions that add AuxKernels
   void addPressureOrTemperatureAux(const std::string & kernel_type);
   void addNSVelocityAux(unsigned int component);
-  void addNSEnthalpyAux();
+  void addEnthalpyAux();
   void addNSMachAux();
   void addNSInternalEnergyAux();
   void addSpecificVolumeComputation();

--- a/modules/navier_stokes/src/actions/AddNavierStokesKernelsAction.C
+++ b/modules/navier_stokes/src/actions/AddNavierStokesKernelsAction.C
@@ -65,8 +65,8 @@ AddNavierStokesKernelsAction::act()
     addNSSUPGMomentum(component);
 
   // Add AuxKernels.
-  addPressureOrTemperatureAux("NSPressureAux");
-  addPressureOrTemperatureAux("NSTemperatureAux");
+  addPressureOrTemperatureAux("PressureAux");
+  addPressureOrTemperatureAux("TemperatureAux");
   addNSEnthalpyAux();
   addNSMachAux();
   addNSInternalEnergyAux();
@@ -219,13 +219,13 @@ void
 AddNavierStokesKernelsAction::addPressureOrTemperatureAux(const std::string & kernel_type)
 {
   InputParameters params = _factory.getValidParams(kernel_type);
-  std::string var_name = (kernel_type == "NSPressureAux" ? NS::pressure : NS::temperature);
+  std::string var_name = (kernel_type == "PressureAux" ? NS::pressure : NS::temperature);
   params.set<AuxVariableName>("variable") = var_name;
 
   // coupled variables
-  params.set<CoupledName>(NS::internal_energy) = {NS::internal_energy};
-  params.set<CoupledName>(NS::specific_volume) = {NS::specific_volume};
-  params.set<UserObjectName>("fluid_properties") = _fp_name;
+  params.set<CoupledName>("e") = {NS::internal_energy};
+  params.set<CoupledName>("v") = {NS::specific_volume};
+  params.set<UserObjectName>("fp") = _fp_name;
 
   _problem->addAuxKernel(kernel_type, var_name + "_auxkernel", params);
 }

--- a/modules/navier_stokes/src/actions/AddNavierStokesKernelsAction.C
+++ b/modules/navier_stokes/src/actions/AddNavierStokesKernelsAction.C
@@ -67,7 +67,7 @@ AddNavierStokesKernelsAction::act()
   // Add AuxKernels.
   addPressureOrTemperatureAux("PressureAux");
   addPressureOrTemperatureAux("TemperatureAux");
-  addNSEnthalpyAux();
+  addEnthalpyAux();
   addNSMachAux();
   addNSInternalEnergyAux();
   addSpecificVolumeComputation();
@@ -182,16 +182,16 @@ AddNavierStokesKernelsAction::addNSMachAux()
 }
 
 void
-AddNavierStokesKernelsAction::addNSEnthalpyAux()
+AddNavierStokesKernelsAction::addEnthalpyAux()
 {
-  const std::string kernel_type = "NSEnthalpyAux";
+  const std::string kernel_type = "EnthalpyAux";
 
   InputParameters params = _factory.getValidParams(kernel_type);
   params.set<AuxVariableName>("variable") = NS::enthalpy;
 
   // coupled variables
   params.set<CoupledName>(NS::density) = {NS::density};
-  params.set<CoupledName>(NS::total_energy) = {NS::total_energy};
+  params.set<CoupledName>("rho_et") = {NS::total_energy};
   params.set<CoupledName>(NS::pressure) = {NS::pressure};
 
   _problem->addAuxKernel(kernel_type, "enthalpy_auxkernel", params);

--- a/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSEnthalpyAux.C
@@ -35,6 +35,8 @@ NSEnthalpyAux::NSEnthalpyAux(const InputParameters & parameters)
     _rhoE(coupledValue(NS::total_energy)),
     _pressure(coupledValue(NS::pressure))
 {
+  mooseDeprecated("The NSEnthalpyAux auxiliary kernel has been replaced by the EnthalpyAux "
+                  "auxiliary kernel");
 }
 
 Real

--- a/modules/navier_stokes/src/auxkernels/NSPressureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSPressureAux.C
@@ -43,7 +43,7 @@ NSPressureAux::NSPressureAux(const InputParameters & parameters)
     _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
   mooseDeprecated("The NSPressureAux aux kernel has been replaced by the "
-    "PressureAux kernel in the fluid properties module.");
+                  "PressureAux kernel in the fluid properties module.");
 }
 
 Real

--- a/modules/navier_stokes/src/auxkernels/NSPressureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSPressureAux.C
@@ -42,6 +42,8 @@ NSPressureAux::NSPressureAux(const InputParameters & parameters)
     _internal_energy(coupledValue(NS::internal_energy)),
     _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
+  mooseDeprecated("The NSPressureAux aux kernel has been replaced by the "
+    "PressureAux kernel in the fluid properties module.");
 }
 
 Real

--- a/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
@@ -44,7 +44,7 @@ NSTemperatureAux::NSTemperatureAux(const InputParameters & parameters)
     _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
   mooseDeprecated("The NSTemperatureAux aux kernel has been replaced by the "
-    "TemperatureAux kernel in the fluid properties module.");
+                  "TemperatureAux kernel in the fluid properties module.");
 }
 
 Real

--- a/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
+++ b/modules/navier_stokes/src/auxkernels/NSTemperatureAux.C
@@ -43,6 +43,8 @@ NSTemperatureAux::NSTemperatureAux(const InputParameters & parameters)
     _internal_energy(coupledValue(NS::internal_energy)),
     _fp(getUserObject<IdealGasFluidProperties>("fluid_properties"))
 {
+  mooseDeprecated("The NSTemperatureAux aux kernel has been replaced by the "
+    "TemperatureAux kernel in the fluid properties module.");
 }
 
 Real


### PR DESCRIPTION
The Navier-Stokes module has three auxiliary kernels that are either duplicated in the fluid properties module or even within the Navier-Stokes module itself. This MR

- deprecates `NSTemperatureAux` in favor of the `TemperatureAux` kernel in the fluid properties module
- deprecates `NSPressureAux` in favor of the `PressureAux` kernel in the fluid properties module

While the original issue only refers to `NSTemperatureAux` and `NSPressureAux`, I realized that `NSEnthalpyAux` is also entirely duplicated, so this MR also

- deprecates `NSEnthalpyAux` in favor of the `EnthalpyAux` kernel in the Navier-Stokes modulel

Refs #13028
