### PR TITLE
Ray tracing doco improvements

### DIFF
--- a/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
@@ -14,9 +14,9 @@ We begin with the standard "simple diffusion" problem:
 For this problem, we seek the value of the integral
 
 !equation
-\int_L u_h(\vec{r})~dr, \quad L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}
+\int_L u_h(\vec{r})~dr, \quad L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}\,,
 
-for the lines defined by
+where $u_h$ is the finite-element solution, for the lines defined by
 
 !equation
 \vec{r}_1 = (0, 0)\,, \quad \vec{r}_2 = (5, 5)

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
@@ -14,17 +14,17 @@ We begin with the standard "simple diffusion" problem:
 For this problem, we seek the value of the integral
 
 !equation
-\int_L u_h~dr, \quad L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}
+\int_L u_h(\vec{r})~dr, \quad L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}
 
 for the lines defined by
 
 !equation
-\vec{r}_1 = (0, 0)\,, \quad \vec{r}_1 = (5, 5)
+\vec{r}_1 = (0, 0)\,, \quad \vec{r}_2 = (5, 5)
 
 and
 
 !equation
-\vec{r}_1 = (5, 0)\,, \quad \vec{r}_1 = (5, 5)
+\vec{r}_1 = (5, 0)\,, \quad \vec{r}_2 = (5, 5)
 
 For simplicity, we will denote the lines as `diag` and `right_up`, respectively.
 

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_integrals.md
@@ -11,22 +11,27 @@ We begin with the standard "simple diffusion" problem:
 
 !listing modules/ray_tracing/test/tests/ray_kernels/variable_integral_ray_kernel/simple_diffusion_line_integral.i start=Mesh end=Outputs
 
-For this problem, we seek the value of the integral
+For this problem, we seek the value of the integrals (where $u_h$ is the finite-element solution)
 
 !equation
-\int_L u_h(\vec{r})~dr, \quad L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}\,,
-
-where $u_h$ is the finite-element solution, for the lines defined by
-
-!equation
-\vec{r}_1 = (0, 0)\,, \quad \vec{r}_2 = (5, 5)
+\int_{L_1} u_h(\vec{r})~dr, \quad L_1 = \{(0, 0) + t(5, 5) \mid t \in [0, 1]\}\,,
 
 and
 
 !equation
-\vec{r}_1 = (5, 0)\,, \quad \vec{r}_2 = (5, 5)
+\int_{L_2} u_h(\vec{r})~dr, \quad L_2 = \{(5, 0) + t(5, 5) \mid t \in [0, 1]\}\,,
 
-For simplicity, we will denote the lines as `diag` and `right_up`, respectively.
+in which we will denote the first line, $L_1$, as `diag` and the second, $L_2$, as `right_up` for simplicity.
+
+Note that the integral along the second line, $L_2$, is trivial due to the Dirichlet boundary condition,
+
+!equation
+u_h(5, y) = 1\,, \quad y \in [0, 5]\,,
+
+which implies
+
+!equation
+\int_{L_2} u_h(\vec{r})~dr = \int_0^5 u_h(5, y)\,dy = \int_0^5 dy = 5\,, \quad L_2 = \{(5, 0) + t(5, 5) \mid t \in [0, 1]\}\,.
 
 ## Defining the Study
 

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_sources.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_sources.md
@@ -31,7 +31,17 @@ The `line_source` [LineSourceRayKernel.md] contributes to the variable `u` for [
 
 The visualized result follows in [result].
 
-!media large_media/ray_tracing/simple_diffusion_line_source.png id=result style=width:70%; caption=Simple diffusion line source example result.
+!row!
+!col small=12 medium=6 large=6
+!media large_media/ray_tracing/simple_diffusion_line_source.png
+       id=result
+       caption=Simple diffusion line source example result.
+
+!col small=12 medium=6 large=6
+!media large_media/ray_tracing/simple_diffusion_line_source_mesh.png
+      caption=The result pictured in [result] with a mesh overlay.
+      id=result-mesh
+!row-end!
 
 Just for the purposes of producing a more appealing picture, let's add some adaptivity to the mix to refine the region around the ray.
 
@@ -47,4 +57,14 @@ Setting the number of adaptivity steps to 5 via a command line argument, i.e.:
 
 leads to the well-refined and visually satisfying result below in [result-adaptivity].
 
-!media large_media/ray_tracing/simple_diffusion_line_source_adaptivity.png id=result-adaptivity style=width:70%; caption=Simple diffusion line source example result with adaptivity.
+!row!
+!col small=12 medium=6 large=6
+!media large_media/ray_tracing/simple_diffusion_line_source_adaptivity.png
+       id=result-adaptivity
+       caption=Simple diffusion line source example result with adaptivity.
+
+!col small=12 medium=6 large=6
+!media large_media/ray_tracing/simple_diffusion_line_source_adaptivity_mesh.png
+      caption=The result pictured in [result-adaptivity] with a mesh overlay.
+      id=result-adaptivity-mesh
+!row-end!

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_sources.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/examples/line_sources.md
@@ -8,6 +8,32 @@ We begin with the standard "simple diffusion" problem:
 
 !listing modules/ray_tracing/test/tests/ray_kernels/line_source_ray_kernel/simple_diffusion_line_source.i start=Mesh end=UserObjects
 
+Within this problem, we wish to define a constant line source with constant $c = 5$ between the two points
+
+!equation
+\vec{r}_1 = (1, 1) \quad \text{and} \quad \vec{r}_2 = (5, 2)\,.
+
+The strong form of this system is
+
+!equation
+-\nabla \cdot \nabla u(\vec{r}) = c \delta_L(\vec{r})\,, \quad x \in [0, 5]\,, \quad y \in [0, 5]\,,
+
+!equation
+u(0, y) = 0\,, \quad y \in [0, 5]\,,
+
+!equation
+u(5, y) = 1\,, \quad y \in [0, 5]\,,
+
+where
+
+!equation
+\delta_L(\vec{r}) =
+\begin{cases}
+1\,, & \vec{r} \in L \\
+0\,, & \text{otherwise}
+\end{cases}\,,\quad
+L = \{\vec{r}_1 + t\vec{r}_2 \mid t \in [0, 1]\}\,.
+
 ### Defining the Study
 
 A [RepeatableRayStudy.md] is defined that generates and executes the rays that compute the line source:

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/index.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/index.md
@@ -2,7 +2,7 @@
 
 The ray tracing module traces rays through the finite element mesh. Notable features include:
 
-- Supports all planar finite element types in MOOSE
+- Supports tracing in meshes with planar sides (2D and 3D)
 - Supports mesh adaptivity
 - Supports contribution to residuals and Jacobians along ray segments
 - Supports ray interaction with internal and external boundaries

--- a/modules/ray_tracing/doc/content/modules/ray_tracing/index.md
+++ b/modules/ray_tracing/doc/content/modules/ray_tracing/index.md
@@ -4,7 +4,7 @@ The ray tracing module traces rays through the finite element mesh. Notable feat
 
 - Supports tracing in meshes with planar sides (2D and 3D)
 - Supports mesh adaptivity
-- Supports contribution to residuals and Jacobians along ray segments
+- Supports contribution to residuals and Jacobians (with full coupling support) along ray segments
 - Supports ray interaction with internal and external boundaries
 - Supports storage and manipulation of data unique to each ray
 - Supports ray interaction with field variables


### PR DESCRIPTION
Closes #16507

@WilkAndy, for starters, thank you so much for taking a look at this. I've been pretty busy working on getting the implementation documented which left more to be desired for the simple examples.

Here's a summary with your comments:

> Does RayTracing only work for 2D meshes? The lead page states "planar finite elements" that suggests 2D, but then in my naivety i can't see why 3D meshes are super difficult.

It definitely does. What I meant to say here was planar _sides_. We also support non-planar sides to some extent with an approximation, which does pretty well if your mesh is only a _little_ non-planar. 

See 2bdad2d56971c74dd8756e2575fddacdda62453a and https://mooseframework.inl.gov/docs/PRs/16512/site/modules/ray_tracing/index.html

> In the first equation of https://mooseframework.inl.gov/modules/ray_tracing/examples/line_integrals.html , what is "u_h"? Why isn't it just "u"? Also, i wouldn't include the measure (dr) as i think that's confusing.

This is u_h because it's the integral of the FEM solution, not the true analytic solution. For the comment about dr, I changed u_h -> u_h(\vec{r}) to make this clearer.

See https://mooseframework.inl.gov/docs/PRs/16512/site/modules/ray_tracing/examples/line_integrals.html

> The second equations of https://mooseframework.inl.gov/modules/ray_tracing/examples/line_integrals.html should have r_1 and r_2 - currently they just have r_1.

Fixed in 3df19a699a8685e8133bc5dcee929b9ee393322a.

> I think it'd be nice in https://mooseframework.inl.gov/modules/ray_tracing/examples/line_integrals.html to actually write what you're trying to compute, viz something like \int_{0}^{5} dx sqrt{2}x/5 (or however you want to write it), just because in order to verify the results i had to look back at the input file and see that u = x/5 for this example.

I'm a bit stuck on this because that would require me getting the analytic solution which I think is a little overkill for this example. I really do think that the general form is good enough, but if you disagree I can try at it.

> In https://mooseframework.inl.gov/modules/ray_tracing/examples/line_sources.html i really think you need to write the DE you're trying to solve, viz \nabla^{2}u = 5\delta(x-ray), where ray is specified by the RepeatableRayStudy (and \delta is the 2D Dirac delta function). The reason is that it took me a while to figure this out - i wondered what the "5" was in LineSourceRayKernel, for instance.

I agree. I added the strong form for this system in f69aef27794c84268259502b8fb759f2d987bde6 and https://mooseframework.inl.gov/docs/PRs/16512/site/modules/ray_tracing/examples/line_sources.html

> Might be nice to see the mesh in the pics in https://mooseframework.inl.gov/modules/ray_tracing/examples/line_sources.html

Done and done in 7bef522b36fbcc61dbb3d8351854a4b839c82150 and https://mooseframework.inl.gov/docs/PRs/16512/site/modules/ray_tracing/examples/line_sources.html

> Might be nice to mention more about Jacobians. These are really important in PorousFlow so i need to know whether i can include all Jacobian contributions.

This one is a toughie. We definitely support full coupling. The issue is finding an example that involves coupling and a line source that is general enough to put in the framework. There is a test object for this (see https://github.com/idaholab/moose/blob/next/modules/ray_tracing/test/src/ray_kernels/CoupledLineSourceRayKernelTestTempl.C). If you can think of an example, please let me know.

For now, I added a simple comment about full coupling support in 40b4cdbb87db1049b3d77919d5a1e59970db1995 and https://mooseframework.inl.gov/docs/PRs/16512/site/modules/ray_tracing/index.html.


