### PR TITLE
MUMPS not needed to run PorousFlow examples

### DIFF
--- a/modules/porous_flow/examples/thm_example/2D.i
+++ b/modules/porous_flow/examples/thm_example/2D.i
@@ -394,7 +394,7 @@
 []
 
 [Preconditioning]
-  active = 'mumps'
+  active = 'smp'
   [./smp]
     type = SMP
     full = true

--- a/modules/porous_flow/examples/thm_example/tests
+++ b/modules/porous_flow/examples/thm_example/tests
@@ -8,7 +8,6 @@
     heavy = true
     max_time = 1000
     threading = '!pthreads'
-    mumps = true
     issues = '#11110'
     design = 'thm_example.md'
     requirement = 'An example of a 2-phase THM benchmark problem shall be demonstrated in PorousFlow'

--- a/modules/porous_flow/examples/tutorial/tests
+++ b/modules/porous_flow/examples/tutorial/tests
@@ -158,7 +158,6 @@
     input = '13.i'
     exodiff = '13_out.e'
     threading = '!pthreads'
-    mumps = True
     issues = '#10959'
     design = 'tutorial_13.md'
     requirement = 'PorousFlow tutorial shall explain how to include precipitation-dissolution and equilibrium chemical systems in PorousFlow simulations'


### PR DESCRIPTION
Fixes #16951

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
