### PR TITLE
Moving SurrogateTester to EvaluateSurrogate

### DIFF
--- a/modules/combined/examples/stochastic/poly_chaos_uniform.i
+++ b/modules/combined/examples/stochastic/poly_chaos_uniform.i
@@ -117,7 +117,7 @@
     sensitivity_order = 'first second total'
   []
   [storage]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     sampler = sample
     model = 'temp_center_inner  temp_center_outer  temp_end_inner  temp_end_outer
              dispx_center_inner dispx_center_outer dispx_end_inner dispx_end_outer

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_chaos_surrogate.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_chaos_surrogate.md
@@ -90,7 +90,7 @@ Evaluating a polynomial chaos surrogate model is exactly the same as any other t
 
 !listing examples/surrogates/poly_chaos_normal.i block=Distributions Samplers caption=Defining sampler for evaluation -- Normal distributions
 
-!listing examples/surrogates/poly_chaos_uniform.i block=samp_avg samp_max caption=Evaluating surrogate with [SurrogateTester](SurrogateTester.C)
+!listing examples/surrogates/poly_chaos_uniform.i block=samp_avg samp_max caption=Evaluating surrogate with [EvaluateSurrogate](EvaluateSurrogate.C)
 
 ### Statistical Moments
 

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
@@ -74,6 +74,6 @@ See [Surrogates](Surrogates/index.md) for more information on the `getModelData`
 
 ### evaluate
 
-`evaluate` is a public member function required for all surrogate models. This is where surrogate model is actually used. `evaluate` takes in parameter values and returns the surrogate's estimation of the quantity of interest. See [SurrogateTester](SurrogateTester.C) for an example on how the `evaluate` function is used.
+`evaluate` is a public member function required for all surrogate models. This is where surrogate model is actually used. `evaluate` takes in parameter values and returns the surrogate's estimation of the quantity of interest. See [EvaluateSurrogate](EvaluateSurrogate.C) for an example on how the `evaluate` function is used.
 
 !listing NearestPointSurrogate.C re=Real\sNearestPointSurrogate::evaluate.*?^}

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_evaluate.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_evaluate.md
@@ -32,7 +32,7 @@ In this example, the surrogate is evaluated at points given by a sampler. Here w
 
 ### Sampling Surrogate
 
-Evaluating a surrogate model occurs within objects that obtain the surrogate object's reference and call the `evaluate` function. In this example, we will use [SurrogateTester](SurrogateTester.C) to evaluate the surrogate, this function is for testing purposes only. [SurrogateTester](SurrogateTester.C) takes in a sampler and the surrogate model as inputs, and evaluates the surrogate at the points given by the sampler.
+Evaluating a surrogate model occurs within objects that obtain the surrogate object's reference and call the `evaluate` function. In this example, we will use [EvaluateSurrogate.md] to evaluate the surrogate, this function is for testing purposes only. [EvaluateSurrogate.md] takes in a sampler and the surrogate model as inputs, and evaluates the surrogate at the points given by the sampler.
 
 !listing nearest_point_uniform.i block=VectorPostprocessors
 

--- a/modules/stochastic_tools/doc/content/source/surrogates/PolynomialRegressionSurrogate.md
+++ b/modules/stochastic_tools/doc/content/source/surrogates/PolynomialRegressionSurrogate.md
@@ -34,7 +34,7 @@ of the surrogate model, the same objects can be used in the `Samplers` block:
 
 !listing polynomial_regression/evaluate.i block=Samplers
 
-Finally, a vector postprocessor of type `SurrogateTester` is created to extract the approximate value of the
+Finally, a vector postprocessor of type `EvaluateSurrogate` is created to extract the approximate value of the
 QoI(s):
 
 !listing polynomial_regression/evaluate.i block=VectorPostprocessors

--- a/modules/stochastic_tools/doc/content/source/vectorpostprocessors/EvaluateSurrogate.md
+++ b/modules/stochastic_tools/doc/content/source/vectorpostprocessors/EvaluateSurrogate.md
@@ -1,0 +1,49 @@
+# EvaluateSurrogate
+
+!syntax description /VectorPostprocessors/EvaluateSurrogate
+
+## Overview
+
+The EvaluateSurrogate object takes in a sampler and surrogate models and executes the `evaluate` method within each surrogate for each row of the sampler.
+See [examples/surrogate_creation.md], [examples/surrogate_training.md], and [examples/surrogate_evaluate.md] for more information regarding surrogate modeling.
+
+For convenience, the parameter [!param](/VectorPostprocessors/EvaluateSurrogate/output_samples) is included so that the values from the sampler are included in the output.
+Beware that setting this parameter to true can cause a large data output.
+
+## Example Syntax
+
+!listing modules/stochastic_tools/test/tests/surrogates/nearest_point/evaluate.i caption=Simple example using SurrogateEvaluate
+
+!listing caption=CSV output when `output_samples = false`
+surrogate
+8
+8
+24
+40
+56
+72
+88
+104
+120
+136
+...
+
+!listing caption=CSV output when `output_samples = true`
+surrogate,sample_p0,sample_p1,sample_p2
+8,0.25,0.25,0.25
+8,0.25,0.25,1.25
+24,0.25,0.25,2.25
+40,0.25,0.25,3.25
+56,0.25,0.25,4.25
+72,0.25,0.25,5.25
+88,0.25,0.25,6.25
+104,0.25,0.25,7.25
+120,0.25,0.25,8.25
+136,0.25,0.25,9.25
+...
+
+!syntax parameters /VectorPostprocessors/EvaluateSurrogate
+
+!syntax inputs /VectorPostprocessors/EvaluateSurrogate
+
+!syntax children /VectorPostprocessors/EvaluateSurrogate

--- a/modules/stochastic_tools/examples/surrogates/nearest_point_normal.i
+++ b/modules/stochastic_tools/examples/surrogates/nearest_point_normal.i
@@ -36,12 +36,12 @@
 # Sampling surrogate
 [VectorPostprocessors]
   [samp_avg]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = nearest_point_avg
     sampler = sample
   []
   [samp_max]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = nearest_point_max
     sampler = sample
   []

--- a/modules/stochastic_tools/examples/surrogates/nearest_point_uniform.i
+++ b/modules/stochastic_tools/examples/surrogates/nearest_point_uniform.i
@@ -36,12 +36,12 @@
 # Sampling surrogate
 [VectorPostprocessors]
   [samp_avg]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = nearest_point_avg
     sampler = sample
   []
   [samp_max]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = nearest_point_max
     sampler = sample
   []

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_normal.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_normal.i
@@ -47,12 +47,12 @@
 # Computing statistics
 [VectorPostprocessors]
   [samp_avg]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos_avg
     sampler = sample
   []
   [samp_max]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos_max
     sampler = sample
   []

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform.i
@@ -47,12 +47,12 @@
 # Computing statistics
 [VectorPostprocessors]
   [samp_avg]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos_avg
     sampler = sample
   []
   [samp_max]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos_max
     sampler = sample
   []

--- a/modules/stochastic_tools/examples/surrogates/polynomial_regression/normal_surr.i
+++ b/modules/stochastic_tools/examples/surrogates/polynomial_regression/normal_surr.i
@@ -47,12 +47,12 @@
 # Computing statistics
 [VectorPostprocessors]
   [pc_max_res]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = pc_max
     sampler = sample
   []
   [pr_max_res]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = pr_max
     sampler = sample
   []

--- a/modules/stochastic_tools/examples/surrogates/polynomial_regression/uniform_surr.i
+++ b/modules/stochastic_tools/examples/surrogates/polynomial_regression/uniform_surr.i
@@ -47,12 +47,12 @@
 # Computing statistics
 [VectorPostprocessors]
   [pc_max_res]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = pc_max
     sampler = sample
   []
   [pr_max_res]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = pr_max
     sampler = sample
   []

--- a/modules/stochastic_tools/include/vectorpostprocessors/EvaluateSurrogate.h
+++ b/modules/stochastic_tools/include/vectorpostprocessors/EvaluateSurrogate.h
@@ -18,12 +18,14 @@
 /**
  * A tool for output Sampler data.
  */
-class SurrogateTester : public GeneralVectorPostprocessor, SamplerInterface, SurrogateModelInterface
+class EvaluateSurrogate : public GeneralVectorPostprocessor,
+                          SamplerInterface,
+                          SurrogateModelInterface
 {
 public:
   static InputParameters validParams();
 
-  SurrogateTester(const InputParameters & parameters);
+  EvaluateSurrogate(const InputParameters & parameters);
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;

--- a/modules/stochastic_tools/src/vectorpostprocessors/EvaluateSurrogate.C
+++ b/modules/stochastic_tools/src/vectorpostprocessors/EvaluateSurrogate.C
@@ -8,30 +8,31 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 // Stocastic Tools Includes
-#include "SurrogateTester.h"
+#include "EvaluateSurrogate.h"
 
 #include "Sampler.h"
 
-registerMooseObject("StochasticToolsTestApp", SurrogateTester);
+registerMooseObject("StochasticToolsApp", EvaluateSurrogate);
 
 InputParameters
-SurrogateTester::validParams()
+EvaluateSurrogate::validParams()
 {
   InputParameters params = GeneralVectorPostprocessor::validParams();
   params += SamplerInterface::validParams();
   params += SurrogateModelInterface::validParams();
-  params.addClassDescription("Tool for sampling surrogate model.");
-  params.addRequiredParam<std::vector<UserObjectName>>("model", "Name of surrogate model.");
+  params.addClassDescription("Tool for sampling surrogate models.");
+  params.addRequiredParam<std::vector<UserObjectName>>("model", "Name of surrogate models.");
   params += SamplerInterface::validParams();
-  params.addRequiredParam<SamplerName>(
-      "sampler", "Sampler to use for evaluating PCE model (mainly for testing).");
-  params.addParam<bool>("output_samples",
-                        false,
-                        "True to output value of samples from sampler (this may be VERY large).");
+  params.addRequiredParam<SamplerName>("sampler",
+                                       "Sampler to use for evaluating surrogate models.");
+  params.addParam<bool>(
+      "output_samples",
+      false,
+      "True to output value of parameter values from samples (this may be VERY large).");
   return params;
 }
 
-SurrogateTester::SurrogateTester(const InputParameters & parameters)
+EvaluateSurrogate::EvaluateSurrogate(const InputParameters & parameters)
   : GeneralVectorPostprocessor(parameters),
     SamplerInterface(this),
     SurrogateModelInterface(this),
@@ -53,7 +54,7 @@ SurrogateTester::SurrogateTester(const InputParameters & parameters)
 }
 
 void
-SurrogateTester::initialize()
+EvaluateSurrogate::initialize()
 {
   for (auto & vec : _value_vector)
     vec->resize(_sampler.getNumberOfLocalRows(), 0);
@@ -64,7 +65,7 @@ SurrogateTester::initialize()
 }
 
 void
-SurrogateTester::execute()
+EvaluateSurrogate::execute()
 {
   // Loop over samples
   for (dof_id_type p = _sampler.getLocalRowBegin(); p < _sampler.getLocalRowEnd(); ++p)
@@ -81,7 +82,7 @@ SurrogateTester::execute()
 }
 
 void
-SurrogateTester::finalize()
+EvaluateSurrogate::finalize()
 {
   for (auto & vec : _value_vector)
     _communicator.gather(0, *vec);

--- a/modules/stochastic_tools/test/include/vectorpostprocessors/GaussianProcessTester.h
+++ b/modules/stochastic_tools/test/include/vectorpostprocessors/GaussianProcessTester.h
@@ -10,16 +10,13 @@
 #pragma once
 
 // MOOSE includes
-#include "GeneralVectorPostprocessor.h"
-#include "SamplerInterface.h"
-#include "SurrogateModelInterface.h"
-#include "SurrogateTester.h"
+#include "EvaluateSurrogate.h"
 #include "GaussianProcess.h"
 
 /**
  * A tool for output Gaussian Process Surrogate data.
  */
-class GaussianProcessTester : public SurrogateTester
+class GaussianProcessTester : public EvaluateSurrogate
 {
 public:
   static InputParameters validParams();

--- a/modules/stochastic_tools/test/src/vectorpostprocessors/GaussianProcessTester.C
+++ b/modules/stochastic_tools/test/src/vectorpostprocessors/GaussianProcessTester.C
@@ -17,12 +17,12 @@ registerMooseObject("StochasticToolsTestApp", GaussianProcessTester);
 InputParameters
 GaussianProcessTester::validParams()
 {
-  InputParameters params = SurrogateTester::validParams();
+  InputParameters params = EvaluateSurrogate::validParams();
   return params;
 }
 
 GaussianProcessTester::GaussianProcessTester(const InputParameters & parameters)
-  : SurrogateTester(parameters)
+  : EvaluateSurrogate(parameters)
 {
   const auto & model_names = getParam<std::vector<UserObjectName>>("model");
   _GP_model.resize(_model.size());
@@ -37,7 +37,7 @@ GaussianProcessTester::GaussianProcessTester(const InputParameters & parameters)
 void
 GaussianProcessTester::initialize()
 {
-  SurrogateTester::initialize();
+  EvaluateSurrogate::initialize();
   for (auto & vec : _std_vector)
     vec->resize(_sampler.getNumberOfLocalRows(), 0);
 }
@@ -66,7 +66,7 @@ GaussianProcessTester::execute()
 void
 GaussianProcessTester::finalize()
 {
-  SurrogateTester::finalize();
+  EvaluateSurrogate::finalize();
   for (auto & vec : _std_vector)
     _communicator.gather(0, *vec);
 }

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/cartesian.i
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/cartesian.i
@@ -21,7 +21,7 @@
     outputs = none
   []
   [results]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = surrogate
     sampler = test
     output_samples = true

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/evaluate.i
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/evaluate.i
@@ -12,7 +12,7 @@
 
 [VectorPostprocessors]
   [results]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = surrogate
     sampler = test
     execute_on = final

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_mc.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_mc.i
@@ -60,7 +60,7 @@
     execute_on = final
   []
   [pc_samp]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos
     sampler = sample
     output_samples = true

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad.i
@@ -66,7 +66,7 @@
     execute_on = final
   []
   [pc_samp]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos
     sampler = sample
     output_samples = true

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad.i
@@ -66,7 +66,7 @@
     execute_on = final
   []
   [pc_samp]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = poly_chaos
     sampler = sample
     output_samples = true

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/evaluate.i
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/evaluate.i
@@ -12,7 +12,7 @@
 
 [VectorPostprocessors]
   [results]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = surrogate
     sampler = test
     execute_on = final

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train_and_evaluate.i
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train_and_evaluate.i
@@ -21,7 +21,7 @@
     outputs = none
   []
   [results]
-    type = SurrogateTester
+    type = EvaluateSurrogate
     model = surrogate
     sampler = test
     output_samples = true


### PR DESCRIPTION
This PR moves the test object SurrogateTester to a regular object EvaluateSurrogate.

Closes #15635 
