### PR TITLE
Fixed scripts/update_and_rebuild_petsc_alt.sh

### DIFF
--- a/scripts/update_and_rebuild_petsc_alt.sh
+++ b/scripts/update_and_rebuild_petsc_alt.sh
@@ -16,6 +16,8 @@ echo "use only. Please use scripts/update_and_rebuild_petsc.sh instead."
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $SCRIPT_DIR
 
+cd $SCRIPT_DIR/..
+
 # Initialize petsc submodule
 git_dir=`git rev-parse --show-cdup 2>/dev/null`
 if [[ $? == 0 && "x$git_dir" == "x" ]]; then


### PR DESCRIPTION
```
❯ cd ~/projects/moose/
❯ rm -rf petsc
❯ cd scripts
❯ ./update_and_rebuild_petsc_alt.sh
*** WARNING ***
scripts/update_and_rebuild_petsc_alt.sh is intended for internal
use only. Please use scripts/update_and_rebuild_petsc.sh instead.
/Users/milljm/projects/moose/scripts
./update_and_rebuild_petsc_alt.sh: line 30: cd: /Users/milljm/projects/moose/scripts/../petsc: No such file or directory
error: pathspec 'v3.11.4' did not match any file(s) known to git
git checkout command failed, are your proxy settings correct?
```

Close #17955