### PR TITLE
Make mooseAssert non-empty in NDEBUG modes

### DIFF
--- a/framework/include/base/MooseError.h
+++ b/framework/include/base/MooseError.h
@@ -91,7 +91,7 @@ operator<<(std::ostream & os, const std::tuple<T...> & tup)
   } while (0)
 
 #ifdef NDEBUG
-#define mooseAssert(asserted, msg)
+#define mooseAssert(asserted, msg) ((void)0)
 #else
 #define mooseAssert(asserted, msg)                                                                 \
   do                                                                                               \


### PR DESCRIPTION
Closes #15838
