### PR TITLE
Add python3-pip to Apt installs.

### DIFF
--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -23,6 +23,7 @@ apt-get install -y \
   libhwloc-dev \
   python3 \
   python3-dev \
+  python3-pip \
   cmake \
   curl \
   bison \


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Added installation of `python3-pip` to Apt package installs for Docker image builds based on Ubuntu.  Fixes #15179.