### PR TITLE
Compute strain energy rate density in a parent class

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADAnisotropicReturnCreepStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/ADAnisotropicReturnCreepStressUpdateBase.h
@@ -22,20 +22,6 @@ public:
 
   ADAnisotropicReturnCreepStressUpdateBase(const InputParameters & parameters);
 
-  /**
-   * Compute the strain energy rate density for this inelastic model for the current step.
-   * @param stress The stress tensor at the end of the step
-   * @param strain_rate The strain rate at the end of the step
-   * @return The computed strain energy rate density
-   */
-  virtual Real
-  computeStrainEnergyRateDensity(const ADMaterialProperty<RankTwoTensor> & /*stress*/,
-                                 const ADMaterialProperty<RankTwoTensor> & /*strain_rate*/)
-  {
-    mooseError(
-        "The computation of strain energy rate density needs to be implemented by a child class");
-  }
-
 protected:
   virtual void initQpStatefulProperties() override;
   virtual void propagateQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/materials/ADAnisotropicReturnPlasticityStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/ADAnisotropicReturnPlasticityStressUpdateBase.h
@@ -22,16 +22,6 @@ public:
 
   ADAnisotropicReturnPlasticityStressUpdateBase(const InputParameters & parameters);
 
-  /**
-   * Compute the strain energy rate density for this inelastic model for the current step.
-   * @param stress The stress tensor at the end of the step
-   * @param strain_rate The strain rate at the end of the step
-   * @return The computed strain energy rate density
-   */
-  virtual Real
-  computeStrainEnergyRateDensity(const ADMaterialProperty<RankTwoTensor> & stress,
-                                 const ADMaterialProperty<RankTwoTensor> & strain_rate) = 0;
-
 protected:
   virtual void initQpStatefulProperties() override;
   virtual void propagateQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/materials/ADHillCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADHillCreepStressUpdate.h
@@ -34,10 +34,6 @@ public:
 
   ADHillCreepStressUpdate(const InputParameters & parameters);
 
-  virtual Real
-  computeStrainEnergyRateDensity(const ADMaterialProperty<RankTwoTensor> & stress,
-                                 const ADMaterialProperty<RankTwoTensor> & strain_rate) override;
-
 protected:
   virtual void computeStressInitialize(const ADDenseVector & stress_dev,
                                        const ADDenseVector & stress,

--- a/modules/tensor_mechanics/include/materials/ADHillPlasticityStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADHillPlasticityStressUpdate.h
@@ -25,10 +25,6 @@ public:
 
   ADHillPlasticityStressUpdate(const InputParameters & parameters);
 
-  virtual Real
-  computeStrainEnergyRateDensity(const ADMaterialProperty<RankTwoTensor> & stress,
-                                 const ADMaterialProperty<RankTwoTensor> & strain_rate) override;
-
 protected:
   virtual void computeStressInitialize(const ADDenseVector & stress_dev,
                                        const ADDenseVector & stress,

--- a/modules/tensor_mechanics/include/materials/ADPowerLawCreepStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADPowerLawCreepStressUpdate.h
@@ -28,7 +28,7 @@ public:
 
   ADPowerLawCreepStressUpdate(const InputParameters & parameters);
 
-  virtual ADReal
+  virtual Real
   computeStrainEnergyRateDensity(const ADMaterialProperty<RankTwoTensor> & stress,
                                  const ADMaterialProperty<RankTwoTensor> & strain_rate) override;
 

--- a/modules/tensor_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/RadialReturnCreepStressUpdateBase.h
@@ -27,20 +27,6 @@ public:
   using RadialReturnStressUpdateTempl<is_ad>::propagateQpStatefulPropertiesRadialReturn;
   using SingleVariableReturnMappingSolutionTempl<is_ad>::computeDerivative;
 
-  /**
-   * Compute the strain energy rate density for this inelastic model for the current step.
-   * @param stress The stress tensor at the end of the step
-   * @param strain_rate The strain rate at the end of the step
-   * @return The computed strain energy rate density
-   */
-  virtual GenericReal<is_ad> computeStrainEnergyRateDensity(
-      const GenericMaterialProperty<RankTwoTensor, is_ad> & /*stress*/,
-      const GenericMaterialProperty<RankTwoTensor, is_ad> & /*strain_rate*/)
-  {
-    mooseError(
-        "The computation of strain energy rate density needs to be implemented by a child class");
-  }
-
 protected:
   virtual void initQpStatefulProperties() override;
   virtual void propagateQpStatefulProperties() override;

--- a/modules/tensor_mechanics/include/materials/StrainEnergyRateDensity.h
+++ b/modules/tensor_mechanics/include/materials/StrainEnergyRateDensity.h
@@ -17,11 +17,8 @@
 
 // select the appropriate class based on the is_ad boolean parameter
 template <bool is_ad>
-using GenericRadialReturnCreepStressUpdateBase =
-    typename std::conditional<is_ad,
-                              ADRadialReturnCreepStressUpdateBase,
-                              RadialReturnCreepStressUpdateBase>::type;
-
+using GenericStressUpdateBase =
+    typename std::conditional<is_ad, ADStressUpdateBase, StressUpdateBase>::type;
 /**
  * StrainEnergyRateDensity calculates the strain energy rate density.
  */
@@ -54,7 +51,7 @@ private:
   const unsigned _num_models;
 
   /// The user supplied list of inelastic models to compute the strain energy release rate
-  std::vector<GenericRadialReturnCreepStressUpdateBase<is_ad> *> _inelastic_models;
+  std::vector<GenericStressUpdateBase<is_ad> *> _inelastic_models;
 };
 
 typedef StrainEnergyRateDensityTempl<false> StrainEnergyRateDensity;

--- a/modules/tensor_mechanics/include/materials/StressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/StressUpdateBase.h
@@ -157,6 +157,21 @@ public:
    */
   virtual void storeIncrementalMaterialProperties(){};
 
+  /**
+   * Compute the strain energy rate density for this inelastic model for the current step.
+   * @param stress The stress tensor at the end of the step
+   * @param strain_rate The strain rate at the end of the step
+   * @return The computed strain energy rate density
+   */
+  virtual Real computeStrainEnergyRateDensity(
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & /*stress*/,
+      const GenericMaterialProperty<RankTwoTensor, is_ad> & /*strain_rate*/)
+  {
+    mooseError(
+        "The computation of strain energy rate density needs to be implemented by a child class");
+    return 0.0;
+  }
+
 protected:
   /// Name used as a prefix for all material properties related to the stress update model.
   const std::string _base_name;

--- a/modules/tensor_mechanics/src/materials/ADHillCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADHillCreepStressUpdate.C
@@ -267,12 +267,3 @@ ADHillCreepStressUpdate::computeStressFinalize(const ADRankTwoTensor & creepStra
   else
     _max_integration_error_time_step = std::numeric_limits<Real>::max();
 }
-
-Real
-ADHillCreepStressUpdate::computeStrainEnergyRateDensity(
-    const ADMaterialProperty<RankTwoTensor> & /*stress*/,
-    const ADMaterialProperty<RankTwoTensor> & /*strain_rate*/)
-{
-  mooseError("computeStrainEnergyRateDensity not implemented for anisotropic creep.");
-  return 0.0;
-}

--- a/modules/tensor_mechanics/src/materials/ADHillPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADHillPlasticityStressUpdate.C
@@ -343,12 +343,3 @@ ADHillPlasticityStressUpdate::computeStressFinalize(
   ADReal omega = computeOmega(delta_gamma, _stress_np1);
   _hardening_variable[_qp] = computeHardeningValue(delta_gamma, omega);
 }
-
-Real
-ADHillPlasticityStressUpdate::computeStrainEnergyRateDensity(
-    const ADMaterialProperty<RankTwoTensor> & /*stress*/,
-    const ADMaterialProperty<RankTwoTensor> & /*strain_rate*/)
-{
-  mooseError("computeStrainEnergyRateDensity not implemented for anisotropic creep.");
-  return 0.0;
-}

--- a/modules/tensor_mechanics/src/materials/ADPowerLawCreepStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADPowerLawCreepStressUpdate.C
@@ -79,7 +79,7 @@ ADPowerLawCreepStressUpdate::computeDerivative(const ADReal & effective_trial_st
   return creep_rate_derivative * _dt - 1.0;
 }
 
-ADReal
+Real
 ADPowerLawCreepStressUpdate::computeStrainEnergyRateDensity(
     const ADMaterialProperty<RankTwoTensor> & stress,
     const ADMaterialProperty<RankTwoTensor> & strain_rate)
@@ -89,7 +89,7 @@ ADPowerLawCreepStressUpdate::computeStrainEnergyRateDensity(
 
   Real creep_factor = _n_exponent / (_n_exponent + 1);
 
-  return creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]);
+  return MetaPhysicL::raw_value(creep_factor * stress[_qp].doubleContraction((strain_rate)[_qp]));
 }
 
 bool

--- a/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
+++ b/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
@@ -47,12 +47,11 @@ StrainEnergyRateDensityTempl<is_ad>::StrainEnergyRateDensityTempl(
 
   std::vector<MaterialName> models = getParam<std::vector<MaterialName>>("inelastic_models");
 
-  // Store inelastic models as generic RadialreturnCreepStressUpdateBase.
+  // Store inelastic models as generic StressUpdateBase.
   for (unsigned int i = 0; i < _num_models; ++i)
   {
-    GenericRadialReturnCreepStressUpdateBase<is_ad> * inelastic_model_stress_update =
-        dynamic_cast<GenericRadialReturnCreepStressUpdateBase<is_ad> *>(
-            &getMaterialByName(models[i]));
+    GenericStressUpdateBase<is_ad> * inelastic_model_stress_update =
+        dynamic_cast<GenericStressUpdateBase<is_ad> *>(&getMaterialByName(models[i]));
 
     if (inelastic_model_stress_update)
       _inelastic_models.push_back(inelastic_model_stress_update);


### PR DESCRIPTION
`StressUpdateBase` now handles the computation of strain energy rate density, therefore, the functionality that relies on this computation can work on constitutive laws that do not inherit from our RadialReturn classes.

It should not have any side effect other than enabling more general use of the strain energy rate densities. This can be especially relevant when using constitutive laws from external libraries that use `StressUpdateBase` as the entry point.

Refs. #15517