### PR TITLE
Remove order parameter from mechanical contact

### DIFF
--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_hex27.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_hex27.i
@@ -27,7 +27,6 @@
 [GlobalParams]
   volumetric_locking_correction = false
   displacements = 'disp_x disp_y disp_z'
-  order = SECOND
 []
 
 [Mesh]#Comment

--- a/modules/contact/test/tests/hertz_spherical/hertz_contact_rz_quad8.i
+++ b/modules/contact/test/tests/hertz_spherical/hertz_contact_rz_quad8.i
@@ -27,7 +27,6 @@
 [GlobalParams]
   volumetric_locking_correction = false
   displacements = 'disp_x disp_y'
-  order = SECOND
 []
 
 [Problem]

--- a/modules/contact/test/tests/ring_contact/ring_contact.i
+++ b/modules/contact/test/tests/ring_contact/ring_contact.i
@@ -5,7 +5,6 @@
 #
 
 [GlobalParams]
-  order = SECOND
   displacements = 'disp_x disp_y disp_z'
   volumetric_locking_correction = false
 []


### PR DESCRIPTION
Inconsistencies can occur if primal variable order does not equal the order set in ContactAction. This changes the creation of the order of AuxVariables created in ContactAction to match that of the primal variables as necessary.

Refs #15761.

