### PR TITLE
Shorten some AD Jacobian tests

### DIFF
--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/tests
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/tests
@@ -42,7 +42,7 @@
       input = 'small.i'
       ratio_tol = 1e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=3 -snes_test_err 1e-9'
+      cli_args = 'Executioner/num_steps=2 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       method = 'OPT'
@@ -55,7 +55,7 @@
       input = 'finite.i'
       ratio_tol = 1e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=3 -snes_test_err 1e-9'
+      cli_args = 'Executioner/num_steps=2 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       method = 'OPT'


### PR DESCRIPTION
After #14701 residual evaluation is more expensive than
it used to be with AD and forming finite differenced Jacobians
for PETSc Jacobian tests evaluates a ton of residuals. So
some of these tests need to be shortened to avoid timeout

