### PR TITLE
Validate geochemistry database prior to use

### DIFF
--- a/modules/geochemistry/include/utils/GeochemicalDatabaseReader.h
+++ b/modules/geochemistry/include/utils/GeochemicalDatabaseReader.h
@@ -232,8 +232,16 @@ public:
 
   /**
    * Parse the thermodynamic database
+   * @param filename Name of thermodynamic database file
    */
-  void read(FileName filename);
+  void read(const FileName filename);
+
+  /**
+   * Validate the thermodynamic database
+   * @param filename Name of thermodynamic database file
+   * @param db JSON database read from filename
+   */
+  void validate(const FileName filename, const nlohmann::json & db);
 
   /**
    * Sometimes the free electron's equilibrium reaction is defined in terms of O2(g) which is not a
@@ -244,19 +252,19 @@ public:
 
   /**
    * Get the activity model type
-   * @retrun activity model
+   * @return activity model
    */
   std::string getActivityModel() const;
 
   /**
    * Get the fugacity model type
-   * @retrun fugacity model
+   * @return fugacity model
    */
   std::string getFugacityModel() const;
 
   /**
    * Get the equilibrium constant model type
-   * @retrun equilibrium constant model
+   * @return equilibrium constant model
    */
   std::string getLogKModel() const;
 

--- a/modules/geochemistry/unit/src/GeochemicalDatabaseReaderTest.C
+++ b/modules/geochemistry/unit/src/GeochemicalDatabaseReaderTest.C
@@ -19,6 +19,25 @@ TEST(GeochemicalDatabaseReaderTest, filename)
   EXPECT_EQ(database.filename(), "database/moose_testdb.json");
 }
 
+TEST(GeochemicalDatabaseReaderTest, faultyDB)
+{
+  // Test that the database validator throws an error when a faulty
+  // database is read (the full range of validation errors are tested
+  // in GeochemicalDatabaseValidatorTest.C)
+  try
+  {
+    GeochemicalDatabaseReader database("database/faultydbs/missing_header.json");
+  }
+  catch (const std::exception & err)
+  {
+    const std::string msg = "The MOOSE database database/faultydbs/missing_header.json does not "
+                            "have a required \"Header\" field";
+
+    std::size_t pos = std::string(err.what()).find(msg);
+    ASSERT_TRUE(pos != std::string::npos);
+  }
+}
+
 TEST(GeochemicalDatabaseReaderTest, getActivityModel)
 {
   GeochemicalDatabaseReader database("database/moose_testdb.json");


### PR DESCRIPTION
The get methods in GeochemicalDatabaseReader assume that
all of the data in the database is correctly formatted and
of the correct type for each species. We should validate the
database after reading it and prior to getting data from it
to make sure that everything is correct, and just as importantly,
throw informative errors about any invalid entries.

Refs #14986
