### PR TITLE
Make the target time on the executioner available. 

### DIFF
--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -99,6 +99,12 @@ public:
   virtual Real getTime() { return _time; };
 
   /**
+   * Get the current target time
+   * @return target time
+   */
+  virtual Real getTargetTime() { return _target_time; }
+
+  /**
    * Set the current time.
    */
   virtual void setTime(Real t) { _time = t; };


### PR DESCRIPTION
Expose the target time to other Moose objects to have finer control of `ExternalProblem::syncSolutions`. 

Closes #16736