### PR TITLE
ADComputeSmearedCrackingStress

### DIFF
--- a/modules/tensor_mechanics/doc/content/source/materials/ADAbruptSoftening.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADAbruptSoftening.md
@@ -1,0 +1,29 @@
+# AD Abrupt Softening
+
+!syntax description /Materials/ADAbruptSoftening
+
+## Description
+
+The material `ADAbruptSoftening` computes the reduced stress and stiffness
+in the direction of a crack according to a step function. The computed
+cracked stiffness ratio softens the tensile response of the material once the
+principle stress exceeds the cracking stress threshold of the material. 
+It uses automatic differentiation for the computation of its Jacobian. 
+For more details, refer to the non-AD version [`AbruptSoftening`](/AbruptSoftening.md).
+
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i block=Materials/abrupt_softening
+
+`ADAbruptSoftening` must be run in conjunction with the fixed ad smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i block=Materials/elastic_stress
+
+!syntax parameters /Materials/ADAbruptSoftening
+
+!syntax inputs /Materials/ADAbruptSoftening
+
+!syntax children /Materials/ADAbruptSoftening
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADComputeSmearedCrackingStress.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADComputeSmearedCrackingStress.md
@@ -1,0 +1,17 @@
+# AD Compute Smeared Cracking Stress
+
+!syntax description /Materials/ADComputeSmearedCrackingStress
+
+## Description
+Similar to the [`ComputeSmearedCrackingStress`](/ComputeSmearedCrackingStress.md) object
+except that the Jacobian of the internal forces is computed via automatic differentiation.
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.i block=Materials/elastic_stress
+
+!syntax parameters /Materials/ADComputeSmearedCrackingStress
+
+!syntax inputs /Materials/ADComputeSmearedCrackingStress
+
+!syntax children /Materials/ADComputeSmearedCrackingStress

--- a/modules/tensor_mechanics/doc/content/source/materials/ADExponentialSoftening.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADExponentialSoftening.md
@@ -1,0 +1,29 @@
+# AD Exponential Softening
+
+!syntax description /Materials/ADExponentialSoftening
+
+## Description
+
+The material `ADExponentialSoftening` computes the reduced stress and stiffness
+in the direction of a crack according to a exponential function. The computed
+cracked stiffness ratio softens the tensile response of the material once the
+principle stress exceeds the cracking stress threshold of the material. 
+It uses automatic differentiation for the computation of its Jacobian.
+
+For more details, refer to the non-AD version [ExponentialSoftening](/ExponentialSoftening.md).
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i block=Materials/exponential_softening
+
+`ADExponentialSoftening` must be run in conjunction with the ad fixed smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i block=Materials/cracking_stress
+
+!syntax parameters /Materials/ADExponentialSoftening
+
+!syntax inputs /Materials/ADExponentialSoftening
+
+!syntax children /Materials/ADExponentialSoftening
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ADPowerLawSoftening.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ADPowerLawSoftening.md
@@ -1,0 +1,33 @@
+# AD Power Law Softening
+
+!syntax description /Materials/ADPowerLawSoftening
+
+## Description
+
+The material `ADPowerLawSoftening` computes the reduced stress and stiffness along
+the direction of a crack according to a power law equation. The computed
+reduced stiffness softens the tensile response of the material once the principle
+stress applied to a material exceeds the cracking stress threshold of the material. 
+It uses automatic differentiation for the computation of its Jacobian.
+As with the other smeared cracking softening models, which all follow the
+nomenclature convention of using the `Softening` suffix, this model is intended
+to be used with the [ADComputeSmearedCrackingStress](/ADComputeSmearedCrackingStress.md)
+material.
+
+For more details, refer to the non-AD class [PowerLawSoftening](/PowerLawSoftening.md).
+
+## Example Input File
+
+!listing modules/tensor_mechanics/test/tests/smeared_cracking/cracking_power.i block=Materials/power_law_softening
+
+`ADPowerLawSoftening` must be run in conjunction with the ad fixed smeared cracking material model as shown below:
+
+!listing modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_power.i block=Materials/elastic_stress
+
+!syntax parameters /Materials/ADPowerLawSoftening
+
+!syntax inputs /Materials/ADPowerLawSoftening
+
+!syntax children /Materials/ADPowerLawSoftening
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
@@ -25,11 +25,11 @@ public:
 
   virtual void computeCrackingRelease(ADReal & stress,
                                       ADReal & stiffness_ratio,
-                                      const ADReal strain,
-                                      const ADReal crack_initiation_strain,
-                                      const ADReal crack_max_strain,
-                                      const ADReal cracking_stress,
-                                      const ADReal youngs_modulus) override;
+                                      const ADReal & strain,
+                                      const ADReal & crack_initiation_strain,
+                                      const ADReal & crack_max_strain,
+                                      const ADReal & cracking_stress,
+                                      const ADReal & youngs_modulus) override;
 
 protected:
   /// Residual stress after full softening

--- a/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ADSmearedCrackSofteningBase.h"
+
+// Forward declaration
+
+/**
+ * AbruptSoftening is a smeared crack softening model that abruptly
+ * drops the stress upon crack initiation. It is for use with
+ * ComputeSmearedCrackingStress.
+ */
+class ADAbruptSoftening : public ADSmearedCrackSofteningBase
+{
+public:
+  static InputParameters validParams();
+
+  ADAbruptSoftening(const InputParameters & parameters);
+
+  virtual void computeCrackingRelease(ADReal & stress,
+                                      ADReal & stiffness_ratio,
+                                      const ADReal strain,
+                                      const ADReal crack_initiation_strain,
+                                      const ADReal crack_max_strain,
+                                      const ADReal cracking_stress,
+                                      const ADReal youngs_modulus) override;
+
+protected:
+  /// Residual stress after full softening
+  const Real & _residual_stress;
+};

--- a/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADAbruptSoftening.h
@@ -11,12 +11,10 @@
 
 #include "ADSmearedCrackSofteningBase.h"
 
-// Forward declaration
-
 /**
- * AbruptSoftening is a smeared crack softening model that abruptly
- * drops the stress upon crack initiation. It is for use with
- * ComputeSmearedCrackingStress.
+ * ADAbruptSoftening is a smeared crack softening model that abruptly
+ * drops the stress upon crack initiation and relies on automatic
+ * differentiation. It is for use with ADComputeSmearedCrackingStress.
  */
 class ADAbruptSoftening : public ADSmearedCrackSofteningBase
 {

--- a/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
@@ -155,5 +155,5 @@ protected:
 
   /// The user-supplied list of softening models to be used in the 3 crack directions
   /// TODO
-  std::vector<SmearedCrackSofteningBase *> _softening_models;
+  std::vector<ADSmearedCrackSofteningBase *> _softening_models;
 };

--- a/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
@@ -11,7 +11,7 @@
 
 #include "ColumnMajorMatrix.h"
 #include "ADComputeMultipleInelasticStress.h"
-#include "SmearedCrackSofteningBase.h"
+#include "ADSmearedCrackSofteningBase.h"
 #include "Function.h"
 
 /**

--- a/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
@@ -1,0 +1,159 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ColumnMajorMatrix.h"
+#include "ADComputeMultipleInelasticStress.h"
+#include "SmearedCrackSofteningBase.h"
+#include "Function.h"
+
+/**
+ * ComputeSmearedCrackingStress computes the stress for a finite strain
+ * material with smeared cracking
+ */
+class ADComputeSmearedCrackingStress : public ADComputeMultipleInelasticStress
+{
+public:
+  static InputParameters validParams();
+
+  ADComputeSmearedCrackingStress(const InputParameters & parameters);
+
+  virtual void initialSetup() override;
+  virtual void initQpStatefulProperties() override;
+  virtual void computeQpStress() override;
+
+protected:
+  /**
+   * Update the local elasticity tensor (_local_elasticity_tensor)
+   * due to the effects of cracking.
+   */
+  void updateLocalElasticityTensor();
+
+  /**
+   * Update all cracking-related state variables and the stress
+   * tensor due to cracking in all directions.
+   */
+  virtual void updateCrackingStateAndStress();
+
+  /**
+   * Compute the effect of the cracking release model on the stress
+   * and stiffness in the direction of a single crack.
+   * @param i Index of current crack direction
+   * @param sigma Stress in direction of crack
+   * @param stiffness_ratio Ratio of damaged to original stiffness
+   *                        in cracking direction
+   * @param strain_in_crack_dir Strain in the current crack direction
+   * @param cracking_stress Threshold tensile stress for crack initiation
+   * @param cracking_alpha Initial slope of exponential softening model
+   * @param youngs_modulus Young's modulus
+   */
+  virtual void computeCrackingRelease(int i,
+                                      ADReal & sigma,
+                                      ADReal & stiffness_ratio,
+                                      const ADReal strain_in_crack_dir,
+                                      const ADReal cracking_stress,
+                                      const ADReal cracking_alpha,
+                                      const ADReal youngs_modulus);
+
+  /**
+   * Get the number of known crack directions. This includes cracks
+   * in prescribed directions (even if not yet active) and active
+   * cracks in other directions.
+   * @return number of known crack directions
+   */
+  virtual unsigned int getNumKnownCrackDirs() const;
+
+  /**
+   * Compute the crack strain in the crack coordinate system. Also
+   * computes the crack orientations, and stores in _crack_rotation.
+   * @param strain_in_crack_dir Computed strains in crack directions
+   */
+  void computeCrackStrainAndOrientation(ADRealVectorValue & strain_in_crack_dir);
+
+  /**
+   * Updates the full stress tensor to account for the effect of cracking
+   * using the provided stresses in the crack directions. The tensor is
+   * rotated into the crack coordinates, modified, and rotated back.
+   * @param tensor Stress tensor to be updated
+   * @param sigma Vector of stresses in crack directions
+   */
+  void updateStressTensorForCracking(ADRankTwoTensor & tensor, const ADRealVectorValue & sigma);
+
+  /**
+   * Check to see whether there was cracking in any diretion in the previous
+   * time step.
+   * @return true if cracked, false if not cracked
+   */
+  bool previouslyCracked();
+
+  /// Enum defining the crack release model
+  const enum class CrackingRelease { abrupt, exponential, power } _cracking_release;
+
+  ///@{ Input parameters for smeared crack models
+
+  /// Ratio of the residual stress after being fully cracked to the tensile
+  /// cracking threshold stress
+  const ADReal _cracking_residual_stress;
+
+  /// Threshold at which cracking initiates if tensile stress exceeds it
+  const ADVariableValue & _cracking_stress;
+
+  /// User-prescribed cracking directions
+  std::vector<unsigned int> _prescribed_crack_directions;
+
+  /// Maximum number of cracks permitted at a material point
+  const unsigned int _max_cracks;
+
+  /// Defines transition to changed stiffness during unloading
+  const ADReal _cracking_neg_fraction;
+
+  /// Controls slope of exponential softening curve
+  const ADReal _cracking_beta;
+
+  /// Controls the amount of shear retained
+  const ADReal _shear_retention_factor;
+
+  /// Controls the maximum amount that the damaged elastic stress is corrected
+  /// to folow the release model during a time step
+  const ADReal _max_stress_correction;
+  ///@}
+
+  //@{ Damage (goes from 0 to 1) in crack directions
+  ADMaterialProperty<RealVectorValue> & _crack_damage;
+  const MaterialProperty<RealVectorValue> & _crack_damage_old;
+  ///@}
+
+  /// Vector of values going from 1 to 0 as crack damage accumulates. Legacy
+  /// property for backward compatibility -- remove in the future.
+  ADMaterialProperty<RealVectorValue> & _crack_flags;
+
+  //@{ Rotation tensor used to rotate tensors into crack local coordinates
+  ADMaterialProperty<RankTwoTensor> & _crack_rotation;
+  const MaterialProperty<RankTwoTensor> & _crack_rotation_old;
+  ///@}
+
+  //@{ Strain in direction of crack upon crack initiation
+  ADMaterialProperty<RealVectorValue> & _crack_initiation_strain;
+  const MaterialProperty<RealVectorValue> & _crack_initiation_strain_old;
+  ///@}
+
+  //@{ Maximum strain in direction of crack
+  ADMaterialProperty<RealVectorValue> & _crack_max_strain;
+  const MaterialProperty<RealVectorValue> & _crack_max_strain_old;
+  ///@}
+
+  //@{ Variables used by multiple methods within the calculation for a single material point
+  ADRankFourTensor _local_elasticity_tensor;
+  ///@}
+
+  /// The user-supplied list of softening models to be used in the 3 crack directions
+  /// TODO
+  std::vector<SmearedCrackSofteningBase *> _softening_models;
+};

--- a/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
@@ -57,10 +57,10 @@ protected:
   virtual void computeCrackingRelease(int i,
                                       ADReal & sigma,
                                       ADReal & stiffness_ratio,
-                                      const ADReal strain_in_crack_dir,
-                                      const ADReal cracking_stress,
-                                      const ADReal cracking_alpha,
-                                      const ADReal youngs_modulus);
+                                      const ADReal & strain_in_crack_dir,
+                                      const ADReal & cracking_stress,
+                                      const ADReal & cracking_alpha,
+                                      const ADReal & youngs_modulus);
 
   /**
    * Get the number of known crack directions. This includes cracks
@@ -149,10 +149,12 @@ protected:
   const MaterialProperty<RealVectorValue> & _crack_max_strain_old;
   ///@}
 
-  //@{ Variables used by multiple methods within the calculation for a single material point
+  /// Variables used by multiple methods within the calculation for a single material point
   ADRankFourTensor _local_elasticity_tensor;
-  ///@}
 
   /// The user-supplied list of softening models to be used in the 3 crack directions
   std::vector<ADSmearedCrackSofteningBase *> _softening_models;
+
+  /// Vector helper to update local elasticity tensor
+  std::vector<ADReal> _local_elastic_vector;
 };

--- a/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeSmearedCrackingStress.h
@@ -15,7 +15,7 @@
 #include "Function.h"
 
 /**
- * ComputeSmearedCrackingStress computes the stress for a finite strain
+ * ADComputeSmearedCrackingStress computes the stress for a finite strain
  * material with smeared cracking
  */
 class ADComputeSmearedCrackingStress : public ADComputeMultipleInelasticStress
@@ -154,6 +154,5 @@ protected:
   ///@}
 
   /// The user-supplied list of softening models to be used in the 3 crack directions
-  /// TODO
   std::vector<ADSmearedCrackSofteningBase *> _softening_models;
 };

--- a/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
@@ -14,7 +14,8 @@
 /**
  * ExponentialSoftening is a smeared crack softening model that
  * uses an exponential softening curve. It is for use with
- * ComputeSmearedCrackingStress.
+ * ADComputeSmearedCrackingStress and relies on automatic
+ * differentiation.
  */
 class ADExponentialSoftening : public ADSmearedCrackSofteningBase
 {

--- a/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
@@ -26,11 +26,11 @@ public:
 
   virtual void computeCrackingRelease(ADReal & stress,
                                       ADReal & stiffness_ratio,
-                                      const ADReal strain,
-                                      const ADReal crack_initiation_strain,
-                                      const ADReal crack_max_strain,
-                                      const ADReal cracking_stress,
-                                      const ADReal youngs_modulus) override;
+                                      const ADReal & strain,
+                                      const ADReal & crack_initiation_strain,
+                                      const ADReal & crack_max_strain,
+                                      const ADReal & cracking_stress,
+                                      const ADReal & youngs_modulus) override;
 
 protected:
   /// Residual stress after full softening

--- a/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADExponentialSoftening.h
@@ -9,27 +9,27 @@
 
 #pragma once
 
-#include "SmearedCrackSofteningBase.h"
+#include "ADSmearedCrackSofteningBase.h"
 
 /**
  * ExponentialSoftening is a smeared crack softening model that
  * uses an exponential softening curve. It is for use with
  * ComputeSmearedCrackingStress.
  */
-class ExponentialSoftening : public SmearedCrackSofteningBase
+class ADExponentialSoftening : public ADSmearedCrackSofteningBase
 {
 public:
   static InputParameters validParams();
 
-  ExponentialSoftening(const InputParameters & parameters);
+  ADExponentialSoftening(const InputParameters & parameters);
 
-  virtual void computeCrackingRelease(Real & stress,
-                                      Real & stiffness_ratio,
-                                      const Real strain,
-                                      const Real crack_initiation_strain,
-                                      const Real crack_max_strain,
-                                      const Real cracking_stress,
-                                      const Real youngs_modulus) override;
+  virtual void computeCrackingRelease(ADReal & stress,
+                                      ADReal & stiffness_ratio,
+                                      const ADReal strain,
+                                      const ADReal crack_initiation_strain,
+                                      const ADReal crack_max_strain,
+                                      const ADReal cracking_stress,
+                                      const ADReal youngs_modulus) override;
 
 protected:
   /// Residual stress after full softening

--- a/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
@@ -11,12 +11,11 @@
 
 #include "ADSmearedCrackSofteningBase.h"
 
-// Forward declaration
-
 /**
  * ADPowerLawSoftening is a smeared crack softening model that
  * uses a power law equation to soften the tensile response.
- * It is for use with ADComputeSmearedCrackingStress.
+ * It is for use with ADComputeSmearedCrackingStress and uses
+ * automatic differentiation.
  */
 class ADPowerLawSoftening : public ADSmearedCrackSofteningBase
 {

--- a/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
@@ -26,11 +26,11 @@ public:
 
   virtual void computeCrackingRelease(ADReal & stress,
                                       ADReal & stiffness_ratio,
-                                      const ADReal strain,
-                                      const ADReal crack_initiation_strain,
-                                      const ADReal crack_max_strain,
-                                      const ADReal cracking_stress,
-                                      const ADReal youngs_modulus) override;
+                                      const ADReal & strain,
+                                      const ADReal & crack_initiation_strain,
+                                      const ADReal & crack_max_strain,
+                                      const ADReal & cracking_stress,
+                                      const ADReal & youngs_modulus) override;
 
 protected:
   /// Reduction factor applied to the initial stiffness each time a new crack initiates

--- a/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
+++ b/modules/tensor_mechanics/include/materials/ADPowerLawSoftening.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ADSmearedCrackSofteningBase.h"
+
+// Forward declaration
+
+/**
+ * ADPowerLawSoftening is a smeared crack softening model that
+ * uses a power law equation to soften the tensile response.
+ * It is for use with ADComputeSmearedCrackingStress.
+ */
+class ADPowerLawSoftening : public ADSmearedCrackSofteningBase
+{
+public:
+  static InputParameters validParams();
+
+  ADPowerLawSoftening(const InputParameters & parameters);
+
+  virtual void computeCrackingRelease(ADReal & stress,
+                                      ADReal & stiffness_ratio,
+                                      const ADReal strain,
+                                      const ADReal crack_initiation_strain,
+                                      const ADReal crack_max_strain,
+                                      const ADReal cracking_stress,
+                                      const ADReal youngs_modulus) override;
+
+protected:
+  /// Reduction factor applied to the initial stiffness each time a new crack initiates
+  const Real & _stiffness_reduction;
+};

--- a/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
+++ b/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
@@ -41,11 +41,11 @@ public:
    */
   virtual void computeCrackingRelease(ADReal & stress,
                                       ADReal & stiffness_ratio,
-                                      const ADReal strain,
-                                      const ADReal crack_initiation_strain,
-                                      const ADReal crack_max_strain,
-                                      const ADReal cracking_stress,
-                                      const ADReal youngs_modulus) = 0;
+                                      const ADReal & strain,
+                                      const ADReal & crack_initiation_strain,
+                                      const ADReal & crack_max_strain,
+                                      const ADReal & cracking_stress,
+                                      const ADReal & youngs_modulus) = 0;
 
   ///@{ Retained as empty methods to avoid a warning from ADMaterial.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
   void resetQpProperties() final {}

--- a/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
+++ b/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
@@ -13,12 +13,10 @@
 #include "InputParameters.h"
 #include "ADMaterial.h"
 
-// Forward declaration
-
 /**
  * ADSmearedCrackSofteningBase is the base class for a set of models that define the
  * softening behavior of a crack under loading in a given direction.
- * These models are called by ComputeSmearedCrackingStress, so they
+ * These models are called by ADComputeSmearedCrackingStress, so they
  * must have the compute=false flag set in the parameter list.
  */
 class ADSmearedCrackSofteningBase : public ADMaterial

--- a/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
+++ b/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
@@ -1,0 +1,56 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Conversion.h"
+#include "InputParameters.h"
+#include "ADMaterial.h"
+
+// Forward declaration
+
+/**
+ * ADSmearedCrackSofteningBase is the base class for a set of models that define the
+ * softening behavior of a crack under loading in a given direction.
+ * These models are called by ComputeSmearedCrackingStress, so they
+ * must have the compute=false flag set in the parameter list.
+ */
+class ADSmearedCrackSofteningBase : public ADMaterial
+{
+public:
+  static InputParameters validParams();
+
+  ADSmearedCrackSofteningBase(const InputParameters & parameters);
+
+  /**
+   * Compute the effect of the cracking release model on the stress
+   * and stiffness in the direction of a single crack.
+   * @param stress Stress in direction of crack
+   * @param stiffness_ratio Ratio of damaged to original stiffness
+   *                        in cracking direction
+   * @param strain Strain in the current crack direction
+   * @param crack_initiation_strain Strain in crack direction when crack
+   *                                first initiated
+   * @param crack_max_strain Maximum strain in crack direction
+   * @param cracking_stress Threshold tensile stress for crack initiation
+   * @param youngs_modulus Young's modulus
+   */
+  virtual void computeCrackingRelease(ADReal & stress,
+                                      ADReal & stiffness_ratio,
+                                      const ADReal strain,
+                                      const ADReal crack_initiation_strain,
+                                      const ADReal crack_max_strain,
+                                      const ADReal cracking_stress,
+                                      const ADReal youngs_modulus) = 0;
+
+  ///@{ Retained as empty methods to avoid a warning from ADMaterial.C in framework. These methods are unused in all inheriting classes and should not be overwritten.
+  void resetQpProperties() final {}
+  void resetProperties() final {}
+  ///@}
+};

--- a/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
@@ -18,7 +18,8 @@ ADAbruptSoftening::validParams()
 {
   InputParameters params = ADSmearedCrackSofteningBase::validParams();
   params.addClassDescription("Softening model with an abrupt stress release upon cracking. This "
-                             "class is intended to be used with ComputeSmearedCrackingStress.");
+                             "class relies on automatic differentiation and is intended to be used "
+                             "with ADComputeSmearedCrackingStress.");
   params.addRangeCheckedParam<Real>(
       "residual_stress",
       0.0,

--- a/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
@@ -36,11 +36,11 @@ ADAbruptSoftening::ADAbruptSoftening(const InputParameters & parameters)
 void
 ADAbruptSoftening::computeCrackingRelease(ADReal & stress,
                                           ADReal & stiffness_ratio,
-                                          const ADReal /*strain*/,
-                                          const ADReal crack_initiation_strain,
-                                          const ADReal crack_max_strain,
-                                          const ADReal cracking_stress,
-                                          const ADReal youngs_modulus)
+                                          const ADReal & /*strain*/,
+                                          const ADReal & crack_initiation_strain,
+                                          const ADReal & crack_max_strain,
+                                          const ADReal & cracking_stress,
+                                          const ADReal & youngs_modulus)
 {
   if (_residual_stress == 0.0)
   {

--- a/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADAbruptSoftening.C
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADAbruptSoftening.h"
+
+#include "MooseMesh.h"
+
+registerMooseObject("TensorMechanicsApp", ADAbruptSoftening);
+
+InputParameters
+ADAbruptSoftening::validParams()
+{
+  InputParameters params = ADSmearedCrackSofteningBase::validParams();
+  params.addClassDescription("Softening model with an abrupt stress release upon cracking. This "
+                             "class is intended to be used with ComputeSmearedCrackingStress.");
+  params.addRangeCheckedParam<Real>(
+      "residual_stress",
+      0.0,
+      "residual_stress <= 1 & residual_stress >= 0",
+      "The fraction of the cracking stress allowed to be maintained following a crack.");
+  return params;
+}
+
+ADAbruptSoftening::ADAbruptSoftening(const InputParameters & parameters)
+  : ADSmearedCrackSofteningBase(parameters), _residual_stress(getParam<Real>("residual_stress"))
+{
+}
+
+void
+ADAbruptSoftening::computeCrackingRelease(ADReal & stress,
+                                          ADReal & stiffness_ratio,
+                                          const ADReal /*strain*/,
+                                          const ADReal crack_initiation_strain,
+                                          const ADReal crack_max_strain,
+                                          const ADReal cracking_stress,
+                                          const ADReal youngs_modulus)
+{
+  if (_residual_stress == 0.0)
+  {
+    const Real tiny = 1.e-16;
+    stiffness_ratio = tiny;
+    stress = tiny * crack_initiation_strain * youngs_modulus;
+  }
+  else
+  {
+    stress = _residual_stress * cracking_stress;
+    stiffness_ratio = stress / (crack_max_strain * youngs_modulus);
+  }
+}

--- a/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
@@ -1,0 +1,681 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADComputeSmearedCrackingStress.h"
+#include "ElasticityTensorTools.h"
+#include "ADStressUpdateBase.h"
+#include "Conversion.h"
+
+registerMooseObject("TensorMechanicsApp", ADComputeSmearedCrackingStress);
+
+InputParameters
+ADComputeSmearedCrackingStress::validParams()
+{
+  InputParameters params = ADComputeMultipleInelasticStress::validParams();
+  params.addClassDescription("Compute stress using a fixed smeared cracking model");
+  MooseEnum cracking_release("abrupt exponential power", "abrupt");
+  params.addDeprecatedParam<MooseEnum>(
+      "cracking_release",
+      cracking_release,
+      "The cracking release type.  'abrupt' (default) gives an abrupt "
+      "stress release, 'exponential' uses an exponential softening model, "
+      "and 'power' uses a power law",
+      "This is replaced by the use of 'softening_models' together with a separate block defining "
+      "a softening model");
+  params.addParam<std::vector<MaterialName>>(
+      "softening_models",
+      "The material objects used to compute softening behavior for loading a crack."
+      "Either 1 or 3 models must be specified. If a single model is specified, it is"
+      "used for all directions. If 3 models are specified, they will be used for the"
+      "3 crack directions in sequence");
+  params.addDeprecatedParam<Real>(
+      "cracking_residual_stress",
+      0.0,
+      "The fraction of the cracking stress allowed to be maintained following a crack.",
+      "This is replaced by the use of 'softening_models' together with a separate block defining "
+      "a softening model");
+  params.addRequiredCoupledVar(
+      "cracking_stress",
+      "The stress threshold beyond which cracking occurs. Negative values prevent cracking.");
+  MultiMooseEnum direction("x y z");
+  params.addParam<MultiMooseEnum>(
+      "prescribed_crack_directions", direction, "Prescribed directions of first cracks");
+  params.addParam<unsigned int>(
+      "max_cracks", 3, "The maximum number of cracks allowed at a material point.");
+  params.addRangeCheckedParam<Real>("cracking_neg_fraction",
+                                    0,
+                                    "cracking_neg_fraction <= 1 & cracking_neg_fraction >= 0",
+                                    "The fraction of the cracking strain at which "
+                                    "a transition begins during decreasing "
+                                    "strain to the original stiffness.");
+  params.addDeprecatedParam<Real>(
+      "cracking_beta",
+      1.0,
+      "Coefficient used to control the softening in the exponential model.  "
+      "When set to 1, the initial softening slope is equal to the negative "
+      "of the Young's modulus.  Smaller numbers scale down that slope.",
+      "This is replaced by the use of 'softening_models' together with a separate block defining "
+      "a softening model");
+  params.addParam<Real>(
+      "max_stress_correction",
+      1.0,
+      "Maximum permitted correction to the predicted stress as a ratio of the "
+      "stress change to the predicted stress from the previous step's damage level. "
+      "Values less than 1 will improve robustness, but not be as accurate.");
+
+  params.addRangeCheckedParam<Real>(
+      "shear_retention_factor",
+      0.0,
+      "shear_retention_factor>=0 & shear_retention_factor<=1.0",
+      "Fraction of original shear stiffness to be retained after cracking");
+  params.set<std::vector<MaterialName>>("inelastic_models") = {};
+
+  return params;
+}
+
+ADComputeSmearedCrackingStress::ADComputeSmearedCrackingStress(const InputParameters & parameters)
+  : ADComputeMultipleInelasticStress(parameters),
+    _cracking_release(getParam<MooseEnum>("cracking_release").getEnum<CrackingRelease>()),
+    _cracking_residual_stress(getParam<Real>("cracking_residual_stress")),
+    _cracking_stress(adCoupledValue("cracking_stress")),
+    _max_cracks(getParam<unsigned int>("max_cracks")),
+    _cracking_neg_fraction(getParam<Real>("cracking_neg_fraction")),
+    _cracking_beta(getParam<Real>("cracking_beta")),
+    _shear_retention_factor(getParam<Real>("shear_retention_factor")),
+    _max_stress_correction(getParam<Real>("max_stress_correction")),
+    _crack_damage(declareADProperty<RealVectorValue>(_base_name + "crack_damage")),
+    _crack_damage_old(getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_damage")),
+    _crack_flags(declareADProperty<RealVectorValue>(_base_name + "crack_flags")),
+    _crack_rotation(declareADProperty<RankTwoTensor>(_base_name + "crack_rotation")),
+    _crack_rotation_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "crack_rotation")),
+    _crack_initiation_strain(
+        declareADProperty<RealVectorValue>(_base_name + "crack_initiation_strain")),
+    _crack_initiation_strain_old(
+        getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_initiation_strain")),
+    _crack_max_strain(declareADProperty<RealVectorValue>(_base_name + "crack_max_strain")),
+    _crack_max_strain_old(getMaterialPropertyOld<RealVectorValue>(_base_name + "crack_max_strain"))
+{
+  MultiMooseEnum prescribed_crack_directions =
+      getParam<MultiMooseEnum>("prescribed_crack_directions");
+  if (prescribed_crack_directions.size() > 0)
+  {
+    if (prescribed_crack_directions.size() > 3)
+      mooseError("A maximum of three crack directions may be specified");
+    for (unsigned int i = 0; i < prescribed_crack_directions.size(); ++i)
+    {
+      for (unsigned int j = 0; j < i; ++j)
+        if (prescribed_crack_directions[i] == prescribed_crack_directions[j])
+          mooseError("Entries in 'prescribed_crack_directions' cannot be repeated");
+      _prescribed_crack_directions.push_back(
+          static_cast<unsigned int>(prescribed_crack_directions.get(i)));
+    }
+
+    // Fill in the last remaining direction if 2 are specified
+    if (_prescribed_crack_directions.size() == 2)
+    {
+      std::set<unsigned int> available_dirs = {0, 1, 2};
+      for (auto dir : _prescribed_crack_directions)
+        if (available_dirs.erase(dir) != 1)
+          mooseError("Invalid prescribed crack direction:" + Moose::stringify(dir));
+      if (available_dirs.size() != 1)
+        mooseError("Error in finding remaining available crack direction");
+      _prescribed_crack_directions.push_back(*available_dirs.begin());
+    }
+  }
+
+  if (parameters.isParamSetByUser("softening_models"))
+  {
+    if (parameters.isParamSetByUser("cracking_release"))
+      mooseError("In ComputeSmearedCrackingStress cannot specify both 'cracking_release' and "
+                 "'softening_models'");
+    if (parameters.isParamSetByUser("cracking_residual_stress"))
+      mooseError("In ComputeSmearedCrackingStress cannot specify both 'cracking_residual_stress' "
+                 "and 'softening_models'");
+    if (parameters.isParamSetByUser("cracking_beta"))
+      mooseError("In ComputeSmearedCrackingStress cannot specify both 'cracking_beta' and "
+                 "'softening_models'");
+  }
+}
+
+void
+ADComputeSmearedCrackingStress::initQpStatefulProperties()
+{
+  ADComputeMultipleInelasticStress::initQpStatefulProperties();
+
+  _crack_damage[_qp] = 0.0;
+
+  _crack_initiation_strain[_qp] = 0.0;
+  _crack_max_strain[_qp](0) = 0.0;
+
+  switch (_prescribed_crack_directions.size())
+  {
+    case 0:
+    {
+      _crack_rotation[_qp] = ADRankTwoTensor::Identity();
+      break;
+    }
+    case 1:
+    {
+      _crack_rotation[_qp].zero();
+      switch (_prescribed_crack_directions[0])
+      {
+        case 0:
+        {
+          _crack_rotation[_qp](0, 0) = 1.0;
+          _crack_rotation[_qp](1, 1) = 1.0;
+          _crack_rotation[_qp](2, 2) = 1.0;
+          break;
+        }
+        case 1:
+        {
+          _crack_rotation[_qp](1, 0) = 1.0;
+          _crack_rotation[_qp](0, 1) = 1.0;
+          _crack_rotation[_qp](2, 2) = 1.0;
+          break;
+        }
+        case 2:
+        {
+          _crack_rotation[_qp](2, 0) = 1.0;
+          _crack_rotation[_qp](0, 1) = 1.0;
+          _crack_rotation[_qp](1, 2) = 1.0;
+          break;
+        }
+      }
+      break;
+    }
+    case 2:
+    {
+      mooseError("Number of prescribed crack directions cannot be 2");
+      break;
+    }
+    case 3:
+    {
+      for (unsigned int i = 0; i < _prescribed_crack_directions.size(); ++i)
+      {
+        ADRealVectorValue crack_dir_vec;
+        crack_dir_vec(_prescribed_crack_directions[i]) = 1.0;
+        _crack_rotation[_qp].fillColumn(i, crack_dir_vec);
+      }
+    }
+  }
+}
+
+void
+ADComputeSmearedCrackingStress::initialSetup()
+{
+  ADComputeMultipleInelasticStress::initialSetup();
+
+  if (!hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC))
+    mooseError("ComputeSmearedCrackingStress requires that the elasticity tensor be "
+               "guaranteed isotropic");
+
+  std::vector<MaterialName> soft_matls = getParam<std::vector<MaterialName>>("softening_models");
+  if (soft_matls.size() != 0)
+  {
+    for (auto soft_matl : soft_matls)
+    {
+      SmearedCrackSofteningBase * scsb =
+          dynamic_cast<SmearedCrackSofteningBase *>(&getMaterialByName(soft_matl));
+      if (scsb)
+        _softening_models.push_back(scsb);
+      else
+        mooseError("Model " + soft_matl +
+                   " is not a softening model that can be used with ComputeSmearedCrackingStress");
+    }
+    if (_softening_models.size() == 1)
+    {
+      // Reuse the same model in all 3 directions
+      _softening_models.push_back(_softening_models[0]);
+      _softening_models.push_back(_softening_models[0]);
+    }
+    else if (_softening_models.size() != 3)
+      mooseError("If 'softening_models' is specified in ComputeSmearedCrackingStress, either 1 or "
+                 "3 models must be provided");
+  }
+}
+
+void
+ADComputeSmearedCrackingStress::computeQpStress()
+{
+  bool force_elasticity_rotation = false;
+
+  if (!previouslyCracked())
+    computeQpStressIntermediateConfiguration();
+  else
+  {
+    _elastic_strain[_qp] = _elastic_strain_old[_qp] + _strain_increment[_qp];
+
+    // Propagate behavior from the (now inactive) inelastic models
+    _inelastic_strain[_qp] = _inelastic_strain_old[_qp];
+    for (auto model : _models)
+    {
+      model->setQp(_qp);
+      model->propagateQpStatefulProperties();
+    }
+
+    // Since the other inelastic models are inactive, they will not limit the time step
+    _matl_timestep_limit[_qp] = std::numeric_limits<Real>::max();
+
+    // update _local_elasticity_tensor based on cracking state in previous time step
+    updateLocalElasticityTensor();
+
+    // Calculate stress in intermediate configuration
+    _stress[_qp] = _local_elasticity_tensor * _elastic_strain[_qp];
+
+    // TODO: Remove unnecessary stuff like force_elasticity_rotation
+    force_elasticity_rotation = true;
+  }
+
+  // compute crack status and adjust stress
+  updateCrackingStateAndStress();
+
+  if (_perform_finite_strain_rotations)
+  {
+    finiteStrainRotation();
+    _crack_rotation[_qp] = _rotation_increment[_qp] * _crack_rotation[_qp];
+  }
+}
+
+void
+ADComputeSmearedCrackingStress::updateLocalElasticityTensor()
+{
+  const ADReal youngs_modulus =
+      ElasticityTensorTools::getIsotropicYoungsModulus(_elasticity_tensor[_qp]);
+
+  bool cracking_locally_active = false;
+
+  const ADReal cracking_stress = _cracking_stress[_qp];
+
+  if (cracking_stress > 0)
+  {
+    ADRealVectorValue stiffness_ratio_local(1.0, 1.0, 1.0);
+    const ADRankTwoTensor & R = _crack_rotation_old[_qp];
+    ADRankTwoTensor ePrime(_elastic_strain_old[_qp]);
+    ePrime.rotate(R.transpose());
+
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      // Update elasticity tensor based on crack status of the end of last time step
+      if (_crack_damage_old[_qp](i) > 0.0)
+      {
+        if (_cracking_neg_fraction == 0.0 && MooseUtils::absoluteFuzzyLessThan(ePrime(i, i), 0.0))
+          stiffness_ratio_local(i) = 1.0;
+        else if (_cracking_neg_fraction > 0.0 &&
+                 ePrime(i, i) < _crack_initiation_strain_old[_qp](i) * _cracking_neg_fraction &&
+                 ePrime(i, i) > -_crack_initiation_strain_old[_qp](i) * _cracking_neg_fraction)
+        {
+          const ADReal etr = _cracking_neg_fraction * _crack_initiation_strain_old[_qp](i);
+          const ADReal Eo = cracking_stress / _crack_initiation_strain_old[_qp](i);
+          const ADReal Ec = Eo * (1.0 - _crack_damage_old[_qp](i));
+          const ADReal a = (Ec - Eo) / (4 * etr);
+          const ADReal b = (Ec + Eo) / 2;
+          // Compute the ratio of the current transition stiffness to the original stiffness
+          stiffness_ratio_local(i) = (2.0 * a * etr + b) / Eo;
+          cracking_locally_active = true;
+        }
+        else
+        {
+          stiffness_ratio_local(i) = (1.0 - _crack_damage_old[_qp](i));
+          cracking_locally_active = true;
+        }
+      }
+    }
+
+    if (cracking_locally_active)
+    {
+      // Update the elasticity tensor in the crack coordinate system
+      const bool c0_coupled = MooseUtils::absoluteFuzzyEqual(stiffness_ratio_local(0), 1.0);
+      const bool c1_coupled = MooseUtils::absoluteFuzzyEqual(stiffness_ratio_local(1), 1.0);
+      const bool c2_coupled = MooseUtils::absoluteFuzzyEqual(stiffness_ratio_local(2), 1.0);
+
+      const ADReal c01 = (c0_coupled && c1_coupled ? 1.0 : 0.0);
+      const ADReal c02 = (c0_coupled && c2_coupled ? 1.0 : 0.0);
+      const ADReal c12 = (c1_coupled && c2_coupled ? 1.0 : 0.0);
+
+      const ADReal c01_shear_retention = (c0_coupled && c1_coupled ? 1.0 : _shear_retention_factor);
+      const ADReal c02_shear_retention = (c0_coupled && c2_coupled ? 1.0 : _shear_retention_factor);
+      const ADReal c12_shear_retention = (c1_coupled && c2_coupled ? 1.0 : _shear_retention_factor);
+
+      // Filling with 9 components is sufficient because these are the only nonzero entries
+      // for isotropic or orthotropic materials.
+      std::vector<ADReal> local_elastic(9);
+
+      local_elastic[0] = (c0_coupled ? _elasticity_tensor[_qp](0, 0, 0, 0)
+                                     : stiffness_ratio_local(0) * youngs_modulus);
+      local_elastic[1] = _elasticity_tensor[_qp](0, 0, 1, 1) * c01;
+      local_elastic[2] = _elasticity_tensor[_qp](0, 0, 2, 2) * c02;
+      local_elastic[3] = (c1_coupled ? _elasticity_tensor[_qp](1, 1, 1, 1)
+                                     : stiffness_ratio_local(1) * youngs_modulus);
+      local_elastic[4] = _elasticity_tensor[_qp](1, 1, 2, 2) * c12;
+      local_elastic[5] = (c2_coupled ? _elasticity_tensor[_qp](2, 2, 2, 2)
+                                     : stiffness_ratio_local(2) * youngs_modulus);
+      local_elastic[6] = _elasticity_tensor[_qp](1, 2, 1, 2) * c12_shear_retention;
+      local_elastic[7] = _elasticity_tensor[_qp](0, 2, 0, 2) * c02_shear_retention;
+      local_elastic[8] = _elasticity_tensor[_qp](0, 1, 0, 1) * c01_shear_retention;
+
+      _local_elasticity_tensor.fillFromInputVector(local_elastic, ADRankFourTensor::symmetric9);
+
+      // Rotate the modified elasticity tensor back into global coordinates
+      _local_elasticity_tensor.rotate(R);
+    }
+  }
+  if (!cracking_locally_active)
+    _local_elasticity_tensor = _elasticity_tensor[_qp];
+}
+
+void
+ADComputeSmearedCrackingStress::updateCrackingStateAndStress()
+{
+  const ADReal youngs_modulus =
+      ElasticityTensorTools::getIsotropicYoungsModulus(_elasticity_tensor[_qp]);
+  const ADReal cracking_alpha = -youngs_modulus;
+
+  ADReal cracking_stress = _cracking_stress[_qp];
+
+  if (cracking_stress > 0)
+  {
+    // Initializing crack states
+    _crack_rotation[_qp] = _crack_rotation_old[_qp];
+
+    for (unsigned i = 0; i < 3; ++i)
+    {
+      _crack_max_strain[_qp](i) = _crack_max_strain_old[_qp](i);
+      _crack_initiation_strain[_qp](i) = _crack_initiation_strain_old[_qp](i);
+      _crack_damage[_qp](i) = _crack_damage_old[_qp](i);
+    }
+
+    // Compute crack orientations: updated _crack_rotation[_qp] based on current strain
+    ADRealVectorValue strain_in_crack_dir;
+    computeCrackStrainAndOrientation(strain_in_crack_dir);
+
+    for (unsigned i = 0; i < 3; ++i)
+    {
+      if (strain_in_crack_dir(i) > _crack_max_strain[_qp](i))
+        _crack_max_strain[_qp](i) = strain_in_crack_dir(i);
+    }
+
+    // Check for new cracks.
+    // Rotate stress to cracked orientation.
+    const ADRankTwoTensor & R = _crack_rotation[_qp];
+    ADRankTwoTensor sigmaPrime(_stress[_qp]);
+    sigmaPrime.rotate(R.transpose()); // stress in crack coordinates
+
+    unsigned int num_cracks = 0;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      if (_crack_damage_old[_qp](i) > 0.0)
+        ++num_cracks;
+    }
+
+    bool cracked(false);
+    ADRealVectorValue sigma;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      sigma(i) = sigmaPrime(i, i);
+
+      ADReal stiffness_ratio = 1.0 - _crack_damage[_qp](i);
+
+      const bool pre_existing_crack = (_crack_damage_old[_qp](i) > 0.0);
+      const bool met_stress_criterion = (sigma(i) > cracking_stress);
+      const bool loading_existing_crack = (strain_in_crack_dir(i) >= _crack_max_strain[_qp](i));
+      const bool allowed_to_crack = (pre_existing_crack || num_cracks < _max_cracks);
+      bool new_crack = false;
+
+      cracked |= pre_existing_crack;
+
+      // Adjustments for newly created cracks
+      if (met_stress_criterion && !pre_existing_crack && allowed_to_crack)
+      {
+        new_crack = true;
+        ++num_cracks;
+
+        // Assume Poisson's ratio drops to zero for this direction.  Stiffness is then Young's
+        // modulus.
+        _crack_initiation_strain[_qp](i) = cracking_stress / youngs_modulus;
+
+        if (_crack_max_strain[_qp](i) < _crack_initiation_strain[_qp](i))
+          _crack_max_strain[_qp](i) = _crack_initiation_strain[_qp](i);
+      }
+
+      // Update stress and stiffness ratio according to specified crack release model
+      if (new_crack || (pre_existing_crack && loading_existing_crack))
+      {
+        cracked = true;
+        //        // TODO: Take care of AD softening models.
+        //        if (_softening_models.size() != 0)
+        //          _softening_models[i]->computeCrackingRelease(sigma(i),
+        //                                                       stiffness_ratio,
+        //                                                       strain_in_crack_dir(i),
+        //                                                       _crack_initiation_strain[_qp](i),
+        //                                                       _crack_max_strain[_qp](i),
+        //                                                       cracking_stress,
+        //                                                       youngs_modulus);
+        //        else
+        //          computeCrackingRelease(i,
+        //                                 sigma(i),
+        //                                 stiffness_ratio,
+        //                                 strain_in_crack_dir(i),
+        //                                 cracking_stress,
+        //                                 cracking_alpha,
+        //                                 youngs_modulus);
+        //        _crack_damage[_qp](i) = 1.0 - stiffness_ratio;
+      }
+
+      else if (cracked && _cracking_neg_fraction > 0 &&
+               _crack_initiation_strain[_qp](i) * _cracking_neg_fraction > strain_in_crack_dir(i) &&
+               -_crack_initiation_strain[_qp](i) * _cracking_neg_fraction < strain_in_crack_dir(i))
+      {
+        const ADReal etr = _cracking_neg_fraction * _crack_initiation_strain[_qp](i);
+        const ADReal Eo = cracking_stress / _crack_initiation_strain[_qp](i);
+        const ADReal Ec = Eo * (1.0 - _crack_damage_old[_qp](i));
+        const ADReal a = (Ec - Eo) / (4.0 * etr);
+        const ADReal b = 0.5 * (Ec + Eo);
+        const ADReal c = 0.25 * (Ec - Eo) * etr;
+        sigma(i) = (a * strain_in_crack_dir(i) + b) * strain_in_crack_dir(i) + c;
+      }
+    }
+
+    if (cracked)
+      updateStressTensorForCracking(_stress[_qp], sigma);
+  }
+
+  _crack_flags[_qp](0) = 1.0 - _crack_damage[_qp](2);
+  _crack_flags[_qp](1) = 1.0 - _crack_damage[_qp](1);
+  _crack_flags[_qp](2) = 1.0 - _crack_damage[_qp](0);
+}
+
+void
+ADComputeSmearedCrackingStress::computeCrackStrainAndOrientation(
+    ADRealVectorValue & strain_in_crack_dir)
+{
+  // The rotation tensor is ordered such that directions for pre-existing cracks appear first
+  // in the list of columns.  For example, if there is one existing crack, its direction is in the
+  // first column in the rotation tensor.
+  const unsigned int num_known_dirs = getNumKnownCrackDirs();
+
+  if (num_known_dirs == 0)
+  {
+    std::vector<ADReal> eigval(3, 0.0);
+    ADRankTwoTensor eigvec;
+
+    _elastic_strain[_qp].symmetricEigenvaluesEigenvectors(eigval, eigvec);
+
+    // If the elastic strain is beyond the cracking strain, save the eigen vectors as
+    // the rotation tensor. Reverse their order so that the third principal strain
+    // (most tensile) will correspond to the first crack.
+    _crack_rotation[_qp].fillColumn(0, eigvec.column(2));
+    _crack_rotation[_qp].fillColumn(1, eigvec.column(1));
+    _crack_rotation[_qp].fillColumn(2, eigvec.column(0));
+
+    strain_in_crack_dir(0) = eigval[2];
+    strain_in_crack_dir(1) = eigval[1];
+    strain_in_crack_dir(2) = eigval[0];
+  }
+  else if (num_known_dirs == 1)
+  {
+    // This is easily the most complicated case.
+    // 1.  Rotate the elastic strain to the orientation associated with the known
+    //     crack.
+    // 2.  Extract the lower 2x2 block into a separate tensor.
+    // 3.  Run the eigen solver on the result.
+    // 4.  Update the rotation tensor to reflect the effect of the 2 eigenvectors.
+
+    // 1.
+    const ADRankTwoTensor & R = _crack_rotation[_qp];
+    RankTwoTensor ePrime(raw_value(_elastic_strain[_qp]));
+    ePrime.rotate(raw_value(R.transpose())); // elastic strain in crack coordinates
+
+    // 2.
+    ColumnMajorMatrix e2x2(2, 2);
+    e2x2(0, 0) = ePrime(1, 1);
+    e2x2(1, 0) = ePrime(2, 1);
+    e2x2(0, 1) = ePrime(1, 2);
+    e2x2(1, 1) = ePrime(2, 2);
+
+    // 3.
+    ColumnMajorMatrix e_val2x1(2, 1);
+    ColumnMajorMatrix e_vec2x2(2, 2);
+    e2x2.eigen(e_val2x1, e_vec2x2);
+
+    // 4.
+    ADRankTwoTensor eigvec(
+        1.0, 0.0, 0.0, 0.0, e_vec2x2(0, 1), e_vec2x2(1, 1), 0.0, e_vec2x2(0, 0), e_vec2x2(1, 0));
+
+    _crack_rotation[_qp] = _crack_rotation_old[_qp] * eigvec; // Roe implementation
+
+    strain_in_crack_dir(0) = ePrime(0, 0);
+    strain_in_crack_dir(1) = e_val2x1(1, 0);
+    strain_in_crack_dir(2) = e_val2x1(0, 0);
+  }
+  else if (num_known_dirs == 2 || num_known_dirs == 3)
+  {
+    // Rotate to cracked orientation and pick off the strains in the rotated
+    // coordinate directions.
+    const ADRankTwoTensor & R = _crack_rotation[_qp];
+    ADRankTwoTensor ePrime(_elastic_strain[_qp]);
+    ePrime.rotate(R.transpose()); // elastic strain in crack coordinates
+
+    strain_in_crack_dir(0) = ePrime(0, 0);
+    strain_in_crack_dir(1) = ePrime(1, 1);
+    strain_in_crack_dir(2) = ePrime(2, 2);
+  }
+  else
+    mooseError("Invalid number of known crack directions");
+}
+
+unsigned int
+ADComputeSmearedCrackingStress::getNumKnownCrackDirs() const
+{
+  unsigned int num_known_dirs = 0;
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    if (_crack_damage_old[_qp](i) > 0.0 || _prescribed_crack_directions.size() >= i + 1)
+      ++num_known_dirs;
+  }
+  return num_known_dirs;
+}
+
+void
+ADComputeSmearedCrackingStress::computeCrackingRelease(int i,
+                                                       ADReal & sigma,
+                                                       ADReal & stiffness_ratio,
+                                                       const ADReal strain_in_crack_dir,
+                                                       const ADReal cracking_stress,
+                                                       const ADReal cracking_alpha,
+                                                       const ADReal youngs_modulus)
+{
+  switch (_cracking_release)
+  {
+    case CrackingRelease::power:
+    {
+      if (sigma > cracking_stress)
+      {
+        stiffness_ratio /= 3.0;
+        sigma = stiffness_ratio * youngs_modulus * strain_in_crack_dir;
+      }
+      break;
+    }
+    case CrackingRelease::exponential:
+    {
+      const ADReal crack_max_strain = _crack_max_strain[_qp](i);
+      mooseAssert(crack_max_strain >= _crack_initiation_strain[_qp](i),
+                  "crack_max_strain must be >= crack_initiation_strain");
+
+      // Compute stress that follows exponental curve
+      sigma =
+          cracking_stress * (_cracking_residual_stress +
+                             (1.0 - _cracking_residual_stress) *
+                                 std::exp(cracking_alpha * _cracking_beta / cracking_stress *
+                                          (crack_max_strain - _crack_initiation_strain[_qp](i))));
+      // Compute ratio of current stiffness to original stiffness
+      stiffness_ratio =
+          sigma * _crack_initiation_strain[_qp](i) / (crack_max_strain * cracking_stress);
+      break;
+    }
+    case CrackingRelease::abrupt:
+    {
+      if (_cracking_residual_stress == 0)
+      {
+        const Real tiny = 1e-16;
+        stiffness_ratio = tiny;
+        sigma = tiny * _crack_initiation_strain[_qp](i) * youngs_modulus;
+      }
+      else
+      {
+        sigma = _cracking_residual_stress * cracking_stress;
+        stiffness_ratio = sigma / (_crack_max_strain[_qp](i) * youngs_modulus);
+      }
+      break;
+    }
+  }
+
+  if (stiffness_ratio < 0)
+  {
+    std::stringstream err;
+    err << "Negative stiffness ratio: " << i << " " << stiffness_ratio << ", "
+        << _crack_max_strain[_qp](i) << ", " << _crack_initiation_strain[_qp](i) << ", "
+        << std::endl;
+    mooseError(err.str());
+  }
+}
+
+void
+ADComputeSmearedCrackingStress::updateStressTensorForCracking(ADRankTwoTensor & tensor,
+                                                              const ADRealVectorValue & sigma)
+{
+  // Get transformation matrix
+  const ADRankTwoTensor & R = _crack_rotation[_qp];
+  // Rotate to crack frame
+  tensor.rotate(R.transpose());
+
+  // Reset stress if cracked
+  for (unsigned int i = 0; i < 3; ++i)
+    if (_crack_damage[_qp](i) > 0.0)
+    {
+      const ADReal stress_correction_ratio = (tensor(i, i) - sigma(i)) / tensor(i, i);
+      if (stress_correction_ratio > _max_stress_correction)
+        tensor(i, i) *= (1.0 - _max_stress_correction);
+      else if (stress_correction_ratio < -_max_stress_correction)
+        tensor(i, i) *= (1.0 + _max_stress_correction);
+      else
+        tensor(i, i) = sigma(i);
+    }
+
+  // Rotate back to global frame
+  tensor.rotate(R);
+}
+
+bool
+ADComputeSmearedCrackingStress::previouslyCracked()
+{
+  for (unsigned int i = 0; i < 3; ++i)
+    if (_crack_damage_old[_qp](i) > 0.0)
+      return true;
+  return false;
+}

--- a/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
@@ -18,7 +18,8 @@ InputParameters
 ADComputeSmearedCrackingStress::validParams()
 {
   InputParameters params = ADComputeMultipleInelasticStress::validParams();
-  params.addClassDescription("Compute stress using a fixed smeared cracking model");
+  params.addClassDescription(
+      "Compute stress using a fixed smeared cracking model. Uses automatic differentiation");
   MooseEnum cracking_release("abrupt exponential power", "abrupt");
   params.addDeprecatedParam<MooseEnum>(
       "cracking_release",

--- a/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeSmearedCrackingStress.C
@@ -243,7 +243,6 @@ ADComputeSmearedCrackingStress::initialSetup()
 void
 ADComputeSmearedCrackingStress::computeQpStress()
 {
-  bool force_elasticity_rotation = false;
 
   if (!previouslyCracked())
     computeQpStressIntermediateConfiguration();
@@ -268,8 +267,6 @@ ADComputeSmearedCrackingStress::computeQpStress()
     // Calculate stress in intermediate configuration
     _stress[_qp] = _local_elasticity_tensor * _elastic_strain[_qp];
 
-    // TODO: Remove unnecessary stuff like force_elasticity_rotation
-    force_elasticity_rotation = true;
   }
 
   // compute crack status and adjust stress

--- a/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
@@ -1,0 +1,77 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADExponentialSoftening.h"
+
+#include "MooseMesh.h"
+
+registerMooseObject("TensorMechanicsApp", ADExponentialSoftening);
+
+InputParameters
+ADExponentialSoftening::validParams()
+{
+  InputParameters params = ADSmearedCrackSofteningBase::validParams();
+  params.addClassDescription(
+      "Softening model with an exponential softening response upon cracking. This "
+      "class is intended to be used with ComputeSmearedCrackingStress.");
+  params.addRangeCheckedParam<Real>(
+      "residual_stress",
+      0.0,
+      "residual_stress <= 1 & residual_stress >= 0",
+      "The fraction of the cracking stress allowed to be maintained following a crack.");
+  params.addRangeCheckedParam<Real>(
+      "alpha",
+      -1.0,
+      "alpha <= 0",
+      "Initial slope of the exponential softening curve at crack initiation. "
+      "If not specified, it is equal to the negative of the Young's modulus.");
+  params.addRangeCheckedParam<Real>(
+      "beta",
+      1.0,
+      "beta >= 0",
+      "Multiplier applied to alpha to control the exponential softening "
+      "behavior.");
+  return params;
+}
+
+ADExponentialSoftening::ADExponentialSoftening(const InputParameters & parameters)
+  : ADSmearedCrackSofteningBase(parameters),
+    _residual_stress(getParam<Real>("residual_stress")),
+    _alpha(getParam<Real>("alpha")),
+    _alpha_set_by_user(parameters.isParamSetByUser("alpha")),
+    _beta(getParam<Real>("beta"))
+{
+}
+
+void
+ADExponentialSoftening::computeCrackingRelease(ADReal & stress,
+                                               ADReal & stiffness_ratio,
+                                               const ADReal /*strain*/,
+                                               const ADReal crack_initiation_strain,
+                                               const ADReal crack_max_strain,
+                                               const ADReal cracking_stress,
+                                               const ADReal youngs_modulus)
+{
+  mooseAssert(crack_max_strain >= crack_initiation_strain,
+              "crack_max_strain must be >= crack_initiation_strain");
+
+  ADReal alpha = 0.0;
+  if (_alpha_set_by_user)
+    alpha = _alpha;
+  else
+    alpha = -youngs_modulus;
+
+  // Compute stress that follows exponental curve
+  stress = cracking_stress *
+           (_residual_stress +
+            (1.0 - _residual_stress) * std::exp(alpha * _beta / cracking_stress *
+                                                (crack_max_strain - crack_initiation_strain)));
+  // Compute ratio of current stiffness to original stiffness
+  stiffness_ratio = stress * crack_initiation_strain / (crack_max_strain * cracking_stress);
+}

--- a/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
@@ -19,7 +19,8 @@ ADExponentialSoftening::validParams()
   InputParameters params = ADSmearedCrackSofteningBase::validParams();
   params.addClassDescription(
       "Softening model with an exponential softening response upon cracking. This "
-      "class is intended to be used with ComputeSmearedCrackingStress.");
+      "class is intended to be used with ADComputeSmearedCrackingStress and relies on automatic "
+      "differentiation.");
   params.addRangeCheckedParam<Real>(
       "residual_stress",
       0.0,

--- a/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADExponentialSoftening.C
@@ -53,11 +53,11 @@ ADExponentialSoftening::ADExponentialSoftening(const InputParameters & parameter
 void
 ADExponentialSoftening::computeCrackingRelease(ADReal & stress,
                                                ADReal & stiffness_ratio,
-                                               const ADReal /*strain*/,
-                                               const ADReal crack_initiation_strain,
-                                               const ADReal crack_max_strain,
-                                               const ADReal cracking_stress,
-                                               const ADReal youngs_modulus)
+                                               const ADReal & /*strain*/,
+                                               const ADReal & crack_initiation_strain,
+                                               const ADReal & crack_max_strain,
+                                               const ADReal & cracking_stress,
+                                               const ADReal & youngs_modulus)
 {
   mooseAssert(crack_max_strain >= crack_initiation_strain,
               "crack_max_strain must be >= crack_initiation_strain");

--- a/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
@@ -36,11 +36,11 @@ ADPowerLawSoftening::ADPowerLawSoftening(const InputParameters & parameters)
 void
 ADPowerLawSoftening::computeCrackingRelease(ADReal & stress,
                                             ADReal & stiffness_ratio,
-                                            const ADReal strain,
-                                            const ADReal /*crack_initiation_strain*/,
-                                            const ADReal /*crack_max_strain*/,
-                                            const ADReal cracking_stress,
-                                            const ADReal youngs_modulus)
+                                            const ADReal & strain,
+                                            const ADReal & /*crack_initiation_strain*/,
+                                            const ADReal & /*crack_max_strain*/,
+                                            const ADReal & cracking_stress,
+                                            const ADReal & youngs_modulus)
 {
   if (stress > cracking_stress)
   {

--- a/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADPowerLawSoftening.h"
+
+#include "MooseMesh.h"
+
+registerMooseObject("TensorMechanicsApp", ADPowerLawSoftening);
+
+InputParameters
+ADPowerLawSoftening::validParams()
+{
+  InputParameters params = ADSmearedCrackSofteningBase::validParams();
+  params.addClassDescription("Softening model with an abrupt stress release upon cracking. This "
+                             "class is intended to be used with ComputeSmearedCrackingStress.");
+  params.addRequiredRangeCheckedParam<Real>(
+      "stiffness_reduction",
+      "stiffness_reduction <= 1 & stiffness_reduction >= 0",
+      "Factor multiplied by the current stiffness each time a new crack forms");
+  return params;
+}
+
+ADPowerLawSoftening::ADPowerLawSoftening(const InputParameters & parameters)
+  : ADSmearedCrackSofteningBase(parameters),
+    _stiffness_reduction(getParam<Real>("stiffness_reduction"))
+{
+}
+
+void
+ADPowerLawSoftening::computeCrackingRelease(ADReal & stress,
+                                            ADReal & stiffness_ratio,
+                                            const ADReal strain,
+                                            const ADReal /*crack_initiation_strain*/,
+                                            const ADReal /*crack_max_strain*/,
+                                            const ADReal cracking_stress,
+                                            const ADReal youngs_modulus)
+{
+  if (stress > cracking_stress)
+  {
+    // This is equivalent to k = k_0 * (stiffness_reduction)^n, where n is the number of cracks
+    stiffness_ratio *= _stiffness_reduction;
+    stress = stiffness_ratio * youngs_modulus * strain;
+  }
+}

--- a/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
+++ b/modules/tensor_mechanics/src/materials/ADPowerLawSoftening.C
@@ -18,7 +18,8 @@ ADPowerLawSoftening::validParams()
 {
   InputParameters params = ADSmearedCrackSofteningBase::validParams();
   params.addClassDescription("Softening model with an abrupt stress release upon cracking. This "
-                             "class is intended to be used with ComputeSmearedCrackingStress.");
+                             "class is intended to be used with ADComputeSmearedCrackingStress and "
+                             "relies on automatic differentiation.");
   params.addRequiredRangeCheckedParam<Real>(
       "stiffness_reduction",
       "stiffness_reduction <= 1 & stiffness_reduction >= 0",

--- a/modules/tensor_mechanics/src/materials/ADSmearedCrackSofteningBase.C
+++ b/modules/tensor_mechanics/src/materials/ADSmearedCrackSofteningBase.C
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADSmearedCrackSofteningBase.h"
+
+#include "MooseMesh.h"
+
+InputParameters
+ADSmearedCrackSofteningBase::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Calculates the softening behavior in a given crack direction. This "
+                             "class is intended to be used with ADComputeSmearedCrackingStress.");
+  // These models are to be called by another model, so set compute=false
+  params.set<bool>("compute") = false;
+  params.suppressParameter<bool>("compute");
+  return params;
+}
+
+ADSmearedCrackSofteningBase::ADSmearedCrackSofteningBase(const InputParameters & parameters)
+  : ADMaterial(parameters)
+{
+}

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.cmp
@@ -1,0 +1,25 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:             0.1 @ t5
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-4
+	disp_x  # min:               0 @ t1,n1	max:             0.1 @ t5,n5
+	disp_y  # min:               0 @ t1,n1	max:               0 @ t1,n1
+	disp_z  # min:               0 @ t1,n1	max:               0 @ t1,n1
+
+ELEMENT VARIABLES relative 1.e-6 floor 1.e-4
+	stress_xx  # min:               0 @ t1,b1,e1	max:       1365078.9 @ t3,b1,e1
+	stress_yy  # min:               0 @ t1,b1,e1	max:   1.7601769e-28 @ t5,b1,e1
+	stress_zz  # min:               0 @ t1,b1,e1	max:   1.6926718e-28 @ t5,b1,e1
+	stress_xy  # min:               0 @ t1,b1,e1	max:   2.0512872e-11 @ t3,b1,e1
+	stress_yz  # min:               0 @ t1,b1,e1	max:   7.0642738e-29 @ t5,b1,e1
+	stress_zx  # min:               0 @ t1,b1,e1	max:   1.1556548e-12 @ t3,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.i
@@ -1,0 +1,93 @@
+#
+# Simple pull test for cracking.
+# The stress increases for two steps and then drops to zero.
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 1 2 3  4'
+    y = '0 1 0 -1 0'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pull]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = 4
+    function = displ
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 2
+    value = 0.0
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = 3
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 2.8e7
+    poissons_ratio = 0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 1.68e6
+    softening_models = abrupt_softening
+  [../]
+  [./abrupt_softening]
+    type = ADAbruptSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
+  petsc_options_value = '101                asm      lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-8
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 0.1
+  dt = 0.025
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking.i
@@ -72,7 +72,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
   petsc_options_value = '101                asm      lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_deprecated.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_deprecated.i
@@ -68,7 +68,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
   petsc_options_value = '101                asm      lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_deprecated.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_deprecated.i
@@ -1,0 +1,90 @@
+#
+# Simple pull test for cracking.
+# The stress increases for two steps and then drops to zero.
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 1 2 3  4'
+    y = '0 1 0 -1 0'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pull]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = 4
+    function = displ
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 2
+    value = 0.0
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = 3
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 2.8e7
+    poissons_ratio = 0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 1.68e6
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
+  petsc_options_value = '101                asm      lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-8
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 0.1
+  dt = 0.025
+[]
+
+[Outputs]
+  exodus = true
+  file_base = cracking_out
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.cmp
@@ -1,0 +1,25 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               6 @ t301
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-4
+	disp_x  # min:               0 @ t1,n1	max:          0.0035 @ t301,n5
+	disp_y  # min:               0 @ t1,n1	max:         0.00175 @ t301,n5
+	disp_z  # min:               0 @ t1,n1	max:    0.0002100481 @ t20,n5
+
+ELEMENT VARIABLES relative 1.e-6 floor 1.e-1
+	stress_xx  # min:               0 @ t1,b1,e1	max:     1.17458e+08 @ t19,b1,e1
+	stress_yy  # min:               0 @ t1,b1,e1	max:     0.086518747 @ t269,b1,e1
+	stress_zz  # min:               0 @ t1,b1,e1	max:   0.00020735613 @ t11,b1,e1
+	stress_xy  # min:               0 @ t1,b1,e1	max:       348.60403 @ t252,b1,e1
+	stress_yz  # min:               0 @ t1,b1,e1	max:     0.014236508 @ t271,b1,e1
+	stress_zx  # min:               0 @ t1,b1,e1	max:     0.023182835 @ t252,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.i
@@ -1,0 +1,118 @@
+#
+# Test to exercise the exponential stress release
+#
+# Stress vs. strain should show a linear relationship until cracking,
+#   an exponential stress release, a linear relationship back to zero
+#   strain, a linear relationship with the original stiffness in
+#   compression and then back to zero strain, a linear relationship
+#   back to the exponential curve, and finally further exponential
+#   stress release.
+#
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displx]
+    type = PiecewiseLinear
+    x = '0 1       2  3      4 5       6'
+    y = '0 0.00175 0 -0.0001 0 0.00175 0.0035'
+  [../]
+  [./disply]
+    type = PiecewiseLinear
+    x = '0 5 6'
+    y = '0 0 .00175'
+  [../]
+  [./displz]
+    type = PiecewiseLinear
+    x = '0 2 3'
+    y = '0 0 .0035'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pullx]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = 4
+    function = displx
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+  [./fix_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = '11 12'
+    value = 0.0
+  [../]
+  [./move_y]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = '15 16'
+    function = disply
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = '3'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 186.5e9
+    poissons_ratio = .316
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 119.3e6
+    softening_models = exponential_softening
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type'
+  petsc_options_value = '101                lu'
+
+  line_search = 'none'
+  l_max_its = 100
+  l_tol = 1e-6
+
+  nl_max_its = 10
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1.e-4
+
+  start_time = 0.0
+  dt = 0.02
+  dtmin = 0.02
+  num_steps = 300
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential.i
@@ -95,7 +95,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type'
   petsc_options_value = '101                lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential_deprecated.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential_deprecated.i
@@ -1,0 +1,120 @@
+#
+# Test to exercise the exponential stress release
+#
+# Stress vs. strain should show a linear relationship until cracking,
+#   an exponential stress release, a linear relationship back to zero
+#   strain, a linear relationship with the original stiffness in
+#   compression and then back to zero strain, a linear relationship
+#   back to the exponential curve, and finally further exponential
+#   stress release.
+#
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displx]
+    type = PiecewiseLinear
+    x = '0 1       2  3      4 5       6'
+    y = '0 0.00175 0 -0.0001 0 0.00175 0.0035'
+  [../]
+  [./disply]
+    type = PiecewiseLinear
+    x = '0 5 6'
+    y = '0 0 .00175'
+  [../]
+  [./displz]
+    type = PiecewiseLinear
+    x = '0 2 3'
+    y = '0 0 .0035'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pullx]
+    type = ADFunctionDirichletBC
+    #type = FunctionDirichletBC
+    variable = disp_x
+    boundary = 4
+    function = displx
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+
+  [./fix_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = '11 12'
+    value = 0.0
+  [../]
+
+  [./move_y]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = '15 16'
+    function = disply
+  [../]
+
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = '3'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 186.5e9
+    poissons_ratio = .316
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 119.3e6
+    cracking_release = exponential
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type'
+  petsc_options_value = '101                lu'
+
+  line_search = 'none'
+  l_max_its = 100
+  l_tol = 1e-6
+
+  nl_max_its = 10
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1.e-4
+
+  start_time = 0.0
+  dt = 0.02
+  dtmin = 0.02
+  num_steps = 300
+[]
+
+[Outputs]
+  exodus = true
+  file_base = cracking_exponential_out
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential_deprecated.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_exponential_deprecated.i
@@ -96,7 +96,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type'
   petsc_options_value = '101                lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.cmp
@@ -1,0 +1,26 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:             0.2 @ t81
+
+GLOBAL VARIABLES relative 1.e-6 floor 1.e-10
+	elem_crack_flags_x  # min:               0 @ t1	max:               1 @ t2
+	elem_strain_xx      # min:               0 @ t1	max:    0.0029955077 @ t41
+	elem_stress_xx      floor 1.e-9 # min:               0 @ t1	max:       999750.08 @ t21
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-10
+	disp_x  floor 1.e-9 # min:               0 @ t1,n1	max:           0.001 @ t41,n7
+	disp_y  # min:               0 @ t1,n1	max:   7.4709978e-20 @ t23,n8
+
+ELEMENT VARIABLES relative 1.e-6 floor 1.e-10
+	cracking_stress_fn  # min:         1100000 @ t1,b1,e3	max:         1200000 @ t1,b1,e1
+	crack_flags2        # min:               0 @ t1,b1,e1	max:               1 @ t2,b1,e1
+	stress_xx           floor 1.e-3 # min:               0 @ t1,b1,e1	max:       999750.08 @ t21,b1,e3
+	stress_yy           floor 1.e-3 # min:               0 @ t1,b1,e1	max:   2.2790544e-26 @ t22,b1,e3
+	stress_zz           floor 1.e-3 # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1
+	stress_xy           floor 1.e-3 # min:               0 @ t1,b1,e1	max:   1.4363895e-10 @ t22,b1,e2
+	stress_yz           floor 1.e-3 # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1
+	stress_zx           floor 1.e-3 # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1
+	strain_xx           # min:               0 @ t1,b1,e1	max:    0.0029955077 @ t41,b1,e3
+	strain_yy           # min:               0 @ t1,b1,e1	max:   4.5715664e-38 @ t41,b1,e3
+	strain_xy           # min:               0 @ t1,b1,e1	max:   1.3547984e-19 @ t41,b1,e3
+	strain_yz           # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
@@ -1,0 +1,142 @@
+#
+# Simple pull test for cracking. This tests the option to prescribe the
+# cracking strength using an AuxVariable. In this case, an elemental
+# AuxVariable is used, and a function is used to prescribe its value.
+# One of the elements is weaker than the others, so the crack localizes
+# in that element.
+#
+[Mesh]
+   file = plate.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
+[AuxVariables]
+  [./cracking_stress_fn]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./crack_flags2]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 0.1 0.2 0.3 0.4'
+    y = '0 0.001 0 -0.001 0'
+  [../]
+  [./fstress]
+    type = ParsedFunction
+    value = 'if(x > 0.667, 1.1e6, 1.2e6)'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx strain_xx strain_yy strain_xy strain_yz'
+  [../]
+[]
+
+[AuxKernels]
+  [./cracking_stress_fn]
+    type = FunctionAux
+    variable = cracking_stress_fn
+    function = fstress
+    execute_on = initial
+  [../]
+  [./crack_flags2]
+    type = ADMaterialRealVectorValueAux
+    property = crack_flags
+    variable = crack_flags2
+   component = 2
+  [../]
+[]
+
+[BCs]
+  [./pull]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = '3 4'
+    function = displ
+  [../]
+
+  [./pin_x]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary =  '1 2'
+    value = 0
+  [../]
+  [./pin_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = '1 4'
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 200.0e7
+    poissons_ratio = 0.0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = cracking_stress_fn
+    softening_models = abrupt_softening
+  [../]
+  [./abrupt_softening]
+    type = ADAbruptSoftening
+    residual_stress = 0.0
+  [../]
+[]
+
+[Postprocessors]
+  [./elem_stress_xx]
+    type = ElementalVariableValue
+    variable = stress_xx
+    elementid = 2
+  [../]
+  [./elem_strain_xx]
+    type = ElementalVariableValue
+    variable = strain_xx
+    elementid = 2
+  [../]
+  [./elem_crack_flags_x]
+    type = ElementalVariableValue
+    variable = crack_flags2
+    elementid = 2
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+
+  petsc_options_iname = '-ksp_gmres_restart'
+  petsc_options_value = '101               '
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-6
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 0.2
+  dt = 0.0025
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
@@ -119,8 +119,7 @@
 
 [Executioner]
   type = Transient
-
-  solve_type = PJFNK
+  solve_type = Newton
 
   petsc_options_iname = '-ksp_gmres_restart'
   petsc_options_value = '101               '

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_function.i
@@ -41,6 +41,7 @@
     strain = FINITE
     add_variables = true
     generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx strain_xx strain_yy strain_xy strain_yz'
+    use_automatic_differentiation = true
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_multiple_softening.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_multiple_softening.i
@@ -1,0 +1,133 @@
+# Test of cracking with direction-specific release models in 3
+# directions. Block is first pulled in one direction, and then
+# held while it is sequentially pulled in the other two
+# directions. Poisson's ratio is zero so that the cracking in one
+# direction doesn't affect the others.
+
+# Softening in the three directions should follow the laws for the
+# prescribed models in the three directions, which are power law (x),
+# exponential (y), and abrupt (z).
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 1
+  nz = 1
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displx]
+    type = PiecewiseLinear
+    x = '0 1 2 3'
+    y = '0 1 1 1'
+  [../]
+  [./disply]
+    type = PiecewiseLinear
+    x = '0 1 2 3'
+    y = '0 0 1 1'
+  [../]
+  [./displz]
+    type = PiecewiseLinear
+    x = '0 1 2 3'
+    y = '0 0 0 1'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pullx]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = right
+    function = displx
+  [../]
+  [./pully]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = top
+    function = disply
+  [../]
+  [./pullz]
+    type = ADFunctionDirichletBC
+    variable = disp_z
+    boundary = front
+    function = displz
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = back
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 2.8e7
+    poissons_ratio = 0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 1.68e6
+    softening_models = 'power_law_softening exponential_softening abrupt_softening'
+    prescribed_crack_directions = 'x y z'
+  [../]
+  [./power_law_softening]
+    type = ADPowerLawSoftening
+    stiffness_reduction = 0.3333
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+  [../]
+  [./abrupt_softening]
+    type = ADAbruptSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
+  petsc_options_value = '101                asm      lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-8
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 3.0
+  dt = 0.01
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_multiple_softening.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_multiple_softening.i
@@ -112,7 +112,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
   petsc_options_value = '101                asm      lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_plane_stress.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_plane_stress.i
@@ -110,9 +110,7 @@
 
 [Executioner]
   type = Transient
-  #Preconditioned JFNK (default)
-  solve_type = 'PJFNK'
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
   petsc_options_value = '101                asm      lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_plane_stress.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_plane_stress.i
@@ -1,0 +1,133 @@
+################################################################################
+#
+# 1x1x1 cube, single element
+# simulate plane stress
+# pull in +y direction on right surface to produce shear strain
+#
+#
+#
+#          ____________
+#         /|          /|
+#        / |  5      / |                       -X  Left   1
+#       /__________ /  |                       +X  Right  4
+#      |   |    3  |   |                       +Y  Top    5
+#      | 1 |       | 4 |                       -Y  Bottom 2
+#      |   |_6_____|___|           y           +Z  Front  6
+#      |  /        |  /            ^           -Z  Back   3
+#      | /    2    | /             |
+#      |/__________|/              |
+#                                  ----> x
+#                                 /
+#                                /
+#                               z
+#
+#
+#
+#################################################################################
+
+[Mesh]
+  file = cube.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 0.1 0.2 0.3 0.4'
+    y = '0 0.0026 0 -0.0026 0'
+  [../]
+  [./pressure]
+    type = PiecewiseLinear
+    x = '0 0.1 0.2 0.3 0.4'
+    y = '0 0   0    0   0'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pull_y]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = 4
+    function = displ
+  [../]
+  [./pin_x]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = '1  4'
+    value = 0.0
+  [../]
+  [./pin_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 1
+    value = 0.0
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = '3'
+    value = 0.0
+  [../]
+  [./front]
+    type = ADPressure
+    variable = disp_z
+    component = 2
+    boundary = 6
+    function = pressure
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 200.0e3
+    poissons_ratio = .3
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 120
+    shear_retention_factor = 0.1
+    softening_models = exponential_softening
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+    residual_stress = 0.1
+    beta = 0.1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  #Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
+  petsc_options_value = '101                asm      lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-8
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 0.4
+  dt = 0.04
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_pln_str.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_pln_str.cmp
@@ -1,0 +1,25 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:             0.4 @ t11
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-4
+	disp_x  # min:               0 @ t1,n1	max:               0 @ t1,n1
+	disp_y  # min:               0 @ t1,n1	max:         0.00208 @ t8,n5
+	disp_z  # min:               0 @ t1,n1	max:   0.00044581335 @ t9,n1
+
+ELEMENT VARIABLES relative 1.e-6 floor 1.e-4
+	stress_xx  # min:               0 @ t1,b1,e1	max:       58.103902 @ t4,b1,e1
+	stress_yy  # min:               0 @ t1,b1,e1	max:       58.103902 @ t4,b1,e1
+	stress_zz  # min:               0 @ t1,b1,e1	max:   1.6385656e-09 @ t4,b1,e1
+	stress_xy  # min:               0 @ t1,b1,e1	max:       170.46728 @ t4,b1,e1
+	stress_yz  # min:               0 @ t1,b1,e1	max:   1.1013647e-14 @ t9,b1,e1
+	stress_zx  # min:               0 @ t1,b1,e1	max:   9.1896436e-15 @ t9,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_power.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_power.i
@@ -80,7 +80,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
   petsc_options_value = '101                asm      lu'
 

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_power.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_power.i
@@ -1,0 +1,101 @@
+#
+# Simple test of power law softening law for smeared cracking.
+# Upon reaching the failure stress in the x direction, the
+# softening model abruptly reduces the stress to a fraction
+# of its original value, and re-loading occurs at a reduced
+# stiffness. This is repeated multiple times.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 1
+  nz = 1
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 1 2 3  4'
+    y = '0 1 0 -1 0'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pull]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = right
+    function = displ
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0.0
+  [../]
+  [./back]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = back
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 2.8e7
+    poissons_ratio = 0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 1.68e6
+    softening_models = power_law_softening
+  [../]
+  [./power_law_softening]
+    type = ADPowerLawSoftening
+    stiffness_reduction = 0.3333
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type'
+  petsc_options_value = '101                asm      lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-8
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 1.0
+  dt = 0.01
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.cmp
@@ -1,0 +1,24 @@
+COORDINATES absolute 1.e-6
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:             110 @ t111
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-10
+	disp_x  # min:               0 @ t1,n1	max:             2.1 @ t111,n3
+	disp_y  # min:               0 @ t1,n1	max:               1 @ t106,n8
+	disp_z  # min:               0 @ t1,n1	max:               0 @ t1,n1
+
+ELEMENT VARIABLES relative 1.e-5 floor 1.e-10
+	crack_flags1  # min:               0 @ t1,b1,e1	max:               1 @ t2,b1,e1
+	crack_flags2  # min:               0 @ t1,b1,e1	max:               1 @ t2,b1,e1
+	crack_flags3  # min:               0 @ t1,b1,e1	max:               1 @ t2,b1,e1
+	stress_xx     floor 1.e-2 # min:               0 @ t1,b1,e1	max:   2.2029254e+09 @ t106,b1,e1
+	stress_yy     floor 1.e-2 # min:               0 @ t1,b1,e1	max:     4.51333e+09 @ t4,b1,e1
+	stress_zz     floor 1.e-2 # min:               0 @ t1,b1,e1	max:   8.6499032e-17 @ t101,b1,e1
+	stress_xy     floor 1.e-2 # min:               0 @ t1,b1,e1	max:   0.00019602985 @ t58,b1,e1
+	stress_yz     floor 1.e-2 # min:               0 @ t1,b1,e1	max:    0.0003086898 @ t26,b1,e1
+	stress_zx     floor 1.e-2 # min:               0 @ t1,b1,e1	max:   0.00011675393 @ t26,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i
@@ -144,7 +144,7 @@
 
 [Executioner]
   type = Transient
-
+  solve_type = Newton
   petsc_options_iname = '-ksp_gmres_restart -pc_type'
   petsc_options_value = '101                lu'
   line_search = 'none'

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rotation.i
@@ -1,0 +1,195 @@
+# This test is to ensure that the smeared cracking model correctly handles finite
+# rotation of cracked elements.
+
+# This consists of a single element that is first  subjected to tensile loading
+# in the y-direction via a prescribed displacement. This loading is sufficiently
+# high to crack the material in that direction, but not completely unload. The
+# prescribed displacement is then reversed so that the element is returned to its
+# original configuration.
+
+# In the next phase of the analysis, this element is then rotated 90 degrees by
+# prescribing the displacement of the bottom of the element. The prescribed
+# displacement BC used to crack the element in the first phase is deactivated.
+
+# Once the element is fully rotated, a new BC is activated on what was originally
+# the top surface (but is now the surface on the right hand side) to pull in
+# the x-direction.
+
+# If everything is working correctly, the model should re-load on the original
+# crack (which should be rotated along with the elemnent) up to the peak stress
+# in the first phase of the analysis, and then continue the unloading process
+# as the crack strains continue to increase. Throughout this analysis, there should
+# only be a single crack, as manifested in the crack_flags variables.
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[AuxVariables]
+  [./crack_flags1]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./crack_flags2]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./crack_flags3]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  [./crack_flags1]
+    type = ADMaterialRealVectorValueAux
+    property = crack_flags
+    variable = crack_flags1
+    component = 0
+  [../]
+  [./crack_flags2]
+    type = ADMaterialRealVectorValueAux
+    property = crack_flags
+    variable = crack_flags2
+    component = 1
+  [../]
+  [./crack_flags3]
+    type = ADMaterialRealVectorValueAux
+    property = crack_flags
+    variable = crack_flags3
+    component = 2
+  [../]
+[]
+
+[BCs]
+  [./x_pin]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = '15 16'
+    value = 0.0
+  [../]
+  [./y_pin]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = '15 16'
+    value = 0.0
+  [../]
+  [./z_all]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = '11 12 13 14 15 16 17 18'
+    value = 0.0
+  [../]
+  [./x_lb]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = '11 12'
+    function = 'if(t<10,0,if(t>=100,1,1-cos((t-10)*pi/180)))'
+  [../]
+  [./y_lb]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = '11 12'
+    function = 'if(t<10,0,if(t>=100,1,sin((t-10)*pi/180)))'
+  [../]
+  [./x_lt]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = '13 14'
+    function = '2+(t-100)*0.01'
+  [../]
+  [./x_rt]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = '17 18'
+    function = '1+(t-100)*0.01'
+  [../]
+  [./top_pull]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = '13 14 17 18'
+    function = 'if(t<5,t*0.01,0.05-(t-5)*0.01)'
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 100.e9
+    poissons_ratio = 0.
+  [../]
+  [./cracking_stress]
+    type = ADComputeSmearedCrackingStress
+    shear_retention_factor = 0.1
+    cracking_stress = 3.e9
+    softening_models = exponential_softening
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type'
+  petsc_options_value = '101                lu'
+  line_search = 'none'
+
+  l_max_its = 100
+  l_tol = 1e-5
+
+  nl_max_its = 100
+  nl_abs_tol = 1e-5
+  nl_rel_tol = 1e-12
+
+  start_time = 0
+  end_time = 110
+  dt = 1
+[]
+
+[Controls]
+  [./p1]
+    type = TimePeriod
+    start_time = 0.0
+    end_time = 10.0
+    disable_objects = 'BCs/x_lt BCs/x_rt'
+    enable_objects = 'BCs/top_pull'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+  [../]
+  [./p2]
+    type = TimePeriod
+    start_time = 10.0
+    end_time = 101.0
+    disable_objects = 'BCs/x_lt BCs/x_rt BCs/top_pull'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+  [../]
+  [./p3]
+    type = TimePeriod
+    start_time = 101.0
+    end_time = 110.0
+    enable_objects = 'BCs/x_lt BCs/x_rt'
+    disable_objects = 'BCs/top_pull'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.cmp
@@ -1,0 +1,19 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 1.0e-8
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES
+	disp_x relative 1.e-6 floor 1.e-4
+	disp_y relative 1.e-6 floor 1.e-4
+ELEMENT VARIABLES 
+	stress_xx relative 1.e-6 floor 1.e-4
+	stress_yy relative 1.e-6 floor 1.e-4 
+	stress_zz relative 1.e-6 floor 1.e-4
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i
@@ -1,0 +1,94 @@
+#
+
+[Mesh]
+  file = cracking_rz_test.e
+[]
+
+[Problem]
+  coord_type = RZ
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
+[Functions]
+  [./displ]
+    type = PiecewiseLinear
+    x = '0 1 2 3  4'
+    y = '0 1 0 -1 0'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pull]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = 2
+    function = displ
+  [../]
+  [./left]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 3
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 4.0e7
+    poissons_ratio = 0.0
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 1.68e6
+    softening_models = abrupt_softening
+  [../]
+  [./abrupt_softening]
+    type = ADAbruptSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+
+
+  petsc_options_iname = '-ksp_gmres_restart'
+  petsc_options_value = '101               '
+
+
+  line_search = 'none'
+
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-2
+  l_tol = 1e-5
+  start_time = 0.0
+  end_time = 0.1
+  dt = 0.025
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz.i
@@ -68,16 +68,12 @@
 
 [Executioner]
   type = Transient
-
-  solve_type = PJFNK
-
+  solve_type = Newton
 
   petsc_options_iname = '-ksp_gmres_restart'
   petsc_options_value = '101               '
 
-
   line_search = 'none'
-
 
   l_max_its = 100
   nl_max_its = 100

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exp.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exp.cmp
@@ -1,0 +1,24 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               6 @ t1202
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-4
+	disp_x  # min:               0 @ t1,n1	max:   0.00020452287 @ t75,n2
+	disp_y  # min:               0 @ t1,n1	max:          0.0035 @ t1202,n2
+
+ELEMENT VARIABLES relative 1.e-6 floor 5.e-3
+	stress_xx  # min:               0 @ t1,b1,e1	max:   0.00011799418 @ t46,b1,e1
+	stress_yy  # min:               0 @ t1,b1,e1	max:   1.1908885e+08 @ t74,b1,e1
+	stress_zz  # min:               0 @ t1,b1,e1	max:   0.00011799428 @ t46,b1,e1
+	stress_xy  # min:               0 @ t1,b1,e1	max:     1.40819e-09 @ t56,b1,e1
+	stress_yz  # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1
+	stress_zx  # min:               0 @ t1,b1,e1	max:               0 @ t1,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exponential.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exponential.i
@@ -1,0 +1,103 @@
+#
+# Test to exercise the exponential stress release
+#
+# Stress vs. strain should show a linear relationship until cracking,
+#   an exponential stress release, a linear relationship back to zero
+#   strain, a linear relationship with the original stiffness in
+#   compression and then back to zero strain, a linear relationship
+#   back to the exponential curve, and finally further exponential
+#   stress release.
+
+[Mesh]
+  file = cracking_rz_test.e
+[]
+
+[Problem]
+  coord_type = RZ
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y'
+[]
+
+[Functions]
+  [./disply]
+    type = PiecewiseLinear
+    x = '0 1       2  3      4 5       6'
+    y = '0 0.00175 0 -0.0001 0 0.00175 0.0035'
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./pully]
+    type = ADFunctionDirichletBC
+    variable = disp_y
+    boundary = 4
+    function = disply
+  [../]
+  [./bottom]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 3
+    value = 0.0
+  [../]
+
+  [./sides]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 186.5e9
+    poissons_ratio = 0.316
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 119.3e6
+    softening_models = exponential_softening
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'PJFNK'
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type'
+  petsc_options_value = '101                lu'
+
+  line_search = 'none'
+  l_max_its = 100
+  l_tol = 1e-5
+
+  nl_max_its = 10
+  nl_rel_tol = 1e-8
+
+  nl_abs_tol = 1e-4
+
+  start_time = 0.0
+  end_time = 6.0
+  dt = 0.005
+  dtmin = 0.005
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exponential.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_exponential.i
@@ -77,8 +77,7 @@
 
 [Executioner]
   type = Transient
-
-  solve_type = 'PJFNK'
+  solve_type = Newton
 
   petsc_options_iname = '-ksp_gmres_restart -pc_type'
   petsc_options_value = '101                lu'

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_test.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_rz_test.e
@@ -1,0 +1,1 @@
+../smeared_cracking/cracking_rz_test.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_test.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_test.e
@@ -1,0 +1,1 @@
+../smeared_cracking/cracking_test.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.cmp
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.cmp
@@ -1,0 +1,25 @@
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:               3 @ t302
+
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 1.e-4
+	disp_x  # min:               0 @ t1,n1	max:         0.00175 @ t101,n5
+	disp_y  # min:               0 @ t1,n1	max:      0.00175875 @ t201,n4
+	disp_z  # min:               0 @ t1,n1	max:       0.0017675 @ t302,n5
+
+ELEMENT VARIABLES relative 1.e-3 floor 1.e-3
+	stress_xx  # min:               0 @ t1,b1,e1	max:   1.1788874e+08 @ t38,b1,e1
+	stress_yy  # min:               0 @ t1,b1,e1	max:   1.3048802e+08 @ t136,b1,e1
+	stress_zz  # min:               0 @ t1,b1,e1	max:   1.6589566e+08 @ t236,b1,e1
+	stress_xy  # min:               0 @ t1,b1,e1	max:   1.5506955e-08 @ t136,b1,e1
+	stress_yz  # min:               0 @ t1,b1,e1	max:   7.9004763e-09 @ t137,b1,e1
+	stress_zx  # min:               0 @ t1,b1,e1	max:   8.0138776e-10 @ t28,b1,e1
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.i
@@ -1,0 +1,151 @@
+#
+
+[Mesh]
+  file = cracking_test.e
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Functions]
+  [./displx]
+    type = PiecewiseLinear
+    x = '0 1'
+    y = '0 0.00175'
+  [../]
+  [./velocity_y]
+    type = ParsedFunction
+    value = 'if(t < 2, 0.00175, 0)'
+  [../]
+  [./velocity_z]
+    type = ParsedFunction
+    value = 0.00175
+  [../]
+[]
+
+[Modules/TensorMechanics/Master]
+  [./all]
+    strain = FINITE
+    add_variables = true
+    generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_zx'
+    use_automatic_differentiation = true
+  [../]
+[]
+
+[BCs]
+  [./fix_x]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  [../]
+  [./move_x]
+    type = ADFunctionDirichletBC
+    variable = disp_x
+    boundary = 4
+    function = displx
+  [../]
+
+  [./fix_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 2
+    value = 0.0
+  [../]
+  [./move_y]
+    type = PresetVelocity
+    variable = disp_y
+    boundary = 5
+    function = velocity_y
+#    time_periods = 'p2 p3'
+  [../]
+
+  [./fix_z]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = 3
+    value = 0.0
+  [../]
+  [./move_z]
+    type = PresetVelocity
+    variable = disp_z
+    boundary = 6
+    function = velocity_z
+#    time_periods = 'p3'
+  [../]
+[]
+
+[Materials]
+  [./elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 186.5e9
+    poissons_ratio = .316
+  [../]
+  [./elastic_stress]
+    type = ADComputeSmearedCrackingStress
+    cracking_stress = 119.3e6
+    softening_models = exponential_softening
+  [../]
+  [./exponential_softening]
+    type = ADExponentialSoftening
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  petsc_options_iname = '-ksp_gmres_restart -pc_type'
+  petsc_options_value = '101                lu'
+
+
+  line_search = 'none'
+
+
+  l_max_its = 100
+  l_tol = 1e-5
+
+  nl_max_its = 100
+  nl_abs_tol = 1e-4
+  #nl_rel_tol = 1e-4
+  nl_rel_tol = 1e-6
+
+  start_time = 0.0
+  end_time = 3.0
+  dt = 0.01
+[]
+
+[Controls]
+  [./p1]
+    type = TimePeriod
+    start_time = 0.0
+    end_time = 1.0
+    disable_objects = 'BCs/move_y BCs/move_z'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+  [../]
+
+  [./p2]
+    type = TimePeriod
+    start_time = 1.0
+    end_time = 2.0
+    disable_objects = 'BCs/move_z'
+    enable_objects = 'BCs/move_y'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+  [../]
+
+  [./p3]
+    type = TimePeriod
+    start_time = 2.0
+    end_time = 3.0
+    enable_objects = 'BCs/move_y BCs/move_z'
+    reverse_on_false = false
+    execute_on = 'initial timestep_begin'
+    set_sync_times = true
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.i
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cracking_xyz.i
@@ -94,6 +94,7 @@
 
 [Executioner]
   type = Transient
+  solve_type = Newton
 
   petsc_options_iname = '-ksp_gmres_restart -pc_type'
   petsc_options_value = '101                lu'

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cube.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/cube.e
@@ -1,0 +1,1 @@
+../smeared_cracking/cube.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_exponential_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_exponential_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_exponential_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_function_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_function_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_function_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_multiple_softening_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_multiple_softening_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_multiple_softening_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_plane_stress_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_plane_stress_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_plane_stress_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_power_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_power_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_power_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rotation_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rotation_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_rotation_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rz_exponential_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rz_exponential_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_rz_exponential_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rz_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_rz_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_rz_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_xyz_out.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/gold/cracking_xyz_out.e
@@ -1,0 +1,1 @@
+../../smeared_cracking/gold/cracking_xyz_out.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/plate.e
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/plate.e
@@ -1,0 +1,1 @@
+../smeared_cracking/plate.e

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
@@ -1,6 +1,6 @@
 [Tests]
-design = 'source/materials/ComputeSmearedCrackingStress.md'
-issues = '#6815 #9227'
+design = 'source/materials/ADComputeSmearedCrackingStress.md'
+issues = '#6815 #9227 #15311'
   [./cracking]
     type = Exodiff
     input = cracking.i

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
@@ -1,0 +1,132 @@
+[Tests]
+design = 'source/materials/ComputeSmearedCrackingStress.md'
+issues = '#6815 #9227'
+  [./cracking]
+    type = Exodiff
+    input = cracking.i
+    exodiff = cracking_out.e
+    custom_cmp = cracking.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate cracking on a specimen under tension in cartesian coordinates using AD and match non-AD methods.'
+  [../]
+  [./cracking_deprecated]
+    type = Exodiff
+    input = cracking_deprecated.i
+    exodiff = cracking_out.e
+    custom_cmp = cracking.cmp
+    prereq = cracking
+    allow_deprecated = true
+    requirement = 'The MOOSE TensorMechanics module shall simulate cracking on a specimen under tension in cartesian coordinates using the deprecated input file using AD and match non-AD methods.'
+  [../]
+  [./cracking_rz]
+    type = Exodiff
+    input = cracking_rz.i
+    exodiff = cracking_rz_out.e
+    custom_cmp = cracking_rz.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate cracking on a specimen under tension in rz coordinates using AD and match non-AD methods.'
+  [../]
+  [./cracking_function]
+    type = Exodiff
+    input = cracking_function.i
+    exodiff = cracking_function_out.e
+    custom_cmp = cracking_function.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate cracking while the cracking strength is prescribed by an elemental AuxVariable using AD and match non-AD methods.'
+  [../]
+  [./exponential]
+    type = Exodiff
+    input = cracking_exponential.i
+    exodiff = cracking_exponential_out.e
+    custom_cmp = cracking_exponential.cmp
+    use_old_floor = true
+    requirement = 'The MOOSE TensorMechanics module shall simulate exponential stress release using AD and match non-AD methods.'
+  [../]
+  [./exponential_deprecated]
+    type = Exodiff
+    input = cracking_exponential.i
+    exodiff = cracking_exponential_out.e
+    custom_cmp = cracking_exponential.cmp
+    use_old_floor = true
+    prereq = exponential
+    allow_deprecated = true
+    requirement = 'The MOOSE TensorMechanics module shall simulate exponential stress relase, using the deprecated input file using AD and match non-AD methods.'
+  [../]
+  [./rz_exponential]
+    type = Exodiff
+    input = cracking_rz_exponential.i
+    exodiff = cracking_rz_exponential_out.e
+    custom_cmp = cracking_rz_exp.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate exponential stress relase while using the rz coordinate system using AD and match non-AD methods.'
+  [../]
+  [./power]
+    type = Exodiff
+    input = cracking_power.i
+    exodiff = cracking_power_out.e
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate softening using the power law for smeared cracking using AD and match non-AD methods.'
+  [../]
+  [./multiple_softening]
+    type = Exodiff
+    input = cracking_multiple_softening.i
+    exodiff = cracking_multiple_softening_out.e
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate the prescribed softening laws in three directions, power law (x), exponential (y), and abrupt (z) using AD and match non-AD methods.'
+  [../]
+  [./xyz]
+    type = Exodiff
+    input = cracking_xyz.i
+    exodiff = cracking_xyz_out.e
+    use_old_floor = true
+    custom_cmp = cracking_xyz.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate smeared cracking in the x y and z directions using AD and match non-AD methods.'
+  [../]
+  [./plane_stress]
+    type = Exodiff
+    input = cracking_plane_stress.i
+    exodiff = cracking_plane_stress_out.e
+    use_old_floor = true
+    custom_cmp = cracking_pln_str.cmp
+    requirement = 'The MOOSE TensorMechanics module shall simulate smeared cracking under plane stress conditions using AD and match non-AD methods.'
+  [../]
+  [./cracking_rotation]
+    type = Exodiff
+    input = cracking_rotation.i
+    exodiff = cracking_rotation_out.e
+    use_old_floor = true
+    custom_cmp = cracking_rotation.cmp
+    max_parallel = 1
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate that the smeared cracking model correctly handles finite rotation of cracked elements using AD and match non-AD methods.'
+  [../]
+  [./cracking_rotation_pres_dir_x]
+    type = Exodiff
+    input = cracking_rotation.i
+    exodiff = cracking_rotation_out.e
+    use_old_floor = true
+    custom_cmp = cracking_rotation.cmp
+    #Prescribe the first crack to be in x (which doesn't crack), and reorder crack_flags to match original case
+    cli_args = 'Materials/cracking_stress/prescribed_crack_directions=x AuxKernels/crack_flags3/component=1 AuxKernels/crack_flags2/component=2'
+    max_parallel = 1
+    prereq = cracking_rotation
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate the finite rotation of cracked elements where the crack is prescribed in x using AD and match non-AD methods.'
+  [../]
+  [./cracking_rotation_pres_dir_z]
+    type = Exodiff
+    input = cracking_rotation.i
+    exodiff = cracking_rotation_out.e
+    use_old_floor = true
+    custom_cmp = cracking_rotation.cmp
+    #Prescribe the first crack to be in z (which doesn't crack), and reorder crack_flags to match original case
+    cli_args = 'Materials/cracking_stress/prescribed_crack_directions=z AuxKernels/crack_flags3/component=1 AuxKernels/crack_flags2/component=2'
+    max_parallel = 1
+    prereq = cracking_rotation_pres_dir_x
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate the finite rotation of cracked elements where the crack is prescribed in z using AD and match non-AD methods.'
+  [../]
+  [./cracking_rotation_pres_dir_xz]
+    type = Exodiff
+    input = cracking_rotation.i
+    exodiff = cracking_rotation_out.e
+    use_old_floor = true
+    custom_cmp = cracking_rotation.cmp
+    #Prescribe the first two cracks to be in x and z (which dosn't crack), and reorder crack_flags to match original case
+    cli_args = "Materials/cracking_stress/prescribed_crack_directions='x z' AuxKernels/crack_flags3/component=0 AuxKernels/crack_flags2/component=1 AuxKernels/crack_flags1/component=2"
+    max_parallel = 1
+    prereq = cracking_rotation_pres_dir_z
+    requirement = 'The MOOSE TensorMechanics module shall demonstrate the finite rotation of cracked elements where two cracks are prescribed in x and z using AD and match non-AD methods.'
+  [../]
+[]

--- a/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
+++ b/modules/tensor_mechanics/test/tests/ad_smeared_cracking/tests
@@ -129,4 +129,14 @@ issues = '#6815 #9227 #15311'
     prereq = cracking_rotation_pres_dir_z
     requirement = 'The MOOSE TensorMechanics module shall demonstrate the finite rotation of cracked elements where two cracks are prescribed in x and z using AD and match non-AD methods.'
   [../]
+
+  [./ad_multiple_softening_jacobian]
+    type = 'PetscJacobianTester'
+    input = cracking_multiple_softening.i
+    run_sim = 'True'
+    cli_args = 'Outputs/exodus=false'
+    ratio_tol = 1e-4
+    difference_tol = 1
+    requirement = 'The MOOSE TensorMechanics module shall compute accurate AD Jacobian of system with multiple softening laws.'
+  [../]
 []


### PR DESCRIPTION
This PR converts `ComputeSmearedCrackingStress` to automatic differentiation, together with other used classes, such as `SmearedCrackSofteningBase`.

The approach used here is to create a separate AD version.

Refs #15311 

@lynnmunday 
