### PR TITLE
Provide application level option for controlling new nonzero behavior

### DIFF
--- a/framework/doc/content/source/base/MooseApp.md
+++ b/framework/doc/content/source/base/MooseApp.md
@@ -2,3 +2,27 @@
 
 The `MooseApp` object is the base class for [!ac](MOOSE) based applications and serves as the
 entry point for running all aspects of a simulation.
+
+## Nonzero reallocation behavior
+
+The MOOSE framework and libMesh work together to supply a sparsity pattern to
+PETSc which informs how much memory is allocated for the system matrix. If the
+sparsity pattern is too small, then PETSc will be forced to allocate new memory
+during matrix assembly if user code tries to add/set a matrix entry that wasn't
+preallocated by the sparsity pattern. This allocation at matrix assembly time
+can significantly slow down a simulation. MOOSE and libMesh are known to
+generate accurate sparsity patterns in most cases; however, for complex
+multi-body problems like mechanical and thermal contact, the sparsity pattern
+may be incorrect. Because of this, by default MOOSE does not error if PETSc is
+forced to do new nonzero allocations during matrix assembly. However, if an
+application developer expects their physics to have accurate sparsity patterns,
+they may override the default MOOSE behavior and error on new nonzero
+allocations. This can give the application developer peace-of-mind that their
+applications will not produce quiet nonzero allocations at run-time.
+
+Overriding the default nonzero allocation behavior can be accomplished by
+overriding the virtual function `bool
+MooseApp::errorOnJacobianNonzeroReallocation() const`. The `MooseApp` default is
+`false`, although this will hopefully be changed in the not-too-distant
+future. Note that the application level code setting can always be overridden at
+the input-file level by specifying a value for `Problem/error_on_jacobian_nonzero_reallocation`.

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -794,6 +794,13 @@ public:
   }
   ///@}
 
+  /**
+   * Whether this application should by default error on Jacobian nonzero reallocations. The
+   * application level setting can always be overridden by setting the \p
+   * error_on_jacobian_nonzero_reallocation parameter in the \p Problem block of the input file
+   */
+  virtual bool errorOnJacobianNonzeroReallocation() const { return false; }
+
 protected:
   /**
    * Whether or not this MooseApp has cached a Backup to use for restart / recovery

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -143,7 +143,6 @@ FEProblemBase::validParams()
                         "Eigenvalue system (Automatically determined based "
                         "on executioner)");
   params.addParam<bool>("error_on_jacobian_nonzero_reallocation",
-                        false,
                         "This causes PETSc to error if it had to reallocate memory in the Jacobian "
                         "matrix due to not having enough nonzeros");
   params.addParam<bool>("ignore_zeros_in_jacobian",
@@ -284,7 +283,9 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _line_search(nullptr),
     _using_ad_mat_props(false),
     _error_on_jacobian_nonzero_reallocation(
-        getParam<bool>("error_on_jacobian_nonzero_reallocation")),
+        isParamValid("error_on_jacobian_nonzero_reallocation")
+            ? getParam<bool>("error_on_jacobian_nonzero_reallocation")
+            : _app.errorOnJacobianNonzeroReallocation()),
     _ignore_zeros_in_jacobian(getParam<bool>("ignore_zeros_in_jacobian")),
     _force_restart(getParam<bool>("force_restart")),
     _skip_additional_restart_data(getParam<bool>("skip_additional_restart_data")),

--- a/modules/navier_stokes/include/base/NavierStokesApp.h
+++ b/modules/navier_stokes/include/base/NavierStokesApp.h
@@ -26,4 +26,6 @@ public:
   static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
   static void registerExecFlags(Factory & factory);
   static void associateSyntaxDepends(Syntax & syntax, ActionFactory & action_factory);
+
+  bool errorOnJacobianNonzeroReallocation() const override final { return true; }
 };

--- a/modules/navier_stokes/test/include/base/NavierStokesTestApp.h
+++ b/modules/navier_stokes/test/include/base/NavierStokesTestApp.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "MooseApp.h"
+#include "NavierStokesApp.h"
 
-class NavierStokesTestApp : public MooseApp
+class NavierStokesTestApp : public NavierStokesApp
 {
 public:
   static InputParameters validParams();

--- a/modules/navier_stokes/test/include/kernels/MallocKernel.h
+++ b/modules/navier_stokes/test/include/kernels/MallocKernel.h
@@ -1,0 +1,25 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Kernel.h"
+
+class MallocKernel final : public Kernel
+{
+public:
+  static InputParameters validParams();
+
+  MallocKernel(const InputParameters & parameters);
+
+  void jacobianSetup() override;
+
+protected:
+  Real computeQpResidual() override;
+};

--- a/modules/navier_stokes/test/src/base/NavierStokesTestApp.C
+++ b/modules/navier_stokes/test/src/base/NavierStokesTestApp.C
@@ -22,7 +22,7 @@ NavierStokesTestApp::validParams()
 
 registerKnownLabel("NavierStokesTestApp");
 
-NavierStokesTestApp::NavierStokesTestApp(InputParameters parameters) : MooseApp(parameters)
+NavierStokesTestApp::NavierStokesTestApp(InputParameters parameters) : NavierStokesApp(parameters)
 {
   NavierStokesTestApp::registerAll(
       _factory, _action_factory, _syntax, getParam<bool>("allow_test_objects"));

--- a/modules/navier_stokes/test/src/kernels/MallocKernel.C
+++ b/modules/navier_stokes/test/src/kernels/MallocKernel.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MallocKernel.h"
+#include "SystemBase.h"
+
+registerMooseObject("NavierStokesTestApp", MallocKernel);
+
+InputParameters
+MallocKernel::validParams()
+{
+  return Kernel::validParams();
+}
+
+MallocKernel::MallocKernel(const InputParameters & parameters) : Kernel(parameters) {}
+
+void
+MallocKernel::jacobianSetup()
+{
+  auto & sys_mat = _sys.getMatrix(_sys.systemMatrixTag());
+
+  // Add to an off-diagional
+  sys_mat.add(0, 1, 0);
+}
+
+Real
+MallocKernel::computeQpResidual()
+{
+  return 0;
+}

--- a/modules/navier_stokes/test/tests/ins/nonzero-malloc/test.i
+++ b/modules/navier_stokes/test/tests/ins/nonzero-malloc/test.i
@@ -1,0 +1,187 @@
+[GlobalParams]
+  gravity = '0 0 0'
+  pspg = true
+[]
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 1.0
+    ymin = 0
+    ymax = 1.0
+    nx = 5
+    ny = 5
+  []
+  [./corner_node]
+    type = ExtraNodesetGenerator
+    new_boundary = 'pinned_node'
+    nodes = '0'
+    input = gen
+  [../]
+[]
+
+[Variables]
+  [./vel_x]
+  [../]
+
+  [./vel_y]
+  [../]
+
+  [./T]
+    [./InitialCondition]
+      type = ConstantIC
+      value = 1.0
+    [../]
+  [../]
+
+  [./p]
+  [../]
+[]
+
+[Kernels]
+  # mass
+  [./mass]
+    type = INSMass
+    variable = p
+    u = vel_x
+    v = vel_y
+    p = p
+  [../]
+
+  # x-momentum, time
+  [./x_momentum_time]
+    type = INSMomentumTimeDerivative
+    variable = vel_x
+  [../]
+
+  # x-momentum, space
+  [./x_momentum_space]
+    type = INSMomentumLaplaceForm
+    variable = vel_x
+    u = vel_x
+    v = vel_y
+    p = p
+    component = 0
+  [../]
+
+  # y-momentum, time
+  [./y_momentum_time]
+    type = INSMomentumTimeDerivative
+    variable = vel_y
+  [../]
+
+  # y-momentum, space
+  [./y_momentum_space]
+    type = INSMomentumLaplaceForm
+    variable = vel_y
+    u = vel_x
+    v = vel_y
+    p = p
+    component = 1
+  [../]
+
+ # temperature
+ [./temperature_time]
+   type = INSTemperatureTimeDerivative
+   variable = T
+ [../]
+
+ [./temperature_space]
+   type = INSTemperature
+   variable = T
+   u = vel_x
+   v = vel_y
+ [../]
+
+  [malloc]
+    type = MallocKernel
+    # Variable choice doesn't matter
+    variable = vel_x
+  []
+[]
+
+[BCs]
+  [./x_no_slip]
+    type = DirichletBC
+    variable = vel_x
+    boundary = 'bottom right left'
+    value = 0.0
+  [../]
+
+  [./lid]
+    type = FunctionDirichletBC
+    variable = vel_x
+    boundary = 'top'
+    function = 'lid_function'
+  [../]
+
+  [./y_no_slip]
+    type = DirichletBC
+    variable = vel_y
+    boundary = 'bottom right top left'
+    value = 0.0
+  [../]
+
+  [./T_hot]
+    type = DirichletBC
+    variable = T
+    boundary = 'bottom'
+    value = 1
+  [../]
+
+  [./T_cold]
+    type = DirichletBC
+    variable = T
+    boundary = 'top'
+    value = 0
+  [../]
+
+  [./pressure_pin]
+    type = DirichletBC
+    variable = p
+    boundary = 'pinned_node'
+    value = 0
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu cp k'
+    prop_values = '1  1  1  .01'
+  [../]
+[]
+
+[Functions]
+  [./lid_function]
+    # We pick a function that is exactly represented in the velocity
+    # space so that the Dirichlet conditions are the same regardless
+    # of the mesh spacing.
+    type = ParsedFunction
+    value = '4*x*(1-x)'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 5
+  dt = .5
+  dtmin = .5
+  petsc_options_iname = '-pc_type -pc_asm_overlap -sub_pc_type -sub_pc_factor_levels'
+  petsc_options_value = 'asm      2               ilu          4'
+  line_search = 'none'
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-13
+  nl_max_its = 6
+  l_tol = 1e-6
+  l_max_its = 500
+[]
+
+[Outputs]
+  file_base = lid_driven_out
+  exodus = true
+  perf_graph = true
+[]

--- a/modules/navier_stokes/test/tests/ins/nonzero-malloc/tests
+++ b/modules/navier_stokes/test/tests/ins/nonzero-malloc/tests
@@ -1,0 +1,12 @@
+[Tests]
+  issues = '#7901'
+  design = 'MooseApp.md'
+  [malloc]
+    type = RunException
+    input = test.i
+    expect_err = 'New nonzero at.*caused a malloc'
+    requirement = 'The system shall allow MOOSE applications to specify nonzero malloc behavior; for the Navier-Stokes application, new nonzero allocations shall be errors.'
+    allow_test_objects = True
+    executable_pattern = 'navier_stokes'
+  []
+[]


### PR DESCRIPTION
Applications may now override the `MooseApp` default for what to do when
PETSc is forced to allocate a new nonzero entry during
Jacobian/preconditioner construction. The default is to not error when
these allocations happen. The downside to this is is that runtime may be
significantly slowed without the user having any idea that slow-down is
occurring because of new nonzero allocations.

Refs #7901

