### PR TITLE
shorten names of tests in distributed_rectilinear_mesh_generator

### DIFF
--- a/test/tests/meshgenerators/distributed_rectilinear_mesh_generator/tests
+++ b/test/tests/meshgenerators/distributed_rectilinear_mesh_generator/tests
@@ -2,7 +2,7 @@
    design = 'meshgenerators/DistributedRectilinearMeshGenerator.md'
    issues = '#11485'
 
-  [./distributed_rectilinear_mesh_generator]
+  [./mesh_generator]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     exodiff = 'distributed_rectilinear_mesh_generator_out.e'
@@ -10,7 +10,7 @@
     requirement = 'MOOSE shall be able to generate 2D Quad4 mesh in parallel'
   [../]
 
-  [./distributed_rectilinear_mesh_generator_1D]
+  [./1D]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     cli_args = 'Mesh/gmg/dim=1 Outputs/file_base=distributed_rectilinear_mesh_generator_out_1d Outputs/hide="pid npid" '
@@ -18,7 +18,7 @@
     requirement = 'MOOSE shall be able to generate 1D EDGE2 mesh in parallel.'
   [../]
 
-  [./distributed_rectilinear_mesh_generator_3D]
+  [./3D]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     exodiff = 'distributed_rectilinear_mesh_generator_out_3d.e'
@@ -26,7 +26,7 @@
     requirement = 'MOOSE shall be able to generate 3D HEX8 mesh in parallel.'
   [../]
 
-  [./distributed_rectilinear_mesh_generator_3D_ptscotch]
+  [./3D_ptscotch]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     exodiff = 'distributed_rectilinear_mesh_generator_out_3d_ptscotch.e'
@@ -37,7 +37,7 @@
     requirement = 'MOOSE shall be able to generate 3D HEX8 mesh in parallel using ptscotch partitioner'
   [../]
 
-  [./distributed_rectilinear_mesh_generator_3D_hierarch]
+  [./3D_hierarch]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     exodiff = 'distributed_rectilinear_mesh_generator_out_3d_hierarch.e'
@@ -47,7 +47,7 @@
     requirement = 'MOOSE shall be able to generate 3D HEX8 mesh in parallel using hierarch partitioner'
   [../]
 
-  [./drmg_3d_scomm_out]
+  [./3d_scomm_out]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator.i'
     exodiff = 'drmg_3d_scomm_out.e'
@@ -57,7 +57,7 @@
     requirement = 'MOOSE shall be able to generate a first-order hexahedral mesh in parallel using a small number of cores for the graph partitioner.'
   [../]
 
-  [./drmg_3d_scomm_10_out]
+  [./3d_scomm_10_out]
     type = 'RunException'
     input = 'distributed_rectilinear_mesh_generator.i'
     expect_err = 'Number of cores for the graph partitioner is too large'
@@ -67,7 +67,7 @@
     requirement = 'MOOSE shall error out if the number of cores for partition is larger than the total number of cores.'
   [../]
 
-  [./distributed_rectilinear_mesh_generator_mesh_adaptivity]
+  [./mesh_adaptivity]
     type = 'Exodiff'
     input = 'distributed_rectilinear_mesh_generator_adaptivity.i'
     exodiff = 'distributed_rectilinear_mesh_generator_adaptivity_out.e'


### PR DESCRIPTION
The name is, just so long, it ends up going beyond the max terminal width length.



Closes #15492

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
