### PR TITLE
Fix DerivativeParsedMaterial Docs

### DIFF
--- a/framework/doc/content/source/materials/DerivativeParsedMaterial.md
+++ b/framework/doc/content/source/materials/DerivativeParsedMaterial.md
@@ -24,30 +24,20 @@ In phase field, an application would be the definition of a mobility term
 M = \frac D{\frac{\partial^2 F}{\partial c^2}}
 \end{equation}
 
-containing the second derivative of a free energy $F$ as
+containing the second derivative of a free energy $F$, or a custom switching function derivative in a Grand potential model
 
-```yaml
-  [./mob]
-    type = DerivativeParsedMaterial
-    args = c
-    f_name = M
-    material_property_names = 'd2F:=D[F(c),c,c]'
-    constant_names = D
-    constant_expressions = 1e-3
-    function = D/d2F
-  [../]
-```
+!listing modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialPFM.i block=Materials/coupled_eta_function
 
-The mobility $M$ defined above would have accurately constructed automatic derivatives w.r.t. $c$, which contain third and higher derivatives of $F$ (make sure to set the `derivative_order` of F high enough!).
+The *ft* defined above would have accurately constructed automatic derivatives w.r.t. $\eta$ (`eta`), which contain second and higher derivatives of $h$ (make sure to set the `derivative_order` of $h$ high enough!).
 
 The `material_property_names` are parsed by the [`FunctionMaterialPropertyDescriptor` class](http://mooseframework.org/docs/doxygen/modules/classFunctionMaterialPropertyDescriptor.html), which understands the following syntax:
 
 | Expression | Description |
 | - | - |
-| `F` | A material property called _F_ with no declared variable dependencies (i.e. vanishing derivatives)|
-|`F(c,phi)` | A material property called _F_ with declared dependence on 'c' and 'phi' (uses `DerivativeFunctionMaterial` rules to look up the derivatives) using the round-bracket-notation|
-|`d3x:=D[x(a,b),a,a,b]` | The third derivative $$\frac{\partial^3x}{\partial^2a\partial b}$$ of the a,b-dependent material property _x_, which will be referred to as `d3x` in the function expression|
-|`dF:=D[F,c]` | Derivative of _F_ w.r.t. _c_. Although the c-dependence of _F_ is not explicitly declared using the round-bracket-notation it is implicitly assumed as a derivative w.r.t. _c_ is requested|
+| `F` | A material property called *F* with no declared variable dependencies (i.e. vanishing derivatives) |
+| `F(c,phi)` | A material property called *F* with declared dependence on 'c' and 'phi' (uses `DerivativeFunctionMaterial` rules to look up the derivatives) using the round-bracket-notation |
+| `d3x:=D[x(a,b),a,a,b]` | The third derivative $\frac{\partial^3x}{\partial^2a\partial b}$ of the a,b-dependent material property *x*, which will be referred to as `d3x` in the function expression |
+| `dF:=D[F,c]` | Derivative of *F* w.r.t. *c*. Although the c-dependence of *F* is not explicitly declared using the round-bracket-notation it is implicitly assumed as a derivative w.r.t. *c* is requested |
 
 Add `outputs=exodus` to the material block to automatically write all derivatives and the free energy to the exodus output.
 

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -417,7 +417,7 @@ clobberall: clobber
 	@echo "Building .clang_complete file"
 	@echo "-xc++" > .clang_complete
 	@echo "-std=c++11" >> .clang_complete
-	@for item in $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES); do \
+	@for item in $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE); do \
           echo $$item >> .clang_complete;  \
         done
 
@@ -426,12 +426,12 @@ compile_commands.json:
 ifeq (4.0,$(firstword $(sort $(MAKE_VERSION) 4.0)))
 	$(file > .compile_commands.json,$(CURDIR))
 	$(file >> .compile_commands.json,$(libmesh_CXX))
-	$(file >> .compile_commands.json,$(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES))
+	$(file >> .compile_commands.json,$(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE))
 	$(file >> .compile_commands.json,$(compile_commands_all_srcfiles))
 else
 	@echo $(CURDIR) > .compile_commands.json
 	@echo $(libmesh_CXX) >> .compile_commands.json
-	@echo $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) $(ADDITIONAL_INCLUDES) >> .compile_commands.json
+	@echo $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) >> .compile_commands.json
 	@echo $(compile_commands_all_srcfiles) >> .compile_commands.json
 endif
 	@$(FRAMEWORK_DIR)/scripts/compile_commands.py < .compile_commands.json > compile_commands.json


### PR DESCRIPTION
Fix some formatting issues. Also remove duplicate compiler flags in `compile_commands.json` (`ADDITIONAL_INCLUDES` is already appended to `app_INCLUDES`)

Refs #14988, #8772