### PR TITLE
Do not construct solve objects in executioner base class

### DIFF
--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -131,6 +131,9 @@ protected:
   FEProblemBase & _problem;
   MooseEigenSystem & _eigen_sys;
 
+  /// dummy solve object for properly setting PETSc options
+  FEProblemSolve _feproblem_solve;
+
   /// Storage for the eigenvalue computed by the executioner
   PostprocessorValue & _eigenvalue;
 

--- a/framework/include/executioners/Eigenvalue.h
+++ b/framework/include/executioners/Eigenvalue.h
@@ -11,7 +11,7 @@
 
 #include "libmesh/libmesh_config.h"
 
-#include "Steady.h"
+#include "Executioner.h"
 
 class InputParameters;
 class Eigenvalue;
@@ -56,6 +56,11 @@ public:
    */
   virtual void checkIntegrity();
 
+  /**
+   * Get the number of grid sequencing steps
+   */
+  unsigned int numGridSteps() const { return _feproblem_solve.numGridSteps(); }
+
 private:
   /**
    * Prepare right petsc options
@@ -65,6 +70,10 @@ private:
 
 protected:
   EigenProblem & _eigen_problem;
+
+  /// inner-most solve object to perform Newton solve with SLEPc
+  FEProblemSolve _feproblem_solve;
+
   /// Postprocessor value that scales solution when eigensolve is finished
   const PostprocessorValue * const _normalization;
 

--- a/framework/include/executioners/Executioner.h
+++ b/framework/include/executioners/Executioner.h
@@ -116,9 +116,6 @@ public:
    */
   virtual bool lastSolveConverged() const = 0;
 
-  /// Return the underlining FEProblemSolve object.
-  FEProblemSolve & feProblemSolve() { return _feproblem_solve; }
-
   /// Return underlying PicardSolve object.
   PicardSolve & picardSolve()
   {
@@ -149,9 +146,10 @@ public:
   const bool & verbose() const { return _verbose; }
 
   /**
-   * Get the number of grid sequencing steps
+   * Return supported iteration methods that can work with MultiApps on timestep_begin and
+   * timestep_end
    */
-  unsigned int numGridSteps() const { return _num_grid_steps; }
+  static MooseEnum iterationMethods() { return MooseEnum("picard secant steffensen", "picard"); }
 
 protected:
   /**
@@ -165,8 +163,6 @@ protected:
 
   FEProblemBase & _fe_problem;
 
-  FEProblemSolve _feproblem_solve;
-
   MooseEnum _iteration_method;
   std::unique_ptr<FixedPointSolve> _fixed_point_solve;
 
@@ -175,12 +171,4 @@ protected:
 
   /// True if printing out additional information
   const bool & _verbose;
-
-  /// The number of steps to perform in a grid sequencing algorithm. This is one
-  /// less than the number of grids requested by the user in their input,
-  /// e.g. if they requested num_grids = 1, then there won't be any steps
-  /// because we only need to perform one solve per time-step. Storing this
-  /// member in this way allows for easy boolean operations, e.g. if (_num_grid_steps)
-  /// as opposed to if (_num_grids)
-  const unsigned int _num_grid_steps;
 };

--- a/framework/include/executioners/FEProblemSolve.h
+++ b/framework/include/executioners/FEProblemSolve.h
@@ -36,10 +36,23 @@ public:
     mooseError("Cannot set inner solve for FEProblemSolve");
   }
 
+  /**
+   * Return the number of grid sequencing steps
+   */
+  unsigned int numGridSteps() const { return _num_grid_steps; }
+
 protected:
   /// Splitting
   std::vector<std::string> _splitting;
 
   /// Moose provided line searches
   static std::set<std::string> const _moose_line_searches;
+
+  /// The number of steps to perform in a grid sequencing algorithm. This is one
+  /// less than the number of grids requested by the user in their input,
+  /// e.g. if they requested num_grids = 1, then there won't be any steps
+  /// because we only need to perform one solve per time-step. Storing this
+  /// member in this way allows for easy boolean operations, e.g. if (_num_grid_steps)
+  /// as opposed to if (_num_grids)
+  const unsigned int _num_grid_steps;
 };

--- a/framework/include/executioners/Steady.h
+++ b/framework/include/executioners/Steady.h
@@ -52,6 +52,8 @@ public:
 protected:
   FEProblemBase & _problem;
 
+  FEProblemSolve _feproblem_solve;
+
   Real _system_time;
   int & _time_step;
   Real & _time;

--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -204,9 +204,15 @@ public:
    */
   virtual void forceNumSteps(const unsigned int num_steps) { _num_steps = num_steps; }
 
+  /// Return the solve object wrapped by time stepper
+  virtual SolveObject * timeStepSolveObject() { return _fixed_point_solve.get(); }
+
 protected:
   /// Here for backward compatibility
   FEProblemBase & _problem;
+
+  /// inner-most solve object to perform Newton solve with PETSc on every time step
+  FEProblemSolve _feproblem_solve;
 
   /// Reference to nonlinear system base for faster access
   NonlinearSystemBase & _nl;

--- a/framework/src/actions/CreateExecutionerAction.C
+++ b/framework/src/actions/CreateExecutionerAction.C
@@ -56,7 +56,8 @@ CreateExecutionerAction::act()
                "EigenProblem, and Steady and Transient need a FEProblem");
 
   // If enabled, automatically create a Preconditioner if the [Preconditioning] block is not found
-  if (_auto_preconditioning && !_awh.hasActions("add_preconditioning"))
+  if (_auto_preconditioning && !_awh.hasActions("add_preconditioning") &&
+      _moose_object_pars.isParamValid("solve_type"))
     setupAutoPreconditioning();
 
   _app.setExecutioner(std::move(executioner));

--- a/framework/src/executioners/EigenExecutionerBase.C
+++ b/framework/src/executioners/EigenExecutionerBase.C
@@ -25,6 +25,8 @@ EigenExecutionerBase::validParams()
   InputParameters params = Executioner::validParams();
   params.addClassDescription("Executioner for eigenvalue problems.");
 
+  params += FEProblemSolve::validParams();
+
   params.addRequiredParam<PostprocessorName>("bx_norm", "To evaluate |Bx| for the eigenvalue");
   params.addParam<PostprocessorName>("normalization", "To evaluate |x| for normalization");
   params.addParam<Real>("normal_factor", "Normalize x to make |x| equal to this factor");
@@ -56,6 +58,7 @@ EigenExecutionerBase::EigenExecutionerBase(const InputParameters & parameters)
   : Executioner(parameters),
     _problem(_fe_problem),
     _eigen_sys(static_cast<MooseEigenSystem &>(_problem.getNonlinearSystemBase())),
+    _feproblem_solve(*this),
     _eigenvalue(addAttributeReporter("eigenvalue", getParam<Real>("k0"))),
     _source_integral(getPostprocessorValue("bx_norm")),
     _source_integral_old(1),

--- a/framework/src/timesteppers/TimeStepper.C
+++ b/framework/src/timesteppers/TimeStepper.C
@@ -160,7 +160,7 @@ TimeStepper::constrainStep(Real & dt)
 void
 TimeStepper::step()
 {
-  _converged = _executioner.fixedPointSolve().solve();
+  _converged = _executioner.timeStepSolveObject()->solve();
 }
 
 void

--- a/test/tests/geomsearch/patch_update_strategy/always-grid-sequence.i
+++ b/test/tests/geomsearch/patch_update_strategy/always-grid-sequence.i
@@ -56,7 +56,7 @@
     variable = receiver
     paired_variable = linear_field
     paired_boundary = rightleft
-    execute_on = timestep_end
+    execute_on = 'nonlinear timestep_end'
     boundary = leftright
   [../]
   [./y_displacement]

--- a/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
+++ b/test/tests/multiapps/picard_multilevel/2level_picard/mutilevel_app.i
@@ -69,6 +69,7 @@
   fixed_point_rel_tol = 1E-3
   fixed_point_abs_tol = 1.0e-05
   fixed_point_max_its = 2
+  accept_on_max_fixed_point_iteration = true
 []
 
 [MultiApps]

--- a/test/tests/multiapps/steffensen/steady_main.i
+++ b/test/tests/multiapps/steffensen/steady_main.i
@@ -63,6 +63,7 @@
   fixed_point_algorithm = 'steffensen'
   fixed_point_max_its = 30
   transformed_variables = 'u'
+  accept_on_max_fixed_point_iteration = true
 []
 
 [Outputs]


### PR DESCRIPTION
Close #18152.

This is more complicated than what I expected. Even though there are some code duplications, I think this is still the right design. This is needed by Griffin where there are custom executioners do not use `FEProblemSolve`.

While doing this, I moved some code in `Executioner` like grid sequencing and auto scaling into `FEProblemSolve`. I think this is the right thing to do because I do not think wrapping Picard iterations by grid sequencing is the design we want. @lindsayad if this is indeed intentional, I can revert it. Also because of this change, three tests need to be fixed. Two of them can be fixed by adding `accept_on_max_fixed_point_iteration` because now the code is not breaking the grid sequencing loop but the AMR loop causing one output skipped when the maximum number of fixed pointer iterations is hit. The other one I do not have much clue:
```
geomsearch/patch_update_strategy.always-grid-sequencing
```
It exodiffs with a variable `receiver` in the test on `always-grid-sequence_out.e-s002`. I will need @lindsayad 's help here.

This can be reviewed by @GiudGiud.
