### PR TITLE
Geochemistry: constants added, robust activity, swapper enhancements

### DIFF
--- a/modules/geochemistry/include/utils/GeochemistryConstants.h
+++ b/modules/geochemistry/include/utils/GeochemistryConstants.h
@@ -1,0 +1,15 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseTypes.h"
+
+constexpr Real MOLES_PER_KG_WATER = 55.51;
+constexpr Real LOGTEN = 2.30258509299404;

--- a/modules/geochemistry/include/utils/GeochemistryConstants.h
+++ b/modules/geochemistry/include/utils/GeochemistryConstants.h
@@ -11,8 +11,11 @@
 
 #include "MooseTypes.h"
 
+namespace GeochemistryConstants
+{
 constexpr Real MOLES_PER_KG_WATER = 55.51;
 constexpr Real LOGTEN = 2.30258509299404;
 constexpr Real FARADAY = 96485.3415;    // Coulombs . mol^-1
 constexpr Real GAS_CONSTANT = 8.314472; // m^2 . kg . s^-2 . K^-1 . mol^-1
 constexpr Real CELSIUS_TO_KELVIN = 273.15;
+}

--- a/modules/geochemistry/include/utils/GeochemistryConstants.h
+++ b/modules/geochemistry/include/utils/GeochemistryConstants.h
@@ -13,3 +13,6 @@
 
 constexpr Real MOLES_PER_KG_WATER = 55.51;
 constexpr Real LOGTEN = 2.30258509299404;
+constexpr Real FARADAY = 96485.3415;    // Coulombs . mol^-1
+constexpr Real GAS_CONSTANT = 8.314472; // m^2 . kg . s^-2 . K^-1 . mol^-1
+constexpr Real CELSIUS_TO_KELVIN = 273.15;

--- a/modules/geochemistry/include/utils/GeochemistrySpeciesSwapper.h
+++ b/modules/geochemistry/include/utils/GeochemistrySpeciesSwapper.h
@@ -92,6 +92,44 @@ public:
                    unsigned basis_index_to_replace,
                    unsigned eqm_index_to_insert);
 
+  /**
+   * Check that replacing the named basis species with the named equilibrium species is valid, and
+   * then perform this swap by altering the mgd data structure, and calculate the bulk composition
+   * of the new system.
+   * A mooseError or mooseException will result if the swap is invalid
+   * @param mgd The ModelGeochemicalDatabase that holds all information regarding basis
+   * components, equilibrium species, stoichiometries, etc
+   * @param[in/out] bulk_composition Upon entry, the bulk composition in the original basis.  Upon
+   * exit, the bulk composition in the basis after the swap
+   * @param replace_this The basis component that will be removed from the basis and added to the
+   * equilibrium species list
+   * @param with_this The equilibrium species that will be removed from the equilibrium species list
+   * and added to the basis component list
+   */
+  void performSwap(ModelGeochemicalDatabase & mgd,
+                   DenseVector<Real> & bulk_composition,
+                   const std::string & replace_this,
+                   const std::string & with_this);
+
+  /**
+   * Check that replacing the indexed basis species with the indexed equilibrium species is valid,
+   * and then perform this swap by altering the mgd data structure, and calculate the bulk
+   * composition of the new system.
+   * A mooseError or mooseException will result if the swap is invalid
+   * @param mgd The ModelGeochemicalDatabase that holds all information regarding basis
+   * components, equilibrium species, stoichiometries, etc
+   * @param[in/out] bulk_composition Upon entry, the bulk composition in the original basis.  Upon
+   * exit, the bulk composition in the basis after the swap
+   * @param basis_index_to_replace The index of the basis component that will be removed from the
+   * basis and added to the equilibrium species list
+   * @param eqm_index_to_insert The index of the equilibrium species that will be removed from the
+   * equilibrium species list and added to the basis component list
+   */
+  void performSwap(ModelGeochemicalDatabase & mgd,
+                   DenseVector<Real> & bulk_composition,
+                   unsigned basis_index_to_replace,
+                   unsigned eqm_index_to_insert);
+
 private:
   /**
    * Construct the swap matrix, and its inverse, that describes the swap between the indexed basis
@@ -122,6 +160,15 @@ private:
   void alterMGD(ModelGeochemicalDatabase & mgd,
                 unsigned basis_index_to_replace,
                 unsigned eqm_index_to_insert);
+
+  /**
+   * Calculate the bulk composition in the new basis based on the bulk composition in the original
+   * basis
+   * @param basis_size Size of basis, which is only used for error checking
+   * @param[in/out] bulk_composition Upon entry, the bulk composition in the original basis.  Upon
+   * exit, the bulk composition in the basis after the swap
+   */
+  void alterBulkComposition(unsigned basis_size, DenseVector<Real> & bulk_composition) const;
 
   /// tolerance for matrix inversion and stoichiometric coefficients
   Real _stoi_tol;

--- a/modules/geochemistry/src/utils/GeochemistryActivity.C
+++ b/modules/geochemistry/src/utils/GeochemistryActivity.C
@@ -9,15 +9,15 @@
 
 #include "GeochemistryActivity.h"
 #include "libmesh/utility.h"
-
-Real moles_per_kg_water = 55.51;
-Real logten = 2.30258509299404;
+#include "GeochemistryConstants.h"
 
 namespace GeochemistryActivity
 {
 Real
 log10ActCoeffDHBdot(Real charge, Real ion_size, Real sqrt_ionic_strength, Real A, Real B, Real Bdot)
 {
+  if (sqrt_ionic_strength <= 0.0)
+    return 0.0; // guard against unphysical inputs that might occur during a Newton process
   return -A * Utility::pow<2>(charge) * sqrt_ionic_strength /
              (1.0 + ion_size * B * sqrt_ionic_strength) +
          Bdot * Utility::pow<2>(sqrt_ionic_strength);
@@ -26,6 +26,8 @@ log10ActCoeffDHBdot(Real charge, Real ion_size, Real sqrt_ionic_strength, Real A
 Real
 log10ActCoeffDHBdotNeutral(Real ionic_strength, Real a, Real b, Real c, Real d)
 {
+  if (ionic_strength <= 0.0)
+    return 0.0; // guard against unphysical inputs that might occur during a Newton process
   return a * ionic_strength + b * Utility::pow<2>(ionic_strength) +
          c * Utility::pow<3>(ionic_strength) + d * Utility::pow<4>(ionic_strength);
 }
@@ -33,12 +35,16 @@ log10ActCoeffDHBdotNeutral(Real ionic_strength, Real a, Real b, Real c, Real d)
 Real
 log10ActCoeffDHBdotAlternative(Real ionic_strength, Real Bdot)
 {
+  if (ionic_strength <= 0.0)
+    return 0.0; // guard against unphysical inputs that might occur during a Newton process
   return Bdot * ionic_strength;
 }
 
 Real
 log10ActCoeffDavies(Real charge, Real sqrt_ionic_strength, Real A)
 {
+  if (sqrt_ionic_strength <= 0.0)
+    return 0.0; // guard against unphysical inputs that might occur during a Newton process
   return -A * Utility::pow<2>(charge) *
          (sqrt_ionic_strength / (1.0 + sqrt_ionic_strength) -
           0.3 * Utility::pow<2>(sqrt_ionic_strength));
@@ -48,14 +54,16 @@ Real
 lnActivityDHBdotWater(
     Real stoichiometric_ionic_strength, Real A, Real atilde, Real btilde, Real ctilde, Real dtilde)
 {
+  if (stoichiometric_ionic_strength <= 0.0)
+    return 0.0; // guard against unphysical inputs that might occur during a Newton process
   const Real bhat = 1.0 + atilde * std::sqrt(stoichiometric_ionic_strength);
   const Real inner = bhat - 2.0 * std::log(bhat) - 1.0 / bhat;
   const Real outer = 1.0 -
-                     A * logten / Utility::pow<3>(atilde) / stoichiometric_ionic_strength * inner +
+                     A * LOGTEN / Utility::pow<3>(atilde) / stoichiometric_ionic_strength * inner +
                      0.5 * btilde * stoichiometric_ionic_strength +
                      2.0 * ctilde * Utility::pow<2>(stoichiometric_ionic_strength) / 3.0 +
                      0.75 * dtilde * Utility::pow<3>(stoichiometric_ionic_strength);
-  return -2.0 * stoichiometric_ionic_strength * outer / moles_per_kg_water;
+  return -2.0 * stoichiometric_ionic_strength * outer / MOLES_PER_KG_WATER;
 }
 
 } // namespace GeochemistryActivity

--- a/modules/geochemistry/src/utils/GeochemistryActivity.C
+++ b/modules/geochemistry/src/utils/GeochemistryActivity.C
@@ -59,11 +59,12 @@ lnActivityDHBdotWater(
   const Real bhat = 1.0 + atilde * std::sqrt(stoichiometric_ionic_strength);
   const Real inner = bhat - 2.0 * std::log(bhat) - 1.0 / bhat;
   const Real outer = 1.0 -
-                     A * LOGTEN / Utility::pow<3>(atilde) / stoichiometric_ionic_strength * inner +
+                     A * GeochemistryConstants::LOGTEN / Utility::pow<3>(atilde) /
+                         stoichiometric_ionic_strength * inner +
                      0.5 * btilde * stoichiometric_ionic_strength +
                      2.0 * ctilde * Utility::pow<2>(stoichiometric_ionic_strength) / 3.0 +
                      0.75 * dtilde * Utility::pow<3>(stoichiometric_ionic_strength);
-  return -2.0 * stoichiometric_ionic_strength * outer / MOLES_PER_KG_WATER;
+  return -2.0 * stoichiometric_ionic_strength * outer / GeochemistryConstants::MOLES_PER_KG_WATER;
 }
 
 } // namespace GeochemistryActivity

--- a/modules/geochemistry/unit/src/GeochemistryActivityTest.C
+++ b/modules/geochemistry/unit/src/GeochemistryActivityTest.C
@@ -22,8 +22,6 @@ const Real atilde = 1.5551;
 const Real btilde = 0.036478;
 const Real ctilde = 0.0064366;
 const Real dtilde = -0.0007132;
-Real moles_per_kg_water = 55.51;
-Real logten = 2.30258509299404;
 
 TEST(GeochemistryActivityTest, log10ActCoeffDHBdot)
 {
@@ -35,6 +33,8 @@ TEST(GeochemistryActivityTest, log10ActCoeffDHBdot)
                   charge, ionic_rad, std::sqrt(ionic_str), A, B, Bdot),
               log10gold,
               1E-9);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdot(charge, ionic_rad, 0.0, A, B, Bdot), 0.0);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdot(charge, ionic_rad, -1.0, A, B, Bdot), 0.0);
 }
 
 TEST(GeochemistryActivityTest, log10ActCoeffDavies)
@@ -44,6 +44,8 @@ TEST(GeochemistryActivityTest, log10ActCoeffDavies)
   const Real log10gold = -0.489368197345647;
   ASSERT_NEAR(
       GeochemistryActivity::log10ActCoeffDavies(charge, std::sqrt(ionic_str), A), log10gold, 1E-9);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDavies(charge, 0.0, A), 0.0);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDavies(charge, -1.0, A), 0.0);
 }
 
 TEST(GeochemistryActivityTest, log10ActCoeffDHBdotAlternative)
@@ -52,6 +54,8 @@ TEST(GeochemistryActivityTest, log10ActCoeffDHBdotAlternative)
   const Real log10gold = 0.00348;
   ASSERT_NEAR(
       GeochemistryActivity::log10ActCoeffDHBdotAlternative(ionic_str, Bdot), log10gold, 1E-9);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdotAlternative(0.0, Bdot), 0.0);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdotAlternative(-1.0, Bdot), 0.0);
 }
 
 TEST(GeochemistryActivityTest, log10ActCoeffDHBdotNeutral)
@@ -60,6 +64,8 @@ TEST(GeochemistryActivityTest, log10ActCoeffDHBdotNeutral)
   const Real log10gold = 0.0242961312;
   ASSERT_NEAR(
       GeochemistryActivity::log10ActCoeffDHBdotNeutral(ionic_str, a, b, c, d), log10gold, 1E-9);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdotNeutral(0.0, a, b, c, d), 0.0);
+  ASSERT_EQ(GeochemistryActivity::log10ActCoeffDHBdotNeutral(-1.0, a, b, c, d), 0.0);
 }
 
 TEST(GeochemistryActivityTest, lnActivityDHBdotWater)
@@ -70,4 +76,8 @@ TEST(GeochemistryActivityTest, lnActivityDHBdotWater)
       GeochemistryActivity::lnActivityDHBdotWater(ionic_str, A, atilde, btilde, ctilde, dtilde),
       loggold,
       1E-9);
+  ASSERT_EQ(GeochemistryActivity::lnActivityDHBdotWater(0.0, A, atilde, btilde, ctilde, dtilde),
+            0.0);
+  ASSERT_EQ(GeochemistryActivity::lnActivityDHBdotWater(-1.0, A, atilde, btilde, ctilde, dtilde),
+            0.0);
 }


### PR DESCRIPTION
You've seen the Constants stuff, @loganharbour .   Here are a few extra additions (not too many lines - will hopefully take you only about 5 mins to review):

- GeochemistryActivity uses the Constants, and also is made a bit more robust against unphysical inputs

- The Swapper is enhanced so it computes bulk composition in the new basis, which is needed when actual simulations are performed

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
