### PR TITLE
do not increment _current_step during xfem repeated step

### DIFF
--- a/framework/src/timesteppers/TimeSequenceStepperBase.C
+++ b/framework/src/timesteppers/TimeSequenceStepperBase.C
@@ -116,7 +116,7 @@ void
 TimeSequenceStepperBase::step()
 {
   TimeStepper::step();
-  if (converged())
+  if (converged() && !_executioner.picardSolve().XFEMRepeatStep())
     _current_step++;
 }
 


### PR DESCRIPTION
closes #16694

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
