### PR TITLE
Dof value accessors should be const

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -136,12 +136,29 @@ protected:
   virtual const VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
+   * Returns value of a coupled lower-dimensional variable
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Reference to a VariableValue for the coupled variable
+   */
+  virtual const VariableValue & coupledValueLower(const std::string & var_name,
+                                                  unsigned int comp = 0);
+
+  /**
    * Returns value of a coupled variable for use in Automatic Differentiation
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables
    * @return Reference to a ADVariableValue for the coupled variable
    */
   const ADVariableValue & adCoupledValue(const std::string & var_name, unsigned int comp = 0);
+
+  /**
+   * Returns value of a coupled lower-dimensional variable for use in Automatic Differentiation
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Reference to a ADVariableValue for the coupled variable
+   */
+  const ADVariableValue & adCoupledValueLower(const std::string & var_name, unsigned int comp = 0);
 
   /**
    * Returns value of a coupled vector variable for use in Automatic Differentiation

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -491,34 +491,34 @@ public:
    */
   void addSolutionNeighbor(const DenseVector<Number> & v);
 
-  const DoFValue & dofValue();
-  const DoFValue & dofValues();
-  const DoFValue & dofValuesOld();
-  const DoFValue & dofValuesOlder();
-  const DoFValue & dofValuesPreviousNL();
-  const DoFValue & dofValuesNeighbor();
-  const DoFValue & dofValuesOldNeighbor();
-  const DoFValue & dofValuesOlderNeighbor();
-  const DoFValue & dofValuesPreviousNLNeighbor();
-  const DoFValue & dofValuesDot();
-  const DoFValue & dofValuesDotNeighbor();
-  const DoFValue & dofValuesDotNeighborResidual();
-  const DoFValue & dofValuesDotOld();
-  const DoFValue & dofValuesDotOldNeighbor();
-  const DoFValue & dofValuesDotDot();
-  const DoFValue & dofValuesDotDotNeighbor();
-  const DoFValue & dofValuesDotDotNeighborResidual();
-  const DoFValue & dofValuesDotDotOld();
-  const DoFValue & dofValuesDotDotOldNeighbor();
-  const MooseArray<Number> & dofValuesDuDotDu();
-  const MooseArray<Number> & dofValuesDuDotDuNeighbor();
-  const MooseArray<Number> & dofValuesDuDotDotDu();
-  const MooseArray<Number> & dofValuesDuDotDotDuNeighbor();
+  const DoFValue & dofValue() const;
+  const DoFValue & dofValues() const;
+  const DoFValue & dofValuesOld() const;
+  const DoFValue & dofValuesOlder() const;
+  const DoFValue & dofValuesPreviousNL() const;
+  const DoFValue & dofValuesNeighbor() const;
+  const DoFValue & dofValuesOldNeighbor() const;
+  const DoFValue & dofValuesOlderNeighbor() const;
+  const DoFValue & dofValuesPreviousNLNeighbor() const;
+  const DoFValue & dofValuesDot() const;
+  const DoFValue & dofValuesDotNeighbor() const;
+  const DoFValue & dofValuesDotNeighborResidual() const;
+  const DoFValue & dofValuesDotOld() const;
+  const DoFValue & dofValuesDotOldNeighbor() const;
+  const DoFValue & dofValuesDotDot() const;
+  const DoFValue & dofValuesDotDotNeighbor() const;
+  const DoFValue & dofValuesDotDotNeighborResidual() const;
+  const DoFValue & dofValuesDotDotOld() const;
+  const DoFValue & dofValuesDotDotOldNeighbor() const;
+  const MooseArray<Number> & dofValuesDuDotDu() const;
+  const MooseArray<Number> & dofValuesDuDotDuNeighbor() const;
+  const MooseArray<Number> & dofValuesDuDotDotDu() const;
+  const MooseArray<Number> & dofValuesDuDotDotDuNeighbor() const;
 
   /**
    * Return the AD dof values
    */
-  const MooseArray<ADReal> & adDofValues();
+  const MooseArray<ADReal> & adDofValues() const;
 
   /**
    * Compute and store incremental change in solution at QPs based on increment_vec
@@ -613,7 +613,7 @@ public:
   const DoFValue & nodalVectorTagValue(TagID tag);
   const DoFValue & nodalMatrixTagValue(TagID tag);
 
-  const typename Moose::ADType<OutputType>::type & adNodalValue();
+  const typename Moose::ADType<OutputType>::type & adNodalValue() const;
 
   virtual void computeNodalValues() override;
   virtual void computeNodalNeighborValues() override;
@@ -633,14 +633,14 @@ protected:
 
 template <typename OutputType>
 inline const MooseArray<ADReal> &
-MooseVariableFE<OutputType>::adDofValues()
+MooseVariableFE<OutputType>::adDofValues() const
 {
   return _element_data->adDofValues();
 }
 
 template <typename OutputType>
 inline const typename Moose::ADType<OutputType>::type &
-MooseVariableFE<OutputType>::adNodalValue()
+MooseVariableFE<OutputType>::adNodalValue() const
 {
   return _element_data->adNodalValue();
 }

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -419,6 +419,7 @@ public:
   /// lower-d element solution
   const ADTemplateVariableValue<OutputType> & adSlnLower() const { return _lower_data->adSln(); }
   const FieldVariableValue & slnLower() const { return _lower_data->sln(Moose::Current); }
+  const FieldVariableValue & slnLowerOld() const { return _lower_data->sln(Moose::Old); }
 
   /// Actually compute variable values from the solution vectors
   virtual void computeElemValues() override;
@@ -518,7 +519,7 @@ public:
   /**
    * Return the AD dof values
    */
-  const MooseArray<ADReal> & adDofValues() const;
+  const MooseArray<ADReal> & adDofValues() const override;
 
   /**
    * Compute and store incremental change in solution at QPs based on increment_vec

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -336,7 +336,7 @@ public:
   const MooseArray<Number> & dofValuesDuDotDotDuNeighbor();
 
   /// Returns the AD dof values.
-  const MooseArray<ADReal> & adDofValues();
+  const MooseArray<ADReal> & adDofValues() const override;
 
   /// Note: const monomial is always the case - higher order solns are
   /// reconstructed - so this is simpler func than FE equivalent.
@@ -369,7 +369,7 @@ protected:
 
 template <typename OutputType>
 inline const MooseArray<ADReal> &
-MooseVariableFV<OutputType>::adDofValues()
+MooseVariableFV<OutputType>::adDofValues() const
 {
   return _element_data->adDofValues();
 }

--- a/framework/include/variables/MooseVariableField.h
+++ b/framework/include/variables/MooseVariableField.h
@@ -124,4 +124,9 @@ public:
    * AD neighbor time derivative getter
    */
   virtual const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const = 0;
+
+  /**
+   * Return the AD dof values
+   */
+  virtual const MooseArray<ADReal> & adDofValues() const = 0;
 };

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -227,7 +227,7 @@ MooseVariableFE<OutputType>::addSolutionNeighbor(const DenseVector<Number> & v)
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValue()
+MooseVariableFE<OutputType>::dofValue() const
 {
   mooseDeprecated("Use dofValues instead of dofValue");
   return dofValues();
@@ -235,140 +235,140 @@ MooseVariableFE<OutputType>::dofValue()
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValues()
+MooseVariableFE<OutputType>::dofValues() const
 {
   return _element_data->dofValues();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesOld()
+MooseVariableFE<OutputType>::dofValuesOld() const
 {
   return _element_data->dofValuesOld();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesOlder()
+MooseVariableFE<OutputType>::dofValuesOlder() const
 {
   return _element_data->dofValuesOlder();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesPreviousNL()
+MooseVariableFE<OutputType>::dofValuesPreviousNL() const
 {
   return _element_data->dofValuesPreviousNL();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesNeighbor()
+MooseVariableFE<OutputType>::dofValuesNeighbor() const
 {
   return _neighbor_data->dofValues();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesOldNeighbor()
+MooseVariableFE<OutputType>::dofValuesOldNeighbor() const
 {
   return _neighbor_data->dofValuesOld();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesOlderNeighbor()
+MooseVariableFE<OutputType>::dofValuesOlderNeighbor() const
 {
   return _neighbor_data->dofValuesOlder();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesPreviousNLNeighbor()
+MooseVariableFE<OutputType>::dofValuesPreviousNLNeighbor() const
 {
   return _neighbor_data->dofValuesPreviousNL();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDot()
+MooseVariableFE<OutputType>::dofValuesDot() const
 {
   return _element_data->dofValuesDot();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotDot()
+MooseVariableFE<OutputType>::dofValuesDotDot() const
 {
   return _element_data->dofValuesDotDot();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotOld()
+MooseVariableFE<OutputType>::dofValuesDotOld() const
 {
   return _element_data->dofValuesDotOld();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotDotOld()
+MooseVariableFE<OutputType>::dofValuesDotDotOld() const
 {
   return _element_data->dofValuesDotDotOld();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotNeighbor()
+MooseVariableFE<OutputType>::dofValuesDotNeighbor() const
 {
   return _neighbor_data->dofValuesDot();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotDotNeighbor()
+MooseVariableFE<OutputType>::dofValuesDotDotNeighbor() const
 {
   return _neighbor_data->dofValuesDotDot();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotOldNeighbor()
+MooseVariableFE<OutputType>::dofValuesDotOldNeighbor() const
 {
   return _neighbor_data->dofValuesDotOld();
 }
 
 template <typename OutputType>
 const typename MooseVariableFE<OutputType>::DoFValue &
-MooseVariableFE<OutputType>::dofValuesDotDotOldNeighbor()
+MooseVariableFE<OutputType>::dofValuesDotDotOldNeighbor() const
 {
   return _neighbor_data->dofValuesDotDotOld();
 }
 
 template <typename OutputType>
 const MooseArray<Number> &
-MooseVariableFE<OutputType>::dofValuesDuDotDu()
+MooseVariableFE<OutputType>::dofValuesDuDotDu() const
 {
   return _element_data->dofValuesDuDotDu();
 }
 
 template <typename OutputType>
 const MooseArray<Number> &
-MooseVariableFE<OutputType>::dofValuesDuDotDotDu()
+MooseVariableFE<OutputType>::dofValuesDuDotDotDu() const
 {
   return _element_data->dofValuesDuDotDotDu();
 }
 
 template <typename OutputType>
 const MooseArray<Number> &
-MooseVariableFE<OutputType>::dofValuesDuDotDuNeighbor()
+MooseVariableFE<OutputType>::dofValuesDuDotDuNeighbor() const
 {
   return _neighbor_data->dofValuesDuDotDu();
 }
 
 template <typename OutputType>
 const MooseArray<Number> &
-MooseVariableFE<OutputType>::dofValuesDuDotDotDuNeighbor()
+MooseVariableFE<OutputType>::dofValuesDuDotDotDuNeighbor() const
 {
   return _neighbor_data->dofValuesDuDotDotDu();
 }


### PR DESCRIPTION
These methods return const references so there's absolutely no reason
why they shouldn't be labeled const

Refs #15259
