### PR TITLE
Deprecate EBSDMesh, add EBSDMeshGenerator

### DIFF
--- a/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
+++ b/modules/combined/examples/phase_field-mechanics/EBSD_reconstruction_grain_growth_mech.i
@@ -2,9 +2,11 @@
 # Then, an isotropic grain model is run with linear elasticity and an anisotropic
 # elasticity tensor that uses the measured EBSD angles.
 [Mesh]
-  uniform_refine = 2 #Mesh can go two levels coarser than the EBSD grid
-  type = EBSDMesh
-  filename = IN100_128x128.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    uniform_refine = 2 #Mesh can go two levels coarser than the EBSD grid
+    filename = IN100_128x128.txt
+  []
 []
 
 [GlobalParams]
@@ -14,90 +16,90 @@
 []
 
 [Variables]
-  [./PolycrystalVariables] #Polycrystal variable generation (30 order parameters)
-  [../]
-  [./disp_x]
-  [../]
-  [./disp_y]
-  [../]
+  [PolycrystalVariables] #Polycrystal variable generation (30 order parameters)
+  []
+  [disp_x]
+  []
+  [disp_y]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
-  [../]
-  [./gt_indices]
+  [bnds]
+  []
+  [gt_indices]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./vonmises_stress]
+  []
+  [vonmises_stress]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./C1111]
+  []
+  [C1111]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./phi1]
+  []
+  [phi1]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./Phi]
+  []
+  [Phi]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./phi2]
+  []
+  [phi2]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./EBSD_grain]
+  []
+  [EBSD_grain]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./ReconVarIC]
+  [PolycrystalICs]
+    [ReconVarIC]
       ebsd_reader = ebsd
       coloring_algorithm = bt
-    [../]
-  [../]
+    []
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
-  [./PolycrystalElasticDrivingForce]
-  [../]
-  [./TensorMechanics]
-  [../]
+  [PolycrystalKernel]
+  []
+  [PolycrystalElasticDrivingForce]
+  []
+  [TensorMechanics]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
-  [./gt_indices]
+  []
+  [gt_indices]
     type = FeatureFloodCountAux
     variable = gt_indices
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
-  [../]
-  [./C1111]
+  []
+  [C1111]
     type = RankFourAux
     variable = C1111
     rank_four_tensor = elasticity_tensor
@@ -106,80 +108,80 @@
     index_k = 0
     index_i = 0
     execute_on = timestep_end
-  [../]
-  [./vonmises_stress]
+  []
+  [vonmises_stress]
     type = RankTwoScalarAux
     variable = vonmises_stress
     rank_two_tensor = stress
     scalar_type = VonMisesStress
     execute_on = timestep_end
-  [../]
-  [./phi1]
+  []
+  [phi1]
     type = OutputEulerAngles
     variable = phi1
     euler_angle_provider = ebsd
     grain_tracker = grain_tracker
     output_euler_angle = 'phi1'
     execute_on = 'initial'
-  [../]
-  [./Phi]
+  []
+  [Phi]
     type = OutputEulerAngles
     variable = Phi
     euler_angle_provider = ebsd
     grain_tracker = grain_tracker
     output_euler_angle = 'Phi'
     execute_on = 'initial'
-  [../]
-  [./phi2]
+  []
+  [phi2]
     type = OutputEulerAngles
     variable = phi2
     euler_angle_provider = ebsd
     grain_tracker = grain_tracker
     output_euler_angle = 'phi2'
     execute_on = 'initial'
-  [../]
-  [./grain_aux]
+  []
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = EBSD_grain
     ebsd_reader = ebsd
     data_name = 'feature_id'
     execute_on = 'initial'
-  [../]
+  []
 []
 
 [BCs]
-  [./top_displacement]
+  [top_displacement]
     type = DirichletBC
     variable = disp_y
     boundary = top
     value = -2.0
-  [../]
-  [./x_anchor]
+  []
+  [x_anchor]
     type = DirichletBC
     variable = disp_x
     boundary = 'left right'
     value = 0.0
-  [../]
-  [./y_anchor]
+  []
+  [y_anchor]
     type = DirichletBC
     variable = disp_y
     boundary = bottom
     value = 0.0
-  [../]
+  []
 []
 
 [Modules]
-  [./PhaseField]
-    [./EulerAngles2RGB]
+  [PhaseField]
+    [EulerAngles2RGB]
       crystal_structure = cubic
       euler_angle_provider = ebsd
       grain_tracker = grain_tracker
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./Copper]
+  [Copper]
     # T = 500 # K
     type = GBEvolution
     block = 0
@@ -191,44 +193,44 @@
     molar_volume = 7.11e-6; # Molar volume in m^3/mol
     length_scale = 1.0e-6
     time_scale = 1.0e-6
-  [../]
-  [./ElasticityTensor]
+  []
+  [ElasticityTensor]
     type = ComputePolycrystalElasticityTensor
     grain_tracker = grain_tracker
-  [../]
-  [./strain]
+  []
+  [strain]
     type = ComputeSmallStrain
     block = 0
     displacements = 'disp_x disp_y'
-  [../]
-  [./stress]
+  []
+  [stress]
     type = ComputeLinearElasticStress
     block = 0
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./dt]
+  [dt]
     type = TimestepSize
-  [../]
-  [./n_elements]
+  []
+  [n_elements]
     type = NumElems
     execute_on = 'initial timestep_end'
-  [../]
-  [./n_nodes]
+  []
+  [n_nodes]
     type = NumNodes
     execute_on = 'initial timestep_end'
-  [../]
-  [./DOFs]
+  []
+  [DOFs]
     type = NumDOFs
-  [../]
+  []
 []
 
 [UserObjects]
-  [./ebsd]
+  [ebsd]
     type = EBSDReader
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTrackerElasticity
     compute_var_to_feature_map = true
     ebsd_reader = ebsd
@@ -236,7 +238,7 @@
     fill_method = symmetric9
     C_ijkl = '1.27e5 0.708e5 0.708e5 1.27e5 0.708e5 1.27e5 0.7355e5 0.7355e5 0.7355e5'
     euler_angle_provider = ebsd
-  [../]
+  []
 []
 
 [Executioner]
@@ -252,19 +254,19 @@
   start_time = 0.0
   num_steps = 30
   dt = 10
-  [./Adaptivity]
+  [Adaptivity]
     initial_adaptivity = 0
     refine_fraction = 0.7
     coarsen_fraction = 0.1
     max_h_level = 2
-  [../]
-  [./TimeStepper]
+  []
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.9
     dt = 10.0
     growth_factor = 1.1
     optimal_iterations = 7
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
+++ b/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
@@ -6,12 +6,12 @@ The mesh is generated from the EBSD information, to get an optimal reconstructio
 is accomplished in the mesh block using the EBSDMeshGenerator type. The same data file used with the EBSD
 reader is used in the EBSDReader UserObject.  The mesh is created with one node per data point in the
 EBSD data file. If you wish to use mesh adaptivity and allow the mesh to get coarser during the
-simulation, the "uniform_refine" parameter is used to set how many times the mesh can be
+simulation, the [!param](/Mesh/uniform_refine) parameter is used to set how many times the mesh can be
 coarsened. For this to work the number of elements along _each_ dimension has to be divisible by
-$2^u$ where $u$ is the value of the ```uniform_refine``` parameter.
+$2^u$ where $u$ is the value of the [!param](/Mesh/uniform_refine) parameter.
 
 !alert warning title="uniform_refine" parameter
-Contrary to other mesh objects the "uniform_refine" parameter will not affect the resolution of the
+Contrary to other mesh objects the [!param](/Mesh/uniform_refine) parameter will not affect the resolution of the
 final mesh. It sets the levels of coarsening that can be applied to the EBSD data.
 
 !syntax parameters /Mesh/EBSDMeshGenerator

--- a/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
+++ b/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
@@ -1,0 +1,21 @@
+# EBSDMeshGenerator
+
+!syntax description /Mesh/EBSDMeshGenerator
+
+The mesh is generated from the EBSD information, to get an optimal reconstruction of the data. This
+is accomplished in the mesh block using the EBSDMeshGenerator type. The same data file used with the EBSD
+reader is used in the EBSDReader UserObject.  The mesh is created with one node per data point in the
+EBSD data file. If you wish to use mesh adaptivity and allow the mesh to get coarser during the
+simulation, the "uniform_refine" parameter is used to set how many times the mesh can be
+coarsened. For this to work the number of elements along _each_ dimension has to be divisible by
+$2^u$ where $u$ is the value of the ```uniform_refine``` parameter.
+
+!alert warning title="uniform_refine" parameter
+Contrary to other mesh objects the "uniform_refine" parameter will not affect the resolution of the
+final mesh. It sets the levels of coarsening that can be applied to the EBSD data.
+
+!syntax parameters /Mesh/EBSDMeshGenerator
+
+!syntax inputs /Mesh/EBSDMeshGenerator
+
+!syntax children /Mesh/EBSDMeshGenerator

--- a/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
+++ b/modules/phase_field/doc/content/source/meshgenerators/EBSDMeshGenerator.md
@@ -8,10 +8,10 @@ reader is used in the EBSDReader UserObject.  The mesh is created with one node 
 EBSD data file. If you wish to use mesh adaptivity and allow the mesh to get coarser during the
 simulation, the [!param](/Mesh/uniform_refine) parameter is used to set how many times the mesh can be
 coarsened. For this to work the number of elements along _each_ dimension has to be divisible by
-$2^u$ where $u$ is the value of the [!param](/Mesh/uniform_refine) parameter.
+$2^u$ where $u$ is the value of the [!param](/Mesh/EBSDMeshGenerator/uniform_refine) parameter.
 
 !alert warning title="uniform_refine" parameter
-Contrary to other mesh objects the [!param](/Mesh/uniform_refine) parameter will not affect the resolution of the
+Contrary to other mesh objects the [!param](/Mesh/EBSDMeshGenerator/uniform_refine) parameter will not affect the resolution of the
 final mesh. It sets the levels of coarsening that can be applied to the EBSD data.
 
 !syntax parameters /Mesh/EBSDMeshGenerator

--- a/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
+++ b/modules/phase_field/examples/ebsd_reconstruction/IN100-111grn.i
@@ -1,7 +1,9 @@
 [Mesh]
-  type = EBSDMesh
-  filename = IN100_120x120.txt
-  uniform_refine = 2
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = IN100_120x120.txt
+    uniform_refine = 2
+  []
 []
 
 [GlobalParams]
@@ -10,171 +12,171 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     enable_var_coloring = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     flood_entity_type = ELEMENTAL
     compute_halo_maps = true # For displaying HALO fields
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
-  [../]
-  [./unique_grains_ic]
+  [bnds]
+  []
+  [unique_grains_ic]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ghost_elements]
+  []
+  [ghost_elements]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./halos]
+  []
+  [halos]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./var_indices_ic]
+  []
+  [var_indices_ic]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ebsd_grains]
+  []
+  [ebsd_grains]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
+  [PolycrystalKernel]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
-  [./ghost_elements]
+  []
+  [ghost_elements]
     type = FeatureFloodCountAux
     variable = ghost_elements
     field_display = GHOSTED_ENTITIES
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
-  [../]
-  [./halos]
+  []
+  [halos]
     type = FeatureFloodCountAux
     variable = halos
     field_display = HALOS
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
-  [../]
-  [./var_indices_ic]
+  []
+  [var_indices_ic]
     type = FeatureFloodCountAux
     variable = var_indices_ic
     execute_on = 'initial'
     flood_counter = ebsd
     field_display = VARIABLE_COLORING
-  [../]
-  [./unique_grains_ic]
+  []
+  [unique_grains_ic]
     type = FeatureFloodCountAux
     variable = unique_grains_ic
     execute_on = 'initial'
     flood_counter = ebsd
     field_display = UNIQUE_REGION
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
-  [../]
-  [./grain_aux]
+  []
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = ebsd_grains
     ebsd_reader = ebsd_reader
     data_name = 'feature_id'
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [Modules]
-  [./PhaseField]
-    [./EulerAngles2RGB]
+  [PhaseField]
+    [EulerAngles2RGB]
       crystal_structure = cubic
       euler_angle_provider = ebsd_reader
       grain_tracker = grain_tracker
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./Copper]
+  [Copper]
     # T = 500 # K
     type = GBEvolution
     T = 500
-    wGB = 0.6               # um
-    GBmob0 = 2.5e-6         # m^4/(Js) from Schoenfelder 1997
-    Q = 0.23                # Migration energy in eV
-    GBenergy = 0.708        # GB energy in J/m^2
-    molar_volume = 7.11e-6  # Molar volume in m^3/mol
+    wGB = 0.6 # um
+    GBmob0 = 2.5e-6 # m^4/(Js) from Schoenfelder 1997
+    Q = 0.23 # Migration energy in eV
+    GBenergy = 0.708 # GB energy in J/m^2
+    molar_volume = 7.11e-6 # Molar volume in m^3/mol
     length_scale = 1.0e-6
     time_scale = 1.0e-6
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./dt]
+  [dt]
     type = TimestepSize
-  [../]
-  [./n_elements]
+  []
+  [n_elements]
     type = NumElems
     execute_on = 'initial timestep_end'
-  [../]
-  [./n_nodes]
+  []
+  [n_nodes]
     type = NumNodes
     execute_on = 'initial timestep_end'
-  [../]
-  [./DOFs]
+  []
+  [DOFs]
     type = NumDOFs
-  [../]
+  []
 []
 
 [Executioner]
@@ -193,20 +195,20 @@
   start_time = 0.0
   num_steps = 30
 
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.9
     dt = 10.0
     growth_factor = 1.1
     optimal_iterations = 7
-  [../]
+  []
 
-  [./Adaptivity]
+  [Adaptivity]
     initial_adaptivity = 2
     refine_fraction = 0.7
     coarsen_fraction = 0.1
     max_h_level = 2
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/phase_field/include/meshgenerators/EBSDMeshGenerator.h
+++ b/modules/phase_field/include/meshgenerators/EBSDMeshGenerator.h
@@ -46,7 +46,7 @@ protected:
   void readEBSDHeader();
 
   /// Name of the file containing the EBSD data
-  std::string _filename;
+  const FileName & _filename;
 
   /// EBSD data file mesh information
   Geometry _geometry;

--- a/modules/phase_field/include/meshgenerators/EBSDMeshGenerator.h
+++ b/modules/phase_field/include/meshgenerators/EBSDMeshGenerator.h
@@ -9,25 +9,23 @@
 
 #pragma once
 
-#include "GeneratedMesh.h"
-#include "EBSDMeshGenerator.h"
+#include "GeneratedMeshGenerator.h"
 
 #include <array>
 
 /**
  * Mesh generated from parameters
  */
-class EBSDMesh : public GeneratedMesh
+class EBSDMeshGenerator : public GeneratedMeshGenerator
 {
 public:
   static InputParameters validParams();
 
-  EBSDMesh(const InputParameters & parameters);
-  virtual ~EBSDMesh();
+  EBSDMeshGenerator(const InputParameters & parameters);
 
-  virtual void buildMesh();
+  std::unique_ptr<MeshBase> generate() override;
 
-  struct EBSDMeshGeometry
+  struct Geometry
   {
     // grid spacing
     std::array<Real, 3> d;
@@ -40,7 +38,7 @@ public:
   };
 
   // Interface functions for the EBSDReader
-  const EBSDMeshGenerator::Geometry & getEBSDGeometry() const { return _geometry; }
+  const Geometry & getEBSDGeometry() const { return _geometry; }
   const std::string & getEBSDFilename() const { return _filename; }
 
 protected:
@@ -51,5 +49,5 @@ protected:
   std::string _filename;
 
   /// EBSD data file mesh information
-  EBSDMeshGenerator::Geometry _geometry;
+  Geometry _geometry;
 };

--- a/modules/phase_field/src/mesh/EBSDMesh.C
+++ b/modules/phase_field/src/mesh/EBSDMesh.C
@@ -42,6 +42,11 @@ EBSDMesh::validParams()
 EBSDMesh::EBSDMesh(const InputParameters & parameters)
   : GeneratedMesh(parameters), _filename(getParam<FileName>("filename"))
 {
+  mooseDeprecated(
+      "EBSDMesh is deprecated, please use the EBSDMeshGenerator instead. For example:\n\n[Mesh]\n  "
+      "type = EBDSMesh\n  filename = my_ebsd_data.dat\n[]\n\nbecomes\n\n[Mesh]\n  [ebsd_mesh]\n    "
+      "type = EBDSMeshGenerator\n    filename = my_ebsd_data.dat\n  []\n[]");
+
   if (_nx != 1 || _ny != 1 || _nz != 1)
     mooseWarning("Do not specify mesh geometry information, it is read from the EBSD file.");
 }

--- a/modules/phase_field/src/meshgenerators/EBSDMeshGenerator.C
+++ b/modules/phase_field/src/meshgenerators/EBSDMeshGenerator.C
@@ -1,0 +1,164 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "EBSDMeshGenerator.h"
+#include "MooseApp.h"
+
+#include <fstream>
+
+registerMooseObject("PhaseFieldApp", EBSDMeshGenerator);
+
+InputParameters
+EBSDMeshGenerator::validParams()
+{
+  InputParameters params = GeneratedMeshGenerator::validParams();
+  params.addClassDescription("Mesh generated from a specified DREAM.3D EBSD data file.");
+  params.addRequiredParam<FileName>("filename", "The name of the file containing the EBSD data");
+  params.addParam<unsigned int>(
+      "uniform_refine", 0, "Number of coarsening levels available in adaptive mesh refinement.");
+
+  // suppress parameters
+  params.suppressParameter<MooseEnum>("dim");
+  params.set<MooseEnum>("dim") = MooseEnum("1=1 2 3", "1");
+  params.suppressParameter<unsigned int>("nx");
+  params.suppressParameter<unsigned int>("ny");
+  params.suppressParameter<unsigned int>("nz");
+  params.suppressParameter<Real>("xmin");
+  params.suppressParameter<Real>("ymin");
+  params.suppressParameter<Real>("zmin");
+  params.suppressParameter<Real>("xmax");
+  params.suppressParameter<Real>("ymax");
+  params.suppressParameter<Real>("zmax");
+
+  return params;
+}
+
+EBSDMeshGenerator::EBSDMeshGenerator(const InputParameters & parameters)
+  : GeneratedMeshGenerator(parameters), _filename(getParam<FileName>("filename"))
+{
+  if (_nx != 1 || _ny != 1 || _nz != 1)
+    mooseWarning("Do not specify mesh geometry information, it is read from the EBSD file.");
+}
+
+void
+EBSDMeshGenerator::readEBSDHeader()
+{
+  std::ifstream stream_in(_filename.c_str());
+
+  if (!stream_in)
+    paramError("filename", "Can't open EBSD file: ", _filename);
+
+  // Labels to look for in the header
+  std::vector<std::string> labels = {
+      "x_step", "x_dim", "y_step", "y_dim", "z_step", "z_dim", "x_min", "y_min", "z_min"};
+
+  // Dimension variables to store once they are found in the header
+  // X_step, X_Dim, Y_step, Y_Dim, Z_step, Z_Dim
+  // We use Reals even though the Dim values should all be integers...
+  std::vector<Real> label_vals(labels.size(), 0.0);
+
+  std::string line;
+  while (std::getline(stream_in, line))
+  {
+    // We need to process the comment lines that have:
+    // X_step, X_Dim
+    // Y_step, Y_Dim
+    // Z_step, Z_Dim
+    // in them. The labels are case insensitive.
+    if (line.find("#") == 0)
+    {
+      // Process lines that start with a comment character (comments and meta data)
+      std::transform(line.begin(), line.end(), line.begin(), ::tolower);
+
+      for (unsigned i = 0; i < labels.size(); ++i)
+        if (line.find(labels[i]) != std::string::npos)
+        {
+          std::string dummy;
+          std::istringstream iss(line);
+          iss >> dummy >> dummy >> label_vals[i];
+
+          // One label per line, break out of for loop over labels
+          break;
+        }
+    }
+    else
+      // first non comment line marks the end of the header
+      break;
+  }
+
+  // Copy stuff out of the label_vars array into class variables
+  _geometry.d[0] = label_vals[0];
+  _geometry.n[0] = label_vals[1];
+  _geometry.min[0] = label_vals[6];
+
+  _geometry.d[1] = label_vals[2];
+  _geometry.n[1] = label_vals[3];
+  _geometry.min[1] = label_vals[7];
+
+  _geometry.d[2] = label_vals[4];
+  _geometry.n[2] = label_vals[5];
+  _geometry.min[2] = label_vals[8];
+
+  unsigned int dim;
+
+  // determine mesh dimension
+  for (dim = 3; dim > 0 && _geometry.n[dim - 1] == 0; --dim)
+    ;
+
+  // check if the data has nonzero stepsizes
+  for (unsigned i = 0; i < dim; ++i)
+  {
+    if (_geometry.n[i] == 0)
+      mooseError("Error reading header, EBSD grid size is zero.");
+    if (_geometry.d[i] == 0.0)
+      mooseError("Error reading header, EBSD data step size is zero.");
+  }
+
+  if (dim == 0)
+    mooseError("Error reading header, EBSD data is zero dimensional.");
+
+  _geometry.dim = dim;
+}
+
+std::unique_ptr<MeshBase>
+EBSDMeshGenerator::generate()
+{
+  readEBSDHeader();
+
+  unsigned int uniform_refine = getParam<unsigned int>("uniform_refine");
+  _dim = (_geometry.dim == 1 ? "1" : (_geometry.dim == 2 ? "2" : "3"));
+
+  std::array<unsigned int, 3> nr;
+  nr[0] = _geometry.n[0];
+  nr[1] = _geometry.n[1];
+  nr[2] = _geometry.n[2];
+
+  // set min/max box length
+  _xmin = _geometry.min[0];
+  _xmax = nr[0] * _geometry.d[0] + _geometry.min[0];
+  _ymin = _geometry.min[1];
+  _ymax = nr[1] * _geometry.d[1] + _geometry.min[1];
+  _zmin = _geometry.min[2];
+  _zmax = nr[2] * _geometry.d[2] + _geometry.min[2];
+
+  // check if the requested uniform refine level is possible and determine initial grid size
+  for (unsigned int i = 0; i < uniform_refine; ++i)
+    for (unsigned int j = 0; j < _geometry.dim; ++j)
+    {
+      if (nr[j] % 2 != 0)
+        mooseError("EBSDMeshGenerator error. Requested uniform_refine levels not possible.");
+      nr[j] /= 2;
+    }
+
+  _nx = nr[0];
+  _ny = nr[1];
+  _nz = nr[2];
+
+  return GeneratedMeshGenerator::generate();
+}

--- a/modules/phase_field/src/meshgenerators/EBSDMeshGenerator.C
+++ b/modules/phase_field/src/meshgenerators/EBSDMeshGenerator.C
@@ -55,7 +55,7 @@ EBSDMeshGenerator::readEBSDHeader()
     paramError("filename", "Can't open EBSD file: ", _filename);
 
   // Labels to look for in the header
-  std::vector<std::string> labels = {
+  const std::vector<std::string> labels = {
       "x_step", "x_dim", "y_step", "y_dim", "z_step", "z_dim", "x_min", "y_min", "z_min"};
 
   // Dimension variables to store once they are found in the header

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_ebsd.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_ebsd.i
@@ -1,6 +1,8 @@
 [Mesh]
-  type = EBSDMesh
-  filename = 'test.txt'
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = 'test.txt'
+  []
 []
 
 [GlobalParams]
@@ -9,16 +11,16 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     threshold = 0.2
     connecting_threshold = 0.08
@@ -26,130 +28,130 @@
     compute_halo_maps = true # For displaying HALO fields
     polycrystal_ic_uo = ebsd
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
-  [../]
-  [./unique_grains]
+  [bnds]
+  []
+  [unique_grains]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./ebsd_grains]
+  []
+  [ebsd_grains]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./phi1]
+  []
+  [phi1]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./halo0]
+  []
+  [halo0]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./halo1]
+  []
+  [halo1]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./halo2]
+  []
+  [halo2]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./halo3]
+  []
+  [halo3]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
+  [PolycrystalKernel]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = timestep_end
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
-  [./grain_aux]
+  []
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = ebsd_grains
     ebsd_reader = ebsd_reader
     data_name = 'feature_id'
     execute_on = 'initial timestep_end'
-  [../]
-  [./phi1]
+  []
+  [phi1]
     type = OutputEulerAngles
     euler_angle_provider = ebsd_reader
     output_euler_angle = phi1
     grain_tracker = grain_tracker
     variable = phi1
-  [../]
-    [./halo0]
+  []
+  [halo0]
     type = FeatureFloodCountAux
     variable = halo0
     map_index = 0
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo1]
+  []
+  [halo1]
     type = FeatureFloodCountAux
     variable = halo1
     map_index = 1
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo2]
+  []
+  [halo2]
     type = FeatureFloodCountAux
     variable = halo2
     map_index = 2
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo3]
+  []
+  [halo3]
     type = FeatureFloodCountAux
     variable = halo3
     map_index = 3
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
+  []
 []
 
 [Materials]
-  [./CuGrGr]
+  [CuGrGr]
     type = GBEvolution
     T = 500 #K
     wGB = 0.75 #micron
@@ -160,18 +162,18 @@
     Q = 0.23
     GBenergy = 0.708
     molar_volume = 7.11e-6
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./n_nodes]
+  [n_nodes]
     type = NumNodes
     execute_on = timestep_end
-  [../]
+  []
 
-  [./DOFs]
+  [DOFs]
     type = NumDOFs
-  [../]
+  []
 []
 
 [Executioner]
@@ -180,7 +182,8 @@
 
   #Preconditioned JFNK (default)
   solve_type = 'PJFNK'
-  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart -pc_hypre_boomeramg_strong_threshold'
+  petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart '
+                        '-pc_hypre_boomeramg_strong_threshold'
   petsc_options_value = 'hypre boomeramg 31 0.7'
   l_tol = 1.0e-4
   l_max_its = 20

--- a/modules/phase_field/test/tests/grain_tracker_test/split_grain.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/split_grain.i
@@ -1,6 +1,8 @@
 [Mesh]
-  type = EBSDMesh
-  filename = EBSD_split_grain.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = EBSD_split_grain.txt
+  []
 []
 
 [GlobalParams]
@@ -9,147 +11,147 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     enable_var_coloring = true
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     flood_entity_type = ELEMENTAL
     compute_halo_maps = true # For displaying HALO fields
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
-  [../]
-  [./unique_grains]
+  [bnds]
+  []
+  [unique_grains]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ghost_elements]
+  []
+  [ghost_elements]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./halos]
+  []
+  [halos]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./ebsd_grains]
+  []
+  [ebsd_grains]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
+  [PolycrystalKernel]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
-  [./ghost_elements]
+  []
+  [ghost_elements]
     type = FeatureFloodCountAux
     variable = ghost_elements
     field_display = GHOSTED_ENTITIES
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
-  [../]
-  [./halos]
+  []
+  [halos]
     type = FeatureFloodCountAux
     variable = halos
     field_display = HALOS
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     execute_on = 'initial timestep_end'
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
-  [../]
-  [./grain_aux]
+  []
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = ebsd_grains
     ebsd_reader = ebsd_reader
     data_name = 'feature_id'
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [Modules]
-  [./PhaseField]
-    [./EulerAngles2RGB]
+  [PhaseField]
+    [EulerAngles2RGB]
       crystal_structure = cubic
       euler_angle_provider = ebsd_reader
       grain_tracker = grain_tracker
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./Copper]
+  [Copper]
     # T = 500 # K
     type = GBEvolution
     T = 500
-    wGB = 0.6               # um
-    GBmob0 = 2.5e-6         # m^4/(Js) from Schoenfelder 1997
-    Q = 0.23                # Migration energy in eV
-    GBenergy = 0.708        # GB energy in J/m^2
-    molar_volume = 7.11e-6  # Molar volume in m^3/mol
+    wGB = 0.6 # um
+    GBmob0 = 2.5e-6 # m^4/(Js) from Schoenfelder 1997
+    Q = 0.23 # Migration energy in eV
+    GBenergy = 0.708 # GB energy in J/m^2
+    molar_volume = 7.11e-6 # Molar volume in m^3/mol
     length_scale = 1.0e-6
     time_scale = 1.0e-6
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./n_elements]
+  [n_elements]
     type = NumElems
     execute_on = 'initial timestep_end'
-  [../]
-  [./n_nodes]
+  []
+  [n_nodes]
     type = NumNodes
     execute_on = 'initial timestep_end'
-  [../]
-  [./DOFs]
+  []
+  [DOFs]
     type = NumDOFs
-  [../]
+  []
 []
 
 [Executioner]
@@ -168,13 +170,13 @@
   start_time = 0.0
   num_steps = 2
 
-  [./TimeStepper]
+  [TimeStepper]
     type = IterationAdaptiveDT
     cutback_factor = 0.9
     dt = 10.0
     growth_factor = 1.1
     optimal_iterations = 7
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/phase_field/test/tests/reconstruction/1phase_evolution.i
+++ b/modules/phase_field/test/tests/reconstruction/1phase_evolution.i
@@ -4,8 +4,10 @@
 #
 
 [Mesh]
-  type = EBSDMesh
-  filename = IN100_001_28x28_Marmot.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = IN100_001_28x28_Marmot.txt
+  []
 []
 
 [GlobalParams]
@@ -14,66 +16,66 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
+  [PolycrystalKernel]
+  []
 []
 
 [AuxVariables]
-  [./feature]
+  [feature]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./bnds]
-  [../]
+  []
+  [bnds]
+  []
 []
 
 [AuxKernels]
-  [./feature]
+  [feature]
     type = EBSDReaderAvgDataAux
     variable = feature
     ebsd_reader = ebsd_reader
     grain_tracker = grain_tracker
     data_name = feature_id
     execute_on = 'initial timestep_end'
-  [../]
-  [./bnds]
+  []
+  [bnds]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [Materials]
-  [./CuGrGr]
+  [CuGrGr]
     # Material properties
     type = GBEvolution # Quantitative material properties for copper grain growth.  Dimensions are nm and ns
     block = 0 # Block ID (only one block in this problem)
@@ -85,7 +87,7 @@
     #outputs = exodus
     length_scale = 1e-06
     time_scale = 1e-6
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/1phase_reconstruction.i
+++ b/modules/phase_field/test/tests/reconstruction/1phase_reconstruction.i
@@ -14,8 +14,10 @@
 
 [Mesh]
   # Create a mesh representing the EBSD data
-  type = EBSDMesh
-  filename = IN100_001_28x28_Marmot.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = IN100_001_28x28_Marmot.txt
+  []
 []
 
 [GlobalParams]
@@ -25,40 +27,40 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     # Read in the EBSD data. Uses the filename given in the mesh block.
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     # For displaying HALO fields
     compute_halo_maps = true
     # Link in the ebsd userobject here so that grain tracker can extract info from it
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
+  [PolycrystalVariables]
     # Create all the order parameters
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       # Uses the data from the user object 'ebsd' to initialize the variables for all the order parameters.
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 #ENDDOC - End of the file section that is included in the documentation. Do not change this line!
 
@@ -69,93 +71,93 @@
 []
 
 [AuxVariables]
-  [./PHI1]
-  [../]
-  [./PHI]
-  [../]
-  [./PHI2]
-  [../]
-  [./GRAIN]
-  [../]
-  [./unique_grains]
-  [../]
-  [./var_indices]
-  [../]
-  [./halo0]
-  [../]
-  [./halo1]
-  [../]
-  [./halo2]
-  [../]
-  [./halo3]
-  [../]
+  [PHI1]
+  []
+  [PHI]
+  []
+  [PHI2]
+  []
+  [GRAIN]
+  []
+  [unique_grains]
+  []
+  [var_indices]
+  []
+  [halo0]
+  []
+  [halo1]
+  []
+  [halo2]
+  []
+  [halo3]
+  []
 []
 
 [AuxKernels]
-  [./phi1_aux]
+  [phi1_aux]
     type = EBSDReaderPointDataAux
     variable = PHI1
     ebsd_reader = ebsd_reader
     data_name = 'phi1'
-  [../]
-  [./phi_aux]
+  []
+  [phi_aux]
     type = EBSDReaderPointDataAux
     variable = PHI
     ebsd_reader = ebsd_reader
     data_name = 'phi'
-  [../]
-  [./phi2_aux]
+  []
+  [phi2_aux]
     type = EBSDReaderPointDataAux
     variable = PHI2
     ebsd_reader = ebsd_reader
     data_name = 'phi2'
-  [../]
-  [./grain_aux]
+  []
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = GRAIN
     ebsd_reader = ebsd_reader
     data_name = 'feature_id'
-  [../]
-  [./unique_grains]
+  []
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
-  [./halo0]
+  []
+  [halo0]
     type = FeatureFloodCountAux
     variable = halo0
     map_index = 0
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo1]
+  []
+  [halo1]
     type = FeatureFloodCountAux
     variable = halo1
     map_index = 1
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo2]
+  []
+  [halo2]
     type = FeatureFloodCountAux
     variable = halo2
     map_index = 2
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
-  [./halo3]
+  []
+  [halo3]
     type = FeatureFloodCountAux
     variable = halo3
     map_index = 3
     field_display = HALOS
     flood_counter = grain_tracker
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/2phase_reconstruction.i
+++ b/modules/phase_field/test/tests/reconstruction/2phase_reconstruction.i
@@ -15,94 +15,96 @@
 
 [Mesh]
   # Create a mesh representing the EBSD data
-  type = EBSDMesh
-  filename = 'Ti_2Phase_28x28_ebsd.txt'
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = 'Ti_2Phase_28x28_ebsd.txt'
+  []
 []
 
 [UserObjects]
-  [./ebsd]
+  [ebsd]
     # Read in the EBSD data. Uses the filename given in the mesh block.
     type = EBSDReader
-  [../]
+  []
 []
 
 [Variables]
   # Creates the two variables being initialized
-  [./c1]
-  [../]
-  [./c2]
-  [../]
+  [c1]
+  []
+  [c2]
+  []
 []
 
 [ICs]
-  [./phase1_recon]
+  [phase1_recon]
     # Initializes the variable info from the ebsd data
     type = ReconPhaseVarIC
     ebsd_reader = ebsd
     phase = 1
     variable = c1
-  [../]
-  [./phase2_recon]
+  []
+  [phase2_recon]
     type = ReconPhaseVarIC
     ebsd_reader = ebsd
     phase = 2
     variable = c2
-  [../]
+  []
 []
 #ENDDOC - End of the file section that is included in the documentation. Do not change this line!
 
 [AuxVariables]
-  [./PHI1]
+  [PHI1]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./PHI]
+  []
+  [PHI]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./APHI2]
+  []
+  [APHI2]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./PHI2]
+  []
+  [PHI2]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./PHASE]
+  []
+  [PHASE]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./phi1_aux]
+  [phi1_aux]
     type = EBSDReaderPointDataAux
     variable = PHI1
     ebsd_reader = ebsd
     data_name = 'phi1'
     execute_on = 'initial'
-  [../]
-  [./phi_aux]
+  []
+  [phi_aux]
     type = EBSDReaderPointDataAux
     variable = PHI
     ebsd_reader = ebsd
     data_name = 'phi'
     execute_on = 'initial'
-  [../]
-  [./phi2_aux]
+  []
+  [phi2_aux]
     type = EBSDReaderPointDataAux
     variable = PHI2
     ebsd_reader = ebsd
     data_name = 'phi2'
     execute_on = 'initial'
-  [../]
-  [./phase_aux]
+  []
+  [phase_aux]
     type = EBSDReaderPointDataAux
     variable = PHASE
     ebsd_reader = ebsd
     data_name = 'phase'
     execute_on = 'initial'
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/2phase_reconstruction2.i
+++ b/modules/phase_field/test/tests/reconstruction/2phase_reconstruction2.i
@@ -13,8 +13,10 @@
 # moose/docs/content/modules/phase_field/ICs/EBSD.md
 
 [Mesh]
-  type = EBSDMesh
-  filename = Ti_2Phase_28x28_ebsd.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = Ti_2Phase_28x28_ebsd.txt
+  []
 []
 
 [GlobalParams]
@@ -23,30 +25,30 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     phase = 1
     output_adjacency_matrix = true
-  [../]
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       # select only data for phase 1 from the EBSD file
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 #ENDDOC - End of the file section that is included in the documentation. Do not change this line!
 

--- a/modules/phase_field/test/tests/reconstruction/2phase_reconstruction3.i
+++ b/modules/phase_field/test/tests/reconstruction/2phase_reconstruction3.i
@@ -12,8 +12,10 @@
 []
 
 [Mesh]
-  type = EBSDMesh
-  filename = Renumbered.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = Renumbered.txt
+  []
 []
 
 [GlobalParams]
@@ -22,46 +24,46 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     phase = 1
     output_adjacency_matrix = true
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [AuxVariables]
-  [./GRAIN]
+  [GRAIN]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./grain_aux]
+  [grain_aux]
     type = EBSDReaderPointDataAux
     variable = GRAIN
     ebsd_reader = ebsd_reader
     data_name = 'feature_id'
     execute_on = 'initial'
-  [../]
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/2phase_reconstruction4.i
+++ b/modules/phase_field/test/tests/reconstruction/2phase_reconstruction4.i
@@ -10,8 +10,10 @@
 []
 
 [Mesh]
-  type = EBSDMesh
-  filename = ebsd_40x40_2_phase.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = ebsd_40x40_2_phase.txt
+  []
 []
 
 [GlobalParams]
@@ -20,50 +22,50 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     phase = 2
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     polycrystal_ic_uo = ebsd
     remap_grains = false
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./var_indices]
+  [var_indices]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./var_indices]
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/EulerAngleVariables2RGBAux.i
+++ b/modules/phase_field/test/tests/reconstruction/EulerAngleVariables2RGBAux.i
@@ -1,83 +1,85 @@
 [Mesh]
-  type = EBSDMesh
-  filename = IN100_001_28x28_Clean_Marmot.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = IN100_001_28x28_Clean_Marmot.txt
+  []
 []
 
 [UserObjects]
-  [./ebsd]
+  [ebsd]
     type = EBSDReader
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./phi1]
+  [phi1]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./phi]
+  []
+  [phi]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./phi2]
+  []
+  [phi2]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 
-  [./phase]
+  [phase]
     order = CONSTANT
     family = MONOMIAL
-  [../]
-  [./symmetry]
+  []
+  [symmetry]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 
-  [./rgb]
+  [rgb]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./phi1_aux]
+  [phi1_aux]
     type = EBSDReaderPointDataAux
     variable = phi1
     ebsd_reader = ebsd
     data_name = phi1
     execute_on = initial
-  [../]
-  [./phi_aux]
+  []
+  [phi_aux]
     type = EBSDReaderPointDataAux
     variable = phi
     ebsd_reader = ebsd
     data_name = phi
     execute_on = initial
-  [../]
-  [./phi2_aux]
+  []
+  [phi2_aux]
     type = EBSDReaderPointDataAux
     variable = phi2
     ebsd_reader = ebsd
     data_name = phi2
     execute_on = initial
-  [../]
+  []
 
-  [./phase_aux]
+  [phase_aux]
     type = EBSDReaderPointDataAux
     variable = phase
     ebsd_reader = ebsd
     data_name = phase
     execute_on = initial
-  [../]
+  []
 
-  [./symmetry_aux]
+  [symmetry_aux]
     type = EBSDReaderPointDataAux
     variable = symmetry
     ebsd_reader = ebsd
-    data_name =  symmetry
+    data_name = symmetry
     execute_on = initial
-  [../]
+  []
 
-  [./rgb]
+  [rgb]
     type = EulerAngleVariables2RGBAux
     variable = rgb
     phi1 = phi1
@@ -86,7 +88,7 @@
     phase = phase
     symmetry = symmetry
     execute_on = initial
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/euler2rgb_no_grain_region.i
+++ b/modules/phase_field/test/tests/reconstruction/euler2rgb_no_grain_region.i
@@ -1,6 +1,8 @@
 [Mesh]
-  type = EBSDMesh
-  filename = ebsd_small.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = ebsd_small.txt
+  []
 []
 
 [GlobalParams]
@@ -9,80 +11,80 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
     execute_on = initial
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = bt
     ebsd_reader = ebsd_reader
     phase = 2
     output_adjacency_matrix = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
-  [./void_phase]
+    []
+  []
+  [void_phase]
     type = ReconPhaseVarIC
     variable = c
     ebsd_reader = ebsd_reader
     phase = 1
-  [../]
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [AuxVariables]
-#  active = 'c bnds'
+  #  active = 'c bnds'
 
-  [./c]
-  [../]
-  [./bnds]
-  [../]
-  [./ebsd_numbers]
+  [c]
+  []
+  [bnds]
+  []
+  [ebsd_numbers]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 
   # Note: Not active
-  [./unique_grains]
+  [unique_grains]
     family = MONOMIAL
     order = CONSTANT
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     family = MONOMIAL
     order = CONSTANT
-  [../]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
+  [PolycrystalKernel]
     c = c
-  [../]
+  []
 []
 
 [AuxKernels]
-#  active = 'BndsCalc'
+  #  active = 'BndsCalc'
 
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
-  [./ebsd_numbers]
+  []
+  [ebsd_numbers]
     type = EBSDReaderAvgDataAux
     data_name = feature_id
     ebsd_reader = ebsd_reader
@@ -90,39 +92,39 @@
     variable = ebsd_numbers
     phase = 2
     execute_on = 'initial timestep_end'
-  [../]
+  []
 
   # Note: Not active
-  [./unique_grains]
+  [unique_grains]
     type = FeatureFloodCountAux
     variable = unique_grains
     flood_counter = grain_tracker
     field_display = UNIQUE_REGION
     execute_on = 'initial timestep_end'
-  [../]
-  [./var_indices]
+  []
+  [var_indices]
     type = FeatureFloodCountAux
     variable = var_indices
     flood_counter = grain_tracker
     field_display = VARIABLE_COLORING
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [Modules]
-  [./PhaseField]
-    [./EulerAngles2RGB]
+  [PhaseField]
+    [EulerAngles2RGB]
       crystal_structure = cubic
       grain_tracker = grain_tracker
       euler_angle_provider = ebsd_reader
       no_grain_color = '.1 .1 .1'
       phase = 2
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./bulk]
+  [bulk]
     type = GBEvolution
     block = 0
     T = 2273
@@ -132,7 +134,7 @@
     Q = 2.77
     length_scale = 1.0e-6
     time_scale = 60.0
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/euler2rgb_non_uniform_orientation.i
+++ b/modules/phase_field/test/tests/reconstruction/euler2rgb_non_uniform_orientation.i
@@ -1,6 +1,8 @@
 [Mesh]
-  type = EBSDMesh
-  filename = ebsd_scan.txt
+  [ebsd_mesh]
+    type = EBSDMeshGenerator
+    filename = ebsd_scan.txt
+  []
 []
 
 [GlobalParams]
@@ -9,95 +11,95 @@
 []
 
 [UserObjects]
-  [./ebsd_reader]
+  [ebsd_reader]
     type = EBSDReader
     bins = 40
-  [../]
-  [./ebsd]
+  []
+  [ebsd]
     type = PolycrystalEBSD
     coloring_algorithm = jp
     ebsd_reader = ebsd_reader
     enable_var_coloring = true
-  [../]
-  [./grain_tracker]
+  []
+  [grain_tracker]
     type = GrainTracker
     flood_entity_type = ELEMENTAL
     compute_halo_maps = true # For displaying HALO fields
     polycrystal_ic_uo = ebsd
-  [../]
+  []
 []
 
 [ICs]
-  [./PolycrystalICs]
-    [./PolycrystalColoringIC]
+  [PolycrystalICs]
+    [PolycrystalColoringIC]
       polycrystal_ic_uo = ebsd
-    [../]
-  [../]
+    []
+  []
 []
 
 [Variables]
-  [./PolycrystalVariables]
-  [../]
+  [PolycrystalVariables]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
-  [../]
+  [bnds]
+  []
 []
 
 [Kernels]
-  [./PolycrystalKernel]
-  [../]
+  [PolycrystalKernel]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = 'initial timestep_end'
-  [../]
+  []
 []
 
 [Modules]
-  [./PhaseField]
-    [./EulerAngles2RGB]
+  [PhaseField]
+    [EulerAngles2RGB]
       crystal_structure = cubic
       euler_angle_provider = ebsd_reader
       grain_tracker = grain_tracker
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./Copper]
+  [Copper]
     # T = 500 # K
     type = GBEvolution
     T = 500
-    wGB = 0.6               # um
-    GBmob0 = 2.5e-6         # m^4/(Js) from Schoenfelder 1997
-    Q = 0.23                # Migration energy in eV
-    GBenergy = 0.708        # GB energy in J/m^2
-    molar_volume = 7.11e-6  # Molar volume in m^3/mol
+    wGB = 0.6 # um
+    GBmob0 = 2.5e-6 # m^4/(Js) from Schoenfelder 1997
+    Q = 0.23 # Migration energy in eV
+    GBenergy = 0.708 # GB energy in J/m^2
+    molar_volume = 7.11e-6 # Molar volume in m^3/mol
     length_scale = 1.0e-6
     time_scale = 1.0e-6
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./dt]
+  [dt]
     type = TimestepSize
-  [../]
-  [./n_elements]
+  []
+  [n_elements]
     type = NumElems
     execute_on = 'initial timestep_end'
-  [../]
-  [./n_nodes]
+  []
+  [n_nodes]
     type = NumNodes
     execute_on = 'initial timestep_end'
-  [../]
-  [./DOFs]
+  []
+  [DOFs]
     type = NumDOFs
-  [../]
+  []
 []
 
 [Executioner]

--- a/modules/phase_field/test/tests/reconstruction/tests
+++ b/modules/phase_field/test/tests/reconstruction/tests
@@ -25,7 +25,7 @@
     input = '1phase_reconstruction.i'
 
     # Read in a 2-phase file but ignore phase
-    cli_args = 'Mesh/filename=ebsd_40x40_2_phase.txt GlobalParams/op_num=6 Outputs/file_base=1phase_reconstruction_40x40_out'
+    cli_args = 'Mesh/ebsd_mesh/filename=ebsd_40x40_2_phase.txt GlobalParams/op_num=6 Outputs/file_base=1phase_reconstruction_40x40_out'
     exodiff = '1phase_reconstruction_40x40_out.e'
 
     issues = "#9110"


### PR DESCRIPTION
Closes #16062 

Helpful deprecation message:

```
examples/ebsd_reconstruction.IN100-111grn: *** ERROR ***
examples/ebsd_reconstruction.IN100-111grn:
examples/ebsd_reconstruction.IN100-111grn:
examples/ebsd_reconstruction.IN100-111grn: Deprecated code:
examples/ebsd_reconstruction.IN100-111grn: EBSDMesh is deprecated, please use the EBSDMeshGenerator instead. For example:
examples/ebsd_reconstruction.IN100-111grn:
examples/ebsd_reconstruction.IN100-111grn: [Mesh]
examples/ebsd_reconstruction.IN100-111grn:   type = EBDSMesh
examples/ebsd_reconstruction.IN100-111grn:   filename = my_ebsd_data.dat
examples/ebsd_reconstruction.IN100-111grn: []
examples/ebsd_reconstruction.IN100-111grn:
examples/ebsd_reconstruction.IN100-111grn: becomes
examples/ebsd_reconstruction.IN100-111grn:
examples/ebsd_reconstruction.IN100-111grn: [Mesh]
examples/ebsd_reconstruction.IN100-111grn:   [ebsd_mesh]
examples/ebsd_reconstruction.IN100-111grn:     type = EBDSMeshGenerator
examples/ebsd_reconstruction.IN100-111grn:     filename = my_ebsd_data.dat
examples/ebsd_reconstruction.IN100-111grn:   []
examples/ebsd_reconstruction.IN100-111grn: []
examples/ebsd_reconstruction.IN100-111grn:
```