### PR TITLE
Require MUMPS in all HFEM tests that use it

### DIFF
--- a/test/tests/kernels/hfem/tests
+++ b/test/tests/kernels/hfem/tests
@@ -49,6 +49,7 @@
     exodiff = 'robin_displaced_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with displaced meshes.'
     mesh_mode = replicated
+    mumps = true
   []
   [robin_adpatation]
     type = 'RunException'


### PR DESCRIPTION
Fixes #17622

A better solution would be to not use MUMPS here, IMHO.  Surely HFEM
matrix conditioning isn't so wonky that we can't handle a small test
case without a direct solver?