### PR TITLE
Enhance Coupleable API to better support is_ad classes 

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -141,7 +141,7 @@ protected:
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue for the coupled variable
    */
-  template <bool is_ad = false>
+  template <bool is_ad>
   const GenericVariableValue<is_ad> & coupledGenericValue(const std::string & var_name,
                                                           unsigned int comp = 0);
 
@@ -322,7 +322,7 @@ protected:
    * @return Reference to a VariableGradient containing the gradient of the coupled variable
    * @see Kernel::gradient
    */
-  template <bool is_ad = false>
+  template <bool is_ad>
   const GenericVariableGradient<is_ad> & coupledGenericGradient(const std::string & var_name,
                                                                 unsigned int comp = 0);
 
@@ -842,21 +842,21 @@ protected:
    * Returns zero value templated with automatic differentiation boolean
    * @return Reference to a const GenericVariableValue
    */
-  template <bool is_ad = false>
+  template <bool is_ad>
   const GenericVariableValue<is_ad> & genericZeroValue();
 
   /**
    * Returns zero gradient templated with automatic differentiation boolean
    * @return Reference to a const GenericVariableValue
    */
-  template <bool is_ad = false>
+  template <bool is_ad>
   const GenericVariableGradient<is_ad> & genericZeroGradient();
 
   /**
    * Returns zero second derivative templated with automatic differentiation boolean
    * @return Reference to a const GenericVariableValue
    */
-  template <bool is_ad = false>
+  template <bool is_ad>
   const GenericVariableSecond<is_ad> & genericZeroSecond();
 
 protected:

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -136,7 +136,7 @@ protected:
   virtual const VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
-   * Returns value of a coupled TODO helper function for coupling ad/regular variable values
+   * Returns value of a coupled variable for use in templated auatomatic differentiation classes
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables
    * @return Reference to a VariableValue for the coupled variable
@@ -314,6 +314,17 @@ protected:
    * @see Kernel::gradient
    */
   const ADVariableGradient & adCoupledGradient(const std::string & var_name, unsigned int comp = 0);
+
+  /**
+   * Returns gradient of a coupled variable for use in templated automatic differentiation
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Reference to a VariableGradient containing the gradient of the coupled variable
+   * @see Kernel::gradient
+   */
+  template <bool is_ad = false>
+  const GenericVariableGradient<is_ad> & coupledGenericGradient(const std::string & var_name,
+                                                                unsigned int comp = 0);
 
   /**
    * Returns gradient of a coupled vector variable for use in Automatic Differentation

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -136,6 +136,16 @@ protected:
   virtual const VariableValue & coupledValue(const std::string & var_name, unsigned int comp = 0);
 
   /**
+   * Returns value of a coupled TODO helper function for coupling ad/regular variable values
+   * @param var_name Name of coupled variable
+   * @param comp Component number for vector of coupled variables
+   * @return Reference to a VariableValue for the coupled variable
+   */
+  template <bool is_ad = false>
+  const GenericVariableValue<is_ad> & coupledGenericValue(const std::string & var_name,
+                                                          unsigned int comp = 0);
+
+  /**
    * Returns value of a coupled variable for use in Automatic Differentiation
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables
@@ -801,21 +811,25 @@ protected:
   // coupled-dof-values-end
 
   /**
-   *  method that returns _zero to RESIDUAL computing objects and _ad_zero to JACOBIAN
-   * computing objects
+   * Returns zero value templated with automatic differentiation boolean
+   * @return Reference to a const GenericVariableValue
    */
-  const ADVariableValue & adZeroValue();
+  template <bool is_ad = false>
+  const GenericVariableValue<is_ad> & genericZeroValue();
 
   /**
-   *  method that returns _grad_zero to RESIDUAL computing objects and _ad_grad_zero to
-   * JACOBIAN computing objects
+   * Returns zero gradient templated with automatic differentiation boolean
+   * @return Reference to a const GenericVariableValue
    */
-  const ADVariableGradient & adZeroGradient();
+  template <bool is_ad = false>
+  const GenericVariableValue<is_ad> & genericZeroGradient();
 
   /**
-   * Retrieve a zero second for automatic differentiation
+   * Returns zero second derivative templated with automatic differentiation boolean
+   * @return Reference to a const GenericVariableValue
    */
-  const ADVariableSecond & adZeroSecond();
+  template <bool is_ad = false>
+  const GenericVariableValue<is_ad> & genericZeroSecond();
 
 protected:
   // Reference to the interface's input parameters

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -822,6 +822,23 @@ protected:
   // coupled-dof-values-end
 
   /**
+   * method that returns _zero to RESIDUAL computing objects and _ad_zero to JACOBIAN
+   * computing objects
+   */
+  const ADVariableValue & adZeroValue();
+
+  /**
+   *  method that returns _grad_zero to RESIDUAL computing objects and _ad_grad_zero to
+   * JACOBIAN computing objects
+   */
+  const ADVariableGradient & adZeroGradient();
+
+  /**
+   * Retrieve a zero second for automatic differentiation
+   */
+  const ADVariableSecond & adZeroSecond();
+
+  /**
    * Returns zero value templated with automatic differentiation boolean
    * @return Reference to a const GenericVariableValue
    */

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -822,14 +822,14 @@ protected:
    * @return Reference to a const GenericVariableValue
    */
   template <bool is_ad = false>
-  const GenericVariableValue<is_ad> & genericZeroGradient();
+  const GenericVariableGradient<is_ad> & genericZeroGradient();
 
   /**
    * Returns zero second derivative templated with automatic differentiation boolean
    * @return Reference to a const GenericVariableValue
    */
   template <bool is_ad = false>
-  const GenericVariableValue<is_ad> & genericZeroSecond();
+  const GenericVariableSecond<is_ad> & genericZeroSecond();
 
 protected:
   // Reference to the interface's input parameters

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -362,6 +362,16 @@ struct ADType<VariableValue>
 {
   typedef ADVariableValue type;
 };
+template <>
+struct ADType<VariableGradient>
+{
+  typedef ADVariableGradient type;
+};
+template <>
+struct ADType<VariableSecond>
+{
+  typedef ADVariableSecond type;
+};
 
 } // namespace Moose
 
@@ -435,6 +445,10 @@ template <bool is_ad>
 using GenericRankFourTensor = typename Moose::GenericStruct<RankFourTensor, is_ad>::type;
 template <bool is_ad>
 using GenericVariableValue = typename Moose::GenericStruct<VariableValue, is_ad>::type;
+template <bool is_ad>
+using GenericVariableGradient = typename Moose::GenericStruct<VariableGradient, is_ad>::type;
+template <bool is_ad>
+using GenericVariableSecond = typename Moose::GenericStruct<VariableSecond, is_ad>::type;
 
 #define declareADValidParams(ADObjectType)                                                         \
   template <>                                                                                      \

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1593,9 +1593,9 @@ Coupleable::getADDefaultSecond()
   return _ad_default_second;
 }
 
-template <bool is_ad>
-const GenericVariableValue<is_ad> &
-Coupleable::genericZeroValue()
+template <>
+const GenericVariableValue<false> &
+Coupleable::genericZeroValue<false>()
 {
   return _zero;
 }
@@ -1607,9 +1607,9 @@ Coupleable::genericZeroValue<true>()
   return _ad_zero;
 }
 
-template <bool is_ad>
-const GenericVariableGradient<is_ad> &
-Coupleable::genericZeroGradient()
+template <>
+const GenericVariableGradient<false> &
+Coupleable::genericZeroGradient<false>()
 {
   return _grad_zero;
 }
@@ -1621,9 +1621,9 @@ Coupleable::genericZeroGradient<true>()
   return _ad_grad_zero;
 }
 
-template <bool is_ad>
-const GenericVariableSecond<is_ad> &
-Coupleable::genericZeroSecond()
+template <>
+const GenericVariableSecond<false> &
+Coupleable::genericZeroSecond<false>()
 {
   return _second_zero;
 }
@@ -1635,6 +1635,19 @@ Coupleable::genericZeroSecond<true>()
   return _ad_second_zero;
 }
 
+template <>
+const GenericVariableGradient<false> &
+Coupleable::coupledGenericGradient<false>(const std::string & var_name, unsigned int comp)
+{
+  return coupledGradient(var_name, comp);
+}
+
+template <>
+const GenericVariableGradient<true> &
+Coupleable::coupledGenericGradient<true>(const std::string & var_name, unsigned int comp)
+{
+  return adCoupledGradient(var_name, comp);
+}
 // Explicit instantiations
 
 template const Real & Coupleable::getDefaultNodalValue<Real>(const std::string & var_name,

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -396,14 +396,18 @@ Coupleable::coupled(const std::string & var_name, unsigned int comp)
   }
 }
 
-template <bool is_ad>
-const GenericVariableValue<is_ad> &
-Coupleable::coupledGenericValue(const std::string & var_name, unsigned int comp)
+template <>
+const GenericVariableValue<false> &
+Coupleable::coupledGenericValue<false>(const std::string & var_name, unsigned int comp)
 {
-  if (!is_ad)
-    return coupledValue(var_name, comp);
-  else
-    return adCoupledValue(var_name, comp);
+  return coupledValue(var_name, comp);
+}
+
+template <>
+const GenericVariableValue<true> &
+Coupleable::coupledGenericValue<true>(const std::string & var_name, unsigned int comp)
+{
+  return adCoupledValue(var_name, comp);
 }
 
 const VariableValue &
@@ -1593,30 +1597,42 @@ template <bool is_ad>
 const GenericVariableValue<is_ad> &
 Coupleable::genericZeroValue()
 {
-  if (!is_ad)
-    return _zero;
-  else
-    return _ad_zero;
+  return _zero;
+}
+
+template <>
+const GenericVariableValue<true> &
+Coupleable::genericZeroValue<true>()
+{
+  return _ad_zero;
 }
 
 template <bool is_ad>
-const GenericVariableValue<is_ad> &
+const GenericVariableGradient<is_ad> &
 Coupleable::genericZeroGradient()
 {
-  if (!is_ad)
-    return _grad_zero;
-  else
-    return _ad_grad_zero;
+  return _grad_zero;
+}
+
+template <>
+const GenericVariableGradient<true> &
+Coupleable::genericZeroGradient<true>()
+{
+  return _ad_grad_zero;
 }
 
 template <bool is_ad>
-const GenericVariableValue<is_ad> &
+const GenericVariableSecond<is_ad> &
 Coupleable::genericZeroSecond()
 {
-  if (!is_ad)
-    return _second_zero;
-  else
-    return _ad_second_zero;
+  return _second_zero;
+}
+
+template <>
+const GenericVariableSecond<true> &
+Coupleable::genericZeroSecond<true>()
+{
+  return _ad_second_zero;
 }
 
 // Explicit instantiations

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -396,6 +396,16 @@ Coupleable::coupled(const std::string & var_name, unsigned int comp)
   }
 }
 
+template <bool is_ad>
+const GenericVariableValue<is_ad> &
+Coupleable::coupledGenericValue(const std::string & var_name, unsigned int comp)
+{
+  if (!is_ad)
+    return coupledValue(var_name, comp);
+  else
+    return adCoupledValue(var_name, comp);
+}
+
 const VariableValue &
 Coupleable::coupledValue(const std::string & var_name, unsigned int comp)
 {
@@ -1579,22 +1589,34 @@ Coupleable::getADDefaultSecond()
   return _ad_default_second;
 }
 
-const ADVariableValue &
-Coupleable::adZeroValue()
+template <bool is_ad>
+const GenericVariableValue<is_ad> &
+Coupleable::genericZeroValue()
 {
-  return _ad_zero;
+  if (!is_ad)
+    return _zero;
+  else
+    return _ad_zero;
 }
 
-const ADVariableGradient &
-Coupleable::adZeroGradient()
+template <bool is_ad>
+const GenericVariableValue<is_ad> &
+Coupleable::genericZeroGradient()
 {
-  return _ad_grad_zero;
+  if (!is_ad)
+    return _grad_zero;
+  else
+    return _ad_grad_zero;
 }
 
-const ADVariableSecond &
-Coupleable::adZeroSecond()
+template <bool is_ad>
+const GenericVariableValue<is_ad> &
+Coupleable::genericZeroSecond()
 {
-  return _ad_second_zero;
+  if (!is_ad)
+    return _second_zero;
+  else
+    return _ad_second_zero;
 }
 
 // Explicit instantiations

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1593,6 +1593,27 @@ Coupleable::getADDefaultSecond()
   return _ad_default_second;
 }
 
+const ADVariableValue &
+Coupleable::adZeroValue()
+{
+  mooseDeprecated("Method adZeroValue() is deprecated. Use '_ad_zero' instead.");
+  return _ad_zero;
+}
+
+const ADVariableGradient &
+Coupleable::adZeroGradient()
+{
+  mooseDeprecated("Method adZeroGradient() is deprecated. Use '_ad_grad_zero' instead.");
+  return _ad_grad_zero;
+}
+
+const ADVariableSecond &
+Coupleable::adZeroSecond()
+{
+  mooseDeprecated("Method adZeroSecond() is deprecated. Use '_ad_second_zero' instead.");
+  return _ad_second_zero;
+}
+
 template <>
 const GenericVariableValue<false> &
 Coupleable::genericZeroValue<false>()

--- a/modules/misc/src/materials/ADDensity.C
+++ b/modules/misc/src/materials/ADDensity.C
@@ -37,7 +37,7 @@ ADDensity::ADDensity(const InputParameters & parameters)
     _grad_disp[i] = &adCoupledGradient("displacements", i);
 
   // fill remaining components with zero
-  _grad_disp.resize(3, &adZeroGradient());
+  _grad_disp.resize(3, &_ad_grad_zero);
 }
 
 void

--- a/modules/tensor_mechanics/src/materials/ADCompute2DFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DFiniteStrain.C
@@ -37,8 +37,8 @@ ADCompute2DFiniteStrain::initialSetup()
   {
     if (_out_of_plane_direction == i)
     {
-      _disp[i] = &adZeroValue();
-      _grad_disp[i] = &adZeroGradient();
+      _disp[i] = &_ad_zero;
+      _grad_disp[i] = &_ad_grad_zero;
     }
     else
     {

--- a/modules/tensor_mechanics/src/materials/ADCompute2DIncrementalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DIncrementalStrain.C
@@ -36,8 +36,8 @@ ADCompute2DIncrementalStrain::initialSetup()
   {
     if (_out_of_plane_direction == i)
     {
-      _disp[i] = &adZeroValue();
-      _grad_disp[i] = &adZeroGradient();
+      _disp[i] = &_ad_zero;
+      _grad_disp[i] = &_ad_grad_zero;
     }
     else
     {

--- a/modules/tensor_mechanics/src/materials/ADCompute2DSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADCompute2DSmallStrain.C
@@ -36,8 +36,8 @@ ADCompute2DSmallStrain::initialSetup()
   {
     if (_out_of_plane_direction == i)
     {
-      _disp[i] = &adZeroValue();
-      _grad_disp[i] = &adZeroGradient();
+      _disp[i] = &_ad_zero;
+      _grad_disp[i] = &_ad_grad_zero;
     }
     else
     {

--- a/modules/tensor_mechanics/src/materials/ADComputePlaneFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputePlaneFiniteStrain.C
@@ -35,7 +35,7 @@ ADComputePlaneFiniteStrain::ADComputePlaneFiniteStrain(const InputParameters & p
     _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain")),
     _out_of_plane_strain_coupled(isCoupled("out_of_plane_strain")),
     _out_of_plane_strain(_out_of_plane_strain_coupled ? adCoupledValue("out_of_plane_strain")
-                                                      : adZeroValue()),
+                                                      : _ad_zero),
     _out_of_plane_strain_old(_out_of_plane_strain_coupled ? coupledValueOld("out_of_plane_strain")
                                                           : _zero)
 {

--- a/modules/tensor_mechanics/src/materials/ADComputePlaneIncrementalStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputePlaneIncrementalStrain.C
@@ -35,7 +35,7 @@ ADComputePlaneIncrementalStrain::ADComputePlaneIncrementalStrain(const InputPara
     _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain")),
     _out_of_plane_strain_coupled(isCoupled("out_of_plane_strain")),
     _out_of_plane_strain(_out_of_plane_strain_coupled ? adCoupledValue("out_of_plane_strain")
-                                                      : adZeroValue()),
+                                                      : _ad_zero),
     _out_of_plane_strain_old(_out_of_plane_strain_coupled ? coupledValueOld("out_of_plane_strain")
                                                           : _zero)
 {

--- a/modules/tensor_mechanics/src/materials/ADComputePlaneSmallStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputePlaneSmallStrain.C
@@ -34,7 +34,7 @@ ADComputePlaneSmallStrain::ADComputePlaneSmallStrain(const InputParameters & par
     _scalar_out_of_plane_strain_coupled(isParamValid("scalar_out_of_plane_strain")),
     _out_of_plane_strain_coupled(isCoupled("out_of_plane_strain")),
     _out_of_plane_strain(_out_of_plane_strain_coupled ? adCoupledValue("out_of_plane_strain")
-                                                      : adZeroValue()),
+                                                      : _ad_zero),
     _nscalar_strains(coupledScalarComponents("scalar_out_of_plane_strain"))
 {
   if (_out_of_plane_strain_coupled && _scalar_out_of_plane_strain_coupled)

--- a/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
@@ -78,8 +78,8 @@ ADComputeStrainBase::initialSetup()
   // set unused dimensions to zero
   for (unsigned i = _ndisp; i < 3; ++i)
   {
-    _disp[i] = &adZeroValue();
-    _grad_disp[i] = &adZeroGradient();
+    _disp[i] = &_ad_zero;
+    _grad_disp[i] = &_ad_grad_zero;
   }
 }
 


### PR DESCRIPTION
Enhance `Coupleable` API to better support templated automatic differentiation --`is_ad`- classes.

`coupledGeneric` values and `genericZero` values have been added.

Refs. #15207

@vanwdani 