### PR TITLE
Please do gather periodic boundaries when we need ghosted boundaries

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -1648,11 +1648,15 @@ MooseMesh::detectPairedSidesets()
     }
   }
 
-  // For a distributed mesh, boundaries may be distributed as well. We therefore
-  // collect information from everyone.
-  // If we already performed ghostGhostedBoundaries, all boundaries are gathered
-  // to every single processor, then we do not do gather boundary ids here
-  if (_use_distributed_mesh && !_need_ghost_ghosted_boundaries)
+  // For a distributed mesh, boundaries may be distributed as well. We therefore collect information
+  // from everyone. If the mesh is already serial, then there is no need to do an allgather. Note
+  // that this is just going to gather information about what the periodic bc ids are. We are not
+  // gathering any remote elements or anything like that. It's just that the GhostPointNeighbors
+  // ghosting functor currently relies on the fact that every process agrees on whether we have
+  // periodic boundaries; every process that thinks there are periodic boundaries will call
+  // MeshBase::sub_point_locator which makes a parallel_object_only() assertion (right or wrong). So
+  // we all need to go there (or not go there)
+  if (_use_distributed_mesh && !_mesh->is_serial())
   {
     // Pack all data together so that we send them via one communication
     // pair: boundary side --> boundary ids.

--- a/test/tests/meshgenerators/distributed_rectilinear_mesh_generator/tests
+++ b/test/tests/meshgenerators/distributed_rectilinear_mesh_generator/tests
@@ -24,6 +24,7 @@
     exodiff = 'distributed_rectilinear_mesh_generator_out_3d.e'
     cli_args = 'Mesh/gmg/dim=3 Mesh/gmg/nx=20 Mesh/gmg/ny=20 Mesh/gmg/nz=20 Outputs/file_base=distributed_rectilinear_mesh_generator_out_3d Outputs/hide="pid npid" '
     requirement = 'MOOSE shall be able to generate 3D HEX8 mesh in parallel.'
+    valgrind = 'NONE'
   [../]
 
   [./3D_ptscotch]

--- a/test/tests/meshgenerators/dmg_displaced_mesh/tests
+++ b/test/tests/meshgenerators/dmg_displaced_mesh/tests
@@ -22,6 +22,7 @@
     rel_err = 1e-4
     requirement = "The system shall support mesh adaptivity with periodic boundary conditions on a distributed generated displaced mesh."
     method = '!dbg' # periodic timeout
+    valgrind = 'NONE'
   [../]
 
   [./pbc_adaptivity_nemesis]

--- a/test/tests/mortar/convergence-studies/solution-continuity/tests
+++ b/test/tests/mortar/convergence-studies/solution-continuity/tests
@@ -8,6 +8,7 @@
     requirement = 'The system shall be able to demonstrate asymptotically correct convergence rates of 3 and 3 for a mortar solution continuity problem with an equal geometric discretization when using a second order basis for the temperature variable and a second order basis for the Lagrange multiplier.'
     method = '!dbg'
     required_python_packages = 'sympy pandas matplotlib'
+    mumps = 'TRUE'
   []
   [p2p1]
     type = PythonUnitTest
@@ -16,6 +17,7 @@
     requirement = 'The system shall be able to demonstrate asymptotically correct convergence rates of 3 and 2 for a mortar solution continuity problem with an equal geometric discretization when using a second order basis for the temperature variable and a first order basis for the Lagrange multiplier.'
     method = '!dbg'
     required_python_packages = 'sympy pandas matplotlib'
+    mumps = 'TRUE'
   []
   [p2p0]
     type = PythonUnitTest
@@ -24,6 +26,7 @@
     requirement = 'The system shall be able to demonstrate asymptotically correct convergence rates of 2 and 1 for a mortar solution continuity problem with an equal geometric discretization when using a second order basis for the temperature variable and a zeroth order basis for the Lagrange multiplier.'
     method = '!dbg'
     required_python_packages = 'sympy pandas matplotlib'
+    mumps = 'TRUE'
   []
   [p1p1]
     type = PythonUnitTest
@@ -32,6 +35,7 @@
     requirement = 'The system shall be able to demonstrate asymptotically correct convergence rates of 2 and 2 for a mortar solution continuity problem with an equal geometric discretization when using a first order basis for the temperature variable and a first order basis for the Lagrange multiplier.'
     method = '!dbg'
     required_python_packages = 'sympy pandas matplotlib'
+    mumps = 'TRUE'
   []
   [p1p0]
     type = PythonUnitTest
@@ -40,5 +44,6 @@
     requirement = 'The system shall be able to demonstrate asymptotically correct convergence rates of 2 and 1 for a mortar solution continuity problem with an equal geometric discretization when using a first order basis for the temperature variable and a zeroth order basis for the Lagrange multiplier.'
     method = '!dbg'
     required_python_packages = 'sympy pandas matplotlib'
+    mumps = 'TRUE'
   []
 []


### PR DESCRIPTION
I actually think that the previous check was backwards...we should
*definitely* gather periodic boundaries when we *do* want ghosted boundaries. We were
failing some distributed recover tests because
`_need_ghost_ghosted_boundaries` was `true`, and our mesh was actually
distributed after the changes in #15338