### PR TITLE
Fix sed|grep location in moose-libmesh

### DIFF
--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -13,6 +13,11 @@ function sed_replace(){
         sed -i '' -e "s|${BUILD_PREFIX}|${PREFIX}|g" $PREFIX/libmesh/bin/libmesh-config
     else
         sed -i'' -e "s|${BUILD_PREFIX}|${PREFIX}|g" $PREFIX/libmesh/bin/libmesh-config
+
+        # Fix hard paths to /usr/bin/ when most operating system want these tools in /bin
+        sed -i'' -e "s|/usr/bin/sed|/bin/sed|g" $PREFIX/libmesh/contrib/bin/libtool
+        sed -i'' -e "s|/usr/bin/grep|/bin/grep|g" $PREFIX/libmesh/contrib/bin/libtool
+        sed -i'' -e "s|/usr/bin/dd|/bin/dd|g" $PREFIX/libmesh/contrib/bin/libtool
     fi
 }
 

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2020.11.04" %}
 


### PR DESCRIPTION
Fix the paths to `sed`, `grep`, and `dd` in libtool, in moose-libmesh Conda package.
Note: This fix has already been published by a manual build of moose-libmesh. This PR
formally resolves the issue.

Closes #16412

