### PR TITLE
Fix samplertransientmultiapp issue when number of samples is less than MPI process

### DIFF
--- a/modules/stochastic_tools/include/multiapps/SamplerTransientMultiApp.h
+++ b/modules/stochastic_tools/include/multiapps/SamplerTransientMultiApp.h
@@ -74,5 +74,6 @@ private:
   const PerfID _perf_solve_step;
   const PerfID _perf_solve_batch_step;
   const PerfID _perf_initial_setup;
+  const PerfID _perf_command_line_args;
   ///@}
 };

--- a/modules/stochastic_tools/test/tests/multiapps/sampler_transient_multiapp/tests
+++ b/modules/stochastic_tools/test/tests/multiapps/sampler_transient_multiapp/tests
@@ -21,8 +21,8 @@
               'master_transient_cmd_control_out_runner4.e'
 
     requirement = 'The system shall provide the ability to set a transient sub-application command '
-                  'line parameters from a sample distributio.'
+                  'line parameters from a sample distribution.'
 
-    issues = '#17486'
+    issues = '#17486 #17548'
   []
 []


### PR DESCRIPTION
closes #17548

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
