### PR TITLE
Reinstating two PorousFlow tests

### DIFF
--- a/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
+++ b/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
@@ -132,6 +132,9 @@
 [Executioner]
   type = Steady
   solve_type = Newton
+  nl_rel_tol = 1E-12
+  petsc_options_iname = '-pc_factor_shift_type'
+  petsc_options_value = 'NONZERO'
 []
 
 [Outputs]

--- a/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
+++ b/modules/porous_flow/test/tests/gravity/fully_saturated_grav01c.i
@@ -2,6 +2,7 @@
 # 1phase, 2-component, constant fluid-bulk, constant viscosity, constant permeability
 # fully saturated with fully-saturated Kernel
 # For better agreement with the analytical solution (ana_pp), just increase nx
+# NOTE: the numerics described by this input file is quite delicate.  Firstly, the steady-state solution does not depend on the mass-fraction distribution, so the mass-fraction variable can assume any values (with the constraint that its integral is the same as the initial condition).  Secondly, because the PorousFlowFullySaturatedDarcyFlow does no upwinding, the steady-state porepressure distribution can contain non-physical oscillations.  The solver choice and mesh choice used below mean the result is as expected, but changing these can produce different results.
 
 [Mesh]
   type = GeneratedMesh

--- a/modules/porous_flow/test/tests/gravity/tests
+++ b/modules/porous_flow/test/tests/gravity/tests
@@ -133,9 +133,8 @@
     csvdiff = 'fully_saturated_grav01c.csv'
     rel_err = 1.0E-5
     threading = '!pthreads'
-    skip = "#12505"
     requirement = "PorousFlow shall be able to find steady-state and long-time transient porepressure when gravity is nonzero: for single-phase fully-saturated, single-phase partially-saturated, two-phase PP formulations, and two-phase PS formulations"
-    issues = '#6845 #7677 #8073 #8585 #8574 #9537'
+    issues = '#6845 #7677 #8073 #8585 #8574 #9537 #12505'
     design = 'porous_flow/governing_equations.md porous_flow/tests/gravity/gravity_tests.md'
   [../]
   [./grav01d]

--- a/modules/porous_flow/test/tests/gravity/tests
+++ b/modules/porous_flow/test/tests/gravity/tests
@@ -133,6 +133,7 @@
     csvdiff = 'fully_saturated_grav01c.csv'
     rel_err = 1.0E-5
     threading = '!pthreads'
+    max_parallel = 1
     requirement = "PorousFlow shall be able to find steady-state and long-time transient porepressure when gravity is nonzero: for single-phase fully-saturated, single-phase partially-saturated, two-phase PP formulations, and two-phase PS formulations"
     issues = '#6845 #7677 #8073 #8585 #8574 #9537 #12505'
     design = 'porous_flow/governing_equations.md porous_flow/tests/gravity/gravity_tests.md'

--- a/modules/porous_flow/test/tests/jacobian/tests
+++ b/modules/porous_flow/test/tests/jacobian/tests
@@ -311,13 +311,12 @@
   [./eff_stress04]
     type = 'PetscJacobianTester'
     input = 'eff_stress04.i'
-    ratio_tol = 1E-7
+    ratio_tol = 1E-6
     difference_tol = 1E10
     cli_args = 'Executioner/num_steps=1'
     threading = '!pthreads'
-    skip = "#12506"
     requirement = "PorousFlow shall compute all Jacobian entries of all Kernels"
-    issues = '#6845'
+    issues = '#6845 #12506'
     design = 'porous_flow/tutorial_09.md porous_flow/tutorial_02.md porous_flow/solvers.md porous_flow/nonlinear_convergence_problems.md PorousFlowDictator.md'
   [../]
   [./mass_vol_exp01]


### PR DESCRIPTION
Needed to change some petsc behaviour in one of them

In the second, changed some finite-difference tolerances

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
