### PR TITLE
Dont execute stateful materials when doing mortar

### DIFF
--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -165,6 +165,11 @@ public:
    */
   virtual const std::set<unsigned int> & getMatPropDependencies() const = 0;
 
+  /**
+   * @return Whether this material has stateful properties
+   */
+  bool hasStatefulProperties() const { return _has_stateful_property; }
+
 protected:
   /**
    * Evaluate material properties on subdomain

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -82,8 +82,15 @@ public:
   /// material properties for given element (and possible side)
   void swap(const Elem & elem, unsigned int side = 0);
 
-  /// Reinit material properties for given element (and possible side)
-  void reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats);
+  /**
+   * Reinit material properties for given element (and possible side)
+   * @param mats The material objects for which to compute properties
+   * @param execute_stateful Whether to execute material objects that have stateful properties. This
+   * should be \p false when for example executing material objects for mortar contexts in which
+   * stateful properties don't make sense
+   */
+  void reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats,
+              bool execute_stateful = true);
 
   /// Calls the reset method of Materials to ensure that they are in a proper state.
   void reset(const std::vector<std::shared_ptr<MaterialBase>> & mats);

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -693,9 +693,37 @@ public:
   virtual void prepareMaterials(SubdomainID blk_id, THREAD_ID tid);
 
   virtual void reinitMaterials(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful = true);
-  virtual void reinitMaterialsFace(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful = true);
-  virtual void
-  reinitMaterialsNeighbor(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful = true);
+
+  /**
+   * reinit materials on element faces
+   * @param blk_id The subdomain on which the element owning the face lives
+   * @param tid The thread id
+   * @param swap_stateful Whether to swap stateful material properties between \p MaterialData and
+   * \p MaterialPropertyStorage
+   * @param execute_stateful Whether to execute material objects that have stateful properties. This
+   * should be \p false when for example executing material objects for mortar contexts in which
+   * stateful properties don't make sense
+   */
+  virtual void reinitMaterialsFace(SubdomainID blk_id,
+                                   THREAD_ID tid,
+                                   bool swap_stateful = true,
+                                   bool execute_stateful = true);
+
+  /**
+   * reinit materials on the neighboring element face
+   * @param blk_id The subdomain on which the neighbor element lives
+   * @param tid The thread id
+   * @param swap_stateful Whether to swap stateful material properties between \p MaterialData and
+   * \p MaterialPropertyStorage
+   * @param execute_stateful Whether to execute material objects that have stateful properties. This
+   * should be \p false when for example executing material objects for mortar contexts in which
+   * stateful properties don't make sense
+   */
+  virtual void reinitMaterialsNeighbor(SubdomainID blk_id,
+                                       THREAD_ID tid,
+                                       bool swap_stateful = true,
+                                       bool execute_stateful = true);
+
   /**
    * For finite volume bcs, we need to be able to initialize and compute
    * materials on ghost elements (elements that don't exist on the mesh - on
@@ -706,8 +734,22 @@ public:
    */
   virtual void
   reinitMaterialsNeighborGhost(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful = true);
-  virtual void
-  reinitMaterialsBoundary(BoundaryID boundary_id, THREAD_ID tid, bool swap_stateful = true);
+
+  /**
+   * reinit materials on a boundary
+   * @param boundary_id The boundary on which to reinit corresponding materials
+   * @param tid The thread id
+   * @param swap_stateful Whether to swap stateful material properties between \p MaterialData and
+   * \p MaterialPropertyStorage
+   * @param execute_stateful Whether to execute material objects that have stateful properties. This
+   * should be \p false when for example executing material objects for mortar contexts in which
+   * stateful properties don't make sense
+   */
+  virtual void reinitMaterialsBoundary(BoundaryID boundary_id,
+                                       THREAD_ID tid,
+                                       bool swap_stateful = true,
+                                       bool execute_stateful = true);
+
   virtual void
   reinitMaterialsInterface(BoundaryID boundary_id, THREAD_ID tid, bool swap_stateful = true);
   /*

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -140,14 +140,6 @@ ComputeMortarFunctor::operator()()
     _fe_problem.reinitElemFaceRef(
         reinit_slave_elem, slave_side_id, _slave_boundary_id, TOLERANCE, &custom_xi1_pts);
 
-    // reinit higher-dimensional element face materials
-    {
-      // Set up Sentinels so that, even if one of the reinitMaterialsXXX() calls throws, we
-      // still remember to swap back during stack unwinding.
-      SwapBackSentinel face_sentinel(_fe_problem, &FEProblemBase::swapBackMaterialsFace, /*tid=*/0);
-      _fe_problem.reinitMaterialsFace(slave_ip->subdomain_id(), /*tid=*/0);
-    }
-
     if (_has_master)
     {
       //  Compute custom integration points for the master side
@@ -170,18 +162,27 @@ ComputeMortarFunctor::operator()()
       _fe_problem.reinitNeighborFaceRef(
           reinit_master_elem, master_side_id, _master_boundary_id, TOLERANCE, &custom_xi2_pts);
 
-      // reinit higher-dimensional neighbor face materials
-      {
-        SwapBackSentinel neighbor_sentinel(
-            _fe_problem, &FEProblemBase::swapBackMaterialsNeighbor, /*tid=*/0);
-        _fe_problem.reinitMaterialsNeighbor(master_ip->subdomain_id(), /*tid=*/0);
-      }
+      // reinit neighbor materials, but be careful not to execute stateful materials since
+      // conceptually they don't make sense with mortar (they're not interpolary)
+      _fe_problem.reinitMaterialsNeighbor(master_ip->subdomain_id(),
+                                          /*tid=*/0,
+                                          /*swap_stateful=*/false,
+                                          /*execute_stateful=*/false);
     }
 
     // reinit the variables/residuals/jacobians on the lower dimensional element corresponding to
     // the slave face. This must be done last after the dof indices have been prepared for the
     // slave (element) and master (neighbor)
     _subproblem.reinitLowerDElemRef(slave_face_elem, &custom_xi1_pts);
+
+    // reinit higher-dimensional slave face/boundary materials. Do this after we reinit lower-d
+    // variables in case we want to pull the lower-d variable values into the slave face/boundary
+    // materials. Be careful not to execute stateful materials since conceptually
+    // they don't make sense with mortar (they're not interpolary)
+    _fe_problem.reinitMaterialsFace(
+        slave_ip->subdomain_id(), /*tid=*/0, /*swap_stateful=*/false, /*execute_stateful=*/false);
+    _fe_problem.reinitMaterialsBoundary(
+        _slave_boundary_id, /*tid=*/0, /*swap_stateful=*/false, /*execute_stateful=*/false);
 
     if (!_fe_problem.currentlyComputingJacobian())
     {

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -141,9 +141,10 @@ MaterialBase::registerPropName(std::string prop_name, bool is_get, Prop_State st
     _supplied_prop_ids.insert(property_id);
 
     _props_to_flags[prop_name] |= static_cast<int>(state);
-    if (static_cast<int>(state) % 2 == 0)
-      _has_stateful_property = true;
   }
+
+  if (static_cast<int>(state) % 2 == 0)
+    _has_stateful_property = true;
 
   // Store material properties for block ids
   for (const auto & block_id : blockIDs())

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -67,10 +67,18 @@ MaterialData::swap(const Elem & elem, unsigned int side /* = 0*/)
 }
 
 void
-MaterialData::reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats)
+MaterialData::reinit(const std::vector<std::shared_ptr<MaterialBase>> & mats, bool execute_stateful)
 {
   for (const auto & mat : mats)
+  {
+    // Mortar objects may use ordinary material properties but stateful properties conceptually
+    // don't make sense (at least not without doing expensive projections potentially at every
+    // linear iteration)
+    if (!execute_stateful && mat->hasStatefulProperties())
+      continue;
+
     mat->computeProperties();
+  }
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3087,7 +3087,10 @@ FEProblemBase::reinitMaterials(SubdomainID blk_id, THREAD_ID tid, bool swap_stat
 }
 
 void
-FEProblemBase::reinitMaterialsFace(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful)
+FEProblemBase::reinitMaterialsFace(SubdomainID blk_id,
+                                   THREAD_ID tid,
+                                   bool swap_stateful,
+                                   bool execute_stateful)
 {
   if (hasActiveMaterialProperties(tid))
   {
@@ -3106,7 +3109,8 @@ FEProblemBase::reinitMaterialsFace(SubdomainID blk_id, THREAD_ID tid, bool swap_
 
     if (_materials[Moose::FACE_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
       _bnd_material_data[tid]->reinit(
-          _materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
+          _materials[Moose::FACE_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid),
+          execute_stateful);
   }
 }
 
@@ -3140,7 +3144,10 @@ FEProblemBase::reinitMaterialsNeighborGhost(SubdomainID blk_id, THREAD_ID tid, b
 }
 
 void
-FEProblemBase::reinitMaterialsNeighbor(SubdomainID blk_id, THREAD_ID tid, bool swap_stateful)
+FEProblemBase::reinitMaterialsNeighbor(SubdomainID blk_id,
+                                       THREAD_ID tid,
+                                       bool swap_stateful,
+                                       bool execute_stateful)
 {
   if (hasActiveMaterialProperties(tid))
   {
@@ -3160,12 +3167,16 @@ FEProblemBase::reinitMaterialsNeighbor(SubdomainID blk_id, THREAD_ID tid, bool s
 
     if (_materials[Moose::NEIGHBOR_MATERIAL_DATA].hasActiveBlockObjects(blk_id, tid))
       _neighbor_material_data[tid]->reinit(
-          _materials[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid));
+          _materials[Moose::NEIGHBOR_MATERIAL_DATA].getActiveBlockObjects(blk_id, tid),
+          execute_stateful);
   }
 }
 
 void
-FEProblemBase::reinitMaterialsBoundary(BoundaryID boundary_id, THREAD_ID tid, bool swap_stateful)
+FEProblemBase::reinitMaterialsBoundary(BoundaryID boundary_id,
+                                       THREAD_ID tid,
+                                       bool swap_stateful,
+                                       bool execute_stateful)
 {
   if (hasActiveMaterialProperties(tid))
   {
@@ -3182,7 +3193,8 @@ FEProblemBase::reinitMaterialsBoundary(BoundaryID boundary_id, THREAD_ID tid, bo
           _discrete_materials.getActiveBoundaryObjects(boundary_id, tid));
 
     if (_materials.hasActiveBoundaryObjects(boundary_id, tid))
-      _bnd_material_data[tid]->reinit(_materials.getActiveBoundaryObjects(boundary_id, tid));
+      _bnd_material_data[tid]->reinit(_materials.getActiveBoundaryObjects(boundary_id, tid),
+                                      execute_stateful);
   }
 }
 

--- a/test/src/materials/SpatialStatefulMaterial.C
+++ b/test/src/materials/SpatialStatefulMaterial.C
@@ -44,5 +44,9 @@ SpatialStatefulMaterial::initQpStatefulProperties()
 void
 SpatialStatefulMaterial::computeQpProperties()
 {
+#ifndef NDEBUG
+  if (_t_step == 1 && !MooseUtils::absoluteFuzzyEqual(_diffusivity_old[_qp], _initial_diffusivity))
+    mooseError("stateful properties have not been properly intialized!");
+#endif
   _diffusivity[_qp] = _diffusivity_old[_qp] + _q_point[_qp](0) + _q_point[_qp](1);
 }

--- a/test/tests/mortar/gap-conductance-2d-non-conforming/gap-conductance.i
+++ b/test/tests/mortar/gap-conductance-2d-non-conforming/gap-conductance.i
@@ -92,6 +92,10 @@
     prop_values = '.03'
     block = '1 2'
   []
+  [./ssm]
+    type = SpatialStatefulMaterial
+    block = '1 2'
+  [../]
 []
 
 


### PR DESCRIPTION
Stateful material properties are "fixed" in place for a given element and side; material properties are not interpolary. For a context like mortar in which the mesh tends to change dynamically, it does not make sense to implement quantities that need state as material properties. E.g. for a dynamic mesh, we are constantly changing the mortar mesh and the location of the integration points where these stateful quantities need to be evaluated. Given that the location of the integration points is constantly changing, quantities that need stateful information have to be interpolary; e.g. they should probably be finite element variables. They definitely should not be stateful material properties.

@recuero just you're aware of what I'm doing...
