### PR TITLE
Expose executioner num_steps to time stepper.

### DIFF
--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -192,6 +192,12 @@ public:
    */
   virtual Real relativeSolutionDifferenceNorm();
 
+  /**
+   * Set the number of time steps
+   * @param num_steps number of time steps
+   */
+  virtual void forceNumSteps(const unsigned int num_steps) { _num_steps = num_steps; }
+
 protected:
   /// Here for backward compatibility
   FEProblemBase & _problem;

--- a/framework/include/timesteppers/TimeStepper.h
+++ b/framework/include/timesteppers/TimeStepper.h
@@ -87,6 +87,12 @@ public:
 
   virtual void forceTimeStep(Real dt);
 
+  /**
+   * Set the number of time steps
+   * @param num_steps number of time steps
+   */
+  virtual void forceNumSteps(const unsigned int num_steps);
+
   ///@{
   /**
    * Add a sync time

--- a/framework/src/timesteppers/TimeStepper.C
+++ b/framework/src/timesteppers/TimeStepper.C
@@ -203,3 +203,9 @@ TimeStepper::forceTimeStep(Real dt)
 {
   _current_dt = dt;
 }
+
+void
+TimeStepper::forceNumSteps(const unsigned int num_steps)
+{
+  _executioner.forceNumSteps(num_steps);
+}


### PR DESCRIPTION
This allows external applications that define a time stepper (but not necessarily an executioner) to control the end of the simulation when it is based on a number of time steps. This is implemented in the same way that the time stepper can control the simulation end in terms of an end time. Therefore from an encapsulation perspective, I this small extension makes sense.

Closes #16460
