### PR TITLE
Removed the slepc link

### DIFF
--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -97,8 +97,7 @@ if [ -z "$go_fast" ]; then
       --download-superlu_dist=1 \
       --download-mumps=1 \
       --download-scalapack=1 \
-      --download-slepc=git://https://gitlab.com/slepc/slepc.git \
-      --download-slepc-commit= 59ff81b \
+      --download-slepc=1 \
       --with-mpi=1 \
       --with-cxx-dialect=C++11 \
       --with-fortran-bindings=0 \


### PR DESCRIPTION
Closes #15429

I should make conda-build use `update_and_rebuild_petsc.sh ` as well

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
