### PR TITLE
Fix getPairs input parameters helper and add tests

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -122,7 +122,6 @@ public:
 
   const std::set<std::string> & getAllTasks() const { return _all_tasks; }
 
-  ///@{
   /**
    * Retrieve a parameter for the object
    * @param name The name of the parameter
@@ -130,7 +129,6 @@ public:
    */
   template <typename T>
   const T & getParam(const std::string & name) const;
-  ///@}
 
   /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
@@ -140,6 +138,19 @@ public:
   T getCheckedPointerParam(const std::string & name, const std::string & error_string = "") const
   {
     return parameters().getCheckedPointerParam<T>(name, error_string);
+  }
+
+  /**
+   * Retrieve two parameters and provide pair of parameters for the object
+   * @param param1 The name of first parameter
+   * @param param2 The name of second parameter
+   * @return Vector of pairs of first and second parameters
+   */
+  template <typename T1, typename T2>
+  std::vector<std::pair<T1, T2>> getParamPairs(const std::string & param1,
+                                               const std::string & param2) const
+  {
+    return parameters().getPairs<T1, T2>(param1, param2);
   }
 
   inline bool isParamValid(const std::string & name) const { return _pars.isParamValid(name); }

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -31,7 +31,7 @@ InputParameters validParams<MooseObject>();
 [[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
 
 /**
- * Generates a canonical paramError prefix for param-related error/warning/info messages.
+ * Get canonical paramError prefix for param-related error/warning/info messages.
  *
  * Use this for building custom messages when the default paramError isn't
  * quite what you need.
@@ -269,19 +269,7 @@ template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>>
 MooseObject::getParamPairs(const std::string & param1, const std::string & param2) const
 {
-  auto v1 = getParam<std::vector<T1>>(param1);
-  auto v2 = getParam<std::vector<T2>>(param2);
-
-  if (v1.size() != v2.size())
-    callMooseErrorRaw("Vector parameters " + paramErrorPrefix(_pars, param1) +
-                          "(size: " + v1.size() + ") and " + paramErrorPrefix(_pars, param2) +
-                          "(size: " + v2.size() + ") are of different lengths \n",
-                      &_app);
-
-  std::vector<std::pair<T1, T2>> parameter_pair;
-  for (std::size_t i = 0; i < v1.size(); ++i)
-    parameter_pair.emplace_back(std::make_pair(v1[i], v2[i]));
-  return parameter_pair;
+  return _pars.getPairs<T1, T2>(param1, param2);
 }
 
 template <typename... Args>

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -95,7 +95,10 @@ public:
    */
   template <typename T1, typename T2>
   std::vector<std::pair<T1, T2>> getParamPairs(const std::string & param1,
-                                               const std::string & param2) const;
+                                               const std::string & param2) const
+  {
+    return _pars.getPairs<T1, T2>(param1, param2);
+  }
 
   /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
@@ -263,13 +266,6 @@ const T &
 MooseObject::getParam(const std::string & name) const
 {
   return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
-}
-
-template <typename T1, typename T2>
-std::vector<std::pair<T1, T2>>
-MooseObject::getParamPairs(const std::string & param1, const std::string & param2) const
-{
-  return _pars.getPairs<T1, T2>(param1, param2);
 }
 
 template <typename... Args>

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -95,20 +95,14 @@ public:
    */
   template <typename T1, typename T2>
   std::vector<std::pair<T1, T2>> getParamPairs(const std::string & param1,
-                                               const std::string & param2) const
-  {
-    return _pars.getPairs<T1, T2>(param1, param2);
-  }
+                                               const std::string & param2) const;
 
   /**
    * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
    * The template parameter must be a pointer or an error will be thrown.
    */
   template <typename T>
-  T getCheckedPointerParam(const std::string & name, const std::string & error_string = "") const
-  {
-    return parameters().getCheckedPointerParam<T>(name, error_string);
-  }
+  T getCheckedPointerParam(const std::string & name, const std::string & error_string = "") const;
 
   /**
    * Test if the supplied parameter is valid
@@ -290,4 +284,19 @@ void
 MooseObject::paramInfo(const std::string & param, Args... args) const
 {
   mooseInfo(paramErrorMsg(param, std::forward<Args>(args)...));
+}
+
+template <typename T1, typename T2>
+std::vector<std::pair<T1, T2>>
+MooseObject::getParamPairs(const std::string & param1, const std::string & param2) const
+{
+  return _pars.getPairs<T1, T2>(param1, param2);
+}
+
+template <typename T>
+T
+MooseObject::getCheckedPointerParam(const std::string & name,
+                                    const std::string & error_string) const
+{
+  return parameters().getCheckedPointerParam<T>(name, error_string);
 }

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -112,9 +112,9 @@ std::string stringify(FEFamily f);
 /// Add pair stringify to support maps
 template <typename T, typename U>
 std::string
-stringify(const std::pair<T, U> & p)
+stringify(const std::pair<T, U> & p, const std::string & delim = ":")
 {
-  return stringify(p.first) + ':' + stringify(p.second);
+  return stringify(p.first) + delim + stringify(p.second);
 }
 
 /**

--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1593,8 +1593,8 @@ template <typename R1, typename R2, typename V1, typename V2>
 std::vector<std::pair<R1, R2>>
 InputParameters::getPairs(const std::string & param1, const std::string & param2) const
 {
-  auto v1 = get<V1>(param1);
-  auto v2 = get<V2>(param2);
+  const auto & v1 = get<V1>(param1);
+  const auto & v2 = get<V2>(param2);
 
   auto controllable = getControllableParameters();
   if (controllable.count(param1) || controllable.count(param2))

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -890,18 +890,20 @@ const static struct AnyType
 
 template <typename T1, typename T2>
 bool
-wildcardEqual(T1 a, T2 b)
+wildcardEqual(const T1 & a, const T2 & b)
 {
   return a == b;
 }
 
 template <typename T>
-bool wildcardEqual(T, AnyType)
+bool
+wildcardEqual(const T &, AnyType)
 {
   return true;
 }
 template <typename T>
-bool wildcardEqual(AnyType, T)
+bool
+wildcardEqual(AnyType, const T &)
 {
   return true;
 }
@@ -912,7 +914,7 @@ bool wildcardEqual(AnyType, T)
  */
 template <typename C, typename M1, typename M2>
 typename C::iterator
-findPair(C & container, M1 first, M2 second)
+findPair(C & container, const M1 & first, const M2 & second)
 {
   return std::find_if(container.begin(), container.end(), [&](auto & item) {
     return wildcardEqual(first, item.first) && wildcardEqual(second, item.second);

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -883,16 +883,52 @@ struct canBroadcast<std::vector<T>>
                                 std::is_same<T, std::string>::value;
 };
 
+///@{ Comparison helpers that support the MooseUtils::Any wildcard which will match any value
+const static struct AnyType
+{
+} Any;
+
+template <typename T1, typename T2>
+bool
+wildcardEqual(T1 a, T2 b)
+{
+  return a == b;
+}
+
+template <typename T>
+bool wildcardEqual(T, AnyType)
+{
+  return true;
+}
+template <typename T>
+bool wildcardEqual(AnyType, T)
+{
+  return true;
+}
+///@}
+
+/**
+ * Find a specific pair in a container matching on first, second or both pair components
+ */
+template <typename C, typename M1, typename M2>
+typename C::iterator
+findPair(C & container, M1 first, M2 second)
+{
+  return std::find_if(container.begin(), container.end(), [&](auto & item) {
+    return wildcardEqual(first, item.first) && wildcardEqual(second, item.second);
+  });
+}
+
 /**
  * Construct a valid bounding box from 2 arbitrary points
  *
  * If you have 2 points in space and you wish to construct a bounding box, you should use
  * this method to avoid unexpected behavior of the underlying BoundingBox class in libMesh.
- * BoundingBox class expect 2 points whose coordinates are "sorted" (i.e., x-, y- and -z coordinates
- * of the first point are smaller then the corresponding coordinates of the second point).
- * If this "sorting" is not present, the BoundingBox class will build an empty box and any further
- * testing of points inside the box will fail. This method will allow you to obtain the correct
- * bounding box for any valid combination of 2 corner points of a box.
+ * BoundingBox class expect 2 points whose coordinates are "sorted" (i.e., x-, y- and -z
+ * coordinates of the first point are smaller then the corresponding coordinates of the second
+ * point). If this "sorting" is not present, the BoundingBox class will build an empty box and
+ * any further testing of points inside the box will fail. This method will allow you to obtain
+ * the correct bounding box for any valid combination of 2 corner points of a box.
  *
  * @param p1 First corner of the constructed bounding box
  * @param p2 Second corner of the constructed bounding box

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -23,10 +23,7 @@ class Transient;
 std::string
 paramErrorPrefix(const InputParameters & params, const std::string & param)
 {
-  auto prefix = param + ":";
-  if (!params.inputLocation(param).empty())
-    prefix = params.inputLocation(param) + ": (" + params.paramFullpath(param) + ")";
-  return prefix;
+  return params.errorPrefix(param);
 }
 
 defineLegacyParams(MooseObject);

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1108,3 +1108,12 @@ InputParameters::getControllableParameters() const
       controllable.emplace(it->first);
   return controllable;
 }
+
+std::string
+InputParameters::errorPrefix(const std::string & param) const
+{
+  auto prefix = param + ":";
+  if (!inputLocation(param).empty())
+    prefix = inputLocation(param) + ": (" + paramFullpath(param) + ")";
+  return prefix;
+}

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -10,6 +10,7 @@
 // MOOSE includes
 #include "InputParameters.h"
 #include "MultiMooseEnum.h"
+#include "Conversion.h"
 #include "gtest/gtest.h"
 
 TEST(InputParameters, checkControlParamPrivateError)
@@ -316,6 +317,26 @@ TEST(InputParameters, getPairs)
   {
     EXPECT_EQ(pairs[i].first, num_words[i]);
     EXPECT_EQ(pairs[i].second, i);
+  }
+}
+
+TEST(InputParameters, getPairsMultiMooseEnum)
+{
+  std::vector<std::string> v1{"zero", "one", "two", "three"};
+  auto s1 = Moose::stringify(v1, " ");
+  std::vector<std::string> v2{"null", "eins", "zwei", "drei"};
+  auto s2 = Moose::stringify(v2, " ");
+
+  InputParameters p = emptyInputParameters();
+  p.addParam<MultiMooseEnum>("first", MultiMooseEnum(s1, s1), "");
+  p.addParam<MultiMooseEnum>("second", MultiMooseEnum(s2, s2), "");
+
+  auto pairs = p.getPairs<MooseEnumItem, MooseEnumItem>("first", "second");
+
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_EQ(pairs[i].first, v1[i]);
+    EXPECT_EQ(pairs[i].second, v2[i]);
   }
 }
 

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -301,3 +301,68 @@ TEST(InputParameters, setPPandVofPP)
 
   // EXPECT_EQ(p1.getDefaultPostprocessorValue("pp_name"), 1);
 }
+
+TEST(InputParameters, getPairs)
+{
+  std::vector<std::string> num_words{"zero", "one", "two", "three"};
+
+  InputParameters p = emptyInputParameters();
+  p.addParam<std::vector<std::string>>("first", num_words, "");
+  p.addParam<std::vector<int>>("second", std::vector<int>{0, 1, 2, 3}, "");
+
+  auto pairs = p.getPairs<std::string, int>("first", "second");
+
+  for (int i = 0; i < 4; ++i)
+  {
+    EXPECT_EQ(pairs[i].first, num_words[i]);
+    EXPECT_EQ(pairs[i].second, i);
+  }
+}
+
+TEST(InputParameters, getPairsLength)
+{
+  std::vector<std::string> num_words{"zero", "one", "two"};
+
+  InputParameters p = emptyInputParameters();
+  p.addParam<std::vector<std::string>>("first", num_words, "");
+  p.addParam<std::vector<int>>("second", std::vector<int>{0, 1, 2, 3}, "");
+
+  try
+  {
+    auto pairs = p.getPairs<std::string, int>("first", "second");
+    FAIL() << "Missing expected exception.";
+  }
+  catch (const std::exception & e)
+  {
+    std::string msg(e.what());
+    ASSERT_TRUE(
+        msg.find(
+            "Vector parameters first:(size: 3) and second:(size: 4) are of different lengths") !=
+        std::string::npos)
+        << "Failed with unexpected error message: " << msg;
+  }
+}
+
+TEST(InputParameters, getPairsControllable)
+{
+  std::vector<std::string> num_words{"zero", "one", "two", "three"};
+
+  InputParameters p = emptyInputParameters();
+  p.addParam<std::vector<std::string>>("first", num_words, "");
+  p.addParam<std::vector<int>>("second", std::vector<int>{0, 1, 2, 3}, "");
+  p.declareControllable("first");
+
+  try
+  {
+    auto pairs = p.getPairs<std::string, int>("first", "second");
+    FAIL() << "Missing expected exception.";
+  }
+  catch (const std::exception & e)
+  {
+    std::string msg(e.what());
+    ASSERT_TRUE(msg.find("first: and/or second: are controllable parameters and cannot be "
+                         "retireved using MooseObject::getParamPairs/InputParameters::getPairs") !=
+                std::string::npos)
+        << "Failed with unexpected error message: " << msg;
+  }
+}


### PR DESCRIPTION
This moves the helper around so it can be used from actions (the contact actions are a candidate, and I already have a PR ready for them), fixes the error messages, check to prevent fetching of controllable parameters, and adds unit tests for the functionality itself and the error checking.

This also adds support for MultiMooseEnums, which result in a pair component of type MooseEnumItem. This will facilitate the use of this helper fit the PETSc options iname/value parameter pair (again, I already have a PR ready for that).

Refs #18456