### PR TITLE
More Memory Logging

### DIFF
--- a/framework/doc/content/source/utils/PerfGraph.md
+++ b/framework/doc/content/source/utils/PerfGraph.md
@@ -99,22 +99,22 @@ Some other capability the `PerfGraph` has is the ability to print formatted tabl
 The `print()` method prints out an indented set of section names and shows their timing like so:
 
 ```
--------------------------------------------------------------------------------------------------------------
-|                 Section                |   Self(s)  |    %   | Children(s) |    %   |  Total(s)  |    %   |
--------------------------------------------------------------------------------------------------------------
-| App                                    |      0.004 |   1.95 |       0.207 |  98.05 |      0.212 | 100.00 |
-|   FEProblem::computeUserObjects        |      0.000 |   0.07 |       0.000 |   0.00 |      0.000 |   0.07 |
-|   FEProblem::solve                     |      0.014 |   6.59 |       0.119 |  56.44 |      0.133 |  63.03 |
-|     FEProblem::computeResidualInternal |      0.000 |   0.01 |       0.079 |  37.45 |      0.079 |  37.45 |
-|     FEProblem::computeJacobianInternal |      0.000 |   0.01 |       0.040 |  18.83 |      0.040 |  18.84 |
-|     Console::outputStep                |      0.000 |   0.12 |       0.000 |   0.00 |      0.000 |   0.12 |
-|   FEProblem::outputStep                |      0.000 |   0.04 |       0.001 |   0.42 |      0.001 |   0.46 |
-|     PerfGraphOutput::outputStep        |      0.000 |   0.00 |       0.000 |   0.00 |      0.000 |   0.00 |
-|     Console::outputStep                |      0.001 |   0.32 |       0.000 |   0.00 |      0.001 |   0.32 |
-|     CSV::outputStep                    |      0.000 |   0.10 |       0.000 |   0.00 |      0.000 |   0.10 |
--------------------------------------------------------------------------------------------------------------
+Performance Graph:
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+|                  Section                 | Calls | Mem(MB) |   Self(s)  |   Avg(s)   |    %   | Children(s) |   Avg(s)   |    %   |  Total(s)  |   Avg(s)   |    %   |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| MooseTestApp (main)                      |     1 |     769 |      0.008 |      0.008 |   0.04 |      23.127 |     23.127 |  99.96 |     23.135 |     23.135 | 100.00 |
+|   FEProblem::outputStep                  |     2 |      72 |      0.001 |      0.001 |   0.01 |       1.284 |      0.642 |   5.55 |      1.285 |      0.642 |   5.55 |
+|   Steady::PicardSolve                    |     1 |     287 |      0.000 |      0.000 |   0.00 |      12.635 |     12.635 |  54.61 |     12.635 |     12.635 |  54.61 |
+|     FEProblem::solve                     |     1 |     287 |      2.525 |      2.525 |  10.92 |      10.108 |     10.108 |  43.69 |     12.634 |     12.634 |  54.61 |
+|       FEProblem::computeResidualInternal |    15 |       0 |      0.000 |      0.000 |   0.00 |       7.980 |      0.532 |  34.49 |      7.980 |      0.532 |  34.49 |
+|       FEProblem::computeJacobianInternal |     2 |      15 |      0.000 |      0.000 |   0.00 |       2.128 |      1.064 |   9.20 |      2.128 |      1.064 |   9.20 |
+|     FEProblem::outputStep                |     1 |       0 |      0.001 |      0.001 |   0.00 |       0.000 |      0.000 |   0.00 |      0.001 |      0.001 |   0.00 |
+|   Steady::final                          |     1 |       0 |      0.000 |      0.000 |   0.00 |       0.001 |      0.001 |   0.00 |      0.001 |      0.001 |   0.00 |
+|     FEProblem::outputStep                |     1 |       0 |      0.001 |      0.001 |   0.00 |       0.000 |      0.000 |   0.00 |      0.001 |      0.001 |   0.00 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-`Self` time is the time actually taken by the section while `Children` time is the cumulative time of all of the sub-sections below that section and `Total` is the sum of the two.  The `%` columns represent the percent of the total run-time of the app for the number in the column to the left.
+`Calls` is the number of times that section was run. `Mem` is the total memory (in Megabytes) created within and underneath that section. `Self` time is the time actually taken by the section while `Children` time is the cumulative time of all of the sub-sections below that section and `Total` is the sum of the two.  The `Avg` and `%` columns represent the average and percent of the total run-time of the app for the number in the column to the left.
 
 There are also two other ways to print information out about the graph using `printHeaviestBranch()` and `printHeaviestSections()`.  These are described well over on the [/PerfGraphOutput.md] page.

--- a/framework/doc/content/source/utils/PerfGraph.md
+++ b/framework/doc/content/source/utils/PerfGraph.md
@@ -100,21 +100,21 @@ The `print()` method prints out an indented set of section names and shows their
 
 ```
 Performance Graph:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-|                  Section                 | Calls | Mem(MB) |   Self(s)  |   Avg(s)   |    %   | Children(s) |   Avg(s)   |    %   |  Total(s)  |   Avg(s)   |    %   |
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| MooseTestApp (main)                      |     1 |     769 |      0.008 |      0.008 |   0.04 |      23.127 |     23.127 |  99.96 |     23.135 |     23.135 | 100.00 |
-|   FEProblem::outputStep                  |     2 |      72 |      0.001 |      0.001 |   0.01 |       1.284 |      0.642 |   5.55 |      1.285 |      0.642 |   5.55 |
-|   Steady::PicardSolve                    |     1 |     287 |      0.000 |      0.000 |   0.00 |      12.635 |     12.635 |  54.61 |     12.635 |     12.635 |  54.61 |
-|     FEProblem::solve                     |     1 |     287 |      2.525 |      2.525 |  10.92 |      10.108 |     10.108 |  43.69 |     12.634 |     12.634 |  54.61 |
-|       FEProblem::computeResidualInternal |    15 |       0 |      0.000 |      0.000 |   0.00 |       7.980 |      0.532 |  34.49 |      7.980 |      0.532 |  34.49 |
-|       FEProblem::computeJacobianInternal |     2 |      15 |      0.000 |      0.000 |   0.00 |       2.128 |      1.064 |   9.20 |      2.128 |      1.064 |   9.20 |
-|     FEProblem::outputStep                |     1 |       0 |      0.001 |      0.001 |   0.00 |       0.000 |      0.000 |   0.00 |      0.001 |      0.001 |   0.00 |
-|   Steady::final                          |     1 |       0 |      0.000 |      0.000 |   0.00 |       0.001 |      0.001 |   0.00 |      0.001 |      0.001 |   0.00 |
-|     FEProblem::outputStep                |     1 |       0 |      0.001 |      0.001 |   0.00 |       0.000 |      0.000 |   0.00 |      0.001 |      0.001 |   0.00 |
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------
+|                  Section                 | Calls |   Self(s)  |   Avg(s)   |    %   | Mem(MB) |  Total(s)  |   Avg(s)   |    %   | Mem(MB) |
+----------------------------------------------------------------------------------------------------------------------------------------------
+| MooseTestApp (main)                      |     1 |      0.008 |      0.008 |   0.66 |       1 |      1.259 |      1.259 | 100.00 |      67 |
+|   FEProblem::outputStep                  |     2 |      0.001 |      0.000 |   0.04 |       0 |      0.064 |      0.032 |   5.09 |       8 |
+|   Steady::PicardSolve                    |     1 |      0.000 |      0.000 |   0.01 |       0 |      0.717 |      0.717 |  56.92 |      32 |
+|     FEProblem::solve                     |     1 |      0.134 |      0.134 |  10.61 |      29 |      0.716 |      0.716 |  56.89 |      32 |
+|       FEProblem::computeResidualInternal |    14 |      0.000 |      0.000 |   0.01 |       0 |      0.458 |      0.033 |  36.34 |       1 |
+|       FEProblem::computeJacobianInternal |     2 |      0.000 |      0.000 |   0.00 |       0 |      0.125 |      0.062 |   9.91 |       2 |
+|     FEProblem::outputStep                |     1 |      0.000 |      0.000 |   0.02 |       0 |      0.000 |      0.000 |   0.02 |       0 |
+|   Steady::final                          |     1 |      0.000 |      0.000 |   0.00 |       0 |      0.000 |      0.000 |   0.02 |       0 |
+|     FEProblem::outputStep                |     1 |      0.000 |      0.000 |   0.01 |       0 |      0.000 |      0.000 |   0.02 |       0 |
+----------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-`Calls` is the number of times that section was run. `Mem` is the total memory (in Megabytes) created within and underneath that section. `Self` time is the time actually taken by the section while `Children` time is the cumulative time of all of the sub-sections below that section and `Total` is the sum of the two.  The `Avg` and `%` columns represent the average and percent of the total run-time of the app for the number in the column to the left.
+`Calls` is the number of times that section was run. `Self` time is the time actually taken by the section while `Children` time is the cumulative time of all of the sub-sections below that section and `Total` is the sum of the two.  The `Avg` and `%` columns represent the average and percent of the total run-time of the app for the number in the column to the left. `Mem` is the memory (in Megabytes) for the column to the left (Self or Total).
 
 There are also two other ways to print information out about the graph using `printHeaviestBranch()` and `printHeaviestSections()`.  These are described well over on the [/PerfGraphOutput.md] page.

--- a/framework/doc/content/source/utils/PerfGraph.md
+++ b/framework/doc/content/source/utils/PerfGraph.md
@@ -115,6 +115,6 @@ Performance Graph:
 ----------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-`Calls` is the number of times that section was run. `Self` time is the time actually taken by the section while `Children` time is the cumulative time of all of the sub-sections below that section and `Total` is the sum of the two.  The `Avg` and `%` columns represent the average and percent of the total run-time of the app for the number in the column to the left. `Mem` is the memory (in Megabytes) for the column to the left (Self or Total).
+`Calls` is the number of times that section was run. `Self` time is the time actually taken by the section and `Total` is the sum of the `Self` time and the time of all of the sub-actions below that section.  The `Avg` and `%` columns represent the average and percent of the total run-time of the app for the number in the column to the left. `Mem` is the memory (in Megabytes) for the column to the left (Self or Total).
 
 There are also two other ways to print information out about the graph using `printHeaviestBranch()` and `printHeaviestSections()`.  These are described well over on the [/PerfGraphOutput.md] page.

--- a/framework/include/utils/PerfGraph.h
+++ b/framework/include/utils/PerfGraph.h
@@ -49,6 +49,8 @@ public:
     SELF_PERCENT,
     CHILDREN_PERCENT,
     TOTAL_PERCENT,
+    SELF_MEMORY,
+    CHILDREN_MEMORY,
     TOTAL_MEMORY
   };
 
@@ -152,6 +154,28 @@ public:
   }
 
   /**
+   * Get a reference to the self memory usage for a section
+   *
+   * This reference can be held onto and the value
+   * will be updated anyting updateTiming() is called
+   */
+  const long int & getSelfMemory(const std::string & section_name)
+  {
+    return _section_time[section_name]._self_memory;
+  }
+
+  /**
+   * Get a reference to the children memory usage for a section
+   *
+   * This reference can be held onto and the value
+   * will be updated anyting updateTiming() is called
+   */
+  const long int & getChildrenMemory(const std::string & section_name)
+  {
+    return _section_time[section_name]._children_memory;
+  }
+
+  /**
    * Get a reference to the total memory usage for a section
    *
    * This reference can be held onto and the value
@@ -170,19 +194,17 @@ public:
 protected:
   typedef VariadicTable<std::string,
                         unsigned long int,
+                        Real,
+                        Real,
+                        Real,
                         long int,
                         Real,
                         Real,
                         Real,
-                        Real,
-                        Real,
-                        Real,
-                        Real,
-                        Real,
-                        Real>
+                        long int>
       FullTable;
 
-  typedef VariadicTable<std::string, unsigned long int, long int, Real, Real, Real> HeaviestTable;
+  typedef VariadicTable<std::string, unsigned long int, Real, Real, Real, long int> HeaviestTable;
 
   /**
    * Use to hold the time for each section
@@ -195,6 +217,8 @@ protected:
     Real _children = 0.;
     Real _total = 0.;
     unsigned long int _num_calls = 0;
+    long int _self_memory = 0;
+    long int _children_memory = 0;
     long int _total_memory = 0;
   };
 

--- a/framework/include/utils/PerfGraph.h
+++ b/framework/include/utils/PerfGraph.h
@@ -15,6 +15,7 @@
 #include "IndirectSort.h"
 #include "ConsoleStream.h"
 #include "MooseError.h"
+#include "MemoryUtils.h"
 
 // System Includes
 #include <array>
@@ -47,7 +48,8 @@ public:
     TOTAL_AVG,
     SELF_PERCENT,
     CHILDREN_PERCENT,
-    TOTAL_PERCENT
+    TOTAL_PERCENT,
+    TOTAL_MEMORY
   };
 
   /**
@@ -150,6 +152,17 @@ public:
   }
 
   /**
+   * Get a reference to the total memory usage for a section
+   *
+   * This reference can be held onto and the value
+   * will be updated anyting updateTiming() is called
+   */
+  const long int & getTotalMemory(const std::string & section_name)
+  {
+    return _section_time[section_name]._total_memory;
+  }
+
+  /**
    * Udates the time section_time and time for all currently running nodes
    */
   void updateTiming();
@@ -157,6 +170,7 @@ public:
 protected:
   typedef VariadicTable<std::string,
                         unsigned long int,
+                        long int,
                         Real,
                         Real,
                         Real,
@@ -168,7 +182,7 @@ protected:
                         Real>
       FullTable;
 
-  typedef VariadicTable<std::string, unsigned long int, Real, Real, Real> HeaviestTable;
+  typedef VariadicTable<std::string, unsigned long int, long int, Real, Real, Real> HeaviestTable;
 
   /**
    * Use to hold the time for each section
@@ -181,6 +195,7 @@ protected:
     Real _children = 0.;
     Real _total = 0.;
     unsigned long int _num_calls = 0;
+    long int _total_memory = 0;
   };
 
   /**
@@ -284,4 +299,3 @@ protected:
   // Here so PerfGuard is the only thing that can call push/pop
   friend class PerfGuard;
 };
-

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -37,7 +37,8 @@ public:
   /**
    * Set the current start time
    */
-  void setStartTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time, const long int memory)
+  void setStartTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time,
+                             const long int memory)
   {
     _start_time = time;
     _start_memory = memory;
@@ -46,7 +47,8 @@ public:
   /**
    * Add some time into this Node by taking the difference with the time passed in
    */
-  void addTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time, const long int memory)
+  void addTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time,
+                        const long int memory)
   {
     _total_time += time - _start_time;
     _total_memory += memory - _start_memory;

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -113,6 +113,16 @@ public:
   /**
    * Get the amount of memory added by this node
    */
+  long int selfMemory();
+
+  /**
+   * Get the amount of memory added by this node
+   */
+  long int childrenMemory();
+
+  /**
+   * Get the amount of memory added by this node
+   */
   long int totalMemory() { return _total_memory; }
 
 protected:

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -17,6 +17,7 @@
 
 
 #include "MooseTypes.h"
+#include "MemoryUtils.h"
 
 #include <map>
 
@@ -26,7 +27,7 @@ public:
   /**
    * Create a PerfNode with the given ID
    */
-  PerfNode(const PerfID id) : _id(id), _total_time(0), _num_calls(0) {}
+  PerfNode(const PerfID id) : _id(id), _total_time(0), _num_calls(0), _total_memory(0) {}
 
   /**
    * Get the ID of this Node
@@ -36,17 +37,19 @@ public:
   /**
    * Set the current start time
    */
-  void setStartTime(const std::chrono::time_point<std::chrono::steady_clock> time)
+  void setStartTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time, const long int memory)
   {
     _start_time = time;
+    _start_memory = memory;
   }
 
   /**
    * Add some time into this Node by taking the difference with the time passed in
    */
-  void addTime(const std::chrono::time_point<std::chrono::steady_clock> time)
+  void addTimeAndMemory(const std::chrono::time_point<std::chrono::steady_clock> time, const long int memory)
   {
     _total_time += time - _start_time;
+    _total_memory += memory - _start_memory;
   }
 
   /**
@@ -57,7 +60,7 @@ public:
   /**
    * Add some time into this Node
    */
-  void addTime(const std::chrono::steady_clock::duration time) { _total_time += time; }
+  void addTimeAndMemory(const std::chrono::steady_clock::duration time) { _total_time += time; }
 
   /**
    * Get a child node with the unique id given
@@ -105,6 +108,11 @@ public:
    */
   unsigned long int numCalls() { return _num_calls; }
 
+  /**
+   * Get the amount of memory added by this node
+   */
+  long int totalMemory() { return _total_memory; }
+
 protected:
   /// The unique ID for the section this Node corresponds to
   PerfID _id;
@@ -115,10 +123,15 @@ protected:
   /// The total elapsed time for this node
   std::chrono::steady_clock::duration _total_time;
 
+  /// The starting memory for this node
+  long unsigned int _start_memory;
+
   /// Number of times this node has been called
   long unsigned int _num_calls;
+
+  /// The total memory added while this node is active
+  long unsigned int _total_memory;
 
   /// Timers that are directly underneath this node
   std::map<PerfID, std::unique_ptr<PerfNode>> _children;
 };
-

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -60,11 +60,6 @@ public:
   void incrementNumCalls() { _num_calls++; }
 
   /**
-   * Add some time into this Node
-   */
-  void addTimeAndMemory(const std::chrono::steady_clock::duration time) { _total_time += time; }
-
-  /**
    * Get a child node with the unique id given
    *
    * Note: this will automatically create the Node internally if it needs to.

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -113,17 +113,17 @@ public:
   /**
    * Get the amount of memory added by this node
    */
-  long int selfMemory();
+  long int selfMemory() const;
 
   /**
    * Get the amount of memory added by this node
    */
-  long int childrenMemory();
+  long int childrenMemory() const;
 
   /**
    * Get the amount of memory added by this node
    */
-  long int totalMemory() { return _total_memory; }
+  long int totalMemory() const { return _total_memory; }
 
 protected:
   /// The unique ID for the section this Node corresponds to

--- a/framework/include/utils/TimedPrint.h
+++ b/framework/include/utils/TimedPrint.h
@@ -95,7 +95,8 @@ public:
 
       MemoryUtils::Stats stats;
       MemoryUtils::getMemoryStats(stats);
-      auto start_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+      auto start_memory =
+          MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
 
       unsigned int offset = 0;
       if (done_future.wait_for(initial_wait) == std::future_status::timeout ||
@@ -128,7 +129,8 @@ public:
         std::chrono::duration<double> duration = end - start;
 
         MemoryUtils::getMemoryStats(stats);
-        auto end_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+        auto end_memory =
+            MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
         int memory_increment = end_memory - start_memory; // int on purpose so it can be negative
 
         auto original_precision = out.precision();
@@ -136,9 +138,8 @@ public:
 
         out << std::setw(WRAP_LENGTH - offset) << ' ' << " [" << COLOR_YELLOW << std::setw(6)
             << std::fixed << std::setprecision(2) << duration.count() << " s" << COLOR_DEFAULT
-            << ']' << " [" << COLOR_YELLOW << std::setw(5)
-            << std::fixed << memory_increment << " MB" << COLOR_DEFAULT
-            << ']';
+            << ']' << " [" << COLOR_YELLOW << std::setw(5) << std::fixed << memory_increment
+            << " MB" << COLOR_DEFAULT << ']';
 
         // Restore the original stream state
         out.precision(original_precision);

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -126,6 +126,10 @@ PerfGraph::getTime(const TimeType type, const std::string & section_name)
       return 100. * (section_it->second._children / app_time);
     case TOTAL_PERCENT:
       return 100. * (section_it->second._total / app_time);
+    case SELF_MEMORY:
+      return section_it->second._self_memory;
+    case CHILDREN_MEMORY:
+      return section_it->second._children_memory;
     case TOTAL_MEMORY:
       return section_it->second._total_memory;
     default:
@@ -203,6 +207,8 @@ PerfGraph::updateTiming()
     section_time._self = 0.;
     section_time._children = 0.;
     section_time._total = 0.;
+    section_time._self_memory = 0;
+    section_time._children_memory = 0;
     section_time._total_memory = 0.;
   }
 
@@ -230,6 +236,9 @@ PerfGraph::recursivelyFillTime(PerfNode * current_node)
   auto children = std::chrono::duration<double>(current_node->childrenTime()).count();
   auto total = std::chrono::duration<double>(current_node->totalTime()).count();
   auto num_calls = current_node->numCalls();
+
+  auto self_memory = current_node->selfMemory();
+  auto children_memory = current_node->childrenMemory();
   auto total_memory = current_node->totalMemory();
 
   // RHS insertion on purpose
@@ -239,6 +248,9 @@ PerfGraph::recursivelyFillTime(PerfNode * current_node)
   section_time._children += children;
   section_time._total += total;
   section_time._num_calls += num_calls;
+
+  section_time._self_memory += self_memory;
+  section_time._children_memory += children_memory;
   section_time._total_memory += total_memory;
 
   for (auto & child_it : current_node->children())
@@ -282,20 +294,22 @@ PerfGraph::recursivelyPrintGraph(PerfNode * current_node,
     auto total_avg = total / static_cast<Real>(num_calls);
     auto total_percent = 100. * total / total_root_time;
 
+    auto self_memory = current_node->selfMemory();
     auto total_memory = current_node->totalMemory();
 
     vtable.addRow(section,
                   num_calls,
-                  total_memory,
                   self,
                   self_avg,
                   self_percent,
-                  children,
-                  children_avg,
-                  children_percent,
+                  self_memory,
+                  //                  children,
+                  //                  children_avg,
+                  //                  children_percent,
                   total,
                   total_avg,
-                  total_percent);
+                  total_percent,
+                  total_memory);
 
     current_depth++;
   }
@@ -332,20 +346,22 @@ PerfGraph::recursivelyPrintHeaviestGraph(PerfNode * current_node,
   auto total_avg = total / static_cast<Real>(num_calls);
   auto total_percent = 100. * total / total_root_time;
 
+  auto self_memory = current_node->selfMemory();
   auto total_memory = current_node->totalMemory();
 
   vtable.addRow(section,
                 num_calls,
-                total_memory,
                 self,
                 self_avg,
                 self_percent,
-                children,
-                children_avg,
-                children_percent,
+                self_memory,
+                //                children,
+                //                children_avg,
+                //                children_percent,
                 total,
                 total_avg,
-                total_percent);
+                total_percent,
+                total_memory);
 
   current_depth++;
 
@@ -373,32 +389,47 @@ PerfGraph::print(const ConsoleStream & console, unsigned int level)
   console << "\nPerformance Graph:\n";
   FullTable vtable({"Section",
                     "Calls",
-                    "Mem(MB)",
                     "Self(s)",
                     "Avg(s)",
                     "%",
-                    "Children(s)",
-                    "Avg(s)",
-                    "%",
+                    "Mem(MB)",
+                    // "Children(s)",
+                    // "Avg(s)",
+                    // "%",
                     "Total(s)",
                     "Avg(s)",
-                    "%"},
+                    "%",
+                    "Mem(MB)"},
                    10);
 
-  vtable.setColumnFormat({VariadicTableColumnFormat::AUTO,      // Section Name
-                          VariadicTableColumnFormat::AUTO,      // Calls
-                          VariadicTableColumnFormat::AUTO,      // Memory
-                          VariadicTableColumnFormat::FIXED,     // Self
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT,   // %
-                          VariadicTableColumnFormat::FIXED,     // Children
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT,   // %
-                          VariadicTableColumnFormat::FIXED,     // Total
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT}); // %
+  vtable.setColumnFormat({
+      VariadicTableColumnFormat::AUTO,    // Section Name
+      VariadicTableColumnFormat::AUTO,    // Calls
+      VariadicTableColumnFormat::FIXED,   // Self
+      VariadicTableColumnFormat::FIXED,   // Avg.
+      VariadicTableColumnFormat::PERCENT, // %
+      VariadicTableColumnFormat::AUTO,    // Memory
+      // VariadicTableColumnFormat::FIXED,     // Children
+      // VariadicTableColumnFormat::FIXED,     // Avg.
+      // VariadicTableColumnFormat::PERCENT,   // %
+      VariadicTableColumnFormat::FIXED,   // Total
+      VariadicTableColumnFormat::FIXED,   // Avg.
+      VariadicTableColumnFormat::PERCENT, // %
+      VariadicTableColumnFormat::AUTO,    // Memory
+  });                                     // %
 
-  vtable.setColumnPrecision({1, 0, 0, 3, 3, 2, 3, 3, 2, 3, 3, 2});
+  vtable.setColumnPrecision({
+      1, // Section Name
+      0, // Calls
+      3, // Self
+      3, // Avg.
+      2, // %
+      0, // Memory
+      3, // Total
+      3, // Avg.
+      2, // %
+      0, // Memory
+  });
 
   recursivelyPrintGraph(_root_node.get(), vtable, level);
   vtable.print(console);
@@ -412,32 +443,45 @@ PerfGraph::printHeaviestBranch(const ConsoleStream & console)
   console << "\nHeaviest Branch:\n";
   FullTable vtable({"Section",
                     "Calls",
-                    "Mem(MB)",
                     "Self(s)",
                     "Avg(s)",
                     "%",
-                    "Children(s)",
-                    "Avg(s)",
-                    "%",
+                    "Mem(MB)",
+                    // "Children(s)",
+                    // "Avg(s)",
+                    // "%",
                     "Total(s)",
                     "Avg(s)",
-                    "%"},
+                    "%",
+                    "Mem(MB)"},
                    10);
 
-  vtable.setColumnFormat({VariadicTableColumnFormat::AUTO,      // Section Name
-                          VariadicTableColumnFormat::AUTO,      // Calls
-                          VariadicTableColumnFormat::AUTO,      // Memory
-                          VariadicTableColumnFormat::FIXED,     // Self
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT,   // %
-                          VariadicTableColumnFormat::FIXED,     // Children
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT,   // %
-                          VariadicTableColumnFormat::FIXED,     // Total
-                          VariadicTableColumnFormat::FIXED,     // Avg.
-                          VariadicTableColumnFormat::PERCENT}); // %
+  vtable.setColumnFormat({VariadicTableColumnFormat::AUTO,    // Section Name
+                          VariadicTableColumnFormat::AUTO,    // Calls
+                          VariadicTableColumnFormat::FIXED,   // Self
+                          VariadicTableColumnFormat::FIXED,   // Avg.
+                          VariadicTableColumnFormat::PERCENT, // %
+                          VariadicTableColumnFormat::AUTO,    // Memory
+                          // VariadicTableColumnFormat::FIXED,     // Children
+                          // VariadicTableColumnFormat::FIXED,     // Avg.
+                          // VariadicTableColumnFormat::PERCENT,   // %
+                          VariadicTableColumnFormat::FIXED,   // Total
+                          VariadicTableColumnFormat::FIXED,   // Avg.
+                          VariadicTableColumnFormat::PERCENT, // %
+                          VariadicTableColumnFormat::AUTO});  // Memory
 
-  vtable.setColumnPrecision({1, 0, 0, 3, 3, 2, 3, 3, 2, 3, 3, 2});
+  vtable.setColumnPrecision({
+      1, // Section Name
+      0, // Calls
+      3, // Self
+      3, // Avg.
+      2, // %
+      0, // Memory
+      3, // Total
+      3, // Avg.
+      2, // %
+      0, // Memory
+  });
 
   recursivelyPrintHeaviestGraph(_root_node.get(), vtable);
   vtable.print(console);
@@ -467,16 +511,16 @@ PerfGraph::printHeaviestSections(const ConsoleStream & console, const unsigned i
                         return false;
                       });
 
-  HeaviestTable vtable({"Section", "Calls", "Mem(MB)", "Self(s)", "Avg.", "%"}, 10);
+  HeaviestTable vtable({"Section", "Calls", "Self(s)", "Avg.", "%", "Mem(MB)"}, 10);
 
   vtable.setColumnFormat({VariadicTableColumnFormat::AUTO, // Doesn't matter
                           VariadicTableColumnFormat::AUTO,
-                          VariadicTableColumnFormat::AUTO,
                           VariadicTableColumnFormat::FIXED,
                           VariadicTableColumnFormat::FIXED,
-                          VariadicTableColumnFormat::PERCENT});
+                          VariadicTableColumnFormat::PERCENT,
+                          VariadicTableColumnFormat::AUTO});
 
-  vtable.setColumnPrecision({1, 1, 1, 3, 3, 2});
+  vtable.setColumnPrecision({1, 1, 3, 3, 2, 1});
 
   mooseAssert(!_section_time_ptrs.empty(),
               "updateTiming() must be run before printHeaviestSections()!");

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -34,7 +34,8 @@ PerfGraph::PerfGraph(const std::string & root_name)
 
   MemoryUtils::Stats stats;
   MemoryUtils::getMemoryStats(stats);
-  auto start_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+  auto start_memory =
+      MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
 
   // Set the initial time
   _root_node->setStartTimeAndMemory(std::chrono::steady_clock::now(), start_memory);
@@ -142,7 +143,8 @@ PerfGraph::push(const PerfID id)
 
   MemoryUtils::Stats stats;
   MemoryUtils::getMemoryStats(stats);
-  auto start_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+  auto start_memory =
+      MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
 
   // Set the start time
   new_node->setStartTimeAndMemory(std::chrono::steady_clock::now(), start_memory);
@@ -166,7 +168,8 @@ PerfGraph::pop()
 
   MemoryUtils::Stats stats;
   MemoryUtils::getMemoryStats(stats);
-  auto now_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+  auto now_memory =
+      MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
 
   _stack[_current_position]->addTimeAndMemory(std::chrono::steady_clock::now(), now_memory);
 
@@ -181,7 +184,8 @@ PerfGraph::updateTiming()
 
   MemoryUtils::Stats stats;
   MemoryUtils::getMemoryStats(stats);
-  auto now_memory =  MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
+  auto now_memory =
+      MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
 
   for (unsigned int i = 0; i <= _current_position; i++)
   {

--- a/framework/src/utils/PerfNode.C
+++ b/framework/src/utils/PerfNode.C
@@ -35,13 +35,13 @@ PerfNode::childrenTime() const
 }
 
 long int
-PerfNode::selfMemory()
+PerfNode::selfMemory() const
 {
   return _total_memory - childrenMemory();
 }
 
 long int
-PerfNode::childrenMemory()
+PerfNode::childrenMemory() const
 {
   long int children_memory = 0;
 

--- a/framework/src/utils/PerfNode.C
+++ b/framework/src/utils/PerfNode.C
@@ -33,3 +33,20 @@ PerfNode::childrenTime() const
 
   return children_time;
 }
+
+long int
+PerfNode::selfMemory()
+{
+  return _total_memory - childrenMemory();
+}
+
+long int
+PerfNode::childrenMemory()
+{
+  long int children_memory = 0;
+
+  for (auto & child_it : _children)
+    children_memory += child_it.second->totalMemory();
+
+  return children_memory;
+}


### PR DESCRIPTION
Work towards satisfying #15444 .  Inspired by #15446

This extends both the `TimedPrint` and `PerfGraph` capabilities to also track memory usage.

Example of new `TimedPrint`:

![image](https://user-images.githubusercontent.com/870705/85061276-c993b280-b163-11ea-85b4-1fe6747e2a25.png)

Example of new `PerfGraph`:

![image](https://user-images.githubusercontent.com/870705/85061430-08c20380-b164-11ea-8096-55044f7cc928.png)
