### PR TITLE
AD props alone don't mean we have AD residual objects

### DIFF
--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -443,7 +443,6 @@ template <typename T>
 ADMaterialProperty<T> &
 MaterialBase::declareADPropertyByName(const std::string & prop_name)
 {
-  _fe_problem.usingADMatProps(true);
   registerPropName(prop_name, false, MaterialBase::CURRENT);
   return materialData().declareADProperty<T>(prop_name);
 }

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -485,8 +485,6 @@ template <typename T>
 const ADMaterialProperty<T> &
 MaterialPropertyInterface::getADMaterialPropertyByName(const MaterialPropertyName & name)
 {
-  _mi_feproblem.usingADMatProps(true);
-
   checkExecutionStage();
   checkMaterialProperty(name);
 

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1757,22 +1757,6 @@ public:
   PetscOptions & petscOptionsDatabase() { return _petsc_option_data_base; }
 #endif
 
-  /**
-   * Set the global automatic differentiaion (AD) flag which indicates whether any consumer has
-   * requested an AD material property or whether any suppier has declared an AD material property
-   */
-  void usingADMatProps(bool using_ad_mat_props)
-  {
-    _using_ad_mat_props = using_ad_mat_props;
-    if (_using_ad_mat_props)
-      haveADObjects(true);
-  }
-
-  /**
-   * Whether any object has requested/supplied an AD material property
-   */
-  bool usingADMatProps() const { return _using_ad_mat_props; }
-
   /// Set boolean flag to true to store solution time derivative
   virtual void setUDotRequested(const bool u_dot_requested) { _u_dot_requested = u_dot_requested; };
 


### PR DESCRIPTION
And so we shouldn't toggle `FEProblemBase::usingADObjects(true)` just
because someone has declared an AD property or retrieved an AD property.
Moreover the `FEProblemBase::usingADMatProps` API is no longer useful
now that we no longer mix AD and regular material properties, so it can
be safely removed. This will resolve the issue for
[SAM/SAM#389](https://xgitlab.cels.anl.gov/SAM/SAM/-/merge_requests/389)
