### PR TITLE
Let DerivativeParsedMaterial properly initQpStatefulProperties

### DIFF
--- a/framework/src/materials/DerivativeParsedMaterialHelper.C
+++ b/framework/src/materials/DerivativeParsedMaterialHelper.C
@@ -221,11 +221,7 @@ template <bool is_ad>
 void
 DerivativeParsedMaterialHelperTempl<is_ad>::initQpStatefulProperties()
 {
-  if (_prop_F)
-    (*_prop_F)[_qp] = 0.0;
-
-  for (auto & D : _derivatives)
-    (*D._mat_prop)[_qp] = 0.0;
+  computeQpProperties();
 }
 
 template <bool is_ad>

--- a/framework/src/materials/ParsedMaterialHelper.C
+++ b/framework/src/materials/ParsedMaterialHelper.C
@@ -196,8 +196,7 @@ template <bool is_ad>
 void
 ParsedMaterialHelper<is_ad>::initQpStatefulProperties()
 {
-  if (_prop_F)
-    (*_prop_F)[_qp] = 0.0;
+  computeQpProperties();
 }
 
 template <bool is_ad>


### PR DESCRIPTION
close #17430

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
