### PR TITLE
Allow libmesh to condense all variables into one group if possible

### DIFF
--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -643,10 +643,6 @@ SystemBase::addVariable(const std::string & var_type,
         fe_type.family == MONOMIAL_VEC)
       mooseError("Vector family type cannot be used in an array variable");
 
-    // Turn off automatic variable group identification so that we can be sure that this variable
-    // group will be ordered exactly like it should be
-    system().identify_variable_groups(false);
-
     // Build up the variable names
     std::vector<std::string> var_names;
     for (unsigned int i = 0; i < components; i++)


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Closes #15231 

Let us check how many tests will fail with this deletion. And work a right way to fix the issues.
