### PR TITLE
Update conda packages to clang 11

### DIFF
--- a/conda/compilers/build.sh
+++ b/conda/compilers/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -eu
-install -d $PREFIX/share
-install -m 644 moose-compilers $PREFIX/share
 # Allow mpirun/exec to oversubscribe without errors
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<'EOF' > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"

--- a/conda/compilers/meta.yaml
+++ b/conda/compilers/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 1 %}
-{% set version = "2020.04.13" %}
+{% set version = "2020.11.24" %}
 {% set strbuild = "build_" + build|string %}
 
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
@@ -29,7 +29,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm9 {{ libllvm }}                 # [osx]
+    - libllvm11 {{ libllvm }}                 # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]

--- a/conda/compilers/meta.yaml
+++ b/conda/compilers/meta.yaml
@@ -9,8 +9,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://mooseframework.org/source_packages/moose-compilers.tar.gz
-  sha256: {{ sha256 }}
+  path: .
 
 build:
   number: {{ build }}  # [linux,osx]
@@ -36,10 +35,6 @@ requirements:
     - libclang {{ libclang }}                # [osx]
     - libcxx {{ libcxx }}                    # [osx]
     - make                                   # [unix]
-
-test:
-  commands:
-    - test -f $PREFIX/share/moose-compilers
 
 about:
   home: https://mooseframework.org/

--- a/conda/libmesh-vtk/build.sh
+++ b/conda/libmesh-vtk/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+export PATH=/bin:$PATH
 
 if [[ $mpi == "openmpi" ]]; then
   export OMPI_MCA_plm=isolated

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -29,7 +29,7 @@ mpi:
   - moose-mpich
 
 moose_mpich:
-  - 3.3.2 build_3
+  - 3.3.2 build_4
 
 pin_run_as_build:
   moose_mpich: x.x.x

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 
 {% set vtk_version = vtk_version %}

--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -eux
+set -eu
+export PATH=/bin:$PATH
+
 export PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
 export PETSC_DIR=`pkg-config PETSc --variable=prefix`
 

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -24,10 +24,10 @@ libpng:
   - 1.6.37 hed695b0_0 # [linux]
 
 moose_petsc:
- - 3.14.2 build_0
+ - 3.14.2 build_1
 
 moose_libmesh_vtk:
- - 6.3.0 build_3
+ - 6.3.0 build_4
 
 pin_run_as_build:
   moose_petsc: x.x.x

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2020.12.10" %}
 

--- a/conda/mpich/build.sh
+++ b/conda/mpich/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+export PATH=/bin:$PATH
 
 export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -11,31 +11,31 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 libllvm:
-  - 9.0.1 ha1b3eb9_0
+  - 11.0.0 hf85e3d2_0
 
 libclang:
-  - 9.0.1 default_hf57f61e_0
+  - 11.0.0 default_h9e6edd0_2
 
 compilerrt:
-  - 9.0.1 h6a512c6_0
+  - 11.0.0 h01488ec_2
 
 compilerrtosx:
-  - 9.0.1 h6a512c6_0
+  - 11.0.0 hd3c4e95_2
 
 clangxx:
-  - 9.0.1 default_hf57f61e_0
+  - 11.0.0 default_h9e6edd0_2
 
 clangosx:
-  - 9.0.1 h05bbb7f_0
+  - 11.0.0 hb91bd55_5
 
 clangxxosx:
-  - 9.0.1 h05bbb7f_0
+  - 11.0.0 h7e1b574_5
 
 clang:
-  - 9.0.1 default_hf57f61e_0
+  - 11.0.0 h694c41f_2
 
 llvmopenmp:
-  - 9.0.1 h28b9765_2
+  - 11.0.0 h73239a0_1
 
 osxfortran:
   - 7.3.0 h22b1bf0_7
@@ -53,7 +53,7 @@ gccimpl:
   - 7.3.0 hd420e75_5
 
 libcxx:
-  - 9.0.1 1
+  - 11.0.0 h4c3b8ed_1
 
 moose_compilers:
-  - 2020.04.13
+  - 2020.11.24

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.3.2" %}
 
@@ -30,7 +30,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm9 {{ libllvm }}                 # [osx]
+    - libllvm11 {{ libllvm }}                 # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]
@@ -49,7 +49,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm9 {{ libllvm }}                 # [osx]
+    - libllvm11 {{ libllvm }}                 # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eu
+export PATH=/bin:$PATH
+
 export PETSC_DIR=$SRC_DIR
 export PETSC_ARCH=arch-conda-c-opt
 

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -14,7 +14,7 @@ mpi:
   - moose-mpich
 
 moose_mpich:
-  - 3.3.2 build_3
+  - 3.3.2 build_4
 
 libblas:
   - 3.8.0 15_openblas # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.14.2" %}
 

--- a/framework/contrib/gtest/gtest/gtest.h
+++ b/framework/contrib/gtest/gtest/gtest.h
@@ -51,6 +51,15 @@
 #ifndef GTEST_INCLUDE_GTEST_GTEST_H_
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
+// This warning is a known issue since 2019 (https://github.com/google/googletest/issues/2224)
+// Google has yet to fix it, so we will direct clang > 9 to ignore the warnings.
+#ifdef __clang__
+#if (__clang_major__ > 9)
+// This was introduced in clang 10
+#pragma clang diagnostic ignored "-Wdeprecated-copy"
+#endif // clang > 9
+#endif
+
 #include <limits>
 #include <ostream>
 #include <vector>

--- a/framework/contrib/gtest/gtest/gtest.h
+++ b/framework/contrib/gtest/gtest/gtest.h
@@ -54,6 +54,7 @@
 // This warning is a known issue since 2019 (https://github.com/google/googletest/issues/2224)
 // Google has yet to fix it, so we will direct clang > 9 to ignore the warnings.
 #ifdef __clang__
+#pragma clang diagnostic push
 #if (__clang_major__ > 9)
 // This was introduced in clang 10
 #pragma clang diagnostic ignored "-Wdeprecated-copy"
@@ -21197,5 +21198,10 @@ int RUN_ALL_TESTS() GTEST_MUST_USE_RESULT_;
 inline int RUN_ALL_TESTS() {
   return ::testing::UnitTest::GetInstance()->Run();
 }
+
+// Restore warnings to other classes (see top of file for info on ignored warnings)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #endif  // GTEST_INCLUDE_GTEST_GTEST_H_

--- a/framework/include/utils/MultiIndex.h
+++ b/framework/include/utils/MultiIndex.h
@@ -150,6 +150,9 @@ public:
     return *this;
   }
 
+  // Compiler generated copy constructor
+  const_noconst_iterator(const const_noconst_iterator &) = default;
+
   // prefix ++
   const_noconst_iterator & operator++()
   {

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -2163,7 +2163,7 @@ MooseApp::getRelationshipManagerInfo() const
         counts[demangle(typeid(*gf).name())]++;
     }
 
-    for (const auto pair : counts)
+    for (const auto & pair : counts)
       info_strings.emplace_back(std::make_pair(
           "Default", pair.first + (pair.second > 1 ? " x " + std::to_string(pair.second) : "")));
   }
@@ -2187,7 +2187,7 @@ MooseApp::getRelationshipManagerInfo() const
         counts[demangle(typeid(*gf).name())]++;
     }
 
-    for (const auto pair : counts)
+    for (const auto & pair : counts)
       info_strings.emplace_back(
           std::make_pair("Default",
                          pair.first + (pair.second > 1 ? " x " + std::to_string(pair.second) : "") +

--- a/framework/src/postprocessors/NumRelationshipManagers.C
+++ b/framework/src/postprocessors/NumRelationshipManagers.C
@@ -46,19 +46,19 @@ NumRelationshipManagers::getValue()
   unsigned int count = 0;
   if (_rm_type == "GEOMETRIC")
   {
-    for (const auto rm : rms)
+    for (const auto & rm : rms)
       if (rm->isType(Moose::RelationshipManagerType::GEOMETRIC))
         ++count;
   }
   else if (_rm_type == "ALGEBRAIC")
   {
-    for (const auto rm : rms)
+    for (const auto & rm : rms)
       if (rm->isType(Moose::RelationshipManagerType::ALGEBRAIC))
         ++count;
   }
   else if (_rm_type == "COUPLING")
   {
-    for (const auto rm : rms)
+    for (const auto & rm : rms)
       if (rm->isType(Moose::RelationshipManagerType::COUPLING))
         ++count;
   }

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -151,7 +151,7 @@ EigenProblem::computeJacobianTag(const NumericVector<Number> & soln,
 
   // Add any other user-added matrix tags if they have associated matrices
   const auto & matrix_tags = getMatrixTags();
-  for (const auto matrix_tag : matrix_tags)
+  for (const auto & matrix_tag : matrix_tags)
     if (_nl_eigen->hasMatrix(matrix_tag.second))
       _fe_matrix_tags.insert(matrix_tag.second);
 
@@ -234,7 +234,7 @@ EigenProblem::computeJacobianAB(const NumericVector<Number> & soln,
 
   // Add any other user-added matrix tags if they have associated matrices
   const auto & matrix_tags = getMatrixTags();
-  for (const auto matrix_tag : matrix_tags)
+  for (const auto & matrix_tag : matrix_tags)
     if (_nl_eigen->hasMatrix(matrix_tag.second))
       _fe_matrix_tags.insert(matrix_tag.second);
 

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1883,7 +1883,7 @@ FeatureFloodCount::FeatureData::updateBBoxExtremes(MeshBase & mesh)
     _bboxes.resize(num_regions + 1);
 
     decltype(num_regions) region = 1;
-    for (const auto list_ref : disjoint_regions)
+    for (const auto & list_ref : disjoint_regions)
     {
       for (const auto elem_id : list_ref)
         updateBBoxExtremesHelper(_bboxes[region], *mesh.elem_ptr(elem_id));

--- a/modules/tensor_mechanics/include/utils/EulerAngles.h
+++ b/modules/tensor_mechanics/include/utils/EulerAngles.h
@@ -11,6 +11,8 @@
 
 #include "MooseTypes.h"
 #include "libmesh/vector_value.h"
+// Ignore depcrecated copy warnings for this class from libmesh Eigen contrib
+#include "libmesh/ignore_warnings.h"
 #include <Eigen/Geometry>
 
 // forward declaration
@@ -36,3 +38,6 @@ public:
   // Euler to Quaternions
   Eigen::Quaternion<Real> toQuaternion();
 };
+
+// Restore warnings for other classes
+#include "libmesh/restore_warnings.h"


### PR DESCRIPTION
Updates moose-mpich conda recipe to use clang_osx-64 11.0.0 build hb91bd55_5 for new SDK support and updates related dependencies as a result of that change. 

Still to do:
- [x] Percolate changes to moose-mpich to other packages
- [x] Fixup new warnings in libMesh (see libmesh/libmesh#2812), gtest, and MOOSE
- [x] ~~Update any needed Linux dependencies~~ EDIT: none needed

Tagging @milljm 

Refs #16291 