### PR TITLE
Print an understandable message when a user-specified path/file does not exist

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -862,8 +862,20 @@ realpath(const std::string & path)
 {
 #ifdef LIBMESH_HAVE_PETSC
   char dummy[PETSC_MAX_PATH_LEN];
+#if defined(PETSC_HAVE_REALPATH)
+  // If "realpath" is adopted by PETSc and
+  // "path" does not exist, then PETSc will print a misleading message.
+  // [0]PETSC ERROR: Error in external library
+  // [0]PETSC ERROR: realpath()
+  // [0]PETSC ERROR: See https://www.mcs.anl.gov/petsc/documentation/faq.html for trouble shooting.
+  // [0]PETSC ERROR: Petsc Release Version 3.13.3, unknown
+  // We here override the misleading message with a better one.
+  if (!::realpath(path.c_str(), dummy))
+    mooseError("Failed to get real path for ", path);
+#endif
   if (PetscGetRealPath(path.c_str(), dummy))
     mooseError("Failed to get real path for ", path);
+
   return dummy;
 #else
 #ifndef __WIN32__

--- a/test/tests/misc/realpath_exception/tests
+++ b/test/tests/misc/realpath_exception/tests
@@ -1,0 +1,11 @@
+[Tests]
+  design = 'Parser.md'
+  issues = '#15718'
+
+  [./except01]
+    type = RunException
+    input = not_exist.i
+    expect_err = 'Failed to get real path for'
+    requirement = "The system shall print an understandable message when a user-specified path/file does not exist."
+  [../]
+[]


### PR DESCRIPTION
Fixed this misleading petsc error message:

```
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: Error in external library
[0]PETSC ERROR: realpath()
[0]PETSC ERROR: See https://www.mcs.anl.gov/petsc/documentation/faq.html for trouble shooting.
[0]PETSC ERROR: Petsc Release Version 3.12.5, unknown 
```


Closes #15718

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
