### PR TITLE
Create 'parameters' package to be used by all python tools

### DIFF
--- a/python/parameters/InputParameters.py
+++ b/python/parameters/InputParameters.py
@@ -1,0 +1,275 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+from collections import OrderedDict
+import enum
+import logging
+import copy
+
+from .Parameter import Parameter
+
+class InputParameters(object):
+    """
+    A warehouse for creating and storing options
+    """
+
+    class ErrorMode(enum.Enum):
+        """Defines the error mode."""
+        WARNING = 1  # logging.warning
+        ERROR = 2    # logging.error
+        EXCEPTION =3 # logging.critical and raises InputParametersException
+
+    class InputParameterException(Exception):
+        """Custom Exception used in for ErrorMode.EXCEPTION"""
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    LOG = logging.getLogger('InputParameters')
+
+    def __init__(self, mode=ErrorMode.WARNING):
+        self.__mode = mode
+        self.__parameters = OrderedDict()
+
+    def add(self, *args, **kwargs):
+        """
+        Add a new Parameter to the warehouse
+
+        Inputs:
+            see Parameter.py
+        """
+        if args[0] in self.__parameters:
+            self.__errorHelper("Cannot add parameter, the parameter '{}' already exists.", args[0])
+            return
+
+        default = kwargs.get('default', None)
+        if isinstance(default, InputParameters):
+            kwargs['vtype'] = InputParameters
+
+        self.__parameters[args[0]] = Parameter(*args, **kwargs)
+
+    def __contains__(self, name):
+        """
+        Allows keys to be tested via "in" keyword.
+        """
+        return name in self.__parameters
+
+    def __iadd__(self, params):
+        """
+        Append another Parameter objects options into this container.
+
+        Inputs:
+           options[InputParameters]: An instance of an InputParameters object to append.
+        """
+        for key in params.keys():
+            self.__parameters[key] = params._InputParameters__parameters[key]
+        return self
+
+    def items(self):
+        """
+        Provides dict.items() functionality.
+        """
+        for name, param in self.__parameters.items():
+            yield name, param.value
+
+    def values(self):
+        """
+        Provides dict.values() functionality.
+        """
+        for param in self.__parameters.values():
+            yield param.value
+
+    def keys(self):
+        """
+        Provides dict.keys() functionality.
+        """
+        return self.__parameters.keys()
+
+    def remove(self, name):
+        """
+        Remove an option from the warehouse.
+
+        Inputs:
+            name[str]: The name of the Parameter to remove
+        """
+        if name not in self.__parameters:
+            self.__errorHelper("Cannot remove parameter, the parameter '{}' does not exist.", name)
+        else:
+            self.__parameters.pop(name)
+
+    def isValid(self, name):
+        """
+        Test if the given option is valid (i.e., !None). (public)
+
+        Inputs:
+            name[str]: The name of the Parameter to retrieve
+        """
+        opt = self.__parameters.get(name, None)
+        if opt is None:
+            self.__errorHelper("Cannot determine if the parameters is valid, the parameter '{}' does not exist.", name)
+            return None
+        else:
+            return opt.value is not None
+
+    def setDefault(self, name, default):
+        """
+        Set the default value, this will onluy set the value if it is None
+        """
+        opt = self.__parameters.get(name, None)
+        if opt is None:
+            self.__errorHelper("Cannot set default, the parameter '{}' does not exist.", name)
+        else:
+            opt.default = default
+
+    def getDefault(self, name):
+        """
+        Return the default value
+        """
+        opt = self.__parameters.get(name, None)
+        if opt is None:
+            self.__errorHelper("Cannot get default, the parameter '{}' does not exist.", name)
+            return None
+        return opt.default
+
+    def isDefault(self, name):
+        """
+        Return True if the supplied option is set to the default value.
+
+        Inputs:
+            name[str]: The name of the Parameter to test.
+        """
+        opt = self.__parameters.get(name, None)
+        if opt is None:
+            self.__errorHelper("Cannot determine if the parameter is default, the parameter '{}' does not exist.", name)
+            return None
+        return opt.value == opt.default
+
+    def set(self, name, *args, **kwargs):
+        """
+        Set the value of a parameter or update contents of a sub-parameters.
+
+        If the associated parameter is an InputParameters object and the value is a dict, update
+        the parameters via InputParameters.update
+
+        Use:
+           params.set('foo', 42)            # foo is an 'int'
+           params.set('bar', year=1980)     # bar is an 'InputParameters' object
+           params.set('bar', {'year':1980}) # bar is an 'InputParameters' object
+
+        Inputs:
+            name[str]: The name of the Parameter to modify
+            value|kwargs: The value to set the parameter or key, value pairs if the parameter is
+                          an InputParameters object
+        """
+        opt = self.__parameters.get(name, None)
+
+        if opt is None:
+            self.__errorHelper("Cannot set value, the parameter '{}' does not exist.", name)
+
+        elif isinstance(opt.value, InputParameters):
+            if len(args) > 0 and kwargs:
+                self.__errorHelper("Key, value pairs are not allowed when setting the '{}' parameter with a supplied dict argument.", name)
+            elif len(args) == 1 and isinstance(args[0], dict):
+                opt.value.update(**args[0])
+            elif len(args) == 1 and isinstance(args[0], InputParameters):
+                opt.value = args[0]
+            elif len(args) == 1:
+                self.__errorHelper("The second argument for the '{}' parameter must be a dict() or InputParametrs object.", name)
+            else:
+                opt.value.update(**kwargs)
+        else:
+            if len(args) != 1:
+                self.__errorHelper("A single second argument is required for the '{}' parameter.", name)
+            elif kwargs:
+                self.__errorHelper("Key, value pairs are not allowed when setting the '{}' parameter.", name)
+            else:
+                opt.value = args[0]
+
+    def get(self, name):
+        """
+        Overload for accessing the parameter value by name with []
+
+        Inputs:
+            name[str]: The name of the Parameter to retrieve
+        """
+        opt = self.__parameters.get(name, None)
+        if opt is None:
+            self.__errorHelper("Cannot get value, the parameter '{}' does not exist.", name)
+            return None
+        else:
+            return opt.value
+
+    def hasParameter(self, name):
+        """
+        Test that the parameter exists.
+
+        Inputs:
+            name[str]: The name of the Parameter to check
+        """
+        return name in self.__parameters
+
+    def update(self, *args, **kwargs):
+        """"
+        Update the options given key, value pairs
+
+        Inputs:
+            *args: InputParameters objects to use for updating this object.
+            **kwargs: key, values pairs to used for updating this object.
+        """
+        # Unused options
+        unused = set()
+
+        # Update from InputParameters object
+        for opt in args:
+            if not isinstance(opt, InputParameters):
+                self.__errorHelper("The supplied arguments must be InputParameters objects or key, value pairs.")
+            else:
+                for key in opt.keys():
+                    if self.hasParameter(key):
+                        self.set(key, opt.get(key))
+                    else:
+                        unused.add(key)
+
+        # Update from kwargs
+        for k, v in kwargs.items():
+            if k in self.keys():
+                self.set(k, v)
+            else:
+                unused.add(k)
+
+        # Warning for unused
+        if len(unused) > 0:
+            msg = 'The following parameters do not exist: {}'
+            self.__errorHelper(msg, ' '.join(unused))
+
+    def __str__(self):
+        """
+        Allows print to work with this class.
+        """
+        return self.toString()
+
+    def toString(self):
+        """
+        Create a string of all parameters using Parameter.toString
+        """
+        out = []
+        for param in self.itervalues():
+            out.append(param.toString())
+        return '\n\n'.join(out)
+
+    def __errorHelper(self, text, *args, **kwargs):
+        """
+        Produce warning, error, or exception based on operation mode.
+        """
+        msg = text.format(*args, **kwargs)
+        if self.__mode == InputParameters.ErrorMode.WARNING:
+            self.LOG.warning(msg)
+        elif self.__mode == InputParameters.ErrorMode.ERROR:
+            self.LOG.error(msg)
+        else:
+            self.LOG.critical(msg)
+            raise InputParameters.InputParameterException(msg)

--- a/python/parameters/Parameter.py
+++ b/python/parameters/Parameter.py
@@ -1,0 +1,246 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+import textwrap
+import logging
+LOG = logging.getLogger(__file__)
+
+class Parameter(object):
+    """
+    Storage container for an "param" that can be type checked, restricted, and documented.
+
+    The meta data within this object is designed to be immutable, the only portion of this class
+    that can be changed (without demangling) is the assigned value and the default, via the
+    associated setter methods.
+
+    Inputs:
+        name[str]: The name of the option.
+        default[]: The default value, if "vtype" is set the type must match.
+        doc[str]: A documentation string, which is used in the option dump.
+        vtype[type]: The python type that this option is to be restricted.
+        allow[tuple]: A tuple of allowed values, if vtype is set the types within must match.
+        size[int]: Defines the size of an array, setting size will automatically set the array flag.
+        array[bool]: Define the option as an "array", which if 'vtype' is set restricts the values
+                     within the tuple to match types.
+        required[bool]: Define if the option is required; see InputParameters.py
+        private[bool]: Define if the options is private; see InputParameters.py. A parameter name
+                       that starts with and underscore is assumed to be private
+    """
+    def __init__(self, name, default=None, doc=None, vtype=None, allow=None, size=None,
+                 array=False, required=False, private=None):
+
+        # Force vtype to be a tuple to allow multiple types to be defined
+        if isinstance(vtype, type):
+            vtype = (vtype,)
+
+        self.__name = name         # option name
+        self.__value = None        # current value
+        self.__default = default   # default value
+        self.__vtype = vtype       # option type
+        self.__allow = allow       # list of allowed values
+        self.__doc = doc           # documentation string
+        self.__array = array       # create an array
+        self.__size = size         # array size
+        self.__required = required # see validate()
+
+        if not isinstance(self.__name, str):
+            msg = "The supplied 'name' argument must be a 'str', but {} was provided."
+            raise TypeError(msg.format(type(self.__name)))
+
+        # private option, must be after name to allow startswith to work without error
+        self.__private = private if (private is not None) else self.__name.startswith('_')
+
+        if (self.__doc is not None) and (not isinstance(self.__doc, str)):
+            msg = "The supplied 'doc' argument must be a 'str', but {} was provided."
+            raise TypeError(msg.format(type(self.__doc)))
+
+        if (self.__vtype is not None) and (any(not isinstance(v, type) for v in self.__vtype)):
+            msg = "The supplied 'vtype' argument must be a 'type', but {} was provided."
+            raise TypeError(msg.format(type(self.__vtype)))
+
+        if (self.__allow is not None) and (not isinstance(self.__allow, tuple)):
+            msg = "The supplied 'allow' argument must be a 'tuple', but {} was provided."
+            raise TypeError(msg.format(type(self.__allow)))
+
+        if (self.__vtype is not None) and (self.__allow is not None):
+            for value in self.__allow:
+                if not isinstance(value, self.__vtype):
+                    msg = "The supplied 'allow' argument must be a 'tuple' of {} items, but a {} " \
+                            "item was provided."
+                    raise TypeError(msg.format(self.__vtype, type(value)))
+
+        if (self.__size is not None) and (not isinstance(self.__size, int)):
+            msg = "The supplied 'size' argument must be a 'int', but {} was provided."
+            raise TypeError(msg.format(type(self.__size)))
+
+        if not isinstance(self.__required, bool):
+            msg = "The supplied 'required' argument must be a 'bool', but {} was provided."
+            raise TypeError(msg.format(type(self.__required)))
+
+        if not isinstance(self.__private, bool):
+            msg = "The supplied 'required' argument must be a 'bool', but {} was provided."
+            raise TypeError(msg.format(type(self.__required)))
+
+        elif self.__size is not None:
+            self.__array = True
+
+        if default is not None:
+            self.value = default
+
+    @property
+    def name(self):
+        """Returns the option name."""
+        return self.__name
+
+    @property
+    def value(self):
+        """Returns the option value."""
+        return self.__value
+
+    @property
+    def default(self):
+        """Returns the default value for the option."""
+        return self.__default
+
+    @property
+    def doc(self):
+        """Returns the documentation string."""
+        return self.__doc
+
+    @property
+    def allow(self):
+        """Returns the allowable values for the option."""
+        return self.__allow
+
+    @property
+    def size(self):
+        """Returns the size of the option."""
+        return self.__size
+
+    @property
+    def vtype(self):
+        """Returns the variable type."""
+        return self.__vtype
+
+    @property
+    def required(self):
+        """Returns if the option required state."""
+        return self.__required
+
+    @property
+    def private(self):
+        """Returns if the option private state."""
+        return self.__private
+
+    @default.setter
+    def default(self, value):
+        """Set the default value for this option."""
+        self.__default = value
+        if self.__value is None:
+            self.value = self.__default
+
+    @value.setter
+    def value(self, val):
+        """
+        Sets the value and performs a myriad of consistency checks.
+        """
+
+        if val is None:
+            self.__value = None
+            return
+
+        if self.__array and not isinstance(val, tuple):
+            msg = "'%s' was defined as an array, which require %s for assignment, but a %s was " \
+                  "provided."
+            LOG.warning(msg, self.name, tuple, type(val))
+            return
+
+        if self.__array:
+            for v in val:
+                if self.__vtype is not None:
+                    for vtype in self.__vtype:
+                        try:
+                            v = vtype(v)
+                            break
+                        except (ValueError, TypeError):
+                            pass
+
+                if (self.__vtype is not None) and not isinstance(v, self.__vtype):
+                    msg = "The values within '%s' must be of type %s but %s provided."
+                    LOG.warning(msg, self.name, self.__vtype, type(v))
+                    return
+
+            if self.__size is not None:
+                if len(val) != self.__size:
+                    msg = "'%s' was defined as an array with length %s but a value with length %s " \
+                          "was provided."
+                    LOG.warning(msg, self.name, self.__size, len(val))
+                    return
+
+        else:
+            if self.__vtype is not None:
+                for vtype in self.__vtype:
+                    try:
+                        val = vtype(val)
+                        break
+                    except (ValueError, TypeError):
+                        pass
+
+            if (self.__vtype is not None) and not isinstance(val, self.__vtype):
+                msg = "'%s' must be of type %s but %s provided."
+                LOG.warning(msg, self.name, self.__vtype, type(val))
+                return
+
+        # Check that the value is allowed
+        if (self.__allow is not None) and (val != None) and (val not in self.__allow):
+            msg = "Attempting to set '%s' to a value of %s but only the following are allowed: %s"
+            LOG.warning(msg, self.name, val, self.__allow)
+            return
+
+        self.__value = val
+
+    def validate(self):
+        """Validate that the Parameter is in the correct state."""
+        if self.__required and (self.value is None):
+            msg = "The Parameter '%s' is marked as required, but no value is assigned."
+            LOG.warning(msg, self.name)
+            return 1
+        return 0
+
+    def toString(self):
+        """Create a string of Parameter information."""
+        out = [self.__name]
+
+        if self.__doc is not None:
+            wrapper = textwrap.TextWrapper()
+            wrapper.initial_indent = ' '*2
+            wrapper.subsequent_indent = ' '*2
+            wrapper.width = 100
+            out += wrapper.wrap(self.__doc)
+
+        out += ['    Value:   {}'.format(repr(self.value))]
+
+        if self.__default is not None:
+            out += ['    Default: {}'.format(repr(self.__default))]
+
+        if self.__vtype is not None:
+            out += ['    Type(s): {}'.format(tuple([t.__name__ for t in self.__vtype]))]
+
+        if self.__allow is not None:
+            wrapper = textwrap.TextWrapper()
+            wrapper.initial_indent = '    Allow:   '
+            wrapper.subsequent_indent = ' '*len(wrapper.initial_indent)
+            wrapper.width = 100 - len(wrapper.initial_indent)
+            out += wrapper.wrap(repr(self.__allow))
+
+        return '\n'.join(out)
+
+
+    def __str__(self):
+        """Support print statement on Parameter object."""
+        return self.toString()

--- a/python/parameters/__init__.py
+++ b/python/parameters/__init__.py
@@ -1,0 +1,2 @@
+from .Parameter import Parameter
+from .InputParameters import InputParameters

--- a/python/parameters/test/test_InputParameters.py
+++ b/python/parameters/test/test_InputParameters.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+#pylint: disable=missing-docstring
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+import sys
+import re
+import unittest
+from parameters import InputParameters
+
+class TestInputParameters(unittest.TestCase):
+
+    def testAdd(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertEqual(list(params.keys()), ['foo'])
+        self.assertFalse(params.isValid('foo'))
+        self.assertIn('foo', params)
+        self.assertIsNone(params.get('foo'))
+        self.assertTrue(params.hasParameter('foo'))
+
+        with self.assertLogs(level='WARNING') as log:
+            params.add('foo')
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot add parameter, the parameter 'foo' already exists.", log.output[0])
+
+    def testContains(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertIn('foo', params)
+        self.assertNotIn('bar', params)
+
+    def testIAdd(self):
+        params = InputParameters()
+        params.add('foo')
+
+        params2 = InputParameters()
+        params2.add('bar')
+
+        params += params2
+        self.assertIn('foo', params)
+        self.assertIn('bar', params)
+
+    def testItems(self):
+        params = InputParameters()
+        params.add('foo', 1949)
+        params.add('bar', 1980)
+
+        gold = [('foo', 1949), ('bar', 1980)]
+        for i, (k, v) in enumerate(params.items()):
+            self.assertEqual(k, gold[i][0])
+            self.assertEqual(v, gold[i][1])
+
+    def testValues(self):
+        params = InputParameters()
+        params.add('foo', 1949)
+        params.add('bar', 1980)
+
+        gold = [1949, 1980]
+        for i, v in enumerate(params.values()):
+            self.assertEqual(v, gold[i])
+
+    def testKeys(self):
+        params = InputParameters()
+        params.add('foo', 1949)
+        params.add('bar', 1980)
+
+        gold = ['foo', 'bar']
+        for i, v in enumerate(params.keys()):
+            self.assertEqual(v, gold[i])
+
+    def testRemove(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertTrue(params.hasParameter('foo'))
+        params.remove('foo')
+        self.assertFalse(params.hasParameter('foo'))
+
+        with self.assertLogs(level='WARNING') as log:
+            params.remove('bar')
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot remove parameter, the parameter 'bar' does not exist", log.output[0])
+
+    def testIsValid(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertFalse(params.isValid('foo'))
+        params.set('foo', 1980)
+        self.assertTrue(params.isValid('foo'))
+
+        with self.assertLogs(level='WARNING') as log:
+            self.assertIsNone(params.isValid('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot determine if the parameters is valid, the parameter 'bar' does not exist", log.output[0])
+
+    def testSetDefault(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertIsNone(params.get('foo'))
+        params.setDefault('foo', 1980)
+        self.assertEqual(params.get('foo'), 1980)
+
+        params.add('bar', default=1980)
+        params.setDefault('bar', 1949)
+        self.assertEqual(params.get('bar'), 1980)
+        self.assertEqual(params.getDefault('bar'), 1949)
+
+        with self.assertLogs(level='WARNING') as log:
+            params.setDefault('other', 1980)
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot set default, the parameter 'other' does not exist", log.output[0])
+
+    def testGetDefault(self):
+        params = InputParameters()
+        params.add('foo', default=42)
+        params.set('foo', 54)
+        self.assertEqual(params.getDefault('foo'), 42)
+
+        with self.assertLogs(level='WARNING') as log:
+            self.assertIsNone(params.getDefault('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot get default, the parameter 'bar' does not exist", log.output[0])
+
+    def testIsDefault(self):
+        params = InputParameters()
+        params.add('foo', default=1949)
+        self.assertTrue(params.isDefault('foo'))
+        params.set('foo', 1980)
+        self.assertFalse(params.isDefault('foo'))
+
+        with self.assertLogs(level='WARNING') as log:
+            self.assertIsNone(params.isDefault('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot determine if the parameter is default, the parameter 'bar' does not exist", log.output[0])
+
+    def testSet(self):
+        params = InputParameters()
+        params.add('foo')
+        params.set('foo', 42)
+        self.assertEqual(list(params.keys()), ['foo'])
+        self.assertTrue(params.isValid('foo'))
+        self.assertIn('foo', params)
+        self.assertIsNotNone(params.get('foo'))
+        self.assertEqual(params.get('foo'), 42)
+        self.assertTrue(params.hasParameter('foo'))
+
+        with self.assertLogs(level='WARNING') as log:
+            params.set('bar', 1980)
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot set value, the parameter 'bar' does not exist", log.output[0])
+
+        # Sub-options
+        params2 = InputParameters()
+        params2.add('bar')
+        params.add('sub', params2)
+        params.set('sub', {'bar':2013})
+        self.assertEqual(params2.get('bar'), 2013)
+        self.assertEqual(params.get('sub').get('bar'), 2013)
+
+        params2.set('bar', 1954)
+        self.assertEqual(params2.get('bar'), 1954)
+        self.assertEqual(params.get('sub').get('bar'), 1954)
+
+        params3 = InputParameters()
+        params3.add('bar', default=2011)
+        params.set('sub', params3)
+        self.assertEqual(params2.get('bar'), 1954)
+        self.assertEqual(params3.get('bar'), 2011)
+        self.assertEqual(params.get('sub').get('bar'), 2011)
+
+        params.set('sub', bar=1944)
+        self.assertEqual(params2.get('bar'), 1954)
+        self.assertEqual(params3.get('bar'), 1944)
+        self.assertEqual(params.get('sub').get('bar'), 1944)
+
+        # More errors
+        with self.assertLogs(level='WARNING') as log:
+            params.set('foo', 1980, this='that')
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Key, value pairs are not allowed when setting the 'foo' parameter.", log.output[0])
+
+        with self.assertLogs(level='WARNING') as log:
+            params.set('foo', 1980, 2011)
+            params.set('foo')
+
+        self.assertEqual(len(log.output), 2)
+        self.assertIn("A single second argument is required for the 'foo' parameter.", log.output[0])
+        self.assertIn("A single second argument is required for the 'foo' parameter.", log.output[1])
+
+        with self.assertLogs(level='WARNING') as log:
+            params.set('sub', 1980, bar=1948)
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Key, value pairs are not allowed when setting the 'sub' parameter with a supplied dict argument.", log.output[0])
+
+        with self.assertLogs(level='WARNING') as log:
+            params.set('sub', 1980)
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("The second argument for the 'sub' parameter must be a dict() or InputParametrs object", log.output[0])
+
+    def testGet(self):
+        params = InputParameters()
+        params.add('foo', default=1980)
+        self.assertEqual(params.get('foo'), 1980)
+
+        with self.assertLogs(level='WARNING') as log:
+            self.assertIsNone(params.get('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot get value, the parameter 'bar' does not exist", log.output[0])
+
+    def testHasParameter(self):
+        params = InputParameters()
+        params.add('foo')
+        self.assertTrue(params.hasParameter('foo'))
+        self.assertFalse(params.hasParameter('bar'))
+
+    def testUpdate(self):
+        params = InputParameters()
+        params.add('foo')
+        params.update(foo=1980)
+        self.assertEqual(params.get('foo'), 1980)
+
+        params2 = InputParameters()
+        params2.add('foo', 2013)
+
+        params.update(params2)
+        self.assertEqual(params.get('foo'), 2013)
+
+        with self.assertLogs(level='WARNING') as log:
+            params.update(foo=2011, bar=2013)
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("The following parameters do not exist: bar", log.output[0])
+
+    def testErrorMode(self):
+        params = InputParameters(InputParameters.ErrorMode.WARNING)
+        with self.assertLogs(level='WARNING') as log:
+            self.assertIsNone(params.isValid('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot determine if the parameters is valid, the parameter 'bar' does not exist", log.output[0])
+
+        params = InputParameters(InputParameters.ErrorMode.ERROR)
+        with self.assertLogs(level='ERROR') as log:
+            self.assertIsNone(params.isValid('bar'))
+        self.assertEqual(len(log.output), 1)
+        self.assertIn("Cannot determine if the parameters is valid, the parameter 'bar' does not exist", log.output[0])
+
+        params = InputParameters(InputParameters.ErrorMode.EXCEPTION)
+        with self.assertRaises(InputParameters.InputParameterException):
+            with self.assertLogs(level='CRITICAL') as log:
+                self.assertIsNone(params.isValid('bar'))
+            self.assertEqual(len(log.output), 1)
+            self.assertIn("Cannot determine if the parameters is valid, the parameter 'bar' does not exist", log.output[0])
+
+if __name__ == '__main__':
+    unittest.main(module=__name__, verbosity=2, buffer=True, exit=False)

--- a/python/parameters/test/test_Parameter.py
+++ b/python/parameters/test/test_Parameter.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+#pylint: disable=missing-docstring
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+import sys
+import re
+import unittest
+import logging
+from parameters import Parameter
+
+class TestParameter(unittest.TestCase):
+
+    def testMinimal(self):
+        opt = Parameter('foo')
+        self.assertEqual(opt.name, 'foo')
+        self.assertIsNone(opt.default)
+        self.assertIsNone(opt.value)
+
+    def testValue(self):
+        opt = Parameter('foo')
+        self.assertEqual(opt.name, 'foo')
+        self.assertIsNone(opt.default)
+        self.assertIsNone(opt.value)
+
+        self.value = 12345
+        self.assertEqual(self.value, 12345)
+
+    def testDefault(self):
+        opt = Parameter('foo', default=12345)
+        self.assertEqual(opt.name, 'foo')
+        self.assertEqual(opt.default, 12345)
+        self.assertEqual(opt.value, 12345)
+
+        opt.value = '12345'
+        self.assertEqual(opt.default, 12345)
+        self.assertEqual(opt.value, '12345')
+
+    def testAllow(self):
+        opt = Parameter('foo', allow=(1, 'two'))
+        self.assertIsNone(opt.default)
+        self.assertIsNone(opt.value)
+
+        opt.value = 1
+        self.assertEqual(opt.value, 1)
+
+        opt.value = 'two'
+        self.assertEqual(opt.value, 'two')
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = 4
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("Attempting to set 'foo' to a value of 4 but only the following are allowed: (1, 'two')", cm.output[0])
+
+    def testType(self):
+        opt = Parameter('foo', vtype=int)
+        self.assertIsNone(opt.default)
+        self.assertIsNone(opt.value)
+
+        opt.value = 1
+        self.assertEqual(opt.value, 1)
+
+        opt.value = 4.7
+        self.assertEqual(opt.value, 4)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = 's'
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("'foo' must be of type (<class 'int'>,) but <class 'str'> provided.", cm.output[0])
+
+    def testTypeWithAllow(self):
+
+        opt = Parameter('foo', vtype=int, allow=(1,2))
+        self.assertIsNone(opt.default)
+        self.assertIsNone(opt.value)
+
+        opt.value = 2
+        self.assertEqual(opt.value, 2)
+
+        opt.value = 1
+        self.assertEqual(opt.value, 1)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = 4
+        self.assertEqual(len(cm.output), 1)
+
+        self.assertIn("Attempting to set 'foo' to a value of 4 but only the following are allowed: (1, 2)", cm.output[0])
+        self.assertEqual(opt.value, 1)
+
+    def testAllowWithTypeError(self):
+
+        with self.assertRaises(TypeError) as e:
+            Parameter('foo', allow='wrong')
+        self.assertIn("The supplied 'allow' argument must be a 'tuple', but <class 'str'> was provided.", str(e.exception))
+
+        with self.assertRaises(TypeError) as e:
+            Parameter('foo', vtype=int, allow=(1,'2'))
+        self.assertIn("The supplied 'allow' argument must be a 'tuple' of (<class 'int'>,) items, but a <class 'str'> item was provided.", str(e.exception))
+
+    def testArray(self):
+        opt = Parameter('foo', default=(1,2), array=True)
+        self.assertEqual(opt._Parameter__array, True)
+        self.assertEqual(opt.value, (1,2))
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = 4
+        self.assertIn("'foo' was defined as an array, which require <class 'tuple'> for assignment, but a <class 'int'> was provided.", cm.output[0])
+
+        opt.value = (3, 4)
+        self.assertEqual(opt.value, (3,4))
+
+        opt.value = ('1', )
+        self.assertEqual(opt.value, ('1',))
+
+        opt = Parameter('foo', vtype=int, array=True)
+        self.assertEqual(opt._Parameter__array, True)
+        self.assertIsNone(opt.value)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = 4
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("'foo' was defined as an array, which require <class 'tuple'> for assignment, but a <class 'int'> was provided.", cm.output[0])
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = ('x', )
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("The values within 'foo' must be of type (<class 'int'>,) but <class 'str'> provided.", cm.output[0])
+        self.assertIsNone(opt.value)
+
+        opt.value = (1, )
+        self.assertEqual(opt.value, (1,))
+
+    def testSize(self):
+        opt = Parameter('foo', size=4)
+        self.assertEqual(opt._Parameter__array, True)
+        self.assertEqual(opt._Parameter__size, 4)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            opt.value = (1,2,3)
+        self.assertIn("'foo' was defined as an array with length 4 but a value with length 3 was provided.", cm.output[0])
+
+    def testDoc(self):
+        opt = Parameter('foo', doc='This is foo, not bar.')
+        self.assertEqual(opt.doc, 'This is foo, not bar.')
+
+        opt = Parameter('foo', doc=u'This is foo, not bar.')
+        self.assertEqual(opt.doc, u'This is foo, not bar.')
+
+        with self.assertRaises(TypeError) as e:
+            Parameter('foo', doc=42)
+        self.assertIn("The supplied 'doc' argument must be a 'str', but <class 'int'> was provided.", str(e.exception))
+
+    def testName(self):
+        opt = Parameter('foo')
+        self.assertEqual(opt.name, 'foo')
+
+        opt = Parameter(u'foo')
+        self.assertEqual(opt.name, u'foo')
+
+        with self.assertRaises(TypeError) as e:
+            Parameter(42)
+        self.assertIn("The supplied 'name' argument must be a 'str', but <class 'int'> was provided.", str(e.exception))
+
+    def testRequired(self):
+        opt = Parameter('year', required=True)
+        self.assertEqual(opt.required, True)
+
+        with self.assertLogs(level=logging.WARNING) as cm:
+            retcode = opt.validate()
+        self.assertEqual(retcode, 1)
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("The Parameter 'year' is marked as required, but no value is assigned.", cm.output[0])
+
+        with self.assertRaises(TypeError) as e:
+            Parameter('year', required="wrong")
+        self.assertIn("The supplied 'required' argument must be a 'bool', but <class 'str'> was provided.", str(e.exception))
+
+        opt.value = 1980
+        self.assertEqual(opt.validate(), 0)
+
+    def testSetDefault(self):
+        opt = Parameter('year', default=1980)
+        self.assertEqual(opt.value, 1980)
+        self.assertEqual(opt.default, 1980)
+
+        opt.default = 1949
+        self.assertEqual(opt.value, 1980)
+        self.assertEqual(opt.default, 1949)
+
+        opt = Parameter('year')
+        self.assertEqual(opt.value, None)
+        opt.default = 1949
+        self.assertEqual(opt.value, 1949)
+        self.assertEqual(opt.default, 1949)
+
+    def testPrivate(self):
+        opt = Parameter('year')
+        self.assertEqual(opt.private, False)
+
+        opt = Parameter('year', private=True)
+        self.assertEqual(opt.private, True)
+
+        opt = Parameter('_year', private=False)
+        self.assertEqual(opt.private, False)
+
+        opt = Parameter('_year')
+        self.assertEqual(opt.private, True)
+
+    def testToString(self):
+        opt = Parameter('year')
+        s = str(opt)
+        self.assertIn('Value:   None', s)
+        self.assertNotIn('Default', s)
+        self.assertNotIn('Type', s)
+        self.assertNotIn('Allow', s)
+
+        opt = Parameter('year', default=1980, vtype=int, allow=(1949, 1954, 1975, 1980))
+        opt.value = 1954
+        s = str(opt)
+        self.assertIn('Value:   1954', s)
+        self.assertIn('Default: 1980', s)
+        self.assertIn("Type(s): ('int',)", s)
+        self.assertIn('Allow:   (1949, 1954, 1975, 1980)', s)
+
+        opt = Parameter('year', default=1980, doc="The best year.")
+        s = str(opt)
+        self.assertIn("best", s)
+
+if __name__ == '__main__':
+    unittest.main(module=__name__, verbosity=2, buffer=True)

--- a/python/parameters/test/tests
+++ b/python/parameters/test/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [Parameter]
+    type = PythonUnitTest
+    input = test_Parameter.py
+  []
+  [InputParameters]
+    type = PythonUnitTest
+    input = test_InputParameters.py
+  []
+[]


### PR DESCRIPTION
This is the first step of creating a unified "parameters" package that can be used by all the 
python tools in MOOSE: TestHarness, chigger, peacock, MooseDocs,...

This package is an improved version of the "Option/Options" objects in chigger that were developed to mimic the current TestHarness parameters but be more robust and fully tested. 

The two versions exist because chigger was at one time a stand-alone application. This is the beginning of a single package for all the parameter/options across the various projects.

I would like to get this in and then migrate the TestHarness and MooseDocs to use it. I will then be updating to a new version of chigger (that is still in development) and after that some improvements to peacock (still in development). This is a long term transition.

(refs #12095)

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
