### PR TITLE
make values in constantVectorPostprocessor optional for use with transfers

### DIFF
--- a/framework/src/vectorpostprocessors/ConstantVectorPostprocessor.C
+++ b/framework/src/vectorpostprocessors/ConstantVectorPostprocessor.C
@@ -21,7 +21,7 @@ ConstantVectorPostprocessor::validParams()
       "Populate constant VectorPostprocessorValue directly from input file.");
   params.addParam<std::vector<std::string>>("vector_names",
                                             "Names of the column vectors in this object");
-  params.addRequiredParam<std::vector<std::vector<Real>>>(
+  params.addParam<std::vector<std::vector<Real>>>(
       "value",
       "Vector values this object will have. Leading dimension must be equal to leading dimension "
       "of vector_names parameter.");
@@ -43,10 +43,19 @@ ConstantVectorPostprocessor::ConstantVectorPostprocessor(const InputParameters &
   for (unsigned int j = 0; j < nvec; ++j)
     _value[j] = &declareVector(names[j]);
 
-  std::vector<std::vector<Real>> v = getParam<std::vector<std::vector<Real>>>("value");
-  if (v.size() != nvec)
-    paramError("value",
-               "Leading dimension must be equal to leading dimension of vector_names parameter.");
+  std::vector<std::vector<Real>> v;
+  if (isParamValid("value"))
+  {
+    v = getParam<std::vector<std::vector<Real>>>("value");
+    if (v.size() != nvec)
+      paramError("value",
+                 "Leading dimension must be equal to leading dimension of vector_names parameter.");
+  }
+  else
+  {
+    for (unsigned int i = 0; i < nvec; ++i)
+      v.push_back({std::numeric_limits<Real>::max()});
+  }
 
   if (processor_id() == 0)
   {

--- a/test/tests/transfers/reporter_transfer/sub1.i
+++ b/test/tests/transfers/reporter_transfer/sub1.i
@@ -12,7 +12,6 @@
   [to_sub_vpp]
     type = ConstantVectorPostprocessor
     vector_names = 'a b'
-    value = '11 11 11 ; 21 21 21'
   []
   [from_sub_vpp]
     type = ConstantVectorPostprocessor

--- a/test/tests/transfers/reporter_transfer/tests
+++ b/test/tests/transfers/reporter_transfer/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'MultiAppReporterTransfer.md MultiAppCloneReporterTransfer.md'
-  issues = '#16055'
+  issues = '#16055 #17885'
 
   [vpp]
     requirement = "The system shall support the ability to transfer vectorpostprocessor data "


### PR DESCRIPTION
Fill in values in the constantvpp with numeric_max values if none are given in the input file.  Now only the names are required in the input file which will make it easier to use the constantVpp with transfers
closes #17885 
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
