### PR TITLE
Remove extra StorkTestApp.C templates and add Geochemistry module loader

### DIFF
--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -28,6 +28,9 @@
 #ifdef FUNCTIONAL_EXPANSION_TOOLS_ENABLED
 #include "FunctionalExpansionToolsApp.h"
 #endif
+#ifdef GEOCHEMISTRY_ENABLED
+#include "GeochemistryApp.h"
+#endif
 #ifdef HEAT_CONDUCTION_ENABLED
 #include "HeatConductionApp.h"
 #endif
@@ -344,6 +347,10 @@ ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 
 #ifdef FSI_ENABLED
   FsiApp::registerAll(f, af, s);
+#endif
+
+#ifdef GEOCHEMISTRY_ENABLED
+  GeochemistryApp::registerAll(f, af, s);
 #endif
 
 #ifdef HEAT_CONDUCTION_ENABLED

--- a/scripts/stork.sh
+++ b/scripts/stork.sh
@@ -105,6 +105,7 @@ rm -f $dir/Makefile.*
 rm -f $dir/unit/Makefile.*
 rm -f $dir/run_tests.*
 rm -f $dir/src/base/StorkApp.C.*
+rm -f $dir/test/src/base/StorkTestApp.C.*
 rm -f $dir/doc/config.yml.*
 rm -f $dir/doc/moosedocs.py.*
 


### PR DESCRIPTION
- Adding shell command to remove the counterpart `${kind}` version of the `StorkTestApp.C` file (refs #12595).
- Adding call to `GeochemistryApp::registerAll(f, af, s)` in the module loader. Without it, other applications cannot use its syntax even though it builds it (refs #14725).

###Edit:
- Also updating `large_media` with new `falcon` directory (refs idaholab/falcon#45)