### PR TITLE
Add emacs to package installs.

### DIFF
--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -28,7 +28,8 @@ apt-get install -y \
   curl \
   bison \
   flex \
-  libboost-all-dev
+  libboost-all-dev \
+  emacs
 
 # Clear cache
 rm -rf /var/lib/apt/lists/*

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -37,7 +37,8 @@ yum install -y \
   tar \
   libtool \
   libtirpc \
-  libtirpc-devel
+  libtirpc-devel \
+  emacs
 
 # Clear cache
 yum clean all


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
I have added an install for `emacs` to the following files in `docker_ci`.
* `apt_installs.sh`
* `yum_installs.sh`

Closes #15621.