### PR TITLE
add docs to make install target

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -404,6 +404,7 @@ $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend
 
 ###### install stuff #############
 
+docs_dir := $(APPLICATION_DIR)/doc
 bindst = $(bin_install_dir)/$(notdir $(app_EXEC))
 binlink = $(tests_install_dir)/$(notdir $(app_EXEC))
 
@@ -450,7 +451,12 @@ install_lib_%: % all
 $(binlink): all install_$(APPLICATION_NAME)_tests
 	@ln -s ../../../bin/$(notdir $(app_EXEC)) $@
 
-$(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests $(binlink)
+install_$(APPLICATION_NAME)_docs:
+	@echo "Installing docs"
+	@mkdir -p $(docs_install_dir)
+	@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
+
+$(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests install_$(APPLICATION_NAME)_docs $(binlink)
 	@echo "Installing $<"
 	@mkdir -p $(bin_install_dir)
 	@cp $< $@

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -418,7 +418,7 @@ ifneq ($(app_test_LIB),)
 	lib_install_targets += $(dir $(app_test_LIB))install_lib_$(notdir $(app_test_LIB))
 endif
 
-install_libs: $(lib_install_targets) install_lib_$(notdir $(moose_LIB)) install_lib_$(notdir $(pcre_LIB)) install_lib_$(notdir $(hit_LIB))
+install_libs: $(lib_install_targets)
 
 install_$(APPLICATION_NAME)_tests: all
 	@echo "Installing tests"

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -405,29 +405,6 @@ libpath_framework = $(MOOSE_DIR)/framework/$(libname_framework)
 libname_pcre = $(shell grep "dlname='.*'" $(MOOSE_DIR)/framework/contrib/pcre/libpcre-$(METHOD).la 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")
 libpath_pcre = $(MOOSE_DIR)/framework/contrib/pcre/$(libname_pcre)
 
-install_lib_$(notdir $(moose_LIB)): $(moose_LIB) all
-	@echo "Installing $<"
-	@mkdir -p $(lib_install_dir)
-	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
-	@$(eval libdst := $(lib_install_dir)/$(libname))
-	@cp $(dir $<)$(libname) $(libdst)
-	@$(call patch_rpath,$(libdst),../$(lib_install_suffix)/.)
-	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
-
-install_lib_$(notdir $(pcre_LIB)): $(pcre_LIB) all
-	@echo "Installing $<"
-	@mkdir -p $(lib_install_dir)
-	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
-	@$(eval libdst := $(lib_install_dir)/$(libname))
-	@cp $(dir $<)$(libname) $(libdst)
-
-install_lib_$(notdir $(hit_LIB)): $(hit_LIB) all
-	@echo "Installing $<"
-	@mkdir -p $(lib_install_dir)
-	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
-	@$(eval libdst := $(lib_install_dir)/$(libname))
-	@cp $(dir $<)$(libname) $(libdst)
-
 #
 # Clean targets
 #

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1151,7 +1151,7 @@ MooseApp::run()
       std::ifstream ifs(docmsgfile);
       std::string content((std::istreambuf_iterator<char>(ifs)),
                           (std::istreambuf_iterator<char>()));
-      content.replace(content.find("LOCAL_SITE_HOME"), content.length(), docmsg);
+      content.replace(content.find("$LOCAL_SITE_HOME"), content.length(), docmsg);
       docmsg = content;
     }
 

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -90,21 +90,15 @@ testsDir(const std::string & app_name)
     return installed_path;
   return Moose::getExecutablePath();
 }
+
 std::string
 docsDir(const std::string & app_name)
 {
   std::string installed_path = pathjoin(Moose::getExecutablePath(), "../share", app_name, "doc");
-
-  auto docfile = pathjoin(installed_path, "TODO-DOCSFILE?");
-  auto mooserepofile = pathjoin(Moose::getExecutablePath(), "../../MOOSEDOCS?");
-  auto appfile = pathjoin(Moose::getExecutablePath(), "../../APPDOCS?");
+  auto docfile = pathjoin(installed_path, "css/moose.css");
   if (pathExists(docfile) && checkFileReadable(docfile))
     return installed_path;
-  // check case where we are in moose repo moose_test dir setup
-  else if (pathExists(mooserepofile) && checkFileReadable(mooserepofile))
-    return pathjoin(Moose::getExecutablePath(), "../../MOOSEDOCS?");
-  // assume we are in a  regular app dir setup
-  return pathjoin(Moose::getExecutablePath(), "../../APPDOCS?");
+  return "";
 }
 
 std::string


### PR DESCRIPTION
This also adds a `--docs` flag that prints out the location of any built+installed docs site (if one exists).  The message that is printed out for the docs command defaults to a file:/// url to the index.html for the installed site.  An optional `$PREFIX/share/[appname]/doc/docmsg.txt` file can be created that replaces the message and can include a $LOCAL_SITE_HOME placeholder that is filled with the url.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
