### PR TITLE
import resource globally

### DIFF
--- a/python/TestHarness/testers/bench.py
+++ b/python/TestHarness/testers/bench.py
@@ -10,12 +10,19 @@
 
 import subprocess
 import time
+import sys
 import os
 import gc
 import shutil
 import csv
 import tempfile
 import threading
+
+# try to import the resource module. We check further down if it failed
+try:
+    import resource
+except:
+    pass
 
 from TestHarness.testers.Tester import Tester
 
@@ -134,10 +141,7 @@ class SpeedTest(Tester):
     # override
     def checkRunnable(self, options):
         # check if resource is available
-        try:
-            import resource
-        except Exception:
-            self.addCaveats('skipped (no resource)')
+        if 'resource' not in sys.modules:
             return False
 
         # if user is not explicitly running benchmarks, we only run moose once and just check


### PR DESCRIPTION
`import`s are scoped, so the previous approach of importing in `checkRunnable` did leave the module unavailable in other classes and methods in the file.

Refs #15074