### PR TITLE
Allowed 2-phase interfaces to be called in TwoPhaseFluidPropertiesIndependent

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -49,6 +49,7 @@ public:
   virtual Real mu_from_v_e(Real v, Real e) const override;
   virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
   virtual Real k_from_v_e(Real v, Real e) const override;
+  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
   virtual Real s_from_v_e(Real v, Real e) const override;
   virtual void s_from_v_e(Real v, Real e, Real & s, Real & ds_dv, Real & ds_de) const override;
   virtual Real s_from_p_T(Real p, Real T) const override;

--- a/modules/fluid_properties/include/userobjects/TwoPhaseFluidPropertiesIndependent.h
+++ b/modules/fluid_properties/include/userobjects/TwoPhaseFluidPropertiesIndependent.h
@@ -17,7 +17,7 @@
 /**
  * 2-phase fluid properties for 2 independent single-phase fluid properties.
  *
- * This class throws errors if any 2-phase interfaces are called.
+ * By default, this class throws errors if any 2-phase interfaces are called.
  */
 class TwoPhaseFluidPropertiesIndependent : public TwoPhaseFluidProperties
 {
@@ -27,17 +27,27 @@ public:
   TwoPhaseFluidPropertiesIndependent(const InputParameters & parameters);
 
   virtual Real p_critical() const override;
+  virtual Real T_triple() const override;
   virtual Real T_sat(Real p) const override;
+  virtual DualReal T_sat(const DualReal & p) const override;
   virtual Real p_sat(Real T) const override;
+  virtual DualReal p_sat(const DualReal & T) const override;
   virtual Real dT_sat_dp(Real p) const override;
+  virtual Real L_fusion() const override;
+  virtual Real sigma_from_T(Real T) const override;
+  virtual DualReal sigma_from_T(const DualReal & T) const override;
+  virtual Real dsigma_dT_from_T(Real T) const override;
 
   virtual bool supportsPhaseChange() const override { return false; }
 
+protected:
   /**
-   * Calls \c mooseError with a message saying that this class cannot call
-   * 2-phase fluid properties.
+   * Returns a dummy zero value or throws a \c mooseError.
    */
-  [[noreturn]] void throwNotImplementedError() const;
+  Real getTwoPhaseInterfaceDummyValue() const;
+
+  /// If true, throw an error when a 2-phase interface is called. Else, return a zero value.
+  const bool _error_on_unimplemented;
 };
 
 #pragma GCC diagnostic pop

--- a/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/IdealGasFluidProperties.C
@@ -174,6 +174,15 @@ IdealGasFluidProperties::mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, R
 
 Real IdealGasFluidProperties::k_from_v_e(Real, Real) const { return _k; }
 
+void
+IdealGasFluidProperties::k_from_v_e(
+    Real /*v*/, Real /*e*/, Real & k, Real & dk_dv, Real & dk_de) const
+{
+  k = _k;
+  dk_dv = 0;
+  dk_de = 0;
+}
+
 Real
 IdealGasFluidProperties::s_from_v_e(Real v, Real e) const
 {

--- a/modules/fluid_properties/src/userobjects/TwoPhaseFluidPropertiesIndependent.C
+++ b/modules/fluid_properties/src/userobjects/TwoPhaseFluidPropertiesIndependent.C
@@ -22,36 +22,93 @@ TwoPhaseFluidPropertiesIndependent::validParams()
 
   params.makeParamRequired<UserObjectName>("fp_liquid");
   params.makeParamRequired<UserObjectName>("fp_vapor");
+  params.addParam<bool>(
+      "error_on_unimplemented",
+      true,
+      "If true, throw an error when a 2-phase interface is called. Else, return a zero value.");
 
   return params;
 }
 
 TwoPhaseFluidPropertiesIndependent::TwoPhaseFluidPropertiesIndependent(
     const InputParameters & parameters)
-  : TwoPhaseFluidProperties(parameters)
+  : TwoPhaseFluidProperties(parameters),
 
+    _error_on_unimplemented(getParam<bool>("error_on_unimplemented"))
 {
   _fp_liquid = &getUserObject<SinglePhaseFluidProperties>("fp_liquid");
   _fp_vapor = &getUserObject<SinglePhaseFluidProperties>("fp_vapor");
 }
 
-[[noreturn]] void
-TwoPhaseFluidPropertiesIndependent::throwNotImplementedError() const
+Real
+TwoPhaseFluidPropertiesIndependent::getTwoPhaseInterfaceDummyValue() const
 {
-  mooseError(
-      name(),
-      ": The 2-phase fluid properties class 'TwoPhaseFluidPropertiesIndependent' does not allow "
-      "calling any 2-phase property interfaces.");
+  if (_error_on_unimplemented)
+    mooseError(
+        name(),
+        ": The 2-phase fluid properties class 'TwoPhaseFluidPropertiesIndependent' does not allow "
+        "calling any 2-phase property interfaces.");
+  else
+    return 0;
 }
 
 Real
 TwoPhaseFluidPropertiesIndependent::p_critical() const
 {
-  throwNotImplementedError();
+  return getTwoPhaseInterfaceDummyValue();
 }
 
-Real TwoPhaseFluidPropertiesIndependent::T_sat(Real) const { throwNotImplementedError(); }
+Real
+TwoPhaseFluidPropertiesIndependent::T_triple() const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
 
-Real TwoPhaseFluidPropertiesIndependent::p_sat(Real) const { throwNotImplementedError(); }
+Real TwoPhaseFluidPropertiesIndependent::T_sat(Real) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
 
-Real TwoPhaseFluidPropertiesIndependent::dT_sat_dp(Real) const { throwNotImplementedError(); }
+DualReal
+TwoPhaseFluidPropertiesIndependent::T_sat(const DualReal &) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+Real TwoPhaseFluidPropertiesIndependent::p_sat(Real) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+DualReal
+TwoPhaseFluidPropertiesIndependent::p_sat(const DualReal &) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+Real TwoPhaseFluidPropertiesIndependent::dT_sat_dp(Real) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+Real
+TwoPhaseFluidPropertiesIndependent::L_fusion() const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+Real TwoPhaseFluidPropertiesIndependent::sigma_from_T(Real) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+DualReal
+TwoPhaseFluidPropertiesIndependent::sigma_from_T(const DualReal &) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}
+
+Real TwoPhaseFluidPropertiesIndependent::dsigma_dT_from_T(Real) const
+{
+  return getTwoPhaseInterfaceDummyValue();
+}

--- a/modules/fluid_properties/test/tests/two_phase_fluid_properties_independent/tests
+++ b/modules/fluid_properties/test/tests/two_phase_fluid_properties_independent/tests
@@ -1,13 +1,29 @@
 [Tests]
-  [./test]
+  [test]
     type = CSVDiff
     input = 'test.i'
     csvdiff = 'test_out.csv'
     rel_err = 1e-8
     allow_test_objects = true
     threading = '!pthreads'
-  [../]
-  [./call_2phase_property]
+  []
+  [no_error_on_unimplemented]
+    type = RunApp
+    input = 'test.i'
+    cli_args = "
+      Modules/FluidProperties/fp_2phase/error_on_unimplemented=false
+      AuxVariables/T_sat/family=LAGRANGE
+      AuxVariables/T_sat/order=FIRST
+      AuxKernels/T_sat_aux/type=SaturationTemperatureAux
+      AuxKernels/T_sat_aux/variable=T_sat
+      AuxKernels/T_sat_aux/p=p
+      AuxKernels/T_sat_aux/fp_2phase=fp_2phase
+      AuxKernels/T_sat_aux/execute_on=initial
+      Outputs/csv=false"
+    allow_test_objects = true
+    threading = '!pthreads'
+  []
+  [error:error_on_unimplemented]
     type = 'RunException'
     input = 'test.i'
     cli_args = "
@@ -21,5 +37,5 @@
     expect_err = "The 2-phase fluid properties class 'TwoPhaseFluidPropertiesIndependent' does not allow calling any 2-phase property interfaces"
     allow_test_objects = true
     threading = '!pthreads'
-  [../]
+  []
 []


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
