### PR TITLE
added exception handling guards

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADSingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/ADSingleVariableReturnMappingSolution.h
@@ -14,6 +14,7 @@
 #include "InputParameters.h"
 
 class ConsoleStream;
+class FEProblemBase;
 
 /**
  * Base class that provides capability for Newton return mapping
@@ -24,7 +25,8 @@ class ADSingleVariableReturnMappingSolution
 public:
   static InputParameters validParams();
 
-  ADSingleVariableReturnMappingSolution(const InputParameters & parameters);
+  ADSingleVariableReturnMappingSolution(const InputParameters & parameters,
+                                        FEProblemBase * fe_problem_ptr = nullptr);
   virtual ~ADSingleVariableReturnMappingSolution() {}
 
 protected:
@@ -99,6 +101,8 @@ protected:
    * @param total_it               Total iteration count
    */
   virtual void outputIterationSummary(std::stringstream * iter_output, const unsigned int total_it);
+
+  FEProblemBase * _fe_problem_ptr;
 
   /// Whether to check to see whether iterative solution is within admissible range, and set within that range if outside
   bool _check_range;

--- a/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
@@ -262,10 +262,12 @@ ADComputeMultipleInelasticStress::updateQpState(
            (l2norm_delta_stress / first_l2norm_delta_stress) > _relative_tolerance &&
            _num_models != 1);
 
-  if (counter == _max_iterations && l2norm_delta_stress > _absolute_tolerance &&
-      (l2norm_delta_stress / first_l2norm_delta_stress) > _relative_tolerance)
-    mooseException(
-        "In ", _name, ": Max stress iteration hit during ADComputeMultipleInelasticStress solve!");
+  if (_current_execute_flag == EXEC_NONLINEAR || _current_execute_flag == EXEC_LINEAR)
+    if (counter == _max_iterations && l2norm_delta_stress > _absolute_tolerance &&
+        (l2norm_delta_stress / first_l2norm_delta_stress) > _relative_tolerance)
+      mooseException("In ",
+                     _name,
+                     ": Max stress iteration hit during ADComputeMultipleInelasticStress solve!");
 
   combined_inelastic_strain_increment.zero();
   for (unsigned i_rmm = 0; i_rmm < _num_models; ++i_rmm)

--- a/modules/tensor_mechanics/src/materials/ADRadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADRadialReturnStressUpdate.C
@@ -41,7 +41,7 @@ ADRadialReturnStressUpdate::validParams()
 
 ADRadialReturnStressUpdate::ADRadialReturnStressUpdate(const InputParameters & parameters)
   : ADStressUpdateBase(parameters),
-    ADSingleVariableReturnMappingSolution(parameters),
+    ADSingleVariableReturnMappingSolution(parameters, &_fe_problem),
     _effective_inelastic_strain(declareADProperty<Real>(
         _base_name + getParam<std::string>("effective_inelastic_strain_name"))),
     _effective_inelastic_strain_old(getMaterialPropertyOld<Real>(

--- a/modules/tensor_mechanics/src/materials/ADSingleVariableReturnMappingSolution.C
+++ b/modules/tensor_mechanics/src/materials/ADSingleVariableReturnMappingSolution.C
@@ -15,6 +15,7 @@
 #include "ConsoleStreamInterface.h"
 #include "Conversion.h"
 #include "MathUtils.h"
+#include "FEProblemBase.h"
 
 #include "DualRealOps.h"
 
@@ -55,8 +56,9 @@ ADSingleVariableReturnMappingSolution::validParams()
 }
 
 ADSingleVariableReturnMappingSolution::ADSingleVariableReturnMappingSolution(
-    const InputParameters & parameters)
-  : _check_range(false),
+    const InputParameters & parameters, FEProblemBase * fe_problem_ptr)
+  : _fe_problem_ptr(fe_problem_ptr),
+    _check_range(false),
     _line_search(true),
     _bracket_solution(true),
     _internal_solve_output_on(
@@ -107,6 +109,11 @@ ADSingleVariableReturnMappingSolution::returnMappingSolve(const ADReal & effecti
       internalSolve(effective_trial_stress,
                     scalar,
                     _internal_solve_full_iteration_history ? iter_output.get() : nullptr);
+
+  if (_fe_problem_ptr && _fe_problem_ptr->getCurrentExecuteOnFlag() != EXEC_LINEAR &&
+      _fe_problem_ptr->getCurrentExecuteOnFlag() != EXEC_NONLINEAR)
+    solve_state = SolveState::SUCCESS;
+
   if (solve_state != SolveState::SUCCESS &&
       _internal_solve_output_on != InternalSolveOutput::ALWAYS)
   {
@@ -184,6 +191,8 @@ ADSingleVariableReturnMappingSolution::internalSolve(const ADReal effective_tria
   while (_iteration < _max_its && !converged(_residual, reference_residual) &&
          !convergedAcceptable(_iteration, reference_residual))
   {
+    mooseAssert(computeDerivative(effective_trial_stress, scalar) != 0,
+                "Derivative cannot be zero");
     scalar_increment = -_residual / computeDerivative(effective_trial_stress, scalar);
     scalar = scalar_old + scalar_increment;
 
@@ -281,7 +290,8 @@ ADSingleVariableReturnMappingSolution::internalSolve(const ADReal effective_tria
     _residual_history[_iteration % _num_resids] = MetaPhysicL::raw_value(_residual);
   }
 
-  if (std::isnan(_residual) || std::isinf(MetaPhysicL::raw_value(_residual)))
+  if (std::isnan(_residual) || std::isinf(MetaPhysicL::raw_value(_residual)) ||
+      std::isnan(scalar) || std::isinf(MetaPhysicL::raw_value(scalar)))
     return SolveState::NAN_INF;
 
   if (_iteration == _max_its)
@@ -390,6 +400,8 @@ ADSingleVariableReturnMappingSolution::outputIterationStep(std::stringstream * i
     *iter_output << " iteration=" << it
                  << " trial_stress=" << MetaPhysicL::raw_value(effective_trial_stress)
                  << " scalar=" << MetaPhysicL::raw_value(scalar) << " residual=" << residual
+                 << " derivative="
+                 << MetaPhysicL::raw_value(computeDerivative(effective_trial_stress, scalar))
                  << " ref_res=" << reference_residual
                  << " rel_res=" << std::abs(residual) / reference_residual
                  << " rel_tol=" << _relative_tolerance << " abs_res=" << std::abs(residual)
@@ -402,7 +414,12 @@ ADSingleVariableReturnMappingSolution::outputIterationSummary(std::stringstream 
                                                               const unsigned int total_it)
 {
   if (iter_output)
+  {
     *iter_output << "In " << total_it << " iterations the residual went from "
                  << MetaPhysicL::raw_value(_initial_residual) << " to "
-                 << MetaPhysicL::raw_value(_residual) << " in '" << _svrms_name << "'.\n";
+                 << MetaPhysicL::raw_value(_residual) << " in '" << _svrms_name << "'";
+    if (_fe_problem_ptr)
+      *iter_output << " during " << _fe_problem_ptr->getCurrentExecuteOnFlag();
+    *iter_output << ".\n";
+  }
 }

--- a/modules/tensor_mechanics/test/tests/ad_viscoplasticity_stress_update/exact.i
+++ b/modules/tensor_mechanics/test/tests/ad_viscoplasticity_stress_update/exact.i
@@ -138,7 +138,7 @@
   [../]
   [./gtn]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 1 # arbitrary
     viscoplasticity_model = GTN
     base_name = gtn
@@ -147,7 +147,7 @@
   [../]
   [./lps_ten]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 10
     base_name = ten
     outputs = all
@@ -155,7 +155,7 @@
   [../]
   [./lps_five]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 5
     base_name = five
     outputs = all
@@ -163,7 +163,7 @@
   [../]
   [./lps_three]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 3
     base_name = three
     outputs = all
@@ -171,7 +171,7 @@
   [../]
   [./lps_two]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 2
     base_name = two
     outputs = all
@@ -179,7 +179,7 @@
   [../]
   [./lps_onepointfive]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 1.5
     base_name = onepointfive
     outputs = all
@@ -187,7 +187,7 @@
   [../]
   [./lps_one]
     type = ADViscoplasticityStressUpdate
-    coefficient = 0
+    coefficient = 1e-50
     power = 1
     base_name = one
     outputs = all


### PR DESCRIPTION
Adds a couple guards for mooseException to avoid run terminations. Also passes a `FEProblemBase` pointer to `ADSingleVariableReturnMappingSolution` to be able to access some run information.

Ref #16263
