### PR TITLE
Add `unique_test_id` parameter to TestHarness.

### DIFF
--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -29,6 +29,7 @@ class Tester(MooseObject):
         params.addParam('max_time',   300, "The maximum in seconds that the test will be allowed to run.")
         params.addParam('skip',     "Provide a reason this test will be skipped.")
         params.addParam('deleted',         "Tests that only show up when using the '-e' option (Permanently skipped or not implemented).")
+        params.addParam('unique_test_id', "The unique hash given to a test")
 
         params.addParam('heavy',    False, "Set to True if this test should only be run when the '--heavy' option is used.")
         params.addParam('group',       [], "A list of groups for which this test belongs.")
@@ -214,6 +215,10 @@ class Tester(MooseObject):
     def getMaxTime(self):
         """ return maximum time elapse before reporting a 'timeout' status """
         return float(self.specs['max_time'])
+
+    def getUniqueTestID(self):
+        """ return unique hash for test """
+        return self.specs['unique_test_id']
 
     def getRunnable(self, options):
         """ return bool and cache results, if this test can run """

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -58,7 +58,7 @@ class Tester(MooseObject):
         params.addParam('method',        ['ALL'], "A test that runs under certain executable configurations ('ALL', 'OPT', 'DBG', 'DEVEL', 'OPROF', 'PRO')")
         params.addParam('library_mode',  ['ALL'], "A test that only runs when libraries are built under certain configurations ('ALL', 'STATIC', 'DYNAMIC')")
         params.addParam('dtk',           ['ALL'], "A test that runs only if DTK is detected ('ALL', 'TRUE', 'FALSE')")
-        params.addParam('unique_ids',    ['ALL'], "A test that runs only if UNIQUE_IDs are enabled ('ALL', 'TRUE', 'FALSE')")
+        params.addParam('unique_ids',    ['ALL'], "Deprecated. Use unique_id instead.")
         params.addParam('recover',       True,    "A test that runs with '--recover' mode enabled")
         params.addParam('vtk',           ['ALL'], "A test that runs only if VTK is detected ('ALL', 'TRUE', 'FALSE')")
         params.addParam('tecplot',       ['ALL'], "A test that runs only if Tecplot is detected ('ALL', 'TRUE', 'FALSE')")

--- a/test/tests/mesh/unique_ids/tests
+++ b/test/tests/mesh/unique_ids/tests
@@ -5,7 +5,7 @@
   [./replicated_mesh]
     type = 'RunApp'
     input = 'unique_ids.i'
-    unique_ids = True
+    unique_id = True
     min_parallel = 2
     requirement = 'The system shall support having a truly unique_id (never recycled) for all mesh elements and nodes when using replicated mesh.'
   [../]
@@ -13,7 +13,7 @@
   [./distributed_mesh]
     type = 'RunApp'
     input = 'unique_ids.i'
-    unique_ids = True
+    unique_id = True
     cli_args = '--distributed-mesh'
     min_parallel = 2
     prereq = 'replicated_mesh'


### PR DESCRIPTION
In order to track tests overtime, a unique hash can be given to a test that will
survive file-path/name changes. This is particularly important for long-running
assessment cases that gather performance data during nightly runs. Currently,
there is no 1:1 mapping relationship between test-name, test-output, or
test-results.

See Refs gitlab/idaholab/bison#1178 for more details.

@dschwen 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
