### PR TITLE
PorousFlow: utils for hysteretic relative permeabilities added

### DIFF
--- a/modules/porous_flow/include/utils/PorousFlowCubic.h
+++ b/modules/porous_flow/include/utils/PorousFlowCubic.h
@@ -1,0 +1,42 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseTypes.h"
+
+/**
+ * Utility to produce the value and derivative of a cubic function at a point.  The cubic is defined
+ * by values and derivatives at two points.
+ */
+
+namespace PorousFlowCubic
+{
+/**
+ * Cubic function f(x) that satisfies
+ * f(x0) = y0
+ * f'(x0) = y0p
+ * f(x1) = y1
+ * f'(x1) = y1p
+ * @param x the argument
+ * @return value of the cubic function at x
+ */
+Real cubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
+
+/**
+ * Derivative of cubic function, f(x), with respect to x.  f(x) satisfies
+ * f(x0) = y0
+ * f'(x0) = y0p
+ * f(x1) = y1
+ * f'(x1) = y1p
+ * @param x the argument
+ * @return the derivative of the cubic function at x
+ */
+Real dcubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
+}

--- a/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
+++ b/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
@@ -339,28 +339,6 @@ d2saturationHys(Real pc,
                 const HighCapillaryPressureExtension & high_ext = HighCapillaryPressureExtension());
 
 /**
- * Cubic function f(x) that satisfies
- * f(x0) = y0
- * f'(x0) = y0p
- * f(x1) = y1
- * f'(x1) = y1p
- * @param x the argument
- * @return cubic as a function of x
- */
-Real cubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
-
-/**
- * Derivative of cubic function, f(x), with respect to x.  f(x) satisfies
- * f(x0) = y0
- * f'(x0) = y0p
- * f(x1) = y1
- * f'(x1) = y1p
- * @param x the argument
- * @return the derivative of the cubic as a function of x
- */
-Real dcubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
-
-/**
  * Hysteretic relative permeability for liquid
  * @param sl liquid saturation
  * @param slr residual liquid saturation.  For sl < slr, this function will always return 0

--- a/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
+++ b/modules/porous_flow/include/utils/PorousFlowVanGenuchten.h
@@ -337,4 +337,152 @@ d2saturationHys(Real pc,
                 Real n,
                 const LowCapillaryPressureExtension & low_ext = LowCapillaryPressureExtension(),
                 const HighCapillaryPressureExtension & high_ext = HighCapillaryPressureExtension());
+
+/**
+ * Cubic function f(x) that satisfies
+ * f(x0) = y0
+ * f'(x0) = y0p
+ * f(x1) = y1
+ * f'(x1) = y1p
+ * @param x the argument
+ * @return cubic as a function of x
+ */
+Real cubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
+
+/**
+ * Derivative of cubic function, f(x), with respect to x.  f(x) satisfies
+ * f(x0) = y0
+ * f'(x0) = y0p
+ * f(x1) = y1
+ * f'(x1) = y1p
+ * @param x the argument
+ * @return the derivative of the cubic as a function of x
+ */
+Real dcubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p);
+
+/**
+ * Hysteretic relative permeability for liquid
+ * @param sl liquid saturation
+ * @param slr residual liquid saturation.  For sl < slr, this function will always return 0
+ * @param sgrdel value of gas saturation where van Genuchten wetting capillary-pressure expression
+ * -> 0.  This depends on the turning-point saturation when drying became wetting, using the Land
+ * equation
+ * @param sgrmax maximum value possible for sgrdel.  This will be equal to sgrdel if the
+ * turning-point saturation is small
+ * @param sldel value of the turning-point saturation when drying became wetting
+ * @param m van-Genuchten m parameter
+ * @param upper_liquid_param cubic modification of the wetting relative permeability will occur
+ * between upper_liquid_param * (1 - sgrdel) and 1 - 0.5 * sgrdel.  0 < upper_liquid_param <= 1.
+ * Usually upper_liquid_param is close to 1 (eg 0.9)
+ * @param y0 value of the unmodified wetting relative permeability at sl = upper_liquid_param * (1 -
+ * sgrdel)
+ * @param y0p value of the derivtaive of the unmodified wetting relative permeability at sl =
+ * upper_liquid_param * (1 - sgrdel)
+ * @param y1 value of the unmodified wetting relative permeability at sl = 1 - 0.5 * sgrdel
+ * @param y1p value of the derivtaive of the unmodified wetting relative permeability at sl = 1 -
+ * 0.5 * sgrdel
+ */
+Real relativePermeabilityHys(Real sl,
+                             Real slr,
+                             Real sgrdel,
+                             Real sgrmax,
+                             Real sldel,
+                             Real m,
+                             Real upper_liquid_param,
+                             Real y0,
+                             Real y0p,
+                             Real y1,
+                             Real y1p);
+
+/**
+ * Derivative of Hysteretic relative permeability for liquid, with respect to liquid saturation
+ * @param sl liquid saturation
+ * @param slr residual liquid saturation.  For sl < slr, this function will always return 0
+ * @param sgrdel value of gas saturation where van Genuchten wetting capillary-pressure expression
+ * -> 0.  This depends on the turning-point saturation when drying became wetting, using the Land
+ * equation
+ * @param sgrmax maximum value possible for sgrdel.  This will be equal to sgrdel if the
+ * turning-point saturation is small
+ * @param sldel value of the turning-point saturation when drying became wetting
+ * @param m van-Genuchten m parameter
+ * @param upper_liquid_param cubic modification of the wetting relative permeability will occur
+ * between upper_liquid_param * (1 - sgrdel) and 1 - 0.5 * sgrdel.  0 < upper_liquid_param <= 1.
+ * Usually upper_liquid_param is close to 1 (eg 0.9)
+ * @param y0 value of the unmodified wetting relative permeability at sl = upper_liquid_param * (1 -
+ * sgrdel)
+ * @param y0p value of the derivtaive of the unmodified wetting relative permeability at sl =
+ * upper_liquid_param * (1 - sgrdel)
+ * @param y1 value of the unmodified wetting relative permeability at sl = 1 - 0.5 * sgrdel
+ * @param y1p value of the derivtaive of the unmodified wetting relative permeability at sl = 1 -
+ * 0.5 * sgrdel
+ */
+Real drelativePermeabilityHys(Real sl,
+                              Real slr,
+                              Real sgrdel,
+                              Real sgrmax,
+                              Real sldel,
+                              Real m,
+                              Real upper_liquid_param,
+                              Real y0,
+                              Real y0p,
+                              Real y1,
+                              Real y1p);
+
+/**
+ * Hysteretic relative permeability for gas
+ * @param sl liquid saturation
+ * @param slr residual liquid saturation.  For sl < slr, this function will always return 0
+ * @param sgrdel value of gas saturation where van Genuchten wetting capillary-pressure expression
+ * -> 0.  This depends on the turning-point saturation when drying became wetting, using the Land
+ * equation
+ * @param sgrmax maximum value possible for sgrdel.  This will be equal to sgrdel if the
+ * turning-point saturation is small
+ * @param sldel value of the turning-point saturation when drying became wetting
+ * @param m van-Genuchten m parameter
+ * @param gamma index satisfying gamma > 0.  Usually gamma = 1/3.
+ * @param k_rg_max Maximum value of unextended gas relative permeability.  If no low-saturation
+ * extension is used then gas relative permeability = k_rg_max for sl <= slr.  Satisfies 0 <
+ * k_rg_max <= 1.  Frequently k_rg_max = 1 is used
+ * @param y0p Value of the derivative of the low-saturation extension at sl = slr.  If an extension
+ * is used then the gas relative permeability in the region sl <= slr is a cubic whose value is
+ * unity at sl = 0, and derivative is zero at sl = 0
+ */
+Real relativePermeabilityNWHys(Real sl,
+                               Real slr,
+                               Real sgrdel,
+                               Real sgrmax,
+                               Real sldel,
+                               Real m,
+                               Real gamma,
+                               Real k_rg_max,
+                               Real y0p);
+
+/**
+ * Derivative of hysteretic relative permeability for gas with respect to the liquid saturation
+ * @param sl liquid saturation
+ * @param slr residual liquid saturation.  For sl < slr, this function will always return 0
+ * @param sgrdel value of gas saturation where van Genuchten wetting capillary-pressure expression
+ * -> 0.  This depends on the turning-point saturation when drying became wetting, using the Land
+ * equation
+ * @param sgrmax maximum value possible for sgrdel.  This will be equal to sgrdel if the
+ * turning-point saturation is small
+ * @param sldel value of the turning-point saturation when drying became wetting
+ * @param m van-Genuchten m parameter
+ * @param gamma index satisfying gamma > 0.  Usually gamma = 1/3.
+ * @param k_rg_max Maximum value of unextended gas relative permeability.  If no low-saturation
+ * extension is used then gas relative permeability = k_rg_max for sl <= slr.  Satisfies 0 <
+ * k_rg_max <= 1.  Frequently k_rg_max = 1 is used
+ * @param y0p Value of the derivative of the low-saturation extension at sl = slr.  If an extension
+ * is used then the gas relative permeability in the region sl <= slr is a cubic whose value is
+ * unity at sl = 0, and derivative is zero at sl = 0
+ */
+Real drelativePermeabilityNWHys(Real sl,
+                                Real slr,
+                                Real sgrdel,
+                                Real sgrmax,
+                                Real sldel,
+                                Real m,
+                                Real gamma,
+                                Real k_rg_max,
+                                Real y0p);
 }

--- a/modules/porous_flow/src/utils/PorousFlowCubic.C
+++ b/modules/porous_flow/src/utils/PorousFlowCubic.C
@@ -1,0 +1,54 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PorousFlowCubic.h"
+#include "libmesh/utility.h"
+
+namespace PorousFlowCubic
+{
+Real
+cubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p)
+{
+  mooseAssert(x0 != x1, "PorousFlowCubic: x0 cannot equal x1");
+  const Real d = x1 - x0;
+  const Real d2 = Utility::pow<2>(d);
+  const Real mean = 0.5 * (x1 + x0);
+  const Real sq3 = 0.5 * std::sqrt(3.0) * d;
+  const Real term1 = y0p * (x - x0) * Utility::pow<2>(x - x1) /
+                     d2; // term1(x0) = term1(x1) = term1'(x1) = 0, term1'(x0) = y0p
+  const Real term2 = y1p * (x - x1) * Utility::pow<2>(x - x0) /
+                     d2; // term2(x0) = term2(x1) = term2'(x0) = 0, term2'(x1) = y1p
+  const Real term3 = (x - mean - sq3) * (x - mean) * (x - mean + sq3);
+  // term3' = (x - mean) * (x - mean + sq3) + (x - mean - sq3) * (x - mean + sq3) + (x - mean - sq3)
+  // * (x - mean)
+  //        = 3 (x - mean)^2 - sq3^2
+  // note term3' = 0 when x = mean +/- sq3/sqrt(3) = 0.5 * (x1 + x0) +/- 0.5 * (x1 - x0) = {x1, x0}
+  const Real term3_x0 = (x0 - mean - sq3) * (x0 - mean) * (x0 - mean + sq3);
+  const Real term3_x1 = (x1 - mean - sq3) * (x1 - mean) * (x1 - mean + sq3);
+  return (y0 * (term3 - term3_x1) + y1 * (term3_x0 - term3)) / (term3_x0 - term3_x1) + term1 +
+         term2;
+}
+
+Real
+dcubic(Real x, Real x0, Real y0, Real y0p, Real x1, Real y1, Real y1p)
+{
+  mooseAssert(x0 != x1, "PorousFlowCubic: x0 cannot equal x1");
+  const Real d = x1 - x0;
+  const Real d2 = Utility::pow<2>(d);
+  const Real mean = 0.5 * (x1 + x0);
+  const Real sq3 = 0.5 * std::sqrt(3.0) * d;
+  const Real term1_prime = y0p * (Utility::pow<2>(x - x1) + (x - x0) * 2 * (x - x1)) / d2;
+  const Real term2_prime = y1p * (Utility::pow<2>(x - x0) + (x - x1) * 2 * (x - x0)) / d2;
+  const Real term3_prime =
+      3.0 * Utility::pow<2>(mean) - 6 * mean * x - 0.75 * d2 + 3.0 * Utility::pow<2>(x);
+  const Real term3_x0 = (x0 - mean - sq3) * (x0 - mean) * (x0 - mean + sq3);
+  const Real term3_x1 = (x1 - mean - sq3) * (x1 - mean) * (x1 - mean + sq3);
+  return (y0 - y1) * term3_prime / (term3_x0 - term3_x1) + term1_prime + term2_prime;
+}
+}

--- a/modules/porous_flow/test/tests/hysteresis/hys.py
+++ b/modules/porous_flow/test/tests/hysteresis/hys.py
@@ -105,7 +105,7 @@ def krel_liquid(sl, slr, sgrdel, sgrmax, sldel, m, upper_liquid_param, y0, y0p, 
     if (sl < slr):
         return 0.0
     sl_bar = (sl - slr) / (1.0 - slr)
-    if sgrdel == 0.0: # along the drying curve
+    if (sgrdel == 0.0 or sl <= sldel): # along the drying curve
         s_gt_bar = 0.0
         a = math.pow(1.0 - math.pow(sl_bar, 1.0 / m), m)
         b = 0.0
@@ -177,7 +177,7 @@ def krel_liquid_prime(sl, slr, sgrdel, sgrmax, sldel, m, upper_liquid_param):
             b = s_gt_bar / (1.0 - sl_bar_del) * math.pow(1.0 - math.pow(sl_bar_del, 1.0 / m), m)
             bprime = s_gt_bar_prime * b / s_gt_bar
     kr = math.sqrt(sl_bar) * math.pow(1.0 - a - b, 2)
-    return 0.5 * kr / sl_bar - math.sqrt(sl_bar) * 2.0 * (1.0 - a - b) * (aprime + bprime)
+    return 0.5 * kr / sl_bar * sl_bar_prime - math.sqrt(sl_bar) * 2.0 * (1.0 - a - b) * (aprime + bprime)
 
 def krel_gas(sl, slr, sgrdel, sgrmax, sldel, m, gamma, k_rg_max, y0p):
     if (sl < slr):
@@ -185,7 +185,7 @@ def krel_gas(sl, slr, sgrdel, sgrmax, sldel, m, gamma, k_rg_max, y0p):
             return 1.0
         return cubic(sl, 0.0, 1.0, 0.0, slr, k_rg_max, y0p)
     sl_bar = (sl - slr) / (1.0 - slr)
-    if sgrdel == 0.0: # on the drying curve
+    if (sgrdel == 0.0 or sl < sldel): # on the drying curve
         s_gt_bar = 0.0
     else:
         if (sldel < slr): # turning point occured below slr, but "there is no hysteresis along the extension" according to p6 of Doughty2008.  The above checked that sl >= slr.  I assume the wetting relperm curve is the same as if the turning point = slr:
@@ -205,7 +205,7 @@ def krel_gas(sl, slr, sgrdel, sgrmax, sldel, m, gamma, k_rg_max, y0p):
 def krel_gas_prime(sl, slr, sgrdel, sgrmax, sldel, m, gamma, k_rg_max):
     if (sl < slr):
         if (k_rg_max == 1.0):
-            return 1.0
+            return 0.0
         return 0.0 # NOTE: this is incorrect but it is never used
     if (sl > 1.0 - sgrdel):
         return 0.0 # always zero, irrespective of any hysteresis

--- a/modules/porous_flow/unit/src/PorousFlowCubicTest.C
+++ b/modules/porous_flow/unit/src/PorousFlowCubicTest.C
@@ -1,0 +1,62 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "gtest/gtest.h"
+
+#include "PorousFlowCubic.h"
+
+const double eps = 1.0E-8;
+
+/// Test cubic
+TEST(PorousFlowCubic, cubic)
+{
+  EXPECT_NEAR(3.0, PorousFlowCubic::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(4.0,
+              (PorousFlowCubic::cubic(2.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(6.0, PorousFlowCubic::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(7.0,
+              (PorousFlowCubic::cubic(5.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(-6.0, PorousFlowCubic::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(4.0, PorousFlowCubic::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(3.0, PorousFlowCubic::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(48.0, PorousFlowCubic::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+}
+
+/// Test dcubic
+TEST(PorousFlowCubic, dcubic)
+{
+  EXPECT_NEAR(4.0, PorousFlowCubic::dcubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(7.0, PorousFlowCubic::dcubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(PorousFlowCubic::dcubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowCubic::cubic(1.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowCubic::dcubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowCubic::cubic(3.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowCubic::dcubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowCubic::cubic(4.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowCubic::dcubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowCubic::cubic(7.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowCubic::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+}

--- a/modules/porous_flow/unit/src/PorousFlowVanGenuchtenTest.C
+++ b/modules/porous_flow/unit/src/PorousFlowVanGenuchtenTest.C
@@ -834,54 +834,6 @@ TEST(PorousFlowVanGenuchten, d2sathys)
   }
 }
 
-/// Test cubic
-TEST(PorousFlowVanGenuchten, cubic)
-{
-  EXPECT_NEAR(3.0, PorousFlowVanGenuchten::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(4.0,
-              (PorousFlowVanGenuchten::cubic(2.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-  EXPECT_NEAR(6.0, PorousFlowVanGenuchten::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(7.0,
-              (PorousFlowVanGenuchten::cubic(5.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-  EXPECT_NEAR(-6.0, PorousFlowVanGenuchten::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(4.0, PorousFlowVanGenuchten::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(3.0, PorousFlowVanGenuchten::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(48.0, PorousFlowVanGenuchten::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-}
-
-/// Test dcubic
-TEST(PorousFlowVanGenuchten, dcubic)
-{
-  EXPECT_NEAR(4.0, PorousFlowVanGenuchten::dcubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(7.0, PorousFlowVanGenuchten::dcubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
-  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
-              (PorousFlowVanGenuchten::cubic(1.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
-              (PorousFlowVanGenuchten::cubic(3.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
-              (PorousFlowVanGenuchten::cubic(4.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
-              (PorousFlowVanGenuchten::cubic(7.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
-               PorousFlowVanGenuchten::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
-                  eps,
-              1.0E-5);
-}
-
 /// Test relativePermeabilityHys
 TEST(PorousFlowVanGenuchten, relativePermeabilityHys)
 {

--- a/modules/porous_flow/unit/src/PorousFlowVanGenuchtenTest.C
+++ b/modules/porous_flow/unit/src/PorousFlowVanGenuchtenTest.C
@@ -833,3 +833,416 @@ TEST(PorousFlowVanGenuchten, d2sathys)
                 1.0E-5);
   }
 }
+
+/// Test cubic
+TEST(PorousFlowVanGenuchten, cubic)
+{
+  EXPECT_NEAR(3.0, PorousFlowVanGenuchten::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(4.0,
+              (PorousFlowVanGenuchten::cubic(2.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(6.0, PorousFlowVanGenuchten::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(7.0,
+              (PorousFlowVanGenuchten::cubic(5.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(-6.0, PorousFlowVanGenuchten::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(4.0, PorousFlowVanGenuchten::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(3.0, PorousFlowVanGenuchten::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(48.0, PorousFlowVanGenuchten::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+}
+
+/// Test dcubic
+TEST(PorousFlowVanGenuchten, dcubic)
+{
+  EXPECT_NEAR(4.0, PorousFlowVanGenuchten::dcubic(2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(7.0, PorousFlowVanGenuchten::dcubic(5.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0), 1.0E-12);
+  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowVanGenuchten::cubic(1.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowVanGenuchten::cubic(3.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(3.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowVanGenuchten::cubic(4.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::dcubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
+              (PorousFlowVanGenuchten::cubic(7.0 + eps, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0) -
+               PorousFlowVanGenuchten::cubic(7.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)) /
+                  eps,
+              1.0E-5);
+}
+
+/// Test relativePermeabilityHys
+TEST(PorousFlowVanGenuchten, relativePermeabilityHys)
+{
+  // Tests for sldel = 0.5 >= slr = 0.2
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // zero because sl < slr
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.2, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // zero because sl = slr
+  EXPECT_NEAR(0.002847974503642625,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying because sl <= sldel
+  EXPECT_NEAR(0.002847974503642625,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying because sgrdel = 0
+  EXPECT_NEAR(0.05828443549816974,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.5, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying because sl <= sldel
+  EXPECT_NEAR(0.10056243969693253,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.08943153676247108,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying because sgrdel = 0
+  EXPECT_NEAR(0.3159149169921876,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.8, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // cubic
+  EXPECT_NEAR(0.8011290515690178,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.95, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying, because sl > cubic modification region
+
+  // Tests for sldel = 0.15 < slr = 0.2
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.1, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // zero because sl < slr
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.2, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // zero because sl = slr
+  EXPECT_NEAR(0.005858393312913491,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.3, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.002847974503642625,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying because sgrdel = 0
+  EXPECT_NEAR(0.1363562523627124,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.55, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.31,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.7, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // cubic
+  EXPECT_NEAR(0.8011290515690178,
+              PorousFlowVanGenuchten::relativePermeabilityHys(
+                  0.95, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12); // drying, because sl > cubic modification region
+}
+
+/// Test drelativePermeabilityHys
+TEST(PorousFlowVanGenuchten, drelativePermeabilityHys)
+{
+  // essentially follow the testing strategy in the relativePermeabilityHys Test, but do not test
+  // the derivative at the points where it is discontinuous
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-12);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3 + eps, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55 + eps, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.8, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.8 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.8, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.95, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.95 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.95, 0.2, 0.15, 0.25, 0.5, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.1, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.3, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3 + eps, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3 + eps, 0.2, 0.0, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.55, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55 + eps, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.55, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.7, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.7 + eps, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.7, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityHys(
+                  0.95, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2),
+              (PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.95 + eps, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2) -
+               PorousFlowVanGenuchten::relativePermeabilityHys(
+                   0.95, 0.2, 0.15, 0.25, 0.15, 0.9, 0.9, 0.3, 0.5, 0.45, 2.2)) /
+                  eps,
+              1.0E-5);
+}
+
+/// Test relativePermeabilityNWHys
+TEST(PorousFlowVanGenuchten, relativePermeabilityNWHys)
+{
+  // Tests for sldel = 0.5 >= slr = 0.2
+  EXPECT_NEAR(0.91875,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // cubic extension region because sl < slr
+  EXPECT_NEAR(1.0,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 1.0, -0.75),
+              1.0E-12); // cubic extension region because sl < slr, but k_rg_max = 1
+  EXPECT_NEAR(0.8,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.2, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // at boundary of extension since sl = slr
+  EXPECT_NEAR(0.6368139633459233,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // drying because sl <= sldel
+  EXPECT_NEAR(0.6368139633459233,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // drying because sgrdel = 0
+  EXPECT_NEAR(0.33222054246699,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.5, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // drying because sl <= sldel
+  EXPECT_NEAR(0.24397255389213568,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.2691316236913443,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // drying because sgrdel = 0
+  EXPECT_NEAR(0.01509148277290631,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.85, 0.2, 0.05, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.85, 0.2, 0.18, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // sl > 1 - s_gr_del
+
+  // Tests for sldel = 0.15 < slr = 0.2
+  EXPECT_NEAR(0.91875,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.1, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // cubic extension region because sl < slr
+  EXPECT_NEAR(1.0,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.1, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 1.0, -0.75),
+              1.0E-12); // cubic extension region because sl < slr, but k_rg_max = 1
+  EXPECT_NEAR(0.8,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.2, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // at boundary of extension since sl = slr
+  EXPECT_NEAR(0.5616820966427329,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.3, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.6368139633459233,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // wetting = drying because sgrdel = 0
+  EXPECT_NEAR(0.11086138435665097,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.55, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // wetting
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                  0.76, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // always zero for large saturation
+}
+
+/// Test drelativePermeabilityNWHys
+TEST(PorousFlowVanGenuchten, drelativePermeabilityNWHys)
+{
+  // Testing strategy follows the relativePermeabilityNWHys strategy, except the points at which the
+  // derivative is not defined are not tested
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.1 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // cubic extension region because sl < slr
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.1, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 1.0, -0.75),
+              1.0E-12); // cubic extension region because sl < slr, but k_rg_max = 1
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // drying because sl <= sldel
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3 + eps, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // drying because sgrdel = 0
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.45, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.45 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.45, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // drying because sl <= sldel
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55 + eps, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55, 0.2, 0.15, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // wetting
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55 + eps, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55, 0.2, 0.0, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // drying because sgrdel = 0
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.85, 0.2, 0.05, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.85 + eps, 0.2, 0.05, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.85, 0.2, 0.05, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // wetting
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.85, 0.2, 0.18, 0.25, 0.5, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // sl > 1 - s_gr_del
+
+  // Tests for sldel = 0.15 < slr = 0.2
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.1, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.1 + eps, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.1, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // cubic extension region because sl < slr
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.1, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 1.0, -0.75),
+              1.0E-12); // cubic extension region because sl < slr, but k_rg_max = 1
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.3, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3 + eps, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // wetting
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3 + eps, 0.2, 0.0, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.3, 0.2, 0.0, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // wetting = drying because sgrdel = 0
+  EXPECT_NEAR(PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.55, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              (PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55 + eps, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75) -
+               PorousFlowVanGenuchten::relativePermeabilityNWHys(
+                   0.55, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75)) /
+                  eps,
+              1.0E-5); // wetting
+  EXPECT_NEAR(0.0,
+              PorousFlowVanGenuchten::drelativePermeabilityNWHys(
+                  0.76, 0.2, 0.18, 0.25, 0.15, 0.9, 0.3, 0.8, -0.75),
+              1.0E-12); // always zero for large saturation
+}


### PR DESCRIPTION
Also, a few minor errors corrected in hys.py

Fixes #16296

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
