### PR TITLE
Fix phase field unit test

### DIFF
--- a/modules/phase_field/unit/include/EBSDMeshErrorTest.h
+++ b/modules/phase_field/unit/include/EBSDMeshErrorTest.h
@@ -13,7 +13,7 @@
 #include "gtest_include.h"
 
 // Moose includes
-#include "EBSDMesh.h"
+#include "EBSDMeshGenerator.h"
 #include "InputParameters.h"
 #include "MooseParsedFunction.h"
 #include "PhaseFieldApp.h"
@@ -39,10 +39,10 @@ protected:
       oss << name << "_" << i;
 
       // generate input parameter set
-      InputParameters params = validParams<EBSDMesh>();
+      InputParameters params = validParams<EBSDMeshGenerator>();
       params.addPrivateParam("_moose_app", _app.get());
       params.set<std::string>("_object_name") = oss.str();
-      params.set<std::string>("_type") = "EBSDMesh";
+      params.set<std::string>("_type") = "EBSDMeshGenerator";
 
       // set a single parameter
       params.set<T>(param_list[i]) = T(1.0);
@@ -53,7 +53,7 @@ protected:
       try
       {
         // construct mesh object
-        std::unique_ptr<EBSDMesh> mesh = libmesh_make_unique<EBSDMesh>(params);
+        auto mesh = std::make_unique<EBSDMeshGenerator>(params);
         // TODO: fix and uncomment this - it was missing before.
         // FAIL() << "mesh construction should have failed but didn't";
       }

--- a/modules/phase_field/unit/src/EBSDMeshErrorTest.C
+++ b/modules/phase_field/unit/src/EBSDMeshErrorTest.C
@@ -12,22 +12,22 @@
 TEST_F(EBSDMeshErrorTest, fileDoesNotExist)
 {
   // generate input parameter set
-  InputParameters params = validParams<EBSDMesh>();
+  InputParameters params = validParams<EBSDMeshGenerator>();
   params.addPrivateParam("_moose_app", _app.get());
   params.set<std::string>("_object_name", "EBSD");
-  params.set<std::string>("_type") = "EBSDMesh";
+  params.set<std::string>("_type") = "EBSDMeshGenerator";
 
   // set filename
   params.set<FileName>("filename") = "FILEDOESNOTEXIST";
 
-  // construct mesh object
-  std::unique_ptr<EBSDMesh> mesh = libmesh_make_unique<EBSDMesh>(params);
+  // construct mesh generator object
+  auto mesh = std::make_unique<EBSDMeshGenerator>(params);
 
   try
   {
     // trigger mesh building with invalid EBSD filename
-    mesh->buildMesh();
-    FAIL() << "buildMesh should have failed but didn't";
+    mesh->generate();
+    FAIL() << "generate should have failed but didn't";
   }
   catch (const std::exception & e)
   {
@@ -46,7 +46,7 @@ TEST_F(EBSDMeshErrorTest, headerError)
       {"data/ebsd/ebsd3D_zerosize.txt", "Error reading header, EBSD grid size is zero."},
       {"data/ebsd/ebsd3D_zerodim.txt", "Error reading header, EBSD data is zero dimensional."},
       {"data/ebsd/ebsd3D_norefine.txt",
-       "EBSDMesh error. Requested uniform_refine levels not possible."},
+       "EBSDMeshGenerator error. Requested uniform_refine levels not possible."},
   };
 
   for (unsigned int i = 0; i < ntestcase; ++i)
@@ -55,23 +55,23 @@ TEST_F(EBSDMeshErrorTest, headerError)
     auto error = testcase[i][1];
 
     // generate input parameter set
-    InputParameters params = validParams<EBSDMesh>();
+    auto params = EBSDMeshGenerator::validParams();
     params.addPrivateParam("_moose_app", _app.get());
     params.set<std::string>("_object_name") = filename; // use the filename to define a unique name
-    params.set<std::string>("_type") = "EBSDMesh";
+    params.set<std::string>("_type") = "EBSDMeshGenerator";
 
     // set filename
     params.set<FileName>("filename") = filename;
     params.set<unsigned int>("uniform_refine") = 2;
 
     // construct mesh object
-    std::unique_ptr<EBSDMesh> mesh = libmesh_make_unique<EBSDMesh>(params);
+    auto mesh = std::make_unique<EBSDMeshGenerator>(params);
 
     try
     {
       // trigger mesh building with invalid EBSD filename
-      mesh->buildMesh();
-      FAIL() << "buildMesh should have failed but didn't";
+      mesh->generate();
+      FAIL() << "generate should have failed but didn't";
     }
     catch (const std::exception & e)
     {


### PR DESCRIPTION
Closes #18521

Before:

```
> ./run_tests
[==========] Running 6 tests from 4 test cases.
[----------] Global test environment set-up.
[----------] 1 test from EBSDAccessFunctorsTest
[ RUN      ] EBSDAccessFunctorsTest.test
[       OK ] EBSDAccessFunctorsTest.test (0 ms)
[----------] 1 test from EBSDAccessFunctorsTest (0 ms total)

[----------] 1 test from Euler2RGBTest
[ RUN      ] Euler2RGBTest.test
[       OK ] Euler2RGBTest.test (0 ms)
[----------] 1 test from Euler2RGBTest (0 ms total)

[----------] 3 tests from EBSDMeshErrorTest
[ RUN      ] EBSDMeshErrorTest.fileDoesNotExist


*** Warning, This code is deprecated and will be removed in future versions:
EBSDMesh is deprecated, please use the EBSDMeshGenerator instead. For example:

[Mesh]
  type = EBDSMesh
  filename = my_ebsd_data.dat
[]

becomes

[Mesh]
  [ebsd_mesh]
    type = EBDSMeshGenerator
    filename = my_ebsd_data.dat
  []
[]
Stack frames: 14
0: 0   libmesh_opt.0.dylib                 0x000000010f02c6f5 libMesh::print_trace(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) + 1141
1: 1   libphase_field-opt.0.dylib          0x000000010cb52a1e void moose::internal::mooseDeprecatedStream<ConsoleStream const, char const (&) [238]>(ConsoleStream const&, bool, char const (&) [238]) + 814
2: 2   libphase_field-opt.0.dylib          0x000000010cb515ed EBSDMesh::EBSDMesh(InputParameters const&) + 317
3: 3   libphase_field-unit-opt.0.dylib     0x000000010cb195fd EBSDMeshErrorTest_fileDoesNotExist_Test::TestBody() + 525
4: 4   libgtest.0.dylib                    0x000000010ed7f8c4 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 84
5: 5   libgtest.0.dylib                    0x000000010ed7f80d testing::Test::Run() + 253
6: 6   libgtest.0.dylib                    0x000000010ed80510 testing::TestInfo::Run() + 304
7: 7   libgtest.0.dylib                    0x000000010ed80e47 testing::TestCase::Run() + 247
8: 8   libgtest.0.dylib                    0x000000010ed864e7 testing::internal::UnitTestImpl::RunAllTests() + 967
9: 9   libgtest.0.dylib                    0x000000010ed85f74 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 84
10: 10  libgtest.0.dylib                    0x000000010ed85ed6 testing::UnitTest::Run() + 166
11: 11  phase_field-unit-opt                0x000000010cb072ac main + 172
12: 12  libdyld.dylib                       0x00007fff2042ef3d start + 1
13: 13  ???                                 0x0000000000000001 0x0 + 1

[       OK ] EBSDMeshErrorTest.fileDoesNotExist (16 ms)
[ RUN      ] EBSDMeshErrorTest.headerError
[       OK ] EBSDMeshErrorTest.headerError (15 ms)
[ RUN      ] EBSDMeshErrorTest.geometrySpecifiedError
[       OK ] EBSDMeshErrorTest.geometrySpecifiedError (15 ms)
[----------] 3 tests from EBSDMeshErrorTest (46 ms total)

[----------] 1 test from ExpressionBuilderTest
[ RUN      ] ExpressionBuilderTest.test
[       OK ] ExpressionBuilderTest.test (0 ms)
[----------] 1 test from ExpressionBuilderTest (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 4 test cases ran. (46 ms total)
[  PASSED  ] 6 tests.
```

After:

```
> ./run_tests
[==========] Running 6 tests from 4 test cases.
[----------] Global test environment set-up.
[----------] 1 test from EBSDAccessFunctorsTest
[ RUN      ] EBSDAccessFunctorsTest.test
[       OK ] EBSDAccessFunctorsTest.test (0 ms)
[----------] 1 test from EBSDAccessFunctorsTest (0 ms total)

[----------] 1 test from Euler2RGBTest
[ RUN      ] Euler2RGBTest.test
[       OK ] Euler2RGBTest.test (0 ms)
[----------] 1 test from Euler2RGBTest (0 ms total)

[----------] 3 tests from EBSDMeshErrorTest
[ RUN      ] EBSDMeshErrorTest.fileDoesNotExist
[       OK ] EBSDMeshErrorTest.fileDoesNotExist (15 ms)
[ RUN      ] EBSDMeshErrorTest.headerError
[       OK ] EBSDMeshErrorTest.headerError (16 ms)
[ RUN      ] EBSDMeshErrorTest.geometrySpecifiedError
[       OK ] EBSDMeshErrorTest.geometrySpecifiedError (15 ms)
[----------] 3 tests from EBSDMeshErrorTest (46 ms total)

[----------] 1 test from ExpressionBuilderTest
[ RUN      ] ExpressionBuilderTest.test
[       OK ] ExpressionBuilderTest.test (0 ms)
[----------] 1 test from ExpressionBuilderTest (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 4 test cases ran. (46 ms total)
[  PASSED  ] 6 tests.
```