### PR TITLE
All props in stateful storage should be non-AD

### DIFF
--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -63,17 +63,6 @@ public:
   virtual bool isAD() = 0;
 
   /**
-   * Creates a regular material property, copying any existing qp values from this
-   */
-  virtual PropertyValue * makeRegularProperty() = 0;
-
-  /**
-   * Creates an AD material property, copying any existing qp *values* from this. Derivative
-   * information is zeroed
-   */
-  virtual PropertyValue * makeADProperty() = 0;
-
-  /**
    * Copy the value of a Property from one specific to a specific qp in this Property.
    * Important note: this copy operation loses AD derivative information if either this
    * or the rhs is not an AD material property
@@ -122,9 +111,6 @@ public:
   virtual ~MaterialPropertyBase() {}
 
   bool isAD() override { return is_ad; }
-
-  PropertyValue * makeRegularProperty() override;
-  PropertyValue * makeADProperty() override;
 
   /**
    * @returns a read-only reference to the parameter value.
@@ -244,34 +230,6 @@ rawValueEqualityHelper(std::vector<T1> & out, const std::vector<T2> & in)
     rawValueEqualityHelper(out[i], in[i]);
 }
 }
-}
-
-template <typename T, bool is_ad>
-PropertyValue *
-MaterialPropertyBase<T, is_ad>::makeRegularProperty()
-{
-  auto * new_prop = new MaterialProperty<T>;
-
-  new_prop->resize(this->size());
-
-  for (MooseIndex(_value) i = 0; i < _value.size(); ++i)
-    moose::internal::rawValueEqualityHelper((*new_prop)[i], _value[i]);
-
-  return new_prop;
-}
-
-template <typename T, bool is_ad>
-PropertyValue *
-MaterialPropertyBase<T, is_ad>::makeADProperty()
-{
-  auto * new_prop = new ADMaterialProperty<T>;
-
-  new_prop->resize(this->size());
-
-  for (MooseIndex(_value) i = 0; i < _value.size(); ++i)
-    moose::internal::rawValueEqualityHelper((*new_prop)[i], _value[i]);
-
-  return new_prop;
 }
 
 template <typename T, bool is_ad>

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -124,7 +124,7 @@ public:
    * properties are
    * reused for computing current properties. This is called when solve succeeded.
    */
-  void shift(const FEProblemBase & fe_problem);
+  void shift();
 
   /**
    * Copy material properties from elem_from to elem_to. Thread safe.

--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -25,16 +25,16 @@ struct MooseADWrapperStruct<Real, true>
   typedef ADReal type;
 };
 
-template <template <typename> class W>
-struct MooseADWrapperStruct<W<Real>, true>
+template <template <typename> class W, typename T, bool is_ad>
+struct MooseADWrapperStruct<W<T>, is_ad>
 {
-  typedef W<ADReal> type;
+  typedef W<typename MooseADWrapperStruct<T, is_ad>::type> type;
 };
 
-template <template <typename> class W>
-struct MooseADWrapperStruct<std::vector<W<Real>>, true>
+template <typename T, bool is_ad>
+struct MooseADWrapperStruct<std::vector<T>, is_ad>
 {
-  typedef std::vector<W<ADReal>> type;
+  typedef std::vector<typename MooseADWrapperStruct<T, is_ad>::type> type;
 };
 
 template <typename T, bool is_ad>

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5168,13 +5168,13 @@ FEProblemBase::advanceState()
   _reporter_data.copyValuesBack();
 
   if (_material_props.hasStatefulProperties())
-    _material_props.shift(*this);
+    _material_props.shift();
 
   if (_bnd_material_props.hasStatefulProperties())
-    _bnd_material_props.shift(*this);
+    _bnd_material_props.shift();
 
   if (_neighbor_material_props.hasStatefulProperties())
-    _neighbor_material_props.shift(*this);
+    _neighbor_material_props.shift();
 }
 
 void


### PR DESCRIPTION
Otherwise we will multiply our memory usage by 51x which isn't ideal.

Closes #16836
