### PR TITLE
use MOOSE_JOBS when configuring petsc

### DIFF
--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -89,13 +89,19 @@ if [ ! -z "$PETSC_PREFIX" ]; then
   PFX_STR="--prefix=$PETSC_PREFIX"
 fi
 
+# Use --with-make-np if MOOSE_JOBS is given
+MAKE_NP_STR=""
+if [ ! -z "$MOOSE_JOBS" ]; then
+  MAKE_NP_STR="--with-make-np=$MOOSE_JOBS"
+fi
+
 cd $SCRIPT_DIR/../petsc
 
 # If we're not going fast, remove the build directory and reconfigure
 if [ -z "$go_fast" ]; then
   rm -rf $SCRIPT_DIR/../petsc/$PETSC_ARCH
 
-  ./configure $(echo $PFX_STR) \
+  ./configure $(echo $PFX_STR) $(echo $MAKE_NP_STR) \
       --download-hypre=1 \
       --with-debugging=no \
       --with-shared-libraries=1 \
@@ -111,13 +117,12 @@ if [ -z "$go_fast" ]; then
       --with-cxx-dialect=C++11 \
       --with-fortran-bindings=0 \
       --with-sowing=0 \
-      --with-make-np=${MOOSE_JOBS:-1} \
       $*
 
   exitIfExitCode $?
 fi
 
-make all -j ${MOOSE_JOBS:-1}
+make all
 exitIfExitCode $?
 
 if [ ! -z "$PFX_STR" ]; then

--- a/scripts/update_and_rebuild_petsc.sh
+++ b/scripts/update_and_rebuild_petsc.sh
@@ -111,6 +111,7 @@ if [ -z "$go_fast" ]; then
       --with-cxx-dialect=C++11 \
       --with-fortran-bindings=0 \
       --with-sowing=0 \
+      --with-make-np=${MOOSE_JOBS:-1} \
       $*
 
   exitIfExitCode $?


### PR DESCRIPTION
As discussed on Slack with @fdkong and @milljm , the `scripts/update_and_rebuild_petsc.sh` script should use MOOSE_JOBS when compiling. Closes ref #16179.
