### PR TITLE
Ondemand application usage documentation page

### DIFF
--- a/modules/doc/content/application_usage/index.md
+++ b/modules/doc/content/application_usage/index.md
@@ -10,6 +10,8 @@ These documentation pages aid in running MOOSE-based applications.  For developm
 
 [Peacock](peacock.md) - Graphical user interface and results visualization
 
+[OnDemand](ondemand.md) - Web based user interface to submit jobs to INL HPC
+
 [Tracked Apps](tracked_apps.md) - A list of applications being developped
 
 [Troubleshooting Failed Solves](failed_solves.md)

--- a/modules/doc/content/application_usage/ondemand.md
+++ b/modules/doc/content/application_usage/ondemand.md
@@ -1,10 +1,12 @@
 # Open OnDemand
 
-[Open OnDemand]() is a web based HPC access portal. OnDemand allows users to access HPC files, open shells, access Linux desktops, use other interactive apps, and build job submissions to submit to a cluster, all from the web browser.  
+[Open OnDemand](https://openondemand.org) is a web based HPC access portal. OnDemand allows users to access HPC files, open shells, access Linux desktops, use other interactive apps, and build job submissions to submit to a cluster, all from the web browser.  From the OnDemand web portal, users who have been given permission, are able to use level 1 code access.
 
-### Access
+## Access
 
 Idaho National Lab's Open OnDemand instance can be accessed externally via https://hpcondemand.inl.gov/ with your INL HPC username and pin + token or internally at https://ondemand.hpc.inl.gov with your INL HPC username and password.
+
+Once authenticated in the OnDemand system, the top navigation bar has a menu item "NCRC". Clicking on this will show a dropdown menu that is populated with the NCRC apps that you have been granted level 1 access to. The following documentation is applicable for each level 1 NCRC application.
 
 ## Submission and Job Information
 
@@ -18,14 +20,14 @@ This is the full path to your input file that will be submitted to the applicabl
 app-opt **-i input.i**
 ```
 
-You do not need the `app-opt -i` and you need the full path to your equivalent of `input.i`. The "Select File" button should open a dialog that will allow you to browse your INL HPC folder structure and manually selet your input file to prevent typos in the full path to the input file.
+You do not need the `app-opt -i` and you need the full path to your equivalent of `input.i`. The "Select File" button should open a dialog that will allow you to browse your INL HPC folder structure and manually select your input file to prevent typos in the full path to the input file.
 
 ## Advanced Code and Input Settings
 
 ### Specific Version Hash
 This option allows you to run a specific build of the herd code. To get a list of the different version hashes that are allowed here, you can open a terminal on the appropriate cluster and run `module spider APP` and you will be presented with multiple versions of each herd application. 
 
-To get more information about each build... **TODO IDK**
+To get more information about each build, put `--help` or `-h` in the advanced parameters field below. Using the `--help` or `-h` flag will print the command help information to your output file and return.
 
 ### Advanced Parameters
 By default, your submission of this forms creates a basic submission command that gets submitted to the requested 

--- a/modules/doc/content/application_usage/ondemand.md
+++ b/modules/doc/content/application_usage/ondemand.md
@@ -1,0 +1,70 @@
+# Open OnDemand
+
+[Open OnDemand]() is a web based HPC access portal. OnDemand allows users to access HPC files, open shells, access Linux desktops, use other interactive apps, and build job submissions to submit to a cluster, all from the web browser.  
+
+### Access
+
+Idaho National Lab's Open OnDemand instance can be accessed externally via https://hpcondemand.inl.gov/ with your INL HPC username and pin + token or internally at https://ondemand.hpc.inl.gov with your INL HPC username and password.
+
+## Submission and Job Information
+
+### Specifying a Project
+Every job submission is required to have a project specified. This is normally entered with the PBS "-P" option. However, you do not need to enter "-P" here, just the project name. Project names must be selected from the list on [HPC Web](http://hpcweb.hpc.inl.gov/home/pbs#specifying-a-project). If more than one project name is appropriate, use your best judgment to choose the most applicable project name. If no project name is available that is applicable to your job, use one of the general-purpose technical area job names, e.g., “ne_gen” for nuclear energy applications.
+
+### Input File
+This is the full path to your input file that will be submitted to the applicable executable. If your input file were to be submitted via the command line, it may look like:
+
+```bash
+app-opt **-i input.i**
+```
+
+You do not need the `app-opt -i` and you need the full path to your equivalent of `input.i`. The "Select File" button should open a dialog that will allow you to browse your INL HPC folder structure and manually selet your input file to prevent typos in the full path to the input file.
+
+## Advanced Code and Input Settings
+
+### Specific Version Hash
+This option allows you to run a specific build of the herd code. To get a list of the different version hashes that are allowed here, you can open a terminal on the appropriate cluster and run `module spider APP` and you will be presented with multiple versions of each herd application. 
+
+To get more information about each build... **TODO IDK**
+
+### Advanced Parameters
+By default, your submission of this forms creates a basic submission command that gets submitted to the requested 
+cluster.
+
+```bash
+app-opt -i /home/user/input.i
+```
+
+This form field allows you to add additional parameters. For example, if you wish to run performance logging, you can add a `-t` or `--timing` in this box and your application would then be executed as:
+
+```bash
+app-opt -t -i /home/user/input.i
+app-opt --timing -i /home/user/input.i
+```
+
+You are allowed to put more than one in this box. Everything that you put in this box will be entered between  `app-opt` and your input file `-i /home/user/input.i`.
+
+To get a full list and more explanation on these command line options, please see the [command line usage documentation](https://mooseframework.inl.gov/application_usage/command_line_usage.html).
+
+## Working Directory Information
+By default, your working directory is set to the same directory where your input file is located. You can change this if you would prefer a different directory by checking the checkbox and entering the new directory. You can also use the "Select Directory" button to get a file dialog box to select the directory instead of typing it out by hand.
+
+## HPC Information
+The HPC information section is an interactive form to create your scheduler submission.
+
+- Select the cluster you wish to run on. The amount of resources and the time you may request for your submission for will depend on the cluster.
+- Enter the number of hours for your request. If your submission finishes before the number of hours has passed, your job will end.
+- Enter the number of nodes for your job.
+- Select the number of cores for your job.
+- The following table shows the limitations of each system
+
+| Cluster  | Max Cores per Node | Max Hours |
+|----------|--------------------|--------------|
+| Falcon   | 36                 | 336          | 
+| Lemhi    | 40                 | 72           |
+| Sawtooth | 48                 | 168          |
+
+### Advanced HPC Submission Settings
+By default, the scheduler decides how much memory to assign to the job if the amount of memory is not explicity provided. You can change this default behavior by clicking the "Show advanced HPC submission settings" checkbox and entering the amount of memory. 
+
+You can also select the max amount of memory for a node if you would like to use all of a node. Selecting all of the cores for a node also provides the max amount of memory.

--- a/modules/doc/content/application_usage/ondemand.md
+++ b/modules/doc/content/application_usage/ondemand.md
@@ -4,13 +4,14 @@
 
 ## Access
 
-Idaho National Lab's Open OnDemand instance can be accessed externally via https://hpcondemand.inl.gov/ with your INL HPC username and pin + token or internally at https://ondemand.hpc.inl.gov with your INL HPC username and password.
+Idaho National Lab's Open OnDemand instance can be accessed externally via [hpcondemand.inl.gov](https://hpcondemand.inl.gov/) with your INL HPC username and pin + token or internally at [ondemand.hpc.inl.gov](https://ondemand.hpc.inl.gov) with your INL HPC username and password.
 
 Once authenticated in the OnDemand system, the top navigation bar has a menu item "NCRC". Clicking on this will show a dropdown menu that is populated with the NCRC apps that you have been granted level 1 access to. The following documentation is applicable for each level 1 NCRC application.
 
 ## Submission and Job Information
 
 ### Specifying a Project
+
 Every job submission is required to have a project specified. This is normally entered with the PBS "-P" option. However, you do not need to enter "-P" here, just the project name. Project names must be selected from the list on [HPC Web](http://hpcweb.hpc.inl.gov/home/pbs#specifying-a-project). If more than one project name is appropriate, use your best judgment to choose the most applicable project name. If no project name is available that is applicable to your job, use one of the general-purpose technical area job names, e.g., “ne_gen” for nuclear energy applications.
 
 ### Input File
@@ -25,11 +26,13 @@ You do not need the `app-opt -i` and you need the full path to your equivalent o
 ## Advanced Code and Input Settings
 
 ### Specific Version Hash
+
 This option allows you to run a specific build of the herd code. To get a list of the different version hashes that are allowed here, you can open a terminal on the appropriate cluster and run `module spider APP` and you will be presented with multiple versions of each herd application. 
 
 To get more information about each build, put `--help` or `-h` in the advanced parameters field below. Using the `--help` or `-h` flag will print the command help information to your output file and return.
 
 ### Advanced Parameters
+
 By default, your submission of this forms creates a basic submission command that gets submitted to the requested 
 cluster.
 
@@ -49,9 +52,11 @@ You are allowed to put more than one in this box. Everything that you put in thi
 To get a full list and more explanation on these command line options, please see the [command line usage documentation](https://mooseframework.inl.gov/application_usage/command_line_usage.html).
 
 ## Working Directory Information
+
 By default, your working directory is set to the same directory where your input file is located. You can change this if you would prefer a different directory by checking the checkbox and entering the new directory. You can also use the "Select Directory" button to get a file dialog box to select the directory instead of typing it out by hand.
 
 ## HPC Information
+
 The HPC information section is an interactive form to create your scheduler submission.
 
 - Select the cluster you wish to run on. The amount of resources and the time you may request for your submission for will depend on the cluster.
@@ -67,6 +72,7 @@ The HPC information section is an interactive form to create your scheduler subm
 | Sawtooth | 48                 | 168          |
 
 ### Advanced HPC Submission Settings
+
 By default, the scheduler decides how much memory to assign to the job if the amount of memory is not explicity provided. You can change this default behavior by clicking the "Show advanced HPC submission settings" checkbox and entering the amount of memory. 
 
 You can also select the max amount of memory for a node if you would like to use all of a node. Selecting all of the cores for a node also provides the max amount of memory.


### PR DESCRIPTION
## Reason
I was tasked with creating a documentation page that explains the binary access OnDemand forms that users can use to submit code to INL HPC systems.

## Design
Tried to follow the peacock documentation page as a guide while writing this documentation.

## Impact
This adds an additional documentation page.

