### PR TITLE
Fix a bug introduced in PR 16192

### DIFF
--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -283,10 +283,10 @@ SetupMeshAction::act()
       // We want to set the MeshBase object to that coming from mesh generators when the following
       // conditions are met:
       // 1. We have mesh generators
-      // 2. We are not: recovering/restarting and we are the master application
-      if (!_app.getMeshGeneratorNames().empty() &&
-          !((_app.isUseSplit() || _app.isRecovering() || _app.isRestarting()) &&
-            _app.isUltimateMaster()))
+      // 2. We are not using the pre-split mesh
+      // 3. We are not: recovering/restarting and we are the master application
+      if (!_app.getMeshGeneratorNames().empty() && !_app.isUseSplit() &&
+          !((_app.isRecovering() || _app.isRestarting()) && _app.isUltimateMaster()))
       {
         auto mesh_base = _app.getMeshGeneratorMesh();
         if (_mesh->allowRemoteElementRemoval() != mesh_base->allow_remote_element_removal())


### PR DESCRIPTION
This bug does not show up in MOOSE tests because we do not have any test with main+sub apps and using pre-split mesh but caught by a recent test in Griffin with a special MultiApp. I am not sure if we want to add a test for this because this feature should be used in a very rare setting, typically the main and sub apps are using the same mesh, thus they can share the command-line argument like `--use-split --split-file foo`. It is a little hard to protect this usage for this specific setting. I am open to suggestions if you have any. Other than this, this fix should not break anything and be good to go. Refer to #16192.
