### PR TITLE
Allow multiple element sides on same sideset for elemental boundary auxkernel

### DIFF
--- a/framework/include/auxkernels/AuxKernel.h
+++ b/framework/include/auxkernels/AuxKernel.h
@@ -180,6 +180,16 @@ protected:
    */
   const typename OutputTools<ComputeValueType>::VariableValue & uOlder() const;
 
+  /**
+   * Whether or not to check for repeated element sides on the sideset to which
+   * the auxkernel is restricted (if boundary restricted _and_ elemental). Setting
+   * this to false will allow an element with more than one face on the boundary
+   * to which it is restricted allow contribution to the element's value(s). This
+   * flag allows auxkernels that evaluate boundary-restricted elemental auxvariables
+   * to have more than one element face on the boundary of interest.
+   */
+  const bool & _check_boundary_restricted;
+
   /// Subproblem this kernel is part of
   SubProblem & _subproblem;
   /// System this kernel is part of

--- a/test/tests/auxkernels/element_aux_boundary/tests
+++ b/test/tests/auxkernels/element_aux_boundary/tests
@@ -24,4 +24,12 @@
     issues = '#5061'
     design = 'syntax/AuxKernels/index.md'
   [../]
+  [./boundary_unrestricted_error_test]
+    type = RunApp
+    input = 'high_order_boundary_aux.i'
+    cli_args = "AuxKernels/real_property/boundary='0 1' AuxKernels/real_property/check_boundary_restricted=false --color off"
+    requirement = "MOOSE shall allow skipping error if a boundary restricted elemental auxiliary kernel is evaluated on an element with multiple boundary sides"
+    issues = '#17424'
+    design = 'syntax/AuxKernels/index.md'
+  [../]
 []

--- a/test/tests/auxkernels/element_aux_boundary/tests
+++ b/test/tests/auxkernels/element_aux_boundary/tests
@@ -28,7 +28,7 @@
     type = RunApp
     input = 'high_order_boundary_aux.i'
     cli_args = "AuxKernels/real_property/boundary='0 1' AuxKernels/real_property/check_boundary_restricted=false --color off"
-    requirement = "MOOSE shall allow skipping error if a boundary restricted elemental auxiliary kernel is evaluated on an element with multiple boundary sides"
+    requirement = "The system shall allow a boundary restricted elemental auxiliary kernel to be evaluated on an element with multiple boundary sides by setting an input parameter."
     issues = '#17424'
     design = 'syntax/AuxKernels/index.md'
   [../]

--- a/test/tests/auxkernels/element_aux_boundary/tests
+++ b/test/tests/auxkernels/element_aux_boundary/tests
@@ -31,5 +31,6 @@
     requirement = "The system shall allow a boundary restricted elemental auxiliary kernel to be evaluated on an element with multiple boundary sides by setting an input parameter."
     issues = '#17424'
     design = 'syntax/AuxKernels/index.md'
+    prereq = 'ho_boundary_restricted_test'
   [../]
 []


### PR DESCRIPTION
This PR adds a flag that lets you skip the error check that an element doesn't have more than one side on a boundary for boundary-restricted elemental auxkernels. Open to other name ideas for this flag!

Closes #17424