### PR TITLE
Fixed indexing in ACBarrierFunction.C to prevent indexing outisde of …

### DIFF
--- a/modules/phase_field/include/kernels/ACBarrierFunction.h
+++ b/modules/phase_field/include/kernels/ACBarrierFunction.h
@@ -33,6 +33,7 @@ protected:
   const MaterialProperty<Real> & _gamma;
   const MaterialProperty<Real> & _dmudvar;
   const MaterialProperty<Real> & _d2mudvar2;
+  const JvarMap & _eta_map;
 
   const std::vector<VariableName> _vname;
   std::vector<const MaterialProperty<Real> *> _d2mudvardeta;

--- a/modules/phase_field/include/kernels/ACBarrierFunction.h
+++ b/modules/phase_field/include/kernels/ACBarrierFunction.h
@@ -33,10 +33,10 @@ protected:
   const MaterialProperty<Real> & _gamma;
   const MaterialProperty<Real> & _dmudvar;
   const MaterialProperty<Real> & _d2mudvar2;
-  const JvarMap & _eta_map;
 
   const std::vector<VariableName> _vname;
   std::vector<const MaterialProperty<Real> *> _d2mudvardeta;
+  const JvarMap & _vmap;
 
 private:
   Real calculateF0(); /// calculates the free energy function

--- a/modules/phase_field/src/kernels/ACBarrierFunction.C
+++ b/modules/phase_field/src/kernels/ACBarrierFunction.C
@@ -32,7 +32,7 @@ ACBarrierFunction::ACBarrierFunction(const InputParameters & parameters)
     _d2mudvar2(getMaterialPropertyDerivative<Real>("mu", _uname, _uname)),
     _vname(getParam<std::vector<VariableName>>("v")),
     _d2mudvardeta(_n_eta),
-    _eta_map(getParameterJvarMap("v"))
+    _vmap(getParameterJvarMap("v"))
 {
   for (unsigned int i = 0; i < _n_eta; ++i)
     _d2mudvardeta[i] = &getMaterialPropertyDerivative<Real>("mu", _uname, _vname[i]);
@@ -75,15 +75,15 @@ ACBarrierFunction::computeQpOffDiagJacobian(unsigned int jvar)
     if (i != j)
       sum_etai2 += (*_vals[i])[_qp] * (*_vals[i])[_qp];
 
-  auto etavar = mapJvarToCvar(jvar, _eta_map);
+  auto etavar = mapJvarToCvar(jvar, _vmap);
   if (etavar >= 0)
   {
-  df0deta_base = (*_vals[etavar])[_qp] * (*_vals[etavar])[_qp] - 1.0 +
-                 2.0 * _gamma[_qp] * (_u[_qp] * _u[_qp] + sum_etai2);
-  df0deta = (*_vals[etavar])[_qp] * df0deta_base;
+    df0deta_base = (*_vals[etavar])[_qp] * (*_vals[etavar])[_qp] - 1.0 +
+                   2.0 * _gamma[_qp] * (_u[_qp] * _u[_qp] + sum_etai2);
+    df0deta = (*_vals[etavar])[_qp] * df0deta_base;
 
-  return ((*_d2mudvardeta[etavar])[_qp] * calculateF0() + _dmudvar[_qp] * df0deta) * _phi[_j][_qp] *
-         _test[_i][_qp] * _L[_qp];
+    return ((*_d2mudvardeta[etavar])[_qp] * calculateF0() + _dmudvar[_qp] * df0deta) *
+           _phi[_j][_qp] * _test[_i][_qp] * _L[_qp];
   }
   return 0.0;
 }

--- a/modules/phase_field/src/kernels/ACBarrierFunction.C
+++ b/modules/phase_field/src/kernels/ACBarrierFunction.C
@@ -31,7 +31,8 @@ ACBarrierFunction::ACBarrierFunction(const InputParameters & parameters)
     _dmudvar(getMaterialPropertyDerivative<Real>("mu", _uname)),
     _d2mudvar2(getMaterialPropertyDerivative<Real>("mu", _uname, _uname)),
     _vname(getParam<std::vector<VariableName>>("v")),
-    _d2mudvardeta(_n_eta)
+    _d2mudvardeta(_n_eta),
+    _eta_map(getParameterJvarMap("v"))
 {
   for (unsigned int i = 0; i < _n_eta; ++i)
     _d2mudvardeta[i] = &getMaterialPropertyDerivative<Real>("mu", _uname, _vname[i]);
@@ -74,12 +75,17 @@ ACBarrierFunction::computeQpOffDiagJacobian(unsigned int jvar)
     if (i != j)
       sum_etai2 += (*_vals[i])[_qp] * (*_vals[i])[_qp];
 
-  df0deta_base = (*_vals[j])[_qp] * (*_vals[j])[_qp] - 1.0 +
+  auto etavar = mapJvarToCvar(jvar, _eta_map);
+  if (etavar >= 0)
+  {
+  df0deta_base = (*_vals[etavar])[_qp] * (*_vals[etavar])[_qp] - 1.0 +
                  2.0 * _gamma[_qp] * (_u[_qp] * _u[_qp] + sum_etai2);
-  df0deta = (*_vals[j])[_qp] * df0deta_base;
+  df0deta = (*_vals[etavar])[_qp] * df0deta_base;
 
-  return ((*_d2mudvardeta[j])[_qp] * calculateF0() + _dmudvar[_qp] * df0deta) * _phi[_j][_qp] *
+  return ((*_d2mudvardeta[etavar])[_qp] * calculateF0() + _dmudvar[_qp] * df0deta) * _phi[_j][_qp] *
          _test[_i][_qp] * _L[_qp];
+  }
+  return 0.0;
 }
 
 Real


### PR DESCRIPTION
Reason:
ACBarrierFunction.C gives segmentation fault when coupled with TensorMechanics. The addition of displacement variables causes computeQpOffDiagJacobian to index outside of _vals, which only contains order parameters. 

Design:
Only allow for indexing over length of _vals, otherwise return zero. Submitting patch under advisement  from @laagesen. 

Impact:
Allows for coupling of Allen-Cahn type formulations to mechanics using TensorMechanics. Closes #17541

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
