### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,6 +1,6 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2020.11.04" %}
+{% set version = "2020.12.04" %}
 
 package:
   name: moose-libmesh


### PR DESCRIPTION
Update libmesh

Summary of changes:
  - Add const get_periodic_boundaries API in DofMap
  - Remove non-unique DOF ids in Build::sorted_connected_dofs()
  - Use parallel_sync for SparsityPattern
  - Add method for identifying singular nodes and use in inverse_map
  - Fix deprecated header warning introduced in a48c762c73
  - Don't apply a regex to the string "All Tests"
  - Add warnings arising from clang 11 to ignore_warnings
  - Add bounding box scaling
  - Fix --disable-metaphysicl builds
  - Fix NemesisIO Hex27 output issue
  - Revert DistributedMesh in adaptivity_ex5
  - Add missing diagnostic push
  - Remove potential deadlock with Singletons and RemoteElem
  - Minor changes to RBConstructionBase and related code
  - Add variadic template VecScatterBeginEnd() helper function
  - Support IsoGeometric Analysis meshes in System::project_vector()
  - Add VecGhostLocalFormRAII helper class
  - More packed_range sends in node constraints code
  - InfFE fixes

@cticenhour @loganharbour 
