### PR TITLE
Fixing up generated header dependencies for submodules

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -309,8 +309,14 @@ else
 endif
 
 app_GIT_DIR := $(shell cd "$(APPLICATION_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
-# Use wildcard in case the files don't exist
-app_HEADER_deps := $(wildcard $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index)
+app_HEADER_deps := $(realpath $(app_GIT_DIR)/.git/HEAD $(app_GIT_DIR)/.git/index)
+ifeq (x$(app_HEADER_deps),x)
+  # Files don't exist, this must be a submodule in which case these files are located in master repo's modules directory
+  # ".git" in this case is a file, not a folder that contains the real location of the ".git" folder
+  app_GIT_DIR := $(realpath $(app_GIT_DIR)/$(shell cut -d' ' -f 2 $(app_GIT_DIR)/.git))
+  app_HEADER_deps := $(realpath $(app_GIT_DIR)/HEAD $(app_GIT_DIR)/index)
+endif
+
 # Target-specific Variable Values (See GNU-make manual)
 $(app_HEADER): curr_dir    := $(APPLICATION_DIR)
 $(app_HEADER): curr_app    := $(APPLICATION_NAME)

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -276,8 +276,13 @@ all: libmesh_submodule_status header_symlinks $(moose_revision_header) moose
 
 # revision header
 moose_GIT_DIR := $(shell cd "$(FRAMEWORK_DIR)" && which git &> /dev/null && git rev-parse --show-toplevel)
-# Use wildcard in case the files don't exist
-moose_HEADER_deps := $(wildcard $(moose_GIT_DIR)/.git/HEAD $(moose_GIT_DIR)/.git/index)
+moose_HEADER_deps := $(realpath $(moose_GIT_DIR)/.git/HEAD $(moose_GIT_DIR)/.git/index)
+ifeq (x$(moose_HEADER_deps),x)
+  # Files don't exist, this must be a submodule in which case these files are located in master repo's modules directory
+  # ".git" in this case is a file, not a folder that contains the real location of the ".git" folder
+  moose_GIT_DIR := $(realpath $(moose_GIT_DIR)/$(shell cut -d' ' -f 2 $(moose_GIT_DIR)/.git))
+  moose_HEADER_deps := $(realpath $(moose_GIT_DIR)/HEAD $(moose_GIT_DIR)/index)
+endif
 
 $(moose_revision_header): $(moose_HEADER_deps)
 	@echo "Checking if header needs updating: "$@"..."


### PR DESCRIPTION
closes #16637

I believe this fixes the nasty header problem. I tested this in a few of the umbrella repos and saw the expected behaviors after touching all and subsets of the submodules:

```
Submodule path 'foo': checked out '5a162d0e8a9e79b45f1368eecfba6d0f284af3bd'
Submodule path 'bar': checked out '3ee502f39743356d2bfb235cf7eacfb809f8ed5c'
Submodule path 'baz': checked out '8674d2f57c34ea77ff9a7cf2d03b98a48c903506'
Submodule path 'biz': checked out '11e6336f3a6d072e33c1fdce2a5c7fa15d4d8ab4'
Submodule path 'moose': checked out '00f391953c6b81ced1db217a613316bfe4aed4f3'
Submodule path 'jazz': checked out '62cf88bf22cbbb1aabd223320769895464e080fd'
Submodule path 'junk': checked out 'f4ad60e26d2ae2a1c31171c85009f07e95f1c76c'
permcj@thearchitect{~/projects/purple_slug}[update_submodules]$ make -j45                                                                                (moose)
Using HIT from /Users/permcj/projects/moose/moosetools/contrib/hit
Checking if header needs updating: /Users/permcj/projects/purple_slug/foo/include/base/FooRevision.h...
Checking if header needs updating: /Users/permcj/projects/purple_slug/bar/include/base/BarRevision.h...
Checking if header needs updating: /Users/permcj/projects/purple_slug/baz/include/base/BazRevision.h...
Checking if header needs updating: /Users/permcj/projects/purple_slug/biz/include/base/BizRevision.h...
Checking if header needs updating: /Users/permcj/projects/purple_slug/jazz/include/base/JazzRevision.h...
Checking if header needs updating: /Users/permcj/projects/purple_slug/junk/include/base/JunkRevision.h...
```

For this test, I set $MOOSE_DIR and didn't change it even though the (unused) submodule was updated. As expected, it picked up MOOSE from the MOOSE_DIR and correctly picked up the dependencies for all the submodules updating only those submodules' headers. Additionally, I didn't update one of the other submodules and it isn't reflected in this output at all. This might be it guys! 

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
