### PR TITLE
Add pseudo quadrature point to ADNodalBCTempl

### DIFF
--- a/framework/include/bcs/ADNodalBC.h
+++ b/framework/include/bcs/ADNodalBC.h
@@ -42,6 +42,9 @@ protected:
   /// current node being processed
   const Node * const & _current_node;
 
+  /// Pseudo-"quadrature point" index (Always zero for the current node)
+  const unsigned int _qp = 0;
+
   /// Value of the unknown variable this BC is acting on
   const typename Moose::ADType<T>::type & _u;
 


### PR DESCRIPTION
Add pseudo quadrature point to `ADNodalBCTempl` to allow classes deriving from `ADDirichletBC` to have the same access to variables as kernels and material properties, just as in `NodalBC`.

Closes #15218 
