### PR TITLE
Add API for creating specific libMesh mesh type

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -262,6 +262,15 @@ public:
   std::unique_ptr<MeshBase> buildMeshBaseObject(ParallelType override_type = ParallelType::DEFAULT);
 
   /**
+   * Shortcut method to construct a libMesh mesh instance. The created derived-from-MeshBase object
+   * will have its \p allow_remote_element_removal flag set to whatever our value is. We will also
+   * attach any geometric \p RelationshipManagers that have been requested by our simulation objects
+   * to the \p MeshBase object
+   */
+  template <typename T>
+  T buildTypedMesh(unsigned int dim = libMesh::invalid_uint);
+
+  /**
    * Method to set the mesh_base object. If this method is NOT called prior to calling init(), a
    * MeshBase object will be automatically constructed and set.
    */

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -24,6 +24,8 @@
 // libMesh
 #include "libmesh/elem_range.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/distributed_mesh.h"
 #include "libmesh/node_range.h"
 #include "libmesh/nanoflann.hpp"
 #include "libmesh/vector_value.h"
@@ -265,7 +267,9 @@ public:
    * Shortcut method to construct a libMesh mesh instance. The created derived-from-MeshBase object
    * will have its \p allow_remote_element_removal flag set to whatever our value is. We will also
    * attach any geometric \p RelationshipManagers that have been requested by our simulation objects
-   * to the \p MeshBase object
+   * to the \p MeshBase object. If the parameter \p dim is not provided, then its value will be
+   * taken from the input file mesh block. This API should be used by any \p MeshGenerator that
+   * needs to build a \p MeshBase object
    */
   template <typename T>
   T buildTypedMesh(unsigned int dim = libMesh::invalid_uint);
@@ -1601,3 +1605,15 @@ struct MooseMesh::const_bnd_elem_iterator : variant_filter_iterator<MeshBase::Pr
  */
 typedef StoredRange<MooseMesh::const_bnd_node_iterator, const BndNode *> ConstBndNodeRange;
 typedef StoredRange<MooseMesh::const_bnd_elem_iterator, const BndElement *> ConstBndElemRange;
+
+template <typename T>
+T
+MooseMesh::buildTypedMesh(unsigned int dim)
+{
+  if (dim == libMesh::invalid_uint)
+    dim = getParam<MooseEnum>("dim");
+
+  T mesh(_communicator, dim);
+
+  return mesh;
+}

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2310,6 +2310,18 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
   return mesh;
 }
 
+template <typename T>
+T
+MooseMesh::buildTypedMesh(unsigned int dim)
+{
+  if (dim == libMesh::invalid_uint)
+    dim = getParam<MooseEnum>("dim");
+
+  T mesh(_communicator, dim);
+
+  return mesh;
+}
+
 void
 MooseMesh::setMeshBase(std::unique_ptr<MeshBase> mesh_base)
 {
@@ -3199,3 +3211,6 @@ MooseMesh::buildFaceInfo()
     }
   }
 }
+
+template ReplicatedMesh MooseMesh::buildTypedMesh(unsigned int);
+template DistributedMesh MooseMesh::buildTypedMesh(unsigned int);

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -27,18 +27,15 @@
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/mesh_communication.h"
-#include "libmesh/parallel_mesh.h"
 #include "libmesh/periodic_boundary_base.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/serial_mesh.h"
 #include "libmesh/mesh_inserter_iterator.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/mesh_inserter_iterator.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_elem.h"
-#include "libmesh/parallel_mesh.h"
 #include "libmesh/parallel_node.h"
 #include "libmesh/parallel_ghost_sync.h"
 #include "libmesh/utility.h"
@@ -2310,18 +2307,6 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
   return mesh;
 }
 
-template <typename T>
-T
-MooseMesh::buildTypedMesh(unsigned int dim)
-{
-  if (dim == libMesh::invalid_uint)
-    dim = getParam<MooseEnum>("dim");
-
-  T mesh(_communicator, dim);
-
-  return mesh;
-}
-
 void
 MooseMesh::setMeshBase(std::unique_ptr<MeshBase> mesh_base)
 {
@@ -3211,6 +3196,3 @@ MooseMesh::buildFaceInfo()
     }
   }
 }
-
-template ReplicatedMesh MooseMesh::buildTypedMesh(unsigned int);
-template DistributedMesh MooseMesh::buildTypedMesh(unsigned int);


### PR DESCRIPTION
Right now BISON does a lot of manual creation of `ReplicatedMesh` in
their `MeshGenerators`. The problem with this is that it makes it
impossible for us to properly signal not to delete remote elements or to
attach appropriate ghosting functors if our simulation objects have
indicated that we need them. We should have an easy API for
`MeshGenerators` to construct specific types of libMesh meshes that would
then encourage generator developers to go through the `MooseMesh`
object, which will allow us to do our remote element deletion signalling
and attach appropriate relationship managers/ghosting functors. Of
course remote element management is not relevant for `ReplicatedMeshes`
but we want to anticipate possible `DistributedMesh` generation in
the future. If this goes in, then I can update BISON to use the new API, which
will then make it forward compatible with #15338, and hopefully help me not
disrupt CI.

Refs #14329