### PR TITLE
Use MeshBase data to inform us when we should prepare

### DIFF
--- a/framework/include/actions/SetupMeshCompleteAction.h
+++ b/framework/include/actions/SetupMeshCompleteAction.h
@@ -23,10 +23,7 @@ public:
 
   SetupMeshCompleteAction(InputParameters params);
 
-  bool completeSetup(MooseMesh * mesh);
-
   virtual void act() override;
 
   PerfID _uniform_refine_timer;
 };
-

--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -327,7 +327,7 @@ public:
   virtual const Elem * queryElemPtr(const dof_id_type i) const;
 
   /**
-   * Setter/getter for the _is_prepared flag.
+   * Setter/getter for whether the mesh is prepared
    */
   bool prepared() const;
   virtual void prepared(bool state);
@@ -460,10 +460,11 @@ public:
   const RealVectorValue & getNormalByBoundaryID(BoundaryID id) const;
 
   /**
-   * Calls prepare_for_use() if force=true on the underlying Mesh object, then communicates various
-   * boundary information on parallel meshes. Also calls update() internally.
+   * Calls prepare_for_use() if the underlying MeshBase object isn't prepared, then communicates
+   * various boundary information on parallel meshes. Also calls update() internally. We maintain
+   * the boolean parameter in order to maintain backwards compatability but it doesn't do anything
    */
-  void prepare(bool force = false);
+  void prepare(bool = false);
 
   /**
    * Calls buildNodeListFromSideList(), buildNodeList(), and buildBndElemList().
@@ -1121,10 +1122,7 @@ protected:
   bool _is_nemesis;
 
   /// True if prepare has been called on the mesh
-  bool _is_prepared;
-
-  /// True if prepare_for_use should be called when Mesh is prepared
-  bool _needs_prepare_for_use;
+  bool _moose_mesh_prepared = false;
 
   /// The elements that were just refined.
   std::unique_ptr<ConstElemPointerRange> _refined_elements;

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -39,17 +39,6 @@ SetupMeshCompleteAction::SetupMeshCompleteAction(InputParameters params)
 {
 }
 
-bool
-SetupMeshCompleteAction::completeSetup(MooseMesh * mesh)
-{
-  bool prepared = mesh->prepared();
-
-  if (!prepared)
-    mesh->prepare();
-
-  return prepared;
-}
-
 void
 SetupMeshCompleteAction::act()
 {
@@ -116,9 +105,9 @@ SetupMeshCompleteAction::act()
   else
   {
     // Prepare the mesh (may occur multiple times)
-    completeSetup(_mesh.get());
+    _mesh->prepare();
 
     if (_displaced_mesh)
-      completeSetup(_displaced_mesh.get());
+      _displaced_mesh->prepare();
   }
 }

--- a/framework/src/meshgenerators/FancyExtruderGenerator.C
+++ b/framework/src/meshgenerators/FancyExtruderGenerator.C
@@ -562,5 +562,7 @@ FancyExtruderGenerator::generate()
     }
   }
 
+  mesh->set_isnt_prepared();
+
   return mesh;
 }

--- a/framework/src/meshgenerators/SideSetsGeneratorBase.C
+++ b/framework/src/meshgenerators/SideSetsGeneratorBase.C
@@ -64,6 +64,17 @@ SideSetsGeneratorBase::setup(MeshBase & mesh)
   _fe_face = FEBase::build(dim, fe_type);
   _qface = libmesh_make_unique<QGauss>(dim - 1, FIRST);
   _fe_face->attach_quadrature_rule(_qface.get());
+
+  // We will want to Change the below code when we have more fine-grained control over advertising
+  // what we need need and how we satisfy those needs. For now we know we need to have neighbors per
+  // #15823...and we do have an explicit `find_neighbors` call...but we don't have a
+  // `neighbors_found` API and it seems off to do:
+  //
+  // if (!mesh.is_prepared())
+  //   mesh.find_neighbors()
+
+  if (!mesh.is_prepared())
+    mesh.prepare_for_use();
 }
 
 void

--- a/test/tests/meshgenerators/fancy_extruder_generator/need-neighbors.i
+++ b/test/tests/meshgenerators/fancy_extruder_generator/need-neighbors.i
@@ -1,0 +1,51 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 1
+  []
+  [extrude]
+    type = FancyExtruderGenerator
+    input = gmg
+    heights = '1'
+    num_layers = '1'
+    direction = '0 1 0'
+  []
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = LAGRANGE
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [bottom]
+    type = DirichletBC
+    variable = u
+    boundary = '0'
+    value = 0
+  []
+  [top]
+    type = DirichletBC
+    variable = u
+    boundary = '1'
+    value = 1
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/meshgenerators/fancy_extruder_generator/tests
+++ b/test/tests/meshgenerators/fancy_extruder_generator/tests
@@ -10,4 +10,11 @@
     design = 'FancyExtruderGenerator.md'
     issues = '#13276 #3554 #5634'
   [../]
+  [prepare_mesh]
+    type = 'RunApp'
+    input = need-neighbors.i
+    requirement = 'The system shall make sure the mesh is prepared after a mesh generator has indicated the mesh is not prepared and before running a solve.'
+    issues = '#15944 #15936 #15823'
+    design = 'FancyExtruderGenerator.md'
+  []
 []


### PR DESCRIPTION
We also can signal to the `MeshBase` object if we've done some
operation that renders the mesh unprepared. If we do this meticulously
then we can trust checks of the `is_prepared` flag to tell us when we
need to `prepare_for_use` or not

Closes #15944 #15936 #15823
