### PR TITLE
Don't use LU in FV scalar advection test

### DIFF
--- a/test/tests/fvkernels/fv_constant_scalar_advection/2D_constant_scalar_advection.i
+++ b/test/tests/fvkernels/fv_constant_scalar_advection/2D_constant_scalar_advection.i
@@ -54,8 +54,6 @@
 
 [Executioner]
   type = Transient
-  petsc_options_iname = '-pc_type'
-  petsc_options_value = 'lu'
   petsc_options = '-snes_converged_reason'
   nl_abs_tol = 1e-7
   nl_rel_tol = 1e-8


### PR DESCRIPTION
This test fails with `-p4 --distributed-mesh` when executed with
PETSc version 3.11.4 as discussed on libmesh/libmesh#2552. The
failure reason is:

```
 0 Nonlinear |R| = 2.757015e-01
      0 Linear |R| = 2.757015e-01
  Linear solve did not converge due to DIVERGED_PC_FAILED iterations 0
                 PC_FAILED due to FACTOR_OUTMEMORY
Nonlinear solve did not converge due to DIVERGED_LINE_SEARCH iterations 0
```

This test appears to run fine with default
```
-pc_type bjacobi -sub_pc_type ilu
```
so I've restored those defaults. This is a testament to how buggy
MUMPS (the default PETSc direct solver) seems to be. This problem
runs fine with `-pc_factor_mat_solver_type superlu_dist`
