### PR TITLE
Add conda-build to moose-tools module

### DIFF
--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - pylatexenc
     - jinja2
     - mako
+    - conda-build
     - python {{ python }}
 
 test:


### PR DESCRIPTION
The new `scripts/verify_conda_libmesh.py` requires `conda-build` modules to determine if libmesh is current. This script fails silently if the user doesn't have these modules installed. It would be better to include these tools as part of the moose environment.

Closes #15364

@dschwen @milljm 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
