### PR TITLE
Fix bug that creates empty directories when using abs path.

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -759,6 +759,11 @@ linearPartitionChunk(dof_id_type num_items, dof_id_type num_chunks, dof_id_type 
 std::string realpath(const std::string & path);
 
 /**
+ * Like python's os.path.relpath
+ */
+std::string relativepath(const std::string & path, const std::string & start = ".");
+
+/**
  * Custom type trait that has a ::value of true for types that cam be use interchangably
  * with Real. Most notably it is false for complex numbers, which do not have a
  * strict ordering (and therefore no <,>,<=,>= operators).

--- a/framework/src/outputs/FileOutput.C
+++ b/framework/src/outputs/FileOutput.C
@@ -84,7 +84,12 @@ FileOutput::FileOutput(const InputParameters & parameters)
   }
 
   // Check the file directory of file_base and create if needed
-  std::string base = "./" + _file_base;
+  // Check if _file_base is an absolute path
+  std::string base;
+  if (_file_base.find_first_of("/", 0) == 0)
+    base = "./" + MooseUtils::relativepath(_file_base);
+  else
+    base = "./" + _file_base;
   base = base.substr(0, base.find_last_of('/'));
 
   if (_app.processor_id() == 0 && access(base.c_str(), W_OK) == -1)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -878,6 +878,44 @@ realpath(const std::string & path)
 #endif
 }
 
+std::string
+relativepath(const std::string & path, const std::string & start)
+{
+  std::vector<std::string> vecpath;
+  std::vector<std::string> vecstart;
+  size_t index_size;
+  unsigned int same_size(0);
+
+  vecpath = split(path, "/");
+  vecstart = split(realpath(start), "/");
+  if (vecstart.size() < vecpath.size())
+    index_size = vecstart.size();
+  else
+    index_size = vecpath.size();
+
+  for (unsigned int i = 0; i < index_size; ++i)
+  {
+    if (vecstart[i] != vecpath[i])
+    {
+      same_size = i;
+      break;
+    }
+  }
+
+  std::string relative_path("");
+  for (unsigned int i = 0; i < (vecstart.size() - same_size); ++i)
+    relative_path += "../";
+
+  for (unsigned int i = same_size; i < vecpath.size(); ++i)
+  {
+    relative_path += vecpath[i];
+    if (i < (vecpath.size() - 1))
+      relative_path += "/";
+  }
+
+  return relative_path;
+}
+
 BoundingBox
 buildBoundingBox(const Point & p1, const Point & p2)
 {


### PR DESCRIPTION
Add: MooseUtils::relativepath function that constructs a
relative path when given a string.

Add: Check for absolute path in FileOutput.C.

Refs #14942

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

@dschwen 