### PR TITLE
Install adreal monolithic header for jit in conda packages

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -383,7 +383,11 @@ moose_share_dir = $(share_dir)/moose
 python_install_dir = $(moose_share_dir)/python
 bin_install_dir = $(PREFIX)/bin
 
-install: install_libs install_bin install_harness install_exodiff
+install: install_libs install_bin install_harness install_exodiff install_adreal_monolith
+
+install_adreal_monolith: ADRealMonolithic.h
+	@ mkdir -p $(moose_include_dir)
+	@cp -f $< $(moose_include_dir)/
 
 install_exodiff: all
 	@echo "Installing exodiff"
@@ -485,9 +489,9 @@ clobberall: clobber
           echo $$item >> .clang_complete;  \
         done
 
-ADRealMonolithic.h:
+ADRealMonolithic.h: $(MOOSE_DIR)/framework/include/utils/ADReal.h
 	@echo "Building monolithic ADReal header for JIT compilation"
-	@$(libmesh_CXX) -E $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -imacros cmath -x c++-header $(MOOSE_DIR)/framework/include/utils/ADReal.h > ADRealMonolithic.h
+	@$(libmesh_CXX) -E $(libmesh_CPPFLAGS) $(CXXFLAGS) $(libmesh_CXXFLAGS) $(app_INCLUDES) $(libmesh_INCLUDE) -imacros cmath -x c++-header $< > $@
 
 compile_commands_all_srcfiles := $(moose_srcfiles) $(srcfiles)
 compile_commands.json:


### PR DESCRIPTION
Ties mods in #17902 into the installation target.

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
So necessary headers are installed that we need for jit to work in installed environments (e.g. conda packages).

## Design
Just install a header needed for fparser jit stuff at runtime.

## Impact
no api breakage.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
