### PR TITLE
Converting computeQpResidual to pass-by-reference for array kernels.

### DIFF
--- a/framework/doc/content/source/variables/ArrayMooseVariable.md
+++ b/framework/doc/content/source/variables/ArrayMooseVariable.md
@@ -2,6 +2,8 @@
 
 !syntax description /Variables/ArrayMooseVariable
 
+## Overview
+
 An array variable is define as a set of standard field variables with the same finite element family and order.
 Each standard variable of an array variable is referred to as a component of the array variable.
 An array kernel is a MOOSE kernel operating on an array variable and assembles the residuals and Jacobians for all the components of the array variable.
@@ -30,65 +32,133 @@ OutputType is the data type used for templating.
 RealEigenVector is a typedef in [MooseTypes.h] as *Eigen::Matrix<Real, Eigen::Dynamic, 1>*.
 OutputShape is for the type of shape functions and OutputData is the type of basis function expansion coefficients that are stored in the moose array variable grabbed from the solution vector.
 
-The final form of an array kernel is quite simple. Using `ArrayDiffusion` as an example. The `computeQpResidual` function has
+## Kernels for Array Variables
 
-```
-  return _grad_u[_qp] * _array_grad_test[_i][_qp] * (*_d)[_qp];
-```
+Since array variables have a different OutputData type, standard Kernels cannot be used on array variables. Kernels for array variables, or ArrayKernels, must derive from `ArrayKernel` which have different virtual functions for `computeQpResidual`, `computeQpJacobian`, and `computeQpOffDiagJacobian`. The declaration of these functions are below:
 
-where `_grad_u[_qp]` is an `Eigen::Matrix` with number of rows being equal to the number of components of the array variable and number of columns being `LIBMESH_DIM`. `_array_grad_test[_i][_qp]` is an `Eigen::Map` of classic `_grad_test[_i][_qp]` which is in type of `Gradient`. Thanks to the Eigen matrix arithmetic operators, we can have a simple multiplication expression here. `_d` is a pointer of a material property of `Real` type for scalar diffusion coefficient. Here we assume the diffusion coefficient is the same for all components. The returned value is RealEigenVector, i.e. an Eigen vector.
+!listing language=cpp
+virtual void computeQpResidual(RealEigenVector & residual) = 0;
+virtual RealEigenVector computeQpJacobian();
+virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar);
 
-Of course, if we have different diffusion coefficients for different components, we will have something like
+When defining a `computeQpResidual` in a derived class, this function +must+ define the residual in the input arguement (`residual`). This input is already properly sized when called in ArrayKernel.C. `computeQpJacobian` must return a vector defining the on-diagonal terms of the Jacobian. `computeQpOffDiagJacobian` must return a matrix with number of rows equal to the number of components and number of columns being the number of components in `jvar.`
 
-```
-    RealEigenVector v = _grad_u[_qp] * _array_grad_test[_i][_qp];
-    for (unsigned int i = 0; i < _var.count(); ++i)
-      v(i) *= (*_d_array)[_qp](i);
-```
+Using [ArrayDiffusion.md] as an example. The `computeQpResidual` function has
 
-`_var.count()` gives the number of components of the array variable.
-If we have coupled diffusion terms, i.e. diffusion coefficient is a matrix, we will have
+!listing ArrayDiffusion.C re=void\sArrayDiffusion::computeQpResidual.*?^}
 
-```
-  return (*_d_2d_array)[_qp] * (_grad_u[_qp] * _array_grad_test[_i][_qp]);
-```
+where `_grad_u[_qp]` is an `Eigen::Matrix` with number of rows being equal to the number of components of the array variable and number of columns being `LIBMESH_DIM`. `_array_grad_test[_i][_qp]` is an `Eigen::Map` of classic `_grad_test[_i][_qp]` which is in type of `Gradient`. Thanks to the Eigen matrix arithmetic operators, we can have a simple multiplication expression here. `_d` is a pointer of a material property of `Real` type for scalar diffusion coefficient. Here we assume the diffusion coefficient is the same for all components. `_d_array` is a pointer to a `RealEigenVector` material
+property, here we assume there is a diffusion coefficient for each component with no
+coupling. `_d_2d_array` is a pointer to a `RealEigenMatrix` material property, where
+the diffusion coefficient is represented as dense matrix. See [ArrayDiffusion.md] for more details.
 
 Correspondingly the `computeQpJacobian` has
 
-```
-    return RealEigenVector::Constant(_var.count(),
-                                     _grad_phi[_j][_qp] * _grad_test[_i][_qp] * (*_d)[_qp]);
-```
-
-for a scalar diffusion coefficient or
-
-```
-    return _grad_phi[_j][_qp] * _grad_test[_i][_qp] * (*_d_array)[_qp];
-```
-
-for an array diffusion coefficient or
-
-```
-    return _grad_phi[_j][_qp] * _grad_test[_i][_qp] * (*_d_2d_array)[_qp].diagonal();
-```
-
-for a matrix diffusion coefficient.
+!listing ArrayDiffusion.C re=RealEigenVector\sArrayDiffusion::computeQpJacobian.*?^}
 
 It is noted that only the diagonal entries of the diffusion coefficients are used in the fully-coupled case because `computeQpJacobian` is supposed to only assemble the block-diagonal part of the Jacobian.
 The full local Jacobian is assembled in function `computeQpOffDiagJacobian`, where when the off-diagonal variable is the array variable, we have
 
-```
-  return _grad_phi[_j][_qp] * _grad_test[_i][_qp] * (*_d_2d_array)[_qp];
-```
+!listing ArrayDiffusion.C
+  re=RealEigenMatrix\sArrayDiffusion::computeQpOffDiagJacobian.*?^}
 
 The retuned value is in type of an Eigen matrix with number of rows and columns equal to the number of components.
 
+`ArrayKernel` also has virtual functions including:
+
+!listing language=cpp
+virtual void initQpResidual();
+virtual void initQpJacobian();
+virtual void initQpOffDiagJacobian(const MooseVariableFEBase & jvar);
+
+Which are functions that are called inside the quadrature point loop, but outside the test/shape function loop. This is useful to perform operations that depend on position (quadrature point) but do not depend on the test/shape function. For instance, [ArrayDiffusion.md] uses `initQpResidual` to check if the size of the vector or matrix diffusion coefficient matches the number of components in the variable:
+
+!listing ArrayDiffusion.C re=void\sArrayDiffusion::initQpResidual.*?^}
+
 Future work:
 
-- To profile the code with large number of variables to find the hot spots and fix them if there are any.
-- To change the current dof ordering for elemental variables so that we can avoid bunch of if statements with `isNodal()` in `MooseVariableFE.C`, (refer to [libMesh Issue 2114](https://github.com/libMesh/libmesh/issues/2114).
+- To change the current dof ordering for elemental variables so that we can avoid bunch of if statements with `isNodal()` in `MooseVariableFE.C`, (refer to [libMesh Issue 2114](https://github.com/libMesh/libmesh/issues/2114)).
 - To use Eigen::Map for faster solution vector access.
 - To implement ArrayInterfaceKernel and ArrayConstraints.
+
+## Useful Eigen API
+
+Linear algebra is very easy using Eigen, it has a lot of API for matrix arithmetic and manipulation that simplifies code and helps developers avoid writing their own loops. For a full list of functions, visit the [Eigen matrix doxygen](http://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html), which is relevant to the `RealEigenVector` and `RealEigenMatrix` types in MOOSE. Below is a list of commonly used functions for residual and jacobian evaluations. For exposition here is a definition of a vector and matrix:
+
+!equation
+\vec{v} =
+\begin{bmatrix}
+v_1 \\ v_2 \\ \vdots \\ v_n
+\end{bmatrix}
+\quad , \quad
+M =
+\begin{bmatrix}
+m_{11} & m_{12} & \dots & m_{1n} \\
+m_{21} & m_{22} & \dots & m_{2n} \\
+\vdots & \vdots & \ddots & \vdots \\
+m_{n1} & m_{n2} & \dots & m_{nn}
+\end{bmatrix}
+.
+
+- Set all elements to same value:
+
+  !equation
+  \vec{v}\texttt{.setZero()} \rightarrow v_i = 0, i=1,...,n
+
+  !equation
+  \vec{v}\texttt{.setOnes()} \rightarrow v_i = 1, i=1,...,n
+
+  !equation
+  \vec{v}\texttt{.setConstant(}a\texttt{)} \rightarrow v_i = a, i=1,...,n
+
+- Change matrix representation:
+
+  !equation
+  \vec{v}\texttt{.asDiagonal()} \rightarrow
+  \begin{bmatrix}
+  v_1 &     &        &     \\
+      & v_2 &        &     \\
+      &     & \ddots &     \\
+      &     &        & v_n \\
+  \end{bmatrix}
+
+  !equation
+  M\texttt{.diagonal()} \rightarrow
+  \begin{bmatrix}
+  m_{11} \\ m_{22} \\ \vdots \\ m_{nn}
+  \end{bmatrix}
+
+- Element-wise operations:
+
+  !equation
+  \vec{v} \texttt{ = } \vec{v}\texttt{.cwiseProduct(}\vec{w}\texttt{)} \rightarrow v_i = v_iw_i, i=1,...,n
+
+  !equation
+  \vec{v}\texttt{.array() /= } \vec{w}\texttt{.array()} \rightarrow v_i = v_i/w_i, i=1,...,n
+
+## Eigen Tips and Tricks (Advanced)
+
+Eigen has some unique features that, when used properly, can significantly impact performance. Here are some recommendations that can improve code performance.
+
+- [Aliasing](http://eigen.tuxfamily.org/dox/group__TopicAliasing.html) is a technique in Eigen that contructs temporary objects when performing matrix multiplications, this is to avoid overriding data that needs to be used later in the computation. For instance `vec = mat * vec` will create a temporary vector for `mat * vec` then assign it to `vec` at the end. However, `vec2 = mat * vec1` does not need this temporary object and assign the result to `vec2` directly, this aliasing can be avoided by doing `vec2.noalias()`. The `noalias()` function should be used with extreme caution since it can cause erroneous results.
+
+- Eigen uses what's known as [expression templates](https://en.wikipedia.org/wiki/Expression_templates), enabling operations to be known at compile time. This allows multiple operations to occur in a single element element loop, providing more compiler optimization and improved cache efficiency. With this in mind, it is often better to write multiple Eigen operations in a single line or assignment. For instance, with the following syntax:
+
+  !listing! language=cpp
+  a = 3*b + 4*c + 5*d
+  !listing-end!
+
+  Eigen will compile to a single for loop:
+
+  !listing! language=cpp
+  for (unsigned int i = 0; i < b.size(); ++i)
+    a[i] = 3*b[i] + 4*c[i] + 5*d[i];
+  !listing-end!
+
+- Eigen also has a interface for accessing raw buffers using its [Map class](http://eigen.tuxfamily.org/dox/group__TutorialMapClass.html).
+
+For a better understanding of Eigen and using it to its full potential, it is highly recommended to go through Eigen's [tutorials](http://eigen.tuxfamily.org/dox/modules.html).
+
 
 !syntax parameters  /Variables/ArrayMooseVariable
 

--- a/framework/include/bcs/ArrayDirichletBC.h
+++ b/framework/include/bcs/ArrayDirichletBC.h
@@ -29,7 +29,7 @@ public:
   ArrayDirichletBC(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
 
   /// The value for this BC
   const RealEigenVector & _values;

--- a/framework/include/bcs/ArrayIntegratedBC.h
+++ b/framework/include/bcs/ArrayIntegratedBC.h
@@ -47,7 +47,7 @@ protected:
   /**
    * Method for computing the residual at quadrature points
    */
-  virtual RealEigenVector computeQpResidual() = 0;
+  virtual void computeQpResidual(RealEigenVector & residual) = 0;
 
   /**
    * Method for computing the diagonal Jacobian at quadrature points
@@ -111,4 +111,8 @@ protected:
 
   /// Number of components of the array variable
   const unsigned int _count;
+
+private:
+  /// Work vector for residual
+  RealEigenVector _work_vector;
 };

--- a/framework/include/bcs/ArrayIntegratedBC.h
+++ b/framework/include/bcs/ArrayIntegratedBC.h
@@ -45,7 +45,7 @@ public:
 
 protected:
   /**
-   * Method for computing the residual at quadrature points
+   * Method for computing the residual at quadrature points, to be filled in \p residual.
    */
   virtual void computeQpResidual(RealEigenVector & residual) = 0;
 

--- a/framework/include/bcs/ArrayNodalBC.h
+++ b/framework/include/bcs/ArrayNodalBC.h
@@ -46,7 +46,7 @@ protected:
   /// Value of the unknown variable this BC is acting on
   const RealEigenVector & _u;
 
-  virtual RealEigenVector computeQpResidual() = 0;
+  virtual void computeQpResidual(RealEigenVector & residual) = 0;
 
   /**
    * The user can override this function to compute the "on-diagonal"
@@ -60,4 +60,8 @@ protected:
    * computing an off-diagonal jacobian component.
    */
   virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar);
+
+private:
+  /// Work vector for residual
+  RealEigenVector _work_vector;
 };

--- a/framework/include/bcs/ArrayNodalBC.h
+++ b/framework/include/bcs/ArrayNodalBC.h
@@ -46,6 +46,10 @@ protected:
   /// Value of the unknown variable this BC is acting on
   const RealEigenVector & _u;
 
+  /**
+   * Compute this BC's contribution to the residual at the current quadrature point,
+   * to be filled in \p residual.
+   */
   virtual void computeQpResidual(RealEigenVector & residual) = 0;
 
   /**
@@ -60,6 +64,9 @@ protected:
    * computing an off-diagonal jacobian component.
    */
   virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar);
+
+  /// Number of components of the array variable
+  const unsigned int _count;
 
 private:
   /// Work vector for residual

--- a/framework/include/bcs/ArrayPenaltyDirichletBC.h
+++ b/framework/include/bcs/ArrayPenaltyDirichletBC.h
@@ -24,7 +24,7 @@ public:
   ArrayPenaltyDirichletBC(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
 
 private:

--- a/framework/include/bcs/ArrayVacuumBC.h
+++ b/framework/include/bcs/ArrayVacuumBC.h
@@ -24,7 +24,7 @@ public:
   ArrayVacuumBC(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
 
   /// Ratio of u to du/dn

--- a/framework/include/bcs/EigenArrayDirichletBC.h
+++ b/framework/include/bcs/EigenArrayDirichletBC.h
@@ -24,7 +24,7 @@ public:
   EigenArrayDirichletBC(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
 
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(MooseVariableFEBase & jvar) override;

--- a/framework/include/dgkernels/ArrayDGDiffusion.h
+++ b/framework/include/dgkernels/ArrayDGDiffusion.h
@@ -27,11 +27,15 @@ public:
   ArrayDGDiffusion(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual(Moose::DGResidualType type) override;
+  virtual void initQpResidual(Moose::DGResidualType type) override;
+  virtual void computeQpResidual(Moose::DGResidualType type, RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian(Moose::DGJacobianType type) override;
 
   Real _epsilon;
   Real _sigma;
   const MaterialProperty<RealEigenVector> & _diff;
   const MaterialProperty<RealEigenVector> & _diff_neighbor;
+
+  RealEigenVector _res1;
+  RealEigenVector _res2;
 };

--- a/framework/include/dgkernels/ArrayDGKernel.h
+++ b/framework/include/dgkernels/ArrayDGKernel.h
@@ -65,7 +65,7 @@ public:
 protected:
   /**
    * This is the virtual that derived classes should override for computing the residual on
-   * neighboring element.
+   * neighboring element. Residual to be filled in \p residual.
    */
   virtual void computeQpResidual(Moose::DGResidualType type, RealEigenVector & residual) = 0;
 

--- a/framework/include/dgkernels/ArrayDGKernel.h
+++ b/framework/include/dgkernels/ArrayDGKernel.h
@@ -67,7 +67,7 @@ protected:
    * This is the virtual that derived classes should override for computing the residual on
    * neighboring element.
    */
-  virtual RealEigenVector computeQpResidual(Moose::DGResidualType type) = 0;
+  virtual void computeQpResidual(Moose::DGResidualType type, RealEigenVector & residual) = 0;
 
   /**
    * This is the virtual that derived classes should override for computing the Jacobian on
@@ -142,4 +142,8 @@ protected:
   const std::vector<Eigen::Map<RealDIMValue>> & _array_normals;
   /// Number of components of the array variable
   const unsigned int _count;
+
+private:
+  /// Work vector for residual computation
+  RealEigenVector _work_vector;
 };

--- a/framework/include/kernels/ArrayDiffusion.h
+++ b/framework/include/kernels/ArrayDiffusion.h
@@ -24,7 +24,8 @@ public:
   ArrayDiffusion(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void initQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 

--- a/framework/include/kernels/ArrayKernel.h
+++ b/framework/include/kernels/ArrayKernel.h
@@ -44,7 +44,8 @@ public:
 
 protected:
   /**
-   * Compute this Kernel's contribution to the residual at the current quadrature point
+   * Compute this Kernel's contribution to the residual at the current quadrature point,
+   * to be filled in \p residual.
    */
   virtual void computeQpResidual(RealEigenVector & residual) = 0;
 

--- a/framework/include/kernels/ArrayKernel.h
+++ b/framework/include/kernels/ArrayKernel.h
@@ -46,7 +46,7 @@ protected:
   /**
    * Compute this Kernel's contribution to the residual at the current quadrature point
    */
-  virtual RealEigenVector computeQpResidual() = 0;
+  virtual void computeQpResidual(RealEigenVector & residual) = 0;
 
   /**
    * Compute this Kernel's contribution to the diagonal Jacobian at the current quadrature point

--- a/framework/include/kernels/ArrayReaction.h
+++ b/framework/include/kernels/ArrayReaction.h
@@ -24,7 +24,7 @@ public:
   ArrayReaction(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 

--- a/framework/include/kernels/ArrayTimeDerivative.h
+++ b/framework/include/kernels/ArrayTimeDerivative.h
@@ -25,7 +25,7 @@ public:
   ArrayTimeDerivative(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 

--- a/framework/src/bcs/ArrayDirichletBC.C
+++ b/framework/src/bcs/ArrayDirichletBC.C
@@ -31,8 +31,8 @@ ArrayDirichletBC::ArrayDirichletBC(const InputParameters & parameters)
 {
 }
 
-RealEigenVector
-ArrayDirichletBC::computeQpResidual()
+void
+ArrayDirichletBC::computeQpResidual(RealEigenVector & residual)
 {
-  return _u - _values;
+  residual = _u - _values;
 }

--- a/framework/src/bcs/ArrayDirichletBC.C
+++ b/framework/src/bcs/ArrayDirichletBC.C
@@ -29,6 +29,9 @@ ArrayDirichletBC::validParams()
 ArrayDirichletBC::ArrayDirichletBC(const InputParameters & parameters)
   : ArrayNodalBC(parameters), _values(getParam<RealEigenVector>("values"))
 {
+  if (_values.size() != _count)
+    paramError(
+        "values", "Number of 'values' must equal number of variable components (", _count, ").");
 }
 
 void

--- a/framework/src/bcs/ArrayIntegratedBC.C
+++ b/framework/src/bcs/ArrayIntegratedBC.C
@@ -90,6 +90,7 @@ ArrayIntegratedBC::computeResidual()
     initQpResidual();
     for (_i = 0; _i < _test.size(); _i++)
     {
+      _work_vector.setZero();
       computeQpResidual(_work_vector);
       mooseAssert(_work_vector.size() == _count,
                   "Size of local residual is not equal to the number of array variable compoments");

--- a/framework/src/bcs/ArrayIntegratedBC.C
+++ b/framework/src/bcs/ArrayIntegratedBC.C
@@ -38,7 +38,8 @@ ArrayIntegratedBC::ArrayIntegratedBC(const InputParameters & parameters)
     _phi(_assembly.phiFace(_var)),
     _test(_var.phiFace()),
     _u(_is_implicit ? _var.sln() : _var.slnOld()),
-    _count(_var.count())
+    _count(_var.count()),
+    _work_vector(_count)
 {
   addMooseVariableDependency(mooseVariable());
 
@@ -89,10 +90,11 @@ ArrayIntegratedBC::computeResidual()
     initQpResidual();
     for (_i = 0; _i < _test.size(); _i++)
     {
-      RealEigenVector residual = _JxW[_qp] * _coord[_qp] * computeQpResidual();
-      mooseAssert(residual.size() == _count,
+      computeQpResidual(_work_vector);
+      mooseAssert(_work_vector.size() == _count,
                   "Size of local residual is not equal to the number of array variable compoments");
-      _assembly.saveLocalArrayResidual(_local_re, _i, _test.size(), residual);
+      _work_vector *= _JxW[_qp] * _coord[_qp];
+      _assembly.saveLocalArrayResidual(_local_re, _i, _test.size(), _work_vector);
     }
   }
 

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -43,6 +43,7 @@ ArrayNodalBC::computeResidual()
 {
   if (_var.isNodalDefined())
   {
+    _work_vector.setZero();
     computeQpResidual(_work_vector);
 
     for (auto tag_id : _vector_tags)

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -33,7 +33,8 @@ ArrayNodalBC::ArrayNodalBC(const InputParameters & parameters)
     _var(*mooseVariable()),
     _current_node(_var.node()),
     _u(_var.nodalValue()),
-    _work_vector(_var.count())
+    _count(_var.count()),
+    _work_vector(_count)
 {
   addMooseVariableDependency(mooseVariable());
 }
@@ -45,6 +46,8 @@ ArrayNodalBC::computeResidual()
   {
     _work_vector.setZero();
     computeQpResidual(_work_vector);
+    mooseAssert(_work_vector.size() == _count,
+                "Size of local residual is not equal to the number of array variable components");
 
     for (auto tag_id : _vector_tags)
       if (_sys.hasVector(tag_id))

--- a/framework/src/bcs/ArrayNodalBC.C
+++ b/framework/src/bcs/ArrayNodalBC.C
@@ -32,7 +32,8 @@ ArrayNodalBC::ArrayNodalBC(const InputParameters & parameters)
                                             Moose::VarFieldType::VAR_FIELD_ARRAY),
     _var(*mooseVariable()),
     _current_node(_var.node()),
-    _u(_var.nodalValue())
+    _u(_var.nodalValue()),
+    _work_vector(_var.count())
 {
   addMooseVariableDependency(mooseVariable());
 }
@@ -42,11 +43,11 @@ ArrayNodalBC::computeResidual()
 {
   if (_var.isNodalDefined())
   {
-    RealEigenVector res = computeQpResidual();
+    computeQpResidual(_work_vector);
 
     for (auto tag_id : _vector_tags)
       if (_sys.hasVector(tag_id))
-        _var.insertNodalValue(_sys.getVector(tag_id), res);
+        _var.insertNodalValue(_sys.getVector(tag_id), _work_vector);
   }
 }
 

--- a/framework/src/bcs/ArrayPenaltyDirichletBC.C
+++ b/framework/src/bcs/ArrayPenaltyDirichletBC.C
@@ -32,6 +32,9 @@ ArrayPenaltyDirichletBC::ArrayPenaltyDirichletBC(const InputParameters & paramet
     _p(getParam<Real>("penalty")),
     _v(getParam<RealEigenVector>("value"))
 {
+  if (_v.size() != _count)
+    paramError(
+        "value", "Number of 'values' must equal number of variable components (", _count, ").");
 }
 
 void

--- a/framework/src/bcs/ArrayPenaltyDirichletBC.C
+++ b/framework/src/bcs/ArrayPenaltyDirichletBC.C
@@ -34,10 +34,10 @@ ArrayPenaltyDirichletBC::ArrayPenaltyDirichletBC(const InputParameters & paramet
 {
 }
 
-RealEigenVector
-ArrayPenaltyDirichletBC::computeQpResidual()
+void
+ArrayPenaltyDirichletBC::computeQpResidual(RealEigenVector & residual)
 {
-  return _p * _test[_i][_qp] * (_u[_qp] - _v);
+  residual = _p * _test[_i][_qp] * (_u[_qp] - _v);
 }
 
 RealEigenVector

--- a/framework/src/bcs/ArrayVacuumBC.C
+++ b/framework/src/bcs/ArrayVacuumBC.C
@@ -31,10 +31,10 @@ ArrayVacuumBC::ArrayVacuumBC(const InputParameters & parameters)
   _alpha /= 2;
 }
 
-RealEigenVector
-ArrayVacuumBC::computeQpResidual()
+void
+ArrayVacuumBC::computeQpResidual(RealEigenVector & residual)
 {
-  return _alpha.cwiseProduct(_u[_qp]) * _test[_i][_qp];
+  residual = _alpha.cwiseProduct(_u[_qp]) * _test[_i][_qp];
 }
 
 RealEigenVector

--- a/framework/src/bcs/ArrayVacuumBC.C
+++ b/framework/src/bcs/ArrayVacuumBC.C
@@ -28,6 +28,10 @@ ArrayVacuumBC::ArrayVacuumBC(const InputParameters & parameters)
     _alpha(isParamValid("alpha") ? getParam<RealEigenVector>("alpha")
                                  : RealEigenVector::Ones(_count))
 {
+  if (_alpha.size() != _count)
+    paramError(
+        "alpha", "Number of values must equal number of variable components (", _count, ").");
+
   _alpha /= 2;
 }
 

--- a/framework/src/bcs/EigenArrayDirichletBC.C
+++ b/framework/src/bcs/EigenArrayDirichletBC.C
@@ -29,10 +29,10 @@ EigenArrayDirichletBC::EigenArrayDirichletBC(const InputParameters & parameters)
 {
 }
 
-RealEigenVector
-EigenArrayDirichletBC::computeQpResidual()
+void
+EigenArrayDirichletBC::computeQpResidual(RealEigenVector & residual)
 {
-  return RealEigenVector::Zero(_var.count());
+  residual.setZero();
 }
 
 RealEigenVector

--- a/framework/src/dgkernels/ArrayDGDiffusion.C
+++ b/framework/src/dgkernels/ArrayDGDiffusion.C
@@ -35,41 +35,51 @@ ArrayDGDiffusion::ArrayDGDiffusion(const InputParameters & parameters)
     _epsilon(getParam<Real>("epsilon")),
     _sigma(getParam<Real>("sigma")),
     _diff(getMaterialProperty<RealEigenVector>("diff")),
-    _diff_neighbor(getNeighborMaterialProperty<RealEigenVector>("diff"))
+    _diff_neighbor(getNeighborMaterialProperty<RealEigenVector>("diff")),
+    _res1(_count),
+    _res2(_count)
 {
 }
 
-RealEigenVector
-ArrayDGDiffusion::computeQpResidual(Moose::DGResidualType type)
+void
+ArrayDGDiffusion::initQpResidual(Moose::DGResidualType type)
 {
-  RealEigenVector r = RealEigenVector::Zero(_count);
-
   const unsigned int elem_b_order = _var.order();
   const Real h_elem =
       _current_elem_volume / _current_side_volume * 1. / Utility::pow<2>(elem_b_order);
 
+  _res1.noalias() = _diff[_qp].asDiagonal() * _grad_u[_qp] * _array_normals[_qp];
+  _res1.noalias() += _diff_neighbor[_qp].asDiagonal() * _grad_u_neighbor[_qp] * _array_normals[_qp];
+  _res1 *= 0.5;
+  _res1 -= (_u[_qp] - _u_neighbor[_qp]) * _sigma / h_elem;
+
   switch (type)
   {
     case Moose::Element:
-      r -= (_diff[_qp].cwiseProduct(_grad_u[_qp] * _array_normals[_qp]) +
-            _diff_neighbor[_qp].cwiseProduct(_grad_u_neighbor[_qp] * _array_normals[_qp])) *
-           (0.5 * _test[_i][_qp]);
-      r += _diff[_qp].cwiseProduct(_u[_qp] - _u_neighbor[_qp]) * (_epsilon * 0.5) *
-           (_grad_test[_i][_qp] * _normals[_qp]);
-      r += (_u[_qp] - _u_neighbor[_qp]) * (_sigma / h_elem * _test[_i][_qp]);
+      _res2.noalias() = _diff[_qp].asDiagonal() * (_u[_qp] - _u_neighbor[_qp]) * _epsilon * 0.5;
       break;
 
     case Moose::Neighbor:
-      r += (_diff[_qp].cwiseProduct(_grad_u[_qp] * _array_normals[_qp]) +
-            _diff_neighbor[_qp].cwiseProduct(_grad_u_neighbor[_qp] * _array_normals[_qp])) *
-           (0.5 * _test_neighbor[_i][_qp]);
-      r += _diff_neighbor[_qp].cwiseProduct(_u[_qp] - _u_neighbor[_qp]) * (_epsilon * 0.5) *
-           (_grad_test_neighbor[_i][_qp] * _normals[_qp]);
-      r -= (_u[_qp] - _u_neighbor[_qp]) * (_sigma / h_elem * _test_neighbor[_i][_qp]);
+      _res2.noalias() =
+          _diff_neighbor[_qp].asDiagonal() * (_u[_qp] - _u_neighbor[_qp]) * _epsilon * 0.5;
       break;
   }
+}
 
-  return r;
+void
+ArrayDGDiffusion::computeQpResidual(Moose::DGResidualType type, RealEigenVector & residual)
+{
+  switch (type)
+  {
+    case Moose::Element:
+      residual = -_res1 * _test[_i][_qp] + _res2 * (_grad_test[_i][_qp] * _normals[_qp]);
+      break;
+
+    case Moose::Neighbor:
+      residual =
+          _res1 * _test_neighbor[_i][_qp] + _res2 * (_grad_test_neighbor[_i][_qp] * _normals[_qp]);
+      break;
+  }
 }
 
 RealEigenVector

--- a/framework/src/dgkernels/ArrayDGDiffusion.C
+++ b/framework/src/dgkernels/ArrayDGDiffusion.C
@@ -44,6 +44,10 @@ ArrayDGDiffusion::ArrayDGDiffusion(const InputParameters & parameters)
 void
 ArrayDGDiffusion::initQpResidual(Moose::DGResidualType type)
 {
+  mooseAssert(_diff[_qp].size() == _count && _diff_neighbor[_qp].size() == _count,
+              "'diff' size is inconsistent with the number of components of array "
+              "variable");
+
   const unsigned int elem_b_order = _var.order();
   const Real h_elem =
       _current_elem_volume / _current_side_volume * 1. / Utility::pow<2>(elem_b_order);

--- a/framework/src/dgkernels/ArrayDGDiffusion.C
+++ b/framework/src/dgkernels/ArrayDGDiffusion.C
@@ -48,6 +48,7 @@ ArrayDGDiffusion::initQpResidual(Moose::DGResidualType type)
   const Real h_elem =
       _current_elem_volume / _current_side_volume * 1. / Utility::pow<2>(elem_b_order);
 
+  // WARNING: use noalias() syntax with caution. See ArrayDiffusion.C for more details.
   _res1.noalias() = _diff[_qp].asDiagonal() * _grad_u[_qp] * _array_normals[_qp];
   _res1.noalias() += _diff_neighbor[_qp].asDiagonal() * _grad_u_neighbor[_qp] * _array_normals[_qp];
   _res1 *= 0.5;

--- a/framework/src/dgkernels/ArrayDGKernel.C
+++ b/framework/src/dgkernels/ArrayDGKernel.C
@@ -139,6 +139,7 @@ ArrayDGKernel::computeElemNeighResidual(Moose::DGResidualType type)
     initQpResidual(type);
     for (_i = 0; _i < test_space.size(); _i++)
     {
+      _work_vector.setZero();
       computeQpResidual(type, _work_vector);
       mooseAssert(_work_vector.size() == _count,
                   "Size of local residual is not equal to the number of array variable compoments");

--- a/framework/src/kernels/ArrayKernel.C
+++ b/framework/src/kernels/ArrayKernel.C
@@ -103,6 +103,7 @@ ArrayKernel::computeResidual()
     initQpResidual();
     for (_i = 0; _i < _test.size(); _i++)
     {
+      _work_vector.setZero();
       computeQpResidual(_work_vector);
       mooseAssert(_work_vector.size() == _count,
                   "Size of local residual is not equal to the number of array variable compoments");

--- a/framework/src/kernels/ArrayKernel.C
+++ b/framework/src/kernels/ArrayKernel.C
@@ -43,7 +43,8 @@ ArrayKernel::ArrayKernel(const InputParameters & parameters)
     _grad_phi(_assembly.gradPhi(_var)),
     _u(_is_implicit ? _var.sln() : _var.slnOld()),
     _grad_u(_is_implicit ? _var.gradSln() : _var.gradSlnOld()),
-    _count(_var.count())
+    _count(_var.count()),
+    _work_vector(_count)
 {
   addMooseVariableDependency(mooseVariable());
 
@@ -102,9 +103,10 @@ ArrayKernel::computeResidual()
     initQpResidual();
     for (_i = 0; _i < _test.size(); _i++)
     {
-      _work_vector = computeQpResidual() * _JxW[_qp] * _coord[_qp];
+      computeQpResidual(_work_vector);
       mooseAssert(_work_vector.size() == _count,
                   "Size of local residual is not equal to the number of array variable compoments");
+      _work_vector *= _JxW[_qp] * _coord[_qp];
       _assembly.saveLocalArrayResidual(_local_re, _i, _test.size(), _work_vector);
     }
   }

--- a/framework/src/kernels/ArrayReaction.C
+++ b/framework/src/kernels/ArrayReaction.C
@@ -56,6 +56,7 @@ ArrayReaction::computeQpResidual(RealEigenVector & residual)
     mooseAssert((*_r_array)[_qp].size() == _var.count(),
                 "reaction_coefficient size is inconsistent with the number of components of array "
                 "variable");
+    // WARNING: use noalias() syntax with caution. See ArrayDiffusion.C for more details.
     residual.noalias() = (*_r_array)[_qp].asDiagonal() * _u[_qp] * _test[_i][_qp];
   }
 
@@ -67,6 +68,7 @@ ArrayReaction::computeQpResidual(RealEigenVector & residual)
     mooseAssert((*_r_2d_array)[_qp].rows() == _var.count(),
                 "reaction_coefficient size is inconsistent with the number of components of array "
                 "variable");
+    // WARNING: use noalias() syntax with caution. See ArrayDiffusion.C for more details.
     residual.noalias() = (*_r_2d_array)[_qp] * _u[_qp] * _test[_i][_qp];
   }
 }

--- a/framework/src/kernels/ArrayReaction.C
+++ b/framework/src/kernels/ArrayReaction.C
@@ -44,18 +44,19 @@ ArrayReaction::ArrayReaction(const InputParameters & parameters)
   }
 }
 
-RealEigenVector
-ArrayReaction::computeQpResidual()
+void
+ArrayReaction::computeQpResidual(RealEigenVector & residual)
 {
+
   if (_r)
-    return (*_r)[_qp] * _u[_qp] * _test[_i][_qp];
+    residual = (*_r)[_qp] * _u[_qp] * _test[_i][_qp];
 
   else if (_r_array)
   {
     mooseAssert((*_r_array)[_qp].size() == _var.count(),
                 "reaction_coefficient size is inconsistent with the number of components of array "
                 "variable");
-    return ((*_r_array)[_qp].array() * _u[_qp].array()) * _test[_i][_qp];
+    residual.noalias() = (*_r_array)[_qp].asDiagonal() * _u[_qp] * _test[_i][_qp];
   }
 
   else
@@ -66,7 +67,7 @@ ArrayReaction::computeQpResidual()
     mooseAssert((*_r_2d_array)[_qp].rows() == _var.count(),
                 "reaction_coefficient size is inconsistent with the number of components of array "
                 "variable");
-    return (*_r_2d_array)[_qp] * _u[_qp] * _test[_i][_qp];
+    residual.noalias() = (*_r_2d_array)[_qp] * _u[_qp] * _test[_i][_qp];
   }
 }
 

--- a/framework/src/kernels/ArrayTimeDerivative.C
+++ b/framework/src/kernels/ArrayTimeDerivative.C
@@ -54,6 +54,7 @@ ArrayTimeDerivative::computeQpResidual(RealEigenVector & residual)
     mooseAssert((*_coeff_array)[_qp].size() == _var.count(),
                 "time_derivative_coefficient size is inconsistent with the number of components "
                 "in array variable");
+    // WARNING: use noalias() syntax with caution. See ArrayDiffusion.C for more details.
     residual.noalias() = (*_coeff_array)[_qp].asDiagonal() * _u_dot[_qp] * _test[_i][_qp];
   }
   else
@@ -64,6 +65,7 @@ ArrayTimeDerivative::computeQpResidual(RealEigenVector & residual)
     mooseAssert((*_coeff_2d_array)[_qp].rows() == _var.count(),
                 "time_derivative_coefficient size is inconsistent with the number of components "
                 "in array variable");
+    // WARNING: use noalias() syntax with caution. See ArrayDiffusion.C for more details.
     residual.noalias() = (*_coeff_2d_array)[_qp] * _u_dot[_qp] * _test[_i][_qp];
   }
 }

--- a/framework/src/kernels/ArrayTimeDerivative.C
+++ b/framework/src/kernels/ArrayTimeDerivative.C
@@ -44,17 +44,17 @@ ArrayTimeDerivative::ArrayTimeDerivative(const InputParameters & parameters)
   }
 }
 
-RealEigenVector
-ArrayTimeDerivative::computeQpResidual()
+void
+ArrayTimeDerivative::computeQpResidual(RealEigenVector & residual)
 {
   if (_coeff)
-    return (*_coeff)[_qp] * _u_dot[_qp] * _test[_i][_qp];
+    residual = (*_coeff)[_qp] * _u_dot[_qp] * _test[_i][_qp];
   else if (_coeff_array)
   {
     mooseAssert((*_coeff_array)[_qp].size() == _var.count(),
                 "time_derivative_coefficient size is inconsistent with the number of components "
                 "in array variable");
-    return ((*_coeff_array)[_qp].array() * _u_dot[_qp].array()) * _test[_i][_qp];
+    residual.noalias() = (*_coeff_array)[_qp].asDiagonal() * _u_dot[_qp] * _test[_i][_qp];
   }
   else
   {
@@ -64,7 +64,7 @@ ArrayTimeDerivative::computeQpResidual()
     mooseAssert((*_coeff_2d_array)[_qp].rows() == _var.count(),
                 "time_derivative_coefficient size is inconsistent with the number of components "
                 "in array variable");
-    return (*_coeff_2d_array)[_qp] * _u_dot[_qp] * _test[_i][_qp];
+    residual.noalias() = (*_coeff_2d_array)[_qp] * _u_dot[_qp] * _test[_i][_qp];
   }
 }
 

--- a/test/include/kernels/ArrayCoupledForce.h
+++ b/test/include/kernels/ArrayCoupledForce.h
@@ -19,7 +19,7 @@ public:
   ArrayCoupledForce(const InputParameters & parameters);
 
 protected:
-  virtual RealEigenVector computeQpResidual() override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
 
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 

--- a/test/src/kernels/ArrayCoupledForce.C
+++ b/test/src/kernels/ArrayCoupledForce.C
@@ -39,10 +39,10 @@ ArrayCoupledForce::ArrayCoupledForce(const InputParameters & parameters)
     mooseError("We are testing the coupling of a standard variable to an array variable");
 }
 
-RealEigenVector
-ArrayCoupledForce::computeQpResidual()
+void
+ArrayCoupledForce::computeQpResidual(RealEigenVector & residual)
 {
-  return -_coef * (_v[_qp] * _test[_i][_qp]);
+  residual = -_coef * _v[_qp] * _test[_i][_qp];
 }
 
 RealEigenMatrix


### PR DESCRIPTION
This PR converts the `computeQpResidual` API in array kernels to pass-by-reference. This allows for more flexibility in optimizing this function for large array variables. See the discussion in #16504 for more details. I've also added some documentation in ArrayMooseVariable.md for some of the things I've learned through the process of optimizing residual evaluations.

Closes #16504 