### PR TITLE
Fix some windows breakage

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -60,9 +60,8 @@ endif
 UNAME10 := $(shell uname | cut -c-10)
 ifeq ($(UNAME10), MINGW64_NT)
 	# disable unity build and header symlinking
-	MOOSE_HEADER_SYMLINKS := false
-	MOOSE_UNITY           := false
-
+	MOOSE_UNITY        := false
+	libmesh_LDFLAGS    += -no-undefined
 	pyhit_LIB          := $(FRAMEWORK_DIR)/../python/pyhit/hit.pyd
 	pyhit_COMPILEFLAGS := $(shell $(pyconfig) --cflags --ldflags --libs)
 else

--- a/framework/src/utils/ADFParser.C
+++ b/framework/src/utils/ADFParser.C
@@ -16,16 +16,20 @@ ADFParser::ADFParser(const ADFParser & cpy) : FunctionParserAD(cpy), _epsilon(1e
 bool
 ADFParser::JITCompile()
 {
+#if LIBMESH_HAVE_FPARSER_JIT
   auto result = JITCompileHelper("ADReal", ADFPARSER_INCLUDES, "#include \"ADReal.h\"\n");
+
   if (!result)
+#endif
     mooseError("ADFParser::JITCompile() failed. Evaluation not possible.");
+
   return true;
 }
 
 ADReal
 ADFParser::Eval(const ADReal * vars)
 {
-  mooseAssert(compiledFunction, "ADFParser objects mut be JIT compiled before evaluation!");
+  mooseAssert(compiledFunction, "ADFParser objects must be JIT compiled before evaluation!");
   ADReal ret;
   (*reinterpret_cast<CompiledFunctionPtr<ADReal>>(compiledFunction))(&ret, vars, pImmed, _epsilon);
   return ret;

--- a/unit/src/ADFParserTest.C
+++ b/unit/src/ADFParserTest.C
@@ -15,6 +15,8 @@ TEST(ADFparserTest, JITCompile)
 {
   std::string func = "2 + 4*x + 8*x^2 + 16*y^2 + 2*y^4";
 
+  // ADFParser only works with JIT support right now
+#if LIBMESH_HAVE_FPARSER_JIT
   ADFParser fparser;
   fparser.Parse(func, "x,y");
   fparser.Optimize();
@@ -33,4 +35,5 @@ TEST(ADFparserTest, JITCompile)
   EXPECT_EQ(p, s);
   EXPECT_EQ(p.derivatives()[0], s.derivatives()[0]);
   EXPECT_EQ(p.derivatives()[1], s.derivatives()[1]);
+#endif
 }


### PR DESCRIPTION
We really need something like header symlinks, as the command lines for compiling get too long for msys2! However there are not fully featured symlinks on msys2, so for now I'm copying headers instead. This also fixes a breakage due to the JIT refactor.

Refs #14591