### PR TITLE
Damage dependent on stress tensor

### DIFF
--- a/modules/tensor_mechanics/include/materials/CombinedScalarDamage.h
+++ b/modules/tensor_mechanics/include/materials/CombinedScalarDamage.h
@@ -24,7 +24,7 @@ public:
   void initialSetup() override;
 
 protected:
-  virtual void updateQpDamageIndex() override;
+  virtual void updateQpDamageIndex(const RankTwoTensor * stress) override;
 
   enum class CombinationType
   {

--- a/modules/tensor_mechanics/include/materials/DamageBase.h
+++ b/modules/tensor_mechanics/include/materials/DamageBase.h
@@ -31,7 +31,7 @@ public:
   /**
    * Update the internal variable(s) that evolve the damage
    */
-  virtual void updateDamage();
+  virtual void updateDamage(const RankTwoTensor * stress = nullptr);
 
   /**
    * Update the current stress tensor for effects of damage.

--- a/modules/tensor_mechanics/include/materials/ScalarDamageBase.h
+++ b/modules/tensor_mechanics/include/materials/ScalarDamageBase.h
@@ -25,7 +25,7 @@ public:
 
   virtual void initQpStatefulProperties() override;
 
-  virtual void updateDamage() override;
+  virtual void updateDamage(const RankTwoTensor * stress = nullptr) override;
 
   virtual void updateStressForDamage(RankTwoTensor & stress_new) override;
 
@@ -44,7 +44,7 @@ protected:
   const MaterialPropertyName _damage_index_name;
 
   /// Update the damage index at the current qpoint
-  virtual void updateQpDamageIndex() = 0;
+  virtual void updateQpDamageIndex(const RankTwoTensor * stress = nullptr) = 0;
 
   ///@{ Material property that provides the damage index
   MaterialProperty<Real> & _damage_index;

--- a/modules/tensor_mechanics/include/materials/ScalarMaterialDamage.h
+++ b/modules/tensor_mechanics/include/materials/ScalarMaterialDamage.h
@@ -24,7 +24,7 @@ public:
   ScalarMaterialDamage(const InputParameters & parameters);
 
 protected:
-  virtual void updateQpDamageIndex() override;
+  virtual void updateQpDamageIndex(const RankTwoTensor * stress = nullptr) override;
 
   ///@{ Material property that provides the damage index
   const MaterialProperty<Real> & _damage_property;

--- a/modules/tensor_mechanics/src/materials/CombinedScalarDamage.C
+++ b/modules/tensor_mechanics/src/materials/CombinedScalarDamage.C
@@ -54,7 +54,7 @@ CombinedScalarDamage::initialSetup()
 }
 
 void
-CombinedScalarDamage::updateQpDamageIndex()
+CombinedScalarDamage::updateQpDamageIndex(const RankTwoTensor * /*stress = nullptr*/)
 {
   switch (_combination_type)
   {

--- a/modules/tensor_mechanics/src/materials/ComputeDamageStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeDamageStress.C
@@ -47,7 +47,7 @@ ComputeDamageStress::computeQpStress()
   ComputeFiniteStrainElasticStress::computeQpStress();
 
   _damage_model->setQp(_qp);
-  _damage_model->updateDamage();
+  _damage_model->updateDamage(&_stress[_qp]);
   _damage_model->updateStressForDamage(_stress[_qp]);
   _damage_model->finiteStrainRotation(_rotation_increment[_qp]);
   _damage_model->updateJacobianMultForDamage(_Jacobian_mult[_qp]);

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -195,7 +195,7 @@ ComputeMultipleInelasticStress::computeQpStress()
   if (_damage_model)
   {
     _damage_model->setQp(_qp);
-    _damage_model->updateDamage();
+    _damage_model->updateDamage(&_stress[_qp]);
     _damage_model->updateStressForDamage(_stress[_qp]);
     _damage_model->finiteStrainRotation(_rotation_increment[_qp]);
     _damage_model->updateJacobianMultForDamage(_Jacobian_mult[_qp]);

--- a/modules/tensor_mechanics/src/materials/DamageBase.C
+++ b/modules/tensor_mechanics/src/materials/DamageBase.C
@@ -41,7 +41,7 @@ DamageBase::setQp(unsigned int qp)
 }
 
 void
-DamageBase::updateDamage()
+DamageBase::updateDamage(const RankTwoTensor * /*stress = nullptr*/)
 {
 }
 

--- a/modules/tensor_mechanics/src/materials/ScalarDamageBase.C
+++ b/modules/tensor_mechanics/src/materials/ScalarDamageBase.C
@@ -64,7 +64,7 @@ ScalarDamageBase::getQpDamageIndex(unsigned int qp)
 }
 
 void
-ScalarDamageBase::updateDamage()
+ScalarDamageBase::updateDamage(const RankTwoTensor * /*stress*/)
 {
   updateQpDamageIndex();
 }

--- a/modules/tensor_mechanics/src/materials/ScalarMaterialDamage.C
+++ b/modules/tensor_mechanics/src/materials/ScalarMaterialDamage.C
@@ -30,7 +30,7 @@ ScalarMaterialDamage::ScalarMaterialDamage(const InputParameters & parameters)
 }
 
 void
-ScalarMaterialDamage::updateQpDamageIndex()
+ScalarMaterialDamage::updateQpDamageIndex(const RankTwoTensor * /*stress*/)
 {
   _damage_index[_qp] = _damage_property[_qp];
 


### PR DESCRIPTION
Enable the use of the stress tensor for the computation of material damage.

This can be used, e.g., to account for tri-axiality effects in steel's creep failure.

Refs. #15517.

