### PR TITLE
Creating intermediate class for STM trainers

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1076,6 +1076,9 @@ FEProblemBase::initialSetup()
   if (_line_search)
     _line_search->initialSetup();
 
+  // Perform Reporter get/declare check
+  _reporter_data.check();
+
   _app.checkRegistryLabels();
   setCurrentExecuteOnFlag(EXEC_NONE);
 }
@@ -6473,9 +6476,6 @@ FEProblemBase::checkProblemIntegrity()
   // variables matches the order of the elements in the displaced
   // mesh.
   checkDisplacementOrders();
-
-  // Perform Reporter get/declare check
-  _reporter_data.check();
 }
 
 void

--- a/modules/combined/examples/stochastic/poly_chaos_train_uniform.i
+++ b/modules/combined/examples/stochastic/poly_chaos_train_uniform.i
@@ -85,19 +85,19 @@
     check_multiapp_execute_on = false
   []
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = storage
-    from_postprocessor = 'temp_center_inner  temp_center_outer  temp_end_inner  temp_end_outer
-                          dispx_center_inner dispx_center_outer dispx_end_inner dispx_end_outer
-                          dispz_inner dispz_outer'
+    stochastic_reporter = storage
+    from_reporter = 'temp_center_inner/value  temp_center_outer/value  temp_end_inner/value  temp_end_outer/value
+                     dispx_center_inner/value dispx_center_outer/value dispx_end_inner/value dispx_end_outer/value
+                     dispz_inner/value dispz_outer/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [storage]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -107,80 +107,70 @@
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:temp_center_inner'
+    response = storage/data:temp_center_inner:value
   []
   [temp_center_outer]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:temp_center_outer'
+    response = storage/data:temp_center_outer:value
   []
   [temp_end_inner]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:temp_end_inner'
+    response = storage/data:temp_end_inner:value
   []
   [temp_end_outer]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:temp_end_outer'
+    response = storage/data:temp_end_outer:value
   []
   [dispx_center_inner]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispx_center_inner'
+    response = storage/data:dispx_center_inner:value
   []
   [dispx_center_outer]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispx_center_outer'
+    response = storage/data:dispx_center_outer:value
   []
   [dispx_end_inner]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispx_end_inner'
+    response = storage/data:dispx_end_inner:value
   []
   [dispx_end_outer]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispx_end_outer'
+    response = storage/data:dispx_end_outer:value
   []
   [dispz_inner]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispz_inner'
+    response = storage/data:dispz_inner:value
   []
   [dispz_outer]
     type = PolynomialChaosTrainer
     execute_on = timestep_end
     order = 4
     sampler = sample
-    results_vpp = storage
-    results_vector = 'data:dispz_outer'
+    response = storage/data:dispz_outer:value
   []
 []
 

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/combined_example_2d_trans_diff.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/combined_example_2d_trans_diff.md
@@ -91,16 +91,16 @@ It is not visible, but the sampler prepares 216 parameter vectors altogether.
 
 !listing surrogates/combined/trans_diff_2d/trans_diff_trainer.i block=Samplers  
 
-The objects in blocks `Controls`, `MultiApps`, `Transfers` and `VectorPostprocessors`
+The objects in blocks `Controls`, `MultiApps`, `Transfers` and `Reporters`
 are responsible for managing the communication between the trainer and sub-applications,
 execution of the sub-applications and the collection of the results.
 For a more detailed description of these blocks see [examples/parameter_study.md]
 and [surrogate_training.md].
 
-!listing surrogates/combined/trans_diff_2d/trans_diff_trainer.i block=MultiApps Controls Transfers VectorPostprocessors
+!listing surrogates/combined/trans_diff_2d/trans_diff_trainer.i block=MultiApps Controls Transfers Reporters
 
 Next, six trainers (three different surrogates for each QoI) are defined in the `Trainers` block.
-These objects use the data from `Samplers` and `VectorPostprocessors`.
+These objects use the data from `Samplers` and `Reporters`.
 A polynomial chaos surrogate of
 order 5, a polynomial regression surrogate with a
 polynomial of degree at most 4 and a nearest point surrogate is used for both QoIs in this work.

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_chaos_surrogate.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_chaos_surrogate.md
@@ -46,7 +46,7 @@ Because PC expansion uses very specific types of polynomials, using numerical qu
 
 Running the sub app and transferring data back and forth for PC is exactly the same as any other type of surrogate. See [Training a surrogate model](/examples/surrogate_training.md) on more details on setting up this part of the input file.
 
-!listing examples/surrogates/poly_chaos_uniform_quad.i block=MultiApps Controls Transfers VectorPostprocessors
+!listing examples/surrogates/poly_chaos_uniform_quad.i block=MultiApps Controls Transfers Reporters
 
 
 ### Trainers
@@ -55,8 +55,7 @@ The PC training object is defined within the [Trainers](Trainers/index.md) block
 
 - [!param](/Trainers/PolynomialChaosTrainer/distributions) specify the type of polynomials to use for the expansion, it is very import that these distributions match the distributions given to the sampler.
 - [!param](/Trainers/PolynomialChaosTrainer/sampler) is the object that will provide sample points which are given to the sub app during execution.
-- [!param](/Trainers/PolynomialChaosTrainer/results_vpp) specifies the result object for storing the computed values.
-- [!param](/Trainers/PolynomialChaosTrainer/results_vector) specifies the result vector, within the result object, for storing the computed values.
+- [!param](/Trainers/PolynomialChaosTrainer/response) specifies the result vector for storing the computed values.
 - [!param](/Trainers/PolynomialChaosTrainer/order) defines the maximum order of the PC expansion, this parameter ultimately defines the accuracy and complexity of the surrogate model.
 
 !listing examples/surrogates/poly_chaos_uniform_mc.i block=Trainers

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_regression_surrogate.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/poly_regression_surrogate.md
@@ -111,17 +111,17 @@ to match the number of samples in the tensor-product quadrature set of [Quadratu
 
 !listing surrogates/polynomial_regression/normal_train.i block=Samplers  
 
-The objects in blocks `Controls`, `MultiApps`, `Transfers` and `VectorPostprocessors`
+The objects in blocks `Controls`, `MultiApps`, `Transfers` and `Reporters`
 are responsible for managing the communication between master and sub-applications,
 execution of the sub-applications and the collection of the results.
 For a more detailed description of these blocks see [examples/parameter_study.md]
 and [surrogate_training.md].
 
-!listing surrogates/polynomial_regression/normal_train.i block=MultiApps Controls Transfers VectorPostprocessors
+!listing surrogates/polynomial_regression/normal_train.i block=MultiApps Controls Transfers Reporters
 
 The next step is to set up two `Trainer` objects to generate the surrogate models
 from the available data. This can be done in the `Trainers` block. It is visible that
-both examples use the data from `Sampler` and `VectorPostprocessor` objects. A polynomial chaos surrogate of
+both examples use the data from `Sampler` and `Reporter` objects. A polynomial chaos surrogate of
 order 8 and a polynomial regression surrogate with a
 polynomial of degree at most 4 is used in this study.
 The [PolynomialChaosTrainer.md] also needs knowledge about the underlying parameter distributions
@@ -181,7 +181,7 @@ The statistical moments obtained by the execution of the
 
 It can be observed that the polynomial chaos surrogate gives results closer to the reference values.
 It is also visible that by increasing the polynomial order for the regression, the accuracy
-in the standard deviation slightly decreases. 
+in the standard deviation slightly decreases.
 The histogram of the results is presented in [uniform_hist]. It is important to mention
 that the results for the polynomial regression surrogate were obtained using `max_degree=4`.
 It is apparent that the two methods give similar solutions.

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
@@ -20,11 +20,11 @@ The trainer requires the input of a sampler, so that it understands how many dat
 
 ### Constructor
 
-All trainers are based on SurrogateTrainer, which provides the necessary interface for saving the surrogate model data and gathering response/predictor data. All the data meant to be saved and gathered is defined in the constructor of the training object. In [NearestPointTrainer](NearestPointTrainer.md), the variable `_sample_points` is declared as the necessary surrogate data, see [Trainers](Trainers/index.md) for more information on declaring model data. The variables `_response` and `_predictors` refer to the data being used for training, these are in the form of reporter values and gathered through the `getTrainingData` API.
+All trainers are based on SurrogateTrainer, which provides the necessary interface for saving the surrogate model data and gathering response/predictor data. All the data meant to be saved and gathered is defined in the constructor of the training object. In [NearestPointTrainer](NearestPointTrainer.md), the variable `_sample_points` is declared as the necessary surrogate data, see [Trainers](Trainers/index.md) for more information on declaring model data. The variables `_response`, `_predictors`, and `_predictor_cols` refer to the data being used for training. `_response` and `_predictors` are in the form of reporter values and gathered through the `getTrainingData` API. `_predictor_cols` refer to the sampler column being used for training.
 
 !listing NearestPointTrainer.C re=NearestPointTrainer::NearestPointTrainer.*?^}
 
-The member variables `_sample_points`, `_response`, and `_predictors` are defined in the header file:
+The member variables `_sample_points`, `_response`, `_predictors`, and `_predictor_cols` are defined in the header file:
 
 !listing NearestPointTrainer.h start=protected end=}; include-start=False
 

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_creation.md
@@ -4,63 +4,53 @@ This example goes through the process of creating a custom surrogate model, in h
 
 ## Overview
 
-Building a surrogate model requires the creation of two objects: SurrogateTrainer and SurrogateModel. The SurrogateTrainer uses information from samplers and results to construct variables to be saved into a `.rd` file at the conclusion of the training run. The SurrogateMode object loads the data from the `.rd` and contains a function called `evaluate` that evaluates the surrogate model at a given input. The SurrogateTrainer and Surrogate are heavily tied together where each have the same member variables, the difference being one saves the data and the other loads it. It might be beneficial to have an interface class that contains common functions for training and evaluating, to avoid duplicate code. This example will not go into the creation of this interface class.
+Building a surrogate model requires the creation of two objects: SurrogateTrainer and SurrogateModel. The SurrogateTrainer uses information from samplers and results to construct variables to be saved into a `.rd` file at the conclusion of the training run. The SurrogateModel object loads the data from the `.rd` and contains a function called `evaluate` that evaluates the surrogate model at a given input. The SurrogateTrainer and Surrogate are heavily tied together where each have the same member variables, the difference being one saves the data and the other loads it. It might be beneficial to have an interface class that contains common functions for training and evaluating, to avoid duplicate code. This example will not go into the creation of this interface class.
 
 ## Creating a Trainer
 
-This example will go over the creation of [NearestPointTrainer](NearestPointTrainer.md). [Trainers](Trainers/index.md) are technically a type of [GeneralUserObject.md] with the same `validParams`, `initialSetup`, `initialize`, `execute`, and `finalize` functions that are executed during the object's call.
+This example will go over the creation of [NearestPointTrainer](NearestPointTrainer.md). [Trainers](Trainers/index.md) are derived from `SurrogateTrainer` which performs a loop over the training data and calls virtual functions that derived classes are meant to override to perform the proper training.
 
 ### validParams
 
-Typically, the trainer requires the input of a sampler, so that it understands what the inputs of the full-order model were run. The trainer also needs the output values from the full-order model which are stored in a [vector postprocessor](VectorPostprocessors/index.md).
+The trainer requires the input of a sampler, so that it understands how many data points are included and how they are distributed across processors. The trainer also needs the predictor and response values from the full-order model which are stored in a [vector postprocessor](VectorPostprocessors/index.md) or [reporter](Reporters/index.md).
+
+!listing SurrogateTrainer.C re=InputParameters\sSurrogateTrainer::validParams.*?^}
 
 !listing NearestPointTrainer.C re=InputParameters\sNearestPointTrainer::validParams.*?^}
 
 ### Constructor
 
-All trainers are based on SurrogateTrainer, which provides the necessary interface for saving the surrogate model data. All the data meant to be saved is defined in the constructor of the training object. In [NearestPointTrainer](NearestPointTrainer.md), the variable `_sample_points` is declared as the necessary surrogate data, see [Trainers](Trainers/index.md) for more information on declaring model data:
+All trainers are based on SurrogateTrainer, which provides the necessary interface for saving the surrogate model data and gathering response/predictor data. All the data meant to be saved and gathered is defined in the constructor of the training object. In [NearestPointTrainer](NearestPointTrainer.md), the variable `_sample_points` is declared as the necessary surrogate data, see [Trainers](Trainers/index.md) for more information on declaring model data. The variables `_response` and `_predictors` refer to the data being used for training, these are in the form of reporter values and gathered through the `getTrainingData` API.
 
 !listing NearestPointTrainer.C re=NearestPointTrainer::NearestPointTrainer.*?^}
 
-The member variable `_sample_points` is defined in the header file:
+The member variables `_sample_points`, `_response`, and `_predictors` are defined in the header file:
 
-!listing NearestPointTrainer.h start=_sample_points end=_sample_points include-end=true
+!listing NearestPointTrainer.h start=protected end=}; include-start=False
 
-### initialSetup
+### preTrain
 
-Since [UserObjects](UserObjects/index.md) are constructed before [Samplers](Samplers/index.md) and [VectorPostprocessors](VectorPostprocessors/index.md), the sampler and vector postprocessor variables need to be set in `initialSetup`:
+`preTrain()` is called before the sampler loop. For [NearestPointTrainer.md], we resize `_sample_points` appropriately:
 
-!listing NearestPointTrainer.C re=void\sNearestPointTrainer::initialSetup.*?^}
+!listing NearestPointTrainer.C re=void\sNearestPointTrainer::preTrain.*?^}
 
-`_values_distributed` simply determines whether the values in the vector postprocessor are distributed, which necessitates different indices when looping through them. Since the definition of these variables is outside the constructor, they need to be pointers:
+Note that `getNumberOfLocalRows()` is used to size the array, this is so that each processor contains a portion of the samples and results. We will gather all samples in `postTrain()`.
 
-!listing NearestPointTrainer.h start=/// Sampler end=_values_ptr include-end=true
+### train
 
-### initialize
+`train()` is where the actual training occurs. This function is called during the sampler loop for each row, at which time the member variables `_row`, `_local_row`, and ones gathered with `getTrainingData` are updated:
 
-`initialize` is called before `execute` is called for all [UserObjects](UserObjects/index.md). For [NearestPointTrainer.md], a check of the size of the sampler is performed and vector postprocessor and resize `_sample_points` appropriately:
+!listing NearestPointTrainer.C re=void\sNearestPointTrainer::train.*?^}
 
-!listing NearestPointTrainer.C re=void\sNearestPointTrainer::initialize.*?^}
+### postTrain
 
-Note that `getNumberOfRows()` is used to size the array, this is so that each processor contains a portion of the samples and results. We will gather all samples in `finalize`.
+`postTrain()` is called after the sampler loop. This is typically where processor communication happens. Here, we use `postTrain()` to gather all the local `_sample_points` so that each processor has the full copy. `_communicator.allgather` makes it so that every processor has a copy of the full array and `_communicator.gather` makes it so that only one of the processors has the full copy, the latter is typically used because outputting only happens on the root processor. See [libMesh::Parallel::Communicator](http://libmesh.github.io/doxygen/classlibMesh_1_1Parallel_1_1Communicator.html) for more communication options.
 
-### execute
-
-`execute` is where the actual training occurs. Here, a loop through the local processor's samples is performed to gather the parameter data and results:
-
-!listing NearestPointTrainer.C re=void\sNearestPointTrainer::execute.*?^}
-
-The `offset` variable is defined by whether or not the vector postprocessor values are distributed. Also, the `ind` variable defines the offset for saving the distributed samples.
-
-### finalize
-
-`finalize` is called after `execute` is called for all [UserObjects](UserObjects/index.md). This is typically where processor communication happens. Here, we use `finalize` to gather all the local `_sample_points` so that each processor has the full copy. `_communicator.allgather` makes it so that every processor has a copy of the full array and `_communicator.gather` makes it so that only one of the processors has the full copy, the latter is typically used because outputting only happens on the root processor. See [libMesh::Parallel::Communicator](http://libmesh.github.io/doxygen/classlibMesh_1_1Parallel_1_1Communicator.html) for more communication options.
-
-!listing NearestPointTrainer.C re=void\sNearestPointTrainer::finalize.*?^}
+!listing NearestPointTrainer.C re=void\sNearestPointTrainer::postTrain.*?^}
 
 ## Creating a Surrogate
 
-This example will go over the creation of [NearestPointSurrogate](NearestPointSurrogate.md). [Surrogates](Surrogates/index.md) are a specialized version of a [GeneralUserObject.md] that must have the `evaluate` public member function. The `validParams` for a surrogate will generally define how the surrogate is evaluated. [NearestPointSurrogate.md] does not have any options for the method of evaluation.
+This example will go over the creation of [NearestPointSurrogate](NearestPointSurrogate.md). [Surrogates](Surrogates/index.md) are a specialized version of a MooseObject that must have the `evaluate` public member function. The `validParams` for a surrogate will generally define how the surrogate is evaluated. [NearestPointSurrogate.md] does not have any options for the method of evaluation.
 
 ### Constructor
 

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_training.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_training.md
@@ -105,19 +105,20 @@ The [!param](/Samplers/CartesianProduct/linear_space_items) parameter defines a 
 
 ### Transferring Results
 
-After each perturbed simulation of the sub app is finished, the results are transferred to the master app. [SamplerPostprocessorTransfer.md] is used to transfer postprocessors from the sub app to a [StochasticResults.md] vector postprocessor in the master app.
+After each perturbed simulation of the sub app is finished, the results are transferred to the master app. [SamplerReporterTransfer.md] is used to transfer postprocessors, vectorpostprocessors, or reporter values from the sub app to a [StochasticReporter.md] in the master app.
 
-!listing examples/surrogates/nearest_point_training.i block=Transfers VectorPostprocessors
+!listing examples/surrogates/nearest_point_training.i block=Transfers Reporters
 
-Here, there are two transfers that transfer the sub app postprocessors computing $\bar{T}$ and $T_{\infty}$ to two different master app vector postprocessors. The [!param](/VectorPostprocessors/StochasticResults/outputs) parameter is set to `none` so it doesn't output the unnecessary results to a CSV file. The trainer will directly grab the data from the vector postprocessors.
+Here, there are two transfers that transfer the sub app postprocessors computing $\bar{T}$ and $T_{\infty}$ to two different master app reporters. The [!param](/Reporters/StochasticReporter/outputs) parameter is set to `none` so it doesn't output the unnecessary results to a CSV file. The trainer will directly grab the data from the reporters.
 
 ### Training Object
 
-Training objects typically take in sampler and results data to train the surrogate model. The sampler points are taken directly from the sampler by defining [!param](/Trainers/NearestPointTrainer/sampler). The results are taken directly from a vector postprocessor, the object is defined by [!param](/Trainers/NearestPointTrainer/results_vpp) and the specific vector in the object is defined by [!param](/Trainers/NearestPointTrainer/results_vector).
+Training objects take in sampler and results data to train the surrogate model. The sampler points are taken directly from the sampler by defining [!param](/Trainers/NearestPointTrainer/sampler). The results are taken directly from a reporter or vector postprocessor, the object is defined by [!param](/Trainers/NearestPointTrainer/response) and [!param](/Trainers/NearestPointTrainer/predictors).
 
 !listing examples/surrogates/nearest_point_training.i block=Trainers
 
-[StochasticResults.md] defines the vector name by the name of sampler that was given, which is why we know that the vector names are `grid` in this example.
+In the `nearest_point_avg` trainer, we see that the predictor values are from sampler columns, given with the syntax `sampler/col_<index>`. In the `nearest_point_max` trainer, the predictor names were not specified, which indicates that all the sampler columns are used as predictors.
+[StochasticReporter.md] defines the reporter name by the name of the transfer executing the transfer, which is why we know that the values names are `data` in this example.
 
 ### Outputting Training Data
 

--- a/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_training.md
+++ b/modules/stochastic_tools/doc/content/modules/stochastic_tools/examples/surrogate_training.md
@@ -117,7 +117,7 @@ Training objects take in sampler and results data to train the surrogate model. 
 
 !listing examples/surrogates/nearest_point_training.i block=Trainers
 
-In the `nearest_point_avg` trainer, we see that the predictor values are from sampler columns, given with the syntax `sampler/col_<index>`. In the `nearest_point_max` trainer, the predictor names were not specified, which indicates that all the sampler columns are used as predictors.
+In the `nearest_point_avg` trainer, we see that the predictor values are from a VPP and sampler columns. In the `nearest_point_max` trainer, the predictor names were not specified, which indicates that all the sampler columns are used as predictors.
 [StochasticReporter.md] defines the reporter name by the name of the transfer executing the transfer, which is why we know that the values names are `data` in this example.
 
 ### Outputting Training Data

--- a/modules/stochastic_tools/doc/content/source/surrogates/PolynomialChaos.md
+++ b/modules/stochastic_tools/doc/content/source/surrogates/PolynomialChaos.md
@@ -158,11 +158,11 @@ or quadrature,
 
 !listing poly_chaos/master_2d_quad.i block=Samplers/quadrature
 
-It is important that the order in the quadrature sampler input matches the order in the PolynomialChaos input. The sampler is then used by the MultiApp and Transfers to sample the sub-app, the QoI from the app is then put in a vectorpostprocessor:
+It is important that the order in the quadrature sampler input matches the order in the PolynomialChaos input. The sampler is then used by the MultiApp and Transfers to sample the sub-app, the QoI from the app is then put in a reporter:
 
-!listing poly_chaos/master_2d_quad.i block=VectorPostprocessors/storage
+!listing poly_chaos/master_2d_quad.i block=Reporters
 
-All this information is ready to be sent to the PolynomialChaos user object:
+All this information is ready to be sent to the PolynomialChaos trainer:
 
 !listing poly_chaos/master_2d_quad.i block=Surrogates Trainers
 

--- a/modules/stochastic_tools/doc/content/syntax/Trainers/index.md
+++ b/modules/stochastic_tools/doc/content/syntax/Trainers/index.md
@@ -3,21 +3,48 @@
 ## Overview
 
 Objects within the `[Trainers]` block are derived from `SurrogateTrainer` and
-are designed for creating training data for use with a model (see [Surrogates/index.md]). The
-trainer objects derive from the `GeneralUserObject`
-class of MOOSE (see [UserObjects/index.md]).
+are designed for creating training data for use with a model (see [Surrogates/index.md]).
 
 ## Creating a SurrogateTrainer
 
-To create a trainer the new object should inherit from `SurrogateTrainer`, which are a part of the
-MOOSE [UserObjects/index.md].  As a UserObject based tool a trainer object requires that the
-`execute` method be overridden. The execute method should perform all the necessary calculations for
-computing the training data, please refer to [#training-data] for details regarding declare training
-data. The method will execute once per execution flag (see [SetupInterface.md]) on each processor.
+To create a trainer the new object should inherit from `SurrogateTrainer`, which is derived
+from [GeneralUserObject.md]. `SurrogateTrainer` overrides the `execute()` function to loop
+through the rows of a given [sampler](Samplers/index.md), specified by the
+[!param](/Trainers/NearestPointTrainer/sampler) parameter:
+
+!listing SurrogateTrainer.C re=void\sSurrogateTrainer::execute.*?^}
+
+The method will execute once per execution flag (see [SetupInterface.md]) on each processor.
+There are three virtual functions that derived class can and should override:
+
+!listing SurrogateTrainer.h start=protected: end=postTrain include-start=False include-end=True
+
+- `preTrain()` is called before the sampler loop and is typically used for resizing variables for the given number of data points.
+- `train()` is called within the sampler loop where member variables `_local_row`, `_row`, and those declared with `getTrainingData` are updated.
+- `postTrain()` is called after the sampler loop and is typically used for MPI communication.
+
+## Gathering Training Data
+
+In order to ease the of gathering the required data needed for training, `SurrogateTrainer`
+includes API to get reporter data which takes care of the necessary size checks and
+distributed data indexing.
+The idea behind this is to emulate the element loop behavior in other MOOSE objects.
+For instance, in a kernel, the value of _u corresponds to the solution in an element.
+Here data referenced with `getTrainingData` will correspond to the the value of the
+data in a sampler row. The returned reference is to be used in the `train()` function.
+There are four functions that derived classes can call to gather training data:
+
+!listing SurrogateTrainer.h start=TRAINING_DATA_BEGIN end=TRAINING_DATA_END include-start=False
+
+- `getTrainingData<T>(const std::string & param)` will get training data from a reporter value of type `std::vector<T>`, whose name is defined by the `param` parameter of type `ReporterName`.
+- `getTrainingDataVector<T>(const std::string & param)` will get a vector of training data from a reporter value of type `std::vector<T>`, whose names are defined by the `param` parameter of type `std::vector<ReporterName>`.
+- `getTrainingData<T>(const ReporterName & rname)` will get a vector of training data from a reporter value of type `std::vector<T>`, whose name is defined by `rname`. One can retrieve a sampler column with the `sampler/col_<index>` syntax, but `T` must be `Real`.
+- `getSamplerData()` will simply return a vector of the sampler row.
+
 
 ## Declaring Training Data id=training-data
 
-Training data must be declare in the object constructor using the `declareModelData` methods, which
+Model data must be declare in the object constructor using the `declareModelData` methods, which
 are defined as follows. The desired type is provided as the template argument (`T`) and name to
 the data is the first input parameter. The second option, if provided, is the initial value
 for the training data. The name provided is arbitrary, but is used by the model object(s) designed
@@ -26,7 +53,7 @@ to work with the training data (see [Surrogates/index.md]).
 !listing SurrogateTrainer.h start=MOOSEDOCS_BEGIN end=MOOSEDOCS_END include-start=False
 
 These methods return a reference to the desired type that should be populated in the aforementioned
-execute method. For example, in the [PolynomialChaosTrainer.md] trainer object a scalar value,
+`train()` method. For example, in the [PolynomialChaosTrainer.md] trainer object a scalar value,
 "order", is stored stored by declaring a reference to the desired type in the header.
 
 !listing PolynomialChaosTrainer.h line=_order
@@ -39,9 +66,9 @@ data initialization.
 The training data system leverages the [restart/Restartable.md] within MOOSE. As such, the data
 store can be of an arbitrary type and is automatically used for restarting simulations.
 
-## Output Training Data
+## Output Mdoel Data
 
-Training data can be output to a binary file using the [SurrogateTrainerOutput.md] object.
+Training model data can be output to a binary file using the [SurrogateTrainerOutput.md] object.
 
 ## Example Input File Syntax
 

--- a/modules/stochastic_tools/doc/content/syntax/Trainers/index.md
+++ b/modules/stochastic_tools/doc/content/syntax/Trainers/index.md
@@ -36,9 +36,7 @@ There are four functions that derived classes can call to gather training data:
 
 !listing SurrogateTrainer.h start=TRAINING_DATA_BEGIN end=TRAINING_DATA_END include-start=False
 
-- `getTrainingData<T>(const std::string & param)` will get training data from a reporter value of type `std::vector<T>`, whose name is defined by the `param` parameter of type `ReporterName`.
-- `getTrainingDataVector<T>(const std::string & param)` will get a vector of training data from a reporter value of type `std::vector<T>`, whose names are defined by the `param` parameter of type `std::vector<ReporterName>`.
-- `getTrainingData<T>(const ReporterName & rname)` will get a vector of training data from a reporter value of type `std::vector<T>`, whose name is defined by `rname`. One can retrieve a sampler column with the `sampler/col_<index>` syntax, but `T` must be `Real`.
+- `getTrainingData<T>(const ReporterName & rname)` will get a vector of training data from a reporter value of type `std::vector<T>`, whose name is defined by `rname`.
 - `getSamplerData()` will simply return a vector of the sampler row.
 
 

--- a/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_trainer.i
+++ b/modules/stochastic_tools/examples/surrogates/combined/trans_diff_2d/trans_diff_trainer.i
@@ -47,17 +47,17 @@
 
 [Transfers]
   [results]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = runner
     sampler = sample
-    to_vector_postprocessor = trainer_results
-    from_postprocessor = 'time_max time_min'
+    stochastic_reporter = trainer_results
+    from_reporter = 'time_max/value time_min/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [trainer_results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -68,8 +68,7 @@
     order = 5
     distributions = 'C_dist f_dist init_dist'
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_max
+    response = trainer_results/results:time_max:value
   []
   [pc_min]
     type = PolynomialChaosTrainer
@@ -77,22 +76,19 @@
     order = 5
     distributions = 'C_dist f_dist init_dist'
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_min
+    response = trainer_results/results:time_min:value
   []
   [np_max]
     type = NearestPointTrainer
     execute_on = final
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_max
+    response = trainer_results/results:time_max:value
   []
   [np_min]
     type = NearestPointTrainer
     execute_on = final
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_min
+    response = trainer_results/results:time_min:value
   []
   [pr_max]
     type = PolynomialRegressionTrainer
@@ -100,8 +96,7 @@
     execute_on = final
     max_degree = 4
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_max
+    response = trainer_results/results:time_max:value
   []
   [pr_min]
     type = PolynomialRegressionTrainer
@@ -109,8 +104,7 @@
     execute_on = final
     max_degree = 4
     sampler = sample
-    results_vpp = trainer_results
-    results_vector = results:time_min
+    response = trainer_results/results:time_min:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/gaussian_process/GP_normal_mc.i
+++ b/modules/stochastic_tools/examples/surrogates/gaussian_process/GP_normal_mc.i
@@ -52,17 +52,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg'
+    stochastic_reporter = results
+    from_reporter = 'avg/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -73,10 +73,8 @@
     covariance_function = 'rbf'
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
     tao_options = '-tao_bncg_type gd'
     tune_parameters = ' signal_variance length_factor'
     tuning_min = ' 1e-9 1e-3'

--- a/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_1D.i
+++ b/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_1D.i
@@ -57,23 +57,26 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = train_sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg'
+    stochastic_reporter = results
+    from_reporter = 'avg/value'
   []
 []
 
+[Reporters]
+  [results]
+    type = StochasticReporter
+  []
+[]
 
 [Trainers]
   [GP_avg_trainer]
     type = GaussianProcessTrainer
     execute_on = timestep_end
-    distributions = 'q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
     covariance_function = 'rbf'
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
@@ -98,9 +101,6 @@
 
 # # Computing statistics
 [VectorPostprocessors]
-  [results]
-    type = StochasticResults
-  []
   [cart_avg]
     type = EvaluateGaussianProcess
     model = gauss_process_avg

--- a/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_1D_tuned.i
+++ b/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_1D_tuned.i
@@ -57,11 +57,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = train_sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg'
+    stochastic_reporter = results
+    from_reporter = 'avg/value'
+  []
+[]
+
+[Reporters]
+  [results]
+    type = StochasticReporter
   []
 []
 
@@ -72,10 +78,8 @@
     covariance_function = 'rbf'
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
     tao_options = '-tao_bncg_type kd'
     tune_parameters = ' signal_variance length_factor'
     tuning_min = ' 1e-9 1e-9'
@@ -101,9 +105,6 @@
 
 # # Computing statistics
 [VectorPostprocessors]
-  [results]
-    type = StochasticResults
-  []
   [hyperparams]
     type = GaussianProcessData
     gp_name = 'gauss_process_avg'

--- a/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_2D.i
+++ b/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_2D.i
@@ -48,17 +48,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = train_sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg'
+    stochastic_reporter = results
+    from_reporter = 'avg/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -69,10 +69,8 @@
     covariance_function = 'rbf'
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_2D_tuned.i
+++ b/modules/stochastic_tools/examples/surrogates/gaussian_process/gaussian_process_uniform_2D_tuned.i
@@ -48,19 +48,20 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = train_sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg'
+    stochastic_reporter = results
+    from_reporter = 'avg/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
+
 
 [Trainers]
   [GP_avg_trainer]
@@ -70,10 +71,8 @@
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
     tao_options = '-tao_bncg_type kd'
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
     tune_parameters = ' signal_variance length_factor'
     tuning_min = ' 1e-9 1e-9'
     tuning_max = ' 1e16  1e16'

--- a/modules/stochastic_tools/examples/surrogates/nearest_point_training.i
+++ b/modules/stochastic_tools/examples/surrogates/nearest_point_training.i
@@ -51,12 +51,21 @@
   []
 []
 
+[VectorPostprocessors]
+  [sampler_data]
+    type = SamplerData
+    sampler = grid
+    parallel_type = DISTRIBUTED
+  []
+[]
+
 [Trainers]
   [nearest_point_avg]
     type = NearestPointTrainer
     execute_on = timestep_end
     sampler = grid
-    predictors = 'sampler/col_0 sampler/col_1 sampler/col_2 sampler/col_3'
+    predictors = 'sampler_data/grid_0'
+    predictor_cols = '1 2 3'
     response = results/data:avg:value
   []
   [nearest_point_max]

--- a/modules/stochastic_tools/examples/surrogates/nearest_point_training.i
+++ b/modules/stochastic_tools/examples/surrogates/nearest_point_training.i
@@ -36,17 +36,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = grid
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg max'
+    stochastic_reporter = results
+    from_reporter = 'avg/value max/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
     outputs = none
   []
 []
@@ -56,15 +56,14 @@
     type = NearestPointTrainer
     execute_on = timestep_end
     sampler = grid
-    results_vpp = results
-    results_vector = data:avg
+    predictors = 'sampler/col_0 sampler/col_1 sampler/col_2 sampler/col_3'
+    response = results/data:avg:value
   []
   [nearest_point_max]
     type = NearestPointTrainer
     execute_on = timestep_end
     sampler = grid
-    results_vpp = results
-    results_vector = data:max
+    response = results/data:max:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_normal_mc.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_normal_mc.i
@@ -52,17 +52,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg max'
+    stochastic_reporter = results
+    from_reporter = 'avg/value max/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -73,8 +73,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
   []
   [poly_chaos_max]
     type = PolynomialChaosTrainer
@@ -82,8 +81,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:max
+    response = results/data:max:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_normal_quad.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_normal_quad.i
@@ -52,17 +52,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg max'
+    stochastic_reporter = results
+    from_reporter = 'avg/value max/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -73,8 +73,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
   []
   [poly_chaos_max]
     type = PolynomialChaosTrainer
@@ -82,8 +81,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:max
+    response = results/data:max:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform_mc.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform_mc.i
@@ -52,17 +52,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg max'
+    stochastic_reporter = results
+    from_reporter = 'avg/value max/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -73,8 +73,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
   []
   [poly_chaos_max]
     type = PolynomialChaosTrainer
@@ -82,8 +81,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:max
+    response = results/data:max:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform_quad.i
+++ b/modules/stochastic_tools/examples/surrogates/poly_chaos_uniform_quad.i
@@ -52,17 +52,17 @@
 
 [Transfers]
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = sub
     sampler = sample
-    to_vector_postprocessor = results
-    from_postprocessor = 'avg max'
+    stochastic_reporter = results
+    from_reporter = 'avg/value max/value'
   []
 []
 
-[VectorPostprocessors]
+[Reporters]
   [results]
-    type = StochasticResults
+    type = StochasticReporter
   []
 []
 
@@ -73,8 +73,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg:value
   []
   [poly_chaos_max]
     type = PolynomialChaosTrainer
@@ -82,8 +81,7 @@
     order = 10
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = sample
-    results_vpp = results
-    results_vector = data:max
+    response = results/data:max:value
   []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/polynomial_regression/normal_train.i
+++ b/modules/stochastic_tools/examples/surrogates/polynomial_regression/normal_train.i
@@ -69,27 +69,24 @@
 
 [Transfers]
   [pc_data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = pc_sub
     sampler = pc_sampler
-    to_vector_postprocessor = pc_results
-    from_postprocessor = 'max'
+    stochastic_reporter = results
+    from_reporter = 'max/value'
   []
   [pr_data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = pr_sub
     sampler = pr_sampler
-    to_vector_postprocessor = pr_results
-    from_postprocessor = 'max'
+    stochastic_reporter = results
+    from_reporter = 'max/value'
   []
 []
 
-[VectorPostprocessors]
-  [pc_results]
-    type = StochasticResults
-  []
-  [pr_results]
-    type = StochasticResults
+[Reporters]
+  [results]
+    type = StochasticReporter
   []
 []
 
@@ -100,8 +97,7 @@
     order = 8
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = pc_sampler
-    results_vpp = pc_results
-    results_vector = pc_data:max
+    response = results/pc_data:max:value
   []
   [pr_max]
     type = PolynomialRegressionTrainer
@@ -109,8 +105,7 @@
     regression_type = "ols"
     max_degree = 4
     sampler = pr_sampler
-    results_vpp = pr_results
-    results_vector = pr_data:max
+    response = results/pr_data:max:value
     []
 []
 

--- a/modules/stochastic_tools/examples/surrogates/polynomial_regression/uniform_train.i
+++ b/modules/stochastic_tools/examples/surrogates/polynomial_regression/uniform_train.i
@@ -69,27 +69,24 @@
 
 [Transfers]
   [pc_data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = pc_sub
     sampler = pc_sampler
-    to_vector_postprocessor = pc_results
-    from_postprocessor = 'max'
+    stochastic_reporter = results
+    from_reporter = 'max/value'
   []
   [pr_data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = pr_sub
     sampler = pr_sampler
-    to_vector_postprocessor = pr_results
-    from_postprocessor = 'max'
+    stochastic_reporter = results
+    from_reporter = 'max/value'
   []
 []
 
-[VectorPostprocessors]
-  [pc_results]
-    type = StochasticResults
-  []
-  [pr_results]
-    type = StochasticResults
+[Reporters]
+  [results]
+    type = StochasticReporter
   []
 []
 
@@ -100,8 +97,7 @@
     order = 8
     distributions = 'k_dist q_dist L_dist Tinf_dist'
     sampler = pc_sampler
-    results_vpp = pc_results
-    results_vector = pc_data:max
+    response = results/pc_data:max:value
   []
   [pr_max]
     type = PolynomialRegressionTrainer
@@ -109,9 +105,8 @@
     execute_on = timestep_end
     max_degree = 4
     sampler = pr_sampler
-    results_vpp = pr_results
-    results_vector = pr_data:max
-    []
+    response = results/pr_data:max:value
+  []
 []
 
 [Outputs]

--- a/modules/stochastic_tools/include/interfaces/SurrogateModelInterface.h
+++ b/modules/stochastic_tools/include/interfaces/SurrogateModelInterface.h
@@ -15,7 +15,7 @@
 
 // Forward declarations
 class SurrogateModel;
-class SurrogateTrainer;
+class SurrogateTrainerBase;
 class SurrogateModelInterface;
 
 template <>
@@ -53,7 +53,7 @@ public:
    */
   template <typename T = SurrogateModel>
   T & getSurrogateModel(const std::string & name) const;
-  template <typename T = SurrogateTrainer>
+  template <typename T = SurrogateTrainerBase>
   T & getSurrogateTrainer(const std::string & name) const;
   ///@}
 
@@ -65,7 +65,7 @@ public:
    */
   template <typename T = SurrogateModel>
   T & getSurrogateModelByName(const UserObjectName & name) const;
-  template <typename T = SurrogateTrainer>
+  template <typename T = SurrogateTrainerBase>
   T & getSurrogateTrainerByName(const UserObjectName & name) const;
 
   ///@}
@@ -114,7 +114,8 @@ template <typename T>
 T &
 SurrogateModelInterface::getSurrogateTrainerByName(const UserObjectName & name) const
 {
-  SurrogateTrainer * base_ptr = &_smi_feproblem.getUserObject<SurrogateTrainer>(name, _smi_tid);
+  SurrogateTrainerBase * base_ptr =
+      &_smi_feproblem.getUserObject<SurrogateTrainerBase>(name, _smi_tid);
   T * obj_ptr = dynamic_cast<T *>(base_ptr);
   if (!obj_ptr)
     mooseError("Failed to find a SurrogateTrainer object of type " + std::string(typeid(T).name()) +

--- a/modules/stochastic_tools/include/surrogates/GaussianProcessTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/GaussianProcessTrainer.h
@@ -23,10 +23,9 @@ class GaussianProcessTrainer : public SurrogateTrainer, public CovarianceInterfa
 public:
   static InputParameters validParams();
   GaussianProcessTrainer(const InputParameters & parameters);
-  virtual void initialSetup() override;
-  virtual void initialize() override;
-  virtual void execute() override;
-  virtual void finalize() override;
+  virtual void preTrain() override;
+  virtual void train() override;
+  virtual void postTrain() override;
 
   CovarianceFunctionBase * getCovarPtr() const { return _covariance_function; }
 
@@ -54,26 +53,11 @@ public:
 #endif
 
 private:
-  /// Sampler from which the parameters were perturbed
-  Sampler * _sampler = nullptr;
-
-  /// Vector postprocessor of the results from perturbing the model with _sampler
-  const VectorPostprocessorValue * _values_ptr = nullptr;
-
-  /// True when _sampler data is distributed
-  bool _values_distributed;
-
-  /// Total number of parameters/dimensions
-  unsigned int _n_params;
-
   /// Paramaters (x) used for training, along with statistics
   RealEigenMatrix & _training_params;
 
   /// Standardizer for use with params (x)
   StochasticTools::Standardizer & _param_standardizer;
-
-  /// Data (y) used for training
-  RealEigenMatrix _training_data;
 
   /// Standardizer for use with data (y)
   StochasticTools::Standardizer & _data_standardizer;
@@ -93,11 +77,11 @@ private:
   /// Switch for training data(y) standardization
   bool _standardize_data;
 
+  /// Covariance function object
+  CovarianceFunctionBase * _covariance_function;
+
   /// Type of covariance function used for this surrogate
   std::string & _covar_type;
-
-  /// Covariance function object
-  CovarianceFunctionBase * _covariance_function = nullptr;
 
 #ifdef LIBMESH_HAVE_PETSC
   /// Flag to toggle hyperparameter tuning/optimization
@@ -124,6 +108,18 @@ private:
 
   /// Vector hyperparameters. Stored for use in surrogate
   std::unordered_map<std::string, std::vector<Real>> & _hyperparam_vec_map;
+
+  /// Response value
+  const Real & _rval;
+
+  /// Predictor values
+  const std::vector<const Real *> _pvals;
+
+  /// Total number of parameters/dimensions
+  unsigned int _n_params;
+
+  /// Data (y) used for training
+  RealEigenMatrix _training_data;
 };
 
 template <>

--- a/modules/stochastic_tools/include/surrogates/GaussianProcessTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/GaussianProcessTrainer.h
@@ -109,11 +109,17 @@ private:
   /// Vector hyperparameters. Stored for use in surrogate
   std::unordered_map<std::string, std::vector<Real>> & _hyperparam_vec_map;
 
+  /// Data from the current sampler row
+  const std::vector<Real> & _sampler_row;
+
   /// Response value
   const Real & _rval;
 
-  /// Predictor values
-  const std::vector<const Real *> _pvals;
+  /// Predictor values from reporters
+  std::vector<const Real *> _pvals;
+
+  /// Columns from sampler for predictors
+  std::vector<unsigned int> _pcols;
 
   /// Total number of parameters/dimensions
   unsigned int _n_params;

--- a/modules/stochastic_tools/include/surrogates/NearestPointTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/NearestPointTrainer.h
@@ -16,22 +16,17 @@ class NearestPointTrainer : public SurrogateTrainer
 public:
   static InputParameters validParams();
   NearestPointTrainer(const InputParameters & parameters);
-  virtual void initialSetup() override;
-  virtual void initialize() override;
-  virtual void execute() override;
-  virtual void finalize() override;
+  virtual void preTrain() override;
+  virtual void train() override;
+  virtual void postTrain() override;
 
 protected:
   /// Map containing sample points and the results
   std::vector<std::vector<Real>> & _sample_points;
 
-private:
-  /// Sampler from which the parameters were perturbed
-  Sampler * _sampler = nullptr;
+  /// Response value
+  const Real & _response;
 
-  /// Vector postprocessor of the results from perturbing the model with _sampler
-  const VectorPostprocessorValue * _values_ptr = nullptr;
-
-  /// True when _sampler data is distributed
-  bool _values_distributed = false; // default to false; set in initialSetup
+  /// Predictor values
+  const std::vector<const Real *> _predictors;
 };

--- a/modules/stochastic_tools/include/surrogates/NearestPointTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/NearestPointTrainer.h
@@ -24,9 +24,15 @@ protected:
   /// Map containing sample points and the results
   std::vector<std::vector<Real>> & _sample_points;
 
+  /// Data from the current sampler row
+  const std::vector<Real> & _sampler_row;
+
   /// Response value
   const Real & _response;
 
-  /// Predictor values
-  const std::vector<const Real *> _predictors;
+  /// Columns from sampler for predictors
+  std::vector<unsigned int> _predictor_cols;
+
+  /// Predictor values from reporters
+  std::vector<const Real *> _predictors;
 };

--- a/modules/stochastic_tools/include/surrogates/PODReducedBasisTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/PODReducedBasisTrainer.h
@@ -24,7 +24,7 @@ class ReplicatedMesh;
 
 typedef StochasticTools::DistributedData<std::shared_ptr<DenseVector<Real>>> DistributedSnapshots;
 
-class PODReducedBasisTrainer : public SurrogateTrainer
+class PODReducedBasisTrainer : public SurrogateTrainerBase
 {
 public:
   static InputParameters validParams();

--- a/modules/stochastic_tools/include/surrogates/PolynomialChaosTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/PolynomialChaosTrainer.h
@@ -21,27 +21,15 @@ class PolynomialChaosTrainer : public SurrogateTrainer
 public:
   static InputParameters validParams();
   PolynomialChaosTrainer(const InputParameters & parameters);
-  virtual void initialSetup() override;
-  virtual void initialize() override;
-  virtual void execute() override;
-  virtual void finalize() override;
+  virtual void train() override;
+  virtual void postTrain() override;
 
 private:
-  // TODO: Move as much of these to constructor initialization
+  /// Predictor values (taken from sampler)
+  const std::vector<Real> & _pvals;
 
-  /// Sampler from which the parameters were perturbed
-  Sampler * _sampler;
-
-  /// QuadratureSampler pointer, necessary for applying quadrature weights
-  QuadratureSampler * _quad_sampler;
-
-  /// Vector postprocessor of the results from perturbing the model with _sampler
-  const VectorPostprocessorValue * _values_ptr = nullptr;
-
-  /// True when _sampler data is distributed
-  bool _values_distributed;
-
-  // The following items are stored using declareModelData for use as a trained model.
+  /// Response results
+  const Real & _rval;
 
   /// Maximum polynomial order. The sum of 1D polynomial orders does not go above this value.
   const unsigned int & _order;
@@ -49,15 +37,18 @@ private:
   /// Total number of parameters/dimensions
   unsigned int & _ndim;
 
-  /// Total number of coefficient (defined by size of _tuple)
-  std::size_t & _ncoeff;
-
   /// A _ndim-by-_ncoeff matrix containing the appropriate one-dimensional polynomial order
   std::vector<std::vector<unsigned int>> & _tuple;
+
+  /// Total number of coefficient (defined by size of _tuple)
+  std::size_t & _ncoeff;
 
   /// These are the coefficients we are after in the PC expansion
   std::vector<Real> & _coeff;
 
   /// The distributions used for sampling
   std::vector<std::unique_ptr<const PolynomialQuadrature::Polynomial>> & _poly;
+
+  /// QuadratureSampler pointer, necessary for applying quadrature weights
+  QuadratureSampler * _quad_sampler;
 };

--- a/modules/stochastic_tools/include/surrogates/PolynomialRegressionTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/PolynomialRegressionTrainer.h
@@ -25,11 +25,17 @@ public:
   virtual void postTrain() override;
 
 private:
+  /// Data from the current sampler row
+  const std::vector<Real> & _sampler_row;
+
   /// Response value
   const Real & _rval;
 
-  /// Predictor values
-  const std::vector<const Real *> _pvals;
+  /// Predictor values from reporters
+  std::vector<const Real *> _pvals;
+
+  /// Columns from sampler for predictors
+  std::vector<unsigned int> _pcols;
 
   /// Number of dimensions.
   const unsigned int _n_dims;

--- a/modules/stochastic_tools/include/surrogates/PolynomialRegressionTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/PolynomialRegressionTrainer.h
@@ -20,49 +20,41 @@ public:
 
   PolynomialRegressionTrainer(const InputParameters & parameters);
 
-  virtual void initialSetup() override;
+  virtual void train() override;
 
-  virtual void initialize() override;
+  virtual void postTrain() override;
 
-  virtual void execute() override;
+private:
+  /// Response value
+  const Real & _rval;
 
-  virtual void finalize() override;
+  /// Predictor values
+  const std::vector<const Real *> _pvals;
 
-protected:
-  /// Coefficients of regression model
-  std::vector<Real> & _coeff;
-
-  /// Matirx co containing the touples of the powers for each term
-  std::vector<std::vector<unsigned int>> & _power_matrix;
+  /// Number of dimensions.
+  const unsigned int _n_dims;
 
   /// Types for the polynomial regression
   const MooseEnum & _regression_type;
 
-private:
-  /// Maximum polynomial degree, limiting the sum of constituent polynomial degrees.
-  const unsigned int & _max_degree;
-
   /// The penalty parameter for Ridge regularization
   const Real & _penalty;
 
-  /// Number of dimensions.
-  unsigned int _n_dims;
+  /// Coefficients of regression model
+  std::vector<Real> & _coeff;
+
+  /// Maximum polynomial degree, limiting the sum of constituent polynomial degrees.
+  const unsigned int & _max_degree;
+
+  /// Matirx co containing the touples of the powers for each term
+  const std::vector<std::vector<unsigned int>> & _power_matrix;
 
   /// Number of terms in the polynomial expression.
-  unsigned int _n_poly_terms;
+  const unsigned int _n_poly_terms;
 
   ///@{
   /// Matrix and rhs for the regression problem
   DenseMatrix<Real> _matrix;
   DenseVector<Real> _rhs;
   ///@}
-
-  /// Sampler from which the parameters were perturbed
-  Sampler * _sampler = nullptr;
-
-  /// Vector postprocessor of the results from perturbing the model with _sampler
-  const VectorPostprocessorValue * _values_ptr = nullptr;
-
-  /// True when _sampler data is distributed
-  bool _values_distributed = false; // default to false; set in initialSetup
 };

--- a/modules/stochastic_tools/include/surrogates/SurrogateTrainer.h
+++ b/modules/stochastic_tools/include/surrogates/SurrogateTrainer.h
@@ -13,11 +13,26 @@
 #include "GeneralUserObject.h"
 #include "LoadSurrogateDataAction.h"
 
-class SurrogateTrainer : public GeneralUserObject
+#include "Sampler.h"
+#include "RestartableDataIO.h"
+#include "StochasticToolsApp.h"
+
+class TrainingDataBase;
+template <typename T>
+class TrainingData;
+
+/**
+ * This is the base trainer class whose main functionality is the API for declaring
+ * model data. All trainer must at least derive from this. Unless a trainer needs
+ * to perform its own loop through data, it is highly recommended to derive from
+ * SurrogateTrainer.
+ */
+class SurrogateTrainerBase : public GeneralUserObject
 {
 public:
   static InputParameters validParams();
-  SurrogateTrainer(const InputParameters & parameters);
+  SurrogateTrainerBase(const InputParameters & parameters);
+
   virtual void initialize() {}                         // not required, but available
   virtual void finalize() {}                           // not required, but available
   virtual void threadJoin(const UserObject &) final {} // GeneralUserObjects are not threaded
@@ -53,7 +68,7 @@ private:
 
 template <typename T>
 T &
-SurrogateTrainer::declareModelData(const std::string & data_name)
+SurrogateTrainerBase::declareModelData(const std::string & data_name)
 {
   RestartableData<T> & data_ref = declareModelDataHelper<T>(data_name);
   return data_ref.set();
@@ -61,7 +76,7 @@ SurrogateTrainer::declareModelData(const std::string & data_name)
 
 template <typename T>
 T &
-SurrogateTrainer::declareModelData(const std::string & data_name, const T & value)
+SurrogateTrainerBase::declareModelData(const std::string & data_name, const T & value)
 {
   RestartableData<T> & data_ref = declareModelDataHelper<T>(data_name);
   data_ref.set() = value;
@@ -70,7 +85,7 @@ SurrogateTrainer::declareModelData(const std::string & data_name, const T & valu
 
 template <typename T>
 RestartableData<T> &
-SurrogateTrainer::declareModelDataHelper(const std::string & data_name)
+SurrogateTrainerBase::declareModelDataHelper(const std::string & data_name)
 {
   auto data_ptr = libmesh_make_unique<RestartableData<T>>(data_name, nullptr);
   RestartableDataValue & value =
@@ -78,3 +93,193 @@ SurrogateTrainer::declareModelDataHelper(const std::string & data_name)
   RestartableData<T> & data_ref = static_cast<RestartableData<T> &>(value);
   return data_ref;
 }
+
+/**
+ * This is the main trainer base class. The main purpose is to avoid a lot of code
+ * duplication from performing sampler loops and dealing with distributed data. There
+ * three functions that derived trainer should override: preTrain, train, and postTrain.
+ * Derived class should also use the getTrainingData functionality, which provides a
+ * refernce to vector reporter data in its current state within the sampler loop.
+ *
+ * The idea behind this is to emulate the element loop behaiviour in other MOOSE objects.
+ * For instance, in a kernel, the value of _u corresponds to the solution in an element.
+ * Here data referenced with getTrainingData will correspond to the the value of the
+ * data in a sampler row.
+ */
+class SurrogateTrainer : public SurrogateTrainerBase
+{
+public:
+  static InputParameters validParams();
+  SurrogateTrainer(const InputParameters & parameters);
+
+  virtual void initialize() final;
+  virtual void execute() final;
+  virtual void finalize() final{};
+
+protected:
+  /*
+   * Setup function called before sampler loop
+   */
+  virtual void preTrain() {}
+
+  /*
+   * Function needed to be overried, called during sampler loop
+   */
+  virtual void train() {}
+
+  /*
+   * Function called after sampler loop, used for mpi communication mainly
+   */
+  virtual void postTrain() {}
+
+  // TRAINING_DATA_BEGIN
+
+  /*
+   * Get a reference to training data given a parameter
+   */
+  template <typename T>
+  const T & getTrainingData(const std::string & param);
+
+  /*
+   * Get a reference to a vector of training data given a parameter
+   * @param use_sampler_default determines whether to use sampler columns if param is invalid
+   */
+  template <typename T>
+  std::vector<const T *> getTrainingDataVector(const std::string & param,
+                                               bool use_sampler_default = false);
+
+  /*
+   * Get a reference to training data given a reporter name
+   */
+  template <typename T>
+  const T & getTrainingData(const ReporterName & rname);
+
+  /*
+   * Get a reference to the sampler row data
+   */
+  const std::vector<Real> & getSamplerData() const { return _row_data; };
+
+  // TRAINING_DATA_END
+
+  /// Sampler being used for training
+  Sampler & _sampler;
+
+  /// During training loop, this is the row index of the data
+  dof_id_type _row;
+  /// During training loop, this is the local row index of the data
+  dof_id_type _local_row;
+
+private:
+  /*
+   * Called at the beginning of execute() to make sure values are set properly
+   */
+  void checkIntegrity() const;
+
+  /// Sampler data for the current row
+  std::vector<Real> _row_data;
+
+  /// Vector of reporter names and their corresponding values (to be filled by getTrainingData)
+  std::unordered_map<ReporterName, std::shared_ptr<TrainingDataBase>> _training_data;
+};
+
+template <typename T>
+const T &
+SurrogateTrainer::getTrainingData(const std::string & param)
+{
+  return getTrainingData<T>(getParam<ReporterName>(param));
+}
+
+template <typename T>
+std::vector<const T *>
+SurrogateTrainer::getTrainingDataVector(const std::string & param, bool use_sampler_default)
+{
+  std::vector<const T *> vals;
+  if (isParamValid(param) || !use_sampler_default)
+  {
+    for (const ReporterName & rname : getParam<std::vector<ReporterName>>(param))
+      vals.push_back(&getTrainingData<T>(rname));
+  }
+  else
+  {
+    if (!std::is_same<T, Real>::value)
+      mooseError("Training data values must be type Real if taken from sampler.");
+    for (const Real & col : _row_data)
+      vals.push_back(&col);
+  }
+
+  return vals;
+}
+
+template <typename T>
+const T &
+SurrogateTrainer::getTrainingData(const ReporterName & rname)
+{
+  if (rname.getObjectName() == "sampler")
+  {
+    if (!std::is_same<T, Real>::value)
+      mooseError("Training data values must be type Real if taken from sampler.");
+
+    std::size_t ind = rname.getValueName().find("_");
+    if (ind != std::string::npos)
+    {
+      unsigned int col = MooseUtils::stringToInteger(rname.getValueName().substr(ind + 1), true);
+      if (col >= _sampler.getNumberOfCols())
+        mooseError("Training data from sampler ",
+                   rname,
+                   " is requesting an index greater than the number of sampler columns (",
+                   _sampler.getNumberOfCols(),
+                   ").");
+      return _row_data[col];
+    }
+    else
+      mooseError("Predictor data ", rname, " from sampler is in the wrong format.");
+  }
+  else
+  {
+    auto it = _training_data.find(rname);
+    if (it != _training_data.end())
+    {
+      auto data = std::dynamic_pointer_cast<TrainingData<T>>(it->second);
+      if (!data)
+        mooseError("Reporter value ", rname, " already exists but is of different type.");
+      return data->get();
+    }
+    else
+    {
+      const std::vector<T> & rval = getReporterValueByName<std::vector<T>>(rname);
+      _training_data[rname] = std::make_shared<TrainingData<T>>(rval);
+      return std::dynamic_pointer_cast<TrainingData<T>>(_training_data[rname])->get();
+    }
+  }
+}
+
+class TrainingDataBase
+{
+public:
+  TrainingDataBase() : _is_distributed(false) {}
+
+  virtual ~TrainingDataBase() = default;
+
+  virtual dof_id_type size() const = 0;
+  virtual void setCurrentIndex(dof_id_type index) = 0;
+  bool & isDistributed() { return _is_distributed; }
+
+protected:
+  bool _is_distributed;
+};
+
+template <typename T>
+class TrainingData : public TrainingDataBase
+{
+public:
+  TrainingData(const std::vector<T> & vector) : _vector(vector) {}
+
+  virtual dof_id_type size() const override { return _vector.size(); }
+  virtual void setCurrentIndex(dof_id_type index) override { _value = _vector[index]; }
+
+  const T & get() const { return _value; }
+
+private:
+  const std::vector<T> & _vector;
+  T _value;
+};

--- a/modules/stochastic_tools/include/transfers/SamplerReporterTransfer.h
+++ b/modules/stochastic_tools/include/transfers/SamplerReporterTransfer.h
@@ -70,9 +70,6 @@ protected:
   /// Name of the reporter value for multiapp convergence
   const ReporterName _converged_name;
 
-  /// Whether or not reporter values have been cloned
-  bool _initialized;
-
   /// StochasticReporter object where values are being transferred
   StochasticReporter * _results = nullptr;
 };

--- a/modules/stochastic_tools/src/base/StochasticToolsApp.C
+++ b/modules/stochastic_tools/src/base/StochasticToolsApp.C
@@ -40,7 +40,7 @@ StochasticToolsApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax
   // Adds [Trainers] block
   registerSyntaxTask("AddSurrogateAction", "Trainers/*", "add_trainer");
   registerMooseObjectTask("add_trainer", SurrogateTrainer, false);
-  addTaskDependency("add_trainer", "add_user_object");
+  addTaskDependency("add_trainer", "add_sampler");
 
   // Adds [Surrogates] block
   registerSyntaxTask("AddSurrogateAction", "Surrogates/*", "add_surrogate");

--- a/modules/stochastic_tools/src/interfaces/SurrogateModelInterface.C
+++ b/modules/stochastic_tools/src/interfaces/SurrogateModelInterface.C
@@ -51,15 +51,15 @@ SurrogateModelInterface::getSurrogateModel(const std::string & name) const
 }
 
 template <>
-SurrogateTrainer &
+SurrogateTrainerBase &
 SurrogateModelInterface::getSurrogateTrainerByName(const UserObjectName & name) const
 {
-  return _smi_feproblem.getUserObject<SurrogateTrainer>(name);
+  return _smi_feproblem.getUserObject<SurrogateTrainerBase>(name);
 }
 
 template <>
-SurrogateTrainer &
+SurrogateTrainerBase &
 SurrogateModelInterface::getSurrogateTrainer(const std::string & name) const
 {
-  return getSurrogateTrainerByName<SurrogateTrainer>(_smi_params.get<UserObjectName>(name));
+  return getSurrogateTrainerByName<SurrogateTrainerBase>(_smi_params.get<UserObjectName>(name));
 }

--- a/modules/stochastic_tools/src/outputs/SurrogateTrainerOutput.C
+++ b/modules/stochastic_tools/src/outputs/SurrogateTrainerOutput.C
@@ -41,7 +41,7 @@ SurrogateTrainerOutput::output(const ExecFlagType & /*type*/)
     RestartableDataIO restartable_data_io(_app);
     for (const auto & surrogate_name : _trainers)
     {
-      const SurrogateTrainer & trainer = getSurrogateTrainerByName(surrogate_name);
+      const SurrogateTrainerBase & trainer = getSurrogateTrainerByName(surrogate_name);
       const std::string filename =
           this->filename() + "_" + surrogate_name + restartable_data_io.getRestartableDataExt();
 

--- a/modules/stochastic_tools/src/surrogates/GaussianProcessTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/GaussianProcessTrainer.C
@@ -28,15 +28,15 @@ GaussianProcessTrainer::validParams()
   params += CovarianceInterface::validParams();
   params.addClassDescription(
       "Provides data preperation and training for a Gaussian Process surrogate model.");
-  params.addRequiredParam<SamplerName>("sampler", "Training set defined by a sampler object.");
-  params.addRequiredParam<VectorPostprocessorName>(
-      "results_vpp", "Vectorpostprocessor with results of samples created by trainer.");
-  params.addRequiredParam<std::string>(
-      "results_vector",
-      "Name of vector from vectorpostprocessor with results of samples created by trainer");
+  params.addRequiredParam<ReporterName>(
+      "response",
+      "Reporter value of response results, can be vpp with <vpp_name>/<vector_name> or sampler "
+      "column with 'sampler/col_<index>'.");
+  params.addParam<std::vector<ReporterName>>(
+      "predictors",
+      "Reporter values used as the independent random variables, sampler columns can be used with "
+      "'sampler/col_<index>' syntax. Default is to use all sampler columns.");
   params.addRequiredParam<UserObjectName>("covariance_function", "Name of covariance function.");
-  params.addRequiredParam<std::vector<DistributionName>>(
-      "distributions", "Names of the distributions samples were taken from.");
   params.addParam<bool>(
       "standardize_params", true, "Standardize (center and scale) training parameters (x values)");
   params.addParam<bool>(
@@ -58,16 +58,15 @@ GaussianProcessTrainer::GaussianProcessTrainer(const InputParameters & parameter
     CovarianceInterface(parameters),
     _training_params(declareModelData<RealEigenMatrix>("_training_params")),
     _param_standardizer(declareModelData<StochasticTools::Standardizer>("_param_standardizer")),
-    _training_data(),
     _data_standardizer(declareModelData<StochasticTools::Standardizer>("_data_standardizer")),
     _K(declareModelData<RealEigenMatrix>("_K")),
     _K_results_solve(declareModelData<RealEigenMatrix>("_K_results_solve")),
     _K_cho_decomp(declareModelData<Eigen::LLT<RealEigenMatrix>>("_K_cho_decomp")),
     _standardize_params(getParam<bool>("standardize_params")),
     _standardize_data(getParam<bool>("standardize_data")),
-    _covar_type(declareModelData<std::string>("_covar_type")),
     _covariance_function(
         getCovarianceFunctionByName(getParam<UserObjectName>("covariance_function"))),
+    _covar_type(declareModelData<std::string>("_covar_type", _covariance_function->type())),
 #ifdef LIBMESH_HAVE_PETSC
     _do_tuning(isParamValid("tune_parameters")),
     _tao_options(getParam<std::string>("tao_options")),
@@ -75,8 +74,11 @@ GaussianProcessTrainer::GaussianProcessTrainer(const InputParameters & parameter
     _tao_comm(MPI_COMM_SELF),
 #endif
     _hyperparam_map(declareModelData<std::unordered_map<std::string, Real>>("_hyperparam_map")),
-    _hyperparam_vec_map(
-        declareModelData<std::unordered_map<std::string, std::vector<Real>>>("_hyperparam_vec_map"))
+    _hyperparam_vec_map(declareModelData<std::unordered_map<std::string, std::vector<Real>>>(
+        "_hyperparam_vec_map")),
+    _rval(getTrainingData<Real>("response")),
+    _pvals(getTrainingDataVector<Real>("predictors", true)),
+    _n_params(_pvals.size())
 
 {
 #ifdef LIBMESH_HAVE_PETSC
@@ -112,70 +114,24 @@ GaussianProcessTrainer::GaussianProcessTrainer(const InputParameters & parameter
 }
 
 void
-GaussianProcessTrainer::initialSetup()
+GaussianProcessTrainer::preTrain()
 {
-
-  // Results VPP
-  _values_distributed = isVectorPostprocessorDistributed("results_vpp");
-  _values_ptr = &getVectorPostprocessorValue(
-      "results_vpp", getParam<std::string>("results_vector"), !_values_distributed);
-
-  // Sampler
-  _sampler = &getSamplerByName(getParam<SamplerName>("sampler"));
-  _n_params = _sampler->getNumberOfCols();
-
-  // Check if sampler dimension matches number of distributions
-  std::vector<DistributionName> dname = getParam<std::vector<DistributionName>>("distributions");
-  if (dname.size() != _n_params)
-    mooseError("Sampler number of columns does not match number of inputted distributions.");
+  _training_params.setZero(_sampler.getNumberOfRows(), _n_params);
+  _training_data.setZero(_sampler.getNumberOfRows(), 1);
 }
 
 void
-GaussianProcessTrainer::initialize()
+GaussianProcessTrainer::train()
 {
-  // Check if results of samples matches number of samples
-  __attribute__((unused)) dof_id_type num_rows =
-      _values_distributed ? _sampler->getNumberOfLocalRows() : _sampler->getNumberOfRows();
+  for (unsigned int d = 0; d < _n_params; ++d)
+    _training_params(_row, d) = *_pvals[d];
 
-  if (num_rows != _values_ptr->size())
-    paramError("results_vpp",
-               "The number of elements in '",
-               getParam<VectorPostprocessorName>("results_vpp"),
-               "/",
-               getParam<std::string>("results_vector"),
-               "' is not equal to the number of samples in '",
-               getParam<SamplerName>("sampler"),
-               "'!");
-
-  _covar_type = _covariance_function->type();
-
-  mooseAssert(_sampler->getNumberOfRows() == _values_ptr->size(),
-              "Number of sampler rows not equal to number of results in selected VPP.");
+  // Loading result data from response reporter
+  _training_data(_row, 0) = _rval;
 }
 
 void
-GaussianProcessTrainer::execute()
-{
-  dof_id_type offset = _values_distributed ? _sampler->getLocalRowBegin() : 0;
-
-  // Consider the possibility of a very large matrix load.
-  _training_params.setZero(_sampler->getNumberOfRows(), _sampler->getNumberOfCols());
-  _training_data.setZero(_sampler->getNumberOfRows(), 1);
-  for (dof_id_type p = _sampler->getLocalRowBegin(); p < _sampler->getLocalRowEnd(); ++p)
-  {
-    // Loading parameters from sampler
-    std::vector<Real> data = _sampler->getNextLocalRow();
-    for (unsigned int d = 0; d < data.size(); ++d)
-      _training_params(p, d) = data[d];
-
-    // Loading result data from VPP
-    _training_data(p, 0) = (*_values_ptr)[p - offset];
-  }
-}
-
-void
-
-GaussianProcessTrainer::finalize()
+GaussianProcessTrainer::postTrain()
 {
   for (unsigned int ii = 0; ii < _training_params.rows(); ++ii)
   {

--- a/modules/stochastic_tools/src/surrogates/NearestPointTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/NearestPointTrainer.C
@@ -17,69 +17,45 @@ NearestPointTrainer::validParams()
 {
   InputParameters params = SurrogateTrainer::validParams();
   params.addClassDescription("Loops over and saves sample values for [NearestPointSurrogate.md].");
-  params.addRequiredParam<SamplerName>("sampler", "Training set defined by a sampler object.");
-  params.addRequiredParam<VectorPostprocessorName>(
-      "results_vpp", "Vectorpostprocessor with results of samples created by trainer.");
-  params.addRequiredParam<std::string>(
-      "results_vector",
-      "Name of vector from vectorpostprocessor with results of samples created by trainer");
+  params.addRequiredParam<ReporterName>(
+      "response",
+      "Reporter value of response results, can be vpp with <vpp_name>/<vector_name> or sampler "
+      "column with 'sampler/col_<index>'.");
+  params.addParam<std::vector<ReporterName>>(
+      "predictors",
+      "Reporter values used as the independent random variables, sampler columns can be used with "
+      "'sampler/col_<index>' syntax. Default is to use all sampler columns.");
 
   return params;
 }
 
 NearestPointTrainer::NearestPointTrainer(const InputParameters & parameters)
   : SurrogateTrainer(parameters),
-    _sample_points(declareModelData<std::vector<std::vector<Real>>>("_sample_points"))
+    _sample_points(declareModelData<std::vector<std::vector<Real>>>("_sample_points")),
+    _response(getTrainingData<Real>("response")),
+    _predictors(getTrainingDataVector<Real>("predictors", true))
 {
+  _sample_points.resize(_predictors.size() + 1);
 }
 
 void
-NearestPointTrainer::initialSetup()
+NearestPointTrainer::preTrain()
 {
-  // Results VPP
-  _values_distributed = isVectorPostprocessorDistributed("results_vpp");
-  _values_ptr = &getVectorPostprocessorValue(
-      "results_vpp", getParam<std::string>("results_vector"), !_values_distributed);
-
-  // Sampler
-  _sampler = &getSamplerByName(getParam<SamplerName>("sampler"));
-}
-
-void
-NearestPointTrainer::initialize()
-{
-  // Check if results of samples matches number of samples
-  __attribute__((unused)) dof_id_type num_rows =
-      _values_distributed ? _sampler->getNumberOfLocalRows() : _sampler->getNumberOfRows();
-  mooseAssert(num_rows == _values_ptr->size(),
-              "Sampler number of rows does not match number of results from vector postprocessor.");
-
   // Resize to number of sample points
-  _sample_points.resize(_sampler->getNumberOfCols() + 1);
   for (auto & it : _sample_points)
-    it.resize(_sampler->getNumberOfLocalRows());
+    it.resize(_sampler.getNumberOfLocalRows());
 }
 
 void
-NearestPointTrainer::execute()
+NearestPointTrainer::train()
 {
-  // Offset for replicated/distributed result data
-  dof_id_type offset = _values_distributed ? _sampler->getLocalRowBegin() : 0;
-
-  // Loop over samples
-  for (dof_id_type p = _sampler->getLocalRowBegin(); p < _sampler->getLocalRowEnd(); ++p)
-  {
-    std::vector<Real> data = _sampler->getNextLocalRow();
-
-    dof_id_type ind = p - _sampler->getLocalRowBegin();
-    for (unsigned int i = 0; i < data.size(); ++i)
-      _sample_points[i][ind] = data[i];
-    _sample_points[data.size()][ind] = (*_values_ptr)[p - offset];
-  }
+  for (unsigned int i = 0; i < _predictors.size(); ++i)
+    _sample_points[i][_local_row] = *_predictors[i];
+  _sample_points.back()[_local_row] = _response;
 }
 
 void
-NearestPointTrainer::finalize()
+NearestPointTrainer::postTrain()
 {
   for (auto & it : _sample_points)
     _communicator.allgather(it);

--- a/modules/stochastic_tools/src/surrogates/PODReducedBasisTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/PODReducedBasisTrainer.C
@@ -20,7 +20,7 @@ registerMooseObject("StochasticToolsApp", PODReducedBasisTrainer);
 InputParameters
 PODReducedBasisTrainer::validParams()
 {
-  InputParameters params = SurrogateTrainer::validParams();
+  InputParameters params = SurrogateTrainerBase::validParams();
 
   params.addClassDescription("Computes the reduced subspace plus the reduced operators for "
                              "POD-RB surrogate.");
@@ -42,7 +42,7 @@ PODReducedBasisTrainer::validParams()
 }
 
 PODReducedBasisTrainer::PODReducedBasisTrainer(const InputParameters & parameters)
-  : SurrogateTrainer(parameters),
+  : SurrogateTrainerBase(parameters),
     _var_names(declareModelData<std::vector<std::string>>(
         "_var_names", getParam<std::vector<std::string>>("var_names"))),
     _error_res(getParam<std::vector<Real>>("error_res")),

--- a/modules/stochastic_tools/src/surrogates/PolynomialChaosTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/PolynomialChaosTrainer.C
@@ -18,12 +18,8 @@ PolynomialChaosTrainer::validParams()
 {
   InputParameters params = SurrogateTrainer::validParams();
   params.addClassDescription("Computes and evaluates polynomial chaos surrogate model.");
-  params.addRequiredParam<SamplerName>("sampler", "Training set defined by a sampler object.");
-  params.addRequiredParam<VectorPostprocessorName>(
-      "results_vpp", "Vectorpostprocessor with results of samples created by trainer.");
-  params.addRequiredParam<std::string>(
-      "results_vector",
-      "Name of vector from vectorpostprocessor with results of samples created by trainer");
+  params.addRequiredParam<ReporterName>(
+      "response", "Reporter value of response results, can be vpp with <vpp_name>/<vector_name>.");
   params.addRequiredParam<unsigned int>("order", "Maximum polynomial order.");
   params.addRequiredParam<std::vector<DistributionName>>(
       "distributions", "Names of the distributions samples were taken from.");
@@ -33,98 +29,60 @@ PolynomialChaosTrainer::validParams()
 
 PolynomialChaosTrainer::PolynomialChaosTrainer(const InputParameters & parameters)
   : SurrogateTrainer(parameters),
+    _pvals(getSamplerData()),
+    _rval(getTrainingData<Real>(getParam<ReporterName>("response"))),
     _order(declareModelData<unsigned int>("_order", getParam<unsigned int>("order"))),
-    _ndim(declareModelData<unsigned int>("_ndim")),
-    _ncoeff(declareModelData<std::size_t>("_ncoeff")),
-    _tuple(declareModelData<std::vector<std::vector<unsigned int>>>("_tuple")),
+    _ndim(declareModelData<unsigned int>("_ndim", _sampler.getNumberOfCols())),
+    _tuple(declareModelData<std::vector<std::vector<unsigned int>>>(
+        "_tuple", StochasticTools::MultiDimPolynomialGenerator::generateTuple(_ndim, _order))),
+    _ncoeff(declareModelData<std::size_t>("_ncoeff", _tuple.size())),
     _coeff(declareModelData<std::vector<Real>>("_coeff")),
     _poly(declareModelData<std::vector<std::unique_ptr<const PolynomialQuadrature::Polynomial>>>(
-        "_poly"))
+        "_poly")),
+    _quad_sampler(dynamic_cast<QuadratureSampler *>(&_sampler))
 {
-}
+  // Check if number of distributions is correct
+  if (_ndim != _sampler.getNumberOfCols())
+    paramError("distributions",
+               "Sampler number of columns does not match number of inputted distributions.");
 
-void
-PolynomialChaosTrainer::initialize()
-{
+  // Make polynomials
+  for (const auto & nm : getParam<std::vector<DistributionName>>("distributions"))
+    _poly.push_back(PolynomialQuadrature::makePolynomial(&getDistributionByName(nm)));
+
   _coeff.resize(_ncoeff, 0);
 }
 
 void
-PolynomialChaosTrainer::initialSetup()
+PolynomialChaosTrainer::train()
 {
-  // Setup data needed for training
-  _tuple = StochasticTools::MultiDimPolynomialGenerator::generateTuple(
-      getParam<std::vector<DistributionName>>("distributions").size(), _order);
-  _ncoeff = _tuple.size();
-
-  // Results VPP
-  _values_distributed = isVectorPostprocessorDistributed("results_vpp");
-  const ReporterName r_name(getParam<VectorPostprocessorName>("results_vpp"),
-                            getParam<std::string>("results_vector"));
-  auto mode = _values_distributed ? REPORTER_MODE_DISTRIBUTED : REPORTER_MODE_REPLICATED;
-  _values_ptr = &getReporterValueByName<VectorPostprocessorValue>(r_name, mode);
-
-  // Sampler
-  _sampler = &getSamplerByName(getParam<SamplerName>("sampler"));
-  _ndim = _sampler->getNumberOfCols();
-
-  // Special circumstances if sampler is quadrature
-  _quad_sampler = dynamic_cast<QuadratureSampler *>(_sampler);
-
-  // Check if sampler dimension matches number of distributions
-  std::vector<DistributionName> dname = getParam<std::vector<DistributionName>>("distributions");
-  if (dname.size() != _ndim)
-    mooseError("Sampler number of columns does not match number of inputted distributions.");
-  for (auto nm : dname)
-    _poly.push_back(PolynomialQuadrature::makePolynomial(&getDistributionByName(nm)));
-}
-
-void
-PolynomialChaosTrainer::execute()
-{
-  // Check if results of samples matches number of samples
-  __attribute__((unused)) dof_id_type num_rows =
-      _values_distributed ? _sampler->getNumberOfLocalRows() : _sampler->getNumberOfRows();
-  mooseAssert(num_rows == _values_ptr->size(),
-              "Sampler number of rows does not match number of results from vector postprocessor.");
-
-  // Initialize storage for polynomial calculations
   DenseMatrix<Real> poly_val(_ndim, _order);
 
-  // Offset for replicated/distributed result data
-  dof_id_type offset = _values_distributed ? _sampler->getLocalRowBegin() : 0;
+  // Evaluate polynomials to avoid duplication
+  for (unsigned int d = 0; d < _ndim; ++d)
+    for (unsigned int i = 0; i < _order; ++i)
+      poly_val(d, i) = _poly[d]->compute(i, _pvals[d]);
 
-  // Loop over samples
-  for (dof_id_type p = _sampler->getLocalRowBegin(); p < _sampler->getLocalRowEnd(); ++p)
+  // Loop over coefficients
+  for (std::size_t i = 0; i < _ncoeff; ++i)
   {
-    std::vector<Real> data = _sampler->getNextLocalRow();
+    Real val = _rval;
+    // Loop over parameters
+    for (std::size_t d = 0; d < _ndim; ++d)
+      val *= poly_val(d, _tuple[i][d]);
 
-    // Evaluate polynomials to avoid duplication
-    for (unsigned int d = 0; d < _ndim; ++d)
-      for (unsigned int i = 0; i < _order; ++i)
-        poly_val(d, i) = _poly[d]->compute(i, data[d]);
-
-    // Loop over coefficients
-    for (std::size_t i = 0; i < _ncoeff; ++i)
-    {
-      Real val = (*_values_ptr)[p - offset];
-      // Loop over parameters
-      for (std::size_t d = 0; d < _ndim; ++d)
-        val *= poly_val(d, _tuple[i][d]);
-
-      if (_quad_sampler)
-        val *= _quad_sampler->getQuadratureWeight(p);
-      _coeff[i] += val;
-    }
+    if (_quad_sampler)
+      val *= _quad_sampler->getQuadratureWeight(_row);
+    _coeff[i] += val;
   }
 }
 
 void
-PolynomialChaosTrainer::finalize()
+PolynomialChaosTrainer::postTrain()
 {
   gatherSum(_coeff);
 
   if (!_quad_sampler)
     for (std::size_t i = 0; i < _ncoeff; ++i)
-      _coeff[i] /= _sampler->getNumberOfRows();
+      _coeff[i] /= _sampler.getNumberOfRows();
 }

--- a/modules/stochastic_tools/src/surrogates/PolynomialRegressionTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/PolynomialRegressionTrainer.C
@@ -19,12 +19,14 @@ PolynomialRegressionTrainer::validParams()
 
   params.addClassDescription("Computes coefficients for polynomial regession model.");
 
-  params.addRequiredParam<SamplerName>("sampler", "Training set defined by a sampler object.");
-  params.addRequiredParam<VectorPostprocessorName>(
-      "results_vpp", "Vectorpostprocessor with results of samples created by trainer.");
-  params.addRequiredParam<std::string>(
-      "results_vector",
-      "Name of vector from vectorpostprocessor with results of samples created by trainer.");
+  params.addRequiredParam<ReporterName>(
+      "response",
+      "Reporter value of response results, can be vpp with <vpp_name>/<vector_name> or sampler "
+      "column with 'sampler/col_<index>'.");
+  params.addParam<std::vector<ReporterName>>(
+      "predictors",
+      "Reporter values used as the independent random variables, sampler columns can be used with "
+      "'sampler/col_<index>' syntax. Default is to use all sampler columns.");
   MooseEnum rtype("ols=0 ridge=1");
   params.addRequiredParam<MooseEnum>(
       "regression_type", rtype, "The type of regression to perform.");
@@ -37,118 +39,72 @@ PolynomialRegressionTrainer::validParams()
 
 PolynomialRegressionTrainer::PolynomialRegressionTrainer(const InputParameters & parameters)
   : SurrogateTrainer(parameters),
-    _coeff(declareModelData<std::vector<Real>>("_coeff")),
-    _power_matrix(declareModelData<std::vector<std::vector<unsigned int>>>("_power_matrix")),
+    _rval(getTrainingData<Real>("response")),
+    _pvals(getTrainingDataVector<Real>("predictors", true)),
+    _n_dims(_pvals.size()),
     _regression_type(getParam<MooseEnum>("regression_type")),
+    _penalty(getParam<Real>("penalty")),
+    _coeff(declareModelData<std::vector<Real>>("_coeff")),
     _max_degree(
         declareModelData<unsigned int>("_max_degree", getParam<unsigned int>("max_degree"))),
-    _penalty(getParam<Real>("penalty"))
+    _power_matrix(declareModelData<std::vector<std::vector<unsigned int>>>(
+        "_power_matrix",
+        StochasticTools::MultiDimPolynomialGenerator::generateTuple(_n_dims, _max_degree + 1))),
+    _n_poly_terms(_power_matrix.size()),
+    _matrix(_n_poly_terms, _n_poly_terms),
+    _rhs(_n_poly_terms)
 {
-}
+  _coeff.resize(_n_poly_terms);
 
-void
-PolynomialRegressionTrainer::initialSetup()
-{
   // Throwing a warning if the penalty parameter is set with OLS regression
   if (_regression_type == "ols" && _penalty != 0)
     mooseWarning("Penalty parameter is not used for OLS regression, found penalty=", _penalty);
 
-  // Results VPP
-  _values_distributed = isVectorPostprocessorDistributed("results_vpp");
-  _values_ptr = &getVectorPostprocessorValue(
-      "results_vpp", getParam<std::string>("results_vector"), !_values_distributed);
-
-  // Sampler
-  _sampler = &getSamplerByName(getParam<SamplerName>("sampler"));
-
-  _n_dims = _sampler->getNumberOfCols();
-
-  // Initializing power matrix, using _max_degree+1 to tackle the indexing offset
-  // within generateTuple
-  _power_matrix =
-      StochasticTools::MultiDimPolynomialGenerator::generateTuple(_n_dims, _max_degree + 1);
-
-  _n_poly_terms = _power_matrix.size();
-
   // Check if we have enough data points to solve the problem
-  if (_sampler->getNumberOfRows() <= _n_poly_terms)
+  if (_sampler.getNumberOfRows() <= _n_poly_terms)
     mooseError("Number of data points must be greater than the number of terms in the polynomial.");
-
-  // Resize _coeff, _matrix, _rhs to number of sampler columns
-  _coeff.resize(_n_poly_terms);
-  _matrix.resize(_n_poly_terms, _n_poly_terms);
-  _rhs.resize(_n_poly_terms);
 }
 
 void
-PolynomialRegressionTrainer::initialize()
+PolynomialRegressionTrainer::train()
 {
-  // Check if results of samples matches number of samples
-  __attribute__((unused)) dof_id_type num_rows =
-      _values_distributed ? _sampler->getNumberOfLocalRows() : _sampler->getNumberOfRows();
+  // Caching the different powers of data to accelerate the assembly of the
+  // system
+  DenseMatrix<Real> data_pow(_n_dims, _max_degree + 1);
+  for (unsigned int d = 0; d < _n_dims; ++d)
+    for (unsigned int i = 0; i <= _max_degree; ++i)
+      data_pow(d, i) = pow(*_pvals[d], i);
 
-  if (num_rows != _values_ptr->size())
-    paramError("results_vpp",
-               "The number of elements in '",
-               getParam<VectorPostprocessorName>("results_vpp"),
-               "/",
-               getParam<std::string>("results_vector"),
-               "' is not equal to the number of samples in '",
-               getParam<SamplerName>("sampler"),
-               "'!");
-}
-
-void
-PolynomialRegressionTrainer::execute()
-{
-  // Offset for replicated/distributed result data
-  dof_id_type offset = _values_distributed ? _sampler->getLocalRowBegin() : 0;
-
-  // Loop over samples
-  for (dof_id_type p = _sampler->getLocalRowBegin(); p < _sampler->getLocalRowEnd(); ++p)
+  for (unsigned int i = 0; i < _n_poly_terms; ++i)
   {
-    std::vector<Real> data = _sampler->getNextLocalRow();
+    std::vector<unsigned int> i_powers(_power_matrix[i]);
 
-    // Caching the different powers of data to accelerate the assembly of the
-    // system
-    DenseMatrix<Real> data_pow(data.size(), _max_degree + 1);
-    for (unsigned int d = 0; d < data.size(); ++d)
-      for (unsigned int i = 0; i <= _max_degree; ++i)
-        data_pow(d, i) = pow(data[d], i);
+    Real i_value(1.0);
+    for (unsigned int ii = 0; ii < _n_dims; ++ii)
+      i_value *= data_pow(ii, i_powers[ii]);
 
-    for (unsigned int i = 0; i < _n_poly_terms; ++i)
+    for (unsigned int j = 0; j < _n_poly_terms; ++j)
     {
-      std::vector<unsigned int> i_powers(_power_matrix[i]);
+      std::vector<unsigned int> j_powers(_power_matrix[j]);
 
-      Real i_value(1.0);
-      for (unsigned int ii = 0; ii < data.size(); ++ii)
-        i_value *= data_pow(ii, i_powers[ii]);
+      Real j_value(1.0);
+      for (unsigned int jj = 0; jj < _n_dims; ++jj)
+        j_value *= data_pow(jj, j_powers[jj]);
 
-      for (unsigned int j = 0; j < _n_poly_terms; ++j)
-      {
-        std::vector<unsigned int> j_powers(_power_matrix[j]);
-
-        Real j_value(1.0);
-        for (unsigned int jj = 0; jj < data.size(); ++jj)
-          j_value *= data_pow(jj, j_powers[jj]);
-
-        _matrix(i, j) += i_value * j_value;
-      }
-
-      _rhs(i) += i_value * (*_values_ptr)[p - offset];
+      _matrix(i, j) += i_value * j_value;
     }
+
+    _rhs(i) += i_value * _rval;
   }
 
   // Adding penalty term for Ridge regularization
   if (_regression_type == "ridge")
     for (unsigned int i = 0; i < _n_poly_terms; ++i)
-    {
       _matrix(i, i) += _penalty;
-    }
 }
 
 void
-PolynomialRegressionTrainer::finalize()
+PolynomialRegressionTrainer::postTrain()
 {
   gatherSum(_matrix.get_values());
   gatherSum(_rhs.get_values());

--- a/modules/stochastic_tools/src/surrogates/SurrogateTrainer.C
+++ b/modules/stochastic_tools/src/surrogates/SurrogateTrainer.C
@@ -13,16 +13,104 @@
 #include "StochasticToolsApp.h"
 
 InputParameters
-SurrogateTrainer::validParams()
+SurrogateTrainerBase::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
   params.registerBase("SurrogateTrainer");
   return params;
 }
 
-SurrogateTrainer::SurrogateTrainer(const InputParameters & parameters)
-  : GeneralUserObject(parameters),
-    _model_meta_data_name(_type + "_" + name())
+SurrogateTrainerBase::SurrogateTrainerBase(const InputParameters & parameters)
+  : GeneralUserObject(parameters), _model_meta_data_name(_type + "_" + name())
 {
   _app.registerRestartableDataMapName(_model_meta_data_name, name());
+}
+
+InputParameters
+SurrogateTrainer::validParams()
+{
+  InputParameters params = SurrogateTrainerBase::validParams();
+  params.addRequiredParam<SamplerName>("sampler",
+                                       "Sampler used to create predictor and response data.");
+  return params;
+}
+
+SurrogateTrainer::SurrogateTrainer(const InputParameters & parameters)
+  : SurrogateTrainerBase(parameters),
+    _sampler(getSampler("sampler")),
+    _row_data(_sampler.getNumberOfCols())
+{
+}
+
+void
+SurrogateTrainer::initialize()
+{
+  // Figure out if data is distributed
+  for (auto & pair : _training_data)
+  {
+    const ReporterName & name = pair.first;
+    TrainingDataBase & data = *pair.second;
+
+    const auto & mode = _fe_problem.getReporterData().getReporterMode(name);
+    if (mode == REPORTER_MODE_DISTRIBUTED || (mode == REPORTER_MODE_ROOT && processor_id() != 0))
+      data.isDistributed() = true;
+    else if (mode == REPORTER_MODE_REPLICATED ||
+             (mode == REPORTER_MODE_ROOT && processor_id() == 0))
+      data.isDistributed() = false;
+    else
+      mooseError("Predictor reporter value ", name, " is not of supported mode.");
+  }
+}
+
+void
+SurrogateTrainer::execute()
+{
+  checkIntegrity();
+
+  _row = _sampler.getLocalRowBegin();
+  _local_row = 0;
+
+  preTrain();
+
+  for (_row = _sampler.getLocalRowBegin(); _row < _sampler.getLocalRowEnd(); ++_row)
+  {
+    // Need to do this manually in order to keep the iterators valid
+    const std::vector<Real> data = _sampler.getNextLocalRow();
+    for (unsigned int i = 0; i < _row_data.size(); ++i)
+      _row_data[i] = data[i];
+
+    // Set training data
+    for (auto & pair : _training_data)
+      pair.second->setCurrentIndex((pair.second->isDistributed() ? _local_row : _row));
+
+    train();
+
+    _local_row++;
+  }
+
+  postTrain();
+}
+
+void
+SurrogateTrainer::checkIntegrity() const
+{
+  // Check that the number of sampler columns hasn't changed
+  if (_row_data.size() != _sampler.getNumberOfCols())
+    mooseError("Number of sampler columns has changed.");
+
+  // Check that training data is correctly sized
+  for (auto & pair : _training_data)
+  {
+    dof_id_type rsize = pair.second->size();
+    dof_id_type nrow =
+        pair.second->isDistributed() ? _sampler.getNumberOfLocalRows() : _sampler.getNumberOfRows();
+    if (rsize != nrow)
+      mooseError("Reporter value ",
+                 pair.first,
+                 " of size ",
+                 rsize,
+                 " does not match sampler size (",
+                 nrow,
+                 ").");
+  }
 }

--- a/modules/stochastic_tools/src/transfers/SamplerReporterTransfer.C
+++ b/modules/stochastic_tools/src/transfers/SamplerReporterTransfer.C
@@ -47,8 +47,7 @@ SamplerReporterTransfer::SamplerReporterTransfer(const InputParameters & paramet
         isParamValid("prefix")
             ? getReporterNamesHelper(getParam<std::string>("prefix"), _sr_name, _sub_reporter_names)
             : getReporterNamesHelper(_name, _sr_name, _sub_reporter_names)),
-    _converged_name(_sr_name, StochasticReporter::convergedReporterName()),
-    _initialized(false)
+    _converged_name(_sr_name, StochasticReporter::convergedReporterName())
 {
 }
 
@@ -60,17 +59,13 @@ SamplerReporterTransfer::initialSetup()
   _results = dynamic_cast<StochasticReporter *>(&uo);
   if (!_results)
     paramError("stochastic_reporter", "This object must be a 'StochasticReporter' object.");
+
+  intitializeStochasticReporters();
 }
 
 void
 SamplerReporterTransfer::initializeFromMultiapp()
 {
-  if (!_initialized)
-  {
-    intitializeStochasticReporters();
-    _initialized = true;
-  }
-
   resizeStochasticReporters();
 }
 
@@ -90,12 +85,6 @@ SamplerReporterTransfer::finalizeFromMultiapp()
 void
 SamplerReporterTransfer::execute()
 {
-  if (!_initialized)
-  {
-    intitializeStochasticReporters();
-    _initialized = true;
-  }
-
   resizeStochasticReporters();
 
   for (dof_id_type i = _sampler_ptr->getLocalRowBegin(); i < _sampler_ptr->getLocalRowEnd(); ++i)

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_Matern_half_int.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_Matern_half_int.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'   #Choose a Matern with half-integer argument for the kernel
     standardize_params = 'true'           #Center and scale the training params
     standardize_data = 'true'             #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_Matern_half_int_tuned.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_Matern_half_int_tuned.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'   #Choose a Matern with half-integer argument for the kernel
     standardize_params = 'true'           #Center and scale the training params
     standardize_data = 'true'             #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
     tao_options = '-tao_bncg_type ssml_bfgs'
     tune_parameters = ' signal_variance length_factor'
     tuning_min = ' 1e-9 1e-9'

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_exponential.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_exponential.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'           #Choose an exponential for the kernel
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_exponential_tuned.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_exponential_tuned.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'           #Choose an exponential for the kernel
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
     tao_options = '-tao_bncg_type ssml_bfgs'
     tune_parameters = 'signal_variance length_factor'
     tuning_min = ' 1e-9 1e-9'

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'             #Choose a squared exponential for the kernel
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential_training.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential_training.i
@@ -63,10 +63,8 @@
     covariance_function = 'covar'             #Choose a squared exponential for the kernel
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential_tuned.i
+++ b/modules/stochastic_tools/test/tests/surrogates/gaussian_process/GP_squared_exponential_tuned.i
@@ -88,10 +88,8 @@
     covariance_function = 'covar'             #Choose a squared exponential for the kernel
     standardize_params = 'true'               #Center and scale the training params
     standardize_data = 'true'                 #Center and scale the training data
-    distributions = 'k_dist q_dist'
     sampler = train_sample
-    results_vpp = results
-    results_vector = data:avg
+    response = results/data:avg
     tao_options = '-tao_bncg_type ssml_bfgs'
     tune_parameters = ' signal_variance length_factor'
     tuning_min = ' 1e-9 1e-9'

--- a/modules/stochastic_tools/test/tests/surrogates/load_store/train.i
+++ b/modules/stochastic_tools/test/tests/surrogates/load_store/train.i
@@ -63,8 +63,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/load_store/train_and_evaluate.i
+++ b/modules/stochastic_tools/test/tests/surrogates/load_store/train_and_evaluate.i
@@ -69,8 +69,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/predictor_response.i
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/predictor_response.i
@@ -4,11 +4,15 @@
 [Samplers]
   [sample]
     type = CartesianProduct
-    linear_space_items = '0 1 10'
+    linear_space_items = '0 1 10
+                          0 1 10
+                          0 1 10'
   []
   [test]
     type = CartesianProduct
-    linear_space_items = '0.25 0.5 20'
+    linear_space_items = '0.25 1 10
+                          0.25 1 10
+                          0.25 1 10'
   []
 []
 
@@ -16,7 +20,7 @@
   [values]
     type = GFunction
     sampler = sample
-    q_vector = '0'
+    q_vector = '0 0 0'
     execute_on = INITIAL
     outputs = none
   []
@@ -24,8 +28,16 @@
     type = EvaluateSurrogate
     model = surrogate
     sampler = test
-    output_samples = true
     execute_on = final
+  []
+[]
+
+[Trainers]
+  [train]
+    type = NearestPointTrainer
+    sampler = sample
+    predictors = 'sampler/col_0 sampler/col_1 sampler/col_2'
+    response = values/g_values
   []
 []
 
@@ -36,15 +48,7 @@
   []
 []
 
-[Trainers]
-  [train]
-    type = NearestPointTrainer
-    sampler = sample
-    response = values/g_values
-  []
-[]
-
 [Outputs]
   csv = true
-  execute_on = FINAL
+  execute_on = final
 []

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/predictor_response.i
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/predictor_response.i
@@ -17,6 +17,11 @@
 []
 
 [VectorPostprocessors]
+  [sampler_data]
+    type = SamplerData
+    sampler = sample
+    parallel_type = DISTRIBUTED
+  []
   [values]
     type = GFunction
     sampler = sample
@@ -36,7 +41,8 @@
   [train]
     type = NearestPointTrainer
     sampler = sample
-    predictors = 'sampler/col_0 sampler/col_1 sampler/col_2'
+    predictors = 'sampler_data/sample_0'
+    predictor_cols = '1 2'
     response = values/g_values
   []
 []

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/tests
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/tests
@@ -15,13 +15,21 @@
     allow_test_objects = true
     csvdiff = 'evaluate_out_results_0002.csv'
     prereq = train # Creates data files that this test uses
-    detail = 'evaluating and '
+    detail = 'evaluating, '
   []
   [train_and_load]
     type = CSVDiff
     input = cartesian.i
     allow_test_objects = true
     csvdiff = 'cartesian_out_results_0002.csv'
-    detail = 'training and loading.'
+    detail = 'training and loading, and '
+  []
+  [predictors]
+    type = CSVDiff
+    input = predictor_response.i
+    allow_test_objects = true
+    cli_args = 'Outputs/file_base=evaluate_out'
+    csvdiff = 'evaluate_out_results_0002.csv'
+    detail = 'using explictly specified predictors.'
   []
 []

--- a/modules/stochastic_tools/test/tests/surrogates/nearest_point/train.i
+++ b/modules/stochastic_tools/test/tests/surrogates/nearest_point/train.i
@@ -24,8 +24,7 @@
   [train]
     type = NearestPointTrainer
     sampler = sample
-    results_vpp = values
-    results_vector = g_values
+    response = values/g_values
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_mc.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_mc.i
@@ -41,19 +41,21 @@
     to_control = 'stochastic'
   []
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = quad_sub
     sampler = sample
-    to_vector_postprocessor = storage
-    from_postprocessor = avg
+    stochastic_reporter = storage
+    from_reporter = avg/value
+  []
+[]
+
+[Reporters]
+  [storage]
+    type = StochasticReporter
   []
 []
 
 [VectorPostprocessors]
-  [storage]
-    type = StochasticResults
-    parallel_type = REPLICATED
-  []
   [pc_coeff]
     type = PolynomialChaosData
     pc_name = poly_chaos
@@ -82,8 +84,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = sample
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg:value
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad.i
@@ -47,19 +47,21 @@
     to_control = 'stochastic'
   []
   [data]
-    type = SamplerPostprocessorTransfer
+    type = SamplerReporterTransfer
     multi_app = quad_sub
     sampler = quadrature
-    to_vector_postprocessor = storage
-    from_postprocessor = avg
+    stochastic_reporter = storage
+    from_reporter = avg/value
+  []
+[]
+
+[Reporters]
+  [storage]
+    type = StochasticReporter
   []
 []
 
 [VectorPostprocessors]
-  [storage]
-    type = StochasticResults
-    parallel_type = REPLICATED
-  []
   [pc_coeff]
     type = PolynomialChaosData
     pc_name = poly_chaos
@@ -88,8 +90,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg:value
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_locs.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_locs.i
@@ -83,8 +83,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_moment.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2d_quad_moment.i
@@ -76,8 +76,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad.i
@@ -88,8 +88,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_locs.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_locs.i
@@ -83,8 +83,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_moment.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/master_2dnorm_quad_moment.i
@@ -76,8 +76,7 @@
     order = 5
     distributions = 'D_dist S_dist'
     sampler = quadrature
-    results_vpp = storage
-    results_vector = data:avg
+    response = storage/data:avg
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/sobol.i
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/sobol.i
@@ -26,7 +26,7 @@
     type = PolynomialChaosSobolStatistics
     pc_name = poly_chaos
     sensitivity_order = 'all total'
-    execute_on = final
+    execute_on = timestep_end
   []
 []
 
@@ -40,12 +40,11 @@
 [Trainers]
   [poly_chaos]
     type = PolynomialChaosTrainer
-    execute_on = final
+    execute_on = timestep_end
     order = 4
     distributions = 'uniform uniform uniform uniform uniform uniform'
     sampler = sample
-    results_vpp = results
-    results_vector = g_values
+    response = results/g_values
   []
 []
 

--- a/modules/stochastic_tools/test/tests/surrogates/poly_chaos/tests
+++ b/modules/stochastic_tools/test/tests/surrogates/poly_chaos/tests
@@ -15,14 +15,14 @@
       input = master_2d_quad.i
       allow_test_objects = true
       csvdiff = 'master_2d_quad_out_pc_samp_0002.csv'
-      detail = 'Quadrature sampler with Uniform distribution, '
+      detail = 'Quadrature sampler with Uniform distribution, and '
     []
     [gauss_hermite]
       type = CSVDiff
       input = master_2dnorm_quad.i
       allow_test_objects = true
       csvdiff = 'master_2dnorm_quad_out_pc_samp_0002.csv'
-      detail = 'Quadrature sampler with Normal distribution, and '
+      detail = 'Quadrature sampler with Normal distribution.'
     []
   []
   [statistics]

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/errors/error.i
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/errors/error.i
@@ -30,8 +30,7 @@
     type = PolynomialRegressionTrainer
     regression_type = "ols"
     sampler = sample
-    results_vpp = values
-    results_vector = g_values
+    response = values/g_values
     max_degree = 3
   []
 []

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/errors/tests
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/errors/tests
@@ -9,7 +9,7 @@
       type = RunException
       input = error.i
       allow_test_objects = true
-      expect_err = "The number of elements in 'values/g_values' is not equal to the number of samples in 'sample'!"
+      expect_err = "Reporter value values/g_values of size 1000 does not match sampler size \(100\)."
       detail = "the number of samples does not match the number of results."
     []
   []

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train.i
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train.i
@@ -25,8 +25,7 @@
     type = PolynomialRegressionTrainer
     regression_type = "ols"
     sampler = sample
-    results_vpp = values
-    results_vector = g_values
+    response = values/g_values
     max_degree = 3
   []
 []

--- a/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train_and_evaluate.i
+++ b/modules/stochastic_tools/test/tests/surrogates/polynomial_regression/train_and_evaluate.i
@@ -41,8 +41,7 @@
     type = PolynomialRegressionTrainer
     regression_type = "ols"
     sampler = sample
-    results_vpp = values
-    results_vector = g_values
+    response = values/g_values
     max_degree = 3
   []
 []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/batch_parallel.json
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/batch_parallel.json
@@ -11,6 +11,21 @@
                     },
                     "values": [
                         {
+                            "name": "data:constant:str",
+                            "type": "std::vector<std::string>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:mesh:sidesets",
+                            "type": "std::vector<std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/batch_parallel.json.1
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/batch_parallel.json.1
@@ -11,6 +11,21 @@
                     },
                     "values": [
                         {
+                            "name": "data:constant:str",
+                            "type": "std::vector<std::string>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:mesh:sidesets",
+                            "type": "std::vector<std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_batch_out.json
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_batch_out.json
@@ -9,6 +9,21 @@
                     },
                     "values": [
                         {
+                            "name": "data:constant:str",
+                            "type": "std::vector<std::string>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:mesh:sidesets",
+                            "type": "std::vector<std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >>",
+                            "value": []
+                        },
+                        {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json
@@ -11,6 +11,11 @@
                     },
                     "values": [
                         {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.1
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.1
@@ -11,6 +11,11 @@
                     },
                     "values": [
                         {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.2
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.2
@@ -11,6 +11,11 @@
                     },
                     "values": [
                         {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.3
+++ b/modules/stochastic_tools/test/tests/transfers/sampler_reporter/gold/main_small_out.json.3
@@ -11,6 +11,11 @@
                     },
                     "values": [
                         {
+                            "name": "data:pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
                             "name": "multiapp_converged",
                             "type": "std::vector<bool>",
                             "value": []

--- a/test/include/reporters/TestReporter.h
+++ b/test/include/reporters/TestReporter.h
@@ -67,3 +67,17 @@ public:
   virtual void finalize() override {}
   virtual void execute() override {}
 };
+
+class TestGetReporterDeclaredInInitialSetupReporter : public GeneralReporter
+{
+public:
+  static InputParameters validParams();
+  TestGetReporterDeclaredInInitialSetupReporter(const InputParameters & parameters);
+  virtual void initialize() override {}
+  virtual void finalize() override {}
+  virtual void execute() override;
+
+protected:
+  const Real & _value_declared_in_initial_setup;
+  Real & _the_value_of_the_reporter;
+};

--- a/test/src/reporters/TestReporter.C
+++ b/test/src/reporters/TestReporter.C
@@ -12,6 +12,7 @@
 registerMooseObject("MooseTestApp", TestDeclareReporter);
 registerMooseObject("MooseTestApp", TestGetReporter);
 registerMooseObject("MooseTestApp", TestDeclareInitialSetupReporter);
+registerMooseObject("MooseTestApp", TestGetReporterDeclaredInInitialSetupReporter);
 
 InputParameters
 TestDeclareReporter::validParams()
@@ -148,4 +149,27 @@ TestDeclareInitialSetupReporter::initialSetup()
 {
   Real & value = declareValueByName<Real>("value");
   value = getParam<Real>("value");
+}
+
+InputParameters
+TestGetReporterDeclaredInInitialSetupReporter::validParams()
+{
+  InputParameters params = GeneralReporter::validParams();
+  params.addRequiredParam<ReporterName>("other_reporter",
+                                        "The reporter name that was declared in initialSetup");
+  return params;
+}
+
+TestGetReporterDeclaredInInitialSetupReporter::TestGetReporterDeclaredInInitialSetupReporter(
+    const InputParameters & parameters)
+  : GeneralReporter(parameters),
+    _value_declared_in_initial_setup(getReporterValue<Real>("other_reporter")),
+    _the_value_of_the_reporter(declareValueByName<Real>("other_value"))
+{
+}
+
+void
+TestGetReporterDeclaredInInitialSetupReporter::execute()
+{
+  _the_value_of_the_reporter = _value_declared_in_initial_setup;
 }

--- a/test/tests/reporters/declare_initial_setup/declare_initial_setup_with_get.i
+++ b/test/tests/reporters/declare_initial_setup/declare_initial_setup_with_get.i
@@ -1,0 +1,37 @@
+[Mesh]
+  [generate]
+    type = GeneratedMeshGenerator
+    dim = 1
+  []
+[]
+
+[Variables/u]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Problem]
+  kernel_coverage_check = false
+  solve = false
+[]
+
+[Reporters]
+  [initialSetup]
+    type = TestDeclareInitialSetupReporter
+    value = 1980
+  []
+  [get]
+    type = TestGetReporterDeclaredInInitialSetupReporter
+    other_reporter = initialSetup/value
+  []
+[]
+
+[Outputs]
+  [out]
+    type = JSON
+    execute_on = FINAL
+    execute_system_information_on = NONE
+  []
+[]

--- a/test/tests/reporters/declare_initial_setup/gold/declare_initial_setup_with_get_out.json
+++ b/test/tests/reporters/declare_initial_setup/gold/declare_initial_setup_with_get_out.json
@@ -1,0 +1,37 @@
+{
+    "time_steps": [
+        {
+            "reporters": {
+                "initialSetup": {
+                    "info": {
+                        "name": "initialSetup",
+                        "type": "TestDeclareInitialSetupReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "value",
+                            "type": "double",
+                            "value": 1980.0
+                        }
+                    ]
+                },
+                "get": {
+                    "info": {
+                        "name": "get",
+                        "type": "TestGetReporterDeclaredInInitialSetupReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "other_value",
+                            "type": "double",
+                            "value": 1980.0
+                        }
+                    ]
+                }
+
+            },
+            "time": 2.0,
+            "time_step": 2
+        }
+    ]
+}

--- a/test/tests/reporters/declare_initial_setup/tests
+++ b/test/tests/reporters/declare_initial_setup/tests
@@ -21,4 +21,12 @@
       detail = "and with other values declared at construction time."
     []
   []
+
+  [decalareInitialSetup_with_get]
+    requirement = "The system shall support getting a reference to an aggregate calculation before it is created."
+    issues = '#17468'
+    type = JSONDiff
+    input = declare_initial_setup_with_get.i
+    jsondiff = declare_initial_setup_with_info.json
+  []
 []

--- a/test/tests/reporters/declare_initial_setup/tests
+++ b/test/tests/reporters/declare_initial_setup/tests
@@ -27,6 +27,6 @@
     issues = '#17468'
     type = JSONDiff
     input = declare_initial_setup_with_get.i
-    jsondiff = declare_initial_setup_with_info.json
+    jsondiff = declare_initial_setup_with_get_out.json
   []
 []


### PR DESCRIPTION
This PR creates an intermediate SurrogateTrainer class which generalizes some API that was duplicated heavily in the trainers. It allows for gathering generic training data, performs proper size checks, deals with proper indexing for distributed/replicated/root data, and does the sampler loop on its on. I tried to make it similar to the Kernel-Coupleable/Material interface.

I fixed some random bugs along the way and updated all the examples to the "modern" objects.

Refs #16166

Closes #17468 
