### PR TITLE
Remove non *.hpc.inl.gov domains from INL HPC proxy

### DIFF
--- a/scripts/hpc_proxy.pac
+++ b/scripts/hpc_proxy.pac
@@ -7,13 +7,9 @@
 // See the link for more information.
 
 function FindProxyForURL(url, host) {
-  // For [*.hpc.inl.gov, hpcweb.inl.gov, moosebuild.inl.gov, hpcsc.inl.gov],
-  // first attempt to use the SOCKS proxy. If no success,
-  // attempt a direct connection (useful when on the INL VPN)
-  if (dnsDomainIs(host, ".hpc.inl.gov") ||
-      dnsDomainIs(host, "hpcweb.inl.gov") ||
-      dnsDomainIs(host, "moosebuild.inl.gov") ||
-      dnsDomainIs(host, "hpcsc.inl.gov"))
+  // For *.hpc.inl.gov, first attempt to use the SOCKS proxy.
+  // If no success, attempt a direct connection (useful when on the INL VPN)
+  if (dnsDomainIs(host, ".hpc.inl.gov"))
     return "SOCKS5 localhost:5555; DIRECT";
   // For all other domains, use direct access (no proxy)
   return "DIRECT";


### PR DESCRIPTION
Closes #18070

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

<!--Why do you need this feature or what is the enhancement?-->


<!--A concise description (design) of the enhancement.-->


<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
