### PR TITLE
fix error handling+msg in recent mods to porous flow line sink

### DIFF
--- a/modules/porous_flow/src/dirackernels/PorousFlowLineGeometry.C
+++ b/modules/porous_flow/src/dirackernels/PorousFlowLineGeometry.C
@@ -18,6 +18,7 @@ PorousFlowLineGeometry::validParams()
   InputParameters params = DiracKernel::validParams();
   params.addParam<std::string>(
       "point_file",
+      "",
       "The file containing the coordinates of the points and their weightings that approximate the "
       "line sink.  The physical meaning of the weightings depend on the scenario, eg, they may be "
       "borehole radii.  Each line in the file must contain a space-separated weight and "
@@ -93,7 +94,7 @@ PorousFlowLineGeometry::PorousFlowLineGeometry(const InputParameters & parameter
                  "PorousFlowLineGeometry: wrong number of arguments - got ",
                  base.size(),
                  ", expected ",
-                 _mesh.dimension(),
+                 _mesh.dimension() + 1,
                  " '<weight> <x> [<y> [z]]'");
 
     for (int i = base.size(); i < 4; i++)


### PR DESCRIPTION
Fixes the error message added in #15528 - and allows more convenient omission of an optional parameter.

ref #15528

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
