### PR TITLE
XFEM cleanup

### DIFF
--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -80,15 +80,13 @@ XFEM::getCrackTipOrigin(std::map<unsigned int, const Elem *> & elem_id_crack_tip
        ++mit1)
   {
     unsigned int elem_id = mit1->first->id();
-    if (elem_id > 999999)
+    if (elem_id == std::numeric_limits<unsigned int>::max())
     {
       elem_id_map[m] = mit1->first;
       m--;
     }
     else
-    {
       elem_id_map[elem_id] = mit1->first;
-    }
   }
 
   for (std::map<unsigned int, const Elem *>::iterator mit1 = elem_id_map.begin();
@@ -596,7 +594,7 @@ XFEM::markCutEdgesByState(Real time)
 
     // find the first cut edge
     unsigned int nsides = CEMElem->numEdges();
-    unsigned int orig_cut_side_id = 999999;
+    unsigned int orig_cut_side_id = std::numeric_limits<unsigned int>::max();
     Real orig_cut_distance = -1.0;
     EFANode * orig_node = NULL;
     EFAEdge * orig_edge = NULL;

--- a/modules/xfem/src/efa/EFAElement.C
+++ b/modules/xfem/src/efa/EFAElement.C
@@ -110,20 +110,12 @@ EFAElement::getGlobalNodeFromLocalNode(const EFANode * local_node) const
 unsigned int
 EFAElement::getLocalNodeIndex(EFANode * node) const
 {
-  unsigned int local_node_id = 99999;
-  bool found_local_node = false;
   for (unsigned int i = 0; i < _num_nodes; ++i)
   {
     if (_nodes[i] == node)
-    {
-      found_local_node = true;
-      local_node_id = i;
-      break;
-    }
+      return i;
   }
-  if (!found_local_node)
-    EFAError("In EFAelement::getLocalNodeIndex, cannot find the given node");
-  return local_node_id;
+  EFAError("In EFAelement::getLocalNodeIndex, cannot find the given node");
 }
 
 void

--- a/modules/xfem/src/efa/EFAElement2D.C
+++ b/modules/xfem/src/efa/EFAElement2D.C
@@ -1406,7 +1406,7 @@ bool
 EFAElement2D::getEdgeNodeParametricCoordinate(EFANode * node, std::vector<double> & para_coor) const
 {
   // get the parametric coords of a node in an element edge
-  unsigned int edge_id = 99999;
+  unsigned int edge_id = std::numeric_limits<unsigned int>::max();
   bool edge_found = false;
   for (unsigned int i = 0; i < _num_edges; ++i)
   {
@@ -1517,7 +1517,7 @@ EFAElement2D::getFragmentEdgeID(unsigned int elem_edge_id, unsigned int & frag_e
   // N.B. if the elem edge contains two frag edges, this method will only return
   // the first frag edge ID
   bool frag_edge_found = false;
-  frag_edge_id = 99999;
+  frag_edge_id = std::numeric_limits<unsigned int>::max();
   if (_fragments.size() == 1)
   {
     for (unsigned int j = 0; j < _fragments[0]->numEdges(); ++j)
@@ -1608,7 +1608,7 @@ unsigned int
 EFAElement2D::getTipEdgeID() const
 {
   // if this element is a crack tip element, returns the crack tip edge's ID
-  unsigned int tip_edge_id = 99999;
+  unsigned int tip_edge_id = std::numeric_limits<unsigned int>::max();
   if (_fragments.size() == 1) // crack tip element with a partial fragment saved
   {
     for (unsigned int i = 0; i < _num_edges; ++i)
@@ -1695,7 +1695,7 @@ EFAElement2D::fragmentEdgeAlreadyCut(unsigned int ElemEdgeID) const
     has_cut = true;
   else
   {
-    unsigned int FragEdgeID = 99999;
+    unsigned int FragEdgeID = std::numeric_limits<unsigned int>::max();
     if (getFragmentEdgeID(ElemEdgeID, FragEdgeID))
     {
       EFAEdge * frag_edge = getFragmentEdge(0, FragEdgeID);
@@ -1740,7 +1740,8 @@ EFAElement2D::addEdgeCut(unsigned int edge_id,
     bool add2elem = true;
 
     // check if it is necessary to add cuts to fragment
-    unsigned int frag_edge_id = 99999; // the id of the partially overlapping fragment edge
+    // id of partially overlapping fragment edge
+    unsigned int frag_edge_id = std::numeric_limits<unsigned int>::max();
     EFAEdge * frag_edge = NULL;
     EFANode * frag_edge_node1 = NULL;
     double frag_pos = -1.0;

--- a/modules/xfem/src/efa/EFAElement3D.C
+++ b/modules/xfem/src/efa/EFAElement3D.C
@@ -462,7 +462,6 @@ EFAElement3D::getNeighborIndex(const EFAElement * neighbor_elem) const
       if (_face_neighbors[i][j] == neighbor_elem)
         return i;
   EFAError("in getNeighborIndex() element ", _id, " does not have neighbor ", neighbor_elem->id());
-  return 99999;
 }
 
 void
@@ -1390,7 +1389,7 @@ bool
 EFAElement3D::getFaceNodeParametricCoordinates(EFANode * node, std::vector<double> & xi_3d) const
 {
   // get the parametric coords of a node in an element face
-  unsigned int face_id = 99999;
+  unsigned int face_id = std::numeric_limits<unsigned int>::max();
   bool face_found = false;
   for (unsigned int i = 0; i < _num_faces; ++i)
   {
@@ -1742,7 +1741,7 @@ EFAElement3D::getFragmentFaceID(unsigned int elem_face_id, unsigned int & frag_f
   // N.B. if the elem edge contains two frag edges, this method will only return
   // the first frag edge ID
   bool frag_face_found = false;
-  frag_face_id = 99999;
+  frag_face_id = std::numeric_limits<unsigned int>::max();
   if (_fragments.size() == 1)
   {
     for (unsigned int j = 0; j < _fragments[0]->numFaces(); ++j)
@@ -1766,8 +1765,7 @@ EFAElement3D::getFragmentFaceEdgeID(unsigned int ElemFaceID,
 {
   // Purpose: given an edge of an elem face, find which frag face's edge it contains
   bool frag_edge_found = false;
-  FragFaceID = 99999;
-  FragFaceEdgeID = 99999;
+  FragFaceID = FragFaceEdgeID = std::numeric_limits<unsigned int>::max();
   if (getFragmentFaceID(ElemFaceID, FragFaceID))
   {
     EFAEdge * elem_edge = _faces[ElemFaceID]->getEdge(ElemFaceEdgeID);
@@ -1790,7 +1788,7 @@ EFAElement3D::isPhysicalEdgeCut(unsigned int ElemFaceID,
                                 unsigned int ElemFaceEdgeID,
                                 double position) const
 {
-  unsigned int FragFaceID = 99999, FragFaceEdgeID = 99999;
+  unsigned int FragFaceID, FragFaceEdgeID = std::numeric_limits<unsigned int>::max();
   bool is_in_real = false;
   if (_fragments.size() == 0)
   {
@@ -1979,7 +1977,7 @@ EFAElement3D::fragmentFaceAlreadyCut(unsigned int ElemFaceID) const
     has_cut = true;
   else
   {
-    unsigned int FragFaceID = 99999;
+    unsigned int FragFaceID = std::numeric_limits<unsigned int>::max();
     if (getFragmentFaceID(ElemFaceID, FragFaceID))
     {
       EFAFace * frag_face = getFragmentFace(0, FragFaceID);

--- a/modules/xfem/src/efa/EFAFace.C
+++ b/modules/xfem/src/efa/EFAFace.C
@@ -649,9 +649,7 @@ EFAFace::adjacentCommonEdge(const EFAFace * other_face) const
       if (other_face->ownsEdge(_edges[i]))
         return i;
   }
-  else
-    EFAError("this face is not adjacent with other_face");
-  return 99999;
+  EFAError("this face is not adjacent with other_face");
 }
 
 bool

--- a/modules/xfem/src/efa/EFAFragment2D.C
+++ b/modules/xfem/src/efa/EFAFragment2D.C
@@ -174,7 +174,7 @@ EFAFragment2D::combineTipEdges()
     EFAError("In combine_tip_edges() the frag must have host_elem");
 
   bool has_tip_edges = false;
-  unsigned int elem_tip_edge_id = 99999;
+  unsigned int elem_tip_edge_id = std::numeric_limits<unsigned int>::max();
   std::vector<unsigned int> frag_tip_edge_id;
   for (unsigned int i = 0; i < _host_elem->numEdges(); ++i)
   {

--- a/modules/xfem/src/efa/EFAFragment3D.C
+++ b/modules/xfem/src/efa/EFAFragment3D.C
@@ -288,7 +288,6 @@ EFAFragment3D::getFaceID(EFAFace * face) const
     if (_faces[i] == face)
       return i;
   EFAError("face not found in get_face_id()");
-  return 99999;
 }
 
 void

--- a/modules/xfem/src/efa/ElementFragmentAlgorithm.C
+++ b/modules/xfem/src/efa/ElementFragmentAlgorithm.C
@@ -598,7 +598,7 @@ ElementFragmentAlgorithm::getElemByID(unsigned int id)
 unsigned int
 ElementFragmentAlgorithm::getElemIdByNodes(unsigned int * node_id)
 {
-  unsigned int elem_id = 99999;
+  unsigned int elem_id = std::numeric_limits<unsigned int>::max();
   std::map<unsigned int, EFAElement *>::iterator eit;
   for (eit = _elements.begin(); eit != _elements.end(); ++eit)
   {


### PR DESCRIPTION
Remove the usage of strings of 9s to initialize large values for unsigned ints