### PR TITLE
Remove cavity pressure Jacobian test

### DIFF
--- a/modules/combined/test/tests/ad_cavity_pressure/tests
+++ b/modules/combined/test/tests/ad_cavity_pressure/tests
@@ -110,17 +110,6 @@
       exodiff = 'additional_volume_out.e'
       detail = 'when including an additional volume that communicates with the cavity.'
     [../]
-    [./additional_volume-jac]
-      type = 'PetscJacobianTester'
-      input = 'additional_volume.i'
-      ratio_tol = 5e-8
-      difference_tol = 1e-4 
-      cli_args = 'Executioner/num_steps=1 -snes_test_err 1e-9'
-      run_sim = True
-      heavy = True
-      method = 'OPT'
-      detail = 'when including an addditional volume that communicates with the cavity and calculate a perfect Jacobian.'
-    [../]
   []
 
   [error]


### PR DESCRIPTION
We can't guarantee a perfect Jacobian when the user couples
in a postprocessor value. Maybe someday we will think about
supporting dense coupling, but that day is not today

Refs #15016

