### PR TITLE
Revert change to MooseApp start_time

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -291,7 +291,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _file_base_set_by_user(false),
     _output_position_set(false),
     _start_time_set(false),
-    _start_time(-std::numeric_limits<Real>::max()),
+    _start_time(0.0),
     _global_time_offset(0.0),
     _output_warehouse(*this),
     _input_parameter_warehouse(new InputParameterWarehouse()),

--- a/framework/src/executioners/Transient.C
+++ b/framework/src/executioners/Transient.C
@@ -186,7 +186,7 @@ Transient::Transient(const InputParameters & parameters)
   // is (in case anyone else is interested.
   if (_app.hasStartTime())
     _start_time = _app.getStartTime();
-  else if (parameters.isParamSetByUser("start_time") && !_app.isRecovering())
+  else if (parameters.isParamSetByUser("start_time"))
     _app.setStartTime(_start_time);
 
   _time = _time_old = _start_time;


### PR DESCRIPTION
This is reverting a change to the MooseApp `_start_time` from #15772 that was causing errors in Griffin.

Refs #15766 