### PR TITLE
Add option to INS action to not add temperature variable

### DIFF
--- a/modules/navier_stokes/src/actions/INSAction.C
+++ b/modules/navier_stokes/src/actions/INSAction.C
@@ -14,6 +14,7 @@
 #include "AddVariableAction.h"
 #include "MooseObject.h"
 #include "INSADObjectTracker.h"
+#include "NonlinearSystemBase.h"
 
 // MOOSE includes
 #include "FEProblem.h"
@@ -324,7 +325,8 @@ INSAction::act()
       }
     }
 
-    if (getParam<bool>("add_temperature_equation"))
+    if (getParam<bool>("add_temperature_equation") &&
+        !_problem->getNonlinearSystemBase().hasVariable(_temperature_variable_name))
     {
       params.set<std::vector<Real>>("scaling") = {getParam<Real>("temperature_scaling")};
       _problem->addVariable(var_type, _temperature_variable_name, params);

--- a/modules/navier_stokes/test/tests/ins/wall_convection/gold/steady-action-no-temp-var.e
+++ b/modules/navier_stokes/test/tests/ins/wall_convection/gold/steady-action-no-temp-var.e
@@ -1,0 +1,1 @@
+steady_out.e

--- a/modules/navier_stokes/test/tests/ins/wall_convection/steady-action.i
+++ b/modules/navier_stokes/test/tests/ins/wall_convection/steady-action.i
@@ -11,6 +11,11 @@
   []
 []
 
+[Variables]
+  active = ''
+  [temperature][]
+[]
+
 [Modules]
   [IncompressibleNavierStokes]
     equation_type = steady-state

--- a/modules/navier_stokes/test/tests/ins/wall_convection/tests
+++ b/modules/navier_stokes/test/tests/ins/wall_convection/tests
@@ -15,4 +15,13 @@
     design = 'INSADEnergyAmbientConvection.md'
     issues = '#15500'
   []
+  [steady-action-no-temp-var]
+    type = 'Exodiff'
+    input = 'steady-action.i'
+    exodiff = 'steady-action-no-temp-var.e'
+    cli_args = "Variables/active='temperature' Outputs/file_base=steady-action-no-temp-var"
+    requirement = 'The system shall be able to add a incompressible Navier-Stokes energy/temperature equation using an action, but use a temperature variable already added in the input file.'
+    design = 'INSAction.md'
+    issues = '#15607'
+  []
 []


### PR DESCRIPTION
This option allows the user to add the temperature equation without
adding the temperature variable. This is useful in multiphysics settings
where the temperature variable may live on blocks where the INS
equations do not.

Closes #15607

