### PR TITLE
map to unordered_map for augmenting sparsity

### DIFF
--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -274,9 +274,9 @@ public:
   /**
    * Finds the implicit sparsity graph between geometrically related dofs.
    */
-  void
-  findImplicitGeometricCouplingEntries(GeometricSearchData & geom_search_data,
-                                       std::map<dof_id_type, std::vector<dof_id_type>> & graph);
+  void findImplicitGeometricCouplingEntries(
+      GeometricSearchData & geom_search_data,
+      std::unordered_map<dof_id_type, std::vector<dof_id_type>> & graph);
 
   /**
    * Adds entries to the Jacobian in the correct positions for couplings coming from dofs being

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -272,13 +272,6 @@ public:
   void computeResidual(NumericVector<Number> & residual, TagID tag_id);
 
   /**
-   * Finds the implicit sparsity graph between geometrically related dofs.
-   */
-  void findImplicitGeometricCouplingEntries(
-      GeometricSearchData & geom_search_data,
-      std::unordered_map<dof_id_type, std::vector<dof_id_type>> & graph);
-
-  /**
    * Adds entries to the Jacobian in the correct positions for couplings coming from dofs being
    * coupled that
    * are related geometrically (i.e. near each other across a gap).
@@ -945,6 +938,13 @@ protected:
   DiagonalMatrix<Number> _scaling_matrix;
 
 private:
+  /**
+   * Finds the implicit sparsity graph between geometrically related dofs.
+   */
+  void findImplicitGeometricCouplingEntries(
+      GeometricSearchData & geom_search_data,
+      std::unordered_map<dof_id_type, std::vector<dof_id_type>> & graph);
+
   /**
    * Setup group scaling containers
    */

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1732,7 +1732,8 @@ NonlinearSystemBase::getNodeDofs(dof_id_type node_id, std::vector<dof_id_type> &
 
 void
 NonlinearSystemBase::findImplicitGeometricCouplingEntries(
-    GeometricSearchData & geom_search_data, std::map<dof_id_type, std::vector<dof_id_type>> & graph)
+    GeometricSearchData & geom_search_data,
+    std::unordered_map<dof_id_type, std::vector<dof_id_type>> & graph)
 {
   std::map<std::pair<unsigned int, unsigned int>, NearestNodeLocator *> & nearest_node_locators =
       geom_search_data._nearest_node_locators;
@@ -1850,14 +1851,14 @@ NonlinearSystemBase::addImplicitGeometricCouplingEntries(GeometricSearchData & g
   // this work with tag system
   auto & jacobian = getMatrix(systemMatrixTag());
 
-  std::map<dof_id_type, std::vector<dof_id_type>> graph;
+  std::unordered_map<dof_id_type, std::vector<dof_id_type>> graph;
 
   findImplicitGeometricCouplingEntries(geom_search_data, graph);
 
   for (const auto & it : graph)
   {
     dof_id_type dof = it.first;
-    const std::vector<dof_id_type> & row = it.second;
+    const auto & row = it.second;
 
     for (const auto & coupled_dof : row)
       jacobian.add(dof, coupled_dof, 0);
@@ -3031,7 +3032,7 @@ NonlinearSystemBase::augmentSparsity(SparsityPattern::Graph & sparsity,
   {
     _fe_problem.updateGeomSearch();
 
-    std::map<dof_id_type, std::vector<dof_id_type>> graph;
+    std::unordered_map<dof_id_type, std::vector<dof_id_type>> graph;
 
     findImplicitGeometricCouplingEntries(_fe_problem.geomSearchData(), graph);
 
@@ -3054,7 +3055,7 @@ NonlinearSystemBase::augmentSparsity(SparsityPattern::Graph & sparsity,
       if (dof < first_dof_on_proc || dof >= end_dof_on_proc)
         continue;
 
-      const std::vector<dof_id_type> & row = git.second;
+      const auto & row = git.second;
 
       SparsityPattern::Row & sparsity_row = sparsity[local_dof];
 


### PR DESCRIPTION
`std::map::operator[]` was really punishing us in profiling so I think
it makes sense to switch to a container whose lookup is on average
constant instead of log(N).

On a case given to me by @snschune the change here took me from

![dont-solve](https://user-images.githubusercontent.com/10248304/125847219-41df539f-ee93-4044-9fa4-3504b8f35dc9.png)

to

![half-change-structs](https://user-images.githubusercontent.com/10248304/125847232-446fec93-43fa-4599-bc2b-5ed1ced030d4.png)

which is a 35% reduction in the timing of `NonlinearSystemBase::findImplicitGeoemtricCouplingEntries`

Refs #18353

