### PR TITLE
Make troubleshooting page link optional to keep application docs working

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -22,6 +22,6 @@ and an experimental [WSL](installation/windows10.md) option is available.
 
 !include getting_started/installation/test_moose.md
 
-Head back over to the [getting_started/index.md] page to continue your tour of MOOSE.
+Head back over to the [getting_started/index.md optional=True] page to continue your tour of MOOSE.
 
 !include installation/uninstall_conda.md

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -1,6 +1,6 @@
 ## Install Miniconda3 id=installconda
 
-Installing Miniconda3 is straight forward. Download, install, and configure. If you run into issues during these steps, please visit our [troubleshooting guide for Conda](troubleshooting.md#condaissues).
+Installing Miniconda3 is straight forward. Download, install, and configure. If you run into issues during these steps, please visit the MOOSE [troubleshooting guide for Conda](troubleshooting.md#condaissues optional=True).
 
 - +Linux Users:+
 

--- a/modules/doc/content/getting_started/installation/installation_troubleshooting.md
+++ b/modules/doc/content/getting_started/installation/installation_troubleshooting.md
@@ -1,5 +1,5 @@
 ## Install Troubleshooting
 
-Please see our [FAQ](help/faq/index.md) page for common issues. If your issue is not listed, this
+Please see the MOOSE [FAQ](help/faq/index.md optional=True) page for common issues. If your issue is not listed, this
 would be an excellent time to join us on our
 [mailing list](https://groups.google.com/forum/#!forum/moose-users) and ask for help!

--- a/modules/doc/content/getting_started/installation/post_moose_install.md
+++ b/modules/doc/content/getting_started/installation/post_moose_install.md
@@ -1,7 +1,7 @@
 ## Learn More
 
 Now that you have a working MOOSE Framework stack,
-[consider checking out the examples](examples/index.md) for a beginning tour of how to use input
+[consider checking out the MOOSE examples](examples/index.md optional=True) for a beginning tour of how to use input
 files and implement your own custom behavior for MOOSE.
 
 ## Join the Community


### PR DESCRIPTION
(refs #15443)

I don't understand why this made it through.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
