### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -24,7 +24,9 @@ else
     TUNING="-march=nocona -mtune=haswell"
 fi
 
-unset LIBMESH_DIR CFLAGS CPPFLAGS CXXFLAGS FFLAGS LIBS
+unset LIBMESH_DIR CFLAGS CPPFLAGS CXXFLAGS FFLAGS LIBS \
+      LDFLAGS DEBUG_CPPFLAGS DEBUG_CFLAGS DEBUG_CXXFLAGS \
+      FORTRANFLAGS DEBUG_FFLAGS DEBUG_FORTRANFLAGS
 export F90=mpifort
 export F77=mpifort
 export FC=mpifort
@@ -56,7 +58,8 @@ EOF`
                      --prefix=${PREFIX}/libmesh \
                      --with-vtk-lib=${BUILD_PREFIX}/libmesh-vtk/lib \
                      --with-vtk-include=${BUILD_PREFIX}/libmesh-vtk/include/vtk-${SHORT_VTK_NAME} \
-                     --with-methods="opt dbg devel oprof"
+                     --with-methods="opt dbg devel oprof" \
+                     --without-gdb-command
 
 make -j $CPU_COUNT
 make install

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -24,7 +24,7 @@ libpng:
   - 1.6.37 hed695b0_0 # [linux]
 
 moose_petsc:
- - 3.12.5 build_1
+ - 3.12.5 build_2
 
 moose_libmesh_vtk:
  - 6.3.0 build_3

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,6 +1,6 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2020.04.13" %}
+{% set version = "2020.05.13" %}
 
 package:
   name: moose-libmesh
@@ -35,6 +35,8 @@ test:
     - test -f $PREFIX/libmesh/lib/libmesh_opt.so        # [linux]
     - test -f $PREFIX/libmesh/lib/libmetaphysicl.dylib  # [osx]
     - test -f $PREFIX/libmesh/lib/libmetaphysicl.so     # [linux]
+    - test -f $PREFIX/libmesh/lib/libtimpi_opt.dylib    # [osx]
+    - test -f $PREFIX/libmesh/lib/libtimpi_opt.so       # [linux]
 
 about:
   home: http://libmesh.github.io/

--- a/conda/libmesh/patches/submodule.patch
+++ b/conda/libmesh/patches/submodule.patch
@@ -2,7 +2,7 @@ diff --git a/.gitmodules b/.gitmodules
 index 802d79f33..b70a06a4a 100644
 --- a/.gitmodules
 +++ b/.gitmodules
-@@ -1,6 +1,6 @@
+@@ -1,9 +1,9 @@
  [submodule "contrib/metaphysicl"]
  	path = contrib/metaphysicl
 -	url = ../../roystgnr/MetaPhysicL
@@ -11,3 +11,7 @@ index 802d79f33..b70a06a4a 100644
  	path = contrib/timpi
 -	url = ../../libMesh/TIMPI
 +	url = https://github.com/libMesh/TIMPI
+ [submodule "m4/autoconf-submodule"]
+ 	path = m4/autoconf-submodule
+-	url = ../../libMesh/autoconf-submodule
++	url = https://github.com/libMesh/autoconf-submodule

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1468,11 +1468,14 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
     ierr = VecDuplicate(v, x);
     CHKERRQ(ierr);
   }
+
+#if PETSC_RELEASE_LESS_THAN(3, 13, 0)
   ierr = PetscObjectCompose((PetscObject)*x, "DM", (PetscObject)dm);
   CHKERRQ(ierr);
-
+#else
   ierr = VecSetDM(*x, dm);
   CHKERRQ(ierr);
+#endif
   PetscFunctionReturn(0);
 }
 


### PR DESCRIPTION
Summary of changes:

  - Make Elem::interior_parent always safe to call
  - Support shell preconditioning matrix in eigen system
  - Add dual shape functions
  - Add hash specialization for FEType
  - Added an API to retrieve eigenvalue
  - Fix an overzealous assertion in unpack_indexing
  - Update to MetaPhysicL 1.0.2
  - Make "NumericVector localize()" scalable if possible
  - Try appending to a VariableGroup in add_variables
  - Revert "Use push_parallel_packed_range in scatter_constraints"
  - Fixes for "make distcheck"
  - Don't undef or define MPI_REAL
  - Use push_parallel_packed_range in scatter_constraints
  - Use common m4 files from a submodule
  - Let user control sorting method used by BoundaryInfo::build_side_list()
  - Adding number of threads option to LibMeshInit.
  - QGaussLobatto: add fallback on regular Gauss quadrature
  - Add Tri::quality(SHAPE) metric.
  - Fixed valgrind issue with VecSetDM
  - Fix node unique_id in xda for libMesh 0.9.2
  - Use terser make_range() in place of IntRange<T> where possible.
  - Add templated make_range() helper functions.
  - Don't renumber with parallel and non-contiguous numbering
  - AbaqusIO: Add support for "MASS" elements and "NODE" sidesets.
  - Respect empty variables in Nemesis_IO::write_nodal_data
  - More robust Partitioner::set_node_processor_ids
  - Introduce std::reference_wrapper for more examples
  - Use numerically stable Edge3::volume() algorithm
  - RB fix: fix to RBEIMConstruction
  - Multiple file support in meshtool
  - Small fix to RBConstruction
  - Introduce std::reference_wrapper in fem_system_ex1
  - Make Edge3::volume() calculation more robust.
  - Don't swap LIBS and CPPFLAGS
  - RBConstruction update to store an untransformed basis.
  - Smooth libmesh for PETSc-3.13
  - Fix flux error estimates when flux weights not in approximation space
  - Introduce std::reference_wrapper in fem_system_ex3
  - RBConstruction change: Small change to train_reduced_basis().
  - Update to post_process_elem_matrix_and_vector in RBConstruction
  - Bugfix in rb_construction_base.C
  - DofMap::add_constraint_row(): assert there is no diagonal entry
  - RBConstruction change to element post-processing
  - macrofice second-derivative quantities
  - Fixes for build_sphere(DistributedMesh)
  - Fix adjoint Dirichlet constraints with AMR
  - The 'extra_checks' parameter should match 'secure' for backwards comp…
  - FEMSystem assert should work with new casts
  - PetscSolverException: use specific error message if available
  - Add 'extra_checks' parameter to FEMap::inverse_map()
  - Add DirichletBoundary copy assignment operator.
  - FileSolutionHistory class
  - Testing unique_id uniqueness

Also, for conda, make sure we build libmesh without the gdb command.
Then I don't have to pass --without-gdb-backtrace every time.
Trying to spawn a gdb process takes forever. Nobody got time
for that.

Finally, in conda test and make sure we created a TIMPI library

Refs #14922
