### PR TITLE
promote "initial_condition" parameter to the variable action level

### DIFF
--- a/framework/src/actions/AddICAction.C
+++ b/framework/src/actions/AddICAction.C
@@ -20,6 +20,14 @@ InputParameters
 AddICAction::validParams()
 {
   InputParameters params = MooseObjectAction::validParams();
+
+  // This is to help with input file validation.  When ICs are created with
+  // this action, they are nested underneath a variable in the input file - so
+  // we implicitly already know the variable name from this nesting and users
+  // don't need to specify it for us with the parameter.  So we say here that
+  // the variable param is provided by the action.
+  params.set<std::vector<std::string>>("__provides_to_subobjects__") = {"variable"};
+
   return params;
 }
 

--- a/framework/src/actions/AddICAction.C
+++ b/framework/src/actions/AddICAction.C
@@ -26,7 +26,7 @@ AddICAction::validParams()
   // we implicitly already know the variable name from this nesting and users
   // don't need to specify it for us with the parameter.  So we say here that
   // the variable param is provided by the action.
-  params.set<std::vector<std::string>>("__provides_to_subobjects__") = {"variable"};
+  params.set<std::vector<std::string>>("_object_params_set_by_action") = {"variable"};
 
   return params;
 }

--- a/framework/src/actions/AddOutputAction.C
+++ b/framework/src/actions/AddOutputAction.C
@@ -30,6 +30,9 @@ AddOutputAction::validParams()
 {
   InputParameters params = MooseObjectAction::validParams();
   params.addClassDescription("Action responsible for creating Output objects.");
+  // This is to help with input file validation.  FEProblem adds file_base to
+  // all objects that don't have it set from the input file.
+  params.set<std::vector<std::string>>("_object_params_set_by_action") = {"file_base"};
   return params;
 }
 

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -53,6 +53,8 @@ AddVariableAction::validParams()
                              "allowed)");
   params.addParam<std::vector<Real>>("scaling",
                                      "Specifies a scaling factor to apply to this variable");
+  params.addParam<std::vector<Real>>("initial_condition",
+                                     "Specifies the initial condition for this variable");
   return params;
 }
 
@@ -150,7 +152,7 @@ AddVariableAction::act()
   addVariable(var_name);
 
   // Set the initial condition
-  if (_moose_object_pars.isParamValid("initial_condition"))
+  if (_pars.isParamValid("initial_condition"))
     createInitialConditionAction();
 }
 
@@ -160,7 +162,7 @@ AddVariableAction::createInitialConditionAction()
   // Variable name
   std::string var_name = name();
 
-  auto value = _moose_object_pars.get<std::vector<Real>>("initial_condition");
+  auto value = _pars.get<std::vector<Real>>("initial_condition");
 
   // Create the object name
   std::string long_name("");

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -52,8 +52,6 @@ MooseVariableBase::validParams()
   params.addParam<MooseEnum>(
       "family", family, "Specifies the family of FE shape functions to use for this variable.");
 
-  params.addParam<std::vector<Real>>("initial_condition",
-                                     "Specifies the initial condition for this variable");
   // ArrayVariable capability
   params.addRangeCheckedParam<unsigned int>(
       "components", 1, "components>0", "Number of components for an array variable");


### PR DESCRIPTION
This helps with external-tool validation of input file syntax.  And
makes things more clean anyway - the parameter is only used by the
action - it should be owned by the action.  Fixes #14231.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
