### PR TITLE
Add user dev to MOOSE Docker image

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -25,6 +25,14 @@ WORKDIR /opt
 ARG MOOSE_JOBS=1
 
 #-----------------------------------------------------------------------------#
+# Add user dev
+#-----------------------------------------------------------------------------#
+RUN useradd dev ; \
+mkdir -p /home/dev/.ssh ; \
+chmod 700 /home/dev/.ssh ; \
+chown -R dev:dev /home/dev
+
+#-----------------------------------------------------------------------------#
 # Install managed packages and clear cache
 #-----------------------------------------------------------------------------#
 
@@ -88,7 +96,9 @@ ENV PETSC_DIR=/usr/local
 ARG LIBMESH_REV
 ENV LIBMESH_DIR=/usr/local \
 libmesh_CPPFLAGS="-D LIBMESH_HAVE_XDR"
+
 COPY scripts/update_and_rebuild_libmesh.sh ${MOOSE_DIR}/scripts/update_and_rebuild_libmesh.sh
+
 RUN git clone https://github.com/libMesh/libmesh.git ; \
 cd libmesh ; \
 git checkout ${LIBMESH_REV} ; \
@@ -100,8 +110,12 @@ rm -rf libmesh/* libmesh/.* || true
 #-----------------------------------------------------------------------------#
 # Copy and build MOOSE framework and tests
 #-----------------------------------------------------------------------------#
-COPY . ${MOOSE_DIR}
+RUN chown -R dev:dev /opt /home/dev
+
+USER dev
+COPY --chown=dev:dev . ${MOOSE_DIR}
 RUN cd test ; make -j ${MOOSE_JOBS}
+USER root
 
 #-----------------------------------------------------------------------------#
 # Add needed env vars to /etc/environment


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
All changes took place in `docker_ci/Dockerfile`.  Toward the top, user `dev` is established, and further down the following happens.
* Set `chown -R dev:dev` on almost empty `/opt`
* Copy and build MOOSE as user `dev`

By default, the image runs with user `root`, so ownership of `/opt` doesn't affect default behavior.  Fixes #15864.