### PR TITLE
PerfGraph Live Print Fixes

### DIFF
--- a/framework/src/actions/CommonOutputAction.C
+++ b/framework/src/actions/CommonOutputAction.C
@@ -120,7 +120,7 @@ CommonOutputAction::validParams()
 
   params.addParam<bool>("perf_graph_live", true, "Enables printing of live progress messages");
   params.addParam<Real>(
-      "perf_graph_live_time_limit", 1.0, "Time (in seconds) to wait before printing a message.");
+      "perf_graph_live_time_limit", 5.0, "Time (in seconds) to wait before printing a message.");
   params.addParam<unsigned int>(
       "perf_graph_live_mem_limit", 100, "Memory (in MB) to cause a message to be printed.");
 

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -42,7 +42,7 @@ PerfGraph::PerfGraph(const std::string & root_name,
     _active(true),
     _live_print_active(true),
     _destructing(false),
-    _live_print_time_limit(1.0),
+    _live_print_time_limit(5.0),
     _live_print_mem_limit(100),
     _live_print(std::make_unique<PerfGraphLivePrint>(*this, app))
 {

--- a/framework/src/utils/PerfGraphLivePrint.C
+++ b/framework/src/utils/PerfGraphLivePrint.C
@@ -290,7 +290,7 @@ PerfGraphLivePrint::start()
     // can occur - but the predicate here keeps us from doing anything in that case.
     // This will either wait until 1 second has passed, the signal is sent, _or_ a spurious
     // wakeup happens to find that there is work to do.
-    _perf_graph._finished_section.wait_for(lock, std::chrono::duration<Real>(1.), [this] {
+    _perf_graph._finished_section.wait_for(lock, std::chrono::duration<Real>(_time_limit), [this] {
       // Get destructing first so that the execution_list will be in sync
       this->_currently_destructing = _perf_graph._destructing;
 

--- a/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
+++ b/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
@@ -34,7 +34,7 @@
 
 [Problem]
   type = SlowProblem
-  seconds_to_sleep = 4
+  seconds_to_sleep = 7
 []
 
 [Executioner]


### PR DESCRIPTION
Fix possible timing bug with live print and increase the default wait to 5 seconds 

refs #15444