### PR TITLE
fix order test

### DIFF
--- a/test/tests/quadrature/order/material_with_order.i
+++ b/test/tests/quadrature/order/material_with_order.i
@@ -1,4 +1,5 @@
 [Mesh]
+  parallel_type = REPLICATED
   [cmg]
     type = CartesianMeshGenerator
     dim = 2


### PR DESCRIPTION
This test uses the cartesian mesh generator - which always creates a
replicated mesh by default.  So without forcing replicated from the
input file, the recover tests try to read in the replicated mesh from
the checkpoint files into a distributed mesh object.  That doesn't work.
This fixes failures introduced by #15790.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
