### PR TITLE
Remove legacy const_cast for primary and secondary conversion

### DIFF
--- a/modules/heat_conduction/src/materials/GapConductance.C
+++ b/modules/heat_conduction/src/materials/GapConductance.C
@@ -166,8 +166,6 @@ GapConductance::GapConductance(const InputParameters & parameters)
                  "Emissivities must have values between 0 and 1. You provided: ",
                  emissivity_primary);
   }
-  // Need this for backwards compatability with BISON
-  const_cast<InputParameters &>(_pars).set<Real>("emissivity_master") = emissivity_primary;
 
   Real emissivity_secondary = parameters.isParamSetByUser("emissivity_slave")
                                   ? getParam<Real>("emissivity_slave")
@@ -182,8 +180,6 @@ GapConductance::GapConductance(const InputParameters & parameters)
                  "Emissivities must have values between 0 and 1. You provided: ",
                  emissivity_secondary);
   }
-  // Need this for backwards compatability with BISON
-  const_cast<InputParameters &>(_pars).set<Real>("emissivity_slave") = emissivity_secondary;
 
   _emissivity = emissivity_primary != 0.0 && emissivity_secondary != 0.0
                     ? 1.0 / emissivity_primary + 1.0 / emissivity_secondary - 1


### PR DESCRIPTION
Refs #15457.

This change is necessary to allow BISON deprecated testing to pass. This might have to wait for the merge in BISON to get to master before it will pass.
