### PR TITLE
WIP: Enhancement of new eigenvalue solver

### DIFF
--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -678,6 +678,8 @@ enum EigenSolveType
   EST_JACOBI_DAVIDSON, ///< Jacobi-Davidson
   EST_NONLINEAR_POWER, ///< Nonlinear inverse power
   EST_NEWTON,          ///< Newton-based eigen solver
+  EST_PJFNK,           ///< Preconditioned Jacobian-free Newton Krylov
+  EST_JFNK             ///< Jacobian-free Newton Krylov
 };
 
 /**

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -381,5 +381,7 @@ bool
 EigenProblem::isNonlinearEigenvalueSolver()
 {
   return solverParams()._eigen_solve_type == Moose::EST_NONLINEAR_POWER ||
-         solverParams()._eigen_solve_type == Moose::EST_NEWTON;
+         solverParams()._eigen_solve_type == Moose::EST_NEWTON ||
+         solverParams()._eigen_solve_type == Moose::EST_PJFNK ||
+         solverParams()._eigen_solve_type == Moose::EST_JFNK;
 }

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -83,6 +83,8 @@ initEigenSolveType()
     eigen_solve_type_to_enum["JACOBI_DAVIDSON"] = EST_JACOBI_DAVIDSON;
     eigen_solve_type_to_enum["NONLINEAR_POWER"] = EST_NONLINEAR_POWER;
     eigen_solve_type_to_enum["NEWTON"] = EST_NEWTON;
+    eigen_solve_type_to_enum["PJFNK"] = EST_PJFNK;
+    eigen_solve_type_to_enum["JFNK"] = EST_JFNK;
   }
 }
 


### PR DESCRIPTION
- [ ] Better support of Picard iteration. Eigenvalue should be able to work as either a mater app or a sub-app. See details #12767

- [ ] The Eigenvalue should be able to start from a given initial solution. It is useful for depletion calculations.  Closes #12767

- [ ] Output eigenvalue after solve. I want to output a regular eigenvalue in console, but I would also add one option to allow users to output the inverse of eigenvalue. Nuetroinic community always wants to see the inverse of eigenvalue. Closes #14292

- [ ] It is better to make the residual monitors (Nonlinear |R| and Linear |R| ) consistent with those of the regular nonlinear solver.

- [x] Add short cuts: PJFNK, JFNK. Some users may like to use the new eigenvalue solver via old input file options.
 



Refs #15513

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
