### PR TITLE
This fixes some make warnings when building moose

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -447,6 +447,10 @@ install_lib_$(notdir $(app_LIB)): $(app_LIB) all
 	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
 	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
 
+# sometimes app_test_LIB is an empty string when this app.mk file is
+# included/processed - so we guard against this case and don't create a recipe
+# if it is empty.
+ifneq ($(notdir $(app_test_LIB)),)
 install_lib_$(notdir $(app_test_LIB)): $(app_test_LIB) all
 	@echo "Installing $<"
 	@mkdir -p $(lib_install_dir)
@@ -456,6 +460,7 @@ install_lib_$(notdir $(app_test_LIB)): $(app_test_LIB) all
 	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
 	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
 	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
+endif
 
 $(binlink): all install_$(APPLICATION_NAME)_tests
 	@ln -s ../../../bin/$(notdir $(app_EXEC)) $@

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -412,9 +412,9 @@ ifneq ($(wildcard $(APPLICATION_DIR)/test/.),)
 	test_dir := $(APPLICATION_DIR)/test
 endif
 
-lib_install_targets = $(foreach lib,$(applibs),install_lib_$(notdir  $(lib)))
+lib_install_targets = $(foreach lib,$(applibs),$(dir $(lib))install_lib_$(notdir $(lib)))
 ifneq ($(app_test_LIB),)
-	lib_install_targets += install_lib_$(notdir $(app_test_LIB))
+	lib_install_targets += $(dir $(app_test_LIB))install_lib_$(notdir $(app_test_LIB))
 endif
 
 install_libs: $(lib_install_targets) install_lib_$(notdir $(moose_LIB)) install_lib_$(notdir $(pcre_LIB)) install_lib_$(notdir $(hit_LIB))
@@ -434,7 +434,7 @@ else
 endif
 endif
 
-install_lib_$(notdir $(app_LIB)): $(app_LIB) all
+install_lib_%: % all
 	@echo "Installing $<"
 	@mkdir -p $(lib_install_dir)
 	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
@@ -446,21 +446,6 @@ install_lib_$(notdir $(app_LIB)): $(app_LIB) all
 	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
 	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
 	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
-
-# sometimes app_test_LIB is an empty string when this app.mk file is
-# included/processed - so we guard against this case and don't create a recipe
-# if it is empty.
-ifneq ($(notdir $(app_test_LIB)),)
-install_lib_$(notdir $(app_test_LIB)): $(app_test_LIB) all
-	@echo "Installing $<"
-	@mkdir -p $(lib_install_dir)
-	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
-	@$(eval libdst := $(lib_install_dir)/$(libname))
-	@cp $(dir $<)$(libname) $(libdst)
-	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
-endif
 
 $(binlink): all install_$(APPLICATION_NAME)_tests
 	@ln -s ../../../bin/$(notdir $(app_EXEC)) $@


### PR DESCRIPTION
These warnings were introduced in #16411.  Just need to guard against
the case where app.mk is included when the test lib variable is empty.  @YaqiWang - this should fix those warnings you were seeing.

Also generalized/fixed some issues about how we install/handle dep libs.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
