### PR TITLE
Wrap warning in a do-once statement to avoid overload. Refs #17047

### DIFF
--- a/modules/heat_transfer/src/materials/HeatConductionMaterial.C
+++ b/modules/heat_transfer/src/materials/HeatConductionMaterial.C
@@ -91,13 +91,8 @@ HeatConductionMaterialTempl<is_ad>::computeQpProperties()
   {
     if (_temperature[_qp] < *_min_T)
     {
-      mooseDoOnce(mooseWarning("Temperature (",
-                               _temperature[_qp],
-                               ") is below min_T (",
-                               *_min_T,
-                               ") at ",
-                               _q_point[_qp],
-                               ". \nUsing min_T instead of temperature."));
+      flagSolutionWarning("Temperature below specified minimum (" + std::to_string(*_min_T) +
+                          "). min_T will be used instead.");
       qp_temperature = *_min_T;
     }
   }

--- a/modules/heat_transfer/src/materials/HeatConductionMaterial.C
+++ b/modules/heat_transfer/src/materials/HeatConductionMaterial.C
@@ -91,13 +91,13 @@ HeatConductionMaterialTempl<is_ad>::computeQpProperties()
   {
     if (_temperature[_qp] < *_min_T)
     {
-      mooseWarning("Temperature (",
-                   _temperature[_qp],
-                   ") is below min_T (",
-                   *_min_T,
-                   ") at ",
-                   _q_point[_qp],
-                   ". \nUsing min_T instead of temperature.");
+      mooseDoOnce(mooseWarning("Temperature (",
+                               _temperature[_qp],
+                               ") is below min_T (",
+                               *_min_T,
+                               ") at ",
+                               _q_point[_qp],
+                               ". \nUsing min_T instead of temperature."));
       qp_temperature = *_min_T;
     }
   }

--- a/modules/heat_transfer/test/tests/transient_heat/tests
+++ b/modules/heat_transfer/test/tests/transient_heat/tests
@@ -18,9 +18,9 @@
     design = 'HeatConductionTimeDerivative.md'
   []
   [transient_heat_t_limit]
-    type = 'RunException'
+    type = 'RunApp'
     input = 'transient_heat_derivatives.i'
-    expect_err = 'is below min_T'
+    expect_out = '(is below min_T|specified minimum)'
     cli_args = 'Materials/constant/min_T=10'
     requirement = 'The system shall use a lower temperature limit to compute the specific heat'
     issues = '#26647'


### PR DESCRIPTION
Prevent user saturation with warnings when a single warning would be just as effective. 

Closes #17047