### PR TITLE
Put --no-as-needed in linker flags

### DIFF
--- a/framework/build.mk
+++ b/framework/build.mk
@@ -54,6 +54,22 @@ else
 endif
 endif
 
+# Google Test relies on static construction of objects in test
+# compilation units to register those tests, but with some Linux
+# distributions (Ubuntu 21.04 for me; others in
+# https://github.com/idaholab/moose/issues/16092 ) shared libraries
+# don't get loaded by default (and thus don't call constructors of
+# static objects by default) unless the shared library satisfies a
+# missing symbol, or unless we force it to load with a special linker
+# flag.  The flag may require GCC or GNU ld, and if we don't support
+# it it's not safe to use it, so test first.
+NO_AS_NEEDED_FLAG = -Wl,--no-as-needed
+HAVE_NO_AS_NEEDED := $(shell echo 'int main(void){return 0;}' > as_needed_test.C; if $(libmesh_CXX) $(NO_AS_NEEDED_FLAG) as_needed_test.C -o as_needed_test.x 2>/dev/null; then echo yes; else echo no; fi; rm -f as_needed_test.C as_needed_test.x)
+
+ifeq ($(HAVE_NO_AS_NEEDED),yes)
+  libmesh_LDFLAGS += $(NO_AS_NEEDED_FLAG)
+endif
+
 # Make.common used to provide an obj-suffix which was related to the
 # machine in question (from config.guess, i.e. @host@ in
 # contrib/utils/Make.common.in) and the $(METHOD).


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

This fixes #16092 for me on Ubuntu 21.04, where presumably the default linker behavior is --as-needed?  As explained in that ticket: when we only interact with a library by invoking the constructors of its static initialized objects, --as-needed breaks our interaction by failing to determine that the library has to be loaded at all.

## Design
<!--A concise description (design) of the enhancement.-->

Passing --no-as-needed to the linker tells it not to use missing/provided symbols to determine a shared library is "needed", and just to load every linked library.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

There's a chance this will cause problems on linkers other than GNU ld.  I'm not sure how widely the --no-as-needed option has been adopted.



<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
