### PR TITLE
Optimize eigen decomposition for Hill tensor

### DIFF
--- a/modules/tensor_mechanics/include/materials/ADGeneralizedRadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADGeneralizedRadialReturnStressUpdate.h
@@ -113,6 +113,11 @@ public:
    */
   bool requiresIsotropicTensor() override { return true; }
 
+  /**
+   * Check if an anisotropic matrix is block diagonal
+   */
+  bool isBlockDiagonal(const AnisotropyMatrixReal & A);
+
 protected:
   virtual void initQpStatefulProperties() override;
 

--- a/modules/tensor_mechanics/include/materials/ADGeneralizedRadialReturnStressUpdate.h
+++ b/modules/tensor_mechanics/include/materials/ADGeneralizedRadialReturnStressUpdate.h
@@ -37,6 +37,7 @@ struct cast_impl<ADReal, int>
 // typedef Eigen::Matrix<ADReal, 6, 6, Eigen::DontAlign> AnisotropyMatrix;
 
 typedef Eigen::Matrix<Real, 6, 6, Eigen::DontAlign> AnisotropyMatrixReal;
+typedef Eigen::Matrix<Real, 3, 3, Eigen::DontAlign> AnisotropyMatrixRealBlock;
 
 /**
  * ADGeneralizedRadialReturnStressUpdate computes the generalized radial return stress increment for

--- a/modules/tensor_mechanics/src/materials/ADGeneralizedRadialReturnStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADGeneralizedRadialReturnStressUpdate.C
@@ -179,3 +179,17 @@ ADGeneralizedRadialReturnStressUpdate::outputIterationSummary(std::stringstream 
   }
   ADGeneralizedReturnMappingSolution::outputIterationSummary(iter_output, total_it);
 }
+
+bool
+ADGeneralizedRadialReturnStressUpdate::isBlockDiagonal(const AnisotropyMatrixReal & A)
+{
+  AnisotropyMatrixRealBlock A_bottom_left(A.block<3, 3>(0, 3));
+  AnisotropyMatrixRealBlock A_top_right(A.block<3, 3>(3, 0));
+
+  for (unsigned int index_i = 0; index_i < 3; index_i++)
+    for (unsigned int index_j = 0; index_j < 3; index_j++)
+      if (A_bottom_left(index_i, index_j) != 0 || A_top_right(index_i, index_j) != 0)
+        return false;
+
+  return true;
+}

--- a/modules/tensor_mechanics/src/materials/ADHillElastoPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADHillElastoPlasticityStressUpdate.C
@@ -201,16 +201,40 @@ ADHillElastoPlasticityStressUpdate::computeElasticityTensorEigenDecomposition()
     for (unsigned int index_j = 0; index_j < dimension; index_j++)
       B_eigen(index_i, index_j) = MetaPhysicL::raw_value(b_matrix(index_i, index_j));
 
-  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixReal> es_b(B_eigen);
+  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_left(B_eigen.block<3, 3>(0, 0));
+  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_right(B_eigen.block<3, 3>(3, 3));
 
-  auto lambda_b = es_b.eigenvalues();
-  auto v_b = es_b.eigenvectors();
-  for (unsigned int index_i = 0; index_i < dimension; index_i++)
-    _b_eigenvalues[_qp](index_i) = lambda_b(index_i);
+  auto lambda_b_left = es_b_left.eigenvalues();
+  auto v_b_left = es_b_left.eigenvectors();
 
-  for (unsigned int index_i = 0; index_i < dimension; index_i++)
-    for (unsigned int index_j = 0; index_j < dimension; index_j++)
-      _b_eigenvectors[_qp](index_i, index_j) = v_b(index_i, index_j);
+  auto lambda_b_right = es_b_right.eigenvalues();
+  auto v_b_right = es_b_right.eigenvectors();
+
+  _b_eigenvalues[_qp](0) = lambda_b_left(0);
+  _b_eigenvalues[_qp](1) = lambda_b_left(1);
+  _b_eigenvalues[_qp](2) = lambda_b_left(2);
+  _b_eigenvalues[_qp](3) = lambda_b_right(0);
+  _b_eigenvalues[_qp](4) = lambda_b_right(1);
+  _b_eigenvalues[_qp](5) = lambda_b_right(2);
+
+  _b_eigenvectors[_qp](0, 0) = v_b_left(0, 0);
+  _b_eigenvectors[_qp](0, 1) = v_b_left(0, 1);
+  _b_eigenvectors[_qp](0, 2) = v_b_left(0, 2);
+  _b_eigenvectors[_qp](1, 0) = v_b_left(1, 0);
+  _b_eigenvectors[_qp](1, 1) = v_b_left(1, 1);
+  _b_eigenvectors[_qp](1, 2) = v_b_left(1, 2);
+  _b_eigenvectors[_qp](2, 0) = v_b_left(2, 0);
+  _b_eigenvectors[_qp](2, 1) = v_b_left(2, 1);
+  _b_eigenvectors[_qp](2, 2) = v_b_left(2, 2);
+  _b_eigenvectors[_qp](3, 3) = v_b_right(0, 0);
+  _b_eigenvectors[_qp](3, 4) = v_b_right(0, 1);
+  _b_eigenvectors[_qp](3, 5) = v_b_right(0, 2);
+  _b_eigenvectors[_qp](4, 3) = v_b_right(1, 0);
+  _b_eigenvectors[_qp](4, 4) = v_b_right(1, 1);
+  _b_eigenvectors[_qp](4, 5) = v_b_right(1, 2);
+  _b_eigenvectors[_qp](5, 3) = v_b_right(2, 0);
+  _b_eigenvectors[_qp](5, 4) = v_b_right(2, 1);
+  _b_eigenvectors[_qp](5, 5) = v_b_right(2, 2);
 
   _alpha_matrix[_qp] = sqrt_Delta;
   _alpha_matrix[_qp].right_multiply(_b_eigenvectors[_qp]);

--- a/modules/tensor_mechanics/src/materials/ADHillElastoPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADHillElastoPlasticityStressUpdate.C
@@ -201,40 +201,56 @@ ADHillElastoPlasticityStressUpdate::computeElasticityTensorEigenDecomposition()
     for (unsigned int index_j = 0; index_j < dimension; index_j++)
       B_eigen(index_i, index_j) = MetaPhysicL::raw_value(b_matrix(index_i, index_j));
 
-  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_left(B_eigen.block<3, 3>(0, 0));
-  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_right(B_eigen.block<3, 3>(3, 3));
+  if (isBlockDiagonal(B_eigen))
+  {
+    Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_left(B_eigen.block<3, 3>(0, 0));
+    Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es_b_right(B_eigen.block<3, 3>(3, 3));
 
-  auto lambda_b_left = es_b_left.eigenvalues();
-  auto v_b_left = es_b_left.eigenvectors();
+    auto lambda_b_left = es_b_left.eigenvalues();
+    auto v_b_left = es_b_left.eigenvectors();
 
-  auto lambda_b_right = es_b_right.eigenvalues();
-  auto v_b_right = es_b_right.eigenvectors();
+    auto lambda_b_right = es_b_right.eigenvalues();
+    auto v_b_right = es_b_right.eigenvectors();
 
-  _b_eigenvalues[_qp](0) = lambda_b_left(0);
-  _b_eigenvalues[_qp](1) = lambda_b_left(1);
-  _b_eigenvalues[_qp](2) = lambda_b_left(2);
-  _b_eigenvalues[_qp](3) = lambda_b_right(0);
-  _b_eigenvalues[_qp](4) = lambda_b_right(1);
-  _b_eigenvalues[_qp](5) = lambda_b_right(2);
+    _b_eigenvalues[_qp](0) = lambda_b_left(0);
+    _b_eigenvalues[_qp](1) = lambda_b_left(1);
+    _b_eigenvalues[_qp](2) = lambda_b_left(2);
+    _b_eigenvalues[_qp](3) = lambda_b_right(0);
+    _b_eigenvalues[_qp](4) = lambda_b_right(1);
+    _b_eigenvalues[_qp](5) = lambda_b_right(2);
 
-  _b_eigenvectors[_qp](0, 0) = v_b_left(0, 0);
-  _b_eigenvectors[_qp](0, 1) = v_b_left(0, 1);
-  _b_eigenvectors[_qp](0, 2) = v_b_left(0, 2);
-  _b_eigenvectors[_qp](1, 0) = v_b_left(1, 0);
-  _b_eigenvectors[_qp](1, 1) = v_b_left(1, 1);
-  _b_eigenvectors[_qp](1, 2) = v_b_left(1, 2);
-  _b_eigenvectors[_qp](2, 0) = v_b_left(2, 0);
-  _b_eigenvectors[_qp](2, 1) = v_b_left(2, 1);
-  _b_eigenvectors[_qp](2, 2) = v_b_left(2, 2);
-  _b_eigenvectors[_qp](3, 3) = v_b_right(0, 0);
-  _b_eigenvectors[_qp](3, 4) = v_b_right(0, 1);
-  _b_eigenvectors[_qp](3, 5) = v_b_right(0, 2);
-  _b_eigenvectors[_qp](4, 3) = v_b_right(1, 0);
-  _b_eigenvectors[_qp](4, 4) = v_b_right(1, 1);
-  _b_eigenvectors[_qp](4, 5) = v_b_right(1, 2);
-  _b_eigenvectors[_qp](5, 3) = v_b_right(2, 0);
-  _b_eigenvectors[_qp](5, 4) = v_b_right(2, 1);
-  _b_eigenvectors[_qp](5, 5) = v_b_right(2, 2);
+    _b_eigenvectors[_qp](0, 0) = v_b_left(0, 0);
+    _b_eigenvectors[_qp](0, 1) = v_b_left(0, 1);
+    _b_eigenvectors[_qp](0, 2) = v_b_left(0, 2);
+    _b_eigenvectors[_qp](1, 0) = v_b_left(1, 0);
+    _b_eigenvectors[_qp](1, 1) = v_b_left(1, 1);
+    _b_eigenvectors[_qp](1, 2) = v_b_left(1, 2);
+    _b_eigenvectors[_qp](2, 0) = v_b_left(2, 0);
+    _b_eigenvectors[_qp](2, 1) = v_b_left(2, 1);
+    _b_eigenvectors[_qp](2, 2) = v_b_left(2, 2);
+    _b_eigenvectors[_qp](3, 3) = v_b_right(0, 0);
+    _b_eigenvectors[_qp](3, 4) = v_b_right(0, 1);
+    _b_eigenvectors[_qp](3, 5) = v_b_right(0, 2);
+    _b_eigenvectors[_qp](4, 3) = v_b_right(1, 0);
+    _b_eigenvectors[_qp](4, 4) = v_b_right(1, 1);
+    _b_eigenvectors[_qp](4, 5) = v_b_right(1, 2);
+    _b_eigenvectors[_qp](5, 3) = v_b_right(2, 0);
+    _b_eigenvectors[_qp](5, 4) = v_b_right(2, 1);
+    _b_eigenvectors[_qp](5, 5) = v_b_right(2, 2);
+  }
+  else
+  {
+    Eigen::SelfAdjointEigenSolver<AnisotropyMatrixReal> es_b(B_eigen);
+
+    auto lambda_b = es_b.eigenvalues();
+    auto v_b = es_b.eigenvectors();
+    for (unsigned int index_i = 0; index_i < dimension; index_i++)
+      _b_eigenvalues[_qp](index_i) = lambda_b(index_i);
+
+    for (unsigned int index_i = 0; index_i < dimension; index_i++)
+      for (unsigned int index_j = 0; index_j < dimension; index_j++)
+        _b_eigenvectors[_qp](index_i, index_j) = v_b(index_i, index_j);
+  }
 
   _alpha_matrix[_qp] = sqrt_Delta;
   _alpha_matrix[_qp].right_multiply(_b_eigenvectors[_qp]);

--- a/modules/tensor_mechanics/src/materials/ADHillPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/ADHillPlasticityStressUpdate.C
@@ -218,16 +218,30 @@ ADHillPlasticityStressUpdate::computeHillTensorEigenDecomposition(const ADDenseM
     for (unsigned int index_j = 0; index_j < dimension; index_j++)
       A(index_i, index_j) = MetaPhysicL::raw_value(hill_tensor(index_i, index_j));
 
-  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixReal> es(A);
+  Eigen::SelfAdjointEigenSolver<AnisotropyMatrixRealBlock> es(A.block<3, 3>(0, 0));
 
   auto lambda = es.eigenvalues();
   auto v = es.eigenvectors();
-  for (unsigned int index_i = 0; index_i < dimension; index_i++)
-    _eigenvalues_hill(index_i) = lambda(index_i);
 
-  for (unsigned int index_i = 0; index_i < dimension; index_i++)
-    for (unsigned int index_j = 0; index_j < dimension; index_j++)
-      _eigenvectors_hill(index_i, index_j) = v(index_i, index_j);
+  _eigenvalues_hill(0) = lambda(0);
+  _eigenvalues_hill(1) = lambda(1);
+  _eigenvalues_hill(2) = lambda(2);
+  _eigenvalues_hill(3) = A(3, 3);
+  _eigenvalues_hill(4) = A(4, 4);
+  _eigenvalues_hill(5) = A(5, 5);
+
+  _eigenvectors_hill(0, 0) = v(0, 0);
+  _eigenvectors_hill(0, 1) = v(0, 1);
+  _eigenvectors_hill(0, 2) = v(0, 2);
+  _eigenvectors_hill(1, 0) = v(1, 0);
+  _eigenvectors_hill(1, 1) = v(1, 1);
+  _eigenvectors_hill(1, 2) = v(1, 2);
+  _eigenvectors_hill(2, 0) = v(2, 0);
+  _eigenvectors_hill(2, 1) = v(2, 1);
+  _eigenvectors_hill(2, 2) = v(2, 2);
+  _eigenvectors_hill(3, 3) = 1.0;
+  _eigenvectors_hill(4, 4) = 1.0;
+  _eigenvectors_hill(5, 5) = 1.0;
 }
 
 ADReal


### PR DESCRIPTION
- Optimizes the eigen decomposition in the Hill tensor material classes. 
- Utilizes the block diagonal decomposition approach. 

Refs #16016 
