### PR TITLE
Output only when action is in action

### DIFF
--- a/framework/src/actions/MaterialOutputAction.C
+++ b/framework/src/actions/MaterialOutputAction.C
@@ -202,9 +202,10 @@ MaterialOutputAction::act()
       oss << "\n  " << var_name;
       _problem->addAuxVariable("MooseVariableConstMonomial", var_name, params);
     }
-    _console << COLOR_CYAN << "The following total " << material_names.size()
-             << " aux variables:" << oss.str() << "\nare added for automatic output by " << type()
-             << "." << COLOR_DEFAULT << std::endl;
+    if (material_names.size() > 0)
+      _console << COLOR_CYAN << "The following total " << material_names.size()
+               << " aux variables:" << oss.str() << "\nare added for automatic output by " << type()
+               << "." << COLOR_DEFAULT << std::endl;
   }
   else
   {


### PR DESCRIPTION
This is a fix-up for #17083. Otherwise we see unnecessary outputs from this action because this action is added by MOOSE automatically. Refer to  #17082. @aeslaughter Sorry about this. 