### PR TITLE
Improve UserObjectInterface errors

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -882,9 +882,10 @@ public:
   /**
    * Get the user object by its name
    * @param name The name of the user object being retrieved
+   * @param tid The thread of the user object (defaults to 0)
    * @return Const reference to the user object
    */
-  const UserObject & getUserObjectBase(const std::string & name) const;
+  const UserObject & getUserObjectBase(const std::string & name, const THREAD_ID tid = 0) const;
 
   /**
    * Check if there if a user object of given name

--- a/framework/include/userobject/DiscreteElementUserObject.h
+++ b/framework/include/userobject/DiscreteElementUserObject.h
@@ -32,5 +32,6 @@ public:
   virtual void finalize() override final;
   virtual void threadJoin(const UserObject &) override final;
   /// @}
-};
 
+  bool needThreadedCopy() const override final { return true; }
+};

--- a/framework/include/userobject/GeneralUserObject.h
+++ b/framework/include/userobject/GeneralUserObject.h
@@ -50,22 +50,26 @@ public:
   /**
    * Store dependency among same object types for proper execution order
    */
-  virtual const PostprocessorValue & getPostprocessorValue(const std::string & name,
-                                                           unsigned int index = 0);
-  virtual const PostprocessorValue & getPostprocessorValueByName(const PostprocessorName & name);
+  const PostprocessorValue & getPostprocessorValue(const std::string & name,
+                                                   unsigned int index = 0) const override final;
+  const PostprocessorValue &
+  getPostprocessorValueByName(const PostprocessorName & name) const override final;
 
-  virtual const VectorPostprocessorValue &
-  getVectorPostprocessorValue(const std::string & name, const std::string & vector_name) override;
-  virtual const VectorPostprocessorValue &
+  const VectorPostprocessorValue &
+  getVectorPostprocessorValue(const std::string & name,
+                              const std::string & vector_name) const override final;
+  const VectorPostprocessorValue &
   getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
-                                    const std::string & vector_name) override;
+                                    const std::string & vector_name) const override final;
 
-  virtual const VectorPostprocessorValue & getVectorPostprocessorValue(
-      const std::string & name, const std::string & vector_name, bool use_broadcast) override;
-  virtual const VectorPostprocessorValue &
+  const VectorPostprocessorValue &
+  getVectorPostprocessorValue(const std::string & name,
+                              const std::string & vector_name,
+                              bool use_broadcast) const override final;
+  const VectorPostprocessorValue &
   getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
                                     const std::string & vector_name,
-                                    bool use_broadcast) override;
+                                    bool use_broadcast) const override final;
 
   ///@}
 
@@ -73,6 +77,6 @@ protected:
   virtual void addReporterDependencyHelper(const ReporterName & state_name) override;
 
 protected:
-  std::set<std::string> _depend_vars;
+  mutable std::set<std::string> _depend_vars;
   std::set<std::string> _supplied_vars;
 };

--- a/framework/include/userobject/ThreadedGeneralUserObject.h
+++ b/framework/include/userobject/ThreadedGeneralUserObject.h
@@ -21,5 +21,6 @@ public:
   virtual ~ThreadedGeneralUserObject() = default;
   virtual void threadJoin(const UserObject &) override;
   virtual void subdomainSetup() override{};
-};
 
+  bool needThreadedCopy() const override final { return true; }
+};

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -175,31 +175,37 @@ public:
   }
 
   template <typename T>
-  const T & getUserObject(const std::string & name)
+  const T & getUserObject(const std::string & param_name) const
   {
-    _depend_uo.insert(_pars.get<UserObjectName>(name));
-    return UserObjectInterface::getUserObject<T>(name);
+    const auto & uo = UserObjectInterface::getUserObject<T>(param_name);
+    _depend_uo.insert(_pars.get<UserObjectName>(param_name));
+    return uo;
   }
 
   template <typename T>
-  const T & getUserObjectByName(const UserObjectName & name)
+  const T & getUserObjectByName(const UserObjectName & object_name) const
   {
-    _depend_uo.insert(name);
-    return UserObjectInterface::getUserObjectByName<T>(name);
+    const auto & uo = UserObjectInterface::getUserObjectByName<T>(object_name);
+    _depend_uo.insert(object_name);
+    return uo;
   }
 
-  const UserObject & getUserObjectBase(const UserObjectName & name)
+  const UserObject & getUserObjectBase(const UserObjectName & param_name) const
   {
-    return getUserObjectBaseByName(_pars.get<UserObjectName>(name));
+    const auto & uo = UserObjectInterface::getUserObjectBase(param_name);
+    _depend_uo.insert(uo.name());
+    return uo;
   }
 
-  const UserObject & getUserObjectBaseByName(const UserObjectName & name)
+  const UserObject & getUserObjectBaseByName(const UserObjectName & object_name) const
   {
-    _depend_uo.insert(name);
-    return UserObjectInterface::getUserObjectBaseByName(name);
+    const auto & uo = UserObjectInterface::getUserObjectBaseByName(object_name);
+    _depend_uo.insert(object_name);
+    return uo;
   }
 
-  const PostprocessorValue & getPostprocessorValue(const std::string & name, unsigned int index = 0)
+  virtual const PostprocessorValue & getPostprocessorValue(const std::string & name,
+                                                           unsigned int index = 0) const
   {
     if (hasPostprocessor(name, index))
     {
@@ -214,38 +220,43 @@ public:
     return PostprocessorInterface::getPostprocessorValue(name, index);
   }
 
-  const PostprocessorValue & getPostprocessorValueByName(const PostprocessorName & name)
+  virtual const PostprocessorValue &
+  getPostprocessorValueByName(const PostprocessorName & name) const
   {
     _depend_uo.insert(name);
     return PostprocessorInterface::getPostprocessorValueByName(name);
   }
 
-  const VectorPostprocessorValue & getVectorPostprocessorValue(const std::string & name,
-                                                               const std::string & vector_name)
+  virtual const VectorPostprocessorValue &
+  getVectorPostprocessorValue(const std::string & name,
+                              const std::string & vector_name) const override
   {
     _depend_uo.insert(_pars.get<VectorPostprocessorName>(name));
     return VectorPostprocessorInterface::getVectorPostprocessorValue(name, vector_name);
   }
 
-  const VectorPostprocessorValue &
+  virtual const VectorPostprocessorValue &
   getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
-                                    const std::string & vector_name)
+                                    const std::string & vector_name) const override
   {
     _depend_uo.insert(name);
     return VectorPostprocessorInterface::getVectorPostprocessorValueByName(name, vector_name);
   }
 
-  const VectorPostprocessorValue & getVectorPostprocessorValue(const std::string & name,
-                                                               const std::string & vector_name,
-                                                               bool needs_broadcast)
+  virtual const VectorPostprocessorValue &
+  getVectorPostprocessorValue(const std::string & name,
+                              const std::string & vector_name,
+                              bool needs_broadcast) const override
   {
     _depend_uo.insert(_pars.get<VectorPostprocessorName>(name));
     return VectorPostprocessorInterface::getVectorPostprocessorValue(
         name, vector_name, needs_broadcast);
   }
 
-  const VectorPostprocessorValue & getVectorPostprocessorValueByName(
-      const VectorPostprocessorName & name, const std::string & vector_name, bool needs_broadcast)
+  virtual const VectorPostprocessorValue &
+  getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
+                                    const std::string & vector_name,
+                                    bool needs_broadcast) const override
   {
     _depend_uo.insert(name);
     return VectorPostprocessorInterface::getVectorPostprocessorValueByName(
@@ -253,7 +264,8 @@ public:
   }
 
   const ScatterVectorPostprocessorValue &
-  getScatterVectorPostprocessorValue(const std::string & name, const std::string & vector_name)
+  getScatterVectorPostprocessorValue(const std::string & name,
+                                     const std::string & vector_name) const override final
   {
     _depend_uo.insert(_pars.get<VectorPostprocessorName>(name));
     return VectorPostprocessorInterface::getScatterVectorPostprocessorValue(name, vector_name);
@@ -261,7 +273,7 @@ public:
 
   const ScatterVectorPostprocessorValue &
   getScatterVectorPostprocessorValueByName(const std::string & name,
-                                           const std::string & vector_name)
+                                           const std::string & vector_name) const override final
   {
     _depend_uo.insert(name);
     return VectorPostprocessorInterface::getScatterVectorPostprocessorValueByName(name,
@@ -288,5 +300,5 @@ private:
   UserObject * _primary_thread_copy = nullptr;
 
   /// Depend UserObjects that to be used by AuxKernel for finding the full UO dependency
-  std::set<UserObjectName> _depend_uo;
+  mutable std::set<UserObjectName> _depend_uo;
 };

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -280,6 +280,14 @@ public:
                                                                                   vector_name);
   }
 
+  /**
+   * Whether or not a threaded copy of this object is needed when obtaining it in
+   * another object, like via the UserObjectInterface.
+   *
+   * Derived classes should override this as needed.
+   */
+  virtual bool needThreadedCopy() const { return false; }
+
 protected:
   /// Reference to the Subproblem for this user object
   SubProblem & _subproblem;

--- a/framework/include/userobject/UserObjectInterface.h
+++ b/framework/include/userobject/UserObjectInterface.h
@@ -10,11 +10,10 @@
 #pragma once
 
 // MOOSE includes
-#include "FEProblemBase.h"
 #include "MooseTypes.h"
+#include "FEProblemBase.h"
 
 // Forward declarations
-class InputParameters;
 class UserObject;
 
 /**
@@ -32,61 +31,107 @@ public:
   UserObjectInterface(const MooseObject * moose_object);
 
   /**
-   * Get an user object with a given parameter name
-   * @param name The name of the parameter key of the user object to retrieve
-   * @return The user object with name associated with the parameter 'name'
+   * @return The name of the user object associated with the parameter \p param_name
+   */
+  UserObjectName getUserObjectName(const std::string & param_name) const;
+
+  /**
+   * @return Whether or not a UserObject exists with the name given by the parameter \p param_name.
+   */
+  bool hasUserObject(const std::string & param_name) const;
+  /*
+   * @return Whether or not a UserObject exists with the name \p object_name.
+   */
+  bool hasUserObjectByName(const UserObjectName & object_name) const;
+
+  /**
+   * Get an user object with a given parameter \p param_name
+   * @param param_name The name of the parameter key of the user object to retrieve
+   * @return The user object with name associated with the parameter \p param_name
    */
   template <class T>
-  const T & getUserObject(const std::string & name) const;
+  const T & getUserObject(const std::string & param_name) const;
 
   /**
-   * Get an user object with a given name
-   * @param name The name of the user object to retrieve
-   * @return The user object with the name
+   * Get an user object with the name \p object_name
+   * @param object_name The name of the user object to retrieve
+   * @return The user object with the name \p object_name
    */
   template <class T>
-  const T & getUserObjectByName(const std::string & name) const;
+  const T & getUserObjectByName(const UserObjectName & object_name) const;
 
   /**
-   * Get an user object with a given parameter name
-   * @param name The name of the parameter key of the user object to retrieve
-   * @return The user object with name associated with the parameter 'name'
+   * Get an user object with a given parameter \p param_name
+   * @param param_name The name of the parameter key of the user object to retrieve
+   * @return The user object with name associated with the parameter \p param_name
    */
-  const UserObject & getUserObjectBase(const std::string & name) const;
+  const UserObject & getUserObjectBase(const std::string & param_name) const;
 
   /**
-   * Get an user object with a given name
-   * @param name The name of the user object to retrieve
-   * @return The user object with the name
+   * Get an user object with the name \p object_name
+   * @param object_name The name of the user object to retrieve
+   * @return The user object with the name \p object_name
    */
-  const UserObject & getUserObjectBaseByName(const std::string & name) const;
+  const UserObject & getUserObjectBaseByName(const UserObjectName & object_name) const;
 
 private:
-  /// Parameters of the object with this interface
-  const InputParameters & _uoi_params;
+  /**
+   * Internal helper that casts the UserObject \p uo_base to the reqested type. Exits with
+   * a useful error if the casting failed. If the parameter \p param_name is provided and
+   * is valid, a paramError() will be used instead.
+   */
+  template <class T>
+  const T & castUserObject(const UserObject & uo_base, const std::string & param_name = "") const;
+
+  /// Gets a UserObject's type; avoids including UserObject.h in the UserObjectInterface
+  const std::string & userObjectType(const UserObject & uo) const;
+  /// Gets a UserObject's name; avoids including UserObject.h in the UserObjectInterface
+  const std::string & userObjectName(const UserObject & uo) const;
+
+  /// Moose object using the interface
+  const MooseObject & _uoi_moose_object;
 
   /// Reference to the FEProblemBase instance
-  FEProblemBase & _uoi_feproblem;
+  const FEProblemBase & _uoi_feproblem;
 
   /// Thread ID
-  THREAD_ID _uoi_tid;
-
-  /// Check if the threaded copy of the user object is needed
-  bool needThreadedCopy(const UserObject & uo) const;
+  const THREAD_ID _uoi_tid;
 };
 
 template <class T>
 const T &
-UserObjectInterface::getUserObject(const std::string & name) const
+UserObjectInterface::castUserObject(const UserObject & uo_base,
+                                    const std::string & param_name /* = "" */) const
 {
-  unsigned int tid = needThreadedCopy(getUserObjectBase(name)) ? _uoi_tid : 0;
-  return _uoi_feproblem.getUserObject<T>(_uoi_params.get<UserObjectName>(name), tid);
+  const T * uo = dynamic_cast<const T *>(&uo_base);
+
+  if (!uo)
+  {
+    std::stringstream oss;
+    oss << "The provided object \"" << userObjectName(uo_base) << "\" of type "
+        << userObjectType(uo_base)
+        << " is not derived from the required type.\n\nThe object must derive from "
+        << libMesh::demangle(typeid(T).name()) << ".";
+
+    if (_uoi_moose_object.parameters().isParamValid(param_name))
+      _uoi_moose_object.paramError(param_name, oss.str());
+    else
+      _uoi_moose_object.mooseError(oss.str());
+  }
+
+  return *uo;
 }
 
 template <class T>
 const T &
-UserObjectInterface::getUserObjectByName(const std::string & name) const
+UserObjectInterface::getUserObject(const std::string & param_name) const
 {
-  unsigned int tid = needThreadedCopy(getUserObjectBaseByName(name)) ? _uoi_tid : 0;
-  return _uoi_feproblem.getUserObject<T>(name, tid);
+  return castUserObject<T>(getUserObjectBase(param_name), param_name);
+}
+
+template <class T>
+const T &
+UserObjectInterface::getUserObjectByName(const UserObjectName & object_name) const
+{
+  return castUserObject<T>(getUserObjectBaseByName(object_name));
 }

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -448,7 +448,7 @@ public:
   /**
    * Prints the type of the requested parameter by name
    */
-  std::string type(const std::string & name);
+  std::string type(const std::string & name) const;
 
   /**
    * Returns a Boolean indicating whether the specified parameter is private or not

--- a/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
+++ b/framework/include/vectorpostprocessors/VectorPostprocessorInterface.h
@@ -54,7 +54,7 @@ public:
    * getVectorPostprocessorValueOldByName
    */
   virtual const VectorPostprocessorValue &
-  getVectorPostprocessorValue(const std::string & name, const std::string & vector_name);
+  getVectorPostprocessorValue(const std::string & name, const std::string & vector_name) const;
 
   /**
    * DEPRECATED: Use the new version where you need to specify whether or
@@ -75,7 +75,7 @@ public:
    */
   virtual const VectorPostprocessorValue &
   getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
-                                    const std::string & vector_name);
+                                    const std::string & vector_name) const;
 
   /**
    * DEPRECATED: Use the new version where you need to specify whether or
@@ -88,8 +88,8 @@ public:
    *
    * see getVectorPostprocessorValue
    */
-  const VectorPostprocessorValue & getVectorPostprocessorValueOld(const std::string & name,
-                                                                  const std::string & vector_name);
+  const VectorPostprocessorValue &
+  getVectorPostprocessorValueOld(const std::string & name, const std::string & vector_name) const;
 
   /**
    * DEPRECATED: Use the new version where you need to specify whether or
@@ -109,7 +109,7 @@ public:
    */
   const VectorPostprocessorValue &
   getVectorPostprocessorValueOldByName(const VectorPostprocessorName & name,
-                                       const std::string & vector_name);
+                                       const std::string & vector_name) const;
 
   /**
    * Retrieve the value of a VectorPostprocessor
@@ -128,7 +128,7 @@ public:
    * getVectorPostprocessorValueOldByName
    */
   virtual const VectorPostprocessorValue & getVectorPostprocessorValue(
-      const std::string & name, const std::string & vector_name, bool needs_broadcast);
+      const std::string & name, const std::string & vector_name, bool needs_broadcast) const;
 
   /**
    * Retrieve the value of the VectorPostprocessor
@@ -146,8 +146,10 @@ public:
    * see getVectorPostprocessorValue getVectorPostprocessorValueOldByName
    * getVectorPostprocessorValueByName
    */
-  virtual const VectorPostprocessorValue & getVectorPostprocessorValueByName(
-      const VectorPostprocessorName & name, const std::string & vector_name, bool needs_broadcast);
+  virtual const VectorPostprocessorValue &
+  getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
+                                    const std::string & vector_name,
+                                    bool needs_broadcast) const;
 
   /**
    * Retrieve the old value of a VectorPostprocessor
@@ -160,7 +162,7 @@ public:
    * see getVectorPostprocessorValue
    */
   virtual const VectorPostprocessorValue & getVectorPostprocessorValueOld(
-      const std::string & name, const std::string & vector_name, bool needs_broadcast);
+      const std::string & name, const std::string & vector_name, bool needs_broadcast) const;
 
   /**
    * Retrieve the old value of a VectorPostprocessor
@@ -177,8 +179,10 @@ public:
    *
    * see getVectorPostprocessorValueByName
    */
-  virtual const VectorPostprocessorValue & getVectorPostprocessorValueOldByName(
-      const VectorPostprocessorName & name, const std::string & vector_name, bool needs_broadcast);
+  virtual const VectorPostprocessorValue &
+  getVectorPostprocessorValueOldByName(const VectorPostprocessorName & name,
+                                       const std::string & vector_name,
+                                       bool needs_broadcast) const;
 
   /**
    * Return the scatter value for the post processor
@@ -192,7 +196,8 @@ public:
    * @return The reference to the current scatter value
    */
   virtual const ScatterVectorPostprocessorValue &
-  getScatterVectorPostprocessorValue(const std::string & name, const std::string & vector_name);
+  getScatterVectorPostprocessorValue(const std::string & name,
+                                     const std::string & vector_name) const;
 
   /**
    * Return the scatter value for the post processor
@@ -207,7 +212,7 @@ public:
    */
   virtual const ScatterVectorPostprocessorValue &
   getScatterVectorPostprocessorValueByName(const std::string & name,
-                                           const std::string & vector_name);
+                                           const std::string & vector_name) const;
 
   /**
    * Return the old scatter value for the post processor
@@ -221,7 +226,8 @@ public:
    * @return The reference to the old scatter value
    */
   virtual const ScatterVectorPostprocessorValue &
-  getScatterVectorPostprocessorValueOld(const std::string & name, const std::string & vector_name);
+  getScatterVectorPostprocessorValueOld(const std::string & name,
+                                        const std::string & vector_name) const;
 
   /**
    * Return the old scatter value for the post processor
@@ -236,7 +242,7 @@ public:
    */
   virtual const ScatterVectorPostprocessorValue &
   getScatterVectorPostprocessorValueOldByName(const std::string & name,
-                                              const std::string & vector_name);
+                                              const std::string & vector_name) const;
 
   /**
    * Determine if the VectorPostprocessor data exists
@@ -298,7 +304,7 @@ private:
                                             const std::string & vector_name) const;
 
   /// Whether or not to force broadcasting by default
-  bool _broadcast_by_default;
+  const bool _broadcast_by_default;
 
   /// VectorPostprocessorInterface Parameters
   const InputParameters & _vpi_params;
@@ -307,7 +313,7 @@ private:
   FEProblemBase & _vpi_feproblem;
 
   /// Thread ID
-  THREAD_ID _vpi_tid;
+  const THREAD_ID _vpi_tid;
 
   /// Reference to the ReporterData that stores the vector
   ReporterData & _vpi_reporter_data;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -3418,17 +3418,18 @@ FEProblemBase::addUserObject(const std::string & user_object_name,
 }
 
 const UserObject &
-FEProblemBase::getUserObjectBase(const std::string & name) const
+FEProblemBase::getUserObjectBase(const std::string & name, const THREAD_ID tid /* = 0 */) const
 {
   std::vector<UserObject *> objs;
   theWarehouse()
       .query()
       .condition<AttribSystem>("UserObject")
-      .condition<AttribThread>(0)
+      .condition<AttribThread>(tid)
       .condition<AttribName>(name)
       .queryInto(objs);
   if (objs.empty())
     mooseError("Unable to find user object with name '" + name + "'");
+  mooseAssert(objs.size() == 1, "Should only find one UO");
   return *(objs[0]);
 }
 

--- a/framework/src/userobject/GeneralUserObject.C
+++ b/framework/src/userobject/GeneralUserObject.C
@@ -48,7 +48,7 @@ GeneralUserObject::getSuppliedItems()
 }
 
 const PostprocessorValue &
-GeneralUserObject::getPostprocessorValue(const std::string & name, unsigned int index)
+GeneralUserObject::getPostprocessorValue(const std::string & name, unsigned int index) const
 {
   // is this a vector of pp names, we use the number of default entries
   // to figure that out
@@ -60,7 +60,7 @@ GeneralUserObject::getPostprocessorValue(const std::string & name, unsigned int 
 }
 
 const PostprocessorValue &
-GeneralUserObject::getPostprocessorValueByName(const PostprocessorName & name)
+GeneralUserObject::getPostprocessorValueByName(const PostprocessorName & name) const
 {
   _depend_vars.insert(name);
   return UserObject::getPostprocessorValueByName(name);
@@ -68,7 +68,7 @@ GeneralUserObject::getPostprocessorValueByName(const PostprocessorName & name)
 
 const VectorPostprocessorValue &
 GeneralUserObject::getVectorPostprocessorValue(const std::string & name,
-                                               const std::string & vector_name)
+                                               const std::string & vector_name) const
 {
   _depend_vars.insert(_pars.get<VectorPostprocessorName>(name));
   return UserObject::getVectorPostprocessorValue(name, vector_name);
@@ -76,7 +76,7 @@ GeneralUserObject::getVectorPostprocessorValue(const std::string & name,
 
 const VectorPostprocessorValue &
 GeneralUserObject::getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
-                                                     const std::string & vector_name)
+                                                     const std::string & vector_name) const
 {
   _depend_vars.insert(name);
   return UserObject::getVectorPostprocessorValueByName(name, vector_name);
@@ -85,7 +85,7 @@ GeneralUserObject::getVectorPostprocessorValueByName(const VectorPostprocessorNa
 const VectorPostprocessorValue &
 GeneralUserObject::getVectorPostprocessorValue(const std::string & name,
                                                const std::string & vector_name,
-                                               bool use_broadcast)
+                                               bool use_broadcast) const
 {
   _depend_vars.insert(_pars.get<VectorPostprocessorName>(name));
   return UserObject::getVectorPostprocessorValue(name, vector_name, use_broadcast);
@@ -94,7 +94,7 @@ GeneralUserObject::getVectorPostprocessorValue(const std::string & name,
 const VectorPostprocessorValue &
 GeneralUserObject::getVectorPostprocessorValueByName(const VectorPostprocessorName & name,
                                                      const std::string & vector_name,
-                                                     bool use_broadcast)
+                                                     bool use_broadcast) const
 {
   _depend_vars.insert(name);
   return UserObject::getVectorPostprocessorValueByName(name, vector_name, use_broadcast);

--- a/framework/src/userobject/UserObjectInterface.C
+++ b/framework/src/userobject/UserObjectInterface.C
@@ -7,34 +7,98 @@
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
-// MOOSE includes
 #include "UserObjectInterface.h"
+
+// MOOSE includes
+#include "FEProblemBase.h"
 #include "DiscreteElementUserObject.h"
 #include "ThreadedGeneralUserObject.h"
-#include "InputParameters.h"
 
 UserObjectInterface::UserObjectInterface(const MooseObject * moose_object)
-  : _uoi_params(moose_object->parameters()),
-    _uoi_feproblem(*_uoi_params.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
-    _uoi_tid(_uoi_params.have_parameter<THREAD_ID>("_tid") ? _uoi_params.get<THREAD_ID>("_tid") : 0)
+  : _uoi_moose_object(*moose_object),
+    _uoi_feproblem(*_uoi_moose_object.parameters().getCheckedPointerParam<FEProblemBase *>(
+        "_fe_problem_base")),
+    _uoi_tid(_uoi_moose_object.parameters().have_parameter<THREAD_ID>("_tid")
+                 ? _uoi_moose_object.parameters().get<THREAD_ID>("_tid")
+                 : 0)
 {
 }
 
-const UserObject &
-UserObjectInterface::getUserObjectBase(const std::string & name) const
+UserObjectName
+UserObjectInterface::getUserObjectName(const std::string & param_name) const
 {
-  return _uoi_feproblem.getUserObjectBase(_uoi_params.get<UserObjectName>(name));
-}
+  const auto & params = _uoi_moose_object.parameters();
 
-const UserObject &
-UserObjectInterface::getUserObjectBaseByName(const std::string & name) const
-{
-  return _uoi_feproblem.getUserObjectBase(name);
+  if (!params.isParamValid(param_name))
+    _uoi_moose_object.mooseError("Failed to get a parameter with the name \"",
+                                 param_name,
+                                 "\".",
+                                 "\n\nKnown parameters:\n",
+                                 _uoi_moose_object.parameters());
+
+  // Other interfaces will use this interface (PostprocessorInterface, VectorPostprocessorInterface)
+  // to grab UOs with a specialized name, so we need to check them all
+  UserObjectName name;
+  if (params.have_parameter<UserObjectName>(param_name))
+    name = params.get<UserObjectName>(param_name);
+  else if (params.have_parameter<PostprocessorName>(param_name))
+    name = params.get<PostprocessorName>(param_name);
+  else if (params.have_parameter<VectorPostprocessorName>(param_name))
+    name = params.get<VectorPostprocessorName>(param_name);
+  else if (params.have_parameter<std::string>(param_name))
+    name = params.get<std::string>(param_name);
+  else
+    _uoi_moose_object.paramError(param_name,
+                                 "Parameter of type \"",
+                                 params.type(param_name),
+                                 "\" is not an expected type for getting the name of a UserObject");
+
+  return name;
 }
 
 bool
-UserObjectInterface::needThreadedCopy(const UserObject & uo) const
+UserObjectInterface::hasUserObject(const std::string & param_name) const
 {
-  return (dynamic_cast<const DiscreteElementUserObject *>(&uo) != NULL) ||
-         (dynamic_cast<const ThreadedGeneralUserObject *>(&uo) != NULL);
+  return hasUserObjectByName(getUserObjectName(param_name));
+}
+
+bool
+UserObjectInterface::hasUserObjectByName(const UserObjectName & object_name) const
+{
+  return _uoi_feproblem.hasUserObject(object_name);
+}
+
+const UserObject &
+UserObjectInterface::getUserObjectBase(const std::string & param_name) const
+{
+  const auto object_name = getUserObjectName(param_name);
+  if (!hasUserObjectByName(object_name))
+    _uoi_moose_object.paramError(
+        param_name, "The requested object with the name \"", object_name, "\" was not found.");
+
+  return getUserObjectBaseByName(object_name);
+}
+
+const UserObject &
+UserObjectInterface::getUserObjectBaseByName(const UserObjectName & object_name) const
+{
+  if (!hasUserObjectByName(object_name))
+    _uoi_moose_object.mooseError(
+        "The requested object with the name \"", object_name, "\" was not found.");
+
+  const auto & uo_base_tid0 = _uoi_feproblem.getUserObjectBase(object_name, /* tid = */ 0);
+  const THREAD_ID tid = uo_base_tid0.needThreadedCopy() ? _uoi_tid : 0;
+  return _uoi_feproblem.getUserObjectBase(object_name, tid);
+}
+
+const std::string &
+UserObjectInterface::userObjectType(const UserObject & uo) const
+{
+  return uo.type();
+}
+
+const std::string &
+UserObjectInterface::userObjectName(const UserObject & uo) const
+{
+  return uo.name();
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -585,13 +585,16 @@ InputParameters::getAutoBuildVectors() const
 }
 
 std::string
-InputParameters::type(const std::string & name)
+InputParameters::type(const std::string & name) const
 {
+  if (!_values.count(name))
+    mooseError("Parameter \"", name, "\" not found.\n\n", *this);
+
   if (_coupled_vars.find(name) != _coupled_vars.end())
     return "std::vector<VariableName>";
-  else if (_params.count(name) > 0 && !_params[name]._custom_type.empty())
-    return _params[name]._custom_type;
-  return _values[name]->type();
+  else if (_params.count(name) > 0 && !_params.at(name)._custom_type.empty())
+    return _params.at(name)._custom_type;
+  return _values.at(name)->type();
 }
 
 std::string

--- a/framework/src/vectorpostprocessors/VectorPostprocessorInterface.C
+++ b/framework/src/vectorpostprocessors/VectorPostprocessorInterface.C
@@ -27,7 +27,7 @@ VectorPostprocessorInterface::VectorPostprocessorInterface(const MooseObject * m
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValue(const std::string & name,
-                                                          const std::string & vector_name)
+                                                          const std::string & vector_name) const
 {
   return getVectorPostprocessorValueByName(_vpi_params.get<VectorPostprocessorName>(name),
                                            vector_name);
@@ -35,14 +35,14 @@ VectorPostprocessorInterface::getVectorPostprocessorValue(const std::string & na
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueByName(
-    const VectorPostprocessorName & name, const std::string & vector_name)
+    const VectorPostprocessorName & name, const std::string & vector_name) const
 {
   return getVectorPostprocessorByNameHelper(name, vector_name, _broadcast_by_default, 0);
 }
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueOld(const std::string & name,
-                                                             const std::string & vector_name)
+                                                             const std::string & vector_name) const
 {
   return getVectorPostprocessorValueOldByName(_vpi_params.get<VectorPostprocessorName>(name),
                                               vector_name);
@@ -50,7 +50,7 @@ VectorPostprocessorInterface::getVectorPostprocessorValueOld(const std::string &
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueOldByName(
-    const VectorPostprocessorName & name, const std::string & vector_name)
+    const VectorPostprocessorName & name, const std::string & vector_name) const
 {
   return getVectorPostprocessorByNameHelper(name, vector_name, _broadcast_by_default, 1);
 }
@@ -58,7 +58,7 @@ VectorPostprocessorInterface::getVectorPostprocessorValueOldByName(
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValue(const std::string & name,
                                                           const std::string & vector_name,
-                                                          bool needs_broadcast)
+                                                          bool needs_broadcast) const
 {
   return getVectorPostprocessorValueByName(
       _vpi_params.get<VectorPostprocessorName>(name), vector_name, needs_broadcast);
@@ -66,7 +66,9 @@ VectorPostprocessorInterface::getVectorPostprocessorValue(const std::string & na
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueByName(
-    const VectorPostprocessorName & name, const std::string & vector_name, bool needs_broadcast)
+    const VectorPostprocessorName & name,
+    const std::string & vector_name,
+    bool needs_broadcast) const
 {
   return getVectorPostprocessorByNameHelper(
       name, vector_name, needs_broadcast || _broadcast_by_default, 0);
@@ -75,7 +77,7 @@ VectorPostprocessorInterface::getVectorPostprocessorValueByName(
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueOld(const std::string & name,
                                                              const std::string & vector_name,
-                                                             bool needs_broadcast)
+                                                             bool needs_broadcast) const
 {
   return getVectorPostprocessorValueOldByName(
       _vpi_params.get<VectorPostprocessorName>(name), vector_name, needs_broadcast);
@@ -83,15 +85,17 @@ VectorPostprocessorInterface::getVectorPostprocessorValueOld(const std::string &
 
 const VectorPostprocessorValue &
 VectorPostprocessorInterface::getVectorPostprocessorValueOldByName(
-    const VectorPostprocessorName & name, const std::string & vector_name, bool needs_broadcast)
+    const VectorPostprocessorName & name,
+    const std::string & vector_name,
+    bool needs_broadcast) const
 {
   return getVectorPostprocessorByNameHelper(
       name, vector_name, needs_broadcast || _broadcast_by_default, 1);
 }
 
 const ScatterVectorPostprocessorValue &
-VectorPostprocessorInterface::getScatterVectorPostprocessorValue(const std::string & name,
-                                                                 const std::string & vector_name)
+VectorPostprocessorInterface::getScatterVectorPostprocessorValue(
+    const std::string & name, const std::string & vector_name) const
 {
   return getScatterVectorPostprocessorValueByName(_vpi_params.get<VectorPostprocessorName>(name),
                                                   vector_name);
@@ -99,15 +103,15 @@ VectorPostprocessorInterface::getScatterVectorPostprocessorValue(const std::stri
 
 const ScatterVectorPostprocessorValue &
 VectorPostprocessorInterface::getScatterVectorPostprocessorValueByName(
-    const std::string & name, const std::string & vector_name)
+    const std::string & name, const std::string & vector_name) const
 {
   auto vpp_context_ptr = getVectorPostprocessorContextByNameHelper(name, vector_name);
   return vpp_context_ptr->getScatterValue();
 }
 
 const ScatterVectorPostprocessorValue &
-VectorPostprocessorInterface::getScatterVectorPostprocessorValueOld(const std::string & name,
-                                                                    const std::string & vector_name)
+VectorPostprocessorInterface::getScatterVectorPostprocessorValueOld(
+    const std::string & name, const std::string & vector_name) const
 {
   return getScatterVectorPostprocessorValueOldByName(_vpi_params.get<VectorPostprocessorName>(name),
                                                      vector_name);
@@ -115,7 +119,7 @@ VectorPostprocessorInterface::getScatterVectorPostprocessorValueOld(const std::s
 
 const ScatterVectorPostprocessorValue &
 VectorPostprocessorInterface::getScatterVectorPostprocessorValueOldByName(
-    const std::string & name, const std::string & vector_name)
+    const std::string & name, const std::string & vector_name) const
 {
   auto vpp_context_ptr = getVectorPostprocessorContextByNameHelper(name, vector_name);
   return vpp_context_ptr->getScatterValueOld();

--- a/test/include/userobjects/NullUserObject.h
+++ b/test/include/userobjects/NullUserObject.h
@@ -1,0 +1,27 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralUserObject.h"
+
+/**
+ * A test UserObject that does nothing.
+ */
+class NullUserObject : public GeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  NullUserObject(const InputParameters & params);
+
+  virtual void initialize(){};
+  virtual void execute(){};
+  virtual void finalize(){};
+};

--- a/test/include/userobjects/UserObjectInterfaceErrorTest.h
+++ b/test/include/userobjects/UserObjectInterfaceErrorTest.h
@@ -1,0 +1,27 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralUserObject.h"
+
+/**
+ * A UserObject that tests errors produced by the UserObjectInterface.
+ */
+class UserObjectInterfaceErrorTest : public GeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  UserObjectInterfaceErrorTest(const InputParameters & params);
+
+  virtual void initialize(){};
+  virtual void execute(){};
+  virtual void finalize(){};
+};

--- a/test/src/userobjects/NullUserObject.C
+++ b/test/src/userobjects/NullUserObject.C
@@ -1,0 +1,22 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "NullUserObject.h"
+
+#include "Terminator.h"
+
+registerMooseObject("MooseTestApp", NullUserObject);
+
+InputParameters
+NullUserObject::validParams()
+{
+  return GeneralUserObject::validParams();
+}
+
+NullUserObject::NullUserObject(const InputParameters & params) : GeneralUserObject(params) {}

--- a/test/src/userobjects/UserObjectInterfaceErrorTest.C
+++ b/test/src/userobjects/UserObjectInterfaceErrorTest.C
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "UserObjectInterfaceErrorTest.h"
+
+#include "NullUserObject.h"
+#include "ThreadedGeneralUserObject.h"
+
+registerMooseObject("MooseTestApp", UserObjectInterfaceErrorTest);
+
+InputParameters
+UserObjectInterfaceErrorTest::validParams()
+{
+  InputParameters params = GeneralUserObject::validParams();
+
+  params.addRequiredParam<UserObjectName>("uo", "Test parameter for a UserObjectName");
+
+  params.addParam<bool>(
+      "missing_parameter", false, "True to test the error for a missing parameter");
+  params.addParam<bool>(
+      "not_found_by_param",
+      false,
+      "True to test the error for a missing UO when the name is provided via paramater");
+  params.addParam<bool>(
+      "not_found_by_name",
+      false,
+      "True to test the error for a missing UO when the name is directly provided");
+  params.addParam<bool>("bad_cast", false, "True to test the error for a UO that fails the cast");
+
+  return params;
+}
+
+UserObjectInterfaceErrorTest::UserObjectInterfaceErrorTest(const InputParameters & params)
+  : GeneralUserObject(params)
+{
+  if (getParam<bool>("missing_parameter"))
+    getUserObject<NullUserObject>("bad_parameter");
+  if (getParam<bool>("not_found_by_param"))
+    getUserObject<NullUserObject>("uo");
+  if (getParam<bool>("not_found_by_name"))
+    getUserObjectByName<NullUserObject>("not_found_by_name");
+  if (getParam<bool>("bad_cast"))
+    getUserObject<ThreadedGeneralUserObject>("uo");
+}

--- a/test/tests/interfaces/userobjectinterface/tests
+++ b/test/tests/interfaces/userobjectinterface/tests
@@ -1,0 +1,42 @@
+[Tests]
+  design = 'UserObjectInterface.md'
+  issues = '#17446 #17512'
+
+  [errors]
+    requirement = 'The system shall report a reasonable error when requesting a user object when'
+
+    [missing_parameter]
+      type = RunException
+      input = 'uoi_errors.i'
+      cli_args = 'UserObjects/error_test/missing_parameter=true'
+      expect_err = 'Failed to get a parameter with the name "bad_parameter".'
+
+      detail = 'getting the user object name from a parameter and the parameter is not found,'
+    []
+    [not_found_by_param]
+      type = RunException
+      input = 'uoi_errors.i'
+      cli_args = 'UserObjects/error_test/not_found_by_param=true
+                  UserObjects/error_test/uo=bad_uo'
+      expect_err = 'uo\)\:.*The requested object with the name "bad_uo" was not found.'
+
+      detail = 'getting the user object name from a parameter and the user object is not found,'
+    []
+    [not_found_by_name]
+      type = RunException
+      input = 'uoi_errors.i'
+      cli_args = 'UserObjects/error_test/not_found_by_name=true'
+      expect_err = 'The requested object with the name "not_found_by_name" was not found.'
+
+      detail = 'getting the user object by name and the user object is not found,'
+    []
+    [bad_cast]
+      type = RunException
+      input = 'uoi_errors.i'
+      cli_args = 'UserObjects/error_test/bad_cast=true'
+      expect_err = 'The provided object "null_uo" of type NullUserObject is not derived from the required type..*The object must derive from ThreadedGeneralUserObject.'
+
+      detail = 'and the provided user object is not of the correct type.'
+    []
+  []
+[]

--- a/test/tests/interfaces/userobjectinterface/uoi_errors.i
+++ b/test/tests/interfaces/userobjectinterface/uoi_errors.i
@@ -1,0 +1,24 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 1
+  []
+[]
+
+[UserObjects]
+  [null_uo]
+    type = NullUserObject
+  []
+  [error_test]
+    type = UserObjectInterfaceErrorTest
+    uo = null_uo
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]


### PR DESCRIPTION
Small modification to `UserObjectInterface` to throw an error if the type of the user object being grabbed does not match `T`, as well as a test demonstrating the desired behavior for the fluid properties module. 

After discussion with @andrsd, it may be more useful for apps and other users to have this patch directly in `UserObjectInterface`(as opposed to a new `FluidPropertyInterface`) because users no longer would need to modify their source files to take advantage of this check. Plus, this error check is pretty general and would likely be useful to all MOOSE objects with user objects.

I wanted to print the type of `T` to get an even better error message, with

```
T * dummy;
typeid(dummy).name()
```

but apparently that's implementation-dependent. So if there's some way to figure that out in MOOSE, I think that'd be great to add to the error message.

Closes #17446 and refs #17512