### PR TITLE
Add CODEOWNERS for a few modules to test capability

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+/modules/external_petsc_solver @fdkong
+/modules/navier_stokes @lindsayad
+/modules/ray_tracing @loganharbour
+/modules/stochastic_tools @aeslaughter @zachmprince


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
Code owners are a github capability that simplifies review request for specific files. We would like to test the capability with a few modules to start.

## Design
Add a CODEOWNERS file for a few modules.

## Impact
May be annoying. May be useful. TBD.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
