### PR TITLE
Do not run tests that require SLEPc when SLEPc is not available

### DIFF
--- a/modules/ray_tracing/test/tests/userobjects/ray_tracing_study/errors/tests
+++ b/modules/ray_tracing/test/tests/userobjects/ray_tracing_study/errors/tests
@@ -222,6 +222,7 @@
                   Executioner/type=Eigenvalue'
       expect_err = 'is not supported for an eigenvalue solve.'
       allow_test_objects = true
+      slepc = true
       detail = 'when the study is set to execute with residual kernels and an eigenvalue executioner,'
     []
     [error_if_tracing]

--- a/test/tests/problems/eigen_problem/initial_condition/tests
+++ b/test/tests/problems/eigen_problem/initial_condition/tests
@@ -17,6 +17,7 @@
     csvdiff = 'ne_ic_no_free_out_eigenvalues_0001.csv'
     issues = '#17026'
     requirement = "The system shall support eigenvalue execution without free power iterations."
+    slepc = true
   [../]
 
   [./inverse_eigenvalue_postprocessor]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

When SLEPc is not available these 2 tests are executed and fail.

## Design
<!--A concise description (design) of the enhancement.-->

Add SLEPc restriction into a test specification.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

Users running the test suite do not see false positives when they don't have SLEPc installed.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
