### PR TITLE
Prevent strong chance of failed physical point inversion

### DIFF
--- a/framework/include/problems/DisplacedProblem.h
+++ b/framework/include/problems/DisplacedProblem.h
@@ -188,8 +188,7 @@ public:
   virtual void reinitElem(const Elem * elem, THREAD_ID tid) override;
   virtual void reinitElemPhys(const Elem * elem,
                               const std::vector<Point> & phys_points_in_elem,
-                              THREAD_ID tid,
-                              bool = false) override;
+                              THREAD_ID tid) override;
   virtual void
   reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) override;
   virtual void reinitNode(const Node * node, THREAD_ID tid) override;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -390,8 +390,7 @@ public:
   virtual void reinitElem(const Elem * elem, THREAD_ID tid) override;
   virtual void reinitElemPhys(const Elem * elem,
                               const std::vector<Point> & phys_points_in_elem,
-                              THREAD_ID tid,
-                              bool suppress_displaced_init = false) override;
+                              THREAD_ID tid) override;
   virtual void
   reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) override;
   virtual void reinitLowerDElem(const Elem * lower_d_elem,

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -387,8 +387,7 @@ public:
   virtual void reinitElem(const Elem * elem, THREAD_ID tid) = 0;
   virtual void reinitElemPhys(const Elem * elem,
                               const std::vector<Point> & phys_points_in_elem,
-                              THREAD_ID tid,
-                              bool suppress_displaced_init = false) = 0;
+                              THREAD_ID tid) = 0;
   virtual void
   reinitElemFace(const Elem * elem, unsigned int side, BoundaryID bnd_id, THREAD_ID tid) = 0;
   virtual void reinitLowerDElem(const Elem * lower_d_elem,

--- a/framework/include/problems/SubProblem.h
+++ b/framework/include/problems/SubProblem.h
@@ -781,6 +781,11 @@ public:
    */
   virtual bool computingScalingResidual() const = 0;
 
+  /**
+   * Clear dof indices from variables in nl and aux systems
+   */
+  void clearAllDofIndices();
+
 protected:
   /**
    * Helper function called by getVariable that handles the logic for

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -872,6 +872,11 @@ public:
   virtual void residualSetup();
   virtual void jacobianSetup();
 
+  /**
+   * Clear all dof indices from moose variables
+   */
+  void clearAllDofIndices();
+
 protected:
   /**
    * Internal getter for solution owned by libMesh.

--- a/framework/include/variables/MooseVariableBase.h
+++ b/framework/include/variables/MooseVariableBase.h
@@ -156,6 +156,8 @@ public:
 
   void initialSetup() override;
 
+  virtual void clearAllDofIndices() { _dof_indices.clear(); }
+
 protected:
   /// System this variable is part of
   SystemBase & _sys;

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -186,6 +186,8 @@ public:
     return _lower_data->dofIndices();
   }
 
+  void clearAllDofIndices() final;
+
   unsigned int numberOfDofsNeighbor() override { return _neighbor_data->dofIndices().size(); }
 
   const FieldVariablePhiValue & phi() const override { return _element_data->phi(); }

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -209,6 +209,8 @@ public:
     return _neighbor_data->dofIndices();
   }
 
+  void clearAllDofIndices() final;
+
   const FieldVariableValue & vectorTagValue(TagID tag)
   {
     return _element_data->vectorTagValue(tag);

--- a/framework/include/variables/VariableWarehouse.h
+++ b/framework/include/variables/VariableWarehouse.h
@@ -180,6 +180,11 @@ public:
    */
   void jacobianSetup();
 
+  /**
+   * Clear all dof indices from each variable
+   */
+  void clearAllDofIndices();
+
 protected:
   /// list of variable names
   std::vector<VariableName> _names;

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -617,9 +617,11 @@ DisplacedProblem::reinitElem(const Elem * elem, THREAD_ID tid)
 void
 DisplacedProblem::reinitElemPhys(const Elem * elem,
                                  const std::vector<Point> & phys_points_in_elem,
-                                 THREAD_ID tid,
-                                 bool)
+                                 THREAD_ID tid)
 {
+  mooseAssert(_mesh.getMesh().query_elem_ptr(elem->id()) == elem,
+              "Are you calling this method with a undisplaced mesh element?");
+
   _assembly[tid]->reinitAtPhysical(elem, phys_points_in_elem);
 
   _displaced_nl.prepare(tid);
@@ -709,6 +711,9 @@ DisplacedProblem::reinitNeighborPhys(const Elem * neighbor,
                                      const std::vector<Point> & physical_points,
                                      THREAD_ID tid)
 {
+  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+              "Are you calling this method with a undisplaced mesh element?");
+
   // Reinit shape functions
   _assembly[tid]->reinitNeighborAtPhysical(neighbor, neighbor_side, physical_points);
 
@@ -728,6 +733,9 @@ DisplacedProblem::reinitNeighborPhys(const Elem * neighbor,
                                      const std::vector<Point> & physical_points,
                                      THREAD_ID tid)
 {
+  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+              "Are you calling this method with a undisplaced mesh element?");
+
   // Reinit shape functions
   _assembly[tid]->reinitNeighborAtPhysical(neighbor, physical_points);
 

--- a/framework/src/problems/DisplacedProblem.C
+++ b/framework/src/problems/DisplacedProblem.C
@@ -619,7 +619,7 @@ DisplacedProblem::reinitElemPhys(const Elem * elem,
                                  const std::vector<Point> & phys_points_in_elem,
                                  THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(elem->id()) == elem,
+  mooseAssert(_mesh.queryElemPtr(elem->id()) == elem,
               "Are you calling this method with a undisplaced mesh element?");
 
   _assembly[tid]->reinitAtPhysical(elem, phys_points_in_elem);
@@ -711,7 +711,7 @@ DisplacedProblem::reinitNeighborPhys(const Elem * neighbor,
                                      const std::vector<Point> & physical_points,
                                      THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+  mooseAssert(_mesh.queryElemPtr(neighbor->id()) == neighbor,
               "Are you calling this method with a undisplaced mesh element?");
 
   // Reinit shape functions
@@ -733,7 +733,7 @@ DisplacedProblem::reinitNeighborPhys(const Elem * neighbor,
                                      const std::vector<Point> & physical_points,
                                      THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+  mooseAssert(_mesh.queryElemPtr(neighbor->id()) == neighbor,
               "Are you calling this method with a undisplaced mesh element?");
 
   // Reinit shape functions

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1736,7 +1736,7 @@ FEProblemBase::reinitElemPhys(const Elem * elem,
                               const std::vector<Point> & phys_points_in_elem,
                               THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(elem->id()) == elem,
+  mooseAssert(_mesh.queryElemPtr(elem->id()) == elem,
               "Are you calling this method with a displaced mesh element?");
 
   _assembly[tid]->reinitAtPhysical(elem, phys_points_in_elem);
@@ -1885,7 +1885,7 @@ FEProblemBase::reinitNeighborPhys(const Elem * neighbor,
                                   const std::vector<Point> & physical_points,
                                   THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+  mooseAssert(_mesh.queryElemPtr(neighbor->id()) == neighbor,
               "Are you calling this method with a displaced mesh element?");
 
   // Reinits shape the functions at the physical points
@@ -1908,7 +1908,7 @@ FEProblemBase::reinitNeighborPhys(const Elem * neighbor,
                                   const std::vector<Point> & physical_points,
                                   THREAD_ID tid)
 {
-  mooseAssert(_mesh.getMesh().query_elem_ptr(neighbor->id()) == neighbor,
+  mooseAssert(_mesh.queryElemPtr(neighbor->id()) == neighbor,
               "Are you calling this method with a displaced mesh element?");
 
   // Reinits shape the functions at the physical points
@@ -4992,6 +4992,8 @@ FEProblemBase::solve()
 {
   TIME_SECTION(_solve_timer);
 
+  // This prevents stale dof indices from lingering around and possibly leading to invalid reads and
+  // writes. Dof indices may be made stale through operations like mesh adaptivity
   clearAllDofIndices();
   if (_displaced_problem)
     _displaced_problem->clearAllDofIndices();

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -4992,6 +4992,10 @@ FEProblemBase::solve()
 {
   TIME_SECTION(_solve_timer);
 
+  clearAllDofIndices();
+  if (_displaced_problem)
+    _displaced_problem->clearAllDofIndices();
+
 #ifdef LIBMESH_HAVE_PETSC
 #if PETSC_RELEASE_LESS_THAN(3, 12, 0)
   Moose::PetscSupport::petscSetOptions(*this); // Make sure the PETSc options are setup for this app

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -1019,3 +1019,10 @@ SubProblem::hasScalingVector()
     assembly(tid).hasScalingVector();
 }
 #endif
+
+void
+SubProblem::clearAllDofIndices()
+{
+  systemBaseNonlinear().clearAllDofIndices();
+  systemBaseAuxiliary().clearAllDofIndices();
+}

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -981,9 +981,10 @@ NonlinearSystemBase::setConstraintSecondaryValues(NumericVector<Number> & soluti
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
-  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
-              "If we're calling this method with displaced = true, then we better well have a "
-              "displaced problem");
+  if (displaced)
+    mooseAssert(_fe_problem.getDisplacedProblem(),
+                "If we're calling this method with displaced = true, then we better well have a "
+                "displaced problem");
   auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
                                 : static_cast<SubProblem &>(_fe_problem);
 
@@ -1121,9 +1122,10 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
-  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
-              "If we're calling this method with displaced = true, then we better well have a "
-              "displaced problem");
+  if (displaced)
+    mooseAssert(_fe_problem.getDisplacedProblem(),
+                "If we're calling this method with displaced = true, then we better well have a "
+                "displaced problem");
   auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
                                 : static_cast<SubProblem &>(_fe_problem);
 
@@ -1864,9 +1866,10 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
-  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
-              "If we're calling this method with displaced = true, then we better well have a "
-              "displaced problem");
+  if (displaced)
+    mooseAssert(_fe_problem.getDisplacedProblem(),
+                "If we're calling this method with displaced = true, then we better well have a "
+                "displaced problem");
   auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
                                 : static_cast<SubProblem &>(_fe_problem);
 

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -981,6 +981,12 @@ NonlinearSystemBase::setConstraintSecondaryValues(NumericVector<Number> & soluti
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
+  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
+              "If we're calling this method with displaced = true, then we better well have a "
+              "displaced problem");
+  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : static_cast<SubProblem &>(_fe_problem);
+
   if (!displaced)
   {
     GeometricSearchData & geom_search_data = _fe_problem.geomSearchData();
@@ -1032,7 +1038,7 @@ NonlinearSystemBase::setConstraintSecondaryValues(NumericVector<Number> & soluti
 
             // reinit variables on the primary element's face at the contact point
             _fe_problem.setNeighborSubdomainID(primary_elem, 0);
-            _fe_problem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
+            subproblem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
 
             for (const auto & nfc : constraints)
               if (nfc->shouldApply())
@@ -1115,6 +1121,12 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
+  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
+              "If we're calling this method with displaced = true, then we better well have a "
+              "displaced problem");
+  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : static_cast<SubProblem &>(_fe_problem);
+
   if (!displaced)
   {
     GeometricSearchData & geom_search_data = _fe_problem.geomSearchData();
@@ -1178,7 +1190,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
 
             // reinit variables on the primary element's face at the contact point
             _fe_problem.setNeighborSubdomainID(primary_elem, 0);
-            _fe_problem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
+            subproblem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
 
             for (const auto & nfc : constraints)
               if (nfc->shouldApply())
@@ -1306,9 +1318,9 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
         for (const auto & ec : _element_constraints)
         {
           _fe_problem.setCurrentSubdomainID(elem1, tid);
-          _fe_problem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
+          subproblem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
           _fe_problem.setNeighborSubdomainID(elem2, tid);
-          _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
+          subproblem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
           ec->prepareShapes(ec->variable().number());
           ec->prepareNeighborShapes(ec->variable().number());
@@ -1852,6 +1864,12 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
   std::map<std::pair<unsigned int, unsigned int>, PenetrationLocator *> * penetration_locators =
       NULL;
 
+  mooseAssert(displaced ? bool(_fe_problem.getDisplacedProblem().get()) : true,
+              "If we're calling this method with displaced = true, then we better well have a "
+              "displaced problem");
+  auto & subproblem = displaced ? static_cast<SubProblem &>(*_fe_problem.getDisplacedProblem())
+                                : static_cast<SubProblem &>(_fe_problem);
+
   if (!displaced)
   {
     GeometricSearchData & geom_search_data = _fe_problem.geomSearchData();
@@ -1911,7 +1929,7 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
 
             // reinit variables on the primary element's face at the contact point
             _fe_problem.setNeighborSubdomainID(primary_elem, 0);
-            _fe_problem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
+            subproblem.reinitNeighborPhys(primary_elem, primary_side, points, 0);
             for (const auto & nfc : constraints)
             {
               nfc->_jacobian = &jacobian;
@@ -2123,9 +2141,9 @@ NonlinearSystemBase::constraintJacobians(bool displaced)
         for (const auto & ec : _element_constraints)
         {
           _fe_problem.setCurrentSubdomainID(elem1, tid);
-          _fe_problem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
+          subproblem.reinitElemPhys(elem1, info._elem1_constraint_q_point, tid);
           _fe_problem.setNeighborSubdomainID(elem2, tid);
-          _fe_problem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
+          subproblem.reinitNeighborPhys(elem2, info._elem2_constraint_q_point, tid);
 
           ec->prepareShapes(ec->variable().number());
           ec->prepareNeighborShapes(ec->variable().number());

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1552,8 +1552,8 @@ SystemBase::jacobianSetup()
 void
 SystemBase::clearAllDofIndices()
 {
-  for (const auto tid : make_range(libMesh::n_threads()))
-    _vars[tid].clearAllDofIndices();
+  for (auto & var_warehouse : _vars)
+    var_warehouse.clearAllDofIndices();
 }
 
 template MooseVariableFE<Real> & SystemBase::getFieldVariable<Real>(THREAD_ID tid,

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1549,6 +1549,13 @@ SystemBase::jacobianSetup()
     _vars[tid].jacobianSetup();
 }
 
+void
+SystemBase::clearAllDofIndices()
+{
+  for (const auto tid : make_range(libMesh::n_threads()))
+    _vars[tid].clearAllDofIndices();
+}
+
 template MooseVariableFE<Real> & SystemBase::getFieldVariable<Real>(THREAD_ID tid,
                                                                     const std::string & var_name);
 

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -813,6 +813,15 @@ MooseVariableFE<OutputType>::oldestSolutionStateRequested() const
   return state;
 }
 
+template <typename OutputType>
+void
+MooseVariableFE<OutputType>::clearAllDofIndices()
+{
+  _element_data->clearDofIndices();
+  _neighbor_data->clearDofIndices();
+  _lower_data->clearDofIndices();
+}
+
 template class MooseVariableFE<Real>;
 template class MooseVariableFE<RealVectorValue>;
 template class MooseVariableFE<RealEigenVector>;

--- a/framework/src/variables/MooseVariableFV.C
+++ b/framework/src/variables/MooseVariableFV.C
@@ -984,6 +984,14 @@ MooseVariableFV<OutputType>::oldestSolutionStateRequested() const
   return state;
 }
 
+template <typename OutputType>
+void
+MooseVariableFV<OutputType>::clearAllDofIndices()
+{
+  _element_data->clearDofIndices();
+  _neighbor_data->clearDofIndices();
+}
+
 template class MooseVariableFV<Real>;
 // TODO: implement vector fv variable support. This will require some template
 // specializations for various member functions in this and the FV variable

--- a/framework/src/variables/VariableWarehouse.C
+++ b/framework/src/variables/VariableWarehouse.C
@@ -269,6 +269,13 @@ VariableWarehouse::residualSetup()
     pair.second->residualSetup();
 }
 
+void
+VariableWarehouse::clearAllDofIndices()
+{
+  for (auto * var : _vars)
+    var->clearAllDofIndices();
+}
+
 template MooseVariableField<Real> *
 VariableWarehouse::getActualFieldVariable<Real>(const std::string & var_name);
 template MooseVariableField<Real> *

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1434,7 +1434,7 @@ FeatureFloodCount::isNewFeatureOrConnectedRegion(const DofObject * dof_object,
   {
     const Elem * elem = static_cast<const Elem *>(dof_object);
     std::vector<Point> centroid(1, elem->centroid());
-    _subproblem.reinitElemPhys(elem, centroid, 0, /* suppress_displaced_init = */ true);
+    _subproblem.reinitElemPhys(elem, centroid, 0);
     entity_value = _vars[current_index]->sln()[0];
   }
   else

--- a/modules/phase_field/src/postprocessors/GrainTracker.C
+++ b/modules/phase_field/src/postprocessors/GrainTracker.C
@@ -1579,7 +1579,7 @@ GrainTracker::updateFieldInfo()
         }
         else
         {
-          _fe_problem.reinitElemPhys(elem, centroid, 0, /* suppress_displaced_init = */ true);
+          _fe_problem.reinitElemPhys(elem, centroid, 0);
           entity_value = _vars[curr_var]->sln()[0];
         }
       }


### PR DESCRIPTION
Right now when someone calls `FEProblemBase::reinitElemPhys` with a
vector of physical points, we will attempt to invert those physical
points into the reference element space for both undisplaced and
displaced meshes if the latter exists. It is not difficult to imagine
that for a given set of physical points you may easily fall off the
displaced mesh for large enough displacements/deformations. Let's see if
this makes anything fail

Refs #10823 
