### PR TITLE
Nondual Contact

### DIFF
--- a/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
@@ -45,12 +45,12 @@ protected:
   virtual void enforceConstraintOnDof(const DofObject * dof) override;
 
   /// A map from node to weighted gap
-  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal> > _dof_to_weighted_tangential_velocity;
+  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal>>
+      _dof_to_weighted_tangential_velocity;
 
   /// A pointer members that can be used to help avoid copying ADReals
   const ADReal * _tangential_vel_ptr = nullptr;
   const ADReal * _tangential_traction_ptr = nullptr;
-
 
   /// The value of the tangential velocity at the current quadrature point
   ADReal _qp_tangential_velocity;

--- a/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeFrictionalForceLMMechanicalContact.h
@@ -42,13 +42,15 @@ protected:
    * where we actually feed the node-based constraint information into the system residual and
    * Jacobian
    */
-  virtual void enforceConstraintOnNode(const Node * node) override;
+  virtual void enforceConstraintOnDof(const DofObject * dof) override;
 
   /// A map from node to weighted gap
-  std::unordered_map<const Node *, ADReal> _node_to_weighted_tangential_velocity;
+  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal> > _dof_to_weighted_tangential_velocity;
 
-  /// A pointer member that can be used to help avoid copying ADReals
+  /// A pointer members that can be used to help avoid copying ADReals
   const ADReal * _tangential_vel_ptr = nullptr;
+  const ADReal * _tangential_traction_ptr = nullptr;
+
 
   /// The value of the tangential velocity at the current quadrature point
   ADReal _qp_tangential_velocity;

--- a/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
@@ -51,7 +51,7 @@ protected:
    * using an NCP function. This is also where we actually feed the node-based constraint
    * information into the system residual and Jacobian
    */
-  virtual void enforceConstraintOnNode(const Node * node);
+  virtual void enforceConstraintOnDof(const DofObject * dof);
 
   /// x-displacement on the secondary face
   const ADVariableValue & _secondary_disp_x;
@@ -61,6 +61,13 @@ protected:
   const ADVariableValue & _secondary_disp_y;
   /// y-displacement on the primary face
   const ADVariableValue & _primary_disp_y;
+
+  /// For 2D mortar contact no displacement will be specified, so const pointers used
+  const bool _has_disp_z;
+  /// z-displacement on the secondary face
+  const ADVariableValue * const _secondary_disp_z;
+  /// z-displacement on the primary face
+  const ADVariableValue * const _primary_disp_z;
 
   /// The normal index. This is _qp if we are interpolating the nodal normals, else it is _i
   const unsigned int & _normal_index;
@@ -73,9 +80,10 @@ protected:
   /// The value of the gap at the current quadrature point
   ADReal _qp_gap;
 
-  /// A map from node to weighted gap
-  std::unordered_map<const Node *, ADReal> _node_to_weighted_gap;
+  /// A map from node to weighted gap (and weighted traction for non-dual)
+  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal> > _dof_to_weighted_gap;
 
-  /// A pointer member that can be used to help avoid copying ADReals
+  /// A pointer members that can be used to help avoid copying ADReals
   const ADReal * _weighted_gap_ptr = nullptr;
+  const ADReal * _weighted_traction_ptr = nullptr;
 };

--- a/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
+++ b/modules/contact/include/constraints/ComputeWeightedGapLMMechanicalContact.h
@@ -81,7 +81,7 @@ protected:
   ADReal _qp_gap;
 
   /// A map from node to weighted gap (and weighted traction for non-dual)
-  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal> > _dof_to_weighted_gap;
+  std::unordered_map<const DofObject *, std::pair<ADReal, ADReal>> _dof_to_weighted_gap;
 
   /// A pointer members that can be used to help avoid copying ADReals
   const ADReal * _weighted_gap_ptr = nullptr;

--- a/modules/contact/include/constraints/NormalMortarLMMechanicalContact.h
+++ b/modules/contact/include/constraints/NormalMortarLMMechanicalContact.h
@@ -23,11 +23,15 @@ protected:
 
   const MooseVariableFE<Real> * const _secondary_disp_y;
   const MooseVariableFE<Real> * const _primary_disp_y;
+  const MooseVariableFE<Real> * const _secondary_disp_z;
+  const MooseVariableFE<Real> * const _primary_disp_z;
 
   bool _computing_gap_dependence;
 
   const ADVariableValue * _secondary_disp_y_sln;
   const ADVariableValue * _primary_disp_y_sln;
+  const ADVariableValue * _secondary_disp_z_sln;
+  const ADVariableValue * _primary_disp_z_sln;
 
   const Real _epsilon;
 

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -472,6 +472,9 @@ ContactAction::addMortarContact()
 
         if (ndisp > 1)
           params.set<std::vector<VariableName>>("disp_y") = {displacements[1]};
+        if (ndisp > 2)
+          params.set<std::vector<VariableName>>("disp_z") = {displacements[2]};
+
         params.set<bool>("use_displaced_mesh") = true;
 
         _problem->addConstraint("ComputeWeightedGapLMMechanicalContact",
@@ -522,6 +525,8 @@ ContactAction::addMortarContact()
         params.set<std::vector<VariableName>>("disp_x") = {displacements[0]};
         if (ndisp > 1)
           params.set<std::vector<VariableName>>("disp_y") = {displacements[1]};
+        if (ndisp > 2)
+          params.set<std::vector<VariableName>>("disp_z") = {displacements[2]};
 
         params.set<NonlinearVariableName>("variable") = normal_lagrange_multiplier_name;
         params.set<std::vector<VariableName>>("friction_lm") = {
@@ -572,6 +577,8 @@ ContactAction::addMortarContact()
         params.set<VariableName>("secondary_variable") = displacements[0];
         if (ndisp > 1)
           params.set<NonlinearVariableName>("secondary_disp_y") = displacements[1];
+        if (ndisp > 2)
+          params.set<NonlinearVariableName>("secondary_disp_z") = displacements[2];
         // secondary_disp_z is not implemented for tangential (yet).
 
         _problem->addConstraint(

--- a/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
@@ -92,14 +92,15 @@ ComputeFrictionalForceLMMechanicalContact::computeQpIProperties()
     mooseAssert(_i < 1, "Elemental variables must be CONSTANT order.");
 
   // Get the _dof_to_weighted_tangential_velocity map
-  const DofObject * const dof = _friction_var->isNodal() ?
-                                static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i)) :
-                                static_cast<const DofObject *>(_lower_secondary_elem);
+  const DofObject * const dof =
+      _friction_var->isNodal() ? static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i))
+                               : static_cast<const DofObject *>(_lower_secondary_elem);
   _dof_to_weighted_tangential_velocity[dof].first += _test[_i][_qp] * _qp_tangential_velocity;
 
   // For non-dual contact also assemble weighted pressure
   if (!_friction_var->useDual())
-    _dof_to_weighted_tangential_velocity[dof].second += _test[_i][_qp] * _friction_var->adSlnLower()[_qp];
+    _dof_to_weighted_tangential_velocity[dof].second +=
+        _test[_i][_qp] * _friction_var->adSlnLower()[_qp];
   // For dual, on first quadrature point evaluation store nodal value in place of weighted traction
   else if (/*_friction_var->useDual() &&*/ _qp == 0)
   {

--- a/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
@@ -111,11 +111,10 @@ ComputeWeightedGapLMMechanicalContact::computeQpIProperties()
     mooseAssert(_i < 1, "Elemental variables must be CONSTANT order.");
 
   // Get the _dof_to_weighted_gap map
-  const DofObject * const dof = _var->isNodal() ?
-                                static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i)) :
-                                static_cast<const DofObject *>(_lower_secondary_elem);
+  const DofObject * const dof =
+      _var->isNodal() ? static_cast<const DofObject *>(_lower_secondary_elem->node_ptr(_i))
+                      : static_cast<const DofObject *>(_lower_secondary_elem);
   _dof_to_weighted_gap[dof].first += _test[_i][_qp] * _qp_gap;
-
 
   // For non-dual contact assemble weighted traction (lambda represents traction)
   if (!_var->useDual())

--- a/modules/contact/src/constraints/NormalMortarLMMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalMortarLMMechanicalContact.C
@@ -22,6 +22,10 @@ NormalMortarLMMechanicalContact::validParams()
                                          "The y displacement variable on the secondary face");
   params.addParam<NonlinearVariableName>("primary_disp_y",
                                          "The y displacement variable on the primary face");
+  params.addParam<NonlinearVariableName>("secondary_disp_z",
+                                         "The z displacement variable on the secondary face");
+  params.addParam<NonlinearVariableName>("primary_disp_z",
+                                         "The z displacement variable on the primary face");
   MooseEnum ncp_type("min fb", "min");
   params.addParam<MooseEnum>("ncp_function_type",
                              ncp_type,
@@ -42,6 +46,17 @@ NormalMortarLMMechanicalContact::NormalMortarLMMechanicalContact(const InputPara
                         : isParamValid("secondary_disp_y")
                               ? &this->_subproblem.getStandardVariable(
                                     _tid, parameters.getMooseType("secondary_disp_y"))
+                              : nullptr),
+    _secondary_disp_z(isParamValid("secondary_disp_z")
+                          ? &this->_subproblem.getStandardVariable(
+                                _tid, parameters.getMooseType("secondary_disp_z"))
+                          : nullptr),
+    _primary_disp_z(isParamValid("primary_disp_z")
+                        ? &this->_subproblem.getStandardVariable(
+                              _tid, parameters.getMooseType("primary_disp_z"))
+                        : isParamValid("secondary_disp_z")
+                              ? &this->_subproblem.getStandardVariable(
+                                    _tid, parameters.getMooseType("secondary_disp_z"))
                               : nullptr),
     _computing_gap_dependence(false),
     _secondary_disp_y_sln(nullptr),
@@ -79,6 +94,8 @@ NormalMortarLMMechanicalContact::computeQpResidual(Moose::MortarType mortar_type
               _u_primary[_qp].derivatives() - _u_secondary[_qp].derivatives();
           gap_vec(1).derivatives() = (*_primary_disp_y_sln)[_qp].derivatives() -
                                      (*_secondary_disp_y_sln)[_qp].derivatives();
+          gap_vec(2).derivatives() = (*_primary_disp_z_sln)[_qp].derivatives() -
+                                     (*_secondary_disp_z_sln)[_qp].derivatives();
         }
 
         auto gap = gap_vec * _normals[_qp];


### PR DESCRIPTION
Adds 3D mortar and use of nondual basis functions for contact probelms. Addresses refs #17279 (also relevant to issue #18419)

## Reason
Dual shape functions have a number of advantages for discretizing Lagrange Mulitplier variables in mortar contact including stability and diagonal structure of mortar blocks; but in 3D their definition is deformation dependent increasing complexity and decreasing efficiency. This PR extends contact objects to 3D and enables mortar contact with non-dual shape functions.

## Design
Constraint enforcement is generalized from nodes to DoFs.

## Impact
Dual shape functions should be unaffected, 3d and non-dual extension are added.
