### PR TITLE
Add fluid properties for sodium.

### DIFF
--- a/modules/fluid_properties/doc/content/bib/fluid_properties.bib
+++ b/modules/fluid_properties/doc/content/bib/fluid_properties.bib
@@ -286,3 +286,20 @@ from 0 to 1000 C, 0 to 5000 bar, and 0 to 1 X$_{NaCl}$}},
   title = {Revised Release on Surface Tension of Ordinary Water Substance},
   year = {2014}
 }
+
+@techreport{sas,
+  author = {F.E. Dunn},
+  title = {The {SAS4A}/{SASSYS-1} Safety Analysis Code System, Chapter 12: Sodium Voiding Model},
+  institution = {Argonne National Laboratory},
+  number = {ANL/NE-16/19},
+  year = {2017}
+}
+
+@techreport{fink,
+  author = {J.F. Fink and L. Leibowitz},
+  title = {Thermophysical Properties of Sodium},
+  institution = {Argonne National Laboratory},
+  number = {ANL-CEN-RSD-79-1},
+  year = {1979}
+}
+

--- a/modules/fluid_properties/doc/content/source/userobjects/SodiumSaturationFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/SodiumSaturationFluidProperties.md
@@ -1,0 +1,87 @@
+# SodiumSaturationFluidProperties
+
+!syntax description /Modules/FluidProperties/SodiumSaturationFluidProperties
+
+## Description
+
+The `SodiumSaturationFluidProperties` class provides fluid properties for _saturated_ liquid
+sodium based on correlations used in the SAS4A/SASSYS-1 reactor dynamics
+and safety analysis code developed at Argonne National Laboratory for
+liquid metal reactors [!cite](sas). These property models are obtained as
+fits to experimental data, with computational efficiency
+motivating the use of a simpler functional fits than proposed in the original
+references upon which the SAS4a/SASSYS-1 implementation is based,
+namely [!cite](fink). Only for $C_p$ and $C_v$ are the original correlations/data
+used, since the SAS4A/SASSYS-1 implementation does not differentiate between
+$C_p$ and $C_v$ for the saturated liquid.
+
+Density is calculated as an empirical fit to two saturated liquid
+density correlations recommended by Fink and Leibowitz that
+cover the range $371 < T (K) < 2509$:
+
+$\rho=1.00423\times10^3-0.21390T-1.1046\times10^{-5}T^2$
+
+This equation fits the Fink and Leibowitz models to within 9.5%.
+
+The thermal conductivity is a fit to experimental data by Fink and Leibowitz
+below 1500 K, and extrapolated values above 1500 K based on
+a method described by Grosse [!cite](sas):
+
+$k=1.1045\times10^2-6.5112\times10^{-2}T+1.5430\times10^{-5}T^2-2.4617\times10^{-9}T^3$
+
+This equation fits the Fink and Leibowitz data to within 0.5%.
+
+The dynamic viscosity is given as a fit to experimental data by Fink and
+Leibowitz below 1200 K and extrapolated values about 1200 K based on
+a method described by Grosse [!cite](sas):
+
+$\mu=3.6522\times10^{-5}+\frac{0.16626}{T}-\frac{4.56877\times10^1}{T^2}+\frac{2.8733\times10^4}{T^3}$
+
+This equation fits the Fink and Leibowitz data to within 0.5%.
+
+The isobaric and isochoric specific heats are obtained as new fits to the
+experimental data in Fink and Leibowitz over the range $400 < T (K) < 2200$,
+
+$C_p=3.7782\times10^{-1}T^2-1.7191\times10^{-6}T^3+3.0921\times10^{-3}T^2-2.4560T+1.972\times10^3$
+
+$C_v=1.0369\times10^{-8}T^3+3.7164\times10^{-4}T^2-1.0494T+1.5826\times10^3$
+
+The $R^2$ values for both fits are 0.997, where the $C_p$ fit matches experimental
+data to within 0.5%, while for $C_v$ matches experimental data to within 1.5%.
+
+Enthalpy is computed based on the definition of $C_p$,
+
+$C_p\equiv\left(\frac{\partial h}{\partial T}\right)_p$
+
+Neglecting any variation in the saturation conditions with respect to pressure
+(i.e. Poynting-type effects), $h$ can be computed by integrating the above
+expression,
+
+$h(T)-h(T_{ref})=\int_{T_{ref}}^TC_pdT'$
+
+where $T_{ref}$ is a reference temperature and $h(T_{ref})$ is the enthalpy
+at that reference temperature. This expression is used to evaluate enthalpy
+based on the $C_p$ fit as
+
+$h(T)=F(T)-401088.7$
+
+where $F(T)$ is the integral of $C_p$ with respect to temperature evaluated
+at $T$ and $401088.7$ J/kg/K is a constant representing $-F(T_{ref})+h(T_{ref})$
+selected in order to match the Fink and Leibowitz correlation at 371 K.
+This approach, rather than simply using the Fink and Leibowitz correlation outright,
+is used to ensure exact compatibility with thermodynamic definitions and the paricular
+fit for $C_p$ selected in this class.
+Computing $h$ based on an integral of $C_p$ matches the Fink
+and Leibowitz correlations to within 0.2% over the entire range for which
+the $C_p$ fit is valid.
+
+## Range of Validity
+
+These fluid properties correspond to saturated conditions (that is, the sodium is at the
+saturation pressure).
+
+!syntax parameters /Modules/FluidProperties/SodiumSaturationFluidProperties
+
+!syntax inputs /Modules/FluidProperties/SodiumSaturationFluidProperties
+
+!syntax children /Modules/FluidProperties/SodiumSaturationFluidProperties

--- a/modules/fluid_properties/include/userobjects/SodiumSaturationFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SodiumSaturationFluidProperties.h
@@ -23,31 +23,10 @@ public:
 
   SodiumSaturationFluidProperties(const InputParameters & parameters);
 
-  /**
-   * Fluid name
-   *
-   * @return "sodium"
-   */
   virtual std::string fluidName() const override;
 
-  /**
-   * Density from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return density (kg/m$^3$)
-   */
   virtual Real rho_from_p_T(Real p, Real T) const override;
 
-  /**
-   * Density and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
-   * @param[out] rho       density (kg/m$^3$)
-   * @param[out] drho_dp   derivative of density w.r.t. pressure
-   * @param[out] drho_dT   derivative of density w.r.t. temperature
-   */
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
   virtual void rho_from_p_T(const DualReal & p,
@@ -56,144 +35,30 @@ public:
                             DualReal & drho_dp,
                             DualReal & drho_dT) const override;
 
-  /**
-   * Specific volume from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific volume (m$^3$/kg)
-   */
   virtual Real v_from_p_T(Real p, Real T) const override;
-
   virtual DualReal v_from_p_T(const DualReal & p, const DualReal & T) const override;
-
-  /**
-   * Specific volume and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
-   * @param[out] v         specific volume (m$^3$/kg)
-   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
-   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
-   */
   virtual void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
 
-  /**
-   * Specific enthalpy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific enthalpy (J/kg)
-   */
   virtual Real h_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Specific enthalpy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] h       specific enthalpy (J/kg)
-   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
-   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
-   */
   virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  /**
-   * Specific internal energy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific internal energy (J/kg)
-   */
   virtual Real e_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Specific internal energy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] e       specific internal energy (J/kg)
-   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
-   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
-   */
   virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
 
-  /**
-   * Isobaric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isobaric specific heat (J/kg/.K)
-   */
   virtual Real cp_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Isobaric specific heat capacity and its derivatives from pressure and temperature
-   *
-   * @param[in] p       pressure (Pa)
-   * @param[in] T       temperature (K)
-   * @param[out] cp     isobaric specific heat (J/kg/K)
-   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
-   */
   virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
 
   using SinglePhaseFluidProperties::cv_from_p_T;
 
-  /**
-   * Isochoric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isochoric specific heat (J/kg.K)
-   */
   virtual Real cv_from_p_T(Real p, Real T) const override;
   virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const override;
 
-  /**
-   * Molar mass
-   *
-   * @return molar mass (kg/mol)
-   */
   virtual Real molarMass() const override;
 
-  /**
-   * Thermal conductivity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return thermal conductivity  (W/m.K)
-   */
   virtual Real k_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Thermal conductivity and its derivatives wrt pressure and temperature
-   *
-   * @param p           pressure (Pa)
-   * @param T           temperature (K)
-   * @param[out]  k     thermal conductivity  (W/m.K)
-   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
-   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
-   */
   virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  /**
-   * Dynamic viscosity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return dynamic viscosity (Pa.s)
-   */
   virtual Real mu_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Dynamic viscosity and its derivatives wrt pressure and temperature
-   *
-   * @param p             pressure (Pa)
-   * @param T             temperature (K)
-   * @param[out] mu       viscosity (Pa.s)
-   * @param[out] dmu_dp   derivative of viscosity wrt pressure
-   * @param[out] dmu_dT   derivative of viscosity wrt temperature
-   */
   virtual void
   mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 };

--- a/modules/fluid_properties/include/userobjects/SodiumSaturationFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SodiumSaturationFluidProperties.h
@@ -1,0 +1,200 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "SinglePhaseFluidProperties.h"
+
+/**
+ * Fluid properties for liquid sodium at saturation conditions \cite{sas} \cite{fink}.
+ */
+class SodiumSaturationFluidProperties : public SinglePhaseFluidProperties
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+public:
+  static InputParameters validParams();
+
+  SodiumSaturationFluidProperties(const InputParameters & parameters);
+
+  /**
+   * Fluid name
+   *
+   * @return "sodium"
+   */
+  virtual std::string fluidName() const override;
+
+  /**
+   * Density from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return density (kg/m$^3$)
+   */
+  virtual Real rho_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] rho       density (kg/m$^3$)
+   * @param[out] drho_dp   derivative of density w.r.t. pressure
+   * @param[out] drho_dT   derivative of density w.r.t. temperature
+   */
+  virtual void
+  rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
+
+  /**
+   * Specific volume from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific volume (m$^3$/kg)
+   */
+  virtual Real v_from_p_T(Real p, Real T) const override;
+
+  virtual DualReal v_from_p_T(const DualReal & p, const DualReal & T) const override;
+
+  /**
+   * Specific volume and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] v         specific volume (m$^3$/kg)
+   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
+   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
+   */
+  virtual void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
+
+  /**
+   * Specific enthalpy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific enthalpy (J/kg)
+   */
+  virtual Real h_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] h       specific enthalpy (J/kg)
+   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
+   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
+   */
+  virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
+
+  /**
+   * Specific internal energy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific internal energy (J/kg)
+   */
+  virtual Real e_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Specific internal energy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] e       specific internal energy (J/kg)
+   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
+   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
+   */
+  virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
+
+  /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isobaric specific heat (J/kg/.K)
+   */
+  virtual Real cp_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Isobaric specific heat capacity and its derivatives from pressure and temperature
+   *
+   * @param[in] p       pressure (Pa)
+   * @param[in] T       temperature (K)
+   * @param[out] cp     isobaric specific heat (J/kg/K)
+   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
+   */
+  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+
+  using SinglePhaseFluidProperties::cv_from_p_T;
+
+  /**
+   * Isochoric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isochoric specific heat (J/kg.K)
+   */
+  virtual Real cv_from_p_T(Real p, Real T) const override;
+  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const override;
+
+  /**
+   * Molar mass
+   *
+   * @return molar mass (kg/mol)
+   */
+  virtual Real molarMass() const override;
+
+  /**
+   * Thermal conductivity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return thermal conductivity  (W/m.K)
+   */
+  virtual Real k_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Thermal conductivity and its derivatives wrt pressure and temperature
+   *
+   * @param p           pressure (Pa)
+   * @param T           temperature (K)
+   * @param[out]  k     thermal conductivity  (W/m.K)
+   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
+   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
+   */
+  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
+
+  /**
+   * Dynamic viscosity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return dynamic viscosity (Pa.s)
+   */
+  virtual Real mu_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Dynamic viscosity and its derivatives wrt pressure and temperature
+   *
+   * @param p             pressure (Pa)
+   * @param T             temperature (K)
+   * @param[out] mu       viscosity (Pa.s)
+   * @param[out] dmu_dp   derivative of viscosity wrt pressure
+   * @param[out] dmu_dT   derivative of viscosity wrt temperature
+   */
+  virtual void
+  mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+};
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/src/userobjects/SodiumSaturationFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SodiumSaturationFluidProperties.C
@@ -27,7 +27,7 @@ SodiumSaturationFluidProperties::SodiumSaturationFluidProperties(const InputPara
 std::string
 SodiumSaturationFluidProperties::fluidName() const
 {
-  return "sodium";
+  return "sodium_sat";
 }
 
 Real
@@ -126,7 +126,7 @@ SodiumSaturationFluidProperties::e_from_p_T(
   de_dp = -pressure * dv_dp - v;
 
   // definition of e = h - p * v
-  Real cp = cp_from_v_e(v, e);
+  Real cp = cp_from_p_T(pressure, temperature);
   de_dT = cp - pressure * dv_dT;
 }
 

--- a/modules/fluid_properties/src/userobjects/SodiumSaturationFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/SodiumSaturationFluidProperties.C
@@ -1,0 +1,201 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "SodiumSaturationFluidProperties.h"
+
+registerMooseObject("FluidPropertiesApp", SodiumSaturationFluidProperties);
+
+InputParameters
+SodiumSaturationFluidProperties::validParams()
+{
+  InputParameters params = SinglePhaseFluidProperties::validParams();
+  params.addClassDescription("Fluid properties for liquid sodium at saturation conditions");
+  return params;
+}
+
+SodiumSaturationFluidProperties::SodiumSaturationFluidProperties(const InputParameters & parameters)
+  : SinglePhaseFluidProperties(parameters)
+{
+}
+
+std::string
+SodiumSaturationFluidProperties::fluidName() const
+{
+  return "sodium";
+}
+
+Real
+SodiumSaturationFluidProperties::molarMass() const
+{
+  return 22.989769E-3;
+}
+
+Real
+SodiumSaturationFluidProperties::rho_from_p_T(Real /* pressure */, Real temperature) const
+{
+  return 1.00423e3 - 0.21390 * temperature - 1.1046e-5 * temperature * temperature;
+}
+
+void
+SodiumSaturationFluidProperties::rho_from_p_T(
+    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+{
+  rho = rho_from_p_T(pressure, temperature);
+  drho_dp = 0.0;
+  drho_dT = -0.21390 - 1.1046e-5 * 2 * temperature;
+}
+
+void
+SodiumSaturationFluidProperties::rho_from_p_T(const DualReal & pressure,
+                                              const DualReal & temperature,
+                                              DualReal & rho,
+                                              DualReal & drho_dp,
+                                              DualReal & drho_dT) const
+{
+  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
+  drho_dp = 0.0;
+  drho_dT = -0.21390 - 1.1046e-5 * 2 * temperature;
+}
+
+DualReal
+SodiumSaturationFluidProperties::v_from_p_T(const DualReal & /* pressure */,
+                                            const DualReal & temperature) const
+{
+  return 1.0 / (1.00423e3 - 0.21390 * temperature - 1.1046e-5 * temperature * temperature);
+}
+
+Real
+SodiumSaturationFluidProperties::v_from_p_T(Real /* pressure */, Real temperature) const
+{
+  return 1.0 / (1.00423e3 - 0.21390 * temperature - 1.1046e-5 * temperature * temperature);
+}
+
+void
+SodiumSaturationFluidProperties::v_from_p_T(
+    Real pressure, Real temperature, Real & v, Real & dv_dp, Real & dv_dT) const
+{
+  v = v_from_p_T(pressure, temperature);
+  dv_dp = 0.0;
+
+  Real drho_dT = -0.21390 - 1.1046e-5 * 2 * temperature;
+  dv_dT = -v * v * drho_dT;
+}
+
+Real
+SodiumSaturationFluidProperties::h_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  Real t2 = temperature * temperature;
+  return 3.7782E-10 * t2 * t2 * temperature / 5 - 1.7191E-6 * t2 * t2 / 4.0 +
+         3.0921E-3 * t2 * temperature / 3.0 - 2.4560 * t2 / 2.0 + 1972.0 * temperature - 401088.7;
+}
+
+void
+SodiumSaturationFluidProperties::h_from_p_T(
+    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+{
+  h = h_from_p_T(pressure, temperature);
+  dh_dp = 0.0;
+  dh_dT = cp_from_p_T(pressure, temperature);
+}
+
+Real
+SodiumSaturationFluidProperties::e_from_p_T(Real pressure, Real temperature) const
+{
+  // definition of h = e + p * v
+  Real v = v_from_p_T(pressure, temperature);
+  Real h = h_from_p_T(pressure, temperature);
+  return h - pressure * v;
+}
+
+void
+SodiumSaturationFluidProperties::e_from_p_T(
+    Real pressure, Real temperature, Real & e, Real & de_dp, Real & de_dT) const
+{
+  e = e_from_p_T(pressure, temperature);
+
+  Real v, dv_dp, dv_dT;
+  v_from_p_T(pressure, temperature, v, dv_dp, dv_dT);
+
+  // definition of e = h - p * v, with dh/dp = 0
+  de_dp = -pressure * dv_dp - v;
+
+  // definition of e = h - p * v
+  Real cp = cp_from_v_e(v, e);
+  de_dT = cp - pressure * dv_dT;
+}
+
+Real
+SodiumSaturationFluidProperties::cp_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  Real t2 = temperature * temperature;
+  return 3.7782E-10 * t2 * t2 - 1.7191E-6 * t2 * temperature + 3.0921E-3 * t2 -
+         2.4560 * temperature + 1972.0;
+}
+
+void
+SodiumSaturationFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0.0;
+
+  Real t2 = temperature * temperature;
+  dcp_dT =
+      4 * 3.7782E-10 * t2 * temperature - 3 * 1.7191E-6 * t2 + 2 * 3.0921e-3 * temperature - 2.456;
+}
+
+Real
+SodiumSaturationFluidProperties::cv_from_p_T(Real /* pressure */, Real temperature) const
+{
+  Real t2 = temperature * temperature;
+  return 1.0369E-8 * temperature * t2 + 3.7164E-4 * t2 - 1.0494 * temperature + 1582.6;
+}
+
+void
+SodiumSaturationFluidProperties::cv_from_p_T(
+    Real pressure, Real temperature, Real & cv, Real & dcv_dp, Real & dcv_dT) const
+{
+  cv = cv_from_p_T(pressure, temperature);
+  dcv_dp = 0.0;
+  dcv_dT = 3 * 1.0369e-8 * temperature * temperature + 2 * 3.7164e-4 * temperature - 1.0494;
+}
+
+Real
+SodiumSaturationFluidProperties::mu_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 3.6522E-5 + 0.16626 / temperature - 4.56877e1 / (temperature * temperature) +
+         2.8733E4 / (temperature * temperature * temperature);
+}
+
+void
+SodiumSaturationFluidProperties::mu_from_p_T(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = this->mu_from_p_T(pressure, temperature);
+  dmu_dp = 0.0;
+
+  Real t2 = temperature * temperature;
+  dmu_dT = 0.16626 * -1 / t2 - 4.56877E1 * -2 / (temperature * t2) + 2.8733E4 * -3 / (t2 * t2);
+}
+
+Real
+SodiumSaturationFluidProperties::k_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 1.1045e2 - 6.5112e-2 * temperature + 1.5430e-5 * temperature * temperature -
+         2.4617e-9 * temperature * temperature * temperature;
+}
+
+void
+SodiumSaturationFluidProperties::k_from_p_T(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = this->k_from_p_T(pressure, temperature);
+  dk_dp = 0.0;
+  dk_dT = -6.5112e-2 + 2 * 1.5430e-5 * temperature - 3 * 2.4617e-9 * temperature * temperature;
+}

--- a/modules/fluid_properties/unit/include/SodiumSaturationFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/SodiumSaturationFluidPropertiesTest.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+#include "SodiumSaturationFluidProperties.h"
+
+class SodiumSaturationFluidPropertiesTest : public MooseObjectUnitTest
+{
+public:
+  SodiumSaturationFluidPropertiesTest() : MooseObjectUnitTest("FluidPropertiesApp")
+  {
+    buildObjects();
+  }
+
+protected:
+  void buildObjects()
+  {
+    InputParameters uo_pars = _factory.getValidParams("SodiumSaturationFluidProperties");
+    _fe_problem->addUserObject("SodiumSaturationFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<SodiumSaturationFluidProperties>("fp");
+  }
+
+  const SodiumSaturationFluidProperties * _fp;
+};

--- a/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
@@ -13,7 +13,7 @@
 /**
  * Test that the fluid name is correctly returned
  */
-TEST_F(SodiumSaturationFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "sodium"); }
+TEST_F(SodiumSaturationFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "sodium_sat"); }
 
 /**
  * Test that the molar mass is correctly returned
@@ -97,13 +97,13 @@ TEST_F(SodiumSaturationFluidPropertiesTest, density)
   const Real p = 101325;
 
   // Fink and Leibowitz (1979) list density at 370.98 K is 927.3, so the fit agrees well
-  ABS_TEST(_fp->rho_from_p_T(p, Tm), 923.3608692322216, 1e-7);
+  ABS_TEST(_fp->rho_from_p_T(p, Tm), 923.3571594322216, 1e-7);
   DERIV_TEST(_fp->rho_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
   ABS_TEST(_fp->v_from_p_T(p, Tm), 0.001083004544649772, 1e-7);
   DERIV_TEST(_fp->v_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
 
   // Fink and Leibowitz (1979) list density at 800 K is 825.6, so the fit agrees well
-  ABS_TEST(_fp->rho_from_p_T(p, T), 826.04856, 1e-7);
+  ABS_TEST(_fp->rho_from_p_T(p, T), 826.04056, 1e-7);
   DERIV_TEST(_fp->rho_from_p_T, p, T, REL_TOL_DERIVATIVE);
   ABS_TEST(_fp->v_from_p_T(p, T), 0.0012105943078630425, 1e-7);
   DERIV_TEST(_fp->v_from_p_T, p, T, REL_TOL_DERIVATIVE);

--- a/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
@@ -97,21 +97,21 @@ TEST_F(SodiumSaturationFluidPropertiesTest, density)
   const Real p = 101325;
 
   // Fink and Leibowitz (1979) list density at 370.98 K is 927.3, so the fit agrees well
-  ABS_TEST(_fp->rho_from_p_T(p, Tm), 923.3571594322216, 1e-7);
+  ABS_TEST(_fp->rho_from_p_T(p, Tm), 923.3571594322216, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->rho_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
-  ABS_TEST(_fp->v_from_p_T(p, Tm), 0.001083004544649772, 1e-7);
+  ABS_TEST(_fp->v_from_p_T(p, Tm), 0.001083004544649772, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->v_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
 
   // Fink and Leibowitz (1979) list density at 800 K is 825.6, so the fit agrees well
-  ABS_TEST(_fp->rho_from_p_T(p, T), 826.04056, 1e-7);
+  ABS_TEST(_fp->rho_from_p_T(p, T), 826.04056, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->rho_from_p_T, p, T, REL_TOL_DERIVATIVE);
-  ABS_TEST(_fp->v_from_p_T(p, T), 0.0012105943078630425, 1e-7);
+  ABS_TEST(_fp->v_from_p_T(p, T), 0.0012105943078630425, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->v_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
   // Fink and Leibowitz (1979) list density at 1156.5 K is 739.4, so the fit agrees well
-  ABS_TEST(_fp->rho_from_p_T(p, Tb), 742.0807106065, 1e-7);
+  ABS_TEST(_fp->rho_from_p_T(p, Tb), 742.0807106065, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->rho_from_p_T, p, Tb, REL_TOL_DERIVATIVE);
-  ABS_TEST(_fp->v_from_p_T(p, Tb), 0.0013475623145933863, 1e-7);
+  ABS_TEST(_fp->v_from_p_T(p, Tb), 0.0013475623145933863, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->v_from_p_T, p, Tb, REL_TOL_DERIVATIVE);
 }
 

--- a/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SodiumSaturationFluidPropertiesTest.C
@@ -1,0 +1,148 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "SinglePhaseFluidPropertiesTestUtils.h"
+#include "SodiumSaturationFluidPropertiesTest.h"
+
+/**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "sodium"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_fp->molarMass(), 22.989769E-3, REL_TOL_SAVED_VALUE);
+}
+
+/**
+ * Test that the thermal conductivity and its derivatives are
+ * correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, thermalConductivity)
+{
+  const Real T = 800.0;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) list conductivity as 66.8 at 800 K, so the fit agrees well
+  REL_TEST(_fp->k_from_p_T(p, T), 66.9752096, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->k_from_p_T, p, T, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the viscosity and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, viscosity)
+{
+  const Real T = 800.0;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) list viscosity as 0.000229 at 800 K, so the fit agrees well
+  REL_TEST(_fp->mu_from_p_T(p, T), 0.00022907910937500003, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->mu_from_p_T, p, T, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the isobaric specific heat and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, isobaricSpecificHeat)
+{
+  const Real T1 = 400.0;
+  const Real T2 = 800.0;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) show Cp = 1373.6 at 400 K, so the fit agrees well
+  REL_TEST(_fp->cp_from_p_T(p, T1), 1383.985792, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_p_T, p, T1, REL_TOL_DERIVATIVE);
+
+  // Fink and Leibowitz (1979) show Cp = 1263.6 at 800 K, so the fit agrees well
+  REL_TEST(_fp->cp_from_p_T(p, T2), 1260.719872, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cp_from_p_T, p, T2, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the isochoric specific heat and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, isochoricSpecificHeat)
+{
+  const Real T1 = 400.0;
+  const Real T2 = 800.0;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) show Cv = 1230.1 at 400 K, so the fit agrees well
+  REL_TEST(_fp->cv_from_p_T(p, T1), 1222.9660159999999, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cv_from_p_T, p, T1, REL_TOL_DERIVATIVE);
+
+  // Fink and Leibowitz (1979) show Cv = 982.611 at 800 K, so the fit agrees well
+  REL_TEST(_fp->cv_from_p_T(p, T2), 986.2385279999999, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->cv_from_p_T, p, T2, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the density and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, density)
+{
+  const Real Tm = 370.98;
+  const Real T = 800.0;
+  const Real Tb = 1156.5;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) list density at 370.98 K is 927.3, so the fit agrees well
+  ABS_TEST(_fp->rho_from_p_T(p, Tm), 923.3608692322216, 1e-7);
+  DERIV_TEST(_fp->rho_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
+  ABS_TEST(_fp->v_from_p_T(p, Tm), 0.001083004544649772, 1e-7);
+  DERIV_TEST(_fp->v_from_p_T, p, Tm, REL_TOL_DERIVATIVE);
+
+  // Fink and Leibowitz (1979) list density at 800 K is 825.6, so the fit agrees well
+  ABS_TEST(_fp->rho_from_p_T(p, T), 826.04856, 1e-7);
+  DERIV_TEST(_fp->rho_from_p_T, p, T, REL_TOL_DERIVATIVE);
+  ABS_TEST(_fp->v_from_p_T(p, T), 0.0012105943078630425, 1e-7);
+  DERIV_TEST(_fp->v_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  // Fink and Leibowitz (1979) list density at 1156.5 K is 739.4, so the fit agrees well
+  ABS_TEST(_fp->rho_from_p_T(p, Tb), 742.0807106065, 1e-7);
+  DERIV_TEST(_fp->rho_from_p_T, p, Tb, REL_TOL_DERIVATIVE);
+  ABS_TEST(_fp->v_from_p_T(p, Tb), 0.0013475623145933863, 1e-7);
+  DERIV_TEST(_fp->v_from_p_T, p, Tb, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the specific internal energy and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, specificInternalEnergy)
+{
+  const Real T = 800.0;
+  const Real p = 101325;
+
+  ABS_TEST(_fp->e_from_p_T(p, T),
+           _fp->h_from_p_T(p, T) - p * _fp->v_from_p_T(p, T),
+           REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->e_from_p_T, p, T, REL_TOL_DERIVATIVE);
+}
+
+/**
+ * Test that the specific enthalpy and its derivatives are correctly computed.
+ */
+TEST_F(SodiumSaturationFluidPropertiesTest, specificEnthalpy)
+{
+  const Real T = 800.0;
+  const Real p = 101325;
+
+  // Fink and Leibowitz (1979) compute enthalpy at 800 K as 768602, so the fit agrees well
+  ABS_TEST(_fp->h_from_p_T(p, T), 767034.6715200001, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->h_from_p_T, p, T, REL_TOL_DERIVATIVE);
+
+  // Fink and Leibowitz (1979) compute enthalpy at 1156.5 K as 1218803, so the fit agrees well
+  const Real T2 = 1156.5;
+  ABS_TEST(_fp->h_from_p_T(p, T2), 1218897.6776327428, REL_TOL_SAVED_VALUE);
+  DERIV_TEST(_fp->h_from_p_T, p, T2, REL_TOL_DERIVATIVE);
+}


### PR DESCRIPTION
Adds material properties for sodium at liquid saturation conditions. The density correlation doesn't have any dependence on pressure (which means that they cannot be used in Pronghorn because the SUPG stabilization requires derivatives of temperature with respect to internal energy and specific volume). 

I got around this issue with Flibe by adding a tiny dependence on pressure to the density correlation, but unfortunately here the density correlation is not linear and therefore can't be inverted analytically. I'm hoping that with the future FV implementation, we won't need those derivatives anyways, so this might just be a temporary limitation. If it doesn't end up being a temporary limitation, I could add a simple bisection method or something to find `dT_de` and `dT_dv` given the nonlinear `rho(T)` function.

Closes #17411
