### PR TITLE
Fix fortran warning, clean up indentation

### DIFF
--- a/modules/tensor_mechanics/test/plugins/creep_usr_creep.f
+++ b/modules/tensor_mechanics/test/plugins/creep_usr_creep.f
@@ -11,45 +11,48 @@ C
      1     COORDS(*),EC(2),ESW(2)
 C
       DO 3 KK=1,5
- 3       DECRA(KK)=0.D0
-         IF(QTILD.LT.100.) GO TO 10
-         A=2.5E-27
-         XN=5.
-         XM=-.2
-         C1=1./(1.+XM)
-         IF(CMNAME.EQ.'A4')GO TO 5
+         DECRA(KK)=0.D0
+ 3    END DO
+
+      IF(QTILD.LT.100.) GO TO 10
+      A=2.5E-27
+      XN=5.
+      XM=-.2
+      C1=1./(1.+XM)
+      IF(CMNAME.EQ.'A4')GO TO 5
+
 C     TIME HARDENING
-         TERM1=A*QTILD**XN*C1
-         DECRA(1)=TERM1*(TIME(1)**(1.+XM)-(TIME(1)-DTIME)**(1.+XM))
-         IF (LEXIMP.EQ.1) THEN
-            IF (QTILD.EQ.0.0) THEN
-               DECRA(5) = 0.0
-            ELSE
-               DECRA(5)=DECRA(1)*XN/QTILD
-            END IF
-         END IF
-         GO TO 10
- 5       CONTINUE
-C     STRAIN HARDENING
-         EC0=EC(1)
-         TERM1=(A*QTILD**XN*C1)**C1
-         TERM2=TERM1*DTIME+EC0**C1
-         IF (TERM1.EQ.0.0) THEN
-            STATEV(1) = 0.0
+      TERM1=A*QTILD**XN*C1
+      DECRA(1)=TERM1*(TIME(1)**(1.+XM)-(TIME(1)-DTIME)**(1.+XM))
+      IF (LEXIMP.EQ.1) THEN
+         IF (QTILD.EQ.0.0) THEN
+            DECRA(5) = 0.0
          ELSE
-            STATEV(1)=TERM2/TERM1
+            DECRA(5)=DECRA(1)*XN/QTILD
          END IF
-         STATEV(2)=EC(2)
-         DECRA(1)=(TERM2**(1.+XM)-EC0)
-         IF (LEXIMP.EQ.1) THEN
-            IF (QTILD.EQ.0.0) THEN
-               DECRA(5) = 0.0
-            ELSE
-               DECRA(5)=XN*DTIME*TERM2**XM*TERM1/QTILD
-            END IF
+      END IF
+      GO TO 10
+ 5    CONTINUE
+
+C     STRAIN HARDENING
+      EC0=EC(1)
+      TERM1=(A*QTILD**XN*C1)**C1
+      TERM2=TERM1*DTIME+EC0**C1
+      IF (TERM1.EQ.0.0) THEN
+         STATEV(1) = 0.0
+      ELSE
+         STATEV(1)=TERM2/TERM1
+      END IF
+      STATEV(2)=EC(2)
+      DECRA(1)=(TERM2**(1.+XM)-EC0)
+      IF (LEXIMP.EQ.1) THEN
+         IF (QTILD.EQ.0.0) THEN
+            DECRA(5) = 0.0
+         ELSE
+            DECRA(5)=XN*DTIME*TERM2**XM*TERM1/QTILD
          END IF
- 10      CONTINUE
+      END IF
+ 10   CONTINUE
 C
-C     PRINT *, DECRA
-         RETURN
-         END
+      RETURN
+      END


### PR DESCRIPTION
Closes #17766

The indentation was misleading. I hope I fixed that right. 

@hugary1995 what fortran compiler were you using? I wasn't seeing that warning with gfortran 7.3