### PR TITLE
Fix FV Dirac Kernel test for different element numberings

### DIFF
--- a/test/tests/dirackernels/constant_point_source/1d_point_source_fv.i
+++ b/test/tests/dirackernels/constant_point_source/1d_point_source_fv.i
@@ -39,13 +39,13 @@
     type = ConstantPointSource
     variable = u
     value = 1.0
-    point = '0.2 0 0'
+    point = '0.15 0 0'
   []
   [point_source2]
     type = ConstantPointSource
     variable = u
     value = -0.5
-    point = '0.7 0 0'
+    point = '0.65 0 0'
   []
 []
 


### PR DESCRIPTION
From https://github.com/idaholab/moose/pull/16034#issuecomment-720993014:

Ok, so this is a discontinuous discretization problem. Consider this code:
```c++
const Elem *
DiracKernelInfo::findPoint(Point p, const MooseMesh & mesh)
{
  // If the PointLocator has never been created, do so now.  NOTE - WE
  // CAN'T DO THIS if findPoint() is only called on some processors,
  // PointLocatorBase::build() is a 'parallel_only' method!
  if (_point_locator.get() == NULL)
  {
    _point_locator = PointLocatorBase::build(TREE_LOCAL_ELEMENTS, mesh);
    _point_locator->enable_out_of_mesh_mode();
  }

  // Check that the PointLocator is ready to start locating points.
  // So far I do not have any tests that trip this...
  if (_point_locator->initialized() == false)
    mooseError("Error, PointLocator is not initialized!");

  // Note: The PointLocator object returns NULL when the Point is not
  // found within the Mesh.  This is not considered to be an error as
  // far as the DiracKernels are concerned: sometimes the Mesh moves
  // out from the Dirac point entirely and in that case the Point just
  // gets "deactivated".
  const Elem * elem = (*_point_locator)(p);

  // The processors may not agree on which Elem the point is in.  This
  // can happen if a Dirac point lies on the processor boundary, and
  // two or more neighboring processors think the point is in the Elem
  // on *their* side.
  dof_id_type elem_id = elem ? elem->id() : DofObject::invalid_id;

  // We are going to let the element with the smallest ID "win", all other
  // procs will return NULL.
  dof_id_type min_elem_id = elem_id;
  mesh.comm().min(min_elem_id);

  return min_elem_id == elem_id ? elem : NULL;
}
```
Note that we let the lowest element ID determine which element gets to apply the impulse from the Dirac point. Here's our global element numbering for a replicated mesh for your test:
![replicated](https://user-images.githubusercontent.com/10248304/97966458-b7ac5800-1d70-11eb-9145-d081ea7854d1.png)
and then here is with a distributed mesh with 5 processors
![distributed-5-procs](https://user-images.githubusercontent.com/10248304/97966450-b67b2b00-1d70-11eb-8f13-ba6395636c88.png)
So in replicated mesh mode, your point source at 0.2 will be applied to the element with bounds [0.1, 0.2]; however, for the distributed 5-proc case, your point source at 0.2 will be applied to the element with bounds [0.2, 0.3]. For a continuous finite element discretization it makes no difference what element the point source will be applied to. But for a discontinuous formulation, one element and its elemental dof gets the whole source. This understandably changes the solution

Refs #16033 #16034

@cpgr 
