### PR TITLE
Beta (Pearson 1) and Gamma distributions in Stochastic Tools #15779

### DIFF
--- a/modules/stochastic_tools/include/distributions/BetaPearson.h
+++ b/modules/stochastic_tools/include/distributions/BetaPearson.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Distribution.h"
+
+/**
+ * A class used to generate a BetaPearson distribution
+ */
+class BetaPearson : public Distribution
+{
+public:
+  static InputParameters validParams();
+
+  BetaPearson(const InputParameters & parameters);
+
+  virtual Real pdf(const Real & x) const override;
+  virtual Real cdf(const Real & x) const override;
+  virtual Real quantile(const Real & p) const override;
+
+  static Real pdf(const Real & x, const Real & a, const Real & b, const Real & location, const Real & scale);
+  static Real cdf(const Real & x, const Real & a, const Real & b, const Real & location, const Real & scale);
+  static Real quantile(const Real & p, const Real & a, const Real & b, const Real & location, const Real & scale);
+
+protected:
+  ///@{
+  /// Coefficients for the rational function used to approximate the quantile
+  // static const std::array<Real, 6> _a;
+  // static const std::array<Real, 6> _b;
+  ///@}
+
+  /// Parameter a of the Beta distribution
+  const Real & _a;
+
+  /// Parameter b of the Beta distribution
+  const Real & _b;
+
+  /// Location of the Beta distribution
+  const Real & _location;
+
+  /// Scale of the Beta distribution
+  const Real & _scale;
+};

--- a/modules/stochastic_tools/src/distributions/BetaPearson.C
+++ b/modules/stochastic_tools/src/distributions/BetaPearson.C
@@ -1,0 +1,101 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "BetaPearson.h"
+#include "math.h"
+#include "libmesh/utility.h"
+
+registerMooseObject("StochasticToolsApp", BetaPearson);
+
+InputParameters
+BetaPearson::validParams()
+{
+  InputParameters params = Distribution::validParams();
+  params.addClassDescription("BetaPearson distribution");
+  params.addRequiredParam<Real>("a", "Parameter a of the Beta distribution.");
+  params.addRequiredRangeCheckedParam<Real>(
+      "b", "b > 0", "Parameter b of the Beta distribution.");
+  params.addRequiredParam<Real>("location", "Location of the Beta distribution.");
+  params.addRequiredParam<Real>("scale", "Scale of the Beta distribution.");
+  return params;
+}
+
+BetaPearson::BetaPearson(const InputParameters & parameters)
+  : Distribution(parameters),
+    _a(getParam<Real>("a")),
+    _b(getParam<Real>("b")),
+    _location(getParam<Real>("location")),
+    _scale(getParam<Real>("scale"))
+{
+}
+
+Real
+BetaPearson::pdf(const Real & x, const Real & a, const Real & b, const Real & location, const Real & scale)
+{
+  if (((x - location) / scale) > 1 || ((x - location) / scale) < 0){
+    ::mooseError("Error in BetaPearson distribution. Input value outside the bounds.");
+  } else {
+    const Real betafunc = std::tgamma(a) * std::tgamma(b) / std::tgamma(a + b);
+    return std::pow((x - location) / scale, a-1) * std::pow(1-(x - location) / scale, b-1) / betafunc;
+  }
+}
+
+Real
+BetaPearson::cdf(const Real & x, const Real & a, const Real & b, const Real & location, const Real & scale)
+{
+  // Approximated by summing the pdf since Beta cdf is harder to compute
+  if (((x - location) / scale) > 1 || ((x - location) / scale) < 0){
+    ::mooseError("Error in BetaPearson distribution. Input value outside the bounds.");
+  } else {
+    const Real interval = 0.001 * (x - location) / scale;
+    const Real betafunc = std::tgamma(a) * std::tgamma(b) / std::tgamma(a + b);
+    Real sumcdf = 0;
+    for (unsigned i = 0; i < 1000; ++i){
+      Real inp = i * interval;
+      sumcdf = sumcdf + interval * std::pow(inp, a-1) * std::pow((1-inp), b-1) / betafunc;
+    }
+    return sumcdf;
+  }
+}
+
+Real
+BetaPearson::quantile(const Real & p, const Real & a, const Real & b, const Real & location, const Real & scale)
+{
+  // Approximated using the cdf since Beta quantile is harder to compute
+  Real value = 0;
+  for (unsigned i = 0; i <= 1000; ++i){
+    value = i * 0.001;
+    Real difference = std::abs((p - BetaPearson::cdf(value, a, b, 0, 1)));
+    if (difference < 0.005){
+      break;
+    }
+  }
+  return (value * scale + location);
+}
+
+Real
+BetaPearson::pdf(const Real & x) const
+{
+  TIME_SECTION(_perf_pdf);
+  return pdf(x, _a, _b, _location, _scale);
+}
+
+Real
+BetaPearson::cdf(const Real & x) const
+{
+  TIME_SECTION(_perf_cdf);
+  return cdf(x, _a, _b, _location, _scale);
+}
+
+Real
+BetaPearson::quantile(const Real & p) const
+{
+  TIME_SECTION(_perf_quantile);
+  return quantile(p, _a, _b, _location, _scale);
+}

--- a/modules/stochastic_tools/test/tests/distributions/betapearson.i
+++ b/modules/stochastic_tools/test/tests/distributions/betapearson.i
@@ -1,0 +1,41 @@
+[StochasticTools]
+[]
+
+[Distributions]
+  [betapearson]
+    type = BetaPearson
+    a = 5
+    b = 5
+    location = 5
+    scale = 2
+  []
+[]
+
+[Postprocessors]
+  [cdf]
+    type = TestDistributionPostprocessor
+    distribution = betapearson
+    value = 6.5
+    method = cdf
+    execute_on = initial
+  []
+  [pdf]
+    type = TestDistributionPostprocessor
+    distribution = betapearson
+    value = 6.5
+    method = pdf
+    execute_on = initial
+  []
+  [quantile]
+    type = TestDistributionPostprocessor
+    distribution = betapearson
+    value = 0.5
+    method = quantile
+    execute_on = initial
+  []
+[]
+
+[Outputs]
+  execute_on = 'INITIAL'
+  csv = true
+[]

--- a/modules/stochastic_tools/test/tests/distributions/gold/betapearson_out.csv
+++ b/modules/stochastic_tools/test/tests/distributions/gold/betapearson_out.csv
@@ -1,0 +1,2 @@
+time,cdf,pdf,quantile
+0,0.9511,0.7787,6.0

--- a/modules/stochastic_tools/test/tests/distributions/tests
+++ b/modules/stochastic_tools/test/tests/distributions/tests
@@ -22,6 +22,17 @@
       detail = 'Weibull (3 parameter),'
     []
 
+    [betapearson]
+      type = CSVDiff
+      input = betapearson.i
+      csvdiff = 'betapearson_out.csv'
+      allow_test_objects = true
+      abs_zero = 5e-7
+      rel_err = 1e-3
+
+      detail = 'Beta (Pearson type 1)'
+    []
+
     [normal]
       type = CSVDiff
       input = normal.i


### PR DESCRIPTION
## Reason
Currently, Beta (Pearson 1) and Gamma distributions do not seem to exist unless the Boost library is relied upon.

## Design
Beta (Pearson 1) and Gamma distribution classes are added to the Stochastic Tools

## Impact
Beta (Pearson 1) and Gamma distributions are basic and can support uncertainty quantification studies in the future.

closes #15779 