### PR TITLE
Allow user setting of timestep tolerance for multiapps.

### DIFF
--- a/framework/src/multiapps/TransientMultiApp.C
+++ b/framework/src/multiapps/TransientMultiApp.C
@@ -208,7 +208,7 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
       Real app_time_offset = _apps[i]->getGlobalTimeOffset();
 
       // Maybe this MultiApp was already solved
-      if ((ex->getTime() + app_time_offset + 2e-14 >= target_time) ||
+      if ((ex->getTime() + app_time_offset + ex->timestepTol() >= target_time) ||
           (ex->getTime() >= ex->endTime()))
         continue;
 
@@ -262,7 +262,7 @@ TransientMultiApp::solveStep(Real dt, Real target_time, bool auto_advance)
         bool local_first = _first;
 
         // Now do all of the solves we need
-        while ((!at_steady && ex->getTime() + app_time_offset + 2e-14 < target_time) ||
+        while ((!at_steady && ex->getTime() + app_time_offset + ex->timestepTol() < target_time) ||
                !ex->lastSolveConverged())
         {
           if (local_first != true)


### PR DESCRIPTION
Allow users to control the timestep tolerance for synchronization when using multiapps, rather than a fixed value.

Closes #16642
