### PR TITLE
Ability to specify reporter type in MultiAppCloneReporterTransfer

### DIFF
--- a/framework/include/transfers/ReporterTransferInterface.h
+++ b/framework/include/transfers/ReporterTransferInterface.h
@@ -31,6 +31,11 @@ public:
   ReporterTransferInterface(const Transfer * transfer);
 
 protected:
+  static MultiMooseEnum standardTransferTypes()
+  {
+    return MultiMooseEnum("bool=0 integer=1 real=2 string=3");
+  }
+
   /*
    * This function allows derived objects how the "from" reporters should be transferred.
    * I.e. whether we are transferring the entire data or part of it. Without calling this
@@ -95,6 +100,19 @@ protected:
                     const ReporterMode & mode);
 
   /*
+   * Helper for declaring a new reporter value in a FEProblem that has specified type.
+   *
+   * @param reporter_name reporter name of the clone
+   * @param fe_problem The FEProblem that references the reporter data to declare clone
+   * @param type The type of reporter to declare
+   * @param mode ReporterMode to declare value as
+   */
+  void declareClone(const ReporterName & rname,
+                    FEProblemBase & problem,
+                    const std::string & type,
+                    const ReporterMode & mode);
+
+  /*
    * Helper for declaring a new vector reporter value in a FEProblem that contains
    * the same type as the reporter value in another FEProblem.
    *
@@ -108,6 +126,19 @@ protected:
                           const ReporterName & to_reporter,
                           const FEProblemBase & from_problem,
                           FEProblemBase & to_problem,
+                          const ReporterMode & mode);
+
+  /*
+   * Helper for declaring a new reporter value in a FEProblem that has specified type.
+   *
+   * @param reporter_name reporter name of the vector clone
+   * @param fe_problem The FEProblem that references the reporter data to declare vector clone
+   * @param type The type of reporter to declare the vector
+   * @param mode ReporterMode to declare value as
+   */
+  void declareVectorClone(const ReporterName & rname,
+                          FEProblemBase & problem,
+                          const std::string & type,
                           const ReporterMode & mode);
 
   /*

--- a/framework/src/transfers/ReporterTransferInterface.C
+++ b/framework/src/transfers/ReporterTransferInterface.C
@@ -97,6 +97,29 @@ ReporterTransferInterface::declareClone(const ReporterName & from_reporter,
 }
 
 void
+ReporterTransferInterface::declareClone(const ReporterName & rname,
+                                        FEProblemBase & problem,
+                                        const std::string & type,
+                                        const ReporterMode & mode)
+{
+  ReporterData & rdata = problem.getReporterData(ReporterData::WriteKey());
+  if (type == "bool")
+    rdata.declareReporterValue<bool, ReporterGeneralContext<bool>>(rname, mode, _rti_transfer);
+  else if (type == "integer")
+    rdata.declareReporterValue<int, ReporterGeneralContext<int>>(rname, mode, _rti_transfer);
+  else if (type == "real")
+    rdata.declareReporterValue<Real, ReporterGeneralContext<Real>>(rname, mode, _rti_transfer);
+  else if (type == "string")
+    rdata.declareReporterValue<std::string, ReporterGeneralContext<std::string>>(
+        rname, mode, _rti_transfer);
+  else
+    _rti_transfer.mooseError("Unknown reporter type, ", type, ".");
+
+  // Hide variables (if requested in parameters) if name is associated with a reporter object
+  hideVariableHelper(rname, problem);
+}
+
+void
 ReporterTransferInterface::declareVectorClone(const ReporterName & from_reporter,
                                               const ReporterName & to_reporter,
                                               const FEProblemBase & from_problem,
@@ -111,6 +134,32 @@ ReporterTransferInterface::declareVectorClone(const ReporterName & from_reporter
 
   // Hide variables (if requested in parameters) if name is associated with a reporter object
   hideVariableHelper(to_reporter, to_problem);
+}
+
+void
+ReporterTransferInterface::declareVectorClone(const ReporterName & rname,
+                                              FEProblemBase & problem,
+                                              const std::string & type,
+                                              const ReporterMode & mode)
+{
+  ReporterData & rdata = problem.getReporterData(ReporterData::WriteKey());
+  if (type == "bool")
+    rdata.declareReporterValue<std::vector<bool>, ReporterVectorContext<bool>>(
+        rname, mode, _rti_transfer);
+  else if (type == "integer")
+    rdata.declareReporterValue<std::vector<int>, ReporterVectorContext<int>>(
+        rname, mode, _rti_transfer);
+  else if (type == "real")
+    rdata.declareReporterValue<std::vector<Real>, ReporterVectorContext<Real>>(
+        rname, mode, _rti_transfer);
+  else if (type == "string")
+    rdata.declareReporterValue<std::vector<std::string>, ReporterVectorContext<std::string>>(
+        rname, mode, _rti_transfer);
+  else
+    _rti_transfer.mooseError("Unknown reporter type, ", type, ".");
+
+  // Hide variables (if requested in parameters) if name is associated with a reporter object
+  hideVariableHelper(rname, problem);
 }
 
 void

--- a/test/tests/transfers/reporter_transfer/clone_type.i
+++ b/test/tests/transfers/reporter_transfer/clone_type.i
@@ -1,0 +1,55 @@
+[Mesh/generate]
+  type = GeneratedMeshGenerator
+  dim = 1
+[]
+
+[Problem]
+  kernel_coverage_check = false
+  solve = false
+[]
+
+[Reporters]
+  [receiver]
+    type = ConstantReporter
+  []
+[]
+
+[MultiApps]
+  [multi_reporter]
+    type = TransientMultiApp
+    input_files = 'sub0.i sub0.i sub0.i sub0.i'
+    positions = '0 0 0
+                 0 0 0
+                 0 0 0
+                 0 0 0'
+    cli_args = 'Postprocessors/from_sub_pp/default=3.1415926;Reporters/from_sub_rep/integer_values=10;Reporters/from_sub_rep/string_values=ten;Outputs/active=""
+                Postprocessors/from_sub_pp/default=1.5707963;Reporters/from_sub_rep/integer_values=11;Reporters/from_sub_rep/string_values=twenty;Outputs/active=""
+                Postprocessors/from_sub_pp/default=1.0471975;Reporters/from_sub_rep/integer_values=12;Reporters/from_sub_rep/string_values=thirty;Outputs/active=""
+                Postprocessors/from_sub_pp/default=0.7853981;Reporters/from_sub_rep/integer_values=13;Reporters/from_sub_rep/string_values=forty;Outputs/active=""'
+    max_procs_per_app = 1
+  []
+[]
+
+[Transfers]
+  [multi_rep]
+    type = MultiAppCloneReporterTransfer
+    from_reporters = 'from_sub_pp/value from_sub_rep/int from_sub_rep/str'
+    to_reporter = receiver
+    multi_app = multi_reporter
+    reporter_type = 'real integer string'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  [out]
+    type = JSON
+    execute_system_information_on = NONE
+    vectorpostprocessors_as_reporters = true
+  []
+  execute_on = timestep_end
+[]

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json
@@ -1,0 +1,41 @@
+{
+    "number_of_parts": 6,
+    "part": 0,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": [
+                                3.1415926
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": [
+                                10
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": [
+                                "ten"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.1
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.1
@@ -1,0 +1,41 @@
+{
+    "number_of_parts": 6,
+    "part": 1,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": [
+                                1.5707963
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": [
+                                11
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": [
+                                "twenty"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.2
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.2
@@ -1,0 +1,41 @@
+{
+    "number_of_parts": 6,
+    "part": 2,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": [
+                                1.0471975
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": [
+                                12
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": [
+                                "thirty"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.3
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.3
@@ -1,0 +1,41 @@
+{
+    "number_of_parts": 6,
+    "part": 3,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": [
+                                0.7853981
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": [
+                                13
+                            ]
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": [
+                                "forty"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.4
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.4
@@ -1,0 +1,35 @@
+{
+    "number_of_parts": 6,
+    "part": 4,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": []
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": []
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.5
+++ b/test/tests/transfers/reporter_transfer/gold/clone_type_out.json.5
@@ -1,0 +1,35 @@
+{
+    "number_of_parts": 6,
+    "part": 5,
+    "time_steps": [
+        {
+            "reporters": {
+                "receiver": {
+                    "info": {
+                        "name": "receiver",
+                        "type": "ConstantReporter"
+                    },
+                    "values": [
+                        {
+                            "name": "multi_rep:from_sub_pp:value",
+                            "type": "std::vector<double>",
+                            "value": []
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:int",
+                            "type": "std::vector<int>",
+                            "value": []
+                        },
+                        {
+                            "name": "multi_rep:from_sub_rep:str",
+                            "type": "std::vector<std::string>",
+                            "value": []
+                        }
+                    ]
+                }
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/transfers/reporter_transfer/tests
+++ b/test/tests/transfers/reporter_transfer/tests
@@ -97,4 +97,26 @@
       detail = 'in parallel.'
     []
   []
+
+  [clone_type]
+    requirement = 'If processors do not contain a sub-application and reporter clone transfer is requested, the system shall '
+    [type_specified]
+      type = JSONDiff
+      input = clone_type.i
+      jsondiff = 'clone_type_out.json clone_type_out.json.1 clone_type_out.json.2 clone_type_out.json.3 clone_type_out.json.4 clone_type_out.json.5'
+      skip_keys = 'part number_of_parts'
+      min_parallel = 6
+      max_parallel = 6
+      detail = 'be able to transfer if reporter types are specified and'
+    []
+    [error]
+      type = RunException
+      input = clone.i
+      cli_args = 'MultiApps/multi_reporter/max_procs_per_app=1'
+      match_literal = True
+      expect_err = "For a direct reporter clone, all processors must be associated with a sub-application. If you know the type of reporter being transferred, please consider using the 'reporter_type' parameter for an indirect clone."
+      min_parallel = 5
+      detail = 'error if types are not specified.'
+    []
+  []
 []


### PR DESCRIPTION
This PR adds another parameter in MultiAppCloneReporterTransfer (`reporter_type`), which allows processors that do not own a sub-application to declare a clone reporter value.

Closes #17751