### PR TITLE
Show postprocessor history when the postprocessor is used for Picard convergence check

### DIFF
--- a/framework/src/executioners/PicardSolve.C
+++ b/framework/src/executioners/PicardSolve.C
@@ -194,6 +194,7 @@ PicardSolve::solve()
   }
 
   Real pp_scaling = 1.0;
+  std::ostringstream pp_history;
 
   for (_picard_it = 0; _picard_it < _picard_max_its; ++_picard_it)
   {
@@ -248,6 +249,11 @@ PicardSolve::solve()
           !getParam<bool>("direct_pp_value"))
         pp_scaling = *_picard_custom_pp;
       pp_new = *_picard_custom_pp;
+
+      auto ppname = getParam<PostprocessorName>("picard_custom_pp");
+      pp_history << std::setw(2) << _picard_it + 1 << " Picard " << ppname << " = "
+                 << Console::outputNorm(std::numeric_limits<Real>::max(), pp_new) << "\n";
+      _console << pp_history.str();
     }
 
     if (solve_converged)

--- a/test/tests/multiapps/picard/picard_custom_postprocessor.i
+++ b/test/tests/multiapps/picard/picard_custom_postprocessor.i
@@ -76,6 +76,7 @@
   picard_max_its = 30
   disable_picard_residual_norm_check = true
   picard_custom_pp = unorm_err
+  nl_abs_tol = 1e-14
 []
 
 [Outputs]

--- a/test/tests/multiapps/picard/tests
+++ b/test/tests/multiapps/picard/tests
@@ -117,4 +117,14 @@
     issues = '#14642'
     requirement = "The system shall allow convergence check with the convergence of a user defined postprocessor."
   [../]
+  [./postprocessor_convergence_history]
+    type = 'RunApp'
+    input = 'picard_custom_postprocessor.i'
+    cli_args = 'Executioner/direct_pp_value=true Outputs/file_base=picard_custom_pp_history_out'
+    expect_out = '9 Picard unorm_err'
+    recover = false
+    design = 'multiapps/FullSolveMultiApp.md'
+    issues = '#16940'
+    requirement = "The system shall show the Picard convergence history of a user defined postprocessor that is used for convergence check."
+  [../]
 []


### PR DESCRIPTION
Close #16940.

Note that postprocessor value is printed after a Picard iteration not like the residual norm whose initial value can be evaluated before starting Picard iteration.
