### PR TITLE
Add nonlinear residual pingpong check

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -100,7 +100,8 @@ enum class MooseNonlinearConvergenceReason
   DIVERGED_FUNCTION_COUNT = -2,
   DIVERGED_FNORM_NAN = -4,
   DIVERGED_LINE_SEARCH = -6,
-  DIVERGED_DTOL = -9
+  DIVERGED_DTOL = -9,
+  DIVERGED_NL_RESIDUAL_PINGPONG = -10
 };
 
 // The idea with these enums is to abstract the reasons for
@@ -1890,6 +1891,12 @@ public:
 
   bool haveDisplaced() const override final { return _displaced_problem.get(); }
 
+  /// method setting the maximum number of allowable non linear residual pingpong
+  void setMaxNLPingPong(const unsigned int n_max_nl_pingpong)
+  {
+    _n_max_nl_pingpong = n_max_nl_pingpong;
+  }
+
 protected:
   /// Create extra tagged vectors and matrices
   void createTagVectors();
@@ -1911,6 +1918,10 @@ protected:
   int & _t_step;
   Real & _dt;
   Real & _dt_old;
+
+  /// maximum numbver
+  unsigned int _n_nl_pingpong = 0;
+  unsigned int _n_max_nl_pingpong = std::numeric_limits<unsigned int>::max();
 
   std::shared_ptr<NonlinearSystemBase> _nl;
   std::shared_ptr<AuxiliarySystem> _aux;

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -75,7 +75,7 @@ FEProblemSolve::validParams()
   params.addParam<Real>("nl_abs_step_tol", 0., "Nonlinear Absolute step Tolerance");
   params.addParam<Real>("nl_rel_step_tol", 0., "Nonlinear Relative step Tolerance");
   params.addParam<unsigned int>(
-      "n_max_nonlinear_pinpong",
+      "n_max_nonlinear_pingpong",
       100,
       "The maximum number of times the non linear residual can ping pong "
       "before requesting halting the current evalution and requesting timestep cut");
@@ -174,7 +174,7 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
 
   _problem.skipExceptionCheck(getParam<bool>("skip_exception_check"));
 
-  _problem.setMaxNLPingPong(getParam<unsigned int>("n_max_nonlinear_pinpong"));
+  _problem.setMaxNLPingPong(getParam<unsigned int>("n_max_nonlinear_pingpong"));
 
   _nl.setDecomposition(_splitting);
 }

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -74,6 +74,11 @@ FEProblemSolve::validParams()
   params.addParam<Real>("nl_div_tol", 1.0e10, "Nonlinear Divergence Tolerance");
   params.addParam<Real>("nl_abs_step_tol", 0., "Nonlinear Absolute step Tolerance");
   params.addParam<Real>("nl_rel_step_tol", 0., "Nonlinear Relative step Tolerance");
+  params.addParam<unsigned int>(
+      "n_max_nonlinear_pinpong",
+      100,
+      "The maximum number of times the non linear residual can ping pong "
+      "before requesting halting the current evalution and requesting timestep cut");
   params.addParam<bool>(
       "snesmf_reuse_base",
       true,
@@ -168,6 +173,8 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
                               _pars.isParamSetByUser("snesmf_reuse_base"));
 
   _problem.skipExceptionCheck(getParam<bool>("skip_exception_check"));
+
+  _problem.setMaxNLPingPong(getParam<unsigned int>("n_max_nonlinear_pinpong"));
 
   _nl.setDecomposition(_splitting);
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6590,8 +6590,8 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
 
   // Check for nonlinear residual pingpong.
   // Pingpong will always start from a residual increase
-  const bool increase = fnorm > fnorm_old ? true : false;
-  if ((_n_nl_pingpong % 2 == 1 && !increase) || (_n_nl_pingpong % 2 == 0 && increase))
+  if ((_n_nl_pingpong % 2 == 1 && !(fnorm > fnorm_old)) ||
+      (_n_nl_pingpong % 2 == 0 && fnorm > fnorm_old))
     _n_nl_pingpong += 1;
   else
     _n_nl_pingpong = 0;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6574,12 +6574,34 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
   NonlinearSystemBase & system = getNonlinearSystemBase();
   MooseNonlinearConvergenceReason reason = MooseNonlinearConvergenceReason::ITERATING;
 
+  Real fnorm_old;
   // This is the first residual before any iterations have been done,
   // but after preset BCs (if any) have been imposed on the solution
   // vector.  We save it, and use it to detect convergence if
   // compute_initial_residual_before_preset_bcs=false.
   if (it == 0)
+  {
     system._initial_residual_after_preset_bcs = fnorm;
+    fnorm_old = fnorm;
+    _n_nl_pingpong = 0;
+  }
+  else
+    fnorm_old = system._last_nl_rnorm;
+
+  // ping pong will alwasy start with an increase in the residual value.
+  const bool increase = fnorm > fnorm_old ? true : false;
+
+  if (_n_nl_pingpong == 0 && increase)
+    _n_nl_pingpong += 1;
+  else if (_n_nl_pingpong == 0 && !increase)
+    _n_nl_pingpong = 0;
+  else
+  {
+    if ((_n_nl_pingpong % 2 == 1 && !increase) || (_n_nl_pingpong % 2 == 0 && increase))
+      _n_nl_pingpong += 1;
+    else
+      _n_nl_pingpong = 0;
+  }
 
   std::ostringstream oss;
   if (fnorm != fnorm)
@@ -6628,6 +6650,11 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
       oss << "Diverged due to initial residual " << the_residual << " > divergence tolerance "
           << divtol << " * initial residual " << the_residual << '\n';
       reason = MooseNonlinearConvergenceReason::DIVERGED_DTOL;
+    }
+    else if (_n_nl_pingpong > _n_max_nl_pingpong)
+    {
+      oss << "Diverged due to maximum non linear residual pingpong achieved" << '\n';
+      reason = MooseNonlinearConvergenceReason::DIVERGED_NL_RESIDUAL_PINGPONG;
     }
   }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6588,20 +6588,13 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
   else
     fnorm_old = system._last_nl_rnorm;
 
-  // ping pong will alwasy start with an increase in the residual value.
+  // Check for nonlinear residual pingpong.
+  // Pingpong will always start from a residual increase
   const bool increase = fnorm > fnorm_old ? true : false;
-
-  if (_n_nl_pingpong == 0 && increase)
+  if ((_n_nl_pingpong % 2 == 1 && !increase) || (_n_nl_pingpong % 2 == 0 && increase))
     _n_nl_pingpong += 1;
-  else if (_n_nl_pingpong == 0 && !increase)
-    _n_nl_pingpong = 0;
   else
-  {
-    if ((_n_nl_pingpong % 2 == 1 && !increase) || (_n_nl_pingpong % 2 == 0 && increase))
-      _n_nl_pingpong += 1;
-    else
-      _n_nl_pingpong = 0;
-  }
+    _n_nl_pingpong = 0;
 
   std::ostringstream oss;
   if (fnorm != fnorm)

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -435,6 +435,10 @@ petscNonlinearConverged(SNES snes,
       *reason = SNES_DIVERGED_LINE_SEARCH;
 #endif
       break;
+
+    case MooseNonlinearConvergenceReason::DIVERGED_NL_RESIDUAL_PINGPONG:
+      *reason = SNES_DIVERGED_LINE_SEARCH;
+      break;
   }
 
   return 0;

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -437,7 +437,7 @@ petscNonlinearConverged(SNES snes,
       break;
 
     case MooseNonlinearConvergenceReason::DIVERGED_NL_RESIDUAL_PINGPONG:
-      *reason = SNES_DIVERGED_LINE_SEARCH;
+      *reason = SNES_DIVERGED_LOCAL_MIN;
       break;
   }
 

--- a/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
+++ b/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
@@ -63,12 +63,6 @@
 [Executioner]
   type = FixedPointSteady
   nl_rel_tol = 1e-50
-  nl_abs_tol = 1e-15
-  nl_max_its = 50
   line_search = none
   n_max_nonlinear_pingpong = 2
-[]
-
-[Outputs]
-  exodus = true
 []

--- a/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
+++ b/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
@@ -1,0 +1,74 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 4
+  ny = 4
+  xmin = -1
+  xmax = 1
+  ymin = -1
+  ymax = 1
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 0.1
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+  [./power]
+    type = PReaction
+    variable = u
+    coefficient = 0.2
+    power = -5
+    # Comment out this will make fixed point iteration converged in one iteration.
+    # However, this makes the solving diverge and require a proper initial condition (>1.00625).
+    vector_tags = 'previous'
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = VacuumBC
+    variable = u
+    boundary = left
+  [../]
+
+  [./right]
+    type = NeumannBC
+    variable = u
+    boundary = right
+    value = 10
+  [../]
+[]
+
+[Postprocessors]
+  [./unorm]
+    type = ElementL2Norm
+    variable = u
+  [../]
+[]
+
+[Problem]
+  type = FixedPointProblem
+  fp_tag_name = 'previous'
+[]
+
+[Executioner]
+  type = FixedPointSteady
+  nl_rel_tol = 1e-50
+  nl_abs_tol = 1e-15
+  nl_max_its = 50
+  line_search = none
+  n_max_nonlinear_pinpong = 2
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
+++ b/test/tests/executioners/nl_pingpong/nonlinear_residual_pingpong.i
@@ -66,7 +66,7 @@
   nl_abs_tol = 1e-15
   nl_max_its = 50
   line_search = none
-  n_max_nonlinear_pinpong = 2
+  n_max_nonlinear_pingpong = 2
 []
 
 [Outputs]

--- a/test/tests/executioners/nl_pingpong/tests
+++ b/test/tests/executioners/nl_pingpong/tests
@@ -2,8 +2,8 @@
   [./nl_pingpong]
     type = RunApp
     input = 'nonlinear_residual_pingpong.i'
-    expect_out = "Nonlinear solve did not converge due to DIVERGED_LINE_SEARCH"
-    requirement = 'MOOSE shall kill execution when non linear residual pingpong is detected.'
+    expect_out = "Nonlinear solve did not converge"
+    requirement = 'The system shall consider a nonlinear solve diverged if the nonlinear residual oscillates by a user-controlled number of times.'
     issues = '#16376'
     design = 'FEProblemSolve.md'
   [../]

--- a/test/tests/executioners/nl_pingpong/tests
+++ b/test/tests/executioners/nl_pingpong/tests
@@ -3,7 +3,7 @@
     type = RunApp
     input = 'nonlinear_residual_pingpong.i'
     expect_out = "Nonlinear solve did not converge due to DIVERGED_LINE_SEARCH"
-    requirement = 'MOOSE shall kill execution when non linear residual pinpong is detected.'
+    requirement = 'MOOSE shall kill execution when non linear residual pingpong is detected.'
     issues = '#16376'
     design = 'FEProblemSolve.md'
   [../]

--- a/test/tests/executioners/nl_pingpong/tests
+++ b/test/tests/executioners/nl_pingpong/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [./nl_pingpong]
+    type = RunApp
+    input = 'nonlinear_residual_pingpong.i'
+    expect_out = "Nonlinear solve did not converge due to DIVERGED_LINE_SEARCH"
+    requirement = 'MOOSE shall kill execution when non linear residual pinpong is detected.'
+    issues = '#16376'
+    design = 'FEProblemSolve.md'
+  [../]
+[]


### PR DESCRIPTION
Added the parameter `n_max_nonlinear_pinpong` to `FEproblmeSolve`. this parameter is set by default to 100.
the value of `n_max_nonlinear_pinpong` is used inside `FEProblemBase::checkNonlinearConvergence` as threshold value to determine if pingpong is present and execution of teh current timestep shoudl be interrupted.
The value `n_max_nonlinear_pinpong` can be set from teh executioner block in the input file.