### PR TITLE
Allow user to set PETSC_ARCH for submodule

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -119,7 +119,9 @@ if [ -z "$PETSC_DIR" ]; then
   echo "PETSc maint branch."
   echo "IMPORTANT: If you did not run the update_and_rebuild_petsc.sh script yet, please run it before building libMesh"
   export PETSC_DIR=$SCRIPT_DIR/../petsc
-  export PETSC_ARCH=arch-moose
+  if [ -z "$PETSC_ARCH" ]; then
+    export PETSC_ARCH=arch-moose
+  fi
 fi
 
 # If we're not going fast, remove the build directory and reconfigure

--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -56,7 +56,9 @@ fi
 
 # Set PETSc envir
 export PETSC_DIR=$SCRIPT_DIR/../petsc
-export PETSC_ARCH=arch-moose
+if [ -z "$PETSC_ARCH" ]; then
+    export PETSC_ARCH=arch-moose
+fi
 
 
 cd $SCRIPT_DIR/..


### PR DESCRIPTION
I like to control the naming of my `PETSC_ARCH`, e.g. `clang` or `gcc`, etc.
