### PR TITLE
suppress clang -wpedantic warning in from boost 

### DIFF
--- a/modules/stochastic_tools/include/distributions/BoostDistribution.h
+++ b/modules/stochastic_tools/include/distributions/BoostDistribution.h
@@ -14,6 +14,7 @@
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
 #include "libmesh/ignore_warnings.h"
 #pragma GCC diagnostic ignored "-Wparentheses"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <boost/math/distributions.hpp>
 #include "libmesh/restore_warnings.h"
 #else

--- a/modules/stochastic_tools/include/distributions/BoostDistribution.h
+++ b/modules/stochastic_tools/include/distributions/BoostDistribution.h
@@ -14,7 +14,7 @@
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
 #include "libmesh/ignore_warnings.h"
 #pragma GCC diagnostic ignored "-Wparentheses"
-#pragma clang diagnostic ignored "-Wpedantic"
+#pragma clang diagnostic ignored "-Wall"
 #include <boost/math/distributions.hpp>
 #include "libmesh/restore_warnings.h"
 #else

--- a/modules/stochastic_tools/include/distributions/BoostDistribution.h
+++ b/modules/stochastic_tools/include/distributions/BoostDistribution.h
@@ -14,7 +14,7 @@
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
 #include "libmesh/ignore_warnings.h"
 #pragma GCC diagnostic ignored "-Wparentheses"
-#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma clang diagnostic ignored "-Wpedantic"
 #include <boost/math/distributions.hpp>
 #include "libmesh/restore_warnings.h"
 #else


### PR DESCRIPTION
<!--
- added pragma around boost include to suppress -Wpedantic warning.  
This pragma and the one next to it can be removed once the libmesh ignore_warnings.h file is updated to suppress these warnings for clang.
- ref #15157
-->
