### PR TITLE
Don't create scaling vector when we aren't doing AD

### DIFF
--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -336,6 +336,9 @@ public:
   virtual void initialSetup();
   virtual void timestepSetup();
 
+  using SubProblem::haveADObjects;
+  void haveADObjects(bool have_ad_objects) override;
+
 protected:
   FEProblemBase & _mproblem;
   MooseMesh & _mesh;

--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -333,6 +333,9 @@ public:
 
   bool computingScalingResidual() const override final;
 
+  virtual void initialSetup();
+  virtual void timestepSetup();
+
 protected:
   FEProblemBase & _mproblem;
   MooseMesh & _mesh;

--- a/framework/include/systems/AuxiliarySystem.h
+++ b/framework/include/systems/AuxiliarySystem.h
@@ -46,11 +46,11 @@ public:
 
   virtual void addExtraVectors() override;
 
-  virtual void initialSetup();
-  virtual void timestepSetup();
-  virtual void subdomainSetup();
-  virtual void residualSetup();
-  virtual void jacobianSetup();
+  virtual void initialSetup() override;
+  virtual void timestepSetup() override;
+  virtual void subdomainSetup() override;
+  virtual void residualSetup() override;
+  virtual void jacobianSetup() override;
   virtual void updateActive(THREAD_ID tid);
 
   virtual void addVariable(const std::string & var_type,

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -97,8 +97,10 @@ public:
   virtual bool computingInitialResidual() { return _computing_initial_residual; }
 
   // Setup Functions ////
-  virtual void initialSetup();
-  virtual void timestepSetup();
+  virtual void initialSetup() override;
+  virtual void timestepSetup() override;
+  virtual void residualSetup() override;
+  virtual void jacobianSetup() override;
 
   virtual void setupFiniteDifferencedPreconditioner() = 0;
   void setupFieldDecomposition();
@@ -346,6 +348,7 @@ public:
    */
   void onTimestepBegin();
 
+  using SystemBase::subdomainSetup;
   /**
    * Called from assembling when we hit a new subdomain
    * @param subdomain ID of the new subdomain

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -865,6 +865,13 @@ public:
    */
   bool solutionStatesInitialized() const { return _solution_states_initialized; }
 
+  /// Setup Functions
+  virtual void initialSetup();
+  virtual void timestepSetup();
+  virtual void subdomainSetup();
+  virtual void residualSetup();
+  virtual void jacobianSetup();
+
 protected:
   /**
    * Internal getter for solution owned by libMesh.

--- a/framework/include/variables/MooseVariableBase.h
+++ b/framework/include/variables/MooseVariableBase.h
@@ -154,6 +154,8 @@ public:
    */
   void eigen(bool eigen) { _is_eigen = eigen; }
 
+  void initialSetup() override;
+
 protected:
   /// System this variable is part of
   SystemBase & _sys;

--- a/framework/include/variables/VariableWarehouse.h
+++ b/framework/include/variables/VariableWarehouse.h
@@ -156,6 +156,21 @@ public:
   const std::vector<MooseVariableScalar *> & scalars() const;
 
   /**
+   * Call initialSetup for all variables
+   */
+  void initialSetup();
+
+  /**
+   * Call timestepSetup for all variables
+   */
+  void timestepSetup();
+
+  /**
+   * Call subdomainSetup for all variables
+   */
+  void subdomainSetup();
+
+  /**
    * Call residualSetup for all variables
    */
   void residualSetup();

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -1075,3 +1075,17 @@ DisplacedProblem::computingScalingResidual() const
 {
   return _mproblem.computingScalingResidual();
 }
+
+void
+DisplacedProblem::initialSetup()
+{
+  _displaced_nl.initialSetup();
+  _displaced_aux.initialSetup();
+}
+
+void
+DisplacedProblem::timestepSetup()
+{
+  _displaced_nl.timestepSetup();
+  _displaced_aux.timestepSetup();
+}

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -1089,3 +1089,10 @@ DisplacedProblem::timestepSetup()
   _displaced_nl.timestepSetup();
   _displaced_aux.timestepSetup();
 }
+
+void
+DisplacedProblem::haveADObjects(const bool have_ad_objects)
+{
+  _have_ad_objects = have_ad_objects;
+  _mproblem.SubProblem::haveADObjects(have_ad_objects);
+}

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6971,11 +6971,11 @@ FEProblemBase::addOutput(const std::string & object_type,
 }
 
 void
-FEProblemBase::haveADObjects(bool have_ad_objects)
+FEProblemBase::haveADObjects(const bool have_ad_objects)
 {
   _have_ad_objects = have_ad_objects;
   if (_displaced_problem)
-    _displaced_problem->haveADObjects(have_ad_objects);
+    _displaced_problem->SubProblem::haveADObjects(have_ad_objects);
 }
 
 const SystemBase &

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -911,6 +911,10 @@ FEProblemBase::initialSetup()
   // Auxilary variable initialSetup calls
   _aux->initialSetup();
 
+  if (_displaced_problem)
+    // initialSetup for displaced systems
+    _displaced_problem->initialSetup();
+
   _nl->setSolution(*(_nl->system().current_local_solution.get()));
 
   // Update the nearest node searches (has to be called after the problem is all set up)
@@ -1160,6 +1164,10 @@ FEProblemBase::timestepSetup()
 
   _aux->timestepSetup();
   _nl->timestepSetup();
+
+  if (_displaced_problem)
+    // timestepSetup for displaced systems
+    _displaced_problem->timestepSetup();
 
   for (THREAD_ID tid = 0; tid < n_threads; tid++)
   {

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -101,6 +101,8 @@ AuxiliarySystem::addExtraVectors()
 void
 AuxiliarySystem::initialSetup()
 {
+  SystemBase::initialSetup();
+
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.sort(tid);
@@ -129,6 +131,8 @@ AuxiliarySystem::initialSetup()
 void
 AuxiliarySystem::timestepSetup()
 {
+  SystemBase::timestepSetup();
+
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.timestepSetup(tid);
@@ -144,6 +148,8 @@ AuxiliarySystem::timestepSetup()
 void
 AuxiliarySystem::subdomainSetup()
 {
+  SystemBase::subdomainSetup();
+
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.subdomainSetup(tid);
@@ -159,6 +165,8 @@ AuxiliarySystem::subdomainSetup()
 void
 AuxiliarySystem::jacobianSetup()
 {
+  SystemBase::jacobianSetup();
+
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.jacobianSetup(tid);
@@ -174,6 +182,8 @@ AuxiliarySystem::jacobianSetup()
 void
 AuxiliarySystem::residualSetup()
 {
+  SystemBase::residualSetup();
+
   for (unsigned int tid = 0; tid < libMesh::n_threads(); tid++)
   {
     _aux_scalar_storage.residualSetup(tid);

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1513,6 +1513,41 @@ SystemBase::computingScalingJacobian() const
   return _subproblem.computingScalingJacobian();
 }
 
+void
+SystemBase::initialSetup()
+{
+  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+    _vars[tid].initialSetup();
+}
+
+void
+SystemBase::timestepSetup()
+{
+  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+    _vars[tid].timestepSetup();
+}
+
+void
+SystemBase::subdomainSetup()
+{
+  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+    _vars[tid].subdomainSetup();
+}
+
+void
+SystemBase::residualSetup()
+{
+  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+    _vars[tid].residualSetup();
+}
+
+void
+SystemBase::jacobianSetup()
+{
+  for (THREAD_ID tid = 0; tid < libMesh::n_threads(); tid++)
+    _vars[tid].jacobianSetup();
+}
+
 template MooseVariableFE<Real> & SystemBase::getFieldVariable<Real>(THREAD_ID tid,
                                                                     const std::string & var_name);
 

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -179,7 +179,7 @@ MooseVariableBase::initialSetup()
 {
 #ifdef MOOSE_GLOBAL_AD_INDEXING
   // Currently the scaling vector is only used through AD residual computing objects
-  if (_subproblem.haveADObjects() && !_sys.hasVector("scaling_factors") &&
+  if (_subproblem.haveADObjects() &&
       std::find_if(_scaling_factor.begin(), _scaling_factor.end(), [](const Real element) {
         return !MooseUtils::absoluteFuzzyEqual(element, 1.);
       }) != _scaling_factor.end())

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -172,12 +172,17 @@ void
 MooseVariableBase::scalingFactor(const std::vector<Real> & factor)
 {
   _scaling_factor = factor;
+}
 
+void
+MooseVariableBase::initialSetup()
+{
 #ifdef MOOSE_GLOBAL_AD_INDEXING
-  if (!_sys.hasVector("scaling_factors") &&
-      std::find_if(factor.begin(), factor.end(), [](const Real element) {
+  // Currently the scaling vector is only used through AD residual computing objects
+  if (_subproblem.haveADObjects() && !_sys.hasVector("scaling_factors") &&
+      std::find_if(_scaling_factor.begin(), _scaling_factor.end(), [](const Real element) {
         return !MooseUtils::absoluteFuzzyEqual(element, 1.);
-      }) != factor.end())
+      }) != _scaling_factor.end())
     _sys.addScalingVector();
 #endif
 }

--- a/framework/src/variables/VariableWarehouse.C
+++ b/framework/src/variables/VariableWarehouse.C
@@ -235,6 +235,27 @@ VariableWarehouse::getActualFieldVariable<RealEigenVector>(unsigned int var_numb
 }
 
 void
+VariableWarehouse::initialSetup()
+{
+  for (auto & pair : _all_objects)
+    pair.second->initialSetup();
+}
+
+void
+VariableWarehouse::timestepSetup()
+{
+  for (auto & pair : _all_objects)
+    pair.second->timestepSetup();
+}
+
+void
+VariableWarehouse::subdomainSetup()
+{
+  for (auto & pair : _all_objects)
+    pair.second->subdomainSetup();
+}
+
+void
 VariableWarehouse::jacobianSetup()
 {
   for (auto & pair : _all_objects)

--- a/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite_noaction.i
+++ b/modules/contact/test/tests/mortar_tm/2drz/frictionless_second/finite_noaction.i
@@ -228,6 +228,7 @@ name = 'finite_noaction'
   dtmin = 0.1
   timestep_tolerance = 1e-6
   line_search = 'contact'
+  snesmf_reuse_base = false
 []
 
 [Postprocessors]

--- a/test/tests/kernels/array_kernels/array_diffusion_test.i
+++ b/test/tests/kernels/array_kernels/array_diffusion_test.i
@@ -10,6 +10,7 @@
     order = FIRST
     family = LAGRANGE
     components = 2
+    scaling = '.9 .9'
   []
 []
 


### PR DESCRIPTION
With the merge of #16440, global AD became our default config. Griffin
revealed some undesirable behavior in the global AD code-base
post-merge. We were creating the `NumericVector` of scaling factors
anytime that any variable had a non-unity scaling factor; however, this
vector is actually only ever used through AD residual/jacobian computing
objects. There is another issue which is that the
`assembleScalingVector` code does not yet work with array variables,
which is the reason Griffin failed: we were trying to assemble this
unnecessary vector, and that code triggered the assertion about not
working with array variables. https://github.com/idaholab/moose/issues/16820 created for that.
In the meantime (and in the future) we will not build the scaling vector
if we do not have AD objects

