### PR TITLE
Adding Conda/OpenMP suppression

### DIFF
--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -173,3 +173,12 @@
    fun:dmumps_numvolsndrcv_
    ...
 }
+{
+   Conda_OpenMP_false_positive
+   Memcheck:Param
+   sched_setaffinity(mask)
+   ...
+   fun:syscall
+   obj:*/lib/libomp.so
+   ...
+}


### PR DESCRIPTION
Add a conda specific openmp suppression to allow Valgrind to work on our
Conda targets.

Closes #15082

