### PR TITLE
Fix distributed sweep failing test

### DIFF
--- a/test/tests/mortar/mortar-q-points/tests
+++ b/test/tests/mortar/mortar-q-points/tests
@@ -6,6 +6,7 @@
     input = test.i
     exodiff = 'test_out.e'
     requirement = 'The system shall give access to the locations in physical space of mortar segment element quadrature points.'
+    abs_zero = 5e-10
   []
   [jac]
     type = PetscJacobianTester


### PR DESCRIPTION
Just requires raising the exodiff floor from 1e-10 to 5e-10. This test
was failing on CIVET [here](https://civet.inl.gov/job/627359/) as well
as in other places.

refs #16182

