### PR TITLE
FV manual scaling and manual/auto combo scaling

### DIFF
--- a/framework/doc/content/source/systems/NonlinearSystemBase.md
+++ b/framework/doc/content/source/systems/NonlinearSystemBase.md
@@ -21,9 +21,71 @@ you may have a null space (all Neumann boundary conditions for example), or you 
 scaling between variables in a multi-physics simulation. You may even have run into issues if you
 have nodal boundary conditions (which introduce values of unity on the diagonals) and the Jacobian
 entries from your physics (kernels) are very large. You want your condition number to be as close to
-unity as possible. To address the latter problem or poor relative scaling between variables, you
+unity as possible.
+
+### Automatic scaling id=auto-scaling
+
+To address a poor condition number, which can often be the result of poor relative scaling between variables, you
 can use MOOSE's automatic scaling feature which will bring different physics Jacobians as close to
 unity as possible. To turn on this feature, set the `automatic_scaling`
 parameter in the `Executioner` block to `true`. Additionally, if you want to update scaling factors
 at every time step then set `Executioner/compute_scaling_once=false`. By default this latter
 parameter is set to `true` in order to save computational expense.
+
+By default scaling factors are computed solely based on information from
+`compute.*Jacobian` methods. However, residual information or a hybrid of
+Jacobian and residual information may also be used by setting the `Executioner`
+parameter `resid_vs_jac_scaling_param`. The default value is `0`, signaling pure
+Jacobian scaling. Setting a value of `1` requests pure residual scaling. Any
+value in-between `0` and `1` represents a hybrid of residual and Jacobian.
+
+Another parameter relevant to automatic scaling is the `scaling_group_variables`
+parameter. Variables in a group will have a
+single common factor applied to them. Multiple groups can be used with
+semicolons separating them. An example of this is shown in the `Executioner`
+block example below where residual/Jacobian information from all the
+displacement (`disp_`) variables would be used to determine a single scaling
+factor for themselves, and similarly the residual/Jacobian information from all
+the velocity (`vel_`) variables would be used to determine a single scaling
+factor for themselves.
+
+```
+[Executioner]
+:
+:
+  automatic_scaling = true
+  scaling_group_variables = 'disp_x disp_y disp_z; vel_x vel_y vel_z'
+:
+:
+[]
+```
+
+The current implementation of automatic scaling in MOOSE is fairly simple and
+proceeds according to these steps:
+
+1. Compute the on-diagonal Jacobians and/or residuals for all `Kernels`, `ScalarKernels`,
+   `NodalKernels`, and `FVKernels`
+2. Assemble the results
+3. Examine the Jacobian diagonal or residual for every row corresponding to a
+   given variable (or group of variables; recall the `scaling_group_variables`
+   parameter) and then compute a scaling factor such that the maximum absolute
+   value of the Jacobian diagonal or residual across all of a variable's (or
+   group of variables) rows is unity.
+4. If a hybrid of residual and Jacobian scaling has been requested, then a
+   single scaling factor is computed from the residual scaling factor and
+   Jacobian scaling factor. That computation for each variable (group) is done
+   with the following code, where `inverse_scaling_factor` actually denotes that
+   it is the reciprocal/inverse of the final applied variable scaling factor:
+
+```c++
+inverse_scaling_factors[i] =
+    std::exp(_resid_vs_jac_scaling_param * std::log(resid_inverse_scaling_factors[i]) +
+             (1 - _resid_vs_jac_scaling_param) * std::log(jac_inverse_scaling_factors[i]));
+```
+
+
+We only execute kernel objects because objects like `BoundaryConditions`,
+`DGKernels`, `InterfaceKernels`, and `Constraints` may apply penalty factors or
+introduce global constraints for things like Dirichlet conditions or hanging
+nodes in mesh adaptivity. We want our scaling factors to represent our physics,
+not penalties or constraints.

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -269,12 +269,10 @@ public:
   /// AD
   const ADTemplateVariableValue<OutputType> & adSln() const override
   {
-    checkIndexingScalingCompatibility();
     return _element_data->adSln();
   }
   const ADTemplateVariableGradient<OutputType> & adGradSln() const override
   {
-    checkIndexingScalingCompatibility();
     return _element_data->adGradSln();
   }
 
@@ -309,34 +307,28 @@ public:
 
   const ADTemplateVariableSecond<OutputType> & adSecondSln() const override
   {
-    checkIndexingScalingCompatibility();
     return _element_data->adSecondSln();
   }
   const ADTemplateVariableValue<OutputType> & adUDot() const override
   {
-    checkIndexingScalingCompatibility();
     return _element_data->adUDot();
   }
 
   /// neighbor AD
   const ADTemplateVariableValue<OutputType> & adSlnNeighbor() const override
   {
-    checkIndexingScalingCompatibility();
     return _neighbor_data->adSln();
   }
   const ADTemplateVariableGradient<OutputType> & adGradSlnNeighbor() const override
   {
-    checkIndexingScalingCompatibility();
     return _neighbor_data->adGradSln();
   }
   const ADTemplateVariableSecond<OutputType> & adSecondSlnNeighbor() const override
   {
-    checkIndexingScalingCompatibility();
     return _neighbor_data->adSecondSln();
   }
   const ADTemplateVariableValue<OutputType> & adUDotNeighbor() const override
   {
-    checkIndexingScalingCompatibility();
     return _neighbor_data->adUDot();
   }
 
@@ -555,15 +547,6 @@ protected:
   std::unique_ptr<MooseVariableDataFV<OutputType>> _neighbor_data;
 
 private:
-  /**
-   * Check and see whether the AD indexing scheme is compatible with the scaling factors. Currently
-   * non-unity scaling is not supported when doing global dof indexing. This is because we add
-   * Jacobian entries based only on a global index, and we do not a priori know what variable, and
-   * hence scaling factor, that global index is tied to. Eventually we will implement some
-   * global-index-to-var lookup that we use after we've cached all of our Jacobian entries
-   */
-  void checkIndexingScalingCompatibility() const;
-
   /// The current (ghosted) solution. Note that this needs to be stored as a reference to a pointer
   /// because the solution might not exist at the time that this variable is constructed, so we
   /// cannot safely dereference at that time
@@ -580,9 +563,6 @@ private:
   const FieldVariablePhiGradient & _grad_phi_neighbor;
 
 #ifdef MOOSE_GLOBAL_AD_INDEXING
-  /// Whether we've already performed a scaling factor check for this variable
-  mutable bool _scaling_params_checked = false;
-
   /// A cache for storing gradients on elements
   mutable std::unordered_map<const Elem *, VectorValue<ADReal>> _elem_to_grad;
 
@@ -608,20 +588,4 @@ inline const MooseArray<ADReal> &
 MooseVariableFV<OutputType>::adDofValues() const
 {
   return _element_data->adDofValues();
-}
-
-template <typename OutputType>
-inline void
-MooseVariableFV<OutputType>::checkIndexingScalingCompatibility() const
-{
-#ifdef MOOSE_GLOBAL_AD_INDEXING
-  if (!_scaling_params_checked)
-  {
-    for (const auto scaling_factor : _scaling_factor)
-      if (scaling_factor != 1.)
-        this->paramError("scaling", "Scaling with global AD indexing is not yet implemented.");
-
-    _scaling_params_checked = true;
-  }
-#endif
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3314,6 +3314,12 @@ NonlinearSystemBase::computeScaling()
 
   TIME_SECTION(_compute_scaling_timer);
 
+#ifdef MOOSE_GLOBAL_AD_INDEXING
+  // It's funny but we need to assemble our vector of scaling factors here otherwise we will be
+  // applying scaling factors of 0 during Assembly of our scaling Jacobian
+  assembleScalingVector();
+#endif
+
   // container for repeated access of element global dof indices
   std::vector<dof_id_type> dof_indices;
 

--- a/test/tests/fvkernels/scaling/tests
+++ b/test/tests/fvkernels/scaling/tests
@@ -16,5 +16,26 @@
     absent_out = '20 of 40 singular values'
     input = auto-scaling.i
     requirement = 'The system shall be able to condition a system automatically through variable scaling factors.'
+    prereq = 'bad'
+  []
+  [good_manual]
+    type = Exodiff
+    exodiff = 'auto-scaling_out.e'
+    expect_out = ' 0 of 40 singular values'
+    absent_out = '20 of 40 singular values'
+    input = auto-scaling.i
+    cli_args = 'Executioner/automatic_scaling=false Variables/u/scaling=1e0 Variables/v/scaling=1e18'
+    requirement = 'The system shall be able to condition a system manually through variable scaling factors.'
+    prereq = 'good'
+  []
+  [combined_manual_automatic]
+    type = Exodiff
+    exodiff = 'auto-scaling_out.e'
+    expect_out = ' 0 of 40 singular values'
+    absent_out = '20 of 40 singular values'
+    input = auto-scaling.i
+    cli_args = 'Variables/v/scaling=1e-20'
+    requirement = 'The system shall be able to sequentially apply manual and automatic scaling and in the case of poor manual scaling, restore the condition number automatically.'
+    prereq = 'good_manual'
   []
 []


### PR DESCRIPTION
Tests:

- Manual scaling of FV
- That scaling produced by combo manual/automatic and pure automatic is the same

Also adds some more documentation of automatic scaling

@GiudGiud I don't know if 83c86ac is/was related to your observation of automatic scaling sending variables to zero? I wouldn't think so because before 83c86ac we would simply use whatever manual scaling factors were supplied. Also please check whether this added automatic scaling documentation is clear/helpful!