### PR TITLE
Update docs, fix unity build 

### DIFF
--- a/framework/contrib/pcre/include/config.h
+++ b/framework/contrib/pcre/include/config.h
@@ -206,7 +206,7 @@ them both to 0; an emulation function will be used. */
 #endif
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+ */
 #ifndef LT_OBJDIR
 #define LT_OBJDIR ".libs/"
 #endif
@@ -312,8 +312,11 @@ them both to 0; an emulation function will be used. */
    in the C sense, but which are internal to the library. */
 /* #undef PCRE_EXP_DEFN */
 
-/* Define to any value if linking statically (TODO: make nice with Libtool) */
-/* #undef PCRE_STATIC */
+/* Define to any value if linking statically - which we tell users to do on Windows
+   (TODO: make nice with Libtool) */
+#ifdef __WIN32__
+#define PCRE_STATIC 1
+#endif
 
 /* When calling PCRE via the POSIX interface, additional working storage is
    required for holding the pointers to capturing substrings because PCRE

--- a/modules/doc/content/getting_started/installation/msys2.md
+++ b/modules/doc/content/getting_started/installation/msys2.md
@@ -139,7 +139,7 @@ Start the configure and build process with...
 ```
 mkdir build
 cd build
-../configure --with-methods='opt' --prefix=$HOME/projects/libmesh/installed --with-static=yes --with-shared=no --enable-static --disable-shared --enable-netcdf-required NETCDF_DIR=C:/msys64/mingw64
+../configure --with-methods='opt' --prefix=$HOME/projects/libmesh/installed --with-static=yes --with-shared=no --enable-static --disable-shared --enable-unique-id --disable-maintainer-mode --enable-petsc-hypre-required --enable-metaphysicl-required --enable-netcdf-required NETCDF_DIR=C:/msys64/mingw64
 make && make install
 ```
 
@@ -153,9 +153,6 @@ METHOD=opt scripts/update_and_rebuild_libmesh.sh --enable-static --disable-share
 This will take a few minutes.
 
 # MOOSE
-
-!alert note
-On Windows `MOOSE_HEADER_SYMLINKS` and `MOOSE_UNITY` are automatically set to false.
 
 Now it is finally time to build MOOSE. We'll start with the framework and the
 tests. (adjust the `-j` option to you number of available cores)


### PR DESCRIPTION
Greatly speeds up compiling on msys2 by re-enabling (and fixing) unity build. Updates installation instructions. Set pcre configuration to static compilation on windows.

Refs #14591