### PR TITLE
Add object information to MooseObject::moose[Error/Warning]()

### DIFF
--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -75,3 +75,12 @@ callMooseErrorRaw(std::string & msg, MooseApp * app)
     prefix = app->name();
   moose::internal::mooseErrorRaw(msg, prefix);
 }
+
+std::string
+MooseObject::errorPrefix(const std::string & error_type) const
+{
+  std::stringstream oss;
+  oss << "The following " << error_type << " occurred in the object \"" << name()
+      << "\", of type \"" << type() << "\".\n\n";
+  return oss.str();
+}


### PR DESCRIPTION
Closes #16863

There is one issue with this: for errors and warnings that already include some of this information, we will get repetetive information. However, for warnings and errors that _do not_ have extraneous information, this adds a LOT of useful information to the error. I think it's better to have extraneous information than no information at all.
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
