### PR TITLE
Allow N non linear iteration before perform nonlinear divergence checks and add an absolute divergence tolerance 

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -214,7 +214,6 @@ public:
                             const Real abstol,
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
-                            const PetscBool force_iteration,
                             const Real initial_residual_before_preset_bcs,
                             const Real div_threshold);
 
@@ -1916,7 +1915,9 @@ public:
   }
 
   /// method setting the minimum number of nonlinear iterations before performing divergence checks
-  void setNLForcedIterations(const unsigned int /*nl_forced_its*/);
+  void setNLForcedIterations(const unsigned int nl_forced_its) { _nl_forced_its = nl_forced_its; }
+
+  unsigned int getNLForcedIterations() { return _nl_forced_its; };
 
   /// method setting the absolute divergence tolerance
   void setNLAbsoluteDivergenceTolerance(const Real abs_nl_divtol)

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1916,7 +1916,7 @@ public:
   }
 
   /// method setting the minimum number of nonlinear iterations before performing divergence checks
-  void setNLForcedIterations(const unsigned int nl_forced_its) { _nl_forced_its = nl_forced_its; }
+  void setNLForcedIterations(const unsigned int /*nl_forced_its*/);
 
   /// method setting the absolute divergence tolerance
   void setNLAbsoluteDivergenceTolerance(const Real abs_nl_divtol)

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1915,6 +1915,15 @@ public:
     _n_max_nl_pingpong = n_max_nl_pingpong;
   }
 
+  /// method setting the minimum number of nonlinear iterations before performing divergence checks
+  void setNLForcedIterations(const unsigned int nl_forced_its) { _nl_forced_its = nl_forced_its; }
+
+  /// method setting the absolute divergence tolerance
+  void setNLAbsoluteDivergenceTolerance(const Real abs_nl_divtol)
+  {
+    _abs_nl_divtol = abs_nl_divtol;
+  }
+
 protected:
   /// Create extra tagged vectors and matrices
   void createTagVectors();
@@ -1940,6 +1949,12 @@ protected:
   /// maximum numbver
   unsigned int _n_nl_pingpong = 0;
   unsigned int _n_max_nl_pingpong = std::numeric_limits<unsigned int>::max();
+
+  /// the number of forced nonlinear iterations
+  int _nl_forced_its = 0;
+
+  /// the absolute non linear divergnce tolerance
+  Real _abs_nl_divtol = -1;
 
   std::shared_ptr<NonlinearSystemBase> _nl;
   std::shared_ptr<AuxiliarySystem> _aux;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1915,14 +1915,18 @@ public:
   }
 
   /// method setting the minimum number of nonlinear iterations before performing divergence checks
-  void setNLForcedIterations(const unsigned int nl_forced_its) { _nl_forced_its = nl_forced_its; }
+  void setNonlinearForcedIterations(const unsigned int nl_forced_its)
+  {
+    _nl_forced_its = nl_forced_its;
+  }
 
-  unsigned int getNLForcedIterations() { return _nl_forced_its; };
+  /// method returning the number of forced nonlinear iterations
+  unsigned int getNonlinearForcedIterations() const { return _nl_forced_its; };
 
   /// method setting the absolute divergence tolerance
-  void setNLAbsoluteDivergenceTolerance(const Real abs_nl_divtol)
+  void setNonlinearAbsoluteDivergenceTolerance(const Real nl_abs_div_tol)
   {
-    _abs_nl_divtol = abs_nl_divtol;
+    _nl_abs_div_tol = nl_abs_div_tol;
   }
 
 protected:
@@ -1955,7 +1959,7 @@ protected:
   int _nl_forced_its = 0;
 
   /// the absolute non linear divergnce tolerance
-  Real _abs_nl_divtol = -1;
+  Real _nl_abs_div_tol = -1;
 
   std::shared_ptr<NonlinearSystemBase> _nl;
   std::shared_ptr<AuxiliarySystem> _aux;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1958,7 +1958,7 @@ protected:
   /// the number of forced nonlinear iterations
   int _nl_forced_its = 0;
 
-  /// the absolute non linear divergnce tolerance
+  /// the absolute non linear divergence tolerance
   Real _nl_abs_div_tol = -1;
 
   std::shared_ptr<NonlinearSystemBase> _nl;

--- a/framework/include/problems/ReferenceResidualProblem.h
+++ b/framework/include/problems/ReferenceResidualProblem.h
@@ -43,7 +43,6 @@ public:
                             const Real abstol,
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
-                            const PetscBool force_iteration,
                             const Real initial_residual_before_preset_bcs,
                             const Real div_threshold) override;
 

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -187,6 +187,8 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
 
   _problem.setNLForcedIterations(getParam<unsigned int>("nl_forced_its"));
 
+  _problem.setNLForcedIterations(getParam<unsigned int>("nl_forced_its"));
+
   _problem.setNLAbsoluteDivergenceTolerance(getParam<Real>("nl_abs_div_tol"));
 
   _nl.setDecomposition(_splitting);

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -68,8 +68,7 @@ FEProblemSolve::validParams()
   params.addParam<Real>("l_abs_tol", 1.0e-50, "Linear Absolute Tolerance");
   params.addParam<unsigned int>("l_max_its", 10000, "Max Linear Iterations");
   params.addParam<unsigned int>("nl_max_its", 50, "Max Nonlinear Iterations");
-  params.addParam<unsigned int>(
-      "nl_forced_its", 0, "The number of nonlinear iteration before performing divergence checks");
+  params.addParam<unsigned int>("nl_forced_its", 0, "The Number of Forced Nonlinear Iterations");
   params.addParam<unsigned int>("nl_max_funcs", 10000, "Max Nonlinear solver function evaluations");
   params.addParam<Real>("nl_abs_tol", 1.0e-50, "Nonlinear Absolute Tolerance");
   params.addParam<Real>("nl_rel_tol", 1.0e-8, "Nonlinear Relative Tolerance");
@@ -185,11 +184,9 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
 
   _problem.setMaxNLPingPong(getParam<unsigned int>("n_max_nonlinear_pingpong"));
 
-  _problem.setNLForcedIterations(getParam<unsigned int>("nl_forced_its"));
+  _problem.setNonlinearForcedIterations(getParam<unsigned int>("nl_forced_its"));
 
-  _problem.setNLForcedIterations(getParam<unsigned int>("nl_forced_its"));
-
-  _problem.setNLAbsoluteDivergenceTolerance(getParam<Real>("nl_abs_div_tol"));
+  _problem.setNonlinearAbsoluteDivergenceTolerance(getParam<Real>("nl_abs_div_tol"));
 
   _nl.setDecomposition(_splitting);
 }

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -68,10 +68,19 @@ FEProblemSolve::validParams()
   params.addParam<Real>("l_abs_tol", 1.0e-50, "Linear Absolute Tolerance");
   params.addParam<unsigned int>("l_max_its", 10000, "Max Linear Iterations");
   params.addParam<unsigned int>("nl_max_its", 50, "Max Nonlinear Iterations");
+  params.addParam<unsigned int>(
+      "nl_forced_its", 0, "The number of nonlinear iteration before performing divergence checks");
   params.addParam<unsigned int>("nl_max_funcs", 10000, "Max Nonlinear solver function evaluations");
   params.addParam<Real>("nl_abs_tol", 1.0e-50, "Nonlinear Absolute Tolerance");
   params.addParam<Real>("nl_rel_tol", 1.0e-8, "Nonlinear Relative Tolerance");
-  params.addParam<Real>("nl_div_tol", 1.0e10, "Nonlinear Divergence Tolerance");
+  params.addParam<Real>(
+      "nl_div_tol",
+      1.0e10,
+      "Nonlinear Relative Divergence Tolerance. A negative value disables this check.");
+  params.addParam<Real>(
+      "nl_abs_div_tol",
+      1.0e50,
+      "Nonlinear Absolute Divergence Tolerance. A negative value disables this check.");
   params.addParam<Real>("nl_abs_step_tol", 0., "Nonlinear Absolute step Tolerance");
   params.addParam<Real>("nl_rel_step_tol", 0., "Nonlinear Relative step Tolerance");
   params.addParam<unsigned int>(
@@ -175,6 +184,10 @@ FEProblemSolve::FEProblemSolve(Executioner * ex)
   _problem.skipExceptionCheck(getParam<bool>("skip_exception_check"));
 
   _problem.setMaxNLPingPong(getParam<unsigned int>("n_max_nonlinear_pingpong"));
+
+  _problem.setNLForcedIterations(getParam<unsigned int>("nl_forced_its"));
+
+  _problem.setNLAbsoluteDivergenceTolerance(getParam<Real>("nl_abs_div_tol"));
 
   _nl.setDecomposition(_splitting);
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6700,13 +6700,19 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
           << '\n';
       reason = MooseNonlinearConvergenceReason::CONVERGED_SNORM_RELATIVE;
     }
-    else if (divtol > 0 && fnorm > the_residual * divtol)
+    else if (divtol > 0 && it >= _nl_forced_its && fnorm > the_residual * divtol)
     {
       oss << "Diverged due to initial residual " << the_residual << " > divergence tolerance "
           << divtol << " * initial residual " << the_residual << '\n';
       reason = MooseNonlinearConvergenceReason::DIVERGED_DTOL;
     }
-    else if (_n_nl_pingpong > _n_max_nl_pingpong)
+    else if (_abs_nl_divtol > 0 && it >= _nl_forced_its && fnorm > _abs_nl_divtol)
+    {
+      oss << "Diverged due to residual " << fnorm << " > absolute divergence tolerance "
+          << _abs_nl_divtol << '\n';
+      reason = MooseNonlinearConvergenceReason::DIVERGED_DTOL;
+    }
+    else if (it >= _nl_forced_its && _n_nl_pingpong > _n_max_nl_pingpong)
     {
       oss << "Diverged due to maximum non linear residual pingpong achieved" << '\n';
       reason = MooseNonlinearConvergenceReason::DIVERGED_NL_RESIDUAL_PINGPONG;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6627,7 +6627,6 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
                                          const Real abstol,
                                          const PetscInt nfuncs,
                                          const PetscInt max_funcs,
-                                         const PetscBool force_iteration,
                                          const Real initial_residual_before_preset_bcs,
                                          const Real div_threshold)
 {
@@ -7099,13 +7098,4 @@ FEProblemBase::resizeMaterialData(const Moose::MaterialDataType data_type,
       mooseError("Unrecognized material data type.");
       break;
   }
-}
-
-void
-FEProblemBase::setNLForcedIterations(const unsigned int nl_forced_its)
-{
-  if (_petsc_options.flags.contains("-snes_force_iteration") && nl_forced_its == 0)
-    _nl_forced_its = 1;
-  else
-    _nl_forced_its = nl_forced_its;
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6705,10 +6705,10 @@ FEProblemBase::checkNonlinearConvergence(std::string & msg,
           << divtol << " * initial residual " << the_residual << '\n';
       reason = MooseNonlinearConvergenceReason::DIVERGED_DTOL;
     }
-    else if (_abs_nl_divtol > 0 && fnorm > _abs_nl_divtol)
+    else if (_nl_abs_div_tol > 0 && fnorm > _nl_abs_div_tol)
     {
       oss << "Diverged due to residual " << fnorm << " > absolute divergence tolerance "
-          << _abs_nl_divtol << '\n';
+          << _nl_abs_div_tol << '\n';
       reason = MooseNonlinearConvergenceReason::DIVERGED_DTOL;
     }
     else if (_n_nl_pingpong > _n_max_nl_pingpong)

--- a/framework/src/problems/ReferenceResidualProblem.C
+++ b/framework/src/problems/ReferenceResidualProblem.C
@@ -405,7 +405,6 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
                                                     const Real abstol,
                                                     const PetscInt nfuncs,
                                                     const PetscInt max_funcs,
-                                                    const PetscBool force_iteration,
                                                     const Real initial_residual_before_preset_bcs,
                                                     const Real /*div_threshold*/)
 {
@@ -446,7 +445,7 @@ ReferenceResidualProblem::checkNonlinearConvergence(std::string & msg,
     oss << "Failed to converge, function norm is NaN\n";
     reason = MooseNonlinearConvergenceReason::DIVERGED_FNORM_NAN;
   }
-  else if (fnorm < abstol && !force_iteration)
+  else if ((it >= _nl_forced_its) && fnorm < abstol)
   {
     oss << "Converged due to function norm " << fnorm << " < " << abstol << std::endl;
     reason = MooseNonlinearConvergenceReason::CONVERGED_FNORM_ABS;

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -347,22 +347,20 @@ petscNonlinearConverged(SNES snes,
 
   // Whether or not to force SNESSolve() take at least one iteration regardless of the initial
   // residual norm
-  PetscBool force_iteration = PETSC_FALSE;
 #if !PETSC_VERSION_LESS_THAN(3, 8, 4)
+  PetscBool force_iteration = PETSC_FALSE;
   ierr = SNESGetForceIteration(snes, &force_iteration);
   CHKERRABORT(problem.comm().get(), ierr);
-#endif
 
-  if (force_iteration && !(problem.getNLForcedIterations()))
-    problem.setNLForcedIterations(1);
+  if (force_iteration && !(problem.getNonlinearForcedIterations()))
+    problem.setNonlinearForcedIterations(1);
 
-  if (!force_iteration && (problem.getNLForcedIterations()))
+  if (!force_iteration && (problem.getNonlinearForcedIterations()))
   {
-#if !PETSC_VERSION_LESS_THAN(3, 8, 4)
     ierr = SNESSetForceIteration(snes, PETSC_TRUE);
     CHKERRABORT(problem.comm().get(), ierr);
-#endif
   }
+#endif
 
 // See if SNESSetFunctionDomainError() has been called.  Note:
 // SNESSetFunctionDomainError() and SNESGetFunctionDomainError()

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -353,6 +353,17 @@ petscNonlinearConverged(SNES snes,
   CHKERRABORT(problem.comm().get(), ierr);
 #endif
 
+  if (force_iteration && !(problem.getNLForcedIterations()))
+    problem.setNLForcedIterations(1);
+
+  if (!force_iteration && (problem.getNLForcedIterations()))
+  {
+#if !PETSC_VERSION_LESS_THAN(3, 8, 4)
+    ierr = SNESSetForceIteration(snes, PETSC_TRUE);
+    CHKERRABORT(problem.comm().get(), ierr);
+#endif
+  }
+
 // See if SNESSetFunctionDomainError() has been called.  Note:
 // SNESSetFunctionDomainError() and SNESGetFunctionDomainError()
 // were added in different releases of PETSc.
@@ -385,7 +396,6 @@ petscNonlinearConverged(SNES snes,
                                         atol,
                                         nfuncs,
                                         maxf,
-                                        force_iteration,
                                         system._initial_residual_before_preset_bcs,
                                         std::numeric_limits<Real>::max());
 

--- a/modules/contact/include/problems/AugmentedLagrangianContactProblem.h
+++ b/modules/contact/include/problems/AugmentedLagrangianContactProblem.h
@@ -42,7 +42,6 @@ public:
                             const Real abstol,
                             const PetscInt nfuncs,
                             const PetscInt max_funcs,
-                            const PetscBool force_iteration,
                             const Real ref_resid,
                             const Real div_threshold) override;
 

--- a/modules/contact/src/problems/AugmentedLagrangianContactProblem.C
+++ b/modules/contact/src/problems/AugmentedLagrangianContactProblem.C
@@ -64,7 +64,6 @@ AugmentedLagrangianContactProblem::checkNonlinearConvergence(std::string & msg,
                                                              const Real abstol,
                                                              const PetscInt nfuncs,
                                                              const PetscInt /*max_funcs*/,
-                                                             const PetscBool force_iteration,
                                                              const Real ref_resid,
                                                              const Real /*div_threshold*/)
 {
@@ -84,7 +83,6 @@ AugmentedLagrangianContactProblem::checkNonlinearConvergence(std::string & msg,
                                                           abstol,
                                                           nfuncs,
                                                           my_max_funcs,
-                                                          force_iteration,
                                                           ref_resid,
                                                           my_div_threshold);
 

--- a/test/tests/executioners/nl_divergence_tolerance/nl_abs_divergence_tolerance.i
+++ b/test/tests/executioners/nl_divergence_tolerance/nl_abs_divergence_tolerance.i
@@ -1,0 +1,63 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 15
+  ny = 15
+[]
+
+[Variables]
+  [./u]
+    scaling = 1e-5
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = left
+    value = -1000
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = right
+    value = 100000
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = 'implicit-euler'
+  line_search = 'none'
+  solve_type = PJFNK
+
+  l_max_its = 20
+  nl_max_its = 20
+  nl_abs_div_tol = 1e+7
+  nl_div_tol = 1e+50
+  dt = 1
+  num_steps = 2
+
+  petsc_options = '-snes_converged_reason -ksp_converged_reason '
+  petsc_options_iname = '-pc_type -pc_hypre_type '
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/executioners/nl_divergence_tolerance/tests
+++ b/test/tests/executioners/nl_divergence_tolerance/tests
@@ -15,7 +15,7 @@
     type = RunApp
     input = 'nl_abs_divergence_tolerance.i'
     expect_out = "Nonlinear solve did not converge due to DIVERGED_DTOL iterations 1"
-    requirement = 'The system shall consider a nonlinear solve diverged if the nonlinear residaul exceeds the absolute divergence tolerance while iterating'
+    requirement = 'The system shall consider a nonlinear solve diverged if the nonlinear residual exceeds the absolute divergence tolerance while iterating'
     issues = '#16474'
     design = 'FEProblemSolve.md'
   [../]

--- a/test/tests/executioners/nl_divergence_tolerance/tests
+++ b/test/tests/executioners/nl_divergence_tolerance/tests
@@ -1,4 +1,4 @@
-[Tests]  
+[Tests]
   design = 'syntax/Executioner/index.md'
   [./test]
     type = 'Exodiff'
@@ -10,5 +10,13 @@
     mesh_mode = REPLICATED
     requirement = "The Executioner system shall support the PETSc non-linear divergence tolerance."
     issues = '#13991'
+  [../]
+  [./test_abs_divtol]
+    type = RunApp
+    input = 'nl_abs_divergence_tolerance.i'
+    expect_out = "Nonlinear solve did not converge due to DIVERGED_DTOL iterations 1"
+    requirement = 'The system shall consider a nonlinear solve diverged if the nonlinear residaul exceeds the absolute divergence tolerance while iterating'
+    issues = '#16474'
+    design = 'FEProblemSolve.md'
   [../]
 []

--- a/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
+++ b/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
@@ -1,0 +1,67 @@
+###########################################################
+# This is a simple test of the Kernel System.
+# It solves the Laplacian equation on a small 2x2 grid.
+# The "Diffusion" kernel is used to calculate the
+# residuals of the weak form of this operator.
+#
+# @Requirement F3.30
+###########################################################
+
+[Mesh]
+  [./square]
+    type = GeneratedMeshGenerator
+    nx = 2
+    ny = 2
+    dim = 2
+  [../]
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  active = 'diff'
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[BCs]
+  # BCs cannot be preset due to Jacobian test
+  active = 'left right'
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = 3
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = 1
+    value = 1
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+
+  solve_type = 'NEWTON'
+[]
+
+[Outputs]
+  file_base = out
+  exodus = true
+[]

--- a/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
+++ b/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
@@ -1,12 +1,3 @@
-###########################################################
-# This is a simple test of the Kernel System.
-# It solves the Laplacian equation on a small 2x2 grid.
-# The "Diffusion" kernel is used to calculate the
-# residuals of the weak form of this operator.
-#
-# @Requirement F3.30
-###########################################################
-
 [Mesh]
   [./square]
     type = GeneratedMeshGenerator

--- a/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
+++ b/test/tests/executioners/nl_forced_its/2d_diffusion_test.i
@@ -57,7 +57,9 @@
 
 [Executioner]
   type = Steady
-
+  nl_forced_its = 2
+  nl_abs_tol = 1e-10
+  nl_rel_tol = 1e-50
   solve_type = 'NEWTON'
 []
 

--- a/test/tests/executioners/nl_forced_its/nl_forced_its.i
+++ b/test/tests/executioners/nl_forced_its/nl_forced_its.i
@@ -49,7 +49,7 @@
   l_max_its = 20
   nl_max_its = 20
   nl_forced_its = 2
-  nl_abs_div_tol = 1e+7
+  nl_abs_div_tol = 1e+5
 
   dt = 1
   num_steps = 2

--- a/test/tests/executioners/nl_forced_its/nl_forced_its.i
+++ b/test/tests/executioners/nl_forced_its/nl_forced_its.i
@@ -1,0 +1,64 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 15
+  ny = 15
+[]
+
+[Variables]
+  [./u]
+    scaling = 1e-5
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = CoefDiffusion
+    variable = u
+    coef = 0.1
+  [../]
+  [./time]
+    type = TimeDerivative
+    variable = u
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = left
+    value = -1000
+  [../]
+  [./right]
+    type = DirichletBC
+    variable = u
+    preset = false
+    boundary = right
+    value = 100000
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = 'implicit-euler'
+  line_search = 'none'
+  solve_type = PJFNK
+
+  l_max_its = 20
+  nl_max_its = 20
+  nl_forced_its = 4
+  nl_abs_div_tol = 1e+5
+
+  dt = 1
+  num_steps = 2
+
+  petsc_options = '-snes_converged_reason -ksp_converged_reason '
+  petsc_options_iname = '-pc_type -pc_hypre_type '
+  petsc_options_value = 'hypre boomeramg'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/executioners/nl_forced_its/nl_forced_its.i
+++ b/test/tests/executioners/nl_forced_its/nl_forced_its.i
@@ -48,8 +48,8 @@
 
   l_max_its = 20
   nl_max_its = 20
-  nl_forced_its = 4
-  nl_abs_div_tol = 1e+5
+  nl_forced_its = 2
+  nl_abs_div_tol = 1e+7
 
   dt = 1
   num_steps = 2

--- a/test/tests/executioners/nl_forced_its/tests
+++ b/test/tests/executioners/nl_forced_its/tests
@@ -8,4 +8,13 @@
     issues = '#16474'
     design = 'FEProblemSolve.md'
   [../]
+  [./test_force_3_iterations]
+    type = 'RunApp'
+    input = '2d_diffusion_test.i'
+    expect_out = "Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 3"
+    cli_args = 'Executioner/nl_abs_tol=1e+1 Executioner/nl_forced_its=3'
+    requirement = 'MOOSE shall force the prescribed number of non linear iterations even if convergence tolerance is already satisfied.'
+    issues = '#16474'
+    design = 'FEProblemSolve.md'
+  [../]
 []

--- a/test/tests/executioners/nl_forced_its/tests
+++ b/test/tests/executioners/nl_forced_its/tests
@@ -11,8 +11,7 @@
   [./test_force_3_iterations]
     type = 'RunApp'
     input = '2d_diffusion_test.i'
-    expect_out = "Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 3"
-    cli_args = 'Executioner/nl_abs_tol=1e+1 Executioner/nl_forced_its=3'
+    expect_out = 'Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 2'
     requirement = 'MOOSE shall force the prescribed number of non linear iterations even if convergence tolerance is already satisfied.'
     issues = '#16474'
     design = 'FEProblemSolve.md'

--- a/test/tests/executioners/nl_forced_its/tests
+++ b/test/tests/executioners/nl_forced_its/tests
@@ -1,0 +1,11 @@
+[Tests]
+  design = 'syntax/Executioner/index.md'
+  [./test_nl_forced_iterations]
+    type = RunApp
+    input = 'nl_forced_its.i'
+    expect_out = "Nonlinear solve did not converge due to DIVERGED_DTOL iterations 4"
+    requirement = 'The system shall perform n non linear iterations before checking for non linear divergence'
+    issues = '#16474'
+    design = 'FEProblemSolve.md'
+  [../]
+[]

--- a/test/tests/executioners/nl_forced_its/tests
+++ b/test/tests/executioners/nl_forced_its/tests
@@ -3,7 +3,7 @@
   [./test_nl_forced_iterations]
     type = RunApp
     input = 'nl_forced_its.i'
-    expect_out = "Nonlinear solve did not converge due to DIVERGED_DTOL iterations 4"
+    expect_out = "Nonlinear solve did not converge due to DIVERGED_DTOL iterations 2"
     requirement = 'The system shall perform n non linear iterations before checking for non linear divergence'
     issues = '#16474'
     design = 'FEProblemSolve.md'

--- a/test/tests/executioners/nl_forced_its/tests
+++ b/test/tests/executioners/nl_forced_its/tests
@@ -8,7 +8,7 @@
     issues = '#16474'
     design = 'FEProblemSolve.md'
   [../]
-  [./test_force_3_iterations]
+  [./test_force_2_nl_iterations]
     type = 'RunApp'
     input = '2d_diffusion_test.i'
     expect_out = 'Nonlinear solve converged due to CONVERGED_FNORM_ABS iterations 2'


### PR DESCRIPTION
closes #16474 

Add `nl_forced_its` and `nl_abs_div_tol` paramters to `FEProblemSolve.C`.
Implemented relevant logic in `FEProblemBase.C`.

