### PR TITLE
FV: speed things up a bit

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -1661,6 +1661,8 @@ private:
   /// The AD version of the current coordinate transformation coefficients
   MooseArray<DualReal> _ad_coord;
 
+  std::vector<std::unique_ptr<QBase>> _holder_qrule_fv_face;
+
   /// Holds volume qrules for each dimension
   std::map<unsigned int, QBase *> _holder_qrule_volume;
   /// Holds arbitrary qrules for each dimension

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -42,6 +42,7 @@ class SparseMatrix;
 }
 
 // MOOSE Forward Declares
+class FaceInfo;
 class MooseMesh;
 class ArbitraryQuadrature;
 class SystemBase;
@@ -542,6 +543,8 @@ public:
    * Reinitialize the assembly data on the side of a element at the custom reference points
    */
   void reinit(const Elem * elem, unsigned int side, const std::vector<Point> & reference_points);
+
+  void reinitFVFace(const FaceInfo & fi);
 
   /**
    * Reinitialize an element and its neighbor along a particular side.

--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -271,6 +271,10 @@ template <typename RangeType>
 OnScopeExit
 ComputeFVFluxThread<RangeType>::reinitVariables(const FaceInfo & fi)
 {
+  // TODO: this skips necessary FE reinit.  In addition to this call, we need
+  // to conditionally do some FE-specific reinit here if we have any active FE
+  // variables.  However, we still want to keep/do FV-style quadrature.
+  // Figure out how to do all this some day.
   _fe_problem.assembly(_tid).reinitFVFace(fi);
 
   // TODO: for FE variables, this is handled via setting needed vars through

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1679,6 +1679,37 @@ Assembly::reinit(const Elem * elem, const std::vector<Point> & reference_points)
 }
 
 void
+Assembly::reinitFVFace(const FaceInfo & fi)
+{
+  _current_elem = &fi.elem();
+  _current_neighbor_elem = fi.neighborPtr();
+  _current_side = fi.elemSideID();
+  _current_neighbor_side = fi.neighborSideID();
+  mooseAssert(_current_subdomain_id == _current_elem->subdomain_id(),
+              "current subdomain has been set incorrectly");
+
+  _current_elem_volume_computed = false;
+  _current_side_volume_computed = false;
+
+  prepareResidual();
+  prepareNeighbor();
+  prepareJacobianBlock();
+
+  unsigned int elem_dimension = _current_elem->dim();
+
+  // Make sure the qrule is the right one
+  if (_current_qrule_face != _holder_qrule_face[elem_dimension])
+  {
+    _current_qrule_face = _holder_qrule_face[elem_dimension];
+    setFaceQRule(_current_qrule_face, elem_dimension);
+  }
+
+  if (_current_side_elem)
+    delete _current_side_elem;
+  _current_side_elem = _current_elem->build_side_ptr(_current_side).release();
+}
+
+void
 Assembly::reinit(const Elem * elem, unsigned int side)
 {
   _current_elem = elem;


### PR DESCRIPTION
This improves FV simple diffusion speed by ~4x.  I just added an FV-specific assembly reinit function and quadrature rule.  There is room for another 1.5-2x speedup going forward, but this should be a welcome improvement for the time being.  Notably, FV diffusion is still a bit slower than FE diffusion because FV needs both the face and the elemental loops - and we don't currently/yet skip the FE specific stuff in the elemental loop.  This just skips FE specific stuff in the face loop.
