### PR TITLE
Create additional orders and families for material outputs

### DIFF
--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
@@ -27,6 +27,7 @@ protected:
   void actEigenstrainNames();
   void actOutputMatProp();
   void actGatherActionParameters();
+  void verifyOrderAndFamilyOutputs();
 
   virtual std::string getKernelType();
   virtual InputParameters getKernelParameters(std::string type);
@@ -99,6 +100,8 @@ protected:
 
   /// output materials to generate scalar stress/strain tensor quantities
   std::vector<std::string> _generate_output;
+  std::vector<std::string> _material_output_order;
+  std::vector<std::string> _material_output_family;
 
   /// booleans used to determine if cylindrical axis points are passed
   bool _cylindrical_axis_point1_valid;

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsActionBase.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsActionBase.h
@@ -19,6 +19,8 @@ public:
   TensorMechanicsActionBase(const InputParameters & params);
 
   static MultiMooseEnum outputPropertiesType();
+  static MultiMooseEnum materialOutputOrders();
+  static MultiMooseEnum materialOutputFamilies();
 
 public:
   ///@{ table data for output generation

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
@@ -10,6 +10,7 @@
 #include "TensorMechanicsActionBase.h"
 #include "CommonTensorMechanicsAction.h"
 #include "ActionWarehouse.h"
+#include "AddAuxVariableAction.h"
 #include "ComputeFiniteStrain.h"
 
 // map tensor name shortcuts to tensor material property names
@@ -133,7 +134,18 @@ TensorMechanicsActionBase::validParams()
   params.addParam<MultiMooseEnum>("generate_output",
                                   TensorMechanicsActionBase::outputPropertiesType(),
                                   "Add scalar quantity output for stress and/or strain");
-  params.addParamNamesToGroup("generate_output", "Output");
+
+  params.addParam<MultiMooseEnum>(
+      "material_output_order",
+      TensorMechanicsActionBase::materialOutputOrders(),
+      "Specifies the order of the FE shape function to use for this variable.");
+
+  params.addParam<MultiMooseEnum>(
+      "material_output_family",
+      TensorMechanicsActionBase::materialOutputFamilies(),
+      "Specifies the family of FE shape functions to use for this variable.");
+  params.addParamNamesToGroup("generate_output material_output_order material_output_family",
+                              "Output");
 
   return params;
 }
@@ -152,11 +164,39 @@ TensorMechanicsActionBase::TensorMechanicsActionBase(const InputParameters & par
     MultiMooseEnum generate_output = getParam<MultiMooseEnum>("generate_output");
     MultiMooseEnum additional_generate_output =
         getParam<MultiMooseEnum>("additional_generate_output");
+    MultiMooseEnum material_output_order = getParam<MultiMooseEnum>("material_output_order");
+    MultiMooseEnum additional_material_output_order =
+        getParam<MultiMooseEnum>("additional_material_output_order");
+    MultiMooseEnum material_output_family = getParam<MultiMooseEnum>("material_output_family");
+    MultiMooseEnum additional_material_output_family =
+        getParam<MultiMooseEnum>("additional_material_output_family");
     for (auto & output : additional_generate_output)
       generate_output.push_back(output);
+    for (auto & order : additional_material_output_order)
+      material_output_order.push_back(order);
+    for (auto & family : additional_material_output_family)
+      material_output_family.push_back(family);
 
     _pars.set<MultiMooseEnum>("generate_output") = generate_output;
   }
+}
+
+MultiMooseEnum
+TensorMechanicsActionBase::materialOutputOrders()
+{
+  std::string orders = "";
+  orders = AddAuxVariableAction::getAuxVariableOrders().getRawNames();
+
+  return MultiMooseEnum(orders);
+}
+
+MultiMooseEnum
+TensorMechanicsActionBase::materialOutputFamilies()
+{
+  std::string families = "";
+  families = AddAuxVariableAction::getAuxVariableFamilies().getRawNames();
+
+  return MultiMooseEnum(families);
 }
 
 MultiMooseEnum

--- a/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsActionBase.C
@@ -184,8 +184,7 @@ TensorMechanicsActionBase::TensorMechanicsActionBase(const InputParameters & par
 MultiMooseEnum
 TensorMechanicsActionBase::materialOutputOrders()
 {
-  std::string orders = "";
-  orders = AddAuxVariableAction::getAuxVariableOrders().getRawNames();
+  auto orders = AddAuxVariableAction::getAuxVariableOrders().getRawNames();
 
   return MultiMooseEnum(orders);
 }
@@ -193,8 +192,7 @@ TensorMechanicsActionBase::materialOutputOrders()
 MultiMooseEnum
 TensorMechanicsActionBase::materialOutputFamilies()
 {
-  std::string families = "";
-  families = AddAuxVariableAction::getAuxVariableFamilies().getRawNames();
+  auto families = AddAuxVariableAction::getAuxVariableFamilies().getRawNames();
 
   return MultiMooseEnum(families);
 }

--- a/modules/tensor_mechanics/test/tests/action/material_output_order.i
+++ b/modules/tensor_mechanics/test/tests/action/material_output_order.i
@@ -1,0 +1,139 @@
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+  origin = '0 0 2'
+  direction = '0 0 1'
+  polar_moment_of_inertia = pmi
+  factor = t
+[]
+
+[Mesh]
+  [ring]
+    type = AnnularMeshGenerator
+    nr = 1
+    nt = 30
+    rmin = 0.95
+    rmax = 1
+  []
+  [extrude]
+    type = MeshExtruderGenerator
+    input = ring
+    extrusion_vector = '0 0 2'
+    bottom_sideset = 'bottom'
+    top_sideset = 'top'
+    num_layers = 5
+  []
+[]
+
+[AuxVariables]
+  [alpha_var]
+  []
+  [shear_stress_var]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[AuxKernels]
+  [alpha]
+    type = RotationAngle
+    variable = alpha_var
+  []
+  [shear_stress]
+    type = ParsedAux
+    variable = shear_stress_var
+    args = 'stress_yz stress_xz'
+    function = 'sqrt(stress_yz^2 + stress_xz^2)'
+  []
+[]
+
+[BCs]
+  # fix bottom
+  [fix_x]
+    type = DirichletBC
+    boundary = bottom
+    variable = disp_x
+    value = 0
+  []
+  [fix_y]
+    type = DirichletBC
+    boundary = bottom
+    variable = disp_y
+    value = 0
+  []
+  [fix_z]
+    type = DirichletBC
+    boundary = bottom
+    variable = disp_z
+    value = 0
+  []
+
+  # twist top
+  [twist_x]
+    type = Torque
+    boundary = top
+    variable = disp_x
+  []
+  [twist_y]
+    type = Torque
+    boundary = top
+    variable = disp_y
+  []
+  [twist_z]
+    type = Torque
+    boundary = top
+    variable = disp_z
+  []
+[]
+
+[Modules/TensorMechanics/Master]
+  [all]
+    add_variables = true
+    strain = SMALL
+    generate_output = 'vonmises_stress stress_yz stress_xz'
+  []
+[]
+
+[Postprocessors]
+  [pmi]
+    type = PolarMomentOfInertia
+    boundary = top
+    # execute_on = 'INITIAL NONLINEAR'
+    execute_on = 'INITIAL'
+  []
+  [alpha]
+    type = SideAverageValue
+    variable = alpha_var
+    boundary = top
+  []
+  [shear_stress]
+    type = ElementAverageValue
+    variable = shear_stress_var
+  []
+[]
+
+[Materials]
+  [stress]
+    type = ComputeLinearElasticStress
+  []
+  [elastic]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 0.3
+    shear_modulus = 100
+  []
+[]
+
+[Executioner]
+  # type = Steady
+  type = Transient
+  num_steps = 1
+  solve_type = PJFNK
+  petsc_options_iname = '-pctype'
+  petsc_options_value = 'lu'
+  nl_max_its = 150
+[]
+
+[Outputs]
+  exodus = true
+  print_linear_residuals = false
+  perf_graph = true
+[]

--- a/modules/tensor_mechanics/test/tests/action/tests
+++ b/modules/tensor_mechanics/test/tests/action/tests
@@ -125,4 +125,21 @@
     design = 'syntax/Modules/TensorMechanics/Master/index.md'
     requirement = 'The TensorMechanics MasterAction shall extract eigenstrain names from material classes and correctly output these names to the console.'
   [../]
+
+  [material_output_order_empty]
+    type = RunApp
+    input = 'material_output_order.i'
+    expect_out = 'all: CONSTANT,CONSTANT,CONSTANT\n.*\nall: MONOMIAL,MONOMIAL,MONOMIAL\n'
+    design = 'syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The TensorMechanics MasterAction shall determine the necessary orders and families to apply to material outputs.'
+  []
+  [material_output_order_error1]
+    type = RunException
+    input = 'material_output_order.i'
+    cli_args = "Modules/TensorMechanics/Master/material_output_family='LAGRANGE MONOMIAL'"
+    expect_err = 'The number of family assigned to material outputs must be: 0 to be assigned CONSTANT; 1 to assign all outputs the same value, or the same size as the number of generate outputs listed.'
+    prereq = 'material_output_order_empty'
+    design = 'syntax/Modules/TensorMechanics/Master/index.md'
+    requirement = 'The TensorMechanics MasterAction shall error if an the material outputs and or families do not match the number of material outputs.'
+  []
 []

--- a/modules/tensor_mechanics/test/tests/action/tests
+++ b/modules/tensor_mechanics/test/tests/action/tests
@@ -137,7 +137,7 @@
     type = RunException
     input = 'material_output_order.i'
     cli_args = "Modules/TensorMechanics/Master/material_output_family='LAGRANGE MONOMIAL'"
-    expect_err = 'The number of family assigned to material outputs must be: 0 to be assigned CONSTANT; 1 to assign all outputs the same value, or the same size as the number of generate outputs listed.'
+    expect_err = 'The number of families assigned to material outputs must be: 0 to be assigned MONOMIAL; 1 to assign all outputs the same value, or the same size as the number of generate outputs listed.'
     prereq = 'material_output_order_empty'
     design = 'syntax/Modules/TensorMechanics/Master/index.md'
     requirement = 'The TensorMechanics MasterAction shall error if an the material outputs and or families do not match the number of material outputs.'


### PR DESCRIPTION
Refs #14823

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
Continues work previously done in previous year.  Allows for the automatic creation of higher order material outputs with regard to order and families.
-->
