### PR TITLE
Use a separate control parameter to print out action dependencies

### DIFF
--- a/framework/include/actions/ActionWarehouse.h
+++ b/framework/include/actions/ActionWarehouse.h
@@ -198,12 +198,24 @@ public:
   void executeActionsWithAction(const std::string & name);
 
   /**
-   * This method sets a Boolean which is used to show debugging information during
-   * various warehouse operations during the problem setup phase.
+   * This method sets a Boolean which is used to print information about action dependencies
+   * before various warehouse operations during the problem setup phase.
+   * @param state Flag indicating whether to print action dependencies.
+   */
+  void showActionDependencies(bool state = true) { _show_action_dependencies = state; }
+
+  /**
+   * This method sets a Boolean which is used to show information about action execution
+   * of various warehouse operations during the problem setup phase.
    * @param state Flag indicating whether to show action information.
    */
   void showActions(bool state = true) { _show_actions = state; }
 
+  /**
+   * This method sets a Boolean which is used to show debugging information when
+   * actions are inserted in the warehouse by the parser.
+   * @param state Flag indicating whether to show action insertion.
+   */
   void showParser(bool state = true) { _show_parser = state; }
 
   //// Getters
@@ -267,8 +279,11 @@ protected:
    */
   bool _generator_valid;
 
-  // DEBUGGING
+  /// Whether or not the action warehouse prints the action dependency information
+  bool _show_action_dependencies;
+  /// Whether or not the action warehouse prints the action execution information
   bool _show_actions;
+  /// Whether or not to print messages when actions are inserted in the warehouse by the parser
   bool _show_parser;
 
   // When executing the actions in the warehouse, this string will always contain

--- a/framework/src/actions/ActionWarehouse.C
+++ b/framework/src/actions/ActionWarehouse.C
@@ -321,7 +321,7 @@ ActionWarehouse::printActionDependencySets() const
     }
   }
 
-  if (_show_actions)
+  if (_show_action_dependencies)
     _console << oss.str() << std::endl;
 }
 
@@ -330,7 +330,7 @@ ActionWarehouse::executeAllActions()
 {
   _completed_tasks.clear();
 
-  if (_show_actions)
+  if (_show_action_dependencies)
   {
     _console << "[DBG][ACT] Action Dependency Sets:\n";
     printActionDependencySets();
@@ -352,7 +352,7 @@ ActionWarehouse::executeAllActions()
     MemoryUtils::getMemoryStats(stats);
     auto usage =
         MemoryUtils::convertBytes(stats._physical_memory, MemoryUtils::MemUnits::Megabytes);
-    _console << "[DBG][ACT] Finished executing all actions with memory usage " << usage << "MB"
+    _console << "[DBG][ACT] Finished executing all actions with memory usage " << usage << "MB\n"
              << std::endl;
   }
 }

--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -31,6 +31,7 @@ SetupDebugAction::validParams()
       "show_var_residual_norms",
       false,
       "Print the residual norms of the individual solution variables at each nonlinear iteration");
+  params.addParam<bool>("show_action_dependencies", false, "Print out the action dependencies");
   params.addParam<bool>("show_actions", false, "Print out the actions being executed");
   params.addParam<bool>(
       "show_parser", false, "Shows parser block extraction and debugging information");
@@ -54,6 +55,7 @@ SetupDebugAction::validParams()
 
 SetupDebugAction::SetupDebugAction(InputParameters parameters) : Action(parameters)
 {
+  _awh.showActionDependencies(getParam<bool>("show_action_dependencies"));
   _awh.showActions(getParam<bool>("show_actions"));
   _awh.showParser(getParam<bool>("show_parser"));
 }

--- a/test/tests/actions/debug_block/debug_print_actions_test.i
+++ b/test/tests/actions/debug_block/debug_print_actions_test.i
@@ -44,6 +44,7 @@
 []
 
 [Debug]
+  show_action_dependencies = true
   show_actions = true
   show_top_residuals = 5
 []


### PR DESCRIPTION
Close #17929.
