### PR TITLE
adding average point separation postprocessor

### DIFF
--- a/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
+++ b/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
@@ -4,6 +4,8 @@
 
 ## Description
 
+This `PostProcessor` computes the average distance between two sets of points specified in two arrays defined with the `first_point` and `last_point` parameters. The point positions account for the current displacements, so this distance will evolve over time for a deforming body. If the separation between two specific points is desired, single points rather than a arrays of points can be specified.
+
 This `PostProcessor` computes average distance between a set of points specified in two array `first_point` and `last_point`.
 
 ## Example Input File Syntax

--- a/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
+++ b/modules/tensor_mechanics/doc/content/source/postprocessors/AveragePointSeparation.md
@@ -1,0 +1,19 @@
+# AveragePointSeparation
+
+!syntax description /Postprocessors/AveragePointSeparation
+
+## Description
+
+This `PostProcessor` computes average distance between a set of points specified in two array `first_point` and `last_point`.
+
+## Example Input File Syntax
+
+!listing modules/tensor_mechanics/test/tests/AveragePointSeparation/AveragePointSeparation.i block=Postprocessors/avg_disp
+
+!syntax parameters /Postprocessors/AveragePointSeparation
+
+!syntax inputs /Postprocessors/AveragePointSeparation
+
+!syntax children /Postprocessors/AveragePointSeparation
+
+!bibtex bibliography

--- a/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
+++ b/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralPostprocessor.h"
+
+/**
+ * Compute the value of a variable at a specified location.
+ *
+ * Warning: This postprocessor may result in undefined behavior if utilized with
+ * non-continuous elements and the point being located lies on an element boundary.
+ */
+class AveragePointSeparation : public GeneralPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  AveragePointSeparation(const InputParameters & parameters);
+
+  virtual void initialize() override {}
+  virtual void execute() override;
+  virtual void finalize() override {}
+  virtual Real getValue() override;
+
+protected:
+  std::vector<VariableName> _displacements;
+
+  /// The vector of displacements number we are operating on
+  std::vector<int> _disp_num;
+
+  /// A reference to the system containing the variable
+  const System & _system;
+
+  /// The point to locate
+  const std::vector<Point> & _first_point;
+  const std::vector<Point> & _last_point;
+
+  /// The value of the variable at the desired location
+  Real _value;
+};

--- a/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
+++ b/modules/tensor_mechanics/include/postprocessors/AveragePointSeparation.h
@@ -11,12 +11,6 @@
 
 #include "GeneralPostprocessor.h"
 
-/**
- * Compute the value of a variable at a specified location.
- *
- * Warning: This postprocessor may result in undefined behavior if utilized with
- * non-continuous elements and the point being located lies on an element boundary.
- */
 class AveragePointSeparation : public GeneralPostprocessor
 {
 public:
@@ -38,10 +32,10 @@ protected:
   /// A reference to the system containing the variable
   const System & _system;
 
-  /// The point to locate
+  /// The vectors of start and end points
   const std::vector<Point> & _first_point;
   const std::vector<Point> & _last_point;
 
-  /// The value of the variable at the desired location
+  /// The value of the average separation between the sets of points
   Real _value;
 };

--- a/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
+++ b/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
@@ -1,0 +1,88 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "AveragePointSeparation.h"
+
+// MOOSE includes
+#include "Function.h"
+#include "MooseMesh.h"
+#include "MooseVariable.h"
+#include "SubProblem.h"
+
+#include "libmesh/system.h"
+
+#include "ComputeIncrementalBeamStrain.h"
+#include "Assembly.h"
+#include "NonlinearSystem.h"
+
+#include "libmesh/quadrature.h"
+#include "libmesh/utility.h"
+
+registerMooseObject("TensorMechanicsApp", AveragePointSeparation);
+
+defineLegacyParams(AveragePointSeparation);
+
+InputParameters
+AveragePointSeparation::validParams()
+{
+  InputParameters params = GeneralPostprocessor::validParams();
+  params.addRequiredParam<std::vector<VariableName>>(
+      "displacements",
+      "The displacements appropriate for the simulation geometry and coordinate system");
+  params.addRequiredParam<std::vector<Point>>("first_point",
+                                              "A list of first points in the numerical domain");
+  params.addRequiredParam<std::vector<Point>>("last_point",
+                                              "A list of last points in the numerical domain");
+  params.addClassDescription(
+      "Compute the average separation between a list of two specified locations");
+  return params;
+}
+
+AveragePointSeparation::AveragePointSeparation(const InputParameters & parameters)
+  : GeneralPostprocessor(parameters),
+    _displacements(getParam<std::vector<VariableName>>("displacements")),
+
+    _system(_subproblem.getSystem(_displacements[0])),
+    _first_point(getParam<std::vector<Point>>("first_point")),
+    _last_point(getParam<std::vector<Point>>("last_point")),
+    _value(0)
+{
+  // fetch coupled variables and gradients (as stateful properties if necessary)
+  _disp_num = std::vector<int>(_displacements.size());
+  for (unsigned int i = 0; i < _displacements.size(); ++i)
+    _disp_num[i] = _subproblem
+                       .getVariable(_tid,
+                                    _displacements[i],
+                                    Moose::VarKindType::VAR_ANY,
+                                    Moose::VarFieldType::VAR_FIELD_STANDARD)
+                       .number();
+}
+
+void
+AveragePointSeparation::execute()
+{
+  _value = 0.;
+  Real sq_diff;
+  for (unsigned int i = 0; i < _first_point.size(); ++i)
+  {
+    sq_diff = 0;
+    for (unsigned int j = 0; j < _displacements.size(); ++j)
+      sq_diff += Utility::pow<2>(_system.point_value(_disp_num[j], _first_point[i], false) -
+                                 _system.point_value(_disp_num[j], _last_point[i], false));
+
+    _value += std::sqrt(sq_diff);
+  }
+  _value = _value / _first_point.size();
+}
+
+Real
+AveragePointSeparation::getValue()
+{
+  return _value;
+}

--- a/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
+++ b/modules/tensor_mechanics/src/postprocessors/AveragePointSeparation.C
@@ -40,7 +40,7 @@ AveragePointSeparation::validParams()
   params.addRequiredParam<std::vector<Point>>("last_point",
                                               "A list of last points in the numerical domain");
   params.addClassDescription(
-      "Compute the average separation between a list of two specified locations");
+      "Computes the average separation on deformed mesh between two sets of points");
   return params;
 }
 
@@ -62,6 +62,9 @@ AveragePointSeparation::AveragePointSeparation(const InputParameters & parameter
                                     Moose::VarKindType::VAR_ANY,
                                     Moose::VarFieldType::VAR_FIELD_STANDARD)
                        .number();
+
+  if(_first_point.size() != _last_point.size())
+    mooseerror("first point and last point array should have the same size.");
 }
 
 void
@@ -73,8 +76,8 @@ AveragePointSeparation::execute()
   {
     sq_diff = 0;
     for (unsigned int j = 0; j < _displacements.size(); ++j)
-      sq_diff += Utility::pow<2>(_system.point_value(_disp_num[j], _first_point[i], false) -
-                                 _system.point_value(_disp_num[j], _last_point[i], false));
+      sq_diff += Utility::pow<2>((_first_point[i](j) + _system.point_value(_disp_num[j], _first_point[i], false)) -
+                                 (_last_point[i](j) + _system.point_value(_disp_num[j], _last_point[i], false)));
 
     _value += std::sqrt(sq_diff);
   }

--- a/modules/tensor_mechanics/test/tests/AveragePointSeparation/AveragePointSeparation.i
+++ b/modules/tensor_mechanics/test/tests/AveragePointSeparation/AveragePointSeparation.i
@@ -1,0 +1,246 @@
+# Test for small strain Euler beam axial loading in x direction.
+
+# Modeling a pipe with an OD of 10 inches and ID of 8 inches
+# The length of the pipe is 5 feet (60 inches) and E = 30e6
+# G = 11.5384615385e6 with nu = 0.3
+# The applied axial load is 50000 lb which results in a
+# displacement of 3.537e-3 inches at the end
+
+# delta = PL/AE = 50000 * 60 / pi (5^2 - 4^2) * 30e6 = 3.537e-3
+
+# In this analysis the applied force is used as a BC
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+  xmin = 0.0
+  xmax = 60.0
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Variables]
+  [./disp_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./disp_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_x]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_y]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+  [./rot_z]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixz1]
+    type = DirichletBC
+    variable = disp_z
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr1]
+    type = DirichletBC
+    variable = rot_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr2]
+    type = DirichletBC
+    variable = rot_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr3]
+    type = DirichletBC
+    variable = rot_z
+    boundary = left
+    value = 0.0
+  [../]
+[]
+
+[NodalKernels]
+  [./force_x2]
+    type = ConstantRate
+    variable = disp_x
+    boundary = right
+    rate = 50000.0
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+[Executioner]
+  type = Transient
+  solve_type = PJFNK
+  line_search = 'none'
+  nl_max_its = 15
+  nl_rel_tol = 1e-10
+  nl_abs_tol = 1e-8
+
+  dt = 1
+  dtmin = 1
+  end_time = 2
+[]
+
+[Kernels]
+  [./solid_disp_x]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 0
+    variable = disp_x
+  [../]
+  [./solid_disp_y]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 1
+    variable = disp_y
+  [../]
+  [./solid_disp_z]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 2
+    variable = disp_z
+  [../]
+  [./solid_rot_x]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 3
+    variable = rot_x
+  [../]
+  [./solid_rot_y]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 4
+    variable = rot_y
+  [../]
+  [./solid_rot_z]
+    type = StressDivergenceBeam
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    component = 5
+    variable = rot_z
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityBeam
+    shear_coefficient = 1.0
+    youngs_modulus = 30e6
+    poissons_ratio = 0.3
+    block = 0
+    outputs = exodus
+    output_properties = 'material_stiffness material_flexure'
+  [../]
+  [./strain]
+    type = ComputeIncrementalBeamStrain
+    block = '0'
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+    area = 28.274
+    Ay = 0.0
+    Az = 0.0
+    Iy = 1.0
+    Iz = 1.0
+    y_orientation = '0.0 1.0 0.0'
+  [../]
+  [./stress]
+    type = ComputeBeamResultants
+    block = 0
+    outputs = exodus
+    output_properties = 'forces moments'
+  [../]
+[]
+
+[Postprocessors]
+  [./disp_x60]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y60]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./disp_x30]
+    type = PointValue
+    point = '30.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y30]
+    type = PointValue
+    point = '30.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./disp_x0]
+    type = PointValue
+    point = '0.0 0.0 0.0'
+    variable = disp_x
+  [../]
+  [./disp_y0]
+    type = PointValue
+    point = '0.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./avg_disp]
+    type = AveragePointSeparation
+    first_point = '60.0 0.0 0.0
+                   30.0 0.0 0.0'
+    last_point  = '30.0 0.0 0.0
+                    0.0 0.0 0.0'
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+  [./forces_x]
+    type = PointValue
+    point = '60.0 0.0 0.0'
+    variable = forces_x
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  exodus = true
+[]


### PR DESCRIPTION
# Reason
Currently to calculate deformation between two points in a domain, we need to get displacement in each direction for individual points and then manually obtain the deformation.

# Design
A new postprocessor is required to obtain deformation between two points.

# Impact
Reduces the length of input file.
#18751 