### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,6 +1,6 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2020.10.05" %}
+{% set version = "2020.11.04" %}
 
 package:
   name: moose-libmesh


### PR DESCRIPTION
Summary of changes:

  - Add sanity check to System::init_data() 
  - Continue petsc_unique_ptr refactor
  - Drop SHA1 and use C++11 std::hash
  - Add/use petsc_unique_ptr template alias
  - SparsityPattern refactoring
  - Add EDGE4 case to get_refspace_nodes
  - RB: Fix an issue where nodes in multiple nodesets were assembled twice
  - Use unique_ptrs to clean up PETSc objects
  - Fix CompareTypes typos in type_vector
  - Default/delete special functions for System classes.
  - Exodus copy fixes
  - Add API to tell mesh it is not prepared
  - Don't potentially throw from 'exceptionless' error macros
  - Make ReferenceCounter::increment_{de,con}structor_count() noexcept
  - Re-enable check_dirichlet_bcid_consistency()
  - Mention "make uninstall" in README.md
  - Deprecate public MeshBase::boundary_info member
  - Updates to InfFEBase::build_elem()
  - Ubuntu 20.10 clang 11 warning fixes
  - Ubuntu 20.10 (gcc 10.2) fixes
  - Move LinearSolver to ImplicitSystem
  - UnsteadySolver: old_local_nonlinear_solution should be a std::shared_ptr
  - Simplify unique_ptr return statements
  - Fix incorrect use of unique_ptrs in TransientSystem
  - PeriodicBoundaries should store unique_ptrs instead of dumb ptrs
  - Simplify DiagonalMatrix::zero_clone() slightly
  - Add ExodusII_IO::write_nodeset_data() API
  - Rebase #2506 and some minor clean-up
  - TypeVector overloads for std::norm and friends for Eigen::Matrix
  - Unsteady Adjoint Error Estimation Implementation (Model Error)
  - Submodule updates
  - Avoid manual memory management in System class
  - More IGA tests
  - Use "-f" when using mv to overwrite our own files 
