### PR TITLE
Adjust ncpus appropriately

### DIFF
--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -82,7 +82,7 @@ class RunPBS(QueueManager):
         template['mpi_procs'] = job.getMetaData().get('QUEUEING_NCPUS', 1)
 
         # Compute node requirement
-        if self.options.pbs_node_cpus:
+        if self.options.pbs_node_cpus and template['mpi_procs'] > self.options.pbs_node_cpus:
             nodes = template['mpi_procs']/self.options.pbs_node_cpus
             template['mpi_procs'] = self.options.pbs_node_cpus
         else:

--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -84,6 +84,7 @@ class RunPBS(QueueManager):
         # Compute node requirement
         if self.options.pbs_node_cpus:
             nodes = template['mpi_procs']/self.options.pbs_node_cpus
+            template['mpi_procs'] = self.options.pbs_node_cpus
         else:
             nodes = 1
         template['nodes'] = math.ceil(nodes)


### PR DESCRIPTION
After applying the math to adjust node count for min_parallel, set ncpus
to what the end user supplied.

Closes #17204

