### PR TITLE
More paranoid initialization of RMs

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1077,9 +1077,6 @@ private:
   /// longer accessible
   bool _popped_final_mesh_generator;
 
-  /// Whether geometric relationship managers were already attached
-  bool _geometric_rms_attached;
-
   bool _profiling = false;
 
   // Allow FEProblemBase to set the recover/restart state, so make it a friend

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -340,8 +340,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _restore_cached_backup_timer(_perf_graph.registerSection("MooseApp::restoreCachedBackup", 2)),
     _create_minimal_app_timer(_perf_graph.registerSection("MooseApp::createMinimalApp", 3)),
     _automatic_automatic_scaling(getParam<bool>("automatic_automatic_scaling")),
-    _popped_final_mesh_generator(false),
-    _geometric_rms_attached(false)
+    _popped_final_mesh_generator(false)
 {
 #ifdef HAVE_GPERFTOOLS
   if (std::getenv("MOOSE_PROFILE_BASE"))
@@ -1928,8 +1927,6 @@ MooseApp::attachRelationshipManagers(MeshBase & mesh, MooseMesh & moose_mesh)
       }
     }
   }
-
-  _geometric_rms_attached = true;
 }
 
 void
@@ -1939,7 +1936,7 @@ MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType rm_type)
   {
     if (rm->isType(rm_type))
     {
-      if (rm_type == Moose::RelationshipManagerType::GEOMETRIC && !_geometric_rms_attached)
+      if (rm_type == Moose::RelationshipManagerType::GEOMETRIC)
       {
         // The problem is not built yet - so the ActionWarehouse currently owns the mesh
         MooseMesh * const mesh = _action_warehouse.mesh().get();


### PR DESCRIPTION
THM is currently building a `MeshBase` object during the `setup_mesh`
task which is earlier than any other `MeshBase` generation that I've
seen. `setup_mesh` happens before `add_geometric_rms`, so when the THM
`MeshBase` object is built, the geometric RMs aren't arround to attach
when `MooseApp::attachRelationshipManagers(MeshBase &, MooseMesh &)` is
called and hence they also aren't initialized in that call. Before I
had a `_geometric_rms_attached` flag in `MooseApp` that was designed to
avoid trying to init geoemtric RMs again, but there's really no need for
that. `RelationshipManager::init` doesn't do anything if it's already
been `_inited` and `MeshBase::add_ghosting_functor` is essentially a
no-op because it stores ghosting functors in a set. So it's not a
correctness/optimization concern to try init'ing all the geometric RMs
again when the
`MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType)`
overload is called, and it helps protect our users if they build their
meshes at unexpected times (unexpected with respect to the framework
library).

Refs #15338