### PR TITLE
Ensure deviatoric of rank two tensor is actually deviatoric

### DIFF
--- a/framework/include/utils/RankTwoTensorImplementation.h
+++ b/framework/include/utils/RankTwoTensorImplementation.h
@@ -469,6 +469,19 @@ RankTwoTensorTempl<T>::deviatoric() const
 {
   RankTwoTensorTempl<T> deviatoric(*this);
   deviatoric.addIa(-1.0 / 3.0 * this->tr()); // actually construct deviatoric part
+
+  // Sometimes numerical precision results in a non-zero trace of the deviatoric tensor. Ensure that
+  // doesn't happen here by subtracting any extra volumetric components
+  T trace = deviatoric.tr();
+  unsigned int it = 0;
+  while (it < 3 && trace != 0.0)
+  {
+    deviatoric.addIa(-1.0 / 3.0 * trace);
+    trace = deviatoric.tr();
+    if (std::abs(trace) < 1.0e-11)
+      break;
+    ++it;
+  }
   return deviatoric;
 }
 


### PR DESCRIPTION
Closes #15666

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
