### PR TITLE
Always render system headers when listing complete app syntax

### DIFF
--- a/python/moosesyntax/nodes.py
+++ b/python/moosesyntax/nodes.py
@@ -83,19 +83,20 @@ class SyntaxNode(NodeBase):
         if self.markdown is None:
             self.markdown = os.path.join(self.fullpath().lstrip('/'), 'index.md')
 
-    def groups(self, syntax=True, actions=True, objects=False):
+    def groups(self, syntax=True, actions=True, objects=False, **kwargs):
         """
-        Return groups associated with this Actions (i.e., where the syntax is defined).
+        Return groups associated with this node (i.e., where the syntax is defined). The **kwargs
+        may be used to pass the named arguments to __nodeFinder, e.g., recursive=True.
         """
         out = set([self.group]) if self.group is not None else set()
         if syntax:
-            for node in self.syntax():
+            for node in self.syntax(**kwargs):
                 out.update(node.groups())
         if actions:
-            for node in self.actions():
+            for node in self.actions(**kwargs):
                 out.update(node.groups())
         if objects:
-            for node in self.objects():
+            for node in self.objects(**kwargs):
                 out.update(node.groups())
         return out
 


### PR DESCRIPTION
@jessecarterMOOSE @aeslaughter  

## Reason
A fix for the broken phase field systems page.

## Design
Always render headers/links for the system even if it has no child objects, which is the case for Adaptivity. 

## Impact
I'm guessing there's a more fundamental issue here in the style sheets and/or with the scrollspy bar, but I'm thinking we ought to be unconditionally rendering the system headers anyways.

![Screenshot from 2021-05-19 19-55-49](https://user-images.githubusercontent.com/41302548/118909447-42edd500-b8e0-11eb-8ec1-dc53b464aae7.png)

(closes #17843)