### PR TITLE
Detect and apply hard-coded mesh generator parallel type during recover

### DIFF
--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -69,6 +69,7 @@ ConcentricCircleMeshGenerator::ConcentricCircleMeshGenerator(const InputParamete
     _smoothing_max_it(getParam<unsigned int>("smoothing_max_it")),
     _portion(getParam<MooseEnum>("portion"))
 {
+  declareMeshProperty("use_distributed_mesh", false);
 
   if (_num_sectors % 2 != 0)
     paramError("num_sectors", "must be an even number.");

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -136,6 +136,7 @@ DistributedRectilinearMeshGenerator::DistributedRectilinearMeshGenerator(
     _linear_partition(getParam<bool>("linear_partition")),
     _num_side_layers(getParam<unsigned>("num_side_layers"))
 {
+  declareMeshProperty("use_distributed_mesh", true);
 }
 
 template <>

--- a/framework/src/meshgenerators/ImageMeshGenerator.C
+++ b/framework/src/meshgenerators/ImageMeshGenerator.C
@@ -49,6 +49,7 @@ ImageMeshGenerator::ImageMeshGenerator(const InputParameters & parameters)
     _scale_to_one(getParam<bool>("scale_to_one")),
     _cells_per_pixel(getParam<Real>("cells_per_pixel"))
 {
+  declareMeshProperty("use_distributed_mesh", false);
 }
 
 std::unique_ptr<MeshBase>

--- a/framework/src/meshgenerators/RinglebMeshGenerator.C
+++ b/framework/src/meshgenerators/RinglebMeshGenerator.C
@@ -60,6 +60,8 @@ RinglebMeshGenerator::RinglebMeshGenerator(const InputParameters & parameters)
     _outer_wall_bid(getParam<boundary_id_type>("outer_wall_bid")),
     _triangles(getParam<bool>("triangles"))
 {
+  declareMeshProperty("use_distributed_mesh", false);
+
   // catch likely user errors
   if (_kmax <= _kmin)
     mooseError("RinglebMesh: kmax must be greater than kmin");

--- a/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
+++ b/framework/src/meshgenerators/SpiralAnnularMeshGenerator.C
@@ -62,6 +62,8 @@ SpiralAnnularMeshGenerator::SpiralAnnularMeshGenerator(const InputParameters & p
     _exterior_bid(getParam<boundary_id_type>("exterior_bid")),
     _initial_delta_r(2 * libMesh::pi * _inner_radius / _nodes_per_ring)
 {
+  declareMeshProperty("use_distributed_mesh", false);
+
   // catch likely user errors
   if (_outer_radius <= _inner_radius)
     mooseError("SpiralAnnularMesh: outer_radius must be greater than inner_radius");

--- a/test/tests/bcs/dmg_periodic/dmg_periodic_bc.i
+++ b/test/tests/bcs/dmg_periodic/dmg_periodic_bc.i
@@ -9,8 +9,6 @@
     ymax = 40
     zmax = 0
   []
-  # We need this for recovering
-  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/bcs/dmg_periodic/dmg_simple_periodic_bc.i
+++ b/test/tests/bcs/dmg_periodic/dmg_simple_periodic_bc.i
@@ -9,8 +9,6 @@
     ymax = 1
     zmax = 1
   []
-  # We need this for recovering
-  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/mesh/boundary_subdomain_list/tests
+++ b/test/tests/mesh/boundary_subdomain_list/tests
@@ -8,6 +8,5 @@
     requirement = 'The system shall output all boundary and subdomain connections.'
     design = 'MooseMesh.md'
     issues = '#14971 #15019'
-    recover = false
   []
 []

--- a/test/tests/mesh/face_info/tests
+++ b/test/tests/mesh/face_info/tests
@@ -31,7 +31,6 @@
       csvdiff = 'face_info_two_region_quads_out_face_info_1_0001.csv '
                 'face_info_two_region_quads_out_face_info_2_0001.csv '
                 'face_info_two_region_quads_out_face_info_3_0001.csv'
-      recover = false
 
       detail = "quadrilateral elements in multiple regions."
     []

--- a/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/adaptivity.i
@@ -10,8 +10,6 @@
     nx = 20
     ny = 20
   []
-  # Only need when do recover
-  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/pbc_adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/dmg_displaced_mesh/pbc_adaptivity.i
@@ -7,8 +7,6 @@
     xmax = 40
     ymax = 40
   []
-  # This parameter is used for restart
-  parallel_type = DISTRIBUTED
 []
 
 [GlobalParams]

--- a/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator.i
@@ -5,8 +5,6 @@
     nx = 100
     ny = 100
   []
-  # Only need when do recover
-  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator_adaptivity.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/generator/distributed_rectilinear_mesh_generator_adaptivity.i
@@ -5,8 +5,6 @@
     nx = 10
     ny = 10
   []
-  # Only need when do recover
-  parallel_type = distributed
 []
 
 [Variables]

--- a/test/tests/meshgenerators/distributed_rectilinear/ghosting_elements/num_layers.i
+++ b/test/tests/meshgenerators/distributed_rectilinear/ghosting_elements/num_layers.i
@@ -12,8 +12,6 @@
     linear_partition=true
     num_side_layers = 2
   []
-  # Only need when do recover
-  parallel_type = distributed
 []
 
 [AuxVariables]


### PR DESCRIPTION
Right now a `MeshGenerator` can hard code a replicated mesh build
and this will trigger `_use_distributed_mesh = false` in
`MooseMesh`. However, when we recover with `--use-distributed-mesh`
`_use_distributed_mesh` becomes `true` in `MooseMesh` and then in
`MooseMesh::init` when we build the `MeshBase` object we build a
`DistributedMesh` and then read in a checkpoint file that was
written by a `ReplicatedMesh`. Needless to say, that doesn't
work. So my solution is to declare the mesh
property "use_distributed_mesh" in those `MeshGenerators` that
hard-code their parallel type. Then we can retrieve that mesh
property in the `SetupMeshAction` to ensure we properly set the
parallel type before creating the `MeshBase` object when
recovering/restarting.
