### PR TITLE
Do communication in NodalSum in finalize and not getValue

### DIFF
--- a/framework/include/postprocessors/NodalSum.h
+++ b/framework/include/postprocessors/NodalSum.h
@@ -28,6 +28,7 @@ public:
   NodalSum(const InputParameters & parameters);
 
   virtual void initialize() override;
+  virtual void finalize() override;
   virtual void execute() override;
   virtual Real getValue() override;
 
@@ -36,4 +37,3 @@ public:
 protected:
   Real _sum;
 };
-

--- a/framework/src/postprocessors/NodalSum.C
+++ b/framework/src/postprocessors/NodalSum.C
@@ -47,9 +47,13 @@ NodalSum::execute()
 Real
 NodalSum::getValue()
 {
-  gatherSum(_sum);
-
   return _sum;
+}
+
+void
+NodalSum::finalize()
+{
+  gatherSum(_sum);
 }
 
 void


### PR DESCRIPTION
`NodalSum` doesn't use finalize for communication because it predates the introduction of finalize. This PR modernizes `NodalSum`