### PR TITLE
Convert warnings to errors in SQA report for geochemistry

### DIFF
--- a/modules/geochemistry/doc/sqa_reports.yml
+++ b/modules/geochemistry/doc/sqa_reports.yml
@@ -26,5 +26,3 @@ Requirements:
     geochemistry:
         directories:
             - ${MOOSE_DIR}/modules/geochemistry
-        log_duplicate_requirement: WARNING
-        log_design_files: WARNING


### PR DESCRIPTION
#16300 fixed a few problems in the geochemistry module with SQA, now that those are fixed the warnings are being promoted to errors so they don't creep back in. Thanks @WilkAndy!
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
