### PR TITLE
Add option to specify out-of-plane pressure using a material 

### DIFF
--- a/framework/src/materials/ParsedMaterialBase.C
+++ b/framework/src/materials/ParsedMaterialBase.C
@@ -43,7 +43,7 @@ ParsedMaterialBase::validParams()
 
   // Function expression
   params.addRequiredParam<std::string>("function",
-                                       "FParser function expression for the phase free energy");
+                                       "FParser function expression for the parsed material");
 
   return params;
 }

--- a/modules/tensor_mechanics/doc/content/source/userobjects/GeneralizedPlaneStrainUserObject.md
+++ b/modules/tensor_mechanics/doc/content/source/userobjects/GeneralizedPlaneStrainUserObject.md
@@ -8,7 +8,7 @@ For a given scalar out-of-plane strain variable, the equilibrium condition in th
 \begin{equation}
 	\int_{A}{\sigma_{zz}dA} = \bar{N}_{zz}
 \end{equation}
-where $\bar{N}_{zz}$ is an applied force or integrated stress.  Thus, the residual corresponding to the scalar out-of-plane strain variable is
+where $\bar{N}_{zz}$ is an externally applied force.  Thus, the residual corresponding to the scalar out-of-plane strain variable is
 \begin{equation}
 	R = \int_{A}{\sigma_{zz}dA} - \bar{N}_{zz}
 \end{equation}
@@ -16,6 +16,8 @@ and the corresponding diagonal jacobian is
 \begin{equation}
 	K_{zz} = \frac{\partial R_{zz}}{\partial \epsilon_{zz}} = \int_{A}{\frac{\partial \sigma_{zz}}{\partial \epsilon_{zz}}dA} = \int_{A}{C_{2222}dA}
 \end{equation}
+
+The externally applied force, $\bar{N}_{zz}$, can be imposed as the integral of a pressure applied over the area. This pressure can be imposed using either a function (using the `out_of_plane_pressure_function` parameter), or a material property (using the `out_of_plane_pressure_material` parameter).
 
 The reference residual value used by [GeneralizedPlaneStrainReferenceResidual](/GeneralizedPlaneStrainReferenceResidual.md) is computed as
 \begin{equation}

--- a/modules/tensor_mechanics/include/userobjects/GeneralizedPlaneStrainUserObject.h
+++ b/modules/tensor_mechanics/include/userobjects/GeneralizedPlaneStrainUserObject.h
@@ -43,8 +43,12 @@ protected:
   /// A Userobject that carries the subblock ID for all elements
   const SubblockIndexProvider * _subblock_id_provider;
 
-  const Function & _out_of_plane_pressure;
-  const Real _factor;
+  /// Function defining applied out-of-plane pressure
+  const Function * _out_of_plane_pressure_function;
+  /// Material property defining applied out-of-plane pressure
+  const MaterialProperty<Real> & _out_of_plane_pressure_material;
+  /// Factor applied to out-of-plane pressure applied by function and material
+  const Real _pressure_factor;
 
   /// The direction of the out-of-plane strain scalar variable
   unsigned int _scalar_out_of_plane_strain_direction;

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -218,10 +218,30 @@ TensorMechanicsAction::act()
       auto action_params = _action_factory.getValidParams(type);
       action_params.set<bool>("_built_by_moose") = true;
       action_params.set<std::string>("registered_identifier") = "(AutoBuilt)";
-      action_params.applyParameters(parameters(), {"use_displaced_mesh"});
+
+      // Skipping selected parameters in applyParameters() and then manually setting them only if
+      // they are set by the user is just to prevent both the current and deprecated variants of
+      // these parameters from both getting passed to the UserObject. Once we get rid of the
+      // deprecated versions, we can just set them all with applyParameters().
+      action_params.applyParameters(parameters(),
+                                    {"use_displaced_mesh",
+                                     "out_of_plane_pressure",
+                                     "out_of_plane_pressure_function",
+                                     "factor",
+                                     "pressure_factor"});
       action_params.set<bool>("use_displaced_mesh") = _use_displaced_mesh;
-      if (isParamValid("pressure_factor"))
-        action_params.set<Real>("factor") = getParam<Real>("pressure_factor");
+
+      if (parameters().isParamSetByUser("out_of_plane_pressure"))
+        action_params.set<FunctionName>("out_of_plane_pressure") =
+            getParam<FunctionName>("out_of_plane_pressure");
+      if (parameters().isParamSetByUser("out_of_plane_pressure_function"))
+        action_params.set<FunctionName>("out_of_plane_pressure_function") =
+            getParam<FunctionName>("out_of_plane_pressure_function");
+      if (parameters().isParamSetByUser("factor"))
+        action_params.set<Real>("factor") = getParam<Real>("factor");
+      if (parameters().isParamSetByUser("pressure_factor"))
+        action_params.set<Real>("pressure_factor") = getParam<Real>("pressure_factor");
+
       // Create and add the action to the warehouse
       auto action = MooseSharedNamespace::static_pointer_cast<MooseObjectAction>(
           _action_factory.create(type, name() + "_gps", action_params));

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
@@ -108,12 +108,24 @@ TensorMechanicsActionBase::validParams()
   MooseEnum outOfPlaneDirection("x y z", "z");
   params.addParam<MooseEnum>(
       "out_of_plane_direction", outOfPlaneDirection, "The direction of the out-of-plane strain.");
-  params.addParam<FunctionName>("out_of_plane_pressure",
-                                "0",
-                                "Function used to prescribe pressure in the out-of-plane direction "
-                                "(y for 1D Axisymmetric or z for 2D Cartesian problems)");
-  params.addParam<Real>("pressure_factor", 1.0, "Scale factor applied to prescribed pressure");
+  params.addDeprecatedParam<FunctionName>(
+      "out_of_plane_pressure",
+      "Function used to prescribe pressure (applied toward the body) in the out-of-plane direction "
+      "(y for 1D Axisymmetric or z for 2D Cartesian problems)",
+      "This has been replaced by 'out_of_plane_pressure_function'");
+  params.addParam<FunctionName>(
+      "out_of_plane_pressure_function",
+      "Function used to prescribe pressure (applied toward the body) in the out-of-plane direction "
+      "(y for 1D Axisymmetric or z for 2D Cartesian problems)");
+  params.addParam<Real>(
+      "pressure_factor",
+      "Scale factor applied to prescribed out-of-plane pressure (both material and function)");
+  params.addParam<MaterialPropertyName>("out_of_plane_pressure_material",
+                                        "0",
+                                        "Material used to prescribe pressure (applied toward the "
+                                        "body) in the out-of-plane direction");
   params.addParamNamesToGroup("planar_formulation scalar_out_of_plane_strain out_of_plane_pressure "
+                              "out_of_plane_pressure_material out_of_plane_pressure_function "
                               "pressure_factor out_of_plane_direction out_of_plane_strain",
                               "Out-of-plane stress/strain");
 

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/out_of_plane_pressure.i
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/out_of_plane_pressure.i
@@ -82,8 +82,8 @@
         use_displaced_mesh = true
         displacements = 'disp_x disp_y'
         scalar_out_of_plane_strain = scalar_strain_zz
-        out_of_plane_pressure = traction_function
-        factor = 1e5
+        out_of_plane_pressure_function = traction_function
+        pressure_factor = 1e5
       [../]
     [../]
   [../]
@@ -193,6 +193,13 @@
   [../]
   [./stress]
     type = ComputeLinearElasticStress
+  [../]
+  # This material is not used for anything in the base verison of this test,
+  # but is used in a variant of the test with cli_args
+  [./traction_material]
+    type = GenericFunctionMaterial
+    prop_names = traction_material
+    prop_values = traction_function
   [../]
 []
 

--- a/modules/tensor_mechanics/test/tests/generalized_plane_strain/tests
+++ b/modules/tensor_mechanics/test/tests/generalized_plane_strain/tests
@@ -57,14 +57,25 @@
     design = 'GeneralizedPlaneStrainAction.md'
     issues = '#7840'
   [../]
-  [./out_of_plane_pressure]
+  [./out_of_plane_pressure_function]
     type = 'Exodiff'
     input = 'out_of_plane_pressure.i'
     exodiff = 'out_of_plane_pressure_out.e'
     abs_zero = 1e-9
-    requirement = 'The system shall support setting the out-of-plane pressure for generalized plane strain problems'
+    requirement = 'The system shall support setting the out-of-plane pressure using a function for generalized plane strain problems'
     design = 'GeneralizedPlaneStrainAction.md'
     issues = '#7840'
+  [../]
+  [./out_of_plane_pressure_material]
+    type = 'Exodiff'
+    input = 'out_of_plane_pressure.i'
+    exodiff = 'out_of_plane_pressure_out.e'
+    cli_args = 'Modules/TensorMechanics/GeneralizedPlaneStrain/gps/out_of_plane_pressure_function=0 Modules/TensorMechanics/GeneralizedPlaneStrain/gps/out_of_plane_pressure_material=traction_material' 
+    abs_zero = 1e-9
+    requirement = 'The system shall support setting the out-of-plane pressure using a material property for generalized plane strain problems'
+    design = 'GeneralizedPlaneStrainAction.md'
+    issues = '#17250'
+#    prereq = out_of_plane_pressure_function
   [../]
   [./generalized_plane_strain_scalar_vector]
     type = 'Exodiff'


### PR DESCRIPTION
closes #17250

This adds the following options to GeneralizedPlaneStrainUserObject,
GeneralizedPlaneStrain, and TensorMechanicsAction:
out_of_plane_pressure_material
out_of_plane_pressure_function
pressure_factor

and deprecates the following parameters:
out_of_plane_pressure
factor
