### PR TITLE
Jacobian testing for non ad laromance

### DIFF
--- a/modules/tensor_mechanics/test/tests/rom_stress_update/2drzSmall.i
+++ b/modules/tensor_mechanics/test/tests/rom_stress_update/2drzSmall.i
@@ -21,7 +21,8 @@
 
 [Modules/TensorMechanics/Master]
   [./all]
-    strain = FINITE
+    strain = small
+    incremental = true
     add_variables = true
     generate_output = vonmises_stress
   [../]
@@ -67,6 +68,7 @@
   [./stress]
     type = ComputeMultipleInelasticStress
     inelastic_models = rom_stress_prediction
+    tangent_operator = nonlinear
   [../]
   [./rom_stress_prediction]
     type = SS316HLAROMANCEStressUpdateTest

--- a/modules/tensor_mechanics/test/tests/rom_stress_update/tests
+++ b/modules/tensor_mechanics/test/tests/rom_stress_update/tests
@@ -11,13 +11,39 @@
       petsc_version = '>=3.9.0'
       allow_test_objects = true
     [../]
+    [./3d-jac]
+      type = 'PetscJacobianTester'
+      input = '3d.i'
+      prereq = 'rom/3d'
+      ratio_tol = 5e-7
+      method = 'opt'
+      cli_args = 'Executioner/num_steps=2'
+      difference_tol = 1
+      run_sim = True
+      detail = 'in 3D and compute a perfect Jacobian.'
+      allow_test_objects = true
+    [../]
 
-    [./2drz]
+    [./2drzSmall]
       type = 'CSVDiff'
-      input = '2drz.i'
+      input = '2drzSmall.i'
       csvdiff = '2drz_out.csv'
-      detail = 'in 2DRz.'
+      detail = 'in 2DRz using small strain.'
+      cli_args = 'Outputs/file_base=2drz_out'
       petsc_version = '>=3.9.0'
+      allow_test_objects = true
+      rel_err = 2e-5
+    [../]
+    [./2drzSmall-jac]
+      type = 'PetscJacobianTester'
+      input = '2drzSmall.i'
+      method = 'opt'
+      prereq = 'rom/2drzSmall'
+      ratio_tol = 5e-6
+      difference_tol = 1
+      cli_args = 'Executioner/num_steps=2'
+      run_sim = True
+      detail = 'in 2DRz and compute a perfect Jacobian using small strain.'
       allow_test_objects = true
     [../]
 


### PR DESCRIPTION
add testing for non ad laromance model
closes #16989

I made the nonAD test small strain to try to limit the error in the jacobian to the laromance model.  The nonlinear tangent method is slightly better than the elastic tangent for this example.  I had to modify the tolerances for the csvdiff on the gold file for the non jacobian test now that the strain is small.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
