### PR TITLE
Removed `./` and `../` HIT syntax in `stork/`

### DIFF
--- a/stork/test/tests/kernels/simple_diffusion/simple_diffusion.i
+++ b/stork/test/tests/kernels/simple_diffusion/simple_diffusion.i
@@ -6,30 +6,30 @@
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = right
     value = 1
-  [../]
+  []
 []
 
 [Executioner]

--- a/stork/test/tests/kernels/simple_diffusion/tests
+++ b/stork/test/tests/kernels/simple_diffusion/tests
@@ -1,7 +1,7 @@
 [Tests]
-  [./test]
+  [test]
     type = 'Exodiff'
     input = 'simple_diffusion.i'
     exodiff = 'simple_diffusion_out.e'
-  [../]
+  []
 []


### PR DESCRIPTION
This reopens #15756, which became stale during the HPC shutdown.

(closes #15755) (refs #15300)
