### PR TITLE
Unify AD and non-AD StressUpdateBase signatures

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADViscoplasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADViscoplasticityStressUpdate.h
@@ -28,7 +28,9 @@ public:
                            ADRankTwoTensor & stress_new,
                            const RankTwoTensor & stress_old,
                            const ADRankFourTensor & elasticity_tensor,
-                           const RankTwoTensor & elastic_strain_old) override;
+                           const RankTwoTensor & elastic_strain_old,
+                           bool compute_full_tangent_operator = false,
+                           RankFourTensor & tangent_operator = identityTensor) override;
 
   virtual ADReal minimumPermissibleValue(const ADReal & effective_trial_stress) const override;
 

--- a/modules/tensor_mechanics/include/materials/ADViscoplasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADViscoplasticityStressUpdate.h
@@ -30,7 +30,7 @@ public:
                            const ADRankFourTensor & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
                            bool compute_full_tangent_operator = false,
-                           RankFourTensor & tangent_operator = identityTensor) override;
+                           RankFourTensor & tangent_operator = _identityTensor) override;
 
   virtual ADReal minimumPermissibleValue(const ADReal & effective_trial_stress) const override;
 

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -60,23 +60,16 @@ public:
    * @param compute_full_tangent_operator Flag currently unused by this class
    * @param tangent_operator              Currently a copy of the elasticity tensor in this class
    */
-  virtual void updateState(RankTwoTensor & /*strain_increment*/,
-                           RankTwoTensor & /*inelastic_strain_increment*/,
-                           const RankTwoTensor & /*rotation_increment*/,
-                           RankTwoTensor & /*stress_new*/,
-                           const RankTwoTensor & /*stress_old*/,
-                           const RankFourTensor & /*elasticity_tensor*/,
-                           const RankTwoTensor & /*elastic_strain_old*/,
-                           bool /*compute_full_tangent_operator*/,
-                           RankFourTensor & /*tangent_operator*/) override;
 
-  virtual void updateState(ADRankTwoTensor & /*strain_increment*/,
-                           ADRankTwoTensor & /*inelastic_strain_increment*/,
-                           const ADRankTwoTensor & /*rotation_increment*/,
-                           ADRankTwoTensor & /*stress_new*/,
-                           const RankTwoTensor & /*stress_old*/,
-                           const ADRankFourTensor & /*elasticity_tensor*/,
-                           const RankTwoTensor & /*elastic_strain_old*/) override;
+  virtual void updateState(GenericRankTwoTensor<is_ad> & strain_increment,
+                           GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
+                           const GenericRankTwoTensor<is_ad> & rotation_increment,
+                           GenericRankTwoTensor<is_ad> & stress_new,
+                           const RankTwoTensor & stress_old,
+                           const GenericRankFourTensor<is_ad> & elasticity_tensor,
+                           const RankTwoTensor & elastic_strain_old,
+                           bool compute_full_tangent_operator = false,
+                           RankFourTensor & tangent_operator = identityTensor) override;
 
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -74,23 +74,15 @@ public:
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep
    */
-  virtual void updateStateSubstep(RankTwoTensor & /*strain_increment*/,
-                                  RankTwoTensor & /*inelastic_strain_increment*/,
-                                  const RankTwoTensor & /*rotation_increment*/,
-                                  RankTwoTensor & /*stress_new*/,
+  virtual void updateStateSubstep(GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+                                  GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+                                  const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+                                  GenericRankTwoTensor<is_ad> & /*stress_new*/,
                                   const RankTwoTensor & /*stress_old*/,
-                                  const RankFourTensor & /*elasticity_tensor*/,
+                                  const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
                                   const RankTwoTensor & /*elastic_strain_old*/,
-                                  bool /*compute_full_tangent_operator*/,
-                                  RankFourTensor & /*tangent_operator*/) override;
-
-  virtual void updateStateSubstep(ADRankTwoTensor & /*strain_increment*/,
-                                  ADRankTwoTensor & /*inelastic_strain_increment*/,
-                                  const ADRankTwoTensor & /*rotation_increment*/,
-                                  ADRankTwoTensor & /*stress_new*/,
-                                  const RankTwoTensor & /*stress_old*/,
-                                  const ADRankFourTensor & /*elasticity_tensor*/,
-                                  const RankTwoTensor & /*elastic_strain_old*/) override;
+                                  bool compute_full_tangent_operator = false,
+                                  RankFourTensor & tangent_operator = identityTensor) override;
 
   virtual Real
   computeReferenceResidual(const GenericReal<is_ad> & effective_trial_stress,

--- a/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnStressUpdate.h
@@ -61,28 +61,30 @@ public:
    * @param tangent_operator              Currently a copy of the elasticity tensor in this class
    */
 
-  virtual void updateState(GenericRankTwoTensor<is_ad> & strain_increment,
-                           GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
-                           const GenericRankTwoTensor<is_ad> & rotation_increment,
-                           GenericRankTwoTensor<is_ad> & stress_new,
-                           const RankTwoTensor & stress_old,
-                           const GenericRankFourTensor<is_ad> & elasticity_tensor,
-                           const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator = false,
-                           RankFourTensor & tangent_operator = identityTensor) override;
+  virtual void updateState(
+      GenericRankTwoTensor<is_ad> & strain_increment,
+      GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
+      const GenericRankTwoTensor<is_ad> & rotation_increment,
+      GenericRankTwoTensor<is_ad> & stress_new,
+      const RankTwoTensor & stress_old,
+      const GenericRankFourTensor<is_ad> & elasticity_tensor,
+      const RankTwoTensor & elastic_strain_old,
+      bool compute_full_tangent_operator = false,
+      RankFourTensor & tangent_operator = StressUpdateBaseTempl<is_ad>::_identityTensor) override;
 
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep
    */
-  virtual void updateStateSubstep(GenericRankTwoTensor<is_ad> & /*strain_increment*/,
-                                  GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
-                                  const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
-                                  GenericRankTwoTensor<is_ad> & /*stress_new*/,
-                                  const RankTwoTensor & /*stress_old*/,
-                                  const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
-                                  const RankTwoTensor & /*elastic_strain_old*/,
-                                  bool compute_full_tangent_operator = false,
-                                  RankFourTensor & tangent_operator = identityTensor) override;
+  virtual void updateStateSubstep(
+      GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+      GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+      const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+      GenericRankTwoTensor<is_ad> & /*stress_new*/,
+      const RankTwoTensor & /*stress_old*/,
+      const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
+      const RankTwoTensor & /*elastic_strain_old*/,
+      bool compute_full_tangent_operator = false,
+      RankFourTensor & tangent_operator = StressUpdateBaseTempl<is_ad>::_identityTensor) override;
 
   virtual Real
   computeReferenceResidual(const GenericReal<is_ad> & effective_trial_stress,

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -29,8 +29,6 @@ enum class TangentCalculationMethod
   PARTIAL
 };
 
-static RankFourTensor identityTensor = RankFourTensor(RankFourTensor::initIdentityFour);
-
 /**
  * StressUpdateBase is a material that is not called by MOOSE because
  * of the compute=false flag set in the parameter list.  This class is a base class
@@ -82,28 +80,30 @@ public:
    * compute_full_tangent_operator=false, then tangent_operator=elasticity_tensor is an appropriate
    * choice.  tangent_operator is only computed if _fe_problem.currentlyComputingJacobian() = true
    */
-  virtual void updateState(GenericRankTwoTensor<is_ad> & strain_increment,
-                           GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
-                           const GenericRankTwoTensor<is_ad> & rotation_increment,
-                           GenericRankTwoTensor<is_ad> & stress_new,
-                           const RankTwoTensor & stress_old,
-                           const GenericRankFourTensor<is_ad> & elasticity_tensor,
-                           const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator = false,
-                           RankFourTensor & tangent_operator = identityTensor);
+  virtual void
+  updateState(GenericRankTwoTensor<is_ad> & strain_increment,
+              GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
+              const GenericRankTwoTensor<is_ad> & rotation_increment,
+              GenericRankTwoTensor<is_ad> & stress_new,
+              const RankTwoTensor & stress_old,
+              const GenericRankFourTensor<is_ad> & elasticity_tensor,
+              const RankTwoTensor & elastic_strain_old,
+              bool compute_full_tangent_operator = false,
+              RankFourTensor & tangent_operator = StressUpdateBaseTempl<is_ad>::_identityTensor);
 
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep
    */
-  virtual void updateStateSubstep(GenericRankTwoTensor<is_ad> & /*strain_increment*/,
-                                  GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
-                                  const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
-                                  GenericRankTwoTensor<is_ad> & /*stress_new*/,
-                                  const RankTwoTensor & /*stress_old*/,
-                                  const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
-                                  const RankTwoTensor & /*elastic_strain_old*/,
-                                  bool compute_full_tangent_operator = false,
-                                  RankFourTensor & tangent_operator = identityTensor);
+  virtual void updateStateSubstep(
+      GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+      GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+      const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+      GenericRankTwoTensor<is_ad> & /*stress_new*/,
+      const RankTwoTensor & /*stress_old*/,
+      const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
+      const RankTwoTensor & /*elastic_strain_old*/,
+      bool compute_full_tangent_operator = false,
+      RankFourTensor & tangent_operator = StressUpdateBaseTempl<is_ad>::_identityTensor);
 
   /// Sets the value of the global variable _qp for inheriting classes
   void setQp(unsigned int qp);
@@ -160,6 +160,12 @@ public:
 protected:
   /// Name used as a prefix for all material properties related to the stress update model.
   const std::string _base_name;
+
+  static RankFourTensor _identityTensor;
 };
 typedef StressUpdateBaseTempl<false> StressUpdateBase;
 typedef StressUpdateBaseTempl<true> ADStressUpdateBase;
+
+template <bool is_ad>
+RankFourTensor StressUpdateBaseTempl<is_ad>::_identityTensor =
+    RankFourTensor(RankFourTensor::initIdentityFour);

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -29,6 +29,8 @@ enum class TangentCalculationMethod
   PARTIAL
 };
 
+static RankFourTensor identityTensor = RankFourTensor(RankFourTensor::initIdentityFour);
+
 /**
  * StressUpdateBase is a material that is not called by MOOSE because
  * of the compute=false flag set in the parameter list.  This class is a base class
@@ -80,23 +82,16 @@ public:
    * compute_full_tangent_operator=false, then tangent_operator=elasticity_tensor is an appropriate
    * choice.  tangent_operator is only computed if _fe_problem.currentlyComputingJacobian() = true
    */
-  virtual void updateState(RankTwoTensor & strain_increment,
-                           RankTwoTensor & inelastic_strain_increment,
-                           const RankTwoTensor & rotation_increment,
-                           RankTwoTensor & stress_new,
+  virtual void updateState(GenericRankTwoTensor<is_ad> & strain_increment,
+                           GenericRankTwoTensor<is_ad> & inelastic_strain_increment,
+                           const GenericRankTwoTensor<is_ad> & rotation_increment,
+                           GenericRankTwoTensor<is_ad> & stress_new,
                            const RankTwoTensor & stress_old,
-                           const RankFourTensor & elasticity_tensor,
+                           const GenericRankFourTensor<is_ad> & elasticity_tensor,
                            const RankTwoTensor & elastic_strain_old,
-                           bool compute_full_tangent_operator,
-                           RankFourTensor & tangent_operator);
+                           bool compute_full_tangent_operator = false,
+                           RankFourTensor & tangent_operator = identityTensor);
 
-  virtual void updateState(ADRankTwoTensor & strain_increment,
-                           ADRankTwoTensor & inelastic_strain_increment,
-                           const ADRankTwoTensor & rotation_increment,
-                           ADRankTwoTensor & stress_new,
-                           const RankTwoTensor & stress_old,
-                           const ADRankFourTensor & elasticity_tensor,
-                           const RankTwoTensor & elastic_strain_old);
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep
    */
@@ -173,6 +168,5 @@ protected:
   /// Name used as a prefix for all material properties related to the stress update model.
   const std::string _base_name;
 };
-
 typedef StressUpdateBaseTempl<false> StressUpdateBase;
 typedef StressUpdateBaseTempl<true> ADStressUpdateBase;

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -95,23 +95,16 @@ public:
   /**
    * Similar to the updateState function, this method updates the strain and stress for one substep
    */
-  virtual void updateStateSubstep(RankTwoTensor & /*strain_increment*/,
-                                  RankTwoTensor & /*inelastic_strain_increment*/,
-                                  const RankTwoTensor & /*rotation_increment*/,
-                                  RankTwoTensor & /*stress_new*/,
+  virtual void updateStateSubstep(GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+                                  GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+                                  const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+                                  GenericRankTwoTensor<is_ad> & /*stress_new*/,
                                   const RankTwoTensor & /*stress_old*/,
-                                  const RankFourTensor & /*elasticity_tensor*/,
+                                  const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
                                   const RankTwoTensor & /*elastic_strain_old*/,
-                                  bool /*compute_full_tangent_operator*/,
-                                  RankFourTensor & /*tangent_operator*/);
+                                  bool compute_full_tangent_operator = false,
+                                  RankFourTensor & tangent_operator = identityTensor);
 
-  virtual void updateStateSubstep(ADRankTwoTensor & /*strain_increment*/,
-                                  ADRankTwoTensor & /*inelastic_strain_increment*/,
-                                  const ADRankTwoTensor & /*rotation_increment*/,
-                                  ADRankTwoTensor & /*stress_new*/,
-                                  const RankTwoTensor & /*stress_old*/,
-                                  const ADRankFourTensor & /*elasticity_tensor*/,
-                                  const RankTwoTensor & /*elastic_strain_old*/);
   /// Sets the value of the global variable _qp for inheriting classes
   void setQp(unsigned int qp);
 

--- a/modules/tensor_mechanics/src/materials/ADViscoplasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADViscoplasticityStressUpdate.C
@@ -78,7 +78,9 @@ ADViscoplasticityStressUpdate::updateState(ADRankTwoTensor & elastic_strain_incr
                                            ADRankTwoTensor & stress,
                                            const RankTwoTensor & /*stress_old*/,
                                            const ADRankFourTensor & elasticity_tensor,
-                                           const RankTwoTensor & elastic_strain_old)
+                                           const RankTwoTensor & elastic_strain_old,
+                                           bool /*compute_full_tangent_operator = false*/,
+                                           RankFourTensor & /*tangent_operator = identityTensor*/)
 {
   // Compute initial hydrostatic stress and porosity
   if (_pore_shape == PoreShapeModel::CYLINDRICAL)

--- a/modules/tensor_mechanics/src/materials/ADViscoplasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADViscoplasticityStressUpdate.C
@@ -80,7 +80,7 @@ ADViscoplasticityStressUpdate::updateState(ADRankTwoTensor & elastic_strain_incr
                                            const ADRankFourTensor & elasticity_tensor,
                                            const RankTwoTensor & elastic_strain_old,
                                            bool /*compute_full_tangent_operator = false*/,
-                                           RankFourTensor & /*tangent_operator = identityTensor*/)
+                                           RankFourTensor & /*tangent_operator = _identityTensor*/)
 {
   // Compute initial hydrostatic stress and porosity
   if (_pore_shape == PoreShapeModel::CYLINDRICAL)

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -217,7 +217,7 @@ RadialReturnStressUpdateTempl<true>::updateState(
     const ADRankFourTensor & elasticity_tensor,
     const RankTwoTensor & elastic_strain_old,
     bool /*compute_full_tangent_operator = false*/,
-    RankFourTensor & /*tangent_operator = identityTensor*/)
+    RankFourTensor & /*tangent_operator = _identityTensor*/)
 {
   // compute the deviatoric trial stress and trial strain from the current intermediate
   // configuration

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -264,23 +264,6 @@ RadialReturnStressUpdateTempl<true>::updateState(
   computeStressFinalize(inelastic_strain_increment);
 }
 
-template <bool is_ad>
-void
-RadialReturnStressUpdateTempl<is_ad>::updateStateSubstep(
-    RankTwoTensor & /*strain_increment*/,
-    RankTwoTensor & /*inelastic_strain_increment*/,
-    const RankTwoTensor & /*rotation_increment*/,
-    RankTwoTensor & /*stress_new*/,
-    const RankTwoTensor & /*stress_old*/,
-    const RankFourTensor & /*elasticity_tensor*/,
-    const RankTwoTensor & /*elastic_strain_old*/,
-    bool /*compute_full_tangent_operator*/,
-    RankFourTensor & /*tangent_operator*/)
-{
-  mooseError("updateStateSubstep called: the version without tangent computation should be "
-             "called instead");
-}
-
 template <>
 void
 RadialReturnStressUpdateTempl<false>::updateStateSubstep(RankTwoTensor & strain_increment,
@@ -372,21 +355,6 @@ RadialReturnStressUpdateTempl<false>::updateStateSubstep(RankTwoTensor & strain_
   _dt = dt_original;
 }
 
-template <bool is_ad>
-void
-RadialReturnStressUpdateTempl<is_ad>::updateStateSubstep(
-    ADRankTwoTensor & /*strain_increment*/,
-    ADRankTwoTensor & /*inelastic_strain_increment*/,
-    const ADRankTwoTensor & /*rotation_increment*/,
-    ADRankTwoTensor & /*stress_new*/,
-    const RankTwoTensor & /*stress_old*/,
-    const ADRankFourTensor & /*elasticity_tensor*/,
-    const RankTwoTensor & /*elastic_strain_old*/)
-{
-  mooseError(
-      "updateStateSubstep called: the version with tangent computation should be called instead");
-}
-
 template <>
 void
 RadialReturnStressUpdateTempl<true>::updateStateSubstep(
@@ -396,7 +364,9 @@ RadialReturnStressUpdateTempl<true>::updateStateSubstep(
     ADRankTwoTensor & stress_new,
     const RankTwoTensor & stress_old,
     const ADRankFourTensor & elasticity_tensor,
-    const RankTwoTensor & elastic_strain_old)
+    const RankTwoTensor & elastic_strain_old,
+    bool /*compute_full_tangent_operator*/,
+    RankFourTensor & /*tangent_operator*/)
 {
   const unsigned int total_substeps = calculateNumberSubsteps(strain_increment);
 

--- a/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/RadialReturnStressUpdate.C
@@ -150,22 +150,6 @@ RadialReturnStressUpdateTempl<false>::computeTangentOperator(Real effective_tria
   }
 }
 
-template <bool is_ad>
-void
-RadialReturnStressUpdateTempl<is_ad>::updateState(RankTwoTensor & /*strain_increment*/,
-                                                  RankTwoTensor & /*inelastic_strain_increment*/,
-                                                  const RankTwoTensor & /*rotation_increment*/,
-                                                  RankTwoTensor & /*stress_new*/,
-                                                  const RankTwoTensor & /*stress_old*/,
-                                                  const RankFourTensor & /*elasticity_tensor*/,
-                                                  const RankTwoTensor & /*elastic_strain_old*/,
-                                                  bool /*compute_full_tangent_operator*/,
-                                                  RankFourTensor & /*tangent_operator*/)
-{
-  mooseError(
-      "updateState called: the version without tangent computation should be called instead");
-}
-
 template <>
 void
 RadialReturnStressUpdateTempl<false>::updateState(RankTwoTensor & strain_increment,
@@ -222,28 +206,18 @@ RadialReturnStressUpdateTempl<false>::updateState(RankTwoTensor & strain_increme
       effective_trial_stress, stress_new, compute_full_tangent_operator, tangent_operator);
 }
 
-template <bool is_ad>
-void
-RadialReturnStressUpdateTempl<is_ad>::updateState(ADRankTwoTensor & /*strain_increment*/,
-                                                  ADRankTwoTensor & /*inelastic_strain_increment*/,
-                                                  const ADRankTwoTensor & /*rotation_increment*/,
-                                                  ADRankTwoTensor & /*stress_new*/,
-                                                  const RankTwoTensor & /*stress_old*/,
-                                                  const ADRankFourTensor & /*elasticity_tensor*/,
-                                                  const RankTwoTensor & /*elastic_strain_old*/)
-{
-  mooseError("updateState called: the version with tangent computation should be called instead");
-}
-
 template <>
 void
-RadialReturnStressUpdateTempl<true>::updateState(ADRankTwoTensor & strain_increment,
-                                                 ADRankTwoTensor & inelastic_strain_increment,
-                                                 const ADRankTwoTensor & /*rotation_increment*/,
-                                                 ADRankTwoTensor & stress_new,
-                                                 const RankTwoTensor & /*stress_old*/,
-                                                 const ADRankFourTensor & elasticity_tensor,
-                                                 const RankTwoTensor & elastic_strain_old)
+RadialReturnStressUpdateTempl<true>::updateState(
+    ADRankTwoTensor & strain_increment,
+    ADRankTwoTensor & inelastic_strain_increment,
+    const ADRankTwoTensor & /*rotation_increment*/,
+    ADRankTwoTensor & stress_new,
+    const RankTwoTensor & /*stress_old*/,
+    const ADRankFourTensor & elasticity_tensor,
+    const RankTwoTensor & elastic_strain_old,
+    bool /*compute_full_tangent_operator = false*/,
+    RankFourTensor & /*tangent_operator = identityTensor*/)
 {
   // compute the deviatoric trial stress and trial strain from the current intermediate
   // configuration

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -65,28 +65,16 @@ StressUpdateBaseTempl<is_ad>::computeTimeStepLimit()
 
 template <bool is_ad>
 void
-StressUpdateBaseTempl<is_ad>::updateState(RankTwoTensor & /*strain_increment*/,
-                                          RankTwoTensor & /*inelastic_strain_increment*/,
-                                          const RankTwoTensor & /*rotation_increment*/,
-                                          RankTwoTensor & /*stress_new*/,
-                                          const RankTwoTensor & /*stress_old*/,
-                                          const RankFourTensor & /*elasticity_tensor*/,
-                                          const RankTwoTensor & /*elastic_strain_old*/,
-                                          bool /*compute_full_tangent_operator*/,
-                                          RankFourTensor & /*tangent_operator*/)
-{
-  mooseError("updateState called: it needs to be implemented by your inelastic model");
-}
-
-template <bool is_ad>
-void
-StressUpdateBaseTempl<is_ad>::updateState(ADRankTwoTensor & /*strain_increment*/,
-                                          ADRankTwoTensor & /*inelastic_strain_increment*/,
-                                          const ADRankTwoTensor & /*rotation_increment*/,
-                                          ADRankTwoTensor & /*stress_new*/,
-                                          const RankTwoTensor & /*stress_old*/,
-                                          const ADRankFourTensor & /*elasticity_tensor*/,
-                                          const RankTwoTensor & /*elastic_strain_old*/)
+StressUpdateBaseTempl<is_ad>::updateState(
+    GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+    GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+    const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+    GenericRankTwoTensor<is_ad> & /*stress_new*/,
+    const RankTwoTensor & /*stress_old*/,
+    const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
+    const RankTwoTensor & /*elastic_strain_old*/,
+    bool /*compute_full_tangent_operator = false*/,
+    RankFourTensor & /*tangent_operator = identityTensor*/)
 {
   mooseError("updateState called: it needs to be implemented by your inelastic model");
 }

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -81,30 +81,16 @@ StressUpdateBaseTempl<is_ad>::updateState(
 
 template <bool is_ad>
 void
-StressUpdateBaseTempl<is_ad>::updateStateSubstep(RankTwoTensor & /*strain_increment*/,
-                                                 RankTwoTensor & /*inelastic_strain_increment*/,
-                                                 const RankTwoTensor & /*rotation_increment*/,
-                                                 RankTwoTensor & /*stress_new*/,
-                                                 const RankTwoTensor & /*stress_old*/,
-                                                 const RankFourTensor & /*elasticity_tensor*/,
-                                                 const RankTwoTensor & /*elastic_strain_old*/,
-                                                 bool /*compute_full_tangent_operator*/,
-                                                 RankFourTensor & /*tangent_operator*/)
-{
-  this->template paramError(
-      "use_substep",
-      "updateStateSubstep called: it needs to be implemented by your inelastic model");
-}
-
-template <bool is_ad>
-void
-StressUpdateBaseTempl<is_ad>::updateStateSubstep(ADRankTwoTensor & /*strain_increment*/,
-                                                 ADRankTwoTensor & /*inelastic_strain_increment*/,
-                                                 const ADRankTwoTensor & /*rotation_increment*/,
-                                                 ADRankTwoTensor & /*stress_new*/,
-                                                 const RankTwoTensor & /*stress_old*/,
-                                                 const ADRankFourTensor & /*elasticity_tensor*/,
-                                                 const RankTwoTensor & /*elastic_strain_old*/)
+StressUpdateBaseTempl<is_ad>::updateStateSubstep(
+    GenericRankTwoTensor<is_ad> & /*strain_increment*/,
+    GenericRankTwoTensor<is_ad> & /*inelastic_strain_increment*/,
+    const GenericRankTwoTensor<is_ad> & /*rotation_increment*/,
+    GenericRankTwoTensor<is_ad> & /*stress_new*/,
+    const RankTwoTensor & /*stress_old*/,
+    const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
+    const RankTwoTensor & /*elastic_strain_old*/,
+    bool /*compute_full_tangent_operator*/,
+    RankFourTensor & /*tangent_operator*/)
 {
   this->template paramError(
       "use_substep",

--- a/modules/tensor_mechanics/src/materials/StressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/StressUpdateBase.C
@@ -74,7 +74,7 @@ StressUpdateBaseTempl<is_ad>::updateState(
     const GenericRankFourTensor<is_ad> & /*elasticity_tensor*/,
     const RankTwoTensor & /*elastic_strain_old*/,
     bool /*compute_full_tangent_operator = false*/,
-    RankFourTensor & /*tangent_operator = identityTensor*/)
+    RankFourTensor & /*tangent_operator = _identityTensor*/)
 {
   mooseError("updateState called: it needs to be implemented by your inelastic model");
 }


### PR DESCRIPTION
Clean up `StressUpdateBase` to allow easier inheritance and avoid errors downstream.
Design and functionality should remain unchanged.

Downstream AD classes will need to update their signature.
Refs. #16016.