### PR TITLE
Correct typo in cutback_factor_at_failure docstring. 

### DIFF
--- a/framework/src/timesteppers/TimeStepper.C
+++ b/framework/src/timesteppers/TimeStepper.C
@@ -24,7 +24,7 @@ TimeStepper::validParams()
       "cutback_factor_at_failure",
       0.5,
       "cutback_factor_at_failure>0 & cutback_factor_at_failure<1",
-      "Factor to apply to timestep if it a time step fails to convergence.");
+      "Factor to apply to timestep if a time step fails to converge.");
 
   params.registerBase("TimeStepper");
 


### PR DESCRIPTION
## Reason
Improve documentation.

## Design
Corrected typo.

## Impact
No expected changes.

Closes #18538

tag @ahuxford