### PR TITLE
Improve bound checking laromance 

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADLAROMANCEStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/ADLAROMANCEStressUpdateBase.h
@@ -155,6 +155,14 @@ protected:
                        const bool derivative = false);
 
   /**
+   * Returns the material specific value for the low bound cutoff of the ROM output,
+   * before transformation, and prevents the calculation of a strain value outside
+   * the ROM calibration database. Should be overwritten by inheriting classes.
+   * @return value of the ROM specific strain calibration bound
+   */
+  virtual Real romStrainCutoff() = 0;
+
+  /**
    * Calculate the value or derivative of Legendre polynomial up to 3rd order
    * @param value Input to Legendre polynomial
    * @param degree Degree of Legendre polynomial

--- a/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
@@ -692,10 +692,13 @@ ADLAROMANCEStressUpdateBase::convertOutput(const std::vector<Real> & old_input_v
     return 0.0;
 
   ADReal expout = std::exp(rom_output);
-  if (expout > 1.0e-10)
-    expout -= 1.000000E-10;
+  mooseAssert(expout > 0.0, "ROM calculated strain increment is zero or negative");
+
+  const Real rom_strain_cutoff_value = romStrainCutoff();
+  if (expout > rom_strain_cutoff_value)
+    expout -= rom_strain_cutoff_value;
   else
-    expout = -1.0E-10 * 1.0E-10 / expout + 1.0E-10;
+    expout = -rom_strain_cutoff_value * rom_strain_cutoff_value / expout + rom_strain_cutoff_value;
 
   return -expout * old_input_values[out_index] * _dt;
 }
@@ -799,7 +802,11 @@ ADLAROMANCEStressUpdateBase::computeStressFinalize(const ADRankTwoTensor & plast
   {
     _cell_dislocations[_qp] = _old_input_values[_cell_output_index];
     _wall_dislocations[_qp] = _old_input_values[_wall_output_index];
-    mooseException("The negative values of the cell dislocation density, ", MetaPhysicL::raw_value(_cell_dislocations[_qp]), ", and/or wall dislocation density, ", MetaPhysicL::raw_value(_wall_dislocations[_qp]), ". Cutting timestep.");
+    mooseException("The negative values of the cell dislocation density, ",
+                   MetaPhysicL::raw_value(_cell_dislocations[_qp]),
+                   ", and/or wall dislocation density, ",
+                   MetaPhysicL::raw_value(_wall_dislocations[_qp]),
+                   ". Cutting timestep.");
   }
 
   if (_verbose)

--- a/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
@@ -794,28 +794,12 @@ ADLAROMANCEStressUpdateBase::computeStressFinalize(const ADRankTwoTensor & plast
   _cell_dislocations[_qp] = _old_input_values[_cell_output_index] + _cell_dislocation_increment;
   _wall_dislocations[_qp] = _old_input_values[_wall_output_index] + _wall_dislocation_increment;
 
-  // Prevent the ROM from proceeding with new dislocation values that will be out of bounds
-  if ((_cell_dislocations[_qp] < _global_limits[_cell_input_index][0]) ||
-      (_cell_dislocations[_qp] > _global_limits[_cell_input_index][1]))
+  // Prevent the ROM from calculating and proceding with negative dislocations
+  if (_cell_dislocations[_qp] < 0.0 || _wall_dislocations[_qp] < 0.0)
   {
-    mooseException("The calculated value of the cell dislocations, ",
-                   MetaPhysicL::raw_value(_cell_dislocations[_qp]),
-                   " is outside of the allowable evolution bounds: ( ",
-                   _global_limits[_cell_input_index][0],
-                   " , ",
-                   _global_limits[_cell_input_index][1],
-                   " ). Cutting the timestep.");
-  }
-  else if ((_wall_dislocations[_qp] < _global_limits[_wall_input_index][0]) ||
-           (_wall_dislocations[_qp] > _global_limits[_wall_input_index][1]))
-  {
-    mooseException("The calculated value of the wall dislocations, ",
-                   MetaPhysicL::raw_value(_wall_dislocations[_qp]),
-                   " is outside of the allowable evolution bounds: ( ",
-                   _global_limits[_wall_input_index][0],
-                   " , ",
-                   _global_limits[_wall_input_index][1],
-                   " ). Cutting the timestep.");
+    _cell_dislocations[_qp] = _old_input_values[_cell_output_index];
+    _wall_dislocations[_qp] = _old_input_values[_wall_output_index];
+    mooseException("The negative values of the cell dislocation density, ", MetaPhysicL::raw_value(_cell_dislocations[_qp]), ", and/or wall dislocation density, ", MetaPhysicL::raw_value(_wall_dislocations[_qp]), ". Cutting timestep.");
   }
 
   if (_verbose)

--- a/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/ADLAROMANCEStressUpdateBase.C
@@ -692,7 +692,7 @@ ADLAROMANCEStressUpdateBase::convertOutput(const std::vector<Real> & old_input_v
     return 0.0;
 
   ADReal expout = std::exp(rom_output);
-  mooseAssert(expout > 0.0, "ROM calculated strain increment is zero or negative");
+  mooseAssert(expout > 0.0, "ROM calculated strain increment is not strictly positive");
 
   const Real rom_strain_cutoff_value = romStrainCutoff();
   if (expout > rom_strain_cutoff_value)

--- a/modules/tensor_mechanics/test/include/materials/SS316HLAROMANCEStressUpdateTest.h
+++ b/modules/tensor_mechanics/test/include/materials/SS316HLAROMANCEStressUpdateTest.h
@@ -23,4 +23,6 @@ protected:
   virtual std::vector<std::vector<std::vector<Real>>> getTransformCoefs() override;
   virtual std::vector<std::vector<std::vector<Real>>> getInputLimits() override;
   virtual std::vector<std::vector<std::vector<Real>>> getCoefs() override;
+
+  virtual Real romStrainCutoff() override { return 1.0e-10; }
 };


### PR DESCRIPTION
Includes two commits to allow easy adaption based on discussion:
  1. Corrects the logic operator and checks the ROM output values in `computeStressFinalize`
  2. Replaces the use of the `checkInputWindows` method in `computeStressFinalize` to throw an exception and cut the timestep if the calculated dislocation densities are outside of the allowable evolution bounds
    - This approach leverages the treatment in the ROM to reset the input effective strain value at the maximum allowable, regardless of the actual simulation value (per email conversations)

fyi @lynnmunday @tophmatthews @bwspenc 

Marked as WIP only to prevent testing while Civet is down

Refs #14046