### PR TITLE
Disable valgrind for boussinesq benchmarks

### DIFF
--- a/modules/navier_stokes/test/tests/ins/boussinesq/benchmark/tests
+++ b/modules/navier_stokes/test/tests/ins/boussinesq/benchmark/tests
@@ -8,6 +8,7 @@
     cli_args = 'rayleigh=1e3 Outputs/file_base=1e3'
     requirement = 'The system shall be able to reproduce benchmark results for a Rayleigh number of 1e3.'
     method = '!dbg'
+    valgrind = 'none'
   []
   [1e4]
     type = Exodiff
@@ -16,6 +17,7 @@
     cli_args = 'rayleigh=1e4 Outputs/file_base=1e4'
     requirement = 'The system shall be able to reproduce benchmark results for a Rayleigh number of 1e4.'
     method = '!dbg'
+    valgrind = 'none'
   []
   [1e5]
     type = Exodiff
@@ -24,6 +26,7 @@
     cli_args = 'rayleigh=1e5 Outputs/file_base=1e5'
     requirement = 'The system shall be able to reproduce benchmark results for a Rayleigh number of 1e5.'
     method = '!dbg'
+    valgrind = 'none'
   []
   [1e6]
     type = Exodiff
@@ -33,5 +36,6 @@
     requirement = 'The system shall be able to reproduce benchmark results for a Rayleigh number of 1e6.'
     method = '!dbg'
     abs_zero = 1e-9
+    valgrind = 'none'
   []
 []


### PR DESCRIPTION
These tests take a little under a minute with non-debug methods and this
is long enough to lead to valgrind timeouts. We already have boussinesq
tests that are shorter running that hit the same code paths, so we
shouldn't be decreasing any valgrind coverage here for normal modules
valgrind. Moreover, I'll just add these to the heavy target so they still run.

Refs #16023

