### PR TITLE
Fix location of conf_vars.mk

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -9,7 +9,7 @@ LIBMESH_DIR       ?= $(MOOSE_DIR)/libmesh/installed
 MOOSE_JOBS        ?= 8
 
 # Include variables defined by MOOSE configure if it's been run
--include $(FRAMEWORK_DIR)/conf_vars.mk
+-include $(MOOSE_DIR)/conf_vars.mk
 
 # If the user has no environment variable
 # called METHOD, he gets optimized mode.


### PR DESCRIPTION
`build.mk` was looking in the framework directory which is where
configure used to be run. However, configure products are now
in the root moose directory.

Refs #15869

