### PR TITLE
Minor updates to validation schema used by NEAMS Workbench

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -814,7 +814,8 @@ MooseApp::setupOptions()
     JsonSyntaxTree tree("");
     _parser.buildJsonSyntaxTree(tree);
     SONDefinitionFormatter formatter;
-    Moose::out << formatter.toString(tree.getRoot()) << "\n";
+    Moose::out << "%-START-SON-DEFINITION-%\n"
+               << formatter.toString(tree.getRoot()) << "\n%-END-SON-DEFINITION-%\n";
     _ready_to_exit = true;
   }
   else if (isParamValid("yaml"))

--- a/framework/src/outputs/formatters/SONDefinitionFormatter.C
+++ b/framework/src/outputs/formatters/SONDefinitionFormatter.C
@@ -118,7 +118,7 @@ SONDefinitionFormatter::addBlock(const std::string & block_name,
   // also ensure that the block [./declarator] is the expected block_decl from above
   addLine("decl{");
   _level++;
-  addLine("MinOccurs=1");
+  addLine("MinOccurs=0");
   addLine("MaxOccurs=1");
   addLine("ValType=String");
   if (!is_starblock)
@@ -290,7 +290,7 @@ SONDefinitionFormatter::addParameters(const nlohmann::json & params)
     std::string basic_type = param["basic_type"];
     bool is_array = false;
     if (cpp_type == "FunctionExpression" || cpp_type == "FunctionName" ||
-        basic_type.compare(0, 6, "Array:") == 0)
+        basic_type.compare(0, 6, "Array:") == 0 || cpp_type.compare(0, 13, "Eigen::Matrix") == 0)
       is_array = true;
     pcrecpp::RE(".+<([A-Za-z0-9_' ':]*)>.*").GlobalReplace("\\1", &cpp_type);
     pcrecpp::RE("(Array:)*(.*)").GlobalReplace("\\2", &basic_type);
@@ -310,7 +310,7 @@ SONDefinitionFormatter::addParameters(const nlohmann::json & params)
       bool required = param["required"];
       if (required && def.empty())
         addLine("ChildAtLeastOne=[ \"" + backtrack(_level) + "GlobalParams/" + name +
-                "/value\"   \"" + name + "/value\"" + " ]");
+                "/value\"   \"" + name + "\" ]");
     }
 
     // *** open parameter

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -397,4 +397,18 @@
     design = 'SONDefinitionFormatter.md'
     valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]
+
+  [./definition_scraping_markers]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '%-START-SON-DEFINITION-%.*?%-END-SON-DEFINITION-%'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#17324'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check beginning and ending markers'
+    design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
+  [../]
 []

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -233,7 +233,7 @@
   [./definition_childatleastone_test]
     type = 'RunApp'
     input = 'IGNORED'
-    expect_out = 'ChildAtLeastOne=\[\s*?"../../../GlobalParams/inside/value"\s*?"inside/value"\s*?\]'
+    expect_out = 'ChildAtLeastOne=\[\s*?"../../../GlobalParams/inside/value"\s*?"inside"\s*?\]'
     cli_args = '--definition'
     # suppress error checking, the word 'ERROR' shows up in the definition dump
     errors = 'zzzzzzzzzz'
@@ -366,6 +366,34 @@
     max_buffer_size = -1
     issues = '#14277'
     requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Array type MinOccurs zero'
+    design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
+  [../]
+
+  [./definition_declarator_minoccurs_zero_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'Variables\'{.*?InputDefault="Variables".*?decl{.*?MinOccurs=0.*?ValEnums=\[ "Variables" \].*?}.*?\'active\'{.*?} % end parameter active.*?} % end block Variables'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#17324'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check declarator MinOccurs zero'
+    design = 'SONDefinitionFormatter.md'
+    valgrind = 'NONE' # Tested in "definition_input_choices_test"
+  [../]
+
+  [./definition_eigen_matrix_type_maxoccurs_nolimit_test]
+    type = 'RunApp'
+    input = 'IGNORED'
+    expect_out = '\'prop_value\'{.*?InputTmpl=MooseParam.*?InputType=key_array.*?\'value\'{.*?MinOccurs=0.*?MaxOccurs=NoLimit.*?}.*?} % end parameter prop_value'
+    cli_args = '--definition'
+    # suppress error checking, the word 'ERROR' shows up in the definition dump
+    errors = 'zzzzzzzzzz'
+    max_buffer_size = -1
+    issues = '#17324'
+    requirement = 'MOOSE shall be able to convert a JsonSyntaxTree into Standard Object Notation (SON) for use by the NEAMS workbench. Check Eigen::Matrix type MaxOccurs NoLimit'
     design = 'SONDefinitionFormatter.md'
     valgrind = 'NONE' # Tested in "definition_input_choices_test"
   [../]


### PR DESCRIPTION
Update SONDefinitionFormatter for NEAMS Workbench (Closes #17324)

  - Remove declarator requirement by changing MinOccurs=1 to MinOccurs=0
  - Change MaxOccurs=1 to MaxOccurs=NoLimit on Eigen::Matrix type values
  - Point ChildAtLeastOne rule paths at parent rather than value context
    
Update NEAMS schema print for consistent scraping (Closes #17395)

  - Add markers to --definition dump to assist header and banner removal
