### PR TITLE
Add a default divergence tolerance value

### DIFF
--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -71,7 +71,7 @@ FEProblemSolve::validParams()
   params.addParam<unsigned int>("nl_max_funcs", 10000, "Max Nonlinear solver function evaluations");
   params.addParam<Real>("nl_abs_tol", 1.0e-50, "Nonlinear Absolute Tolerance");
   params.addParam<Real>("nl_rel_tol", 1.0e-8, "Nonlinear Relative Tolerance");
-  params.addParam<Real>("nl_div_tol", -1, "Nonlinear Divergence Tolerance");
+  params.addParam<Real>("nl_div_tol", 1.0e10, "Nonlinear Divergence Tolerance");
   params.addParam<Real>("nl_abs_step_tol", 0., "Nonlinear Absolute step Tolerance");
   params.addParam<Real>("nl_rel_step_tol", 0., "Nonlinear Relative step Tolerance");
   params.addParam<bool>(


### PR DESCRIPTION
@keniley1 had a simulation termination issue that could have been
avoided with a reasonable value for a divergence tolerance. After some
discussion with @fdkong and @bwspenc, we arrived at a value of 1e10 that
should catch egregious increases in the nonlinear residual without
impacting models that demand modest increases in the residual before
converging.

Refs #14154
