### PR TITLE
Forward compatibility with libmesh #2850

### DIFF
--- a/framework/include/restart/DataIO.h
+++ b/framework/include/restart/DataIO.h
@@ -858,6 +858,7 @@ dataLoad(std::istream & stream, Backup *& backup, void * context)
 
 void dataLoad(std::istream & stream, Point & p, void * context);
 
+#ifndef TIMPI_HAVE_STRING_PACKING
 /**
  * The following methods are specializations for using the libMesh::Parallel::packed_range_*
  * routines
@@ -927,3 +928,5 @@ public:
 } // namespace Parallel
 
 } // namespace libMesh
+
+#endif

--- a/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
+++ b/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
@@ -1,9 +1,16 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 10
-  construct_node_list_from_side_list = false
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 10
+    ny = 10
+  []
+  [rename]
+    type = RenameBoundaryGenerator
+    input = gen
+    old_boundary_name = 'left'
+    new_boundary_name = 'renamed_left'
+  []
 []
 
 [Variables]

--- a/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
+++ b/test/tests/mesh/node_list_from_side_list/node_list_from_side_list.i
@@ -8,8 +8,8 @@
   [rename]
     type = RenameBoundaryGenerator
     input = gen
-    old_boundary_name = 'left'
-    new_boundary_name = 'renamed_left'
+    old_boundary = 'left'
+    new_boundary = 'renamed_left'
   []
 []
 


### PR DESCRIPTION
libmesh/libmesh#2850 actually adds non-empty node-sets at the end of
`MeshTools::Generate::build_cube` so you can no longer rely on
`build_node_list_from_side_list = false` to result in no node-sets. We
will also be adding a `Packing<string>` definition in the TIMPI sources
after libmesh/timpi#61 so we need to get out ahead of that and
conditionally define `Packing<string>` in MOOSE

