### PR TITLE
fix deprecated warnings  in input files

### DIFF
--- a/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
+++ b/modules/combined/test/tests/gap_heat_transfer_jac/two_blocks.i
@@ -48,7 +48,6 @@
     formulation = kinematic
     tangential_tolerance = 1e-1
     penalty = 1e10
-    system = Constraint
   [../]
 []
 

--- a/modules/combined/test/tests/heat_convection/heat_convection_function.i
+++ b/modules/combined/test/tests/heat_convection/heat_convection_function.i
@@ -10,7 +10,7 @@
   [../]
   [./htc]
     type = ParsedFunction
-    value = 10.0
+    value = 10.0*5.7                 # convective heat transfer coefficient (w/m^2-K)[50 BTU/hr-ft^2-F]
   [../]
 []
 
@@ -37,8 +37,7 @@
     type = ConvectiveFluxFunction  # Convective flux, e.g. q'' = h*(Tw - Tf)
     boundary = 12
     variable = temp
-    coefficient = 5.7                   # convective heat transfer coefficient (w/m^2-K)[50 BTU/hr-ft^2-F]
-    coefficient_function = htc
+    coefficient = htc
     T_infinity = t_infinity
   [../]                                  # Convective End
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_locs.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_locs.i
@@ -25,7 +25,7 @@
 
 [Samplers]
   [grid]
-    type = CartesianProductSampler
+    type = CartesianProduct
     linear_space_items = '2.5 0.5 10  2.5 0.5 10'
   []
   [quadrature]

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_locs.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_locs.i
@@ -25,7 +25,7 @@
 
 [Samplers]
   [grid]
-    type = CartesianProductSampler
+    type = CartesianProduct
     linear_space_items = '2.5 0.5 10  3 1 10'
   []
   [quadrature]

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/tests
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/tests
@@ -28,8 +28,8 @@
       type = CSVDiff
       input = master_2dnorm_quad.i
       allow_test_objects = true
-      cli_args = 'Distributions/D_dist/type=BoostNormalDistribution '
-                 'Distributions/S_dist/type=BoostNormalDistribution '
+      cli_args = 'Distributions/D_dist/type=BoostNormal '
+                 'Distributions/S_dist/type=BoostNormal '
                  'Outputs/file_base=boost_2dnorm_quad'
       csvdiff = 'boost_2dnorm_quad_pc_samp_0002.csv'
       boost = true

--- a/modules/tensor_mechanics/test/tests/shell/static/beam_bending_moment_AD_2.i
+++ b/modules/tensor_mechanics/test/tests/shell/static/beam_bending_moment_AD_2.i
@@ -32,19 +32,19 @@
 # y = -0.57735 * (t/2) is 10 Pa at any location along the length of the beam.
 
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 1
-  ny = 4
-  xmin = 0.0
-  xmax = 1.0
-  ymin = 0.0
-  ymax = 10.0
-[]
-
-[MeshModifiers]
+  [./gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 1
+    ny = 4
+    xmin = 0.0
+    xmax = 1.0
+    ymin = 0.0
+    ymax = 10.0
+  []
   [./rotate]
-    type = Transform
+    type = TransformGenerator
+    input = gen
     transform = ROTATE
     vector_value = '0 90 0'
   [../]


### PR DESCRIPTION
This fixes all of the deprecated warnings in modules except for an sm contact warning.  Is there something I add to that input file to allow deprecated variables?
@bwspenc @aeslaughter 
ref #15251

