### PR TITLE
Restore correct operation of groups option in syntax list

### DIFF
--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -562,7 +562,7 @@ class SyntaxCompleteCommand(SyntaxListCommand):
             if child.removed or child.test:
                 continue
 
-            if (groups is None) or (child.group in groups):
+            if (groups is None) or (child.groups(actions=True, syntax=True, objects=True).intersection(groups)):
                 url = os.path.join('syntax', child.markdown)
                 h = core.Heading(parent, level=level, id_=self.settings['id'])
                 autolink.AutoLink(h, page=url, string=str(child.fullpath().strip('/')))

--- a/python/moosesyntax/nodes.py
+++ b/python/moosesyntax/nodes.py
@@ -83,15 +83,20 @@ class SyntaxNode(NodeBase):
         if self.markdown is None:
             self.markdown = os.path.join(self.fullpath().lstrip('/'), 'index.md')
 
-    def groups(self):
+    def groups(self, syntax=True, actions=True, objects=False):
         """
         Return groups associated with this Actions (i.e., where the syntax is defined).
         """
         out = set([self.group]) if self.group is not None else set()
-        for node in self.actions():
-            out.update(node.groups())
-        for node in self.syntax():
-            out.update(node.groups())
+        if syntax:
+            for node in self.syntax():
+                out.update(node.groups())
+        if actions:
+            for node in self.actions():
+                out.update(node.groups())
+        if objects:
+            for node in self.objects():
+                out.update(node.groups())
         return out
 
     def parameters(self):


### PR DESCRIPTION
@elementx54 This should fix the problem in BISON.
(closes #16160)


<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
