### PR TITLE
fixing up some phase field documentation formatting, broken links, etc

### DIFF
--- a/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Equations.md
+++ b/modules/phase_field/doc/content/modules/phase_field/Phase_Field_Equations.md
@@ -167,8 +167,8 @@ It is divided into three pieces, each implemented in their own kernel, as shown 
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
 | - | - | - | - | - |
-$\left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right)$ | $\eta_j$ | | | [`TimeDerivative`](/TimeDerivative.md) |
-$\left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right)$ | $\eta_j$ | $\kappa_j,\ L$ | | [`ACInterface`](/ACInterface.md) |
+$\left(  \frac{\partial \eta_j}{\partial t}, \psi_m \right)$ | $\eta_j$ | - | - | [`TimeDerivative`](/TimeDerivative.md) |
+$\left( \nabla(\kappa_j\eta_j), \nabla (L\psi_m) \right)$ | $\eta_j$ | $\kappa_j,\ L$ | - | [`ACInterface`](/ACInterface.md) |
 $L \left( \frac{\partial f_{loc}}{\partial \eta_j} + \frac{\partial E_d}{\partial \eta_j}, \psi_m \right)$ | $\eta_j$ | $L$ | $\frac{\partial f_{loc} }{\partial \eta_j}, \frac{\partial E_d }{\partial \eta_j}$ | [`AllenCahn`](/AllenCahn.md) |
 
 The residual for the direct solution of the Cahn-Hilliard equation (without boundary terms) is
@@ -179,8 +179,8 @@ The residual for the direct solution of the Cahn-Hilliard equation (without boun
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
 | - | - | - | - | - |
-$\left(  \frac{\partial c_i}{\partial t}, \psi_m \right)$ | $c_i$ | | | [`TimeDerivative`](/TimeDerivative.md) |
-$\left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right)$ | $c_i$ | $\kappa_i$, $M_i$, $\nabla M_i$ | | [`CHInterface`](/CHInterface.md) |
+$\left(  \frac{\partial c_i}{\partial t}, \psi_m \right)$ | $c_i$ | - | - | [`TimeDerivative`](/TimeDerivative.md) |
+$\left( \kappa_i \nabla^2 c_i, \nabla \cdot (M_i \nabla \psi_m ) \right)$ | $c_i$ | $\kappa_i$, $M_i$, $\nabla M_i$ | - | [`CHInterface`](/CHInterface.md) |
 $\left(M_i \left( \nabla \frac{\partial f_{loc} }{\partial c_i} + \nabla  \frac{\partial E_d}{\partial c_i} \right),\nabla \psi \right)$ | $c_i$ | $M_i$ | $\frac{\partial^2 f_{loc} }{\partial c_i^2}$, $\frac{\partial^2 E_d }{\partial c_i^2}$ | [`CahnHilliard`](/CahnHilliard.md) |
 
 In the split form of the Cahn-Hilliard solution, the two residual equations are
@@ -193,16 +193,16 @@ In the split form of the Cahn-Hilliard solution, the two residual equations are
 
 | Residual term | Variable | Parameters | Energy derivative | Kernel |
 | - | - | - | - | - |
-| $\left(  \frac{\partial c_i}{\partial t}, \psi_m \right)$ | $\mu$ | | | [`CoupledTimeDerivative`](/CoupledTimeDerivative.md) |
-|$\left( M_i  \nabla \mu, \nabla \psi_m \right)$ | $\mu$ | $M_i$ | | [`SplitCHWRes`](/SplitCHWRes.md) |
-| $\left( -\kappa_i \nabla^2 c_i +  \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right)$ | $c$ | $\kappa_i$ | $\frac{\partial f_{loc} }{\partial c_i}$, $\frac{\partial E_d }{\partial c_i}$ | [`SplitCHParsed`](/SplitCHParsed.md) |
+$\left(  \frac{\partial c_i}{\partial t}, \psi_m \right)$ | $\mu$ | - | - | [`CoupledTimeDerivative`](/CoupledTimeDerivative.md) |
+$\left( M_i  \nabla \mu, \nabla \psi_m \right)$ | $\mu$ | $M_i$ | - | [`SplitCHWRes`](/SplitCHWRes.md) |
+$\left( -\kappa_i \nabla^2 c_i +  \frac{\partial f_{loc}}{\partial c_i} + \frac{\partial E_d}{\partial c_i} - \mu_i \right)$ | $c$ | $\kappa_i$ | $\frac{\partial f_{loc} }{\partial c_i}$, $\frac{\partial E_d }{\partial c_i}$ | [`SplitCHParsed`](/SplitCHParsed.md) |
 
 ## See also
 
-- [Phase Field FAQ](FAQ) - Frequently asked questions for MOOSE phase-field models.
+- [Phase Field FAQ](FAQ.md) - Frequently asked questions for MOOSE phase-field models.
 - [Actions](phase_field/Actions.md) - Simplify the setup of of the phase field equations using MOOSE actions
-- [Free Energy Materials](FunctionMaterials/FreeEnergy) - The key component in the modular free energy phase field modeling approach. This page lists the available function materials and explains how to define a free energy function and combine multiple free energy contributions (including elastic energy) into a total free energy.
-- [Function Material Kernels](FunctionMaterialKernels) - Kernels which utilize free energy densities provides by Function Material. These are the recommended phase field kernels.
-- [ExpressionBuilder](ExpressionBuilder) - Use automatic differentiation with Free energies defined in the C++ code.
-- [Multi Phase Models](MultiPhaseModels) - Combine multiple single phase free energies into multiphase field models using these tools.
-- Free energies can also be combined with the deformation energy calculated using the Tensor Mechanics module.
+- [Free Energy Materials](FunctionMaterials/FreeEnergy.md) - The key component in the modular free energy phase field modeling approach. This page lists the available function materials and explains how to define a free energy function and combine multiple free energy contributions (including elastic energy) into a total free energy.
+- [Function Material Kernels](FunctionMaterialKernels.md) - Kernels which utilize free energy densities provides by Function Material. These are the recommended phase field kernels.
+- [ExpressionBuilder](FunctionMaterials/ExpressionBuilder.md) - Use automatic differentiation with Free energies defined in the C++ code.
+- [Multi-Phase Models](MultiPhase/WBM.md) - Combine multiple single phase free energies into multiphase field models using these tools.
+- [Mechanics Coupling](Mechanics_Coupling.md) - Free energies can also be combined with the deformation energy calculated using the Tensor Mechanics module.

--- a/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
@@ -17,7 +17,7 @@ CoupledSwitchingTimeDerivative::validParams()
   InputParameters params = CoupledTimeDerivative::validParams();
   params.addClassDescription(
       "Coupled time derivative Kernel that multiplies the time derivative by "
-      "$\\frac{dh_\\alpha}{d\\eta_i} F_\\alpha + \\frac{dh_\\beta}{d\\eta_i} F_\\beta + \\dots)");
+      "$\\frac{dh_\\alpha}{d\\eta_i} F_\\alpha + \\frac{dh_\\beta}{d\\eta_i} F_\\beta + \\dots$");
   params.addRequiredParam<std::vector<MaterialPropertyName>>(
       "Fj_names", "List of functions for each phase. Place in same order as hj_names!");
   params.addRequiredParam<std::vector<MaterialPropertyName>>(

--- a/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
+++ b/modules/phase_field/src/kernels/KKSPhaseChemicalPotential.C
@@ -19,8 +19,8 @@ KKSPhaseChemicalPotential::validParams()
 {
   InputParameters params = Kernel::validParams();
   params.addClassDescription("KKS model kernel to enforce the pointwise equality of phase chemical "
-                             "potentials  dFa/dca = dFb/dcb. The non-linear variable of this "
-                             "kernel is ca.");
+                             "potentials $dF_a/dc_a = dF_b/dc_b$. The non-linear variable of this "
+                             "kernel is $c_a$.");
   params.addRequiredCoupledVar(
       "cb", "Phase b concentration"); // note that ca is u, the non-linear variable!
   params.addRequiredParam<MaterialPropertyName>("fa_name",

--- a/modules/phase_field/src/kernels/KKSPhaseConcentration.C
+++ b/modules/phase_field/src/kernels/KKSPhaseConcentration.C
@@ -16,8 +16,8 @@ KKSPhaseConcentration::validParams()
 {
   InputParameters params = Kernel::validParams();
   params.addClassDescription("KKS model kernel to enforce the decomposition of concentration into "
-                             "phase concentration  (1-h(eta))*ca + h(eta)*cb - c = 0. The "
-                             "non-linear variable of this kernel is cb.");
+                             "phase concentration  $(1-h(\\eta))c_a + h(\\eta)c_b - c = 0$. The "
+                             "non-linear variable of this kernel is $c_b$.");
   params.addRequiredCoupledVar("ca", "Phase a concentration");
   params.addRequiredCoupledVar("c", "Real concentration");
   params.addRequiredCoupledVar("eta", "Phase a/b order parameter");

--- a/modules/phase_field/src/materials/ADMathFreeEnergy.C
+++ b/modules/phase_field/src/materials/ADMathFreeEnergy.C
@@ -16,7 +16,7 @@ ADMathFreeEnergy::validParams()
 {
   InputParameters params = ADMaterial::validParams();
   params.addClassDescription("Material that implements the math free energy and its derivatives: "
-                             "\nF = 1/4(1 + c)^2*(1 - c)^2");
+                             "\n$F = 1/4(1 + c)^2(1 - c)^2$");
   params.addParam<MaterialPropertyName>("f_name", "F", "function property name");
   params.addRequiredCoupledVar("c", "Concentration variable");
   return params;

--- a/modules/phase_field/src/materials/BarrierFunctionMaterial.C
+++ b/modules/phase_field/src/materials/BarrierFunctionMaterial.C
@@ -15,9 +15,9 @@ InputParameters
 BarrierFunctionMaterial::validParams()
 {
   InputParameters params = OrderParameterFunctionMaterial::validParams();
-  params.addClassDescription("Helper material to provide g(eta) and its derivative in a "
-                             "polynomial.\nSIMPLE: eta^2*(1-eta)^2\nLOW: eta*(1-eta)"
-                             "\nHIGH: eta^2*(1-eta^2)^2");
+  params.addClassDescription("Helper material to provide $g(\\eta)$ and its derivative in a "
+                             "polynomial.\nSIMPLE: $\\eta^2(1-\\eta)^2$\nLOW: $\\eta(1-\\eta)$"
+                             "\nHIGH: $\\eta^2(1-\\eta^2)^2$");
   MooseEnum g_order("SIMPLE=0 LOW HIGH", "SIMPLE");
   params.addParam<MooseEnum>("g_order", g_order, "Polynomial order of the barrier function g(eta)");
   params.addParam<bool>("well_only",

--- a/modules/phase_field/src/materials/MathFreeEnergy.C
+++ b/modules/phase_field/src/materials/MathFreeEnergy.C
@@ -16,7 +16,7 @@ MathFreeEnergy::validParams()
 {
   InputParameters params = DerivativeFunctionMaterialBase::validParams();
   params.addClassDescription("Material that implements the math free energy and its derivatives: "
-                             "\nF = 1/4(1 + c)^2*(1 - c)^2");
+                             "\n$F = 1/4(1 + c)^2(1 - c)^2$");
   params.addRequiredCoupledVar("c", "Concentration variable");
   return params;
 }

--- a/modules/phase_field/src/materials/SwitchingFunction3PhaseMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunction3PhaseMaterial.C
@@ -15,9 +15,10 @@ InputParameters
 SwitchingFunction3PhaseMaterial::validParams()
 {
   InputParameters params = DerivativeParsedMaterialHelper::validParams();
-  params.addClassDescription("Material for switching function that prevents formation of a third "
-                             "phase at a two-phase interface: $h_i = \\eta_i^2/4 [15 (1-\\eta_i) [1 + "
-                             "\\eta_i - (\\eta_k - \\eta_j)^2] + \\eta_i (9\\eta_i^2 - 5)]$");
+  params.addClassDescription(
+      "Material for switching function that prevents formation of a third "
+      "phase at a two-phase interface: $h_i = \\eta_i^2/4 [15 (1-\\eta_i) [1 + "
+      "\\eta_i - (\\eta_k - \\eta_j)^2] + \\eta_i (9\\eta_i^2 - 5)]$");
   params.addRequiredCoupledVar("eta_i", "Order parameter i");
   params.addRequiredCoupledVar("eta_j", "Order parameter j");
   params.addRequiredCoupledVar("eta_k", "Order parameter k");

--- a/modules/phase_field/src/materials/SwitchingFunction3PhaseMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunction3PhaseMaterial.C
@@ -16,8 +16,8 @@ SwitchingFunction3PhaseMaterial::validParams()
 {
   InputParameters params = DerivativeParsedMaterialHelper::validParams();
   params.addClassDescription("Material for switching function that prevents formation of a third "
-                             "phase at a two-phase interface: h_i = eta_i^2/4 * [15 (1-eta_i) [1 + "
-                             "eta_i - (eta_k - eta_j)^2] + eta_i * (9eta_i^2 - 5)]");
+                             "phase at a two-phase interface: $h_i = \\eta_i^2/4 [15 (1-\\eta_i) [1 + "
+                             "\\eta_i - (\\eta_k - \\eta_j)^2] + \\eta_i (9\\eta_i^2 - 5)]$");
   params.addRequiredCoupledVar("eta_i", "Order parameter i");
   params.addRequiredCoupledVar("eta_j", "Order parameter j");
   params.addRequiredCoupledVar("eta_k", "Order parameter k");

--- a/modules/phase_field/src/materials/SwitchingFunctionMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunctionMaterial.C
@@ -15,9 +15,9 @@ InputParameters
 SwitchingFunctionMaterial::validParams()
 {
   InputParameters params = OrderParameterFunctionMaterial::validParams();
-  params.addClassDescription("Helper material to provide h(eta) and its derivative in one of two "
-                             "polynomial forms.\nSIMPLE: 3*eta^2-2*eta^3\nHIGH: "
-                             "eta^3*(6*eta^2-15*eta+10)");
+  params.addClassDescription("Helper material to provide $h(\\eta)$ and its derivative in one of two "
+                             "polynomial forms.\nSIMPLE: $3\\eta^2-2\\eta^3$\nHIGH: "
+                             "$\\eta^3(6\\eta^2-15\\eta+10)$");
   MooseEnum h_order("SIMPLE=0 HIGH", "SIMPLE");
   params.addParam<MooseEnum>(
       "h_order", h_order, "Polynomial order of the switching function h(eta)");

--- a/modules/phase_field/src/materials/SwitchingFunctionMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunctionMaterial.C
@@ -15,9 +15,10 @@ InputParameters
 SwitchingFunctionMaterial::validParams()
 {
   InputParameters params = OrderParameterFunctionMaterial::validParams();
-  params.addClassDescription("Helper material to provide $h(\\eta)$ and its derivative in one of two "
-                             "polynomial forms.\nSIMPLE: $3\\eta^2-2\\eta^3$\nHIGH: "
-                             "$\\eta^3(6\\eta^2-15\\eta+10)$");
+  params.addClassDescription(
+      "Helper material to provide $h(\\eta)$ and its derivative in one of two "
+      "polynomial forms.\nSIMPLE: $3\\eta^2-2\\eta^3$\nHIGH: "
+      "$\\eta^3(6\\eta^2-15\\eta+10)$");
   MooseEnum h_order("SIMPLE=0 HIGH", "SIMPLE");
   params.addParam<MooseEnum>(
       "h_order", h_order, "Polynomial order of the switching function h(eta)");


### PR DESCRIPTION
## Reason
Saw some formatting problems while poking around the phase field docs. This PR addresses those. Some of the formulas in the class descriptions were being rendered improperly by moosedocs. Others were fine but were simple enough to change to latex so I went ahead while I was in there.
ref #14988

## Design
Just some changes to markdown and latex in docs.

## Impact
Better documentation.