### PR TITLE
Add Gtest and pip3 installs for Consul/Nomad to Docker Image Build

### DIFF
--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -29,7 +29,8 @@ apt-get install -y \
   bison \
   flex \
   libboost-all-dev \
-  emacs
+  emacs \
+  libgtest-dev
 
 # Clear cache
 rm -rf /var/lib/apt/lists/*

--- a/docker_ci/install_packages.sh
+++ b/docker_ci/install_packages.sh
@@ -9,3 +9,8 @@ for MGR in "${MGR_ARY[@]}"; do
         ./${MGR}_installs.sh
     fi
 done
+
+# Do pip3 installs
+pip3 install \
+    python-consul \
+    python-nomad

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -38,7 +38,8 @@ yum install -y \
   libtool \
   libtirpc \
   libtirpc-devel \
-  emacs
+  emacs \
+  gtest
 
 # Clear cache
 yum clean all


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
In directory `docker_ci`, I have added 
* `gtest` to `yum_installs.sh`
* `libgtest-dev` to `apt_installs.sh`
* `pip3` packages to `install_packages.sh` 
    * `python-consul`
    * `python-nomad`

This ensures the images have Gtest installed, and the use for `pip3` installs for multi-node container jobs is described under `Design` in the issue.  Closes #15981.