### PR TITLE
Support threading in incompressible Navier Stokes

### DIFF
--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -351,6 +351,7 @@ MaterialData::declareHelper(MaterialProperties & props,
     else
       mooseError("Material has no property named: " + prop_name);
   }
+  prop->name(prop_name);
   return *prop;
 }
 
@@ -374,6 +375,7 @@ MaterialData::declareADHelper(MaterialProperties & props,
     else
       mooseError("Material has no property named: " + prop_name);
   }
+  prop->name(prop_name);
   return *prop;
 }
 

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -351,7 +351,7 @@ MaterialData::declareHelper(MaterialProperties & props,
     else
       mooseError("Material has no property named: " + prop_name);
   }
-  prop->name(prop_name);
+  prop->setName(prop_name);
   return *prop;
 }
 
@@ -375,7 +375,7 @@ MaterialData::declareADHelper(MaterialProperties & props,
     else
       mooseError("Material has no property named: " + prop_name);
   }
-  prop->name(prop_name);
+  prop->setName(prop_name);
   return *prop;
 }
 

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -13,7 +13,9 @@
 
 #include "MooseADWrapper.h"
 #include "MooseArray.h"
+#include "MooseTypes.h"
 #include "DataIO.h"
+#include "MooseError.h"
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/tensor_value.h"
@@ -180,6 +182,21 @@ public:
    */
   virtual void load(std::istream & stream) override;
 
+  void name(const MaterialPropertyName & name_in)
+  {
+    mooseAssert(
+        _name.empty() || _name == name_in,
+        "We're trying to apply a new name to a material property. I don't think that makes sense.");
+    _name = name_in;
+  }
+
+  const MaterialPropertyName & name() const
+  {
+    if (_name.empty())
+      mooseError("Retrieving a material property name before it's set.");
+    return _name;
+  }
+
 private:
   /// private copy constructor to avoid shallow copying of material properties
   MaterialPropertyBase(const MaterialPropertyBase<T, is_ad> & /*src*/)
@@ -192,6 +209,9 @@ private:
   {
     mooseError("Material properties must be assigned to references (missing '&')");
   }
+
+  /// the name of this material property
+  MaterialPropertyName _name;
 
 protected:
   /// Stored parameter value.

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -182,7 +182,7 @@ public:
    */
   virtual void load(std::istream & stream) override;
 
-  void name(const MaterialPropertyName & name_in)
+  void setName(const MaterialPropertyName & name_in)
   {
     mooseAssert(
         _name.empty() || _name == name_in,

--- a/modules/navier_stokes/include/userobjects/INSADObjectTracker.h
+++ b/modules/navier_stokes/include/userobjects/INSADObjectTracker.h
@@ -65,8 +65,21 @@ public:
   }
 
 private:
+  template <typename T>
+  static bool notEqual(const T & val1, const T & val2);
+
   InputParameters _tracker_params;
 };
+
+template <typename T>
+bool
+INSADObjectTracker::notEqual(const T & val1, const T & val2)
+{
+  return val1 != val2;
+}
+
+template <>
+bool INSADObjectTracker::notEqual(const MooseEnum & val1, const MooseEnum & val2);
 
 template <typename T>
 void
@@ -75,8 +88,8 @@ INSADObjectTracker::set(const std::string & name, const T & value)
   if (_tracker_params.isParamSetByUser(name))
   {
     const T & current_value = _tracker_params.get<T>(name);
-    if (current_value != value)
-      mooseError("Two INSADObjects set different values for the parameter", name);
+    if (INSADObjectTracker::notEqual(current_value, value))
+      mooseError("Two INSADObjects set different values for the parameter ", name);
   }
   else if (!_tracker_params.have_parameter<T>(name))
     mooseError("Attempting to set parameter ", name, " that is not a valid param");

--- a/modules/navier_stokes/src/kernels/INSADBoussinesqBodyForce.C
+++ b/modules/navier_stokes/src/kernels/INSADBoussinesqBodyForce.C
@@ -39,9 +39,18 @@ INSADBoussinesqBodyForce::INSADBoussinesqBodyForce(const InputParameters & param
   auto & obj_tracker = const_cast<INSADObjectTracker &>(
       _fe_problem.getUserObject<INSADObjectTracker>("ins_ad_object_tracker"));
   obj_tracker.set("has_boussinesq", true);
-  obj_tracker.set("alpha", &getADMaterialProperty<Real>("alpha_name"));
-  obj_tracker.set("ref_temp", &getMaterialProperty<Real>("ref_temp"));
-  obj_tracker.set("temperature", &adCoupledValue("temperature"));
+
+  // We actually want to perform the material property requests during object construction in order
+  // to ensure that material property dependency is recorded correctly (I don't think this should
+  // actually matter for non-Material MaterialPropertyInterface classes, but might as well be
+  // consistent)
+  obj_tracker.set("alpha", getADMaterialProperty<Real>("alpha_name").name());
+  obj_tracker.set("ref_temp", getMaterialProperty<Real>("ref_temp").name());
+
+  mooseAssert(getParam<std::vector<VariableName>>("temperature").size() == 1,
+              "Only expect one variable name for temperature");
+
+  obj_tracker.set("temperature", getParam<std::vector<VariableName>>("temperature")[0]);
   obj_tracker.set("gravity", getParam<RealVectorValue>("gravity"));
 }
 

--- a/modules/navier_stokes/src/kernels/INSADBoussinesqBodyForce.C
+++ b/modules/navier_stokes/src/kernels/INSADBoussinesqBodyForce.C
@@ -47,10 +47,10 @@ INSADBoussinesqBodyForce::INSADBoussinesqBodyForce(const InputParameters & param
   obj_tracker.set("alpha", getADMaterialProperty<Real>("alpha_name").name());
   obj_tracker.set("ref_temp", getMaterialProperty<Real>("ref_temp").name());
 
-  mooseAssert(getParam<std::vector<VariableName>>("temperature").size() == 1,
-              "Only expect one variable name for temperature");
+  if (coupledComponents("temperature") != 1)
+    paramError("temperature", "Only one variable should be used for 'temperature'");
 
-  obj_tracker.set("temperature", getParam<std::vector<VariableName>>("temperature")[0]);
+  obj_tracker.set("temperature", getVar("temperature", 0)->name());
   obj_tracker.set("gravity", getParam<RealVectorValue>("gravity"));
 }
 

--- a/modules/navier_stokes/src/kernels/INSADEnergySource.C
+++ b/modules/navier_stokes/src/kernels/INSADEnergySource.C
@@ -50,9 +50,9 @@ INSADEnergySource::INSADEnergySource(const InputParameters & parameters)
   obj_tracker.set("has_heat_source", true);
   if (has_coupled)
   {
-    mooseAssert(getParam<std::vector<VariableName>>("source_variable").size() == 1,
-                "Only expect one VariableName for the heat source var");
-    obj_tracker.set("heat_source_var", getParam<std::vector<VariableName>>("source_variable")[0]);
+    if (coupledComponents("source_variable") != 1)
+      paramError("source_variable", "Only expect one variable for the 'source_variable' parameter");
+    obj_tracker.set("heat_source_var", getVar("source_variable")->name());
   }
   else if (has_function)
     obj_tracker.set("heat_source_function", getParam<FunctionName>("source_function"));

--- a/modules/navier_stokes/src/kernels/INSADEnergySource.C
+++ b/modules/navier_stokes/src/kernels/INSADEnergySource.C
@@ -49,9 +49,13 @@ INSADEnergySource::INSADEnergySource(const InputParameters & parameters)
       _fe_problem.getUserObject<INSADObjectTracker>("ins_ad_object_tracker"));
   obj_tracker.set("has_heat_source", true);
   if (has_coupled)
-    obj_tracker.set("heat_source_var", &adCoupledValue("source_variable"));
+  {
+    mooseAssert(getParam<std::vector<VariableName>>("source_variable").size() == 1,
+                "Only expect one VariableName for the heat source var");
+    obj_tracker.set("heat_source_var", getParam<std::vector<VariableName>>("source_variable")[0]);
+  }
   else if (has_function)
-    obj_tracker.set("heat_source_function", &getFunction("source_function"));
+    obj_tracker.set("heat_source_function", getParam<FunctionName>("source_function"));
 }
 
 ADReal

--- a/modules/navier_stokes/src/kernels/INSADEnergySource.C
+++ b/modules/navier_stokes/src/kernels/INSADEnergySource.C
@@ -52,7 +52,7 @@ INSADEnergySource::INSADEnergySource(const InputParameters & parameters)
   {
     if (coupledComponents("source_variable") != 1)
       paramError("source_variable", "Only expect one variable for the 'source_variable' parameter");
-    obj_tracker.set("heat_source_var", getVar("source_variable")->name());
+    obj_tracker.set("heat_source_var", getVar("source_variable", 0)->name());
   }
   else if (has_function)
     obj_tracker.set("heat_source_function", getParam<FunctionName>("source_function"));

--- a/modules/navier_stokes/src/kernels/INSADMomentumCoupledForce.C
+++ b/modules/navier_stokes/src/kernels/INSADMomentumCoupledForce.C
@@ -49,19 +49,10 @@ INSADMomentumCoupledForce::INSADMomentumCoupledForce(const InputParameters & par
       _fe_problem.getUserObject<INSADObjectTracker>("ins_ad_object_tracker"));
   obj_tracker.set("has_coupled_force", true);
   if (has_coupled)
-  {
-    std::vector<const ADVectorVariableValue *> coupled_vars;
-    for (const auto i : make_range(coupledComponents("coupled_vector_var")))
-      coupled_vars.push_back(&adCoupledVectorValue("coupled_vector_var", i));
-    obj_tracker.set("coupled_force_var", coupled_vars);
-  }
+    obj_tracker.set("coupled_force_var", getParam<std::vector<VariableName>>("coupled_vector_var"));
   if (has_function)
-  {
-    std::vector<const Function *> coupled_functions;
-    for (const auto & fn_name : getParam<std::vector<FunctionName>>("vector_function"))
-      coupled_functions.push_back(&_fe_problem.getFunction(fn_name, _tid));
-    obj_tracker.set("coupled_force_vector_function", coupled_functions);
-  }
+    obj_tracker.set("coupled_force_vector_function",
+                    getParam<std::vector<FunctionName>>("vector_function"));
 }
 
 ADRealVectorValue

--- a/modules/navier_stokes/src/materials/INSAD3Eqn.C
+++ b/modules/navier_stokes/src/materials/INSAD3Eqn.C
@@ -59,9 +59,13 @@ INSAD3Eqn::initialSetup()
   if ((_has_heat_source = _object_tracker->get<bool>("has_heat_source")))
   {
     if (_object_tracker->isTrackerParamValid("heat_source_var"))
-      _heat_source_var = _object_tracker->get<const ADVariableValue *>("heat_source_var");
+      _heat_source_var =
+          &_subproblem
+               .getStandardVariable(_tid, _object_tracker->get<VariableName>("heat_source_var"))
+               .adSln();
     else if (_object_tracker->isTrackerParamValid("heat_source_function"))
-      _heat_source_function = _object_tracker->get<const Function *>("heat_source_function");
+      _heat_source_function = &_fe_problem.getFunction(
+          _object_tracker->get<FunctionName>("heat_source_function"), _tid);
   }
 }
 

--- a/modules/navier_stokes/src/materials/INSAD3Eqn.C
+++ b/modules/navier_stokes/src/materials/INSAD3Eqn.C
@@ -61,7 +61,7 @@ INSAD3Eqn::initialSetup()
     if (_object_tracker->isTrackerParamValid("heat_source_var"))
       _heat_source_var =
           &_subproblem
-               .getStandardVariable(_tid, _object_tracker->get<VariableName>("heat_source_var"))
+               .getStandardVariable(_tid, _object_tracker->get<std::string>("heat_source_var"))
                .adSln();
     else if (_object_tracker->isTrackerParamValid("heat_source_function"))
       _heat_source_function = &_fe_problem.getFunction(

--- a/modules/navier_stokes/src/materials/INSADMaterial.C
+++ b/modules/navier_stokes/src/materials/INSADMaterial.C
@@ -83,7 +83,7 @@ INSADMaterial::initialSetup()
     _boussinesq_alpha =
         &_material_data->getADProperty<Real>(_object_tracker->get<MaterialPropertyName>("alpha"));
     _temperature =
-        &_subproblem.getStandardVariable(_tid, _object_tracker->get<VariableName>("temperature"))
+        &_subproblem.getStandardVariable(_tid, _object_tracker->get<std::string>("temperature"))
              .adSln();
     _ref_temp =
         &_material_data->getProperty<Real>(_object_tracker->get<MaterialPropertyName>("ref_temp"));

--- a/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
+++ b/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
@@ -77,3 +77,10 @@ addAmbientConvectionParams(InputParameters & params)
                         "The heat transfer coefficient from from ambient surroundings");
   params.addParam<Real>("ambient_temperature", "The ambient temperature");
 }
+
+template <>
+bool
+INSADObjectTracker::notEqual(const MooseEnum & val1, const MooseEnum & val2)
+{
+  return !val1.compareCurrent(val2);
+}

--- a/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
+++ b/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
@@ -36,7 +36,7 @@ INSADObjectTracker::INSADObjectTracker(const InputParameters & parameters)
       "alpha", "The alpha material property for the boussinesq approximation");
   _tracker_params.addParam<MaterialPropertyName>("ref_temp",
                                                  "The reference temperature material property");
-  _tracker_params.addParam<VariableName>("temperature", "The temperature variable");
+  _tracker_params.addParam<std::string>("temperature", "The temperature variable");
   _tracker_params.addParam<RealVectorValue>("gravity", "Direction of the gravity vector");
   _tracker_params.addParam<bool>(
       "has_gravity",
@@ -50,7 +50,7 @@ INSADObjectTracker::INSADObjectTracker(const InputParameters & parameters)
       "has_heat_source", false, "Whether there is a heat source function object in the simulation");
   _tracker_params.addParam<FunctionName>("heat_source_function",
                                          "The function describing the heat source");
-  _tracker_params.addParam<VariableName>(
+  _tracker_params.addParam<std::string>(
       "heat_source_var",
       "Variable describing the volumetric heat source. Note that if this variable evaluates to a "
       "negative number, then this object will be an energy sink");

--- a/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
+++ b/modules/navier_stokes/src/userobjects/INSADObjectTracker.C
@@ -32,11 +32,11 @@ INSADObjectTracker::INSADObjectTracker(const InputParameters & parameters)
       "The form of the viscous term. Options are 'traction' or 'laplace'");
   _tracker_params.addParam<bool>(
       "has_boussinesq", false, "Whether the simulation has the boussinesq approximation");
-  _tracker_params.addParam<const ADMaterialProperty<Real> *>(
+  _tracker_params.addParam<MaterialPropertyName>(
       "alpha", "The alpha material property for the boussinesq approximation");
-  _tracker_params.addParam<const MaterialProperty<Real> *>(
-      "ref_temp", "The reference temperature material property");
-  _tracker_params.addParam<const ADVariableValue *>("temperature", "The temperature variable");
+  _tracker_params.addParam<MaterialPropertyName>("ref_temp",
+                                                 "The reference temperature material property");
+  _tracker_params.addParam<VariableName>("temperature", "The temperature variable");
   _tracker_params.addParam<RealVectorValue>("gravity", "Direction of the gravity vector");
   _tracker_params.addParam<bool>(
       "has_gravity",
@@ -48,9 +48,9 @@ INSADObjectTracker::INSADObjectTracker(const InputParameters & parameters)
 
   _tracker_params.addParam<bool>(
       "has_heat_source", false, "Whether there is a heat source function object in the simulation");
-  _tracker_params.addParam<const Function *>("heat_source_function",
-                                             "The function describing the heat source");
-  _tracker_params.addParam<const ADVariableValue *>(
+  _tracker_params.addParam<FunctionName>("heat_source_function",
+                                         "The function describing the heat source");
+  _tracker_params.addParam<VariableName>(
       "heat_source_var",
       "Variable describing the volumetric heat source. Note that if this variable evaluates to a "
       "negative number, then this object will be an energy sink");
@@ -59,9 +59,9 @@ INSADObjectTracker::INSADObjectTracker(const InputParameters & parameters)
       "has_coupled_force",
       false,
       "Whether the simulation has a force due to a coupled vector variable/vector function");
-  _tracker_params.addParam<std::vector<const ADVectorVariableValue *>>(
-      "coupled_force_var", "Variables imposing coupled forces");
-  _tracker_params.addParam<std::vector<const Function *>>(
+  _tracker_params.addParam<std::vector<VariableName>>("coupled_force_var",
+                                                      "Variables imposing coupled forces");
+  _tracker_params.addParam<std::vector<FunctionName>>(
       "coupled_force_vector_function", "The function(s) standing in as a coupled force(s)");
 }
 

--- a/modules/navier_stokes/test/tests/ins/boussinesq/tests
+++ b/modules/navier_stokes/test/tests/ins/boussinesq/tests
@@ -7,6 +7,14 @@
     exodiff = boussinesq_square_out.e
     requirement = 'The system shall be able to simulate natural convection by adding the Boussinesq approximation to the incompressible Navier-Stokes equations.'
   []
+  [threaded_exo]
+    type = Exodiff
+    input = boussinesq_square.i
+    exodiff = boussinesq_square_out.e
+    requirement = 'The system shall be able to solve mass, momentum, and energy incompressible Navier-Stokes equations with multiple threads.'
+    min_threads = 2
+    issues = '#15713'
+  []
   [jac]
     type = PetscJacobianTester
     input = boussinesq_square.i
@@ -21,6 +29,14 @@
     input = boussinesq_stabilized.i
     exodiff = boussinesq_stabilized_out.e
     requirement = 'The system shall be able to support SUPG and PSPG stabilization of the incompressible Navier Stokes equations including the Boussinesq approximation.'
+  []
+  [threaded_exo_stab]
+    type = Exodiff
+    input = boussinesq_stabilized.i
+    exodiff = boussinesq_stabilized_out.e
+    requirement = 'The system shall be able to solve stablized mass, momentum, and energy incompressible Navier-Stokes equations with multiple threads.'
+    min_threads = 2
+    issues = '#15713'
   []
   [jac_stab]
     type = PetscJacobianTester
@@ -39,5 +55,13 @@
     prereq = 'exo_stab'
     issues = '#15159'
     requirement = 'The system shall be able to reproduce results of incompressible Navier-Stokes with Boussinesq approximation using a customized and condensed action syntax.'
+  []
+  [threaded_exo_stab_action]
+    type = 'Exodiff'
+    input = 'boussinesq_stabilized_action.i'
+    exodiff = 'boussinesq_stabilized_out.e'
+    requirement = 'The system shall be able to solve mass, momentum, and energy incompressible Navier-Stokes equations with a custom action syntax using multiple threads.'
+    min_threads = 2
+    issues = '#15713'
   []
 []


### PR DESCRIPTION
Force `INSADObjectTracker` to take names instead of pointers to threaded data.

Closes #15713
