### PR TITLE
Kernel coverage checking for finite volume

### DIFF
--- a/framework/include/fvkernels/FVElementalKernel.h
+++ b/framework/include/fvkernels/FVElementalKernel.h
@@ -39,11 +39,13 @@ public:
   virtual void computeOffDiagJacobian();
   ///@}
 
+  const MooseVariableFV<Real> & variable() const { return _var; }
+
 protected:
   /// This is the primary function that must be implemented for flux kernel
   /// terms.  Note that solution gradients will be zero unless you are using a
   /// higher-order reconstruction.  Material properties and other values
-  /// should be initialized just like they are for fintie element kernels here -
+  /// should be initialized just like they are for finite element kernels here -
   /// since this is a FE-like volumetric integration term.
   virtual ADReal computeQpResidual() = 0;
 

--- a/framework/include/fvkernels/FVFluxKernel.h
+++ b/framework/include/fvkernels/FVFluxKernel.h
@@ -41,6 +41,8 @@ public:
   virtual void computeJacobian(const FaceInfo & fi);
   /// @}
 
+  const MooseVariableFV<Real> & variable() const { return _var; }
+
 protected:
   /// This is the primary function that must be implemented for flux kernel
   /// terms.  Material properties will be initialized on the face - using any

--- a/framework/include/fvkernels/FVScalarLagrangeMultiplier.h
+++ b/framework/include/fvkernels/FVScalarLagrangeMultiplier.h
@@ -17,7 +17,7 @@
  * \int \phi = \int \phi_0
  *
  * using a Lagrange multiplier approach. E.g. this kernel enforces the constraint that the average
- * value of \phi match \phi_0
+ * value of \phi matches \phi_0
  *
  * In particular, this Kernel implements the residual contribution for
  * the lambda term in Eq. (5), and both terms in Eq. (6) where \int \phi_0 = V_0
@@ -30,6 +30,8 @@ public:
   static InputParameters validParams();
 
   FVScalarLagrangeMultiplier(const InputParameters & parameters);
+
+  const MooseVariableScalar & lambdaVariable() const { return _lambda_var; }
 
 private:
   void computeResidual() override final;

--- a/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/boussinesq.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/boussinesq.i
@@ -23,10 +23,6 @@ temp_ref=${fparse hot_temp / 2.}
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   [u]
     type = INSFVVelocityVariable

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-mixing-length.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-mixing-length.i
@@ -23,7 +23,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-ambient-convection.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-ambient-convection.i
@@ -19,7 +19,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-friction.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-friction.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-extrapolated-outlet-pressure.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-extrapolated-outlet-pressure.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-outflow-bcs.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-outflow-bcs.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-scalar-transport.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-scalar-transport.i
@@ -20,7 +20,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/2d-average-no-slip.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/2d-average-no-slip.i
@@ -17,7 +17,6 @@ velocity_interp_method='average'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
   coord_type = 'RZ'
 []

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/2d-rc-slip.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/2d-rc-slip.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
   coord_type = 'RZ'
 []

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/diverging.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/diverging.i
@@ -9,7 +9,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
   coord_type = 'RZ'
 []

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-with-energy.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-with-energy.i
@@ -19,10 +19,6 @@ advected_interp_method = 'average'
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   [u]
     type = INSFVVelocityVariable

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven.i
@@ -20,10 +20,6 @@ rho=1
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   [u]
     type = INSFVVelocityVariable

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/transient-lid-driven-with-energy.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/transient-lid-driven-with-energy.i
@@ -25,10 +25,6 @@ advected_interp_method = 'average'
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   [u]
     type = INSFVVelocityVariable

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/1d-average.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/1d-average.i
@@ -13,10 +13,6 @@ velocity_interp_method='average'
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   [u]
     type = INSFVVelocityVariable

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-average-with-temp.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-average-with-temp.i
@@ -20,7 +20,6 @@ velocity='velocity'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-average.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-average.i
@@ -18,7 +18,6 @@ force_boundary_execution=true
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-rc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/2d-rc.i
@@ -17,7 +17,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/plane-poiseuille-flow.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/plane-poiseuille-flow.i
@@ -18,7 +18,6 @@ two_term_boundary_expansion=true
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/cylindrical/2d-rc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/cylindrical/2d-rc.i
@@ -15,7 +15,6 @@ rho=1.1
 []
 
 [Problem]
-  kernel_coverage_check = false
   coord_type = 'RZ'
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/rc.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/rc.i
@@ -21,7 +21,6 @@ velocity_interp_method='rc'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = false
   error_on_jacobian_nonzero_reallocation = true
 []

--- a/modules/navier_stokes/test/tests/postprocessors/conservation_INSFV.i
+++ b/modules/navier_stokes/test/tests/postprocessors/conservation_INSFV.i
@@ -37,7 +37,6 @@ velocity_interp_method='average'
 []
 
 [Problem]
-  kernel_coverage_check = false
   fv_bcs_integrity_check = true
 []
 

--- a/test/tests/dirackernels/constant_point_source/1d_point_source_fv.i
+++ b/test/tests/dirackernels/constant_point_source/1d_point_source_fv.i
@@ -22,10 +22,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Materials]
   [diff]
     type = ADGenericConstantMaterial

--- a/test/tests/fvbcs/fv_neumannbc/fv_neumannbc.i
+++ b/test/tests/fvbcs/fv_neumannbc/fv_neumannbc.i
@@ -57,10 +57,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'Newton'

--- a/test/tests/fvbcs/fv_neumannbc/tests
+++ b/test/tests/fvbcs/fv_neumannbc/tests
@@ -22,7 +22,7 @@
     type = RunException
     input = 'fv_neumannbc.i'
     expect_err = 'A FVFluxBC is being triggered on a face which does not connect to a block with the relevant finite volume variable.'
-    cli_args = "Mesh/mesh/subdomain_id='1 2'"
+    cli_args = "Mesh/mesh/subdomain_id='1 2' Problem/kernel_coverage_check=false"
     requirement = 'The system shall error out if a finite volume flux boundary condition is used on a mesh element face that is not connected to an element with the corresponding finite volume variable.'
   []
 []

--- a/test/tests/fvbcs/fv_pp_dirichlet/fv_pp_dirichlet.i
+++ b/test/tests/fvbcs/fv_pp_dirichlet/fv_pp_dirichlet.i
@@ -42,10 +42,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'Newton'

--- a/test/tests/fvkernels/block-restriction/fv-and-fe-block-restriction.i
+++ b/test/tests/fvkernels/block-restriction/fv-and-fe-block-restriction.i
@@ -206,10 +206,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'NEWTON'

--- a/test/tests/fvkernels/fv_burgers/fv_burgers.i
+++ b/test/tests/fvkernels/fv_burgers/fv_burgers.i
@@ -8,10 +8,6 @@
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Variables]
   [./v]
     family = MONOMIAL

--- a/test/tests/fvkernels/fv_euler/fv_euler.i
+++ b/test/tests/fvkernels/fv_euler/fv_euler.i
@@ -6,10 +6,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Variables]
   # we have to impose non-zero initial conditions in order to avoid an initially
   # singular matrix

--- a/test/tests/fvkernels/fv_simple_diffusion/fv_only.i
+++ b/test/tests/fvkernels/fv_simple_diffusion/fv_only.i
@@ -43,10 +43,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'NEWTON'

--- a/test/tests/fvkernels/fv_simple_diffusion/fv_only_refined.i
+++ b/test/tests/fvkernels/fv_simple_diffusion/fv_only_refined.i
@@ -44,10 +44,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = off
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'NEWTON'

--- a/test/tests/indicators/analytical_indicator/analytical_indicator_fv.i
+++ b/test/tests/indicators/analytical_indicator/analytical_indicator_fv.i
@@ -15,10 +15,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Functions]
   [solution]
     type = ParsedFunction

--- a/test/tests/indicators/value_jump_indicator/value_jump_indicator_fv.i
+++ b/test/tests/indicators/value_jump_indicator/value_jump_indicator_fv.i
@@ -24,10 +24,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [ICs]
   [leftright]
     type = BoundingBoxIC

--- a/test/tests/markers/error_fraction_marker/error_fraction_marker_fv.i
+++ b/test/tests/markers/error_fraction_marker/error_fraction_marker_fv.i
@@ -13,10 +13,6 @@
   []
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Functions]
   [solution]
     type = ParsedFunction

--- a/test/tests/materials/boundary_material/fv_material_quadrature.i
+++ b/test/tests/materials/boundary_material/fv_material_quadrature.i
@@ -68,10 +68,6 @@
   petsc_options_value = 'lu'
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Outputs]
   execute_on = 'timestep_end'
   exodus = true

--- a/test/tests/misc/check_error/incomplete_fvkernel_block_coverage_test.i
+++ b/test/tests/misc/check_error/incomplete_fvkernel_block_coverage_test.i
@@ -1,67 +1,57 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 10
-  xmin = 0
-  xmax = 4
-  ymin = 0
-  ymax = 1
+  file = rectangle.e
 []
 
 [Variables]
   active = 'u'
 
   [./u]
-    family = MONOMIAL
     order = CONSTANT
+    family = MONOMIAL
     fv = true
   [../]
 []
 
 [FVKernels]
-  active = 'diff'
+  active = 'diff body_force'
 
   [./diff]
     type = FVDiffusion
     variable = u
-    coeff = '1'
+    block = 1
+    coeff = 1
+  [../]
+
+  [./body_force]
+    type = FVBodyForce
+    variable = u
+    block = 1
+    value = 10
   [../]
 []
 
 [FVBCs]
-  active = 'left right'
+  active = 'right'
 
   [./left]
     type = FVDirichletBC
     variable = u
-    boundary = 3
-    value = 0
+    boundary = 1
+    value = 1
   [../]
 
   [./right]
     type = FVDirichletBC
     variable = u
-    boundary = 1
+    boundary = 2
     value = 1
   [../]
 []
 
 [Executioner]
   type = Steady
-
   solve_type = 'PJFNK'
 []
 
-[Postprocessors]
-  [./integral]
-    type = SideIntegralVariablePostprocessor
-    boundary = 0
-    variable = u
-  [../]
-[]
-
 [Outputs]
-  file_base = fv_out
-  exodus = true
 []

--- a/test/tests/misc/check_error/incomplete_fvkernel_variable_coverage_test.i
+++ b/test/tests/misc/check_error/incomplete_fvkernel_variable_coverage_test.i
@@ -1,42 +1,50 @@
 [Mesh]
-  type = GeneratedMesh
-  dim = 2
-  nx = 10
-  ny = 10
-  xmin = 0
-  xmax = 4
-  ymin = 0
-  ymax = 1
+  [./square]
+    type = GeneratedMeshGenerator
+    nx = 2
+    ny = 2
+    dim = 2
+  [../]
 []
 
 [Variables]
-  active = 'u'
-
   [./u]
-    family = MONOMIAL
     order = CONSTANT
+    family = MONOMIAL
+    fv = true
+  [../]
+
+  [./v]
+    order = CONSTANT
+    family = MONOMIAL
     fv = true
   [../]
 []
 
 [FVKernels]
-  active = 'diff'
+  active = 'diff body_force'
 
   [./diff]
     type = FVDiffusion
     variable = u
-    coeff = '1'
+    coeff = 1
+  [../]
+
+  [./body_force]
+    type = FVBodyForce
+    variable = u
+    value = 10
   [../]
 []
 
 [FVBCs]
-  active = 'left right'
+  active = 'right'
 
   [./left]
     type = FVDirichletBC
     variable = u
     boundary = 3
-    value = 0
+    value = 1
   [../]
 
   [./right]
@@ -49,19 +57,9 @@
 
 [Executioner]
   type = Steady
-
-  solve_type = 'PJFNK'
-[]
-
-[Postprocessors]
-  [./integral]
-    type = SideIntegralVariablePostprocessor
-    boundary = 0
-    variable = u
-  [../]
 []
 
 [Outputs]
-  file_base = fv_out
+  file_base = out
   exodus = true
 []

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -389,6 +389,24 @@
     issues = '#1405'
   [../]
 
+  [./incomplete_fvkernel_block_coverage_test]
+    type = 'RunException'
+    input = 'incomplete_fvkernel_block_coverage_test.i'
+    expect_err = "The following block\(s\) lack an active kernel:"
+
+    requirement = 'The system shall report an error if one or more domain blocks do not have any active FVKernels objects assigned.'
+    issues = '#1405 #15196'
+  [../]
+
+  [./incomplete_fvkernel_variable_coverage_test]
+    type = 'RunException'
+    input = 'incomplete_fvkernel_variable_coverage_test.i'
+    expect_err = "The following variable\(s\) lack an active kernel:"
+
+    requirement = 'The system shall report an error if one or more variables do not have any active FVKernel objects assigned.'
+    issues = '#1405 #15196'
+  [../]
+
   [./invalid_elemental_to_nodal_couple_test]
     type = 'RunException'
     input = 'invalid_aux_coupling_test.i'

--- a/test/tests/postprocessors/element_integral_var_pps/pps_old_value_fv.i
+++ b/test/tests/postprocessors/element_integral_var_pps/pps_old_value_fv.i
@@ -69,10 +69,6 @@
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Executioner]
   type = Steady
   solve_type = 'PJFNK'

--- a/test/tests/postprocessors/element_variable_value/elemental_variable_value_fv.i
+++ b/test/tests/postprocessors/element_variable_value/elemental_variable_value_fv.i
@@ -44,10 +44,6 @@
   petsc_options_value = 'hypre boomeramg'
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Postprocessors]
   [./elem_left]
     type = ElementalVariableValue

--- a/test/tests/postprocessors/interface_value/interface_fv_variable_value_postprocessor.i
+++ b/test/tests/postprocessors/interface_value/interface_fv_variable_value_postprocessor.i
@@ -166,10 +166,6 @@ postprocessor_type = InterfaceAverageVariableValuePostprocessor
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Executioner]
   type = Steady
   solve_type = NEWTON

--- a/test/tests/postprocessors/side_flux_average/side_flux_average_fv.i
+++ b/test/tests/postprocessors/side_flux_average/side_flux_average_fv.i
@@ -73,10 +73,6 @@
   l_tol = 1e-6
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Outputs]
   exodus = true
 []

--- a/test/tests/transfers/multiapp_variable_value_sample_transfer/master_fv.i
+++ b/test/tests/transfers/multiapp_variable_value_sample_transfer/master_fv.i
@@ -90,6 +90,5 @@
 []
 
 [Problem]
-  kernel_coverage_check = false
   parallel_barrier_messaging = false
 []

--- a/test/tests/userobjects/layered_integral/layered_integral_fv_test.i
+++ b/test/tests/userobjects/layered_integral/layered_integral_fv_test.i
@@ -74,10 +74,6 @@
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Executioner]
   type = Steady
 []

--- a/test/tests/userobjects/layered_side_integral/layered_side_flux_average_fv.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_flux_average_fv.i
@@ -82,10 +82,6 @@
   l_tol = 1e-6
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Outputs]
   exodus = true
 []

--- a/test/tests/userobjects/layered_side_integral/layered_side_integral_fv.i
+++ b/test/tests/userobjects/layered_side_integral/layered_side_integral_fv.i
@@ -64,10 +64,6 @@
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Executioner]
   type = Steady
   nl_abs_tol = 1e-14

--- a/test/tests/vectorpostprocessors/point_value_sampler/point_value_sampler_fv.i
+++ b/test/tests/vectorpostprocessors/point_value_sampler/point_value_sampler_fv.i
@@ -67,10 +67,6 @@
   [../]
 []
 
-[Problem]
-  kernel_coverage_check = false
-[]
-
 [Executioner]
   type = Steady
   solve_type = PJFNK


### PR DESCRIPTION
Closes #15196

If there is a way to do a query with 'or' conditions then this can be half as short.
Another option for a cleaner implementation would be to add _fv_kernels (similar to _kernels) to NonLinearSystemBase

This would reduce the FV code size in quite a few locations in that file.

Irregardless (is that a double negative?), this is helpful in itself, and the bloat is minimal compared to the advantages. 