### PR TITLE
Update FAQs, Remove transitional instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,7 +1,7 @@
 # Conda MOOSE Environment
 
-Our preferred method for obtaining dependencies necessary for MOOSE based
-Application development, is via Conda's myriad array of libraries. Follow these
+Our preferred method for obtaining dependencies necessary for MOOSE-based
+application development, is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
 an option to install MOOSE directly on a Windows system is not yet supported.
 On-going efforts are being made to add a conda installation option for Windows,

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,18 +1,11 @@
 # Conda MOOSE Environment
 
-Our preferred method for obtaining libraries necessary for MOOSE based
+Our preferred method for obtaining dependencies necessary for MOOSE based
 Application development, is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
 an option to install MOOSE directly on a Windows system is not yet supported.
 On-going efforts are being made to add a conda installation option for Windows,
 and an experimental [WSL](installation/windows10.md) option is available.
-
-
-!include sqa/minimum_requirements.md
-
-## Prerequisites
-
-!include installation/remove_moose_environment.md
 
 !include installation/install_miniconda.md
 

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -2,6 +2,32 @@
 
 Conda issues can be the root cause for just about any issue on this page. Scroll through this section, for what may look familiar, and follow those instructions:
 
+- #### 404 error, The channel is not accessible or is invalid.
+
+  If you are receiving this, you may be victim of us changing the channel name out from underneath you (Sorry!). Remove the offending channel(s):
+
+  ```bash
+  conda config --remove channels https://mooseframework.org/conda/moose
+  conda config --remove channels https://mooseframework.com/conda/moose
+  conda config --remove channels https://mooseframework.inl.gov/conda/moose
+  ```
+
+  If you receive errors about a channel not present (CondaKeyError), please ignore. You most likely will not have all three 'old' channels. Next, add the correct channel:
+
+  ```bash
+  conda config --add channels idaholab
+  ```
+
+  When you're finished, a `conda config --show channels` should resemble the following:
+
+  ```bash
+  $ conda config --show channels
+  channels:
+    - idaholab
+    - conda-forge
+    - defaults
+  ```
+
 - #### command not found: conda
 
   You have yet to install conda, or your path to it is incorrect or not set. You will need to recall how you installed conda. Our instructions ask to have Miniconda3 installed to your home directory: `~/miniconda3`. Which requires you to set your PATH accordingly:

--- a/modules/doc/content/help/faq/faq_build_libmesh-vtk.md
+++ b/modules/doc/content/help/faq/faq_build_libmesh-vtk.md
@@ -1,0 +1,21 @@
+## How do I compile libMesh with VTK? id=libmesh-vtk
+
+[libMesh] by default is compiled with [VTK] when using our moose-libmesh Conda package. However, if you are attempting to build your own version of libMesh with VTK support, the easiest way to do so, is to install all the dependencies via Conda, and then run the `./update_and_rebuild_libmesh.sh` script:
+
+```bash
+conda create --name custom-libmesh moose-petsc moose-libmesh-vtk
+conda activate custom-libmesh
+cd ~/projects/moose/scripts
+./update_and_rebuild_libmesh.sh
+```
+
+Or, if you wish to build your own [VTK] (beyond the scope of this document), you need to explain to libMesh where this new installation of VTK is by providing the lib and include paths to it:
+
+```bash
+conda create --name custom-libmesh moose-petsc
+conda activate custom-libmesh
+cd ~/projects/moose/scripts
+./update_and_rebuild_libmesh.sh --with-vtk-lib=/path/to/vtk/lib --with-vtk-include=/path/to/vtk/include
+```
+
+[VTK]: https://vtk.org

--- a/modules/doc/content/help/faq/faq_build_libmesh.md
+++ b/modules/doc/content/help/faq/faq_build_libmesh.md
@@ -3,7 +3,7 @@
 libMesh is supplied by our Conda installation. However, if you wish to build and use your own libMesh installation, you can use our
 `update_and_rebuild_libmesh.sh` script.
 
-Due to having moose-libmesh installed, Conda creates and sets an influential environment variable LIBMESH_DIR. One you would have to continually `unset`. It is therefor advisable to create a new Conda environment without moose-libmesh installed:
+Due to having moose-libmesh installed, Conda creates and sets an influential environment variable LIBMESH_DIR that you would have to continually `unset`. It is therefore advisable to create a new Conda environment without moose-libmesh installed:
 
 ```bash
 conda create --name custom-libmesh moose-petsc

--- a/modules/doc/content/help/faq/faq_build_libmesh.md
+++ b/modules/doc/content/help/faq/faq_build_libmesh.md
@@ -1,0 +1,15 @@
+## How do I build and use my own libMesh? id=libmesh-myown
+
+libMesh is supplied by our Conda installation. However, if you wish to build and use your own libMesh installation, you can use our
+`update_and_rebuild_libmesh.sh` script.
+
+Due to having moose-libmesh installed, Conda creates and sets an influential environment variable LIBMESH_DIR. One you would have to continually `unset`. It is therefor advisable to create a new Conda environment without moose-libmesh installed:
+
+```bash
+conda create --name custom-libmesh moose-petsc
+conda activate custom-libmesh
+cd ~/projects/moose/scripts
+./update_and_rebuild_libmesh.sh
+```
+
+The above creates a new Conda environment: 'custom-libmesh', installs the needed PETSc dependency so we can build our own libMesh, activates it, and then builds libMesh.

--- a/modules/doc/content/help/faq/faq_build_petsc.md
+++ b/modules/doc/content/help/faq/faq_build_petsc.md
@@ -1,0 +1,16 @@
+## How do I build and use my own PETSc? id=petsc-myown
+
+PETSc is supplied by our Conda installation. However, if you wish to build and use your own PETSc installation, you can use our
+`update_and_rebuild_petsc.sh` script.
+
+By building your own PETSc, it will be necessary to build your own libMesh as well. It is advisable to operate in an entirely new Conda environment for the sake of keeping your environment sane:
+
+```bash
+conda create --name custom-petsc moose-mpich
+conda activate custom-petsc
+cd ~/projects/moose/scripts
+./update_and_rebuild_petsc.sh
+./update_and_rebuild_libmesh.sh
+```
+
+The above creates a new Conda environment: 'custom-petsc', and installs the needed MPICH dependency. We then activate it, build PETSc, and then libMesh.

--- a/modules/doc/content/help/faq/faq_conda_alternatives.md
+++ b/modules/doc/content/help/faq/faq_conda_alternatives.md
@@ -6,6 +6,8 @@ While we have no other means of providing 'pre-built' libraries, you are not lim
 
 [Spack](https://spack.readthedocs.io/en/latest/index.html) is another alternative, capable of building very optimized stacks for both Linux and MacOS. Spack however does not provide pre-built binaries. Spack instead supplies 'recipes' intended to be run by you, to build the stack.
 
+Perhaps our Advanced Instructions on our [Getting Started](getting_started/index.md) page would suffice?
+
 Lastly, there is always building everything from source if you're up to the challenge!
 
 !include sqa/minimum_requirements.md

--- a/modules/doc/content/help/faq/faq_conda_alternatives.md
+++ b/modules/doc/content/help/faq/faq_conda_alternatives.md
@@ -1,0 +1,11 @@
+## Conda Alternatives
+
+While we have no other means of providing 'pre-built' libraries, you are not limited to only Conda. So long as you meet our minimum requirements (listed below), you should be able to build your own library stack capable of MOOSE based development.
+
+[Homebrew](https://brew.sh/), [MacPorts](https://www.macports.org/), [Fink](https://www.finkproject.org/) are all good alternatives for MacOS machines. These tools can provide you with finished easy-to-install binaries, leaving you only needing to build PETSc, libMesh and then MOOSE/your Application.
+
+[Spack](https://spack.readthedocs.io/en/latest/index.html) is another alternative, capable of building very optimized stacks for both Linux and MacOS. Spack however does not provide pre-built binaries. Spack instead supplies 'recipes' intended to be run by you, to build the stack.
+
+Lastly, there is always building everything from source if you're up to the challenge!
+
+!include sqa/minimum_requirements.md

--- a/modules/doc/content/help/faq/index.md
+++ b/modules/doc/content/help/faq/index.md
@@ -1,68 +1,17 @@
 # Frequently Asked Questions
 
-## Do you have a mailing list where I can ask questions?
+- [I don't like Conda. Are there alternatives?](faq_conda_alternatives.md)
+- [Conda commands are not working...](help/troubleshooting.md#condaissues)
+- [I can't build my application or moose.](help/troubleshooting.md#buildissues)
+- [I get a 'gethostbyname' failure.](help/troubleshooting.md#failingtests)
+- [Some or all of my tests fail.](help/troubleshooting.md#failingtests)
+- [How do I build my own libMesh?](faq/faq_build_libmesh.md)
+- [How do I build my own libMesh with VTK?](faq/faq_build_libmesh-vtk.md)
+- [How do I build my own PETSc?](faq/faq_build_petsc.md)
+
+
+### Mailing lists:
 
 - moose-users@googlegroups.com - Technical Q&A (moderate traffic)
 - moose-announce@googlegroups.com - Announcements (very light traffic)
 - You can also browse our [mailing list](https://groups.google.com/forum/#!forum/moose-users).
-
-## I can not build my application
-
-- Please see our [Build Issues](help/troubleshooting.md#buildissues) troubleshooting section.
-
-## gethostbyname failed, localhost (errno 3) error when running tests
-
-- Please see 'gethostbyname' failure in our [Failing Tests](help/troubleshooting.md#failingtests) troubleshooting section.
-
-## Some/All of my tests fail
-
-- Please see our [Failing Tests](help/troubleshooting.md#failingtests) troubleshooting section.
-
-## How do I build and use my own libMesh? id=libmesh-myown
-
-libMesh is supplied by our Conda installation. However, if you wish to build and use your own libMesh installation, you can use our
-`update_and_rebuild_libmesh.sh` script.
-
-Due to having moose-libmesh installed, Conda creates and sets an influential environment variable LIBMESH_DIR. One you would have to continually `unset`. It is therefor advisable to create a new Conda environment without moose-libmesh installed:
-
-```bash
-conda create --name custom-libmesh moose-petsc
-conda activate custom-libmesh
-cd ~/projects/moose/scripts
-./update_and_rebuild_libmesh.sh
-```
-
-The above creates a new Conda environment: 'custom-libmesh', installs the needed PETSc dependency so we can build our own libMesh, activates it, and then builds libMesh.
-
-## How do I compile libMesh with VTK? id=libmesh-vtk
-
-[libMesh] by default is compiled with [VTK] when using our moose-libmesh Conda package. However, if you are attempting to build your own version of libMesh with VTK support, you will need to either; install moose-libmesh-vtk Conda package and re-run through the above 'How do I build and use my own libMesh' step, or build your own VTK (beyond the scope of this document), and supply the path to your newly built VTK, when running `update_and_rebuild_libmesh.sh`:
-
-```bash
-./update_and_rebuild_libmesh.sh --with-vtk-lib=/path/to/vtk/lib --with-vtk-include=/path/to/vtk/include
-```
-
-## How do I build and use my own PETSc? id=petsc-myown
-
-PETSc is supplied by our Conda installation. However, if you wish to build and use your own PETSc installation, you can use our
-`update_and_rebuild_petsc.sh` script.
-
-By building your own PETSc, it will be necessary to build libMesh as well. And like libMesh (above), it is advisable to operate in an entirely new Conda environment for the sake of keeping your environment sane:
-
-```bash
-conda create --name custom-petsc moose-mpich
-conda activate custom-petsc
-cd ~/projects/moose/scripts
-./update_and_rebuild_petsc.sh
-./update_and_rebuild_libmesh.sh
-```
-
-The above creates a new Conda environment: 'custom-petsc', installs the needed MPICH dependency so we can build our own PETSc, activates it, builds PETSc, and then libMesh.
-
-!alert note title=We just built libMesh
-If following 'How do I build and use my own PETSc', know that during this step we also built libMesh. Making it unnecessary to also perform 'How do I build and use my own libMesh'. Performing both would negate the PETSc build step.
-
-
-[libMesh]: http://libmesh.github.io/
-
-[VTK]: https://vtk.org


### PR DESCRIPTION
Made the FAQs, more FAQ-ish and easier on the eyes.

Removed the transition away from moose-environment package. It was there
long enough.

Added a new section about us switching out the Conda channel name, and
how to fix possible errors.

Closes #15929

