### PR TITLE
Simplify Conda Install, Create Offline Install

### DIFF
--- a/modules/doc/content/getting_started/index.md
+++ b/modules/doc/content/getting_started/index.md
@@ -13,6 +13,7 @@ your operating system/platform and follow the instructions:
   - [getting_started/installation/manual_installation_gcc.md]
   - [getting_started/installation/manual_installation_llvm.md]
   - [getting_started/installation/manual_installation_linux_lldb.md]
+  - [getting_started/installation/offline_installation.md]
 
 When installation is complete, return to this page to continue.
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -16,6 +16,8 @@ and an experimental [WSL](installation/windows10.md) option is available.
 
 !include installation/install_miniconda.md
 
+!include installation/install_conda_moose.md
+
 !include getting_started/installation/clone_moose.md
 
 !include getting_started/installation/test_moose.md

--- a/modules/doc/content/getting_started/installation/install_conda_moose.md
+++ b/modules/doc/content/getting_started/installation/install_conda_moose.md
@@ -1,0 +1,29 @@
+## Install MOOSE Conda Packages id=moosepackages
+
+Install the moose-libmesh and moose-tools package from mooseframework.org, and name your environment 'moose':
+
+```bash
+conda create --name moose moose-libmesh moose-tools
+```
+
+Activate the moose environment +(do this for any new terminal opened)+:
+
+```bash
+conda activate moose
+```
+
+Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again.
+
+You will have successfully activated the moose environment when you see 'moose' within your prompt.
+
+If you close, and re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for each terminal you open. If you wish to make this automatic, you may append `conda activate moose` to your bash or zsh profiles.
+
+The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
+
+```bash
+conda activate moose
+conda update --all
+```
+
+!alert note title= sudo is not necessary
+If you find yourself applying the use of `sudo` for any of the above conda commands... something's not right. The most common reason for needing sudo, is due to an improper installation. Conda *should* be installed to your home directory, and without any use of `sudo`.

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -1,18 +1,15 @@
-## Install Miniconda id=installconda
+## Install Miniconda3 id=installconda
 
-!alert note title= Anaconda also works
-You may choose to use Anaconda if you so desire: [Anaconda for Python 3.x](https://www.anaconda.com/distribution/)
+Installing Miniconda3 is straight forward. Download, install, and configure. If you run into issues during these steps, please visit our [troubleshooting guide for Conda](troubleshooting.md#condaissues).
 
-You may follow Miniconda's instructions: [Install Miniconda3](https://docs.conda.io/en/latest/miniconda.html), however we continuously receive reports of difficulty doing so (especially from our MacOS users). With that said, please use our instructions to install Miniconda instead:
-
-- +Linux:+
+- +Linux Users:+
 
   ```bash
   curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
   ```
 
-- +Macintosh:+
+- +Macintosh Users:+
 
   ```bash
   curl -L -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
@@ -30,41 +27,4 @@ Configure Conda to work with conda-forge, and our mooseframework.org channel:
 ```bash
 conda config --add channels conda-forge
 conda config --add channels https://mooseframework.org/conda/moose
-```
-
-Install the moose-libmesh and moose-tools package from mooseframework.org, and name your environment 'moose':
-
-```bash
-conda create --name moose moose-libmesh moose-tools
-```
-
-Activate the moose environment +(do this for any new terminal opened)+:
-
-```bash
-conda activate moose
-```
-
-Some folks may receive additional instructions when attempting to activate a profile. Follow those instructions, and try to activate the moose environment again.
-
-You will have successfully activated the moose environment when you see 'moose' within your prompt.
-
-If you close, and re-open this terminal window, know that you will need to `conda activate moose` again. You will need to do this for each terminal you open. If you wish to make this automatic, you may append `conda activate moose` to your bash or zsh profiles.
-
-The MOOSE team will make periodic updates to the conda packages. To stay up-to-date, activate the moose environment, and perform an update:
-
-```bash
-conda activate moose
-conda update --all
-```
-
-!alert note title= sudo is not necessary
-If you find yourself applying the use of `sudo` for any of the above conda commands... something's not right. The most common reason for needing sudo, is due to an improper installation. Conda *should* be installed to your home directory, and without any use of `sudo`.
-
-## Uninstall Conda MOOSE Environment
-
-If you wish to remove the moose environment at any time, you may do so using the following commands:
-
-```bash
-conda deactivate   # if 'moose' was currently activated
-conda remove --name moose --all
 ```

--- a/modules/doc/content/getting_started/installation/offline_installation.md
+++ b/modules/doc/content/getting_started/installation/offline_installation.md
@@ -110,7 +110,7 @@ curl -L -O https://github.com/xiaoyeli/superlu_dist/archive/v6.2.0.tar.gz
 curl -L -O https://gitlab.com/slepc/slepc/-/archive/bda551b/slepc-bda551b.tar.gz
 ```
 
-At this point, everything necessary should be downloaded and available in the directory hierarchy at `~/offline`. At this time, you may copy this directory to your offline-no-internet access machine. At the time of this writing, tallying up the disc space used equates to approximately ~2GB. Depending on your internet connection, you may want to compress the entire ~/offline directory instead (saves about 500Mb):
+At this point, everything necessary should be downloaded and available in the directory hierarchy at `~/offline`. At this time, you may copy this directory to your offline-no-internet access machine's home directory. At the time of this writing, tallying up the disc space used equates to approximately ~2GB. Depending on your internet connection, you may want to compress the entire ~/offline directory instead (saves about 500Mb):
 
 ```bash
 cd ~/
@@ -120,14 +120,31 @@ tar -pzcf offline.tar.gz offline
 !alert note
 If operating on a Macintosh machine, creating a tarball to be extracted on a Linux machine produces warnings. They are warnings only, and can be safely ignored.
 
+If copying the tarball over, you can extract it with:
+
+```bash
+tar -xf offline.tar.gz -C ~/
+```
 
 ## Build PETSc, libMesh, and MOOSE
 
-With the tarball copied and extracted on the target machine (`tar -xf offline.tar.gz -C ~/`), or you simply copied the entire `~/offline` directory to your target machine's home directory, we can now build PETSc, libMesh, and MOOSE, using your MPI Wrapper/Compiler established in earlier steps.
+With the `~/offline` directory available in your target machine's home directory, we can now build PETSc, libMesh, and MOOSE, using your MPI Wrapper/Compiler established in earlier steps.
 
 ### PETSc
 
-Configure, build, and install PETSc to `$HOME/libs/petsc`:
+Configure, build, and install PETSc to:`$HOME/libs/petsc`
+
+First, you should set your environment to make use of the compiler and MPI wrapper you established in earlier steps. On HPC machines, this normally involves loading modules. On a workstation, this may mean adjusting your PATH environment variable.
+
+Verify an MPI wrapper is available:
+
+```bash
+which mpicc mpicxx mpif90 mpif77
+```
+
+The `which` command above should return the paths to your MPI wrappers established in earlier steps. If it returns nothing, or fewer paths than the 4 we were asking for, something is wrong. You will need to figure out how to enable your MPI wrapper before proceeding.
+
+With your compilers ready for use, we can now build PETSc:
 
 ```bash
 cd ~/offline/moose/petsc
@@ -156,9 +173,9 @@ Proceed only if PETSc completed successfully.
 
 ### libMesh
 
-Configure, build, and install libMesh to `$HOME/libs/libmesh`.
+Configure, build, and install libMesh to: `$HOME/libs/libmesh`
 
-First, we need to tell libMesh where PETSc is installed, and set the environment to use the MPI wrapper:
+First, we need to tell libMesh where PETSc is installed, and instruct libMesh to specifically use MPI:
 
 ```bash
 export PETSC_DIR=$HOME/libs/petsc

--- a/modules/doc/content/getting_started/installation/offline_installation.md
+++ b/modules/doc/content/getting_started/installation/offline_installation.md
@@ -1,0 +1,218 @@
+# Offline Installation
+
+If you are using a machine (or HPC cluster) with no access to the internet, the following instructions will help you create an environment suitable for MOOSE-based development.
+
+Please be certain, that the machine in which you intend to perform the actual work (which this document will refer to as the 'target' machine), meets our minimum requirements:
+
+!include sqa/minimum_requirements.md
+
+## Dependency List
+
+Ultimately, we will need to build the following stack, to create an environment suitable for MOOSE-based development on the target machine:
+
+- GCC, Or LLVM +and+ GCC
+- MPI Wrapper
+- PETSc, libMesh, and MOOSE
+
+## Prerequisites
+
+Before you begin, know that you will first need to be operating on a machine with internet access.
+
+If you are on a Windows machine, please install [Ubuntu 20.04](https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71) from the Microsoft store, simply to have access to a Linux terminal. Once inside the terminal, install 'git' and 'curl', as that will be needed to clone the repositories involved in later steps (`sudo apt-get install git curl`).
+
+## GCC
+
+It is highly likely the target machine in which you will be operating on will already contain an acceptable version of GCC. Please contact your system administrator for instructions on how to use that systems compiler. If not, you will need to head on over to GNU's [GCC](https://gcc.gnu.org/) site, and follow their instructions on building a GCC compiler at or beyond the above listed minimum version.
+
+## LLVM (optional)
+
+While arguably a [better compiler](https://opensource.apple.com/source/clang/clang-23/clang/tools/clang/www/comparison.html) over traditional GCC, it is more difficult to build. Nevertheless, if you wish to make the attempt, head on over to [llvm.org](http://llvm.org/), to begin.
+
+!alert note
+If you choose LLVM, know that you will also need to build (or use) a GCC toolchain! This is due to the lack of a Fortran compiler included in LLVM.
+
+## MPI Wrapper
+
+If the target machine is an HPC system, it is likely your system already has an MPI wrapper (and thus, a GCC or LLVM compiler). Please contact your system administrator, and ask them how to appropriately make use of that cluster's MPI wrapper. If, by chance you will have to build your own, you have some choices to make; [OpenMPI](https://www.open-mpi.org/), [MVAPICH](https://mvapich.cse.ohio-state.edu/), and [MPICH](https://www.mpich.org/), all work well. You will want to head on over to one of those product sites, and follow their instructions to build yourself an MPI wrapper (using the GCC or LLVM compiler you choose above).
+
+!alert note
+MVAPICH is regarded as the better wrapper for HPC clusters. However, it is also the most difficult to build properly for that clusters specific hardware. While you may be able to *build* it easily enough, you may not have built it *properly* to optimally make use of said cluster's hardware.
+
+## Prepare PETSc, libMesh, and MOOSE for copying
+
+These three libraries can all be obtained from one repository (the moose repository). First, create a top-level directory named 'offline', which will ultimately contain everything we need to transfer over to your target machine.
+
+```bash
+mkdir -p ~/offline/downloads
+```
+
+Next, enter the offline directory, and perform the cloning operation to obtain all three products:
+
+```bash
+cd ~/offline
+git clone https://github.com/idaholab/moose.git
+cd moose
+git checkout master
+git submodule update --init
+git submodule foreach --recursive git submodule update --init
+```
+
+With PETSc cloned as part of the group obtained above, we can use a configure option in PETSc, to obtain a list of contributions we will need to download manually (`--with-package-download-dir`):
+
+```bash
+cd ~/offline/moose/petsc
+./configure \
+ --download-mumps=1 \
+ --download-hypre=1 \
+ --download-slepc=1 \
+ --download-metis=1 \
+ --download-ptscotch=1 \
+ --download-parmetis=1 \
+ --download-scalapack=1 \
+ --download-fblaslapack=1 \
+ --download-superlu_dist=1 \
+ --with-packages-download-dir=~/offline/downloads
+```
+
+As an example, the above command, should return something like this:
+
+```pre
+===============================================================================
+             Configuring PETSc to compile on your system                       
+===============================================================================
+Download the following packages to /home/you/offline/downloads 
+
+fblaslapack ['git://https://bitbucket.org/petsc/pkg-fblaslapack', 'https://bitbucket.org/petsc/pkg-fblaslapack/get/v3.4.2-p2.tar.gz']
+hypre ['git://https://github.com/hypre-space/hypre', 'https://github.com/hypre-space/hypre/archive/93baaa8c9.tar.gz']
+metis ['git://https://bitbucket.org/petsc/pkg-metis.git', 'https://bitbucket.org/petsc/pkg-metis/get/v5.1.0-p8.tar.gz']
+parmetis ['git://https://bitbucket.org/petsc/pkg-parmetis.git', 'https://bitbucket.org/petsc/pkg-parmetis/get/v4.0.3-p6.tar.gz']
+ptscotch ['git:https://gitlab.inria.fr/scotch/scotch', 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/scotch-v6.0.8.tar.gz']
+mumps ['git://https://bitbucket.org/petsc/pkg-mumps.git', 'https://bitbucket.org/petsc/pkg-mumps/get/v5.2.1-p2.tar.gz']
+scalapack ['git://https://bitbucket.org/petsc/pkg-scalapack', 'https://bitbucket.org/petsc/pkg-scalapack/get/v2.0.2-p2.tar.gz']
+superlu_dist ['git://https://github.com/xiaoyeli/superlu_dist', 'https://github.com/xiaoyeli/superlu_dist/archive/v6.2.0.tar.gz']
+slepc ['git://https://gitlab.com/slepc/slepc.git', 'https://gitlab.com/slepc/slepc/-/archive/bda551b/slepc-bda551b.tar.gz']
+```
+
+Your job, will be to parse through the above jargon, and download these packages to `~/offline/downloads`. Be certain to preserve the file name. PETSc is listing several means for which you can obtain these contributions (using either git or traditional web link). For the purpose of simplicity, we will use the traditional web method.
+
++Example ONLY, as file names may be deprecated!:+
+
+```bash
+cd ~/offline/downloads
+curl -L -O https://bitbucket.org/petsc/pkg-fblaslapack/get/v3.4.2-p2.tar.gz
+curl -L -O https://github.com/hypre-space/hypre/archive/93baaa8c9.tar.gz
+curl -L -O https://bitbucket.org/petsc/pkg-metis/get/v5.1.0-p8.tar.gz
+curl -L -O https://bitbucket.org/petsc/pkg-parmetis/get/v4.0.3-p6.tar.gz
+curl -L -O http://ftp.mcs.anl.gov/pub/petsc/externalpackages/scotch-v6.0.8.tar.gz
+curl -L -O https://bitbucket.org/petsc/pkg-mumps/get/v5.2.1-p2.tar.gz
+curl -L -O https://bitbucket.org/petsc/pkg-scalapack/get/v2.0.2-p2.tar.gz
+curl -L -O https://github.com/xiaoyeli/superlu_dist/archive/v6.2.0.tar.gz
+curl -L -O https://gitlab.com/slepc/slepc/-/archive/bda551b/slepc-bda551b.tar.gz
+```
+
+At this point, everything necessary should be downloaded and available in the directory hierarchy at `~/offline`. At this time, you may copy this directory to your offline-no-internet access machine. At the time of this writing, tallying up the disc space used equates to approximately ~2GB. Depending on your internet connection, you may want to compress the entire ~/offline directory instead (saves about 500Mb):
+
+```bash
+cd ~/
+tar -pzcf offline.tar.gz offline
+```
+
+!alert note
+If operating on a Macintosh machine, creating a tarball to be extracted on a Linux machine produces warnings. They are warnings only, and can be safely ignored.
+
+
+## Build PETSc, libMesh, and MOOSE
+
+With the tarball copied and extracted on the target machine (`tar -xf offline.tar.gz -C ~/`), or you simply copied the entire `~/offline` directory to your target machine's home directory, we can now build PETSc, libMesh, and MOOSE, using your MPI Wrapper/Compiler established in earlier steps.
+
+### PETSc
+
+Configure, build, and install PETSc to `$HOME/libs/petsc`:
+
+```bash
+cd ~/offline/moose/petsc
+./configure \
+ --download-mumps=1 \
+ --download-hypre=1 \
+ --download-slepc=1 \
+ --download-metis=1 \
+ --download-ptscotch=1 \
+ --download-parmetis=1 \
+ --download-scalapack=1 \
+ --download-fblaslapack=1 \
+ --download-superlu_dist=1 \
+ --with-packages-download-dir=~/offline/downloads \
+ --with-mpi=1 \
+ --with-debugging=no \
+ --with-cxx-dialect=C++11 \
+ --with-fortran-bindings=0 \
+ --with-shared-libraries=1 \
+ --prefix=$HOME/libs/petsc && make && make install
+```
+
+Unfortunately, any errors incurred during the above step is going to be beyond the scope of this document. Most likely, an error will be related to a missing library by one of the myriad contributions we are asking to build PETSc with. Please submit a detailed log of the error, to our [moose-users mailing list](https://groups.google.com/forum/#!forum/moose-users). But do be prepared to be asked to contact your system administrator; Errors of this nature normally require admin rights to fulfill the dependency.
+
+Proceed only if PETSc completed successfully.
+
+### libMesh
+
+Configure, build, and install libMesh to `$HOME/libs/libmesh`.
+
+First, we need to tell libMesh where PETSc is installed, and set the environment to use the MPI wrapper:
+
+```bash
+export PETSC_DIR=$HOME/libs/petsc
+export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
+```
+
+Now we can configure, build, and install libMesh:
+
+```bash
+cd ~/offline/moose/libmesh
+./configure \
+ --enable-silent-rules \
+ --enable-unique-id \
+ --disable-warnings \
+ --enable-glibcxx-debugging \
+ --with-thread-model=openmp \
+ --disable-maintainer-mode \
+ --enable-petsc-hypre-required \
+ --enable-metaphysicl-required \
+ --with-methods="opt dbg devel" \
+ --prefix=$HOME/libs/libmesh && make -j 6 && make install
+```
+
+Unfortunately, any errors incurred during these steps is going to be beyond the scope of this document. Please submit a detailed log of the error, to our [moose-users mailing list](https://groups.google.com/forum/#!forum/moose-users).
+
+Proceed only if libMesh completed successfully.
+
+### MOOSE
+
+First, we need to tell MOOSE  where libMesh is:
+
+```bash
+export LIBMESH_DIR=$HOME/libs/libmesh
+```
+
+Now we can build MOOSE:
+
+```bash
+export MOOSE_DIR=~/offline/moose
+cd $MOOSE_DIR/test
+make -j 6
+```
+
+Again, any errors incurred during this step, is going to be beyond the scope of this document. Please submit a detailed log of the error, to our [moose-users mailing list](https://groups.google.com/forum/#!forum/moose-users).
+
+## Your Application
+
+With all the libraries built, you are now able to build your application. To recap, there were several environment variables we previously set, which you will need to always set, when you perform any MOOSE-based development. Here are those environment variables again:
+
+```bash
+export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
+export PETSC_DIR=$HOME/libs/petsc
+export LIBMESH_DIR=$HOME/libs/libmesh
+export MOOSE_DIR=$HOME/offline/moose
+```
+
+You will need to set the above variables, each and every time you log in and out of your target machine.

--- a/modules/doc/content/help/development/ccache.md
+++ b/modules/doc/content/help/development/ccache.md
@@ -4,25 +4,25 @@
 
 ## Usage
 
-When using one of our [redistributable packages](getting_started/index.md), one must simply load an additional module to utilize ccache:
+In order to use ccache with MOOSE-based applications, it will be necessary to first build libMesh using ccache. This is due to the fact that each MOOSE-based application will ask libMesh how it was built, and in turn, use the same flags to build itself.
+
+In other words If you are using our Conda moose-libmesh package, then you cannot use ccache. In order to begin using ccache, first create a new conda environment, free of moose-libmesh, and install everything necessary to build libMesh with ccache:
 
 ```bash
-module load ccache
+conda create --name ccache-env moose-petsc moose-tools
+conda activate ccache-env
+export CC="ccache mpicc" CXX="ccache mpicxx"
 ```
 
-After loading this module you'll need to recompile libMesh using our `moose/scripts/update_and_rebuild_libmesh.sh` script. This script will detect the presence of ccache and append the appropriate configure arguments for you.  
-
-Using the ccache module is a "*once you use it, you always have to use it*" type of module. If you forget to load this module after already having used it to build libMesh, you will receive `ccache: command not found` failures when attempting to build MOOSE and MOOSE-based apps.  
-
-Our advice is to add this module to the list of modules that automatically get loaded when ever you open a new terminal. In order to do this add the `module load ccache` command to the end of your bash profile like so:
+Next, build libMesh:
 
 ```bash
-# Source MOOSE profile
-if [ -f /opt/moose/environments/moose_profile ]; then
-       . /opt/moose/environments/moose_profile
-fi
-module load ccache
+cd moose
+scripts/update_and_rebuild_libmesh.sh
 ```
+
+!alert note
+Because ccache is a conda-forge package as opposed to one controlled by the MOOSE development team, it will be necessary for you set your CC and CXX variables manually, each time you `conda activate ccache-env`.
 
 ## Using ccache
 

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -4,19 +4,17 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
 
 - #### command not found
 
-  You have yet to install conda, or your path to it, is incorrect or not set. You will need to recall how you installed conda; Was it Miniconda, or Anaconda? Was it the bash package or a double-click install method?
-
-  If you were following our [Conda](getting_started/installation/conda.md) instructions to the letter, Minconda should be installed at: `~/miniconda3`. Which means you must export your PATH like so:
+  You have yet to install conda, or your path to it is incorrect or not set. You will need to recall how you installed conda. Our instructions ask to have Miniconda3 installed to your home directory: `~/miniconda3`. Which requires you to set your PATH accordingly:
 
   ```bash
   export PATH=~/miniconda3/bin:$PATH
   ```
 
-  To finalize the install, you now need to initialize conda (see `conda init` below).
+  With PATH set, try to run again, what ever command you were initially attempting.
 
 - #### conda activate moose
 
-  If activate is failing, it's possible you have yet to perform a `conda init` *properly*. See conda init below. It could also mean you have an older version of Conda, or that the environment you are trying to activate is somewhere other than where conda thinks it should be, or simply missing / not yet created. Unfortunately, much of what can be diagnosed, is going to be beyond the scope of this document, and better left to the support teams at Miniconda/Anaconda. What we can attempt, is to create a new environment and go from there:
+  If activate is failing, it's possible you have yet to perform a `conda init` *properly*. See conda init below. It could also mean you have an older version of Conda, or that the environment you are trying to activate is somewhere other than where conda thinks it should be, or simply missing / not yet created. Unfortunately, much of what can be diagnosed, is going to be beyond the scope of this document, and better left to the support teams at [Conda](https://docs.conda.io/en/latest/help-support.html). What we can attempt, is to create a new environment and go from there:
 
   ```bash
   conda create --name testing --quiet --yes

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -55,7 +55,7 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
   conda init zsh
   ```
 
-- ### Your issue not listed
+- #### Your issue not listed
 
   The quick fix-attempt, is to re-install the moose-packages:
 


### PR DESCRIPTION
Create a new offline install markdown page.

Simplify Conda install by only supplying commands to install Miniconda3 via bash.
Split up the miniconda install page, so we can use it, without expressively installing
moose.
Fix mention of moose-environment in ccache help.

Closes #15436 #15441 #15414 