### PR TITLE
Build redistributable monolithic header for JIT

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -485,6 +485,10 @@ clobberall: clobber
           echo $$item >> .clang_complete;  \
         done
 
+ADRealMonolithic.h:
+	@echo "Building monolithic ADReal header for JIT compilation"
+	@$(libmesh_CXX) -E $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -imacros cmath -x c++-header $(MOOSE_DIR)/framework/include/utils/ADReal.h > ADRealMonolithic.h
+
 compile_commands_all_srcfiles := $(moose_srcfiles) $(srcfiles)
 compile_commands.json:
 ifeq (4.0,$(firstword $(sort $(MAKE_VERSION) 4.0)))

--- a/framework/src/utils/ADFParser.C
+++ b/framework/src/utils/ADFParser.C
@@ -25,7 +25,14 @@ bool
 ADFParser::JITCompile()
 {
 #if LIBMESH_HAVE_FPARSER_JIT
-  auto result = JITCompileHelper("ADReal", ADFPARSER_INCLUDES, "#include \"ADReal.h\"\n");
+  std::string includes;
+  bool result;
+
+  auto include_path_env = std::getenv("MOOSE_ADFPARSER_JIT_INCLUDE");
+  if (include_path_env)
+    result = JITCompileHelper("ADReal", "", "#include \"" + std::string(include_path_env) + "\"\n");
+  else
+    result = JITCompileHelper("ADReal", ADFPARSER_INCLUDES, "#include \"ADReal.h\"\n");
 
   if (!result)
 #endif

--- a/modules/phase_field/doc/content/modules/phase_field/FunctionMaterials/JITCompilation.md
+++ b/modules/phase_field/doc/content/modules/phase_field/FunctionMaterials/JITCompilation.md
@@ -56,3 +56,20 @@ recompilation. The compiled function respects the current FParser `Epsilon` sett
 
 Almost all FParser opcodes are supported, _except_ `PCall` and `FCall`, which are function calls to
 other FParser objects and calls to custom functions.
+
+## Required header files
+
+JIT compilation for non-AD parsed functions only requires the `cmath` standard
+library header file. Compilation of AD functions with dual numbers  required the
+`ADReal.h` header and all headers recursively included by it. For binary-only
+application distribution these headers may not be readily available.
+
+The make command `make ADRealMonolithic.h` can be used to build a
+redistributable header file sufficient for parsed function JIT compilation. This
+file can be distributed along with the application binary. The application will
+use this header to compile AD parsed material functions when the
+`MOOSE_ADFPARSER_JIT_INCLUDE` environment variable is set. E.g.:
+
+```
+export MOOSE_ADFPARSER_JIT_INCLUDE=/usr/local/include/ADRealMonolithic.h
+```


### PR DESCRIPTION
Adds a new make target `make ADRealMonolithic.h` to build a redistributable header file that is required for parsed function JIT compilation. This can be distributed along with the application binary. The application will use this header to compile AD parsed material functions when the `MOOSE_ADFPARSER_JIT_INCLUDE` environment variable is set. E.g.:

```
export MOOSE_ADFPARSER_JIT_INCLUDE=/usr/local/include/ADRealMonolithic.h
```

Closes #17893