### PR TITLE
Add displacement vars only once

### DIFF
--- a/framework/src/variables/MooseVariable.C
+++ b/framework/src/variables/MooseVariable.C
@@ -15,7 +15,7 @@ template <>
 InputParameters
 validParams<MooseVariable>()
 {
-  auto params = validParams<MooseVariableFEBase>();
+  auto params = MooseVariableFEBase::validParams();
   params.addClassDescription(
       "Represents standard field variables, e.g. Lagrange, Hermite, or non-constant Monomials");
   return params;

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
@@ -27,6 +27,7 @@ protected:
   void actEigenstrainNames();
   void actOutputMatProp();
   void actGatherActionParameters();
+  void actAddVariable();
   void verifyOrderAndFamilyOutputs();
 
   virtual std::string getKernelType();

--- a/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
+++ b/modules/tensor_mechanics/include/actions/TensorMechanicsAction.h
@@ -67,6 +67,9 @@ protected:
   /// set generated from the combined block restrictions of all TensorMechanics/Master action blocks
   std::set<SubdomainID> _subdomain_id_union;
 
+  /// this will be true for only one single TensorMechanics (or derived) action
+  bool _is_primary_action;
+
   /// strain formulation
   enum class Strain
   {


### PR DESCRIPTION
Refs #18475

This does not deal with output variables, which are a lot more complicated to handle (due to varying family/order)!

It also does not warn users about the scaling _not_ being per subblock. I'll probably end up moving the scaling parameter to the top level of the TMA block and remove it from the subblocks.