### PR TITLE
allow app-custom src dependencies during compilation

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -109,7 +109,7 @@ pcre%.$(obj-suffix) : pcre%.cc
           $(libmesh_CXX) $(libmesh_CPPFLAGS) $(ADDITIONAL_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -DHAVE_CONFIG_H -MMD -MP -MF $@.d -MT $@ -c $< -o $@
 
 define CXX_RULE_TEMPLATE
-%$(1).$(obj-suffix) : %.C
+%$(1).$(obj-suffix) : %.C $(ADDITIONAL_SRC_DEPS)
 ifeq ($(1),)
 	@echo "Compiling C++ (in "$$(METHOD)" mode) "$$<"..."
 else


### PR DESCRIPTION
This is useful for apps that may have moose-external dependencies that
they need to compile/build.  Sometimes a moose app file (e.g.
FooMaterial.C) can depend on a file generated by the build of an
external app dependency.  Without this addition - there is not way for
the app developer to tell us about this dependency - which prevents
parallel builds from working properly.

fixes #17800 
