### PR TITLE
Check if moose docs exist before trying to build+install them

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -460,7 +460,7 @@ $(binlink): all install_$(APPLICATION_NAME)_tests
 install_$(APPLICATION_NAME)_docs:
 	@echo "Installing docs"
 	@mkdir -p $(docs_install_dir)
-	@cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir)
+	@if [ -f "$(docs_dir)/moosedocs.py" ]; then cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir); fi
 
 $(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests install_$(APPLICATION_NAME)_docs $(binlink)
 	@echo "Installing $<"


### PR DESCRIPTION
Ref #17280.

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason

Avoid crashing the install process if the repo/app doesn't have any moose docs.

## Design
Just check before trying to build the docs.

## Impact
Affects no-one except makes @milljm's job easier.
