### PR TITLE
Build bounding boxes properly

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -18,6 +18,7 @@
 #include "DualReal.h"
 
 #include "libmesh/compare_types.h"
+#include "libmesh/bounding_box.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/metaphysicl_version.h"
 
@@ -777,6 +778,23 @@ struct IsLikeReal<DualReal>
 {
   static constexpr bool value = true;
 };
+
+/**
+ * Construct a valid bounding box from 2 arbitrary points
+ *
+ * If you have 2 points in space and you wish to construct a bounding box, you should use
+ * this method to avoid unexpected behavior of the underlying BoundingBox class in libMesh.
+ * BoundingBox class expect 2 points whose coordinates are "sorted" (i.e., x-, y- and -z coordinates
+ * of the first point are smaller then the corresponding coordinates of the second point).
+ * If this "sorting" is not present, the BoundingBox class will build an empty box and any further
+ * testing of points inside the box will fail. This method will allow you to obtain the correct
+ * bounding box for any valid combination of 2 corner points of a box.
+ *
+ * @param p1 First corner of the constructed bounding box
+ * @param p2 Second corner of the constructed bounding box
+ * @return Valid bounding box
+ */
+BoundingBox buildBoundingBox(const Point & p1, const Point & p2);
 
 } // MooseUtils namespace
 

--- a/framework/src/markers/BoxMarker.C
+++ b/framework/src/markers/BoxMarker.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "BoxMarker.h"
+#include "MooseUtils.h"
 
 registerMooseObject("MooseApp", BoxMarker);
 
@@ -38,8 +39,8 @@ BoxMarker::BoxMarker(const InputParameters & parameters)
   : Marker(parameters),
     _inside((MarkerValue)(int)parameters.get<MooseEnum>("inside")),
     _outside((MarkerValue)(int)parameters.get<MooseEnum>("outside")),
-    _bounding_box(parameters.get<RealVectorValue>("bottom_left"),
-                  parameters.get<RealVectorValue>("top_right"))
+    _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
+                                               parameters.get<RealVectorValue>("top_right")))
 {
 }
 

--- a/framework/src/meshgenerators/BoundingBoxNodeSetGenerator.C
+++ b/framework/src/meshgenerators/BoundingBoxNodeSetGenerator.C
@@ -10,6 +10,7 @@
 #include "BoundingBoxNodeSetGenerator.h"
 #include "MooseMeshUtils.h"
 #include "CastUniquePointer.h"
+#include "MooseUtils.h"
 
 #include "libmesh/node.h"
 
@@ -43,7 +44,8 @@ BoundingBoxNodeSetGenerator::BoundingBoxNodeSetGenerator(const InputParameters &
   : MeshGenerator(parameters),
     _input(getMesh("input")),
     _location(getParam<MooseEnum>("location")),
-    _bounding_box(getParam<RealVectorValue>("bottom_left"), getParam<RealVectorValue>("top_right"))
+    _bounding_box(MooseUtils::buildBoundingBox(getParam<RealVectorValue>("bottom_left"),
+                                               getParam<RealVectorValue>("top_right")))
 {
 }
 

--- a/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
@@ -12,6 +12,7 @@
 #include "MooseTypes.h"
 #include "MooseMeshUtils.h"
 #include "CastUniquePointer.h"
+#include "MooseUtils.h"
 
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
@@ -64,8 +65,8 @@ SideSetsFromBoundingBoxGenerator::SideSetsFromBoundingBoxGenerator(
     _block_id(parameters.get<SubdomainID>("block_id")),
     _boundary_id_old(parameters.get<std::vector<BoundaryName>>("boundary_id_old")),
     _boundary_id_new(parameters.get<boundary_id_type>("boundary_id_new")),
-    _bounding_box(parameters.get<RealVectorValue>("bottom_left"),
-                  parameters.get<RealVectorValue>("top_right")),
+    _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
+                                               parameters.get<RealVectorValue>("top_right"))),
     _boundary_id_overlap(parameters.get<bool>("boundary_id_overlap"))
 {
   if (dynamic_pointer_cast<DistributedMesh>(_input) != nullptr)

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -10,6 +10,7 @@
 #include "SubdomainBoundingBoxGenerator.h"
 #include "Conversion.h"
 #include "CastUniquePointer.h"
+#include "MooseUtils.h"
 
 #include "libmesh/elem.h"
 
@@ -48,8 +49,8 @@ SubdomainBoundingBoxGenerator::SubdomainBoundingBoxGenerator(const InputParamete
     _input(getMesh("input")),
     _location(parameters.get<MooseEnum>("location")),
     _block_id(parameters.get<subdomain_id_type>("block_id")),
-    _bounding_box(parameters.get<RealVectorValue>("bottom_left"),
-                  parameters.get<RealVectorValue>("top_right"))
+    _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
+                                               parameters.get<RealVectorValue>("top_right")))
 {
 }
 

--- a/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
+++ b/framework/src/meshmodifiers/AddSideSetsFromBoundingBox.C
@@ -11,6 +11,7 @@
 #include "Conversion.h"
 #include "MooseMesh.h"
 #include "MooseTypes.h"
+#include "MooseUtils.h"
 
 #include "libmesh/elem.h"
 
@@ -55,8 +56,8 @@ AddSideSetsFromBoundingBox::AddSideSetsFromBoundingBox(const InputParameters & p
     _location(parameters.get<MooseEnum>("location")),
     _boundary_id_old(parameters.get<std::vector<BoundaryName>>("boundary_id_old")),
     _boundary_id_new(parameters.get<boundary_id_type>("boundary_id_new")),
-    _bounding_box(parameters.get<RealVectorValue>("bottom_left"),
-                  parameters.get<RealVectorValue>("top_right")),
+    _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
+                                               parameters.get<RealVectorValue>("top_right"))),
     _boundary_id_overlap(parameters.get<bool>("boundary_id_overlap"))
 {
 }

--- a/framework/src/meshmodifiers/BoundingBoxNodeSet.C
+++ b/framework/src/meshmodifiers/BoundingBoxNodeSet.C
@@ -9,6 +9,7 @@
 
 #include "BoundingBoxNodeSet.h"
 #include "MooseMesh.h"
+#include "MooseUtils.h"
 
 #include "libmesh/node.h"
 
@@ -42,7 +43,8 @@ validParams<BoundingBoxNodeSet>()
 BoundingBoxNodeSet::BoundingBoxNodeSet(const InputParameters & parameters)
   : MeshModifier(parameters),
     _location(getParam<MooseEnum>("location")),
-    _bounding_box(getParam<RealVectorValue>("bottom_left"), getParam<RealVectorValue>("top_right"))
+    _bounding_box(MooseUtils::buildBoundingBox(getParam<RealVectorValue>("bottom_left"),
+                                               getParam<RealVectorValue>("top_right")))
 {
 }
 

--- a/framework/src/meshmodifiers/SubdomainBoundingBox.C
+++ b/framework/src/meshmodifiers/SubdomainBoundingBox.C
@@ -10,6 +10,7 @@
 #include "SubdomainBoundingBox.h"
 #include "Conversion.h"
 #include "MooseMesh.h"
+#include "MooseUtils.h"
 
 #include "libmesh/elem.h"
 
@@ -45,8 +46,8 @@ SubdomainBoundingBox::SubdomainBoundingBox(const InputParameters & parameters)
   : MeshModifier(parameters),
     _location(parameters.get<MooseEnum>("location")),
     _block_id(parameters.get<SubdomainID>("block_id")),
-    _bounding_box(parameters.get<RealVectorValue>("bottom_left"),
-                  parameters.get<RealVectorValue>("top_right"))
+    _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
+                                               parameters.get<RealVectorValue>("top_right")))
 {
 }
 

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -878,6 +878,15 @@ realpath(const std::string & path)
 #endif
 }
 
+BoundingBox
+buildBoundingBox(const Point & p1, const Point & p2)
+{
+  BoundingBox bb;
+  bb.union_with(p1);
+  bb.union_with(p2);
+  return bb;
+}
+
 } // MooseUtils namespace
 
 std::string


### PR DESCRIPTION
BoundingBox class in libMesh assumes that x-, y- and z- coordinates
are monotonically increasing. "Sort" the coordinates before constructing
the bounding, so that users do not have to think about this.

Refs #1275

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
