### PR TITLE
Added PostprocessorInterface to InitialConditionBase

### DIFF
--- a/framework/include/ics/InitialConditionBase.h
+++ b/framework/include/ics/InitialConditionBase.h
@@ -13,6 +13,7 @@
 #include "Coupleable.h"
 #include "FunctionInterface.h"
 #include "UserObjectInterface.h"
+#include "PostprocessorInterface.h"
 #include "Restartable.h"
 #include "BlockRestrictable.h"
 #include "DependencyResolverInterface.h"
@@ -43,6 +44,7 @@ class InitialConditionBase : public MooseObject,
                              public Coupleable,
                              public FunctionInterface,
                              public UserObjectInterface,
+                             public PostprocessorInterface,
                              public BoundaryRestrictable,
                              public DependencyResolverInterface,
                              public Restartable,
@@ -101,6 +103,7 @@ protected:
 
 private:
   void addUserObjectDependencyHelper(const UserObject & uo) const override final;
+  void addPostprocessorDependencyHelper(const PostprocessorName & name) const override final;
 
   /// Dependent variables
   std::set<std::string> _depend_vars;

--- a/framework/src/ics/InitialConditionBase.C
+++ b/framework/src/ics/InitialConditionBase.C
@@ -47,6 +47,7 @@ InitialConditionBase::InitialConditionBase(const InputParameters & parameters)
                    .isNodal()),
     FunctionInterface(this),
     UserObjectInterface(this),
+    PostprocessorInterface(this),
     BoundaryRestrictable(this, _c_nodal),
     DependencyResolverInterface(),
     Restartable(this, "InitialConditionBases"),
@@ -81,4 +82,11 @@ InitialConditionBase::addUserObjectDependencyHelper(const UserObject & uo) const
 {
   if (!_ignore_uo_dependency)
     _depend_uo.insert(uo.name());
+}
+
+void
+InitialConditionBase::addPostprocessorDependencyHelper(const PostprocessorName & name) const
+{
+  if (!_ignore_uo_dependency)
+    _depend_uo.insert(name);
 }

--- a/modules/doc/content/newsletter/2021_05.md
+++ b/modules/doc/content/newsletter/2021_05.md
@@ -7,4 +7,11 @@ zero-penetration mechanical contact constraints. Interested readers may refer to
 the associated [issue](https://github.com/idaholab/moose/issues/16961) and
 [pull request](https://github.com/idaholab/moose/pull/17189).
 
+## Post-processors Usable in Initial Conditions
+
+We added [/PostprocessorInterface.md] to initial conditions. Post-processor
+values can now be retrieved using `getPostprocessorValue()` and `getPostprocessorValueByName()`,
+and these post-processors will be executed before the initial condition as long
+as their `execute_on` parameters include `INITIAL`.
+
 ## Bug Fixes

--- a/test/include/ics/PostprocessorIC.h
+++ b/test/include/ics/PostprocessorIC.h
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "InitialCondition.h"
+
+/**
+ * This initial condition takes values from post-processor values.
+ */
+class PostprocessorIC : public InitialCondition
+{
+public:
+  static InputParameters validParams();
+
+  PostprocessorIC(const InputParameters & parameters);
+
+  virtual Real value(const Point & p) override;
+
+protected:
+  const PostprocessorValue & _pp1;
+  const PostprocessorValue & _pp2;
+};

--- a/test/src/ics/PostprocessorIC.C
+++ b/test/src/ics/PostprocessorIC.C
@@ -1,0 +1,34 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "PostprocessorIC.h"
+
+registerMooseObject("MooseTestApp", PostprocessorIC);
+
+InputParameters
+PostprocessorIC::validParams()
+{
+  InputParameters params = InitialCondition::validParams();
+  params.addClassDescription("This initial condition takes values from post-processor values.");
+  params.addRequiredParam<PostprocessorName>("pp1", "Name of first test post-processor");
+  return params;
+}
+
+PostprocessorIC::PostprocessorIC(const InputParameters & parameters)
+  : InitialCondition(parameters),
+    _pp1(getPostprocessorValue("pp1")),
+    _pp2(getPostprocessorValueByName("pp2"))
+{
+}
+
+Real
+PostprocessorIC::value(const Point & /*p*/)
+{
+  return _pp1 + _pp2;
+}

--- a/test/tests/ics/postprocessor_interface/gold/postprocessor_interface_out.csv
+++ b/test/tests/ics/postprocessor_interface/gold/postprocessor_interface_out.csv
@@ -1,0 +1,3 @@
+time,integral_pp,pp2,test_var_pp
+0,34,6,40
+1,34,6,40

--- a/test/tests/ics/postprocessor_interface/postprocessor_interface.i
+++ b/test/tests/ics/postprocessor_interface/postprocessor_interface.i
@@ -1,0 +1,66 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  xmin = 0
+  xmax = 10
+  nx = 10
+[]
+
+[Functions]
+  # The integral of this function is 2*3 + 3*6 + 5*2 = 34
+  [test_fn]
+    type = PiecewiseConstant
+    axis = x
+    x = '0 2 5'
+    y = '3 6 2'
+  []
+[]
+
+[Postprocessors]
+  [integral_pp]
+    type = FunctionElementIntegral
+    function = test_fn
+    execute_on = 'INITIAL'
+  []
+  [pp2]
+    type = FunctionValuePostprocessor
+    function = 6
+    execute_on = 'INITIAL'
+  []
+[]
+
+[AuxVariables]
+  [test_var]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[ICs]
+  [test_var_ic]
+    type = PostprocessorIC
+    variable = test_var
+    pp1 = integral_pp
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Postprocessors]
+  # This PP should have the sum of the other two PPs: 34 + 6 = 40
+  [test_var_pp]
+    type = ElementAverageValue
+    variable = test_var
+    execute_on = 'INITIAL'
+  []
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/test/tests/ics/postprocessor_interface/tests
+++ b/test/tests/ics/postprocessor_interface/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [test]
+    type = CSVDiff
+    input = 'postprocessor_interface.i'
+    csvdiff = 'postprocessor_interface_out.csv'
+
+    requirement = 'MOOSE shall allow initial conditions to retrieve post-processor values.'
+    design = '/InitialCondition.md /PostprocessorInterface.md'
+    issues = '#17692'
+  []
+[]


### PR DESCRIPTION
- Added PostprocessorInterface to InitialConditionBase
- Added overloads for InitialConditionBase::getPostprocessorValue
  and InitialConditionBase::getPostprocessorValueByName that add
  the post-processor name to the user object dependency list
- Tested correct dependency resolution of both new overloads
- Added news entry

Closes #17692
