### PR TITLE
Make getNodalValue const

### DIFF
--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -453,15 +453,15 @@ public:
   /**
    * Get the value of this variable at given node
    */
-  OutputData getNodalValue(const Node & node);
+  OutputData getNodalValue(const Node & node) const;
   /**
    * Get the old value of this variable at given node
    */
-  OutputData getNodalValueOld(const Node & node);
+  OutputData getNodalValueOld(const Node & node) const;
   /**
    * Get the t-2 value of this variable at given node
    */
-  OutputData getNodalValueOlder(const Node & node);
+  OutputData getNodalValueOlder(const Node & node) const;
   /**
    * Get the current value of this variable on an element
    * @param[in] elem   Element at which to get value

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -157,21 +157,21 @@ MooseVariableFE<OutputType>::getDofIndices(const Elem * elem,
 
 template <typename OutputType>
 typename MooseVariableFE<OutputType>::OutputData
-MooseVariableFE<OutputType>::getNodalValue(const Node & node)
+MooseVariableFE<OutputType>::getNodalValue(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Current);
 }
 
 template <typename OutputType>
 typename MooseVariableFE<OutputType>::OutputData
-MooseVariableFE<OutputType>::getNodalValueOld(const Node & node)
+MooseVariableFE<OutputType>::getNodalValueOld(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Old);
 }
 
 template <typename OutputType>
 typename MooseVariableFE<OutputType>::OutputData
-MooseVariableFE<OutputType>::getNodalValueOlder(const Node & node)
+MooseVariableFE<OutputType>::getNodalValueOlder(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Older);
 }

--- a/modules/contact/include/constraints/MechanicalContactConstraint.h
+++ b/modules/contact/include/constraints/MechanicalContactConstraint.h
@@ -116,9 +116,9 @@ protected:
 
   /// gap offset from either secondary, primary or both
   const bool _has_secondary_gap_offset;
-  MooseVariable * _secondary_gap_offset_var;
+  const MooseVariable * const _secondary_gap_offset_var;
   const bool _has_mapped_primary_gap_offset;
-  MooseVariable * _mapped_primary_gap_offset_var;
+  const MooseVariable * const _mapped_primary_gap_offset_var;
 
   MooseVariable * _nodal_area_var;
   SystemBase & _aux_system;


### PR DESCRIPTION
I wanted some `MooseVariables` in #14090 to be labeled `const` but
realized that it couldn't be done because `getNodalValue` wasn't marked
`const`. So we rectify that here.

