### PR TITLE
Allow timestepper to control step tolerance. Refs #18334

### DIFF
--- a/framework/include/executioners/Transient.h
+++ b/framework/include/executioners/Transient.h
@@ -180,6 +180,12 @@ public:
   Real & timestepTol() { return _timestep_tolerance; }
 
   /**
+   * Set the timestep tolerance
+   * @param tolerance timestep tolerance
+   */
+  virtual void setTimestepTolerance(const Real & tolerance) { _timestep_tolerance = tolerance; }
+
+  /**
    * Is the current step at a sync point (sync times, time interval, target time, etc)?
    * @return Bool indicataing whether we are at a sync point
    */


### PR DESCRIPTION
## Reason
Allow timestepper to adjust timestep tolerance in executioner. This is a small interface change - if you still prefer that we set the timestep tolerance through the input file, that's fine too - this would just streamline our model setup by preventing tiny time steps derailing a Cardinal simulation.

Closes #18334

## Design
Added interface function for setting timestep tolerance.

## Impact
No forseeable impact except allowing Cardinal to set a higher timestep tolerance default.