### PR TITLE
delete_remote_elements in Distributed MeshGen

### DIFF
--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -1028,6 +1028,10 @@ DistributedRectilinearMeshGenerator::generate()
   mesh->set_mesh_dimension(_dim);
   mesh->set_spatial_dimension(_dim);
 
+  // Let the mesh know that it's not serialized; the libMesh idiom
+  // here "deletes" 0 elements.
+  mesh->delete_remote_elements();
+
   // Switching on MooseEnum
   switch (_dim)
   {


### PR DESCRIPTION
Doing this immediately doesn't actually delete anything or cost
anything, it simply lets a DistributedMesh know that it has been
constructed in a distributed fashion.

Fixes #15088 for me.