### PR TITLE
Use PETSc submodule as the default solver

### DIFF
--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -48,7 +48,9 @@ BUILD_CONFIG=`cat <<"EOF"
   --download-ptscotch=1 \
   --download-parmetis=1 \
   --download-scalapack=1 \
-  --download-superlu_dist=1
+  --download-superlu_dist=1 \
+  --with-fortran-bindings=0 \
+  --with-sowing=0 \
 EOF
 `
 

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.12.5" %}
 
@@ -9,9 +9,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: petsc-{{ version }}.tar.gz
-  url: http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  git_url: ../../petsc
 
 build:
   number: {{ build }}


### PR DESCRIPTION
PETSc submodule in this commit points to 3.12.5

1) Updated PETSc submodule to point  to 3.12.5

2) Changed meta file to take petsc submodule

If everything works correctly, this should not impact users since we are still pointing to the same PETSc hash. 

Closes #15291

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
