### PR TITLE
Return zero for PerfGraph info if a section is registered but not ran

### DIFF
--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -78,10 +78,16 @@ PerfGraph::getNumCalls(const std::string & section_name)
   auto section_it = _section_time.find(section_name);
 
   if (section_it == _section_time.end())
+  {
+    // The section exists but has not ran yet, in which case we can return zero
+    if (_section_name_to_id.count(section_name))
+      return 0;
+
     mooseError(
         "Unknown section_name: ",
         section_name,
         " in PerfGraph::getNumCalls()\nIf you are attempting to retrieve the root use \"Root\".");
+  }
 
   return section_it->second._num_calls;
 }
@@ -94,10 +100,16 @@ PerfGraph::getTime(const TimeType type, const std::string & section_name)
   auto section_it = _section_time.find(section_name);
 
   if (section_it == _section_time.end())
+  {
+    // The section exists but has not ran yet, in which case we can return zero
+    if (_section_name_to_id.count(section_name))
+      return 0;
+
     mooseError(
         "Unknown section_name: ",
         section_name,
         " in PerfGraph::getTime()\nIf you are attempting to retrieve the root use \"Root\".");
+  }
 
   auto app_time = _section_time_ptrs[0]->_total;
 

--- a/test/tests/postprocessors/perf_graph_data/perf_graph.i
+++ b/test/tests/postprocessors/perf_graph_data/perf_graph.i
@@ -34,26 +34,32 @@
 []
 
 [Postprocessors]
-#  active = ''
+  # Getting this information on INITIAL has no practical use, but
+  # we want to make sure that we can obtain information about
+  # a section that has not ran yet.
   [calls]
     type = PerfGraphData
     section_name = FEProblem::computeResidualInternal
     data_type = CALLS
+    execute_on = 'INITIAL TIMESTEP_END'
   []
   [self]
     type = PerfGraphData
     section_name = FEProblem::computeResidualInternal
     data_type = SELF
+    execute_on = 'INITIAL TIMESTEP_END'
   []
   [children]
     type = PerfGraphData
     section_name = FEProblem::computeResidualInternal
     data_type = CHILDREN
+    execute_on = 'INITIAL TIMESTEP_END'
   []
   [total]
     type = PerfGraphData
     section_name = FEProblem::computeResidualInternal
     data_type = TOTAL
+    execute_on = 'INITIAL TIMESTEP_END'
   []
 []
 


### PR DESCRIPTION
Closes #16703

FYI @singhgp4321 - this will allow it to gracefully return zero without error when the section has not ran yet.
