### PR TITLE
Test convertability of AD-regular Rank*Tensors

### DIFF
--- a/framework/include/utils/ADReal.h
+++ b/framework/include/utils/ADReal.h
@@ -1,0 +1,13 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ADRealForward.h"
+#include "DualRealOps.h"

--- a/framework/include/utils/ADRealForward.h
+++ b/framework/include/utils/ADRealForward.h
@@ -1,0 +1,14 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "DualReal.h"
+
+typedef DualReal ADReal;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "Moose.h"
-#include "DualReal.h"
+#include "ADReal.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/id_types.h"
@@ -174,7 +174,6 @@ struct DecrementRank<Eigen::Matrix<Real, Eigen::Dynamic, LIBMESH_DIM>>
 /**
  * various MOOSE typedefs
  */
-typedef DualReal ADReal;
 typedef Real PostprocessorValue;
 typedef std::vector<Real> VectorPostprocessorValue;
 typedef Real ScatterVectorPostprocessorValue;
@@ -331,8 +330,6 @@ typedef libMesh::VectorValue<ADReal> ADRealVectorValue;
 typedef ADRealVectorValue ADRealGradient;
 typedef libMesh::VectorValue<ADReal> ADPoint;
 typedef libMesh::TensorValue<ADReal> ADRealTensorValue;
-typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
-typedef RankFourTensorTempl<ADReal> ADRankFourTensor;
 typedef libMesh::DenseMatrix<ADReal> ADDenseMatrix;
 typedef libMesh::DenseVector<ADReal> ADDenseVector;
 typedef MooseArray<ADReal> ADVariableValue;

--- a/framework/include/utils/RankFourTensor.h
+++ b/framework/include/utils/RankFourTensor.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "Moose.h"
-#include "DualReal.h"
+#include "ADRealForward.h"
 
 #include "libmesh/libmesh.h"
 #include "libmesh/tuple_of.h"
@@ -444,6 +444,7 @@ struct RawType<RankFourTensorTempl<T>>
 
 typedef RankFourTensorTempl<Real> RankFourTensor;
 typedef RankFourTensorTempl<DualReal> DualRankFourTensor;
+typedef RankFourTensorTempl<ADReal> ADRankFourTensor;
 
 template <typename T1, typename T2>
 inline auto operator*(const T1 & a, const RankFourTensorTempl<T2> & b) ->

--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "Moose.h"
-#include "DualReal.h"
+#include "ADRealForward.h"
 #include "MooseUtils.h"
 
 // Any requisite includes here
@@ -581,6 +581,7 @@ struct RawType<RankTwoTensorTempl<T>>
 
 typedef RankTwoTensorTempl<Real> RankTwoTensor;
 typedef RankTwoTensorTempl<DualReal> DualRankTwoTensor;
+typedef RankTwoTensorTempl<ADReal> ADRankTwoTensor;
 
 template <typename T>
 template <typename T2>

--- a/unit/include/RankTwoTensorTest.h
+++ b/unit/include/RankTwoTensorTest.h
@@ -34,4 +34,3 @@ protected:
   RankTwoTensor _unsymmetric0;
   RankTwoTensor _unsymmetric1;
 };
-

--- a/unit/src/RankFourTensorTest.C
+++ b/unit/src/RankFourTensorTest.C
@@ -10,6 +10,9 @@
 #include "gtest/gtest.h"
 
 #include "RankFourTensor.h"
+#include "ADReal.h"
+
+#include "metaphysicl/raw_type.h"
 
 RankFourTensor iSymmetric = RankFourTensor(RankFourTensor::initIdentitySymmetricFour);
 
@@ -68,4 +71,13 @@ TEST(RankFourTensor, invSymm2)
   a(1, 2, 2, 2) = a(2, 1, 2, 2) = 0.1;
 
   EXPECT_NEAR(0, (iSymmetric - a.invSymm() * a).L2norm(), 1E-5);
+}
+
+TEST(RankFourTensor, ADConversion)
+{
+  RankFourTensor reg;
+  ADRankFourTensor ad;
+
+  ad = reg;
+  reg = MetaPhysicL::raw_value(ad);
 }

--- a/unit/src/RankThreeTensorTest.C
+++ b/unit/src/RankThreeTensorTest.C
@@ -15,6 +15,9 @@
 #include "RankThreeTensor.h"
 #include "RankFourTensor.h"
 #include "MooseEnum.h"
+#include "ADReal.h"
+
+#include "metaphysicl/raw_type.h"
 
 TEST(RankThreeTensor, constructors)
 {
@@ -395,4 +398,13 @@ TEST(RankThreeTensor, doubleContraction)
 
     EXPECT_EQ(c(i), value);
   }
+}
+
+TEST(RankThreeTensor, ADConversion)
+{
+  RankThreeTensor reg;
+  ADRankThreeTensor ad;
+
+  ad = reg;
+  reg = MetaPhysicL::raw_value(ad);
 }

--- a/unit/src/RankTwoTensorTest.C
+++ b/unit/src/RankTwoTensorTest.C
@@ -10,8 +10,11 @@
 #include "RankTwoTensorTest.h"
 #include "RankTwoScalarTools.h"
 #include "RankFourTensor.h"
+#include "ADReal.h"
 
 #include "libmesh/point.h"
+
+#include "metaphysicl/raw_type.h"
 
 TEST_F(RankTwoTensorTest, L2norm)
 {
@@ -574,4 +577,13 @@ TEST_F(RankTwoTensorTest, QRFactorization)
   EXPECT_NEAR(4.9029, std::abs(R(0, 2)), 0.0001);
   EXPECT_NEAR(4.4748, std::abs(R(1, 2)), 0.0001);
   EXPECT_NEAR(1.392, std::abs(R(2, 2)), 0.0001);
+}
+
+TEST_F(RankTwoTensorTest, ADConversion)
+{
+  RankTwoTensor reg;
+  ADRankTwoTensor ad;
+
+  ad = reg;
+  reg = MetaPhysicL::raw_value(ad);
 }


### PR DESCRIPTION
It was revealed by Ferret that we didn't have a proper
assignment operator for RankThreeTensors for different
template parameters. Now we test convertability between
all the different Rank*Tensors in MOOSE

Refs idaholab/moose#14701

