### PR TITLE
Streamline jvar map interfcae

### DIFF
--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -77,6 +77,20 @@ public:
                                                             const VariableName & c1,
                                                             const VariableName & c2 = "",
                                                             const VariableName & c3 = "");
+
+  template <typename U>
+  const MaterialProperty<U> &
+  getMaterialPropertyDerivative(const std::string & base,
+                                const VariableName & c1,
+                                unsigned int v2,
+                                unsigned int v3 = libMesh::invalid_uint);
+
+  template <typename U>
+  const MaterialProperty<U> &
+  getMaterialPropertyDerivative(const std::string & base,
+                                unsigned int v1,
+                                unsigned int v2 = libMesh::invalid_uint,
+                                unsigned int v3 = libMesh::invalid_uint);
   ///@}
 
   ///@{
@@ -283,6 +297,36 @@ DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string 
 template <class T>
 template <typename U>
 const MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string & base,
+                                                              const VariableName & c1,
+                                                              unsigned int v2,
+                                                              unsigned int v3)
+{
+  return getMaterialPropertyDerivative<U>(
+      base,
+      c1,
+      this->_coupled_standard_moose_vars[v2]->name(),
+      v3 == libMesh::invalid_uint ? "" : this->_coupled_standard_moose_vars[v3]->name());
+}
+
+template <class T>
+template <typename U>
+const MaterialProperty<U> &
+DerivativeMaterialInterface<T>::getMaterialPropertyDerivative(const std::string & base,
+                                                              unsigned int v1,
+                                                              unsigned int v2,
+                                                              unsigned int v3)
+{
+  return getMaterialPropertyDerivative<U>(
+      base,
+      this->_coupled_standard_moose_vars[v1]->name(),
+      v2 == libMesh::invalid_uint ? "" : this->_coupled_standard_moose_vars[v2]->name(),
+      v3 == libMesh::invalid_uint ? "" : this->_coupled_standard_moose_vars[v3]->name());
+}
+
+template <class T>
+template <typename U>
+const MaterialProperty<U> &
 DerivativeMaterialInterface<T>::getMaterialPropertyDerivativeByName(
     const MaterialPropertyName & base, const std::vector<VariableName> & c)
 {
@@ -313,7 +357,7 @@ DerivativeMaterialInterface<T>::validateCouplingHelper(const MaterialPropertyNam
                                                        const System & system,
                                                        std::vector<VariableName> & missing)
 {
-  unsigned int ncoupled = this->_coupled_moose_vars.size();
+  unsigned int ncoupled = this->_coupled_standard_moose_vars.size();
 
   // iterate over all variables in the current system (in groups)
   for (unsigned int i = 0; i < system.n_variable_groups(); ++i)
@@ -332,7 +376,7 @@ DerivativeMaterialInterface<T>::validateCouplingHelper(const MaterialPropertyNam
         bool is_missing = isNotObjectVariable(jname);
 
         for (unsigned int k = 0; k < ncoupled; ++k)
-          if (this->_coupled_moose_vars[k]->name() == jname)
+          if (this->_coupled_standard_moose_vars[k]->name() == jname)
           {
             is_missing = false;
             break;

--- a/framework/include/materials/DerivativeMaterialInterface.h
+++ b/framework/include/materials/DerivativeMaterialInterface.h
@@ -77,7 +77,13 @@ public:
                                                             const VariableName & c1,
                                                             const VariableName & c2 = "",
                                                             const VariableName & c3 = "");
+  ///@}
 
+  /**
+   *@{ Convenience methods fro retrieving derivative material properties based
+   *   on a mix of variable names `c` and indices `v` into the
+   *   _coupled_standard_moose_vars vector.
+   */
   template <typename U>
   const MaterialProperty<U> &
   getMaterialPropertyDerivative(const std::string & base,

--- a/framework/include/utils/JvarMapInterface.h
+++ b/framework/include/utils/JvarMapInterface.h
@@ -64,6 +64,8 @@ class JvarMapInterfaceBase : public T
 public:
   typedef std::vector<int> JvarMap;
 
+  static InputParameters validParams();
+
   JvarMapInterfaceBase(const InputParameters & parameters);
 
   /// Return index into the _coupled_moose_vars array for a given jvar
@@ -89,6 +91,10 @@ public:
    */
   bool mapJvarToCvar(unsigned int jvar, unsigned int & cvar);
 
+protected:
+  /// number of coupled moose variables
+  const unsigned int _n_args;
+
 private:
   /// number of nonlinear variables in the system
   const std::size_t _jvar_max_size;
@@ -104,8 +110,18 @@ private:
 };
 
 template <class T>
+InputParameters
+JvarMapInterfaceBase<T>::validParams()
+{
+  auto params = T::validParams();
+  params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
+  return params;
+}
+
+template <class T>
 JvarMapInterfaceBase<T>::JvarMapInterfaceBase(const InputParameters & parameters)
   : T(parameters),
+    _n_args(this->_coupled_standard_moose_vars.size()),
     _jvar_max_size(this->_fe_problem.getNonlinearSystemBase().nVariables()),
     _jvar_map(_jvar_max_size, -1)
 {

--- a/modules/heat_conduction/src/kernels/HeatCapacityConductionTimeDerivative.C
+++ b/modules/heat_conduction/src/kernels/HeatCapacityConductionTimeDerivative.C
@@ -16,7 +16,7 @@ defineLegacyParams(HeatCapacityConductionTimeDerivative);
 InputParameters
 HeatCapacityConductionTimeDerivative::validParams()
 {
-  InputParameters params = TimeDerivative::validParams();
+  InputParameters params = JvarMapKernelInterface<TimeDerivative>::validParams();
   params.addClassDescription("Time derivative term $C_p \\frac{\\partial T}{\\partial t}$ of "
                              "the heat equation with the heat capacity $C_p$ as an argument.");
 
@@ -26,7 +26,6 @@ HeatCapacityConductionTimeDerivative::validParams()
 
   params.addParam<MaterialPropertyName>(
       "heat_capacity", "heat_capacity", "Property name of the heat capacity material property");
-  params.addCoupledVar("args", "Vector of additional arguments of the heat capacity");
   return params;
 }
 

--- a/modules/heat_conduction/src/kernels/JouleHeatingSource.C
+++ b/modules/heat_conduction/src/kernels/JouleHeatingSource.C
@@ -16,9 +16,8 @@ defineLegacyParams(JouleHeatingSource);
 InputParameters
 JouleHeatingSource::validParams()
 {
-  InputParameters params = HeatSource::validParams();
+  InputParameters params = JvarMapKernelInterface<HeatSource>::validParams();
   params.addCoupledVar("elec", "Electric potential for joule heating.");
-  params.addCoupledVar("args", "Vector of arguments of the diffusivity");
   params.addParam<MaterialPropertyName>(
       "electrical_conductivity",
       "electrical_conductivity",

--- a/modules/heat_conduction/src/kernels/SpecificHeatConductionTimeDerivative.C
+++ b/modules/heat_conduction/src/kernels/SpecificHeatConductionTimeDerivative.C
@@ -16,7 +16,7 @@ defineLegacyParams(SpecificHeatConductionTimeDerivative);
 InputParameters
 SpecificHeatConductionTimeDerivative::validParams()
 {
-  InputParameters params = TimeDerivative::validParams();
+  InputParameters params = JvarMapKernelInterface<TimeDerivative>::validParams();
   params.addClassDescription(
       "Time derivative term $\\rho c_p \\frac{\\partial T}{\\partial t}$ of "
       "the heat equation with the specific heat $c_p$ and the density $\\rho$ as arguments.");
@@ -29,7 +29,6 @@ SpecificHeatConductionTimeDerivative::validParams()
       "specific_heat", "specific_heat", "Property name of the specific heat material property");
   params.addParam<MaterialPropertyName>(
       "density", "density", "Property name of the density material property");
-  params.addCoupledVar("args", "Vector of additional arguments of the specific heat and density");
   return params;
 }
 

--- a/modules/phase_field/include/kernels/ACBulk.h
+++ b/modules/phase_field/include/kernels/ACBulk.h
@@ -56,27 +56,21 @@ template <typename T>
 ACBulk<T>::ACBulk(const InputParameters & parameters)
   : DerivativeMaterialInterface<JvarMapKernelInterface<KernelValue>>(parameters),
     _L(getMaterialProperty<T>("mob_name")),
-    _dLdop(getMaterialPropertyDerivative<T>("mob_name", _var.name()))
+    _dLdop(getMaterialPropertyDerivative<T>("mob_name", _var.name())),
+    _dLdarg(_n_args)
 {
-  // Get number of coupled variables
-  unsigned int nvar = _coupled_moose_vars.size();
-
-  // reserve space for derivatives
-  _dLdarg.resize(nvar);
-
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < nvar; ++i)
-    _dLdarg[i] = &getMaterialPropertyDerivative<T>("mob_name", _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dLdarg[i] = &getMaterialPropertyDerivative<T>("mob_name", i);
 }
 
 template <typename T>
 InputParameters
 ACBulk<T>::validParams()
 {
-  InputParameters params = ::validParams<KernelValue>();
+  InputParameters params = JvarMapKernelInterface<KernelValue>::validParams();
   params.addClassDescription("Allen-Cahn base Kernel");
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
-  params.addCoupledVar("args", "Vector of arguments of the mobility");
   return params;
 }
 
@@ -121,4 +115,3 @@ ACBulk<T>::computeQpOffDiagJacobian(unsigned int jvar)
   // Set off-diagonal Jacobian term from mobility derivatives
   return (*_dLdarg[cvar])[_qp] * _phi[_j][_qp] * computeDFDOP(Residual) * _test[_i][_qp];
 }
-

--- a/modules/phase_field/include/kernels/ACInterface.h
+++ b/modules/phase_field/include/kernels/ACInterface.h
@@ -60,9 +60,6 @@ protected:
   /// kappa derivative w.r.t. order parameter
   const MaterialProperty<Real> & _dkappadop;
 
-  /// number of coupled variables
-  const unsigned int _nvar;
-
   /// @{ Mobility derivative w.r.t. other coupled variables
   std::vector<const MaterialProperty<Real> *> _dLdarg;
   std::vector<const MaterialProperty<Real> *> _d2Ldargdop;
@@ -75,4 +72,3 @@ protected:
   /// Gradients for all coupled variables
   std::vector<const VariableGradient *> _gradarg;
 };
-

--- a/modules/phase_field/include/kernels/ACKappaFunction.h
+++ b/modules/phase_field/include/kernels/ACKappaFunction.h
@@ -35,15 +35,16 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  const NonlinearVariableName _var_name;
-  const MaterialPropertyName _L_name;
   const MaterialProperty<Real> & _L;
   const MaterialProperty<Real> & _dLdvar;
+
   const MaterialPropertyName _kappa_name;
   const MaterialProperty<Real> & _dkappadvar;
   const MaterialProperty<Real> & _d2kappadvar2;
-  const unsigned int _op_num;
-  std::vector<NonlinearVariableName> _v_name;
+
+  const unsigned int _v_num;
+  JvarMap _v_map;
+
   std::vector<const VariableGradient *> _grad_v;
   std::vector<const MaterialProperty<Real> *> _dLdv;
   std::vector<const MaterialProperty<Real> *> _d2kappadvardv;
@@ -51,4 +52,3 @@ protected:
 private:
   Real computeFg(); /// gradient energy term
 };
-

--- a/modules/phase_field/include/kernels/ACSwitching.h
+++ b/modules/phase_field/include/kernels/ACSwitching.h
@@ -37,7 +37,6 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  const unsigned int _nvar;
   /// name of order parameter that derivatives are taken wrt (needed to retrieve the derivative material properties)
   VariableName _etai_name;
 
@@ -63,4 +62,3 @@ protected:
   /// Second derivatives of the switching functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_d2hjdetaidarg;
 };
-

--- a/modules/phase_field/include/kernels/AllenCahn.h
+++ b/modules/phase_field/include/kernels/AllenCahn.h
@@ -35,10 +35,8 @@ protected:
   virtual Real computeDFDOP(PFFunctionType type);
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  const unsigned int _nvar;
   const MaterialProperty<Real> & _dFdEta;
   const MaterialProperty<Real> & _d2FdEta2;
 
   std::vector<const MaterialProperty<Real> *> _d2FdEtadarg;
 };
-

--- a/modules/phase_field/include/kernels/AllenCahnElasticEnergyOffDiag.h
+++ b/modules/phase_field/include/kernels/AllenCahnElasticEnergyOffDiag.h
@@ -42,10 +42,8 @@ protected:
   /// Mobility
   const MaterialProperty<Real> & _L;
 
-  ///@{ Displacement variables used for off-diagonal Jacobian
-  const unsigned int _ndisp;
-  std::vector<unsigned int> _disp_var;
-  ///@}
+  /// Displacement variables used for off-diagonal Jacobian
+  JvarMap _disp_map;
 
   /// Free energy material properties and derivatives
   const MaterialProperty<RankTwoTensor> & _d2Fdcdstrain;

--- a/modules/phase_field/include/kernels/CoupledAllenCahn.h
+++ b/modules/phase_field/include/kernels/CoupledAllenCahn.h
@@ -39,10 +39,8 @@ protected:
   // coupled variable name
   VariableName _v_name;
 
-  const unsigned int _nvar;
   const MaterialProperty<Real> & _dFdV;
   const MaterialProperty<Real> & _d2FdVdEta;
 
   std::vector<const MaterialProperty<Real> *> _d2FdVdarg;
 };
-

--- a/modules/phase_field/include/kernels/CoupledMaterialDerivative.h
+++ b/modules/phase_field/include/kernels/CoupledMaterialDerivative.h
@@ -45,10 +45,6 @@ protected:
   /// 2nd order material property derivative w.r.t. v then u
   const MaterialProperty<Real> & _d2Fdvdu;
 
-  /// Number of coupled variables
-  const unsigned int _nvar;
-
   /// 2nd order material property derivatives w.r.t. v and then all other coupled variables
   std::vector<const MaterialProperty<Real> *> _d2Fdvdarg;
 };
-

--- a/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
+++ b/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
@@ -30,7 +30,7 @@ InputParameters validParams<CoupledSwitchingTimeDerivative>();
  * model susceptibility equation, \f$ F_a \f$ etc. are the phase densities.
  */
 class CoupledSwitchingTimeDerivative
-    : public DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>
+  : public DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>
 {
 public:
   static InputParameters validParams();
@@ -42,9 +42,6 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-
-  /// Number of coupled variables
-  const unsigned int _nvar;
 
   /// name of order parameter that derivatives are taken wrt (needed to retrieve
   /// the derivative material properties)
@@ -77,4 +74,3 @@ protected:
   /// Second derivatives of the switching functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_d2hjdetaidarg;
 };
-

--- a/modules/phase_field/include/kernels/KKSACBulkBase.h
+++ b/modules/phase_field/include/kernels/KKSACBulkBase.h
@@ -33,9 +33,6 @@ public:
   virtual void initialSetup();
 
 protected:
-  /// Number of coupled variables
-  unsigned int _nvar;
-
   /// name of the order parameter (needed to retrieve the derivative material properties)
   VariableName _eta_name;
 

--- a/modules/phase_field/include/kernels/KKSCHBulk.h
+++ b/modules/phase_field/include/kernels/KKSCHBulk.h
@@ -41,9 +41,6 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  /// Number of coupled variables
-  unsigned int _nvar;
-
   ///@{
   /// Phase concnetration variables
   unsigned int _ca_var;
@@ -73,4 +70,3 @@ private:
   /// Second derivative \f$ d^2Fb/dcb^2 \f$
   const MaterialProperty<Real> & _second_derivative_Fb;
 };
-

--- a/modules/phase_field/include/kernels/KKSMultiACBulkBase.h
+++ b/modules/phase_field/include/kernels/KKSMultiACBulkBase.h
@@ -34,9 +34,6 @@ public:
   virtual void initialSetup();
 
 protected:
-  /// Number of coupled variables
-  unsigned int _nvar;
-
   /// name of order parameter that derivatives are taken wrt (needed to retrieve the derivative material properties)
   VariableName _etai_name;
 
@@ -68,4 +65,3 @@ protected:
   /// Second derivatives of the switching functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_d2hjdetaidarg;
 };
-

--- a/modules/phase_field/include/kernels/KKSSplitCHCRes.h
+++ b/modules/phase_field/include/kernels/KKSSplitCHCRes.h
@@ -45,9 +45,6 @@ protected:
   virtual void initialSetup();
 
 private:
-  /// Number of coupled variables
-  unsigned int _nvar;
-
   ///@{ Phase concnetration variable
   unsigned int _ca_var;
   VariableName _ca_name;

--- a/modules/phase_field/include/kernels/MaskedBodyForce.h
+++ b/modules/phase_field/include/kernels/MaskedBodyForce.h
@@ -41,9 +41,6 @@ protected:
 
   const MaterialProperty<Real> & _mask;
 
-  /// number of coupled variables
-  const unsigned int _nvar;
-
   /// name of the nonlinear variable (needed to retrieve the derivative material properties)
   VariableName _v_name;
 
@@ -53,4 +50,3 @@ protected:
   ///  Reaction rate derivatives w.r.t. other coupled variables
   std::vector<const MaterialProperty<Real> *> _dmaskdarg;
 };
-

--- a/modules/phase_field/include/kernels/MatReaction.h
+++ b/modules/phase_field/include/kernels/MatReaction.h
@@ -61,10 +61,6 @@ protected:
   ///  Reaction rate derivative w.r.t. the variable being added by this kernel
   const MaterialProperty<Real> & _dLdv;
 
-  /// number of coupled variables
-  const unsigned int _nvar;
-
   ///  Reaction rate derivatives w.r.t. other coupled variables
   std::vector<const MaterialProperty<Real> *> _dLdarg;
 };
-

--- a/modules/phase_field/include/kernels/SplitCHParsed.h
+++ b/modules/phase_field/include/kernels/SplitCHParsed.h
@@ -39,10 +39,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  const unsigned int _nvar;
   const MaterialProperty<Real> & _dFdc;
   const MaterialProperty<Real> & _d2Fdc2;
-
   std::vector<const MaterialProperty<Real> *> _d2Fdcdarg;
 };
-

--- a/modules/phase_field/include/kernels/SplitCHWResBase.h
+++ b/modules/phase_field/include/kernels/SplitCHWResBase.h
@@ -63,17 +63,12 @@ SplitCHWResBase<T>::SplitCHWResBase(const InputParameters & parameters)
     _mob(getMaterialProperty<T>("mob_name")),
     _is_coupled(isCoupled("w")),
     _w_var(_is_coupled ? coupled("w") : _var.number()),
-    _grad_w(_is_coupled ? coupledGradient("w") : _grad_u)
+    _grad_w(_is_coupled ? coupledGradient("w") : _grad_u),
+    _dmobdarg(_n_args)
 {
-  // Get number of coupled variables
-  unsigned int nvar = _coupled_moose_vars.size();
-
-  // reserve space for derivatives
-  _dmobdarg.resize(nvar);
-
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < nvar; ++i)
-    _dmobdarg[i] = &getMaterialPropertyDerivative<T>(_mob_name, _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dmobdarg[i] = &getMaterialPropertyDerivative<T>(_mob_name, i);
 }
 
 template <typename T>

--- a/modules/phase_field/src/kernels/ACInterface2DMultiPhase1.C
+++ b/modules/phase_field/src/kernels/ACInterface2DMultiPhase1.C
@@ -73,7 +73,7 @@ ACInterface2DMultiPhase1::computeQpJacobian()
     RealGradient dgradL =
         _grad_phi[_j][_qp] * _dLdop[_qp] + _grad_u[_qp] * _phi[_j][_qp] * _d2Ldop2[_qp];
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
       dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[i])[_qp];
 
     dsum += dgradL * _test[_i][_qp];
@@ -100,7 +100,7 @@ ACInterface2DMultiPhase1::computeQpOffDiagJacobian(unsigned int jvar)
     RealGradient dgradL = _grad_phi[_j][_qp] * (*_dLdarg[cvar])[_qp] +
                           _grad_u[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[cvar])[_qp];
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
       dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldarg2[cvar][i])[_qp];
 
     dsum += dgradL * _test[_i][_qp];

--- a/modules/phase_field/src/kernels/ACInterface2DMultiPhase2.C
+++ b/modules/phase_field/src/kernels/ACInterface2DMultiPhase2.C
@@ -43,7 +43,7 @@ ACInterface2DMultiPhase2::computeQpJacobian()
     RealGradient dgradL =
         _grad_phi[_j][_qp] * _dLdop[_qp] + _grad_u[_qp] * _phi[_j][_qp] * _d2Ldop2[_qp];
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
       dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[i])[_qp];
 
     dsum += dgradL * _test[_i][_qp];
@@ -69,7 +69,7 @@ ACInterface2DMultiPhase2::computeQpOffDiagJacobian(unsigned int jvar)
     RealGradient dgradL = _grad_phi[_j][_qp] * (*_dLdarg[cvar])[_qp] +
                           _grad_u[_qp] * _phi[_j][_qp] * (*_d2Ldargdop[cvar])[_qp];
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
       dgradL += (*_gradarg[i])[_qp] * _phi[_j][_qp] * (*_d2Ldarg2[cvar][i])[_qp];
 
     dsum += dgradL * _test[_i][_qp];

--- a/modules/phase_field/src/kernels/ACInterfaceKobayashi1.C
+++ b/modules/phase_field/src/kernels/ACInterfaceKobayashi1.C
@@ -16,7 +16,7 @@ defineLegacyParams(ACInterfaceKobayashi1);
 InputParameters
 ACInterfaceKobayashi1::validParams()
 {
-  InputParameters params = KernelGrad::validParams();
+  InputParameters params = JvarMapKernelInterface<KernelGrad>::validParams();
   params.addClassDescription("Anisotropic gradient energy Allen-Cahn Kernel Part 1");
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<MaterialPropertyName>("eps_name", "eps", "The anisotropic interface parameter");
@@ -30,7 +30,6 @@ ACInterfaceKobayashi1::validParams()
       "The derivative of the anisotropic interface parameter eps with respect to grad_op");
   params.addParam<MaterialPropertyName>(
       "ddepsdgrad_op_name", "ddepsdgrad_op", "The derivative of deps with respect to grad_op");
-  params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
   return params;
 }
 
@@ -43,21 +42,17 @@ ACInterfaceKobayashi1::ACInterfaceKobayashi1(const InputParameters & parameters)
     _depsdgrad_op(getMaterialProperty<RealGradient>("depsdgrad_op_name")),
     _ddepsdgrad_op(getMaterialProperty<RealGradient>("ddepsdgrad_op_name"))
 {
-  // Get number of coupled variables
-  unsigned int nvar = _coupled_moose_vars.size();
-
   // reserve space for derivatives
-  _dLdarg.resize(nvar);
-  _depsdarg.resize(nvar);
-  _ddepsdarg.resize(nvar);
+  _dLdarg.resize(_n_args);
+  _depsdarg.resize(_n_args);
+  _ddepsdarg.resize(_n_args);
 
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < nvar; ++i)
+  for (unsigned int i = 0; i < _n_args; ++i)
   {
-    const VariableName iname = _coupled_moose_vars[i]->name();
-    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", iname);
-    _depsdarg[i] = &getMaterialPropertyDerivative<Real>("eps_name", iname);
-    _ddepsdarg[i] = &getMaterialPropertyDerivative<Real>("deps_name", iname);
+    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", i);
+    _depsdarg[i] = &getMaterialPropertyDerivative<Real>("eps_name", i);
+    _ddepsdarg[i] = &getMaterialPropertyDerivative<Real>("deps_name", i);
   }
 }
 

--- a/modules/phase_field/src/kernels/ACInterfaceKobayashi2.C
+++ b/modules/phase_field/src/kernels/ACInterfaceKobayashi2.C
@@ -16,7 +16,7 @@ defineLegacyParams(ACInterfaceKobayashi2);
 InputParameters
 ACInterfaceKobayashi2::validParams()
 {
-  InputParameters params = KernelGrad::validParams();
+  InputParameters params = JvarMapKernelInterface<KernelGrad>::validParams();
   params.addClassDescription("Anisotropic Gradient energy Allen-Cahn Kernel Part 2");
   params.addParam<MaterialPropertyName>("mob_name", "L", "The mobility used with the kernel");
   params.addParam<MaterialPropertyName>("eps_name", "eps", "The anisotropic parameter");
@@ -24,7 +24,6 @@ ACInterfaceKobayashi2::validParams()
       "depsdgrad_op_name",
       "depsdgrad_op",
       "The derivative of the anisotropic interface parameter eps with respect to grad_op");
-  params.addCoupledVar("args", "Vector of nonlinear variable arguments this object depends on");
   return params;
 }
 
@@ -33,21 +32,15 @@ ACInterfaceKobayashi2::ACInterfaceKobayashi2(const InputParameters & parameters)
     _L(getMaterialProperty<Real>("mob_name")),
     _dLdop(getMaterialPropertyDerivative<Real>("mob_name", _var.name())),
     _eps(getMaterialProperty<Real>("eps_name")),
-    _depsdgrad_op(getMaterialProperty<RealGradient>("depsdgrad_op_name"))
+    _depsdgrad_op(getMaterialProperty<RealGradient>("depsdgrad_op_name")),
+    _dLdarg(_n_args),
+    _depsdarg(_n_args)
 {
-  // Get number of coupled variables
-  unsigned int nvar = _coupled_moose_vars.size();
-
-  // reserve space for derivatives
-  _dLdarg.resize(nvar);
-  _depsdarg.resize(nvar);
-
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < nvar; ++i)
+  for (unsigned int i = 0; i < _n_args; ++i)
   {
-    const VariableName iname = _coupled_moose_vars[i]->name();
-    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", iname);
-    _depsdarg[i] = &getMaterialPropertyDerivative<Real>("eps_name", iname);
+    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", i);
+    _depsdarg[i] = &getMaterialPropertyDerivative<Real>("eps_name", i);
   }
 }
 

--- a/modules/phase_field/src/kernels/ACSwitching.C
+++ b/modules/phase_field/src/kernels/ACSwitching.C
@@ -28,7 +28,6 @@ ACSwitching::validParams()
 
 ACSwitching::ACSwitching(const InputParameters & parameters)
   : ACBulk<Real>(parameters),
-    _nvar(_coupled_moose_vars.size()),
     _etai_name(_var.name()),
     _Fj_names(getParam<std::vector<MaterialPropertyName>>("Fj_names")),
     _num_j(_Fj_names.size()),
@@ -48,23 +47,21 @@ ACSwitching::ACSwitching(const InputParameters & parameters)
   {
     // get phase free energy
     _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
-    _prop_dFjdarg[n].resize(_nvar);
+    _prop_dFjdarg[n].resize(_n_args);
 
     // get switching derivatives wrt eta_i, the nonlinear variable
     _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name);
     _prop_d2hjdetai2[n] =
         &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, _etai_name);
-    _prop_d2hjdetaidarg[n].resize(_nvar);
+    _prop_d2hjdetaidarg[n].resize(_n_args);
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
     {
-      MooseVariableFEBase * cvar = _coupled_moose_vars[i];
       // Get derivatives of all Fj wrt all coupled variables
-      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], cvar->name());
+      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], i);
 
       // Get second derivatives of all hj wrt eta_i and all coupled variables
-      _prop_d2hjdetaidarg[n][i] =
-          &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, cvar->name());
+      _prop_d2hjdetaidarg[n][i] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, i);
     }
   }
 }

--- a/modules/phase_field/src/kernels/AllenCahn.C
+++ b/modules/phase_field/src/kernels/AllenCahn.C
@@ -25,15 +25,13 @@ AllenCahn::validParams()
 
 AllenCahn::AllenCahn(const InputParameters & parameters)
   : ACBulk<Real>(parameters),
-    _nvar(_coupled_moose_vars.size()),
     _dFdEta(getMaterialPropertyDerivative<Real>("f_name", _var.name())),
     _d2FdEta2(getMaterialPropertyDerivative<Real>("f_name", _var.name(), _var.name())),
-    _d2FdEtadarg(_nvar)
+    _d2FdEtadarg(_n_args)
 {
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-    _d2FdEtadarg[i] =
-        &getMaterialPropertyDerivative<Real>("f_name", _var.name(), _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _d2FdEtadarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _var.name(), i);
 }
 
 void

--- a/modules/phase_field/src/kernels/CoupledAllenCahn.C
+++ b/modules/phase_field/src/kernels/CoupledAllenCahn.C
@@ -28,15 +28,13 @@ CoupledAllenCahn::validParams()
 CoupledAllenCahn::CoupledAllenCahn(const InputParameters & parameters)
   : ACBulk<Real>(parameters),
     _v_name(getVar("v", 0)->name()),
-    _nvar(_coupled_moose_vars.size()),
     _dFdV(getMaterialPropertyDerivative<Real>("f_name", _v_name)),
     _d2FdVdEta(getMaterialPropertyDerivative<Real>("f_name", _v_name, _var.name())),
-    _d2FdVdarg(_nvar)
+    _d2FdVdarg(_n_args)
 {
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-    _d2FdVdarg[i] =
-        &getMaterialPropertyDerivative<Real>("f_name", _v_name, _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _d2FdVdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _v_name, i);
 }
 
 void

--- a/modules/phase_field/src/kernels/CoupledMaterialDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledMaterialDerivative.C
@@ -16,7 +16,7 @@ defineLegacyParams(CoupledMaterialDerivative);
 InputParameters
 CoupledMaterialDerivative::validParams()
 {
-  InputParameters params = Kernel::validParams();
+  InputParameters params = JvarMapKernelInterface<Kernel>::validParams();
   params.addClassDescription("Kernel that implements the first derivative of a function material "
                              "property with respect to a coupled variable.");
   params.addRequiredCoupledVar("v", "Variable to take the derivative with respect to");
@@ -25,9 +25,6 @@ CoupledMaterialDerivative::validParams()
                                         "Function material to take the derivative of (should "
                                         "provide derivative properties - such as a "
                                         "DerivativeParsedMaterial)");
-  params.addCoupledVar(
-      "args",
-      "Vector of other nonlinear variables F depends on (used for computing Jacobian entries)");
   return params;
 }
 
@@ -37,15 +34,11 @@ CoupledMaterialDerivative::CoupledMaterialDerivative(const InputParameters & par
     _v_var(coupled("v")),
     _dFdv(getMaterialPropertyDerivative<Real>("f_name", _v_name)),
     _d2Fdvdu(getMaterialPropertyDerivative<Real>("f_name", _v_name, _var.name())),
-    _nvar(_coupled_moose_vars.size()),
-    _d2Fdvdarg(_nvar)
+    _d2Fdvdarg(_n_args)
 {
   // Get material property derivatives for all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    MooseVariableFEBase * ivar = _coupled_moose_vars[i];
-    _d2Fdvdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _v_name, ivar->name());
-  }
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _d2Fdvdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _v_name, i);
 }
 
 void

--- a/modules/phase_field/src/kernels/CoupledSusceptibilityTimeDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledSusceptibilityTimeDerivative.C
@@ -16,12 +16,11 @@ defineLegacyParams(CoupledSusceptibilityTimeDerivative);
 InputParameters
 CoupledSusceptibilityTimeDerivative::validParams()
 {
-  InputParameters params = CoupledTimeDerivative::validParams();
+  InputParameters params = JvarMapKernelInterface<CoupledTimeDerivative>::validParams();
   params.addClassDescription("A modified coupled time derivative Kernel that multiplies the time "
                              "derivative of a coupled variable by a generalized susceptibility");
   params.addRequiredParam<MaterialPropertyName>(
       "f_name", "Susceptibility function F defined in a FunctionMaterial");
-  params.addCoupledVar("args", "Vector of arguments of the susceptibility");
   return params;
 }
 
@@ -30,11 +29,11 @@ CoupledSusceptibilityTimeDerivative::CoupledSusceptibilityTimeDerivative(
   : DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>(parameters),
     _F(getMaterialProperty<Real>("f_name")),
     _dFdu(getMaterialPropertyDerivative<Real>("f_name", _var.name())),
-    _dFdarg(_coupled_moose_vars.size())
+    _dFdarg(_n_args)
 {
   // fetch derivatives
-  for (unsigned int i = 0; i < _dFdarg.size(); ++i)
-    _dFdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dFdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", i);
 }
 
 void

--- a/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
@@ -30,7 +30,6 @@ CoupledSwitchingTimeDerivative::validParams()
 
 CoupledSwitchingTimeDerivative::CoupledSwitchingTimeDerivative(const InputParameters & parameters)
   : DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>(parameters),
-    _nvar(_coupled_moose_vars.size()), // number of coupled variables
     _v_name(getVar("v", 0)->name()),
     _Fj_names(getParam<std::vector<MaterialPropertyName>>("Fj_names")),
     _num_j(_Fj_names.size()),
@@ -52,22 +51,20 @@ CoupledSwitchingTimeDerivative::CoupledSwitchingTimeDerivative(const InputParame
     // get phase free energy and derivatives
     _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
     _prop_dFjdv[n] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], _var.name());
-    _prop_dFjdarg[n].resize(_nvar);
+    _prop_dFjdarg[n].resize(_n_args);
 
     // get switching function and derivatives wrt eta_i, the nonlinear variable
     _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name);
     _prop_d2hjdetai2[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name, _v_name);
-    _prop_d2hjdetaidarg[n].resize(_nvar);
+    _prop_d2hjdetaidarg[n].resize(_n_args);
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
     {
-      MooseVariableFEBase * cvar = _coupled_moose_vars[i];
       // Get derivatives of all Fj wrt all coupled variables
-      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], cvar->name());
+      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], i);
 
       // Get second derivatives of all hj wrt eta_i and all coupled variables
-      _prop_d2hjdetaidarg[n][i] =
-          &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name, cvar->name());
+      _prop_d2hjdetaidarg[n][i] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name, i);
     }
   }
 }

--- a/modules/phase_field/src/kernels/KKSACBulkBase.C
+++ b/modules/phase_field/src/kernels/KKSACBulkBase.C
@@ -28,7 +28,6 @@ KKSACBulkBase::validParams()
 KKSACBulkBase::KKSACBulkBase(const InputParameters & parameters)
   : ACBulk<Real>(parameters),
     // number of coupled variables (ca, args_a[])
-    _nvar(_coupled_moose_vars.size()),
     _eta_name(_var.name()),
     _prop_Fa(getMaterialProperty<Real>("fa_name")),
     _prop_dFa(getMaterialPropertyDerivative<Real>("fa_name", _eta_name)),
@@ -36,21 +35,19 @@ KKSACBulkBase::KKSACBulkBase(const InputParameters & parameters)
     _prop_d2h(getMaterialPropertyDerivative<Real>("h_name", _eta_name, _eta_name))
 {
   // reserve space for derivatives
-  _derivatives_Fa.resize(_nvar);
-  _derivatives_Fb.resize(_nvar);
-  _grad_args.resize(_nvar);
+  _derivatives_Fa.resize(_n_args);
+  _derivatives_Fb.resize(_n_args);
+  _grad_args.resize(_n_args);
 
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
+  for (unsigned int i = 0; i < _n_args; ++i)
   {
-    MooseVariable * cvar = _coupled_standard_moose_vars[i];
-
     // get the first derivatives of Fa and Fb material property
-    _derivatives_Fa[i] = &getMaterialPropertyDerivative<Real>("fa_name", cvar->name());
-    _derivatives_Fb[i] = &getMaterialPropertyDerivative<Real>("fb_name", cvar->name());
+    _derivatives_Fa[i] = &getMaterialPropertyDerivative<Real>("fa_name", i);
+    _derivatives_Fb[i] = &getMaterialPropertyDerivative<Real>("fb_name", i);
 
     // get the gradient
-    _grad_args[i] = &(cvar->gradSln());
+    _grad_args[i] = &(_coupled_standard_moose_vars[i]->gradSln());
   }
 }
 

--- a/modules/phase_field/src/kernels/KKSACBulkC.C
+++ b/modules/phase_field/src/kernels/KKSACBulkC.C
@@ -34,15 +34,11 @@ KKSACBulkC::KKSACBulkC(const InputParameters & parameters)
     _cb(coupledValue("cb")),
     _prop_dFadca(getMaterialPropertyDerivative<Real>("fa_name", _ca_name)),
     _prop_d2Fadca2(getMaterialPropertyDerivative<Real>("fa_name", _ca_name, _ca_name)),
-    _prop_d2Fadcadarg(_nvar)
+    _prop_d2Fadcadarg(_n_args)
 {
-  // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    // get second partial derivatives wrt ca and other coupled variable
-    const auto & var_name = _coupled_moose_vars[i]->name();
-    _prop_d2Fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _ca_name, var_name);
-  }
+  // get second partial derivatives wrt ca and other coupled variable
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _prop_d2Fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _ca_name, i);
 }
 
 Real

--- a/modules/phase_field/src/kernels/KKSMultiACBulkBase.C
+++ b/modules/phase_field/src/kernels/KKSMultiACBulkBase.C
@@ -29,7 +29,6 @@ KKSMultiACBulkBase::validParams()
 
 KKSMultiACBulkBase::KKSMultiACBulkBase(const InputParameters & parameters)
   : ACBulk<Real>(parameters),
-    _nvar(_coupled_moose_vars.size()), // number of coupled variables
     _etai_name(getVar("eta_i", 0)->name()),
     _etai_var(coupled("eta_i", 0)),
     _Fj_names(getParam<std::vector<MaterialPropertyName>>("Fj_names")),
@@ -51,24 +50,22 @@ KKSMultiACBulkBase::KKSMultiACBulkBase(const InputParameters & parameters)
   {
     // get phase free energy
     _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
-    _prop_dFjdarg[n].resize(_nvar);
+    _prop_dFjdarg[n].resize(_n_args);
 
     // get switching function and derivatives wrt eta_i, the nonlinear variable
     _prop_hj[n] = &getMaterialPropertyByName<Real>(_hj_names[n]);
     _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name);
     _prop_d2hjdetai2[n] =
         &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, _etai_name);
-    _prop_d2hjdetaidarg[n].resize(_nvar);
+    _prop_d2hjdetaidarg[n].resize(_n_args);
 
-    for (unsigned int i = 0; i < _nvar; ++i)
+    for (unsigned int i = 0; i < _n_args; ++i)
     {
-      MooseVariableFEBase * cvar = _coupled_moose_vars[i];
       // Get derivatives of all Fj wrt all coupled variables
-      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], cvar->name());
+      _prop_dFjdarg[n][i] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], i);
 
       // Get second derivatives of all hj wrt eta_i and all coupled variables
-      _prop_d2hjdetaidarg[n][i] =
-          &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, cvar->name());
+      _prop_d2hjdetaidarg[n][i] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _etai_name, i);
     }
   }
 }

--- a/modules/phase_field/src/kernels/KKSMultiACBulkC.C
+++ b/modules/phase_field/src/kernels/KKSMultiACBulkC.C
@@ -32,7 +32,8 @@ KKSMultiACBulkC::KKSMultiACBulkC(const InputParameters & parameters)
     _cjs_var(_num_j),
     _prop_dF1dc1(getMaterialPropertyDerivative<Real>(_Fj_names[0],
                                                      _c1_name)), // Use first Fj in list for dFj/dcj
-    _prop_d2F1dc12(getMaterialPropertyDerivative<Real>(_Fj_names[0], _c1_name, _c1_name))
+    _prop_d2F1dc12(getMaterialPropertyDerivative<Real>(_Fj_names[0], _c1_name, _c1_name)),
+    _prop_d2F1dc1darg(_n_args)
 {
   if (_num_j != coupledComponents("cj_names"))
     paramError("cj_names", "Need to pass in as many cj_names as Fj_names");
@@ -44,18 +45,9 @@ KKSMultiACBulkC::KKSMultiACBulkC(const InputParameters & parameters)
     _cjs_var[i] = coupled("cj_names", i);
   }
 
-  // Resize to number of coupled variables (_nvar from KKSMultiACBulkBase constructor)
-  _prop_d2F1dc1darg.resize(_nvar);
-
-  // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    MooseVariableFEBase * cvar = _coupled_moose_vars[i];
-
-    // get second partial derivatives wrt c1 and other coupled variable
-    _prop_d2F1dc1darg[i] =
-        &getMaterialPropertyDerivative<Real>(_Fj_names[0], _c1_name, cvar->name());
-  }
+  // get second partial derivatives wrt c1 and other coupled variable
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _prop_d2F1dc1darg[i] = &getMaterialPropertyDerivative<Real>(_Fj_names[0], _c1_name, i);
 }
 
 Real

--- a/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
+++ b/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
@@ -60,31 +60,23 @@ KKSPhaseChemicalPotential::KKSPhaseChemicalPotential(const InputParameters & par
     // second derivatives d2F/dx*dca for jacobian diagonal elements
     _d2fadca2(getMaterialPropertyDerivative<Real>("fa_name", _var.name(), _var.name())),
     _d2fbdcbca(getMaterialPropertyDerivative<Real>("fb_name", _cb_name, _var.name())),
+    _d2fadcadarg(_n_args),
+    _d2fbdcbdarg(_n_args),
     // site fractions
     _ka(getParam<Real>("ka")),
     _kb(getParam<Real>("kb"))
 {
-  MooseVariableFEBase * arg;
-  unsigned int i;
-
 #ifdef DEBUG
   _console << "KKSPhaseChemicalPotential(" << name() << ") " << _var.name() << ' ' << _cb_name
            << '\n';
 #endif
 
-  unsigned int nvar = _coupled_moose_vars.size();
-  _d2fadcadarg.resize(nvar);
-  _d2fbdcbdarg.resize(nvar);
-
-  for (i = 0; i < nvar; ++i)
+  // lookup table for the material properties representing the derivatives needed for the
+  // off-diagonal jacobian
+  for (std::size_t i = 0; i < _n_args; ++i)
   {
-    // get the moose variable
-    arg = _coupled_moose_vars[i];
-
-    // lookup table for the material properties representing the derivatives needed for the
-    // off-diagonal jacobian
-    _d2fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _var.name(), arg->name());
-    _d2fbdcbdarg[i] = &getMaterialPropertyDerivative<Real>("fb_name", _cb_name, arg->name());
+    _d2fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _var.name(), i);
+    _d2fbdcbdarg[i] = &getMaterialPropertyDerivative<Real>("fb_name", _cb_name, i);
   }
 }
 

--- a/modules/phase_field/src/kernels/KKSSplitCHCRes.C
+++ b/modules/phase_field/src/kernels/KKSSplitCHCRes.C
@@ -34,21 +34,16 @@ KKSSplitCHCRes::validParams()
 
 KKSSplitCHCRes::KKSSplitCHCRes(const InputParameters & parameters)
   : DerivativeMaterialInterface<JvarMapKernelInterface<SplitCHBase>>(parameters),
-    _nvar(_coupled_moose_vars.size()),
     _ca_var(coupled("ca")),
     _ca_name(getVar("ca", 0)->name()),
     _dFadca(getMaterialPropertyDerivative<Real>("fa_name", _ca_name)),
-    _d2Fadcadarg(_nvar),
+    _d2Fadcadarg(_n_args),
     _w_var(coupled("w")),
     _w(coupledValue("w"))
 {
-  // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    // get the second derivative material property
-    const auto & var_name = this->_coupled_moose_vars[i]->name();
-    _d2Fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _ca_name, var_name);
-  }
+  // get the second derivative material property
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _d2Fadcadarg[i] = &getMaterialPropertyDerivative<Real>("fa_name", _ca_name, i);
 }
 
 void

--- a/modules/phase_field/src/kernels/MaskedBodyForce.C
+++ b/modules/phase_field/src/kernels/MaskedBodyForce.C
@@ -27,17 +27,13 @@ MaskedBodyForce::validParams()
 MaskedBodyForce::MaskedBodyForce(const InputParameters & parameters)
   : DerivativeMaterialInterface<JvarMapKernelInterface<BodyForce>>(parameters),
     _mask(getMaterialProperty<Real>("mask")),
-    _nvar(_coupled_moose_vars.size()),
     _v_name(_var.name()),
     _dmaskdv(getMaterialPropertyDerivative<Real>("mask", _v_name)),
-    _dmaskdarg(_nvar)
+    _dmaskdarg(_n_args)
 {
   // Get derivatives of mask wrt coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    MooseVariableFEBase * cvar = _coupled_moose_vars[i];
-    _dmaskdarg[i] = &getMaterialPropertyDerivative<Real>("mask", cvar->name());
-  }
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dmaskdarg[i] = &getMaterialPropertyDerivative<Real>("mask", i);
 }
 
 void

--- a/modules/phase_field/src/kernels/MatGradSquareCoupled.C
+++ b/modules/phase_field/src/kernels/MatGradSquareCoupled.C
@@ -33,11 +33,10 @@ MatGradSquareCoupled::MatGradSquareCoupled(const InputParameters & parameters)
     _elec_potential_var(coupled("elec_potential")),
     _prefactor(getMaterialProperty<Real>("prefactor")),
     _dprefactor_dphi(getMaterialPropertyDerivative<Real>("prefactor", _var.name())),
-    _dprefactor_darg(_coupled_moose_vars.size())
+    _dprefactor_darg(_n_args)
 {
-  for (unsigned int i = 0; i < _dprefactor_darg.size(); ++i)
-    _dprefactor_darg[i] =
-        &getMaterialPropertyDerivative<Real>("prefactor", _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dprefactor_darg[i] = &getMaterialPropertyDerivative<Real>("prefactor", i);
 }
 
 void

--- a/modules/phase_field/src/kernels/MatReaction.C
+++ b/modules/phase_field/src/kernels/MatReaction.C
@@ -36,15 +36,11 @@ MatReaction::MatReaction(const InputParameters & parameters)
     _eta_name(_var.name()),
     _dLdop(getMaterialPropertyDerivative<Real>("mob_name", _eta_name)),
     _dLdv(getMaterialPropertyDerivative<Real>("mob_name", _v_name)),
-    _nvar(_coupled_moose_vars.size()),
-    _dLdarg(_nvar)
+    _dLdarg(_n_args)
 {
   // Get reaction rate derivatives
-  for (unsigned int i = 0; i < _nvar; ++i)
-  {
-    MooseVariableFEBase * ivar = _coupled_moose_vars[i];
-    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", ivar->name());
-  }
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dLdarg[i] = &getMaterialPropertyDerivative<Real>("mob_name", i);
 }
 
 void

--- a/modules/phase_field/src/kernels/SplitCHParsed.C
+++ b/modules/phase_field/src/kernels/SplitCHParsed.C
@@ -27,17 +27,13 @@ SplitCHParsed::validParams()
 
 SplitCHParsed::SplitCHParsed(const InputParameters & parameters)
   : DerivativeMaterialInterface<JvarMapKernelInterface<SplitCHCRes>>(parameters),
-    _nvar(_coupled_moose_vars.size()),
     _dFdc(getMaterialPropertyDerivative<Real>("f_name", _var.name())),
-    _d2Fdc2(getMaterialPropertyDerivative<Real>("f_name", _var.name(), _var.name()))
+    _d2Fdc2(getMaterialPropertyDerivative<Real>("f_name", _var.name(), _var.name())),
+    _d2Fdcdarg(_n_args)
 {
-  // reserve space for derivatives
-  _d2Fdcdarg.resize(_nvar);
-
   // Iterate over all coupled variables
-  for (unsigned int i = 0; i < _nvar; ++i)
-    _d2Fdcdarg[i] =
-        &getMaterialPropertyDerivative<Real>("f_name", _var.name(), _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _d2Fdcdarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _var.name(), i);
 }
 
 void

--- a/modules/phase_field/src/kernels/SusceptibilityTimeDerivative.C
+++ b/modules/phase_field/src/kernels/SusceptibilityTimeDerivative.C
@@ -30,11 +30,11 @@ SusceptibilityTimeDerivative::SusceptibilityTimeDerivative(const InputParameters
   : DerivativeMaterialInterface<JvarMapKernelInterface<TimeDerivative>>(parameters),
     _Chi(getMaterialProperty<Real>("f_name")),
     _dChidu(getMaterialPropertyDerivative<Real>("f_name", _var.name())),
-    _dChidarg(_coupled_moose_vars.size())
+    _dChidarg(_n_args)
 {
   // fetch derivatives
-  for (unsigned int i = 0; i < _dChidarg.size(); ++i)
-    _dChidarg[i] = &getMaterialPropertyDerivative<Real>("f_name", _coupled_moose_vars[i]->name());
+  for (unsigned int i = 0; i < _n_args; ++i)
+    _dChidarg[i] = &getMaterialPropertyDerivative<Real>("f_name", i);
 }
 
 void


### PR DESCRIPTION
Reduces the number of times users need to directly access `_coupled_standard_moose_vars` (and avoids the confusion with `_coupled_moose_vars`).

This requires a Marmot update - patch is ready.

Refs #14999 