### PR TITLE
Avoid use of libmesh_deprecated() APIs

### DIFF
--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -1295,7 +1295,7 @@ Assembly::computeFaceMap(unsigned dim, const std::vector<Real> & qw, const Elem 
       if (_calculate_face_xyz)
       {
         side_point = side->point(0);
-        auto element_node_number = elem->which_node_am_i(side_number, 0);
+        auto element_node_number = elem->local_side_node(side_number, 0);
 
         unsigned dimension = 0;
         if (_computing_jacobian)
@@ -1341,7 +1341,7 @@ Assembly::computeFaceMap(unsigned dim, const std::vector<Real> & qw, const Elem 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {
         VectorValue<DualReal> side_point = side->point(i);
-        auto element_node_number = elem->which_node_am_i(side_number, i);
+        auto element_node_number = elem->local_side_node(side_number, i);
 
         unsigned dimension = 0;
         if (_computing_jacobian)
@@ -1409,7 +1409,7 @@ Assembly::computeFaceMap(unsigned dim, const std::vector<Real> & qw, const Elem 
       for (unsigned int i = 0; i < n_mapping_shape_functions; i++)
       {
         VectorValue<DualReal> side_point = side->point(i);
-        auto element_node_number = elem->which_node_am_i(side_number, i);
+        auto element_node_number = elem->local_side_node(side_number, i);
 
         unsigned dimension = 0;
         if (_computing_jacobian)

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -448,7 +448,9 @@ AutomaticMortarGeneration::buildMortarSegmentMesh()
   // Set up the the mortar segment neighbor information.
   mortar_segment_mesh.allow_renumbering(true);
   mortar_segment_mesh.skip_partitioning(true);
-  mortar_segment_mesh.prepare_for_use(/*skip_renumbering=*/false, /*skip_find_neighbors=*/true);
+  mortar_segment_mesh.allow_find_neighbors(false);
+  mortar_segment_mesh.prepare_for_use();
+  mortar_segment_mesh.allow_find_neighbors(true);
 
   // (Optionally) Write the mortar segment mesh to file for inspection
   if (_debug)

--- a/framework/src/mesh/AnnularMesh.C
+++ b/framework/src/mesh/AnnularMesh.C
@@ -292,5 +292,5 @@ AnnularMesh::buildMesh()
     }
   }
 
-  mesh.prepare_for_use(false);
+  mesh.prepare_for_use();
 }

--- a/framework/src/mesh/ConcentricCircleMesh.C
+++ b/framework/src/mesh/ConcentricCircleMesh.C
@@ -440,8 +440,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 3);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -453,8 +453,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -479,8 +479,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -492,8 +492,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
@@ -527,8 +527,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 3);
       MeshTools::Modification::change_boundary_id(mesh, 6, 4);
       MeshTools::Modification::change_boundary_id(mesh, 7, 1);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -540,8 +540,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -575,8 +575,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(mesh, 7, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -588,8 +588,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
-      mesh.prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
@@ -616,8 +616,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       MeshTools::Modification::change_boundary_id(portion_two, 6, 3);
       MeshTools::Modification::change_boundary_id(portion_two, 7, 4);
-      mesh.prepare_for_use(false, false);
-      portion_two.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      portion_two.prepare_for_use();
       // 'top_half'
       mesh.stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
 
@@ -631,8 +631,8 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_bottom, 5, 3);
       MeshTools::Modification::change_boundary_id(portion_bottom, 6, 4);
       MeshTools::Modification::change_boundary_id(portion_bottom, 7, 1);
-      mesh.prepare_for_use(false, false);
-      portion_bottom.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      portion_bottom.prepare_for_use();
       // 'full'
       mesh.stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
 
@@ -648,15 +648,15 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(portion_two, 2, 1);
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       // 'top half'
-      mesh.prepare_for_use(false, false);
-      portion_two.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      portion_two.prepare_for_use();
       mesh.stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
-      mesh.prepare_for_use(false, false);
-      portion_bottom.prepare_for_use(false, false);
+      mesh.prepare_for_use();
+      portion_bottom.prepare_for_use();
       mesh.stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
       MeshTools::Modification::change_boundary_id(mesh, 3, 1);
       mesh.get_boundary_info().sideset_name(1) = "outer";
@@ -666,5 +666,5 @@ ConcentricCircleMesh::buildMesh()
   }
   if (_portion != "top_half" && _portion != "right_half" && _portion != "left_half" &&
       _portion != "bottom_half" && _portion != "full")
-    mesh.prepare_for_use(false, false);
+    mesh.prepare_for_use();
 }

--- a/framework/src/mesh/FileMesh.C
+++ b/framework/src/mesh/FileMesh.C
@@ -74,7 +74,7 @@ FileMesh::buildMesh()
     // file.
     bool skip_partitioning_later = getMesh().skip_partitioning();
     getMesh().skip_partitioning(true);
-    getMesh().prepare_for_use(false, false);
+    getMesh().prepare_for_use();
     getMesh().skip_partitioning(skip_partitioning_later);
   }
   else // not reading Nemesis files
@@ -92,7 +92,7 @@ FileMesh::buildMesh()
       _exreader->read(_file_name);
 
       getMesh().allow_renumbering(false);
-      getMesh().prepare_for_use(false, false);
+      getMesh().prepare_for_use();
     }
     else
     {

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -408,7 +408,7 @@ MooseMesh::prepare(bool force)
     {
       CONSOLE_TIMED_PRINT("Preparing for use");
 
-      getMesh().prepare_for_use(false, false);
+      getMesh().prepare_for_use();
     }
   }
   else
@@ -418,7 +418,7 @@ MooseMesh::prepare(bool force)
     // Call prepare_for_use() and DO NOT allow renumbering
     getMesh().allow_renumbering(false);
     if (force || _needs_prepare_for_use)
-      getMesh().prepare_for_use(false, false);
+      getMesh().prepare_for_use();
   }
 
   // Collect (local) subdomain IDs

--- a/framework/src/mesh/RinglebMesh.C
+++ b/framework/src/mesh/RinglebMesh.C
@@ -210,7 +210,7 @@ RinglebMesh::buildMesh()
   }
 
   /// Find neighbors, etc.
-  mesh.prepare_for_use(false, false);
+  mesh.prepare_for_use();
 
   /// Create the triangular elements if required by the user
   if (_triangles)

--- a/framework/src/mesh/SpiralAnnularMesh.C
+++ b/framework/src/mesh/SpiralAnnularMesh.C
@@ -237,7 +237,7 @@ SpiralAnnularMesh::buildMesh()
   mesh.boundary_info->sideset_name(_exterior_bid) = "exterior";
 
   // Find neighbors, etc.
-  mesh.prepare_for_use(false, false);
+  mesh.prepare_for_use();
 
   if (_use_tri6)
   {

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -107,7 +107,7 @@ TiledMesh::buildMesh()
     {
       ExodusII_IO ex(*this);
       ex.read(mesh_file);
-      serial_mesh->prepare_for_use(false, false);
+      serial_mesh->prepare_for_use();
     }
     else
       serial_mesh->read(mesh_file);

--- a/framework/src/meshgenerators/AllSideSetsByNormalsGenerator.C
+++ b/framework/src/meshgenerators/AllSideSetsByNormalsGenerator.C
@@ -67,8 +67,8 @@ AllSideSetsByNormalsGenerator::generate()
       if (elem->neighbor_ptr(side))
         continue;
 
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       {
         // See if we've seen this normal before (linear search)

--- a/framework/src/meshgenerators/AnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/AnnularMeshGenerator.C
@@ -242,7 +242,7 @@ AnnularMeshGenerator::generate()
     }
   }
 
-  mesh->prepare_for_use(false, false);
+  mesh->prepare_for_use();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -750,8 +750,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 3);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -763,8 +763,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -789,8 +789,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(other_mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -802,8 +802,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(other_mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
@@ -837,8 +837,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 3);
       MeshTools::Modification::change_boundary_id(*mesh, 6, 4);
       MeshTools::Modification::change_boundary_id(*mesh, 7, 1);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -850,8 +850,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -885,8 +885,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 4);
       MeshTools::Modification::change_boundary_id(*mesh, 6, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 7, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -898,8 +898,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 1, 5);
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
-      mesh->prepare_for_use(false, false);
-      other_mesh.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      other_mesh.prepare_for_use();
       mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
@@ -926,8 +926,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       MeshTools::Modification::change_boundary_id(portion_two, 6, 3);
       MeshTools::Modification::change_boundary_id(portion_two, 7, 4);
-      mesh->prepare_for_use(false, false);
-      portion_two.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      portion_two.prepare_for_use();
       // 'top_half'
       mesh->stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
 
@@ -941,8 +941,8 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_bottom, 5, 3);
       MeshTools::Modification::change_boundary_id(portion_bottom, 6, 4);
       MeshTools::Modification::change_boundary_id(portion_bottom, 7, 1);
-      mesh->prepare_for_use(false, false);
-      portion_bottom.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      portion_bottom.prepare_for_use();
       // 'full'
       mesh->stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
 
@@ -958,15 +958,15 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(portion_two, 2, 1);
       MeshTools::Modification::change_boundary_id(portion_two, 5, 2);
       // 'top half'
-      mesh->prepare_for_use(false, false);
-      portion_two.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      portion_two.prepare_for_use();
       mesh->stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(*mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
-      mesh->prepare_for_use(false, false);
-      portion_bottom.prepare_for_use(false, false);
+      mesh->prepare_for_use();
+      portion_bottom.prepare_for_use();
       mesh->stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 1);
       mesh->get_boundary_info().sideset_name(1) = "outer";
@@ -977,7 +977,7 @@ ConcentricCircleMeshGenerator::generate()
 
   if (_portion != "top_half" && _portion != "right_half" && _portion != "left_half" &&
       _portion != "bottom_half" && _portion != "full")
-    mesh->prepare_for_use(false, false);
+    mesh->prepare_for_use();
 
   // Laplace smoothing
   LaplaceMeshSmoother lms(*mesh);

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -1011,8 +1011,15 @@ DistributedRectilinearMeshGenerator::buildCube(UnstructuredMesh & mesh,
   // Already partitioned!
   mesh.skip_partitioning(true);
 
-  // No need to renumber or find neighbors - done did it.
-  mesh.prepare_for_use(true, true);
+  // No need to renumber or find neighbors this time - done did it.
+  bool old_allow_renumbering = mesh.allow_renumbering();
+  mesh.allow_renumbering(false);
+  mesh.allow_find_neighbors(false);
+  mesh.prepare_for_use();
+
+  // But we'll want to at least find neighbors after any future mesh changes!
+  mesh.allow_find_neighbors(true);
+  mesh.allow_renumbering(old_allow_renumbering);
 
   // Scale the nodal positions
   scaleNodalPositions<T>(nx, ny, nz, xmin, xmax, ymin, ymax, zmin, zmax, mesh);

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -226,7 +226,7 @@ DistributedRectilinearMeshGenerator::addElement<Edge2>(const dof_id_type nx,
     std::unique_ptr<Node> new_node =
         Node::build(Point(static_cast<Real>(node_offset) / nx, 0, 0), node_offset);
 
-    new_node->set_unique_id() = nx + node_offset;
+    new_node->set_unique_id(nx + node_offset);
     new_node->processor_id() = pid;
 
     node0_ptr = mesh.add_node(std::move(new_node));
@@ -238,7 +238,7 @@ DistributedRectilinearMeshGenerator::addElement<Edge2>(const dof_id_type nx,
     std::unique_ptr<Node> new_node =
         Node::build(Point(static_cast<Real>(node_offset + 1) / nx, 0, 0), node_offset + 1);
 
-    new_node->set_unique_id() = nx + node_offset + 1;
+    new_node->set_unique_id(nx + node_offset + 1);
     new_node->processor_id() = pid;
 
     node1_ptr = mesh.add_node(std::move(new_node));
@@ -247,7 +247,7 @@ DistributedRectilinearMeshGenerator::addElement<Edge2>(const dof_id_type nx,
   Elem * elem = new Edge2;
   elem->set_id(elem_id);
   elem->processor_id() = pid;
-  elem->set_unique_id() = elem_id;
+  elem->set_unique_id(elem_id);
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;
@@ -437,7 +437,7 @@ DistributedRectilinearMeshGenerator::addElement<Quad4>(const dof_id_type nx,
     std::unique_ptr<Node> new_node =
         Node::build(Point(static_cast<Real>(i) / nx, static_cast<Real>(j) / ny, 0), node0_id);
 
-    new_node->set_unique_id() = nx * ny + node0_id;
+    new_node->set_unique_id(nx * ny + node0_id);
     new_node->processor_id() = pid;
 
     node0_ptr = mesh.add_node(std::move(new_node));
@@ -451,7 +451,7 @@ DistributedRectilinearMeshGenerator::addElement<Quad4>(const dof_id_type nx,
     std::unique_ptr<Node> new_node =
         Node::build(Point(static_cast<Real>(i + 1) / nx, static_cast<Real>(j) / ny, 0), node1_id);
 
-    new_node->set_unique_id() = nx * ny + node1_id;
+    new_node->set_unique_id(nx * ny + node1_id);
     new_node->processor_id() = pid;
 
     node1_ptr = mesh.add_node(std::move(new_node));
@@ -465,7 +465,7 @@ DistributedRectilinearMeshGenerator::addElement<Quad4>(const dof_id_type nx,
     std::unique_ptr<Node> new_node = Node::build(
         Point(static_cast<Real>(i + 1) / nx, static_cast<Real>(j + 1) / ny, 0), node2_id);
 
-    new_node->set_unique_id() = nx * ny + node2_id;
+    new_node->set_unique_id(nx * ny + node2_id);
     new_node->processor_id() = pid;
 
     node2_ptr = mesh.add_node(std::move(new_node));
@@ -479,7 +479,7 @@ DistributedRectilinearMeshGenerator::addElement<Quad4>(const dof_id_type nx,
     std::unique_ptr<Node> new_node =
         Node::build(Point(static_cast<Real>(i) / nx, static_cast<Real>(j + 1) / ny, 0), node3_id);
 
-    new_node->set_unique_id() = nx * ny + node3_id;
+    new_node->set_unique_id(nx * ny + node3_id);
     new_node->processor_id() = pid;
 
     node3_ptr = mesh.add_node(std::move(new_node));
@@ -488,7 +488,7 @@ DistributedRectilinearMeshGenerator::addElement<Quad4>(const dof_id_type nx,
   Elem * elem = new Quad4;
   elem->set_id(elem_id);
   elem->processor_id() = pid;
-  elem->set_unique_id() = elem_id;
+  elem->set_unique_id(elem_id);
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;
@@ -666,7 +666,7 @@ DistributedRectilinearMeshGenerator::addPoint<Hex8>(const dof_id_type nx,
     std::unique_ptr<Node> new_node = Node::build(
         Point(static_cast<Real>(i) / nx, static_cast<Real>(j) / ny, static_cast<Real>(k) / nz), id);
 
-    new_node->set_unique_id() = nx * ny * nz + id;
+    new_node->set_unique_id(nx * ny * nz + id);
 
     node_ptr = mesh.add_node(std::move(new_node));
   }
@@ -710,7 +710,7 @@ DistributedRectilinearMeshGenerator::addElement<Hex8>(const dof_id_type nx,
   Elem * elem = new Hex8;
   elem->set_id(elem_id);
   elem->processor_id() = pid;
-  elem->set_unique_id() = elem_id;
+  elem->set_unique_id(elem_id);
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;

--- a/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
+++ b/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
@@ -225,7 +225,7 @@ ElementDeletionGeneratorBase::generate()
    * Action that we need to re-prepare the mesh.
    */
   mesh->contract();
-  mesh->prepare_for_use(false, false);
+  mesh->prepare_for_use();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/FancyExtruderGenerator.C
+++ b/framework/src/meshgenerators/FancyExtruderGenerator.C
@@ -209,7 +209,7 @@ FancyExtruderGenerator::generate()
                                              (current_node_layer - 1) * (orig_nodes + orig_elem) +
                                              node->id();
 
-        new_node->set_unique_id() = uid;
+        new_node->set_unique_id(uid);
 #endif
 
         input_boundary_info.boundary_ids(node, ids_to_copy);
@@ -491,7 +491,7 @@ FancyExtruderGenerator::generate()
                                              (current_layer - 1) * (orig_nodes + orig_elem) +
                                              orig_nodes + elem->id();
 
-        new_elem->set_unique_id() = uid;
+        new_elem->set_unique_id(uid);
 #endif
 
         // maintain the subdomain_id

--- a/framework/src/meshgenerators/FileMeshGenerator.C
+++ b/framework/src/meshgenerators/FileMeshGenerator.C
@@ -55,7 +55,7 @@ FileMeshGenerator::generate()
       io.read(_file_name);
     }
     MeshCommunication().broadcast(*mesh);
-    mesh->prepare_for_use(false, false);
+    mesh->prepare_for_use();
   }
   else if (!has_exodus_integers)
     mesh->read(_file_name);

--- a/framework/src/meshgenerators/PatchMeshGenerator.C
+++ b/framework/src/meshgenerators/PatchMeshGenerator.C
@@ -252,7 +252,7 @@ PatchMeshGenerator::generate()
     boundary_info.nodeset_name(107) = "top_front_left";
   }
 
-  mesh->prepare_for_use(false, false);
+  mesh->prepare_for_use();
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/meshgenerators/RinglebMeshGenerator.C
+++ b/framework/src/meshgenerators/RinglebMeshGenerator.C
@@ -206,7 +206,7 @@ RinglebMeshGenerator::generate()
   }
 
   /// Find neighbors, etc.
-  mesh->prepare_for_use(false, false);
+  mesh->prepare_for_use();
 
   /// Create the triangular elements if required by the user
   if (_triangles)

--- a/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
@@ -86,8 +86,8 @@ SideSetsFromNormalsGenerator::generate()
       if (elem->neighbor_ptr(side))
         continue;
 
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       for (unsigned int i = 0; i < boundary_ids.size(); ++i)
       {

--- a/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
@@ -233,7 +233,7 @@ SpiralAnnularMeshGenerator::generate()
   mesh->boundary_info->sideset_name(_exterior_bid) = "exterior";
 
   // Find neighbors, etc.
-  mesh->prepare_for_use(false, false);
+  mesh->prepare_for_use();
 
   if (_use_tri6)
   {

--- a/framework/src/meshmodifiers/ParsedAddSideset.C
+++ b/framework/src/meshmodifiers/ParsedAddSideset.C
@@ -114,8 +114,8 @@ ParsedAddSideset::modify()
 
     for (unsigned int side = 0; side < elem->n_sides(); ++side)
     {
-      _fe_face->reinit(elem, side);
       const std::vector<Point> & normals = _fe_face->get_normals();
+      _fe_face->reinit(elem, side);
 
       // check normal if requested
       if (_check_normal && std::abs(1.0 - _normal * normals[0]) > _variance)

--- a/framework/src/userobject/SolutionUserObject.C
+++ b/framework/src/userobject/SolutionUserObject.C
@@ -242,15 +242,12 @@ SolutionUserObject::readExodusII()
   if (dynamic_cast<DistributedMesh *>(_mesh.get()))
   {
     _mesh->allow_renumbering(true);
-    _mesh->prepare_for_use(false, false);
+    _mesh->prepare_for_use();
   }
   else
   {
     _mesh->allow_renumbering(false);
-    // Don't worry, calling prepare_for_use with skip_renumber_nodes_and_elements = false is a
-    // no-op. It doesn't do anything. However, if true is passed you'll get a deprecation warning.
-    // So we pass false even though it's now what we mean
-    _mesh->prepare_for_use(false, false);
+    _mesh->prepare_for_use();
   }
 
   // Create EquationSystems object for solution

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -393,13 +393,10 @@ build_cube_Quad4(UnstructuredMesh & mesh, DM da)
   mesh.set_next_unique_id(Mx * My + (Mx - 1) * (My - 1));
 
   // No need to renumber or find neighbors - done did it.
-  // Avoid deprecation message/error by _also_ setting
-  // allow_renumbering(false). This is a bit silly, but we want to
-  // catch cases where people are purely using the old "skip"
-  // interface and not the new flag setting one.
   mesh.allow_renumbering(false);
-  mesh.prepare_for_use(/*skip_renumber (ignored!) = */ false,
-                       /*skip_find_neighbors = */ true);
+  mesh.allow_find_neighbors(false);
+  mesh.prepare_for_use();
+  mesh.allow_find_neighbors(true);
 }
 
 void

--- a/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
+++ b/modules/external_petsc_solver/src/mesh/PETScDMDAMesh.C
@@ -153,7 +153,7 @@ add_element_Quad4(DM da,
   // Bottom Left
   auto node0_ptr = mesh.add_point(Point(static_cast<Real>(i) / nx, static_cast<Real>(j) / ny, 0),
                                   node_id_Quad4(nx, 0, i, j, 0));
-  node0_ptr->set_unique_id() = node_id_Quad4(nx, 0, i, j, 0);
+  node0_ptr->set_unique_id(node_id_Quad4(nx, 0, i, j, 0));
   node0_ptr->set_id() = node0_ptr->unique_id();
   // xpid + ypid * xp is the global processor ID
   node0_ptr->processor_id() = xpid + ypid * xp;
@@ -162,7 +162,7 @@ add_element_Quad4(DM da,
   auto node1_ptr =
       mesh.add_point(Point(static_cast<Real>(i + 1) / nx, static_cast<Real>(j) / ny, 0),
                      node_id_Quad4(nx, 0, i + 1, j, 0));
-  node1_ptr->set_unique_id() = node_id_Quad4(nx, 0, i + 1, j, 0);
+  node1_ptr->set_unique_id(node_id_Quad4(nx, 0, i + 1, j, 0));
   node1_ptr->set_id() = node1_ptr->unique_id();
   node1_ptr->processor_id() = xpidplus + ypid * xp;
 
@@ -170,7 +170,7 @@ add_element_Quad4(DM da,
   auto node2_ptr =
       mesh.add_point(Point(static_cast<Real>(i + 1) / nx, static_cast<Real>(j + 1) / ny, 0),
                      node_id_Quad4(nx, 0, i + 1, j + 1, 0));
-  node2_ptr->set_unique_id() = node_id_Quad4(nx, 0, i + 1, j + 1, 0);
+  node2_ptr->set_unique_id(node_id_Quad4(nx, 0, i + 1, j + 1, 0));
   node2_ptr->set_id() = node2_ptr->unique_id();
   node2_ptr->processor_id() = xpidplus + ypidplus * xp;
 
@@ -178,7 +178,7 @@ add_element_Quad4(DM da,
   auto node3_ptr =
       mesh.add_point(Point(static_cast<Real>(i) / nx, static_cast<Real>(j + 1) / ny, 0),
                      node_id_Quad4(nx, 0, i, j + 1, 0));
-  node3_ptr->set_unique_id() = node_id_Quad4(nx, 0, i, j + 1, 0);
+  node3_ptr->set_unique_id(node_id_Quad4(nx, 0, i, j + 1, 0));
   node3_ptr->set_id() = node3_ptr->unique_id();
   node3_ptr->processor_id() = xpid + ypidplus * xp;
 
@@ -187,7 +187,7 @@ add_element_Quad4(DM da,
   elem->set_id(elem_id);
   elem->processor_id() = pid;
   // Make sure our unique_id doesn't overlap any nodes'
-  elem->set_unique_id() = elem_id + (nx + 1) * (ny + 1);
+  elem->set_unique_id(elem_id + (nx + 1) * (ny + 1));
   elem = mesh.add_elem(elem);
   elem->set_node(0) = node0_ptr;
   elem->set_node(1) = node1_ptr;
@@ -313,7 +313,7 @@ add_node_Qua4(dof_id_type nx,
   // Bottom Left
   auto node0_ptr = mesh.add_point(Point(static_cast<Real>(i) / nx, static_cast<Real>(j) / ny, 0),
                                   node_id_Quad4(nx, 0, i, j, 0));
-  node0_ptr->set_unique_id() = node_id_Quad4(nx, 0, i, j, 0);
+  node0_ptr->set_unique_id(node_id_Quad4(nx, 0, i, j, 0));
   node0_ptr->processor_id() = pid;
 }
 

--- a/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
+++ b/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
@@ -174,7 +174,7 @@ PatchSidesetGenerator::generate()
   }
 
   // partition the boundary mesh
-  boundary_mesh->prepare_for_use(false, false);
+  boundary_mesh->prepare_for_use();
   MooseMesh::setPartitioner(*boundary_mesh, _partitioner_name, false, _pars, *this);
   boundary_mesh->partition(_n_patches);
 

--- a/modules/peridynamics/src/mesh/PeridynamicsMesh.C
+++ b/modules/peridynamics/src/mesh/PeridynamicsMesh.C
@@ -112,7 +112,9 @@ PeridynamicsMesh::buildMesh()
   if (!hasMeshBase())
     _mesh = _app.getMeshGeneratorMesh();
 
-  _mesh->prepare_for_use(/*skip_renumber =*/true, /*skip_find_neighbors=*/false);
+  _mesh->allow_renumbering(false);
+  _mesh->prepare_for_use();
+  _mesh->allow_renumbering(true);
 }
 
 unsigned int

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -638,7 +638,7 @@ protected:
   std::vector<std::map<dof_id_type, int>> _var_index_maps;
 
   /// The data structure used to find neighboring elements give a node ID
-  std::vector<std::vector<const Elem *>> _nodes_to_elem_map;
+  std::unordered_map<dof_id_type, std::vector<const Elem *>> _nodes_to_elem_map;
 
   /// The number of features seen by this object per map
   std::vector<unsigned int> _feature_counts_per_map;

--- a/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
+++ b/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
@@ -85,7 +85,7 @@ SphereSurfaceMeshGenerator::generate()
 
   // we need to prepare distributed meshes before using refinement
   if (!mesh->is_replicated())
-    mesh->prepare_for_use(/*skip_renumber =*/false, /*skip_find_neighbors=*/false);
+    mesh->prepare_for_use();
 
   // Now we have the beginnings of a sphere.
   // Add some more elements by doing uniform refinements and

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -236,9 +236,7 @@ XFEM::updateHeal()
     //    _mesh->contract();
     _mesh->allow_renumbering(false);
     _mesh->skip_partitioning(true);
-    _mesh->prepare_for_use(false, false);
-    //    _mesh->prepare_for_use(true,true); //doing this preserves the numbering, but generates
-    //    warning
+    _mesh->prepare_for_use();
 
     if (_displaced_mesh)
     {
@@ -247,8 +245,7 @@ XFEM::updateHeal()
       MeshCommunication().make_nodes_parallel_consistent(*_displaced_mesh);
       _displaced_mesh->allow_renumbering(false);
       _displaced_mesh->skip_partitioning(true);
-      _displaced_mesh->prepare_for_use(false, false);
-      //      _displaced_mesh->prepare_for_use(true,true);
+      _displaced_mesh->prepare_for_use();
     }
   }
 
@@ -286,16 +283,13 @@ XFEM::update(Real time, NonlinearSystemBase & nl, AuxiliarySystem & aux)
     //    _mesh->contract();
     _mesh->allow_renumbering(false);
     _mesh->skip_partitioning(true);
-    _mesh->prepare_for_use(false, false);
-    //    _mesh->prepare_for_use(true,true); //doing this preserves the numbering, but generates
-    //    warning
+    _mesh->prepare_for_use();
 
     if (_displaced_mesh)
     {
       _displaced_mesh->allow_renumbering(false);
       _displaced_mesh->skip_partitioning(true);
-      _displaced_mesh->prepare_for_use(false, false);
-      //      _displaced_mesh->prepare_for_use(true,true);
+      _displaced_mesh->prepare_for_use();
     }
   }
 


### PR DESCRIPTION
This (re) closes #13921

One of the changes incidentally should offer a nice memory scalability improvement in the interaction of FeatureFloodCount with distributed meshes.