### PR TITLE
Working moose-pyhit version for 3. 6, 7, and 8

### DIFF
--- a/conda/pyhit/build.sh
+++ b/conda/pyhit/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eu
 
+git clean -xfd
 cp -R pyhit $SP_DIR/
 cd src
 make bindings

--- a/conda/pyhit/conda_build_config.yaml
+++ b/conda/pyhit/conda_build_config.yaml
@@ -1,3 +1,25 @@
+CONDA_BUILD_SYSROOT:           # [osx]
+  - /opt/MacOSX10.9.sdk        # [osx]
+
+macos_min_version:             # [osx]
+  - 10.9                       # [osx]
+
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx]
+
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.9                       # [osx]
+
+clangxx:
+  - 11.0.0 default_h9e6edd0_2
+
+gxx:
+  - 7.3.0 h553295d_16
+
 python:
- - 3.7
- - 3.6
+  - 3.6.11
+  - 3.7.8
+  - 3.8.3
+
+pin_run_as_build:
+  python: x.x

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.07.13" %}
+{% set version = "2020.12.17" %}
 
 package:
   name: moose-pyhit
@@ -14,11 +14,21 @@ build:
 
 requirements:
   build:
-    - {{ compiler("cxx") }}
+    - gxx_linux-64 {{ gxx }}                 # [linux]
+    - clangxx      {{ clangxx }}             # [osx]
+    - python       {{ python }}
+    - cython
+
   host:
-    - python {{ python }}
+    - gxx_linux-64 {{ gxx }}                 # [linux]
+    - clangxx      {{ clangxx }}             # [osx]
+    - python       {{ python }}
+    - cython
+
   run:
-    - python {{ python }}
+    - gxx_linux-64 {{ gxx }}                 # [linux]
+    - clangxx      {{ clangxx }}             # [osx]
+    - python       {{ python }}
 
 test:
   imports:


### PR DESCRIPTION
Build moose-pyhit for three Python versions.

Closes #16513
