### PR TITLE
add a function to check the existence of mesh meta data and add mesh meta data

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -525,6 +525,15 @@ public:
                                                  bool read_only,
                                                  const RestartableDataMapName & metaname = "");
 
+  /*
+   * Check if a restartable meta data exists or not.
+   *
+   * @param name The full (unique) name.
+   * @param metaname The name to the meta data storage
+   */
+  bool hasRestartableMetaData(const std::string & name,
+                              const RestartableDataMapName & metaname) const;
+
   /**
    * Return reference to the restartable data object
    * @return A const reference to the restartable data object

--- a/framework/include/interfaces/MeshMetaDataInterface.h
+++ b/framework/include/interfaces/MeshMetaDataInterface.h
@@ -55,6 +55,11 @@ protected:
   template <typename T>
   const T & getMeshProperty(const std::string & data_name, const std::string & prefix);
 
+  /**
+   * Whether or not a mesh meta-data exists.
+   */
+  bool hasMeshProperty(const std::string & data_name, const std::string & prefix) const;
+
 private:
   /// Helper function for actually registering the restartable data.
   RestartableDataValue & registerMetaDataOnApp(const std::string & name,

--- a/framework/include/meshgenerators/AllSideSetsByNormalsGenerator.h
+++ b/framework/include/meshgenerators/AllSideSetsByNormalsGenerator.h
@@ -41,5 +41,7 @@ protected:
   std::set<boundary_id_type> _mesh_boundary_ids;
 
   std::unique_ptr<MeshBase> & _input;
-};
 
+  /// Mesh meta data for holding the map from boundary IDs to the normals of the corresponding bounrares
+  std::map<BoundaryID, RealVectorValue> & _boundary_to_normal_map;
+};

--- a/framework/include/meshgenerators/SideSetsFromNormalsGenerator.h
+++ b/framework/include/meshgenerators/SideSetsFromNormalsGenerator.h
@@ -35,5 +35,6 @@ protected:
   std::vector<BoundaryName> _boundary_names;
 
   std::vector<Point> _normals;
-};
 
+  std::map<BoundaryID, RealVectorValue> & _boundary_to_normal_map;
+};

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -37,6 +37,7 @@ SetupDebugAction::validParams()
       "show_material_props",
       false,
       "Print out the material properties supplied for each block, face, neighbor, and/or sideset");
+  params.addParam<bool>("show_mesh_meta_data", false, "Print out the available mesh meta data");
 
   params.addClassDescription(
       "Adds various debugging type Output objects to the simulation system.");
@@ -76,5 +77,15 @@ SetupDebugAction::act()
     auto params = _factory.getValidParams(type);
     params.set<unsigned int>("num_residuals") = _pars.get<unsigned int>("show_top_residuals");
     _problem->addOutput(type, "_moose_top_residual_debug_output", params);
+  }
+
+  // Print full names of mesh meta data
+  if (getParam<bool>("show_mesh_meta_data"))
+  {
+    _console << "Mesh meta data:\n";
+    for (auto it = _app.getRestartableDataMapBegin(); it != _app.getRestartableDataMapEnd(); ++it)
+      if (it->first == MooseApp::MESH_META_DATA)
+        for (auto & pair : it->second.first)
+          _console << " " << pair.first << std::endl;
   }
 }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1206,6 +1206,20 @@ MooseApp::registerRestartableData(const std::string & name,
   return *insert_pair.first->second.value;
 }
 
+bool
+MooseApp::hasRestartableMetaData(const std::string & name,
+                                 const RestartableDataMapName & metaname) const
+{
+  auto it = _restartable_meta_data.find(metaname);
+  if (it == _restartable_meta_data.end())
+    return false;
+  else
+  {
+    auto & m = it->second.first;
+    return m.find(name) != m.end();
+  }
+}
+
 void
 MooseApp::dynamicAppRegistration(const std::string & app_name,
                                  std::string library_path,

--- a/framework/src/interfaces/MeshMetaDataInterface.C
+++ b/framework/src/interfaces/MeshMetaDataInterface.C
@@ -26,3 +26,11 @@ MeshMetaDataInterface::registerMetaDataOnApp(const std::string & name,
   return _meta_data_app.registerRestartableData(
       name, std::move(data), 0, true, MooseApp::MESH_META_DATA);
 }
+
+bool
+MeshMetaDataInterface::hasMeshProperty(const std::string & data_name,
+                                       const std::string & prefix) const
+{
+  std::string full_name = std::string(SYSTEM) + "/" + prefix + "/" + data_name;
+  return _meta_data_app.hasRestartableMetaData(full_name, MooseApp::MESH_META_DATA);
+}

--- a/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromNormalsGenerator.C
@@ -47,7 +47,9 @@ SideSetsFromNormalsGenerator::validParams()
 SideSetsFromNormalsGenerator::SideSetsFromNormalsGenerator(const InputParameters & parameters)
   : SideSetsGeneratorBase(parameters),
     _input(getMesh("input")),
-    _normals(getParam<std::vector<Point>>("normals"))
+    _normals(getParam<std::vector<Point>>("normals")),
+    _boundary_to_normal_map(
+        declareMeshProperty<std::map<BoundaryID, RealVectorValue>>("boundary_normals"))
 {
   if (typeid(_input).name() == typeid(std::unique_ptr<DistributedMesh>).name())
     mooseError("GenerateAllSideSetsByNormals only works with ReplicatedMesh.");
@@ -100,7 +102,10 @@ SideSetsFromNormalsGenerator::generate()
 
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
   for (unsigned int i = 0; i < boundary_ids.size(); ++i)
+  {
     boundary_info.sideset_name(boundary_ids[i]) = _boundary_names[i];
+    _boundary_to_normal_map[boundary_ids[i]] = _normals[i];
+  }
 
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/test/include/actions/CheckMeshMetaDataAction.h
+++ b/test/include/actions/CheckMeshMetaDataAction.h
@@ -1,0 +1,22 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Action.h"
+
+class CheckMeshMetaDataAction : public Action
+{
+public:
+  static InputParameters validParams();
+
+  CheckMeshMetaDataAction(const InputParameters & params);
+
+  void act() override;
+};

--- a/test/src/actions/CheckMeshMetaDataAction.C
+++ b/test/src/actions/CheckMeshMetaDataAction.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CheckMeshMetaDataAction.h"
+
+registerMooseAction("MooseTestApp", CheckMeshMetaDataAction, "determine_system_type");
+
+InputParameters
+CheckMeshMetaDataAction::validParams()
+{
+  auto params = Action::validParams();
+  params.addRequiredParam<std::string>("mesh_generator_name",
+                                       "The mesh generator providing the mesh meta data");
+  params.addRequiredParam<std::string>("mesh_meta_data_name", "The name of the mesh meta data");
+  return params;
+}
+
+CheckMeshMetaDataAction::CheckMeshMetaDataAction(const InputParameters & params) : Action(params) {}
+
+void
+CheckMeshMetaDataAction::act()
+{
+  auto & mesher_name = getParam<std::string>("mesh_generator_name");
+  auto & data_name = getParam<std::string>("mesh_meta_data_name");
+  if (!hasMeshProperty(data_name, mesher_name))
+    mooseError(mesher_name, " generator does not provide the mesh meta data with name ", data_name);
+  else
+    _console << "Mesh meta data " << data_name << " is provided by mesh generator " << mesher_name
+             << "." << std::endl;
+}

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -85,6 +85,7 @@ MooseTestApp::registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_
     registerSyntax("AddDGDiffusion", "DGDiffusionAction");
     registerSyntax("MeshMetaDataDependenceAction", "AutoLineSamplerTest");
     registerSyntax("AppendMeshGeneratorAction", "ModifyMesh/*");
+    registerSyntax("CheckMeshMetaDataAction", "CheckMeshMetaData");
   }
 }
 

--- a/test/tests/misc/check_mesh_meta_data/check_mesh_meta_data_test.i
+++ b/test/tests/misc/check_mesh_meta_data/check_mesh_meta_data_test.i
@@ -1,0 +1,30 @@
+[Mesh]
+  [square]
+    type = GeneratedMeshGenerator
+    nx = 2
+    ny = 2
+    dim = 2
+  []
+  [normal]
+    type = AllSideSetsByNormalsGenerator
+    input = square
+  []
+[]
+
+[Debug]
+  show_mesh_meta_data = true
+[]
+
+[CheckMeshMetaData]
+  mesh_generator_name = normal
+  mesh_meta_data_name = boundary_normals
+[]
+
+[Problem]
+  solve = false
+  kernel_coverage_check = false
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/misc/check_mesh_meta_data/tests
+++ b/test/tests/misc/check_mesh_meta_data/tests
@@ -1,0 +1,12 @@
+[Tests]
+  [./check_mesh_meta_data]
+    type = 'RunApp'
+    input = 'check_mesh_meta_data_test.i'
+    # Note: AllSideSetsByNormalsGenerator used by this test only works with replicated mesh
+    mesh_mode = REPLICATED
+    issues = '#15987'
+    design = '/MeshMetaDataInterface.md'
+    expect_out = 'Mesh meta data boundary_normals is provided by mesh generator normal'
+    requirement = "The system shall support the ability for actions to query the existence of a mesh attribute (meta data)."
+  [../]
+[]


### PR DESCRIPTION
Refer to #15987.

I am not closing #15987 because we need that issue for removing unnecessary functions in `MooseMesh` once we removed all mesh modifiers.
