### PR TITLE
missing explicit class instantiation that is causing Bison tests to fail

### DIFF
--- a/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/IsotropicPlasticityStressUpdate.C
@@ -254,3 +254,6 @@ IsotropicPlasticityStressUpdateTempl<true>::computeYieldStress(
                      ") is less than zero");
   }
 }
+
+template class IsotropicPlasticityStressUpdateTempl<false>;
+template class IsotropicPlasticityStressUpdateTempl<true>;

--- a/modules/tensor_mechanics/src/materials/IsotropicPowerLawHardeningStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/IsotropicPowerLawHardeningStressUpdate.C
@@ -112,3 +112,6 @@ IsotropicPowerLawHardeningStressUpdateTempl<is_ad>::getIsotropicLameLambda(
         "Check to ensure that your Elasticity Tensor is truly Isotropic: different lambda values");
   return lame_lambda;
 }
+
+template class IsotropicPowerLawHardeningStressUpdateTempl<false>;
+template class IsotropicPowerLawHardeningStressUpdateTempl<true>;

--- a/modules/tensor_mechanics/src/materials/TemperatureDependentHardeningStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/TemperatureDependentHardeningStressUpdate.C
@@ -169,3 +169,6 @@ TemperatureDependentHardeningStressUpdateTempl<is_ad>::computeYieldStress(
     mooseError("The yield stress must be greater than zero, but during the simulation your yield "
                "stress became less than zero.");
 }
+
+template class TemperatureDependentHardeningStressUpdateTempl<false>;
+template class TemperatureDependentHardeningStressUpdateTempl<true>;


### PR DESCRIPTION
This closes   closes #18449

I had a previous PR that was supposed to fix this, (https://github.com/idaholab/moose/pull/18454#pullrequestreview-718579405) but it was missing this.


<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
