### PR TITLE
Make _initial_density in ADDensity material a protected attribute so

### DIFF
--- a/modules/misc/include/materials/ADDensity.h
+++ b/modules/misc/include/materials/ADDensity.h
@@ -22,11 +22,12 @@ protected:
   virtual void initQpStatefulProperties();
   virtual void computeQpProperties();
 
+  const Real _initial_density;
+
 private:
   const Moose::CoordinateSystemType _coord_system;
   std::vector<const ADVariableGradient *> _grad_disp;
   const ADVariableValue & _disp_r;
 
-  const Real _initial_density;
   ADMaterialProperty<Real> & _density;
 };

--- a/modules/misc/src/materials/ADDensity.C
+++ b/modules/misc/src/materials/ADDensity.C
@@ -25,10 +25,10 @@ ADDensity::validParams()
 
 ADDensity::ADDensity(const InputParameters & parameters)
   : ADMaterial(parameters),
+    _initial_density(getParam<Real>("density")),
     _coord_system(getBlockCoordSystem()),
     _grad_disp(adCoupledGradients("displacements")),
     _disp_r(coupledComponents("displacements") ? adCoupledValue("displacements", 0) : _ad_zero),
-    _initial_density(getParam<Real>("density")),
     _density(declareADProperty<Real>("density"))
 {
   if (getParam<bool>("use_displaced_mesh"))


### PR DESCRIPTION
Make `_initial_density` in ADDensity material a protected attribute so it is available to derived classes.

No behaviour changes are anticipated. Attribute is already const so making it protected only allows inherited classes to read and not modify its value. Ordering of attributes in construction is changed due to corresponding reordering in header file declaration.