### PR TITLE
Implement constant mass for ActuallyExplicitEuler

### DIFF
--- a/framework/include/timeintegrators/ActuallyExplicitEuler.h
+++ b/framework/include/timeintegrators/ActuallyExplicitEuler.h
@@ -39,6 +39,8 @@ protected:
    */
   template <typename T, typename T2>
   void computeTimeDerivativeHelper(T & u_dot, const T2 & u_old) const;
+
+  const bool & _constant_mass;
 };
 
 template <typename T, typename T2>

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/1D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/1D/tests
@@ -7,8 +7,9 @@
     type = 'CSVDiff'
     input = '1d_nodalmass_explicit.i'
     csvdiff = '1d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
-                  "1D mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include central difference time integration that correctly "
+                  "calculates the response of a 1D mesh with nodal masses equal to those of a "
+                  "corresponding lumped mass system."
   []
 
   # 1D implicit analysis with nodal masses equivalent to the lumped mass solve
@@ -16,8 +17,9 @@
     type = 'CSVDiff'
     input = '1d_nodalmass_implicit.i'
     csvdiff = '1d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 1D "
-                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include Newmark-beta time integration that correctly calculate "
+                  "the response of a 1D mesh with nodal masses equal to those of a corresponding "
+                  "lumped mass system."
   []
 
   # 1D explicit analysis with lumped mass solve
@@ -27,9 +29,10 @@
     cli_args = Outputs/file_base=1d_nodalmass_explicit_out
     csvdiff = '1d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
-                  "correctly calculate the response of a 1D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system shall include a central difference time integration that when used "
+                  "with the lumped mass shall correctly calculate the response of a 1D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 
   # 1D explicit analysis with constant mass solve
@@ -40,8 +43,9 @@
                'Executioner/TimeIntegrator/use_constant_mass=true'
     csvdiff = '1d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
-                  "correctly calculate the response of a 1D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system shall include central difference time integration that when used with "
+                  "the constant mass option shall correctly calculate the response of a 1D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 []

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/1D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/1D/tests
@@ -1,37 +1,47 @@
 [Tests]
   design = 'CentralDifference.md'
-  issues = '#13964 #9726'
+  issues = '#13964 #9726 #16163'
 
   # 1D explicit analysis with nodal masses equivalent to the lumped mass solve
-  [./explicit_nodalmass]
+  [explicit_nodalmass]
     type = 'CSVDiff'
     input = '1d_nodalmass_explicit.i'
     csvdiff = '1d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate "
-                  "the response of a 1D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
+                  "1D mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 1D implicit analysis with nodal masses equivalent to the lumped mass solve
-  [./implicit_nodalmass]
+  [implicit_nodalmass]
     type = 'CSVDiff'
     input = '1d_nodalmass_implicit.i'
     csvdiff = '1d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate "
-                  "the response of a 1D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 1D "
+                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 1D explicit analysis with lumped mass solve
-  [./explicit_lumped]
+  [explicit_lumped]
     type = 'CSVDiff'
     input = '1d_lumped_explicit.i'
     cli_args = Outputs/file_base=1d_nodalmass_explicit_out
     csvdiff = '1d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass "
-                  "option shall correctly calculate the response of a 1D mesh "
-                  "and produce results that are identical to those calculated using "
-                  "equivalent nodal masses."
-  [../]
+    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
+                  "correctly calculate the response of a 1D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
+
+  # 1D explicit analysis with constant mass solve
+  [explicit_constant_mass]
+    type = 'CSVDiff'
+    input = '1d_lumped_explicit.i'
+    cli_args = 'Outputs/file_base=1d_nodalmass_explicit_out '
+               'Executioner/TimeIntegrator/use_constant_mass=true'
+    csvdiff = '1d_nodalmass_explicit_out.csv'
+    prereq = explicit_nodalmass
+    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
+                  "correctly calculate the response of a 1D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
 []

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/2D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/2D/tests
@@ -7,8 +7,9 @@
     type = 'CSVDiff'
     input = '2d_nodalmass_explicit.i'
     csvdiff = '2d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
-                  "2D mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include central difference time integration that correctly "
+                  "calculates the response of a 2D mesh with nodal masses equal to those of a "
+                  "corresponding lumped mass system."
   []
 
   # 2D implicit analysis with nodal masses equivalent to the lumped mass solve
@@ -16,8 +17,9 @@
     type = 'CSVDiff'
     input = '2d_nodalmass_implicit.i'
     csvdiff = '2d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 2D "
-                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include Newmark-beta time integration that correctly calculates "
+                  "the response of a 2D mesh with nodal masses equal to those of a corresponding "
+                  "lumped mass system."
   []
 
   # 2D explicit analysis with lumped mass solve
@@ -27,9 +29,10 @@
     cli_args = Outputs/file_base=2d_nodalmass_explicit_out
     csvdiff = '2d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
-                  "correctly calculate the response of a 2D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system syall include central difference time integration that when used with "
+                  "the lumped mass option shall correctly calculate the response of a 2D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 
   # 2D explicit analysis with constant mass solve
@@ -40,8 +43,9 @@
                'Executioner/TimeIntegrator/use_constant_mass=true'
     csvdiff = '2d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
-                  "correctly calculate the response of a 2D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system syall include central difference time integration that when used with "
+                  "the constant mass option shall correctly calculate the response of a 2D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 []

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/2D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/2D/tests
@@ -3,35 +3,45 @@
   issues = '#13964 #9726'
 
   # 2D explicit analysis with nodal masses equivalent to the lumped mass solve
-  [./explicit_nodalmass]
+  [explicit_nodalmass]
     type = 'CSVDiff'
     input = '2d_nodalmass_explicit.i'
     csvdiff = '2d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate "
-                  "the response of a 2D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
+                  "2D mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 2D implicit analysis with nodal masses equivalent to the lumped mass solve
-  [./implicit_nodalmass]
+  [implicit_nodalmass]
     type = 'CSVDiff'
     input = '2d_nodalmass_implicit.i'
     csvdiff = '2d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate "
-                  "the response of a 2D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 2D "
+                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 2D explicit analysis with lumped mass solve
-  [./explicit_lumped]
+  [explicit_lumped]
     type = 'CSVDiff'
     input = '2d_lumped_explicit.i'
     cli_args = Outputs/file_base=2d_nodalmass_explicit_out
     csvdiff = '2d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass "
-                  "option shall correctly calculate the response of a 2D mesh "
-                  "and produce results that are identical to those calculated using "
-                  "equivalent nodal masses."
-  [../]
+    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
+                  "correctly calculate the response of a 2D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
+
+  # 2D explicit analysis with constant mass solve
+  [explicit_constant_mass]
+    type = 'CSVDiff'
+    input = '2d_lumped_explicit.i'
+    cli_args = 'Outputs/file_base=2d_nodalmass_explicit_out '
+               'Executioner/TimeIntegrator/use_constant_mass=true'
+    csvdiff = '2d_nodalmass_explicit_out.csv'
+    prereq = explicit_nodalmass
+    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
+                  "correctly calculate the response of a 2D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
 []

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/3D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/3D/tests
@@ -3,35 +3,45 @@
   issues = '#13964 #9726'
 
   # 3D explicit analysis with nodal masses equivalent to the lumped mass solve
-  [./explicit_nodalmass]
+  [explicit_nodalmass]
     type = 'CSVDiff'
     input = '3d_nodalmass_explicit.i'
     csvdiff = '3d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate "
-                  "the response of a 3D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
+                  "3D mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 3D implicit analysis with nodal masses equivalent to the lumped mass solve
-  [./implicit_nodalmass]
+  [implicit_nodalmass]
     type = 'CSVDiff'
     input = '3d_nodalmass_implicit.i'
     csvdiff = '3d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate "
-                  "the response of a 3D mesh with nodal masses equal to those of "
-                  "a corresponding lumped mass system."
-  [../]
+    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 3D "
+                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+  []
 
   # 3D explicit analysis with lumped mass solve
-  [./explicit_lumped]
+  [explicit_lumped]
     type = 'CSVDiff'
     input = '3d_lumped_explicit.i'
     cli_args = Outputs/file_base=3d_nodalmass_explicit_out
     csvdiff = '3d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass "
-                  "option shall correctly calculate the response of a 3D mesh "
-                  "and produce results that are identical to those calculated using "
-                  "equivalent nodal masses."
-  [../]
+    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
+                  "correctly calculate the response of a 3D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
+
+  # 3D explicit analysis with constant mass solve
+  [explicit_constant_mass]
+    type = 'CSVDiff'
+    input = '3d_lumped_explicit.i'
+    cli_args = 'Outputs/file_base=3d_nodalmass_explicit_out '
+               'Executioner/TimeIntegrator/use_constant_mass=true'
+    csvdiff = '3d_nodalmass_explicit_out.csv'
+    prereq = explicit_nodalmass
+    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
+                  "correctly calculate the response of a 3D mesh and produce results that are "
+                  "identical to those calculated using equivalent nodal masses."
+  []
 []

--- a/modules/tensor_mechanics/test/tests/central_difference/lumped/3D/tests
+++ b/modules/tensor_mechanics/test/tests/central_difference/lumped/3D/tests
@@ -7,8 +7,9 @@
     type = 'CSVDiff'
     input = '3d_nodalmass_explicit.i'
     csvdiff = '3d_nodalmass_explicit_out.csv'
-    requirement = "The CentralDifference timeintegrator shall correctly calculate the response of a "
-                  "3D mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include central difference time integration that correctly "
+                  "calculates the response of a 3D mesh with nodal masses equal to those of a "
+                  "corresponding lumped mass system."
   []
 
   # 3D implicit analysis with nodal masses equivalent to the lumped mass solve
@@ -16,8 +17,9 @@
     type = 'CSVDiff'
     input = '3d_nodalmass_implicit.i'
     csvdiff = '3d_nodalmass_implicit_out.csv'
-    requirement = "The NewmarkBeta timeintegrator shall correctly calculate the response of a 3D "
-                  "mesh with nodal masses equal to those of a corresponding lumped mass system."
+    requirement = "The system shall include Newmar-beta time integration that correctly calculates "
+                  "the response of a 3D mesh with nodal masses equal to those of a corresponding "
+                  "lumped mass system."
   []
 
   # 3D explicit analysis with lumped mass solve
@@ -27,9 +29,10 @@
     cli_args = Outputs/file_base=3d_nodalmass_explicit_out
     csvdiff = '3d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the lumped mass option shall "
-                  "correctly calculate the response of a 3D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system shall include central difference time integration that when used with "
+                  "the lumped mass option shall correctly calculate the response of a 3D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 
   # 3D explicit analysis with constant mass solve
@@ -40,8 +43,9 @@
                'Executioner/TimeIntegrator/use_constant_mass=true'
     csvdiff = '3d_nodalmass_explicit_out.csv'
     prereq = explicit_nodalmass
-    requirement = "The CentralDifference timeintegrator used with the constant mass option shall "
-                  "correctly calculate the response of a 3D mesh and produce results that are "
-                  "identical to those calculated using equivalent nodal masses."
+    requirement = "The system shall include central difference time integration that when used with "
+                  "the constant mass option shall correctly calculate the response of a 3D mesh and "
+                  "produce results that are identical to those calculated using equivalent nodal "
+                  "masses."
   []
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Adds `use_constant_mass` option to `ActuallyExplicitEuler` TimeIntegrator to speed up explicit dynamics computations.
@hugary1995 @friedmud 

closes #16163 