### PR TITLE
Strip path separator in test names

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -654,7 +654,7 @@ class TestHarness:
 
                         # Yes, by design test dir will be apart of the output file name
                         output_file = os.path.join(output_dir, '.'.join([os.path.basename(job.getTestDir()),
-                                                                         job.getTestNameShort(),
+                                                                         job.getTestNameShort().replace(os.sep, '.'),
                                                                          status,
                                                                          'txt']))
 


### PR DESCRIPTION
Some tests are sub-tests with a path separator used to designate such a test.
This is causing issues when the TestHarness attempts to write results of said
test to the disc (it tries to include this path separator).

Refs #15671
