### PR TITLE
Improve how cohesive zone model performs rotations

### DIFF
--- a/framework/include/utils/RotationMatrix.h
+++ b/framework/include/utils/RotationMatrix.h
@@ -23,5 +23,7 @@ RealTensorValue rotVecToZ(RealVectorValue vec);
 
 /// provides a rotation matrix that will rotate the vector vec1 to vec2
 RealTensorValue rotVec1ToVec2(RealVectorValue vec1, RealVectorValue vec2);
-}
 
+/// provides a rotation matrix that will rotate the vector vec1 to the [1,0,0], assuming vec1[2]==0
+RealTensorValue rotVec2DToX(const RealVectorValue & vec);
+}

--- a/framework/src/utils/RotationMatrix.C
+++ b/framework/src/utils/RotationMatrix.C
@@ -55,3 +55,14 @@ RotationMatrix::rotVec1ToVec2(RealVectorValue vec1, RealVectorValue vec2)
   RealTensorValue rot2_to_z = rotVecToZ(vec2);
   return rot2_to_z.transpose() * rot1_to_z;
 }
+
+RealTensorValue
+RotationMatrix::rotVec2DToX(const RealVectorValue & vec)
+// provides a rotation matrix that will rotate the vector `vec` to the [1,0,0], assuming vec[2]==0
+{
+  const Real theta = std::atan2(vec(1), vec(0));
+  const Real st = std::sin(theta);
+  const Real ct = std::cos(theta);
+  RealTensorValue rot(ct, st, 0., -st, ct, 0., 0., 0., 1.);
+  return rot;
+}

--- a/framework/src/utils/RotationMatrix.C
+++ b/framework/src/utils/RotationMatrix.C
@@ -63,6 +63,6 @@ RotationMatrix::rotVec2DToX(const RealVectorValue & vec)
   const Real theta = std::atan2(vec(1), vec(0));
   const Real st = std::sin(theta);
   const Real ct = std::cos(theta);
-  RealTensorValue rot(ct, st, 0., -st, ct, 0., 0., 0., 1.);
-  return rot;
+  return RealTensorValue(ct, st, 0., -st, ct, 0., 0., 0., 1.);
+  ;
 }

--- a/modules/tensor_mechanics/include/utils/CohesiveZoneModelTools.h
+++ b/modules/tensor_mechanics/include/utils/CohesiveZoneModelTools.h
@@ -41,4 +41,8 @@ RealVectorValue computeNormalComponents(const RealVectorValue & normal,
 RealVectorValue computeTangentComponents(const RealVectorValue & normal,
                                          const RealVectorValue & vector);
 
+/// compute the czm reference rotation based on the normal in the undeformed configuration and the mesh dimension
+RankTwoTensor computeReferenceRotation(const RealVectorValue & normal,
+                                       const unsigned int mesh_dimension);
+
 } // namespace CohesiveZoneModelTools

--- a/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpBase.C
+++ b/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpBase.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "CZMComputeDisplacementJumpBase.h"
-#include "RotationMatrix.h"
+#include "CohesiveZoneModelTools.h"
 
 InputParameters
 CZMComputeDisplacementJumpBase::validParams()
@@ -85,5 +85,6 @@ CZMComputeDisplacementJumpBase::computeQpProperties()
 void
 CZMComputeDisplacementJumpBase::computeRotationMatrices()
 {
-  _czm_total_rotation[_qp] = RotationMatrix::rotVec1ToVec2(RealVectorValue(1, 0, 0), _normals[_qp]);
+  _czm_total_rotation[_qp] =
+      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _ndisp);
 }

--- a/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpBase.C
+++ b/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpBase.C
@@ -86,5 +86,5 @@ void
 CZMComputeDisplacementJumpBase::computeRotationMatrices()
 {
   _czm_total_rotation[_qp] =
-      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _ndisp);
+      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _mesh.dimension());
 }

--- a/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
+++ b/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
@@ -67,7 +67,7 @@ CZMComputeDisplacementJumpTotalLagrangian::computeRotationMatrices()
 {
 
   _czm_reference_rotation[_qp] =
-      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _ndisp);
+      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _mesh.dimension());
   computeFandR();
   _czm_total_rotation[_qp] = _R[_qp] * _czm_reference_rotation[_qp];
 }

--- a/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
+++ b/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "CZMComputeDisplacementJumpTotalLagrangian.h"
-#include "RotationMatrix.h"
+#include "CohesiveZoneModelTools.h"
 
 registerMooseObject("TensorMechanicsApp", CZMComputeDisplacementJumpTotalLagrangian);
 
@@ -65,8 +65,9 @@ CZMComputeDisplacementJumpTotalLagrangian::computeLocalDisplacementJump()
 void
 CZMComputeDisplacementJumpTotalLagrangian::computeRotationMatrices()
 {
+
   _czm_reference_rotation[_qp] =
-      RotationMatrix::rotVec1ToVec2(RealVectorValue(1, 0, 0), _normals[_qp]);
+      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _ndisp);
   computeFandR();
   _czm_total_rotation[_qp] = _R[_qp] * _czm_reference_rotation[_qp];
 }

--- a/modules/tensor_mechanics/src/utils/CohesiveZoneModelTools.C
+++ b/modules/tensor_mechanics/src/utils/CohesiveZoneModelTools.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "CohesiveZoneModelTools.h"
+#include "RotationMatrix.h"
 
 namespace CohesiveZoneModelTools
 {
@@ -88,6 +89,25 @@ RealVectorValue
 computeTangentComponents(const RealVectorValue & normal, const RealVectorValue & vector)
 {
   return vector - computeNormalComponents(normal, vector);
+}
+
+RankTwoTensor
+computeReferenceRotation(const RealVectorValue & normal, const unsigned int mesh_dimension)
+{
+  RankTwoTensor rot;
+  switch (mesh_dimension)
+  {
+    case 3:
+      rot = RotationMatrix::rotVec1ToVec2(RealVectorValue(1, 0, 0), normal);
+      break;
+    case 2:
+      rot = RotationMatrix::rotVec2DToX(normal).transpose();
+      break;
+    case 1:
+      rot = RankTwoTensor::Identity();
+      break;
+  }
+  return rot;
 }
 
 } // namespace CohesiveZoneModelTools

--- a/modules/tensor_mechanics/src/utils/CohesiveZoneModelTools.C
+++ b/modules/tensor_mechanics/src/utils/CohesiveZoneModelTools.C
@@ -106,6 +106,10 @@ computeReferenceRotation(const RealVectorValue & normal, const unsigned int mesh
     case 1:
       rot = RankTwoTensor::Identity();
       break;
+    default:
+      mooseError("computeReferenceRotation: mesh_dimension value should be 1, 2 or, 3. You "
+                 "provided " +
+                 std::to_string(mesh_dimension));
   }
   return rot;
 }

--- a/unit/src/RotationMatrixTest.C
+++ b/unit/src/RotationMatrixTest.C
@@ -25,6 +25,20 @@ rotVtoU(RealVectorValue v, RealVectorValue u)
   EXPECT_EQ(r.transpose() * r, ident);
 }
 
+void
+rotV2DtoX(RealVectorValue v)
+{
+  RealVectorValue u(1, 0, 0);
+  RealTensorValue ident(1, 0, 0, 0, 1, 0, 0, 0, 1);
+  RealVectorValue vhat = v / v.norm();
+  RealTensorValue r = RotationMatrix::rotVec2DToX(v);
+  RealVectorValue rotated_v = r * vhat;
+  for (unsigned i = 0; i < LIBMESH_DIM; ++i)
+    EXPECT_NEAR(rotated_v(i), u(i), 0.0001);
+  EXPECT_EQ(r * r.transpose(), ident);
+  EXPECT_EQ(r.transpose() * r, ident);
+}
+
 TEST(RotationMatrix, rotVecToVec)
 {
   // rotations of unit vectors to the x, y and z axes
@@ -63,4 +77,23 @@ TEST(RotationMatrix, rotVecToVec)
           RealVectorValue(-0.8023314181426899, 0.23569860131733256, 0.24585385679502592));
   rotVtoU(RealVectorValue(0.9115348224777013, -0.1785871095274909, -0.9938009520887727),
           RealVectorValue(0.7000797283703248, -0.4967869392655946, -0.18288272103373449));
+}
+
+TEST(RotationMatrix, rotV2DtoX)
+{
+  // rotations of unit vectors to the x, and y axes
+  rotV2DtoX(RealVectorValue(1, 0, 0));
+  rotV2DtoX(RealVectorValue(-1, 0, 0));
+  rotV2DtoX(RealVectorValue(0, 1, 0));
+  rotV2DtoX(RealVectorValue(0, -1, 0));
+
+  // more arbitrary vectors
+  rotV2DtoX(RealVectorValue(1, 2, 0));
+  rotV2DtoX(RealVectorValue(-1, 2, 0));
+  rotV2DtoX(RealVectorValue(9, 2, 0));
+  rotV2DtoX(RealVectorValue(-0.7455566879693396, -0.16322143154726376, 0));
+  rotV2DtoX(RealVectorValue(-0.7669989857132189, -0.8822797825649573, 0));
+  rotV2DtoX(RealVectorValue(-0.6195038399590516, 0.24354357871534127, 0));
+  rotV2DtoX(RealVectorValue(0.6418447552756121, 0.9825056348051839, 0));
+  rotV2DtoX(RealVectorValue(0.9115348224777013, -0.1785871095274909, 0));
 }


### PR DESCRIPTION
## Reason
As described in #18697, the cohesive zone model is designed to always use 3D traction-separation laws even when the mesh has 1 or 2 dimensions. However, when using 1D or 2D meshes we still calculate rotation matrices assuming the mesh is 3D. Besides the additional computational burdens, in 2D there is no guarantee to map the unused component of vector and tensor quantities to the third index. By doing this we can improve computational efficiency and we will know which components of the local coordinate system can be discarded (index 3 in 2D and indices 2 and 3 in 1D)

## Design
Add a 2D rotation routine to RotationMatrix and a method to the CohesiveZoneTools that will select the appropriate rotation based on the problem dimensionality

## Impact
None for the users, a better understanding of the problem for developers.
