### PR TITLE
Added imports to pyhit init file

### DIFF
--- a/python/pyhit/__init__.py
+++ b/python/pyhit/__init__.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+
 try:
     from . import hit
 except:


### PR DESCRIPTION
close #16900

Bug Description
Add import os and import subprocess to init file for the pyhit module.

moose\python\pyhit_init_.py:4: in
testdir = os.path.abspath(os.path.join(os.path.dirname(file), '..', '..', 'test'))
E NameError: name 'os' is not defined

Steps to Reproduce
When from . import hit fails.

Issue
pyhit init file missing imports #16900
