### PR TITLE
Protect seeding of derivative vector in getElemValue

### DIFF
--- a/framework/src/variables/MooseVariableFV.C
+++ b/framework/src/variables/MooseVariableFV.C
@@ -509,7 +509,7 @@ MooseVariableFV<OutputType>::getElemValue(const Elem * const elem) const
 
   ADReal value = (*_solution)(index);
 
-  if (ADReal::do_derivatives)
+  if (ADReal::do_derivatives && _var_kind == Moose::VAR_NONLINEAR)
     Moose::derivInsert(value.derivatives(), index, 1.);
 
   return value;


### PR DESCRIPTION
This will help maintain the integrity of the AD-computed Jacobian if
users use aux variables in their residual computations.

Closes #17375