### PR TITLE
Geochem: unit tests now run in opt mode

### DIFF
--- a/modules/geochemistry/src/utils/GeochemistryIonicStrength.C
+++ b/modules/geochemistry/src/utils/GeochemistryIonicStrength.C
@@ -30,17 +30,15 @@ GeochemistryIonicStrength::ionicStrength(const ModelGeochemicalDatabase & mgd,
   const unsigned num_basis = mgd.basis_species_charge.size();
   const unsigned num_eqm = mgd.eqm_species_charge.size();
   const unsigned num_kin = mgd.kin_species_charge.size();
-  mooseAssert(num_basis == basis_species_molality.size(),
-              "Ionic strength calculation: Number of basis species in mgd not equal to the size of "
-              "basis_species_molality");
-  mooseAssert(
-      num_eqm == eqm_species_molality.size(),
-      "Ionic strength calculation: Number of equilibrium species in mgd not equal to the size of "
-      "eqm_species_molality");
-  mooseAssert(
-      num_kin == kin_species_molality.size(),
-      "Ionic strength calculation: Number of kinetic species in mgd not equal to the size of "
-      "kin_species_molality");
+  if (num_basis != basis_species_molality.size())
+    mooseError("Ionic strength calculation: Number of basis species in mgd not equal to the size "
+               "of basis_species_molality");
+  if (num_eqm != eqm_species_molality.size())
+    mooseError("Ionic strength calculation: Number of equilibrium species in mgd not equal to the "
+               "size of eqm_species_molality");
+  if (num_kin != kin_species_molality.size())
+    mooseError("Ionic strength calculation: Number of kinetic species in mgd not equal to the size "
+               "of kin_species_molality");
 
   Real ionic_strength = 0.0;
   for (unsigned i = 0; i < num_basis; ++i)
@@ -69,15 +67,15 @@ GeochemistryIonicStrength::stoichiometricIonicStrength(
   const unsigned num_basis = mgd.basis_species_charge.size();
   const unsigned num_eqm = mgd.eqm_species_charge.size();
   const unsigned num_kin = mgd.kin_species_charge.size();
-  mooseAssert(num_basis == basis_species_molality.size(),
-              "Stoichiometric ionic strength calculation: Number of basis species in mgd not equal "
-              "to the size of basis_species_molality");
-  mooseAssert(num_eqm == eqm_species_molality.size(),
-              "Stoichiometric ionic strength calculation: Number of equilibrium species in mgd not "
-              "equal to the size of eqm_species_molality");
-  mooseAssert(num_kin == kin_species_molality.size(),
-              "Stoichiometric ionic strength calculation: Number of kinetic species in mgd not "
-              "equal to the size of kin_species_molality");
+  if (num_basis != basis_species_molality.size())
+    mooseError("Stoichiometric ionic strength calculation: Number of basis species in mgd not "
+               "equal to the size of basis_species_molality");
+  if (num_eqm != eqm_species_molality.size())
+    mooseError("Stoichiometric ionic strength calculation: Number of equilibrium species in mgd "
+               "not equal to the size of eqm_species_molality");
+  if (num_kin != kin_species_molality.size())
+    mooseError("Stoichiometric ionic strength calculation: Number of kinetic species in mgd not "
+               "equal to the size of kin_species_molality");
 
   Real ionic_strength = 0.0;
   if (_use_only_Cl_molality)


### PR DESCRIPTION
The problem was the unit tests depended on a mooseAssert that was optimised out

Refs #15720
Refs #16092
Refs #15422
Refs #16083
Refs #15422
Refs #16084

Requesting review from @loganharbour 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
