### PR TITLE
Account for moosetools in Docker image.  Fixes #17406.

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -10,13 +10,13 @@
 # arguments to be set using the --build-arg flag.  
 #
 # DISTRO_NAME: Optional.  Linux distribution (ubuntu, centos)
-# DISTRO_VERSION: Optional with above (18.04, 7 respectively)
+# DISTRO_VERSION: Optional with above (20.04, 8 respectively)
 # MOOSE_JOBS: Optional.  Sets number of cores for running make.
 # PETSC_REV: Commit hash of submodule petsc.
 # LIBMESH_REV: Commit hash of submodule libmesh.
 #-----------------------------------------------------------------------------#
 ARG DISTRO_NAME=ubuntu
-ARG DISTRO_VERSION=18.04
+ARG DISTRO_VERSION=20.04
 
 FROM ${DISTRO_NAME}:${DISTRO_VERSION}
 
@@ -106,6 +106,14 @@ git submodule update --init ; \
 cd .. ; \
 ./scripts/update_and_rebuild_libmesh.sh ; \
 rm -rf libmesh/* libmesh/.* || true
+
+#-----------------------------------------------------------------------------#
+ # Copy and build moosetools
+ #-----------------------------------------------------------------------------#
+ ARG MOOSETOOLS_REV
+ RUN git clone https://github.com/idaholab/moosetools.git ; \
+ cd moosetools ; \
+ git checkout ${MOOSETOOLS_REV}
 
 #-----------------------------------------------------------------------------#
 # Copy and build MOOSE framework and tests

--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
                 --build-arg MOOSE_JOBS=$(grep -c ^processor /proc/cpuinfo) \
                 --build-arg PETSC_REV=$(sub_rev petsc) \
                 --build-arg LIBMESH_REV=$(sub_rev libmesh) \
+                --build-arg MOOSETOOLS_REV=$(sub_rev moosetools) \
                 -f "$WORKSPACE/docker_ci/Dockerfile" \
                 -t $DOCKER_TAG .
                 '''


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
Our down-stream herd codes need this to run tests.  Also, due to image layering, we have to explicitly add Git submodules to the image before adding MOOSE.  This enables use of Docker's image caching so long as prior layers haven't changed, which means not rebuilding things like LibMesh and PETSc unless they have changed.  

## Design
<!--A concise description (design) of the enhancement.-->
Added inclusion of submodule `moosetools` to `Dockerfile` and `Jenkinsfile` in directory `docker_ci`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No change to the framework.  Closes #17406.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
