### PR TITLE
Limit use of getNextLocalRow to avoid sampler bugs

### DIFF
--- a/framework/include/samplers/Sampler.h
+++ b/framework/include/samplers/Sampler.h
@@ -286,8 +286,14 @@ private:
   /// Number of seeds
   std::size_t _n_seeds;
 
+  /// The following two members are marked mutable to allow for the getLocalRowBegin/End to operate
+  /// correctly for const object/functions, this index is to track the iteration for the
+  /// getNextLocalRow, it doesn't affect the state of the sampler.
   /// Iterator index for getNextLocalRow method
-  dof_id_type _next_local_row;
+  mutable dof_id_type _next_local_row;
+
+  /// Iterator index to make sure getNextLocalRow is called only once per iteration
+  mutable dof_id_type _previous_next_local_row;
 
   /// Flag for restoring state during getNextLocalRow iteration
   bool _next_local_row_requires_state_restore;

--- a/framework/include/samplers/Sampler.h
+++ b/framework/include/samplers/Sampler.h
@@ -109,6 +109,8 @@ public:
    */
   dof_id_type getLocalRowBegin() const;
   dof_id_type getLocalRowEnd() const;
+  dof_id_type getLocalRowBegin(const dof_id_type positive_offset) const;
+  dof_id_type getLocalRowEnd(const dof_id_type negative_offset) const;
   ///@}
 
 protected:

--- a/framework/src/samplers/Sampler.C
+++ b/framework/src/samplers/Sampler.C
@@ -279,8 +279,11 @@ Sampler::getNextLocalRow()
   }
 
   if ((_next_local_row - _previous_next_local_row) != 1)
-    mooseError(
-        "The 'Sampler::getNextLocalRow' method must be called once, and only once per iteration.");
+  {
+    mooseError("The 'Sampler::getNextLocalRow' method must be called once, and only once per "
+               "iteration. To operate correctly the `Sampler::getLocalRowBegin()` and "
+               "`Sampler::getLocalRowEnd()` methods should be utilzed.");
+  }
 
   std::vector<Real> output(_n_cols);
   computeSampleRow(_next_local_row, output);
@@ -411,18 +414,34 @@ Sampler::getNumberOfLocalRows() const
 dof_id_type
 Sampler::getLocalRowBegin() const
 {
-  checkReinitStatus();
-  _next_local_row = _local_row_begin;
-  _previous_next_local_row = _next_local_row - 1;
-  return _local_row_begin;
+  return getLocalRowBegin(0);
 }
 
 dof_id_type
 Sampler::getLocalRowEnd() const
 {
+  return getLocalRowEnd(0);
+}
+
+dof_id_type
+Sampler::getLocalRowBegin(const dof_id_type positive_offset) const
+{
+  mooseAssert(positive_offset < _n_local_rows,
+              "The supplied positive offset must be less then the number of local rows");
+  checkReinitStatus();
+  _next_local_row = _local_row_begin + positive_offset;
+  _previous_next_local_row = _next_local_row;
+  return _local_row_begin;
+}
+
+dof_id_type
+Sampler::getLocalRowEnd(const dof_id_type negative_offset) const
+{
+  mooseAssert(negative_offset < _n_local_rows,
+              "The supplied negative offset must be less then the number of local rows");
   checkReinitStatus();
   _next_local_row++;
-  return _local_row_end;
+  return _local_row_end - negative_offset;
 }
 
 void

--- a/test/src/userobjects/SamplerTester.C
+++ b/test/src/userobjects/SamplerTester.C
@@ -21,7 +21,7 @@ SamplerTester::validParams()
 
   MooseEnum test_type(
       "mpi thread base_global_vs_local rand_global_vs_local rand_global_vs_next getGlobalSamples "
-      "getLocalSamples getNextLocalRow");
+      "getLocalSamples getNextLocalRow getNextLocalRow_call_twice getNextLocalRow_call_zero");
   params.addParam<MooseEnum>("test_type", test_type, "The type of test to perform.");
   params.set<std::vector<OutputName>>("outputs") = {"none"};
   params.suppressParameter<std::vector<OutputName>>("outputs");
@@ -53,6 +53,24 @@ SamplerTester::execute()
   if (_test_type == "getNextLocalRow")
     for (dof_id_type i = _sampler.getLocalRowBegin(); i < _sampler.getLocalRowEnd(); ++i)
       std::vector<Real> row = _sampler.getNextLocalRow();
+
+  if (_test_type == "getNextLocalRow_call_twice")
+  {
+    for (dof_id_type i = _sampler.getLocalRowBegin(); i < _sampler.getLocalRowEnd(); ++i)
+    {
+      _sampler.getNextLocalRow();
+      _sampler.getNextLocalRow();
+    }
+  }
+
+  if (_test_type == "getNextLocalRow_call_zero")
+  {
+    for (dof_id_type i = _sampler.getLocalRowBegin(); i < _sampler.getLocalRowEnd(); ++i)
+    {
+      if (i != 10)
+        _sampler.getNextLocalRow();
+    }
+  }
 
   if (_test_type == "rand_global_vs_next")
   {

--- a/test/src/userobjects/SamplerTester.C
+++ b/test/src/userobjects/SamplerTester.C
@@ -80,7 +80,7 @@ SamplerTester::execute()
     DenseMatrix<Real> global = _sampler.getGlobalSamples();
 
     // Iterate through some
-    for (dof_id_type i = _sampler.getLocalRowBegin(); i < 7; ++i)
+    for (dof_id_type i = _sampler.getLocalRowBegin(); i < _sampler.getLocalRowEnd(7); ++i)
     {
       std::vector<Real> row = _sampler.getNextLocalRow();
       for (unsigned int j = 0; j < 8; j++)
@@ -93,7 +93,7 @@ SamplerTester::execute()
     DenseMatrix<Real> local = _sampler.getLocalSamples();
 
     // Continue iteration
-    for (dof_id_type i = 7; i < _sampler.getLocalRowEnd(); ++i)
+    for (dof_id_type i = _sampler.getLocalRowBegin(7); i < _sampler.getLocalRowEnd(); ++i)
     {
       std::vector<Real> row = _sampler.getNextLocalRow();
       for (unsigned int j = 0; j < 8; j++)

--- a/test/tests/samplers/base/tests
+++ b/test/tests/samplers/base/tests
@@ -169,7 +169,7 @@
       expect_err = "The number of entries in the DenseMatrix \([0-9]+\) exceeds the allowed limit of [0-9]+."
       cli_args = "Samplers/sample/num_cols=1000000000 Postprocessors/test/test_type=getLocalSamples"
 
-      detail = "if the number of entries in the local sample matrix exceeds the maximum allowed, and"
+      detail = "if the number of entries in the local sample matrix exceeds the maximum allowed,"
     []
     [getNextLocalRow_max]
       type = RunException
@@ -177,7 +177,23 @@
       expect_err = "The number of entries in the std::vector \([0-9]+\) exceeds the allowed limit of [0-9]+."
       cli_args = "Samplers/sample/num_cols=1000000000 Postprocessors/test/test_type=getNextLocalRow"
 
-      detail = "if the number of entries in the local sample matrix row exceeds the maximum allowed."
+      detail = "if the number of entries in the local sample matrix row exceeds the maximum allowed,"
+    []
+    [getNextLocalRow_call_twice]
+      type = RunException
+      input = errors.i
+      expect_err = "The 'Sampler::getNextLocalRow' method must be called once, and only once per iteration."
+      cli_args = "Postprocessors/test/test_type=getNextLocalRow_call_twice"
+
+      detail = "if the access to a local row of the sampler is called more than once per iteration, and"
+    []
+    [getNextLocalRow_call_zero]
+      type = RunException
+      input = errors.i
+      expect_err = "The 'Sampler::getNextLocalRow' method must be called once, and only once per iteration."
+      cli_args = "Postprocessors/test/test_type=getNextLocalRow_call_zero"
+
+      detail = "if the access to a local row of the sampler is not called during iteration."
     []
   []
 


### PR DESCRIPTION
@zachmprince This is the concept I was trying to explain. I think there are a few errors, so something still isn't quite correct in this implementation.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
