### PR TITLE
Start moving some phase field documentation from old wiki to new site

### DIFF
--- a/modules/phase_field/doc/content/modules/phase_field/Anisotropy.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Anisotropy.md
@@ -1,0 +1,17 @@
+# Anisotropy
+
+## `CahnHilliardAnisoFluxBC` boundary condition
+
+## `CHInterfaceAniso` interface kernel
+
+## `CahnHilliardAniso` bulk kernel
+
+## `MatAnisoDiffusion` diffusion kernel
+
+## `SplitCHWResAniso` split Chan-Hilliard kernel
+
+## `ConstantAnisotropicMobility` mobility material
+
+## `CompositeMobilityTensor`
+
+## `GBAnisotropy`

--- a/modules/phase_field/doc/content/modules/phase_field/Anisotropy.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Anisotropy.md
@@ -1,17 +1,22 @@
 # Anisotropy
 
-## `CahnHilliardAnisoFluxBC` boundary condition
+Objects for modeling anisotropic behavior.
 
-## `CHInterfaceAniso` interface kernel
+## Kernels
 
-## `CahnHilliardAniso` bulk kernel
+- [`CahnHilliardAniso`](/CahnHilliardAniso.md): Bulk Cahn-Hilliard Kernel that uses a DerivativeMaterial Free Energy and a tensor (anisotropic) mobility
 
-## `MatAnisoDiffusion` diffusion kernel
+- [`CHInterfaceAniso`](/CHInterfaceAniso.md): Gradient energy Cahn-Hilliard Kernel with a tensor (anisotropic) mobility
 
-## `SplitCHWResAniso` split Chan-Hilliard kernel
+- [`MatAnisoDiffusion`](/MatAnisoDiffusion.md): Diffusion equation Kernel that takes an anisotropic Diffusivity from a material property
 
-## `ConstantAnisotropicMobility` mobility material
+- [`SplitCHWResAniso`](/SplitCHWResAniso.md): Split formulation Cahn-Hilliard Kernel for the chemical potential variable with a tensor (anisotropic) mobility
 
-## `CompositeMobilityTensor`
+## Materials
 
-## `GBAnisotropy`
+- [`ConstantAnisotropicMobility`](/ConstantAnisotropicMobility.md): Provide a constant mobility tensor value
+
+- [`CompositeMobilityTensor`](/CompositeMobilityTensor.md): Assemble a mobility tensor from multiple tensor contributions weighted by material properties
+
+- [`GBAnisotropy`](/GBAnisotropy.md): Specifying grain boundary energy and mobility parameters for individual grain boundaries as defined by order parameter pairs
+

--- a/modules/phase_field/doc/content/modules/phase_field/CALPHAD.md
+++ b/modules/phase_field/doc/content/modules/phase_field/CALPHAD.md
@@ -1,0 +1,36 @@
+# CALPHAD
+
+This is a work in progress.
+
+A script to export MOOSE readable free energy expressions from `*.tdb` thermodynamic database files can be found at
+
+```text
+moose/python/calphad/free_energy.py
+```
+
+The `free_energy.py` tool allows users to extract free energy expressions from `*.tdb`
+thermodynamic database files (ThermoCalc format). The tool exports a list of MOOSE Material blocks
+for each phase (or a user specified subset of phases). The CALPHAD functional expressions are
+implemented using the [`DerivativeParsedMaterial`](/DerivativeParsedMaterial.md) class.
+
+It is up to the user to construct a full MOOSE input file around these material blocks and to rename
+the variables used in the exported form to more suitable names.
+
+## Installation
+
+The [pycalphad](https://github.com/richardotis/pycalphad) Python module is required to perform the
+parsing of the `*.tdb` files. [SymPy](https://github.com/sympy/sympy) is required to build the
+functional forms of the calphad expressions.
+
+To install and/or upgrade these prerequisites use pip:
+
+```text
+pip install --upgrade sympy
+pip install --upgrade pycalphad
+```
+
+## Thermodynamic databases
+
+Database files can be obtained online at
+
+* [Computational Phase Diagram Database](http://cpddb.nims.go.jp/index_en.html) (CPDDB)

--- a/modules/phase_field/doc/content/modules/phase_field/Elastic_Driving_Force_Grain_Growth.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Elastic_Driving_Force_Grain_Growth.md
@@ -1,0 +1,118 @@
+# Elastic Driving Force for Grain Growth
+
+!media /phase_field/moose_pf_hex_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
+    caption=Elastic energy driven grain growth in a 2D hexagaonal copper polycrystal with one shrinking grain. The result was calculated using an example input file from the combined module. The input file is `hex_grain_growth_2D_eldrforce.i`
+
+
+
+
+
+Grain boundaries (GBs) migrate to reduce the free energy of the system. One source of energy that can be reduced is the grain boundary energy, and the standard grain growth model accounts for this driving force (commonly called the curvature driving force). In addition, GBs can migrate to reduce the elastic energy stored in the system. To account for this driving force in the grain growth model, we couple to a mechanics solution.
+
+## Model Summary
+
+In our model, $N_{gr}$ grains are represented by $N_{op}$ order parameters, where $N_{gr} \geq N_{op}$. Each grain has a unique ID $gr$ and is represented by a specific order parameter $op$, though the order parameter used for each grain can change throughout the simulation. The assignment of the order parameters to each grain is controlled by the [GrainTracker](/GrainTracker.md) user object.
+
+The crystal orientation of each grain is described by a set of three Euler angles $[\phi_1, \Phi, \phi_2]_{gr}$. The Euler angles define a rotation tensor $\mathbf{R}_{gr}$ used to rotate the elasticity tensor in the crystal frame of reference $\boldsymbol{\mathcal{C}}_0$ to the current frame. Thus, the elasticity tensor for each grain is fully defined by
+
+\begin{equation}
+\boldsymbol{\mathcal{C}}_{gr} = (\mathbf{R}_{gr} \boxtimes \mathbf{R}_{gr}) \boldsymbol{\mathcal{C}}_0 (\mathbf{R}_{gr} \boxtimes \mathbf{R}_{gr})^T
+\end{equation}
+
+where $\boxtimes$ is the fourth-order tensor product. In the phase field model, the grain boundaries are represented by a diffuse inteface in which multiple order parameters have non-zero values. Thus, the elasticity tensor at any point in space is a weighted average of the elasticity tensors from all grains with non-zero order parameters, i.e.
+
+\begin{equation}
+\boldsymbol{\mathcal{C}}(\mathbf{r}) = \frac{\sum_{gr} h(\eta_{gr}(\mathbf{r})) \boldsymbol{\mathcal{C}}_{gr} }{\sum_{gr} h(\eta_{gr}(\mathbf{r}))},
+\end{equation}
+
+!media /phase_field/moose_pf_hex_grgr_stress_2.png  style=width:200px;padding-left:20px;float:right;
+    caption=Elastic energy driven grain growth in a 2D hexagaonal copper polycrystal with one growing grain. The result was calculated using an example input file from the combined module. The input file is `hex_grain_growth_2D_eldrforce.i`
+
+where the interpolation function $h$ is equal to 0 when $\eta_{gr} = 0$ and 1 when $\eta_{gr}=1$, i.e.
+
+\begin{equation}
+h(\eta_{gr}) = \frac{1}{2}(1 + \sin(\pi((\eta_{gr} - 0.5))
+\end{equation}
+
+The local stress is calculated from the local elasticity tensor according to
+
+\begin{equation}
+\boldsymbol{\sigma}(\mathbf{r}) = \boldsymbol{\mathcal{C}}(\mathbf{r}) \boldsymbol{\epsilon}(\mathbf{r})
+\end{equation}
+
+and the elastic energy density is calculated according to
+
+\begin{equation}
+\begin{aligned}
+E_d =& \frac{1}{2} \boldsymbol{\sigma}(\mathbf{r}) \cdot \boldsymbol{\epsilon}(\mathbf{r}) \\
+    =& \frac{1}{2} \boldsymbol{\mathcal{C}}(\mathbf{r}) \boldsymbol{\epsilon}(\mathbf{r}) \cdot \boldsymbol{\epsilon} (\mathbf{r})
+\end{aligned}
+\end{equation}
+
+The elastic energy is added to the free energy of the system, as shown on the [Basic Phase Field Equations](Phase_Field_Equations.md) page. The Allen-Cahn equation defining the evolution of the order parameters becomes
+
+\begin{equation}
+\frac{\partial \eta_{gr}}{\partial t} = - L \left( \frac{\partial f_{loc}}{\partial \eta_j} +  \frac{\partial E_{d}}{\partial \eta_{gr}} - \kappa_j \nabla^2 \eta_j \right),
+\end{equation}
+
+where
+
+\begin{equation}
+\frac{\partial E_{d}}{\partial \eta_{gr}} = \frac{1}{2} \frac{\partial \boldsymbol{\mathcal{C}}}{\partial \eta_{gr}} \boldsymbol{\epsilon} \cdot \boldsymbol{\epsilon}.
+\end{equation}
+
+The partial derivative of the elasticity tensor with respect to the order parameters is defined by
+
+\begin{equation}
+\frac{\partial \boldsymbol{\mathcal{C}}}{\partial \eta_{gr}} = h'(\eta_{gr}) \frac{ \boldsymbol{\mathcal{C}}_{gr} }{\sum_{gr} h(\eta_{gr})} - h'(\eta_{gr}) \frac{\sum_{gr} h(\eta_{gr}) \boldsymbol{\mathcal{C}}_{gr} }{\left(\sum_{gr} h(\eta_{gr}) \right)^2}.
+\end{equation}
+
+!media /phase_field/moose_pf_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
+    caption=Elastic energy driven grain growth in a 2D copper polycrystal. The result was calculated using an example input file from the combined module. The input file is `poly_grain_growth_2D_eldrforce.i`
+
+## Model Implementation
+
+The additional contribution of elastic energy on the Allen-Cahn equation describing grain growth is implemented in the phase field module with the kernel [ACGrGrElasticDrivingForce](/ACGrGrElasticDrivingForce.md). It only adds the elastic energy contribution, so it must be used with the [ACGrGrPoly](/ACGrGrPoly.md) kernel. The addition to the residual in weak form is
+
+\begin{equation}
+L \left( \frac{\partial E_d}{\partial \eta_{gr}}, \psi_m \right),
+\end{equation}
+
+and is implemented in the code according to
+
+```cpp
+Real
+ACGrGrElasticDrivingForce::computeDFDOP(PFFunctionType type)
+{
+  // Access the heterogeneous strain calculated by the Solid Mechanics kernels
+  RankTwoTensor strain(_elastic_strain[_qp]);
+
+  // Compute the partial derivative of the stress wrt the order parameter
+  RankTwoTensor D_stress = _D_elastic_tensor[_qp] * strain;
+
+  switch (type)
+  {
+    case Residual:
+      return 0.5 * D_stress.doubleContraction(strain); // Compute the deformation energy driving force
+
+    case Jacobian:
+      return 0.0;
+  }
+
+  mooseError("Invalid type passed in");
+}
+```
+
+The stress and strain are computed using kernels from the tensor mechanics module, but a material in the phase field module was created to compute the polycrystal elasticity tensor, [ComputePolycrystalElasticityTensor](/ComputePolycrystalElasticityTensor.md). It also computes the derivatives of the elasticity tensor with respect to all of the order parameters. This material must be used with the [GrainTracker](/GrainTracker.md) user object.
+
+As with the basic grain growth model, creating separate blocks in the input file for every order parameter would be burdensome. Thus, we have implemented an action that adds the elastic driving force kernel for each order parameter. The action is [PolycrystalElasticDrivingForceAction](/PolycrystalElasticDrivingForceAction.md) and it must be used with the [PolycrystalKernelAction](/PolycrystalKernelAction.md).
+
+This capability is tested in
+
+`moose/modules/combined/tests/ACGrGrElasticDrivingForce`
+
+and is demonstrated on larger problems in
+
+`moose/modules/combined/examples/phase_field-mechanics/hex_grain_growth_2D_eldrforce.i`
+
+`moose/modules/combined/examples/phase_field-mechanics/poly_grain_growth_2D_eldrforce.i`

--- a/modules/phase_field/doc/content/modules/phase_field/Elastic_Driving_Force_Grain_Growth.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Elastic_Driving_Force_Grain_Growth.md
@@ -1,6 +1,6 @@
 # Elastic Driving Force for Grain Growth
 
-!media /phase_field/moose_pf_hex_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/moose_pf_hex_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
     caption=Elastic energy driven grain growth in a 2D hexagaonal copper polycrystal with one shrinking grain. The result was calculated using an example input file from the combined module. The input file is `hex_grain_growth_2D_eldrforce.i`
 
 
@@ -25,7 +25,7 @@ where $\boxtimes$ is the fourth-order tensor product. In the phase field model, 
 \boldsymbol{\mathcal{C}}(\mathbf{r}) = \frac{\sum_{gr} h(\eta_{gr}(\mathbf{r})) \boldsymbol{\mathcal{C}}_{gr} }{\sum_{gr} h(\eta_{gr}(\mathbf{r}))},
 \end{equation}
 
-!media /phase_field/moose_pf_hex_grgr_stress_2.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/moose_pf_hex_grgr_stress_2.png  style=width:200px;padding-left:20px;float:right;
     caption=Elastic energy driven grain growth in a 2D hexagaonal copper polycrystal with one growing grain. The result was calculated using an example input file from the combined module. The input file is `hex_grain_growth_2D_eldrforce.i`
 
 where the interpolation function $h$ is equal to 0 when $\eta_{gr} = 0$ and 1 when $\eta_{gr}=1$, i.e.
@@ -67,7 +67,7 @@ The partial derivative of the elasticity tensor with respect to the order parame
 \frac{\partial \boldsymbol{\mathcal{C}}}{\partial \eta_{gr}} = h'(\eta_{gr}) \frac{ \boldsymbol{\mathcal{C}}_{gr} }{\sum_{gr} h(\eta_{gr})} - h'(\eta_{gr}) \frac{\sum_{gr} h(\eta_{gr}) \boldsymbol{\mathcal{C}}_{gr} }{\left(\sum_{gr} h(\eta_{gr}) \right)^2}.
 \end{equation}
 
-!media /phase_field/moose_pf_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/moose_pf_grgr_stress.png  style=width:200px;padding-left:20px;float:right;
     caption=Elastic energy driven grain growth in a 2D copper polycrystal. The result was calculated using an example input file from the combined module. The input file is `poly_grain_growth_2D_eldrforce.i`
 
 ## Model Implementation

--- a/modules/phase_field/doc/content/modules/phase_field/Initial_Conditions.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Initial_Conditions.md
@@ -4,7 +4,7 @@ With the phase field method, the initial condition is critical, as it establishe
 
 ## BoundingBoxIC
 
-!media /phase_field/BoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/BoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
     caption=BoundingBoxIC
 
 BoundingBoxIC allows setting the initial condition of a value inside and outside of a specified box. The box is aligned with the x,y,z axis, and is specified by passing in the x,y,z coordinates of the bottom left point and the top right point. Each of the coordinates of the "bottom_left" point MUST be less than those coordinates in the "top_right" point. When setting the initial condition if bottom_left <= Point <= top_right then the `inside` value is used. Otherwise the `outside` value is used. More information can be found on the [BoundingBoxIC](/BoundingBoxIC.md) syntax page.
@@ -22,7 +22,7 @@ BoundingBoxIC allows setting the initial condition of a value inside and outside
 
 ## RndBoundingBoxIC
 
-!media /phase_field/RndBoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/RndBoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
     caption=RndBoundingBoxIC
 
 Like BoundingBoxIC but the inside and outside values are randomly chosen from a uniform distribution between the `mx_invalue` and `mn_invalue` inside the box and `mx_outvalue` and `mn_outvalue` outside the box. More information can be found on the [RndBoundingBoxIC](/RndBoundingBoxIC.md) syntax page.
@@ -42,7 +42,7 @@ Like BoundingBoxIC but the inside and outside values are randomly chosen from a 
 
 ## SmoothCircleIC
 
-!media /phase_field/SmoothCIrcleIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/SmoothCIrcleIC.png  style=width:200px;padding-left:20px;float:right;
     caption=SmoothCIrcleIC
 
 SmoothcircleIC creates a circle of a given radius centered at a given point in the domain. If `int_width` > zero, the border of the circle with smoothly transition from the `invalue` to the `outvalue`. More information can be found on the [SmoothCircleIC](/SmoothCircleIC.md) syntax page.
@@ -60,7 +60,7 @@ SmoothcircleIC creates a circle of a given radius centered at a given point in t
 
 ## RndSmoothCircleIC
 
-!media /phase_field/RndSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/RndSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
     caption=RndSmoothCircleIC
 
 Same as SmoothCircleIC but the value inside the circle randomly around `invalue` by plus or minus `variation_invalue` and the value outside the circle randomly varies around `outvalue` by plus or minus `variation_outvalue`. More information can be found on the [RndSmoothCircleIC](/RndSmoothCircleIC.md) syntax page.
@@ -80,7 +80,7 @@ Same as SmoothCircleIC but the value inside the circle randomly around `invalue`
 
 ## MultiSmoothCircleIC
 
-!media /phase_field/MultiSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/MultiSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
     caption=MultiSmoothCircleIC
 
 MultiSmoothcircleIC sets variable values by creating `nbub` number of circles with center points randomly positioned throughout the domain. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [MultiSmoothCircleIC](/MultiSmoothCircleIC.md) syntax page.
@@ -103,7 +103,7 @@ MultiSmoothcircleIC sets variable values by creating `nbub` number of circles wi
 
 ## LatticeSmoothCircleIC
 
-!media /phase_field/LatticeSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/LatticeSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
     caption=LatticeSmoothCircleIC
 
 LatticeSmoothcircleIC sets variable values using a set of smooth circles (see SmoothCircleIC) with centers on a uniform lattice, randomly randomly perturbed from the lattice. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [LatticeSmoothCircleIC](/LatticeSmoothCircleIC.md) synatx page.
@@ -125,7 +125,7 @@ LatticeSmoothcircleIC sets variable values using a set of smooth circles (see Sm
 
 ## SpecifiedSmoothCircleIC
 
-!media /phase_field/SpecifiedSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/SpecifiedSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
     caption=SpecifiedSmoothCircleIC
 
 SpecifiedSmoothcircleIC creates a user specified number of smooth circles and specific locations and with specific radii. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [SpecifiedSmoothCircleIC](/SpecifiedSmoothCircleIC.md) syntax page.
@@ -143,7 +143,7 @@ SpecifiedSmoothcircleIC creates a user specified number of smooth circles and sp
 
 ## CrossIC
 
-!media /phase_field/CrossIC.png  style=width:200px;padding-left:20px;float:right;
+!media phase_field/CrossIC.png  style=width:200px;padding-left:20px;float:right;
     caption=CrossIC
 
 CrossIC is a *2D ONLY IC* that sets the variable value to be `average` + `amplitude` within a smooth cross shape and to `average` - `amplitude` outside the cross. The cross is defined within a square defined by the user. More information can be found on the [CrossIC](/CrossIC.md) syntax page

--- a/modules/phase_field/doc/content/modules/phase_field/Initial_Conditions.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Initial_Conditions.md
@@ -1,0 +1,166 @@
+# Initial Conditions
+
+With the phase field method, the initial condition is critical, as it establishes the initial microstructure of the material. MOOSE has a system for creating [Initial Conditions (ICs)](/syntax/ICs/index.html), however there are various initial conditions that have been created as part of the Phase Field Module. The corresponding .C files for each IC can be found in `moose/modules/phase_field/src/ics` except for BoundingBoxIC which is found in `moose/framework/src/ics`.
+
+## BoundingBoxIC
+
+!media /phase_field/BoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=BoundingBoxIC
+
+BoundingBoxIC allows setting the initial condition of a value inside and outside of a specified box. The box is aligned with the x,y,z axis, and is specified by passing in the x,y,z coordinates of the bottom left point and the top right point. Each of the coordinates of the "bottom_left" point MUST be less than those coordinates in the "top_right" point. When setting the initial condition if bottom_left <= Point <= top_right then the `inside` value is used. Otherwise the `outside` value is used. More information can be found on the [BoundingBoxIC](/BoundingBoxIC.md) syntax page.
+
+### Inputs
+
+- `x1`: The x coordinate of the lower left-hand corner of the box
+- `y1`: The y coordinate of the lower left-hand corner of the box
+- `z1`: The z coordinate of the lower left-hand corner of the box
+- `x2`: The x coordinate of the upper right-hand corner of the box
+- `y2`: The y coordinate of the upper right-hand corner of the box
+- `z2`: The z coordinate of the upper right-hand corner of the box
+- `inside`: The value of the variable inside the box
+- `outside`: The value of the variable outside the box
+
+## RndBoundingBoxIC
+
+!media /phase_field/RndBoundingBoxIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=RndBoundingBoxIC
+
+Like BoundingBoxIC but the inside and outside values are randomly chosen from a uniform distribution between the `mx_invalue` and `mn_invalue` inside the box and `mx_outvalue` and `mn_outvalue` outside the box. More information can be found on the [RndBoundingBoxIC](/RndBoundingBoxIC.md) syntax page.
+
+### Inputs
+
+- `x1`: The x coordinate of the lower left-hand corner of the box
+- `y1`: The y coordinate of the lower left-hand corner of the box
+- `z1`: The z coordinate of the lower left-hand corner of the box
+- `x2`: The x coordinate of the upper right-hand corner of the box
+- `y2`: The y coordinate of the upper right-hand corner of the box
+- `z2`: The z coordinate of the upper right-hand corner of the box
+- `mx_inside`: The max value of the variable inside the box
+- `mn_inside`: The min value of the variable inside the box
+- `mx_outside`: The max value of the variable outside the box
+- `mn_outside`: The min value of the variable outside the box
+
+## SmoothCircleIC
+
+!media /phase_field/SmoothCIrcleIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=SmoothCIrcleIC
+
+SmoothcircleIC creates a circle of a given radius centered at a given point in the domain. If `int_width` > zero, the border of the circle with smoothly transition from the `invalue` to the `outvalue`. More information can be found on the [SmoothCircleIC](/SmoothCircleIC.md) syntax page.
+
+### Inputs
+
+- `x1`: The x coordinate of the circle center
+- `y1`: The y coordinate of the circle center
+- `z1`: The z coordinate of the circle center, defaults to 0.
+- `radius`: The radius of the circle
+- `invalue`: The variable value inside the circle
+- `outvalue`: The variable value outside the circle
+- `int_width`: The interfacial width of the void surface.  Defaults to 0.
+- `3D_spheres`: In 3D, whether the objects are spheres or columns, defaults to `true`
+
+## RndSmoothCircleIC
+
+!media /phase_field/RndSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=RndSmoothCircleIC
+
+Same as SmoothCircleIC but the value inside the circle randomly around `invalue` by plus or minus `variation_invalue` and the value outside the circle randomly varies around `outvalue` by plus or minus `variation_outvalue`. More information can be found on the [RndSmoothCircleIC](/RndSmoothCircleIC.md) syntax page.
+
+### Inputs
+
+- `x1`: The x coordinate of the circle center
+- `y1`: The y coordinate of the circle center
+- `z1`: The z coordinate of the circle center, defaults to 0.
+- `radius`: The radius of the circle
+- `invalue`: The variable value inside the circle
+- `outvalue`: The variable value outside the circle
+- `int_width`: The interfacial width of the void surface.  Defaults to 0.
+- `variation_invalue`: Plus or minus this amount on the invalue
+- `variation_outvalue`: Plus or minus this amount on the outvalue
+- `rand_seed`: Seed value for the random number generator, defaults to 12345.
+
+## MultiSmoothCircleIC
+
+!media /phase_field/MultiSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=MultiSmoothCircleIC
+
+MultiSmoothcircleIC sets variable values by creating `nbub` number of circles with center points randomly positioned throughout the domain. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [MultiSmoothCircleIC](/MultiSmoothCircleIC.md) syntax page.
+
+### Inputs
+
+- `radius`: The radius of the circle
+- `invalue`: The variable value inside the circle
+- `outvalue`: The variable value outside the circle
+- `int_width`: The interfacial width of the void surface.  Defaults to 0.
+- `3D_spheres`: In 3D, whether the objects are spheres or columns, defaults to `true`
+- `numbub`: The number of bubbles to be placed on GB
+- `bubspac`: Minimum spacing of bubbles, measured from center to center
+- `numtries`: The number of tries allowed to fit a circle within the domain before throwing an error, defaults to 1000.
+- `Lx`: Length of simulation domain in x-direction
+- `Ly`: Length of simulation domain in y-direction
+- `Lz`: Length of simulation domain in z-direction, defaults to 0
+- `rand_seed`: Seed for the random number generator, defaults to 2000
+- `radius_variation`: Plus or minus fraction of random variation in the bubble radius, defaults to 0
+
+## LatticeSmoothCircleIC
+
+!media /phase_field/LatticeSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=LatticeSmoothCircleIC
+
+LatticeSmoothcircleIC sets variable values using a set of smooth circles (see SmoothCircleIC) with centers on a uniform lattice, randomly randomly perturbed from the lattice. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [LatticeSmoothCircleIC](/LatticeSmoothCircleIC.md) synatx page.
+
+### Inputs
+
+- `radius`: The radius of the circle
+- `invalue`: The variable value inside the circle
+- `outvalue`: The variable value outside the circle
+- `int_width`: The interfacial width of the void surface.  Defaults to 0.
+- `3D_spheres`: In 3D, whether the objects are spheres or columns, defaults to `true`
+- `Rnd_variation`: Percent variation (plus or minus) from circle center location on the lattice.
+- `circles_per_side`: Length 3 vector containing the number of bubbles along each side (x, y, and z).
+- `Lx`: Length of simulation domain in x-direction
+- `Ly`: Length of simulation domain in y-direction
+- `Lz`: Length of simulation domain in z-direction, defaults to 0
+- `rand_seed`: Seed for the random number generator, defaults to 2000
+- `radius_variation`:Plus or minus fraction of random variation in the bubble radius, defaults to 0
+
+## SpecifiedSmoothCircleIC
+
+!media /phase_field/SpecifiedSmoothCircleIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=SpecifiedSmoothCircleIC
+
+SpecifiedSmoothcircleIC creates a user specified number of smooth circles and specific locations and with specific radii. The value within a circle is `invalue` and outside is `outvalue`. More information can be found on the [SpecifiedSmoothCircleIC](/SpecifiedSmoothCircleIC.md) syntax page.
+
+### Inputs
+
+- `invalue`: The variable value inside the circle
+- `outvalue`: The variable value outside the circle
+- `int_width`: The interfacial width of the void surface.  Defaults to 0.
+- `3D_spheres`: In 3D, whether the objects are spheres or columns, defaults to `true`
+- `x_positions`: A vector containing the x-coordinate for each circle center
+- `y_positions`: A vector containing the y-coordinate for each circle center
+- `z_positions`: A vector containing the z-coordinate for each circle center
+- `radii`: A vector containing the radius for each circle
+
+## CrossIC
+
+!media /phase_field/CrossIC.png  style=width:200px;padding-left:20px;float:right;
+    caption=CrossIC
+
+CrossIC is a *2D ONLY IC* that sets the variable value to be `average` + `amplitude` within a smooth cross shape and to `average` - `amplitude` outside the cross. The cross is defined within a square defined by the user. More information can be found on the [CrossIC](/CrossIC.md) syntax page
+
+### Input
+
+- `x1`: The x coordinate of the lower left-hand corner of the box
+- `y1`: The y coordinate of the lower left-hand corner of the box
+- `x2`: The x coordinate of the upper right-hand corner of the box
+- `y2`: The y coordinate of the upper right-hand corner of the box
+- `average`: The average variable value within the domain, defaults to 0
+- `amplitude`: The variation from the average within the cross (`average` + `amplitude`) and outside of the cross (`average` - `amplitude`).
+
+## ThumbIC
+
+Thumb shaped bicrystal for grain boundary mobility tests. More information can be found on the [ThumbIC](/ThumbIC.md) syntax page.
+
+## PolycrystalICs
+
+PolycrystalICs are described [here](ICs/PolycrystalICs.md).

--- a/modules/phase_field/doc/content/modules/phase_field/Mechanics_Coupling.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Mechanics_Coupling.md
@@ -1,0 +1,33 @@
+# Mechanics Coupling
+
+Coupled phase field and mechanics simulations require a MOOSE executable that combine the `phase_field` and `tensor_mechanics` modules. One such executable can be built under `moose/modules/combined`. That directory also contains a set of examples that are worth looking at.
+
+Full coupling between *phase field* and *mechanics* goes both ways:
+
+1. The *phase field* variables influence the *mechanics* properties
+2. The *mechanics* state creates a free energy contribution that enters the *phase field* equations
+
+## Mechanical properties
+
+The mechanical properties of the system can (and will) be a function of the phase field variables in a tightly coupled simulation.
+
+#### Elasticity tensor
+
+Different phases (switched by a non-conserved order parameter) can have different elasticity tensors
+
+- [`CompositeElasticityTensor`](/CompositeElasticityTensor.md optional=true) is a tensor that depends on phase field variables in an arbitrary way.
+
+#### Eigenstrain (misfit strain, stress-free strain)
+
+Different phases (switched by a non-conserved order parameter) can have different eigenstrains. This is used to simulate lattice mismatch between phases.
+
+- [`ComputeVariableEigenstrain`](/ComputeVariableEigenstrain.md optional=true) is a tensor with a variable dependent scalar prefactor. It is best used to turn an eigenstrain on or off depending on a concentration variable.
+- [`CompositeEigenstrain`](/CompositeEigenstrain.md optional=true) is an eigenstrain tensor built from multiple tensor contributions weighted by material properties.
+
+## Elastic free energy
+
+To couple the phase field equations with mechanics a contribution of the deformation energy (elastic energy) needs to enter the free energy density of the system. The phase field equations should be assembled using the `CahnHilliard`, `SplitCHParsed`, and `AllenCahn` [Function Material Kernels](phase_field/FunctionMaterialKernels.md) which all take the free energy as a [Function Material](/phase_field/FunctionMaterials.md).
+
+- Define the *chemical* free energy using a [Function Material](/phase_field/FunctionMaterials.md).
+- The [`ElasticEnergyMaterial`](/ElasticEnergyMaterial.md) will automatically compute the free energy density contribution using the local stresses and strains.
+- Use the [`DerivativeSumMaterial`](/DerivativeSumMaterial.md) to sum the *chemical* and *elastic* free energy contributions to a total free energy (which is then passed to the kernels).

--- a/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Equations.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Equations.md
@@ -168,7 +168,7 @@ It is divided into three pieces, each implemented in their own kernel, as shown 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
 | - | - | - | - | - |
 $\left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right)$ | $\eta_j$ | | | [`TimeDerivative`](/TimeDerivative.md) |
-$\left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right)$ | $\eta_j$ | $\kappa_j,\ L$ | | [`ACInterface`](/ACInterface,md) |
+$\left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right)$ | $\eta_j$ | $\kappa_j,\ L$ | | [`ACInterface`](/ACInterface.md) |
 $L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right)$ | $\eta_j$ | $L$ | $\frac{\partial f_{loc} }{\partial \eta_j}, \frac{\partial E_d }{\partial \eta_j}$ | [`AllenCahn`](/AllenCahn.md) |
 
 The residual for the direct solution of the Cahn-Hilliard equation (without boundary terms) is

--- a/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Model_Units.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Model_Units.md
@@ -1,0 +1,95 @@
+# Phase Field Model Units
+
+While phase field models are often nondimensionalized, the inherent equations are dimensional. Thus, it is critical to understand and correctly implement the units, especially when coupling multiple physics.
+
+## Units Analysis of Phase Field Equations
+
+In the unit analysis, we break the equations down by units, with the following conventions:
+
+- $l$ - length
+- $t$ - time
+- $e$ - energy
+- $mol$ - moles
+
+### Free Energy Functional
+
+The driving force for evolution in the phase field method is the minimization of a free energy functional. The free energy functional is written as
+
+\begin{equation}
+	F = \int_V \big[ f_{loc}(c_1, \ldots,c_N, \eta_1, \ldots, \eta_M) + f_{gr}(c_1, \ldots,c_N, \eta_1,  \ldots, \eta_M) + E_{d} \big] \, dV,
+\end{equation}
+
+where $f_{loc}$ defines the local free energy density with the units $e/l^3$ and is a function of concentration variables $c_i$ (typically a molar fraction)
+and order parameters $\eta_i$. The gradient energy density
+
+\begin{equation}
+	f_{gr} = \sum_i^N \frac{\kappa_i}{2} |\nabla c_i|^2 + \sum^M_j \frac{\kappa_j}{2} |\nabla \eta_j|^2
+\end{equation}
+
+where $\kappa_i$ and $\kappa_j$ are gradient energy coefficients with the units $e/l$.  Finally, $E_d$ describes any additional sources of energy in the system, such as deformation or electrostatic energy, with units of $e/l^3$.
+
+### Allen-Cahn Equation
+
+The Allen-Cahn equation after the variational derivative takes the form
+
+\begin{equation}
+	\frac{\partial \eta_j}{\partial t} = - L \left( \frac{\partial f_{loc}}{\partial \eta_j} +  \frac{\partial E_{d}}{\partial \eta_j} - \kappa_j \nabla^2 \eta_j \right).
+\end{equation}
+
+The units of this equation are
+
+\begin{equation}
+	\frac{1}{t} = - \frac{l^3}{e t} \left( \frac{e}{l^3} +  \frac{e}{l^3} - \frac{e}{l} \frac{1}{l^2} \right).
+\end{equation}
+
+where the units of $L$ are $l^3/(e t)$.
+
+### Cahn-Hilliard Equation
+
+The Cahn-Hilliard equation after the variational derivative takes the form
+
+\begin{equation}
+	\frac{\partial c_i}{\partial t} = V_m \nabla \cdot M_i \nabla \left( \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_{d}}{\partial c_i} - \kappa_i \nabla^2 c_i  \right)
+\end{equation}
+
+where $V_m$ is the molar volume of the reference state of the material with units of $l^3/mol$. The units of this equation are
+
+\begin{equation}
+	\frac{1}{t} = \frac{l^3}{mol} \frac{1}{l} \frac{l^2 mol}{t e} \frac{1}{l} \left( \frac{e}{l^3} + \frac{e}{l^3} - \frac{e}{l} \frac{1}{l^2}  \right)
+\end{equation}
+
+where the units of $M_i$ are $(l^2 mol)/(e t)$. Note that some models include the $V_m$ in the mobility term, such that it has units of $l^5/(t e)$.
+
+### CALPHAD Local Free Energies
+
+A common approach for phase field models is to use free energies for the individual phases taken from the CALPHAD approach. CALPHAD free energies $F_\alpha$ typically have units of $e/mol$, therefore they must be converted to free energy densities using the molar volume according to
+
+\begin{equation}
+f_\alpha = \frac{F_\alpha}{V_m}.
+\end{equation}
+
+Note that when using a multiphase model, the CALPHAD free energies of each phase must be converted with the same reference molar volume $V_m$, with changes in volume between phases handled by stress-free strains.
+
+### Handling Units in MOOSE
+
+There is no inherent unit system in MOOSE. Thus, the units of the phase field equations are set by the user when they define a model. Specifically, the units are set by the local free energy density and the $\kappa$ and mobility parameters ($L$ and $M$). The units in all these terms must be consistent. Additional energy sources, such as the elastic energy, also must have consistent units. In the phase field module, all of these values are created using Material objects. Thus, the units of your system are not set by the kernels but rather by the materials.
+
+One useful practice is to create your material objects to take SI units as input parameters. Then use `length_scale`, `time_scale`, and `energy_scale` input parameters to convert the actual units of the problem. As an example of this, see the [PFParamsPolyFreeEnergy](/PFParamsPolyFreeEnergy.md) material, where the input file block looks like
+
+```yaml
+[./Copper]
+  type = PFParamsPolyFreeEnergy
+  block = 0
+  c = c
+  T = 1000 # K
+  int_width = 30.0
+  length_scale = 1.0e-9
+  time_scale = 1.0e-9
+  D0 = 3.1e-5 # m^2/s, from Brown1980
+  Em = 0.71 # in eV, from Balluffi1978 Table 2
+  Ef = 1.28 # in eV, from Balluffi1978 Table 2
+  surface_energy = 0.7 # J/m^2
+[../]
+```
+
+*Taken from `phase_field/tests/PolynomialFreeEnergy/split_order4_test.i`*

--- a/modules/phase_field/doc/content/modules/phase_field/Quantitative.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Quantitative.md
@@ -1,0 +1,223 @@
+# Quantitative Two Phase Polynomial Free Energies
+
+## Introduction
+
+In a species separation phase field model, a single concentration is used to model a two phase system. The evolution of the concentration is predicted by taking derivatives of a double-well free energy. This free energy can be represented with a simple thermodynamic model such that
+
+\begin{equation}
+f_0(c) = k_b T (c \ln c + (1 - c) \ln(1 - c)) + Wc(1-c)
+\end{equation}
+
+However, the natural logs in this expression can significantly complicate the solution, typically requiring small time steps to converge.
+
+An alternative to the thermodynamic free energy is to use polynomial free energy, which simplifies the numerical solution but decrease the physical accuracy. We have implemented polynomial free energies of three different orders in the phase field module that can be used to solve this problem.
+
+## Polynomial Equations
+
+We have implemented three polynomial free energies of different orders, as shown in the figure.
+
+!media phase_field/free_energies.png style=width:250px;padding-left:20px;float:right;
+    caption=Plot of the three polynomial free energies, with the thermodynamic free energy shown for reference.
+
+The simplest model is the fourth order free energy, where
+
+\begin{equation}
+f^4_0(c) = 16 W (c - c_{eq})^2 (1 - c - c_{eq})^2,
+\end{equation}
+
+Where $W$ is the height of the energy barrier and $c_{eq}$ is the equilibrium concentration.
+
+The sixth and eighth order polynomials are defined by the equation
+
+\begin{equation}
+f^N_0(c) = 2^N W \sum_{n=1}^N H^N_n c^n
+\end{equation}
+
+where
+
+\begin{equation}
+\begin{aligned}
+  H^6_1 =& \frac{3}{2} c_{eq} (c_{eq} - 1) \\
+  H^6_2 =& - \frac{9}{2} c_{eq}^2 + \frac{9}{2} c_{eq} + \frac{3}{4} \\
+  H^6_3 =& 6 c_{eq}^2 - 6 c_{eq} - \frac{7}{2} \\
+  H^6_4 =& - 3.0 c_{eq}^2 + 3.0 c_{eq} + \frac{27}{4} \\
+  H^6_5 =& -6\\
+  H^6_6 =& 2
+\end{aligned}
+\end{equation}
+
+and
+
+\begin{equation}
+\begin{aligned}
+  H^8_1 =& \frac{3}{4} c_{eq}(c_{eq} - 1) \\
+  H^8_2 =&  - \frac{15}{4}c_{eq}^2 + \frac{5}{4} c_{eq} + \frac{3}{8} \\
+  H^8_3 =& 10 c_{eq} - 10 c_{eq} - \frac{11}{4} \\
+  H^8_4 =& - 15 c_{eq}^2 + 15 c_{eq} + \frac{75}{8} \\
+  H^8_5 =& 12 c_{eq}^2 - 12 c_{eq} - 18 \\
+  H^8_6 =& -4 c_{eq}^2 + 4 c_{eq} + 20 \\
+  H^8_7 =& - 12 \\
+  H^8_8 =& 3
+\end{aligned}
+\end{equation}
+
+## Quantitative Model Development
+
+To create a quantitative model using the polynomial free energies, values for the mobility $M$, the barrier height $W$, $\kappa$ and $c_{eq}$ must be determined in terms of measurable quantities.  The equilibrium concentration $c_{eq}$ defines the locations of the wells in the free energy according to
+
+\begin{equation}
+  c_{eq} = e^{-\frac{E_f}{k_b T}}
+\end{equation}
+
+To determine the other parameters, we follow the derivation from [Moelans et al. (2008)](https://doi.org/10.1103/PhysRevB.78.024113).  To simplify the derivation, we consider an interface along the $y$-direction, such that the interfacial width is defined as
+
+\begin{equation}
+\begin{aligned}
+	l_i =& \frac{1}{|d x/d c|_{x=0}} \\
+	    =& \sqrt{\frac{\kappa_N}{2\ \mathrm{max}({f^N_{loc}})}}.
+\end{aligned}
+\end{equation}
+
+The polynomial free energies have been developed such that $\mathrm{max}(f^N_{loc}) = W$, thus
+
+\begin{equation}
+	l_i =  \sqrt{\frac{\kappa}{2 W}}.
+\end{equation}
+
+Therefore, $\kappa_N$ can be expressed as a function of the barrier height and the interfacial width according to
+
+\begin{equation}
+	\kappa = 2 W l_i^2 .\label{eq:kappa}
+\end{equation}
+
+To define the barrier height $W$, we first determine the surface energy.  The surface energy is calculated according to
+
+\begin{equation}
+	\sigma = \int^{+\infty}_{-\infty}  \left( f^N_{loc} + \frac{\kappa}{2} \left( \frac{\partial c}{\partial x} \right)^2 \right) dx.\label{eq:gbenergy1}
+\end{equation}
+
+According to the principles of variational calculus, the functions that extremize the function have zero first derivatives, i.e.
+
+\begin{equation}
+	\frac{\partial f_{loc}}{\partial c} - \kappa \frac{\partial^2 c}{\partial x^2} = 0,
+\end{equation}
+
+or, the integrated equation
+
+\begin{equation}
+	f_{loc} - \frac{\kappa}{2} \left( \frac{\partial c}{\partial x} \right)^2 = 0.
+\end{equation}
+
+By rearranging the equation, we obtain
+
+\begin{equation}
+	\frac{\partial c}{\partial x} = \sqrt{ \frac{2 f^N_{loc}}{\kappa}}. \label{eq:dcdx}
+\end{equation}
+
+Combining these equations gives
+
+\begin{equation}
+\begin{aligned}
+	\sigma =& \int^{+\infty}_{-\infty}  \left( f^N_{loc} + \frac{\kappa}{2} \frac{2 f^N_{loc}}{\kappa} \right) dx \\
+	       =& 2 \int^{+\infty}_{-\infty}   f_{loc}(c) \ dx.
+\end{aligned}
+\end{equation}
+
+After a change of variables and substitution,
+
+\begin{equation}
+\begin{aligned}
+	\sigma =& 2 \int^{1}_{0}  f_{loc}(c) \frac{d x}{d c} dc \\
+	       =& \sqrt{2 \kappa} \int^{1}_{0}  \sqrt{f_{loc}(c)}\ dc. \label{eq:gbenergy2}
+\end{aligned}
+\end{equation}
+
+To define the value of the integral $\int^{1}_0 \sqrt{f_{loc}(c)} \ dc$, we express it as
+
+\begin{equation}
+\begin{aligned}
+	\int^{1}_{0}  \sqrt{f_{loc}(c)}\ dc =& \sqrt{W} \ 2^{\frac{N}{2}}  \int^{1}_{0} \sqrt{\sum_{n=0}^N H^N_n  c^{\frac{n}{2}}} dc \\
+	                                    =& \sqrt{W} \ K_N \label{eq:int}
+\end{aligned}
+\end{equation}
+
+where $K_N  = 2^{\frac{N}{2}}  \int^{1}_{0} \sqrt{\sum_{n=0}^N H^N_n  c^{\frac{n}{2}}} dc$ is a function of $c_{eq}$ that varies for each polynomial order $N$.  If we assume that $c_{eq} \ll 1$, $K_N$ becomes a constant value which we can calculate for each polynomial order, according to
+
+\begin{equation}
+\begin{aligned}
+	K_4 =& \frac{2}{3} \\
+	K_6 =& \frac{3}{16} \sqrt{3} - \frac{9}{64} \sqrt{2} \ln \left(\frac{\sqrt{3} - \sqrt{2}}{\sqrt{3} + \sqrt{2}} \right) \\
+	K_8 =& 0.83551
+\end{aligned}
+\end{equation}
+
+with $K_8$ evaluated numerically.  Thus, the surface energy is equal to
+
+\begin{equation}
+	\sigma = K_N \sqrt{2 \kappa W}. \label{eq:surfenergy}
+\end{equation}
+
+We can then solve for $W$ to obtain
+
+\begin{equation}
+	W = \frac{\sigma^2}{2 K_N^2 \kappa_N}.
+\end{equation}
+
+By combining these equations, we obtain
+
+\begin{equation}
+	\kappa = \frac{\sigma l_i}{ K_N}.
+\end{equation}
+
+This expression is then substituted to give
+
+\begin{equation}
+	W = \frac{\sigma}{2 K_N l_i}.
+\end{equation}
+
+
+The form of the mobility must be derived to produce a quantitative physical behavior.  In order for the phase field model to accurately describe vacancy diffusion, the Cahn-Hilliard equation must be equivalent to Fickian diffusion when $c \ll 1$, i.e.
+
+\begin{equation}
+	\nabla \cdot M \nabla \frac{\partial F}{\partial c} = \nabla \cdot D \nabla c,
+\end{equation}
+
+where $M$ is the mobility for the polynomial free energy and $D$ is the diffusivity.  Thus, for $c \ll 1$
+
+\begin{equation}
+	M = D \frac{\nabla c}{\nabla {\partial f^N_{loc}}/{\partial c}} \label{eq:mob}
+\end{equation}
+
+For each of the polynomial free energies, the value of $\nabla \partial f_{loc}^N/\partial c$ for $c \ll 1$ can be written in the form
+
+\begin{equation}
+	\nabla \frac{\partial f_{loc}^N}{\partial c} = 2^{N+1} H^N_2 W \nabla c \label{eq:mob2}
+\end{equation}
+
+where $H^N_2$ is a polynomial coefficient defined above.   Thus, the value for the mobility is determined by combining the equations to obtain
+
+\begin{equation}
+\begin{aligned}
+	M =&  \frac{D}{2^{N+1} C^N_2 W_N} \\
+	  =& \frac{K_N}{ 2^{N+1} C^N_2} \frac{D l_i}{ \sigma}\label{eq:Mi}
+\end{aligned}
+\end{equation}
+
+
+To summarize, the quantitative expressions for the four model parameters required by the polynomial free energies can be obtained using the equations above.  We restate them here:
+
+\begin{equation}
+\begin{aligned}
+	c_{eq} =& e^{-\frac{E_f}{k_b T}} \\
+	\kappa =& \frac{\sigma l_i}{K_N}  \\
+	W      =& \frac{\sigma}{2 K_N l_i} \\
+	M      =& \frac{K_N}{ 2^{N+1} H^N_2} \frac{D l_i}{ \sigma}
+\end{aligned}
+\end{equation}
+
+
+## Numerical Implementation in the Phase Field Module
+
+The polynomial free energies have been implemented in the [`PolynomialFreeEnergy`](/PolynomialFreeEnergy.md) material in the MOOSE phase field module. The free energies are all contained in the same material, where the order is an input parameter. To minimize required code and coding errors, the free energy derivatives are obtained using automatic differentiation via the [`ExpressionBuilder`](FunctionMaterials/ExpressionBuilder.md) tools. The free energy is used by the parsed kernels, [`SplitCHParsed`](/SplitCHParsed.md) and [`CahnHilliard`](/CahnHilliard.md).
+
+The material properties required for the model have been implemented in the [`PFParamsPolyFreeEnergy`](/PFParamsPolyFreeEnergy.md), which also takes the polynomial order as an input.

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial.md
@@ -1,0 +1,116 @@
+# Phase-Field Tutorial: Spinodal Decomposition of Iron-Chromium Alloy
+
+## Introduction
+
+The purpose of this tutorial is to help new users learn the process of developing a phase-field model in the MOOSE framework. It gives step-by-step instructions for development and introduces various built-in tools that help the system run better. This tutorial does not explain the basis of the phase-field theory or cover object development in MOOSE.
+
+## Problem Setup
+
+We are interested in using phase field to model the spinodal decomposition of an iron-chromium alloy at 500°C over a time scale of one week. We will perform the simulation on a two-dimensional 25nm × 25nm surface. The interactions between iron and chromium are relatively simple and depend solely on the concentrations of the two species. Therefore, the system can be modeled using the [Cahn-Hilliard equation](Phase_Field_Equations.md) with no external energy sources:
+
+\begin{equation}
+\frac {\partial c} {\partial t} = \nabla \cdot M(c) \nabla \left(\frac {\partial f_{loc}(c)}  {\partial c} - \kappa \nabla^2 c\right)
+\end{equation}
+
+In this case, $c$ is the mole fraction of chromium (unitless), $M(c)$ is the mobility of chromium ($\frac {m^2 mol} {J s}$), $f_{loc}(c)$ is the free energy density ($\frac {J} {mol}$), and $\kappa$ is the gradient energy coefficient ($\frac {J m^2} {mol}$). Values for these terms can be looked up in a database or calculated in a thermodynamic software package. In this problem, values were fit to equations which rely on the equation
+
+\begin{equation}
+g_j(c) = A_j c + B_j (1-c) + C_j c · ln(c) + D_j (1-c) ln(1-c)
++ E_j c (1-c) + F_j c (1-c) (2c-1) + G_j c (1-c) (2c-1)^2.
+\end{equation}
+
+The free energy is fit to
+
+\begin{equation}
+f_{loc}(c) = g_f(c).
+\end{equation}
+
+While the mobility is fit to
+
+\begin{equation}
+M(c) = (1-c)^2 c · 10^{g_{Cr}(c)} + c^2 · (1-c) 10^{g_{Fe}(c)}.
+\end{equation}
+
+The coefficients used in these two equations at 500°C are
+
+| f Variable | f Value | Cr Variable | Cr Value | Fe Variable | Fe Value |
+| - | - | - | - | - | - |
+$A_f$ | -24468.31 | $A_{Cr}$ | -32.770969  | $A_{Fe}$ | -31.687117  |
+$B_f$ | -28275.33 | $B_{Cr}$ | -25.8186669 | $B_{Fe}$ | -26.0291774 |
+$C_f$ |  4167.994 | $C_{Cr}$ | -3.29612744 | $C_{Fe}$ |  0.2286581  |
+$D_f$ |  7052.907 | $D_{Cr}$ |  17.669757  | $D_{Fe}$ |  24.3633544 |
+$E_f$ |  12089.93 | $E_{Cr}$ |  37.6197853 | $E_{Fe}$ |  44.3334237 |
+$F_f$ |  2568.625 | $F_{Cr}$ |  20.6941796 | $F_{Fe}$ |  8.72990497 |
+$G_f$ | -2345.293 | $G_{Cr}$ |  10.8095813 | $G_{Fe}$ |  20.956768  |
+
+while the coefficient $\kappa$ is $8.125×10^{-16}$.
+
+The alloy is 45 wt% chromium and is initially uniformly distributed, with minor random variations.
+
+## Problem Analysis
+
+### Units
+
+The initial condition is given in weight percent, but the equations are given to us on a molar basis. Therefore, we can use the molecular weights of chromium to convert the initial condition from 45 wt% to 46.774 mol% chromium.
+
+In units of meters, the mesh would be entered into MOOSE as $25×10^{-9}$ by $25×10^{-9}$. However, MOOSE has a built in tolerance that will not allow mesh nodes to be any closer together than $10^{-6}$. To get around this we need to change the length scale to units of nanometers. To prevent the values from becoming too large or too small, we will also change the energy scale to units of electron volts. The conversion from meters to nanometers is $10^9$. The conversion from joules to electron volts is $6.24150934×10^{18}$. Rather than converting all of the values in the table above, we will program these conversions into the input file and do the conversions within the file.
+
+### Plots
+
+!media /phase_field/energydensitycurve.png  style=width:300px;padding-left:20px;float:right;
+    caption=Free energy density curve for iron-chromium alloy.
+
+The free energy density equation given above is a double-well energy curve, meaning the alloy will want to decompose into two phases with distinct concentrations. The equilibrium concentrations are found at the double tangent line of the free energy density curve. The double tangent line can be solved using a numerical solver. The equilibrium concentrations are 23.6 mol% and 82.3 mol% chromium. We will refer to these as the iron and chromium phases respectively. The curve and the double tangent line are shown to the right:
+
+If we perform a material balance on the surface using the initial condition, we find that 39.5% of the surface should decompose to the chromium phase, with the rest decomposing to the iron phase.
+
+While the curve to the right shows that the mobility varies greatly depending on the concentration, we will begin by assuming that $M(c)$ is constant. There are a lot of values we could choose, but a reasonable one would be the value at our initial condition. At 46.774 mol% chromium, the mobility is $2.2841 × 10^{-26} \frac {m^2 mol} {J s}$.
+
+!media /phase_field/mobilitycurve.png  style=width:300px;padding-left:20px;float:right;
+    caption=Mobility curve for iron-chromium alloy.
+
+### Expectations
+
+We expect three things from this simulation. First, the surface should decompose into the iron and chromium phases at the equilibrium concentrations. Second, the decomposed surface will minimize energy by minimizing the interface contact between the two phases. It does this by shaping the regions as circles or large stripes. Third, most phase field problems reduce the free energy of the surface in an S-curve shape. That is, at the beginning and end of the simulation, there is relatively little change in the free energy of the surface, but there is a rapid decrease somewhere in the middle. We will look for each of these as we develop our model.
+
+## Simulation Development
+
+We will develop a full working code in 5 steps. Each step will build on the code that was written in the previous steps.
+
+### Step 1: Make a Simple Test Model
+
+We will begin by developing the simplest model we can and checking one of our expectations about the result.
+
+[step 1: Test Model](Tutorial/Step1.md)
+
+### Step 2: Make a Faster Test Model
+
+Now that the simplest model is working, lets add some features to improve how it runs.
+
+[step 2: Fast Model](Tutorial/Step2.md)
+
+### Step 3: Add Phase Decomposition to the Model
+
+Now that the model is working and running fast, lets put in the real initial conditions and the real time frame and see if the surface decomposes like we expect it to.
+
+[step 3: Decomposition](Tutorial/Step3.md)
+
+### Step 4: Make the Mobility a Function
+
+It is time to use the mobility function instead of a constant.
+
+[step 4: Mobility Function](Tutorial/Step4.md)
+
+### Step 5: Check the Surface Energy Curve
+
+Let's optimize our convergence and see how the free energy of the surface changes with time.
+
+[step 5: Energy Curve](Tutorial/Step5.md)
+
+## Conclusions
+
+We are now done with this tutorial. We started by defining the problem and the equations and variables that would lead to a solution. Then we developed some expectations for how the problem would behave.
+
+Then we started developing our simulation. We started with the most basic model we could get, then added features to make the model converge faster. As we developed the model we made it more realistic and kept adding features to tell us more information about the system and to help it converge faster.
+
+Along the way we talked about the various blocks and parameters that are required for MOOSE to work properly as well as some of the blocks and parameters that can help it run smoothly. Of course there is a lot more that MOOSE can do. Keep exploring the Wiki to find more features.

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial.md
@@ -57,7 +57,7 @@ In units of meters, the mesh would be entered into MOOSE as $25×10^{-9}$ by $25
 
 ### Plots
 
-!media /phase_field/energydensitycurve.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/energydensitycurve.png  style=width:300px;padding-left:20px;float:right;
     caption=Free energy density curve for iron-chromium alloy.
 
 The free energy density equation given above is a double-well energy curve, meaning the alloy will want to decompose into two phases with distinct concentrations. The equilibrium concentrations are found at the double tangent line of the free energy density curve. The double tangent line can be solved using a numerical solver. The equilibrium concentrations are 23.6 mol% and 82.3 mol% chromium. We will refer to these as the iron and chromium phases respectively. The curve and the double tangent line are shown to the right:
@@ -66,7 +66,7 @@ If we perform a material balance on the surface using the initial condition, we 
 
 While the curve to the right shows that the mobility varies greatly depending on the concentration, we will begin by assuming that $M(c)$ is constant. There are a lot of values we could choose, but a reasonable one would be the value at our initial condition. At 46.774 mol% chromium, the mobility is $2.2841 × 10^{-26} \frac {m^2 mol} {J s}$.
 
-!media /phase_field/mobilitycurve.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/mobilitycurve.png  style=width:300px;padding-left:20px;float:right;
     caption=Mobility curve for iron-chromium alloy.
 
 ### Expectations

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step1.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step1.md
@@ -198,10 +198,10 @@ The outputs block lets us decide what MOOSE tells us about the simulation. We wi
 
 ## Simulation Results
 
-!media /phase_field/simple1out.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/simple1out.png  style=width:300px;padding-left:20px;float:right;
         caption=Final result of Simple Test Model
 
-!media /phase_field/Simple1in.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/Simple1in.png  style=width:300px;padding-left:20px;float:right;
     caption=Initial condition of Simple Test Model.
 
 The first image to the right shows the initial condition of this simulation. The second image shows the end result of the simulation. The result shows that the chromium phase's corners are rounding out and the shape is becoming more circular. This is exactly what we would expect to happen as the surface tries to reduce its free energy. This result is a promising sign that our simulation is working correctly.

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step1.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step1.md
@@ -1,0 +1,211 @@
+# Step 1: Make a Simple Test Model
+
+The input file for this step can be found here: [s1_testmodel.i](https://github.com/idaholab/moose/blob/devel/modules/phase_field/tutorials/spinodal_decomposition/s1_testmodel.i)
+
+## Input File Blocks
+
+We are going to start with the simplest input file we can. We will add on more features and make the model more accurate as we go. We will be using the [Split Cahn-Hilliard](Phase_Field_Equations.md) method because it converges faster than the direct method. The basic blocks we need are: Mesh, Variables, ICs, BCs, Kernels, Materials, Precoditioning, Executioner, and Outputs.
+
+### Mesh
+
+The mesh block is going to create a two dimensional mesh that is 25nm × 25nm and has 100 × 100 elements.
+
+```yaml
+[Mesh]
+  # generate a 2D, 25nm x 25nm mesh
+  type = GeneratedMesh
+  dim = 2
+  elem_type = QUAD4
+  nx = 100
+  ny = 100
+  nz = 0
+  xmin = 0
+  xmax = 25
+  ymin = 0
+  ymax = 25
+  zmin = 0
+  zmax = 0
+[]
+```
+
+### Variables
+
+Because we are using the split form, two variables are defined, the mole fraction of chromium and the chemical potential.
+
+```yaml
+[Variables]
+  [./c]   # Mole fraction of Cr (unitless)
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./w]   # Chemical potential (eV/mol)
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+```
+
+### ICs
+
+To start off we want to check our second expectation. That is, that the surface will minimize its interface region by forming circular or straight line regions. To do this, we will use a Bounding Box Initial Condition with the equilibrium concentrations we calculated from the free energy density curve.
+
+```yaml
+[ICs]
+  # Use a bounding box IC at equilibrium concentrations to make sure the
+  # model behaves as expected.
+  [./testIC]
+    type = BoundingBoxIC
+    variable = c
+    x1 = 5
+    x2 = 20
+    y1 = 5
+    y2 = 20
+    inside = 0.823
+    outside = 0.236
+  [../]
+[]
+```
+
+### BCs
+
+It is common in phase field simulations to use periodic boundary conditions.
+
+```yaml
+[BCs]
+  # periodic BC as is usually done on phase-field models
+  [./Periodic]
+    [./c_bcs]
+      auto_direction = 'x y'
+    [../]
+  [../]
+[]
+```
+
+### Kernels
+
+We will use the kernels specified for the split Cahn-Hilliard equation. Note that here we name the free energy function, the mobility, and the gradient energy coefficient "f_loc", "M", and "kappa_c" respectively. These have the same names in the materials block.
+
+```yaml
+[Kernels]
+  [./w_dot]
+    variable = w
+    v = c
+    type = CoupledTimeDerivative
+  [../]
+  [./coupled_res]
+    variable = w
+    type = SplitCHWRes
+    mob_name = M
+  [../]
+  [./coupled_parsed]
+    variable = c
+    type = SplitCHParsed
+    f_name = f_loc
+    kappa_name = kappa_c
+    w = w
+  [../]
+[]
+```
+
+### Materials
+
+The materials block defines the equations and constants in the model. This is where we will define $f_{loc}(c)$, $M(c)$, and $\kappa$ in MOOSE. To simplify things right now, we are going to define $M(c)$ as a constant value rather than a function. We will also be doing unit conversions in the materials block. Note that each value has the same name as in the kernels block.
+
+In addition to the unit conversions, it was accidentally discovered that the convergence properties can be improved by using a scaling factor, $d$. Both $f_{loc}(c)$ and $\kappa$ are multiplied by $d$, while $M(c)$ is multiplied by the inverse of $d$. This does not change the solution, but it does seem to help the convergence.
+
+```yaml
+[Materials]
+  # d is a scaling factor that makes it easier for the solution to converge
+  # without changing the results. It is defined in each of the materials and
+  # must have the same value in each one.
+  [./constants]
+    # Define constant values kappa_c and M. Eventually M will be replaced with
+    # an equation rather than a constant.
+    type = GenericFunctionMaterial
+    block = 0
+    prop_names = 'kappa_c M'
+    prop_values = '8.125e-16*6.24150934e+18*1e+09^2*1e-27
+                   2.2841e-26*1e+09^2/6.24150934e+18/1e-27'
+                   # kappa_c*eV_J*nm_m^2*d
+                   # M*nm_m^2/eV_J/d
+  [../]
+  [./local_energy]
+    # Defines the function for the local free energy density as given in the
+    # problem, then converts units and adds scaling factor.
+    type = DerivativeParsedMaterial
+    block = 0
+    f_name = f_loc
+    args = c
+    constant_names = 'A   B   C   D   E   F   G  eV_J  d'
+    constant_expressions = '-2.446831e+04 -2.827533e+04 4.167994e+03 7.052907e+03
+                            1.208993e+04 2.568625e+03 -2.354293e+03
+                            6.24150934e+18 1e-27'
+    function = 'eV_J*d*(A*c+B*(1-c)+C*c*log(c)+D*(1-c)*log(1-c)+
+                E*c*(1-c)+F*c*(1-c)*(2*c-1)+G*c*(1-c)*(2*c-1)^2)'
+  [../]
+[]
+```
+
+### Preconditioning
+
+The split Cahn-Hilliard has the best convergence properties when we use the [Newton solver](Solving.md). The newton solver always requires preconditioning.
+
+```yaml
+[Preconditioning]
+  [./coupled]
+    type = SMP
+    full = true
+  [../]
+[]
+```
+
+### Executioner
+
+The executioner block tells MOOSE how to solve the problem. Many of the values in this block are arbitrary and you can experiment with changing them to see how they change the solution. See the the [Executioner](/syntax/Preconditioning/index.html) and [Preconditioning](/syntax/Executioner/index.html) pages for more information on these systems.
+
+Right now our main interest is in seeing if the model is working. So we shortened the time that the simulation runs to just be long enough to see if the grain is becoming circular.
+
+```yaml
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  l_max_its = 30
+  l_tol = 1e-6
+  nl_max_its = 50
+  nl_abs_tol = 1e-9
+  end_time = 86400   # 1 day. We only need to run this long enough to verify
+                     # the model is working properly.
+  petsc_options_iname = '-pc_type -ksp_grmres_restart -sub_ksp_type
+                         -sub_pc_type -pc_asm_overlap'
+  petsc_options_value = 'asm      31                  preonly
+                         ilu          1'
+  dt = 100
+[]
+```
+
+### Outputs
+
+The outputs block lets us decide what MOOSE tells us about the simulation. We will output the initial condition so we can compare it to the final condition.
+
+```yaml
+[Outputs]
+  exodus = true
+  console = true
+  print_perf_log = true
+  output_initial = true
+[]
+```
+
+## Simulation Results
+
+!media /phase_field/simple1out.png  style=width:300px;padding-left:20px;float:right;
+        caption=Final result of Simple Test Model
+
+!media /phase_field/Simple1in.png  style=width:300px;padding-left:20px;float:right;
+    caption=Initial condition of Simple Test Model.
+
+The first image to the right shows the initial condition of this simulation. The second image shows the end result of the simulation. The result shows that the chromium phase's corners are rounding out and the shape is becoming more circular. This is exactly what we would expect to happen as the surface tries to reduce its free energy. This result is a promising sign that our simulation is working correctly.
+
+## Continue
+
+[step 2: Make a Faster Test Model](Step2.md)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step2.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step2.md
@@ -1,0 +1,108 @@
+# Step 2: Make a Faster Test Model
+
+The input file for this step can be found here: [s2_fasttest.i](https://github.com/idaholab/moose/blob/devel/modules/phase_field/tutorials/spinodal_decomposition/s2_fasttest.i)
+
+## Changes to input file
+
+Before we work on improving the accuracy of the model, it is a good idea to add some features that will speed up the solution. We will add adaptive time stepping, prevent MOOSE from taking unnecessary derivatives, and tell MOOSE to output some information that can help us speed up the simulation even more.
+
+### Derivative Order
+
+Parsed materials allow MOOSE to take the derivatives of the input functions automatically, rather than the user having to input the derivatives by hand. MOOSE will default to taking 3rd order derivatives, but in our problem we only need second order derivatives calculated. We can specify that MOOSE should only take second order derivatives and prevent it from taking unnecessary third derivatives.
+
+```yaml
+[./local_energy]
+    # Defines the function for the local free energy density as given in the
+    # problem, then converts units and adds scaling factor.
+    type = DerivativeParsedMaterial
+    block = 0
+    f_name = f_loc
+    args = c
+    constant_names = 'A   B   C   D   E   F   G  eV_J  d'
+    constant_expressions = '-2.446831e+04 -2.827533e+04 4.167994e+03 7.052907e+03
+                            1.208993e+04 2.568625e+03 -2.354293e+03
+                            6.24150934e+18 1e-27'
+    function = 'eV_J*d*(A*c+B*(1-c)+C*c*log(c)+D*(1-c)*log(1-c)+
+                E*c*(1-c)+F*c*(1-c)*(2*c-1)+G*c*(1-c)*(2*c-1)^2)'
+    derivative_order = 2
+  [../]
+```
+
+### Adaptive Time Stepping
+
+Adaptive time stepping lets the simulation change the time step size depending on how quickly the surface is actually changing. There are several ways to tell MOOSE how to decide how to change the time step. For this simulation we will link it to how many iterations it takes the previous time step to converge. This is done in a sub-block of the executioner block.
+
+```yaml
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  l_max_its = 30
+  l_tol = 1e-6
+  nl_max_its = 50
+  nl_abs_tol = 1e-9
+  end_time = 86400   # 1 day. We only need to run this long enough to verify
+                     # the model is working properly.
+  petsc_options_iname = '-pc_type -ksp_gmres_restart -sub_ksp_type -sub_pc_type -pc_asm_overlap'
+  petsc_options_value = 'asm      31                  preonly      ilu          1'
+  [./TimeStepper]
+    # Turn on time stepping
+    type = IterationAdaptiveDT
+    dt = 10
+    cutback_factor = 0.8
+    growth_factor = 1.5
+    optimal_iterations = 7
+  [../]
+[]
+```
+
+### More Information from MOOSE
+
+If we are going to maximize how the solution converges, we need to know some more information. First we are going to have MOOSE tell us how many times it calculated the residual, then we will have it tell us how long it is spending on the simulation. If we know these pieces of information, we can make small changes to the input files and see how those changes affect our convergence.
+
+To do this, we add [Postprocessors](/syntax/Postprocessors/). Eventually we will add a lot to tell us about the simulation, but here we will start with two.
+
+```yaml
+[Postprocessors]
+  [./evaluations]           # Cumulative residual calculations for simulation
+    type = NumResidualEvaluations
+  [../]
+  [./active_time]           # Time computer spent on simulation
+    type = RunTime
+    time_type = active
+  [../]
+[]
+```
+
+Now that we have Postprocessors, we need to output them. We modify the outputs block to output a csv file and a terminal console that will tell us the PostProcessor values.
+
+```yaml
+[Outputs]
+  exodus = true
+  console = true
+  csv = true
+  print_perf_log = true
+  output_initial = true
+  [./console]
+    type = Console
+    max_rows = 10
+  [../]
+[]
+```
+
+There is another option that can improve the speed of convergence. The system converges best if the residuals of all variables are at the same magnitude. MOOSE has an option called scaling, which allows us to multiply the residual of one of the variables by some factor in order to get the residuals to the same magnitude. But before we can do this, we need to know what the residuals are. We add a Debug block to tell us the residuals after every iteration.
+
+```yaml
+[Debug]
+  show_var_residual_norms = true
+[]
+```
+
+## Simulation Results
+
+After running this simulation, you should see that the solution is identical to the first simulation, but it took only a small fraction of the time and only a small fraction of the time steps. We can open the csv file that was generated and see information about how long the simulation took. Additionally, we can look at the terminal screen and see that as each time step converges, the two variable residuals have the same magnitude. No scaling is necessary right now.
+
+Now that the simulation is going fast, we can change it to the real initial conditions and see if it will decompose like we expect it to.
+
+## Continue
+
+[step 3: Add Phase Decomposition to the Model](Step3.md)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step3.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step3.md
@@ -1,0 +1,130 @@
+# Step 3: Add Phase Decomposition to the Model
+
+The input file for this step can be found here: [s3_decomp.i](https://github.com/idaholab/moose/blob/devel/modules/phase_field/tutorials/spinodal_decomposition/s3_decomp.i)
+
+## Changes to input file
+
+We are going to change four things: The initial conditions, the solution time, we are going to add mesh adaptivity, and we will add more Postprocessors.
+
+### Initial Conditions
+
+We know that the initial conditions should be 46.774 mol% chromium with minor variations. We will input this using random initial conditions.
+
+```yaml
+[ICs]
+  [./concentrationIC]   # 46.774 mol% Cr with variations
+    type = RandomIC
+    min = 0.44774
+    max = 0.48774
+    seed = 210
+    variable = c
+  [../]
+[]
+```
+
+Note that the seed is the random number generator seed. It should not effect how the simulation behaves.
+
+### Solution Time
+
+Before we were just running the simulation long enough to begin to see the behavior. Now we want to run it for the full seven days. We change this in the executioner block.
+
+```yaml
+    end_time = 604800   # 7 days
+```
+
+### Mesh Adaptivity
+
+In order to accurately calculate the phase interfaces, we need a relatively fine mesh. However, in the bulk of the phases we can significantly speed up the solution by using a coarse mesh. Luckily, MOOSE comes equipped to let us refine the mesh where we need extra accuracy and coarsen it where we don't. We change the mesh block to look like this:
+
+```yaml
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  distribution = DEFAULT
+  elem_type = QUAD4
+  nx = 25
+  ny = 25
+  nz = 0
+  xmin = 0
+  xmax = 25
+  ymin = 0
+  ymax = 25
+  zmin = 0
+  zmax = 0
+  uniform_refine = 2
+[]
+```
+
+The basic mesh is 25 × 25 elements. This defines the coarsest the mesh can be. The uniform_refine option refines the mesh for the first time step to be a 100 × 100 element mesh. If we do not turn on mesh adaptivity, the mesh would remain 100 × 100 throughout the simulation and it would be the exact same mesh we have used already.
+
+To add mesh adaptivity, we go back to the executioner block, add the adaptivity sub-block, and tell it we want the maximum refinement level to be two factors finer than the coarsest mesh allowed.
+
+```yaml
+[Executioner]
+  type = Transient
+  solve_type = NEWTON
+  l_max_its = 30
+  l_tol = 1e-6
+  nl_max_its = 50
+  nl_abs_tol = 1e-9
+  end_time = 604800   # 7 days
+  petsc_options_iname = '-pc_type -ksp_grmres_restart -sub_ksp_type
+                         -sub_pc_type -pc_asm_overlap'
+  petsc_options_value = 'asm      31                  preonly
+                         ilu          1'
+  [./TimeStepper]
+    type = IterationAdaptiveDT
+    dt = 10
+    cutback_factor = 0.8
+    growth_factor = 1.5
+    optimal_iterations = 7
+  [../]
+  [./Adaptivity]
+    coarsen_fraction = 0.1
+    refine_fraction = 0.7
+    max_h_level = 2
+  [../]
+[]
+```
+
+### Postprocessors
+
+With the mesh adaptivity turned on, we are now interested in how many elements the surface has. We can calculate this by turning the NumNodes Postprocessor on.
+
+We are also interested in how the size of the time step changes throughout the simulation, so we add a TimeStepSize Postprocessor. We can also look at the number of iterations at each time step.
+
+```yaml
+[Postprocessors]
+  [./step_size]             # Size of the time step
+    type = TimestepSize
+  [../]
+  [./iterations]            # Number of iterations needed to converge timestep
+    type = NumNonlinearIterations
+  [../]
+  [./nodes]                 # Number of nodes in mesh
+    type = NumNodes
+  [../]
+  [./evaluations]           # Cumulative residual calculations for simulation
+    type = NumResidualEvaluations
+  [../]
+  [./active_time]           # Time computer spent on simulation
+    type = RunTime
+    time_type = active
+  [../]
+[]
+```
+
+## Simulation Results
+
+!media /phase_field/DecompositionResults.png  style=width:300px;padding-left:20px;float:right;
+        caption=Decomposition Results - Mesh shown
+
+The image to the right is of the results of this simulation. The mesh is shown to see how adaptivity effects the mesh. The mesh remains fine where there is a large concentration gradient, but coarsens in large areas with little change.
+
+We can see that the alloy did decompose into the two phases and that the phases are forming circles. This means our model is likely good. Depending on your random variations in the initial condition, you may also have circles or you could have a stripe through the surface.
+
+Next we are ready to input the mobility as a function and to see and how much of the surface is devoted to each phase.
+
+## Continue
+
+[step 4: Make the Mobility a Function](Step4.md)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step3.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step3.md
@@ -116,7 +116,7 @@ We are also interested in how the size of the time step changes throughout the s
 
 ## Simulation Results
 
-!media /phase_field/DecompositionResults.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/DecompositionResults.png  style=width:300px;padding-left:20px;float:right;
         caption=Decomposition Results - Mesh shown
 
 The image to the right is of the results of this simulation. The mesh is shown to see how adaptivity effects the mesh. The mesh remains fine where there is a large concentration gradient, but coarsens in large areas with little change.

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step4.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step4.md
@@ -1,0 +1,99 @@
+# Step 4: Make the Mobility a Function
+
+The input file for this step can be found here: [s4_mobility.i](https://github.com/idaholab/moose/blob/devel/modules/phase_field/tutorials/spinodal_decomposition/s4_mobility.i)
+
+## Input File Changes
+
+We are going to make two changes to our simulation. First, we will make the mobility a function instead of a constant. Then, we will check if the surface is decomposing to 39.5% chromium phase as the material balance says it should. Both of these changes are primarily in the materials block. We will use a `DerivativeParsedMaterial` to define the equation for mobility, similar to how we defined the free energy density. We will have to remove it from the constants block. Then we will add another material to check if each element is in the chromium phase. The materials block now looks like this:
+
+```yaml
+[Materials]
+  # d is a scaling factor that makes it easier for the solution to converge
+  # without changing the results. It is defined in each of the first three
+  # materials and must have the same value in each one.
+  [./kappa]                  # Gradient energy coefficient (eV nm^2/mol)
+    type = GenericFunctionMaterial
+    prop_names = 'kappa_c'
+    prop_values = '8.125e-16*6.24150934e+18*1e+09^2*1e-27'
+                  # kappa_c*eV_J*nm_m^2*d
+  [../]
+  [./mobility]               # Mobility (nm^2 mol/eV/s)
+    type = DerivativeParsedMaterial
+    f_name = M
+    args = c
+    constant_names =       'Acr    Bcr    Ccr    Dcr
+                            Ecr    Fcr    Gcr
+                            Afe    Bfe    Cfe    Dfe
+                            Efe    Ffe    Gfe
+                            nm_m   eV_J   d'
+    constant_expressions = '-32.770969 -25.8186669 -3.29612744 17.669757
+                            37.6197853 20.6941796  10.8095813
+                            -31.687117 -26.0291774 0.2286581   24.3633544
+                            44.3334237 8.72990497  20.956768
+                            1e+09      6.24150934e+18          1e-27'
+    function = 'nm_m^2/eV_J/d*((1-c)^2*c*10^
+                (Acr*c+Bcr*(1-c)+Ccr*c*log(c)+Dcr*(1-c)*log(1-c)+
+                Ecr*c*(1-c)+Fcr*c*(1-c)*(2*c-1)+Gcr*c*(1-c)*(2*c-1)^2)
+                +c^2*(1-c)*10^
+                (Afe*c+Bfe*(1-c)+Cfe*c*log(c)+Dfe*(1-c)*log(1-c)+
+                Efe*c*(1-c)+Ffe*c*(1-c)*(2*c-1)+Gfe*c*(1-c)*(2*c-1)^2))'
+    derivative_order = 1
+    outputs = exodus
+  [../]
+  [./local_energy]           # Local free energy function (eV/mol)
+    type = DerivativeParsedMaterial
+    f_name = f_loc
+    args = c
+    constant_names = 'A   B   C   D   E   F   G  eV_J  d'
+    constant_expressions = '-2.446831e+04 -2.827533e+04 4.167994e+03 7.052907e+03
+                            1.208993e+04 2.568625e+03 -2.354293e+03
+                            6.24150934e+18 1e-27'
+    function = 'eV_J*d*(A*c+B*(1-c)+C*c*log(c)+D*(1-c)*log(1-c)+
+                E*c*(1-c)+F*c*(1-c)*(2*c-1)+G*c*(1-c)*(2*c-1)^2)'
+    derivative_order = 2
+  [../]
+  [./precipitate_indicator]  # Returns 1/625 if precipitate
+      type = ParsedMaterial
+      f_name = prec_indic
+      args = c
+      function = if(c>0.6,0.0016,0)
+    [../]
+[]
+```
+
+Note that the area of our surface is 625 $nm^2$, and $\frac {1} {625} = 0.0016$. Within the different materials, the argument "block = 0" is not included. It can save time if we can define common arguments once rather than in each material. To do this, we include a global parameters block.
+
+```yaml
+[GlobalParams]
+  block = 0           # The generated mesh is used for all materials and kernels
+[]
+```
+
+The mobility equation is now ready to run. However, the chromium phase fraction will not be output. In order to output it we add a Postprocessor.
+
+```yaml
+  [./precipitate_area]      # Fraction of surface devoted to precipitates
+    type = ElementIntegralMaterialProperty
+    mat_prop = prec_indic
+  [../]
+```
+
+This brings the number of Postprocessors up to 6.
+
+# Results
+
+!media /phase_field/mobilityeq.png  style=width:300px;padding-left:20px;float:right;
+        caption=simulation result
+
+The first figure to the right shows the results of this simulation. As you can see, changing the mobility to a function reduced the number of features. The second figure shows the fraction of the surface covered with the chromium phase as a function of time. It is very close to the 39.5% we calculated, which is promising. It is not exact because of the concentration gradients at the phase interfaces.
+
+If you still have the residual magnitudes outputting to the screen, you may have noticed that the magnitudes changed this time. The residual for the concentration is now several orders of magnitude smaller than the residual for chemical potential. In our next simulation we will scale the concentration variable so that this is not the case.
+
+## Continue
+
+We are almost done. Next, we will calculate the total free energy of the surface and look for its S-curve.
+
+!media /phase_field/surfaceplot.png  style=width:300px;padding-left:20px;float:right;
+                caption=chromium phase fraction
+
+[step 5: Check the Surface Energy Curve](Step5.md)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step4.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step4.md
@@ -82,7 +82,7 @@ This brings the number of Postprocessors up to 6.
 
 # Results
 
-!media /phase_field/mobilityeq.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/mobilityeq.png  style=width:300px;padding-left:20px;float:right;
         caption=simulation result
 
 The first figure to the right shows the results of this simulation. As you can see, changing the mobility to a function reduced the number of features. The second figure shows the fraction of the surface covered with the chromium phase as a function of time. It is very close to the 39.5% we calculated, which is promising. It is not exact because of the concentration gradients at the phase interfaces.
@@ -93,7 +93,7 @@ If you still have the residual magnitudes outputting to the screen, you may have
 
 We are almost done. Next, we will calculate the total free energy of the surface and look for its S-curve.
 
-!media /phase_field/surfaceplot.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/surfaceplot.png  style=width:300px;padding-left:20px;float:right;
                 caption=chromium phase fraction
 
 [step 5: Check the Surface Energy Curve](Step5.md)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step5.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step5.md
@@ -1,0 +1,79 @@
+# Step 5: Energy Curve
+
+The input file for this step can be found here: [s5_energycurve.i](https://github.com/idaholab/moose/blob/devel/modules/phase_field/tutorials/spinodal_decomposition/s5_energycurve.i)
+
+## Input File
+
+We are going to make two more changes and our simulation will be complete. First, since we noticed that the variable residuals did not match, we will scale one of the variables to get a better match. Second, we will calculate the total energy of the surface and output it so that we can check if it has an S-curve shape.
+
+### Scaling
+
+```yaml
+[Variables]
+  [./c]   # Mole fraction of Cr (unitless)
+    order = FIRST
+    family = LAGRANGE
+    scaling = 1e+04
+  [../]
+  [./w]   # Chemical potential (eV/mol)
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+```
+
+If you wish you can remove the debug block, or you can keep it to check that the scaling is correct.
+
+### Free energy curve
+
+Remember our Cahn Hilliard equation:
+
+\begin{equation}
+\frac {\partial c} {\partial t} = \nabla \cdot M(c) \nabla \left(\frac {\partial f_{loc}(c)} {\partial c} - \kappa \nabla^2 c \right).
+\end{equation}
+
+Energy comes from both the free energy density function term and the gradient energy curve. We need to combine these in order to calculate the total energy of the surface. To do this we will define an auxiliary variable, and use a built-in auxiliary kernel to combine the terms. We will output the variable to the Exodus file, and the integral of the variable to the csv file.
+
+```yaml
+[AuxVariables]
+  [./f_density]   # Local energy density (eV/mol)
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[AuxKernels]
+  # Calculates the energy density by combining the local and gradient energies
+  [./f_density]   # (eV/mol/nm^2)
+    type = TotalFreeEnergy
+    variable = f_density
+    f_name = 'f_loc'
+    kappa_names = 'kappa_c'
+    interfacial_vars = c
+  [../]
+[]
+```
+
+The auxiliary variable `f_density` returns the total energy density at each point on the surface. In order to get the total free energy, we have to integrate the variable in a Postprocessor.
+
+```yaml
+  [./total_energy]          # Total free energy at each timestep
+    type = ElementIntegralVariablePostprocessor
+    variable = f_density
+  [../]
+```
+
+If you wish you may remove any of the Postprocessors that you feel are unnecessary for the simulation at this point, or you may continue trying to optimize the simulation by changing values in the `Preconditioning` and `Executioner` blocks.
+
+## Results
+
+!media /phase_field/FreeEnergyCurve.png  style=width:300px;padding-left:20px;float:right;
+                caption=Surface free energy curve
+
+The surface results should look the same as the last simulation. What we really want to look at is what the surface energy looks like throughout the simulation. The plot of the total energy is to the right. Note that the post-processor values are not calculated at the initial condition, so to replicate this plot you must remove that value from the csv file.
+
+From the plot we can see that the energy plot does have the S-curve shape we expected. We have verified that all of our expectations for how the system behaves are correct and therefore we can assume that our model is working correctly.
+
+# Continue
+
+[Tutorial conclusion](Tutorial.md#Conclusions)

--- a/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step5.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Tutorial/Step5.md
@@ -67,7 +67,7 @@ If you wish you may remove any of the Postprocessors that you feel are unnecessa
 
 ## Results
 
-!media /phase_field/FreeEnergyCurve.png  style=width:300px;padding-left:20px;float:right;
+!media phase_field/FreeEnergyCurve.png  style=width:300px;padding-left:20px;float:right;
                 caption=Surface free energy curve
 
 The surface results should look the same as the last simulation. What we really want to look at is what the surface energy looks like throughout the simulation. The plot of the total energy is to the right. Note that the post-processor values are not calculated at the initial condition, so to replicate this plot you must remove that value from the csv file.

--- a/modules/phase_field/doc/content/modules/phase_field/index.md
+++ b/modules/phase_field/doc/content/modules/phase_field/index.md
@@ -12,52 +12,52 @@ this module is found below:
 
 ## Basic Phase Field Model Information
 
-- [Basic Phase Field Equations](phase_field/Phase_Field_Equations.md): Basic information about the equations underlying the phase field module
-- [Expression Builder](FunctionMaterials/ExpressionBuilder.md): Using automatic differentiation of free energy material objects
-- [Solving Phase Field Models](phase_field/Solving.md): Basic info about solving phase field models
-- [Function Material Kernels](phase_field/FunctionMaterialKernels.md): Working with Function Materials that carry around their own derivatives
+- [phase_field/Phase_Field_Equations.md]: Basic information about the equations underlying the phase field module
+- [phase_field/FunctionMaterials/ExpressionBuilder.md]: Using automatic differentiation of free energy material objects
+- [phase_field/Solving.md]: Basic info about solving phase field models
+- [phase_field/FunctionMaterialKernels.md]: Working with Function Materials that carry around their own derivatives
 - [phase_field/FunctionMaterials.md]: Creating material properties based on the value of an arbitrary function expression
 - [phase_field/Phase_Field_Model_Units.md]: Discussion of units in phase field models
 - [phase_field/Anisotropy.md]: Support of anisotropic mobilities and interfacial energies
 - [phase_field/CALPHAD.md]: Using thermodynamic databases to parameterize phase field models
 - [phase_field/Quantitative.md]: Simple two component models using polynomial free energies
-- [FAQ](phase_field/FAQ.md): Frequently asked questions about the phase field modules
+- [phase_field/FAQ.md]: Frequently asked questions about the phase field modules
 
 ## Multiple Phase Models
 
 MOOSE provides capabilities that enable the easy development of multiphase field model. A free energy expression has to be provided for each individual phase. Different systems exist to combine those _phase free energies_ into a _global free energy_.
 
-- [Two-phase Models](MultiPhase/WBMTwoPhase.md): Two phases, one phase order parameter
-- [Kim-Kim-Suzuki Model](MultiPhase/KKS.md): per-phase concentrations, two phases
-- [Multiphase Models](MultiPhase/WBM.md): $N$ phases, $N$ phase order parameters
-- Grand Potential Model: solving a Legendre transform of the phase field equations, where the independent variable is the chemical potential
+- [phase_field/MultiPhase/WBMTwoPhase.md]: Two phases, one phase order parameter
+- [phase_field/MultiPhase/KKS.md]: per-phase concentrations, two phases
+- [phase_field/MultiPhase/WBM.md]: $N$ phases, $N$ phase order parameters
+- [Grand Potential Model](/GrandPotentialKernelAction.md): solving a Legendre transform of the phase field equations, where the independent variable is the chemical potential
 
 !media media/phase_field/solutionrasterizer.png style=width:200px;padding-left:20px;float:right; caption=Atomistic input file generated using the SolutionRasterizer.
 
 ## Multiphysics Coupling
 
-- [phase_field/Mechanics_Coupling.md] - Coupling phase field equations with mechanics
+- [phase_field/Mechanics_Coupling.md]: Coupling phase field equations with mechanics
 
 ## Phase field sub-systems
 
 ### Nucleation
 
-- [Discrete Nucleation](Nucleation/DiscreteNucleation.md): Insertion of nuclei according to a nucleation probability density field
-- [Langevin Noise](Nucleation/LangevinNoise.md): Fluctuation based nucleation
+- [phase_field/Nucleation/DiscreteNucleation.md]: Insertion of nuclei according to a nucleation probability density field
+- [phase_field/Nucleation/LangevinNoise.md]: Fluctuation based nucleation
 
 ### Grain Growth
 
-- [Grain Growth Model](Grain_Growth_Model.md): Background on the phase field model implemented in MOOSE
-- [Grain Tracker Algorithm](/GrainTracker.md)
-- [Grain Boundary Anisotropy](Grain_Boundary_Anisotropy.md)
-- [Elastic_Driving_Force_Grain_Growth.md]
+- [phase_field/Grain_Growth_Model.md]: Background on the phase field model implemented in MOOSE
+- [Grain Tracker Algorithm](/GrainTracker.md): Tracking arbitrary features on an unstructured mesh over time
+- [phase_field/Grain_Boundary_Anisotropy.md]: For systems with misorientation dependence of GB properties
+- [phase_field/Elastic_Driving_Force_Grain_Growth.md]: Coupling mechanics to influence grain growth
 
 ## Initial Conditions
 
 - [phase_field/Initial_Conditions.md]: Basic phase field initial conditions
-- [Polycrystal Initial Conditions](ICs/PolycrystalICs.md)
-- Image Reader: Reconstructing initial conditions from images (SEM, optical, etc.)
-- [EBSD Reader](ICs/EBSD.md): Reconstructing initial conditions from EBSD and EDS data
+- [phase_field/ICs/PolycrystalICs.md]: Creating polycrystalline structures using a variety of methods
+- [Image Reader](/ImageFunction.md): Reconstructing initial conditions from images (SEM, optical, etc.)
+- [EBSD Reader](phase_field/ICs/EBSD.md): Reconstructing initial conditions from EBSD and EDS data
 
 # Tutorials
 
@@ -65,5 +65,5 @@ MOOSE provides capabilities that enable the easy development of multiphase field
 
 ## Misc
 
-- [Automatic Differentiation](FunctionMaterials/AutomaticDifferentiation.md)
-- [Just in Time Compilation](FunctionMaterials/JITCompilation.md)
+- [phase_field/FunctionMaterials/AutomaticDifferentiation.md]: Construct derivatives of a given expression in a symbolic way
+- [phase_field/FunctionMaterials/JITCompilation.md]: Compilation of FunctionParser expressions

--- a/modules/phase_field/doc/content/modules/phase_field/index.md
+++ b/modules/phase_field/doc/content/modules/phase_field/index.md
@@ -16,11 +16,11 @@ this module is found below:
 - [Expression Builder](FunctionMaterials/ExpressionBuilder.md): Using automatic differentiation of free energy material objects
 - [Solving Phase Field Models](phase_field/Solving.md): Basic info about solving phase field models
 - [Function Material Kernels](phase_field/FunctionMaterialKernels.md): Working with Function Materials that carry around their own derivatives
-- [Function Materials](phase_field/FunctionMaterials.md): Creating material properties based on the value of an arbitrary function expression
-- [Phase Field Model Units](phase_field/Phase_Field_Model_Units.md): Discussion of units in phase field models
-- [Anisotropy](phase_field/Anisotropy.md): Support of anisotropic mobilities and interfacial energies
-- [CALPHAD](phase_field/CALPHAD.md): Using thermodynamic databases to parameterize phase field models
-- [Quantitative Two Component Polynomial Free Energies](phase_field/Quantitative.md): Simple two component models using polynomial free energies
+- [phase_field/FunctionMaterials.md]: Creating material properties based on the value of an arbitrary function expression
+- [phase_field/Phase_Field_Model_Units.md]: Discussion of units in phase field models
+- [phase_field/Anisotropy.md]: Support of anisotropic mobilities and interfacial energies
+- [phase_field/CALPHAD.md]: Using thermodynamic databases to parameterize phase field models
+- [phase_field/Quantitative.md]: Simple two component models using polynomial free energies
 - [FAQ](phase_field/FAQ.md): Frequently asked questions about the phase field modules
 
 ## Multiple Phase Models
@@ -36,7 +36,7 @@ MOOSE provides capabilities that enable the easy development of multiphase field
 
 ## Multiphysics Coupling
 
-- [Mechanics Coupling](phase_field/Mechanics_Coupling.md) - Coupling phase field equations with mechanics
+- [phase_field/Mechanics_Coupling.md] - Coupling phase field equations with mechanics
 
 ## Phase field sub-systems
 
@@ -50,18 +50,18 @@ MOOSE provides capabilities that enable the easy development of multiphase field
 - [Grain Growth Model](Grain_Growth_Model.md): Background on the phase field model implemented in MOOSE
 - [Grain Tracker Algorithm](/GrainTracker.md)
 - [Grain Boundary Anisotropy](Grain_Boundary_Anisotropy.md)
-- [Elastic Driving Force For Grain Growth](Elastic_Driving_Force_Grain_Growth.md)
+- [Elastic_Driving_Force_Grain_Growth.md]
 
 ## Initial Conditions
 
-- [Initial Conditions](Initial_Conditions.md): Basic phase field initial conditions
+- [phase_field/Initial_Conditions.md]: Basic phase field initial conditions
 - [Polycrystal Initial Conditions](ICs/PolycrystalICs.md)
 - Image Reader: Reconstructing initial conditions from images (SEM, optical, etc.)
 - [EBSD Reader](ICs/EBSD.md): Reconstructing initial conditions from EBSD and EDS data
 
 # Tutorials
 
-- [Fe-Cr Phase Decomposition](Tutorial.md): Illustrates using parsed function kernels to create a two phase decomposition simulation
+- [Fe-Cr Phase Decomposition](phase_field/Tutorial.md): Illustrates using parsed function kernels to create a two phase decomposition simulation
 
 ## Misc
 

--- a/modules/phase_field/doc/content/modules/phase_field/index.md
+++ b/modules/phase_field/doc/content/modules/phase_field/index.md
@@ -16,10 +16,11 @@ this module is found below:
 - [Expression Builder](FunctionMaterials/ExpressionBuilder.md): Using automatic differentiation of free energy material objects
 - [Solving Phase Field Models](phase_field/Solving.md): Basic info about solving phase field models
 - [Function Material Kernels](phase_field/FunctionMaterialKernels.md): Working with Function Materials that carry around their own derivatives
-- Phase Field Model Units: Discussion of units in phase field models
-- Anisotropy: Support of anisotropic mobilities and interfacial energies
-- CALPHAD: Using thermodynamic databases to parameterize phase field models
-- Quantitative Two Component Polynomial Free Energies: Simple two component models using polynomial free energies
+- [Function Materials](phase_field/FunctionMaterials.md): Creating material properties based on the value of an arbitrary function expression
+- [Phase Field Model Units](phase_field/Phase_Field_Model_Units.md): Discussion of units in phase field models
+- [Anisotropy](phase_field/Anisotropy.md): Support of anisotropic mobilities and interfacial energies
+- [CALPHAD](phase_field/CALPHAD.md): Using thermodynamic databases to parameterize phase field models
+- [Quantitative Two Component Polynomial Free Energies](phase_field/Quantitative.md): Simple two component models using polynomial free energies
 - [FAQ](phase_field/FAQ.md): Frequently asked questions about the phase field modules
 
 ## Multiple Phase Models
@@ -35,7 +36,7 @@ MOOSE provides capabilities that enable the easy development of multiphase field
 
 ## Multiphysics Coupling
 
-- Mechanics Coupling - Coupling phase field equations with mechanics
+- [Mechanics Coupling](phase_field/Mechanics_Coupling.md) - Coupling phase field equations with mechanics
 
 ## Phase field sub-systems
 
@@ -49,21 +50,20 @@ MOOSE provides capabilities that enable the easy development of multiphase field
 - [Grain Growth Model](Grain_Growth_Model.md): Background on the phase field model implemented in MOOSE
 - [Grain Tracker Algorithm](/GrainTracker.md)
 - [Grain Boundary Anisotropy](Grain_Boundary_Anisotropy.md)
-- Elastic Driving Force For Grain Growth
+- [Elastic Driving Force For Grain Growth](Elastic_Driving_Force_Grain_Growth.md)
 
 ## Initial Conditions
 
-- Initial Conditions: Basic phase field initial conditions
+- [Initial Conditions](Initial_Conditions.md): Basic phase field initial conditions
 - [Polycrystal Initial Conditions](ICs/PolycrystalICs.md)
 - Image Reader: Reconstructing initial conditions from images (SEM, optical, etc.)
 - [EBSD Reader](ICs/EBSD.md): Reconstructing initial conditions from EBSD and EDS data
 
 # Tutorials
 
-- Fe-Cr Phase Decomposition: Illustrates using parsed function kernels to create a two phase decomposition simulation
+- [Fe-Cr Phase Decomposition](Tutorial.md): Illustrates using parsed function kernels to create a two phase decomposition simulation
 
 ## Misc
 
 - [Automatic Differentiation](FunctionMaterials/AutomaticDifferentiation.md)
-- [Function Materials](phase_field/FunctionMaterials.md)
 - [Just in Time Compilation](FunctionMaterials/JITCompilation.md)


### PR DESCRIPTION
Several helpful topics that were on the old phase-field wiki did not make it over to the new website. Some info may be outdated or converted incorrectly. I'm hoping to get more eyes on this before going too far.

Pages include:

- [x] Units
- [x] Anisotropy (<-- not much there?)
- [x] CALPHAD
- [x] Quantitative Two Component Polynomial Free Energies
- [x] Mechanics coupling
- [x] Elastic Driving Force For Grain Growth
- [x] Initial Conditions
- [x] Tutorial
- [x] Image Reader (<-- not much there?)

ping @dschwen @laagesen 

ref #14988

