### PR TITLE
Remove read check assertions for sparse AD indexing

### DIFF
--- a/framework/src/bcs/ADIntegratedBC.C
+++ b/framework/src/bcs/ADIntegratedBC.C
@@ -151,8 +151,10 @@ ADIntegratedBCTempl<T>::addJacobian(const MooseVariableFieldBase & jvariable)
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jvariable.phiSize(); _j++)
     {
+#ifndef MOOSE_SPARSE_AD
       mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                   "Out of bounds access in derivative vector.");
+#endif
       _local_ke(_i, _j) += _residuals[_i].derivatives()[ad_offset + _j];
     }
   accumulateTaggedLocalMatrix();

--- a/framework/src/bcs/ADNodalBC.C
+++ b/framework/src/bcs/ADNodalBC.C
@@ -103,7 +103,7 @@ ADNodalBCTempl<T>::computeJacobian()
       for (std::size_t i = 0; i < cached_rows.size(); ++i)
         if (_set_components[i])
         {
-#ifndef MOOSE_GLOBAL_AD_INDEXING
+#ifndef MOOSE_SPARSE_AD
           mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
                       "Out of bounds access in derivative vector.");
 #endif
@@ -147,7 +147,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobian(const unsigned int jvar_num)
         for (std::size_t i = 0; i < cached_rows.size(); ++i)
           if (_set_components[i])
           {
-#ifndef MOOSE_GLOBAL_AD_INDEXING
+#ifndef MOOSE_SPARSE_AD
             mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
                         "Out of bounds access in derivative vector.");
 #endif
@@ -195,7 +195,7 @@ ADNodalBCTempl<T>::computeOffDiagJacobianScalar(unsigned int jvar)
       for (std::size_t i = 0; i < cached_rows.size(); ++i)
         if (_set_components[i])
         {
-#ifndef MOOSE_GLOBAL_AD_INDEXING
+#ifndef MOOSE_SPARSE_AD
           mooseAssert(ad_offset + i < MOOSE_AD_MAX_DOFS_PER_ELEM,
                       "Out of bounds access in derivative vector.");
 #endif

--- a/framework/src/constraints/ADMortarConstraint.C
+++ b/framework/src/constraints/ADMortarConstraint.C
@@ -157,8 +157,10 @@ ADMortarConstraint::computeJacobian(Moose::MortarType mortar_type)
         for (_i = 0; _i < test_space_size; _i++)
           for (_j = 0; _j < shape_space_sizes[type_index]; _j++)
           {
+#ifndef MOOSE_SPARSE_AD
             mooseAssert(ad_offsets[type_index] + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                         "Out of bounds access in derivative vector.");
+#endif
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offsets[type_index] + _j];
           }
         accumulateTaggedLocalMatrix();

--- a/framework/src/dgkernels/ADDGKernel.C
+++ b/framework/src/dgkernels/ADDGKernel.C
@@ -182,8 +182,10 @@ ADDGKernel::computeElemNeighJacobian(Moose::DGJacobianType type)
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
         {
+#ifndef MOOSE_SPARSE_AD
           mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                       "Out of bounds access in derivative vector.");
+#endif
           _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
         }
 
@@ -291,8 +293,10 @@ ADDGKernel::computeOffDiagElemNeighJacobian(Moose::DGJacobianType type, const Mo
         for (_i = 0; _i < test_space.size(); _i++)
           for (_j = 0; _j < loc_phi.size(); _j++)
           {
+#ifndef MOOSE_SPARSE_AD
             mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                         "Out of bounds access in derivative vector.");
+#endif
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
           }
 

--- a/framework/src/fvbcs/FVFluxBC.C
+++ b/framework/src/fvbcs/FVFluxBC.C
@@ -115,8 +115,10 @@ FVFluxBC::computeJacobian(Moose::DGJacobianType type, const ADReal & residual)
                 "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                 "for a number of dof indices equal to  1");
 
+#ifndef MOOSE_SPARSE_AD
     mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
                 "Out of bounds access in derivative vector.");
+#endif
     _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
     accumulateTaggedLocalMatrix();

--- a/framework/src/fvkernels/FVElementalKernel.C
+++ b/framework/src/fvkernels/FVElementalKernel.C
@@ -68,8 +68,10 @@ FVElementalKernel::computeJacobian()
     prepareMatrixTag(_assembly, _var.number(), _var.number());
     auto dofs_per_elem = _subproblem.systemBaseNonlinear().getMaxVarNDofsPerElem();
     auto ad_offset = Moose::adOffset(_var.number(), dofs_per_elem);
+#ifndef MOOSE_SPARSE_AD
     mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
                 "Out of bounds access in derivative vector.");
+#endif
     _local_ke(0, 0) += residual.derivatives()[ad_offset];
     accumulateTaggedLocalMatrix();
   };
@@ -116,8 +118,10 @@ FVElementalKernel::computeOffDiagJacobian()
                   "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                   "for a number of dof indices equal to  1");
 
+#ifndef MOOSE_SPARSE_AD
       mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
                   "Out of bounds access in derivative vector.");
+#endif
       _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
       accumulateTaggedLocalMatrix();

--- a/framework/src/fvkernels/FVFluxKernel.C
+++ b/framework/src/fvkernels/FVFluxKernel.C
@@ -180,8 +180,10 @@ FVFluxKernel::computeJacobian(Moose::DGJacobianType type, const ADReal & residua
                 "The AD derivative indexing below only makes sense for constant monomials, e.g. "
                 "for a number of dof indices equal to  1");
 
+#ifndef MOOSE_SPARSE_AD
     mooseAssert(ad_offset < MOOSE_AD_MAX_DOFS_PER_ELEM,
                 "Out of bounds access in derivative vector.");
+#endif
     _local_ke(0, 0) = residual.derivatives()[ad_offset];
 
     accumulateTaggedLocalMatrix();

--- a/framework/src/interfacekernels/ADInterfaceKernel.C
+++ b/framework/src/interfacekernels/ADInterfaceKernel.C
@@ -172,8 +172,10 @@ ADInterfaceKernelTempl<T>::computeElemNeighJacobian(Moose::DGJacobianType type)
       for (_i = 0; _i < test_space.size(); _i++)
         for (_j = 0; _j < loc_phi.size(); _j++)
         {
+#ifndef MOOSE_SPARSE_AD
           mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                       "Out of bounds access in derivative vector.");
+#endif
           _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
         }
       accumulateTaggedLocalMatrix();
@@ -285,8 +287,10 @@ ADInterfaceKernelTempl<T>::computeOffDiagElemNeighJacobian(Moose::DGJacobianType
         for (_i = 0; _i < test_space.size(); _i++)
           for (_j = 0; _j < loc_phi.size(); _j++)
           {
+#ifndef MOOSE_SPARSE_AD
             mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                         "Out of bounds access in derivative vector.");
+#endif
             _local_ke(_i, _j) += input_residuals[_i].derivatives()[ad_offset + _j];
           }
         accumulateTaggedLocalMatrix();

--- a/framework/src/kernels/ADKernel.C
+++ b/framework/src/kernels/ADKernel.C
@@ -173,8 +173,10 @@ ADKernelTempl<T>::addJacobian(const MooseVariableFieldBase & jvariable)
   for (_i = 0; _i < _test.size(); _i++)
     for (_j = 0; _j < jvariable.phiSize(); _j++)
     {
+#ifndef MOOSE_SPARSE_AD
       mooseAssert(ad_offset + _j < MOOSE_AD_MAX_DOFS_PER_ELEM,
                   "Out of bounds access in derivative vector.");
+#endif
       _local_ke(_i, _j) += _residuals[_i].derivatives()[ad_offset + _j];
     }
 

--- a/framework/src/utils/ADUtils.C
+++ b/framework/src/utils/ADUtils.C
@@ -68,8 +68,10 @@ globalDofIndexToDerivative(const ADReal & ad_real,
     for (MooseIndex(global_indices) local_index = 0; local_index < global_indices.size();
          ++local_index)
     {
+#ifndef MOOSE_SPARSE_AD
       mooseAssert(ad_offset + local_index < MOOSE_AD_MAX_DOFS_PER_ELEM,
                   "Out of bounds access in derivative vector.");
+#endif
       ret_val[global_indices[local_index]] = ad_real.derivatives()[ad_offset + local_index];
     }
   }


### PR DESCRIPTION
We already removed the read check assertion for global sparse AD
indexing in #16741. However, we can also safely remove the read checks
for local sparse AD. This is because it is actually *impossible* to read
out of bounds on a sparse AD container using `operator[]`. This is
because in `DynamicSparseNumberBase::runtime_index_query`, if the
underlying `_indices` data structure doesn't contain the index queried
for in `operator[]`, then we simply return 0. We *never* perform
`operator[]` on the underlying `_data` if the index doesn't already
exist in the `_indices` member. So out of bounds operations on the
sparse container will only ever happen for writes

Refs #16739
