### PR TITLE
Patch Powertools Enabling for Yum Installs

### DIFF
--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-# Enable powertools if present
-PT_REPO=/etc/yum.repos.d/CentOS-PowerTools.repo
-if [ -f $PT_REPO ]; then
-  sed -i 's|^enabled=0|enabled=1|g' $PT_REPO
-fi
+# Update package lists
+yum update -y
+
+# Enable powertools repo
+yum install -y dnf-plugins-core
+yum config-manager --set-enabled powertools
 
 # Needed for subsequent yum installs to work
 touch /var/lib/rpm/*
-
-# Update package lists
-yum update -y
 
 # Install packages
 yum install -y \


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
There used to be a file for the PowerTools repo in CentOS 8 that we could flip `enabled` to one on, but this has stopped existing recently.  Instead of that hack, we now enable the PowerTools repository the proper way through `yum`.  Closes #16654.