### PR TITLE
Fix CIVET result links for master branch documentation

### DIFF
--- a/python/MooseDocs/__init__.py
+++ b/python/MooseDocs/__init__.py
@@ -22,7 +22,7 @@ import mooseutils
 LOG_LEVEL = logging.NOTSET
 
 # The repository root location
-is_git_repo = mooseutils.is_git_repo()
+is_git_repo = mooseutils.git_is_repo()
 if is_git_repo:
     os.environ.setdefault('ROOT_DIR',  mooseutils.git_root_dir())
 elif 'ROOT_DIR' not in os.environ:

--- a/python/MooseDocs/common/get_content.py
+++ b/python/MooseDocs/common/get_content.py
@@ -206,7 +206,7 @@ def get_content(items, in_ext):
 
     # Update the project files
     for root in roots:
-        if mooseutils.is_git_repo(root):
+        if mooseutils.git_is_repo(root):
             MooseDocs.PROJECT_FILES.update(mooseutils.git_ls_files(mooseutils.git_root_dir(root)))
         else:
             MooseDocs.PROJECT_FILES.update(mooseutils.list_files(root))

--- a/python/MooseDocs/extensions/civet.py
+++ b/python/MooseDocs/extensions/civet.py
@@ -82,31 +82,35 @@ class CivetExtension(command.CommandExtension):
         """(override) Generate test reports."""
 
         # Test result database
-        start = time.time()
-        LOG.info("Collecting CIVET results...")
-
         self.__database = dict()
-        for name, category in self.get('remotes').items():
-            working_dir = mooseutils.eval_path(category.get('location', MooseDocs.ROOT_DIR))
-            LOG.info("Gathering CIVET results for '%s' category in %s", name, working_dir)
-            hashes = None
-            if category.get('download_test_results', self.get('download_test_results', True)):
-                hashes = mooseutils.git_civet_hashes(start=self.get('branch'), author=self.get('author'), working_dir=working_dir)
-                LOG.info("Downloading CIVET results for '%s' category in %s", name, working_dir)
 
-            local = mooseutils.eval_path(category.get('test_results_cache', self.get('test_results_cache')))
-            site = (category['url'], category['repo'])
-            local_db = mooseutils.get_civet_results(local=local,
-                                                    hashes=hashes,
-                                                    site=site,
-                                                    cache=local,
-                                                    possible=['OK', 'FAIL', 'DIFF', 'TIMEOUT'],
-                                                    logger=LOG)
-            self.__database.update(local_db)
-        LOG.info("Collecting CIVET results complete [%s sec.]", time.time() - start)
+        # Only populate the database if the specified branch and author match current repository
+        if mooseutils.git_is_branch(self.get('branch')) and \
+           mooseutils.git_is_config('user.name', self.get('author')):
+
+            start = time.time()
+            LOG.info("Collecting CIVET results...")
+            for name, category in self.get('remotes').items():
+                working_dir = mooseutils.eval_path(category.get('location', MooseDocs.ROOT_DIR))
+                LOG.info("Gathering CIVET results for '%s' category in %s", name, working_dir)
+                hashes = None
+                if category.get('download_test_results', self.get('download_test_results', True)):
+                    hashes = mooseutils.git_civet_hashes(start=self.get('branch'), author=self.get('author'), working_dir=working_dir)
+                    LOG.info("Downloading CIVET results for '%s' category in %s", name, working_dir)
+
+                local = mooseutils.eval_path(category.get('test_results_cache', self.get('test_results_cache')))
+                site = (category['url'], category['repo'])
+                local_db = mooseutils.get_civet_results(local=local,
+                                                        hashes=hashes,
+                                                        site=site,
+                                                        cache=local,
+                                                        possible=['OK', 'FAIL', 'DIFF', 'TIMEOUT'],
+                                                        logger=LOG)
+                self.__database.update(local_db)
+            LOG.info("Collecting CIVET results complete [%s sec.]", time.time() - start)
 
         if not self.__database and self.get('generate_test_reports', True):
-            LOG.warning("'generate_test_reports' is being disabled, it requires results to exist but none were located.")
+            LOG.info("CIVET test result reports are being disabled, it requires results to exist and the specified branch ('%s') and author ('%s') to match the current repository.", self.get('branch'), self.get('author'))
             self.update(generate_test_reports=False)
 
         if self.get('generate_test_reports', True):

--- a/python/MooseDocs/extensions/gitutils.py
+++ b/python/MooseDocs/extensions/gitutils.py
@@ -47,7 +47,7 @@ class CommitCommand(command.CommandComponent):
         if content:
             raise exceptions.MooseDocsException("Content is not supported for the 'git commit' command.")
 
-        if not mooseutils.is_git_repo():
+        if not mooseutils.git_is_repo():
             raise exceptions.MooseDocsException("The current working directory is not a git repository.")
 
         core.Word(parent, content=mooseutils.git_commit())

--- a/python/MooseDocs/test/extensions/test_gitutils.py
+++ b/python/MooseDocs/test/extensions/test_gitutils.py
@@ -36,8 +36,8 @@ class TestGitUtilsCommit(MooseDocsTestCase):
         self.assertToken(ast(0), "ErrorToken")
         self.assertIn("Content is not supported for the 'git commit' command.", ast(0)['message'])
 
-        with mock.patch('mooseutils.is_git_repo') as is_git_repo:
-            is_git_repo.return_value = False
+        with mock.patch('mooseutils.git_is_repo') as git_is_repo:
+            git_is_repo.return_value = False
             ast = self.tokenize('!git commit')
         self.assertToken(ast(0), "ErrorToken")
         self.assertIn("The current working directory is not a git repository.", ast(0)['message'])

--- a/python/moosesqa/SQADocumentReport.py
+++ b/python/moosesqa/SQADocumentReport.py
@@ -43,7 +43,7 @@ class SQADocumentReport(SQAReport):
         file_list = list()
         for working_dir in self.working_dirs:
             path = mooseutils.eval_path(working_dir)
-            if mooseutils.is_git_repo(path):
+            if mooseutils.git_is_repo(path):
                 file_list += mooseutils.git_ls_files(path)
             else:
                 file_list += glob.glob(os.path.join(path,'**', '*.*'), recursive=True)

--- a/python/moosesqa/check_documents.py
+++ b/python/moosesqa/check_documents.py
@@ -26,7 +26,7 @@ def check_documents(documents, file_list=None, **kwargs):
     logger = LogHelper(__name__, **kwargs)
 
     # Setup file_list, if not provided
-    if (file_list is None) and (not mooseutils.is_git_repo()):
+    if (file_list is None) and (not mooseutils.git_is_repo()):
         msg = "If the 'file_list' is not provided then the working directory must be a git repository."
         raise ValueError(msg)
     elif file_list is None:

--- a/python/moosesqa/check_requirements.py
+++ b/python/moosesqa/check_requirements.py
@@ -77,7 +77,7 @@ def check_requirements(requirements, file_list=None, color_text=True, allowed_co
     RequirementLogHelper.COLOR_TEXT = color_text
 
     # Setup file_list, if not provided
-    if (file_list is None) and (not mooseutils.is_git_repo()):
+    if (file_list is None) and (not mooseutils.git_is_repo()):
         msg = "If the 'file_list' is not provided then the working directory must be a git repository."
         raise ValueError(msg)
     elif file_list is None:

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -14,7 +14,7 @@ from .mooseutils import generate_filebase, recursive_update, fuzzyEqual, fuzzyAb
 from .gitutils import git_is_repo, git_commit, git_commit_message, git_merge_commits, git_ls_files
 from .gitutils import git_root_dir, git_init_submodule, git_submodule_info, git_version
 from .gitutils import git_authors, git_lines, git_committers, git_localpath, git_repo
-from .gitutils import git_civet_hashes
+from .gitutils import git_civet_hashes, git_is_branch, git_is_config
 from .message import mooseDebug, mooseWarning, mooseMessage, mooseError
 from .MooseException import MooseException
 from .eval_path import eval_path

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -11,7 +11,7 @@ from .mooseutils import find_moose_executable_recursive, run_executable
 from .mooseutils import touch, unique_list, gold, make_chunks, camel_to_space
 from .mooseutils import text_diff, unidiff, text_unidiff, run_profile, list_files, check_output, run_time
 from .mooseutils import generate_filebase, recursive_update, fuzzyEqual, fuzzyAbsoluteEqual
-from .gitutils import is_git_repo, git_commit, git_commit_message, git_merge_commits, git_ls_files
+from .gitutils import git_is_repo, git_commit, git_commit_message, git_merge_commits, git_ls_files
 from .gitutils import git_root_dir, git_init_submodule, git_submodule_info, git_version
 from .gitutils import git_authors, git_lines, git_committers, git_localpath, git_repo
 from .gitutils import git_civet_hashes

--- a/python/mooseutils/__init__.py
+++ b/python/mooseutils/__init__.py
@@ -14,6 +14,7 @@ from .mooseutils import generate_filebase, recursive_update, fuzzyEqual, fuzzyAb
 from .gitutils import is_git_repo, git_commit, git_commit_message, git_merge_commits, git_ls_files
 from .gitutils import git_root_dir, git_init_submodule, git_submodule_info, git_version
 from .gitutils import git_authors, git_lines, git_committers, git_localpath, git_repo
+from .gitutils import git_civet_hashes
 from .message import mooseDebug, mooseWarning, mooseMessage, mooseError
 from .MooseException import MooseException
 from .eval_path import eval_path

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -29,7 +29,7 @@ def git_is_branch(name, working_dir=os.getcwd()):
     If the current location is not a repository, False is returned.
     """
     if git_is_repo(working_dir):
-        out = mooseutils.check_output(['git', 'branch', '--show-current'], cwd=working_dir).strip()
+        out = mooseutils.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=working_dir).strip()
         return out == name
     return False
 

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -13,6 +13,39 @@ import logging
 import collections
 from .mooseutils import check_output
 
+def git_civet_hashes(start='HEAD', author='moosetest', working_dir=os.getcwd()):
+    """
+    Helper function for returning the hashes associated with testing using CIVET.
+
+    In general, this function should be run from the "master" branch or a release tag that
+    stems from a release branch. In this scenario, the script performs the following tasks.
+
+    $ git log --merges --author moosetest -n 1 HEAD
+
+    commit 90123e7b6bd52f1bc36e68aac5d1fa95e76aeb91
+    Merge: 20330877ed d72a8d0d69
+    Author: moosetest <bounces@inl.gov>
+    Date:   Tue May 18 04:24:26 2021 -0600
+
+    Merge commit 'd72a8d0d69e21b4945eedf2e78a7de80b1bd3e6f'
+
+    The first commit that is returned is the commit for the merge: 90123..., which is the
+    merge commit performed by CIVET (i.e., moosetest).
+
+    The second commit this is returned is the commit that contains the merge into the "next" branch
+    for MOOSE or "devel" for applications, in this case 972a8d.... For MOOSE, on CIVET this hash will
+    contain the testing that occurred for the merge into "next" as well as the "devel" testing. For
+    applications this will contain the merge into "devel" testing.
+
+    If this function is run on a differing branch where a merge commit doesn't exist, then None is
+    returned.
+    """
+    cmd = ['git', 'log', '--merges', '--author', author, '-n', '1', start]
+    out = subprocess.run(cmd, capture_output=True, text=True, cwd=working_dir)
+    regex = r"commit (?P<master>[a-f0-9]{40}).*?Merge commit\s+'(?P<devel>[0-9a-f]{40})'"
+    match = re.match(regex, out.stdout, flags=re.DOTALL|re.UNICODE)
+    return (match.group('master'), match.group('devel')) if match else None
+
 def is_git_repo(working_dir=os.getcwd()):
     """
     Return true if the repository is a git repo.

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -46,7 +46,7 @@ def git_civet_hashes(start='HEAD', author='moosetest', working_dir=os.getcwd()):
     match = re.match(regex, out.stdout, flags=re.DOTALL|re.UNICODE)
     return (match.group('master'), match.group('devel')) if match else None
 
-def is_git_repo(working_dir=os.getcwd()):
+def git_is_repo(working_dir=os.getcwd()):
     """
     Return true if the repository is a git repo.
     """

--- a/python/mooseutils/gitutils.py
+++ b/python/mooseutils/gitutils.py
@@ -11,7 +11,27 @@ import re
 import subprocess
 import logging
 import collections
-from .mooseutils import check_output
+import mooseutils
+
+def git_is_config(key, value, working_dir=os.getcwd()):
+    """
+    Return True if the supplied *key* from the git config matches the supplied *value*.
+
+    The command runs `git config --get <key>` and compares the result with *value*.
+    """
+    out = mooseutils.check_output(['git', 'config', '--get', key], cwd=working_dir).strip()
+    return out == value
+
+def git_is_branch(name, working_dir=os.getcwd()):
+    """
+    Return True if the supplied *name* matches the current git branch.
+
+    If the current location is not a repository, False is returned.
+    """
+    if git_is_repo(working_dir):
+        out = mooseutils.check_output(['git', 'branch', '--show-current'], cwd=working_dir).strip()
+        return out == name
+    return False
 
 def git_civet_hashes(start='HEAD', author='moosetest', working_dir=os.getcwd()):
     """
@@ -50,7 +70,7 @@ def git_is_repo(working_dir=os.getcwd()):
     """
     Return true if the repository is a git repo.
     """
-    out = check_output(['git', 'rev-parse', '--is-inside-work-tree'], check=False,
+    out = mooseutils.check_output(['git', 'rev-parse', '--is-inside-work-tree'], check=False,
                        stderr=subprocess.PIPE, cwd=working_dir).strip(' \n')
     return out.lower() == 'true'
 
@@ -58,21 +78,21 @@ def git_commit(working_dir=os.getcwd()):
     """
     Return the current SHA from git.
     """
-    out = check_output(['git', 'rev-parse', 'HEAD'], cwd=working_dir)
+    out = mooseutils.check_output(['git', 'rev-parse', 'HEAD'], cwd=working_dir)
     return out.strip(' \n')
 
 def git_commit_message(sha, working_dir=os.getcwd()):
     """
     Return the the commit message for the supplied SHA
     """
-    out = check_output(['git', 'show', '-s', '--format=%B', sha], cwd=working_dir)
+    out = mooseutils.check_output(['git', 'show', '-s', '--format=%B', sha], cwd=working_dir)
     return out.strip(' \n')
 
 def git_merge_commits(working_dir=os.getcwd()):
     """
     Return the current SHAs for a merge.
     """
-    out = check_output(['git', 'log', '-1', '--merges', '--pretty=format:%P'], cwd=working_dir)
+    out = mooseutils.check_output(['git', 'log', '-1', '--merges', '--pretty=format:%P'], cwd=working_dir)
     return out.strip(' \n').split(' ')
 
 def git_ls_files(working_dir=os.getcwd(), recurse_submodules=False, exclude=None):
@@ -85,7 +105,7 @@ def git_ls_files(working_dir=os.getcwd(), recurse_submodules=False, exclude=None
     if exclude is not None:
         cmd += ['--exclude', exclude]
     out = set()
-    for fname in check_output(cmd, cwd=working_dir).split('\n'):
+    for fname in mooseutils.check_output(cmd, cwd=working_dir).split('\n'):
         out.add(os.path.abspath(os.path.join(working_dir, fname)))
     return out
 
@@ -94,7 +114,7 @@ def git_root_dir(working_dir=os.getcwd()):
     Return the top-level git directory by running 'git rev-parse --show-toplevel'.
     """
     try:
-        return check_output(['git', 'rev-parse', '--show-toplevel'],
+        return mooseutils.check_output(['git', 'rev-parse', '--show-toplevel'],
                             cwd=working_dir, stderr=subprocess.STDOUT).strip('\n')
     except subprocess.CalledProcessError:
         print("The supplied directory is not a git repository: {}".format(working_dir))
@@ -109,7 +129,7 @@ def git_submodule_info(working_dir=os.getcwd(), *args):
           is '--recursive' and there are broken or empty (null) submodules.
     """
     out = dict()
-    result = check_output(['git', 'submodule', 'status', *args], cwd=working_dir)
+    result = mooseutils.check_output(['git', 'submodule', 'status', *args], cwd=working_dir)
     regex = re.compile(r'(?P<status>[\s\-\+U])(?P<sha1>[a-f0-9]{40})\s(?P<name>.*?)\s(?P<refs>(\(.*\))?)')
     for match in regex.finditer(result):
         out[match.group('name')] = (match.group('status'), match.group('sha1'), match.group('refs'))
@@ -129,7 +149,7 @@ def git_version():
     """
     Return the version number as a tuple (major, minor, patch)
     """
-    out = check_output(['git', '--version'], encoding='utf-8')
+    out = mooseutils.check_output(['git', '--version'], encoding='utf-8')
     match = re.search(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)', out)
     if match is None:
         raise SystemError("git --version failed to return correctly formatted version number")
@@ -145,7 +165,7 @@ def git_authors(loc=None):
     if not os.path.exists(loc):
         raise OSError("The supplied location must be a file or directory: {}".format(loc))
     loc = loc or os.getcwd()
-    out = check_output(['git', 'shortlog', '-n', '-c', '-s', '--', loc], encoding='utf-8')
+    out = mooseutils.check_output(['git', 'shortlog', '-n', '-c', '-s', '--', loc], encoding='utf-8')
     names = list()
     for match in re.finditer(r'^\s*\d+\s*(?P<name>.*?)$', out, flags=re.MULTILINE):
         names.append(match.group('name'))
@@ -162,7 +182,7 @@ def git_lines(filename, blank=False):
         raise OSError("File does not exist: {}".format(filename))
     regex = re.compile(r'^.*?\((?P<name>.*?)\s+\d{4}-\d{2}-\d{2}.*?\)\s+(?P<content>.*?)$', flags=re.MULTILINE)
     counts = collections.defaultdict(int)
-    blame = check_output(['git', 'blame', '--', filename], encoding='utf-8')
+    blame = mooseutils.check_output(['git', 'blame', '--', filename], encoding='utf-8')
     for line in blame.splitlines():
         match = regex.search(line)
         if blank or len(match.group('content')) > 0:
@@ -182,7 +202,7 @@ def git_committers(loc=os.getcwd(), *args):
     cmd = ['git', 'shortlog', '-s']
     cmd += args
     cmd += ['--', loc]
-    committers = check_output(cmd, encoding='utf-8')
+    committers = mooseutils.check_output(cmd, encoding='utf-8')
     counts = collections.defaultdict(int)
     for line in committers.splitlines():
         items = line.split("\t", 1)
@@ -204,7 +224,7 @@ def git_repo(loc=os.getcwd(), remotes=['upstream', 'origin']):
         raise OSError("The supplied location must be a directory: {}".format(loc))
 
     lookup = dict()
-    for remote in check_output(['git', 'remote', '-v'], encoding='utf-8', cwd=loc).strip(' \n').split('\n'):
+    for remote in mooseutils.check_output(['git', 'remote', '-v'], encoding='utf-8', cwd=loc).strip(' \n').split('\n'):
         name, addr = remote.split(maxsplit=1)
         lookup[name] = addr
 

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -13,6 +13,7 @@ import unittest
 import mock
 import tempfile
 import subprocess
+import platform
 import mooseutils
 
 #from mooseutils.gitutils import git_submodule_info
@@ -148,6 +149,18 @@ class Test(unittest.TestCase):
         with self.assertRaises(OSError) as e:
             mooseutils.git_repo(os.path.dirname(__file__), remotes=['wrong'])
         self.assertEqual(str(e.exception), "Unable to locate a remote with the name(s): wrong")
+
+    @unittest.skipIf(platform.python_version() < '3.7.0', "Python 3.7 or greater required.")
+    def testGitCivetHashes(self):
+
+        # Release 2021-05-18
+        gold = ('90123e7b6bd52f1bc36e68aac5d1fa95e76aeb91', 'd72a8d0d69e21b4945eedf2e78a7de80b1bd3e6f')
+        hashes = mooseutils.git_civet_hashes('2021-05-18')
+        self.assertEqual(hashes, gold)
+
+        gold = ('df827bfaf6ea29394ce609bdf032bd40a9818cfc', 'c4ec8d4669166086da10470cc99c4b40813eeee9')
+        hashes = mooseutils.git_civet_hashes('df827bfaf6ea29394ce609bdf032bd40a9818cfc')
+        self.assertEqual(hashes, gold)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, buffer=True)

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -170,7 +170,7 @@ class Test(unittest.TestCase):
     def testGitIsBranch(self):
         with mock.patch('mooseutils.check_output', side_effect=['true', 'main']) as mock_check_output:
             self.assertTrue(mooseutils.git_is_branch('main', '/working/dir'))
-        mock_check_output.assert_called_with(['git', 'branch', '--show-current'], cwd='/working/dir')
+        mock_check_output.assert_called_with(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd='/working/dir')
 
         with mock.patch('mooseutils.check_output', side_effect=['false']) as mock_check_output:
             self.assertFalse(mooseutils.git_is_branch('main', '/working/dir'))

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -162,5 +162,19 @@ class Test(unittest.TestCase):
         hashes = mooseutils.git_civet_hashes('df827bfaf6ea29394ce609bdf032bd40a9818cfc')
         self.assertEqual(hashes, gold)
 
+    def testGitIsConfig(self):
+        with mock.patch('mooseutils.check_output', return_value='moosetest') as mock_check_output:
+            self.assertTrue(mooseutils.git_is_config('user.name', 'moosetest', '/working/dir'))
+        mock_check_output.assert_called_with(['git', 'config', '--get', 'user.name'], cwd='/working/dir')
+
+    def testGitIsBranch(self):
+        with mock.patch('mooseutils.check_output', side_effect=['true', 'main']) as mock_check_output:
+            self.assertTrue(mooseutils.git_is_branch('main', '/working/dir'))
+        mock_check_output.assert_called_with(['git', 'branch', '--show-current'], cwd='/working/dir')
+
+        with mock.patch('mooseutils.check_output', side_effect=['false']) as mock_check_output:
+            self.assertFalse(mooseutils.git_is_branch('main', '/working/dir'))
+        mock_check_output.assert_called_once()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, buffer=True)

--- a/python/mooseutils/tests/test_gitutils.py
+++ b/python/mooseutils/tests/test_gitutils.py
@@ -21,39 +21,39 @@ import mooseutils
 class Test(unittest.TestCase):
     def testIsGitRepo(self):
         loc = os.path.dirname(__file__)
-        self.assertTrue(mooseutils.is_git_repo(loc))
+        self.assertTrue(mooseutils.git_is_repo(loc))
 
         loc = tempfile.mkdtemp()
-        self.assertFalse(mooseutils.is_git_repo(loc))
+        self.assertFalse(mooseutils.git_is_repo(loc))
         os.rmdir(loc)
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitCommit(self):
         c = mooseutils.git_commit()
         self.assertEqual(len(c), 40)
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitCommitMessage(self):
         c = 'b863a496dbf1449853be6978c8ac1a9c242d389b' # beautiful commit
         msg = mooseutils.git_commit_message(c)
         self.assertIn('The name is, just so long', msg)
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitMergeCommits(self):
         merges = mooseutils.git_merge_commits()
         self.assertEqual(len(merges[0]), 40)
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitLsFiles(self):
         files = mooseutils.git_ls_files()
         self.assertIn(os.path.abspath(__file__), files)
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitRootDir(self):
         root = mooseutils.git_root_dir()
         self.assertEqual(root, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitSubmoduleInfo(self):
         root = mooseutils.git_root_dir()
         status = mooseutils.git_submodule_info(root)
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
 
     @mock.patch('subprocess.call')
     @mock.patch('mooseutils.gitutils.git_submodule_info')
-    @unittest.skipIf(not mooseutils.is_git_repo(), "Not a Git repository")
+    @unittest.skipIf(not mooseutils.git_is_repo(), "Not a Git repository")
     def testGitInitSubmodule(self, status_func, call_func):
         status_func.return_value = {'test':'-'}
 

--- a/python/pyhit/__init__.py
+++ b/python/pyhit/__init__.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
 
     # If the repository is not a git repository, then give up otherwise try to figure out what to do
-    if not mooseutils.is_git_repo(os.path.dirname(__file__)):
+    if not mooseutils.git_is_repo(os.path.dirname(__file__)):
         raise
 
     moose_dir = mooseutils.git_root_dir(os.path.dirname(__file__))


### PR DESCRIPTION
The fix in #17178 was operating for the PR/devel levels but not linking to the correct pages on
master. This latest change will result in the CIVET badges only being available on the master
documentation. This is the correct behavior, because that is the documentation intended for public
consumption.

(refs #17177)