### PR TITLE
Make coupling more generic

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -144,17 +144,6 @@ protected:
   const ADVariableValue & adCoupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
-   * Returns value of a coupled variable for use in Automatic Differentiation
-   * @tparam T The type of the moose variable
-   * @param moose_var The coupled moose variable
-   * @param var_name The name of the \p moose_var. Used to retrieve default values if no coupled is
-   * actually found
-   * @return Reference to a ADVariableValue for the coupled variable
-   */
-  template <typename T, typename std::enable_if<HasMemberType_OutputShape<T>::value, int>::type = 0>
-  const ADVariableValue & adCoupledValue(const T * moose_var, const std::string & var_name);
-
-  /**
    * Returns value of a coupled vector variable for use in Automatic Differentiation
    * @param var_name Name of coupled vector variable
    * @param comp Component number for vector of coupled variables
@@ -951,6 +940,7 @@ private:
   {
     Ignore,
     Gradient,
+    Second,
     GradientDot,
     Dot,
   };
@@ -1117,24 +1107,6 @@ private:
 private:
   const MooseObject * _obj;
 };
-
-template <typename T, typename std::enable_if<HasMemberType_OutputShape<T>::value, int>::type>
-const ADVariableValue &
-Coupleable::adCoupledValue(const T * moose_var, const std::string & var_name)
-{
-  if (!moose_var)
-    return *getADDefaultValue(var_name);
-  checkFuncType(var_name, VarType::Ignore, FuncAge::Curr);
-
-  if (_c_nodal)
-    mooseError("Not implemented");
-  if (!_c_is_implicit)
-    mooseError("Not implemented");
-
-  if (!_coupleable_neighbor)
-    return moose_var->adSln();
-  return moose_var->adSlnNeighbor();
-}
 
 template <typename T, typename std::enable_if<HasMemberType_OutputShape<T>::value, int>::type>
 T *

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -302,30 +302,33 @@ public:
   {
     return _element_data->adSln();
   }
-  const ADTemplateVariableGradient<OutputType> & adGradSln() const
+  const ADTemplateVariableGradient<OutputType> & adGradSln() const override
   {
     return _element_data->adGradSln();
   }
-  const ADTemplateVariableSecond<OutputType> & adSecondSln() const
+  const ADTemplateVariableSecond<OutputType> & adSecondSln() const override
   {
     return _element_data->adSecondSln();
   }
-  const ADTemplateVariableValue<OutputType> & adUDot() const { return _element_data->adUDot(); }
+  const ADTemplateVariableValue<OutputType> & adUDot() const override
+  {
+    return _element_data->adUDot();
+  }
 
   /// neighbor AD
   const ADTemplateVariableValue<OutputType> & adSlnNeighbor() const override
   {
     return _neighbor_data->adSln();
   }
-  const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const
+  const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const override
   {
     return _neighbor_data->adGradSln();
   }
-  const ADTemplateVariableSecond<OutputType> & adSecondSlnNeighbor() const
+  const ADTemplateVariableSecond<OutputType> & adSecondSlnNeighbor() const override
   {
     return _neighbor_data->adSecondSln();
   }
-  const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const
+  const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const override
   {
     return _neighbor_data->adUDot();
   }

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -244,22 +244,33 @@ public:
   {
     return _element_data->adSln();
   }
-  const ADTemplateVariableGradient<OutputType> & adGradSln() const
+  const ADTemplateVariableGradient<OutputType> & adGradSln() const override
   {
     return _element_data->adGradSln();
   }
-  const ADTemplateVariableValue<OutputType> & adUDot() const { return _element_data->adUDot(); }
+  const ADTemplateVariableSecond<OutputType> & adSecondSln() const override
+  {
+    return _element_data->adSecondSln();
+  }
+  const ADTemplateVariableValue<OutputType> & adUDot() const override
+  {
+    return _element_data->adUDot();
+  }
 
   /// neighbor AD
   const ADTemplateVariableValue<OutputType> & adSlnNeighbor() const override
   {
     return _neighbor_data->adSln();
   }
-  const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const
+  const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const override
   {
     return _neighbor_data->adGradSln();
   }
-  const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const
+  const ADTemplateVariableSecond<OutputType> & adSecondSlnNeighbor() const override
+  {
+    return _neighbor_data->adSecondSln();
+  }
+  const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const override
   {
     return _neighbor_data->adUDot();
   }

--- a/framework/include/variables/MooseVariableField.h
+++ b/framework/include/variables/MooseVariableField.h
@@ -94,4 +94,34 @@ public:
    * AD neighbor solution getter
    */
   virtual const ADTemplateVariableValue<OutputType> & adSlnNeighbor() const = 0;
+
+  /**
+   * AD grad solution getter
+   */
+  virtual const ADTemplateVariableGradient<OutputType> & adGradSln() const = 0;
+
+  /**
+   * AD grad neighbor solution getter
+   */
+  virtual const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const = 0;
+
+  /**
+   * AD second solution getter
+   */
+  virtual const ADTemplateVariableSecond<OutputType> & adSecondSln() const = 0;
+
+  /**
+   * AD second neighbor solution getter
+   */
+  virtual const ADTemplateVariableSecond<OutputType> & adSecondSlnNeighbor() const = 0;
+
+  /**
+   * AD time derivative getter
+   */
+  virtual const ADTemplateVariableValue<OutputType> & adUDot() const = 0;
+
+  /**
+   * AD neighbor time derivative getter
+   */
+  virtual const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const = 0;
 };

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1127,7 +1127,7 @@ Coupleable::coupledSecond(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   if (!var)
     return _default_second;
-  checkFuncType(var_name, VarType::Gradient, FuncAge::Curr);
+  checkFuncType(var_name, VarType::Second, FuncAge::Curr);
 
   if (!_coupleable_neighbor)
     return (_c_is_implicit) ? var->secondSln() : var->secondSlnOlder();
@@ -1140,7 +1140,7 @@ Coupleable::coupledSecondOld(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   if (!var)
     return _default_second;
-  checkFuncType(var_name, VarType::Gradient, FuncAge::Old);
+  checkFuncType(var_name, VarType::Second, FuncAge::Old);
 
   if (!_coupleable_neighbor)
     return (_c_is_implicit) ? var->secondSlnOld() : var->secondSlnOlder();
@@ -1153,7 +1153,7 @@ Coupleable::coupledSecondOlder(const std::string & var_name, unsigned int comp)
   MooseVariable * var = getVar(var_name, comp);
   if (!var)
     return _default_second;
-  checkFuncType(var_name, VarType::Gradient, FuncAge::Older);
+  checkFuncType(var_name, VarType::Second, FuncAge::Older);
 
   if (!_coupleable_neighbor)
     return var->secondSlnOlder();
@@ -1167,7 +1167,7 @@ Coupleable::coupledSecondPreviousNL(const std::string & var_name, unsigned int c
   _c_fe_problem.needsPreviousNewtonIteration(true);
   if (!var)
     return _default_second;
-  checkFuncType(var_name, VarType::Gradient, FuncAge::Curr);
+  checkFuncType(var_name, VarType::Second, FuncAge::Curr);
 
   if (!_coupleable_neighbor)
     return var->secondSlnPreviousNL();
@@ -1385,13 +1385,25 @@ Coupleable::adCoupledValue(const std::string & var_name, unsigned int comp)
 {
   MooseVariableField<Real> * var = getVarHelper<MooseVariableField<Real>>(var_name, comp);
 
-  return adCoupledValue(var, var_name);
+  if (!var)
+    return *getADDefaultValue(var_name);
+  checkFuncType(var_name, VarType::Ignore, FuncAge::Curr);
+
+  if (_c_nodal)
+    mooseError("Not implemented");
+  if (!_c_is_implicit)
+    mooseError("Not implemented");
+
+  if (!_coupleable_neighbor)
+    return var->adSln();
+  return var->adSlnNeighbor();
 }
 
 const ADVariableGradient &
 Coupleable::adCoupledGradient(const std::string & var_name, unsigned int comp)
 {
-  MooseVariable * var = getVar(var_name, comp);
+  MooseVariableField<Real> * var = getVarHelper<MooseVariableField<Real>>(var_name, comp);
+
   if (!var)
     return getADDefaultGradient();
   checkFuncType(var_name, VarType::Gradient, FuncAge::Curr);
@@ -1407,10 +1419,11 @@ Coupleable::adCoupledGradient(const std::string & var_name, unsigned int comp)
 const ADVariableSecond &
 Coupleable::adCoupledSecond(const std::string & var_name, unsigned int comp)
 {
-  MooseVariable * var = getVar(var_name, comp);
+  MooseVariableField<Real> * var = getVarHelper<MooseVariableField<Real>>(var_name, comp);
+
   if (!var)
     return getADDefaultSecond();
-  checkFuncType(var_name, VarType::Gradient, FuncAge::Curr);
+  checkFuncType(var_name, VarType::Second, FuncAge::Curr);
 
   if (!_c_is_implicit)
     mooseError("Not implemented");
@@ -1431,7 +1444,8 @@ adCoupledVectorSecond(const std::string & /*var_name*/, unsigned int /*comp = 0*
 const ADVariableValue &
 Coupleable::adCoupledDot(const std::string & var_name, unsigned int comp)
 {
-  MooseVariable * var = getVar(var_name, comp);
+  MooseVariableField<Real> * var = getVarHelper<MooseVariableField<Real>>(var_name, comp);
+
   if (!var)
     return *getADDefaultValue(var_name);
   checkFuncType(var_name, VarType::Dot, FuncAge::Curr);


### PR DESCRIPTION
E.g. make it so that both FE and FV variables can be directly
coupled through the adCoupledGradient, adCoupledSecond, and
adCoupledDot APIs

Refs #14549
 
@snschune Try this out with the Pronghorn branch. It was working for me (insofar as there were no failed assertions, errors during setup; the solve wasn't converging though...)
