### PR TITLE
Build libmesh without the gdb command

### DIFF
--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -56,7 +56,8 @@ EOF`
                      --prefix=${PREFIX}/libmesh \
                      --with-vtk-lib=${BUILD_PREFIX}/libmesh-vtk/lib \
                      --with-vtk-include=${BUILD_PREFIX}/libmesh-vtk/include/vtk-${SHORT_VTK_NAME} \
-                     --with-methods="opt dbg devel oprof"
+                     --with-methods="opt dbg devel oprof" \
+                     --without-gdb-command
 
 make -j $CPU_COUNT
 make install

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,6 +1,6 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2020.04.13" %}
+{% set version = "2020.04.16" %}
 
 package:
   name: moose-libmesh
@@ -35,6 +35,8 @@ test:
     - test -f $PREFIX/libmesh/lib/libmesh_opt.so        # [linux]
     - test -f $PREFIX/libmesh/lib/libmetaphysicl.dylib  # [osx]
     - test -f $PREFIX/libmesh/lib/libmetaphysicl.so     # [linux]
+    - test -f $PREFIX/libmesh/lib/libtimpi_opt.dylib    # [osx]
+    - test -f $PREFIX/libmesh/lib/libtimpi_opt.so       # [linux]
 
 about:
   home: http://libmesh.github.io/


### PR DESCRIPTION
Then I don't have to pass --without-gdb-backtrace every time.
Trying to spawn a gdb process takes forever. Nobody got time
for that.

Also test and make sure we created a TIMPI library

Refs #14922

