### PR TITLE
Add some relationship manager and action doc

### DIFF
--- a/framework/doc/content/source/actions/Action.md
+++ b/framework/doc/content/source/actions/Action.md
@@ -11,4 +11,17 @@ When actions are built either through the input parser or internally by MOOSE, t
 MOOSE has lots of built-in actions for adding individual objects through input files.
 But MOOSE action system is far beyond the basic capabilities provided by these built-in actions.
 Developers are encouraged to explore the MOOSE actions system to create their own actions in order to perform problem setup in one place and potentially simplify the input syntax significantly.
-One example is to use an action to append a mesh generator that generates a boundary surrounding a particular subdomain for imposing specific boundary conditions, based on the information not necessarily inside of a mesh generator block.
+One example is to use an action to append a mesh generator that generates a
+boundary surrounding a particular subdomain for imposing specific boundary
+conditions, based on the information not necessarily inside of a mesh generator
+block.
+
+## Relationship Managers and Actions
+
+If adding any `MooseObjects` in a custom action and those objects have
+associated relationship managers, then the
+`addRelationshipManagers(Moose::RelationshipManagerType input_rm_type)` must be
+overridden. Both
+the `ContactAction` in the contact module, and `PorousFlowActionBase` in the
+porous flow module provide examples of overriding this method. For the reasons
+behind why this must be done in the action system, please see [RelationshipManager.md#rm_action].

--- a/framework/doc/content/source/relationshipmanagers/RelationshipManager.md
+++ b/framework/doc/content/source/relationshipmanagers/RelationshipManager.md
@@ -105,7 +105,7 @@ would likely attempt to access degrees of freedom in the solution vector
 corresponding to elements that had been deleted (in a `DistributedMesh`
 context), and our simulation would fail.
 
-## Relationship Managers and Actions
+## Relationship Managers and Actions id=rm_action
 
 As explained above, `RelationshipManagers` are usually added to a simulation
 through the `validParams` of `MooseObjects`. However, during simulation setup,

--- a/framework/doc/content/source/relationshipmanagers/RelationshipManager.md
+++ b/framework/doc/content/source/relationshipmanagers/RelationshipManager.md
@@ -104,3 +104,22 @@ because there is less geometric ghosting than algebraic. In this scenario we
 would likely attempt to access degrees of freedom in the solution vector
 corresponding to elements that had been deleted (in a `DistributedMesh`
 context), and our simulation would fail.
+
+## Relationship Managers and Actions
+
+As explained above, `RelationshipManagers` are usually added to a simulation
+through the `validParams` of `MooseObjects`. However, during simulation setup,
+`MooseObjects` themselves do not add the relationship managers because if they
+did it would be too late to have any impact on the simulation...remote elements
+would already be deleted from the mesh because the mesh is prepared way before
+any `MooseObjects` are added (other than `MeshGenerators`). So it is the
+`MooseObjectAction` itself that detects whether a `MooseObject` (through its
+`validParams`) has signaled that it needs a relationship manager and adds
+it. However, if the `MooseObjectAction` is not adding the `MooseObject` , and
+the `MooseObject` is being added through a custom `action`, then that custom
+action has to be responsible for detecting and adding the associated
+relationship managers. The method that the custom `Action` should override to
+add relationsip managers is
+`addRelationshipManagers(Moose::RelationshipManagerType input_rm_type)`. Both
+the `ContactAction` in the contact module, and `PorousFlowActionBase` in the
+porous flow module provide examples of overriding this method.


### PR DESCRIPTION
Had a recent slack question about why a simulation was running differently when interface kernels were added with an input file or through a custom action. The lack of relationship managers in the latter case was the answer. We need to document better what a developer needs to do with respect to RMs when they're creating their actions.