### PR TITLE
Add utility function to create vector of pairs from two input parameters

### DIFF
--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -269,30 +269,22 @@ template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>>
 MooseObject::getParamPair(const std::string & param1, const std::string & param2) const
 {
+  if (!isParamValid(param1))
+    paramError(param1, "Invalid parameter");
+  if (!isParamValid(param2))
+    paramError(param2, "Invalid parameter");
+
+  auto v1 = getParam<std::vector<T1>>(param1);
+  auto v2 = getParam<std::vector<T2>>(param2);
+
+  if (v1.size() != v2.size())
+    callMooseErrorRaw("Sizes of vector parameters " + paramErrorPrefix(_pars, param1) + " and " +
+            paramErrorPrefix(_pars, param2) + " are unequal \n", &_app);
+  
   std::vector<std::pair<T1, T2>> parameter_pair;
-  std::string msg;
-
-  if (isParamValid(param1) && isParamValid(param2))
-  {
-    auto v1 = getParam<std::vector<T1>>(param1);
-    auto v2 = getParam<std::vector<T2>>(param2);
-
-    if (v1.size() == v2.size())
-      for (std::size_t i = 0; i < v1.size(); ++i)
-        parameter_pair.emplace_back(std::make_pair(v1[i], v2[i]));
-    else
-      msg = "Sizes of vector parameters " + paramErrorPrefix(_pars, param1) + " and " +
-            paramErrorPrefix(_pars, param2) + " are unequal \n";
-  }
-  else if (!isParamValid(param1))
-    msg = paramErrorMsg(param1, "Invalid parameter");
-  else if (!isParamValid(param2))
-    msg = paramErrorMsg(param2, "Invalid parameter");
-
-  if (!msg.empty())
-    callMooseErrorRaw(msg, &_app);
-  else
-    return parameter_pair;
+  for (std::size_t i = 0; i < v1.size(); ++i)
+    parameter_pair.emplace_back(std::make_pair(v1[i], v2[i]));
+  return parameter_pair;
 }
 
 template <typename... Args>

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -267,9 +267,10 @@ MooseObject::getParam(const std::string & name) const
 
 template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>>
-MooseObject::getParamPair(const std::string & param1, const std::string & param2)
+MooseObject::getParamPair(const std::string & param1, const std::string & param2) const
 {
   std::vector<std::pair<T1, T2>> parameter_pair;
+  std::string msg;
 
   if (isParamValid(param1) && isParamValid(param2))
   {
@@ -277,13 +278,21 @@ MooseObject::getParamPair(const std::string & param1, const std::string & param2
     auto v2 = getParam<std::vector<T2>>(param2);
 
     if (v1.size() == v2.size())
-      for (size_t i = 0; i < v1.size(); ++i)
-        parameter_pair.push_back(std::make_pair(v1[i], v2[i]));
+      for (std::size_t i = 0; i < v1.size(); ++i)
+        parameter_pair.emplace_back(std::make_pair(v1[i], v2[i]));
     else
-      mooseError("Unequal length of vectors " + param1 + " and " + param2 + " \n");
+      msg = "Sizes of vector parameters " + paramErrorPrefix(_pars, param1) + " and " +
+            paramErrorPrefix(_pars, param2) + " are unequal \n";
   }
+  else if (!isParamValid(param1))
+    msg = paramErrorMsg(param1, "Invalid parameter");
+  else if (!isParamValid(param2))
+    msg = paramErrorMsg(param2, "Invalid parameter");
+
+  if (!msg.empty())
+    callMooseErrorRaw(msg, &_app);
   else
-    mooseError("Invalid Parameter");
+    return parameter_pair;
 }
 
 template <typename... Args>

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -269,17 +269,13 @@ template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>>
 MooseObject::getParamPairs(const std::string & param1, const std::string & param2) const
 {
-  if (!isParamValid(param1))
-    paramError(param1, "Invalid parameter");
-  if (!isParamValid(param2))
-    paramError(param2, "Invalid parameter");
-
   auto v1 = getParam<std::vector<T1>>(param1);
   auto v2 = getParam<std::vector<T2>>(param2);
 
   if (v1.size() != v2.size())
-    callMooseErrorRaw("Sizes of vector parameters " + paramErrorPrefix(_pars, param1) + " and " +
-                          paramErrorPrefix(_pars, param2) + " are unequal \n",
+    callMooseErrorRaw("Vector parameters " + paramErrorPrefix(_pars, param1) +
+                          "(size: " + v1.size() + ") and " + paramErrorPrefix(_pars, param2) +
+                          "(size: " + v2.size() + ") are of different lengths \n",
                       &_app);
 
   std::vector<std::pair<T1, T2>> parameter_pair;

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -94,8 +94,8 @@ public:
    * @return Vector of pairs of first and second parameters
    */
   template <typename T1, typename T2>
-  std::vector<std::pair<T1, T2>> getParamPair(const std::string & param1,
-                                              const std::string & param2) const;
+  std::vector<std::pair<T1, T2>> getParamPairs(const std::string & param1,
+                                               const std::string & param2) const;
 
   /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
@@ -267,7 +267,7 @@ MooseObject::getParam(const std::string & name) const
 
 template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>>
-MooseObject::getParamPair(const std::string & param1, const std::string & param2) const
+MooseObject::getParamPairs(const std::string & param1, const std::string & param2) const
 {
   if (!isParamValid(param1))
     paramError(param1, "Invalid parameter");
@@ -279,8 +279,9 @@ MooseObject::getParamPair(const std::string & param1, const std::string & param2
 
   if (v1.size() != v2.size())
     callMooseErrorRaw("Sizes of vector parameters " + paramErrorPrefix(_pars, param1) + " and " +
-            paramErrorPrefix(_pars, param2) + " are unequal \n", &_app);
-  
+                          paramErrorPrefix(_pars, param2) + " are unequal \n",
+                      &_app);
+
   std::vector<std::pair<T1, T2>> parameter_pair;
   for (std::size_t i = 0; i < v1.size(); ++i)
     parameter_pair.emplace_back(std::make_pair(v1[i], v2[i]));

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -88,6 +88,16 @@ public:
   const T & getParam(const std::string & name) const;
 
   /**
+   * Retrieve two parameters and provide pair of parameters for the object
+   * @param param1 The name of first parameter
+   * @param param2 The name of second parameter
+   * @return Vector of pairs of first and second parameters
+   */
+  template <typename T1, typename T2>
+  std::vector<std::pair<T1, T2>> getParamPair(const std::string & param1,
+                                              const std::string & param2) const;
+
+  /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
    * The template parameter must be a pointer or an error will be thrown.
    */
@@ -253,6 +263,27 @@ const T &
 MooseObject::getParam(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
+}
+
+template <typename T1, typename T2>
+std::vector<std::pair<T1, T2>>
+MooseObject::getParamPair(const std::string & param1, const std::string & param2)
+{
+  std::vector<std::pair<T1, T2>> parameter_pair;
+
+  if (isParamValid(param1) && isParamValid(param2))
+  {
+    auto v1 = getParam<std::vector<T1>>(param1);
+    auto v2 = getParam<std::vector<T2>>(param2);
+
+    if (v1.size() == v2.size())
+      for (size_t i = 0; i < v1.size(); ++i)
+        parameter_pair.push_back(std::make_pair(v1[i], v2[i]));
+    else
+      mooseError("Unequal length of vectors " + param1 + " and " + param2 + " \n");
+  }
+  else
+    mooseError("Invalid Parameter");
 }
 
 template <typename... Args>


### PR DESCRIPTION
- Adds a helper function `getParamPairs` to `MooseObject` that takes two parameters of type std::vector<T1> and std::vector<T2>
```
std::vector<pair<T1,T2> getParamPairs<T1,T2>(const std::string & param1, const std::string & param2);
```
- Performs error checking for vector size, splices them into a single vector of pairs and returns the vector.

closes #18456 
