### PR TITLE
Master App should use the default petsc option database

### DIFF
--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -70,11 +70,18 @@ Eigenvalue::execute()
   // Make sure the SLEPc options are setup for this app
   Moose::SlepcSupport::slepcSetOptions(_eigen_problem, _pars);
 #else
+  // Options need to be setup once only
   if (!_eigen_problem.petscOptionsInserted())
   {
-    PetscOptionsPush(_eigen_problem.petscOptionsDatabase());
+    // Master app has the default data base
+    if (!_app.isUltimateMaster())
+      PetscOptionsPush(_eigen_problem.petscOptionsDatabase());
+
     Moose::SlepcSupport::slepcSetOptions(_eigen_problem, _pars);
-    PetscOptionsPop();
+
+    if (!_app.isUltimateMaster())
+      PetscOptionsPop();
+
     _eigen_problem.petscOptionsInserted() = true;
   }
 #endif

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -280,7 +280,9 @@ void
 EigenProblem::solve()
 {
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  PetscOptionsPush(_petsc_option_data_base);
+  // Master has the default database
+  if (!_app.isUltimateMaster())
+    PetscOptionsPush(_petsc_option_data_base);
 #endif
 
   if (_solve)
@@ -296,7 +298,8 @@ EigenProblem::solve()
     _displaced_problem->syncSolutions();
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  PetscOptionsPop();
+  if (!_app.isUltimateMaster())
+    PetscOptionsPop();
 #endif
 }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -398,7 +398,9 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _mesh.getMesh().remove_ghosting_functor(_mesh.getMesh().default_ghosting());
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  PetscOptionsCreate(&_petsc_option_data_base);
+  // Master app should hold the default database to handle system petsc options
+  if (!_app.isUltimateMaster())
+    PetscOptionsCreate(&_petsc_option_data_base);
 #endif
 }
 
@@ -492,7 +494,8 @@ FEProblemBase::~FEProblemBase()
   }
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  PetscOptionsDestroy(&_petsc_option_data_base);
+  if (!_app.isUltimateMaster())
+    PetscOptionsDestroy(&_petsc_option_data_base);
 #endif
 }
 
@@ -4638,7 +4641,8 @@ FEProblemBase::solve()
 #else
   // Now this database will be the default
   // Each app should have only one database
-  PetscOptionsPush(_petsc_option_data_base);
+  if (!_app.isUltimateMaster())
+    PetscOptionsPush(_petsc_option_data_base);
   // We did not add petsc options to database yet
   if (!_is_petsc_options_inserted)
   {
@@ -4676,7 +4680,8 @@ FEProblemBase::solve()
     _displaced_problem->syncSolutions();
 
 #if !PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  PetscOptionsPop();
+  if (!_app.isUltimateMaster())
+    PetscOptionsPop();
 #endif
 }
 

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1471,7 +1471,8 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
   ierr = PetscObjectCompose((PetscObject)*x, "DM", (PetscObject)dm);
   CHKERRQ(ierr);
 
-  ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
+  ierr = VecSetDM(*x, dm);
+  CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1470,6 +1470,8 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
   }
   ierr = PetscObjectCompose((PetscObject)*x, "DM", (PetscObject)dm);
   CHKERRQ(ierr);
+
+  ierr = VecSetDM(*x, dm);CHKERRQ(ierr);
   PetscFunctionReturn(0);
 }
 

--- a/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
+++ b/test/tests/misc/petsc_option_left/2d_diffusion_petsc_option.i
@@ -1,0 +1,54 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 10
+  []
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = 1
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = 2
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  solve_type = 'NEWTON'
+
+  petsc_options = "-options_left"
+  petsc_options_iname = "-pc_type"
+  petsc_options_value = "hypre"
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/misc/petsc_option_left/tests
+++ b/test/tests/misc/petsc_option_left/tests
@@ -1,0 +1,12 @@
+[Tests]
+  design = 'FEProblem.md'
+  issues = '#15129'
+
+  [test_options_not_left]
+    type = RunApp
+    input = '2d_diffusion_petsc_option.i'
+    absent_out = "Option left.*value.*hypre"
+
+    requirement = "PETSc option database shall work properly"
+  []
+[]


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

The default database includes important system-level options and operations.  The default database should be used in the master app. Make `-options_left, -log_view` work beautifully.


Closes #15129