### PR TITLE
Add auto_advance parameter to PicardSolve

### DIFF
--- a/framework/doc/content/source/postprocessors/TimePostprocessor.md
+++ b/framework/doc/content/source/postprocessors/TimePostprocessor.md
@@ -1,0 +1,9 @@
+# TimePostprocessor
+
+!syntax description /Postprocessors/TimePostprocessor
+
+!syntax parameters /Postprocessors/TimePostprocessor
+
+!syntax inputs /Postprocessors/TimePostprocessor
+
+!syntax children /Postprocessors/TimePostprocessor

--- a/framework/include/executioners/PicardSolve.h
+++ b/framework/include/executioners/PicardSolve.h
@@ -76,6 +76,11 @@ public:
     _picard_self_relaxed_variables = vars;
   }
 
+  /**
+   * Whether sub-applications are automatically advanced no matter what happens during their solves
+   */
+  bool autoAdvance() const;
+
 protected:
   /**
    * Perform one Picard iteration or a full solve.
@@ -162,4 +167,12 @@ private:
   Real _previous_entering_time;
 
   const std::string _solve_message;
+
+  /// Whether the user has set the auto_advance parameter for handling advancement of
+  /// sub-applications in multi-app contexts
+  const bool _auto_advance_set_by_user;
+
+  /// The value of auto_advance set by the user for handling advancement of sub-applications in
+  /// multi-app contexts
+  const bool _auto_advance_user_value;
 };

--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -117,9 +117,11 @@ public:
    * Calls multi-apps executioners' endStep and postStep methods which creates output and advances
    * time (not the time step; see incrementTStep()) among other things. This method is only called
    * for Picard calculations because for loosely coupled calculations the executioners' endStep and
-   * postStep methods are called from solveStep().
+   * postStep methods are called from solveStep(). This may be called with the optional flag \p
+   * recurse_through_multiapp_levels which may be useful if this method is being called for the
+   * *final* time of program execution
    */
-  virtual void finishStep() {}
+  virtual void finishStep(bool /*recurse_through_multiapp_levels*/ = false) {}
 
   /**
    * Save off the state of every Sub App

--- a/framework/include/multiapps/TransientMultiApp.h
+++ b/framework/include/multiapps/TransientMultiApp.h
@@ -41,7 +41,7 @@ public:
 
   virtual void incrementTStep(Real target_time) override;
 
-  virtual void finishStep() override;
+  virtual void finishStep(bool recurse_through_multiapp_levels = false) override;
 
   virtual bool needsRestoration() override;
 

--- a/framework/include/postprocessors/TimePostprocessor.h
+++ b/framework/include/postprocessors/TimePostprocessor.h
@@ -1,0 +1,31 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralPostprocessor.h"
+
+/**
+ * Postprocessor that returns the current time
+ */
+class TimePostprocessor : public GeneralPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  TimePostprocessor(const InputParameters & parameters);
+
+  void initialize() override {}
+  void execute() override {}
+
+  Real getValue() override;
+
+protected:
+  const FEProblemBase & _feproblem;
+};

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1076,9 +1076,10 @@ public:
   }
 
   /**
-   * Finish the MultiApp time step (endStep, postStep) associated with the ExecFlagType
+   * Finish the MultiApp time step (endStep, postStep) associated with the ExecFlagType. Optionally
+   * recurse through all multi-app levels
    */
-  void finishMultiAppStep(ExecFlagType type);
+  void finishMultiAppStep(ExecFlagType type, bool recurse_through_multiapp_levels = false);
 
   /**
    * Backup the MultiApps associated with the ExecFlagType

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -314,10 +314,18 @@ Transient::execute()
   if (lastSolveConverged())
   {
     _t_step++;
-    if (_picard_solve.hasPicardIteration())
+
+    /*
+     * Call the multi-app executioners endStep and
+     * postStep methods when doing Picard or when not automatically advancing sub-applications for
+     * some other reason. We do not perform these calls for loose-coupling/auto-advancement
+     * problems because Transient::endStep and Transient::postStep get called from
+     * TransientMultiApp::solveStep in that case.
+     */
+    if (!_picard_solve.autoAdvance())
     {
-      _problem.finishMultiAppStep(EXEC_TIMESTEP_BEGIN);
-      _problem.finishMultiAppStep(EXEC_TIMESTEP_END);
+      _problem.finishMultiAppStep(EXEC_TIMESTEP_BEGIN, /*recurse_through_multiapp_levels=*/true);
+      _problem.finishMultiAppStep(EXEC_TIMESTEP_END, /*recurse_through_multiapp_levels=*/true);
     }
   }
 
@@ -365,11 +373,12 @@ Transient::incrementStepOrReject()
 
       /*
        * Call the multi-app executioners endStep and
-       * postStep methods when doing Picard. We do not perform these calls for
-       * loose coupling because Transient::endStep and Transient::postStep get
-       * called from TransientMultiApp::solveStep in that case.
+       * postStep methods when doing Picard or when not automatically advancing sub-applications for
+       * some other reason. We do not perform these calls for loose-coupling/auto-advancement
+       * problems because Transient::endStep and Transient::postStep get called from
+       * TransientMultiApp::solveStep in that case.
        */
-      if (_picard_solve.hasPicardIteration())
+      if (!_picard_solve.autoAdvance())
       {
         _problem.finishMultiAppStep(EXEC_TIMESTEP_BEGIN);
         _problem.finishMultiAppStep(EXEC_TIMESTEP_END);

--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -535,7 +535,7 @@ TransientMultiApp::incrementTStep(Real target_time)
 }
 
 void
-TransientMultiApp::finishStep()
+TransientMultiApp::finishStep(bool recurse_through_multiapp_levels)
 {
   if (!_sub_cycling)
   {
@@ -544,6 +544,13 @@ TransientMultiApp::finishStep()
       Transient * ex = _transient_executioners[i];
       ex->endStep();
       ex->postStep();
+      if (recurse_through_multiapp_levels)
+      {
+        ex->feProblem().finishMultiAppStep(EXEC_TIMESTEP_BEGIN,
+                                           /*recurse_through_multiapp_levels=*/true);
+        ex->feProblem().finishMultiAppStep(EXEC_TIMESTEP_END,
+                                           /*recurse_through_multiapp_levels=*/true);
+      }
     }
   }
 }
@@ -585,7 +592,8 @@ TransientMultiApp::computeDT()
   return smallest_dt;
 }
 
-void TransientMultiApp::resetApp(
+void
+TransientMultiApp::resetApp(
     unsigned int global_app,
     Real /*time*/) // FIXME: Note that we are passing in time but also grabbing it below
 {
@@ -611,7 +619,8 @@ void TransientMultiApp::resetApp(
   }
 }
 
-void TransientMultiApp::setupApp(unsigned int i, Real /*time*/) // FIXME: Should we be passing time?
+void
+TransientMultiApp::setupApp(unsigned int i, Real /*time*/) // FIXME: Should we be passing time?
 {
   auto & app = _apps[i];
   Transient * ex = dynamic_cast<Transient *>(app->getExecutioner());

--- a/framework/src/postprocessors/TimePostprocessor.C
+++ b/framework/src/postprocessors/TimePostprocessor.C
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TimePostprocessor.h"
+#include "FEProblem.h"
+
+registerMooseObject("MooseApp", TimePostprocessor);
+
+InputParameters
+TimePostprocessor::validParams()
+{
+  InputParameters params = GeneralPostprocessor::validParams();
+  params.addClassDescription("Reports the current time");
+  return params;
+}
+
+TimePostprocessor::TimePostprocessor(const InputParameters & parameters)
+  : GeneralPostprocessor(parameters), _feproblem(dynamic_cast<FEProblemBase &>(_subproblem))
+{
+}
+
+Real
+TimePostprocessor::getValue()
+{
+  return _feproblem.time();
+}

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4300,7 +4300,7 @@ FEProblemBase::incrementMultiAppTStep(ExecFlagType type)
 }
 
 void
-FEProblemBase::finishMultiAppStep(ExecFlagType type)
+FEProblemBase::finishMultiAppStep(ExecFlagType type, bool recurse_through_multiapp_levels)
 {
   const auto & multi_apps = _multi_apps[type].getActiveObjects();
 
@@ -4310,7 +4310,7 @@ FEProblemBase::finishMultiAppStep(ExecFlagType type)
              << std::endl;
 
     for (const auto & multi_app : multi_apps)
-      multi_app->finishStep();
+      multi_app->finishStep(recurse_through_multiapp_levels);
 
     MooseUtils::parallelBarrierNotify(_communicator, _parallel_barrier_messaging);
 

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/master.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/master.i
@@ -1,0 +1,92 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+  parallel_type = replicated
+[]
+
+[Variables]
+  [./u]
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[AuxKernels]
+  [./set_v]
+    type = FunctionAux
+    variable = v
+    function = 't'
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./coupled_force]
+    type = CoupledForce
+    variable = u
+    v = v
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+  picard_max_its = 1
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-9
+[]
+
+[Outputs]
+  exodus = true
+[]
+
+[MultiApps]
+  [./sub1]
+    type = TransientMultiApp
+    positions = '0 0 0'
+    input_files = picard_sub.i
+    execute_on = 'timestep_end'
+  [../]
+[]
+
+[Transfers]
+  [./u_to_v2]
+    type = MultiAppNearestNodeTransfer
+    direction = to_multiapp
+    multi_app = sub1
+    source_variable = u
+    variable = v2
+  [../]
+[]

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/master.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/master.i
@@ -58,18 +58,12 @@
 
 [Executioner]
   type = Transient
-  num_steps = 5
-  dt = 1
   solve_type = PJFNK
+  num_steps = 2
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
   picard_max_its = 1
-  nl_rel_tol = 1e-8
-  nl_abs_tol = 1e-9
-[]
-
-[Outputs]
-  exodus = true
+  auto_advance = false
 []
 
 [MultiApps]
@@ -89,4 +83,29 @@
     source_variable = u
     variable = v2
   [../]
+  [time_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = time
+    to_postprocessor = master_time
+    direction = to_multiapp
+    multi_app = sub1
+  []
+  [dt_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = dt
+    to_postprocessor = master_dt
+    direction = to_multiapp
+    multi_app = sub1
+  []
+[]
+
+[Postprocessors]
+  [time]
+    type = TimePostprocessor
+    execute_on = 'timestep_end'
+  []
+  [dt]
+    type = TimestepSize
+    execute_on = 'timestep_end'
+  []
 []

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub.i
@@ -1,0 +1,123 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./v]
+  [../]
+[]
+
+[AuxVariables]
+  [./v2]
+  [../]
+  [./v3]
+  [../]
+  [./w]
+  [../]
+[]
+
+[AuxKernels]
+  [./set_w]
+    type = NormalizationAux
+    variable = w
+    source_variable = v
+    normal_factor = 0.1
+  [../]
+[]
+
+[Kernels]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+  [./coupled_force]
+    type = CoupledForce
+    variable = v
+    v = v2
+  [../]
+  [./coupled_force2]
+    type = CoupledForce
+    variable = v
+    v = v3
+  [../]
+  [./td_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left_v]
+    type = FunctionDirichletBC
+    variable = v
+    boundary = left
+    function = func
+  [../]
+  [./right_v]
+    type = DirichletBC
+    variable = v
+    boundary = right
+    value = 0
+  [../]
+[]
+
+[Functions]
+  [func]
+    type = ParsedFunction
+    value = 'if(t < 2.5, 1, 1 / t)'
+  []
+[]
+
+[Postprocessors]
+  [./picard_its]
+    type = NumPicardIterations
+    execute_on = 'initial timestep_end'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+  picard_max_its = 2 # deliberately make it fail at 2 to test the time step rejection behavior
+  nl_rel_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
+  nl_abs_tol = 1e-9
+  picard_rel_tol = 1e-8
+  picard_abs_tol = 1e-9
+[]
+
+[Outputs]
+  exodus = true
+[]
+
+[MultiApps]
+  [./sub2]
+    type = TransientMultiApp
+    positions = '0 0 0'
+    input_files = picard_sub2.i
+    execute_on = timestep_end
+  [../]
+[]
+
+[Transfers]
+  [./v_to_v3]
+    type = MultiAppNearestNodeTransfer
+    direction = from_multiapp
+    multi_app = sub2
+    source_variable = v
+    variable = v3
+  [../]
+  [./w]
+    type = MultiAppNearestNodeTransfer
+    direction = to_multiapp
+    multi_app = sub2
+    source_variable = w
+    variable = w
+  [../]
+[]

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub.i
@@ -76,24 +76,34 @@
     type = NumPicardIterations
     execute_on = 'initial timestep_end'
   [../]
+  [master_time]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [master_dt]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [time]
+    type = TimePostprocessor
+    execute_on = 'timestep_end'
+  []
+  [dt]
+    type = TimestepSize
+    execute_on = 'timestep_end'
+  []
 []
 
 [Executioner]
   type = Transient
-  num_steps = 5
-  dt = 1
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
   picard_max_its = 2 # deliberately make it fail at 2 to test the time step rejection behavior
   nl_rel_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
-  nl_abs_tol = 1e-9
+  l_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
   picard_rel_tol = 1e-8
-  picard_abs_tol = 1e-9
-[]
-
-[Outputs]
-  exodus = true
+  num_steps = 2
 []
 
 [MultiApps]
@@ -120,4 +130,32 @@
     source_variable = w
     variable = w
   [../]
+  [time_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = time
+    to_postprocessor = sub_time
+    direction = to_multiapp
+    multi_app = sub2
+  []
+  [dt_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = dt
+    to_postprocessor = sub_dt
+    direction = to_multiapp
+    multi_app = sub2
+  []
+  [matser_time_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = time
+    to_postprocessor = master_time
+    direction = to_multiapp
+    multi_app = sub2
+  []
+  [master_dt_to_sub]
+    type = MultiAppPostprocessorTransfer
+    from_postprocessor = dt
+    to_postprocessor = master_dt
+    direction = to_multiapp
+    multi_app = sub2
+  []
 []

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub2.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub2.i
@@ -43,15 +43,41 @@
 
 [Executioner]
   type = Transient
-  num_steps = 5
-  dt = 1.0
   solve_type = PJFNK
   petsc_options_iname = '-pc_type -pc_hypre_type'
   petsc_options_value = 'hypre boomeramg'
   nl_rel_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
-  nl_abs_tol = 1e-10
+  l_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
+  num_steps = 2
+[]
+
+[Postprocessors]
+  [master_time]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [master_dt]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [sub_time]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [sub_dt]
+    type = Receiver
+    execute_on = 'timestep_end'
+  []
+  [time]
+    type = TimePostprocessor
+    execute_on = 'timestep_end'
+  []
+  [dt]
+    type = TimestepSize
+    execute_on = 'timestep_end'
+  []
 []
 
 [Outputs]
-  exodus = true
+  csv = true
 []

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub2.i
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/picard_sub2.i
@@ -1,0 +1,57 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 10
+  ny = 10
+[]
+
+[Variables]
+  [./v]
+  [../]
+[]
+
+[AuxVariables]
+  [./w]
+  [../]
+[]
+
+[Kernels]
+  [./diff_v]
+    type = Diffusion
+    variable = v
+  [../]
+  [./td_v]
+    type = TimeDerivative
+    variable = v
+  [../]
+[]
+
+[BCs]
+  [./left_v]
+    type = DirichletBC
+    variable = v
+    boundary = left
+    value = 1
+  [../]
+  [./right_v]
+    type = DirichletBC
+    variable = v
+    boundary = right
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = 1.0
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+  nl_rel_tol = 1e-5 # loose enough to force multiple Picard iterations on this example
+  nl_abs_tol = 1e-10
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/test_multilevel.py
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/test_multilevel.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import numpy as np
+import unittest
+
+class TestMultiLevel(unittest.TestCase):
+    def test(self):
+        data = np.genfromtxt('master_out_sub10_sub20.csv', dtype=float, delimiter=',', names=True)
+
+        # We should have two time steps plus the initial state
+        self.assertEqual(len(data), 3)
+
+        # master, sub, and sub-sub times should all be equivalent
+        for i in range(len(data)):
+            self.assertEqual(data['sub_time'][i], data['master_time'][i])
+            self.assertEqual(data['sub_time'][i], data['time'][i])
+
+        # master, sub, and sub-sub dts should all be equivalent
+        for i in range(len(data['sub_dt'])):
+            self.assertEqual(data['sub_dt'][i], data['dt'][i])
+            self.assertEqual(data['sub_dt'][i], data['master_dt'][i])
+
+        # The second timestep definitely shouldn't be equal to dt
+        self.assertNotEqual(data['time'][2], data['dt'][2])
+
+if __name__ == '__main__':
+    unittest.main(__name__, verbosity=2)

--- a/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/tests
+++ b/test/tests/multiapps/picard_multilevel/multilevel_dt_rejection/tests
@@ -1,0 +1,20 @@
+[Tests]
+  issues = '#15166'
+  design = 'TransientMultiApp.md'
+  [run]
+    type = RunApp
+    input = master.i
+    allow_warnings = True
+    expect_out = 'sub1 failed to converge'
+    max_buffer_size = -1
+    requirement = 'The system shall be able to run multiple timesteps of a multi-level multi-app simulation, handling the case when Picard coupling between two levels fails to converge.'
+  []
+  [python]
+    prereq = 'run'
+    type = PythonUnitTest
+    input = 'test_multilevel.py'
+    test_case = 'TestMultiLevel'
+    requirement = 'The system shall be able to uniformly cut the time-step across levels of a multi-app solve, even when there is no Picard coupling between two levels.'
+    required_python_packages = 'numpy'
+  []
+[]


### PR DESCRIPTION
This allows for uniform time-step cutting across multi-app levels even
when not performing Picard between two levels, e.g. to prevent a
sub-application from auto-advancing despite the state of it's solve, a
user can specify `auto_advance = false` to require the master to cut its
timestep.

Closes #15166
