### PR TITLE
Update conda to clang 12.0.1

### DIFF
--- a/conda/compilers/meta.yaml
+++ b/conda/compilers/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.12.17" %}
+{% set version = "2021.07.23" %}
 {% set strbuild = "build_" + build|string %}
 
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
@@ -28,7 +28,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm11 {{ libllvm }}                # [osx]
+    - libllvm12 {{ libllvm }}                # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 7 %}
+{% set build = 8 %}
 {% set strbuild = "build_" + build|string %}
 {% set vtk_version = "6.3.0" %}
 {% set friendly_version = "6.3" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2021.07.14" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,10 +2,10 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - 2021.07.14 build_0
+  - 2021.07.14 build_1
 
 moose_petsc:
-  - 3.15.1 build_2
+  - 3.15.1 build_3
 
 SHORT_VTK_NAME:
   - 6.3
@@ -14,10 +14,10 @@ vtk_version:
   - 6.3.0
 
 moose_libmesh_vtk:
-  - 6.3.0 build_7
+  - 6.3.0 build_8
 
 moose_mpich:
-  - 3.3.2 build_7
+  - 3.3.2 build_8
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 python:
@@ -165,37 +165,37 @@ zip_keys:
 
 #### Changes to the following require extensive testing
 libllvm:
-  - 11.0.0 hf85e3d2_0
+  - 12.0.1 hd011deb_0
 
 libclang:
-  - 11.0.0 default_h9e6edd0_2
+  - 12.0.1 default_he082bbe_0
 
 compilerrt:
-  - 11.0.0 h01488ec_2
+  - 12.0.1 he01351e_0
 
 compilerrtosx:
-  - 11.0.0 hd3c4e95_2
+  - 12.0.1 hd3f61c9_0
 
 clangxx:
-  - 11.0.0 default_h9e6edd0_2
+  - 12.0.1 default_he082bbe_0
 
 clangosx:
-  - 11.0.0 hb91bd55_5
+  - 12.0.1 hb91bd55_0
 
 clangxxosx:
-  - 11.0.0 h7e1b574_5
+  - 12.0.1 h7e1b574_0
 
 clang:
-  - 11.0.0 h694c41f_2
+  - 12.0.1 h694c41f_0
 
 llvmopenmp:
-  - 11.0.0 h73239a0_1
+  - 12.0.1 hda6cdc1_0
 
 osxfortran:
-  - 7.3.0 h22b1bf0_7
+  - 9.3.0 h18f7dce_14
 
 libcxx:
-  - 11.0.0 h4c3b8ed_1
+  - 12.0.1 habf9029_0
 
 gcc:
   - 9.3.0 h7247604_29
@@ -210,16 +210,16 @@ gccimpl:
   - 9.3.0 h28f5a38_17
 
 libblas:
-  - 3.9.0 8_openblas
+  - 3.9.0 9_openblas
 
 libcblas:
-  - 3.9.0 8_openblas
+  - 3.9.0 9_openblas
 
 liblapack:
-  - 3.9.0 8_openblas
+  - 3.9.0 9_openblas
 
 libopenblas:
-  - 0.3.12 openmp_h63d9170_1
+  - 0.3.15 openmp_h5e1b9a4_1
 
 libglu:
   - 9.0.0 hf484d3e_1000

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 7 %}
+{% set build = 8 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.3.2" %}
 
@@ -30,7 +30,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm11 {{ libllvm }}                # [osx]
+    - libllvm12 {{ libllvm }}                # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]
@@ -49,7 +49,7 @@ requirements:
     - clangxx_osx-64 {{ clangxxosx }}        # [osx]
     - compiler-rt {{ compilerrt }}           # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }} # [osx]
-    - libllvm11 {{ libllvm }}                # [osx]
+    - libllvm12 {{ libllvm }}                # [osx]
     - clang-tools                            # [osx]
     - llvm-openmp {{ llvmopenmp }}           # [osx]
     - gfortran_osx-64 {{ osxfortran }}       # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.15.1" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2021.07.15" %}
+{% set version = "2021.07.23" %}
 
 package:
   name: moose-pyhit

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2021.07.14" %}
+{% set version = "2021.07.23" %}
 
 package:
   name: moose-tools
@@ -26,7 +26,7 @@ requirements:
     - clangxx_osx-64     {{ clangxxosx }}     # [osx]
     - compiler-rt        {{ compilerrt }}     # [osx]
     - compiler-rt_osx-64 {{ compilerrtosx }}  # [osx]
-    - libllvm11          {{ libllvm }}        # [osx]
+    - libllvm12          {{ libllvm }}        # [osx]
     - clang-tools                             # [osx]
     - llvm-openmp        {{ llvmopenmp }}     # [osx]
     - gfortran_osx-64    {{ osxfortran }}     # [osx]


### PR DESCRIPTION
Taking advantage of CIVET to test an update to clang 12.0.1 for the conda packages, so that they can properly function with Xcode / CLT 12.5.

Refs #16291