### PR TITLE
Separate out general and moose specific installation instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -3,8 +3,10 @@
 Our preferred method for obtaining libraries necessary for MOOSE based
 Application development, is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
-Windows is not supported. Effort is being made towards this direction. But it is
-some time out.
+an option to install MOOSE directly on a Windows system is not yet supported.
+On-going efforts are being made to add a conda installation option for Windows,
+and an experimental [WSL](installation/windows10.md) option is available.
+
 
 !include sqa/minimum_requirements.md
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,6 +1,10 @@
 # Conda MOOSE Environment
 
-Our preferred method for obtaining libraries necessary for MOOSE based Application development, is via Conda's myriad array of libraries. Follow these instructions to create an environment on your machine using Conda. At this time, Windows is not supported. Effort is being made towards this direction. But it is some time out.
+Our preferred method for obtaining libraries necessary for MOOSE based
+Application development, is via Conda's myriad array of libraries. Follow these
+instructions to create an environment on your machine using Conda. At this time,
+Windows is not supported. Effort is being made towards this direction. But it is
+some time out.
 
 !include sqa/minimum_requirements.md
 
@@ -8,67 +12,7 @@ Our preferred method for obtaining libraries necessary for MOOSE based Applicati
 
 !include installation/remove_moose_environment.md
 
-## Install Miniconda id=installconda
-
-!alert note title= Anaconda also works
-You may choose to use Anaconda if you so desire: [Anaconda for Python 3.x](https://www.anaconda.com/distribution/)
-
-You may follow Miniconda's instructions: [Install Miniconda3](https://docs.conda.io/en/latest/miniconda.html), however we continuously receive reports of difficulty doing so (especially from our MacOS users). With that said, please use our instructions to install Miniconda instead:
-
-- +Linux:+
-
-  ```bash
-  curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
-  ```
-
-- +Macintosh:+
-
-  ```bash
-  curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-  bash Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/miniconda3
-  ```
-
-With Miniconda installed to your home directory, export PATH, so that it may be used:
-
-```bash
-export PATH=$HOME/miniconda3/bin:$PATH
-```
-
-Configure Conda to work with conda-forge, and our mooseframework.org channel:
-
-```bash
-conda config --add channels conda-forge
-conda config --add channels https://mooseframework.org/conda/moose
-```
-
-Install the moose-libmesh and moose-tools package from mooseframework.org, and name your environment 'moose':
-
-```bash
-conda create --name moose moose-libmesh moose-tools
-```
-
-Activate the moose environment +(do this for any new terminal opened)+:
-
-```bash
-conda activate moose
-```
-
-Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again.
-
-You will have successfully activated the moose environment when you see 'moose' within your prompt.
-
-If you close, and re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for each terminal you open. If you wish to make this automatic, you may append `conda activate moose` to your bash or zsh profiles.
-
-The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
-
-```bash
-conda activate moose
-conda update --all
-```
-
-!alert note title= sudo is not necessary
-If you find yourself applying the use of `sudo` for any of the above conda commands... something's not right. The most common reason for needing sudo, is due to an improper installation. Conda *should* be installed to your home directory, and without any use of `sudo`.
+!include installation/install_miniconda.md
 
 !include getting_started/installation/clone_moose.md
 
@@ -76,11 +20,4 @@ If you find yourself applying the use of `sudo` for any of the above conda comma
 
 Head back over to the [getting_started/index.md] page to continue your tour of MOOSE.
 
-## Uninstall Conda MOOSE Environment
-
-If you wish to remove the moose environment at any time, you may do so using the following commands:
-
-```bash
-conda deactivate   # if 'moose' was currently activated
-conda remove --name moose --all
-```
+!include installation/uninstall_conda.md

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -1,0 +1,70 @@
+## Install Miniconda id=installconda
+
+!alert note title= Anaconda also works
+You may choose to use Anaconda if you so desire: [Anaconda for Python 3.x](https://www.anaconda.com/distribution/)
+
+You may follow Miniconda's instructions: [Install Miniconda3](https://docs.conda.io/en/latest/miniconda.html), however we continuously receive reports of difficulty doing so (especially from our MacOS users). With that said, please use our instructions to install Miniconda instead:
+
+- +Linux:+
+
+  ```bash
+  curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
+  ```
+
+- +Macintosh:+
+
+  ```bash
+  curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+  bash Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/miniconda3
+  ```
+
+With Miniconda installed to your home directory, export PATH, so that it may be used:
+
+```bash
+export PATH=$HOME/miniconda3/bin:$PATH
+```
+
+Configure Conda to work with conda-forge, and our mooseframework.org channel:
+
+```bash
+conda config --add channels conda-forge
+conda config --add channels https://mooseframework.org/conda/moose
+```
+
+Install the moose-libmesh and moose-tools package from mooseframework.org, and name your environment 'moose':
+
+```bash
+conda create --name moose moose-libmesh moose-tools
+```
+
+Activate the moose environment +(do this for any new terminal opened)+:
+
+```bash
+conda activate moose
+```
+
+Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again.
+
+You will have successfully activated the moose environment when you see 'moose' within your prompt.
+
+If you close, and re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for each terminal you open. If you wish to make this automatic, you may append `conda activate moose` to your bash or zsh profiles.
+
+The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
+
+```bash
+conda activate moose
+conda update --all
+```
+
+!alert note title= sudo is not necessary
+If you find yourself applying the use of `sudo` for any of the above conda commands... something's not right. The most common reason for needing sudo, is due to an improper installation. Conda *should* be installed to your home directory, and without any use of `sudo`.
+
+## Uninstall Conda MOOSE Environment
+
+If you wish to remove the moose environment at any time, you may do so using the following commands:
+
+```bash
+conda deactivate   # if 'moose' was currently activated
+conda remove --name moose --all
+```

--- a/modules/doc/content/getting_started/installation/remove_moose_environment.md
+++ b/modules/doc/content/getting_started/installation/remove_moose_environment.md
@@ -1,8 +1,12 @@
 ### Transitional step for pre-existing users
 
-For those of you who have previously installed the moose-environment package, you should remove it. +If you are a first time MOOSE user, please skip down to [Install Miniconda](conda.md#installconda).+ Removal of the moose-envirnment package, is only needed to be performed once.
+For those of you who have previously installed the moose-environment package, you should remove it. Removal of the moose-environment package only needs to be performed once.
 
-- Using Conda, it is no longer neccessary to have /opt/moose present on your machine. Depending on the type of machine you have, please do the following:
+!alert! note title=Step not applicable to first-time users
+If you are a first time MOOSE user, please skip down to [Install Miniconda](install_miniconda.md#installconda).
+!alert-end!
+
+- Using Conda, it is no longer necessary to have /opt/moose present on your machine. Depending on the type of machine you have, please do the following:
 
   | Operating System | Command |
   | :- | -: |

--- a/modules/doc/content/getting_started/installation/uninstall_conda.md
+++ b/modules/doc/content/getting_started/installation/uninstall_conda.md
@@ -1,0 +1,8 @@
+## Uninstall Conda MOOSE Environment
+
+If you wish to remove the moose environment at any time, you may do so using the following commands:
+
+```bash
+conda deactivate   # if 'moose' was currently activated
+conda remove --name moose --all
+```

--- a/modules/doc/content/getting_started/installation/windows10.md
+++ b/modules/doc/content/getting_started/installation/windows10.md
@@ -11,51 +11,7 @@ Caveats:
     - Be sure to choose an OS in which we support. While MOOSE will ultimately work on just about every flavor of Linux, this document assumes you have chosen Ubuntu.
 !alert-end!
 
-Begin by performing the following external sets of instructions. Remember to choose Ubuntu, unless you know what you are doing.
-
-- [Windows Subsystem for Linux (WSL)](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)
-- [VcXsrv](https://sourceforge.net/projects/vcxsrv/reviews/) (Only needed for Peacock)
-
-## Launch VcXsrv
-
-Each time you reboot, or basically each time VcXsrv is *not* running, and you wish to use the graphical capabilities of MOOSE (Peacock), you should start VcXsrv before launching your WSL terminal.
-
-We have found better performance instructing VcXsrv to use software rendering over native OpenGL. When launching VcXsrv, search for the option: "Native opengl", and un-check it. All other options can remain the default.
-
-## Edit Hostname within WSL
-
-Launch the Windows 10 Command Prompt as an Administrator (right-click the Windows Start button, and select Command Prompt(Admin) in the resulting menu that appears), and modify the Windows 10 hosts file (located in `C:\Windows\System32\Drivers\etc\hosts`) to include the results of `hostname` to resolve to 127.0.0.1. This is necessary due to the way
-MPICH (a message passing interface) passes information among itself when running applications (like MOOSE) in parallel.
-
-```
-C:\Users\[your_user_name]> hostname
-DESKTOP-L7BGA7L
-
-C:\Users\[your_user_name]> Notepad "C:\Windows\System32\Drivers\etc\hosts"
-# localhost name resolution is handled within DNS itself.
-#       127.0.0.1       localhost
-#       ::1             localhost
-
-127.0.0.1   DESKTOP-L7BGA7L    <---- ADD THAT
-```
-
-## Update Ubuntu, install additional libraries
-
-Launch WSL, perform an update, and install necessary OpenGL libraries:
-
-```bash
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install x11-apps libglu1-mesa
-```
-
-## Configure WSL to use VcXsrv
-
-Modify your bash profile to allow WSL to connect to VcXsrv.
-
-```bash
-echo "export DISPLAY=localhost:0" >> ~/.bashrc
-```
+!include installation/wsl.md
 
 ## Close the WSL terminal
 

--- a/modules/doc/content/getting_started/installation/wsl.md
+++ b/modules/doc/content/getting_started/installation/wsl.md
@@ -1,0 +1,45 @@
+Begin by performing the following external sets of instructions. Remember to choose Ubuntu, unless you know what you are doing.
+
+- [Windows Subsystem for Linux (WSL)](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)
+- [VcXsrv](https://sourceforge.net/projects/vcxsrv/reviews/) (Only needed for Peacock)
+
+## Launch VcXsrv
+
+Each time you reboot, or basically each time VcXsrv is *not* running, and you wish to use the graphical capabilities of MOOSE (Peacock), you should start VcXsrv before launching your WSL terminal.
+
+We have found better performance instructing VcXsrv to use software rendering over native OpenGL. When launching VcXsrv, search for the option: "Native opengl", and un-check it. All other options can remain the default.
+
+## Edit Hostname within WSL
+
+Launch the Windows 10 Command Prompt as an Administrator (right-click the Windows Start button, and select Command Prompt(Admin) in the resulting menu that appears), and modify the Windows 10 hosts file (located in `C:\Windows\System32\Drivers\etc\hosts`) to include the results of `hostname` to resolve to 127.0.0.1. This is necessary due to the way
+MPICH (a message passing interface) passes information among itself when running applications (like MOOSE) in parallel.
+
+```
+C:\Users\[your_user_name]> hostname
+DESKTOP-L7BGA7L
+
+C:\Users\[your_user_name]> Notepad "C:\Windows\System32\Drivers\etc\hosts"
+# localhost name resolution is handled within DNS itself.
+#       127.0.0.1       localhost
+#       ::1             localhost
+
+127.0.0.1   DESKTOP-L7BGA7L    <---- ADD THAT
+```
+
+## Update Ubuntu, install additional libraries
+
+Launch WSL, perform an update, and install necessary OpenGL libraries:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install x11-apps libglu1-mesa
+```
+
+## Configure WSL to use VcXsrv
+
+Modify your bash profile to allow WSL to connect to VcXsrv.
+
+```bash
+echo "export DISPLAY=localhost:0" >> ~/.bashrc
+```


### PR DESCRIPTION
Will allow for easier inclusion of the general information in downstream apps (and have tested with BISON)

Closes #15209
