### PR TITLE
Remove master slave 

### DIFF
--- a/framework/doc/content/source/utils/InputParameters.md
+++ b/framework/doc/content/source/utils/InputParameters.md
@@ -31,7 +31,7 @@ the second to last paramter right before the doc string.
 ## Deprecating coupled variables
 
 The `InputParameters` class provides a convenient method for deprecating coupled
-variable names called `addDeprecatedCoupledVar`. The method takes four
+variable names called `addDeprecatedCoupledVar`. The method takes three
 arguments. The first corresponds to the deprecated name; the second argument is
 the new, blessed name that users should use. This name should have a
 corresponding `params.addCoupledVar('blessed_name', 'blessed_name_doc_string')`

--- a/framework/include/constraints/NodalConstraint.h
+++ b/framework/include/constraints/NodalConstraint.h
@@ -32,31 +32,7 @@ public:
    * Get the list of primary nodes
    * @return list of primary nodes IDs
    */
-  std::vector<dof_id_type> & getMasterNodeId()
-  {
-    mooseDeprecated(
-        "'getPrimaryNodeId' is deprecated and will be removed on September 1st, 2020. Please "
-        "use 'getPrimaryNodeId' instead.");
-    return _primary_node_vector;
-  }
-
-  /**
-   * Get the list of primary nodes
-   * @return list of primary nodes IDs
-   */
   std::vector<dof_id_type> & getPrimaryNodeId() { return _primary_node_vector; }
-
-  /**
-   * Get the list of connected secondary nodes
-   * @return list of secondary node IDs
-   */
-  std::vector<dof_id_type> & getSlaveNodeId()
-  {
-    mooseDeprecated(
-        "'getSecondaryNodeId' is deprecated and will be removed on September 1st, 2020. Please "
-        "use 'getSecondaryNodeId' instead.");
-    return _connected_nodes;
-  }
 
   /**
    * Get the list of connected secondary nodes

--- a/framework/src/constraints/ConstraintWarehouse.C
+++ b/framework/src/constraints/ConstraintWarehouse.C
@@ -39,9 +39,7 @@ ConstraintWarehouse::addObject(std::shared_ptr<Constraint> object,
   if (nfc)
   {
     MooseMesh & mesh = nfc->getParam<FEProblemBase *>("_fe_problem_base")->mesh();
-    unsigned int secondary =
-        mesh.getBoundaryID(nfc->isParamValid("secondary") ? nfc->getParam<BoundaryName>("secondary")
-                                                          : nfc->getParam<BoundaryName>("slave"));
+    unsigned int secondary = mesh.getBoundaryID(nfc->getParam<BoundaryName>("secondary"));
     bool displaced = nfc->parameters().have_parameter<bool>("use_displaced_mesh") &&
                      nfc->getParam<bool>("use_displaced_mesh");
 

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -60,41 +60,18 @@ EqualValueBoundaryConstraint::validParams()
       "primary",
       std::numeric_limits<unsigned int>::max(),
       "The ID of the primary node. If no ID is provided, first node of secondary set is chosen.");
-  params.addDeprecatedParam<unsigned int>(
-      "master",
-      std::numeric_limits<unsigned int>::max(),
-      "The ID of the primary node. If no ID is provided, first node of secondary set is chosen.",
-      "The 'master' param is deprecated and will be removed on September 1, 2020. Please use the "
-      "'primary' parameter instead.");
   params.addParam<std::vector<unsigned int>>("secondary_node_ids", "The IDs of the secondary node");
   params.addParam<BoundaryName>(
       "secondary", "NaN", "The boundary ID associated with the secondary side");
-  params.addDeprecatedParam<std::vector<unsigned int>>(
-      "slave_node_ids",
-      "The IDs of the slave node",
-      "The 'slave_node_ids' param is deprecated and will be removed on September 1, 2020. Please "
-      "use "
-      "the 'secondary_node_ids' param instead");
-  params.addDeprecatedParam<BoundaryName>(
-      "slave",
-      "NaN",
-      "The boundary ID associated with the slave side",
-      "The 'slave' param is deprecated and will be removed on "
-      "September 1, 2020. Please use the 'secondary' param instead");
   params.addRequiredParam<Real>("penalty", "The penalty used for the boundary term");
   return params;
 }
 
 EqualValueBoundaryConstraint::EqualValueBoundaryConstraint(const InputParameters & parameters)
   : NodalConstraint(parameters),
-    _primary_node_id(parameters.isParamSetByUser("master") ? getParam<unsigned int>("master")
-                                                           : getParam<unsigned int>("primary")),
-    _secondary_node_ids(isParamValid("secondary_node_ids")
-                            ? getParam<std::vector<unsigned int>>("secondary_node_ids")
-                            : getParam<std::vector<unsigned int>>("slave_node_ids")),
-    _secondary_node_set_id(parameters.isParamSetByUser("slave")
-                               ? getParam<BoundaryName>("slave")
-                               : getParam<BoundaryName>("secondary")),
+    _primary_node_id(getParam<unsigned int>("primary")),
+    _secondary_node_ids(getParam<std::vector<unsigned int>>("secondary_node_ids")),
+    _secondary_node_set_id(getParam<BoundaryName>("secondary")),
     _penalty(getParam<Real>("penalty"))
 {
   updateConstrainedNodes();

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -28,14 +28,6 @@ NodeFaceConstraint::validParams()
   InputParameters params = Constraint::validParams();
   params.addParam<BoundaryName>("secondary", "The boundary ID associated with the secondary side");
   params.addParam<BoundaryName>("primary", "The boundary ID associated with the primary side");
-  params.addDeprecatedParam<BoundaryName>("slave",
-                                          "The boundary ID associated with the secondary side",
-                                          "This parameter is deprecated in favor of 'secondary' "
-                                          "and will be removed on September 1st, 2020");
-  params.addDeprecatedParam<BoundaryName>("master",
-                                          "The boundary ID associated with the primary side",
-                                          "This parameter is deprecated in favor of 'primary' and "
-                                          "will be removed on September 1st, 2020");
   params.addParam<Real>("tangential_tolerance",
                         "Tangential distance to extend edges of contact surfaces");
   params.addParam<Real>(
@@ -57,20 +49,16 @@ NodeFaceConstraint::NodeFaceConstraint(const InputParameters & parameters)
     NeighborCoupleableMooseVariableDependencyIntermediateInterface(this, true, false),
     NeighborMooseVariableInterface<Real>(
         this, true, Moose::VarKindType::VAR_NONLINEAR, Moose::VarFieldType::VAR_FIELD_STANDARD),
-    _secondary(isParamValid("secondary") ? _mesh.getBoundaryID(getParam<BoundaryName>("secondary"))
-                                         : _mesh.getBoundaryID(getParam<BoundaryName>("slave"))),
-    _primary(isParamValid("primary") ? _mesh.getBoundaryID(getParam<BoundaryName>("primary"))
-                                     : _mesh.getBoundaryID(getParam<BoundaryName>("master"))),
+    _secondary(_mesh.getBoundaryID(getParam<BoundaryName>("secondary"))),
+    _primary(_mesh.getBoundaryID(getParam<BoundaryName>("primary"))),
     _var(_sys.getFieldVariable<Real>(_tid, parameters.get<NonlinearVariableName>("variable"))),
 
     _primary_q_point(_assembly.qPointsFace()),
     _primary_qrule(_assembly.qRuleFace()),
 
     _penetration_locator(
-        getPenetrationLocator(isParamValid("primary") ? getParam<BoundaryName>("primary")
-                                                      : getParam<BoundaryName>("master"),
-                              isParamValid("secondary") ? getParam<BoundaryName>("secondary")
-                                                        : getParam<BoundaryName>("slave"),
+        getPenetrationLocator(getParam<BoundaryName>("primary"),
+                              getParam<BoundaryName>("secondary"),
                               Utility::string_to_enum<Order>(getParam<MooseEnum>("order")))),
 
     _current_node(_var.node()),
@@ -79,8 +67,7 @@ NodeFaceConstraint::NodeFaceConstraint(const InputParameters & parameters)
     _phi_secondary(1),  // One entry
     _test_secondary(1), // One entry
 
-    _primary_var(isCoupled("primary_variable") ? *getVar("primary_variable", 0)
-                                               : *getVar("master_variable", 0)),
+    _primary_var(*getVar("primary_variable", 0)),
     _primary_var_num(_primary_var.number()),
 
     _phi_primary(_assembly.phiFaceNeighbor(_primary_var)),

--- a/framework/src/constraints/NodeFaceConstraint.C
+++ b/framework/src/constraints/NodeFaceConstraint.C
@@ -46,7 +46,6 @@ NodeFaceConstraint::validParams()
   params.addParam<MooseEnum>("order", orders, "The finite element order used for projections");
 
   params.addCoupledVar("primary_variable", "The variable on the primary side of the domain");
-  params.addDeprecatedCoupledVar("master_variable", "primary_variable", "September 1st, 2020");
 
   return params;
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -479,6 +479,11 @@ InputParameters::checkParams(const std::string & parsing_syntax)
   {
     if (!isParamValid(it.first) && isParamRequired(it.first))
     {
+      // check if an old, deprecated name exists for this parameter that may be specified
+      auto oit = _new_to_deprecated_coupled_vars.find(it.first);
+      if (oit != _new_to_deprecated_coupled_vars.end() && isParamValid(oit->second))
+        continue;
+
       oss << blockLocation() << ": missing required parameter '" << parampath + "/" + it.first
           << "'\n";
       oss << "\tDoc String: \"" + getDocString(it.first) + "\"" << std::endl;

--- a/modules/contact/examples/2d_indenter/indenter_rz_fine.i
+++ b/modules/contact/examples/2d_indenter/indenter_rz_fine.i
@@ -120,7 +120,7 @@
     secondary = '4'
     primary = 6
     variable = frictionless_normal_lm
-    master_variable = disp_x
+    primary_variable = disp_x
     disp_y = disp_y
     use_displaced_mesh = true
     tangential_tolerance = 0.01

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -43,18 +43,8 @@ ContactAction::validParams()
   InputParameters params = Action::validParams();
   params += ContactAction::commonParameters();
 
-  params.addParam<BoundaryName>("primary", "The primary surface");
-  params.addParam<BoundaryName>("secondary", "The secondary surface");
-  params.addDeprecatedParam<BoundaryName>(
-      "master",
-      "The primary surface",
-      "The 'master' parameter will be removed on September 1, 2020. "
-      "Please use the 'primary' parameter instead.");
-  params.addDeprecatedParam<BoundaryName>(
-      "slave",
-      "The secondary surface",
-      "The 'slave' parameter will be removed on September 1, 2020. "
-      "Please use the 'secondary' parameter instead.");
+  params.addRequiredParam<BoundaryName>("primary", "The primary surface");
+  params.addRequiredParam<BoundaryName>("secondary", "The secondary surface");
 
   params.addParam<MeshGeneratorName>("mesh", "", "The mesh generator for mortar method");
   params.addParam<VariableName>("secondary_gap_offset",
@@ -131,10 +121,8 @@ ContactAction::validParams()
 
 ContactAction::ContactAction(const InputParameters & params)
   : Action(params),
-    _primary(isParamValid("primary") ? getParam<BoundaryName>("primary")
-                                     : getParam<BoundaryName>("master")),
-    _secondary(isParamValid("secondary") ? getParam<BoundaryName>("secondary")
-                                         : getParam<BoundaryName>("slave")),
+    _primary(getParam<BoundaryName>("primary")),
+    _secondary(getParam<BoundaryName>("secondary")),
     _model(getParam<MooseEnum>("model")),
     _formulation(getParam<MooseEnum>("formulation")),
     _system(getParam<MooseEnum>("system")),

--- a/modules/contact/src/constraints/MechanicalContactConstraint.C
+++ b/modules/contact/src/constraints/MechanicalContactConstraint.C
@@ -36,11 +36,6 @@ MechanicalContactConstraint::validParams()
 
   params.addRequiredParam<BoundaryName>("boundary", "The primary boundary");
   params.addParam<BoundaryName>("secondary", "The secondary boundary");
-  params.addDeprecatedParam<BoundaryName>("slave",
-                                          "The secondary boundary",
-                                          "The 'slave' parameter is deprecated and will be removed "
-                                          "on September 1, 2020. Please use the "
-                                          "'secondary' parameter instead");
   params.addRequiredParam<unsigned int>("component",
                                         "An integer corresponding to the direction "
                                         "the variable this kernel acts in. (0 for x, "

--- a/modules/contact/src/dampers/ContactSlipDamper.C
+++ b/modules/contact/src/dampers/ContactSlipDamper.C
@@ -24,16 +24,6 @@ ContactSlipDamper::validParams()
       "primary", "IDs of the primary surfaces for which slip reversals should be damped");
   params.addParam<std::vector<int>>(
       "secondary", "IDs of the secondary surfaces for which slip reversals should be damped");
-  params.addDeprecatedParam<std::vector<int>>(
-      "master",
-      "IDs of the primary surfaces for which slip reversals should be damped",
-      "The 'master' param is deprecated and will be removed on September 1, 2020. Please use the "
-      "'primary' parameter instead.");
-  params.addDeprecatedParam<std::vector<int>>(
-      "slave",
-      "IDs of the secondary surfaces for which slip reversals should be damped",
-      "The 'slave' param is deprecated and will be removed on "
-      "September 1, 2020. Please use the 'secondary' param instead");
   params.addParam<Real>(
       "max_iterative_slip", std::numeric_limits<Real>::max(), "Maximum iterative slip");
   params.addRangeCheckedParam<Real>("min_damping_factor",
@@ -70,10 +60,8 @@ ContactSlipDamper::ContactSlipDamper(const InputParameters & parameters)
   if (!_displaced_problem)
     mooseError("Must have displaced problem to use ContactSlipDamper");
 
-  std::vector<int> primary = isParamValid("primary") ? getParam<std::vector<int>>("primary")
-                                                     : getParam<std::vector<int>>("master");
-  std::vector<int> secondary = isParamValid("secondary") ? getParam<std::vector<int>>("secondary")
-                                                         : getParam<std::vector<int>>("slave");
+  std::vector<int> primary = getParam<std::vector<int>>("primary");
+  std::vector<int> secondary = getParam<std::vector<int>>("secondary");
 
   unsigned int num_interactions = primary.size();
   if (num_interactions != secondary.size())

--- a/modules/heat_conduction/src/dirackernels/GapHeatPointSourceMaster.C
+++ b/modules/heat_conduction/src/dirackernels/GapHeatPointSourceMaster.C
@@ -24,11 +24,6 @@ GapHeatPointSourceMaster::validParams()
   InputParameters params = DiracKernel::validParams();
   params.addParam<BoundaryName>("boundary", "The primary boundary");
   params.addParam<BoundaryName>("secondary", "The secondary boundary");
-  params.addDeprecatedParam<BoundaryName>("slave",
-                                          "The secondary boundary",
-                                          "The 'slave' parameter is deprecated and will be removed "
-                                          "on September 1, 2020. Please use the "
-                                          "'secondary' parameter instead");
   params.addParam<MooseEnum>("order", orders, "The finite element order");
   params.set<bool>("use_displaced_mesh") = true;
   params.addParam<Real>("tangential_tolerance",
@@ -46,8 +41,7 @@ GapHeatPointSourceMaster::GapHeatPointSourceMaster(const InputParameters & param
   : DiracKernel(parameters),
     _penetration_locator(
         getPenetrationLocator(getParam<BoundaryName>("boundary"),
-                              isParamValid("secondary") ? getParam<BoundaryName>("secondary")
-                                                        : getParam<BoundaryName>("slave"),
+                              getParam<BoundaryName>("secondary"),
                               Utility::string_to_enum<Order>(getParam<MooseEnum>("order")))),
     _secondary_flux(_sys.getVector("secondary_flux"))
 {


### PR DESCRIPTION
It's been deprecated since the beginning of September. Which should have been long enough to remove it from the applications (spoiler alert, it hasn't, Mastodon and Pronghorn need to be updated). Let's put the pressure on and remove the old nomenclature.

Closes #15457 