### PR TITLE
Add --enable-nodeconstraint in update_and_rebuild_libmesh.sh

### DIFF
--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -161,6 +161,7 @@ if [ -z "$go_fast" ]; then
                                    --disable-maintainer-mode \
                                    --enable-petsc-hypre-required \
                                    --enable-metaphysicl-required \
+                                   --enable-nodeconstraint \
                                    $DISABLE_TIMESTAMPS $VTK_OPTIONS $* | tee -a "$SCRIPT_DIR/$DIAGNOSTIC_LOG" || exit 1
 else
   # The build directory must already exist: you can't do --fast for


### PR DESCRIPTION
Refs #15389

This will give us better coverage for libMesh PRs. Instead of adding this flag to the script, we could turn it on in one or more civet_recipes, just let me know what you prefer. Also I don't know if this will even pass all the MOOSE testing, so let's check that first...
