### PR TITLE
When restarting from exodus all processors need to keep the mesh file open

### DIFF
--- a/framework/src/meshgenerators/FileMeshGenerator.C
+++ b/framework/src/meshgenerators/FileMeshGenerator.C
@@ -59,11 +59,17 @@ FileMeshGenerator::generate()
           getParam<std::vector<std::string>>("exodus_extra_element_integers"));
 
     if (restart_exodus)
+    {
       _app.setExReaderForRestart(std::move(exreader));
-
-    if (mesh->processor_id() == 0)
       exreader->read(_file_name);
-    MeshCommunication().broadcast(*mesh);
+      mesh->allow_renumbering(false);
+    }
+    else
+    {
+      if (mesh->processor_id() == 0)
+        exreader->read(_file_name);
+      MeshCommunication().broadcast(*mesh);
+    }
 
     mesh->prepare_for_use();
   }

--- a/test/tests/ics/from_exodus_solution/tests
+++ b/test/tests/ics/from_exodus_solution/tests
@@ -34,7 +34,6 @@
     exodiff = 'elem_part2_out.e'
     use_old_floor = true
     abs_zero = 1e-09
-    max_parallel = 1
     prereq = 'elem_var_1'
 
     requirement = 'The system shall be able to populate elemental initial conditions from a previous solution file in ExodusII format.'


### PR DESCRIPTION
When working on #15555, I did not realize this. The test for some reason are marked only run with one processor, so we did not catch this error. This PR fixes it and also makes that test run in parallel.
