### PR TITLE
Fix -Wunused-result warning

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1173,7 +1173,9 @@ MooseApp::run()
       if (binname == "")
         mooseError("could not locate installed tests to run (unresolved binary/app name)");
       auto dir = MooseUtils::testsDir(binname);
-      chdir(dir.c_str());
+      int ret = chdir(dir.c_str());
+      if (ret != 0)
+        mooseError("Failed to change to testsDir ", dir);
     }
     int ret = system(cmd.c_str());
     if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)


### PR DESCRIPTION
With GCC 10.2 I get a warning if we don't test the return value of a
chdir() attempt.

Refs #10733