### PR TITLE
Avoid deprecated MeshFunction::init() overload

### DIFF
--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -250,7 +250,7 @@ MultiAppMeshFunctionTransfer::transferVariable(unsigned int i)
                                        *from_sys.current_local_solution,
                                        from_sys.get_dof_map(),
                                        from_var_num));
-    from_func->init(Trees::ELEMENTS);
+    from_func->init();
     from_func->enable_out_of_mesh_mode(OutOfMeshValue);
     local_meshfuns.push_back(from_func);
   }

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -332,7 +332,7 @@ MultiAppProjectionTransfer::execute()
 
     MeshFunction * from_func = new MeshFunction(
         from_problem.es(), *from_sys.current_local_solution, from_sys.get_dof_map(), from_var_num);
-    from_func->init(Trees::ELEMENTS);
+    from_func->init();
     from_func->enable_out_of_mesh_mode(OutOfMeshValue);
     local_meshfuns[i_from] = from_func;
   }


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

This fixes run-time errors (which should have been a compile-time
error...) with --disable-deprecated libMesh builds.

## Design
<!--A concise description (design) of the enhancement.-->

We were never really respecting that tree option in libMesh, so we
stopped supporting it, and deprecated the init overload using it.  New codes
should be using the default init() with no arguments.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

No effect for --enable-deprecated libMesh builds; the elements option being removed here
corresponds to the new (and old) default init behavior.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->

Refs #13921
