### PR TITLE
Ignore missing parentheses warnings out of boost

### DIFF
--- a/modules/stochastic_tools/src/utils/PolynomialQuadrature.C
+++ b/modules/stochastic_tools/src/utils/PolynomialQuadrature.C
@@ -18,8 +18,11 @@
 
 // For quickly computing polynomials
 #ifdef LIBMESH_HAVE_EXTERNAL_BOOST
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include <boost/math/special_functions/legendre.hpp>
 #include <boost/math/special_functions/hermite.hpp>
+#pragma GCC diagnostic pop
 #endif
 
 #include <cmath>


### PR DESCRIPTION
It's amazing how bad I am at spelling parentheses. Want to type parantheses every time. Should turn on ispell in the future in my C++ buffers :rofl: 
