### PR TITLE
improve AD RankTwoTensor eigenvalue routines

### DIFF
--- a/framework/include/utils/RankTwoTensor.h
+++ b/framework/include/utils/RankTwoTensor.h
@@ -598,7 +598,7 @@ RankTwoTensorTempl<T>::operator-(const TypeTensor<T2> & b) const
 template <typename T>
 template <typename T2, typename std::enable_if<ScalarTraits<T2>::value, int>::type>
 RankTwoTensorTempl<typename CompareTypes<T, T2>::supertype>
-    RankTwoTensorTempl<T>::operator*(const T2 & b) const
+RankTwoTensorTempl<T>::operator*(const T2 & b) const
 {
   return TensorValue<T>::operator*(b);
 }
@@ -606,7 +606,7 @@ RankTwoTensorTempl<typename CompareTypes<T, T2>::supertype>
 template <typename T>
 template <typename T2>
 TypeVector<typename CompareTypes<T, T2>::supertype>
-    RankTwoTensorTempl<T>::operator*(const TypeVector<T2> & b) const
+RankTwoTensorTempl<T>::operator*(const TypeVector<T2> & b) const
 {
   return TensorValue<T>::operator*(b);
 }
@@ -614,7 +614,7 @@ TypeVector<typename CompareTypes<T, T2>::supertype>
 template <typename T>
 template <typename T2>
 RankTwoTensorTempl<typename CompareTypes<T, T2>::supertype>
-    RankTwoTensorTempl<T>::operator*(const TypeTensor<T2> & b) const
+RankTwoTensorTempl<T>::operator*(const TypeTensor<T2> & b) const
 {
   return TensorValue<T>::operator*(b);
 }

--- a/framework/include/utils/RankTwoTensorImplementation.h
+++ b/framework/include/utils/RankTwoTensorImplementation.h
@@ -923,7 +923,8 @@ ADRankTwoTensor::symmetricEigenvaluesEigenvectors(std::vector<DualReal> & eigval
 
       iter++;
       if (iter > 30)
-        break;
+        mooseError("Diverged when computing the eigenvalues and eigenvectors for a symmetric "
+                   "rank-2 tensor");
     }
   }
 


### PR DESCRIPTION
ref #14237

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

- Add tolerance parameters to givensRotation, QR, hessenberg and symmetricEigenvaluesEigenvectors.
- Use a generally better shift.
- Combine AD and non-AD versions of QR.
- Error out when eigenvalue decomposition doesn't converge within 30 iterations. (For a 3x3 tensor, if QRRQ doesn't converge within 30 iterations, there is simply something wrong.)