### PR TITLE
Minor fix to MultiappVariableValueSampleTransfer, minor FV asserts fix

### DIFF
--- a/framework/src/fvbcs/FVFluxBC.C
+++ b/framework/src/fvbcs/FVFluxBC.C
@@ -149,7 +149,7 @@ FVFluxBC::computeJacobian(const FaceInfo & fi)
 
   ADReal r = fi.faceArea() * fi.faceCoord() * computeQpResidual();
 
-  mooseAssert(_var.dofIndices().size() == 1, "We're currently built to use CONSTANT MONOMIALS");
+  mooseAssert(_var.dofIndices().size() <= 1, "We're currently built to use CONSTANT MONOMIALS");
 
   auto local_functor = [&](const ADReal & residual, dof_id_type, const std::set<TagID> &) {
     // Even though the elem element is always the non-null pointer on mesh

--- a/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
+++ b/framework/src/transfers/MultiAppVariableValueSampleTransfer.C
@@ -90,6 +90,7 @@ MultiAppVariableValueSampleTransfer::execute()
 
           if (elem && elem->processor_id() == from_mesh.processor_id())
           {
+            from_sub_problem.setCurrentSubdomainID(elem, 0);
             from_sub_problem.reinitElemPhys(elem, point_vec, 0);
 
             mooseAssert(from_var.sln().size() == 1, "No values in u!");

--- a/test/tests/fvkernels/block-restriction/tests
+++ b/test/tests/fvkernels/block-restriction/tests
@@ -11,8 +11,8 @@
     type = RunException
     method = 'devel dbg'
     input = 'fv-and-fe-block-restriction.i'
-    expect_err = 'Multiple objects supply property ID'
-    requirement = 'The system shall error in non-optimized modes if a user supplies a material property with the same name from different block-restricted materials on neighboring subdomains when there are different sets of finite volume flux kernels on those same neighboring subdomains. This is because we have to support ghosting of material properties for block restricted finite volume flux kernels.'
+    expect_err = 'Multiple objects supply properties of ID'
+    requirement = 'The system shall return a warning in non-optimized modes if a user supplies a material property with the same name from different block-restricted materials on neighboring subdomains when there are different sets of finite volume flux kernels on those same neighboring subdomains. This is because we have to support ghosting of material properties for block restricted finite volume flux kernels.'
   []
   [distinct-mats]
     type = Exodiff


### PR DESCRIPTION
Closes #17194 #17193 

Any ideas to reduce the number of warnings output in ComputeFVFluxThread? Maybe a boolean?