### PR TITLE
Output more digits for postprocessor values used for monitoring Picard convergence

### DIFF
--- a/framework/include/outputs/Console.h
+++ b/framework/include/outputs/Console.h
@@ -79,7 +79,8 @@ public:
    * @param old_norm The old residual norm to compare against
    * @param norm The current residual norm
    */
-  static std::string outputNorm(const Real & old_norm, const Real & norm);
+  static std::string
+  outputNorm(const Real & old_norm, const Real & norm, const unsigned int precision = 6);
 
   /**
    * Return system information flags

--- a/framework/src/executioners/PicardSolve.C
+++ b/framework/src/executioners/PicardSolve.C
@@ -250,7 +250,7 @@ PicardSolve::solve()
 
       auto ppname = getParam<PostprocessorName>("picard_custom_pp");
       pp_history << std::setw(2) << _picard_it + 1 << " Picard " << ppname << " = "
-                 << Console::outputNorm(std::numeric_limits<Real>::max(), pp_new) << "\n";
+                 << Console::outputNorm(std::numeric_limits<Real>::max(), pp_new, 8) << "\n";
       _console << pp_history.str();
     }
 

--- a/framework/src/outputs/Console.C
+++ b/framework/src/outputs/Console.C
@@ -532,7 +532,7 @@ Console::writeVariableNorms()
 
 // Quick helper to output the norm in color
 std::string
-Console::outputNorm(const Real & old_norm, const Real & norm)
+Console::outputNorm(const Real & old_norm, const Real & norm, const unsigned int precision)
 {
   std::string color = COLOR_GREEN;
 
@@ -544,7 +544,7 @@ Console::outputNorm(const Real & old_norm, const Real & norm)
     color = COLOR_YELLOW;
 
   std::stringstream oss;
-  oss << std::scientific << color << norm << COLOR_DEFAULT;
+  oss << std::scientific << std::setprecision(precision) << color << norm << COLOR_DEFAULT;
 
   return oss.str();
 }


### PR DESCRIPTION
Close #17890.
