### PR TITLE
Minor eigen improves

### DIFF
--- a/framework/include/executioners/Eigenvalue.h
+++ b/framework/include/executioners/Eigenvalue.h
@@ -56,11 +56,6 @@ public:
    */
   virtual void checkIntegrity();
 
-  /**
-   *  There are two ways to output eigenvalue. "inverse" corresponds to k-eigenvalue
-   */
-  virtual void outputInverseEigenvalue(bool inverse);
-
 private:
   /**
    * Prepare right petsc options

--- a/framework/include/vectorpostprocessors/Eigenvalues.h
+++ b/framework/include/vectorpostprocessors/Eigenvalues.h
@@ -25,12 +25,12 @@ public:
 
   Eigenvalues(const InputParameters & parameters);
 
-  virtual void initialize() override;
+  virtual void initialize() override {}
   virtual void execute() override;
 
 protected:
+  const bool _inverse;
   VectorPostprocessorValue & _eigen_values_real;
   VectorPostprocessorValue & _eigen_values_imag;
   NonlinearEigenSystem * _nl_eigen;
 };
-

--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -64,11 +64,6 @@ Eigenvalue::validParams()
   // If Newton and Inverse Power is combined in SLEPc side
   params.addPrivateParam<bool>("_newton_inverse_power", false);
 
-  params.addParam<bool>("output_inverse_eigenvalue",
-                        false,
-                        " Whether or not the system output the inverse of eigenvaue. It is useful "
-                        "for neutronic simulation.");
-
   params.addParam<Real>("time", 0.0, "System time");
 
 // Add slepc options and eigen problems
@@ -103,11 +98,6 @@ Eigenvalue::Eigenvalue(const InputParameters & parameters)
       getParam<unsigned int>("free_power_iterations");
   _eigen_problem.solverParams()._extra_power_iterations =
       getParam<unsigned int>("extra_power_iterations");
-
-  // Whether or not the system outputs the inverse of eigenvaue.
-  // It is useful for neutron calculations. The inverse of the eigenvalue is the multiplication
-  // factor.
-  _eigen_problem.outputInverseEigenvalue(getParam<bool>("output_inverse_eigenvalue"));
 
   if (!isParamValid("normalization") && isParamValid("normal_factor"))
     paramError("normal_factor",
@@ -209,12 +199,6 @@ Eigenvalue::checkIntegrity()
   // check to make sure that we don't have any time kernels in eigenvaue simulation
   if (_eigen_problem.getNonlinearSystemBase().containsTimeKernel())
     mooseError("You have specified time kernels in your eigenvaue simulation");
-}
-
-void
-Eigenvalue::outputInverseEigenvalue(bool inverse)
-{
-  _eigen_problem.outputInverseEigenvalue(inverse);
 }
 
 #endif

--- a/framework/src/systems/NonlinearEigenSystem.C
+++ b/framework/src/systems/NonlinearEigenSystem.C
@@ -249,15 +249,7 @@ NonlinearEigenSystem::solve()
 
   _eigen_values.resize(n_converged_eigenvalues);
   for (unsigned int n = 0; n < n_converged_eigenvalues; n++)
-  {
-    auto eigenvalue0 = getConvergedEigenvalue(n);
-    // Inverse eigen value if necessary
-    _eigen_values[n].first =
-        (_eigen_problem.isNonlinearEigenvalueSolver() && _eigen_problem.outputInverseEigenvalue())
-            ? 1. / eigenvalue0.first
-            : eigenvalue0.first;
-    _eigen_values[n].second = eigenvalue0.second;
-  }
+    _eigen_values[n] = getConvergedEigenvalue(n);
 
   // Update the active eigenvector to the solution vector
   if (n_converged_eigenvalues)

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -1111,7 +1111,7 @@ mooseSlepcEPSMonitor(EPS eps,
   auto eigenvalue = inverse ? 1.0 / eigenr : eigenr;
 
   // The term "k-eigenvalue" is adopted from the neutronics community.
-  console << " Iteration " << its << std::setprecision(10)
+  console << " Iteration " << its << std::setprecision(10) << std::fixed
           << (inverse ? " k-eigenvalue = " : " eigenvalue = ") << eigenvalue << std::endl;
 
   return 0;

--- a/test/include/base/MooseTestApp.h
+++ b/test/include/base/MooseTestApp.h
@@ -19,6 +19,8 @@ public:
   MooseTestApp(const InputParameters & parameters);
   virtual ~MooseTestApp();
 
+  virtual void executeExecutioner() override;
+
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_test_objs = false);
   static void registerApps();
 };

--- a/test/src/base/MooseTestApp.C
+++ b/test/src/base/MooseTestApp.C
@@ -15,6 +15,7 @@
 
 #include "ActionFactory.h"
 #include "AppFactory.h"
+#include "EigenProblem.h"
 
 #include "MooseTestApp.h"
 
@@ -28,6 +29,12 @@ MooseTestApp::validParams()
                                    "--test_getRestartableDataMap_error",
                                    false,
                                    "Call getRestartableDataMap with a bad name.");
+
+  // Flag for turning how EigenProblem output eigenvalues
+  params.addCommandLineParam<bool>("output_inverse_eigenvalue",
+                                   "--output-inverse-eigenvalue",
+                                   false,
+                                   "True to let EigenProblem output inverse eigenvalue.");
 
   /* MooseTestApp is special because it will have its own
    * binary and we want the default to allow test objects.
@@ -57,6 +64,21 @@ MooseTestApp::MooseTestApp(const InputParameters & parameters) : MooseApp(parame
 }
 
 MooseTestApp::~MooseTestApp() {}
+
+void
+MooseTestApp::executeExecutioner()
+{
+#ifdef LIBMESH_HAVE_SLEPC
+  if (getParam<bool>("output_inverse_eigenvalue"))
+  {
+    auto eigen_problem = dynamic_cast<EigenProblem *>(&(_executioner->feProblem()));
+    if (eigen_problem)
+      eigen_problem->outputInverseEigenvalue(true);
+  }
+#endif
+
+  MooseApp::executeExecutioner();
+}
 
 void
 MooseTestApp::registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_test_objs)

--- a/test/tests/problems/eigen_problem/initial_condition/gold/ne_ic_out_inverse_eigenvalues_0001.csv
+++ b/test/tests/problems/eigen_problem/initial_condition/gold/ne_ic_out_inverse_eigenvalues_0001.csv
@@ -1,2 +1,2 @@
-eigen_values_real,eigen_values_imag
-5.0014600981294,0
+eigen_values_imag,eigen_values_real
+0,5.0014600976647

--- a/test/tests/problems/eigen_problem/initial_condition/tests
+++ b/test/tests/problems/eigen_problem/initial_condition/tests
@@ -11,15 +11,6 @@
     requirement = "The system shall provide an initial guess to Newton if users request."
   [../]
 
-  [./output_inverse_eigenvalue]
-    type = 'CSVDiff'
-    input = 'ne_ic.i'
-    csvdiff = 'ne_ic_out_inverse_eigenvalues_0001.csv'
-    cli_args = 'Executioner/output_inverse_eigenvalue=true Outputs/file_base=ne_ic_out_inverse'
-    slepc_version = '>=3.8.0'
-    requirement = "The system shall provide an option to output the eigenvalue as its inverse."
-  [../]
-
   [./extra_power_iterations]
     type = 'Exodiff'
     input = 'ne_ic.i'

--- a/test/tests/problems/eigen_problem/initial_condition/tests
+++ b/test/tests/problems/eigen_problem/initial_condition/tests
@@ -11,6 +11,25 @@
     requirement = "The system shall provide an initial guess to Newton if users request."
   [../]
 
+  [./inverse_eigenvalue_postprocessor]
+    type = 'CSVDiff'
+    input = 'ne_ic.i'
+    csvdiff = 'ne_ic_out_inverse_eigenvalues_0001.csv'
+    cli_args = 'VectorPostprocessors/eigenvalues/inverse_eigenvalue=true Outputs/file_base=ne_ic_out_inverse'
+    absent_out = 'init_ solve'
+    slepc_version = '>=3.8.0'
+    requirement = "The system shall provide an option to output the eigenvalue as its inverse."
+  [../]
+
+  [./output_inverse_eigenvalue]
+    type = 'RunApp'
+    input = 'ne_ic.i'
+    cli_args = '--output-inverse-eigenvalue Outputs/file_base=ne_ic_dummy'
+    expect_out = 'Iteration 1 k-eigenvalue = 5.00146'
+    slepc_version = '>=3.8.0'
+    requirement = "The system shall provide an option to output the eigenvalue on screen as its inverse."
+  [../]
+
   [./extra_power_iterations]
     type = 'Exodiff'
     input = 'ne_ic.i'


### PR DESCRIPTION
Following #16112.

Make `output_inverse_eigenvalue` as a `MooseApp` parameter so that derived apps can reset that parameter in its `validParams` function to control the default output behavior of eigenvalues. We do not want users to set that parameter in every input.