### PR TITLE
Add LIBMESH_HAVE_XDR directive to libmesh_CPPFLAGS for Docker Builds 

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -86,7 +86,8 @@ ENV PETSC_DIR=/usr/local
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
 ARG LIBMESH_REV
-ENV LIBMESH_DIR=/usr/local
+ENV LIBMESH_DIR=/usr/local \
+libmesh_CPPFLAGS="-D LIBMESH_HAVE_XDR"
 COPY scripts/update_and_rebuild_libmesh.sh ${MOOSE_DIR}/scripts/update_and_rebuild_libmesh.sh
 RUN git clone https://github.com/libMesh/libmesh.git ; \
 cd libmesh ; \

--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -48,14 +48,16 @@ pipeline {
         stage('Run Tests')
         {            
             steps {
-                sh '''
-                # Want to use all available cores
-                NUM_JOBS=$(grep -c ^processor /proc/cpuinfo)
+                ansiColor('xterm') {
+                    sh '''
+                    # Want to use all available cores
+                    NUM_JOBS=$(grep -c ^processor /proc/cpuinfo)
 
-                # Run tests and pipe to accessible log file
-                docker run $DOCKER_TAG /bin/bash -c \
-                "cd test; ./run_tests -j $NUM_JOBS --no-color" | tee test_results.log
-                '''
+                    # Run tests and pipe to accessible log file
+                    docker run $DOCKER_TAG /bin/bash -c \
+                    "cd test; ./run_tests -j $NUM_JOBS" | tee test_results.log
+                    '''
+                }
             }
         }
         

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -34,7 +34,10 @@ yum install -y \
   boost-devel \
   bison \
   flex \
-  tar
+  tar \
+  libtool \
+  libtirpc \
+  libtirpc-devel
 
 # Clear cache
 yum clean all


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
To make the KP-BISON tests on CentOS in Docker happy, I've set the following just prior to building LibMesh in `docker_ci/Dockerfile`.
```
libmesh_CPPFLAGS="-D LIBMESH_HAVE_XDR"
```

While I've verified that MOOSE images for Ubuntu and CentOS build as they should with this change, along with KP-BISON, I have to admit that I don't really know what setting that preprocessor directive actually does. Are there any potential pitfalls with defining `LIBMESH_HAVE_XDR`?

Other changes include adding a couple of `yum` packages that were needed to get the CentOS variant to build, and I've also enabled color for text in `docker_ci/Jenkinsfile`.  Maybe the latter should have been a separate PR, but I figured that'd be a bit petty.

Closes #15391.
