### PR TITLE
Return unique_ptr from buildTypedMesh

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -258,12 +258,16 @@ public:
   virtual std::unique_ptr<MooseMesh> safeClone() const = 0;
 
   /**
+   * Determine whether to use a distributed mesh. Should be called during construction
+   */
+  void determineUseDistributedMesh();
+
+  /**
    * Method to construct a libMesh::MeshBase object that is normally set and used by the MooseMesh
    * object during the "init()" phase. If the parameter \p dim is not
    * provided, then its value will be taken from the input file mesh block.
    */
-  std::unique_ptr<MeshBase> buildMeshBaseObject(unsigned int dim = libMesh::invalid_uint,
-                                                ParallelType override_type = ParallelType::DEFAULT);
+  std::unique_ptr<MeshBase> buildMeshBaseObject(unsigned int dim = libMesh::invalid_uint);
 
   /**
    * Shortcut method to construct a unique pointer to a libMesh mesh instance. The created
@@ -1022,7 +1026,11 @@ public:
   /**
    *  Allow to change parallel type
    */
-  void setParallelType(ParallelType parallel_type) { _parallel_type = parallel_type; }
+  void setParallelType(ParallelType parallel_type)
+  {
+    _parallel_type = parallel_type;
+    determineUseDistributedMesh();
+  }
 
   /*
    * Set/Get the partitioner name

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -22,6 +22,11 @@
 // Forward declarations
 class MeshGenerator;
 class MooseMesh;
+namespace libMesh
+{
+class ReplicatedMesh;
+class DistributedMesh;
+}
 
 template <>
 InputParameters validParams<MeshGenerator>();
@@ -85,6 +90,32 @@ protected:
 
   /// References to the mesh and displaced mesh (currently in the ActionWarehouse)
   std::shared_ptr<MooseMesh> & _mesh;
+
+  /**
+   * Build a \p MeshBase object whose underlying type will be determined by the Mesh input file
+   * block
+   * @param dim The logical dimension of the mesh, e.g. 3 for hexes/tets, 2 for quads/tris. If the
+   * caller doesn't specify a value for \p dim, then the value in the \p Mesh input file block will
+   * be used
+   */
+  std::unique_ptr<MeshBase> buildMeshBaseObject(unsigned int dim = libMesh::invalid_uint);
+
+  /**
+   * Build a replicated mesh
+   * @param dim The logical dimension of the mesh, e.g. 3 for hexes/tets, 2 for quads/tris. If the
+   * caller doesn't specify a value for \p dim, then the value in the \p Mesh input file block will
+   * be used
+   */
+  std::unique_ptr<ReplicatedMesh> buildReplicatedMesh(unsigned int dim = libMesh::invalid_uint);
+
+  /**
+   * Build a distributed mesh that has correct remote element removal behavior and geometric
+   * ghosting functors based on the simulation objects
+   * @param dim The logical dimension of the mesh, e.g. 3 for hexes/tets, 2 for quads/tris. If the
+   * caller doesn't specify a value for \p dim, then the value in the \p Mesh input file block will
+   * be used
+   */
+  std::unique_ptr<DistributedMesh> buildDistributedMesh(unsigned int dim = libMesh::invalid_uint);
 
 private:
   /// A list of generators that are required to run before this generator may run

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2249,7 +2249,7 @@ MooseMesh::clone() const
 }
 
 std::unique_ptr<MeshBase>
-MooseMesh::buildMeshBaseObject(ParallelType override_type)
+MooseMesh::buildMeshBaseObject(unsigned int dim, const ParallelType override_type)
 {
   switch (_parallel_type)
   {
@@ -2274,7 +2274,8 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
   if (_is_nemesis || _app.isUseSplit())
     _use_distributed_mesh = true;
 
-  unsigned dim = getParam<MooseEnum>("dim");
+  if (dim == libMesh::invalid_uint)
+    dim = getParam<MooseEnum>("dim");
 
   std::unique_ptr<MeshBase> mesh;
   if (_use_distributed_mesh)
@@ -2283,7 +2284,7 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
       mooseError("The requested override_type of \"Replicated\" may not be used when MOOSE is "
                  "running with a DistributedMesh");
 
-    mesh = libmesh_make_unique<DistributedMesh>(_communicator, dim);
+    mesh = buildTypedMesh<DistributedMesh>(dim);
     if (_partitioner_name != "default" && _partitioner_name != "parmetis")
     {
       _partitioner_name = "parmetis";
@@ -2296,11 +2297,8 @@ MooseMesh::buildMeshBaseObject(ParallelType override_type)
       mooseError("The requested override_type of \"Distributed\" may not be used when MOOSE is "
                  "running with a ReplicatedMesh");
 
-    mesh = libmesh_make_unique<ReplicatedMesh>(_communicator, dim);
+    mesh = buildTypedMesh<ReplicatedMesh>(dim);
   }
-
-  if (!getParam<bool>("allow_renumbering"))
-    mesh->allow_renumbering(false);
 
   return mesh;
 }

--- a/framework/src/meshgenerators/AnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/AnnularMeshGenerator.C
@@ -111,7 +111,7 @@ std::unique_ptr<MeshBase>
 AnnularMeshGenerator::generate()
 {
   // Have MOOSE construct the correct libMesh::Mesh object using Mesh block and CLI parameters.
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
 
   const Real dt = (_dmax - _dmin) / _nt;
 

--- a/framework/src/meshgenerators/CartesianMeshGenerator.C
+++ b/framework/src/meshgenerators/CartesianMeshGenerator.C
@@ -227,7 +227,7 @@ CartesianMeshGenerator::CartesianMeshGenerator(const InputParameters & parameter
 std::unique_ptr<MeshBase>
 CartesianMeshGenerator::generate()
 {
-  std::unique_ptr<ReplicatedMesh> mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  auto mesh = buildReplicatedMesh(2);
 
   // switching on MooseEnum to generate the reference mesh
   // Note: element type is fixed

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -105,7 +105,7 @@ ConcentricCircleMeshGenerator::ConcentricCircleMeshGenerator(const InputParamete
 std::unique_ptr<MeshBase>
 ConcentricCircleMeshGenerator::generate()
 {
-  auto mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  auto mesh = buildReplicatedMesh(2);
 
   // Set dimension of mesh
   mesh->set_mesh_dimension(2);

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -1040,13 +1040,13 @@ DistributedRectilinearMeshGenerator::buildCube(UnstructuredMesh & mesh,
 std::unique_ptr<MeshBase>
 DistributedRectilinearMeshGenerator::generate()
 {
-  // DistributedRectilinearMeshGenerator always generates a distributed mesh
-  _mesh->setParallelType(MooseMesh::ParallelType::DISTRIBUTED);
   // We will set up boundaries accordingly. We do not want to call
   // ghostGhostedBoundaries in which allgather_packed_range  is unscalable.
   // ghostGhostedBoundaries will gather all boundaries to every single processor
   _mesh->needGhostGhostedBoundaries(false);
-  auto mesh = _mesh->buildMeshBaseObject(MooseMesh::ParallelType::DISTRIBUTED);
+
+  // DistributedRectilinearMeshGenerator always generates a distributed mesh
+  auto mesh = buildDistributedMesh();
 
   MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
 

--- a/framework/src/meshgenerators/ElementGenerator.C
+++ b/framework/src/meshgenerators/ElementGenerator.C
@@ -180,7 +180,7 @@ ElementGenerator::generate()
 
   // If there was no input mesh then let's just make a new one
   if (!mesh)
-    mesh = _mesh->buildMeshBaseObject();
+    mesh = buildMeshBaseObject();
 
   MooseEnum elem_type_enum = getParam<MooseEnum>("elem_type");
   auto elem = getElemType(elem_type_enum);

--- a/framework/src/meshgenerators/FancyExtruderGenerator.C
+++ b/framework/src/meshgenerators/FancyExtruderGenerator.C
@@ -132,7 +132,7 @@ FancyExtruderGenerator::generate()
   // Original copyright: Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
   // Original license is LGPL so it can be used here.
 
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
 
   std::unique_ptr<MeshBase> input = std::move(_input);
 

--- a/framework/src/meshgenerators/FileMeshGenerator.C
+++ b/framework/src/meshgenerators/FileMeshGenerator.C
@@ -44,7 +44,7 @@ FileMeshGenerator::FileMeshGenerator(const InputParameters & parameters)
 std::unique_ptr<MeshBase>
 FileMeshGenerator::generate()
 {
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
 
   bool exodus =
       _file_name.rfind(".exd") < _file_name.size() || _file_name.rfind(".e") < _file_name.size();

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -117,7 +117,7 @@ std::unique_ptr<MeshBase>
 GeneratedMeshGenerator::generate()
 {
   // Have MOOSE construct the correct libMesh::Mesh object using Mesh block and CLI parameters.
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
 
   if (isParamValid("extra_element_integers"))
   {

--- a/framework/src/meshgenerators/ImageMeshGenerator.C
+++ b/framework/src/meshgenerators/ImageMeshGenerator.C
@@ -54,7 +54,7 @@ ImageMeshGenerator::ImageMeshGenerator(const InputParameters & parameters)
 std::unique_ptr<MeshBase>
 ImageMeshGenerator::generate()
 {
-  auto mesh = libmesh_make_unique<ReplicatedMesh>(comm());
+  auto mesh = buildReplicatedMesh();
 
   // A list of filenames of length 1 means we are building a 2D mesh
   if (_filenames.size() == 1)

--- a/framework/src/meshgenerators/MeshGenerator.C
+++ b/framework/src/meshgenerators/MeshGenerator.C
@@ -48,3 +48,30 @@ MeshGenerator::getMeshByName(const MeshGeneratorName & input_mesh_generator)
   _depends_on.push_back(input_mesh_generator);
   return _app.getMeshGeneratorOutput(input_mesh_generator);
 }
+
+std::unique_ptr<MeshBase>
+MeshGenerator::buildMeshBaseObject(unsigned int dim)
+{
+  if (!_mesh)
+    mooseError("We need a MooseMesh object in order to build ReplicatedMesh objects through the "
+               "buildReplicatedMesh API");
+  return _mesh->buildMeshBaseObject(dim);
+}
+
+std::unique_ptr<ReplicatedMesh>
+MeshGenerator::buildReplicatedMesh(unsigned int dim)
+{
+  if (!_mesh)
+    mooseError("We need a MooseMesh object in order to build ReplicatedMesh objects through the "
+               "buildReplicatedMesh API");
+  return _mesh->buildTypedMesh<ReplicatedMesh>(dim);
+}
+
+std::unique_ptr<DistributedMesh>
+MeshGenerator::buildDistributedMesh(unsigned int dim)
+{
+  if (!_mesh)
+    mooseError("We need a MooseMesh object in order to build DistributedMesh objects through the "
+               "buildDistributedMesh API");
+  return _mesh->buildTypedMesh<DistributedMesh>(dim);
+}

--- a/framework/src/meshgenerators/PatchMeshGenerator.C
+++ b/framework/src/meshgenerators/PatchMeshGenerator.C
@@ -101,7 +101,7 @@ PatchMeshGenerator::PatchMeshGenerator(const InputParameters & parameters)
 std::unique_ptr<MeshBase>
 PatchMeshGenerator::generate()
 {
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
 
   unsigned num_nodes = 0;

--- a/framework/src/meshgenerators/RinglebMeshGenerator.C
+++ b/framework/src/meshgenerators/RinglebMeshGenerator.C
@@ -104,7 +104,7 @@ RinglebMeshGenerator::computexy(const std::vector<Real> values,
 std::unique_ptr<MeshBase>
 RinglebMeshGenerator::generate()
 {
-  std::unique_ptr<ReplicatedMesh> mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  std::unique_ptr<ReplicatedMesh> mesh = buildReplicatedMesh(2);
 
   /// Data structure that holds pointers to the Nodes of each streamline.
   std::vector<std::vector<Node *>> stream_nodes(_num_k_pts);

--- a/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
@@ -70,7 +70,7 @@ SpiralAnnularMeshGenerator::SpiralAnnularMeshGenerator(const InputParameters & p
 std::unique_ptr<MeshBase>
 SpiralAnnularMeshGenerator::generate()
 {
-  std::unique_ptr<ReplicatedMesh> mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  std::unique_ptr<ReplicatedMesh> mesh = buildReplicatedMesh(2);
 
   {
     // Compute the radial bias given:

--- a/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
+++ b/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
@@ -110,8 +110,7 @@ PatchSidesetGenerator::generate()
     paramError("sideset_name", "Not a valid boundary");
 
   // create a dim - 1 dimensional mesh
-  auto boundary_mesh =
-      libmesh_make_unique<libMesh::ReplicatedMesh>(comm(), mesh->mesh_dimension() - 1);
+  auto boundary_mesh = buildReplicatedMesh(mesh->mesh_dimension() - 1);
   boundary_mesh->set_mesh_dimension(mesh->mesh_dimension() - 1);
   boundary_mesh->set_spatial_dimension(mesh->mesh_dimension());
 

--- a/modules/peridynamics/src/meshgenerators/MeshGeneratorPD.C
+++ b/modules/peridynamics/src/meshgenerators/MeshGeneratorPD.C
@@ -209,7 +209,7 @@ MeshGeneratorPD::generate()
   dof_id_type n_pd_bonds = pd_mesh.nPDBonds();
 
   // initialize an empty new mesh object
-  std::unique_ptr<MeshBase> new_mesh = _mesh->buildMeshBaseObject();
+  std::unique_ptr<MeshBase> new_mesh = buildMeshBaseObject();
   new_mesh->clear();
   // set new mesh dimension
   new_mesh->set_mesh_dimension(old_mesh->mesh_dimension());

--- a/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
+++ b/modules/phase_field/src/meshgenerators/SphereSurfaceMeshGenerator.C
@@ -45,7 +45,7 @@ std::unique_ptr<MeshBase>
 SphereSurfaceMeshGenerator::generate()
 {
   // Have MOOSE construct the correct libMesh::Mesh object using Mesh block and CLI parameters.
-  auto mesh = _mesh->buildMeshBaseObject();
+  auto mesh = buildMeshBaseObject();
   mesh->set_mesh_dimension(2);
   mesh->set_spatial_dimension(3);
 

--- a/test/tests/mesh/nemesis/nemesis_repartitioning_test.i
+++ b/test/tests/mesh/nemesis/nemesis_repartitioning_test.i
@@ -55,6 +55,7 @@
   type = Steady
   solve_type = 'NEWTON'
   nl_rel_tol = 1e-6
+  nl_abs_tol = 1e-14
   [Adaptivity]
     steps = 1
     refine_fraction = 0.1

--- a/unit/include/BuildMeshTest.h
+++ b/unit/include/BuildMeshTest.h
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "gtest_include.h"
+
+#include "MeshGenerator.h"
+
+class MooseApp;
+class Factory;
+class MooseMesh;
+class InputParameters;
+
+class BuildMeshTest : public ::testing::Test
+{
+protected:
+  void SetUp() override;
+
+  std::shared_ptr<MooseApp> _app;
+  std::shared_ptr<MooseMesh> _moose_mesh;
+  std::shared_ptr<MeshGenerator> _mesh_gen;
+  Factory * _factory;
+};
+
+class BuildMeshBaseTypesGenerator : public MeshGenerator
+{
+public:
+  static InputParameters validParams() { return MeshGenerator::validParams(); }
+
+  BuildMeshBaseTypesGenerator(const InputParameters & params) : MeshGenerator(params) {}
+
+  std::unique_ptr<MeshBase> generate() override final;
+};

--- a/unit/src/BuildMeshTest.C
+++ b/unit/src/BuildMeshTest.C
@@ -1,0 +1,60 @@
+#include "gtest/gtest.h"
+
+#include "BuildMeshTest.h"
+#include "Registry.h"
+#include "MooseApp.h"
+#include "MooseMesh.h"
+#include "MooseUnitApp.h"
+#include "AppFactory.h"
+#include "Factory.h"
+#include "InputParameters.h"
+#include "MeshGeneratorMesh.h"
+#include "MooseError.h"
+#include "CastUniquePointer.h"
+
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/distributed_mesh.h"
+
+#include <memory>
+
+registerMooseObject("MooseUnitApp", BuildMeshBaseTypesGenerator);
+
+std::unique_ptr<MeshBase>
+BuildMeshBaseTypesGenerator::generate()
+{
+  auto mesh = _mesh->buildMeshBaseObject();
+
+  auto rep_mesh = buildReplicatedMesh();
+  auto dist_mesh = buildDistributedMesh();
+
+  const Point p_rep(0), p_dist(0);
+
+  rep_mesh->add_point(p_rep);
+  dist_mesh->add_point(p_dist);
+
+  return dynamic_pointer_cast<MeshBase>(mesh);
+}
+
+void
+BuildMeshTest::SetUp()
+{
+  const char * argv[2] = {"foo", "\0"};
+  _app = AppFactory::createAppShared("MooseUnitApp", 1, (char **)argv);
+  _factory = &_app->getFactory();
+  std::string mesh_type = "MeshGeneratorMesh";
+  std::string mesh_gen_type = "BuildMeshBaseTypesGenerator";
+
+  {
+    InputParameters params = _factory->getValidParams(mesh_type);
+    _moose_mesh = _factory->create<MeshGeneratorMesh>(mesh_type, "moose_mesh", params);
+  }
+
+  _app->actionWarehouse().mesh() = _moose_mesh;
+
+  {
+    InputParameters params = _factory->getValidParams(mesh_gen_type);
+    _mesh_gen = _factory->create<BuildMeshBaseTypesGenerator>(mesh_gen_type, "mesh_gen", params);
+  }
+}
+
+TEST_F(BuildMeshTest, theTest) { _mesh_gen->generate(); }


### PR DESCRIPTION
With the most recent libmesh update in #15867, move constructors for
`MeshBase` derived objects are deleted. In #15901, I was relying on the compiler to
perform named return value optimization, which it is not required to do,
and in fact it did not do. This PR changes the `buildTypedMesh` API to
return a `std::unique_ptr<T>` because `std::unique_ptr` is innately
movable. Moreover per the good suggestion of @dschwen, I've added
protected methods in `MeshGenerator` that can be used by `MeshGenerator`
derived objects to easily build `MeshBase` objects without making calls
through their `MooseMesh _mesh` member.
