### PR TITLE
bump max allowed qps per elem

### DIFF
--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -195,7 +195,7 @@ namespace Moose
 /// up with some overkill complex mechanism for dynamically resizing them.
 /// Eventually, we may need or implement that more sophisticated mechanism and
 /// will no longer need this.
-const size_t constMaxQpsPerElem = 100;
+const size_t constMaxQpsPerElem = 216;
 
 // These are used by MooseVariableData and MooseVariableDataFV
 enum SolutionState

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4733,9 +4733,12 @@ FEProblemBase::updateMaxQps()
 
   unsigned int max_qpts = getMaxQps();
   if (max_qpts > Moose::constMaxQpsPerElem)
-    mooseError("Max quadrature points per element assumptions made in some code (e.g.  Coupleable "
-               "and MaterialPropertyInterface classes) have been violated.\n Complain to Moose "
-               "developers to allow constMaxQpsPerElem to be increased.");
+    mooseError("Max quadrature points per element assumptions made in some code (e.g.  Coupleable ",
+               "and MaterialPropertyInterface classes) have been violated.\n",
+               "Complain to Moose developers to have constMaxQpsPerElem increased from ",
+               Moose::constMaxQpsPerElem,
+               " to ",
+               max_qpts);
   for (unsigned int tid = 0; tid < libMesh::n_threads(); ++tid)
   {
     // the highest available order in libMesh is 43


### PR DESCRIPTION
This bumps the static limit set in #15790 for max qps per elem.  Turns
out there is one test that does 8th order quadrature in 3D in Griffin.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
