### PR TITLE
Get submodule hashes with git ls-files

### DIFF
--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -28,8 +28,7 @@ pipeline {
             steps {
                 sh '''
                 # Setup for getting submodule commit hashes
-                git submodule init
-                sub_rev() { git submodule status $1 | awk '{print $1}' ; }
+                sub_rev() { git ls-files -s $1 | awk '{print $2}' ; }
                 
                 # Build MOOSE image with max cores and compatible submodules
                 docker build \

--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -30,7 +30,8 @@ apt-get install -y \
   flex \
   libboost-all-dev \
   emacs \
-  libgtest-dev
+  libgtest-dev \
+  sudo
 
 # Clear cache
 rm -rf /var/lib/apt/lists/*

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -37,7 +37,8 @@ yum install -y \
   libtirpc \
   libtirpc-devel \
   emacs \
-  gtest
+  gtest \
+  sudo
 
 # Clear cache
 yum clean all


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
For some reason `git submodule status` doesn't show commit hashes after `git submodule init` anymore, so we have to get those with `git ls-files`.

## Design
Changed `docker_ci/Jenkinsfile` to use `git ls-files`.  Also added package manager installs for `sudo` for downstream use.

## Impact
No change to the framework.  Fixes #18616.
