### PR TITLE
Use a PAC (proxy auto config) for the HPC connectivity instructions

### DIFF
--- a/modules/doc/content/help/inl/hpc_remote.md
+++ b/modules/doc/content/help/inl/hpc_remote.md
@@ -55,23 +55,16 @@ domain name in your command above because of the "Host" setting in your SSH conf
 
 ## SOCKS Proxy id=socks-proxy
 
-Adjust the SOCKS proxy settings for your +least+ favorite web browser to reflect the following
-settings:
+In order to access common HPC resources (hpcgitlab.hpc.inl.gov, hpcweb.inl.gov, etc) within a web browser, you must tunnel traffic to said resources using a SOCKS proxy. This is achieved by using a PAC (Proxy-Auto Configuration) file, which we have configured as:
 
-```bash
-localhost:5555
+!listing moose/scripts/hpc_proxy.pac
+
+Add the proxy configuration to your browser via the following url:
+
+```https://raw.githubusercontent.com/idaholab/moose/master/scripts/hpc_proxy.pac
 ```
 
-Choose your +least+ favorite, because once you adjust this setting, you will have to undo this
-setting once you disconnect for that browser to work again. There are other ways to switch back and
-forth by creating profiles. You may want to consult the Internet on how to set this up for your
-browser or OS. FireFox, for example, allows for custom profiles:
-[Firefox: Profile Manager](https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles)
-
-Finally, you may want to enter a few hostnames that you do +not+ want to go resolve through your
-proxy.  These would typically be external INL systems that are resolvable on the Internet
-(e.g. +gitlab.software.inl.gov+, +www.inl.gov+). This will allow you to both internal and external
-INL sites when connected through the SOCKS proxy.
+Documentation is available for doing this within Firefox [here](https://support.mozilla.org/en-US/kb/connection-settings-firefox). Add the URL above within the "Automatic proxy configuration URL" box. We do not recommend utilizing Google Chrome with this functionality because it requires setting a system-wide proxy configuration.
 
 ## Log in to HPC Gitlab
 

--- a/modules/doc/content/help/inl/hpc_remote.md
+++ b/modules/doc/content/help/inl/hpc_remote.md
@@ -55,7 +55,8 @@ domain name in your command above because of the "Host" setting in your SSH conf
 
 ## SOCKS Proxy id=socks-proxy
 
-In order to access common HPC resources (hpcgitlab.hpc.inl.gov, hpcweb.inl.gov, etc) within a web browser, you must tunnel traffic to said resources using a SOCKS proxy. This is achieved by using a PAC (Proxy-Auto Configuration) file, which we have configured as:
+To access common HPC resources (hpcgitlab.hpc.inl.gov, hpcweb.inl.gov, etc) within a web browser, traffic must be routed through a SOCKS proxy. This can be achieved by using a PAC (Proxy-Auto Configuration) file:
+
 
 !listing moose/scripts/hpc_proxy.pac
 
@@ -64,7 +65,7 @@ Add the proxy configuration to your browser via the following url:
 ```https://raw.githubusercontent.com/idaholab/moose/master/scripts/hpc_proxy.pac
 ```
 
-Documentation is available for doing this within Firefox [here](https://support.mozilla.org/en-US/kb/connection-settings-firefox). Add the URL above within the "Automatic proxy configuration URL" box. We do not recommend utilizing Google Chrome with this functionality because it requires setting a system-wide proxy configuration.
+Documentation is available for using [Firefox](https://support.mozilla.org/en-US/kb/connection-settings-firefox). Add the URL above within the "Automatic proxy configuration URL" box. We do not recommend utilizing Google Chrome with this functionality because it requires setting a system-wide proxy configuration.
 
 ## Log in to HPC Gitlab
 

--- a/modules/doc/content/help/inl/hpc_remote.md
+++ b/modules/doc/content/help/inl/hpc_remote.md
@@ -62,7 +62,8 @@ To access common HPC resources (hpcgitlab.hpc.inl.gov, hpcweb.inl.gov, etc) with
 
 Add the proxy configuration to your browser via the following url:
 
-```https://raw.githubusercontent.com/idaholab/moose/master/scripts/hpc_proxy.pac
+```
+https://raw.githubusercontent.com/idaholab/moose/master/scripts/hpc_proxy.pac
 ```
 
 Documentation is available for using [Firefox](https://support.mozilla.org/en-US/kb/connection-settings-firefox). Add the URL above within the "Automatic proxy configuration URL" box. We do not recommend utilizing Google Chrome with this functionality because it requires setting a system-wide proxy configuration.

--- a/scripts/hpc_proxy.pac
+++ b/scripts/hpc_proxy.pac
@@ -1,0 +1,19 @@
+// INL HPC PAC (Proxy-Auto Configuration)
+//
+// Used within the MOOSE HPC connectivity instructions
+// (mooseframework.org/help/inl/hpc_remote.html)
+// to tunnel traffic to common HPC resources
+// using a SOCKS proxy to hpclogin.inl.gov.
+// See the link for more information.
+
+function FindProxyForURL(url, host) {
+  // For [*.hpc.inl.gov, hpcweb.inl.gov, moosebuild.inl.gov],
+  // first attempt to use the SOCKS proxy. If no success,
+  // attempt a direct connection (useful when on the INL VPN)
+  if (shExpMatch(host, "*.hpc.inl.gov") ||
+      dnsDomainIs(host, "hpcweb.inl.gov") ||
+      dnsDomainIs(host, "moosebuild.inl.gov"))
+    return "SOCKS5 localhost:5555; DIRECT";
+  // For all other domains, use direct access (no proxy)
+  return "DIRECT";
+}


### PR DESCRIPTION
Closes #16443