### PR TITLE
fix myriad typos refs #17769

### DIFF
--- a/framework/doc/content/source/executioners/InversePowerMethod.md
+++ b/framework/doc/content/source/executioners/InversePowerMethod.md
@@ -75,7 +75,7 @@ We notice immediately that $\frac{|Bx|}{k}$ remains constant during the iteratio
 
 Also in this simplified algorithm, the solution is automatically normalized making $|Bx|=k$. We can do postprocessing to normalize the solution so that $|x|=c$, where $|.|$ can be any norm and $c$ is a scalar constant.
 
-If the minimum eigenvalue and the second smallest eigenvalue are close, i.e. the dominant ratio is about to one, the inverse power iteration converges very slowly. In such a case, we can apply accelerations, such as Chebyshev acceleration, based on the on-the-fly estimation of the dominant ratio.
+If the minimum eigenvalue and the second smallest eigenvalue are close, i.e. the dominance ratio is about equal to one, the inverse power iteration converges very slowly. In such a case, we can apply accelerations, such as Chebyshev acceleration, based on the on-the-fly estimation of the dominance ratio.
 
 The inverse power method is appealing because we can apply matrix-free schemes on evaluating $Ax - \frac{1}{k}Bx$. We can use PJFNK for inverting $A$ and we do not have to exactly assemble matrix $A$ for the preconditioning purpose.
 

--- a/framework/doc/content/sqa/framework_scs.md
+++ b/framework/doc/content/sqa/framework_scs.md
@@ -80,7 +80,7 @@ natural code one would like to write yields a warning with our default compiler 
 !alert note
 This warning stems from the fact that numeric literals in C++ are treated as "signed ints". There are
 suffixes that can be applied to literals to force the "correct" type, but are you sure you really
-know the correct type? If you are thinking "unsigned int" you are in the majority and unfortunantly
+know the correct type? If you are thinking "unsigned int" you are in the majority and unfortunately
 also wrong. The right type for a container is `::size_type (aka 'unsigned long')`. See the error
 message once more above.
 
@@ -185,5 +185,5 @@ class MyClass:
 - Every destructor must be virtual.
 - All function definitions should be in *.C files.
     - The only exceptions are for inline functions for speed and templates.
-- Thou shall not commit accidental insertion in a std::map by using brackets in a right-hand side operator unless prove is provided that it can't fail.
-- Thou shall use range-based loops or `MooseIndex()` based loops for iteration.
+- Thou shalt not commit accidental insertion in a std::map by using brackets in a right-hand side operator unless prove is provided that it can't fail.
+- Thou shalt use range-based loops or `MooseIndex()` based loops for iteration.

--- a/framework/doc/content/syntax/Executioner/index.md
+++ b/framework/doc/content/syntax/Executioner/index.md
@@ -15,7 +15,7 @@ MOOSE provides Picard iterations in all its executioners for tightly-coupled mul
 MultiApps of two groups of before and after master app and master app are solved sequentially within one Picard iteration.
 The execution order of MutliApps within one group is undefined.
 Relevant data transfers happen before and after each of the two groups of MultiApps runs.
-Because MultiApp allows wrapping another levels of MultiApps, the design enables multi-level Picard iterations automatically.
+Because MultiApp allows wrapping another level of MultiApps, the design enables multi-level Picard iterations automatically.
 Picard iterations can be relaxed to improve the stability of the convergence.
 When a MultiApp is a subapp of a master and a master of its own subapps, MOOSE allows relaxation of the MultiApp solution
 within the master Picard iterations and within the Picard iterations, where the MultiApp is the master, independently.
@@ -23,7 +23,7 @@ within the master Picard iterations and within the Picard iterations, where the 
 ## Automatic and Default Preconditioning
 
 For most simulations there are two types of solve types that will be used: Newton or Preconditioned
-Jacobian Free Newton Krylov (PJFNK). The type is specified using the "solve_type" parameter withing the
+Jacobian Free Newton Krylov (PJFNK). The type is specified using the "solve_type" parameter within the
 Executioner block.
 
 Regardless of solve type, NEWTON or PJFNK, preconditioning is an import part of any simulation

--- a/framework/doc/content/syntax/Materials/index.md
+++ b/framework/doc/content/syntax/Materials/index.md
@@ -84,7 +84,7 @@ Objects that require material properties consume them using one of two functions
 1. `getADMaterialProperty<TYPE>` retrieves a property with a name "property_name" to be
    consumed by the object that will include automatic differentiation.
 
-For on object to consume a property the same basic procedure is followed. First in the consuming
+For an object to consume a property the same basic procedure is followed. First in the consuming
 objects header file a `MaterialProperty` with the correct type (e.g., `Real` for the diffusivity
 example) is declared (in the C++ sense) as follows. Notice, that the member variable is a +const+
 reference. The const is important. Consuming objects cannot modify a property, it only uses the

--- a/framework/doc/content/syntax/MultiApps/index.md
+++ b/framework/doc/content/syntax/MultiApps/index.md
@@ -24,7 +24,7 @@ other MOOSE applications, or might represent external applications. A sub-app ca
 
 ## Input File Syntax
 
-`MultiApp` objects are declared in the `[MultiApps]` block and require a "type" just like may other blocks.
+`MultiApp` objects are declared in the `[MultiApps]` block and require a "type" just like any other block.
 
 The [!param](/MultiApps/TransientMultiApp/app_type) is the name of the `MooseApp` derived app that is going
 to be executed. Generally, this is the name of the application being

--- a/framework/include/problems/EigenProblem.h
+++ b/framework/include/problems/EigenProblem.h
@@ -79,7 +79,7 @@ public:
 
   /**
    * Eigenvector need to be scaled back if it was scaled in an ealier stage
-   * Scaling eigen vector does not affect solution (eigenvaue, eigenvector),
+   * Scaling eigen vector does not affect solution (eigenvalue, eigenvector),
    * but it does affect the convergence rate. To have a optimal converge rate,
    * We pre scale eigen vector using the same factor as that computed in
    * "postScaleEigenVector"
@@ -98,7 +98,7 @@ public:
   void scaleEigenvector(const Real scaling_factor);
 
   /**
-   * Set eigen problem type. Don't need to use this if we use Newton eigenvaue solver.
+   * Set eigen problem type. Don't need to use this if we use Newton eigenvalue solver.
    */
   void setEigenproblemType(Moose::EigenProblemType eigen_problem_type);
 
@@ -210,7 +210,7 @@ protected:
   /// often used to compute initial guess for Newton eigen solver. It is automatically
   /// triggered by Eigenvalue Executioner
   bool _do_free_power_iteration;
-  /// Whether or not output eigenvalue as its inverse. By default, we output regular eigenvaue.
+  /// Whether or not output eigenvalue as its inverse. By default, we output regular eigenvalue.
   bool _output_inverse_eigenvalue;
   /// Timers
   PerfID _compute_jacobian_tag_timer;

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -23,7 +23,7 @@ InputParameters
 EigenExecutionerBase::validParams()
 {
   InputParameters params = Executioner::validParams();
-  params.addClassDescription("Executioner for Eigen value problems.");
+  params.addClassDescription("Executioner for eigenvalue problems.");
 
   params.addRequiredParam<PostprocessorName>("bx_norm", "To evaluate |Bx| for the eigenvalue");
   params.addParam<PostprocessorName>("normalization", "To evaluate |x| for normalization");

--- a/framework/src/executioners/Eigenvalue.C
+++ b/framework/src/executioners/Eigenvalue.C
@@ -26,7 +26,7 @@ Eigenvalue::validParams()
   InputParameters params = Steady::validParams();
 
   params.addClassDescription(
-      "Eigenvalue solves a standard/generalized linear or nonlinear eigenvaue problem");
+      "Eigenvalue solves a standard/generalized linear or nonlinear eigenvalue problem");
 
   // matrix_free will be an invalid for griffin once the integration is done.
   // In this PR, we can not change it. It will still be a valid option when users
@@ -138,7 +138,7 @@ Eigenvalue::init()
 {
   if (_app.isRecovering())
   {
-    _console << "\nCannot recover eigenvaue solves!\nExiting...\n" << std::endl;
+    _console << "\nCannot recover eigenvalue solves!\nExiting...\n" << std::endl;
     return;
   }
 
@@ -196,9 +196,9 @@ Eigenvalue::prepareSolverOptions()
 void
 Eigenvalue::checkIntegrity()
 {
-  // check to make sure that we don't have any time kernels in eigenvaue simulation
+  // check to make sure that we don't have any time kernels in eigenvalue simulation
   if (_eigen_problem.getNonlinearSystemBase().containsTimeKernel())
-    mooseError("You have specified time kernels in your eigenvaue simulation");
+    mooseError("You have specified time kernels in your eigenvalue simulation");
 }
 
 #endif
@@ -287,7 +287,7 @@ Eigenvalue::execute()
   postExecute();
 
 #else
-  mooseError("SLEPc is required for eigenvaue executioner, please use --download-slepc when "
+  mooseError("SLEPc is required for eigenvalue executioner, please use --download-slepc when "
              "configuring PETSc ");
 #endif
 }

--- a/framework/src/executioners/InversePowerMethod.C
+++ b/framework/src/executioners/InversePowerMethod.C
@@ -17,7 +17,7 @@ InputParameters
 InversePowerMethod::validParams()
 {
   InputParameters params = EigenExecutionerBase::validParams();
-  params.addClassDescription("Inverse power method for Eigen value problems.");
+  params.addClassDescription("Inverse power method for eigenvalue problems.");
   params.addParam<PostprocessorName>(
       "xdiff", "", "To evaluate |x-x_previous| for power iterations");
   params.addParam<unsigned int>(

--- a/framework/src/problems/EigenProblem.C
+++ b/framework/src/problems/EigenProblem.C
@@ -394,9 +394,9 @@ EigenProblem::preScaleEigenVector()
   computeResidualTag(
       *_nl_eigen->currentSolution(), _nl_eigen->residualVectorBX(), _nl_eigen->eigenVectorTag());
 
-  // If we do not have eigenvaue yet, we scale 1/|Bx| to unity
+  // If we do not have eigenvalue yet, we scale 1/|Bx| to unity
   std::pair<Real, Real> eig(1, 0);
-  // If there is an eigenvaue, we scale 1/|Bx| to eigenvaue
+  // If there is an eigenvalue, we scale 1/|Bx| to eigenvalue
   if (_active_eigen_index < _nl_eigen->getNumConvergedEigenvalues())
     eig = _nl_eigen->getConvergedEigenvalue(_active_eigen_index);
 
@@ -420,7 +420,7 @@ EigenProblem::postScaleEigenVector()
       if (_active_eigen_index >= _nl_eigen->getNumConvergedEigenvalues())
         mooseError("Number of converged eigenvalues ",
                    _nl_eigen->getNumConvergedEigenvalues(),
-                   " but you required eigenvaue ",
+                   " but you required eigenvalue ",
                    _active_eigen_index);
 
       // when normal factor is not provided, we use the inverse of the norm of

--- a/modules/doc/content/framework_development/warehouses.md
+++ b/modules/doc/content/framework_development/warehouses.md
@@ -32,6 +32,6 @@ In addition, there is a bit of functionality there for holding sets of Kernels t
 `MooseVariable` to make retrieving them quick for Jacobian calculations.
 
 There is some trickiness in `addObject()`.  To support `getActiveVariableBlockObjects()` we want
-to have a `Warehouse` for each variable Kernel's are acting on.  To do that, we have nested
+to have a `Warehouse` for each variable Kernels are acting on.  To do that, we have nested
 `MooseObjectWarehouse`s which we add to in `addObject()`.  However, we need the recursion to stop
 after one level so we can pass `recurse = false` to keep it from recursing to death.

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -1,7 +1,7 @@
 # Conda MOOSE Environment
 
 Our preferred method for obtaining dependencies necessary for MOOSE-based
-application development, is via Conda's myriad array of libraries. Follow these
+application development is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
 an option to install MOOSE directly on a Windows system is not yet supported.
 On-going efforts are being made to add a conda installation option for Windows,

--- a/modules/doc/content/getting_started/new_users.md
+++ b/modules/doc/content/getting_started/new_users.md
@@ -16,7 +16,7 @@ cd ~/projects
 
 Running this script will create a folder named "your_app_name" in the projects directory, this
 application will automatically link against MOOSE. Obviously, the "YourAppName" should be the desired
-name or your application; consider the use of an acronym. Animal names are prefered for
+name of your application; consider the use of an acronym. Animal names are preferred for
 applications, but you are free to choose whatever name suits your needs.
 
 !alert warning title=Execute stork from outside of the MOOSE directory

--- a/modules/level_set/doc/content/modules/level_set/index.md
+++ b/modules/level_set/doc/content/modules/level_set/index.md
@@ -8,7 +8,7 @@ links provided detailed information on the theory and use of the level set modul
 !include modules/level_set/level_set_examples.md
 
 For reference the following tables list the objects contained within the level set module and a brief
-description of there purpose, each object may be selected to navigate to a detailed page.
+description of their purpose; each object may be selected to navigate to a detailed page.
 
 ## Level Set Module Tasks
 

--- a/modules/navier_stokes/doc/content/source/kernels/INSADSmagorinskyEddyViscosity.md
+++ b/modules/navier_stokes/doc/content/source/kernels/INSADSmagorinskyEddyViscosity.md
@@ -12,7 +12,7 @@ adds this term to the momentum equation:
 Where the subgrid-scale eddy viscosity is calculated as:
 
 \begin{equation}
-\nu_{sgs} (C_s \bar{\Delta})^2 ||\bar{\bar{S}}||
+\nu_{sgs} = (C_s \bar{\Delta})^2 ||\bar{\bar{S}}||
 \end{equation}
 
 Where the symmetric strain rate tensor magnitude is calculated by:

--- a/modules/tensor_mechanics/doc/content/modules/tensor_mechanics/index.md
+++ b/modules/tensor_mechanics/doc/content/modules/tensor_mechanics/index.md
@@ -10,7 +10,7 @@ even advanced mechanics models:
 - Tensor implementation matches mathematical theory
 - Straight-forward procedure for adding new physics
 
-The tensor mechanics system can be used to simulation both linear and finite strain mechanics, including
+The tensor mechanics system can be used to simulate both linear and finite strain mechanics, including
 Elasticity and Cosserat elasticity, Plasticity and micromechanics plasticity, Creep, and
 Damage due to cracking and property degradation
 

--- a/test/tests/problems/eigen_problem/initial_condition/tests
+++ b/test/tests/problems/eigen_problem/initial_condition/tests
@@ -62,6 +62,6 @@
     absent_out = '(eps_power_)'
     # Make sure '-eps_view' actually work
     expect_out = 'SNES Object:'
-    requirement = "The system shall support extra power iterations and check eigenvaue."
+    requirement = "The system shall support extra power iterations and check eigenvalue."
   [../]
 []


### PR DESCRIPTION
closes #17769 

## Reason
Makes the MOOSE docs look better by removing a few minor grammar errors and typos.

## Impact
Millions who would otherwise be turned away from MOOSE by typos in the docs will now use the framework.
