### PR TITLE
Add Agent Labeling

### DIFF
--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -12,7 +12,7 @@ and Amazon Linux.
 */
 
 pipeline {
-    agent any
+    agent {label 'jenkins_node || master'}
 
     environment {
         SLACK_SFX = "MOOSE rev ${GIT_COMMIT} on ${DISTRO_NAME} (<${BUILD_URL}|log>)"


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Instead of `agent any`, the MOOSE Jenkins pipelines will run on either `master` (head node) or a node labeled `jenkins_node` (c5.9xlarge).  This will ensure MOOSE pipelines don't run on the smaller nodes `jenkins_node_lite` (t3.xlarge).  Fixes #16040.