### PR TITLE
Update deprecated API uses

### DIFF
--- a/modules/ray_tracing/include/userobjects/RayTracingStudy.h
+++ b/modules/ray_tracing/include/userobjects/RayTracingStudy.h
@@ -1111,7 +1111,7 @@ private:
   const std::unique_ptr<ParallelRayStudy> _parallel_ray_study;
 
   /// Quadrature rule for laying points across a 1D ray segment
-  UniquePtr<QBase> _segment_qrule;
+  std::unique_ptr<QBase> _segment_qrule;
 
   /// Total number of processor crossings for Rays that finished on this processor
   unsigned long long int _ending_processor_crossings;

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -999,7 +999,7 @@ XFEM::healMesh()
             mooseError("Could not find XFEMCutElem for element to be kept in healing");
 
           elem2_displaced->nullify_neighbors();
-          _displaced_mesh->boundary_info->remove(elem2_displaced);
+          _displaced_mesh->get_boundary_info().remove(elem2_displaced);
           _displaced_mesh->delete_elem(elem2_displaced);
         }
 
@@ -1009,7 +1009,7 @@ XFEM::healMesh()
 
         cutelems_to_delete.insert(elem2->unique_id());
         elem2->nullify_neighbors();
-        _mesh->boundary_info->remove(elem2);
+        _mesh->get_boundary_info().remove(elem2);
         unsigned int deleted_elem_id = elem2->id();
         _mesh->delete_elem(elem2);
         if (_debug_output_level > 1)
@@ -1028,7 +1028,7 @@ XFEM::healMesh()
   {
     Node * node_to_delete = sit;
     dof_id_type deleted_node_id = node_to_delete->id();
-    _mesh->boundary_info->remove(node_to_delete);
+    _mesh->get_boundary_info().remove(node_to_delete);
     _mesh->delete_node(node_to_delete);
     if (_debug_output_level > 1)
       _console << "XFEM healing deleted node: " << deleted_node_id << "\n";
@@ -1039,7 +1039,7 @@ XFEM::healMesh()
     for (auto & sit : nodes_to_delete_displaced)
     {
       Node * node_to_delete_displaced = sit;
-      _displaced_mesh->boundary_info->remove(node_to_delete_displaced);
+      _displaced_mesh->get_boundary_info().remove(node_to_delete_displaced);
       _displaced_mesh->delete_node(node_to_delete_displaced);
     }
   }
@@ -1258,8 +1258,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       }
 
       Node * parent_node = parent_elem->node_ptr(j);
-      _mesh->boundary_info->boundary_ids(parent_node, parent_boundary_ids);
-      _mesh->boundary_info->add_node(libmesh_node, parent_boundary_ids);
+      _mesh->get_boundary_info().boundary_ids(parent_node, parent_boundary_ids);
+      _mesh->get_boundary_info().add_node(libmesh_node, parent_boundary_ids);
 
       if (_displaced_mesh)
       {
@@ -1275,8 +1275,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
         libmesh_elem2->set_node(j) = libmesh_node;
 
         parent_node = parent_elem2->node_ptr(j);
-        _displaced_mesh->boundary_info->boundary_ids(parent_node, parent_boundary_ids);
-        _displaced_mesh->boundary_info->add_node(libmesh_node, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().boundary_ids(parent_node, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().add_node(libmesh_node, parent_boundary_ids);
       }
     }
 
@@ -1338,32 +1338,32 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     unsigned int n_sides = parent_elem->n_sides();
     for (unsigned int side = 0; side < n_sides; ++side)
     {
-      _mesh->boundary_info->boundary_ids(parent_elem, side, parent_boundary_ids);
-      _mesh->boundary_info->add_side(libmesh_elem, side, parent_boundary_ids);
+      _mesh->get_boundary_info().boundary_ids(parent_elem, side, parent_boundary_ids);
+      _mesh->get_boundary_info().add_side(libmesh_elem, side, parent_boundary_ids);
     }
     if (_displaced_mesh)
     {
       n_sides = parent_elem2->n_sides();
       for (unsigned int side = 0; side < n_sides; ++side)
       {
-        _displaced_mesh->boundary_info->boundary_ids(parent_elem2, side, parent_boundary_ids);
-        _displaced_mesh->boundary_info->add_side(libmesh_elem2, side, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().boundary_ids(parent_elem2, side, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().add_side(libmesh_elem2, side, parent_boundary_ids);
       }
     }
 
     unsigned int n_edges = parent_elem->n_edges();
     for (unsigned int edge = 0; edge < n_edges; ++edge)
     {
-      _mesh->boundary_info->edge_boundary_ids(parent_elem, edge, parent_boundary_ids);
-      _mesh->boundary_info->add_edge(libmesh_elem, edge, parent_boundary_ids);
+      _mesh->get_boundary_info().edge_boundary_ids(parent_elem, edge, parent_boundary_ids);
+      _mesh->get_boundary_info().add_edge(libmesh_elem, edge, parent_boundary_ids);
     }
     if (_displaced_mesh)
     {
       n_edges = parent_elem2->n_edges();
       for (unsigned int edge = 0; edge < n_edges; ++edge)
       {
-        _displaced_mesh->boundary_info->edge_boundary_ids(parent_elem2, edge, parent_boundary_ids);
-        _displaced_mesh->boundary_info->add_edge(libmesh_elem2, edge, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().edge_boundary_ids(parent_elem2, edge, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().add_edge(libmesh_elem2, edge, parent_boundary_ids);
       }
     }
 
@@ -1373,7 +1373,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       (*_material_data)[0]->copy(*libmesh_elem, *parent_elem, 0);
       for (unsigned int side = 0; side < parent_elem->n_sides(); ++side)
       {
-        _mesh->boundary_info->boundary_ids(parent_elem, side, parent_boundary_ids);
+        _mesh->get_boundary_info().boundary_ids(parent_elem, side, parent_boundary_ids);
         std::vector<boundary_id_type>::iterator it_bd = parent_boundary_ids.begin();
         for (; it_bd != parent_boundary_ids.end(); ++it_bd)
         {
@@ -1442,7 +1442,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     (*_bnd_material_data)[0]->eraseProperty(elem_to_delete);
 
     elem_to_delete->nullify_neighbors();
-    _mesh->boundary_info->remove(elem_to_delete);
+    _mesh->get_boundary_info().remove(elem_to_delete);
     unsigned int deleted_elem_id = elem_to_delete->id();
     _mesh->delete_elem(elem_to_delete);
     if (_debug_output_level > 1)
@@ -1452,7 +1452,7 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
     {
       Elem * elem_to_delete2 = _displaced_mesh->elem_ptr(delete_elements[i]->id());
       elem_to_delete2->nullify_neighbors();
-      _displaced_mesh->boundary_info->remove(elem_to_delete2);
+      _displaced_mesh->get_boundary_info().remove(elem_to_delete2);
       _displaced_mesh->delete_elem(elem_to_delete2);
     }
   }
@@ -2158,7 +2158,7 @@ XFEM::storeMaterialPropertiesForElement(const Elem * parent_elem, const Elem * c
   for (unsigned int side = 0; side < child_elem->n_sides(); ++side)
   {
     std::vector<boundary_id_type> elem_boundary_ids;
-    _mesh->boundary_info->boundary_ids(child_elem, side, elem_boundary_ids);
+    _mesh->get_boundary_info().boundary_ids(child_elem, side, elem_boundary_ids);
     for (auto bdid : elem_boundary_ids)
       if (_fe_problem->needBoundaryMaterialOnSide(bdid, 0))
         need_boundary_materials = true;
@@ -2220,7 +2220,7 @@ XFEM::loadMaterialPropertiesForElement(
   for (unsigned int side = 0; side < elem->n_sides(); ++side)
   {
     std::vector<boundary_id_type> elem_boundary_ids;
-    _mesh->boundary_info->boundary_ids(elem, side, elem_boundary_ids);
+    _mesh->get_boundary_info().boundary_ids(elem, side, elem_boundary_ids);
     for (auto bdid : elem_boundary_ids)
       if (_fe_problem->needBoundaryMaterialOnSide(bdid, 0))
         need_boundary_materials = true;

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -1362,7 +1362,8 @@ XFEM::cutMeshWithEFA(NonlinearSystemBase & nl, AuxiliarySystem & aux)
       n_edges = parent_elem2->n_edges();
       for (unsigned int edge = 0; edge < n_edges; ++edge)
       {
-        _displaced_mesh->get_boundary_info().edge_boundary_ids(parent_elem2, edge, parent_boundary_ids);
+        _displaced_mesh->get_boundary_info().edge_boundary_ids(
+            parent_elem2, edge, parent_boundary_ids);
         _displaced_mesh->get_boundary_info().add_edge(libmesh_elem2, edge, parent_boundary_ids);
       }
     }

--- a/modules/xfem/src/userobjects/LevelSetCutUserObject.C
+++ b/modules/xfem/src/userobjects/LevelSetCutUserObject.C
@@ -57,7 +57,7 @@ LevelSetCutUserObject::cutElementByGeometry(const Elem * elem,
 
   for (unsigned int i = 0; i < n_sides; ++i)
   {
-    UniquePtr<const Elem> curr_side = elem->side_ptr(i);
+    std::unique_ptr<const Elem> curr_side = elem->side_ptr(i);
 
     if (curr_side->type() != EDGE2)
       mooseError("In LevelSetCutUserObject element side must be EDGE2, but type is: ",


### PR DESCRIPTION
Refs #13921

## Reason

C++ `public:` access to the `libMesh::MeshBase::boundary_info` member was deprecated in https://github.com/libMesh/libmesh/pull/2763 last year, and the old `libMesh::UniquePtr` shim class was deprecated in https://github.com/libMesh/libmesh/pull/2910 last month, but we still had a couple files using these old APIs in the MOOSE modules.

## Design

Use the `get_boundary_info()` accessor method in the first case, and good old `std::unique_ptr` in the second.

## Impact

This lets MOOSE compile against a `--disable-deprecated` libMesh build again.