### PR TITLE
Add Parameter to Enable Final Jacobian Testing

### DIFF
--- a/modules/tensor_mechanics/test/tests/ad_anisotropic_creep/tests
+++ b/modules/tensor_mechanics/test/tests/ad_anisotropic_creep/tests
@@ -51,6 +51,20 @@
     rel_err = 1.0e-5
     abs_zero = 1.0e-8
   []
+  [jac]
+    type = 'PetscJacobianTester'
+    input = 'ad_aniso_iso_creep_x_3d.i'
+    run_sim = 'True'
+    cli_args = "Executioner/num_steps=2 Outputs/active='' -snes_test_err 1e-12 "
+               "Materials/elastic_strain/inelastic_models='trial_creep_iso' "
+               "Materials/inactive='trial_creep_aniso_iso' Materials/elasticity_tensor/poissons_ratio=0.25"
+    petsc_version = '>=3.9'
+    ratio_tol = 0.0054
+    difference_tol = 0.1
+    only_final_jacobian = 'True'
+    issues = '#17456'
+    requirement = 'The system shall provide a perfect Jacobian while calculating large deformation creep.'
+  []
   [ad_aniso_iso_aniso]
     type = 'CSVDiff'
     input = 'ad_aniso_iso_creep_x_3d.i'

--- a/python/TestHarness/testers/PetscJacobianTester.py
+++ b/python/TestHarness/testers/PetscJacobianTester.py
@@ -26,6 +26,7 @@ class PetscJacobianTester(RunApp):
                                           "at every non-linear iteration of every time step. This is only "
                                           "relevant for petsc versions >= 3.9.")
         params.addParam('turn_off_exodus_output', True, "Whether to set exodus=false in Outputs")
+        params.addParam('only_final_jacobian', False, "Check only final Jacobian comparison.")
 
         # override default values
         params.valid['valgrind'] = 'NONE'
@@ -130,8 +131,8 @@ class PetscJacobianTester(RunApp):
                     reason = ''
                 else:
                     reason = 'INCORRECT JACOBIAN'
-                    break
-
+                    if str(self.specs['only_final_jacobian']).lower()=="false":
+                        break
 
         if reason != '':
             self.setStatus(self.fail, reason)


### PR DESCRIPTION
The new parameter in `PetscJacobianTester.py` allows for testing of only
the final Jacobian comparison. The default behavior is only changed when
the new parameter is used.

Closes #17456

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
