### PR TITLE
Improve handling of dependencies in HistogramVectorPostprocessor

### DIFF
--- a/framework/include/vectorpostprocessors/HistogramVectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/HistogramVectorPostprocessor.h
@@ -32,6 +32,7 @@ public:
   static InputParameters validParams();
 
   HistogramVectorPostprocessor(const InputParameters & parameters);
+  virtual void initialSetup() override;
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;

--- a/framework/src/vectorpostprocessors/HistogramVectorPostprocessor.C
+++ b/framework/src/vectorpostprocessors/HistogramVectorPostprocessor.C
@@ -34,11 +34,18 @@ HistogramVectorPostprocessor::HistogramVectorPostprocessor(const InputParameters
     _vpp_name(getParam<VectorPostprocessorName>("vpp")),
     _num_bins(getParam<unsigned int>("num_bins"))
 {
+}
+
+void
+HistogramVectorPostprocessor::initialSetup()
+{
   const VectorPostprocessor & vpp = getUserObjectByName<VectorPostprocessor>(_vpp_name);
   for (const auto & vec_name : vpp.getVectorNames())
     _histogram_data[vec_name] = {&declareVector(vec_name + "_lower"),
                                  &declareVector(vec_name + "_upper"),
                                  &declareVector(vec_name)};
+  if (_histogram_data.empty())
+    paramError("vpp", "The specified VectorPostprocessor does not have any declared vectors");
 }
 
 void

--- a/test/include/vectorpostprocessors/EmptyVectorPostprocessor.h
+++ b/test/include/vectorpostprocessors/EmptyVectorPostprocessor.h
@@ -1,0 +1,23 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralVectorPostprocessor.h"
+
+class EmptyVectorPostprocessor : public GeneralVectorPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  EmptyVectorPostprocessor(const InputParameters & parameters);
+
+  virtual void initialize() override;
+  virtual void execute() override;
+};

--- a/test/src/vectorpostprocessors/EmptyVectorPostprocessor.C
+++ b/test/src/vectorpostprocessors/EmptyVectorPostprocessor.C
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "EmptyVectorPostprocessor.h"
+
+registerMooseObject("MooseTestApp", EmptyVectorPostprocessor);
+
+InputParameters
+EmptyVectorPostprocessor::validParams()
+{
+  InputParameters params = GeneralVectorPostprocessor::validParams();
+  params.addClassDescription(
+      "This is a VectorPostprocessor that does not compute any values. Used for testing.");
+  return params;
+}
+
+EmptyVectorPostprocessor::EmptyVectorPostprocessor(const InputParameters & parameters)
+  : GeneralVectorPostprocessor(parameters)
+{
+}
+
+void
+EmptyVectorPostprocessor::initialize()
+{
+}
+
+void
+EmptyVectorPostprocessor::execute()
+{
+}

--- a/test/tests/vectorpostprocessors/histogram_vector_postprocessor/tests
+++ b/test/tests/vectorpostprocessors/histogram_vector_postprocessor/tests
@@ -8,4 +8,14 @@
     design = 'HistogramVectorPostprocessor.md'
     requirement = 'The system shall be able to compute a histogram of each vector of data produced by a vector data producer (VectorPostprocessor).'
   [../]
+
+  [./test_size0_err]
+    type = 'RunException'
+    input = 'histogram_vector_postprocessor.i'
+    cli_args = 'VectorPostprocessors/empty/type=EmptyVectorPostprocessor VectorPostprocessors/histo/vpp=empty'
+    expect_err = "The specified VectorPostprocessor does not have any declared vectors."
+    issues = '#18459'
+    design = 'HistogramVectorPostprocessor.md'
+    requirement = 'The histogram vector postprocessor shall generate an error if the vector postprocessor that it operates on does not have any declared vectors'
+  [../]
 []


### PR DESCRIPTION
closes #18459

- Generate an error if no vectors are provided in the VPP that is used as input.
- Move the initialization to initialSetup() to remove order dependence of VPPs in input file.
- Add a test of the newly-added error.
- Add empty VPP testing object used by this test.