### PR TITLE
Allow a do_last test target

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -379,7 +379,8 @@ class TestHarness:
             if type(params['prereq']) != list:
                 print(("Option 'prereq' needs to be of type list in " + params['test_name']))
                 sys.exit(1)
-            params['prereq'] = [relative_path.replace('/tests/', '') + '.' + item for item in params['prereq']]
+            elif (params['prereq'] != ['ALL']):
+                params['prereq'] = [relative_path.replace('/tests/', '') + '.' + item for item in params['prereq']]
 
         # Double the alloted time for tests when running with the valgrind option
         tester.setValgrindMode(self.options.valgrind_mode)

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -112,6 +112,10 @@ class Job(object):
         """ Return the tester object """
         return self.__tester
 
+    def getSpecs(self):
+        """ Return tester spec params """
+        return self.getTester().specs
+
     def getTestName(self):
         """ Wrapper method to return the testers test name """
         return self.__tester.getTestName()

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -33,7 +33,7 @@ class Tester(MooseObject):
 
         params.addParam('heavy',    False, "Set to True if this test should only be run when the '--heavy' option is used.")
         params.addParam('group',       [], "A list of groups for which this test belongs.")
-        params.addParam('prereq',      [], "A list of prereq tests that need to run successfully before launching this test.")
+        params.addParam('prereq',      [], "A list of prereq tests that need to run successfully before launching this test. When 'prereq = ALL', TestHarness will run this test last. Multiple 'prereq = ALL' tests, or tests that depend on a 'prereq = ALL' test will result in cyclic errors. Naming a test 'ALL' when using 'prereq = ALL' will also result in an error.")
         params.addParam('skip_checks', False, "Tells the TestHarness to skip additional checks (This parameter is set automatically by the TestHarness during recovery tests)")
         params.addParam('scale_refine',    0, "The number of refinements to do when scaling")
         params.addParam('success_message', 'OK', "The successful message")

--- a/python/TestHarness/tests/test_DoLast.py
+++ b/python/TestHarness/tests/test_DoLast.py
@@ -1,0 +1,59 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import subprocess
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testDoLastDuplicate(self):
+        """
+        Test for invalid use of multiple do_last params
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'cyclic_do_last')
+
+        e = cm.exception
+
+        self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.*?FAILED \(Cyclic or Invalid Dependency Detected!\)')
+
+    def testDoLastDepends(self):
+        """
+        Test for invalid use where a test depends on a 'do_last' test
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('-i', 'cyclic_do_last_depends')
+
+        e = cm.exception
+
+        self.assertRegex(e.output.decode('utf-8'), r'tests/test_harness.*?FAILED \(Cyclic or Invalid Dependency Detected!\)')
+
+    def testDoLast(self):
+        """
+        Confirm 'do_last' tested last
+        """
+        output = self.runTests('--no-color', '-i', 'do_last')
+        self.assertRegex(output.decode('utf-8'), 'tests/test_harness.a.*?OK\ntests/test_harness.do_last.*?OK')
+
+    def testDoLastSkipped(self):
+        """
+        Confirm 'do_last' is skipped if a test it depends on failed/skipped.
+        """
+        output = self.runTests('--no-color', '-i', 'do_last_skipped')
+        self.assertRegex(output.decode('utf-8'), 'test_harness.do_last.*?\[SKIPPED DEPENDENCY\] SKIP')
+
+    def testDoLastName(self):
+        """
+        Test for invalid use where a test name is 'ALL' when 'prereq = ALL' is set
+        """
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.runTests('--no-color', '-i', 'do_last_name')
+
+        e = cm.exception
+
+        self.assertRegex(e.output.decode('utf-8'), 'test_harness.*?FAILED \(Test named ALL when "prereq = ALL" elsewhere in test spec file!\)')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -220,4 +220,10 @@
     requirement = "The system shall produces a descriptive error with the file and line number when a test specification parameter is unknown."
     issues = '#14803'
   []
+  [do_last]
+    type = PythonUnitTest
+    input = test_DoLast.py
+    requirement = "TestHarnes shall perform a test after all other tests have passed if specified to do so"
+    issues = '#15230'
+  []
 []

--- a/test/tests/test_harness/cyclic_do_last
+++ b/test/tests/test_harness/cyclic_do_last
@@ -1,0 +1,12 @@
+[Tests]
+  [./a]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+  [./b]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+[]

--- a/test/tests/test_harness/cyclic_do_last_depends
+++ b/test/tests/test_harness/cyclic_do_last_depends
@@ -1,0 +1,12 @@
+[Tests]
+  [./do_last]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+  [./a]
+    type = RunApp
+    input = good.i
+    prereq = do_last
+  [../]
+[]

--- a/test/tests/test_harness/do_last
+++ b/test/tests/test_harness/do_last
@@ -1,0 +1,16 @@
+[Tests]
+  [./do_last]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+  [./a]
+    type = RunApp
+    input = good.i
+    prereq = b
+  [../]
+  [./b]
+    type = RunApp
+    input = good.i
+  [../]
+[]

--- a/test/tests/test_harness/do_last_name
+++ b/test/tests/test_harness/do_last_name
@@ -1,0 +1,11 @@
+[Tests]
+  [./do_last]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+  [./ALL]
+    type = RunApp
+    input = good.i
+  [../]
+[]

--- a/test/tests/test_harness/do_last_skipped
+++ b/test/tests/test_harness/do_last_skipped
@@ -1,0 +1,12 @@
+[Tests]
+  [./do_last]
+    type = RunApp
+    input = good.i
+    prereq = ALL
+  [../]
+  [./a]
+    type = RunApp
+    input = good.i
+    skip = 'do_last should be skipped'
+  [../]
+[]


### PR DESCRIPTION
For test spec files with many tests, and those wishing to have a final 'do this last' test,
users can provide the 'prereq = ALL' param in their test spec files:

Closes #15230
