### PR TITLE
Fix issues related to MOOSE app submodules in python Git utilities

### DIFF
--- a/python/MooseDocs/extensions/gitutils.py
+++ b/python/MooseDocs/extensions/gitutils.py
@@ -7,6 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import os
+# import logging
 import datetime
 import mooseutils
 import MooseDocs
@@ -68,8 +69,11 @@ class SubmoduleHashCommand(command.CommandComponent):
         if not inline:
             raise exceptions.MooseDocsException("The '!git submodule-hash' command is an inline level command, use '[!git!submodule-hash](name)' instead.")
 
-        name =  info['inline']
+        name = info['inline']
         status = mooseutils.git_submodule_info(MooseDocs.ROOT_DIR, '--recursive')
+        # if (name == 'moose') and any([repo.endswith('moose') for repo in status.keys()]) and (status['moose'][0] == '-'):
+        #     logging.getLogger(__name__).warning("The 'moose' submodule exists but has not been initialized.")
+
         for repo, ginfo in status.items():
             if repo.endswith(name):
                 url = self.settings['url']

--- a/python/MooseDocs/extensions/gitutils.py
+++ b/python/MooseDocs/extensions/gitutils.py
@@ -7,7 +7,6 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 import os
-# import logging
 import datetime
 import mooseutils
 import MooseDocs
@@ -71,9 +70,6 @@ class SubmoduleHashCommand(command.CommandComponent):
 
         name = info['inline']
         status = mooseutils.git_submodule_info(MooseDocs.ROOT_DIR, '--recursive')
-        # if (name == 'moose') and any([repo.endswith('moose') for repo in status.keys()]) and (status['moose'][0] == '-'):
-        #     logging.getLogger(__name__).warning("The 'moose' submodule exists but has not been initialized.")
-
         for repo, ginfo in status.items():
             if repo.endswith(name):
                 url = self.settings['url']

--- a/python/MooseDocs/extensions/ifelse.py
+++ b/python/MooseDocs/extensions/ifelse.py
@@ -91,10 +91,7 @@ class IfElseExtension(command.CommandExtension):
     def hasSubmodule(self, name):
         """Helper for the 'hasSubmodule' function."""
         status = mooseutils.git_submodule_info(MooseDocs.ROOT_DIR, '--recursive')
-        for repo, ginfo in status.items():
-            if repo.endswith(name):
-                return True
-        return False
+        return any([repo.endswith(name) for repo in status.keys()])
 
     def extend(self, reader, renderer):
         self.requires(command)

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -71,17 +71,12 @@ def git_root_dir(working_dir=os.getcwd()):
 def git_submodule_info(working_dir=os.getcwd(), *args):
     """
     Return the status of each of the git submodule(s).
-    """
-    command = ['git', 'submodule', 'status', *args]
-    try:
-        result = check_output(command, cwd=working_dir, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        # If the status command failed, it's possible that some submodules are broken, e.g., cannot
-        # be recursed because it is empty, so run a non-initializing update and try again.
-        subprocess.call(['git', 'submodule', 'update', '--recursive'], cwd=working_dir)
-        result = check_output(command, cwd=working_dir)
 
+    NOTE: It is possible that the 'git submodule status' command fails if one of the additional args
+          is '--recursive' and there are broken or empty (null) submodules.
+    """
     out = dict()
+    result = check_output(['git', 'submodule', 'status', *args], cwd=working_dir)
     regex = re.compile(r'(?P<status>[\s\-\+U])(?P<sha1>[a-f0-9]{40})\s(?P<name>.*?)\s(?P<refs>(\(.*\))?)')
     for match in regex.finditer(result):
         out[match.group('name')] = (match.group('status'), match.group('sha1'), match.group('refs'))

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -59,9 +59,9 @@ class Test(unittest.TestCase):
         self.assertIn('large_media', status)
         self.assertIn('libmesh', status)
         self.assertIn('petsc', status)
-        self.assertEqual(len(status['large_media']), 2)
-        self.assertEqual(len(status['libmesh']), 2)
-        self.assertEqual(len(status['petsc']), 2)
+        self.assertEqual(len(status['large_media']), 3)
+        self.assertEqual(len(status['libmesh']), 3)
+        self.assertEqual(len(status['petsc']), 3)
 
     @mock.patch('subprocess.call')
     @mock.patch('mooseutils.gitutils.git_submodule_info')


### PR DESCRIPTION
@aeslaughter 

Regarding the three bugs identified in #17951:

1. Created a regex group `<refs>` in `mooseutils.git_submodule_info()` that matches the `git describe` for active submodules listed when running `git submodule status` and implemented an additional check for this property in `mooseutils.git_init_submodule()`.
2. Implemented a try/catch routine in `mooseutils.git_submodule_info()` that will perform non-initializing updates on submodules if the `check_output()` exits with a `subprocess.CalledProcessError`, indicating that Git threw an error likely the result of trying to recurse in a (somehow) broken submodule.
3. I thought long and hard about it, and I'm not sure what to do about the issue of uninitialized `moose` submodules. I left something of an idea as a comment in `MooseDocs.gitutils.SubmoduleHashCommand()`. As I said, there's really no reason why someone should encounter this issue. Even if `MOOSE_DIR` were not set to the submodule, the `moose` submodule ought to be initialized anyways, since the submodule info generated in, e.g., SQA docs, ought to reflect the appropriate state of submodules in a given MOOSE app, and not those from some other arbitrary version of MOOSE. That is to say, limiting the related functions to search `ROOT_DIR` is definitely the right move, and the developer ought to just ignore the missing submodule errors in SQA docs or initialize `moose`.


(closes #17951) (refs idaholab/falcon#43)