### PR TITLE
Add headers to ConjugateHeatTransfer source

### DIFF
--- a/modules/heat_conduction/include/interfacekernels/ConjugateHeatTransfer.h
+++ b/modules/heat_conduction/include/interfacekernels/ConjugateHeatTransfer.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "InterfaceKernel.h"
 
 /**

--- a/modules/heat_conduction/src/interfacekernels/ConjugateHeatTransfer.C
+++ b/modules/heat_conduction/src/interfacekernels/ConjugateHeatTransfer.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ConjugateHeatTransfer.h"
 
 #include "metaphysicl/raw_type.h"


### PR DESCRIPTION
Adds MOOSE header to ConjugateHeatTransfer source code and header files. 

Refs #15114 
Tagging @loganharbour
