### PR TITLE
add --copy-tests flag for copying installed tests to curr dir.

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -453,8 +453,8 @@ $(binlink): all install_$(APPLICATION_NAME)_tests
 
 install_$(APPLICATION_NAME)_docs:
 	@echo "Installing docs"
-	@mkdir -p $(docs_install_dir)
-	@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
+	#@mkdir -p $(docs_install_dir)
+	#@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
 
 $(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests install_$(APPLICATION_NAME)_docs $(binlink)
 	@echo "Installing $<"

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -453,8 +453,8 @@ $(binlink): all install_$(APPLICATION_NAME)_tests
 
 install_$(APPLICATION_NAME)_docs:
 	@echo "Installing docs"
-	#@mkdir -p $(docs_install_dir)
-	#@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
+	@mkdir -p $(docs_install_dir)
+	@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
 
 $(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests install_$(APPLICATION_NAME)_docs $(binlink)
 	@echo "Installing $<"

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -90,7 +90,10 @@ public:
   virtual std::string appBinaryName() const
   {
     auto name = Moose::getExecutableName();
-    return name.substr(0, name.find_last_of("-"));
+    name = name.substr(0, name.find_last_of("-"));
+    if (name.find_first_of("/") != std::string::npos)
+      name = name.substr(name.find_first_of("/") + 1, std::string::npos);
+    return name;
   }
 
   /**

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -83,9 +83,20 @@ pathjoin(const std::string & s, Args... args)
   return s + "/" + pathjoin(args...);
 }
 
+/// Returns the location of either a local repo run_tests script - or an
+/// installed test runner script if run_tests isn't found.
 std::string runTestsExecutable();
+
+/// Searches in the current working directory and then recursively up in each
+/// parent directory looking for a "testroot" file.  Returns the full path to
+/// the first testroot file found.
 std::string findTestRoot();
-std::string testsDir(const std::string & app_name);
+
+/// Returns the directory of any installed tests - or the empty string if none
+/// are found.
+std::string installedTestsDir(const std::string & app_name);
+
+/// Returns the directory of any installed docs/site.
 std::string docsDir(const std::string & app_name);
 
 /// Replaces all occurences of from in str with to and returns the result.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1170,7 +1170,9 @@ MooseApp::run()
     auto src_dir = MooseUtils::testsDir(binname);
     if (!MooseUtils::checkFileReadable(src_dir, false, false))
       mooseError(
-          "You don't have permissions to read/copy tests from their current installed location.");
+          "You don't have permissions to read/copy tests from their current installed location: \"",
+          src_dir,
+          "\"");
     auto dst_dir = binname + "_tests";
     auto cmdname = Moose::getExecutableName();
     if (cmdname.find_first_of("/") != std::string::npos)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1180,7 +1180,7 @@ MooseApp::run()
                  dst_dir,
                  "\" already exists.\nTo update/recopy tests, rename (\"mv ",
                  dst_dir,
-                 " new_dir_name\") or remove (\"rm ",
+                 " new_dir_name\") or remove (\"rm -r ",
                  dst_dir,
                  "\") the existing directory.\nThen re-run \"",
                  cmdname,

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1167,7 +1167,9 @@ MooseApp::run()
     auto binname = appBinaryName();
     if (binname == "")
       mooseError("could not locate installed tests to run (unresolved binary/app name)");
-    auto src_dir = MooseUtils::testsDir(binname);
+    auto src_dir = MooseUtils::installedTestsDir(binname);
+    if (src_dir == "")
+      mooseError("couldn't locate any installed tests to copy");
     if (!MooseUtils::checkFileReadable(src_dir, false, false))
       mooseError(
           "You don't have permissions to read/copy tests from their current installed location: \"",
@@ -1209,7 +1211,9 @@ MooseApp::run()
       auto binname = appBinaryName();
       if (binname == "")
         mooseError("could not locate installed tests to run (unresolved binary/app name)");
-      auto dir = MooseUtils::testsDir(binname);
+      auto dir = MooseUtils::installedTestsDir(binname);
+      if (dir == "")
+        mooseError("no could not find any tests to run");
 
       auto cmdname = Moose::getExecutableName();
       if (cmdname.find_first_of("/") != std::string::npos)
@@ -1226,7 +1230,7 @@ MooseApp::run()
 
       int ret = chdir(dir.c_str());
       if (ret != 0)
-        mooseError("Failed to change to testsDir ", dir);
+        mooseError("Failed to change to testing directory ", dir);
     }
     int ret = system(cmd.c_str());
     if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1162,7 +1162,7 @@ MooseApp::run()
     return;
   }
 
-  if (isParamValid("copy_tests") && getParam<bool>("copy_tests"))
+  if (getParam<bool>("copy_tests"))
   {
     auto binname = appBinaryName();
     if (binname == "")
@@ -1170,7 +1170,7 @@ MooseApp::run()
     auto src_dir = MooseUtils::testsDir(binname);
     if (!MooseUtils::checkFileReadable(src_dir, false, false))
       mooseError(
-          "You don't have permissions to read/copy tests at their current installed location.");
+          "You don't have permissions to read/copy tests from their current installed location.");
     auto dst_dir = binname + "_tests";
     auto cmdname = Moose::getExecutableName();
     if (cmdname.find_first_of("/") != std::string::npos)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -247,7 +247,7 @@ checkFileReadable(const std::string & filename, bool check_line_endings, bool th
 bool
 checkFileWriteable(const std::string & filename, bool throw_on_unwritable)
 {
-  std::ofstream out(filename.c_str(), std::ofstream::out);
+  std::ofstream out(filename.c_str(), std::ios_base::app);
   if (out.fail())
   {
     if (throw_on_unwritable)

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -81,14 +81,14 @@ findTestRoot()
 }
 
 std::string
-testsDir(const std::string & app_name)
+installedTestsDir(const std::string & app_name)
 {
   std::string installed_path = pathjoin(Moose::getExecutablePath(), "../share", app_name, "test");
 
   auto testroot = pathjoin(installed_path, "testroot");
   if (pathExists(testroot) && checkFileReadable(testroot))
     return installed_path;
-  return Moose::getExecutablePath();
+  return "";
 }
 
 std::string


### PR DESCRIPTION
This is necessary for people with only level-1 access to various moose
apps/codes - the tests will be installed into a location where they
don't have write access - so the test harness can't run them there.
Running this flag copies the installed tests out to an appname_tests dir
that users can cd into and then run them.

ref #16411

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
