### PR TITLE
Fixed "fall through" for PR "New PR: Eigen system supports shell matrices"

### DIFF
--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -289,6 +289,11 @@ PhysicsBasedPreconditioner::apply(const NumericVector<Number> & x, NumericVector
       rhs.close();
     }
 
+    // If there is no off_diag, then u_system.rhs will not be closed.
+    // Thus, we need to close it right here
+    if (!_off_diag[system_var].size())
+      u_system.rhs->close();
+
     // Apply the preconditioner to the small system
     _preconditioners[system_var]->apply(*u_system.rhs, *u_system.solution);
 


### PR DESCRIPTION
```
/opt/civet/build_0/moose/framework/src/utils/SlepcSupport.C:385:40: error: this statement may fall through [-Werror=implicit-fallthrough=]
  385 |       solver_params._eigen_matrix_free = true;
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/opt/civet/build_0/moose/framework/src/utils/SlepcSupport.C:387:5: note: here
  387 |     case Moose::EST_NEWTON:
      |     ^~~~
cc1plus: all warnings being treated as errors
```

We changed APIs in  #15315, and we need to reserve the old APIs for Griffin for a second.

I will go to update Griffin to use new APIs. Once that is done, we could remove the old APIs.

Refs #15315

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
