### PR TITLE
Making !param a modal link

### DIFF
--- a/python/MooseDocs/extensions/appsyntax.py
+++ b/python/MooseDocs/extensions/appsyntax.py
@@ -764,7 +764,7 @@ class RenderParameterToken(components.RenderComponent):
         if 'options' in param:
             p = html.Tag(body, 'p', class_='moose-parameter-description-options')
             html.Tag(p, 'span', string='Options:')
-            html.String(p, content=param['options'])
+            html.String(p, content=", ".join(param['options'].split()))
 
         p = html.Tag(body, 'p', class_='moose-parameter-description')
         if desc:


### PR DESCRIPTION
This PR changes the behavior of the `!param` command for MooseDocs. It is now a link that opens a pop up window with the detailed parameter information that is seen wen doing `!syntax parameters`. Here is an example for `[!param](/Executioner/Steady/solve_type)`:

![image](https://user-images.githubusercontent.com/12819067/110684649-9df5a400-819a-11eb-810f-59099511a9d3.png)

Closes #17236 
