### PR TITLE
reduce jacobian tester runtime 

### DIFF
--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/tests
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_first/tests
@@ -38,7 +38,7 @@
       input = 'small.i'
       ratio_tol = 1e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=3 -snes_test_err 1e-9'
+      cli_args = 'Executioner/end_time=0.3 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       detail = 'using the small strain formulation and calculate a perfect Jacobian.'
@@ -49,7 +49,7 @@
       input = 'finite.i'
       ratio_tol = 5e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=3 -snes_test_err 1e-9'
+      cli_args = 'Executioner/end_time=0.3 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       detail = 'using the finite strain formulation and calculate a perfect Jacobian.'

--- a/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/tests
+++ b/modules/contact/test/tests/mortar_tm/2drz/ad_frictionless_second/tests
@@ -42,7 +42,7 @@
       input = 'small.i'
       ratio_tol = 1e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=2 -snes_test_err 1e-9'
+      cli_args = 'Executioner/end_time=0.2 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       detail = 'using the small strain formulation and calculate a perfect Jacobian.'
@@ -53,7 +53,7 @@
       input = 'finite.i'
       ratio_tol = 1e-3
       difference_tol = 1
-      cli_args = 'Executioner/num_steps=2 -snes_test_err 1e-9'
+      cli_args = 'Executioner/end_time=0.2 -snes_test_err 1e-9'
       run_sim = true
       heavy = true
       detail = 'using the finite strain formulation and calculate a perfect Jacobian.'


### PR DESCRIPTION
Changed the cli-args in the test file to use end_time instead of num_steps.  end_time in the input file was overriding the num_steps being passed in by cli_args.  This test was failing for runtime.
 ref #15141
