### PR TITLE
XFEM accepts more than two cut sides

### DIFF
--- a/modules/xfem/include/base/XFEM.h
+++ b/modules/xfem/include/base/XFEM.h
@@ -323,8 +323,9 @@ private:
    * Data structures to store material properties of the children elements prior to heal. These
    * material properties are copied back to the children elements if the healed element is re-cut.
    */
-  std::map<const Elem *, std::pair<const Elem *, const Elem *>> _healed_elems;
-  std::map<const Elem *, std::pair<bool, bool>> _healed_material_properties_used;
+  std::map<const Elem *, std::map<const GeometricCutSubdomainID, const Elem *>> _healed_elems;
+  std::map<const Elem *, std::map<const GeometricCutSubdomainID, bool>>
+      _healed_material_properties_used;
 
   /// healed geometric cuts
   std::map<const Elem *, const GeometricCutUserObject *> _healed_cuts;
@@ -423,8 +424,8 @@ private:
    * @param elem2       The second child element
    */
   void storeMaterialPropertiesForElements(const Elem * parent_elem,
-                                          const Elem * elem1,
-                                          const Elem * elem2);
+                                          const std::vector<const Elem *> & elems,
+                                          const GeometricCutUserObject * gcuo);
 
   /**
    * Helper function to store the material properties of a healed element
@@ -434,15 +435,15 @@ private:
    */
   void setMaterialPropertiesForElement(const Elem * parent_elem,
                                        const Elem * cut_elem,
-                                       const Elem * elem_from) const;
+                                       const GeometricCutUserObject * gcuo);
 
   /**
-   * Determine which side of the element belongs to relative to the cut
+   * Determine which cut subdomain of the element belongs to relative to the cut
    * @param parent_elem The parent element
    * @param cut_elem    The element being cut
    * @param gcuo        The GeometricCutUserObject for the cut
    */
-  bool getElementSideRelativeToInterface(const Elem * parent_elem,
-                                         const Elem * cut_elem,
-                                         const GeometricCutUserObject * gcuo) const;
+  GeometricCutSubdomainID getGeometricCutSubdomainID(const Elem * parent_elem,
+                                                     const Elem * cut_elem,
+                                                     const GeometricCutUserObject * gcuo) const;
 };

--- a/modules/xfem/include/base/XFEMAppTypes.h
+++ b/modules/xfem/include/base/XFEMAppTypes.h
@@ -13,3 +13,6 @@
 /// Exec flag used to execute MooseObjects while elements are being
 /// marked for cutting by XFEM
 extern const ExecFlagType EXEC_XFEM_MARK;
+
+// XFEM typedefs
+typedef unsigned int GeometricCutSubdomainID;

--- a/modules/xfem/include/userobjects/GeometricCutUserObject.h
+++ b/modules/xfem/include/userobjects/GeometricCutUserObject.h
@@ -11,6 +11,7 @@
 
 // MOOSE includes
 #include "CrackFrontPointsProvider.h"
+#include "XFEMAppTypes.h"
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
@@ -189,7 +190,7 @@ public:
    * @param node Pointer to the node
    * @return an unsigned int indicating the side
    */
-  virtual unsigned int getCutSideID(const Node * /*node*/) const
+  virtual GeometricCutSubdomainID getCutSubdomainID(const Node * /*node*/) const
   {
     mooseError("Objects that inherit from GeometricCutUserObject should override the "
                "getCutSideID method");

--- a/modules/xfem/include/userobjects/LevelSetCutUserObject.h
+++ b/modules/xfem/include/userobjects/LevelSetCutUserObject.h
@@ -43,15 +43,21 @@ public:
    * @param node Pointer to the node
    * @return an unsigned int indicating the side
    */
-  virtual unsigned int getCutSideID(const Node * node) const override;
+  virtual GeometricCutSubdomainID getCutSubdomainID(const Node * node) const override;
 
 protected:
   /// The variable number of the level set variable we using to define the cuts
   const unsigned int _level_set_var_number;
 
-  /// system reference
+  /// System reference
   const System & _system;
 
-  /// the subproblem solution vector
+  /// The subproblem solution vector
   const NumericVector<Number> & _solution;
+
+  /// The ID for the negative side of the cut
+  const GeometricCutSubdomainID _negative_id;
+
+  /// The ID for the positive side of the cut
+  const GeometricCutSubdomainID _positive_id;
 };


### PR DESCRIPTION
This is part 1 of the multi-material system redesign. This PR modifies the moving interface stateful material property management in XFEM to account for multiple cut sides within one element.

closes #16938

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
