### PR TITLE
Rename MooseMesh data member in RelationshipManager

### DIFF
--- a/framework/include/relationshipmanagers/RelationshipManager.h
+++ b/framework/include/relationshipmanagers/RelationshipManager.h
@@ -117,6 +117,9 @@ protected:
   /// Reference to the Mesh object
   MooseMesh & _mesh;
 
+  /// Pointer to the \p MooseMesh object
+  MooseMesh * const _moose_mesh;
+
   /// Pointer to DofMap (may be null if this is geometric only). This is useful for setting coupling
   /// matrices in call-backs from DofMap::reinit
   const DofMap * _dof_map;

--- a/framework/src/relationshipmanagers/RelationshipManager.C
+++ b/framework/src/relationshipmanagers/RelationshipManager.C
@@ -76,6 +76,7 @@ RelationshipManager::RelationshipManager(const InputParameters & parameters)
         "mesh",
         "Mesh is null in RelationshipManager constructor. This could well be because No mesh file "
         "was supplied and no generation block was provided")),
+    _moose_mesh(&_mesh),
     _dof_map(nullptr),
     _attach_geometric_early(getParam<bool>("attach_geometric_early")),
     _rm_type(getParam<Moose::RelationshipManagerType>("rm_type")),


### PR DESCRIPTION
After the most recent libmesh update, we've been shadowing the
`MeshBase _mesh` member from `GhostingFunctor` in our
`RelationshipManager` class. As a precursor to #15338 we add a new
`MooseMesh * const _moose_mesh` data member so that we can gracefully
switch our applications over. Then in #15338 we are going to remove the
shadowing `MooseMesh & _mesh` member

