### PR TITLE
Reset _prev_elem cache when mesh changes

### DIFF
--- a/framework/include/variables/MooseVariableDataFV.h
+++ b/framework/include/variables/MooseVariableDataFV.h
@@ -11,6 +11,7 @@
 
 #include "MooseArray.h"
 #include "MooseTypes.h"
+#include "MeshChangedInterface.h"
 
 #include "libmesh/tensor_tools.h"
 #include "libmesh/vector_value.h"
@@ -38,7 +39,7 @@ class QBase;
 }
 
 template <typename OutputType>
-class MooseVariableDataFV
+class MooseVariableDataFV : public MeshChangedInterface
 {
 public:
   // type for gradient, second and divergence of template class OutputType
@@ -274,6 +275,8 @@ public:
    * (0 = current, 1 = old, 2 = older, etc).
    */
   unsigned int oldestSolutionStateRequested() const;
+
+  void meshChanged() override;
 
 private:
   void initializeSolnVars();

--- a/framework/src/variables/MooseVariableDataFV.C
+++ b/framework/src/variables/MooseVariableDataFV.C
@@ -34,7 +34,8 @@ MooseVariableDataFV<OutputType>::MooseVariableDataFV(const MooseVariableFV<Outpu
                                                      Moose::ElementType element_type,
                                                      const Elem * const & elem)
 
-  : _var(var),
+  : MeshChangedInterface(var.parameters()),
+    _var(var),
     _fe_type(_var.feType()),
     _var_num(_var.number()),
     _var_name(_var.name()),
@@ -1287,6 +1288,13 @@ MooseVariableDataFV<OutputType>::prepareIC()
   mooseAssert(_qrule, "We should have a non-null qrule");
   const auto nqp = _qrule->n_points();
   _u.resize(nqp);
+}
+
+template <typename OutputType>
+void
+MooseVariableDataFV<OutputType>::meshChanged()
+{
+  _prev_elem = nullptr;
 }
 
 template class MooseVariableDataFV<Real>;


### PR DESCRIPTION
There is a non-zero chance that we will call `initDofIndices()` with the
same element before and after adaptivity when its dof indices have
changed, so we must make sure to reset the `_prev_elem` cache in order
to make sure the dof indices get re-initialized

Refs libmesh/libmesh#2963
