### PR TITLE
Changes to correct build of SQA pages

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/fvbcs/FVHeatFluxBC/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/fvbcs/FVHeatFluxBC/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'HeatFluxBC.md'
+  design = 'NSFVHeatFluxBC.md'
   issues = '#57'
   [./local_porosity]
     type = Exodiff

--- a/python/MooseDocs/extensions/civet.py
+++ b/python/MooseDocs/extensions/civet.py
@@ -132,9 +132,14 @@ class CivetExtension(command.CommandExtension):
 
             report_root = self.get('test_reports_location')
             if not self.translator.findPage(report_root, exact=True, throw_on_zero=False):
-                self.translator.addPage(pages.Directory(report_root, source=report_root))
+                self.translator.addPage(pages.Directory(report_root,
+                                                        base=self.translator.destination,
+                                                        source=report_root))
 
-            src = pages.Source('{}/index.md'.format(report_root), source='{}/index.md'.format(report_root),
+            src = pages.Source('{}/index.md'.format(report_root),
+                               output_extension='.md',
+                               base=self.translator.destination,
+                               source='{}/index.md'.format(report_root),
                                read=False, tokenize=False)
             self.translator.addPage(src)
 
@@ -145,7 +150,9 @@ class CivetExtension(command.CommandExtension):
                 count += 1
 
                 fullname = '{}/{}.md'.format(report_root, name)
-                src = pages.Source(fullname, source=fullname, read=False, tokenize=False, key=key)
+                src = pages.Source(fullname, source=fullname, read=False, tokenize=False, key=key,
+                                   output_extension='.md',
+                                   base=self.translator.destination)
                 self.translator.addPage(src)
 
             LOG.info("Creating CIVET result pages complete [%s sec.]", time.time() - start)


### PR DESCRIPTION
The CIVET recipes had a bug that allowed a few regressions to slip into the system regarding SQA. The recipes have been fixed and this gets MOOSE fixed.