### PR TITLE
Make PETScDMDAMesh unique_ids more unique

### DIFF
--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -187,7 +187,7 @@ add_element_Quad4(DM da,
   elem->set_id(elem_id);
   elem->processor_id() = pid;
   // Make sure our unique_id doesn't overlap any nodes'
-  elem->set_unique_id() = elem_id + (nx+1)*(ny+1);
+  elem->set_unique_id() = elem_id + (nx + 1) * (ny + 1);
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;
@@ -390,7 +390,7 @@ build_cube_Quad4(UnstructuredMesh & mesh, DM da)
 
   // We've already set our own unique_id values; now make sure that
   // future mesh modifications use subsequent values.
-  mesh.set_next_unique_id(Mx*My+(Mx-1)*(My-1));
+  mesh.set_next_unique_id(Mx * My + (Mx - 1) * (My - 1));
 
   // No need to renumber or find neighbors - done did it.
   // Avoid deprecation message/error by _also_ setting

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -388,6 +388,10 @@ build_cube_Quad4(UnstructuredMesh & mesh, DM da)
   // Already partitioned!
   mesh.skip_partitioning(true);
 
+  // We've already set our own unique_id values; now make sure that
+  // future mesh modifications use subsequent values.
+  mesh.set_next_unique_id(Mx*My+(Mx-1)*(My-1));
+
   // No need to renumber or find neighbors - done did it.
   // Avoid deprecation message/error by _also_ setting
   // allow_renumbering(false). This is a bit silly, but we want to

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -186,7 +186,8 @@ add_element_Quad4(DM da,
   Elem * elem = new Quad4;
   elem->set_id(elem_id);
   elem->processor_id() = pid;
-  elem->set_unique_id() = elem_id;
+  // Make sure our unique_id doesn't overlap any nodes'
+  elem->set_unique_id() = elem_id + (nx+1)*(ny+1);
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;


### PR DESCRIPTION
This fixes one of the problems in #15193 - Elem unique_id() values coming out of this generator will no longer overlap Node unique_id() values, and unique_ids should continue to be unique after any subsequent mesh modification too.