### PR TITLE
Add out of bounds check code for AD derivative vector

### DIFF
--- a/framework/src/bcs/ADIntegratedBC.C
+++ b/framework/src/bcs/ADIntegratedBC.C
@@ -150,8 +150,11 @@ ADIntegratedBCTempl<T>::addJacobian(const MooseVariableFieldBase & jvariable)
 
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jvariable.phiSize(); _j++)
+    {
+      mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                  "Out of bounds access in derivative vector.");
       _local_ke(_i, _j) += _residuals[_i].derivatives()[ad_offset + _j];
-
+    }
   accumulateTaggedLocalMatrix();
 }
 

--- a/framework/src/bcs/ADNodalBC.C
+++ b/framework/src/bcs/ADNodalBC.C
@@ -102,6 +102,14 @@ ADNodalBCTempl<T>::computeJacobian()
     if (_sys.hasMatrix(tag))
       for (std::size_t i = 0; i < cached_rows.size(); ++i)
         if (_set_components[i])
+        {
+#ifdef MOOSE_GLOBAL_AD_INDEXING
+          mooseAssert(cached_rows[i] < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
+#else
+          mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
+#endif
           _fe_problem.assembly(0).cacheJacobian(cached_rows[i],
                                                 cached_rows[i],
                                                 conversionHelper(residual, i)
@@ -113,6 +121,7 @@ ADNodalBCTempl<T>::computeJacobian()
 #endif
           ],
                                                 tag);
+        }
 }
 
 template <typename T>
@@ -140,6 +149,14 @@ ADNodalBCTempl<T>::computeOffDiagJacobian(const unsigned int jvar_num)
       if (_sys.hasMatrix(tag))
         for (std::size_t i = 0; i < cached_rows.size(); ++i)
           if (_set_components[i])
+          {
+#ifdef MOOSE_GLOBAL_AD_INDEXING
+            mooseAssert(cached_col < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                        "Out of bounds access in derivative vector.");
+#else
+            mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                        "Out of bounds access in derivative vector.");
+#endif
             _fe_problem.assembly(0).cacheJacobian(cached_rows[i],
                                                   cached_col,
                                                   conversionHelper(residual, i)
@@ -151,6 +168,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobian(const unsigned int jvar_num)
 #endif
             ],
                                                   tag);
+          }
   }
 }
 
@@ -182,6 +200,14 @@ ADNodalBCTempl<T>::computeOffDiagJacobianScalar(unsigned int jvar)
     if (_sys.hasMatrix(tag))
       for (std::size_t i = 0; i < cached_rows.size(); ++i)
         if (_set_components[i])
+        {
+#ifdef MOOSE_GLOBAL_AD_INDEXING
+          mooseAssert(scalar_dof_indices[0] < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
+#else
+          mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
+#endif
           _fe_problem.assembly(0).cacheJacobian(cached_rows[i],
                                                 scalar_dof_indices[0],
                                                 conversionHelper(residual, i)
@@ -193,6 +219,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobianScalar(unsigned int jvar)
 #endif
           ],
                                                 tag);
+        }
 }
 
 template class ADNodalBCTempl<Real>;

--- a/framework/src/constraints/ADMortarConstraint.C
+++ b/framework/src/constraints/ADMortarConstraint.C
@@ -156,7 +156,11 @@ ADMortarConstraint::computeJacobian(Moose::MortarType mortar_type)
         prepareMatrixTagLower(_assembly, ivar, jvar, jacobian_types[type_index]);
         for (_i = 0; _i < test_space_size; _i++)
           for (_j = 0; _j < shape_space_sizes[type_index]; _j++)
+          {
+            mooseAssert(ad_offsets[type_index] + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                        "Out of bounds access in derivative vector.");
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offsets[type_index] + _j];
+          }
         accumulateTaggedLocalMatrix();
       }
     }

--- a/framework/src/dgkernels/ADDGKernel.C
+++ b/framework/src/dgkernels/ADDGKernel.C
@@ -181,7 +181,11 @@ ADDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
 
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
+        {
+          mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
           _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
+        }
 
       accumulateTaggedLocalMatrix();
     };
@@ -286,7 +290,11 @@ ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, const Mo
 
         for (_i = 0; _i < test_space.size(); _i++)
           for (_j = 0; _j < loc_phi.size(); _j++)
+          {
+            mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                        "Out of bounds access in derivative vector.");
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
+          }
 
         accumulateTaggedLocalMatrix();
       };

--- a/framework/src/fvbcs/FVFluxBC.C
+++ b/framework/src/fvbcs/FVFluxBC.C
@@ -115,6 +115,8 @@ FVFluxBC::computeJacobian(Moose::DGJacobianType type, const ADReal & residual)
                 "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                 "for a number of dof indices equal to  1");
 
+    mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                "Out of bounds access in derivative vector.");
     _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
     accumulateTaggedLocalMatrix();

--- a/framework/src/fvkernels/FVElementalKernel.C
+++ b/framework/src/fvkernels/FVElementalKernel.C
@@ -68,6 +68,8 @@ FVElementalKernel::computeJacobian()
     prepareMatrixTag(_assembly, _var.number(), _var.number());
     auto dofs_per_elem = _subproblem.systemBaseNonlinear().getMaxVarNDofsPerElem();
     auto ad_offset = Moose::adOffset(_var.number(), dofs_per_elem);
+    mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                "Out of bounds access in derivative vector.");
     _local_ke(0, 0) += residual.derivatives()[ad_offset];
     accumulateTaggedLocalMatrix();
   };
@@ -114,6 +116,8 @@ FVElementalKernel::computeOffDiagJacobian()
                   "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                   "for a number of dof indices equal to  1");
 
+      mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                  "Out of bounds access in derivative vector.");
       _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
       accumulateTaggedLocalMatrix();

--- a/framework/src/fvkernels/FVFluxKernel.C
+++ b/framework/src/fvkernels/FVFluxKernel.C
@@ -180,6 +180,8 @@ FVFluxKernel::computeJacobian(Moose::DGJacobianType type, const ADReal & residua
                 "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                 "for a number of dof indices equal to  1");
 
+    mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                "Out of bounds access in derivative vector.");
     _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
     accumulateTaggedLocalMatrix();

--- a/framework/src/interfacekernels/ADInterfaceKernel.C
+++ b/framework/src/interfacekernels/ADInterfaceKernel.C
@@ -171,8 +171,11 @@ ADInterfaceKernelTempl<T>::computeElemNeighJacobian(Moose::DGJacobianType type)
 
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
+        {
+          mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                      "Out of bounds access in derivative vector.");
           _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
-
+        }
       accumulateTaggedLocalMatrix();
     };
 
@@ -281,8 +284,11 @@ ADInterfaceKernelTempl<T>::computeOffDiagElemNeighJacobian(Moose::DGJacobianType
 
         for (_i = 0; _i < test_space.size(); _i++)
           for (_j = 0; _j < loc_phi.size(); _j++)
+          {
+            mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                        "Out of bounds access in derivative vector.");
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
-
+          }
         accumulateTaggedLocalMatrix();
       };
 

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -172,7 +172,11 @@ ADKernelTempl<T>::addJacobian(const MooseVariableFieldBase & jvariable)
 
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jvariable.phiSize(); _j++)
+    {
+      mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                  "Out of bounds access in derivative vector.");
       _local_ke(_i, _j) += _residuals[_i].derivatives()[ad_offset + _j];
+    }
 
   accumulateTaggedLocalMatrix();
 }

--- a/framework/src/utils/ADUtils.C
+++ b/framework/src/utils/ADUtils.C
@@ -67,7 +67,11 @@ globalDofIndexToDerivative(const ADReal & ad_real,
     // Map from global index to derivative
     for (MooseIndex(global_indices) local_index = 0; local_index < global_indices.size();
          ++local_index)
+    {
+      mooseAssert(ad_offset + local_index < MOOSE_AD_MAX_DOFS_PER_ELEM,
+                  "Out of bounds access in derivative vector.");
       ret_val[global_indices[local_index]] = ad_real.derivatives()[ad_offset + local_index];
+    }
   }
 
   return ret_val;


### PR DESCRIPTION
We've seen the derivative vector of dual numbers being accessed out of bounds, despite the check in `MooseVariableData`. Sometimes the out of bounds access comes _before_ the check in `MooseVariableData` is triggered, sometimes the check is never triggered but the out of bounds access still happens.

**Update: adding this as assertions**

Ping @recuero and @lindsayad 

Closes #16726