### PR TITLE
Residual object

### DIFF
--- a/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEx.h
+++ b/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEx.h
@@ -62,7 +62,7 @@ protected:
    * Note that this can be an approximation or linearization.  In this case it's
    * not because the Jacobian of this operator is easy to calculate.
    */
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   /**
    * Needed for computing off-diagonal terms in Jacobian
@@ -74,4 +74,3 @@ protected:
    */
   const VariableValue & _y;
 };
-

--- a/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEy.h
+++ b/examples/ex18_scalar_kernel/include/scalarkernels/ImplicitODEy.h
@@ -61,7 +61,7 @@ protected:
    * This is essentially the partial derivative of the residual with respect to
    * the variable that is coupled into this kernel.
    */
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   /**
    * Needed for computing off-diagonal terms in Jacobian
@@ -73,4 +73,3 @@ protected:
    */
   const VariableValue & _x;
 };
-

--- a/examples/ex18_scalar_kernel/src/scalarkernels/ImplicitODEx.C
+++ b/examples/ex18_scalar_kernel/src/scalarkernels/ImplicitODEx.C
@@ -48,7 +48,7 @@ ImplicitODEx::computeQpJacobian()
 }
 
 Real
-ImplicitODEx::computeQpOffDiagJacobian(unsigned int jvar)
+ImplicitODEx::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _y_var)
     return -2.; // dF/dy

--- a/examples/ex18_scalar_kernel/src/scalarkernels/ImplicitODEy.C
+++ b/examples/ex18_scalar_kernel/src/scalarkernels/ImplicitODEy.C
@@ -48,7 +48,7 @@ ImplicitODEy::computeQpJacobian()
 }
 
 Real
-ImplicitODEy::computeQpOffDiagJacobian(unsigned int jvar)
+ImplicitODEy::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _x_var)
     return -4.; // dF/dx

--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -1001,6 +1001,11 @@ public:
   {
     return _cm_ff_entry;
   }
+  const std::vector<std::pair<MooseVariableFieldBase *, MooseVariableFieldBase *>> &
+  couplingEntries() const
+  {
+    return _cm_ff_entry;
+  }
   std::vector<std::pair<MooseVariableFieldBase *, MooseVariableFieldBase *>> &
   nonlocalCouplingEntries()
   {

--- a/framework/include/base/NeighborResidualObject.h
+++ b/framework/include/base/NeighborResidualObject.h
@@ -1,0 +1,34 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ResidualObject.h"
+
+/**
+ * This is a base class for objects that can provide residual contributions for both local and
+ * neighbor elements
+ */
+class NeighborResidualObject : public ResidualObject
+{
+public:
+  static InputParameters validParams();
+
+  /**
+   * Class constructor.
+   * @param parameters The InputParameters for the object
+   */
+  NeighborResidualObject(const InputParameters & parameters);
+
+  /**
+   * Prepare neighbor shape functions
+   * @param var_num The variable number whose neighbor shape functions should be prepared
+   */
+  void prepareNeighborShapes(unsigned int var_num);
+};

--- a/framework/include/base/ResidualObject.h
+++ b/framework/include/base/ResidualObject.h
@@ -1,0 +1,122 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObject.h"
+#include "SetupInterface.h"
+#include "CoupleableMooseVariableDependencyIntermediateInterface.h"
+#include "FunctionInterface.h"
+#include "UserObjectInterface.h"
+#include "TransientInterface.h"
+#include "PostprocessorInterface.h"
+#include "VectorPostprocessorInterface.h"
+#include "RandomInterface.h"
+#include "Restartable.h"
+#include "MeshChangedInterface.h"
+#include "TaggingInterface.h"
+
+class MooseMesh;
+class SubProblem;
+class KernelBase;
+class Assembly;
+template <typename>
+class MooseVariableFE;
+typedef MooseVariableFE<Real> MooseVariable;
+typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
+typedef MooseVariableFE<RealEigenVector> ArrayMooseVariable;
+
+/**
+ * This is the common base class for objects that give residual contributions.
+ */
+class ResidualObject : public MooseObject,
+                       public SetupInterface,
+                       public FunctionInterface,
+                       public UserObjectInterface,
+                       public TransientInterface,
+                       public PostprocessorInterface,
+                       public VectorPostprocessorInterface,
+                       public RandomInterface,
+                       public Restartable,
+                       public MeshChangedInterface,
+                       public TaggingInterface
+{
+public:
+  static InputParameters validParams();
+
+  /**
+   * Class constructor.
+   * @param parameters The InputParameters for the object
+   * @param nodal Whether this object is applied to nodes or not
+   */
+  ResidualObject(const InputParameters & parameters, bool nodal = false);
+
+  /// Compute this object's contribution to the residual
+  virtual void computeResidual() = 0;
+
+  /// Compute this object's contribution to the diagonal Jacobian entries
+  virtual void computeJacobian() = 0;
+
+  /**
+   * Computes Jacobian block of the variable of this object with respect to a field variable
+   * @param jvar The field variable
+   */
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/) {}
+
+  /**
+   * Computes jacobian block with respect to a scalar variable
+   * @param jvar The number of the scalar variable
+   */
+  virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) {}
+
+  /**
+   * Compute this object's contribution to the diagonal Jacobian entries
+   * corresponding to nonlocal dofs of the variable
+   */
+  virtual void computeNonlocalJacobian() {}
+
+  /**
+   * Computes Jacobian entries corresponding to nonlocal dofs of the jvar
+   */
+  virtual void computeNonlocalOffDiagJacobian(unsigned int /* jvar */) {}
+
+  /**
+   * Returns the variable that this object operates on.
+   */
+  virtual const MooseVariableBase & variable() const = 0;
+
+  /**
+   * Returns a reference to the SubProblem for which this Kernel is active
+   */
+  SubProblem & subProblem() { return _subproblem; }
+
+protected:
+  virtual void precalculateResidual() {}
+  virtual void precalculateJacobian() {}
+  virtual void precalculateOffDiagJacobian(unsigned int /* jvar */) {}
+
+protected:
+  /// Reference to this kernel's SubProblem
+  SubProblem & _subproblem;
+
+  /// Reference to this kernel's FEProblemBase
+  FEProblemBase & _fe_problem;
+
+  /// Reference to the EquationSystem object
+  SystemBase & _sys;
+
+  /// The thread ID for this kernel
+  THREAD_ID _tid;
+
+  /// Reference to this Kernel's assembly object
+  Assembly & _assembly;
+
+  /// Reference to this Kernel's mesh object
+  MooseMesh & _mesh;
+};

--- a/framework/include/bcs/ADIntegratedBC.h
+++ b/framework/include/bcs/ADIntegratedBC.h
@@ -23,7 +23,7 @@ public:
 
   ADIntegratedBCTempl(const InputParameters & parameters);
 
-  MooseVariableFE<T> & variable() override { return _var; }
+  const MooseVariableFE<T> & variable() const override { return _var; }
 
 private:
   void computeJacobian() override final;

--- a/framework/include/bcs/ADIntegratedBC.h
+++ b/framework/include/bcs/ADIntegratedBC.h
@@ -27,8 +27,8 @@ public:
 
 private:
   void computeJacobian() override final;
-  void computeJacobianBlock(MooseVariableFEBase & jvar) override final;
-  void computeJacobianBlockScalar(unsigned int jvar) override final;
+  void computeOffDiagJacobian(unsigned int jvar) override final;
+  void computeOffDiagJacobianScalar(unsigned int jvar) override final;
 
 protected:
   void computeResidual() override;

--- a/framework/include/bcs/ADNodalBC.h
+++ b/framework/include/bcs/ADNodalBC.h
@@ -23,7 +23,7 @@ public:
 
   ADNodalBCTempl(const InputParameters & parameters);
 
-  MooseVariableFE<T> & variable() override { return _var; }
+  const MooseVariableFE<T> & variable() const override { return _var; }
 
 private:
   void computeResidual() override final;

--- a/framework/include/bcs/ADNodalBC.h
+++ b/framework/include/bcs/ADNodalBC.h
@@ -28,7 +28,7 @@ public:
 private:
   void computeResidual() override final;
   void computeJacobian() override final;
-  void computeOffDiagJacobian(unsigned int jvar) override final;
+  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override final;
   void computeOffDiagJacobianScalar(unsigned int jvar) override final;
 
 protected:

--- a/framework/include/bcs/ADNodalBC.h
+++ b/framework/include/bcs/ADNodalBC.h
@@ -28,7 +28,7 @@ public:
 private:
   void computeResidual() override final;
   void computeJacobian() override final;
-  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override final;
+  void computeOffDiagJacobian(unsigned int jvar) override final;
   void computeOffDiagJacobianScalar(unsigned int jvar) override final;
 
 protected:

--- a/framework/include/bcs/ArrayIntegratedBC.h
+++ b/framework/include/bcs/ArrayIntegratedBC.h
@@ -36,12 +36,12 @@ public:
   /**
    * Computes d-ivar-residual / d-jvar...
    */
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
   /**
    * Computes jacobian block with respect to a scalar variable
    * @param jvar The number of the scalar variable
    */
-  void computeJacobianBlockScalar(unsigned int jvar) override;
+  void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   /**
@@ -57,7 +57,7 @@ protected:
   /**
    * Method for computing an off-diagonal jacobian component at quadrature points.
    */
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
   {
     if (jvar.number() == _var.number())
     {
@@ -74,7 +74,7 @@ protected:
    * This is the virtual that derived classes should override for computing a full Jacobian
    * component
    */
-  virtual RealEigenMatrix computeQpOffDiagJacobianScalar(MooseVariableScalar & jvar)
+  virtual RealEigenMatrix computeQpOffDiagJacobianScalar(const MooseVariableScalar & jvar)
   {
     return RealEigenMatrix::Zero(_var.count(), (unsigned int)jvar.order() + 1);
   }
@@ -93,7 +93,7 @@ protected:
    * Put necessary evaluations depending on qp but independent on test and shape functions here for
    * off-diagonal Jacobian assembly
    */
-  virtual void initQpOffDiagJacobian(MooseVariableFEBase &) {}
+  virtual void initQpOffDiagJacobian(const MooseVariableFEBase &) {}
 
   ArrayMooseVariable & _var;
 

--- a/framework/include/bcs/ArrayIntegratedBC.h
+++ b/framework/include/bcs/ArrayIntegratedBC.h
@@ -29,7 +29,7 @@ public:
 
   ArrayIntegratedBC(const InputParameters & parameters);
 
-  virtual ArrayMooseVariable & variable() override { return _var; }
+  virtual const ArrayMooseVariable & variable() const override { return _var; }
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;

--- a/framework/include/bcs/ArrayNodalBC.h
+++ b/framework/include/bcs/ArrayNodalBC.h
@@ -32,7 +32,7 @@ public:
    * Gets the variable this BC is active on
    * @return the variable
    */
-  virtual ArrayMooseVariable & variable() override { return _var; }
+  virtual const ArrayMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(unsigned int jvar) override;

--- a/framework/include/bcs/ArrayNodalBC.h
+++ b/framework/include/bcs/ArrayNodalBC.h
@@ -35,7 +35,7 @@ public:
   virtual const ArrayMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   ArrayMooseVariable & _var;

--- a/framework/include/bcs/ArrayNodalBC.h
+++ b/framework/include/bcs/ArrayNodalBC.h
@@ -35,7 +35,7 @@ public:
   virtual const ArrayMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   ArrayMooseVariable & _var;

--- a/framework/include/bcs/BoundaryCondition.h
+++ b/framework/include/bcs/BoundaryCondition.h
@@ -10,32 +10,13 @@
 #pragma once
 
 // MOOSE
-#include "MooseObject.h"
-#include "SetupInterface.h"
+#include "ResidualObject.h"
 #include "ParallelUniqueId.h"
-#include "FunctionInterface.h"
 #include "DistributionInterface.h"
-#include "UserObjectInterface.h"
-#include "TransientInterface.h"
-#include "PostprocessorInterface.h"
-#include "VectorPostprocessorInterface.h"
 #include "GeometricSearchInterface.h"
 #include "BoundaryRestrictableRequired.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "TaggingInterface.h"
 
-// Forward declerations
-template <typename>
-class MooseVariableFE;
-typedef MooseVariableFE<Real> MooseVariable;
-typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
-class MooseMesh;
-class Problem;
-class SubProblem;
-class SystemBase;
 class BoundaryCondition;
-class Assembly;
 
 template <>
 InputParameters validParams<BoundaryCondition>();
@@ -43,19 +24,10 @@ InputParameters validParams<BoundaryCondition>();
 /**
  * Base class for creating new types of boundary conditions.
  */
-class BoundaryCondition : public MooseObject,
+class BoundaryCondition : public ResidualObject,
                           public BoundaryRestrictableRequired,
-                          public SetupInterface,
-                          public FunctionInterface,
                           public DistributionInterface,
-                          public UserObjectInterface,
-                          public TransientInterface,
-                          public PostprocessorInterface,
-                          public VectorPostprocessorInterface,
-                          public GeometricSearchInterface,
-                          public Restartable,
-                          public MeshChangedInterface,
-                          public TaggingInterface
+                          public GeometricSearchInterface
 {
 public:
   /**
@@ -66,18 +38,6 @@ public:
   BoundaryCondition(const InputParameters & parameters, bool nodal);
 
   static InputParameters validParams();
-
-  /**
-   * Get a reference to the MooseVariableFE
-   * @return Reference to MooseVariableFE
-   */
-  virtual MooseVariableFEBase & variable() = 0;
-
-  /**
-   * Get a reference to the subproblem
-   * @return Reference to SubProblem
-   */
-  SubProblem & subProblem() { return _subproblem; }
 
   /**
    * Hook for turning the boundary condition on and off.
@@ -91,23 +51,4 @@ public:
    * @return true if the boundary condition should be applied, otherwise false
    */
   virtual bool shouldApply() { return true; }
-
-protected:
-  /// Reference to SubProblem
-  SubProblem & _subproblem;
-
-  /// Reference to FEProblemBase
-  FEProblemBase & _fe_problem;
-
-  /// Reference to SystemBase
-  SystemBase & _sys;
-
-  /// Thread id
-  THREAD_ID _tid;
-
-  /// Reference to assembly
-  Assembly & _assembly;
-
-  /// Mesh this BC is defined on
-  MooseMesh & _mesh;
 };

--- a/framework/include/bcs/IntegratedBC.h
+++ b/framework/include/bcs/IntegratedBC.h
@@ -28,7 +28,7 @@ public:
 
   IntegratedBC(const InputParameters & parameters);
 
-  virtual MooseVariable & variable() override { return _var; }
+  virtual const MooseVariable & variable() const override { return _var; }
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;

--- a/framework/include/bcs/IntegratedBC.h
+++ b/framework/include/bcs/IntegratedBC.h
@@ -37,10 +37,6 @@ public:
    */
   virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
   /**
-   * Deprecated method
-   */
-  virtual void computeJacobianBlock(unsigned jvar);
-  /**
    * Computes jacobian block with respect to a scalar variable
    * @param jvar The number of the scalar variable
    */
@@ -61,6 +57,11 @@ protected:
    * Method for computing an off-diagonal jacobian component at quadrature points.
    */
   virtual Real computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
+
+  /**
+   * Method for computing an off-diagonal jacobian component from a scalar var.
+   */
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int /*jvar*/) { return 0; }
 
   MooseVariable & _var;
 

--- a/framework/include/bcs/IntegratedBC.h
+++ b/framework/include/bcs/IntegratedBC.h
@@ -61,7 +61,11 @@ protected:
   /**
    * Method for computing an off-diagonal jacobian component from a scalar var.
    */
-  virtual Real computeQpOffDiagJacobianScalar(unsigned int /*jvar*/) { return 0; }
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar)
+  {
+    // Backwards compatibility
+    return computeQpOffDiagJacobian(jvar);
+  }
 
   MooseVariable & _var;
 

--- a/framework/include/bcs/IntegratedBC.h
+++ b/framework/include/bcs/IntegratedBC.h
@@ -35,12 +35,12 @@ public:
   /**
    * Computes d-ivar-residual / d-jvar...
    */
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
   /**
    * Computes jacobian block with respect to a scalar variable
    * @param jvar The number of the scalar variable
    */
-  void computeJacobianBlockScalar(unsigned int jvar) override;
+  void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   /**

--- a/framework/include/bcs/IntegratedBCBase.h
+++ b/framework/include/bcs/IntegratedBCBase.h
@@ -31,15 +31,7 @@ public:
 
   IntegratedBCBase(const InputParameters & parameters);
 
-  /**
-   * Computes d-ivar-residual / d-jvar...
-   */
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) = 0;
-  /**
-   * Computes jacobian block with respect to a scalar variable
-   * @param jvar The number of the scalar variable
-   */
-  virtual void computeJacobianBlockScalar(unsigned int jvar) = 0;
+  void prepareShapes(unsigned int var_num) override final;
 
 protected:
   /// current element

--- a/framework/include/bcs/IntegratedBCBase.h
+++ b/framework/include/bcs/IntegratedBCBase.h
@@ -10,16 +10,11 @@
 #pragma once
 
 #include "BoundaryCondition.h"
-#include "RandomInterface.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
 #include "MaterialPropertyInterface.h"
 
 // Forward declarations
 class IntegratedBCBase;
-template <typename>
-class MooseVariableFE;
-typedef MooseVariableFE<Real> MooseVariable;
-typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
 
 template <>
 InputParameters validParams<IntegratedBCBase>();
@@ -28,7 +23,6 @@ InputParameters validParams<IntegratedBCBase>();
  * Base class for deriving any boundary condition of a integrated type
  */
 class IntegratedBCBase : public BoundaryCondition,
-                         public RandomInterface,
                          public CoupleableMooseVariableDependencyIntermediateInterface,
                          public MaterialPropertyInterface
 {
@@ -37,10 +31,6 @@ public:
 
   IntegratedBCBase(const InputParameters & parameters);
 
-  virtual ~IntegratedBCBase();
-
-  virtual void computeResidual() = 0;
-  virtual void computeJacobian() = 0;
   /**
    * Computes d-ivar-residual / d-jvar...
    */
@@ -50,18 +40,6 @@ public:
    * @param jvar The number of the scalar variable
    */
   virtual void computeJacobianBlockScalar(unsigned int jvar) = 0;
-
-  /**
-   * Compute this IntegratedBCBase's contribution to the diagonal Jacobian entries
-   * corresponding to nonlocal dofs of the variable
-   */
-  virtual void computeNonlocalJacobian() {}
-
-  /**
-   * Computes d-residual / d-jvar... corresponding to nonlocal dofs of the jvar
-   * and stores the result in nonlocal ke
-   */
-  virtual void computeNonlocalOffDiagJacobian(unsigned int /* jvar */) {}
 
 protected:
   /// current element

--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -34,7 +34,7 @@ public:
    * Gets the variable this BC is active on
    * @return the variable
    */
-  virtual MooseVariable & variable() override { return _var; }
+  virtual const MooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(unsigned int jvar) override;

--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -37,7 +37,7 @@ public:
   virtual const MooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   MooseVariable & _var;

--- a/framework/include/bcs/NodalBC.h
+++ b/framework/include/bcs/NodalBC.h
@@ -37,7 +37,7 @@ public:
   virtual const MooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   MooseVariable & _var;

--- a/framework/include/bcs/NodalBCBase.h
+++ b/framework/include/bcs/NodalBCBase.h
@@ -37,17 +37,6 @@ public:
 
   NodalBCBase(const InputParameters & parameters);
 
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar) = 0;
-
-  /**
-   * Compute the off-diagonal contributions from scalar variables
-   */
-  virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) override {}
-
   /**
    * Whether to verify that this object is acting on a nodal variable
    */

--- a/framework/include/bcs/NodalBCBase.h
+++ b/framework/include/bcs/NodalBCBase.h
@@ -30,7 +30,6 @@ InputParameters validParams<NodalBCBase>();
  * Base class for deriving any boundary condition that works at nodes
  */
 class NodalBCBase : public BoundaryCondition,
-                    public RandomInterface,
                     public CoupleableMooseVariableDependencyIntermediateInterface
 {
 public:
@@ -38,14 +37,16 @@ public:
 
   NodalBCBase(const InputParameters & parameters);
 
-  virtual void computeResidual() = 0;
-  virtual void computeJacobian() = 0;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar) = 0;
 
   /**
    * Compute the off-diagonal contributions from scalar variables
    */
-  virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) {}
+  virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) override {}
 
   /**
    * Whether to verify that this object is acting on a nodal variable

--- a/framework/include/bcs/NonlocalIntegratedBC.h
+++ b/framework/include/bcs/NonlocalIntegratedBC.h
@@ -40,7 +40,6 @@ public:
    */
   virtual void computeJacobian() override;
   virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
-  using IntegratedBC::computeJacobianBlock;
 
   /**
    * computeNonlocalJacobian and computeNonlocalOffDiagJacobian methods are

--- a/framework/include/bcs/NonlocalIntegratedBC.h
+++ b/framework/include/bcs/NonlocalIntegratedBC.h
@@ -39,7 +39,7 @@ public:
    * jocobians of the integral term from userobject once per dof
    */
   virtual void computeJacobian() override;
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * computeNonlocalJacobian and computeNonlocalOffDiagJacobian methods are

--- a/framework/include/bcs/OneDEqualValueConstraintBC.h
+++ b/framework/include/bcs/OneDEqualValueConstraintBC.h
@@ -32,7 +32,7 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   VariableValue & _lambda;
   unsigned int _lambda_var_number;

--- a/framework/include/bcs/VectorIntegratedBC.h
+++ b/framework/include/bcs/VectorIntegratedBC.h
@@ -28,7 +28,7 @@ public:
 
   VectorIntegratedBC(const InputParameters & parameters);
 
-  virtual VectorMooseVariable & variable() override { return _var; }
+  virtual const VectorMooseVariable & variable() const override { return _var; }
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;

--- a/framework/include/bcs/VectorIntegratedBC.h
+++ b/framework/include/bcs/VectorIntegratedBC.h
@@ -35,12 +35,12 @@ public:
   /**
    * Computes d-ivar-residual / d-jvar...
    */
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
   /**
    * Computes jacobian block with respect to a scalar variable
    * @param jvar The number of the scalar variable
    */
-  void computeJacobianBlockScalar(unsigned int jvar) override;
+  void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   /**

--- a/framework/include/bcs/VectorIntegratedBC.h
+++ b/framework/include/bcs/VectorIntegratedBC.h
@@ -58,6 +58,11 @@ protected:
    */
   virtual Real computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
 
+  /**
+   * Method for computing an off-diagonal jacobian component from a scalar var.
+   */
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int /*jvar*/) { return 0; }
+
   VectorMooseVariable & _var;
 
   /// normals at quadrature points

--- a/framework/include/bcs/VectorNodalBC.h
+++ b/framework/include/bcs/VectorNodalBC.h
@@ -32,7 +32,7 @@ public:
    * Gets the variable this BC is active on
    * @return the variable
    */
-  virtual VectorMooseVariable & variable() override { return _var; }
+  virtual const VectorMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(unsigned int jvar) override;

--- a/framework/include/bcs/VectorNodalBC.h
+++ b/framework/include/bcs/VectorNodalBC.h
@@ -35,7 +35,7 @@ public:
   virtual const VectorMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   VectorMooseVariable & _var;

--- a/framework/include/bcs/VectorNodalBC.h
+++ b/framework/include/bcs/VectorNodalBC.h
@@ -35,7 +35,7 @@ public:
   virtual const VectorMooseVariable & variable() const override { return _var; }
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   VectorMooseVariable & _var;

--- a/framework/include/constraints/Constraint.h
+++ b/framework/include/constraints/Constraint.h
@@ -10,25 +10,11 @@
 #pragma once
 
 // MOOSE includes
-#include "MooseObject.h"
-#include "SetupInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "TransientInterface.h"
+#include "ResidualObject.h"
 #include "GeometricSearchInterface.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "TaggingInterface.h"
 
 // Forward Declarations
-class Assembly;
 class Constraint;
-template <typename>
-class MooseVariableFE;
-typedef MooseVariableFE<Real> MooseVariable;
-typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
-class SubProblem;
-class MooseMesh;
 
 template <>
 InputParameters validParams<Constraint>();
@@ -36,27 +22,12 @@ InputParameters validParams<Constraint>();
 /**
  * Base class for all Constraint types
  */
-class Constraint : public MooseObject,
-                   public SetupInterface,
-                   public FunctionInterface,
-                   public UserObjectInterface,
-                   public TransientInterface,
-                   protected GeometricSearchInterface,
-                   public Restartable,
-                   public MeshChangedInterface,
-                   public TaggingInterface
+class Constraint : public ResidualObject, protected GeometricSearchInterface
 {
 public:
   static InputParameters validParams();
 
   Constraint(const InputParameters & parameters);
-  virtual ~Constraint();
-
-  /**
-   * Subproblem this constraint is part of
-   * @return The reference to the subproblem
-   */
-  SubProblem & subProblem() { return _subproblem; }
 
   virtual bool addCouplingEntriesToJacobian() { return true; }
   virtual void subdomainSetup() override final
@@ -67,13 +38,6 @@ public:
   virtual void residualEnd() {}
 
 protected:
-  SystemBase & _sys;
-
-  THREAD_ID _tid;
-
-  Assembly & _assembly;
-  MooseMesh & _mesh;
-
   unsigned int _i, _j;
   unsigned int _qp;
 };

--- a/framework/include/constraints/Constraint.h
+++ b/framework/include/constraints/Constraint.h
@@ -10,7 +10,7 @@
 #pragma once
 
 // MOOSE includes
-#include "ResidualObject.h"
+#include "NeighborResidualObject.h"
 #include "GeometricSearchInterface.h"
 
 // Forward Declarations
@@ -22,7 +22,7 @@ InputParameters validParams<Constraint>();
 /**
  * Base class for all Constraint types
  */
-class Constraint : public ResidualObject, protected GeometricSearchInterface
+class Constraint : public NeighborResidualObject, protected GeometricSearchInterface
 {
 public:
   static InputParameters validParams();

--- a/framework/include/constraints/CoupledTiedValueConstraint.h
+++ b/framework/include/constraints/CoupledTiedValueConstraint.h
@@ -41,4 +41,3 @@ protected:
   const Real _scaling;
   NumericVector<Number> & _residual_copy;
 };
-

--- a/framework/include/constraints/ElemElemConstraint.h
+++ b/framework/include/constraints/ElemElemConstraint.h
@@ -48,7 +48,7 @@ public:
   /**
    * Computes the residual for the current side.
    */
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /**
    * Computes the element/neighbor-element/neighbor Jacobian
@@ -58,7 +58,7 @@ public:
   /**
    * Computes the jacobian for the current side.
    */
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /**
    * Get the interface ID
@@ -68,7 +68,7 @@ public:
   /**
    * The variable number that this object operates on.
    */
-  MooseVariable & variable() { return _var; }
+  const MooseVariable & variable() const override { return _var; }
 
 protected:
   FEProblemBase & _fe_problem;
@@ -133,4 +133,3 @@ protected:
    */
   virtual Real computeQpJacobian(Moose::DGJacobianType type) = 0;
 };
-

--- a/framework/include/constraints/EqualValueEmbeddedConstraint.h
+++ b/framework/include/constraints/EqualValueEmbeddedConstraint.h
@@ -34,7 +34,7 @@ public:
   virtual void residualEnd() override{};
 
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   virtual bool addCouplingEntriesToJacobian() override { return true; }
 

--- a/framework/include/constraints/EqualValueEmbeddedConstraint.h
+++ b/framework/include/constraints/EqualValueEmbeddedConstraint.h
@@ -34,7 +34,7 @@ public:
   virtual void residualEnd() override{};
 
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual bool addCouplingEntriesToJacobian() override { return true; }
 

--- a/framework/include/constraints/MortarConstraintBase.h
+++ b/framework/include/constraints/MortarConstraintBase.h
@@ -50,6 +50,15 @@ public:
 
   MortarConstraintBase(const InputParameters & parameters);
 
+  virtual void computeResidual() override final
+  {
+    mooseError("MortarConstraintBase do not need computeResidual()");
+  }
+  virtual void computeJacobian() override final
+  {
+    mooseError("MortarConstraintBase do not need computeJacobian()");
+  }
+
   /**
    * Method for computing the residual
    * @param has_primary Whether the mortar segment element projects onto the primary face
@@ -75,7 +84,7 @@ public:
   /**
    * The variable number that this object operates on.
    */
-  const MooseVariable * variable() const { return _var; }
+  const MooseVariable & variable() const override { return *_var; }
 
   /**
    * Whether to use dual mortar

--- a/framework/include/constraints/NodalConstraint.h
+++ b/framework/include/constraints/NodalConstraint.h
@@ -72,17 +72,25 @@ public:
   /**
    * Computes the nodal residual.
    */
+  virtual void computeResidual() override final
+  {
+    mooseError("NodalConstraint do not need computeResidual()");
+  }
   virtual void computeResidual(NumericVector<Number> & residual);
 
   /**
    * Computes the jacobian for the current element.
    */
+  virtual void computeJacobian() override final
+  {
+    mooseError("NodalConstraint do not need computeJacobian()");
+  }
   virtual void computeJacobian(SparseMatrix<Number> & jacobian);
 
   /**
    * The variable number that this object operates on.
    */
-  MooseVariable & variable() { return _var; }
+  const MooseVariable & variable() const override { return _var; }
 
 protected:
   /**

--- a/framework/include/constraints/NodeElemConstraint.h
+++ b/framework/include/constraints/NodeElemConstraint.h
@@ -51,11 +51,7 @@ public:
   virtual void computeJacobian() override;
 
   /// Computes d-residual / d-jvar...
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   /// Gets the indices for all dofs connected to the constraint
   virtual void getConnectedDofIndices(unsigned int var_num);

--- a/framework/include/constraints/NodeElemConstraint.h
+++ b/framework/include/constraints/NodeElemConstraint.h
@@ -51,7 +51,7 @@ public:
   virtual void computeJacobian() override;
 
   /// Computes d-residual / d-jvar...
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// Gets the indices for all dofs connected to the constraint
   virtual void getConnectedDofIndices(unsigned int var_num);

--- a/framework/include/constraints/NodeElemConstraint.h
+++ b/framework/include/constraints/NodeElemConstraint.h
@@ -45,12 +45,16 @@ public:
   void computeSecondaryValue(NumericVector<Number> & current_solution);
 
   /// Computes the residual Nodal residual.
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /// Computes the jacobian for the current element.
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /// Computes d-residual / d-jvar...
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
   /// Gets the indices for all dofs connected to the constraint
@@ -85,7 +89,7 @@ public:
   /**
    * The variable number that this object operates on.
    */
-  MooseVariable & variable() { return _var; }
+  const MooseVariable & variable() const override { return _var; }
 
 protected:
   /// prepare the _secondary_to_primary_map

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -63,11 +63,7 @@ public:
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   /**
    * Gets the indices for all dofs connected to the constraint

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -63,7 +63,7 @@ public:
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Gets the indices for all dofs connected to the constraint

--- a/framework/include/constraints/NodeFaceConstraint.h
+++ b/framework/include/constraints/NodeFaceConstraint.h
@@ -53,16 +53,20 @@ public:
   /**
    * Computes the residual Nodal residual.
    */
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /**
    * Computes the jacobian for the current element.
    */
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /**
    * Computes d-residual / d-jvar...
    */
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
   /**
@@ -101,7 +105,7 @@ public:
   /**
    * The variable number that this object operates on.
    */
-  MooseVariable & variable() { return _var; }
+  const MooseVariable & variable() const override { return _var; }
 
   // TODO: Make this protected or add an accessor
   // Do the same for all the other public members

--- a/framework/include/dgkernels/ADDGKernel.h
+++ b/framework/include/dgkernels/ADDGKernel.h
@@ -24,9 +24,9 @@ private:
   void computeElemNeighResidual(Moose::DGResidualType type) override final;
   void computeElemNeighJacobian(Moose::DGJacobianType type) override final;
   void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                       MooseVariableFEBase & jvar) override final;
+                                       const MooseVariableFEBase & jvar) override final;
   void computeJacobian() override final;
-  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override final;
+  void computeOffDiagJacobian(unsigned int jvar) override final;
 
 protected:
   const MooseVariableFEBase & variable() const override { return _var; }

--- a/framework/include/dgkernels/ADDGKernel.h
+++ b/framework/include/dgkernels/ADDGKernel.h
@@ -24,9 +24,9 @@ private:
   void computeElemNeighResidual(Moose::DGResidualType type) override final;
   void computeElemNeighJacobian(Moose::DGJacobianType type) override final;
   void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                       unsigned int jvar) override final;
+                                       MooseVariableFEBase & jvar) override final;
   void computeJacobian() override final;
-  void computeOffDiagJacobian(unsigned int jvar) override final;
+  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override final;
 
 protected:
   const MooseVariableFEBase & variable() const override { return _var; }

--- a/framework/include/dgkernels/ADDGKernel.h
+++ b/framework/include/dgkernels/ADDGKernel.h
@@ -29,7 +29,7 @@ private:
   void computeOffDiagJacobian(unsigned int jvar) override final;
 
 protected:
-  MooseVariableFEBase & variable() override { return _var; }
+  const MooseVariableFEBase & variable() const override { return _var; }
 
   /// Compute this Kernel's contribution to the residual at the current quadrature point
   virtual ADReal computeQpResidual(Moose::DGResidualType type) = 0;

--- a/framework/include/dgkernels/ArrayDGKernel.h
+++ b/framework/include/dgkernels/ArrayDGKernel.h
@@ -54,13 +54,13 @@ public:
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   /**
    * Computes the element-element off-diagonal Jacobian
    */
   virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               unsigned int jvar) override;
+                                               MooseVariableFEBase & jvar) override;
 
 protected:
   /**

--- a/framework/include/dgkernels/ArrayDGKernel.h
+++ b/framework/include/dgkernels/ArrayDGKernel.h
@@ -54,13 +54,13 @@ public:
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Computes the element-element off-diagonal Jacobian
    */
   virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               MooseVariableFEBase & jvar) override;
+                                               const MooseVariableFEBase & jvar) override;
 
 protected:
   /**
@@ -79,7 +79,7 @@ protected:
    * This is the virtual that derived classes should override for computing the off-diag Jacobian.
    */
   virtual RealEigenMatrix computeQpOffDiagJacobian(Moose::DGJacobianType type,
-                                                   MooseVariableFEBase & jvar)
+                                                   const MooseVariableFEBase & jvar)
   {
     if (jvar.number() == _var.number())
     {
@@ -106,7 +106,7 @@ protected:
    * Put necessary evaluations depending on qp but independent on test and shape functions here for
    * off-diagonal Jacobian assembly
    */
-  virtual void initQpOffDiagJacobian(Moose::DGJacobianType, MooseVariableFEBase &) {}
+  virtual void initQpOffDiagJacobian(Moose::DGJacobianType, const MooseVariableFEBase &) {}
 
   /// Variable this kernel operates on
   ArrayMooseVariable & _var;

--- a/framework/include/dgkernels/ArrayDGKernel.h
+++ b/framework/include/dgkernels/ArrayDGKernel.h
@@ -39,7 +39,7 @@ public:
   /**
    * The variable that this kernel operates on.
    */
-  virtual MooseVariableFEBase & variable() override { return _var; }
+  virtual const MooseVariableFEBase & variable() const override { return _var; }
 
   /**
    * Computes the residual for this element or the neighbor

--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -37,7 +37,7 @@ public:
   /**
    * The variable that this kernel operates on.
    */
-  virtual MooseVariableFEBase & variable() override { return _var; }
+  virtual const MooseVariableFEBase & variable() const override { return _var; }
 
   /**
    * Computes the residual for this element or the neighbor

--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -53,7 +53,7 @@ public:
    * Computes the element-element off-diagonal Jacobian
    */
   virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               MooseVariableFEBase & jvar) override;
+                                               const MooseVariableFEBase & jvar) override;
 
 protected:
   /**

--- a/framework/include/dgkernels/DGKernel.h
+++ b/framework/include/dgkernels/DGKernel.h
@@ -53,7 +53,7 @@ public:
    * Computes the element-element off-diagonal Jacobian
    */
   virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               unsigned int jvar) override;
+                                               MooseVariableFEBase & jvar) override;
 
 protected:
   /**

--- a/framework/include/dgkernels/DGKernelBase.h
+++ b/framework/include/dgkernels/DGKernelBase.h
@@ -75,16 +75,13 @@ public:
   /**
    * Computes the element-element off-diagonal Jacobian
    */
-  virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsigned int jvar) = 0;
+  virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
+                                               MooseVariableFEBase & jvar) = 0;
 
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   /// Current element

--- a/framework/include/dgkernels/DGKernelBase.h
+++ b/framework/include/dgkernels/DGKernelBase.h
@@ -11,7 +11,7 @@
 
 // local includes
 #include "MooseArray.h"
-#include "ResidualObject.h"
+#include "NeighborResidualObject.h"
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
 #include "NeighborCoupleableMooseVariableDependencyIntermediateInterface.h"
@@ -35,7 +35,7 @@ InputParameters validParams<DGKernelBase>();
 /**
  * Serves as a base class for DGKernel and ADDGKernel
  */
-class DGKernelBase : public ResidualObject,
+class DGKernelBase : public NeighborResidualObject,
                      public BlockRestrictable,
                      public BoundaryRestrictable,
                      public NeighborCoupleableMooseVariableDependencyIntermediateInterface,
@@ -76,12 +76,14 @@ public:
    * Computes the element-element off-diagonal Jacobian
    */
   virtual void computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               MooseVariableFEBase & jvar) = 0;
+                                               const MooseVariableFEBase & jvar) = 0;
 
   /**
    * Computes d-residual / d-jvar...
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+
+  void prepareShapes(unsigned int var_num) override final;
 
 protected:
   /// Current element

--- a/framework/include/dgkernels/DGKernelBase.h
+++ b/framework/include/dgkernels/DGKernelBase.h
@@ -11,26 +11,16 @@
 
 // local includes
 #include "MooseArray.h"
-#include "MooseObject.h"
+#include "ResidualObject.h"
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
-#include "SetupInterface.h"
-#include "TransientInterface.h"
-#include "UserObjectInterface.h"
 #include "NeighborCoupleableMooseVariableDependencyIntermediateInterface.h"
-#include "FunctionInterface.h"
 #include "TwoMaterialPropertyInterface.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "TaggingInterface.h"
 #include "ElementIDInterface.h"
 
 #include "Assembly.h"
 
 // Forward Declarations
-class MooseMesh;
-class SubProblem;
-
 class DGKernelBase;
 
 #define usingDGKernelBaseMembers                                                                   \
@@ -45,18 +35,11 @@ InputParameters validParams<DGKernelBase>();
 /**
  * Serves as a base class for DGKernel and ADDGKernel
  */
-class DGKernelBase : public MooseObject,
+class DGKernelBase : public ResidualObject,
                      public BlockRestrictable,
                      public BoundaryRestrictable,
-                     public SetupInterface,
-                     public TransientInterface,
-                     public FunctionInterface,
-                     public UserObjectInterface,
                      public NeighborCoupleableMooseVariableDependencyIntermediateInterface,
                      public TwoMaterialPropertyInterface,
-                     public Restartable,
-                     public MeshChangedInterface,
-                     public TaggingInterface,
                      public ElementIDInterface
 {
 public:
@@ -69,18 +52,6 @@ public:
 
   DGKernelBase(const InputParameters & parameters);
 
-  virtual ~DGKernelBase();
-
-  /**
-   * The variable this kernel operating on.
-   */
-  virtual MooseVariableFEBase & variable() = 0;
-
-  /**
-   * Return a reference to the subproblem.
-   */
-  SubProblem & subProblem() { return _subproblem; }
-
   /**
    * Computes the residual for this element or the neighbor
    */
@@ -89,7 +60,7 @@ public:
   /**
    * Computes the residual for the current side.
    */
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /**
    * Computes the element/neighbor-element/neighbor Jacobian
@@ -99,7 +70,7 @@ public:
   /**
    * Computes the jacobian for the current side.
    */
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /**
    * Computes the element-element off-diagonal Jacobian
@@ -109,17 +80,14 @@ public:
   /**
    * Computes d-residual / d-jvar...
    */
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
 protected:
-  SubProblem & _subproblem;
-  SystemBase & _sys;
-
-  THREAD_ID _tid;
-
-  Assembly & _assembly;
-  MooseMesh & _mesh;
-
+  /// Current element
   const Elem * const & _current_elem;
 
   /// The volume (or length) of the current element

--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -60,11 +60,7 @@ public:
   /**
    * Computes the off-diagonal Jacobian for variable jvar.
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   virtual const MooseVariableField<Real> & variable() const override { return _var; }
 

--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -60,7 +60,7 @@ public:
   /**
    * Computes the off-diagonal Jacobian for variable jvar.
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual const MooseVariableField<Real> & variable() const override { return _var; }
 

--- a/framework/include/dirackernels/DiracKernel.h
+++ b/framework/include/dirackernels/DiracKernel.h
@@ -11,26 +11,15 @@
 
 // MOOSE includes
 #include "DiracKernelInfo.h"
-#include "MooseObject.h"
-#include "SetupInterface.h"
+#include "ResidualObject.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
 #include "MaterialPropertyInterface.h"
-#include "TransientInterface.h"
-#include "PostprocessorInterface.h"
 #include "GeometricSearchInterface.h"
 #include "MooseVariableField.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
 #include "MooseVariableInterface.h"
-#include "TaggingInterface.h"
 
 // Forward Declarations
-class Assembly;
 class DiracKernel;
-class SubProblem;
-class MooseMesh;
 
 template <>
 InputParameters validParams<DiracKernel>();
@@ -42,35 +31,26 @@ InputParameters validParams<DiracKernel>();
  *
  * This is common in point sources / sinks and various other algorithms.
  */
-class DiracKernel : public MooseObject,
-                    public SetupInterface,
+class DiracKernel : public ResidualObject,
                     public CoupleableMooseVariableDependencyIntermediateInterface,
                     public MooseVariableInterface<Real>,
-                    public FunctionInterface,
-                    public UserObjectInterface,
-                    public TransientInterface,
                     public MaterialPropertyInterface,
-                    public PostprocessorInterface,
-                    protected GeometricSearchInterface,
-                    public Restartable,
-                    public MeshChangedInterface,
-                    public TaggingInterface
+                    protected GeometricSearchInterface
 {
 public:
   static InputParameters validParams();
 
   DiracKernel(const InputParameters & parameters);
-  virtual ~DiracKernel() {}
 
   /**
    * Computes the residual for the current element.
    */
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /**
    * Computes the jacobian for the current element.
    */
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /**
    * This gets called by computeOffDiagJacobian() at each quadrature point.
@@ -80,17 +60,13 @@ public:
   /**
    * Computes the off-diagonal Jacobian for variable jvar.
    */
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
-  /**
-   * The variable number that this kernel operates on.
-   */
-  MooseVariableField<Real> & variable();
-
-  /**
-   * Return a reference to the subproblem.
-   */
-  SubProblem & subProblem();
+  virtual const MooseVariableField<Real> & variable() const override { return _var; }
 
   /**
    * This is where the DiracKernel should call addPoint() for each point it needs to have a
@@ -153,18 +129,8 @@ protected:
    */
   unsigned currentPointCachedID();
 
-  SubProblem & _subproblem;
-  SystemBase & _sys;
-
-  THREAD_ID _tid;
-
-  Assembly & _assembly;
-
   /// Variable this kernel acts on
   MooseVariableField<Real> & _var;
-
-  /// Mesh this kernels acts on
-  MooseMesh & _mesh;
 
   /// Coordinate system
   const Moose::CoordinateSystemType & _coord_sys;

--- a/framework/include/dirackernels/VectorPostprocessorPointSource.h
+++ b/framework/include/dirackernels/VectorPostprocessorPointSource.h
@@ -11,7 +11,6 @@
 
 // Moose Includes
 #include "DiracKernel.h"
-#include "VectorPostprocessorInterface.h"
 
 // Forward Declarations
 class VectorPostprocessorPointSource;
@@ -24,7 +23,7 @@ InputParameters validParams<VectorPostprocessorPointSource>();
  * Coordinates and values are given by a vector Postprocessor.  Values and coordinates for the point
  * source are allowed change as the vector Postprocessor is updated.
  */
-class VectorPostprocessorPointSource : public DiracKernel, public VectorPostprocessorInterface
+class VectorPostprocessorPointSource : public DiracKernel
 {
 public:
   static InputParameters validParams();

--- a/framework/include/interfacekernels/ADInterfaceKernel.h
+++ b/framework/include/interfacekernels/ADInterfaceKernel.h
@@ -25,7 +25,7 @@ public:
   ADInterfaceKernelTempl(const InputParameters & parameters);
 
   /// The primary variable that this interface kernel operates on
-  MooseVariableFE<T> & variable() const override { return _var; }
+  const MooseVariableFE<T> & variable() const override { return _var; }
 
   /// The neighbor variable number that this interface kernel operates on
   const MooseVariableFE<T> & neighborVariable() const override { return _neighbor_var; }

--- a/framework/include/interfacekernels/InterfaceKernel.h
+++ b/framework/include/interfacekernels/InterfaceKernel.h
@@ -45,7 +45,7 @@ public:
   InterfaceKernelTempl(const InputParameters & parameters);
 
   /// The primary variable that this interface kernel operates on
-  virtual MooseVariableFE<T> & variable() const override { return _var; }
+  virtual const MooseVariableFE<T> & variable() const override { return _var; }
 
   /// The neighbor variable number that this interface kernel operates on
   virtual const MooseVariableFE<T> & neighborVariable() const override { return _neighbor_var; }

--- a/framework/include/interfacekernels/InterfaceKernelBase.h
+++ b/framework/include/interfacekernels/InterfaceKernelBase.h
@@ -11,7 +11,7 @@
 
 // local includes
 #include "MooseArray.h"
-#include "ResidualObject.h"
+#include "NeighborResidualObject.h"
 #include "BoundaryRestrictable.h"
 #include "NeighborCoupleableMooseVariableDependencyIntermediateInterface.h"
 #include "TwoMaterialPropertyInterface.h"
@@ -27,7 +27,7 @@ InputParameters validParams<InterfaceKernelBase>();
  * InterfaceKernelBase is the base class for all InterfaceKernel type classes.
  */
 
-class InterfaceKernelBase : public ResidualObject,
+class InterfaceKernelBase : public NeighborResidualObject,
                             public BoundaryRestrictable,
                             public NeighborCoupleableMooseVariableDependencyIntermediateInterface,
                             public TwoMaterialPropertyInterface,
@@ -66,6 +66,8 @@ public:
 
   /// Selects the correct Jacobian type and routine to call for the secondary variable jacobian
   virtual void computeNeighborOffDiagJacobian(unsigned int jvar) = 0;
+
+  void prepareShapes(unsigned int var_num) override final;
 
 protected:
   /// Compute jacobians at quadrature points

--- a/framework/include/interfacekernels/InterfaceKernelBase.h
+++ b/framework/include/interfacekernels/InterfaceKernelBase.h
@@ -11,18 +11,10 @@
 
 // local includes
 #include "MooseArray.h"
-#include "MooseObject.h"
+#include "ResidualObject.h"
 #include "BoundaryRestrictable.h"
-#include "SetupInterface.h"
-#include "TransientInterface.h"
-#include "UserObjectInterface.h"
-#include "PostprocessorInterface.h"
 #include "NeighborCoupleableMooseVariableDependencyIntermediateInterface.h"
-#include "FunctionInterface.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
 #include "TwoMaterialPropertyInterface.h"
-#include "TaggingInterface.h"
 #include "ElementIDInterface.h"
 
 // Forward Declarations
@@ -35,18 +27,10 @@ InputParameters validParams<InterfaceKernelBase>();
  * InterfaceKernelBase is the base class for all InterfaceKernel type classes.
  */
 
-class InterfaceKernelBase : public MooseObject,
+class InterfaceKernelBase : public ResidualObject,
                             public BoundaryRestrictable,
-                            public SetupInterface,
-                            public TransientInterface,
-                            public FunctionInterface,
-                            public UserObjectInterface,
-                            public PostprocessorInterface,
                             public NeighborCoupleableMooseVariableDependencyIntermediateInterface,
-                            public Restartable,
-                            public MeshChangedInterface,
                             public TwoMaterialPropertyInterface,
-                            public TaggingInterface,
                             public ElementIDInterface
 {
 public:
@@ -54,14 +38,8 @@ public:
 
   InterfaceKernelBase(const InputParameters & parameters);
 
-  /// The primary variable that this interface kernel operates on
-  virtual MooseVariableFEBase & variable() const = 0;
-
   /// The neighbor variable number that this interface kernel operates on
   virtual const MooseVariableFEBase & neighborVariable() const = 0;
-
-  /// Return a reference to the subproblem.
-  SubProblem & subProblem() { return _subproblem; }
 
   /**
    * Using the passed DGResidual type, selects the correct test function space and residual block,
@@ -89,12 +67,6 @@ public:
   /// Selects the correct Jacobian type and routine to call for the secondary variable jacobian
   virtual void computeNeighborOffDiagJacobian(unsigned int jvar) = 0;
 
-  /// Computes the residual for the current side.
-  virtual void computeResidual() = 0;
-
-  /// Computes the jacobian for the current side.
-  virtual void computeJacobian() = 0;
-
 protected:
   /// Compute jacobians at quadrature points
   virtual Real computeQpJacobian(Moose::DGJacobianType /*type*/) { return 0; }
@@ -107,21 +79,6 @@ protected:
 
   /// The volume of the current neighbor
   const Real & getNeighborElemVolume();
-
-  /// Reference to the controlling finite element problem
-  SubProblem & _subproblem;
-
-  /// Reference to the nonlinear system
-  SystemBase & _sys;
-
-  /// The thread ID
-  THREAD_ID _tid;
-
-  /// Problem assembly
-  Assembly & _assembly;
-
-  /// The problem mesh
-  MooseMesh & _mesh;
 
   /// Pointer reference to the current element
   const Elem * const & _current_elem;

--- a/framework/include/interfaces/ElementIDInterface.h
+++ b/framework/include/interfaces/ElementIDInterface.h
@@ -77,14 +77,14 @@ public:
   /**
    * Whether mesh has an element integer with a given name
    */
-  bool hasElementID(const std::string & id_name) const { return _mesh->hasElementID(id_name); }
+  bool hasElementID(const std::string & id_name) const { return _id_mesh->hasElementID(id_name); }
 
   /**
    * Return the maximum element ID for an element integer with its index
    */
   dof_id_type maxElementID(unsigned int elem_id_index) const
   {
-    return _mesh->maxElementID(elem_id_index);
+    return _id_mesh->maxElementID(elem_id_index);
   }
 
   /**
@@ -92,7 +92,7 @@ public:
    */
   dof_id_type minElementID(unsigned int elem_id_index) const
   {
-    return _mesh->minElementID(elem_id_index);
+    return _id_mesh->minElementID(elem_id_index);
   }
 
   /**
@@ -100,7 +100,7 @@ public:
    */
   bool areElemIDsIdentical(const std::string & id_name1, const std::string & id_name2) const
   {
-    return _mesh->areElemIDsIdentical(id_name1, id_name2);
+    return _id_mesh->areElemIDsIdentical(id_name1, id_name2);
   }
 
   /**
@@ -108,7 +108,7 @@ public:
    */
   std::set<dof_id_type> getAllElemIDs(unsigned int elem_id_index) const
   {
-    return _mesh->getAllElemIDs(elem_id_index);
+    return _id_mesh->getAllElemIDs(elem_id_index);
   }
 
   /**
@@ -118,7 +118,7 @@ public:
   std::set<dof_id_type> getElemIDsOnBlocks(unsigned int elem_id_index,
                                            const std::set<SubdomainID> & blks) const
   {
-    return _mesh->getElemIDsOnBlocks(elem_id_index, blks);
+    return _id_mesh->getElemIDsOnBlocks(elem_id_index, blks);
   }
 
   /**
@@ -137,5 +137,5 @@ private:
   const InputParameters & _obj_parameters;
 
   /// References to the mesh and displaced mesh (currently in the ActionWarehouse)
-  std::shared_ptr<MooseMesh> & _mesh;
+  std::shared_ptr<MooseMesh> & _id_mesh;
 };

--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -34,7 +34,7 @@ public:
 
 private:
   void computeJacobian() override final;
-  void computeOffDiagJacobian(MooseVariableFEBase &) override final;
+  void computeOffDiagJacobian(unsigned int) override final;
   void computeOffDiagJacobianScalar(unsigned int jvar) override final;
 
   /**

--- a/framework/include/kernels/ADKernel.h
+++ b/framework/include/kernels/ADKernel.h
@@ -30,7 +30,7 @@ public:
 
   void jacobianSetup() override;
 
-  MooseVariableFE<T> & variable() override { return _var; }
+  const MooseVariableFE<T> & variable() const override { return _var; }
 
 private:
   void computeJacobian() override final;

--- a/framework/include/kernels/ArrayDiffusion.h
+++ b/framework/include/kernels/ArrayDiffusion.h
@@ -26,7 +26,7 @@ public:
 protected:
   virtual RealEigenVector computeQpResidual() override;
   virtual RealEigenVector computeQpJacobian() override;
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
   /// scalar diffusion coefficient
   const MaterialProperty<Real> * const _d;

--- a/framework/include/kernels/ArrayKernel.h
+++ b/framework/include/kernels/ArrayKernel.h
@@ -40,7 +40,7 @@ public:
    */
   virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
-  virtual ArrayMooseVariable & variable() override { return _var; }
+  virtual const ArrayMooseVariable & variable() const override { return _var; }
 
 protected:
   /**

--- a/framework/include/kernels/ArrayKernel.h
+++ b/framework/include/kernels/ArrayKernel.h
@@ -32,7 +32,7 @@ public:
   virtual void computeJacobian() override;
 
   /// Computes full Jacobian of jvar and the array variable this kernel operates on
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Computes jacobian block with respect to a scalar variable
@@ -57,7 +57,7 @@ protected:
    * This is the virtual that derived classes should override for computing a full Jacobian
    * component
    */
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
   {
     if (jvar.number() == _var.number())
     {
@@ -74,7 +74,7 @@ protected:
    * This is the virtual that derived classes should override for computing a full Jacobian
    * component
    */
-  virtual RealEigenMatrix computeQpOffDiagJacobianScalar(MooseVariableScalar & jvar)
+  virtual RealEigenMatrix computeQpOffDiagJacobianScalar(const MooseVariableScalar & jvar)
   {
     return RealEigenMatrix::Zero(_var.count(), (unsigned int)jvar.order() + 1);
   }
@@ -93,7 +93,7 @@ protected:
    * Put necessary evaluations depending on qp but independent on test and shape functions here for
    * off-diagonal Jacobian assembly
    */
-  virtual void initQpOffDiagJacobian(MooseVariableFEBase & jvar)
+  virtual void initQpOffDiagJacobian(const MooseVariableFEBase & jvar)
   {
     if (jvar.number() == _var.number())
       initQpJacobian();

--- a/framework/include/kernels/ArrayReaction.h
+++ b/framework/include/kernels/ArrayReaction.h
@@ -26,7 +26,7 @@ public:
 protected:
   virtual RealEigenVector computeQpResidual() override;
   virtual RealEigenVector computeQpJacobian() override;
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
   /// scalar diffusion coefficient
   const MaterialProperty<Real> * const _r;

--- a/framework/include/kernels/ArrayTimeDerivative.h
+++ b/framework/include/kernels/ArrayTimeDerivative.h
@@ -27,7 +27,7 @@ public:
 protected:
   virtual RealEigenVector computeQpResidual() override;
   virtual RealEigenVector computeQpJacobian() override;
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
   /// scalar time derivative coefficient
   const MaterialProperty<Real> * const _coeff;

--- a/framework/include/kernels/AverageValueConstraint.h
+++ b/framework/include/kernels/AverageValueConstraint.h
@@ -34,17 +34,16 @@ public:
   static InputParameters validParams();
 
   AverageValueConstraint(const InputParameters & parameters);
-  virtual ~AverageValueConstraint();
 
-  virtual void reinit();
-  virtual void computeResidual();
-  virtual void computeJacobian();
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void reinit() override;
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar);
 
   /// Local index
   unsigned int _i;

--- a/framework/include/kernels/CoupledForce.h
+++ b/framework/include/kernels/CoupledForce.h
@@ -39,4 +39,3 @@ private:
   const VariableValue & _v;
   Real _coef;
 };
-

--- a/framework/include/kernels/CoupledTimeDerivative.h
+++ b/framework/include/kernels/CoupledTimeDerivative.h
@@ -36,4 +36,3 @@ protected:
   const VariableValue & _dv_dot;
   const unsigned int _v_var;
 };
-

--- a/framework/include/kernels/EigenKernel.h
+++ b/framework/include/kernels/EigenKernel.h
@@ -38,8 +38,6 @@ public:
   EigenKernel(const InputParameters & parameters);
   virtual bool enabled() const override;
 
-  using Kernel::computeOffDiagJacobian;
-
 protected:
   /// flag for as an eigen kernel or a normal kernel
   bool _eigen;
@@ -53,4 +51,3 @@ protected:
    */
   const Real * _eigenvalue;
 };
-

--- a/framework/include/kernels/EigenKernel.h
+++ b/framework/include/kernels/EigenKernel.h
@@ -32,7 +32,7 @@ public:
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
   virtual void computeOffDiagJacobianScalar(unsigned int /*jvar*/) override {}
 
   EigenKernel(const InputParameters & parameters);

--- a/framework/include/kernels/Kernel.h
+++ b/framework/include/kernels/Kernel.h
@@ -34,11 +34,6 @@ public:
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   /**
-   * Deprecated method
-   */
-  virtual void computeOffDiagJacobian(unsigned jvar);
-
-  /**
    * Computes jacobian block with respect to a scalar variable
    * @param jvar The number of the scalar variable
    */
@@ -58,10 +53,14 @@ protected:
   virtual Real computeQpJacobian() { return 0; }
 
   /**
-   * This is the virtual that derived classes should override for computing an off-diagonal Jacobian
-   * component.
+   * For coupling standard variables
    */
   virtual Real computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
+
+  /**
+   * For coupling scalar variables
+   */
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int /*jvar*/) { return 0; }
 
   /**
    * For coupling array variables

--- a/framework/include/kernels/Kernel.h
+++ b/framework/include/kernels/Kernel.h
@@ -44,7 +44,7 @@ public:
    */
   virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
-  virtual MooseVariable & variable() override { return _var; }
+  virtual const MooseVariable & variable() const override { return _var; }
 
 protected:
   /**

--- a/framework/include/kernels/Kernel.h
+++ b/framework/include/kernels/Kernel.h
@@ -31,7 +31,7 @@ public:
   virtual void computeJacobian() override;
 
   /// Computes d-residual / d-jvar... storing the result in Ke.
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Computes jacobian block with respect to a scalar variable
@@ -65,7 +65,7 @@ protected:
   /**
    * For coupling array variables
    */
-  virtual RealEigenVector computeQpOffDiagJacobianArray(ArrayMooseVariable & jvar)
+  virtual RealEigenVector computeQpOffDiagJacobianArray(const ArrayMooseVariable & jvar)
   {
     return RealEigenVector::Zero(jvar.count());
   }

--- a/framework/include/kernels/KernelBase.h
+++ b/framework/include/kernels/KernelBase.h
@@ -9,31 +9,11 @@
 
 #pragma once
 
-#include "MooseObject.h"
+#include "ResidualObject.h"
 #include "BlockRestrictable.h"
-#include "SetupInterface.h"
-#include "CoupleableMooseVariableDependencyIntermediateInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "TransientInterface.h"
-#include "PostprocessorInterface.h"
-#include "VectorPostprocessorInterface.h"
 #include "MaterialPropertyInterface.h"
-#include "RandomInterface.h"
 #include "GeometricSearchInterface.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "TaggingInterface.h"
 #include "ElementIDInterface.h"
-
-class MooseMesh;
-class SubProblem;
-class KernelBase;
-class Assembly;
-template <typename>
-class MooseVariableFE;
-typedef MooseVariableFE<Real> MooseVariable;
-typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
 
 template <>
 InputParameters validParams<KernelBase>();
@@ -42,21 +22,11 @@ InputParameters validParams<KernelBase>();
  * This is the common base class for the three main
  * kernel types implemented in MOOSE, Kernel, VectorKernel and ArrayKernel.
  */
-class KernelBase : public MooseObject,
+class KernelBase : public ResidualObject,
                    public BlockRestrictable,
-                   public SetupInterface,
                    public CoupleableMooseVariableDependencyIntermediateInterface,
-                   public FunctionInterface,
-                   public UserObjectInterface,
-                   public TransientInterface,
-                   public PostprocessorInterface,
-                   public VectorPostprocessorInterface,
                    public MaterialPropertyInterface,
-                   public RandomInterface,
                    protected GeometricSearchInterface,
-                   public Restartable,
-                   public MeshChangedInterface,
-                   public TaggingInterface,
                    public ElementIDInterface
 {
 public:
@@ -64,72 +34,8 @@ public:
 
   KernelBase(const InputParameters & parameters);
 
-  virtual ~KernelBase();
-
-  /// Compute this Kernel's contribution to the residual
-  virtual void computeResidual() = 0;
-
-  /// Compute this Kernel's contribution to the diagonal Jacobian entries
-  virtual void computeJacobian() = 0;
-
-  /// Computes d-residual / d-jvar... storing the result in Ke.
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) = 0;
-
-  /**
-   * Computes jacobian block with respect to a scalar variable
-   * @param jvar The number of the scalar variable
-   */
-  virtual void computeOffDiagJacobianScalar(unsigned int jvar) = 0;
-
-  /**
-   * Compute this Kernel's contribution to the diagonal Jacobian entries
-   * corresponding to nonlocal dofs of the variable
-   */
-  virtual void computeNonlocalJacobian() {}
-
-  /**
-   * Computes d-residual / d-jvar... corresponding to nonlocal dofs of the jvar
-   * and stores the result in nonlocal ke
-   */
-  virtual void computeNonlocalOffDiagJacobian(unsigned int /* jvar */) {}
-
-  /**
-   * Returns the variable that this Kernel operates on.
-   */
-  virtual MooseVariableFEBase & variable() = 0;
-
-  /**
-   * Returns a reference to the SubProblem for which this Kernel is active
-   */
-  SubProblem & subProblem() { return _subproblem; }
-
 protected:
-  /**
-   * Following methods are used for Kernels that need to perform a per-element calculation
-   */
-  virtual void precalculateResidual() {}
-  virtual void precalculateJacobian() {}
-  virtual void precalculateOffDiagJacobian(unsigned int /* jvar */) {}
-
-protected:
-  /// Reference to this kernel's SubProblem
-  SubProblem & _subproblem;
-
-  /// Reference to this kernel's FEProblemBase
-  FEProblemBase & _fe_problem;
-
-  /// Reference to the EquationSystem object
-  SystemBase & _sys;
-
-  /// The thread ID for this kernel
-  THREAD_ID _tid;
-
-  /// Reference to this Kernel's assembly object
-  Assembly & _assembly;
-
-  /// Reference to this Kernel's mesh object
-  MooseMesh & _mesh;
-
+  /// Current element
   const Elem * const & _current_elem;
 
   /// Volume of the current element

--- a/framework/include/kernels/KernelGrad.h
+++ b/framework/include/kernels/KernelGrad.h
@@ -43,8 +43,6 @@ public:
 
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
-  using Kernel::computeOffDiagJacobian;
-
 protected:
   /**
    * Called before forming the residual for an element
@@ -58,4 +56,3 @@ protected:
 
   virtual Real computeQpResidual() override;
 };
-

--- a/framework/include/kernels/KernelGrad.h
+++ b/framework/include/kernels/KernelGrad.h
@@ -41,7 +41,7 @@ public:
 
   virtual void computeJacobian() override;
 
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   /**

--- a/framework/include/kernels/KernelValue.h
+++ b/framework/include/kernels/KernelValue.h
@@ -43,8 +43,6 @@ public:
 
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
-  using Kernel::computeOffDiagJacobian;
-
 protected:
   /**
    * Called before forming the residual for an element
@@ -58,4 +56,3 @@ protected:
 
   virtual Real computeQpResidual() final;
 };
-

--- a/framework/include/kernels/KernelValue.h
+++ b/framework/include/kernels/KernelValue.h
@@ -41,7 +41,7 @@ public:
 
   virtual void computeJacobian() override;
 
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   /**

--- a/framework/include/kernels/MatDiffusionBase.h
+++ b/framework/include/kernels/MatDiffusionBase.h
@@ -30,12 +30,12 @@ public:
 
   MatDiffusionBase(const InputParameters & parameters);
 
-  virtual void initialSetup();
+  virtual void initialSetup() override;
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   virtual Real computeQpCJacobian();
 
   /// diffusion coefficient

--- a/framework/include/kernels/NodalScalarKernel.h
+++ b/framework/include/kernels/NodalScalarKernel.h
@@ -31,7 +31,7 @@ public:
   NodalScalarKernel(const InputParameters & parameters);
 
   virtual void reinit() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   /// List of node IDs
@@ -39,4 +39,3 @@ protected:
   /// List of node boundary names
   std::vector<BoundaryName> _boundary_names;
 };
-

--- a/framework/include/kernels/NonlocalKernel.h
+++ b/framework/include/kernels/NonlocalKernel.h
@@ -40,7 +40,6 @@ public:
    */
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /**
    * computeNonlocalJacobian and computeNonlocalOffDiagJacobian methods are
@@ -71,4 +70,3 @@ protected:
 
   unsigned int _k;
 };
-

--- a/framework/include/kernels/NonlocalKernel.h
+++ b/framework/include/kernels/NonlocalKernel.h
@@ -39,7 +39,7 @@ public:
    * jocobians of the integral term from userobject once per dof
    */
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * computeNonlocalJacobian and computeNonlocalOffDiagJacobian methods are

--- a/framework/include/kernels/ODEKernel.h
+++ b/framework/include/kernels/ODEKernel.h
@@ -30,11 +30,10 @@ public:
   virtual void reinit() override;
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual() = 0;
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar);
 };
-

--- a/framework/include/kernels/ODEKernel.h
+++ b/framework/include/kernels/ODEKernel.h
@@ -35,5 +35,11 @@ public:
 protected:
   virtual Real computeQpResidual() = 0;
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar)
+  {
+    // Backwards compatibility
+    return computeQpOffDiagJacobian(jvar);
+  }
+
+  virtual Real computeQpOffDiagJacobian(unsigned int) { return 0; }
 };

--- a/framework/include/kernels/ParsedODEKernel.h
+++ b/framework/include/kernels/ParsedODEKernel.h
@@ -27,7 +27,7 @@ protected:
 
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   /// function expression
   std::string _function;

--- a/framework/include/kernels/ScalarKernel.h
+++ b/framework/include/kernels/ScalarKernel.h
@@ -9,39 +9,17 @@
 
 #pragma once
 
-#include "MooseObject.h"
+#include "ResidualObject.h"
 #include "ScalarCoupleable.h"
-#include "SetupInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "PostprocessorInterface.h"
-#include "TransientInterface.h"
-#include "MeshChangedInterface.h"
-#include "VectorPostprocessorInterface.h"
-#include "TaggingInterface.h"
+#include "MooseVariableScalar.h"
 
 // Forward declarations
 class ScalarKernel;
-class MooseMesh;
-class Problem;
-class SubProblem;
-class Assembly;
-class MooseVariableScalar;
-class SubProblem;
 
 template <>
 InputParameters validParams<ScalarKernel>();
 
-class ScalarKernel : public MooseObject,
-                     public ScalarCoupleable,
-                     public SetupInterface,
-                     public FunctionInterface,
-                     public UserObjectInterface,
-                     public PostprocessorInterface,
-                     public TransientInterface,
-                     public MeshChangedInterface,
-                     protected VectorPostprocessorInterface,
-                     public TaggingInterface
+class ScalarKernel : public ResidualObject, public ScalarCoupleable
 {
 public:
   static InputParameters validParams();
@@ -49,33 +27,26 @@ public:
   ScalarKernel(const InputParameters & parameters);
 
   virtual void reinit() = 0;
-  virtual void computeResidual() = 0;
-  virtual void computeJacobian() = 0;
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
+  virtual void computeOffDiagJacobian(unsigned int /*jvar*/) {}
 
   /**
    * The variable that this kernel operates on.
    */
-  MooseVariableScalar & variable();
-
-  SubProblem & subProblem();
+  virtual const MooseVariableScalar & variable() const override { return _var; }
 
   /**
    * Use this to enable/disable the constraint
    * @return true if the constrain is active
    */
-  virtual bool isActive();
+  virtual bool isActive() { return true; }
 
 protected:
-  SubProblem & _subproblem;
-  SystemBase & _sys;
-
-  THREAD_ID _tid;
-
-  Assembly & _assembly;
   /// Scalar variable
   MooseVariableScalar & _var;
-  MooseMesh & _mesh;
 
   unsigned int _i, _j;
 
@@ -85,4 +56,3 @@ protected:
   /// Old value(s) of the scalar variable
   VariableValue & _u_old;
 };
-

--- a/framework/include/kernels/ScalarKernel.h
+++ b/framework/include/kernels/ScalarKernel.h
@@ -27,11 +27,6 @@ public:
   ScalarKernel(const InputParameters & parameters);
 
   virtual void reinit() = 0;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int /*jvar*/) {}
 
   /**
    * The variable that this kernel operates on.

--- a/framework/include/kernels/ScalarLagrangeMultiplier.h
+++ b/framework/include/kernels/ScalarLagrangeMultiplier.h
@@ -37,11 +37,11 @@ public:
   ScalarLagrangeMultiplier(const InputParameters & parameters);
   virtual ~ScalarLagrangeMultiplier();
 
-  virtual void computeOffDiagJacobianScalar(unsigned int jvar);
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   /// Lagrange multiplier variable ID
   unsigned int _lambda_var;

--- a/framework/include/kernels/VectorKernel.h
+++ b/framework/include/kernels/VectorKernel.h
@@ -58,6 +58,11 @@ protected:
    */
   virtual Real computeQpOffDiagJacobian(unsigned int /*jvar*/) { return 0; }
 
+  /**
+   * For coupling scalar variables
+   */
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int /*jvar*/) { return 0; }
+
   /// This is a regular kernel so we cast to a regular MooseVariable
   VectorMooseVariable & _var;
 

--- a/framework/include/kernels/VectorKernel.h
+++ b/framework/include/kernels/VectorKernel.h
@@ -39,7 +39,7 @@ public:
    */
   virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
-  virtual VectorMooseVariable & variable() override { return _var; }
+  virtual const VectorMooseVariable & variable() const override { return _var; }
 
 protected:
   /**

--- a/framework/include/kernels/VectorKernel.h
+++ b/framework/include/kernels/VectorKernel.h
@@ -31,7 +31,7 @@ public:
   virtual void computeJacobian() override;
 
   /// Computes d-residual / d-jvar... storing the result in Ke.
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Computes jacobian block with respect to a scalar variable

--- a/framework/include/nodalkernels/NodalKernel.h
+++ b/framework/include/nodalkernels/NodalKernel.h
@@ -71,7 +71,7 @@ public:
    * Note: This is NOT what a user would normally want to override.
    * Usually a user would override computeQpOffDiagJacobian()
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   /**

--- a/framework/include/nodalkernels/NodalKernel.h
+++ b/framework/include/nodalkernels/NodalKernel.h
@@ -10,33 +10,15 @@
 #pragma once
 
 // MOOSE
-#include "MooseObject.h"
-#include "BlockRestrictable.h"
-#include "SetupInterface.h"
-#include "FunctionInterface.h"
-#include "UserObjectInterface.h"
-#include "TransientInterface.h"
-#include "PostprocessorInterface.h"
+#include "ResidualObject.h"
 #include "GeometricSearchInterface.h"
 #include "BlockRestrictable.h"
 #include "BoundaryRestrictable.h"
-#include "Restartable.h"
-#include "MeshChangedInterface.h"
-#include "RandomInterface.h"
 #include "CoupleableMooseVariableDependencyIntermediateInterface.h"
 #include "MooseVariableInterface.h"
-#include "TaggingInterface.h"
 
 // Forward declerations
-template <typename>
-class MooseVariableFE;
-typedef MooseVariableFE<Real> MooseVariable;
-typedef MooseVariableFE<VectorValue<Real>> VectorMooseVariable;
-class MooseMesh;
-class SubProblem;
-class SystemBase;
 class NodalKernel;
-class Assembly;
 
 template <>
 InputParameters validParams<NodalKernel>();
@@ -45,21 +27,12 @@ InputParameters validParams<NodalKernel>();
  * Base class for creating new types of boundary conditions
  *
  */
-class NodalKernel : public MooseObject,
+class NodalKernel : public ResidualObject,
                     public BlockRestrictable,
                     public BoundaryRestrictable,
-                    public SetupInterface,
-                    public FunctionInterface,
-                    public UserObjectInterface,
-                    public TransientInterface,
-                    public PostprocessorInterface,
                     public GeometricSearchInterface,
-                    public Restartable,
-                    public MeshChangedInterface,
-                    public RandomInterface,
                     public CoupleableMooseVariableDependencyIntermediateInterface,
-                    public MooseVariableInterface<Real>,
-                    public TaggingInterface
+                    public MooseVariableInterface<Real>
 {
 public:
   /**
@@ -74,13 +47,7 @@ public:
    * Gets the variable this is active on
    * @return the variable
    */
-  MooseVariable & variable();
-
-  /**
-   * Get a reference to the subproblem
-   * @return Reference to SubProblem
-   */
-  SubProblem & subProblem();
+  const MooseVariable & variable() const override { return _var; }
 
   /**
    * Compute the residual at the current node.
@@ -88,7 +55,7 @@ public:
    * Note: This is NOT what a user would normally want to override.
    * Usually a user would override computeQpResidual()
    */
-  virtual void computeResidual();
+  virtual void computeResidual() override;
 
   /**
    * Compute the Jacobian at one node.
@@ -96,7 +63,7 @@ public:
    * Note: This is NOT what a user would normally want to override.
    * Usually a user would override computeQpJacobian()
    */
-  virtual void computeJacobian();
+  virtual void computeJacobian() override;
 
   /**
    * Compute the off-diagonal Jacobian at one node.
@@ -104,6 +71,10 @@ public:
    * Note: This is NOT what a user would normally want to override.
    * Usually a user would override computeQpOffDiagJacobian()
    */
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
+  {
+    computeOffDiagJacobian(jvar.number());
+  }
   virtual void computeOffDiagJacobian(unsigned int jvar);
 
 protected:
@@ -125,26 +96,11 @@ protected:
    */
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  /// Reference to SubProblem
-  SubProblem & _subproblem;
-
   /// Reference to FEProblemBase
   FEProblemBase & _fe_problem;
 
-  /// Reference to SystemBase
-  SystemBase & _sys;
-
-  /// Thread id
-  THREAD_ID _tid;
-
-  /// Reference to assembly
-  Assembly & _assembly;
-
   /// variable this works on
   MooseVariable & _var;
-
-  /// Mesh this is defined on
-  MooseMesh & _mesh;
 
   /// current node being processed
   const Node * const & _current_node;
@@ -165,4 +121,3 @@ protected:
   std::vector<MooseVariableFEBase *> _diag_save_in;
   std::vector<AuxVariableName> _diag_save_in_strings;
 };
-

--- a/framework/include/nodalkernels/NodalKernel.h
+++ b/framework/include/nodalkernels/NodalKernel.h
@@ -71,11 +71,7 @@ public:
    * Note: This is NOT what a user would normally want to override.
    * Usually a user would override computeQpOffDiagJacobian()
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override
-  {
-    computeOffDiagJacobian(jvar.number());
-  }
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   /**

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -529,7 +529,8 @@ public:
    * @param var_name A string which is the name of the variable to get.
    * @return reference the variable (class)
    */
-  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, const std::string & var_name);
+  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid,
+                                                  const std::string & var_name) const;
 
   /**
    * Gets a reference to a variable with specified number
@@ -538,7 +539,7 @@ public:
    * @param var_number libMesh variable number
    * @return reference the variable (class)
    */
-  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, unsigned int var_number);
+  virtual MooseVariableScalar & getScalarVariable(THREAD_ID tid, unsigned int var_number) const;
 
   /**
    * Get the block where a variable of this system is defined

--- a/framework/include/utils/JvarMapInterface.h
+++ b/framework/include/utils/JvarMapInterface.h
@@ -31,7 +31,7 @@ class JvarMapKernelInterface : public JvarMapInterfaceBase<T>
 {
 public:
   JvarMapKernelInterface(const InputParameters & parameters);
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 };
 
 /**
@@ -49,8 +49,7 @@ class JvarMapIntegratedBCInterface : public JvarMapInterfaceBase<T>
 {
 public:
   JvarMapIntegratedBCInterface(const InputParameters & parameters);
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
-  using T::computeJacobianBlock;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 };
 
 /**
@@ -194,10 +193,10 @@ JvarMapIntegratedBCInterface<T>::JvarMapIntegratedBCInterface(const InputParamet
 
 template <class T>
 void
-JvarMapKernelInterface<T>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+JvarMapKernelInterface<T>::computeOffDiagJacobian(const unsigned int jvar)
 {
   // the Kernel is not coupled to the variable; no need to loop over QPs
-  if (this->_jvar_map[jvar.number()] < 0)
+  if (this->_jvar_map[jvar] < 0)
     return;
 
   // call the underlying class' off-diagonal Jacobian
@@ -206,12 +205,12 @@ JvarMapKernelInterface<T>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
 template <class T>
 void
-JvarMapIntegratedBCInterface<T>::computeJacobianBlock(MooseVariableFEBase & jvar)
+JvarMapIntegratedBCInterface<T>::computeOffDiagJacobian(const unsigned int jvar)
 {
   // the Kernel is not coupled to the variable; no need to loop over QPs
-  if (this->_jvar_map[jvar.number()] < 0)
+  if (this->_jvar_map[jvar] < 0)
     return;
 
   // call the underlying class' off-diagonal Jacobian
-  T::computeJacobianBlock(jvar);
+  T::computeOffDiagJacobian(jvar);
 }

--- a/framework/include/utils/JvarMapInterface.h
+++ b/framework/include/utils/JvarMapInterface.h
@@ -32,7 +32,6 @@ class JvarMapKernelInterface : public JvarMapInterfaceBase<T>
 public:
   JvarMapKernelInterface(const InputParameters & parameters);
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using T::computeOffDiagJacobian;
 };
 
 /**

--- a/framework/include/variables/VariableWarehouse.h
+++ b/framework/include/variables/VariableWarehouse.h
@@ -59,14 +59,15 @@ public:
    * @param bnd The boundary id where this variable is defined
    * @param var The variable
    */
-  void addBoundaryVar(BoundaryID bnd, MooseVariableFieldBase * var);
+  void addBoundaryVar(BoundaryID bnd, const MooseVariableFieldBase * var);
 
   /**
    * Add a variable to a set of boundaries
    * @param boundary_ids The boundary ids where this variable is defined
    * @param var The variable
    */
-  void addBoundaryVar(const std::set<BoundaryID> & boundary_ids, MooseVariableFieldBase * var);
+  void addBoundaryVar(const std::set<BoundaryID> & boundary_ids,
+                      const MooseVariableFieldBase * var);
 
   /**
    * Add a map of variables to a set of boundaries
@@ -146,7 +147,7 @@ public:
    * @param bnd The boundary ID
    * @return The list of variables
    */
-  const std::set<MooseVariableFieldBase *> & boundaryVars(BoundaryID bnd) const;
+  const std::set<const MooseVariableFieldBase *> & boundaryVars(BoundaryID bnd) const;
 
   /**
    * Get the list of scalar variables
@@ -199,7 +200,7 @@ protected:
   std::map<std::string, MooseVariableBase *> _var_name;
 
   /// Map to variables that need to be evaluated on a boundary
-  std::map<BoundaryID, std::set<MooseVariableFieldBase *>> _boundary_vars;
+  std::map<BoundaryID, std::set<const MooseVariableFieldBase *>> _boundary_vars;
 
   /// list of all scalar, non-finite element variables
   std::vector<MooseVariableScalar *> _scalar_vars;

--- a/framework/src/base/NeighborResidualObject.C
+++ b/framework/src/base/NeighborResidualObject.C
@@ -1,0 +1,27 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "NeighborResidualObject.h"
+
+InputParameters
+NeighborResidualObject::validParams()
+{
+  return ResidualObject::validParams();
+}
+
+NeighborResidualObject::NeighborResidualObject(const InputParameters & parameters)
+  : ResidualObject(parameters)
+{
+}
+
+void
+NeighborResidualObject::prepareNeighborShapes(const unsigned int var_num)
+{
+  _subproblem.prepareNeighborShapes(var_num, _tid);
+}

--- a/framework/src/base/ResidualObject.C
+++ b/framework/src/base/ResidualObject.C
@@ -1,0 +1,64 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ResidualObject.h"
+#include "Assembly.h"
+#include "MooseVariableFE.h"
+#include "Problem.h"
+#include "SubProblem.h"
+#include "SystemBase.h"
+#include "NonlinearSystem.h"
+
+#include "libmesh/threads.h"
+
+defineLegacyParams(ResidualObject);
+
+InputParameters
+ResidualObject::validParams()
+{
+  auto params = MooseObject::validParams();
+  params += TransientInterface::validParams();
+  params += RandomInterface::validParams();
+  params += MeshChangedInterface::validParams();
+  params += TaggingInterface::validParams();
+
+  params.addRequiredParam<NonlinearVariableName>(
+      "variable", "The name of the variable that this residual object operates on");
+
+  params.declareControllable("enable");
+  return params;
+}
+
+ResidualObject::ResidualObject(const InputParameters & parameters, bool is_nodal)
+  : MooseObject(parameters),
+    SetupInterface(this),
+    FunctionInterface(this),
+    UserObjectInterface(this),
+    TransientInterface(this),
+    PostprocessorInterface(this),
+    // VPPs used by ScalarKernels must be broadcast because we don't know where the
+    // ScalarKernel will end up being evaluated
+    // Note: residual objects should have a valid _moose_base.
+    VectorPostprocessorInterface(this,
+                                 parameters.get<std::string>("_moose_base") == "ScalarKernel"),
+    RandomInterface(parameters,
+                    *parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"),
+                    parameters.get<THREAD_ID>("_tid"),
+                    is_nodal),
+    Restartable(this, parameters.get<std::string>("_moose_base") + "s"),
+    MeshChangedInterface(parameters),
+    TaggingInterface(this),
+    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
+    _fe_problem(*parameters.get<FEProblemBase *>("_fe_problem_base")),
+    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
+    _tid(parameters.get<THREAD_ID>("_tid")),
+    _assembly(_subproblem.assembly(_tid)),
+    _mesh(_subproblem.mesh())
+{
+}

--- a/framework/src/base/ResidualObject.C
+++ b/framework/src/base/ResidualObject.C
@@ -8,16 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ResidualObject.h"
-#include "Assembly.h"
-#include "MooseVariableFE.h"
-#include "Problem.h"
 #include "SubProblem.h"
-#include "SystemBase.h"
-#include "NonlinearSystem.h"
-
-#include "libmesh/threads.h"
-
-defineLegacyParams(ResidualObject);
+#include "InputParameters.h"
 
 InputParameters
 ResidualObject::validParams()
@@ -61,4 +53,10 @@ ResidualObject::ResidualObject(const InputParameters & parameters, bool is_nodal
     _assembly(_subproblem.assembly(_tid)),
     _mesh(_subproblem.mesh())
 {
+}
+
+void
+ResidualObject::prepareShapes(const unsigned int var_num)
+{
+  _subproblem.prepareShapes(var_num, _tid);
 }

--- a/framework/src/bcs/ADIntegratedBC.C
+++ b/framework/src/bcs/ADIntegratedBC.C
@@ -201,7 +201,8 @@ ADIntegratedBCTempl<T>::computeADJacobian(
           if (ivar != _var.number() || !jvariable.hasBlocks(_current_elem->subdomain_id()))
             continue;
 
-          addJacobian(jvariable);
+          // Make sure to get the correct undisplaced/displaced variable
+          addJacobian(getVariable(jvariable.number()));
         }
       };
 
@@ -210,16 +211,16 @@ ADIntegratedBCTempl<T>::computeADJacobian(
 
 template <typename T>
 void
-ADIntegratedBCTempl<T>::computeJacobianBlock(MooseVariableFieldBase & jvar)
+ADIntegratedBCTempl<T>::computeOffDiagJacobian(const unsigned int jvar)
 {
   // Only need to do this once because AD does all the derivatives at once
-  if (jvar.number() == _var.number())
+  if (jvar == _var.number())
     computeADJacobian(_assembly.couplingEntries());
 }
 
 template <typename T>
 void
-ADIntegratedBCTempl<T>::computeJacobianBlockScalar(unsigned int /*jvar*/)
+ADIntegratedBCTempl<T>::computeOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
 }
 

--- a/framework/src/bcs/ADNodalBC.C
+++ b/framework/src/bcs/ADNodalBC.C
@@ -117,14 +117,14 @@ ADNodalBCTempl<T>::computeJacobian()
 
 template <typename T>
 void
-ADNodalBCTempl<T>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ADNodalBCTempl<T>::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
     computeJacobian();
   else
   {
 #ifndef MOOSE_GLOBAL_AD_INDEXING
-    auto ad_offset = Moose::adOffset(jvar.number(), _sys.getMaxVarNDofsPerNode());
+    auto ad_offset = Moose::adOffset(jvar_num, _sys.getMaxVarNDofsPerNode());
 #endif
     auto residual = computeQpResidual();
     const std::vector<dof_id_type> & cached_rows = _var.dofIndices();
@@ -133,7 +133,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
                 "The number of dof indices must be less than the number of settable components");
 
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar_num, 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/bcs/ADNodalBC.C
+++ b/framework/src/bcs/ADNodalBC.C
@@ -117,14 +117,14 @@ ADNodalBCTempl<T>::computeJacobian()
 
 template <typename T>
 void
-ADNodalBCTempl<T>::computeOffDiagJacobian(unsigned int jvar)
+ADNodalBCTempl<T>::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
     computeJacobian();
   else
   {
 #ifndef MOOSE_GLOBAL_AD_INDEXING
-    auto ad_offset = Moose::adOffset(jvar, _sys.getMaxVarNDofsPerNode());
+    auto ad_offset = Moose::adOffset(jvar.number(), _sys.getMaxVarNDofsPerNode());
 #endif
     auto residual = computeQpResidual();
     const std::vector<dof_id_type> & cached_rows = _var.dofIndices();
@@ -133,7 +133,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobian(unsigned int jvar)
                 "The number of dof indices must be less than the number of settable components");
 
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar, 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/bcs/ArrayIntegratedBC.C
+++ b/framework/src/bcs/ArrayIntegratedBC.C
@@ -147,16 +147,17 @@ ArrayIntegratedBC::computeJacobian()
 }
 
 void
-ArrayIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
+ArrayIntegratedBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
+  const auto & jvar = getVariable(jvar_num);
+
   bool same_var = jvar_num == _var.number();
 
   prepareMatrixTag(_assembly, _var.number(), jvar_num);
 
   // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting on
   // the displaced mesh
-  auto phi_size = _sys.getVariable(_tid, jvar_num).dofIndices().size();
+  auto phi_size = jvar.dofIndices().size();
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
@@ -166,7 +167,7 @@ ArrayIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
       {
         RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
         _assembly.saveFullLocalArrayJacobian(
-            _local_ke, _i, _test.size(), _j, jvar.phiSize(), _var.number(), jvar.number(), v);
+            _local_ke, _i, _test.size(), _j, jvar.phiSize(), _var.number(), jvar_num, v);
       }
   }
 
@@ -188,11 +189,11 @@ ArrayIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
 }
 
 void
-ArrayIntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
+ArrayIntegratedBC::computeOffDiagJacobianScalar(unsigned int jvar)
 {
   prepareMatrixTag(_assembly, _var.number(), jvar);
 
-  MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
+  const MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
     {

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -68,13 +68,15 @@ ArrayNodalBC::computeJacobian()
 }
 
 void
-ArrayNodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayNodalBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  RealEigenMatrix cached_val = computeQpOffDiagJacobian(jvar);
+  const auto & jvar = getVariable(jvar_num);
+
+  RealEigenMatrix cached_val = computeQpOffDiagJacobian(const_cast<MooseVariableFieldBase &>(jvar));
 
   dof_id_type cached_row = _var.nodalDofIndex();
   // Note: this only works for Lagrange variables...
-  dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
+  dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar_num, 0);
 
   // Cache the user's computeQpJacobian() value for later use.
   for (auto tag : _matrix_tags)

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -68,21 +68,19 @@ ArrayNodalBC::computeJacobian()
 }
 
 void
-ArrayNodalBC::computeOffDiagJacobian(unsigned int jvar)
+ArrayNodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  MooseVariableFEBase & jv = _sys.getVariable(0, jvar);
-
-  RealEigenMatrix cached_val = computeQpOffDiagJacobian(jv);
+  RealEigenMatrix cached_val = computeQpOffDiagJacobian(jvar);
 
   dof_id_type cached_row = _var.nodalDofIndex();
   // Note: this only works for Lagrange variables...
-  dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar, 0);
+  dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
 
   // Cache the user's computeQpJacobian() value for later use.
   for (auto tag : _matrix_tags)
     if (_sys.hasMatrix(tag))
       for (unsigned int i = 0; i < _var.count(); ++i)
-        for (unsigned int j = 0; j < jv.count(); ++j)
+        for (unsigned int j = 0; j < jvar.count(); ++j)
           _fe_problem.assembly(0).cacheJacobian(
               cached_row + i, cached_col + j, cached_val(i, j), tag);
 }

--- a/framework/src/bcs/BoundaryCondition.C
+++ b/framework/src/bcs/BoundaryCondition.C
@@ -8,22 +8,15 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "BoundaryCondition.h"
-#include "Problem.h"
-#include "SystemBase.h"
-#include "MooseVariableFE.h"
 
 defineLegacyParams(BoundaryCondition);
 
 InputParameters
 BoundaryCondition::validParams()
 {
-  InputParameters params = MooseObject::validParams();
-  params += TransientInterface::validParams();
+  InputParameters params = ResidualObject::validParams();
   params += BoundaryRestrictableRequired::validParams();
-  params += TaggingInterface::validParams();
 
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this boundary condition applies to");
   params.addParam<bool>("use_displaced_mesh",
                         false,
                         "Whether or not this object should use the "
@@ -34,31 +27,15 @@ BoundaryCondition::validParams()
 
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
   params.addCoupledVar("displacements", "The displacements");
-  params.declareControllable("enable");
   params.registerBase("BoundaryCondition");
 
   return params;
 }
 
 BoundaryCondition::BoundaryCondition(const InputParameters & parameters, bool nodal)
-  : MooseObject(parameters),
+  : ResidualObject(parameters, nodal),
     BoundaryRestrictableRequired(this, nodal),
-    SetupInterface(this),
-    FunctionInterface(this),
     DistributionInterface(this),
-    UserObjectInterface(this),
-    TransientInterface(this),
-    PostprocessorInterface(this),
-    VectorPostprocessorInterface(this),
-    GeometricSearchInterface(this),
-    Restartable(this, "BCs"),
-    MeshChangedInterface(parameters),
-    TaggingInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _mesh(_subproblem.mesh())
+    GeometricSearchInterface(this)
 {
 }

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -127,32 +127,34 @@ IntegratedBC::computeJacobian()
 }
 
 void
-IntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
+IntegratedBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  const auto & jvar = getVariable(jvar_num);
+
+  if (jvar_num == _var.number())
   {
     computeJacobian();
     return;
   }
 
-  prepareMatrixTag(_assembly, _var.number(), jvar.number());
+  prepareMatrixTag(_assembly, _var.number(), jvar_num);
 
   // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
   // on the displaced mesh, so we obtain the variable on the proper system
-  auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+  auto phi_size = jvar.dofIndices().size();
   mooseAssert(phi_size * jvar.count() == _local_ke.n(),
               "The size of the phi container does not match the number of local Jacobian columns");
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < phi_size; _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
 
   accumulateTaggedLocalMatrix();
 }
 
 void
-IntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
+IntegratedBC::computeOffDiagJacobianScalar(const unsigned int jvar)
 {
   prepareMatrixTag(_assembly, _var.number(), jvar);
 

--- a/framework/src/bcs/IntegratedBC.C
+++ b/framework/src/bcs/IntegratedBC.C
@@ -129,28 +129,24 @@ IntegratedBC::computeJacobian()
 void
 IntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
 {
-  computeJacobianBlock(jvar.number());
-}
-
-void
-IntegratedBC::computeJacobianBlock(unsigned int jvar)
-{
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
   {
     computeJacobian();
     return;
   }
 
-  prepareMatrixTag(_assembly, _var.number(), jvar);
+  prepareMatrixTag(_assembly, _var.number(), jvar.number());
 
   // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
-  // on the displaced mesh
-  auto phi_size = _sys.getVariable(_tid, jvar).dofIndices().size();
+  // on the displaced mesh, so we obtain the variable on the proper system
+  auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+  mooseAssert(phi_size * jvar.count() == _local_ke.n(),
+              "The size of the phi container does not match the number of local Jacobian columns");
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < phi_size; _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
 
   accumulateTaggedLocalMatrix();
 }
@@ -164,7 +160,7 @@ IntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < jv.order(); _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobianScalar(jvar);
 
   accumulateTaggedLocalMatrix();
 }

--- a/framework/src/bcs/IntegratedBCBase.C
+++ b/framework/src/bcs/IntegratedBCBase.C
@@ -16,7 +16,6 @@ InputParameters
 IntegratedBCBase::validParams()
 {
   InputParameters params = BoundaryCondition::validParams();
-  params += RandomInterface::validParams();
   params += MaterialPropertyInterface::validParams();
 
   params.addParam<std::vector<AuxVariableName>>(
@@ -40,7 +39,6 @@ IntegratedBCBase::validParams()
 
 IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters)
   : BoundaryCondition(parameters, false), // False is because this is NOT nodal
-    RandomInterface(parameters, _fe_problem, _tid, false),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
     MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
     _current_elem(_assembly.elem()),
@@ -57,5 +55,3 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters)
     _diag_save_in_strings(parameters.get<std::vector<AuxVariableName>>("diag_save_in"))
 {
 }
-
-IntegratedBCBase::~IntegratedBCBase() {}

--- a/framework/src/bcs/IntegratedBCBase.C
+++ b/framework/src/bcs/IntegratedBCBase.C
@@ -55,3 +55,9 @@ IntegratedBCBase::IntegratedBCBase(const InputParameters & parameters)
     _diag_save_in_strings(parameters.get<std::vector<AuxVariableName>>("diag_save_in"))
 {
 }
+
+void
+IntegratedBCBase::prepareShapes(const unsigned int var_num)
+{
+  _subproblem.prepareFaceShapes(var_num, _tid);
+}

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -124,14 +124,14 @@ NodalBC::computeJacobian()
 }
 
 void
-NodalBC::computeOffDiagJacobian(unsigned int jvar)
+NodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
     computeJacobian();
   else
   {
     Real cached_val = 0.0;
-    cached_val = computeQpOffDiagJacobian(jvar);
+    cached_val = computeQpOffDiagJacobian(jvar.number());
 
     if (cached_val == 0.)
       // there's no reason to cache this if it's zero, and it can even lead to new nonzero
@@ -140,7 +140,7 @@ NodalBC::computeOffDiagJacobian(unsigned int jvar)
 
     dof_id_type cached_row = _var.nodalDofIndex();
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar, 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/bcs/NodalBC.C
+++ b/framework/src/bcs/NodalBC.C
@@ -124,14 +124,14 @@ NodalBC::computeJacobian()
 }
 
 void
-NodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NodalBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
     computeJacobian();
   else
   {
     Real cached_val = 0.0;
-    cached_val = computeQpOffDiagJacobian(jvar.number());
+    cached_val = computeQpOffDiagJacobian(jvar_num);
 
     if (cached_val == 0.)
       // there's no reason to cache this if it's zero, and it can even lead to new nonzero
@@ -140,7 +140,7 @@ NodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
     dof_id_type cached_row = _var.nodalDofIndex();
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar_num, 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/bcs/NodalBCBase.C
+++ b/framework/src/bcs/NodalBCBase.C
@@ -15,7 +15,6 @@ InputParameters
 NodalBCBase::validParams()
 {
   InputParameters params = BoundaryCondition::validParams();
-  params += RandomInterface::validParams();
   params.addParam<std::vector<AuxVariableName>>(
       "save_in",
       "The name of auxiliary variables to save this BC's residual contributions to.  "
@@ -36,7 +35,6 @@ NodalBCBase::validParams()
 
 NodalBCBase::NodalBCBase(const InputParameters & parameters)
   : BoundaryCondition(parameters, true), // true is for being Nodal
-    RandomInterface(parameters, _fe_problem, _tid, true),
     CoupleableMooseVariableDependencyIntermediateInterface(this, true),
     _save_in_strings(parameters.get<std::vector<AuxVariableName>>("save_in")),
     _diag_save_in_strings(parameters.get<std::vector<AuxVariableName>>("diag_save_in"))

--- a/framework/src/bcs/NonlocalIntegratedBC.C
+++ b/framework/src/bcs/NonlocalIntegratedBC.C
@@ -87,7 +87,7 @@ NonlocalIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
       getUserObjectJacobian(jvar_num, jv.dofIndices()[_j]);
       for (_i = 0; _i < _test.size(); _i++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
     }
   }
 }

--- a/framework/src/bcs/NonlocalIntegratedBC.C
+++ b/framework/src/bcs/NonlocalIntegratedBC.C
@@ -67,24 +67,23 @@ NonlocalIntegratedBC::computeJacobian()
 }
 
 void
-NonlocalIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
+NonlocalIntegratedBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else
   {
-    MooseVariableFEBase & jv = _sys.getVariable(_tid, jvar_num);
+    const auto & jvar = getVariable(jvar_num);
     DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_num);
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar_num).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
 
     for (_j = 0; _j < phi_size;
          _j++) // looping order for _i & _j are reversed for performance improvement
     {
-      getUserObjectJacobian(jvar_num, jv.dofIndices()[_j]);
+      getUserObjectJacobian(jvar_num, jvar.dofIndices()[_j]);
       for (_i = 0; _i < _test.size(); _i++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());

--- a/framework/src/bcs/OneDEqualValueConstraintBC.C
+++ b/framework/src/bcs/OneDEqualValueConstraintBC.C
@@ -49,7 +49,7 @@ OneDEqualValueConstraintBC::computeQpJacobian()
 }
 
 Real
-OneDEqualValueConstraintBC::computeQpOffDiagJacobian(unsigned jvar)
+OneDEqualValueConstraintBC::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _lambda_var_number)
   {

--- a/framework/src/bcs/VectorIntegratedBC.C
+++ b/framework/src/bcs/VectorIntegratedBC.C
@@ -86,7 +86,7 @@ VectorIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
         if (_var.number() == jvar_num)
           _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpJacobian();
         else
-          _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
       }
 
   accumulateTaggedLocalMatrix();
@@ -101,7 +101,7 @@ VectorIntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < jv.order(); _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobianScalar(jvar);
 
   accumulateTaggedLocalMatrix();
 }

--- a/framework/src/bcs/VectorIntegratedBC.C
+++ b/framework/src/bcs/VectorIntegratedBC.C
@@ -70,14 +70,15 @@ VectorIntegratedBC::computeJacobian()
 }
 
 void
-VectorIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
+VectorIntegratedBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
+  const auto & jvar = getVariable(jvar_num);
+
   prepareMatrixTag(_assembly, _var.number(), jvar_num);
 
   // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting on
   // the displaced mesh
-  auto phi_size = _sys.getVariable(_tid, jvar_num).dofIndices().size();
+  auto phi_size = jvar.dofIndices().size();
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < _test.size(); _i++)
@@ -86,14 +87,14 @@ VectorIntegratedBC::computeJacobianBlock(MooseVariableFEBase & jvar)
         if (_var.number() == jvar_num)
           _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpJacobian();
         else
-          _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+          _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
       }
 
   accumulateTaggedLocalMatrix();
 }
 
 void
-VectorIntegratedBC::computeJacobianBlockScalar(unsigned int jvar)
+VectorIntegratedBC::computeOffDiagJacobianScalar(unsigned int jvar)
 {
   prepareMatrixTag(_assembly, _var.number(), jvar);
 

--- a/framework/src/bcs/VectorNodalBC.C
+++ b/framework/src/bcs/VectorNodalBC.C
@@ -67,16 +67,16 @@ VectorNodalBC::computeJacobian()
 }
 
 void
-VectorNodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+VectorNodalBC::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
     computeJacobian();
   else
   {
-    Real cached_val = computeQpOffDiagJacobian(jvar.number());
+    Real cached_val = computeQpOffDiagJacobian(jvar_num);
     const std::vector<dof_id_type> & cached_rows = _var.dofIndices();
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar_num, 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/bcs/VectorNodalBC.C
+++ b/framework/src/bcs/VectorNodalBC.C
@@ -67,16 +67,16 @@ VectorNodalBC::computeJacobian()
 }
 
 void
-VectorNodalBC::computeOffDiagJacobian(unsigned int jvar)
+VectorNodalBC::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
     computeJacobian();
   else
   {
-    Real cached_val = computeQpOffDiagJacobian(jvar);
+    Real cached_val = computeQpOffDiagJacobian(jvar.number());
     const std::vector<dof_id_type> & cached_rows = _var.dofIndices();
     // Note: this only works for Lagrange variables...
-    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar, 0);
+    dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
 
     // Cache the user's computeQpJacobian() value for later use.
     for (auto tag : _matrix_tags)

--- a/framework/src/constraints/Constraint.C
+++ b/framework/src/constraints/Constraint.C
@@ -16,10 +16,7 @@ defineLegacyParams(Constraint);
 InputParameters
 Constraint::validParams()
 {
-  InputParameters params = MooseObject::validParams();
-  // Add the SetupInterface parameter, 'execute_on', default is 'linear'
-  params += SetupInterface::validParams();
-  params += TaggingInterface::validParams();
+  InputParameters params = ResidualObject::validParams();
 
   params.addParam<bool>("use_displaced_mesh",
                         false,
@@ -30,27 +27,12 @@ Constraint::validParams()
                         "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
-  params.declareControllable("enable");
   params.registerBase("Constraint");
 
   return params;
 }
 
 Constraint::Constraint(const InputParameters & parameters)
-  : MooseObject(parameters),
-    SetupInterface(this),
-    FunctionInterface(this),
-    UserObjectInterface(this),
-    TransientInterface(this),
-    GeometricSearchInterface(this),
-    Restartable(this, "Constraints"),
-    MeshChangedInterface(parameters),
-    TaggingInterface(this),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _mesh(_subproblem.mesh())
+  : ResidualObject(parameters), GeometricSearchInterface(this)
 {
 }
-
-Constraint::~Constraint() {}

--- a/framework/src/constraints/Constraint.C
+++ b/framework/src/constraints/Constraint.C
@@ -9,14 +9,14 @@
 
 #include "Constraint.h"
 
-#include "SystemBase.h"
+#include "SubProblem.h"
 
 defineLegacyParams(Constraint);
 
 InputParameters
 Constraint::validParams()
 {
-  InputParameters params = ResidualObject::validParams();
+  InputParameters params = NeighborResidualObject::validParams();
 
   params.addParam<bool>("use_displaced_mesh",
                         false,
@@ -33,6 +33,6 @@ Constraint::validParams()
 }
 
 Constraint::Constraint(const InputParameters & parameters)
-  : ResidualObject(parameters), GeometricSearchInterface(this)
+  : NeighborResidualObject(parameters), GeometricSearchInterface(this)
 {
 }

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -315,7 +315,7 @@ ConstraintWarehouse::subdomainsCovered(std::set<SubdomainID> & subdomains_covere
     const auto & objects = pr.second.getActiveObjects();
     for (const auto & mc : objects)
     {
-      const MooseVariableFEBase * lm_var = mc->variable();
+      const MooseVariableFEBase * lm_var = &mc->variable();
       if (lm_var)
       {
         unique_variables.insert(lm_var->name());
@@ -335,7 +335,7 @@ ConstraintWarehouse::subdomainsCovered(std::set<SubdomainID> & subdomains_covere
     const auto & objects = pr.second.getActiveObjects();
     for (const auto & mc : objects)
     {
-      const MooseVariableFEBase * lm_var = mc->variable();
+      const MooseVariableFEBase * lm_var = &mc->variable();
       if (lm_var)
       {
         unique_variables.insert(lm_var->name());

--- a/framework/src/constraints/ElemElemConstraint.C
+++ b/framework/src/constraints/ElemElemConstraint.C
@@ -26,8 +26,6 @@ ElemElemConstraint::validParams()
 {
   InputParameters params = Constraint::validParams();
   params.addParam<unsigned int>("interface_id", 0, "The id of the interface.");
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this constraint is applied to.");
   return params;
 }
 

--- a/framework/src/constraints/EqualValueEmbeddedConstraint.C
+++ b/framework/src/constraints/EqualValueEmbeddedConstraint.C
@@ -305,36 +305,36 @@ EqualValueEmbeddedConstraint::computeJacobian()
 }
 
 void
-EqualValueEmbeddedConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+EqualValueEmbeddedConstraint::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  getConnectedDofIndices(jvar.number());
+  getConnectedDofIndices(jvar_num);
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
 
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
-      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
+  DenseMatrix<Number> & Knn =
+      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar_num);
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar_num);
   for (_i = 0; _i < _test_secondary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
+      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar_num);
 
   _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
   if (_Kne.m() && _Kne.n())
     for (_i = 0; _i < _test_primary.size(); _i++)
       // Loop over the connected dof indices so we can get all the jacobian contributions
       for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
+        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar_num);
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar_num);
 }
 
 void

--- a/framework/src/constraints/EqualValueEmbeddedConstraint.C
+++ b/framework/src/constraints/EqualValueEmbeddedConstraint.C
@@ -305,36 +305,36 @@ EqualValueEmbeddedConstraint::computeJacobian()
 }
 
 void
-EqualValueEmbeddedConstraint::computeOffDiagJacobian(unsigned int jvar)
+EqualValueEmbeddedConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  getConnectedDofIndices(jvar);
+  getConnectedDofIndices(jvar.number());
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
 
-  DenseMatrix<Number> & Knn =
-      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar);
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
+      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar);
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
   for (_i = 0; _i < _test_secondary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar);
+      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
 
   _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
   if (_Kne.m() && _Kne.n())
     for (_i = 0; _i < _test_primary.size(); _i++)
       // Loop over the connected dof indices so we can get all the jacobian contributions
       for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar);
+        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar);
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
 }
 
 void

--- a/framework/src/constraints/MortarConstraintBase.C
+++ b/framework/src/constraints/MortarConstraintBase.C
@@ -59,6 +59,7 @@ MortarConstraintBase::validParams()
       "primary_variable",
       "Primal variable on primary surface. If this parameter is not provided then the primary "
       "variable will be initialized to the secondary variable");
+  // This parameter has been added. We add it again to update the doc string.
   params.addParam<NonlinearVariableName>(
       "variable",
       "The name of the lagrange multiplier variable that this constraint is applied to. This "

--- a/framework/src/constraints/NodalConstraint.C
+++ b/framework/src/constraints/NodalConstraint.C
@@ -26,8 +26,6 @@ NodalConstraint::validParams()
   params.addParam<MooseEnum>("formulation",
                              formulationtype,
                              "Formulation used to calculate constraint - penalty or kinematic.");
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this constraint is applied to.");
   return params;
 }
 

--- a/framework/src/constraints/NodeElemConstraint.C
+++ b/framework/src/constraints/NodeElemConstraint.C
@@ -162,17 +162,17 @@ NodeElemConstraint::computeJacobian()
 }
 
 void
-NodeElemConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NodeElemConstraint::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  getConnectedDofIndices(jvar.number());
+  getConnectedDofIndices(jvar_num);
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
   _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
-      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar_num);
+  DenseMatrix<Number> & Knn =
+      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar_num);
 
   _phi_secondary.resize(_connected_dof_indices.size());
 
@@ -193,21 +193,21 @@ NodeElemConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
+      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar_num);
 
   if (_Kne.m() && _Kne.n())
     for (_i = 0; _i < _test_primary.size(); _i++)
       // Loop over the connected dof indices so we can get all the jacobian contributions
       for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
+        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar_num);
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar_num);
 }
 
 void

--- a/framework/src/constraints/NodeElemConstraint.C
+++ b/framework/src/constraints/NodeElemConstraint.C
@@ -28,8 +28,6 @@ NodeElemConstraint::validParams()
   params.addRequiredParam<SubdomainName>("primary", "primary block id");
   params.addRequiredCoupledVar("primary_variable",
                                "The variable on the primary side of the domain");
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this constraint is applied to.");
 
   return params;
 }

--- a/framework/src/constraints/NodeElemConstraint.C
+++ b/framework/src/constraints/NodeElemConstraint.C
@@ -162,17 +162,17 @@ NodeElemConstraint::computeJacobian()
 }
 
 void
-NodeElemConstraint::computeOffDiagJacobian(unsigned int jvar)
+NodeElemConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  getConnectedDofIndices(jvar);
+  getConnectedDofIndices(jvar.number());
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
   _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar);
-  DenseMatrix<Number> & Knn =
-      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar);
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
+      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
 
   _phi_secondary.resize(_connected_dof_indices.size());
 
@@ -193,21 +193,21 @@ NodeElemConstraint::computeOffDiagJacobian(unsigned int jvar)
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar);
+      Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
 
   if (_Kne.m() && _Kne.n())
     for (_i = 0; _i < _test_primary.size(); _i++)
       // Loop over the connected dof indices so we can get all the jacobian contributions
       for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar);
+        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar);
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
 }
 
 void

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -47,8 +47,6 @@ NodeFaceConstraint::validParams()
 
   params.addCoupledVar("primary_variable", "The variable on the primary side of the domain");
   params.addDeprecatedCoupledVar("master_variable", "primary_variable", "September 1st, 2020");
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this constraint is applied to.");
 
   return params;
 }

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -218,25 +218,25 @@ NodeFaceConstraint::computeJacobian()
 }
 
 void
-NodeFaceConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NodeFaceConstraint::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  getConnectedDofIndices(jvar.number());
+  getConnectedDofIndices(jvar_num);
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
   _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
 
   // Just do a direct assignment here because the Jacobian coming from assembly has already been
   // properly sized according to the jvar neighbor dof indices. It has also been zeroed
-  _Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
+  _Ken = _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar_num);
 
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
-      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
+  DenseMatrix<Number> & Knn =
+      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar_num);
 
   _phi_secondary.resize(_connected_dof_indices.size());
 
   _qp = 0;
 
-  auto primary_jsize = _sys.getVariable(0, jvar.number()).dofIndicesNeighbor().size();
+  auto primary_jsize = getVariable(jvar_num).dofIndicesNeighbor().size();
 
   // Fill up _phi_secondary so that it is 1 when j corresponds to this dof and 0 for every other dof
   // This corresponds to evaluating all of the connected shape functions at _this_ node
@@ -253,21 +253,21 @@ NodeFaceConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     for (_j = 0; _j < primary_jsize; _j++)
-      _Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
+      _Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar_num);
 
   if (_Kne.m() && _Kne.n())
     for (_i = 0; _i < _test_primary.size(); _i++)
       // Loop over the connected dof indices so we can get all the jacobian contributions
       for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
+        _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar_num);
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < primary_jsize; _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar_num);
 }
 
 void

--- a/framework/src/dgkernels/ADDGKernel.C
+++ b/framework/src/dgkernels/ADDGKernel.C
@@ -223,19 +223,20 @@ ADDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-ADDGKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ADDGKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
   // AD only needs to do one computation for one variable because it does the derivatives all at
   // once
-  if (!excludeBoundary() && jvar.number() == _var.number())
+  if (!excludeBoundary() && jvar_num == _var.number())
   {
+    const auto & jvar = getVariable(jvar_num);
     computeOffDiagElemNeighJacobian(Moose::ElementElement, jvar);
     computeOffDiagElemNeighJacobian(Moose::NeighborNeighbor, jvar);
   }
 }
 
 void
-ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, MooseVariableFEBase &)
+ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, const MooseVariableFEBase &)
 {
   mooseAssert(type == Moose::ElementElement || type == Moose::NeighborNeighbor,
               "With AD you should need one call per side");

--- a/framework/src/dgkernels/ADDGKernel.C
+++ b/framework/src/dgkernels/ADDGKernel.C
@@ -223,11 +223,11 @@ ADDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-ADDGKernel::computeOffDiagJacobian(unsigned int jvar)
+ADDGKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
   // AD only needs to do one computation for one variable because it does the derivatives all at
   // once
-  if (!excludeBoundary() && jvar == _var.number())
+  if (!excludeBoundary() && jvar.number() == _var.number())
   {
     computeOffDiagElemNeighJacobian(Moose::ElementElement, jvar);
     computeOffDiagElemNeighJacobian(Moose::NeighborNeighbor, jvar);
@@ -235,7 +235,7 @@ ADDGKernel::computeOffDiagJacobian(unsigned int jvar)
 }
 
 void
-ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsigned int)
+ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, MooseVariableFEBase &)
 {
   mooseAssert(type == Moose::ElementElement || type == Moose::NeighborNeighbor,
               "With AD you should need one call per side");

--- a/framework/src/dgkernels/ArrayDGKernel.C
+++ b/framework/src/dgkernels/ArrayDGKernel.C
@@ -209,8 +209,10 @@ ArrayDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-ArrayDGKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayDGKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
+  const auto & jvar = getVariable(jvar_num);
+
   // Compute element-element Jacobian
   computeOffDiagElemNeighJacobian(Moose::ElementElement, jvar);
 
@@ -226,7 +228,7 @@ ArrayDGKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
 void
 ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
-                                               MooseVariableFEBase & jvar)
+                                               const MooseVariableFEBase & jvar)
 {
   const ArrayVariableTestValue & test_space =
       (type == Moose::ElementElement || type == Moose::ElementNeighbor) ? _test : _test_neighbor;
@@ -238,7 +240,7 @@ ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
 
   if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    auto & jv0 = static_cast<MooseVariable &>(jvar);
+    const auto & jv0 = static_cast<const MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv0.phiFace()
                                                                           : jv0.phiFaceNeighbor();
@@ -263,7 +265,7 @@ ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
   }
   else if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
   {
-    auto & jv1 = static_cast<ArrayMooseVariable &>(jvar);
+    const auto & jv1 = static_cast<const ArrayMooseVariable &>(jvar);
     const ArrayVariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv1.phiFace()
                                                                           : jv1.phiFaceNeighbor();

--- a/framework/src/dgkernels/ArrayDGKernel.C
+++ b/framework/src/dgkernels/ArrayDGKernel.C
@@ -209,7 +209,7 @@ ArrayDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-ArrayDGKernel::computeOffDiagJacobian(unsigned int jvar)
+ArrayDGKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
   // Compute element-element Jacobian
   computeOffDiagElemNeighJacobian(Moose::ElementElement, jvar);
@@ -225,52 +225,64 @@ ArrayDGKernel::computeOffDiagJacobian(unsigned int jvar)
 }
 
 void
-ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsigned int jvar)
+ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
+                                               MooseVariableFEBase & jvar)
 {
-  MooseVariableFEBase & jv = _sys.getVariable(_tid, jvar);
   const ArrayVariableTestValue & test_space =
       (type == Moose::ElementElement || type == Moose::ElementNeighbor) ? _test : _test_neighbor;
 
   if (type == Moose::ElementElement)
-    prepareMatrixTag(_assembly, _var.number(), jvar);
+    prepareMatrixTag(_assembly, _var.number(), jvar.number());
   else
-    prepareMatrixTagNeighbor(_assembly, _var.number(), jvar, type);
+    prepareMatrixTagNeighbor(_assembly, _var.number(), jvar.number(), type);
 
-  if (jv.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
+  if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_STANDARD)
   {
-    auto & jv0 = static_cast<MooseVariable &>(jv);
+    auto & jv0 = static_cast<MooseVariable &>(jvar);
     const VariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv0.phiFace()
                                                                           : jv0.phiFaceNeighbor();
 
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      initQpOffDiagJacobian(type, jv);
+      initQpOffDiagJacobian(type, jvar);
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
         {
-          RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jv);
-          _assembly.saveFullLocalArrayJacobian(
-              _local_ke, _i, test_space.size(), _j, loc_phi.size(), _var.number(), jvar, v);
+          RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jvar);
+          _assembly.saveFullLocalArrayJacobian(_local_ke,
+                                               _i,
+                                               test_space.size(),
+                                               _j,
+                                               loc_phi.size(),
+                                               _var.number(),
+                                               jvar.number(),
+                                               v);
         }
     }
   }
-  else if (jv.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
+  else if (jvar.fieldType() == Moose::VarFieldType::VAR_FIELD_ARRAY)
   {
-    auto & jv1 = static_cast<ArrayMooseVariable &>(jv);
+    auto & jv1 = static_cast<ArrayMooseVariable &>(jvar);
     const ArrayVariableTestValue & loc_phi =
         (type == Moose::ElementElement || type == Moose::NeighborElement) ? jv1.phiFace()
                                                                           : jv1.phiFaceNeighbor();
 
     for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     {
-      initQpOffDiagJacobian(type, jv);
+      initQpOffDiagJacobian(type, jvar);
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
         {
-          RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jv);
-          _assembly.saveFullLocalArrayJacobian(
-              _local_ke, _i, test_space.size(), _j, loc_phi.size(), _var.number(), jvar, v);
+          RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jvar);
+          _assembly.saveFullLocalArrayJacobian(_local_ke,
+                                               _i,
+                                               test_space.size(),
+                                               _j,
+                                               loc_phi.size(),
+                                               _var.number(),
+                                               jvar.number(),
+                                               v);
         }
     }
   }
@@ -280,7 +292,7 @@ ArrayDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsig
   accumulateTaggedLocalMatrix();
 
   if (_has_diag_save_in && (type == Moose::ElementElement || type == Moose::NeighborNeighbor) &&
-      _var.number() == jvar)
+      _var.number() == jvar.number())
   {
     DenseVector<Number> diag = _assembly.getJacobianDiagonal(_local_ke);
     Threads::spin_mutex::scoped_lock lock(_jacoby_vars_mutex);

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -182,7 +182,8 @@ DGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-DGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, MooseVariableFEBase & jvar)
+DGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type,
+                                          const MooseVariableFEBase & jvar)
 {
   const VariableTestValue & test_space =
       (type == Moose::ElementElement || type == Moose::ElementNeighbor) ? _test : _test_neighbor;

--- a/framework/src/dgkernels/DGKernel.C
+++ b/framework/src/dgkernels/DGKernel.C
@@ -182,7 +182,7 @@ DGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 }
 
 void
-DGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsigned int jvar)
+DGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, MooseVariableFEBase & jvar)
 {
   const VariableTestValue & test_space =
       (type == Moose::ElementElement || type == Moose::ElementNeighbor) ? _test : _test_neighbor;
@@ -190,14 +190,15 @@ DGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, unsigned i
       (type == Moose::ElementElement || type == Moose::NeighborElement) ? _phi : _phi_neighbor;
 
   if (type == Moose::ElementElement)
-    prepareMatrixTag(_assembly, _var.number(), jvar);
+    prepareMatrixTag(_assembly, _var.number(), jvar.number());
   else
-    prepareMatrixTagNeighbor(_assembly, _var.number(), jvar, type);
+    prepareMatrixTagNeighbor(_assembly, _var.number(), jvar.number(), type);
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
     for (_i = 0; _i < test_space.size(); _i++)
       for (_j = 0; _j < loc_phi.size(); _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jvar);
+        _local_ke(_i, _j) +=
+            _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(type, jvar.number());
 
   accumulateTaggedLocalMatrix();
 }

--- a/framework/src/dgkernels/DGKernelBase.C
+++ b/framework/src/dgkernels/DGKernelBase.C
@@ -152,11 +152,11 @@ DGKernelBase::computeJacobian()
 }
 
 void
-DGKernelBase::computeOffDiagJacobian(unsigned int jvar)
+DGKernelBase::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
   if (!excludeBoundary())
   {
-    if (jvar == variable().number())
+    if (jvar.number() == variable().number())
       computeJacobian();
     else
     {

--- a/framework/src/dgkernels/DGKernelBase.C
+++ b/framework/src/dgkernels/DGKernelBase.C
@@ -27,15 +27,10 @@ defineLegacyParams(DGKernelBase);
 InputParameters
 DGKernelBase::validParams()
 {
-  InputParameters params = MooseObject::validParams();
+  InputParameters params = ResidualObject::validParams();
   params += TwoMaterialPropertyInterface::validParams();
-  params += TransientInterface::validParams();
   params += BlockRestrictable::validParams();
   params += BoundaryRestrictable::validParams();
-  params += MeshChangedInterface::validParams();
-  params += TaggingInterface::validParams();
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this boundary condition applies to");
   params.addParam<bool>("use_displaced_mesh",
                         false,
                         "Whether or not this object should use the "
@@ -46,7 +41,6 @@ DGKernelBase::validParams()
   params.addPrivateParam<bool>("_use_undisplaced_reference_points", false);
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
-  params.declareControllable("enable");
   params.addParam<std::vector<AuxVariableName>>(
       "save_in",
       "The name of auxiliary variables to save this Kernel's residual contributions to. "
@@ -76,25 +70,12 @@ Threads::spin_mutex DGKernelBase::_resid_vars_mutex;
 Threads::spin_mutex DGKernelBase::_jacoby_vars_mutex;
 
 DGKernelBase::DGKernelBase(const InputParameters & parameters)
-  : MooseObject(parameters),
+  : ResidualObject(parameters),
     BlockRestrictable(this),
     BoundaryRestrictable(this, false), // false for _not_ nodal
-    SetupInterface(this),
-    TransientInterface(this),
-    FunctionInterface(this),
-    UserObjectInterface(this),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
     TwoMaterialPropertyInterface(this, blockIDs(), boundaryIDs()),
-    Restartable(this, "DGKernels"),
-    MeshChangedInterface(parameters),
-    TaggingInterface(this),
     ElementIDInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _mesh(_subproblem.mesh()),
-
     _current_elem(_assembly.elem()),
     _current_elem_volume(_assembly.elemVolume()),
 
@@ -137,8 +118,6 @@ DGKernelBase::DGKernelBase(const InputParameters & parameters)
 
   _excluded_boundaries.insert(bnd_ids.begin(), bnd_ids.end());
 }
-
-DGKernelBase::~DGKernelBase() {}
 
 void
 DGKernelBase::computeResidual()

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -21,11 +21,8 @@ defineLegacyParams(DiracKernel);
 InputParameters
 DiracKernel::validParams()
 {
-  InputParameters params = MooseObject::validParams();
+  InputParameters params = ResidualObject::validParams();
   params += MaterialPropertyInterface::validParams();
-  params += TaggingInterface::validParams();
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this kernel operates on");
 
   params.addParam<bool>("use_displaced_mesh",
                         false,
@@ -42,36 +39,22 @@ DiracKernel::validParams()
 
   params.addParamNamesToGroup("use_displaced_mesh drop_duplicate_points", "Advanced");
 
-  params.declareControllable("enable");
   params.registerBase("DiracKernel");
 
   return params;
 }
 
 DiracKernel::DiracKernel(const InputParameters & parameters)
-  : MooseObject(parameters),
-    SetupInterface(this),
+  : ResidualObject(parameters),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
     MooseVariableInterface<Real>(this,
                                  false,
                                  "variable",
                                  Moose::VarKindType::VAR_NONLINEAR,
                                  Moose::VarFieldType::VAR_FIELD_STANDARD),
-    FunctionInterface(this),
-    UserObjectInterface(this),
-    TransientInterface(this),
     MaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, Moose::EMPTY_BOUNDARY_IDS),
-    PostprocessorInterface(this),
     GeometricSearchInterface(this),
-    Restartable(this, "DiracKernels"),
-    MeshChangedInterface(parameters),
-    TaggingInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
     _var(mooseVariableField()),
-    _mesh(_subproblem.mesh()),
     _coord_sys(_assembly.coordSystem()),
     _dirac_kernel_info(_subproblem.diracKernelInfo()),
     _current_elem(_var.currentElem()),
@@ -447,18 +430,6 @@ DiracKernel::meshChanged()
 {
   _point_cache.clear();
   _reverse_point_cache.clear();
-}
-
-MooseVariableField<Real> &
-DiracKernel::variable()
-{
-  return _var;
-}
-
-SubProblem &
-DiracKernel::subProblem()
-{
-  return _subproblem;
 }
 
 void

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -130,15 +130,15 @@ DiracKernel::computeJacobian()
 }
 
 void
-DiracKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+DiracKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
   {
     computeJacobian();
   }
   else
   {
-    prepareMatrixTag(_assembly, _var.number(), jvar.number());
+    prepareMatrixTag(_assembly, _var.number(), jvar_num);
 
     const std::vector<unsigned int> * multiplicities =
         _drop_duplicate_points ? NULL : &_local_dirac_kernel_info.getPoints()[_current_elem].second;
@@ -155,7 +155,7 @@ DiracKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
         for (_i = 0; _i < _test.size(); _i++)
           for (_j = 0; _j < _phi.size(); _j++)
-            _local_ke(_i, _j) += multiplicity * computeQpOffDiagJacobian(jvar.number());
+            _local_ke(_i, _j) += multiplicity * computeQpOffDiagJacobian(jvar_num);
       }
     }
 

--- a/framework/src/dirackernels/DiracKernel.C
+++ b/framework/src/dirackernels/DiracKernel.C
@@ -130,15 +130,15 @@ DiracKernel::computeJacobian()
 }
 
 void
-DiracKernel::computeOffDiagJacobian(unsigned int jvar)
+DiracKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
   {
     computeJacobian();
   }
   else
   {
-    prepareMatrixTag(_assembly, _var.number(), jvar);
+    prepareMatrixTag(_assembly, _var.number(), jvar.number());
 
     const std::vector<unsigned int> * multiplicities =
         _drop_duplicate_points ? NULL : &_local_dirac_kernel_info.getPoints()[_current_elem].second;
@@ -155,7 +155,7 @@ DiracKernel::computeOffDiagJacobian(unsigned int jvar)
 
         for (_i = 0; _i < _test.size(); _i++)
           for (_j = 0; _j < _phi.size(); _j++)
-            _local_ke(_i, _j) += multiplicity * computeQpOffDiagJacobian(jvar);
+            _local_ke(_i, _j) += multiplicity * computeQpOffDiagJacobian(jvar.number());
       }
     }
 

--- a/framework/src/dirackernels/VectorPostprocessorPointSource.C
+++ b/framework/src/dirackernels/VectorPostprocessorPointSource.C
@@ -42,7 +42,6 @@ VectorPostprocessorPointSource::validParams()
 
 VectorPostprocessorPointSource::VectorPostprocessorPointSource(const InputParameters & parameters)
   : DiracKernel(parameters),
-    VectorPostprocessorInterface(this),
     _use_broadcast(getParam<bool>("use_broadcast")),
     _vpp_values(getVectorPostprocessorValue(
         "vector_postprocessor", getParam<std::string>("value_name"), _use_broadcast)),

--- a/framework/src/interfacekernels/InterfaceKernelBase.C
+++ b/framework/src/interfacekernels/InterfaceKernelBase.C
@@ -21,14 +21,9 @@ defineLegacyParams(InterfaceKernelBase);
 InputParameters
 InterfaceKernelBase::validParams()
 {
-  InputParameters params = MooseObject::validParams();
-  params += TransientInterface::validParams();
+  InputParameters params = ResidualObject::validParams();
   params += BoundaryRestrictable::validParams();
-  params += MeshChangedInterface::validParams();
-  params += TaggingInterface::validParams();
 
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this boundary condition applies to");
   params.addParam<bool>("use_displaced_mesh",
                         false,
                         "Whether or not this object should use the "
@@ -80,24 +75,11 @@ Threads::spin_mutex InterfaceKernelBase::_resid_vars_mutex;
 Threads::spin_mutex InterfaceKernelBase::_jacoby_vars_mutex;
 
 InterfaceKernelBase::InterfaceKernelBase(const InputParameters & parameters)
-  : MooseObject(parameters),
+  : ResidualObject(parameters),
     BoundaryRestrictable(this, false), // false for _not_ nodal
-    SetupInterface(this),
-    TransientInterface(this),
-    FunctionInterface(this),
-    UserObjectInterface(this),
-    PostprocessorInterface(this),
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
-    Restartable(this, "InterfaceKernels"),
-    MeshChangedInterface(parameters),
     TwoMaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
-    TaggingInterface(this),
     ElementIDInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _mesh(_subproblem.mesh()),
     _current_elem(_assembly.elem()),
     _current_elem_volume(_assembly.elemVolume()),
     _neighbor_elem(_assembly.neighbor()),

--- a/framework/src/interfacekernels/InterfaceKernelBase.C
+++ b/framework/src/interfacekernels/InterfaceKernelBase.C
@@ -21,7 +21,7 @@ defineLegacyParams(InterfaceKernelBase);
 InputParameters
 InterfaceKernelBase::validParams()
 {
-  InputParameters params = ResidualObject::validParams();
+  InputParameters params = NeighborResidualObject::validParams();
   params += BoundaryRestrictable::validParams();
 
   params.addParam<bool>("use_displaced_mesh",
@@ -75,7 +75,7 @@ Threads::spin_mutex InterfaceKernelBase::_resid_vars_mutex;
 Threads::spin_mutex InterfaceKernelBase::_jacoby_vars_mutex;
 
 InterfaceKernelBase::InterfaceKernelBase(const InputParameters & parameters)
-  : ResidualObject(parameters),
+  : NeighborResidualObject(parameters),
     BoundaryRestrictable(this, false), // false for _not_ nodal
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, false, false),
     TwoMaterialPropertyInterface(this, Moose::EMPTY_BLOCK_IDS, boundaryIDs()),
@@ -104,4 +104,10 @@ const Real &
 InterfaceKernelBase::getNeighborElemVolume()
 {
   return _assembly.neighborVolume();
+}
+
+void
+InterfaceKernelBase::prepareShapes(const unsigned int var_num)
+{
+  _subproblem.prepareFaceShapes(var_num, _tid);
 }

--- a/framework/src/interfaces/ElementIDInterface.C
+++ b/framework/src/interfaces/ElementIDInterface.C
@@ -21,7 +21,7 @@
 
 ElementIDInterface::ElementIDInterface(const MooseObject * moose_object)
   : _obj_parameters(moose_object->parameters()),
-    _mesh(moose_object->getMooseApp().actionWarehouse().mesh())
+    _id_mesh(moose_object->getMooseApp().actionWarehouse().mesh())
 {
 }
 
@@ -39,10 +39,10 @@ ElementIDInterface::getElementIDIndex(const std::string & id_parameter_name,
 unsigned int
 ElementIDInterface::getElementIDIndexByName(const std::string & id_name) const
 {
-  if (!_mesh.get())
+  if (!_id_mesh.get())
     mooseError("Mesh is not available for getting element integers");
 
-  auto & mesh_base = _mesh->getMesh();
+  auto & mesh_base = _id_mesh->getMesh();
 
   if (id_name == "subdomain_id")
   {

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -223,7 +223,8 @@ ADKernelTempl<T>::computeADJacobian(
           if (ivar != _var.number() || !jvariable.hasBlocks(_current_elem->subdomain_id()))
             continue;
 
-          addJacobian(jvariable);
+          // Make sure to get the correct undisplaced/displaced variable
+          addJacobian(getVariable(jvariable.number()));
         }
       };
 
@@ -239,7 +240,7 @@ ADKernelTempl<T>::jacobianSetup()
 
 template <typename T>
 void
-ADKernelTempl<T>::computeOffDiagJacobian(MooseVariableFEBase &)
+ADKernelTempl<T>::computeOffDiagJacobian(const unsigned int)
 {
   if (_my_elem != _current_elem)
   {

--- a/framework/src/kernels/ArrayDiffusion.C
+++ b/framework/src/kernels/ArrayDiffusion.C
@@ -84,7 +84,7 @@ ArrayDiffusion::computeQpJacobian()
 }
 
 RealEigenMatrix
-ArrayDiffusion::computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayDiffusion::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
 {
   if (jvar.number() == _var.number() && _d_2d_array)
     return _grad_phi[_j][_qp] * _grad_test[_i][_qp] * (*_d_2d_array)[_qp];

--- a/framework/src/kernels/ArrayKernel.C
+++ b/framework/src/kernels/ArrayKernel.C
@@ -161,17 +161,19 @@ ArrayKernel::computeJacobian()
 }
 
 void
-ArrayKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  bool same_var = (jvar.number() == _var.number());
+  const auto & jvar = getVariable(jvar_num);
 
-  prepareMatrixTag(_assembly, _var.number(), jvar.number());
+  bool same_var = (jvar_num == _var.number());
+
+  prepareMatrixTag(_assembly, _var.number(), jvar_num);
 
   // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting on
   // the displaced mesh
-  auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+  auto phi_size = jvar.dofIndices().size();
 
-  precalculateOffDiagJacobian(jvar.number());
+  precalculateOffDiagJacobian(jvar_num);
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
     initQpOffDiagJacobian(jvar);
@@ -180,7 +182,7 @@ ArrayKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       {
         RealEigenMatrix v = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
         _assembly.saveFullLocalArrayJacobian(
-            _local_ke, _i, _test.size(), _j, phi_size, _var.number(), jvar.number(), v);
+            _local_ke, _i, _test.size(), _j, phi_size, _var.number(), jvar_num, v);
       }
   }
 

--- a/framework/src/kernels/ArrayReaction.C
+++ b/framework/src/kernels/ArrayReaction.C
@@ -83,7 +83,7 @@ ArrayReaction::computeQpJacobian()
 }
 
 RealEigenMatrix
-ArrayReaction::computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayReaction::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
 {
   if (jvar.number() == _var.number() && _r_2d_array)
     return _phi[_j][_qp] * _test[_i][_qp] * (*_r_2d_array)[_qp];

--- a/framework/src/kernels/ArrayTimeDerivative.C
+++ b/framework/src/kernels/ArrayTimeDerivative.C
@@ -81,7 +81,7 @@ ArrayTimeDerivative::computeQpJacobian()
 }
 
 RealEigenMatrix
-ArrayTimeDerivative::computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayTimeDerivative::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
 {
   if (jvar.number() == _var.number() && _coeff_2d_array)
     return _phi[_j][_qp] * _test[_i][_qp] * _du_dot_du[_qp] * (*_coeff_2d_array)[_qp];

--- a/framework/src/kernels/AverageValueConstraint.C
+++ b/framework/src/kernels/AverageValueConstraint.C
@@ -36,8 +36,6 @@ AverageValueConstraint::AverageValueConstraint(const InputParameters & parameter
 {
 }
 
-AverageValueConstraint::~AverageValueConstraint() {}
-
 void
 AverageValueConstraint::reinit()
 {
@@ -79,12 +77,12 @@ AverageValueConstraint::computeQpJacobian()
 }
 
 void
-AverageValueConstraint::computeOffDiagJacobian(unsigned int /*jvar*/)
+AverageValueConstraint::computeOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
 }
 
 Real
-AverageValueConstraint::computeQpOffDiagJacobian(unsigned int /*jvar*/)
+AverageValueConstraint::computeQpOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
   // The off-diagonal contribution for this ScalarKernel (derivative
   // wrt the "primal" field variable) is not _actually_ zero, but we

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -133,9 +133,8 @@ EigenKernel::computeJacobian()
 }
 
 void
-EigenKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+EigenKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (!_is_implicit)
     return;
 
@@ -143,13 +142,15 @@ EigenKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     computeJacobian();
   else
   {
+    const auto & jvar = getVariable(jvar_num);
+
     DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_num);
     _local_ke.resize(ke.m(), ke.n());
     _local_ke.zero();
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
 
     mooseAssert(*_eigenvalue != 0.0, "Can't divide by zero eigenvalue in EigenKernel!");
     Real one_over_eigen = 1.0 / *_eigenvalue;
@@ -157,7 +158,7 @@ EigenKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       for (_j = 0; _j < phi_size; _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           _local_ke(_i, _j) +=
-              _JxW[_qp] * _coord[_qp] * one_over_eigen * computeQpOffDiagJacobian(jvar.number());
+              _JxW[_qp] * _coord[_qp] * one_over_eigen * computeQpOffDiagJacobian(jvar_num);
 
     ke += _local_ke;
   }

--- a/framework/src/kernels/EigenKernel.C
+++ b/framework/src/kernels/EigenKernel.C
@@ -157,7 +157,7 @@ EigenKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       for (_j = 0; _j < phi_size; _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           _local_ke(_i, _j) +=
-              _JxW[_qp] * _coord[_qp] * one_over_eigen * computeQpOffDiagJacobian(jvar_num);
+              _JxW[_qp] * _coord[_qp] * one_over_eigen * computeQpOffDiagJacobian(jvar.number());
 
     ke += _local_ke;
   }

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -157,7 +157,7 @@ Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       for (_i = 0; _i < _test.size(); _i++)
         for (_j = 0; _j < phi_size; _j++)
           for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-            _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+            _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
     }
     else
     {
@@ -179,27 +179,6 @@ Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 }
 
 void
-Kernel::computeOffDiagJacobian(unsigned int jvar)
-{
-  mooseDeprecated("The computeOffDiagJacobian method signature has changed. Developers, please "
-                  "pass in a MooseVariableFEBase reference instead of the variable number");
-  if (jvar == _var.number())
-    computeJacobian();
-  else
-  {
-    prepareMatrixTag(_assembly, _var.number(), jvar);
-
-    precalculateOffDiagJacobian(jvar);
-    for (_i = 0; _i < _test.size(); _i++)
-      for (_j = 0; _j < _phi.size(); _j++)
-        for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
-
-    accumulateTaggedLocalMatrix();
-  }
-}
-
-void
 Kernel::computeOffDiagJacobianScalar(unsigned int jvar)
 {
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
@@ -208,7 +187,7 @@ Kernel::computeOffDiagJacobianScalar(unsigned int jvar)
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jv.order(); _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobianScalar(jvar);
 
   accumulateTaggedLocalMatrix();
 }

--- a/framework/src/kernels/Kernel.C
+++ b/framework/src/kernels/Kernel.C
@@ -132,9 +132,10 @@ Kernel::computeJacobian()
 }
 
 void
-Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+Kernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  auto jvar_num = jvar.number();
+  const auto & jvar = getVariable(jvar_num);
+
   if (jvar_num == _var.number())
     computeJacobian();
   else
@@ -143,7 +144,7 @@ Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
     mooseAssert(
         phi_size * jvar.count() == _local_ke.n(),
         "The size of the phi container does not match the number of local Jacobian columns");
@@ -166,9 +167,9 @@ Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
         for (_j = 0; _j < n; _j++)
           for (_qp = 0; _qp < _qrule->n_points(); _qp++)
           {
-            RealEigenVector v =
-                _JxW[_qp] * _coord[_qp] *
-                computeQpOffDiagJacobianArray(static_cast<ArrayMooseVariable &>(jvar));
+            RealEigenVector v = _JxW[_qp] * _coord[_qp] *
+                                computeQpOffDiagJacobianArray(static_cast<ArrayMooseVariable &>(
+                                    const_cast<MooseVariableFieldBase &>(jvar)));
             for (unsigned int k = 0; k < v.size(); ++k)
               _local_ke(_i, _j + k * n) += v(k);
           }
@@ -179,7 +180,7 @@ Kernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 }
 
 void
-Kernel::computeOffDiagJacobianScalar(unsigned int jvar)
+Kernel::computeOffDiagJacobianScalar(const unsigned int jvar)
 {
   MooseVariableScalar & jv = _sys.getScalarVariable(_tid, jvar);
   prepareMatrixTag(_assembly, _var.number(), jvar);

--- a/framework/src/kernels/KernelBase.C
+++ b/framework/src/kernels/KernelBase.C
@@ -22,16 +22,10 @@ defineLegacyParams(KernelBase);
 InputParameters
 KernelBase::validParams()
 {
-  auto params = MooseObject::validParams();
-  params += TransientInterface::validParams();
+  auto params = ResidualObject::validParams();
   params += BlockRestrictable::validParams();
-  params += RandomInterface::validParams();
-  params += MeshChangedInterface::validParams();
   params += MaterialPropertyInterface::validParams();
-  params += TaggingInterface::validParams();
 
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this Kernel operates on");
   params.addParam<std::vector<AuxVariableName>>(
       "save_in",
       "The name of auxiliary variables to save this Kernel's residual contributions to. "
@@ -53,37 +47,16 @@ KernelBase::validParams()
 
   params.addParamNamesToGroup(" diag_save_in save_in use_displaced_mesh", "Advanced");
   params.addCoupledVar("displacements", "The displacements");
-
-  params.declareControllable("enable");
   return params;
 }
 
 KernelBase::KernelBase(const InputParameters & parameters)
-  : MooseObject(parameters),
+  : ResidualObject(parameters),
     BlockRestrictable(this),
-    SetupInterface(this),
     CoupleableMooseVariableDependencyIntermediateInterface(this, false),
-    FunctionInterface(this),
-    UserObjectInterface(this),
-    TransientInterface(this),
-    PostprocessorInterface(this),
-    VectorPostprocessorInterface(this),
     MaterialPropertyInterface(this, blockIDs(), Moose::EMPTY_BOUNDARY_IDS),
-    RandomInterface(parameters,
-                    *parameters.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"),
-                    parameters.get<THREAD_ID>("_tid"),
-                    false),
     GeometricSearchInterface(this),
-    Restartable(this, "Kernels"),
-    MeshChangedInterface(parameters),
-    TaggingInterface(this),
     ElementIDInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _fe_problem(*parameters.get<FEProblemBase *>("_fe_problem_base")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
-    _mesh(_subproblem.mesh()),
     _current_elem(_assembly.elem()),
     _current_elem_volume(_assembly.elemVolume()),
     _q_point(_assembly.qPoints()),
@@ -99,5 +72,3 @@ KernelBase::KernelBase(const InputParameters & parameters)
   for (decltype(num_disp) i = 0; i < num_disp; ++i)
     _displacements.push_back(coupled("displacements", i));
 }
-
-KernelBase::~KernelBase() {}

--- a/framework/src/kernels/KernelGrad.C
+++ b/framework/src/kernels/KernelGrad.C
@@ -79,9 +79,10 @@ KernelGrad::computeJacobian()
 }
 
 void
-KernelGrad::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+KernelGrad::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
+  const auto & jvar = getVariable(jvar_num);
+
   if (jvar_num == _var.number())
     computeJacobian();
   else
@@ -90,12 +91,12 @@ KernelGrad::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
 
     for (_j = 0; _j < phi_size; _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
         for (_i = 0; _i < _test.size(); _i++)
-          Ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+          Ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
   }
 }
 

--- a/framework/src/kernels/KernelGrad.C
+++ b/framework/src/kernels/KernelGrad.C
@@ -95,7 +95,7 @@ KernelGrad::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     for (_j = 0; _j < phi_size; _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
         for (_i = 0; _i < _test.size(); _i++)
-          Ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          Ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
   }
 }
 

--- a/framework/src/kernels/KernelValue.C
+++ b/framework/src/kernels/KernelValue.C
@@ -95,7 +95,7 @@ KernelValue::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     for (_j = 0; _j < phi_size; _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
         for (_i = 0; _i < _test.size(); _i++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
   }
 }
 

--- a/framework/src/kernels/KernelValue.C
+++ b/framework/src/kernels/KernelValue.C
@@ -79,9 +79,10 @@ KernelValue::computeJacobian()
 }
 
 void
-KernelValue::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+KernelValue::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
+  const auto & jvar = getVariable(jvar_num);
+
   if (jvar_num == _var.number())
     computeJacobian();
   else
@@ -90,12 +91,12 @@ KernelValue::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
 
     for (_j = 0; _j < phi_size; _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
         for (_i = 0; _i < _test.size(); _i++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
   }
 }
 

--- a/framework/src/kernels/NodalScalarKernel.C
+++ b/framework/src/kernels/NodalScalarKernel.C
@@ -75,7 +75,7 @@ NodalScalarKernel::reinit()
 }
 
 void
-NodalScalarKernel::computeOffDiagJacobian(unsigned int jvar)
+NodalScalarKernel::computeOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _var.number())
     computeJacobian();

--- a/framework/src/kernels/NonlocalKernel.C
+++ b/framework/src/kernels/NonlocalKernel.C
@@ -87,7 +87,7 @@ NonlocalKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       getUserObjectJacobian(jvar_num, jvar.dofIndices()[_j]);
       for (_i = 0; _i < _test.size(); _i++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
     }
   }
 }

--- a/framework/src/kernels/NonlocalKernel.C
+++ b/framework/src/kernels/NonlocalKernel.C
@@ -67,18 +67,19 @@ NonlocalKernel::computeJacobian()
 }
 
 void
-NonlocalKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NonlocalKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else
   {
+    const auto & jvar = getVariable(jvar_num);
+
     DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_num);
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    const auto phi_size = jvar.dofIndices().size();
 
     precalculateOffDiagJacobian(jvar_num);
     for (_j = 0; _j < phi_size;
@@ -87,7 +88,7 @@ NonlocalKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       getUserObjectJacobian(jvar_num, jvar.dofIndices()[_j]);
       for (_i = 0; _i < _test.size(); _i++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
     }
   }
 }

--- a/framework/src/kernels/ODEKernel.C
+++ b/framework/src/kernels/ODEKernel.C
@@ -55,26 +55,23 @@ ODEKernel::computeJacobian()
   // compute off-diagonal jacobians wrt scalar variables
   const std::vector<MooseVariableScalar *> & scalar_vars = _sys.getScalarVariables(_tid);
   for (const auto & var : scalar_vars)
-    computeOffDiagJacobian(var->number());
+    computeOffDiagJacobianScalar(var->number());
 }
 
 void
-ODEKernel::computeOffDiagJacobian(unsigned int jvar)
+ODEKernel::computeOffDiagJacobianScalar(unsigned int jvar)
 {
-  if (_sys.isScalarVariable(jvar))
-  {
-    prepareMatrixTag(_assembly, _var.number(), jvar);
+  prepareMatrixTag(_assembly, _var.number(), jvar);
 
-    MooseVariableScalar & var_j = _sys.getScalarVariable(_tid, jvar);
-    for (_i = 0; _i < _var.order(); _i++)
-      for (_j = 0; _j < var_j.order(); _j++)
-      {
-        if (jvar != _var.number())
-          _local_ke(_i, _j) += computeQpOffDiagJacobian(jvar);
-      }
+  MooseVariableScalar & var_j = _sys.getScalarVariable(_tid, jvar);
+  for (_i = 0; _i < _var.order(); _i++)
+    for (_j = 0; _j < var_j.order(); _j++)
+    {
+      if (jvar != _var.number())
+        _local_ke(_i, _j) += computeQpOffDiagJacobianScalar(jvar);
+    }
 
-    accumulateTaggedLocalMatrix();
-  }
+  accumulateTaggedLocalMatrix();
 }
 
 Real
@@ -84,7 +81,7 @@ ODEKernel::computeQpJacobian()
 }
 
 Real
-ODEKernel::computeQpOffDiagJacobian(unsigned int /*jvar*/)
+ODEKernel::computeQpOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
   return 0.;
 }

--- a/framework/src/kernels/ODEKernel.C
+++ b/framework/src/kernels/ODEKernel.C
@@ -79,9 +79,3 @@ ODEKernel::computeQpJacobian()
 {
   return 0.;
 }
-
-Real
-ODEKernel::computeQpOffDiagJacobianScalar(unsigned int /*jvar*/)
-{
-  return 0.;
-}

--- a/framework/src/kernels/ParsedODEKernel.C
+++ b/framework/src/kernels/ParsedODEKernel.C
@@ -158,7 +158,7 @@ ParsedODEKernel::computeQpJacobian()
 }
 
 Real
-ParsedODEKernel::computeQpOffDiagJacobian(unsigned int jvar)
+ParsedODEKernel::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   int i = _arg_index[jvar];
   if (i < 0)

--- a/framework/src/kernels/ScalarKernel.C
+++ b/framework/src/kernels/ScalarKernel.C
@@ -20,12 +20,7 @@ defineLegacyParams(ScalarKernel);
 InputParameters
 ScalarKernel::validParams()
 {
-  InputParameters params = MooseObject::validParams();
-  params += TransientInterface::validParams();
-  params += TaggingInterface::validParams();
-  params.addRequiredParam<NonlinearVariableName>(
-      "variable", "The name of the variable that this kernel operates on");
-
+  InputParameters params = ResidualObject::validParams();
   params.addParam<bool>("use_displaced_mesh",
                         false,
                         "Whether or not this object should use the "
@@ -35,56 +30,16 @@ ScalarKernel::validParams()
                         "the undisplaced mesh will still be used.");
   params.addParamNamesToGroup("use_displaced_mesh", "Advanced");
 
-  params.declareControllable("enable");
-
   params.registerBase("ScalarKernel");
 
   return params;
 }
 
 ScalarKernel::ScalarKernel(const InputParameters & parameters)
-  : MooseObject(parameters),
+  : ResidualObject(parameters),
     ScalarCoupleable(this),
-    SetupInterface(this),
-    FunctionInterface(this),
-    UserObjectInterface(this),
-    PostprocessorInterface(this),
-    TransientInterface(this),
-    MeshChangedInterface(parameters),
-    // VPPs used by ScalarKernels must be broadcast because we don't know where the
-    // ScalarKernel will end up being evaluated
-    VectorPostprocessorInterface(this, /*broadcast_by_default=*/true),
-    TaggingInterface(this),
-    _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
-    _sys(*getCheckedPointerParam<SystemBase *>("_sys")),
-    _tid(parameters.get<THREAD_ID>("_tid")),
-    _assembly(_subproblem.assembly(_tid)),
     _var(_sys.getScalarVariable(_tid, parameters.get<NonlinearVariableName>("variable"))),
-    _mesh(_subproblem.mesh()),
     _u(_is_implicit ? _var.sln() : _var.slnOld()),
     _u_old(_var.slnOld())
 {
-}
-
-void
-ScalarKernel::computeOffDiagJacobian(unsigned int /*jvar*/)
-{
-}
-
-bool
-ScalarKernel::isActive()
-{
-  return true;
-}
-
-MooseVariableScalar &
-ScalarKernel::variable()
-{
-  return _var;
-}
-
-SubProblem &
-ScalarKernel::subProblem()
-{
-  return _subproblem;
 }

--- a/framework/src/kernels/ScalarLagrangeMultiplier.C
+++ b/framework/src/kernels/ScalarLagrangeMultiplier.C
@@ -63,14 +63,14 @@ ScalarLagrangeMultiplier::computeOffDiagJacobianScalar(unsigned int jvar)
     for (_j = 0; _j < jv.order(); _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
       {
-        Real value = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        Real value = _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobianScalar(jvar);
         ken(_i, _j) += value;
         kne(_j, _i) += value;
       }
 }
 
 Real
-ScalarLagrangeMultiplier::computeQpOffDiagJacobian(unsigned int jvar)
+ScalarLagrangeMultiplier::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _lambda_var)
     return _test[_i][_qp];

--- a/framework/src/kernels/VectorKernel.C
+++ b/framework/src/kernels/VectorKernel.C
@@ -99,24 +99,25 @@ VectorKernel::computeJacobian()
 }
 
 void
-VectorKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+VectorKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else
   {
+    const auto & jvar = getVariable(jvar_num);
+
     DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_num);
 
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    const auto phi_size = jvar.dofIndices().size();
 
     precalculateOffDiagJacobian(jvar_num);
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < phi_size; _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
   }
 }
 

--- a/framework/src/kernels/VectorKernel.C
+++ b/framework/src/kernels/VectorKernel.C
@@ -116,7 +116,7 @@ VectorKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < phi_size; _j++)
         for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
+          ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
   }
 }
 
@@ -129,5 +129,5 @@ VectorKernel::computeOffDiagJacobianScalar(unsigned int jvar)
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jv.order(); _j++)
       for (_qp = 0; _qp < _qrule->n_points(); _qp++)
-        ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar);
+        ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobianScalar(jvar);
 }

--- a/framework/src/loops/ComputeDiracThread.C
+++ b/framework/src/loops/ComputeDiracThread.C
@@ -116,13 +116,13 @@ ComputeDiracThread::onElement(const Elem * elem)
     }
 
     // Get a list of coupled variables from the SubProblem
-    auto & coupling_entries = dirac_kernel->subProblem().assembly(_tid).couplingEntries();
+    const auto & coupling_entries = dirac_kernel->subProblem().assembly(_tid).couplingEntries();
 
     // Loop over the list of coupled variable pairs
-    for (auto & it : coupling_entries)
+    for (const auto & it : coupling_entries)
     {
-      MooseVariableFEBase * ivariable = it.first;
-      MooseVariableFEBase * jvariable = it.second;
+      const MooseVariableFEBase * const ivariable = it.first;
+      const MooseVariableFEBase * const jvariable = it.second;
 
       // A variant of the check that is in
       // ComputeFullJacobianThread::computeJacobian().  We
@@ -133,8 +133,8 @@ ComputeDiracThread::onElement(const Elem * elem)
           ivariable->activeOnSubdomain(_subdomain) && jvariable->activeOnSubdomain(_subdomain) &&
           (jvariable->numberOfDofs() > 0))
       {
-        dirac_kernel->subProblem().prepareShapes(jvariable->number(), _tid);
-        dirac_kernel->computeOffDiagJacobian(*jvariable);
+        dirac_kernel->prepareShapes(jvariable->number());
+        dirac_kernel->computeOffDiagJacobian(jvariable->number());
       }
     }
   }

--- a/framework/src/loops/ComputeDiracThread.C
+++ b/framework/src/loops/ComputeDiracThread.C
@@ -134,7 +134,7 @@ ComputeDiracThread::onElement(const Elem * elem)
           (jvariable->numberOfDofs() > 0))
       {
         dirac_kernel->subProblem().prepareShapes(jvariable->number(), _tid);
-        dirac_kernel->computeOffDiagJacobian(jvariable->number());
+        dirac_kernel->computeOffDiagJacobian(*jvariable);
       }
     }
   }

--- a/framework/src/loops/ComputeFullJacobianThread.C
+++ b/framework/src/loops/ComputeFullJacobianThread.C
@@ -259,7 +259,7 @@ ComputeFullJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
         {
           dg->subProblem().prepareFaceShapes(jvar, _tid);
           dg->subProblem().prepareNeighborShapes(jvar, _tid);
-          dg->computeOffDiagJacobian(jvar);
+          dg->computeOffDiagJacobian(jvariable);
         }
       }
     }

--- a/framework/src/loops/ComputeFullJacobianThread.C
+++ b/framework/src/loops/ComputeFullJacobianThread.C
@@ -60,8 +60,8 @@ ComputeFullJacobianThread::computeJacobian()
       for (const auto & kernel : kernels)
         if ((kernel->variable().number() == ivar) && kernel->isImplicit())
         {
-          kernel->subProblem().prepareShapes(jvar, _tid);
-          kernel->computeOffDiagJacobian(jvariable);
+          kernel->prepareShapes(jvar);
+          kernel->computeOffDiagJacobian(jvar);
         }
     }
   }
@@ -92,7 +92,7 @@ ComputeFullJacobianThread::computeJacobian()
           if (nonlocal_kernel)
             if ((kernel->variable().number() == ivar) && kernel->isImplicit())
             {
-              kernel->subProblem().prepareShapes(jvar, _tid);
+              kernel->prepareShapes(jvar);
               kernel->computeNonlocalOffDiagJacobian(jvar);
             }
         }
@@ -156,6 +156,9 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
     if (ivariable.isFV() || jvariable.isFV())
       continue;
 
+    const auto ivar = ivariable.number();
+    const auto jvar = jvariable.number();
+
     if (ivariable.activeOnSubdomain(_subdomain) && jvariable.activeOnSubdomain(_subdomain) &&
         _ibc_warehouse->hasActiveBoundaryObjects(bnd_id, _tid))
     {
@@ -163,10 +166,10 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
       // any)
       const auto & bcs = _ibc_warehouse->getActiveBoundaryObjects(bnd_id, _tid);
       for (const auto & bc : bcs)
-        if (bc->shouldApply() && bc->variable().number() == ivariable.number() && bc->isImplicit())
+        if (bc->shouldApply() && bc->variable().number() == ivar && bc->isImplicit())
         {
-          bc->subProblem().prepareFaceShapes(jvariable.number(), _tid);
-          bc->computeJacobianBlock(jvariable);
+          bc->prepareShapes(jvar);
+          bc->computeOffDiagJacobian(jvar);
         }
     }
   }
@@ -198,7 +201,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
           if (nonlocal_integrated_bc)
             if ((integrated_bc->variable().number() == ivar) && integrated_bc->isImplicit())
             {
-              integrated_bc->subProblem().prepareFaceShapes(jvar, _tid);
+              integrated_bc->prepareShapes(jvar);
               integrated_bc->computeNonlocalOffDiagJacobian(jvar);
             }
         }
@@ -227,7 +230,7 @@ ComputeFullJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
             // Do: dvar / dscalar_var, only want to process only nl-variables (not aux ones)
             for (const auto & jvar : coupled_scalar_vars)
               if (_nl.hasScalarVariable(jvar->name()))
-                bc->computeJacobianBlockScalar(jvar->number());
+                bc->computeOffDiagJacobianScalar(jvar->number());
           }
       }
   }
@@ -257,9 +260,9 @@ ComputeFullJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
         if (dg->variable().number() == ivar && dg->isImplicit() &&
             dg->hasBlocks(neighbor->subdomain_id()) && jvariable.activeOnSubdomain(_subdomain))
         {
-          dg->subProblem().prepareFaceShapes(jvar, _tid);
-          dg->subProblem().prepareNeighborShapes(jvar, _tid);
-          dg->computeOffDiagJacobian(jvariable);
+          dg->prepareShapes(jvar);
+          dg->prepareNeighborShapes(jvar);
+          dg->computeOffDiagJacobian(jvar);
         }
       }
     }
@@ -290,8 +293,8 @@ ComputeFullJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
         if (!interface_kernel->isImplicit())
           continue;
 
-        interface_kernel->subProblem().prepareFaceShapes(jvar, _tid);
-        interface_kernel->subProblem().prepareNeighborShapes(jvar, _tid);
+        interface_kernel->prepareShapes(jvar);
+        interface_kernel->prepareNeighborShapes(jvar);
 
         if (interface_kernel->variable().number() == ivar)
           interface_kernel->computeElementOffDiagJacobian(jvar);

--- a/framework/src/loops/ComputeJacobianThread.C
+++ b/framework/src/loops/ComputeJacobianThread.C
@@ -61,7 +61,7 @@ ComputeJacobianThread::computeJacobian()
     for (const auto & kernel : kernels)
       if (kernel->isImplicit())
       {
-        kernel->subProblem().prepareShapes(kernel->variable().number(), _tid);
+        kernel->prepareShapes(kernel->variable().number());
         kernel->computeJacobian();
         /// done only when nonlocal kernels exist in the system
         if (_fe_problem.checkNonlocalCouplingRequirement())
@@ -98,7 +98,7 @@ ComputeJacobianThread::computeFaceJacobian(BoundaryID bnd_id)
   for (const auto & bc : bcs)
     if (bc->shouldApply() && bc->isImplicit())
     {
-      bc->subProblem().prepareFaceShapes(bc->variable().number(), _tid);
+      bc->prepareShapes(bc->variable().number());
       bc->computeJacobian();
       /// done only when nonlocal integrated_bcs exist in the system
       if (_fe_problem.checkNonlocalCouplingRequirement())
@@ -119,8 +119,8 @@ ComputeJacobianThread::computeInternalFaceJacobian(const Elem * neighbor)
   for (const auto & dg : dgks)
     if (dg->isImplicit())
     {
-      dg->subProblem().prepareFaceShapes(dg->variable().number(), _tid);
-      dg->subProblem().prepareNeighborShapes(dg->variable().number(), _tid);
+      dg->prepareShapes(dg->variable().number());
+      dg->prepareNeighborShapes(dg->variable().number());
       if (dg->hasBlocks(neighbor->subdomain_id()))
         dg->computeJacobian();
     }
@@ -134,8 +134,8 @@ ComputeJacobianThread::computeInternalInterFaceJacobian(BoundaryID bnd_id)
   for (const auto & intk : intks)
     if (intk->isImplicit())
     {
-      intk->subProblem().prepareFaceShapes(intk->variable().number(), _tid);
-      intk->subProblem().prepareNeighborShapes(intk->neighborVariable().number(), _tid);
+      intk->prepareShapes(intk->variable().number());
+      intk->prepareNeighborShapes(intk->neighborVariable().number());
       intk->computeJacobian();
     }
 }

--- a/framework/src/loops/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/loops/ComputeNodalKernelBCJacobiansThread.C
@@ -120,7 +120,7 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
         {
           _fe_problem.reinitNodeFace(node, boundary_id, _tid);
           for (const auto & nodal_kernel : active_involved_kernels)
-            nodal_kernel->computeOffDiagJacobian(jvar);
+            nodal_kernel->computeOffDiagJacobian(jvariable);
 
           _num_cached++;
         }

--- a/framework/src/loops/ComputeNodalKernelBCJacobiansThread.C
+++ b/framework/src/loops/ComputeNodalKernelBCJacobiansThread.C
@@ -120,7 +120,7 @@ ComputeNodalKernelBCJacobiansThread::onNode(ConstBndNodeRange::const_iterator & 
         {
           _fe_problem.reinitNodeFace(node, boundary_id, _tid);
           for (const auto & nodal_kernel : active_involved_kernels)
-            nodal_kernel->computeOffDiagJacobian(jvariable);
+            nodal_kernel->computeOffDiagJacobian(jvar);
 
           _num_cached++;
         }

--- a/framework/src/loops/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/loops/ComputeNodalKernelJacobiansThread.C
@@ -117,7 +117,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
       _fe_problem.reinitNode(node, _tid);
 
       for (const auto & nodal_kernel : active_involved_kernels)
-        nodal_kernel->computeOffDiagJacobian(jvar);
+        nodal_kernel->computeOffDiagJacobian(jvariable);
 
       _num_cached++;
 

--- a/framework/src/loops/ComputeNodalKernelJacobiansThread.C
+++ b/framework/src/loops/ComputeNodalKernelJacobiansThread.C
@@ -117,7 +117,7 @@ ComputeNodalKernelJacobiansThread::onNode(ConstNodeRange::const_iterator & node_
       _fe_problem.reinitNode(node, _tid);
 
       for (const auto & nodal_kernel : active_involved_kernels)
-        nodal_kernel->computeOffDiagJacobian(jvariable);
+        nodal_kernel->computeOffDiagJacobian(jvar);
 
       _num_cached++;
 

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -149,8 +149,10 @@ NodalKernel::computeJacobian()
 }
 
 void
-NodalKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NodalKernel::computeOffDiagJacobian(const unsigned int jvar_num)
 {
+  const auto & jvar = getVariable(jvar_num);
+
   if (_var.isNodalDefined())
   {
     if (jvar.number() == _var.number())

--- a/framework/src/nodalkernels/NodalKernel.C
+++ b/framework/src/nodalkernels/NodalKernel.C
@@ -149,20 +149,20 @@ NodalKernel::computeJacobian()
 }
 
 void
-NodalKernel::computeOffDiagJacobian(unsigned int jvar)
+NodalKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
   if (_var.isNodalDefined())
   {
-    if (jvar == _var.number())
+    if (jvar.number() == _var.number())
       computeJacobian();
     else
     {
       _qp = 0;
-      Real cached_val = computeQpOffDiagJacobian(jvar);
+      Real cached_val = computeQpOffDiagJacobian(jvar.number());
       dof_id_type cached_row = _var.nodalDofIndex();
 
       // Note: this only works for equal order Lagrange variables...
-      dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar, 0);
+      dof_id_type cached_col = _current_node->dof_number(_sys.number(), jvar.number(), 0);
 
       cached_val *= _var.scalingFactor();
 

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -206,7 +206,13 @@ NonlinearEigenSystem::markEigenVariables(MooseObjectTagWarehouse<T> & warehouse)
       auto & mtags = object->getMatrixTags();
       // If it is an eigen kernel, mark its variable as eigen
       if (vtags.find(_Bx_tag) != vtags.end() || mtags.find(_B_tag) != mtags.end())
-        object->variable().eigen(true);
+      {
+        auto vname = object->variable().name();
+        if (hasScalarVariable(vname))
+          getScalarVariable(0, vname).eigen(true);
+        else
+          getVariable(0, vname).eigen(true);
+      }
     }
   }
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1941,7 +1941,7 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
                   nfc->subProblem().prepareShapes(nfc->variable().number(), 0);
                   nfc->subProblem().prepareNeighborShapes(jvar->number(), 0);
 
-                  nfc->computeOffDiagJacobian(jvar->number());
+                  nfc->computeOffDiagJacobian(*jvar);
 
                   // Cache the jacobian block for the secondary side
                   _fe_problem.assembly(0).cacheJacobianBlock(
@@ -2187,7 +2187,7 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
                   nec->subProblem().prepareShapes(nec->variable().number(), 0);
                   nec->subProblem().prepareNeighborShapes(jvar->number(), 0);
 
-                  nec->computeOffDiagJacobian(jvar->number());
+                  nec->computeOffDiagJacobian(*jvar);
 
                   // Cache the jacobian block for the secondary side
                   _fe_problem.assembly(0).cacheJacobianBlock(nec->_Kee,
@@ -2583,7 +2583,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
             // 2.) jvar is "involved" with the BC (including jvar==ivar), and
             // 3.) the BC should apply.
             if ((bc->variable().number() == ivar) && var_set.count(jvar) && bc->shouldApply())
-              bc->computeOffDiagJacobian(jvar);
+              bc->computeOffDiagJacobian(*it.second);
           }
 
           const auto & coupled_scalar_vars = bc->getCoupledMooseScalarVars();

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1272,8 +1272,8 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
           _fe_problem.setNeighborSubdomainID(elem2, tid);
           _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
-          ec->subProblem().prepareShapes(ec->variable().number(), tid);
-          ec->subProblem().prepareNeighborShapes(ec->variable().number(), tid);
+          ec->prepareShapes(ec->variable().number());
+          ec->prepareNeighborShapes(ec->variable().number());
 
           ec->reinit(info);
           ec->computeResidual();
@@ -1875,8 +1875,8 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
               {
                 constraints_applied = true;
 
-                nfc->subProblem().prepareShapes(nfc->variable().number(), 0);
-                nfc->subProblem().prepareNeighborShapes(nfc->variable().number(), 0);
+                nfc->prepareShapes(nfc->variable().number());
+                nfc->prepareNeighborShapes(nfc->variable().number());
 
                 nfc->computeJacobian();
 
@@ -1938,10 +1938,10 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
                   // Need to zero out the matrices first
                   _fe_problem.prepareAssembly(0);
 
-                  nfc->subProblem().prepareShapes(nfc->variable().number(), 0);
-                  nfc->subProblem().prepareNeighborShapes(jvar->number(), 0);
+                  nfc->prepareShapes(nfc->variable().number());
+                  nfc->prepareNeighborShapes(jvar->number());
 
-                  nfc->computeOffDiagJacobian(*jvar);
+                  nfc->computeOffDiagJacobian(jvar->number());
 
                   // Cache the jacobian block for the secondary side
                   _fe_problem.assembly(0).cacheJacobianBlock(
@@ -2082,8 +2082,8 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
           _fe_problem.setNeighborSubdomainID(elem2, tid);
           _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
-          ec->subProblem().prepareShapes(ec->variable().number(), tid);
-          ec->subProblem().prepareNeighborShapes(ec->variable().number(), tid);
+          ec->prepareShapes(ec->variable().number());
+          ec->prepareNeighborShapes(ec->variable().number());
 
           ec->reinit(info);
           ec->computeJacobian();
@@ -2138,8 +2138,8 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
                 constraints_applied = true;
 
                 nec->_jacobian = &jacobian;
-                nec->subProblem().prepareShapes(nec->variable().number(), 0);
-                nec->subProblem().prepareNeighborShapes(nec->variable().number(), 0);
+                nec->prepareShapes(nec->variable().number());
+                nec->prepareNeighborShapes(nec->variable().number());
 
                 nec->computeJacobian();
 
@@ -2184,10 +2184,10 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
                   // Need to zero out the matrices first
                   _fe_problem.prepareAssembly(0);
 
-                  nec->subProblem().prepareShapes(nec->variable().number(), 0);
-                  nec->subProblem().prepareNeighborShapes(jvar->number(), 0);
+                  nec->prepareShapes(nec->variable().number());
+                  nec->prepareNeighborShapes(jvar->number());
 
-                  nec->computeOffDiagJacobian(*jvar);
+                  nec->computeOffDiagJacobian(jvar->number());
 
                   // Cache the jacobian block for the secondary side
                   _fe_problem.assembly(0).cacheJacobianBlock(nec->_Kee,
@@ -2583,7 +2583,7 @@ NonlinearSystemBase::computeJacobianInternal(const std::set<TagID> & tags)
             // 2.) jvar is "involved" with the BC (including jvar==ivar), and
             // 3.) the BC should apply.
             if ((bc->variable().number() == ivar) && var_set.count(jvar) && bc->shouldApply())
-              bc->computeOffDiagJacobian(*it.second);
+              bc->computeOffDiagJacobian(jvar);
           }
 
           const auto & coupled_scalar_vars = bc->getCoupledMooseScalarVars();

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -468,7 +468,8 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name,
 
   // Active BoundaryIDs for the object
   const std::set<BoundaryID> & boundary_ids = bc->boundaryIDs();
-  _vars[tid].addBoundaryVar(boundary_ids, &bc->variable());
+  auto bc_var = dynamic_cast<const MooseVariableFieldBase *>(&bc->variable());
+  _vars[tid].addBoundaryVar(boundary_ids, bc_var);
 
   // Cast to the various types of BCs
   std::shared_ptr<NodalBCBase> nbc = std::dynamic_pointer_cast<NodalBCBase>(bc);
@@ -520,7 +521,7 @@ NonlinearSystemBase::addBoundaryCondition(const std::string & bc_name,
 
       // Active BoundaryIDs for the object
       const std::set<BoundaryID> & boundary_ids = bc->boundaryIDs();
-      _vars[tid].addBoundaryVar(boundary_ids, &bc->variable());
+      _vars[tid].addBoundaryVar(boundary_ids, bc_var);
 
       ibc = std::static_pointer_cast<IntegratedBCBase>(bc);
 
@@ -588,7 +589,8 @@ NonlinearSystemBase::addInterfaceKernel(std::string interface_kernel_name,
         _factory.create<InterfaceKernelBase>(interface_kernel_name, name, parameters, tid);
 
     const std::set<BoundaryID> & boundary_ids = interface_kernel->boundaryIDs();
-    _vars[tid].addBoundaryVar(boundary_ids, &interface_kernel->variable());
+    auto ik_var = dynamic_cast<const MooseVariableFieldBase *>(&interface_kernel->variable());
+    _vars[tid].addBoundaryVar(boundary_ids, ik_var);
 
     _interface_kernels.addObject(interface_kernel, tid);
     _vars[tid].addBoundaryVars(boundary_ids, interface_kernel->getCoupledVars());

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -188,7 +188,7 @@ SystemBase::getActualFieldVariable(THREAD_ID tid, unsigned int var_number)
 }
 
 MooseVariableScalar &
-SystemBase::getScalarVariable(THREAD_ID tid, const std::string & var_name)
+SystemBase::getScalarVariable(THREAD_ID tid, const std::string & var_name) const
 {
   MooseVariableScalar * var = dynamic_cast<MooseVariableScalar *>(_vars[tid].getVariable(var_name));
   if (!var)
@@ -197,7 +197,7 @@ SystemBase::getScalarVariable(THREAD_ID tid, const std::string & var_name)
 }
 
 MooseVariableScalar &
-SystemBase::getScalarVariable(THREAD_ID tid, unsigned int var_number)
+SystemBase::getScalarVariable(THREAD_ID tid, unsigned int var_number) const
 {
   MooseVariableScalar * var =
       dynamic_cast<MooseVariableScalar *>(_vars[tid].getVariable(var_number));

--- a/framework/src/variables/VariableWarehouse.C
+++ b/framework/src/variables/VariableWarehouse.C
@@ -56,14 +56,14 @@ VariableWarehouse::add(const std::string & var_name, std::shared_ptr<MooseVariab
 }
 
 void
-VariableWarehouse::addBoundaryVar(BoundaryID bnd, MooseVariableFEBase * var)
+VariableWarehouse::addBoundaryVar(BoundaryID bnd, const MooseVariableFEBase * var)
 {
   _boundary_vars[bnd].insert(var);
 }
 
 void
 VariableWarehouse::addBoundaryVar(const std::set<BoundaryID> & boundary_ids,
-                                  MooseVariableFEBase * var)
+                                  const MooseVariableFEBase * var)
 {
   for (const auto & bid : boundary_ids)
     addBoundaryVar(bid, var);
@@ -118,7 +118,7 @@ VariableWarehouse::scalars() const
   return _scalar_vars;
 }
 
-const std::set<MooseVariableFEBase *> &
+const std::set<const MooseVariableFEBase *> &
 VariableWarehouse::boundaryVars(BoundaryID bnd) const
 {
   return _boundary_vars.find(bnd)->second;

--- a/modules/contact/include/constraints/MechanicalContactConstraint.h
+++ b/modules/contact/include/constraints/MechanicalContactConstraint.h
@@ -52,7 +52,7 @@ public:
    * Compute off-diagonal Jacobian entries
    * @param jvar The index of the coupled variable
    */
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;
 

--- a/modules/contact/include/constraints/MechanicalContactConstraint.h
+++ b/modules/contact/include/constraints/MechanicalContactConstraint.h
@@ -52,7 +52,7 @@ public:
    * Compute off-diagonal Jacobian entries
    * @param jvar The index of the coupled variable
    */
-  virtual void computeOffDiagJacobian(unsigned int jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;
 

--- a/modules/contact/include/constraints/NormalNodalLMMechanicalContact.h
+++ b/modules/contact/include/constraints/NormalNodalLMMechanicalContact.h
@@ -29,11 +29,12 @@ protected:
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   virtual Real computeQpResidual(Moose::ConstraintType type) override;
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;
-  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type, unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
+                                        unsigned int jvar) override;
 
   const unsigned _disp_y_id;
   const unsigned _disp_z_id;

--- a/modules/contact/include/constraints/NormalNodalLMMechanicalContact.h
+++ b/modules/contact/include/constraints/NormalNodalLMMechanicalContact.h
@@ -29,7 +29,7 @@ protected:
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual Real computeQpResidual(Moose::ConstraintType type) override;
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;

--- a/modules/contact/include/constraints/NormalNodalMechanicalContact.h
+++ b/modules/contact/include/constraints/NormalNodalMechanicalContact.h
@@ -22,14 +22,15 @@ public:
   NormalNodalMechanicalContact(const InputParameters & parameters);
 
   void computeJacobian() override;
-  void computeOffDiagJacobian(unsigned int jvar) override;
+  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
 protected:
   virtual Real computeQpSecondaryValue() override;
 
   virtual Real computeQpResidual(Moose::ConstraintType type) override;
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;
-  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type, unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
+                                        unsigned int jvar) override;
 
   const Real & _lambda;
   const unsigned _lambda_id;

--- a/modules/contact/include/constraints/NormalNodalMechanicalContact.h
+++ b/modules/contact/include/constraints/NormalNodalMechanicalContact.h
@@ -22,7 +22,7 @@ public:
   NormalNodalMechanicalContact(const InputParameters & parameters);
 
   void computeJacobian() override;
-  void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpSecondaryValue() override;

--- a/modules/contact/include/constraints/TangentialNodalLMMechanicalContact.h
+++ b/modules/contact/include/constraints/TangentialNodalLMMechanicalContact.h
@@ -26,11 +26,12 @@ protected:
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(unsigned jvar) override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
 
   virtual Real computeQpResidual(Moose::ConstraintType type) override;
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;
-  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type, unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
+                                        unsigned int jvar) override;
 
   const Real & _contact_pressure;
   const unsigned _contact_pressure_id;

--- a/modules/contact/include/constraints/TangentialNodalLMMechanicalContact.h
+++ b/modules/contact/include/constraints/TangentialNodalLMMechanicalContact.h
@@ -26,7 +26,7 @@ protected:
 
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual Real computeQpResidual(Moose::ConstraintType type) override;
   virtual Real computeQpJacobian(Moose::ConstraintJacobianType type) override;

--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -1798,39 +1798,39 @@ MechanicalContactConstraint::computeJacobian()
 }
 
 void
-MechanicalContactConstraint::computeOffDiagJacobian(unsigned int jvar)
+MechanicalContactConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  getConnectedDofIndices(jvar);
+  getConnectedDofIndices(jvar.number());
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
 
-  DenseMatrix<Number> & Knn =
-      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar);
+  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
+      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 
   if (_primary_secondary_jacobian)
   {
     DenseMatrix<Number> & Ken =
-        _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar);
+        _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
     for (_i = 0; _i < _test_secondary.size(); _i++)
       for (_j = 0; _j < _phi_primary.size(); _j++)
-        Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar);
+        Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
 
     _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
     if (_Kne.m() && _Kne.n())
       for (_i = 0; _i < _test_primary.size(); _i++)
         // Loop over the connected dof indices so we can get all the jacobian contributions
         for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-          _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar);
+          _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
   }
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar);
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
 }
 
 void

--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -1798,39 +1798,39 @@ MechanicalContactConstraint::computeJacobian()
 }
 
 void
-MechanicalContactConstraint::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+MechanicalContactConstraint::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  getConnectedDofIndices(jvar.number());
+  getConnectedDofIndices(jvar_num);
 
   _Kee.resize(_test_secondary.size(), _connected_dof_indices.size());
 
-  DenseMatrix<Number> & Knn = _assembly.jacobianBlockNeighbor(
-      Moose::NeighborNeighbor, _primary_var.number(), jvar.number());
+  DenseMatrix<Number> & Knn =
+      _assembly.jacobianBlockNeighbor(Moose::NeighborNeighbor, _primary_var.number(), jvar_num);
 
   for (_i = 0; _i < _test_secondary.size(); _i++)
     // Loop over the connected dof indices so we can get all the jacobian contributions
     for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+      _Kee(_i, _j) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   if (_primary_secondary_jacobian)
   {
     DenseMatrix<Number> & Ken =
-        _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
+        _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar_num);
     for (_i = 0; _i < _test_secondary.size(); _i++)
       for (_j = 0; _j < _phi_primary.size(); _j++)
-        Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
+        Ken(_i, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar_num);
 
     _Kne.resize(_test_primary.size(), _connected_dof_indices.size());
     if (_Kne.m() && _Kne.n())
       for (_i = 0; _i < _test_primary.size(); _i++)
         // Loop over the connected dof indices so we can get all the jacobian contributions
         for (_j = 0; _j < _connected_dof_indices.size(); _j++)
-          _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
+          _Kne(_i, _j) += computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar_num);
   }
 
   for (_i = 0; _i < _test_primary.size(); _i++)
     for (_j = 0; _j < _phi_primary.size(); _j++)
-      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar.number());
+      Knn(_i, _j) += computeQpOffDiagJacobian(Moose::PrimaryPrimary, jvar_num);
 }
 
 void

--- a/modules/contact/src/constraints/NormalNodalLMMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalNodalLMMechanicalContact.C
@@ -93,28 +93,27 @@ NormalNodalLMMechanicalContact::computeJacobian()
 }
 
 void
-NormalNodalLMMechanicalContact::computeOffDiagJacobian(unsigned jvar)
+NormalNodalLMMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
   {
     computeJacobian();
     return;
   }
 
-  MooseVariableFEBase & var = _sys.getVariable(0, jvar);
   _connected_dof_indices.clear();
-  _connected_dof_indices.push_back(var.nodalDofIndex());
+  _connected_dof_indices.push_back(jvar.nodalDofIndex());
 
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar);
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
 
   for (_j = 0; _j < _phi_primary.size(); ++_j)
-    Ken(0, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar);
+    Ken(0, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
 }
 
 Real NormalNodalLMMechanicalContact::computeQpResidual(Moose::ConstraintType /*type*/)
@@ -171,7 +170,7 @@ Real NormalNodalLMMechanicalContact::computeQpJacobian(Moose::ConstraintJacobian
 
 Real
 NormalNodalLMMechanicalContact::computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
-                                                         unsigned jvar)
+                                                         unsigned int jvar)
 {
   std::map<dof_id_type, PenetrationInfo *>::iterator found =
       _penetration_locator._penetration_info.find(_current_node->id());

--- a/modules/contact/src/constraints/NormalNodalLMMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalNodalLMMechanicalContact.C
@@ -93,13 +93,15 @@ NormalNodalLMMechanicalContact::computeJacobian()
 }
 
 void
-NormalNodalLMMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NormalNodalLMMechanicalContact::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
   {
     computeJacobian();
     return;
   }
+
+  const auto & jvar = getVariable(jvar_num);
 
   _connected_dof_indices.clear();
   _connected_dof_indices.push_back(jvar.nodalDofIndex());
@@ -107,13 +109,13 @@ NormalNodalLMMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jva
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   DenseMatrix<Number> & Ken =
-      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar.number());
+      _assembly.jacobianBlockNeighbor(Moose::ElementNeighbor, _var.number(), jvar_num);
 
   for (_j = 0; _j < _phi_primary.size(); ++_j)
-    Ken(0, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar.number());
+    Ken(0, _j) += computeQpOffDiagJacobian(Moose::SecondaryPrimary, jvar_num);
 }
 
 Real NormalNodalLMMechanicalContact::computeQpResidual(Moose::ConstraintType /*type*/)

--- a/modules/contact/src/constraints/NormalNodalMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalNodalMechanicalContact.C
@@ -52,12 +52,14 @@ NormalNodalMechanicalContact::computeJacobian()
 }
 
 void
-NormalNodalMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+NormalNodalMechanicalContact::computeOffDiagJacobian(const unsigned int jvar_num)
 {
   // Our residual only strongly depends on the lagrange multiplier (the normal vector does indeed
   // depend on displacements but it's complicated and shouldn't be too strong of a dependence)
-  if (jvar.number() != _lambda_id)
+  if (jvar_num != _lambda_id)
     return;
+
+  const auto & jvar = getVariable(jvar_num);
 
   _connected_dof_indices.clear();
   _connected_dof_indices.push_back(jvar.nodalDofIndex());
@@ -65,12 +67,12 @@ NormalNodalMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) = computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+  _Kee(0, 0) = computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 
   _Kne.resize(_test_primary.size(), 1);
 
   for (_i = 0; _i < _test_primary.size(); ++_i)
-    _Kne(_i, 0) = computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
+    _Kne(_i, 0) = computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar_num);
 }
 
 Real

--- a/modules/contact/src/constraints/NormalNodalMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalNodalMechanicalContact.C
@@ -52,26 +52,25 @@ NormalNodalMechanicalContact::computeJacobian()
 }
 
 void
-NormalNodalMechanicalContact::computeOffDiagJacobian(unsigned jvar)
+NormalNodalMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
   // Our residual only strongly depends on the lagrange multiplier (the normal vector does indeed
   // depend on displacements but it's complicated and shouldn't be too strong of a dependence)
-  if (jvar != _lambda_id)
+  if (jvar.number() != _lambda_id)
     return;
 
-  MooseVariableFEBase & var = _sys.getVariable(0, jvar);
   _connected_dof_indices.clear();
-  _connected_dof_indices.push_back(var.nodalDofIndex());
+  _connected_dof_indices.push_back(jvar.nodalDofIndex());
 
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) = computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+  _Kee(0, 0) = computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 
   _Kne.resize(_test_primary.size(), 1);
 
   for (_i = 0; _i < _test_primary.size(); ++_i)
-    _Kne(_i, 0) = computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar);
+    _Kne(_i, 0) = computeQpOffDiagJacobian(Moose::PrimarySecondary, jvar.number());
 }
 
 Real
@@ -109,7 +108,7 @@ Real NormalNodalMechanicalContact::computeQpJacobian(Moose::ConstraintJacobianTy
 
 Real
 NormalNodalMechanicalContact::computeQpOffDiagJacobian(Moose::ConstraintJacobianType type,
-                                                       unsigned jvar)
+                                                       unsigned int jvar)
 {
   std::map<dof_id_type, PenetrationInfo *>::iterator found =
       _penetration_locator._penetration_info.find(_current_node->id());

--- a/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
+++ b/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
@@ -94,22 +94,21 @@ TangentialNodalLMMechanicalContact::computeJacobian()
 }
 
 void
-TangentialNodalLMMechanicalContact::computeOffDiagJacobian(unsigned jvar)
+TangentialNodalLMMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 {
-  if (jvar == _var.number())
+  if (jvar.number() == _var.number())
   {
     computeJacobian();
     return;
   }
 
-  MooseVariableFEBase & var = _sys.getVariable(0, jvar);
   _connected_dof_indices.clear();
-  _connected_dof_indices.push_back(var.nodalDofIndex());
+  _connected_dof_indices.push_back(jvar.nodalDofIndex());
 
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar);
+  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
 }
 
 Real TangentialNodalLMMechanicalContact::computeQpResidual(Moose::ConstraintType /*type*/)
@@ -193,7 +192,7 @@ Real TangentialNodalLMMechanicalContact::computeQpJacobian(Moose::ConstraintJaco
 
 Real
 TangentialNodalLMMechanicalContact::computeQpOffDiagJacobian(Moose::ConstraintJacobianType /*type*/,
-                                                             unsigned jvar)
+                                                             unsigned int jvar)
 {
   std::map<dof_id_type, PenetrationInfo *>::iterator found =
       _penetration_locator._penetration_info.find(_current_node->id());

--- a/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
+++ b/modules/contact/src/constraints/TangentialNodalLMMechanicalContact.C
@@ -94,21 +94,22 @@ TangentialNodalLMMechanicalContact::computeJacobian()
 }
 
 void
-TangentialNodalLMMechanicalContact::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+TangentialNodalLMMechanicalContact::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
   {
     computeJacobian();
     return;
   }
 
+  const auto & jvar = getVariable(jvar_num);
   _connected_dof_indices.clear();
   _connected_dof_indices.push_back(jvar.nodalDofIndex());
 
   _qp = 0;
 
   _Kee.resize(1, 1);
-  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar.number());
+  _Kee(0, 0) += computeQpOffDiagJacobian(Moose::SecondarySecondary, jvar_num);
 }
 
 Real TangentialNodalLMMechanicalContact::computeQpResidual(Moose::ConstraintType /*type*/)

--- a/modules/heat_conduction/include/bcs/GapHeatTransfer.h
+++ b/modules/heat_conduction/include/bcs/GapHeatTransfer.h
@@ -27,8 +27,7 @@ public:
   virtual void initialSetup() override;
   void computeJacobian() override;
 
-  using IntegratedBC::computeJacobianBlock;
-  void computeJacobianBlock(unsigned int jvar) override;
+  void computeJacobianBlock(MooseVariableFEBase & jvar) override;
 
 protected:
   virtual Real computeQpResidual() override;

--- a/modules/heat_conduction/include/bcs/GapHeatTransfer.h
+++ b/modules/heat_conduction/include/bcs/GapHeatTransfer.h
@@ -27,7 +27,7 @@ public:
   virtual void initialSetup() override;
   void computeJacobian() override;
 
-  void computeJacobianBlock(MooseVariableFEBase & jvar) override;
+  void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual() override;

--- a/modules/heat_conduction/src/bcs/GapHeatTransfer.C
+++ b/modules/heat_conduction/src/bcs/GapHeatTransfer.C
@@ -246,19 +246,19 @@ GapHeatTransfer::computeJacobian()
 }
 
 void
-GapHeatTransfer::computeJacobianBlock(MooseVariableFEBase & jvar)
+GapHeatTransfer::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
   {
     computeJacobian();
     return;
   }
 
-  prepareMatrixTag(_assembly, _var.number(), jvar.number());
+  const auto & jvar = getVariable(jvar_num);
 
-  // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
-  // on the displaced mesh
-  auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+  prepareMatrixTag(_assembly, _var.number(), jvar_num);
+
+  auto phi_size = jvar.dofIndices().size();
 
   for (_qp = 0; _qp < _qrule->n_points(); _qp++)
   {
@@ -267,14 +267,14 @@ GapHeatTransfer::computeJacobianBlock(MooseVariableFEBase & jvar)
 
     for (_i = 0; _i < _test.size(); _i++)
       for (_j = 0; _j < phi_size; _j++)
-        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar.number());
+        _local_ke(_i, _j) += _JxW[_qp] * _coord[_qp] * computeQpOffDiagJacobian(jvar_num);
 
     // Ok now do the contribution from the secondary side
     if (_quadrature && _has_info)
     {
       std::vector<dof_id_type> secondary_side_dof_indices;
 
-      _sys.dofMap().dof_indices(_secondary_side, secondary_side_dof_indices, jvar.number());
+      _sys.dofMap().dof_indices(_secondary_side, secondary_side_dof_indices, jvar_num);
 
       DenseMatrix<Number> K_secondary(_var.dofIndices().size(), secondary_side_dof_indices.size());
 
@@ -287,7 +287,7 @@ GapHeatTransfer::computeJacobianBlock(MooseVariableFEBase & jvar)
              _secondary_j < static_cast<unsigned int>(secondary_side_dof_indices.size());
              ++_secondary_j)
           K_secondary(_i, _secondary_j) +=
-              _JxW[_qp] * _coord[_qp] * computeSecondaryQpOffDiagJacobian(jvar.number());
+              _JxW[_qp] * _coord[_qp] * computeSecondaryQpOffDiagJacobian(jvar_num);
 
       _subproblem.assembly(_tid).cacheJacobianBlock(
           K_secondary, _var.dofIndices(), secondary_side_dof_indices, _var.scalingFactor());

--- a/modules/peridynamics/include/kernels/MechanicsBasePD.h
+++ b/modules/peridynamics/include/kernels/MechanicsBasePD.h
@@ -22,7 +22,7 @@ public:
 
   MechanicsBasePD(const InputParameters & parameters);
 
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /**
    * Function to compute local contribution to the off-diagonal Jacobian at the current nodes

--- a/modules/peridynamics/include/kernels/MechanicsBasePD.h
+++ b/modules/peridynamics/include/kernels/MechanicsBasePD.h
@@ -23,7 +23,6 @@ public:
   MechanicsBasePD(const InputParameters & parameters);
 
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /**
    * Function to compute local contribution to the off-diagonal Jacobian at the current nodes

--- a/modules/peridynamics/src/kernels/MechanicsBasePD.C
+++ b/modules/peridynamics/src/kernels/MechanicsBasePD.C
@@ -66,11 +66,11 @@ MechanicsBasePD::prepare()
 }
 
 void
-MechanicsBasePD::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+MechanicsBasePD::computeOffDiagJacobian(const unsigned int jvar_num)
 {
   prepare();
 
-  if (jvar.number() == _var.number())
+  if (jvar_num == _var.number())
     computeJacobian();
   else
   {
@@ -78,19 +78,19 @@ MechanicsBasePD::computeOffDiagJacobian(MooseVariableFEBase & jvar)
     bool active = false;
 
     for (unsigned int i = 0; i < _dim; ++i)
-      if (jvar.number() == _disp_var[i]->number())
+      if (jvar_num == _disp_var[i]->number())
       {
         coupled_component = i;
         active = true;
       }
 
-    if (_temp_coupled && jvar.number() == _temp_var->number())
+    if (_temp_coupled && jvar_num == _temp_var->number())
     {
       coupled_component = 3;
       active = true;
     }
 
-    if (_out_of_plane_strain_coupled && jvar.number() == _out_of_plane_strain_var->number())
+    if (_out_of_plane_strain_coupled && jvar_num == _out_of_plane_strain_var->number())
     {
       coupled_component = 4;
       active = true;
@@ -98,7 +98,7 @@ MechanicsBasePD::computeOffDiagJacobian(MooseVariableFEBase & jvar)
 
     if (active)
     {
-      DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar.number());
+      DenseMatrix<Number> & ke = _assembly.jacobianBlock(_var.number(), jvar_num);
       _local_ke.resize(ke.m(), ke.n());
       _local_ke.zero();
 
@@ -107,7 +107,7 @@ MechanicsBasePD::computeOffDiagJacobian(MooseVariableFEBase & jvar)
       ke += _local_ke;
 
       if (_use_full_jacobian)
-        computePDNonlocalOffDiagJacobian(jvar.number(), coupled_component);
+        computePDNonlocalOffDiagJacobian(jvar_num, coupled_component);
     }
   }
 }

--- a/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
@@ -32,7 +32,7 @@ protected:
   virtual Real computeQpResidual() override;
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// The Darcy part of the flux (this is the non-upwinded part)
   virtual Real darcyQp(unsigned int ph) const;

--- a/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
+++ b/modules/porous_flow/include/kernels/PorousFlowDarcyBase.h
@@ -33,7 +33,6 @@ protected:
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /// The Darcy part of the flux (this is the non-upwinded part)
   virtual Real darcyQp(unsigned int ph) const;

--- a/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
+++ b/modules/porous_flow/src/kernels/PorousFlowDarcyBase.C
@@ -143,9 +143,9 @@ PorousFlowDarcyBase::computeJacobian()
 }
 
 void
-PorousFlowDarcyBase::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+PorousFlowDarcyBase::computeOffDiagJacobian(const unsigned int jvar)
 {
-  computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, jvar.number());
+  computeResidualAndJacobian(JacRes::CALCULATE_JACOBIAN, jvar);
 }
 
 void

--- a/modules/richards/include/bcs/Q2PPiecewiseLinearSink.h
+++ b/modules/richards/include/bcs/Q2PPiecewiseLinearSink.h
@@ -45,8 +45,7 @@ protected:
 
   virtual Real computeQpJacobian() override;
 
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
-  using IntegratedBC::computeJacobianBlock;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 

--- a/modules/richards/include/bcs/RichardsPiecewiseLinearSink.h
+++ b/modules/richards/include/bcs/RichardsPiecewiseLinearSink.h
@@ -48,8 +48,7 @@ protected:
 
   virtual Real computeQpJacobian() override;
 
-  virtual void computeJacobianBlock(MooseVariableFEBase & jvar) override;
-  using IntegratedBC::computeJacobianBlock;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 

--- a/modules/richards/include/kernels/Q2PPorepressureFlux.h
+++ b/modules/richards/include/kernels/Q2PPorepressureFlux.h
@@ -59,7 +59,6 @@ protected:
 
   /// this simply calls upwind
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /// this simply calls upwind
   virtual void computeJacobian() override;

--- a/modules/richards/include/kernels/Q2PPorepressureFlux.h
+++ b/modules/richards/include/kernels/Q2PPorepressureFlux.h
@@ -58,7 +58,7 @@ protected:
   virtual void computeResidual() override;
 
   /// this simply calls upwind
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// this simply calls upwind
   virtual void computeJacobian() override;

--- a/modules/richards/include/kernels/Q2PSaturationFlux.h
+++ b/modules/richards/include/kernels/Q2PSaturationFlux.h
@@ -59,7 +59,6 @@ protected:
 
   /// this simply calls upwind
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /// this simply calls upwind
   virtual void computeJacobian() override;

--- a/modules/richards/include/kernels/Q2PSaturationFlux.h
+++ b/modules/richards/include/kernels/Q2PSaturationFlux.h
@@ -58,7 +58,7 @@ protected:
   virtual void computeResidual() override;
 
   /// this simply calls upwind
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// this simply calls upwind
   virtual void computeJacobian() override;

--- a/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
+++ b/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
@@ -59,7 +59,7 @@ protected:
   virtual void computeResidual() override;
 
   /// this simply calls upwind
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// the derivative of the flux without the upstream mobility terms
   Real computeQpJac(unsigned int dvar);

--- a/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
+++ b/modules/richards/include/kernels/RichardsFullyUpwindFlux.h
@@ -60,7 +60,6 @@ protected:
 
   /// this simply calls upwind
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /// the derivative of the flux without the upstream mobility terms
   Real computeQpJac(unsigned int dvar);

--- a/modules/richards/src/bcs/Q2PPiecewiseLinearSink.C
+++ b/modules/richards/src/bcs/Q2PPiecewiseLinearSink.C
@@ -187,10 +187,10 @@ Q2PPiecewiseLinearSink::computeQpJacobian()
 }
 
 void
-Q2PPiecewiseLinearSink::computeJacobianBlock(MooseVariableFEBase & jvar)
+Q2PPiecewiseLinearSink::computeOffDiagJacobian(const unsigned int jvar)
 {
   prepareNodalValues();
-  IntegratedBC::computeJacobianBlock(jvar);
+  IntegratedBC::computeOffDiagJacobian(jvar);
 }
 
 Real

--- a/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
+++ b/modules/richards/src/bcs/RichardsPiecewiseLinearSink.C
@@ -240,11 +240,11 @@ RichardsPiecewiseLinearSink::computeQpJacobian()
 }
 
 void
-RichardsPiecewiseLinearSink::computeJacobianBlock(MooseVariableFEBase & jvar)
+RichardsPiecewiseLinearSink::computeOffDiagJacobian(const unsigned int jvar)
 {
   if (_fully_upwind)
     prepareNodalValues();
-  IntegratedBC::computeJacobianBlock(jvar);
+  IntegratedBC::computeOffDiagJacobian(jvar);
 }
 
 Real

--- a/modules/richards/src/kernels/Q2PPorepressureFlux.C
+++ b/modules/richards/src/kernels/Q2PPorepressureFlux.C
@@ -105,9 +105,9 @@ Q2PPorepressureFlux::computeJacobian()
 }
 
 void
-Q2PPorepressureFlux::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+Q2PPorepressureFlux::computeOffDiagJacobian(const unsigned int jvar)
 {
-  upwind(false, true, jvar.number());
+  upwind(false, true, jvar);
 }
 
 Real

--- a/modules/richards/src/kernels/Q2PSaturationFlux.C
+++ b/modules/richards/src/kernels/Q2PSaturationFlux.C
@@ -109,9 +109,9 @@ Q2PSaturationFlux::computeJacobian()
 }
 
 void
-Q2PSaturationFlux::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+Q2PSaturationFlux::computeOffDiagJacobian(const unsigned int jvar)
 {
-  upwind(false, true, jvar.number());
+  upwind(false, true, jvar);
 }
 
 Real

--- a/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
+++ b/modules/richards/src/kernels/RichardsFullyUpwindFlux.C
@@ -114,9 +114,9 @@ RichardsFullyUpwindFlux::computeResidual()
 }
 
 void
-RichardsFullyUpwindFlux::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+RichardsFullyUpwindFlux::computeOffDiagJacobian(const unsigned int jvar)
 {
-  upwind(false, true, jvar.number());
+  upwind(false, true, jvar);
   return;
 }
 

--- a/modules/tensor_mechanics/include/constraints/NodalFrictionalConstraint.h
+++ b/modules/tensor_mechanics/include/constraints/NodalFrictionalConstraint.h
@@ -20,6 +20,8 @@ public:
 
   virtual void computeResidual(NumericVector<Number> & residual) override;
   virtual void computeJacobian(SparseMatrix<Number> & jacobian) override;
+  using NodalConstraint::computeJacobian;
+  using NodalConstraint::computeResidual;
 
 protected:
   /**

--- a/modules/tensor_mechanics/include/constraints/NodalStickConstraint.h
+++ b/modules/tensor_mechanics/include/constraints/NodalStickConstraint.h
@@ -20,6 +20,8 @@ public:
 
   virtual void computeResidual(NumericVector<Number> & residual) override;
   virtual void computeJacobian(SparseMatrix<Number> & jacobian) override;
+  using NodalConstraint::computeJacobian;
+  using NodalConstraint::computeResidual;
 
 protected:
   /**

--- a/modules/tensor_mechanics/include/kernels/ALEKernel.h
+++ b/modules/tensor_mechanics/include/kernels/ALEKernel.h
@@ -21,7 +21,7 @@ public:
   ALEKernel(const InputParameters & parameters);
 
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   /// undisplaced problem

--- a/modules/tensor_mechanics/include/kernels/ALEKernel.h
+++ b/modules/tensor_mechanics/include/kernels/ALEKernel.h
@@ -22,7 +22,6 @@ public:
 
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
 protected:
   /// undisplaced problem

--- a/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
@@ -26,7 +26,7 @@ public:
 
   virtual void computeJacobian() override;
 
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual() override { return 0.0; };

--- a/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/InertialForceBeam.h
@@ -27,7 +27,6 @@ public:
   virtual void computeJacobian() override;
 
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
 protected:
   virtual Real computeQpResidual() override { return 0.0; };

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceBeam.h
@@ -21,7 +21,6 @@ public:
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
 protected:
   virtual Real computeQpResidual() override { return 0.0; }

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceBeam.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceBeam.h
@@ -20,7 +20,7 @@ public:
   StressDivergenceBeam(const InputParameters & parameters);
   virtual void computeResidual() override;
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual() override { return 0.0; }

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
@@ -29,7 +29,6 @@ public:
 
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
 protected:
   virtual void initialSetup() override;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensors.h
@@ -28,7 +28,7 @@ public:
   StressDivergenceTensors(const InputParameters & parameters);
 
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
 protected:
   virtual void initialSetup() override;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
@@ -27,7 +27,6 @@ protected:
   virtual Real computeStiffness(unsigned int i, unsigned int j);
   virtual void computeJacobian() override;
   virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
-  using Kernel::computeOffDiagJacobian;
 
   /// Base name of the material system that this kernel applies to
   const std::string _base_name;

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTensorsTruss.h
@@ -26,7 +26,7 @@ protected:
   virtual Real computeQpResidual() override { return 0.0; }
   virtual Real computeStiffness(unsigned int i, unsigned int j);
   virtual void computeJacobian() override;
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual void computeOffDiagJacobian(unsigned int jvar) override;
 
   /// Base name of the material system that this kernel applies to
   const std::string _base_name;

--- a/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
+++ b/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
@@ -26,7 +26,7 @@ public:
   virtual void reinit(){};
   virtual void computeResidual();
   virtual void computeJacobian();
-  virtual void computeOffDiagJacobian(unsigned int /*jvar*/);
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/);
 
 protected:
   virtual void assignComponentIndices(Order var_order);

--- a/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
+++ b/modules/tensor_mechanics/include/scalarkernels/GlobalStrain.h
@@ -23,10 +23,10 @@ public:
 
   GlobalStrain(const InputParameters & parameters);
 
-  virtual void reinit(){};
-  virtual void computeResidual();
-  virtual void computeJacobian();
-  virtual void computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/);
+  virtual void reinit() override {}
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobian(unsigned int) override {}
 
 protected:
   virtual void assignComponentIndices(Order var_order);

--- a/modules/tensor_mechanics/src/kernels/ALEKernel.C
+++ b/modules/tensor_mechanics/src/kernels/ALEKernel.C
@@ -38,8 +38,8 @@ ALEKernel::computeJacobian()
 }
 
 void
-ALEKernel::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+ALEKernel::computeOffDiagJacobian(const unsigned int jvar)
 {
-  _fe_problem.prepareShapes(jvar.number(), _tid);
+  _fe_problem.prepareShapes(jvar, _tid);
   Kernel::computeOffDiagJacobian(jvar);
 }

--- a/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
+++ b/modules/tensor_mechanics/src/kernels/InertialForceBeam.C
@@ -474,7 +474,7 @@ InertialForceBeam::computeJacobian()
 }
 
 void
-InertialForceBeam::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+InertialForceBeam::computeOffDiagJacobian(const unsigned int jvar_num)
 {
   mooseAssert(_beta > 0.0, "InertialForceBeam: Beta parameter should be positive.");
 
@@ -484,7 +484,6 @@ InertialForceBeam::computeOffDiagJacobian(MooseVariableFEBase & jvar)
   else
     factor = (*_du_dotdot_du)[0] + _eta[0] * (1.0 + _alpha) * (*_du_dot_du)[0];
 
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceBeam.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceBeam.C
@@ -174,9 +174,8 @@ StressDivergenceBeam::computeJacobian()
 }
 
 void
-StressDivergenceBeam::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+StressDivergenceBeam::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensors.C
@@ -188,7 +188,7 @@ StressDivergenceTensors::computeJacobian()
 }
 
 void
-StressDivergenceTensors::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+StressDivergenceTensors::computeOffDiagJacobian(const unsigned int jvar)
 {
   if (_volumetric_locking_correction)
   {

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTensorsTruss.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTensorsTruss.C
@@ -116,16 +116,17 @@ StressDivergenceTensorsTruss::computeJacobian()
 }
 
 void
-StressDivergenceTensorsTruss::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+StressDivergenceTensorsTruss::computeOffDiagJacobian(const unsigned int jvar_num)
 {
-  size_t jvar_num = jvar.number();
   if (jvar_num == _var.number())
     computeJacobian();
   else
   {
+    const auto & jvar = getVariable(jvar_num);
+
     // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
     // on the displaced mesh
-    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+    auto phi_size = jvar.dofIndices().size();
 
     unsigned int coupled_component = 0;
     bool disp_coupled = false;

--- a/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
+++ b/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
@@ -73,7 +73,7 @@ GlobalStrain::computeJacobian()
 }
 
 void
-GlobalStrain::computeOffDiagJacobian(unsigned int /*jvar*/)
+GlobalStrain::computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/)
 {
 }
 

--- a/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
+++ b/modules/tensor_mechanics/src/scalarkernels/GlobalStrain.C
@@ -73,11 +73,6 @@ GlobalStrain::computeJacobian()
 }
 
 void
-GlobalStrain::computeOffDiagJacobian(MooseVariableFEBase & /*jvar*/)
-{
-}
-
-void
 GlobalStrain::assignComponentIndices(Order order)
 {
   switch (order)

--- a/test/include/bcs/CoupledDirichletBC.h
+++ b/test/include/bcs/CoupledDirichletBC.h
@@ -26,9 +26,9 @@ public:
   CoupledDirichletBC(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   // The coupled variable
   const VariableValue & _v;

--- a/test/include/bcs/ScalarVarBC.h
+++ b/test/include/bcs/ScalarVarBC.h
@@ -23,8 +23,8 @@ public:
   ScalarVarBC(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   unsigned int _alpha_var;
   VariableValue & _alpha;

--- a/test/include/kernels/ArrayCoupledForce.h
+++ b/test/include/kernels/ArrayCoupledForce.h
@@ -21,7 +21,7 @@ public:
 protected:
   virtual RealEigenVector computeQpResidual() override;
 
-  virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar) override;
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
 private:
   unsigned int _v_var;

--- a/test/include/kernels/CoupledArrayForce.h
+++ b/test/include/kernels/CoupledArrayForce.h
@@ -21,7 +21,7 @@ public:
 protected:
   virtual Real computeQpResidual() override;
 
-  virtual RealEigenVector computeQpOffDiagJacobianArray(ArrayMooseVariable & jvar) override;
+  virtual RealEigenVector computeQpOffDiagJacobianArray(const ArrayMooseVariable & jvar) override;
 
 private:
   unsigned int _v_var;

--- a/test/include/kernels/CoupledForceLagged.h
+++ b/test/include/kernels/CoupledForceLagged.h
@@ -22,11 +22,11 @@ public:
   CoupledForceLagged(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
+  virtual Real computeQpResidual() override;
 
-  virtual Real computeQpJacobian();
+  virtual Real computeQpJacobian() override;
 
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   unsigned int _v_var;
   const VariableValue & _v;

--- a/test/include/kernels/CoupledVectorDiffusion.h
+++ b/test/include/kernels/CoupledVectorDiffusion.h
@@ -21,7 +21,7 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   MooseEnum _state;
   const VectorVariableGradient & _grad_v;

--- a/test/include/kernels/EFieldAdvection.h
+++ b/test/include/kernels/EFieldAdvection.h
@@ -19,9 +19,9 @@ public:
   EFieldAdvection(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const unsigned int _efield_id;
   const VectorVariableValue & _efield;

--- a/test/include/kernels/ExampleShapeElementKernel.h
+++ b/test/include/kernels/ExampleShapeElementKernel.h
@@ -20,13 +20,13 @@ public:
   ExampleShapeElementKernel(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   /// new method for on-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
+  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index) override;
   /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
+  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index) override;
 
   const ExampleShapeElementUserObject & _shp;
   const Real & _shp_integral;

--- a/test/include/kernels/ExampleShapeElementKernel2.h
+++ b/test/include/kernels/ExampleShapeElementKernel2.h
@@ -20,10 +20,10 @@ public:
   ExampleShapeElementKernel2(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
+  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index) override;
 
   const ExampleShapeElementUserObject & _shp;
   const Real & _shp_integral;

--- a/test/include/kernels/OptionallyCoupledForce.h
+++ b/test/include/kernels/OptionallyCoupledForce.h
@@ -22,11 +22,11 @@ public:
   OptionallyCoupledForce(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
+  virtual Real computeQpResidual() override;
 
-  virtual Real computeQpJacobian();
+  virtual Real computeQpJacobian() override;
 
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
 private:
   unsigned int _v_var;

--- a/test/include/kernels/PotentialAdvection.h
+++ b/test/include/kernels/PotentialAdvection.h
@@ -20,9 +20,9 @@ public:
   virtual ~PotentialAdvection();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
 private:
   const unsigned int _potential_id;

--- a/test/include/kernels/VectorCoupledGradientTimeDerivative.h
+++ b/test/include/kernels/VectorCoupledGradientTimeDerivative.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
-  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const VariableGradient & _grad_v_dot;
   const VariableValue & _d_grad_v_dot_dv;

--- a/test/include/kernels/WrongJacobianDiffusion.h
+++ b/test/include/kernels/WrongJacobianDiffusion.h
@@ -27,17 +27,17 @@ protected:
   /**
    * Compute the correct diffusion residual with an arbitrary prefactor applied
    */
-  virtual Real computeQpResidual();
+  virtual Real computeQpResidual() override;
 
   /**
    * Compute the correct diffusion on-diagonal Jacobian with an arbitrary prefactor applied
    */
-  virtual Real computeQpJacobian();
+  virtual Real computeQpJacobian() override;
 
   /**
    * Set a constant off-diagonal Jacobian
    */
-  virtual Real computeQpOffDiagJacobian(unsigned int);
+  virtual Real computeQpOffDiagJacobian(unsigned int) override;
 
 private:
   /// prefactor of the Residual

--- a/test/include/scalarkernels/AlphaCED.h
+++ b/test/include/scalarkernels/AlphaCED.h
@@ -17,17 +17,16 @@ public:
   static InputParameters validParams();
 
   AlphaCED(const InputParameters & parameters);
-  virtual ~AlphaCED();
 
-  virtual void reinit();
-  virtual void computeResidual();
-  virtual void computeJacobian();
-  virtual void computeOffDiagJacobian(unsigned int jvar);
+  virtual void reinit() override;
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobianScalar(unsigned int jvar) override;
 
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar);
 
   unsigned int _i;
 

--- a/test/include/scalarkernels/ImplicitODEx.h
+++ b/test/include/scalarkernels/ImplicitODEx.h
@@ -22,7 +22,7 @@ public:
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar);
 
   unsigned int _y_var;
   VariableValue & _y;

--- a/test/include/scalarkernels/ImplicitODEy.h
+++ b/test/include/scalarkernels/ImplicitODEy.h
@@ -20,9 +20,9 @@ public:
   virtual ~ImplicitODEy();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobianScalar(unsigned int jvar) override;
 
   unsigned int _x_var;
   VariableValue & _x;

--- a/test/src/bcs/ScalarVarBC.C
+++ b/test/src/bcs/ScalarVarBC.C
@@ -33,7 +33,7 @@ ScalarVarBC::computeQpResidual()
 }
 
 Real
-ScalarVarBC::computeQpOffDiagJacobian(unsigned int jvar)
+ScalarVarBC::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _alpha_var)
     return -_test[_i][_qp];

--- a/test/src/kernels/ArrayCoupledForce.C
+++ b/test/src/kernels/ArrayCoupledForce.C
@@ -46,7 +46,7 @@ ArrayCoupledForce::computeQpResidual()
 }
 
 RealEigenMatrix
-ArrayCoupledForce::computeQpOffDiagJacobian(MooseVariableFEBase & jvar)
+ArrayCoupledForce::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
 {
   if (jvar.number() == _v_var)
     return _coef * (-_phi[_j][_qp] * _test[_i][_qp]);

--- a/test/src/kernels/CoupledArrayForce.C
+++ b/test/src/kernels/CoupledArrayForce.C
@@ -47,7 +47,7 @@ CoupledArrayForce::computeQpResidual()
 }
 
 RealEigenVector
-CoupledArrayForce::computeQpOffDiagJacobianArray(ArrayMooseVariable & jvar)
+CoupledArrayForce::computeQpOffDiagJacobianArray(const ArrayMooseVariable & jvar)
 {
   if (jvar.number() == _v_var)
     return _coef * (-_phi[_j][_qp] * _test[_i][_qp]);

--- a/test/src/kernels/CoupledVectorDiffusion.C
+++ b/test/src/kernels/CoupledVectorDiffusion.C
@@ -48,7 +48,7 @@ CoupledVectorDiffusion::computeQpJacobian()
 }
 
 Real
-CoupledVectorDiffusion::computeQpOffDiagJacobian(unsigned jvar)
+CoupledVectorDiffusion::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _v_id && _state == "current")
     return -_grad_phi[_j][_qp].contract(_grad_test[_i][_qp]);

--- a/test/src/kernels/VectorCoupledGradientTimeDerivative.C
+++ b/test/src/kernels/VectorCoupledGradientTimeDerivative.C
@@ -48,7 +48,7 @@ VectorCoupledGradientTimeDerivative::computeQpJacobian()
 }
 
 Real
-VectorCoupledGradientTimeDerivative::computeQpOffDiagJacobian(unsigned jvar)
+VectorCoupledGradientTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _v_id)
     return _test[_i][_qp] * _d_grad_v_dot_dv[_qp] * _standard_grad_phi[_j][_qp];

--- a/test/src/scalarkernels/AlphaCED.C
+++ b/test/src/scalarkernels/AlphaCED.C
@@ -29,8 +29,6 @@ AlphaCED::AlphaCED(const InputParameters & parameters)
 {
 }
 
-AlphaCED::~AlphaCED() {}
-
 void
 AlphaCED::reinit()
 {
@@ -65,12 +63,12 @@ AlphaCED::computeQpJacobian()
 }
 
 void
-AlphaCED::computeOffDiagJacobian(unsigned int /*jvar*/)
+AlphaCED::computeOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
 }
 
 Real
-AlphaCED::computeQpOffDiagJacobian(unsigned int /*jvar*/)
+AlphaCED::computeQpOffDiagJacobianScalar(unsigned int /*jvar*/)
 {
   return 0.;
 }

--- a/test/src/scalarkernels/ImplicitODEx.C
+++ b/test/src/scalarkernels/ImplicitODEx.C
@@ -39,7 +39,7 @@ ImplicitODEx::computeQpJacobian()
 }
 
 Real
-ImplicitODEx::computeQpOffDiagJacobian(unsigned int jvar)
+ImplicitODEx::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _y_var)
     return -2.;

--- a/test/src/scalarkernels/ImplicitODEy.C
+++ b/test/src/scalarkernels/ImplicitODEy.C
@@ -39,7 +39,7 @@ ImplicitODEy::computeQpJacobian()
 }
 
 Real
-ImplicitODEy::computeQpOffDiagJacobian(unsigned int jvar)
+ImplicitODEy::computeQpOffDiagJacobianScalar(unsigned int jvar)
 {
   if (jvar == _x_var)
     return -4.;

--- a/test/tests/restrictable/check_error/tests
+++ b/test/tests/restrictable/check_error/tests
@@ -10,8 +10,7 @@
       type = 'RunException'
       input = 'check_error.i'
       cli_args = "Kernels/diff/test=fe_problem_null"
-      expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a "
-                   "pointer to the MooseMesh via '_mesh'"
+      expect_err = "Parameter _fe_problem_base is NULL"
 
       detail = "regarding the problem being solved or"
 
@@ -21,8 +20,7 @@
       type = 'RunException'
       input = 'check_error.i'
       cli_args = "Kernels/diff/test=mesh_null"
-      expect_err = "The input parameters must contain a pointer to FEProblem via '_fe_problem' or a "
-                   "pointer to the MooseMesh via '_mesh'"
+      expect_err = "Parameter _fe_problem_base is NULL"
 
       detail = "information regarding the finite element mesh."
     []


### PR DESCRIPTION
Close #13609.

This will be useful for the eigen system cleanups.

Note that the second comment went a little further by replacing `computeOffDiagJacobian(unsigned jvar)` with `computeOffDiagJacobian(MooseVariableFEBase & jvar)`. It does not change the interface of `computeQpOffDiagJacobian`. Thus this PR may break applications if applications override `computeOffDiagJacobian`. It should be pretty rare though.
