### PR TITLE
WIP: Add transient capabilities to POD-RB surrogate in STM. 

### DIFF
--- a/modules/stochastic_tools/include/executioners/PODSteady.h
+++ b/modules/stochastic_tools/include/executioners/PODSteady.h
@@ -1,0 +1,37 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Steady.h"
+
+class PODSteady : public Steady
+{
+public:
+  /**
+   * Constructor
+   *
+   * @param parameters The parameters object holding data for the class to use.
+   * @return Whether or not the solve was successful.
+   */
+  static InputParameters validParams();
+
+  PODSteady(const InputParameters & parameters);
+
+  virtual void execute() override;
+
+  virtual bool lastSolveConverged() const override { return _last_solve_converged; }
+
+protected:
+
+  PerfID _post_snapshot_timer;
+
+private:
+  bool _last_solve_converged;
+};

--- a/modules/stochastic_tools/include/executioners/PODTransient.h
+++ b/modules/stochastic_tools/include/executioners/PODTransient.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Transient.h"
+
+// Forward Declarations
+class PODTransient;
+class TimeStepper;
+class FEProblemBase;
+
+class PODTransient : public Transient
+{
+public:
+  static InputParameters validParams();
+
+  PODTransient(const InputParameters & parameters);
+
+  virtual void execute() override;
+
+protected:
+
+  PerfID _post_snapshot_timer;
+
+};

--- a/modules/stochastic_tools/include/multiapps/PODTransientMultiApp.h
+++ b/modules/stochastic_tools/include/multiapps/PODTransientMultiApp.h
@@ -10,7 +10,7 @@
 #pragma once
 
 // MOOSE includes
-#include "SamplerFullSolveMultiApp.h"
+#include "SamplerTransientMultiApp.h"
 #include "PODReducedBasisTrainer.h"
 #include "SamplerInterface.h"
 #include "SurrogateModelInterface.h"
@@ -20,21 +20,21 @@
 class PODSamplerSolutionTransfer;
 class PODResidualTransfer;
 
-class PODFullSolveMultiApp : public SamplerFullSolveMultiApp, SurrogateModelInterface
+class PODTransientMultiApp : public SamplerTransientMultiApp, SurrogateModelInterface
 {
 public:
   static InputParameters validParams();
 
-  PODFullSolveMultiApp(const InputParameters & parameters);
+  PODTransientMultiApp(const InputParameters & parameters);
 
+  /**
+   * Override solveStep to allow for batch execution.
+   */
   virtual bool solveStep(Real dt, Real target_time, bool auto_advance = true) override;
 
   /// Overriding preTransfer to reinit the subappliations if the object needs to be
   /// executed twice.
   virtual void preTransfer(Real dt, Real target_time) override;
-
-  /// Returning the value of the snapshot generation flag.
-  bool snapshotGeneration() { return _snapshot_generation; }
 
 protected:
   /// Returning pointers to the solution transfers. Used in batch mode.

--- a/modules/stochastic_tools/include/surrogates/PODReducedBasisTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/PODReducedBasisTrainer.h
@@ -41,6 +41,9 @@ public:
                    dof_id_type g_ind,
                    const std::shared_ptr<DenseVector<Real>> & snapshot);
 
+  /// Adding a snapshot for a variable with an automatically generated global index.
+  void addSnapshot(dof_id_type v_ind, const std::shared_ptr<DenseVector<Real>> & snapshot);
+
   /// Adding the contribution of a residual to the reduced operators.
   void addToReducedOperator(dof_id_type base_i,
                             dof_id_type tag_i,

--- a/modules/stochastic_tools/include/transfers/PODSamplerSolutionTransfer.h
+++ b/modules/stochastic_tools/include/transfers/PODSamplerSolutionTransfer.h
@@ -13,6 +13,7 @@
 #include "PODReducedBasisTrainer.h"
 #include "StochasticToolsTransfer.h"
 #include "PODFullSolveMultiApp.h"
+#include "PODTransientMultiApp.h"
 
 // Forward declarations
 class PODFullSolveMultiApp;

--- a/modules/stochastic_tools/include/utils/DistributedData.h
+++ b/modules/stochastic_tools/include/utils/DistributedData.h
@@ -36,6 +36,9 @@ public:
   /// Adding a new sample locally with a global index.
   void addNewEntry(dof_id_type glob_i, const T & sample);
 
+  /// Adding a new sample locally with an automatically generated global index.
+  void addNewEntry(const T & sample);
+
   /// Closes the container meaning that no new samples can be added or the
   /// already existing samples canot be changed.
   void closeContainer() { _closed = true; };
@@ -73,6 +76,9 @@ public:
   /// Getting the number of global samples.
   dof_id_type getNumberOfGlobalEntries() const;
 
+  /// Getting the maximum global sample index.
+  dof_id_type getMaxGlobalIndex() const;
+
   /// Getting the number of locally owned samples.
   dof_id_type getNumberOfLocalEntries() const { return _n_local_entries; };
 
@@ -81,6 +87,9 @@ public:
 
   /// Getting the global index of a locally owned sample.
   dof_id_type getGlobalIndex(dof_id_type loc_i) const;
+
+  // Reassigning global indices for the samples.
+  void reassignGlobalIndices();
 
 protected:
   /// The vector where the samples are stored.

--- a/modules/stochastic_tools/src/base/StochasticToolTypes.C
+++ b/modules/stochastic_tools/src/base/StochasticToolTypes.C
@@ -7,19 +7,7 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-#pragma once
+#include "StochasticToolsTypes.h"
+#include "MooseEnumItem.h"
 
-#include "Moose.h"
-
-/// Enum for batch type in stochastic tools MultiApp
-namespace StochasticTools
-{
-enum class MultiAppMode
-{
-  NORMAL = 0,
-  BATCH_RESET = 1,
-  BATCH_RESTORE = 2
-};
-
-extern const ExecFlagType EXEC_POST_SNAPSHOT_GEN;
-}
+const ExecFlagType StochasticTools::EXEC_POST_SNAPSHOT_GEN("POST_SNAPSHOT_GEN");

--- a/modules/stochastic_tools/src/base/StochasticToolsApp.C
+++ b/modules/stochastic_tools/src/base/StochasticToolsApp.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "StochasticToolsApp.h"
-#include "Moose.h"
+#include "StochasticToolsTypes.h"
 #include "AppFactory.h"
 #include "MooseSyntax.h"
 
@@ -73,6 +73,9 @@ StochasticToolsApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax
   // Adds action for loading Covariance data in model
   registerTask("load_covariance_data", true);
   addTaskDependency("load_covariance_data", "load_surrogate_data");
+
+  auto & factory = f; // for registerExecFlags macro
+  registerExecFlag(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
 }
 
 void

--- a/modules/stochastic_tools/src/executioners/PODSteady.C
+++ b/modules/stochastic_tools/src/executioners/PODSteady.C
@@ -16,7 +16,7 @@
 
 #include "libmesh/equation_systems.h"
 
-registerMooseObject("MooseApp", PODSteady);
+registerMooseObject("StochasticToolsApp", PODSteady);
 
 defineLegacyParams(PODSteady);
 
@@ -26,8 +26,6 @@ PODSteady::validParams()
   InputParameters params = Executioner::validParams();
   params.addClassDescription("Executioner for steady-state simulations.");
   params.addParam<Real>("time", 0.0, "System time");
-  ExecFlagEnum & exec = params.set<ExecFlagEnum>("execute_on", true);
-  exec.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
   return params;
 }
 

--- a/modules/stochastic_tools/src/executioners/PODSteady.C
+++ b/modules/stochastic_tools/src/executioners/PODSteady.C
@@ -26,6 +26,8 @@ PODSteady::validParams()
   InputParameters params = Executioner::validParams();
   params.addClassDescription("Executioner for steady-state simulations.");
   params.addParam<Real>("time", 0.0, "System time");
+  ExecFlagEnum & exec = params.set<ExecFlagEnum>("execute_on");
+  exec.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
   return params;
 }
 

--- a/modules/stochastic_tools/src/executioners/PODSteady.C
+++ b/modules/stochastic_tools/src/executioners/PODSteady.C
@@ -1,0 +1,112 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PODSteady.h"
+#include "FEProblem.h"
+#include "Factory.h"
+#include "StochasticToolsApp.h"
+#include "StochasticToolsTypes.h"
+#include "NonlinearSystem.h"
+
+#include "libmesh/equation_systems.h"
+
+registerMooseObject("MooseApp", PODSteady);
+
+defineLegacyParams(PODSteady);
+
+InputParameters
+PODSteady::validParams()
+{
+  InputParameters params = Executioner::validParams();
+  params.addClassDescription("Executioner for steady-state simulations.");
+  params.addParam<Real>("time", 0.0, "System time");
+  return params;
+}
+
+PODSteady::PODSteady(const InputParameters & parameters) : Steady(parameters) {}
+
+void
+PODSteady::execute()
+{
+  if (_app.isRecovering())
+    return;
+
+  _time_step = 0;
+  _time = _time_step;
+  _problem.outputStep(EXEC_INITIAL);
+  _time = _system_time;
+
+  preExecute();
+
+  _problem.advanceState();
+
+  // first step in any steady state solve is always 1 (preserving backwards compatibility)
+  _time_step = 1;
+
+#ifdef LIBMESH_ENABLE_AMR
+
+  // Define the refinement loop
+  unsigned int steps = _problem.adaptivity().getSteps();
+  for (unsigned int r_step = 0; r_step <= steps; r_step++)
+  {
+#endif // LIBMESH_ENABLE_AMR
+    _problem.timestepSetup();
+
+    for (MooseIndex(_num_grid_steps) grid_step = 0; grid_step <= _num_grid_steps; ++grid_step)
+    {
+      _last_solve_converged = _picard_solve.solve();
+
+      if (!lastSolveConverged())
+      {
+        _console << "Aborting as solve did not converge\n";
+        break;
+      }
+
+      if (grid_step != _num_grid_steps)
+        _problem.uniformRefine();
+    }
+
+    _problem.computeIndicators();
+    _problem.computeMarkers();
+
+    // need to keep _time in sync with _time_step to get correct output
+    _time = _time_step;
+    _problem.outputStep(EXEC_TIMESTEP_END);
+    _time = _system_time;
+
+#ifdef LIBMESH_ENABLE_AMR
+    if (r_step != steps)
+    {
+      _problem.adaptMesh();
+    }
+
+    _time_step++;
+  }
+#endif
+
+  {
+    TIME_SECTION(_post_snapshot_timer)
+    _problem.execMultiApps(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+    _problem.execute(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+    _time = _time_step;
+    _problem.outputStep(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+    _time = _system_time;
+  }
+
+  {
+    TIME_SECTION(_final_timer)
+    _problem.execMultiApps(EXEC_FINAL);
+    _problem.execute(EXEC_FINAL);
+    _time = _time_step;
+    _problem.outputStep(EXEC_FINAL);
+    _time = _system_time;
+  }
+
+  postExecute();
+}

--- a/modules/stochastic_tools/src/executioners/PODSteady.C
+++ b/modules/stochastic_tools/src/executioners/PODSteady.C
@@ -26,7 +26,7 @@ PODSteady::validParams()
   InputParameters params = Executioner::validParams();
   params.addClassDescription("Executioner for steady-state simulations.");
   params.addParam<Real>("time", 0.0, "System time");
-  ExecFlagEnum & exec = params.set<ExecFlagEnum>("execute_on");
+  ExecFlagEnum & exec = params.set<ExecFlagEnum>("execute_on", true);
   exec.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
   return params;
 }

--- a/modules/stochastic_tools/src/executioners/PODTransient.C
+++ b/modules/stochastic_tools/src/executioners/PODTransient.C
@@ -1,0 +1,100 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PODTransient.h"
+
+// MOOSE includes
+#include "Factory.h"
+#include "SubProblem.h"
+#include "TimeStepper.h"
+#include "MooseApp.h"
+#include "Conversion.h"
+#include "FEProblem.h"
+#include "NonlinearSystem.h"
+#include "Control.h"
+#include "TimePeriod.h"
+#include "MooseMesh.h"
+#include "AllLocalDofIndicesThread.h"
+#include "TimeIntegrator.h"
+#include "Console.h"
+
+#include "StochasticToolsTypes.h"
+
+registerMooseObject("StochasticToolsApp", PODTransient);
+
+defineLegacyParams(PODTransient);
+
+InputParameters
+PODTransient::validParams()
+{
+  InputParameters params = Transient::validParams();
+  return params;
+}
+
+PODTransient::PODTransient(const InputParameters & parameters) : Transient(parameters) {}
+
+void
+PODTransient::execute()
+{
+  preExecute();
+
+  // Start time loop...
+  while (keepGoing())
+  {
+    incrementStepOrReject();
+    preStep();
+    computeDT();
+    takeStep();
+    endStep();
+    postStep();
+  }
+
+  if (lastSolveConverged())
+  {
+    _t_step++;
+
+    /*
+     * Call the multi-app executioners endStep and
+     * postStep methods when doing Picard or when not automatically advancing sub-applications for
+     * some other reason. We do not perform these calls for loose-coupling/auto-advancement
+     * problems because Transient::endStep and Transient::postStep get called from
+     * TransientMultiApp::solveStep in that case.
+     */
+    if (!_picard_solve.autoAdvance())
+    {
+      _problem.finishMultiAppStep(EXEC_TIMESTEP_BEGIN, /*recurse_through_multiapp_levels=*/true);
+      _problem.finishMultiAppStep(EXEC_TIMESTEP_END, /*recurse_through_multiapp_levels=*/true);
+    }
+  }
+
+  if (!_app.halfTransient())
+  {
+    {
+      TIME_SECTION(_post_snapshot_timer);
+      _problem.execMultiApps(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+      _problem.finalizeMultiApps();
+      _problem.execute(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+      _problem.outputStep(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+    }
+
+    {
+      TIME_SECTION(_final_timer);
+      _problem.execMultiApps(EXEC_FINAL);
+      _problem.finalizeMultiApps();
+      _problem.execute(EXEC_FINAL);
+      _problem.outputStep(EXEC_FINAL);
+    }
+  }
+
+  // This method is to finalize anything else we want to do on the problem side.
+  _problem.postExecute();
+
+  // This method can be overridden for user defined activities in the Executioner.
+  postExecute();
+}

--- a/modules/stochastic_tools/src/multiapps/PODFullSolveMultiApp.C
+++ b/modules/stochastic_tools/src/multiapps/PODFullSolveMultiApp.C
@@ -27,6 +27,8 @@ PODFullSolveMultiApp::validParams()
       "functions.");
   params.addRequiredParam<UserObjectName>(
       "trainer_name", "Trainer object that contains the solutions for different samples.");
+  ExecFlagEnum & exec_enum = params.set<ExecFlagEnum>("execute_on", true);
+  exec_enum.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
 
   return params;
 }

--- a/modules/stochastic_tools/src/multiapps/PODFullSolveMultiApp.C
+++ b/modules/stochastic_tools/src/multiapps/PODFullSolveMultiApp.C
@@ -21,6 +21,7 @@ InputParameters
 PODFullSolveMultiApp::validParams()
 {
   InputParameters params = SamplerFullSolveMultiApp::validParams();
+  params += SurrogateModelInterface::validParams();
   params.addClassDescription(
       "Creates a full-solve type sub-application for each row of a Sampler matrix. "
       "On second call, this object creates residuals for a PODReducedBasisTrainer with given basis "

--- a/modules/stochastic_tools/src/multiapps/PODTransientMultiApp.C
+++ b/modules/stochastic_tools/src/multiapps/PODTransientMultiApp.C
@@ -1,0 +1,219 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+// StochasticTools includes
+#include "PODTransientMultiApp.h"
+#include "Sampler.h"
+#include "StochasticToolsTransfer.h"
+
+registerMooseObject("StochasticToolsApp", PODTransientMultiApp);
+
+InputParameters
+PODTransientMultiApp::validParams()
+{
+  InputParameters params = SamplerTransientMultiApp::validParams();
+  params += SurrogateModelInterface::validParams();
+  params.addClassDescription(
+      "Creates amultiapp which gathers snapshots and residuals for a POD surrogate.");
+  params.addRequiredParam<UserObjectName>(
+      "trainer_name", "Trainer object that contains the solutions for different samples.");
+  ExecFlagEnum & exec_enum = params.set<ExecFlagEnum>("execute_on", true);
+  exec_enum.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
+
+  return params;
+}
+
+PODTransientMultiApp::PODTransientMultiApp(const InputParameters & parameters)
+  : SamplerTransientMultiApp(parameters),
+    SurrogateModelInterface(this),
+    _trainer(getSurrogateTrainer<PODReducedBasisTrainer>("trainer_name"))
+{
+}
+
+void
+PODTransientMultiApp::preTransfer(Real dt, Real target_time)
+{
+  // Reinitialize the problem only if the snapshot generation part is done.
+  // This check has to be switched to simething similar to the one in PODFullSolve Multiapp,
+  // since the current flag is always NONE. Right now this is used to protect agains moving
+  // past the snapsot generation phase.
+  if (_fe_problem.getCurrentExecuteOnFlag() == StochasticTools::EXEC_POST_SNAPSHOT_GEN)
+  {
+    dof_id_type base_size = _trainer.getSumBaseSize();
+    if (base_size < 1)
+      mooseError(
+          "There are no basis vectors available for residual generation."
+          " This indicates that the bases have not been created yet."
+          " The most common cause of this error is the wrong setting"
+          " of the 'execute_on' flags in the PODFullSolveMultiApp and/or PODReducedBasisTrainer.");
+
+    if (_mode == StochasticTools::MultiAppMode::BATCH_RESET ||
+        _mode == StochasticTools::MultiAppMode::BATCH_RESTORE)
+      init(n_processors());
+    else
+      init(base_size);
+
+    initialSetup();
+  }
+  SamplerTransientMultiApp::preTransfer(dt, target_time);
+}
+
+bool
+PODTransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
+{
+  bool last_solve_converged = true;
+  // If snapshot generation phase, solve the subapplications in a regular manner.
+  // Otherwise, compute the residuals only.
+  if (_fe_problem.getCurrentExecuteOnFlag() == StochasticTools::EXEC_POST_SNAPSHOT_GEN)
+  {
+    if (_mode == StochasticTools::MultiAppMode::BATCH_RESET ||
+        _mode == StochasticTools::MultiAppMode::BATCH_RESTORE)
+      computeResidualBatch(target_time);
+    else
+      computeResidual();
+  }
+  else
+  {
+    last_solve_converged = SamplerTransientMultiApp::solveStep(dt, target_time, auto_advance);
+  }
+
+  return last_solve_converged;
+}
+
+void
+PODTransientMultiApp::computeResidual()
+{
+  mooseError("Needs to be refactored based on the handling of the time-derivative.");
+  // // Doing the regular computation but instead of solving the subapplication,
+  // // the residuals for different tags are evaluated.
+  // if (!_has_an_app)
+  //   return;
+  //
+  // Moose::ScopedCommSwapper swapper(_my_comm);
+  //
+  // int rank;
+  // int ierr;
+  // ierr = MPI_Comm_rank(_communicator.get(), &rank);
+  // mooseCheckMPIErr(ierr);
+  //
+  // // Getting the necessary tag names.
+  // const std::vector<std::string> & trainer_tags = _trainer.getTagNames();
+  //
+  // // Looping over the subapplications and computing residuals.
+  // for (unsigned int i = 0; i < _my_num_apps; i++)
+  // {
+  //   // Getting the local problem
+  //   FEProblemBase & problem = _apps[i]->getExecutioner()->feProblem();
+  //
+  //   // Extracting the TagIDs based on tag names from the current subapp.
+  //   std::set<TagID> tags_to_compute;
+  //   for (auto & tag_name : trainer_tags)
+  //     tags_to_compute.insert(problem.getVectorTagID(tag_name));
+  //
+  //   problem.computeResidualTags(tags_to_compute);
+  // }
+}
+
+void
+PODTransientMultiApp::computeResidualBatch(Real /*target_time*/)
+{
+  mooseError("Needs to be refactored based on the handling of the time-derivative.");
+//   // Getting the overall base size from the trainer.
+//   dof_id_type base_size = _trainer.getSumBaseSize();
+//
+//   // Distributing the residual evaluation among processes.
+//   dof_id_type local_base_begin;
+//   dof_id_type local_base_end;
+//   dof_id_type n_local_bases;
+//   MooseUtils::linearPartitionItems(
+//       base_size, n_processors(), processor_id(), n_local_bases, local_base_begin, local_base_end);
+//
+//   // List of active relevant Transfer objects
+//   std::vector<std::shared_ptr<PODSamplerSolutionTransfer>> to_transfers =
+//       getActiveSolutionTransfers(MultiAppTransfer::TO_MULTIAPP);
+//   std::vector<std::shared_ptr<PODResidualTransfer>> from_transfers =
+//       getActiveResidualTransfers(MultiAppTransfer::FROM_MULTIAPP);
+//
+//   // Initialize to/from transfers
+//   for (auto transfer : to_transfers)
+//     transfer->initializeToMultiapp();
+//
+//   for (auto transfer : from_transfers)
+//     transfer->initializeFromMultiapp();
+//
+//   if (_mode == StochasticTools::MultiAppMode::BATCH_RESTORE)
+//     backup();
+//
+//   // Perform batch MultiApp solves
+//   _local_batch_app_index = 0;
+//   for (dof_id_type i = local_base_begin; i < local_base_end; ++i)
+//   {
+//     for (auto & transfer : to_transfers)
+//     {
+//       transfer->setGlobalMultiAppIndex(i);
+//       transfer->executeToMultiapp();
+//     }
+//
+//     computeResidual();
+//
+//     for (auto & transfer : from_transfers)
+//     {
+//       transfer->setGlobalMultiAppIndex(i);
+//       transfer->executeFromMultiapp();
+//     }
+//
+//     if (i < _sampler.getLocalRowEnd() - 1)
+//     {
+//       if (_mode == StochasticTools::MultiAppMode::BATCH_RESTORE)
+//         restore();
+//       else
+//       {
+//         // The app is being reset for the next loop, thus the batch index must be indexed as such
+//         _local_batch_app_index = i + 1;
+//         resetApp(_local_batch_app_index, target_time);
+//         initialSetup();
+//       }
+//     }
+//   }
+//   // Finalize to/from transfers
+//   for (auto transfer : to_transfers)
+//     transfer->finalizeToMultiapp();
+//   for (auto transfer : from_transfers)
+//     transfer->finalizeFromMultiapp();
+}
+
+std::vector<std::shared_ptr<PODSamplerSolutionTransfer>>
+PODTransientMultiApp::getActiveSolutionTransfers(Transfer::DIRECTION direction)
+{
+  std::vector<std::shared_ptr<PODSamplerSolutionTransfer>> output;
+  const ExecuteMooseObjectWarehouse<Transfer> & warehouse =
+      _fe_problem.getMultiAppTransferWarehouse(direction);
+  for (std::shared_ptr<Transfer> transfer : warehouse.getActiveObjects())
+  {
+    auto ptr = std::dynamic_pointer_cast<PODSamplerSolutionTransfer>(transfer);
+    if (ptr)
+      output.push_back(ptr);
+  }
+  return output;
+}
+
+std::vector<std::shared_ptr<PODResidualTransfer>>
+PODTransientMultiApp::getActiveResidualTransfers(Transfer::DIRECTION direction)
+{
+  std::vector<std::shared_ptr<PODResidualTransfer>> output;
+  const ExecuteMooseObjectWarehouse<Transfer> & warehouse =
+      _fe_problem.getMultiAppTransferWarehouse(direction);
+  for (std::shared_ptr<Transfer> transfer : warehouse.getActiveObjects())
+  {
+    auto ptr = std::dynamic_pointer_cast<PODResidualTransfer>(transfer);
+    if (ptr)
+      output.push_back(ptr);
+  }
+  return output;
+}

--- a/modules/stochastic_tools/src/surrogates/PODReducedBasisTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/PODReducedBasisTrainer.C
@@ -147,8 +147,24 @@ PODReducedBasisTrainer::addSnapshot(dof_id_type v_ind,
 }
 
 void
+PODReducedBasisTrainer::addSnapshot(dof_id_type v_ind,
+                                    const std::shared_ptr<DenseVector<Real>> & snapshot)
+{
+  _snapshots[v_ind].addNewEntry(snapshot);
+}
+
+void
 PODReducedBasisTrainer::computeCorrelationMatrix()
 {
+
+  // Reassigning global indices. In case of most stiuations this will not
+  // modify anything. In case of transient simulations, on the other hand, this might
+  // modify the global IDs based on the fact if two elements have the same IDs.
+  for (unsigned int var_i = 0; var_i < _snapshots.size(); ++var_i)
+  {
+    _snapshots[var_i].reassignGlobalIndices();
+  }
+
   // Getting the number of snapshots. It is assumed that every variable has the
   // same number of snapshots. This assumption is used at multiple locations in
   // this source file.

--- a/modules/stochastic_tools/src/transfers/PODSamplerSolutionTransfer.C
+++ b/modules/stochastic_tools/src/transfers/PODSamplerSolutionTransfer.C
@@ -23,6 +23,8 @@ PODSamplerSolutionTransfer::validParams()
   params.addRequiredParam<UserObjectName>("trainer_name",
                                           "Trainer object that contains the solutions"
                                           " for different samples.");
+  ExecFlagEnum & exec_enum = params.set<ExecFlagEnum>("execute_on", true);
+  exec_enum.addAvailableFlags(StochasticTools::EXEC_POST_SNAPSHOT_GEN);
   return params;
 }
 

--- a/modules/stochastic_tools/src/transfers/PODSamplerSolutionTransfer.C
+++ b/modules/stochastic_tools/src/transfers/PODSamplerSolutionTransfer.C
@@ -34,8 +34,21 @@ PODSamplerSolutionTransfer::PODSamplerSolutionTransfer(const InputParameters & p
     _pod_multi_app(std::dynamic_pointer_cast<PODFullSolveMultiApp>(_multi_app)),
     _trainer(getSurrogateTrainer<PODReducedBasisTrainer>("trainer_name"))
 {
+  // This tests if the given multiapp can be cast into a PODFullSolve multiapp.
+  // In the future it would be better to swap this hacky procedure with the
+  // implementation of a PODMultiApp base. The PODTransientMultiapp works as
+  // using a pointer to a fullSolve multiapp too.
+  std::shared_ptr<PODTransientMultiApp> trans_ptr(
+      std::dynamic_pointer_cast<PODTransientMultiApp>(_multi_app));
+  if(trans_ptr)
+  {
+    mooseWarning("Casting PODTransientMultiapp into PODFullSolveMultiapp!");
+    _pod_multi_app = std::dynamic_pointer_cast<PODFullSolveMultiApp>(_multi_app);
+  }
+
   if (!_pod_multi_app)
-    paramError("multi_app", "The Multiapp given is not a PODFullsolveMultiapp!");
+    paramError("multi_app",
+               "The Multiapp given is not a PODFullsolveMultiapp or PODTransientMultiApp!");
 }
 
 void
@@ -86,7 +99,8 @@ PODSamplerSolutionTransfer::execute()
           solution.get(var_dofs, tmp->get_values());
 
           // Copying the temporary vector into the trainer.
-          _trainer.addSnapshot(v_index, i, tmp);
+          // _trainer.addSnapshot(v_index, i, tmp);
+          _trainer.addSnapshot(v_index, tmp);
         }
       }
       break;

--- a/modules/stochastic_tools/test/src/base/StochasticToolsTestApp.C
+++ b/modules/stochastic_tools/test/src/base/StochasticToolsTestApp.C
@@ -12,6 +12,7 @@
 #include "Moose.h"
 #include "AppFactory.h"
 #include "MooseSyntax.h"
+#include "Executioner.h"
 
 InputParameters
 StochasticToolsTestApp::validParams()

--- a/modules/stochastic_tools/test/tests/surrogates/pod_rb/internal/trainer.i
+++ b/modules/stochastic_tools/test/tests/surrogates/pod_rb/internal/trainer.i
@@ -1,4 +1,9 @@
 [StochasticTools]
+  auto_create_executioner = false
+[]
+
+[Executioner]
+  type = PODSteady
 []
 
 [Distributions]
@@ -35,7 +40,7 @@
     input_files = sub.i
     sampler = sample
     trainer_name = 'pod_rb'
-    execute_on = 'timestep_begin final'
+    execute_on = 'timestep_begin POST_SNAPSHOT_GEN'
   []
 []
 
@@ -64,7 +69,7 @@
     sampler = sample
     trainer_name = 'pod_rb'
     direction = 'to_multiapp'
-    execute_on = 'final'
+    execute_on = 'POST_SNAPSHOT_GEN'
     check_multiapp_execute_on = false
   []
   [res]
@@ -72,7 +77,7 @@
     multi_app = sub
     sampler = sample
     trainer_name = "pod_rb"
-    execute_on = 'final'
+    execute_on = 'POST_SNAPSHOT_GEN'
     check_multiapp_execute_on = false
   []
 []

--- a/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/sub.i
+++ b/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/sub.i
@@ -1,0 +1,90 @@
+[Problem]
+  type = FEProblem
+  extra_tag_vectors  = 'diff react bodyf time'
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+  xmax = 10
+[]
+
+[Variables]
+  [u]
+    initial_condition = 0
+  []
+[]
+
+[Kernels]
+  [diffusion]
+    type = MatDiffusion
+    variable = u
+    diffusivity = k
+    extra_vector_tags = 'diff'
+  []
+  [reaction]
+    type = MaterialReaction
+    variable = u
+    coefficient = alpha
+    extra_vector_tags = 'react'
+  []
+  [source]
+    type = BodyForce
+    variable = u
+    value = 1.0
+    extra_vector_tags = 'bodyf'
+  []
+  [time]
+    type = TimeDerivative
+    variable = u
+    extra_vector_tags = 'time'
+  []
+[]
+
+[Materials]
+  [k]
+    type = GenericConstantMaterial
+    prop_names = k
+    prop_values = 1.0
+  []
+  [alpha]
+    type = GenericConstantMaterial
+    prop_names = alpha
+    prop_values = 1.0
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 0
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 0
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 2
+  dt = 0.1
+  solve_type = PJFNK
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Controls]
+  [stochastic]
+    type = SamplerReceiver
+  []
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/surr.i
+++ b/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/surr.i
@@ -1,0 +1,52 @@
+[StochasticTools]
+[]
+
+[Distributions]
+  [k_dist]
+    type = Uniform
+    lower_bound = 2.5
+    upper_bound = 7.5
+  []
+  [alpha_dist]
+    type = Uniform
+    lower_bound = 2.5
+    upper_bound = 7.5
+  []
+  [S_dist]
+    type = Uniform
+    lower_bound = 2.5
+    upper_bound = 7.5
+  []
+[]
+
+[Samplers]
+  [sample]
+    type = LatinHypercube
+    distributions = 'k_dist alpha_dist S_dist'
+    num_rows = 10
+    num_bins = 3
+    execute_on = PRE_MULTIAPP_SETUP
+    seed = 17
+  []
+[]
+
+[Surrogates]
+  [rbpod]
+    type = PODReducedBasisSurrogate
+    filename = 'trainer_out_pod_rb.rd'
+  []
+[]
+
+[VectorPostprocessors]
+  [res]
+    type = PODSurrogateTester
+    model = rbpod
+    sampler = sample
+    variable_name = "u"
+    to_compute = nodal_max
+  []
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/trainer.i
+++ b/modules/stochastic_tools/test/tests/surrogates/pod_rb/transient/trainer.i
@@ -3,7 +3,8 @@
 []
 
 [Executioner]
-  type = PODSteady
+  type = Transient
+  num_steps = 2
 []
 
 [Distributions]
@@ -28,7 +29,7 @@
   [sample]
     type = LatinHypercube
     distributions = 'k_dist alpha_dist S_dist'
-    num_rows = 3
+    num_rows = 2
     num_bins = 3
     execute_on = PRE_MULTIAPP_SETUP
   []
@@ -36,11 +37,10 @@
 
 [MultiApps]
   [sub]
-    type = PODFullSolveMultiApp
+    type = PODTransientMultiApp
     input_files = sub.i
     sampler = sample
     trainer_name = 'pod_rb'
-    execute_on = 'timestep_begin post_snapshot_gen'
   []
 []
 
@@ -51,7 +51,7 @@
     sampler = sample
     parameters = 'Materials/k/prop_values Materials/alpha/prop_values Kernels/source/value'
     to_control = 'stochastic'
-    execute_on = 'timestep_begin'
+    execute_on = 'initial'
     check_multiapp_execute_on = false
   []
   [snapshots]
@@ -60,24 +60,7 @@
     sampler = sample
     trainer_name = 'pod_rb'
     direction = 'from_multiapp'
-    execute_on = 'timestep_begin'
-    check_multiapp_execute_on = false
-  []
-  [pod_modes]
-    type = PODSamplerSolutionTransfer
-    multi_app = sub
-    sampler = sample
-    trainer_name = 'pod_rb'
-    direction = 'to_multiapp'
-    execute_on = 'post_snapshot_gen'
-    check_multiapp_execute_on = false
-  []
-  [res]
-    type = PODResidualTransfer
-    multi_app = sub
-    sampler = sample
-    trainer_name = "pod_rb"
-    execute_on = 'post_snapshot_gen'
+    execute_on = 'timestep_end'
     check_multiapp_execute_on = false
   []
 []
@@ -89,14 +72,6 @@
     error_res = '1e-9'
     tag_names = 'diff react bodyf'
     tag_types = 'op op src'
-    execute_on = 'timestep_begin final'
-  []
-[]
-
-[Outputs]
-  [out]
-    type = SurrogateTrainerOutput
-    trainers = 'pod_rb'
-    execute_on = FINAL
+    execute_on = 'final'
   []
 []


### PR DESCRIPTION
This modification would allow the user to use POD-RB methods for parametric linear transient problems with affine parameter dependence. It would utilize a custom executioner (PODTransient) and multi-app (PODTransientMultiApp) for this purpose. 
Potential issues remaining:
-> Handling of the time-derivative kernel tagging and conversion to reduced operators.
-> Switching the _snapshot_generation flag in PODTransientMultiApp to something that corresponds to given ExecuteFlag. 
-> Implementing the time-integration in the RB surrogate. (Might be able to use Scalar kernels).

Refs. #15538
