### PR TITLE
Handle command-line Outputs/... in fluid properties

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -46,6 +46,7 @@
 #include "PerfGraphInterface.h" // For TIME_SECTIOn
 #include "Attributes.h"
 #include "MooseApp.h"
+#include "CommonOutputAction.h"
 
 // Regular expression includes
 #include "pcrecpp.h"
@@ -911,12 +912,12 @@ MooseApp::setupOptions()
     // Setup the AppFileBase for use by the Outputs or other systems that need output file info
     {
       // Extract the CommonOutputAction
-      const auto & common_actions = _action_warehouse.getActionListByName("common_output");
-
-      const Action * common = *common_actions.begin();
+      const auto common_actions = _action_warehouse.getActions<CommonOutputAction>();
+      mooseAssert(common_actions.size() <= 1, "Should not be more than one CommonOutputAction");
+      const Action * common = common_actions.empty() ? nullptr : *common_actions.begin();
 
       // If file_base is set in CommonOutputAction through parsing input, obtain the file_base
-      if (common->isParamValid("file_base"))
+      if (common && common->isParamValid("file_base"))
       {
         _output_file_base = common->getParam<std::string>("file_base");
         _file_base_set_by_user = true;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -912,7 +912,6 @@ MooseApp::setupOptions()
     {
       // Extract the CommonOutputAction
       const auto & common_actions = _action_warehouse.getActionListByName("common_output");
-      mooseAssert(common_actions.size() == 1, "Should be only one common_output Action");
 
       const Action * common = *common_actions.begin();
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -188,7 +188,6 @@ Console::Console(const InputParameters & parameters)
   // Apply the special common console flags (print_...)
   ActionWarehouse & awh = _app.actionWarehouse();
   const auto & actions = awh.getActionListByName("common_output");
-  mooseAssert(actions.size() == 1, "Should be only one common_output Action");
   Action * common_action = *actions.begin();
 
   // Honor the 'print_linear_residuals' option, only if 'execute_on' has not been set by the user

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -19,6 +19,7 @@
 #include "Moose.h"
 #include "FormattedTable.h"
 #include "NonlinearSystem.h"
+#include "CommonOutputAction.h"
 
 // libMesh includes
 #include "libmesh/enum_norm_type.h"
@@ -187,19 +188,20 @@ Console::Console(const InputParameters & parameters)
 {
   // Apply the special common console flags (print_...)
   ActionWarehouse & awh = _app.actionWarehouse();
-  const auto & actions = awh.getActionListByName("common_output");
-  Action * common_action = *actions.begin();
+  const auto actions = awh.getActions<CommonOutputAction>();
+  mooseAssert(actions.size() <= 1, "Should not be more than one CommonOutputAction");
+  const Action * common = actions.empty() ? nullptr : *actions.begin();
 
   // Honor the 'print_linear_residuals' option, only if 'execute_on' has not been set by the user
   if (!parameters.isParamSetByUser("execute_on"))
   {
-    if (common_action->getParam<bool>("print_linear_residuals"))
+    if (common && common->getParam<bool>("print_linear_residuals"))
       _execute_on.push_back("linear");
     else
       _execute_on.erase("linear");
   }
 
-  if (!_pars.isParamSetByUser("perf_log") && common_action->getParam<bool>("print_perf_log"))
+  if (!_pars.isParamSetByUser("perf_log") && common && common->getParam<bool>("print_perf_log"))
   {
     _perf_log = true;
     _solve_log = true;
@@ -207,9 +209,12 @@ Console::Console(const InputParameters & parameters)
 
   // Append the common 'execute_on' to the setting for this object
   // This is unique to the Console object, all other objects inherit from the common options
-  const ExecFlagEnum & common_execute_on = common_action->getParam<ExecFlagEnum>("execute_on");
-  for (auto & mme : common_execute_on)
-    _execute_on.push_back(mme);
+  if (common)
+  {
+    const ExecFlagEnum & common_execute_on = common->getParam<ExecFlagEnum>("execute_on");
+    for (auto & mme : common_execute_on)
+      _execute_on.push_back(mme);
+  }
 
   // If --show-outputs is used, enable it
   if (_app.getParam<bool>("show_outputs"))

--- a/modules/fluid_properties/src/base/FluidPropertiesApp.C
+++ b/modules/fluid_properties/src/base/FluidPropertiesApp.C
@@ -17,6 +17,7 @@ FluidPropertiesApp::validParams()
 {
   InputParameters params = MooseApp::validParams();
   params.set<bool>("use_legacy_material_output") = false;
+  params.set<bool>("use_legacy_dirichlet_bc") = false;
   return params;
 }
 
@@ -41,7 +42,10 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
   registerSyntaxTask(
       "AddFluidPropertiesAction", "Modules/FluidProperties/*", "add_fluid_properties");
   registerMooseObjectTask("add_fluid_properties", FluidProperties, false);
+  registerMooseObjectTask("add_fp_output", Output, false);
+
   syntax.addDependency("add_fluid_properties", "init_displaced_problem");
+  syntax.addDependency("add_fp_output", "add_output");
 
   syntax.registerActionSyntax("AddFluidPropertiesInterrogatorAction",
                               "FluidPropertiesInterrogator");


### PR DESCRIPTION
@andrsd I combined our work, which allows for the assert to remain. The key was creating the Console object prior to the add_output task executing. Thanks for the help.
 
(closes #16763)
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
