### PR TITLE
Protect against zero size dof dependence before libMesh constraints

### DIFF
--- a/framework/include/base/Assembly.h
+++ b/framework/include/base/Assembly.h
@@ -2771,10 +2771,18 @@ Assembly::processDerivatives(const std::vector<ADReal> & residuals,
     auto current_dofs_set = std::set<dof_id_type>(resid_it->derivatives().nude_indices().begin(),
                                                   resid_it->derivatives().nude_indices().end());
     mooseAssert(compare_dofs_set == current_dofs_set,
-                "We're going to see whether the dof sets are the same");
+                "We're going to see whether the dof sets are the same. IIRC the degree of freedom "
+                "dependence (as indicated by the dof index set held by the ADReal) has to be the "
+                "same for every residual passed to this method otherwise constrain_element_matrix "
+                "will not work.");
   }
 #endif
   auto column_indices = std::vector<dof_id_type>(compare_dofs.begin(), compare_dofs.end());
+
+  // If there's no derivatives then there is nothing to do. Moreover, if we pass zero size column
+  // indices to constrain_element_matrix then we will potentially get errors out of BLAS
+  if (!column_indices.size())
+    return;
 
   DenseMatrix<Number> element_matrix(row_indices.size(), column_indices.size());
   for (const auto i : index_range(row_indices))

--- a/test/tests/kernels/diffusion_with_hanging_node/ad_simple_diffusion.i
+++ b/test/tests/kernels/diffusion_with_hanging_node/ad_simple_diffusion.i
@@ -15,6 +15,11 @@
     type = ADDiffusion
     variable = u
   [../]
+  [force]
+    type = ADBodyForce
+    variable = u
+    function = '0'
+  []
 []
 
 [BCs]

--- a/test/tests/kernels/diffusion_with_hanging_node/tests
+++ b/test/tests/kernels/diffusion_with_hanging_node/tests
@@ -47,7 +47,7 @@
     type = PetscJacobianTester
     input = 'ad_simple_diffusion.i'
     run_sim = True
-    requirement = 'The system shall compute a perfect Jacobian via automatic differentiation for a hanging-node problem.'
+    requirement = 'The system shall compute a perfect Jacobian via automatic differentiation for a hanging-node problem and simultaneously handle automatic differentiation objects that do not actually have nonlinear variable dependence.'
     issues = 'libmesh#1985 #15732'
   []
 []


### PR DESCRIPTION
If we call `constrain_element_matrix` with zero size column indices then
we get errors out of BLAS. This was happening with global AD indexing
since global AD indexing in general only inserts nonzero degree of
freedom dependence.

Test to come. Necessary condition to trigger this error:
- using AD objects with global AD indexing when said objects may not
  have any nonlinear variable dependence (like `ADBodyForce`)
- Have some libmesh constraints like hanging nodes or periodic
  boundaries

Closes #17755
