### PR TITLE
Minor SONDefinitionFormatter updates for NEAMS

### DIFF
--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -216,16 +216,16 @@
     requirement = 'The system shall be able to dump a subset of input file (HIT) syntax.'
   [../]
 
-  [./definition_exists_in_test]
+  [./definition_input_choices_test]
     type = 'RunApp'
     input = 'IGNORED'
-    expect_out = 'ExistsIn=\[\s*?EXTRA:"all"\s*?EXTRA:"none"\s*?"../../../../../Outputs/["*"]/decl"\s*?\]'
+    expect_out = 'InputChoices=\[\s*?"all"\s*?"none"\s*?PATH:"../../../../../Outputs/["*"]/decl"\s*?\]'
     cli_args = '--definition'
     # suppress error checking, the word 'ERROR' shows up in the definition dump
     errors = 'zzzzzzzzzz'
     max_buffer_size = -1
-    issues = '#9651'
-    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ExistsIn'
+    issues = '#16165'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check InputChoices'
     design = 'SONDefinitionFormatter.md'
     valgrind = 'HEAVY'
   [../]
@@ -241,7 +241,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ChildAtLeastOne'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_valenum_test]
@@ -255,7 +255,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ValEnums'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_active_parameter_test]
@@ -269,7 +269,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check active parameter'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_normal_sub_test]
@@ -283,7 +283,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check normal_sub'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_type_sub_test]
@@ -297,7 +297,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check type_sub'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_default_type_test]
@@ -311,7 +311,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check default type'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_minvalinc_inputdefault_test]
@@ -325,21 +325,7 @@
     issues = '#9651'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check MinValInc'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
-  [../]
-
-  [./definition_expressions_are_okay_test]
-    type = 'RunApp'
-    input = 'IGNORED'
-    expect_out = '\'function\'{.*\'value\'{.*ExistsIn=\[\s*EXTRA:"ExpressionsAreOkay"\s*"../../../../../Functions/["*"]/decl"\s*\].*}.*} % end parameter function'
-    cli_args = '--definition'
-    # suppress error checking, the word 'ERROR' shows up in the definition dump
-    errors = 'zzzzzzzzzz'
-    max_buffer_size = -1
-    issues = '#9651'
-    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check ExpressionsAreOkay'
-    design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_block_type_maxoccurs_nolimit_test]
@@ -353,7 +339,7 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Block type MaxOccurs NoLimit'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_functionname_type_maxoccurs_nolimit_test]
@@ -367,7 +353,7 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check FunctionName type MaxOccurs NoLimit'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 
   [./definition_array_type_minoccurs_zero_test]
@@ -381,6 +367,6 @@
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Array type MinOccurs zero'
     design = 'SONDefinitionFormatter.md'
-    valgrind = 'NONE' # Tested in "definition_exists_in_test"
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
 []


### PR DESCRIPTION
This fixes some issues with the `SONDefinitionFormatter` produced schema used by the NEAMS Workbench.

 - Propagates `_object_params_set_by_action` (added in #16178) to un-require specified parameters
 - Changes `ExistsIn` rules to `InputChoices` rules for Workbench autocomplete without validation

closes #16165
