### PR TITLE
Use idaholab as our Conda channel

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -11,7 +11,7 @@ This directory contains the conda recipes necessary for MOOSE Application based 
 
   ```bash
   conda config --add channels conda-forge
-  conda config --add channels https://mooseframework.org/conda/moose
+  conda config --add channels idaholab
   ```
 
 - Install the moose-env package from Idaholab and name your environment 'moose':

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -22,11 +22,11 @@ With Miniconda installed to your home directory, export PATH, so that it may be 
 export PATH=$HOME/miniconda3/bin:$PATH
 ```
 
-Configure Conda to work with conda-forge, and our mooseframework.org channel:
+Configure Conda to work with conda-forge, and our idaholab channel:
 
 ```bash
 conda config --add channels conda-forge
-conda config --add channels https://mooseframework.org/conda/moose
+conda config --add channels idaholab
 ```
 
 !alert warning title=sudo conda

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -55,7 +55,7 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
 
   ```bash
   channels:
-    - https://mooseframework.org/conda/moose
+    - idaholab
     - conda-forge
     - defaults
   ```


### PR DESCRIPTION
With everything being down for almost 2 months, folks have gotten
used to using idaholab as our conda channel.

Closes #15880
