### PR TITLE
Setting MOOSE_SKIP_DOCS env var triggers skipping docs install

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -458,9 +458,13 @@ $(binlink): all install_$(APPLICATION_NAME)_tests
 	@ln -s ../../../bin/$(notdir $(app_EXEC)) $@
 
 install_$(APPLICATION_NAME)_docs:
+ifeq ($(MOOSE_SKIP_DOCS),)
 	@echo "Installing docs"
 	@mkdir -p $(docs_install_dir)
 	@if [ -f "$(docs_dir)/moosedocs.py" ]; then cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir); fi
+else
+	@echo "Skipping docs installation."
+endif
 
 $(bindst): $(app_EXEC) all install_$(APPLICATION_NAME)_tests install_$(APPLICATION_NAME)_docs $(binlink)
 	@echo "Installing $<"


### PR DESCRIPTION
ref #14553

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
To allow installing/packaging of apps that have incomplete/broken docs setups

## Design
Just allow docs installation to be skipped by setting an env var (MOOSE_SKIP_DOCS).

## Impact
Nope - nobody should notice.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
