### PR TITLE
Fix a memory issue revealed by a test in #17672

### DIFF
--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1143,7 +1143,7 @@ protected:
       _default_vector_value;
 
   /// Will hold the default value for optional array coupled variables.
-  mutable std::map<std::string, ArrayVariableValue *> _default_array_value;
+  mutable std::unordered_map<std::string, std::unique_ptr<ArrayVariableValue>> _default_array_value;
 
   /// Will hold the default value for optional vector coupled variables for automatic differentiation.
   mutable std::unordered_map<std::string, std::unique_ptr<MooseArray<ADRealVectorValue>>>

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -347,11 +347,10 @@ Coupleable::getDefaultVectorValue(const std::string & var_name) const
 const ArrayVariableValue *
 Coupleable::getDefaultArrayValue(const std::string & var_name) const
 {
-  std::map<std::string, ArrayVariableValue *>::iterator default_value_it =
-      _default_array_value.find(var_name);
+  auto default_value_it = _default_array_value.find(var_name);
   if (default_value_it == _default_array_value.end())
   {
-    ArrayVariableValue * value = new ArrayVariableValue(_coupleable_max_qps);
+    auto value = libmesh_make_unique<ArrayVariableValue>(_coupleable_max_qps);
     for (unsigned int qp = 0; qp < _coupleable_max_qps; ++qp)
     {
       auto n = _c_parameters.numberDefaultCoupledValues(var_name);
@@ -359,10 +358,11 @@ Coupleable::getDefaultArrayValue(const std::string & var_name) const
       for (unsigned int i = 0; i < n; ++i)
         (*value)[qp](i) = _c_parameters.defaultCoupledValue(var_name, i);
     }
-    default_value_it = _default_array_value.insert(std::make_pair(var_name, value)).first;
+    default_value_it =
+        _default_array_value.insert(std::make_pair(var_name, std::move(value))).first;
   }
 
-  return default_value_it->second;
+  return default_value_it->second.get();
 }
 
 template <typename T>


### PR DESCRIPTION
A default coupling of array variables has a memory issue. Refer to #17672.