### PR TITLE
Change 's' registerAll parameter to 'syntax' in StorkApp.C.app

### DIFF
--- a/stork/src/base/StorkApp.C.app
+++ b/stork/src/base/StorkApp.C.app
@@ -26,9 +26,9 @@ StorkApp::StorkApp(InputParameters parameters) : MooseApp(parameters)
 StorkApp::~StorkApp() {}
 
 void
-StorkApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
+StorkApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax)
 {
-  ModulesApp::registerAll(f, af, s);
+  ModulesApp::registerAll(f, af, syntax);
   Registry::registerObjectsTo(f, {"StorkApp"});
   Registry::registerActionsTo(af, {"StorkApp"});
 


### PR DESCRIPTION
This is to allow for more consistency with `ExampleApp.C` source in tutorials and examples for new users and new app creators, where usage of registration macros like `registerSyntax` is common and encouraged (and leads to build errors using the default `StorkApp.C.app` template).

Closes #17153
Refs Discussion #17152 