### PR TITLE
Adding truss model and AveragePointSeparation

### DIFF
--- a/framework/doc/content/source/postprocessors/AveragePointSeparation.md
+++ b/framework/doc/content/source/postprocessors/AveragePointSeparation.md
@@ -1,0 +1,20 @@
+# AveragePointSeparation
+
+!syntax description /Postprocessors/AveragePointSeparation
+
+## Description
+
+This `PostProcessor` computes average distance between a set of points specified in two array `first_point` and `last_point`.
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/postprocessors/AveragePointSeparation/AveragePointSeparation.i block=Postprocessors/avg_disp
+
+
+!syntax parameters /Postprocessors/AveragePointSeparation
+
+!syntax inputs /Postprocessors/AveragePointSeparation
+
+!syntax children /Postprocessors/AveragePointSeparation
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/kernels/StressDivergenceTruss.md
+++ b/modules/tensor_mechanics/doc/content/source/kernels/StressDivergenceTruss.md
@@ -1,0 +1,16 @@
+# StressDivergenceTruss
+
+!syntax description /Kernels/StressDivergenceTruss
+
+## Description
+
+This class computes the stiffness and jacobian in the truss local coordinate system using material stiffness and the cross-section area.
+This local computation is then transformed to the global coordinate system using the orientation vector of the truss. The component of the force in the $i^{th}$ global coordinate direction is returned as the residual.
+
+!syntax parameters /Kernels/StressDivergenceTruss
+
+!syntax inputs /Kernels/StressDivergenceTruss
+
+!syntax children /Kernels/StressDivergenceTruss
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputeElasticityTruss.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputeElasticityTruss.md
@@ -1,0 +1,13 @@
+# Compute Elasticity Truss
+
+!syntax description /Materials/ComputeElasticityTruss
+
+## Description
+
+This class store material stiffness from the provided Young's modulus.
+
+!syntax parameters /Materials/ComputeElasticityTruss
+
+!syntax inputs /Materials/ComputeElasticityTruss
+
+!syntax children /Materials/ComputeElasticityTruss

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputeIncrementalTrussStrain.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputeIncrementalTrussStrain.md
@@ -1,0 +1,13 @@
+# Compute Incremental Truss Strain
+
+!syntax description /Materials/ComputeIncrementalTrussStrain
+
+## Description
+
+This class computes the small (and finite) displacement increments based on the current length and original length of the truss element. Additionally, the class computes stiffness for truss elements based on the material stiffness and original length and store as a property.
+
+!syntax parameters /Materials/ComputeIncrementalTrussStrain
+
+!syntax inputs /Materials/ComputeIncrementalTrussStrain
+
+!syntax children /Materials/ComputeIncrementalTrussStrain

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputePlasticTrussResultants.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputePlasticTrussResultants.md
@@ -1,0 +1,56 @@
+# Plastic Truss
+
+!syntax description /Materials/ComputePlasticTrussResultants
+
+## Description
+
+The `ComputePlasticTrussResultants` model implements J2 plasticity for 1D truss elements. The axial strain increment of the element is obtained from
+\begin{equation}
+\Delta\varepsilon = {\varepsilon}_{total}^{t} - {\varepsilon}_{total}^{t_{old}} \, ,
+\end{equation}
+where ${\varepsilon}_{total}^{t}$ is the total strain at current time step and ${\varepsilon}_{total}^{t_{old}}$ is the total strain at the previous time step. Here, the nonlinear behavior of the truss is implemented using a J2 plasticity model that can use either simple linear hardening or a user-defined function to define the hardening behavior.
+The trial stress is estimated as
+\begin{equation}
+\sigma^{tr} = \sigma_{old} + E \Delta \varepsilon \, .
+\end{equation}
+
+The yield condition is determined as
+\begin{equation}
+f = |\sigma^{tr}| - E \Delta \varepsilon^p - r -\sigma_y = 0 \, ,
+\end{equation}
+where $E$ is the Young's modulus, $r$ is the hardening function and $\sigma_y$ is the yield stress. When the trial stress is outside of the yield envelop the stresses are brought down using the iterative Newton method.
+In the case of linear hardening, the hardening function is defined as $r=h |\varepsilon^p|$ with $h$ being the hardening constant. In this case, the hardening variable at the beginning of the iterative process is obtained as
+\begin{equation}
+r^{(k)} = r_{old} + h  (\Delta \varepsilon^p)^{(k)} \, .
+\end{equation}
+The plastic strain increment is computed as
+\begin{equation}
+d\Delta \varepsilon^p = \frac{f}{\frac{df}{d\Delta \varepsilon^p}} = \frac{(|\tilde \sigma^{tr}| - E (\Delta \varepsilon^p)^{(k)} - r^k -\sigma_y)}{E + h} = 0 \, .
+\end{equation}
+The plastic strain for the next iteration is updated
+\begin{equation}
+(\Delta \varepsilon^p)^{(k+1)} = (\Delta \varepsilon^p)^{(k)} + d\Delta \varepsilon^p \, .
+\end{equation}
+The iterative process continues until the updated stress lies on the yield curve.
+Then the elastic strain is updated as
+\begin{equation}
+\Delta \varepsilon^e = \Delta \varepsilon - \Delta \varepsilon^p \, .
+\end{equation}
+The updated axial stress is calculated
+\begin{equation}
+\sigma_a = \sigma_{old} + E \Delta \varepsilon^e \, ,
+\end{equation}
+Axial force on the element is calculated as
+\begin{equation}
+f_a = f_{a|old} + E A \Delta \varepsilon^e \, ,
+\end{equation}
+
+## Example Input Syntax
+
+!listing modules/tensor_mechanics/test/tests/truss/truss_plastic_new.i block=Materials/truss
+
+!syntax parameters /Materials/ComputePlasticTrussResultants
+
+!syntax inputs /Materials/ComputePlasticTrussResultants
+
+!syntax children /Materials/ComputePlasticTrussResultants

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputePreStressEigenstrainTruss.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputePreStressEigenstrainTruss.md
@@ -1,0 +1,17 @@
+# Compute PreStress Eigenstrain Truss
+
+!syntax description /Materials/ComputePreStressEigenstrainTruss
+
+## Description
+
+`ComputeThemalExpansionEigenstrainTruss` calculates the thermal strain due to a change in temperature (from the stress-free temperature) using a constant thermal expansion coefficient. This thermal strain is applied only along the axial direction of the truss.
+
+## Example Input Syntax
+
+!listing modules/tensor_mechanics/test/tests/truss/truss_thermal_prestress.i block=Materials/pre_stressing_eig
+
+!syntax parameters /Materials/ComputePreStressEigenstrainTruss
+
+!syntax inputs /Materials/ComputePreStressEigenstrainTruss
+
+!syntax children /Materials/ComputePreStressEigenstrainTruss

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputeThermalExpansionEigenstrainTruss.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputeThermalExpansionEigenstrainTruss.md
@@ -1,0 +1,17 @@
+# Compute Thermal Expansion Eigenstrain Truss
+
+!syntax description /Materials/ComputeThermalExpansionEigenstrainTruss
+
+## Description
+
+`ComputeThemalExpansionEigenstrainTruss` calculates the thermal strain due to a change in temperature (from the stress-free temperature) using a constant thermal expansion coefficient. This thermal strain is applied only along the axial direction of the truss.
+
+## Example Input Syntax
+
+!listing modules/tensor_mechanics/test/tests/truss/truss_thermal.i block=Materials/thermal
+
+!syntax parameters /Materials/ComputeThermalExpansionEigenstrainTruss
+
+!syntax inputs /Materials/ComputeThermalExpansionEigenstrainTruss
+
+!syntax children /Materials/ComputeThermalExpansionEigenstrainTruss

--- a/modules/tensor_mechanics/doc/content/source/materials/ComputeTrussResultants.md
+++ b/modules/tensor_mechanics/doc/content/source/materials/ComputeTrussResultants.md
@@ -1,0 +1,20 @@
+# ComputeTrussResultants
+
+!syntax description /Materials/ComputeTrussResultants
+
+## Description
+
+This class computes the force and axial stress for a truss element from displacement strain increment.
+
+## Example Input Syntax
+
+!listing modules/tensor_mechanics/test/tests/truss/truss_thermal_prestress.i block=Materials/stress
+!listing modules/tensor_mechanics/test/tests/truss/truss_thermal.i block=Materials/stress
+
+!syntax parameters /Materials/ComputeTrussResultants
+
+!syntax inputs /Materials/ComputeTrussResultants
+
+!syntax children /Materials/ComputeTrussResultants
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
+++ b/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
@@ -1,0 +1,20 @@
+# AveragePointSeparation
+
+!syntax description /Postprocessors/AveragePointSeparation
+
+## Description
+
+This `PostProcessor` computes average distance between a set of points specified in two array `first_point` and `last_point`.
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/postprocessors/AveragePointSeparation/AveragePointSeparation.i block=Postprocessors/avg_disp
+
+
+!syntax parameters /Postprocessors/AveragePointSeparation
+
+!syntax inputs /Postprocessors/AveragePointSeparation
+
+!syntax children /Postprocessors/AveragePointSeparation
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/include/kernels/StressDivergenceTruss.h
+++ b/modules/tensor_mechanics/include/kernels/StressDivergenceTruss.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Kernel.h"
+#include "RankTwoTensorForward.h"
+
+class StressDivergenceTruss : public Kernel
+{
+public:
+  static InputParameters validParams();
+
+  StressDivergenceTruss(const InputParameters & parameters);
+  virtual void computeResidual() override;
+  virtual void computeJacobian() override;
+  virtual void computeOffDiagJacobian(MooseVariableFEBase & jvar);
+  using Kernel::computeOffDiagJacobian;
+
+protected:
+  virtual void initialSetup() override;
+  virtual Real computeStiffness(unsigned int i, unsigned int j);
+  virtual Real computeQpResidual() override { return 0.0; }
+
+  /// Direction along which force is calculated
+  const unsigned int _component;
+
+  /// Number of coupled displacement variables
+  unsigned int _ndisp;
+
+  /// Variable numbers corresponding to displacement variables
+  std::vector<unsigned int> _disp_var;
+
+  /// Current force vector in global coordinate system
+  const MaterialProperty<Real> & _force;
+
+  /// Stiffness matrix relating displacement DOFs of same node or across nodes
+  const MaterialProperty<Real> & _e_over_l;
+
+  const std::vector<RealGradient> * _orientation;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeEigenstrainTrussBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeEigenstrainTrussBase.h
@@ -1,0 +1,42 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+/**
+ * ComputeEigenstrainTrussBase is the base class for beam eigenstrain vectors
+ */
+class ComputeEigenstrainTrussBase : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ComputeEigenstrainTrussBase(const InputParameters & parameters);
+
+protected:
+  virtual void initQpStatefulProperties();
+  virtual void computeQpProperties();
+
+  /// Compute the eigenstrain and store in _disp_eigenstrain and _rot_eigenstrain
+  virtual void computeQpEigenstrain() = 0;
+
+  /// Base material property name for the eigenstrain vectors
+  std::string _eigenstrain_name;
+
+  /// Stores the current displacement eigenstrain
+  MaterialProperty<RealVectorValue> & _disp_eigenstrain;
+
+  // /// Stores the current rotational eigenstrain
+  // MaterialProperty<RealVectorValue> & _rot_eigenstrain;
+
+  /// Restartable data to check for the zeroth and first time steps for thermal calculations
+  bool & _step_zero;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeElasticityTruss.h
+++ b/modules/tensor_mechanics/include/materials/ComputeElasticityTruss.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+/**
+ * ComputeElasticityTruss computes the equivalent of the elasticity tensor for the truss element,
+ * which are vectors of material translational and flexural stiffness
+ */
+class ComputeElasticityTruss : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ComputeElasticityTruss(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+
+  /// Material stiffness vector that relates displacement strain increments to force increments
+  MaterialProperty<Real> & _material_stiffness;
+
+  /// Young's modulus of the truss material
+  const VariableValue & _youngs_modulus;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeIncrementalTrussStrain.h
+++ b/modules/tensor_mechanics/include/materials/ComputeIncrementalTrussStrain.h
@@ -1,0 +1,81 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "RankTwoTensor.h"
+
+// Forward Declarations
+class Function;
+
+/**
+ * ComputeIncrementalTrussStrain defines a displacement strain increment and rotation
+ * increment (=1), for small strains.
+ */
+class ComputeIncrementalTrussStrain : public Material
+{
+public:
+  static InputParameters validParams();
+  ComputeIncrementalTrussStrain(const InputParameters & parameters);
+  virtual void computeProperties() override;
+
+protected:
+  virtual void initQpStatefulProperties() override;
+
+  /// Computes the displacement and rotation strain increments
+  void computeQpStrain();
+
+  /// Computes the stiffness matrices
+  void computeStiffnessMatrix();
+
+  std::vector<MooseVariable *> _disp_var;
+
+  /// Number of coupled displacement variables
+  unsigned int _ndisp;
+
+  /// Coupled variable for the truss cross-sectional area
+  const VariableValue & _area;
+
+  /// Material stiffness vector that relates displacement strain increments to force increments
+  const MaterialProperty<Real> & _material_stiffness;
+
+  /// Stiffness matrix between displacement DOFs of same node or across nodes
+  MaterialProperty<Real> & _e_over_l;
+
+  /// Initial length of the truss
+  MaterialProperty<Real> & _original_length;
+
+  /// Current length of the truss
+  MaterialProperty<Real> & _current_length;
+
+  /// Boolean flag to turn on large strain calculation
+  const bool _large_strain;
+
+  /// Rotational transformation from global coordinate system to initial truss local configuration
+  RankTwoTensor _original_local_config;
+
+  /// Current total displacement strain integrated over the cross-section in global coordinate system.
+  MaterialProperty<RealVectorValue> & _total_disp_strain;
+
+  /// Old total displacement strain integrated over the cross-section in global coordinate system.
+  const MaterialProperty<RealVectorValue> & _total_disp_strain_old;
+
+  /// Mechanical displacement strain increment (after removal of eigenstrains) integrated over the cross-section.
+  MaterialProperty<RealVectorValue> & _mech_disp_strain_increment;
+
+  /// Vector of truss eigenstrain names
+  std::vector<MaterialPropertyName> _eigenstrain_names;
+
+  /// Vector of current displacement eigenstrains
+  std::vector<const MaterialProperty<RealVectorValue> *> _disp_eigenstrain;
+
+  /// Vector of old displacement eigenstrains
+  std::vector<const MaterialProperty<RealVectorValue> *> _disp_eigenstrain_old;
+};

--- a/modules/tensor_mechanics/include/materials/ComputePlasticTrussResultants.h
+++ b/modules/tensor_mechanics/include/materials/ComputePlasticTrussResultants.h
@@ -1,0 +1,71 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeTrussResultants.h"
+
+class ComputePlasticTrussResultants : public ComputeTrussResultants
+{
+public:
+  static InputParameters validParams();
+
+  ComputePlasticTrussResultants(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+  virtual void initQpStatefulProperties();
+
+  virtual Real computeHardeningValue(Real scalar);
+  virtual Real computeHardeningDerivative(Real scalar);
+
+  //  yield stress and hardening property input
+  /// Base name of the material system
+  const std::string _base_name;
+
+  Real _yield_stress;
+  const Real _hardening_constant;
+  const Function * const _hardening_function;
+
+  /// Coupled variable for the beam cross-sectional area
+  const VariableValue & _area;
+
+  /// Material stiffness vector that relates displacement strain increment to force increment
+  const MaterialProperty<Real> & _material_stiffness;
+
+  /// Current total displacement strain integrated over the cross-section in global coordinate system.
+  const MaterialProperty<RealVectorValue> & _total_disp_strain;
+
+  /// Old total displacement strain integrated over the cross-section in global coordinate system.
+  const MaterialProperty<RealVectorValue> & _total_disp_strain_old;
+
+  /// convergence tolerance
+  Real _absolute_tolerance;
+  Real _relative_tolerance;
+
+  // const MaterialProperty<Real> & _total_stretch_old;
+  MaterialProperty<Real> & _plastic_strain;
+  const MaterialProperty<Real> & _plastic_strain_old;
+
+  MaterialProperty<Real> & _axial_stress;
+
+  const MaterialProperty<Real> & _axial_stress_old;
+
+  // /// Current force vector in global coordinate system
+  MaterialProperty<Real> & _force;
+
+  /// Old force vector in global coordinate system
+  const MaterialProperty<Real> & _force_old;
+
+  MaterialProperty<Real> & _hardening_variable;
+  const MaterialProperty<Real> & _hardening_variable_old;
+
+  /// maximum no. of iterations
+  const unsigned int _max_its;
+};

--- a/modules/tensor_mechanics/include/materials/ComputePreStressEigenstrainTruss.h
+++ b/modules/tensor_mechanics/include/materials/ComputePreStressEigenstrainTruss.h
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeEigenstrainTrussBase.h"
+#include "DerivativeMaterialInterface.h"
+
+/**
+ * ComputePreStressEigenstrainTruss is a base class for all models that
+ * compute beam eigenstrains due to thermal expansion of a material.
+ */
+class ComputePreStressEigenstrainTruss
+  : public DerivativeMaterialInterface<ComputeEigenstrainTrussBase>
+{
+public:
+  static InputParameters validParams();
+
+  ComputePreStressEigenstrainTruss(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpEigenstrain() override;
+  const Real _pre_stressing_strain;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainTruss.h
+++ b/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainTruss.h
@@ -1,0 +1,31 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeThermalExpansionEigenstrainTrussBase.h"
+#include "DerivativeMaterialInterface.h"
+
+/**
+ * ComputeThermalExpansionEigenstrainTruss computes an eigenstrain for thermal expansion
+ * with a constant expansion coefficient.
+ */
+class ComputeThermalExpansionEigenstrainTruss : public ComputeThermalExpansionEigenstrainTrussBase
+{
+public:
+  static InputParameters validParams();
+
+  ComputeThermalExpansionEigenstrainTruss(const InputParameters & parameters);
+
+protected:
+  virtual void computeThermalStrain(Real & thermal_strain) override;
+
+  /// Constant thermal expansion coefficient
+  const Real & _thermal_expansion_coeff;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainTrussBase.h
+++ b/modules/tensor_mechanics/include/materials/ComputeThermalExpansionEigenstrainTrussBase.h
@@ -1,0 +1,46 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ComputeEigenstrainTrussBase.h"
+#include "DerivativeMaterialInterface.h"
+
+/**
+ * ComputeThermalExpansionEigenstrainTrussBase is a base class for all models that
+ * compute beam eigenstrains due to thermal expansion of a material.
+ */
+class ComputeThermalExpansionEigenstrainTrussBase
+  : public DerivativeMaterialInterface<ComputeEigenstrainTrussBase>
+{
+public:
+  static InputParameters validParams();
+
+  ComputeThermalExpansionEigenstrainTrussBase(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpEigenstrain() override;
+  /*
+   * Compute the total thermal strain relative to the stress-free temperature at
+   * the current temperature
+   *
+   * param thermal_strain    The current total linear thermal strain
+   *                         (\delta L / L)
+   */
+  virtual void computeThermalStrain(Real & thermal_strain) = 0;
+
+  /// Value of temperature at each quadrature point
+  const VariableValue & _temperature;
+
+  /// Value of stress free temperature at each quadrature point
+  const VariableValue & _stress_free_temperature;
+
+  /// Initial orientation of the beam
+  RealGradient _initial_axis;
+};

--- a/modules/tensor_mechanics/include/materials/ComputeTrussResultants.h
+++ b/modules/tensor_mechanics/include/materials/ComputeTrussResultants.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "RankTwoTensor.h"
+
+/**
+ * ComputeTrussResultants computes forces and moments using elasticity
+ */
+class ComputeTrussResultants : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ComputeTrussResultants(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties() override;
+  virtual void initQpStatefulProperties() override;
+
+  /// Coupled variable for the beam cross-sectional area
+  const VariableValue & _area;
+
+  /// Mechanical displacement strain increment in truss local coordinate system
+  const MaterialProperty<RealVectorValue> & _disp_strain_increment;
+
+  /// Material stiffness vector that relates displacement strain increment to force increment
+  const MaterialProperty<Real> & _material_stiffness;
+
+  MaterialProperty<Real> & _axial_stress;
+
+  const MaterialProperty<Real> & _axial_stress_old;
+
+  /// Current force vector in global coordinate system
+  MaterialProperty<Real> & _force;
+
+  /// Old force vector in global coordinate system
+  const MaterialProperty<Real> & _force_old;
+};

--- a/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
+++ b/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
@@ -1,0 +1,55 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralPostprocessor.h"
+
+// Forward Declarations
+class AveragePointSeparation;
+
+template <>
+InputParameters validParams<AveragePointSeparation>();
+
+/**
+ * Compute the value of a variable at a specified location.
+ *
+ * Warning: This postprocessor may result in undefined behavior if utilized with
+ * non-continuous elements and the point being located lies on an element boundary.
+ */
+class AveragePointSeparation : public GeneralPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  AveragePointSeparation(const InputParameters & parameters);
+
+  virtual void initialize() override {}
+  virtual void execute() override;
+  virtual void finalize() override {}
+  virtual Real getValue() override;
+
+protected:
+  // std::vector<MooseVariable *> _disp_var;
+
+  std::vector<VariableName> _displacements;
+
+  /// The vector of displacements number we are operating on
+  std::vector<int> _disp_num;
+
+  /// A reference to the system containing the variable
+  const System & _system;
+
+  /// The point to locate
+  const std::vector<Point> & _first_point;
+  const std::vector<Point> & _last_point;
+
+  /// The value of the variable at the desired location
+  Real _value;
+};

--- a/modules/tensor_mechanics/src/kernels/StressDivergenceTruss.C
+++ b/modules/tensor_mechanics/src/kernels/StressDivergenceTruss.C
@@ -1,0 +1,154 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "StressDivergenceTruss.h"
+
+// MOOSE includes
+#include "Assembly.h"
+#include "Material.h"
+#include "MooseVariable.h"
+#include "SystemBase.h"
+#include "RankTwoTensor.h"
+#include "NonlinearSystem.h"
+#include "MooseMesh.h"
+
+#include "libmesh/quadrature.h"
+
+registerMooseObject("TensorMechanicsApp", StressDivergenceTruss);
+
+InputParameters
+StressDivergenceTruss::validParams()
+{
+  InputParameters params = Kernel::validParams();
+  params.addClassDescription("Quasi-static and dynamic stress divergence kernel for truss element");
+  params.addRequiredParam<unsigned int>(
+      "component",
+      "An integer corresponding to the direction the variable this kernel acts in. (0 for disp_x, "
+      "1 for disp_y, 2 for disp_z)");
+  params.addRequiredCoupledVar(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+  params.set<bool>("use_displaced_mesh") = true;
+  return params;
+}
+
+StressDivergenceTruss::StressDivergenceTruss(const InputParameters & parameters)
+  : Kernel(parameters),
+    _component(getParam<unsigned int>("component")),
+    _ndisp(coupledComponents("displacements")),
+    _disp_var(_ndisp),
+    _force(getMaterialPropertyByName<Real>("forces")),
+    _e_over_l(getMaterialPropertyByName<Real>("e_over_l")),
+    _orientation(NULL)
+{
+  for (unsigned int i = 0; i < _ndisp; ++i)
+    _disp_var[i] = coupled("displacements", i);
+}
+
+void
+StressDivergenceTruss::initialSetup()
+{
+  _orientation = &_subproblem.assembly(_tid).getFE(FEType(), 1)->get_dxyzdxi();
+}
+
+void
+StressDivergenceTruss::computeResidual()
+{
+  prepareVectorTag(_assembly, _var.number());
+
+  mooseAssert(_local_re.size() == 2, "Truss element must have two nodes only.");
+
+  RealGradient orientation((*_orientation)[0]);
+  orientation /= orientation.norm();
+
+  VectorValue<Real> force_local = _force[0] * orientation;
+
+  _local_re(0) = -force_local(_component);
+  _local_re(1) = -_local_re(0);
+
+  accumulateTaggedLocalResidual();
+
+  if (_has_save_in)
+  {
+    Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+    for (unsigned int i = 0; i < _save_in.size(); ++i)
+      _save_in[i]->sys().solution().add_vector(_local_re, _save_in[i]->dofIndices());
+  }
+}
+
+Real
+StressDivergenceTruss::computeStiffness(unsigned int i, unsigned int j)
+{
+  RealGradient orientation((*_orientation)[0]);
+  orientation /= orientation.norm();
+  return orientation(i) * orientation(j) * _e_over_l[0];
+}
+
+void
+StressDivergenceTruss::computeJacobian()
+{
+  prepareMatrixTag(_assembly, _var.number(), _var.number());
+  for (unsigned int i = 0; i < _test.size(); ++i)
+    for (unsigned int j = 0; j < _phi.size(); ++j)
+      if (_component < 3)
+        _local_ke(i, j) = (i == j ? 1 : -1) * computeStiffness(_component, _component);
+
+  accumulateTaggedLocalMatrix();
+
+  if (_has_diag_save_in)
+  {
+    unsigned int rows = _local_ke.m();
+    DenseVector<Number> diag(rows);
+    for (unsigned int i = 0; i < rows; ++i)
+      diag(i) = _local_ke(i, i);
+
+    Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+    for (unsigned int i = 0; i < _diag_save_in.size(); ++i)
+      _diag_save_in[i]->sys().solution().add_vector(diag, _diag_save_in[i]->dofIndices());
+  }
+}
+
+void
+StressDivergenceTruss::computeOffDiagJacobian(MooseVariableFEBase & jvar)
+{
+  size_t jvar_num = jvar.number();
+  if (jvar_num == _var.number())
+    computeJacobian();
+  else
+  {
+    // This (undisplaced) jvar could potentially yield the wrong phi size if this object is acting
+    // on the displaced mesh
+    auto phi_size = _sys.getVariable(_tid, jvar.number()).dofIndices().size();
+
+    unsigned int coupled_component = 0;
+    bool disp_coupled = false;
+
+    for (unsigned int i = 0; i < _ndisp; ++i)
+      if (jvar_num == _disp_var[i])
+      {
+        coupled_component = i;
+        disp_coupled = true;
+        break;
+      }
+
+    if (disp_coupled)
+    {
+      prepareMatrixTag(_assembly, _var.number(), jvar_num);
+
+      for (unsigned int i = 0; i < _test.size(); ++i)
+        for (unsigned int j = 0; j < phi_size; ++j)
+          _local_ke(i, j) += (i == j ? 1 : -1) * computeStiffness(_component, coupled_component);
+
+      accumulateTaggedLocalMatrix();
+    }
+    else if (false) // Need some code here for coupling with temperature
+    {
+    }
+  }
+}

--- a/modules/tensor_mechanics/src/materials/ComputeEigenstrainTrussBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeEigenstrainTrussBase.C
@@ -1,0 +1,51 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeEigenstrainTrussBase.h"
+
+InputParameters
+ComputeEigenstrainTrussBase::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addRequiredParam<std::string>("eigenstrain_name",
+                                       "Material property name for the eigenstrain vector computed "
+                                       "by this model. IMPORTANT: The name of this property must "
+                                       "also be provided to the strain calculator.");
+  return params;
+}
+
+ComputeEigenstrainTrussBase::ComputeEigenstrainTrussBase(const InputParameters & parameters)
+  : Material(parameters),
+    _eigenstrain_name(getParam<std::string>("eigenstrain_name")),
+    _disp_eigenstrain(declareProperty<RealVectorValue>("disp_" + _eigenstrain_name)),
+    _step_zero(declareRestartableData<bool>("step_zero", true))
+{
+}
+
+void
+ComputeEigenstrainTrussBase::initQpStatefulProperties()
+{
+  // This property can be promoted to be stateful by other models that use it,
+  // so it needs to be initalized.
+  RealVectorValue a;
+  _disp_eigenstrain[_qp] = a;
+}
+
+void
+ComputeEigenstrainTrussBase::computeQpProperties()
+{
+  if (_t_step >= 1)
+    _step_zero = false;
+
+  // Skip the eigenstrain calculation in step zero because no solution is computed during
+  // the zeroth step, hence computing the eigenstrain in the zeroth step would result in
+  // an incorrect calculation of mechanical_strain, which is stateful.
+  if (!_step_zero)
+    computeQpEigenstrain();
+}

--- a/modules/tensor_mechanics/src/materials/ComputeElasticityTruss.C
+++ b/modules/tensor_mechanics/src/materials/ComputeElasticityTruss.C
@@ -1,0 +1,38 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeElasticityTruss.h"
+#include "Function.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeElasticityTruss);
+
+InputParameters
+ComputeElasticityTruss::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Computes the equivalent of the elasticity tensor for the truss "
+                             "element, which are vectors of material axial stiffness.");
+  params.addRequiredCoupledVar(
+      "youngs_modulus",
+      "Young's modulus of the material. Can be supplied as either a number or a variable name.");
+  return params;
+}
+
+ComputeElasticityTruss::ComputeElasticityTruss(const InputParameters & parameters)
+  : Material(parameters),
+    _material_stiffness(declareProperty<Real>("material_stiffness")),
+    _youngs_modulus(coupledValue("youngs_modulus"))
+{
+}
+
+void
+ComputeElasticityTruss::computeQpProperties()
+{
+  _material_stiffness[_qp] = _youngs_modulus[_qp];
+}

--- a/modules/tensor_mechanics/src/materials/ComputeIncrementalTrussStrain.C
+++ b/modules/tensor_mechanics/src/materials/ComputeIncrementalTrussStrain.C
@@ -1,0 +1,144 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeIncrementalTrussStrain.h"
+#include "MooseMesh.h"
+#include "Assembly.h"
+#include "NonlinearSystem.h"
+#include "MooseVariable.h"
+#include "Function.h"
+
+#include "libmesh/quadrature.h"
+#include "libmesh/utility.h"
+
+#include "Material.h"
+#include "MooseVariable.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeIncrementalTrussStrain);
+
+InputParameters
+ComputeIncrementalTrussStrain::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Compute a infinitesimal/large strain increment for the truss.");
+  params.addRequiredCoupledVar(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+  params.addRequiredCoupledVar(
+      "area",
+      "Cross-section area of the truss. Can be supplied as either a number or a variable name.");
+  params.addParam<bool>("large_strain", false, "Set to true if large strain are to be calculated.");
+  params.addParam<std::vector<MaterialPropertyName>>(
+      "eigenstrain_names", "List of truss eigenstrains to be applied in this strain calculation.");
+  return params;
+}
+
+ComputeIncrementalTrussStrain::ComputeIncrementalTrussStrain(const InputParameters & parameters)
+  : Material(parameters),
+    _ndisp(coupledComponents("displacements")),
+    _area(coupledValue("area")),
+    _material_stiffness(getMaterialPropertyByName<Real>("material_stiffness")),
+    _e_over_l(declareProperty<Real>("e_over_l")),
+
+    _original_length(declareProperty<Real>("original_length")),
+    _current_length(declareProperty<Real>("current_length")),
+
+    _large_strain(getParam<bool>("large_strain")),
+    _total_disp_strain(declareProperty<RealVectorValue>("total_disp_strain")),
+    _total_disp_strain_old(getMaterialPropertyOld<RealVectorValue>("total_disp_strain")),
+    _mech_disp_strain_increment(declareProperty<RealVectorValue>("mech_disp_strain_increment")),
+    _eigenstrain_names(getParam<std::vector<MaterialPropertyName>>("eigenstrain_names")),
+    _disp_eigenstrain(_eigenstrain_names.size()),
+    _disp_eigenstrain_old(_eigenstrain_names.size())
+{
+  const std::vector<VariableName> & nl_vnames(getParam<std::vector<VariableName>>("displacements"));
+  // fetch coupled variables and gradients (as stateful properties if necessary)
+  for (unsigned int i = 0; i < _ndisp; ++i)
+    _disp_var.push_back(&_fe_problem.getStandardVariable(_tid, nl_vnames[i]));
+
+  if (_large_strain)
+    mooseError("ComputeIncrementalTrussStrain: Large strain calculation does not currently "
+               "support asymmetric truss configurations with non-zero first or third moments of "
+               "area.");
+
+  for (unsigned int i = 0; i < _eigenstrain_names.size(); ++i)
+  {
+    _disp_eigenstrain[i] = &getMaterialProperty<RealVectorValue>("disp_" + _eigenstrain_names[i]);
+    _disp_eigenstrain_old[i] =
+        &getMaterialPropertyOld<RealVectorValue>("disp_" + _eigenstrain_names[i]);
+  }
+}
+
+void
+ComputeIncrementalTrussStrain::initQpStatefulProperties()
+{
+  RealVectorValue temp;
+  _total_disp_strain[_qp](0) = 0;
+  _total_disp_strain[_qp](1) = 0;
+  _total_disp_strain[_qp](2) = 0;
+}
+
+void
+ComputeIncrementalTrussStrain::computeProperties()
+{
+  // calculate original length of a truss element (nodal positions do not change with time as
+  // undisplaced mesh is used by material classes by default) fetch the solution for the two end
+  // nodes for current element
+  std::vector<const Node *> node;
+  for (unsigned int i = 0; i < 2; ++i)
+    node.push_back(_current_elem->node_ptr(i));
+  RealGradient dxyz;
+  for (unsigned int i = 0; i < _ndisp; ++i)
+    dxyz(i) = (*node[1])(i) - (*node[0])(i);
+  for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
+    _original_length[_qp] = dxyz.norm();
+
+  // calculate the current length of a truss element
+  // fetch the solution for the two end nodes
+  NonlinearSystemBase & nonlinear_sys = _fe_problem.getNonlinearSystemBase();
+  const NumericVector<Number> & sol = *nonlinear_sys.currentSolution();
+  std::vector<Real> disp0, disp1;
+  for (unsigned int i = 0; i < _ndisp; ++i)
+  {
+    disp0.push_back(sol(node[0]->dof_number(nonlinear_sys.number(), _disp_var[i]->number(), 0)));
+    disp1.push_back(sol(node[1]->dof_number(nonlinear_sys.number(), _disp_var[i]->number(), 0)));
+  }
+  for (unsigned int i = 0; i < _ndisp; ++i)
+    dxyz(i) += disp1[i] - disp0[i];
+  for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
+    _current_length[_qp] = dxyz.norm();
+
+  // compute strain and the stiffneess matrix
+  for (_qp = 0; _qp < _qrule->n_points(); ++_qp)
+  {
+    computeQpStrain();
+    if (_fe_problem.currentlyComputingJacobian())
+      computeStiffnessMatrix();
+  }
+}
+
+void
+ComputeIncrementalTrussStrain::computeQpStrain()
+{
+  _mech_disp_strain_increment[_qp](0) = _current_length[_qp] / _original_length[_qp] - 1.0;
+  _mech_disp_strain_increment[_qp](1) = 0.;
+  _mech_disp_strain_increment[_qp](2) = 0.;
+
+  _total_disp_strain[_qp] = _mech_disp_strain_increment[_qp];
+
+  for (unsigned int i = 0; i < _eigenstrain_names.size(); ++i)
+    _mech_disp_strain_increment[_qp] -=
+        (*_disp_eigenstrain[i])[_qp] - (*_disp_eigenstrain_old[i])[_qp];
+}
+
+void
+ComputeIncrementalTrussStrain::computeStiffnessMatrix()
+{
+  _e_over_l[_qp] = _material_stiffness[_qp] * _area[_qp] / _original_length[_qp];
+}

--- a/modules/tensor_mechanics/src/materials/ComputePlasticTrussResultants.C
+++ b/modules/tensor_mechanics/src/materials/ComputePlasticTrussResultants.C
@@ -1,0 +1,158 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputePlasticTrussResultants.h"
+#include "ComputeIncrementalTrussStrain.h"
+#include "Function.h"
+#include "MooseException.h"
+#include "MathUtils.h"
+
+registerMooseObject("TensorMechanicsApp", ComputePlasticTrussResultants);
+
+InputParameters
+ComputePlasticTrussResultants::validParams()
+{
+  InputParameters params = ComputeTrussResultants::validParams();
+  params.addClassDescription(
+      "Computes the stress and strain for a truss element with plastic behavior defined by either "
+      "linear hardening or a user-defined hardening function.");
+  params.addRequiredParam<Real>("yield_stress",
+                                "Yield stress after which plastic strain starts accumulating");
+  params.addParam<Real>("hardening_constant", 0.0, "Hardening slope");
+  params.addParam<FunctionName>("hardening_function",
+                                "Engineering stress as a function of plastic strain");
+  params.addRequiredCoupledVar(
+      "area",
+      "Cross-section area of the truss. Can be supplied as either a number or a variable name.");
+  params.addParam<Real>(
+      "absolute_tolerance", 1e-10, "Absolute convergence tolerance for Newton iteration");
+  params.addParam<Real>(
+      "relative_tolerance", 1e-8, "Relative convergence tolerance for Newton iteration");
+  return params;
+}
+
+ComputePlasticTrussResultants::ComputePlasticTrussResultants(const InputParameters & parameters)
+  : ComputeTrussResultants(parameters),
+    _yield_stress(getParam<Real>("yield_stress")), // Read from input file
+    _hardening_constant(getParam<Real>("hardening_constant")),
+    _hardening_function(isParamValid("hardening_function") ? &getFunction("hardening_function")
+                                                           : NULL),
+    _area(coupledValue("area")),
+    _material_stiffness(getMaterialPropertyByName<Real>("material_stiffness")),
+    _total_disp_strain(getMaterialProperty<RealVectorValue>("total_disp_strain")),
+    _total_disp_strain_old(getMaterialPropertyOld<RealVectorValue>("total_disp_strain")),
+
+    _absolute_tolerance(parameters.get<Real>("absolute_tolerance")),
+    _relative_tolerance(parameters.get<Real>("relative_tolerance")),
+
+    _plastic_strain(declareProperty<Real>("plastic_strain")),
+    _plastic_strain_old(getMaterialPropertyOld<Real>("plastic_strain")),
+
+    _axial_stress(declareProperty<Real>("axial_stress")),
+    _axial_stress_old(getMaterialPropertyOld<Real>("axial_stress")),
+    _force(declareProperty<Real>("forces")),
+    _force_old(getMaterialPropertyOld<Real>("forces")),
+    _hardening_variable(declareProperty<Real>("hardening_variable")),
+    _hardening_variable_old(getMaterialPropertyOld<Real>("hardening_variable")),
+    _max_its(1000)
+{
+  if (!parameters.isParamSetByUser("hardening_constant") && !isParamValid("hardening_function"))
+    mooseError("ComputePlasticTrussResultants: Either hardening_constant or hardening_function "
+               "must be defined");
+
+  if (parameters.isParamSetByUser("hardening_constant") && isParamValid("hardening_function"))
+    mooseError("ComputePlasticTrussResultants: Only the hardening_constant or only the "
+               "hardening_function can be defined but not both");
+}
+
+void
+ComputePlasticTrussResultants::initQpStatefulProperties()
+{
+  // ComputeIncrementalTrussStrain::initQpStatefulProperties();
+  _plastic_strain[_qp] = 0.0;
+  _hardening_variable[_qp] = 0.0;
+}
+
+void
+ComputePlasticTrussResultants::computeQpProperties()
+{
+  Real strain_increment = _total_disp_strain[_qp](0) - _total_disp_strain_old[_qp](0);
+  Real trial_stress = _axial_stress_old[_qp] + _material_stiffness[_qp] * strain_increment;
+
+  _hardening_variable[_qp] = _hardening_variable_old[_qp];
+  _plastic_strain[_qp] = _plastic_strain_old[_qp];
+
+  Real yield_condition = std::abs(trial_stress) - _hardening_variable[_qp] - _yield_stress;
+  Real iteration = 0;
+  Real plastic_strain_increment = 0.0;
+  Real elastic_strain_increment = strain_increment;
+
+  if (yield_condition > 0.0)
+  {
+    Real residual = std::abs(trial_stress) - _hardening_variable[_qp] - _yield_stress -
+                    _material_stiffness[_qp] * plastic_strain_increment;
+
+    Real reference_residual =
+        std::abs(trial_stress) - _material_stiffness[_qp] * plastic_strain_increment;
+
+    while (std::abs(residual) > _absolute_tolerance ||
+           std::abs(residual / reference_residual) > _relative_tolerance)
+    {
+      _hardening_variable[_qp] = computeHardeningValue(plastic_strain_increment);
+      Real hardening_slope = computeHardeningDerivative(plastic_strain_increment);
+
+      Real scalar = (std::abs(trial_stress) - _hardening_variable[_qp] - _yield_stress -
+                     _material_stiffness[_qp] * plastic_strain_increment) /
+                    (_material_stiffness[_qp] + hardening_slope);
+      plastic_strain_increment += scalar;
+
+      residual = std::abs(trial_stress) - _hardening_variable[_qp] - _yield_stress -
+                 _material_stiffness[_qp] * plastic_strain_increment;
+
+      reference_residual =
+          std::abs(trial_stress) - _material_stiffness[_qp] * plastic_strain_increment;
+
+      ++iteration;
+      if (iteration > _max_its) // not converging
+        throw MooseException("ComputePlasticTrussResultants: Plasticity model did not converge");
+    }
+    plastic_strain_increment *= MathUtils::sign(trial_stress);
+    _plastic_strain[_qp] += plastic_strain_increment;
+    elastic_strain_increment = strain_increment - plastic_strain_increment;
+  }
+  _axial_stress[_qp] = _axial_stress_old[_qp] + _material_stiffness[_qp] * elastic_strain_increment;
+  _force[_qp] = _force_old[_qp] + _material_stiffness[_qp] * elastic_strain_increment * _area[_qp];
+}
+
+Real
+ComputePlasticTrussResultants::computeHardeningValue(Real scalar)
+{
+  if (_hardening_function)
+  {
+    const Real strain_old = _plastic_strain_old[_qp];
+    const Point p;
+
+    return _hardening_function->value(std::abs(strain_old) + scalar, p) - _yield_stress;
+  }
+
+  return _hardening_variable_old[_qp] + _hardening_constant * scalar;
+}
+
+Real ComputePlasticTrussResultants::computeHardeningDerivative(Real /*scalar*/)
+{
+  if (_hardening_function)
+  {
+    const Real strain_old = _plastic_strain_old[_qp];
+    const Point p;
+
+    return _hardening_function->timeDerivative(std::abs(strain_old), p);
+  }
+
+  return _hardening_constant;
+}

--- a/modules/tensor_mechanics/src/materials/ComputePreStressEigenstrainTruss.C
+++ b/modules/tensor_mechanics/src/materials/ComputePreStressEigenstrainTruss.C
@@ -1,0 +1,34 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputePreStressEigenstrainTruss.h"
+
+registerMooseObject("TensorMechanicsApp", ComputePreStressEigenstrainTruss);
+
+InputParameters
+ComputePreStressEigenstrainTruss::validParams()
+{
+  InputParameters params = ComputeEigenstrainTrussBase::validParams();
+  params.addRequiredParam<Real>("pre_stressing_strain", "pre stressing strain");
+  return params;
+}
+
+ComputePreStressEigenstrainTruss::ComputePreStressEigenstrainTruss(
+    const InputParameters & parameters)
+  : DerivativeMaterialInterface<ComputeEigenstrainTrussBase>(parameters),
+    _pre_stressing_strain(getParam<Real>("pre_stressing_strain"))
+{
+}
+
+void
+ComputePreStressEigenstrainTruss::computeQpEigenstrain()
+{
+  _disp_eigenstrain[_qp].zero();
+  _disp_eigenstrain[_qp](0) = _pre_stressing_strain;
+}

--- a/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainTruss.C
+++ b/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainTruss.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeThermalExpansionEigenstrainTruss.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeThermalExpansionEigenstrainTruss);
+
+InputParameters
+ComputeThermalExpansionEigenstrainTruss::validParams()
+{
+  InputParameters params = ComputeThermalExpansionEigenstrainTrussBase::validParams();
+  params.addClassDescription("Computes eigenstrain due to thermal expansion "
+                             "with a constant coefficient");
+  params.addParam<Real>("thermal_expansion_coeff", "Thermal expansion coefficient");
+
+  return params;
+}
+
+ComputeThermalExpansionEigenstrainTruss::ComputeThermalExpansionEigenstrainTruss(
+    const InputParameters & parameters)
+  : ComputeThermalExpansionEigenstrainTrussBase(parameters),
+    _thermal_expansion_coeff(getParam<Real>("thermal_expansion_coeff"))
+{
+}
+
+void
+ComputeThermalExpansionEigenstrainTruss::computeThermalStrain(Real & thermal_strain)
+{
+  thermal_strain = _thermal_expansion_coeff * (_temperature[_qp] - _stress_free_temperature[_qp]);
+}

--- a/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainTrussBase.C
+++ b/modules/tensor_mechanics/src/materials/ComputeThermalExpansionEigenstrainTrussBase.C
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeThermalExpansionEigenstrainTrussBase.h"
+
+InputParameters
+ComputeThermalExpansionEigenstrainTrussBase::validParams()
+{
+  InputParameters params = ComputeEigenstrainTrussBase::validParams();
+  params.addRequiredCoupledVar("temperature", "Coupled temperature");
+  params.addRequiredCoupledVar("stress_free_temperature",
+                               "Reference temperature at which there is no "
+                               "thermal expansion for thermal eigenstrain "
+                               "calculation");
+  return params;
+}
+
+ComputeThermalExpansionEigenstrainTrussBase::ComputeThermalExpansionEigenstrainTrussBase(
+    const InputParameters & parameters)
+  : DerivativeMaterialInterface<ComputeEigenstrainTrussBase>(parameters),
+    _temperature(coupledValue("temperature")),
+    _stress_free_temperature(coupledValue("stress_free_temperature"))
+{
+}
+
+void
+ComputeThermalExpansionEigenstrainTrussBase::computeQpEigenstrain()
+{
+  Real thermal_strain = 0.0;
+  computeThermalStrain(thermal_strain);
+  _disp_eigenstrain[_qp].zero();
+  _disp_eigenstrain[_qp](0) = thermal_strain;
+}

--- a/modules/tensor_mechanics/src/materials/ComputeTrussResultants.C
+++ b/modules/tensor_mechanics/src/materials/ComputeTrussResultants.C
@@ -1,0 +1,52 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputeTrussResultants.h"
+
+registerMooseObject("TensorMechanicsApp", ComputeTrussResultants);
+
+InputParameters
+ComputeTrussResultants::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription("Compute forces and moments using elasticity");
+  params.addRequiredCoupledVar(
+      "area",
+      "Cross-section area of the truss. Can be supplied as either a number or a variable name.");
+  return params;
+}
+
+ComputeTrussResultants::ComputeTrussResultants(const InputParameters & parameters)
+  : Material(parameters),
+    _area(coupledValue("area")),
+    _disp_strain_increment(
+        getMaterialPropertyByName<RealVectorValue>("mech_disp_strain_increment")),
+    _material_stiffness(getMaterialPropertyByName<Real>("material_stiffness")),
+    _axial_stress(declareProperty<Real>("axial_stress")),
+    _axial_stress_old(getMaterialPropertyOld<Real>("axial_stress")),
+    _force(declareProperty<Real>("forces")),
+    _force_old(getMaterialPropertyOld<Real>("forces"))
+{
+}
+
+void
+ComputeTrussResultants::initQpStatefulProperties()
+{
+  _force[_qp] = 0;
+  _axial_stress[_qp] = 0;
+}
+
+void
+ComputeTrussResultants::computeQpProperties()
+{
+  _force[_qp] =
+      _material_stiffness[_qp] * _disp_strain_increment[_qp](0) * _area[_qp] + _force_old[_qp];
+  _axial_stress[_qp] =
+      _material_stiffness[_qp] * _disp_strain_increment[_qp](0) + _axial_stress_old[_qp];
+}

--- a/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
+++ b/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
@@ -1,0 +1,89 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "AveragePointSeparation.h"
+
+// MOOSE includes
+#include "Function.h"
+#include "MooseMesh.h"
+#include "MooseVariable.h"
+#include "SubProblem.h"
+
+#include "libmesh/system.h"
+
+#include "ComputeIncrementalBeamStrain.h"
+#include "Assembly.h"
+#include "NonlinearSystem.h"
+
+#include "libmesh/quadrature.h"
+#include "libmesh/utility.h"
+
+registerMooseObject("MooseApp", AveragePointSeparation);
+
+defineLegacyParams(AveragePointSeparation);
+
+InputParameters
+AveragePointSeparation::validParams()
+{
+  InputParameters params = GeneralPostprocessor::validParams();
+  params.addRequiredParam<std::vector<VariableName>>(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+  params.addRequiredParam<std::vector<Point>>("first_point",
+                                              "A list of first points in the numerical domain");
+  params.addRequiredParam<std::vector<Point>>("last_point",
+                                              "A list of last points in the numerical domain");
+  params.addClassDescription(
+      "Compute the average separation between a list of two specified locations");
+  return params;
+}
+
+AveragePointSeparation::AveragePointSeparation(const InputParameters & parameters)
+  : GeneralPostprocessor(parameters),
+    _displacements(getParam<std::vector<VariableName>>("displacements")),
+
+    _system(_subproblem.getSystem(_displacements[0])),
+    _first_point(getParam<std::vector<Point>>("first_point")),
+    _last_point(getParam<std::vector<Point>>("last_point")),
+    _value(0)
+{
+  // fetch coupled variables and gradients (as stateful properties if necessary)
+  _disp_num = std::vector<int>(_displacements.size());
+  for (unsigned int i = 0; i < _displacements.size(); ++i)
+    _disp_num[i] = _subproblem
+                       .getVariable(_tid,
+                                    _displacements[i],
+                                    Moose::VarKindType::VAR_ANY,
+                                    Moose::VarFieldType::VAR_FIELD_STANDARD)
+                       .number();
+}
+
+void
+AveragePointSeparation::execute()
+{
+  _value = 0.;
+  Real sq_diff;
+  for (unsigned int i = 0; i < _first_point.size(); ++i)
+  {
+    sq_diff = 0;
+    for (unsigned int j = 0; j < _displacements.size(); ++j)
+      sq_diff += pow(_system.point_value(_disp_num[j], _first_point[i], false) -
+                         _system.point_value(_disp_num[j], _last_point[i], false),
+                     2.0);
+
+    _value += std::sqrt(sq_diff);
+  }
+  _value = _value / _first_point.size();
+}
+
+Real
+AveragePointSeparation::getValue()
+{
+  return _value;
+}

--- a/modules/tensor_mechanics/test/tests/postprocessors/AveragePointSeparation/AveragePointSeparation.i
+++ b/modules/tensor_mechanics/test/tests/postprocessors/AveragePointSeparation/AveragePointSeparation.i
@@ -1,0 +1,246 @@
+# Test for small strain Euler beam axial loading in x direction.
+
+# Modeling a pipe with an OD of 10 inches and ID of 8 inches
+# The length of the pipe is 5 feet (60 inches) and E = 30e6
+# G = 11.5384615385e6 with nu = 0.3
+# The applied axial load is 50000 lb which results in a
+# displacement of 3.537e-3 inches at the end
+
+# delta = PL/AE = 50000 * 60 / pi (5^2 - 4^2) * 30e6 = 3.537e-3
+
+# In this analysis the applied force is used as a BC
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+  xmin = 0.0
+  xmax = 60.0
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixz1]
+    type = DirichletBC
+    variable = disp_z
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr1]
+    type = DirichletBC
+    variable = rot_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr2]
+    type = DirichletBC
+    variable = rot_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr3]
+    type = DirichletBC
+    variable = rot_z
+    boundary = left
+    value = 0.0
+  [../]
+[]
+
+[NodalKernels]
+  [./force_x2]
+    type = ConstantRate
+    variable = disp_x
+    boundary = right
+    rate = 50000.0
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+[Executioner]
+  type = Transient
+  solve_type = PJFNK
+  line_search = 'none'
+  nl_max_its = 15
+  nl_rel_tol = 1e-10
+  nl_abs_tol = 1e-8
+
+  dt = 1
+  dtmin = 1
+  end_time = 2
+[]
+
+[Kernels]
+  [./solid_disp_x]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 0
+    variable = disp_x
+  [../]
+  [./solid_disp_y]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 1
+    variable = disp_y
+  [../]
+  [./solid_disp_z]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 2
+    variable = disp_z
+  [../]
+  [./solid_rot_x]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 3
+    variable = rot_x
+  [../]
+  [./solid_rot_y]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 4
+    variable = rot_y
+  [../]
+  [./solid_rot_z]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 5
+    variable = rot_z
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityBeam
+    shear_coefficient = 1.0
+    youngs_modulus = 30e6
+    poissons_ratio = 0.3
+    block = 0
+    outputs = exodus
+    output_properties = 'material_stiffness material_flexure'
+  [../]
+  [./strain]
+    type = ComputeIncrementalBeamStrain
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    area = 28.274
+    Ay = 0.0
+    Az = 0.0
+    Iy = 1.0
+    Iz = 1.0
+    y_orientation = '0.0 1.0 0.0'
+  [../]
+  [./stress]
+    type = ComputeBeamResultants
+    block = 0
+    outputs = exodus
+    output_properties = 'forces moments'
+  [../]
+[]
+
+[Postprocessors]
+  [./disp_x60]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y60]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./disp_x30]
+    type = PointValue
+    point = '30.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y30]
+    type = PointValue
+    point = '30.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./disp_x0]
+    type = PointValue
+    point = '0.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y0]
+    type = PointValue
+    point = '0.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./avg_disp]
+    type = AveragePointSeparation
+    first_point = '60.0 0.0 0.0
+                   30.0 0.0 0.0'
+    last_point  = '30.0 0.0 0.0
+                    0.0 0.0 0.0'
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+  [./forces_x]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = forces_x
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/SimpleTruss.i
+++ b/modules/tensor_mechanics/test/tests/truss/SimpleTruss.i
@@ -1,0 +1,171 @@
+#
+# Truss in two dimensional space
+#
+# The truss is made of five equilateral triangles supported at each end.
+# The truss starts at (0,0).  At (1,0), there is a point load of 25.
+# The reactions are therefore
+#  Ryleft  = 2/3 * 25 = 16.7
+#  Ryright = 1/3 * 25 = 8.33
+# The area of each member is 0.8.
+# Statics gives the stress in each member.  For example, for element 6 (from
+#   (0,0) to (1/2,sqrt(3)/2)), the force is
+#   f = 2/3 * 25 * 2/sqrt(3) = 100/3/sqrt(3) (compressive)
+#   and the stress is
+#   s = -100/3/sqrt(3)/0.8 = -24.06
+#
+
+[Mesh]
+  type = FileMesh
+  file = simpleTruss.e
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+  [./axial_stress]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./e_over_l]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+#    initial_condition = 1.0
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 1
+    value = 0
+  [../]
+
+  [./fixy4]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 2
+    value = 0
+  [../]
+[]
+
+[DiracKernels]
+  [./pull]
+    type = ConstantPointSource
+    value = -25
+    point = '0.433 0.5 0'
+    variable = disp_y
+  [../]
+[]
+
+[AuxKernels]
+  [./axial_stress]
+    type = MaterialRealAux
+    block = 1
+    property = axial_stress
+    variable = axial_stress
+  [../]
+  [./e_over_l]
+    type = MaterialRealAux
+    block = 1
+    property = e_over_l
+    variable = e_over_l
+  [../]
+  [./area]
+    type = ConstantAux
+    block = 1
+    variable = area
+    value = 0.8
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+
+  petsc_options_iname = '-pc_type -ksp_gmres_restart'
+  petsc_options_value = 'jacobi   101'
+
+  nl_max_its = 15
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  dt = 1
+  num_steps = 1
+  end_time = 1
+[]
+
+[Kernels]
+  [./solid_x]
+    type = StressDivergenceTensorsTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 0
+    variable = disp_x
+    area = area
+    save_in = react_x
+  [../]
+  [./solid_y]
+    type = StressDivergenceTensorsTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 1
+    variable = disp_y
+    area = area
+    save_in = react_y
+  [../]
+[]
+
+[Materials]
+  [./linelast]
+    type = LinearElasticTruss
+    block = 1
+    youngs_modulus = 1e6
+    displacements = 'disp_x disp_y'
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/SimpleTrussNew.i
+++ b/modules/tensor_mechanics/test/tests/truss/SimpleTrussNew.i
@@ -1,0 +1,194 @@
+#
+# Truss in two dimensional space
+#
+# The truss is made of five equilateral triangles supported at each end.
+# The truss starts at (0,0).  At (1,0), there is a point load of 25.
+# The reactions are therefore
+#  Ryleft  = 2/3 * 25 = 16.7
+#  Ryright = 1/3 * 25 = 8.33
+# The area of each member is 0.8.
+# Statics gives the stress in each member.  For example, for element 6 (from
+#   (0,0) to (1/2,sqrt(3)/2)), the force is
+#   f = 2/3 * 25 * 2/sqrt(3) = 100/3/sqrt(3) (compressive)
+#   and the stress is
+#   s = -100/3/sqrt(3)/0.8 = -24.06
+#
+
+[Mesh]
+  type = FileMesh
+  file = simpleTruss.e
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+#  [./axial_stress]
+#    order = CONSTANT
+#    family = MONOMIAL
+#  [../]
+#  [./e_over_l]
+#    order = CONSTANT
+#    family = MONOMIAL
+#  [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+#    initial_condition = 1.0
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 1
+    value = 0
+  [../]
+
+  [./fixy4]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 2
+    value = 0
+  [../]
+[]
+
+[DiracKernels]
+  [./pull]
+    type = ConstantPointSource
+    value = -25
+    point = '0.433 0.5 0'
+    variable = disp_y
+  [../]
+[]
+
+[AuxKernels]
+#  [./axial_stress]
+#    type = MaterialRealAux
+#    block = 1
+#    property = axial_stress
+#    variable = axial_stress
+#  [../]
+#  [./e_over_l]
+#    type = MaterialRealAux
+#    block = 1
+#    property = e_over_l
+#    variable = e_over_l
+#  [../]
+  [./area]
+    type = ConstantAux
+    block = 1
+    variable = area
+    value = 0.8
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+
+  petsc_options_iname = '-pc_type -ksp_gmres_restart'
+  petsc_options_value = 'jacobi   101'
+
+  nl_max_its = 15
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  dt = 1
+  num_steps = 1
+  end_time = 1
+[]
+
+[Kernels]
+  [./solid_x]
+    type = StressDivergenceTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 0
+    variable = disp_x
+    save_in = react_x
+  [../]
+  [./solid_y]
+    type = StressDivergenceTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 1
+    variable = disp_y
+    save_in = react_y
+  [../]
+[]
+
+[Materials]
+#  [./linelast]
+#    type = LinearElasticTruss
+#    block = 1
+#    youngs_modulus = 1e6
+#    displacements = 'disp_x disp_y'
+#  [../]
+  [./elasticity]
+    type = ComputeElasticityTruss
+    youngs_modulus = 1e6
+    block = 1
+  [../]
+  [./strain]
+    type = ComputeIncrementalTrussStrain
+    block = '1'
+    displacements = 'disp_x disp_y'
+    youngs_modulus = 1e6
+    area = area
+    y_orientation = '0.0 0.0 1.0'
+#    eigenstrain_names = 'thermal'
+  [../]
+  [./stress]
+    type = ComputeTrussResultants
+    block = 1
+  [../]
+#  [./thermal]
+#    type = ComputeThermalExpansionEigenstrainTruss
+#    thermal_expansion_coeff = 1e-4
+#    temperature = 100
+#    stress_free_temperature = 0
+#    eigenstrain_name = thermal
+#  [../]
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/truss_2d_new.i
+++ b/modules/tensor_mechanics/test/tests/truss/truss_2d_new.i
@@ -1,0 +1,190 @@
+#
+# Truss in two dimensional space
+#
+# The truss is made of five equilateral triangles supported at each end.
+# The truss starts at (0,0).  At (1,0), there is a point load of 25.
+# The reactions are therefore
+#  Ryleft  = 2/3 * 25 = 16.7
+#  Ryright = 1/3 * 25 = 8.33
+# The area of each member is 0.8.
+# Statics gives the stress in each member.  For example, for element 6 (from
+#   (0,0) to (1/2,sqrt(3)/2)), the force is
+#   f = 2/3 * 25 * 2/sqrt(3) = 100/3/sqrt(3) (compressive)
+#   and the stress is
+#   s = -100/3/sqrt(3)/0.8 = -24.06
+#
+
+[Mesh]
+  type = FileMesh
+  file = truss_2d.e
+  displacements = 'disp_x disp_y'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+ [./axial_stress]
+   order = CONSTANT
+   family = MONOMIAL
+ [../]
+ [./e_over_l]
+   order = CONSTANT
+   family = MONOMIAL
+ [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+#    initial_condition = 1.0
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./react_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxKernels]
+ [./axial_stress]
+   type = MaterialRealAux
+   block = 1
+   property = axial_stress
+   variable = axial_stress
+ [../]
+ [./e_over_l]
+   type = MaterialRealAux
+   block = 1
+   property = e_over_l
+   variable = e_over_l
+ [../]
+  [./area]
+    type = ConstantAux
+    block = 1
+    variable = area
+    value = 0.8
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Functions]
+  [./x2]
+    type = PiecewiseLinear
+    x = '0  1 2 3'
+    y = '0 .5 1 1'
+  [../]
+  [./y2]
+    type = PiecewiseLinear
+    x = '0 1  2 3'
+    y = '0 0 .5 1'
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 1
+    value = 0
+  [../]
+
+  [./fixy4]
+    type = DirichletBC
+    variable = disp_y
+    boundary = 4
+    value = 0
+  [../]
+[]
+
+[DiracKernels]
+  [./pull]
+    type = ConstantPointSource
+    value = -10
+    point = '1 0 0'
+    variable = disp_y
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = PJFNK
+
+  petsc_options_iname = '-pc_type -ksp_gmres_restart'
+  petsc_options_value = 'jacobi   101'
+
+  nl_max_its = 15
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  dt = 1
+  num_steps = 1
+  end_time = 1
+[]
+
+[Kernels]
+  [./solid_x]
+    type = StressDivergenceTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 0
+    variable = disp_x
+    save_in = react_x
+  [../]
+  [./solid_y]
+    type = StressDivergenceTruss
+    block = 1
+    displacements = 'disp_x disp_y'
+    component = 1
+    variable = disp_y
+    save_in = react_y
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityTruss
+    youngs_modulus = 1e6
+  [../]
+  [./strain]
+    type = ComputeIncrementalTrussStrain
+    displacements = 'disp_x disp_y'
+    area = area
+  [../]
+  [./stress]
+    type = ComputeTrussResultants
+    area = area
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/truss_plastic_new.i
+++ b/modules/tensor_mechanics/test/tests/truss/truss_plastic_new.i
@@ -1,0 +1,143 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  elem_type = EDGE
+  nx = 3
+[]
+
+[GlobalParams]
+  displacements = 'disp_x'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+ [./axial_stress]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./e_over_l]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./forces]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Functions]
+  [./hf]
+    type = PiecewiseLinear
+    x = '0    0.0001  0.0003  0.0023'
+    y = '50e6 52e6    54e6    56e6'
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./load]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = right
+    function = 't'
+  [../]
+[]
+
+[AuxKernels]
+  [./axial_stress]
+    type = MaterialRealAux
+    property = axial_stress
+    variable = axial_stress
+  [../]
+  [./e_over_l]
+    type = MaterialRealAux
+    property = e_over_l
+    variable = e_over_l
+  [../]
+  [./forces]
+    type = MaterialRealAux
+    property = forces
+    variable = forces
+  [../]
+  [./area]
+    type = ConstantAux
+    variable = area
+    value = 1
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Postprocessors]
+  [./s_xx]
+    type = ElementIntegralMaterialProperty
+    mat_prop = axial_stress
+  [../]
+  [./forces]
+    type = ElementIntegralMaterialProperty
+    mat_prop = forces
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+  nl_abs_tol = 1e-11
+  l_max_its = 20
+  dt = 1e-3
+  num_steps = 100
+[]
+
+[Kernels]
+  [./solid]
+    type = StressDivergenceTruss
+    component = 0
+    variable = disp_x
+    save_in = react_x
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityTruss
+    youngs_modulus = 1e6
+  [../]
+  [./strain]
+    type = ComputeIncrementalTrussStrain
+    displacements = 'disp_x'
+    area = area
+  [../]
+  [./truss]
+    type = ComputePlasticTrussResultants
+    area = area
+    yield_stress = 1e4
+    hardening_constant = 0.
+    outputs = exodus
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/truss_thermal.i
+++ b/modules/tensor_mechanics/test/tests/truss/truss_thermal.i
@@ -1,0 +1,145 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  elem_type = EDGE
+  nx = 3
+[]
+
+[GlobalParams]
+  displacements = 'disp_x'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+ [./axial_stress]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./e_over_l]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./forces]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./et]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./load]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = right
+    function = 't'
+  [../]
+[]
+
+[AuxKernels]
+  [./axial_stress]
+    type = MaterialRealAux
+    property = axial_stress
+    variable = axial_stress
+  [../]
+  [./e_over_l]
+    type = MaterialRealAux
+    property = e_over_l
+    variable = e_over_l
+  [../]
+  [./forces]
+    type = MaterialRealAux
+    property = forces
+    variable = forces
+  [../]
+  [./area]
+    type = ConstantAux
+    variable = area
+    value = 1
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Postprocessors]
+  [./s_xx]
+    type = ElementIntegralMaterialProperty
+    mat_prop = axial_stress
+  [../]
+  [./forces]
+    type = ElementIntegralMaterialProperty
+    mat_prop = forces
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+  nl_abs_tol = 1e-11
+  l_max_its = 20
+  dt = 1e-1
+  num_steps = 3
+[]
+
+[Kernels]
+  [./solid]
+    type = StressDivergenceTruss
+    component = 0
+    variable = disp_x
+    save_in = react_x
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityTruss
+    youngs_modulus = 1e6
+  [../]
+  [./strain]
+    type = ComputeIncrementalTrussStrain
+    displacements = 'disp_x'
+    area = area
+    eigenstrain_names = 'thermal'
+  [../]
+
+  [./stress]
+    type = ComputeTrussResultants
+    area = area
+  [../]
+  [./thermal]
+    type = ComputeThermalExpansionEigenstrainTruss
+    thermal_expansion_coeff = 1e-4
+    temperature = 100
+    stress_free_temperature = 0
+    eigenstrain_name = thermal
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/truss/truss_thermal_prestress.i
+++ b/modules/tensor_mechanics/test/tests/truss/truss_thermal_prestress.i
@@ -1,0 +1,153 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  elem_type = EDGE
+  nx = 3
+[]
+
+[GlobalParams]
+  displacements = 'disp_x'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[AuxVariables]
+ [./axial_stress]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./e_over_l]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./forces]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./et]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./area]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./react_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./thermal_eig]
+  [../]
+  [./pre_stressing_eig]
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./load]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = right
+    function = 't'
+  [../]
+[]
+
+[AuxKernels]
+  [./axial_stress]
+    type = MaterialRealAux
+    property = axial_stress
+    variable = axial_stress
+  [../]
+  [./e_over_l]
+    type = MaterialRealAux
+    property = e_over_l
+    variable = e_over_l
+  [../]
+  [./forces]
+    type = MaterialRealAux
+    property = forces
+    variable = forces
+  [../]
+  [./area]
+    type = ConstantAux
+    variable = area
+    value = 1
+    execute_on = 'initial timestep_begin'
+  [../]
+[]
+
+[Postprocessors]
+  [./s_xx]
+    type = ElementIntegralMaterialProperty
+    mat_prop = axial_stress
+  [../]
+  [./forces]
+    type = ElementIntegralMaterialProperty
+    mat_prop = forces
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+  nl_abs_tol = 1e-11
+  l_max_its = 20
+  dt = 1e-1
+  num_steps = 3
+[]
+
+[Kernels]
+  [./solid]
+    type = StressDivergenceTruss
+    component = 0
+    variable = disp_x
+    save_in = react_x
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityTruss
+    youngs_modulus = 1e6
+  [../]
+  [./strain]
+    type = ComputeIncrementalTrussStrain
+    displacements = 'disp_x'
+    area = area
+    eigenstrain_names = 'thermal_eig pre_stressing_eig'
+  [../]
+  [./stress]
+    type = ComputeTrussResultants
+    area = area
+  [../]
+  [./thermal_eig]
+    type = ComputeThermalExpansionEigenstrainTruss
+    thermal_expansion_coeff = 1e-5
+    temperature = 100
+    stress_free_temperature = 0
+    eigenstrain_name = thermal_eig
+  [../]
+  [./pre_stressing_eig]
+    type = ComputePreStressEigenstrainTruss
+    pre_stressing_strain = -1e-3
+    eigenstrain_name = pre_stressing_eig
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]


### PR DESCRIPTION
This PR is for
a truss model which is developed in line with the existing beam model. The truss model can take care of multiple eigenstrains too.
AveragePointSeparation postprocessor is also added that calculates average displacement between two points.

closes #16957 