### PR TITLE
Let MOOSE write MeshMetaData when using `MeshOnlyAction` and `MeshSplitAction` and requesting checkpoint files

### DIFF
--- a/framework/include/actions/SplitMeshAction.h
+++ b/framework/include/actions/SplitMeshAction.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "Action.h"
-
+#include "RestartableDataIO.h"
 #include <string>
 
 class SplitMeshAction;
@@ -27,4 +27,3 @@ public:
 
   virtual void act() override;
 };
-

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -54,6 +54,14 @@ public:
    */
   Checkpoint(const InputParameters & parameters);
 
+  /// Method writing MeshMetaData to file. This method is static public so it
+  /// can be called from other classes, thus avoding duplicated code.
+  static void writeMeshMetaData(const processor_id_type pid,
+                                const MooseApp & app,
+                                const std::string & current_file,
+                                CheckpointFileNames & curr_file_struct,
+                                RestartableDataIO & restartable_data_io);
+
   /**
    * Returns the base filename for the checkpoint files
    */

--- a/framework/include/outputs/Checkpoint.h
+++ b/framework/include/outputs/Checkpoint.h
@@ -63,6 +63,14 @@ public:
                                 RestartableDataIO & restartable_data_io);
 
   /**
+   * Method to return the file suffix (ASCII or binary) for the Checkpoint format.
+   */
+  static std::string getMeshFileSuffix(bool is_binary)
+  {
+    return is_binary ? BINARY_MESH_SUFFIX : ASCII_MESH_SUFFIX;
+  }
+
+  /**
    * Returns the base filename for the checkpoint files
    */
   virtual std::string filename() override;
@@ -72,14 +80,6 @@ public:
    * @return String containing the checkpoint output directory
    */
   std::string directory() const;
-
-  /**
-   * Method to return the file suffix (ASCII or binary) for the Checkpoint format.
-   */
-  std::string getMeshFileSuffix(bool is_binary)
-  {
-    return is_binary ? BINARY_MESH_SUFFIX : ASCII_MESH_SUFFIX;
-  }
 
 protected:
   /**

--- a/framework/src/meshgenerators/FileMeshGenerator.C
+++ b/framework/src/meshgenerators/FileMeshGenerator.C
@@ -9,7 +9,7 @@
 
 #include "FileMeshGenerator.h"
 #include "CastUniquePointer.h"
-
+#include "RestartableDataIO.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/exodusII_io.h"
@@ -83,5 +83,28 @@ FileMeshGenerator::generate()
     mesh->read(_file_name);
   }
 
+  if ((_file_name.rfind(".cpr") < _file_name.size() ||
+       _file_name.rfind(".cpa") < _file_name.size()) &&
+      processor_id() == 0)
+  {
+    RestartableDataIO restartable(_app);
+    for (auto map_iter = _app.getRestartableDataMapBegin();
+         map_iter != _app.getRestartableDataMapEnd();
+         ++map_iter)
+    {
+      const RestartableDataMap & meta_data = map_iter->second.first;
+      const std::string & suffix = map_iter->second.second;
+      std::cerr << "suffix " << suffix << "\n";
+      std::cerr << "map_iter " << map_iter->first << "\n";
+      for (auto const & key : meta_data)
+        std::cerr << key.first << "\n";
+      // if (map_iter->first == "MeshMetaData" && suffix == "_mesh" &&
+      // restartable.readRestartableDataHeader(false, suffix))
+      // {
+
+      // restartable.readRestartableData(meta_data, DataNames());
+      // }
+    }
+  }
   return dynamic_pointer_cast<MeshBase>(mesh);
 }

--- a/framework/src/outputs/Checkpoint.C
+++ b/framework/src/outputs/Checkpoint.C
@@ -200,6 +200,7 @@ Checkpoint::writeMeshMetaData(const processor_id_type pid,
       const std::string filename(current_file + suffix +
                                  restartable_data_io.getRestartableDataExt());
 
+      std::cerr << "writing stuff \n";
       curr_file_struct.restart_meta_data.emplace(filename);
       restartable_data_io.writeRestartableData(filename, meta_data);
     }

--- a/test/tests/meshgenerators/meta_data_store/mesh_meta_data_store.i
+++ b/test/tests/meshgenerators/meta_data_store/mesh_meta_data_store.i
@@ -1,4 +1,5 @@
 [Mesh]
+  active='gmg'
   [gmg]
     type = GeneratedMeshGenerator
     dim = 2
@@ -59,4 +60,8 @@
 [Outputs]
   exodus = true
   csv = true
+  [cp]
+    type =Checkpoint
+    binary = false
+  []
 []

--- a/test/tests/meshgenerators/meta_data_store/tests
+++ b/test/tests/meshgenerators/meta_data_store/tests
@@ -33,4 +33,38 @@
     expect_err = "Unable to find RestartableDataMap object for the supplied name"
     requirement = "The system shall error if a invalid identifier is supplied when attempting to retrieve a restart meta data object."
   []
+
+  [meta_data_make_split]
+    type = 'RunApp'
+    input = 'mesh_meta_data_store.i'
+    cli_args = '--split-mesh 1,3 --split-file foo.cpa'
+    issues = '#16003'
+    requirement = "The system shall write meshMetaData to file when using the --split-mesh command."
+  []
+
+  [meta_data_use_split_fmg]
+    type = 'CSVDiff'
+    prereq='meta_data_make_split'
+    csvdiff = 'mesh_meta_data_store_out_line_sampler_between_elems_0000.csv
+             mesh_meta_data_store_out_line_sampler_between_elems_0010.csv
+             mesh_meta_data_store_out_line_sampler_between_elems_0020.csv'
+    input = 'mesh_meta_data_store.i'
+    cli_args = 'Mesh/active=fmg Mesh/fmg/type=FileMeshGenerator Mesh/fmg/file=foo.cpa --distributed-mesh'
+    issues = '#16003'
+    min_parallel = 1
+    max_parallel = 1
+  []
+
+#  [meta_data_use_split]
+#    type = 'CSVDiff'
+#    prereq='meta_data_make_split'
+#    csvdiff = 'mesh_meta_data_store_out_line_sampler_between_elems_0000.csv
+#             mesh_meta_data_store_out_line_sampler_between_elems_0010.csv
+#             mesh_meta_data_store_out_line_sampler_between_elems_0020.csv'
+#    input = 'mesh_meta_data_store.i'
+#    cli_args = '--use-split --split-file foo.cpr'
+#    issue = '#16003'
+#    min_parallel = 3
+#    max_parallel = 3
+#  []
 []


### PR DESCRIPTION
Add a static public member to CheckPoint class to write MeshMetaData in checkpoint files
Call such a method from `MeshOnlyAction` and `MeshSplitAction` to write MeshMetaData to restartable files

ref #16003
