### PR TITLE
Remove overzealous assert in ADComputeFiniteStrain

### DIFF
--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
@@ -147,9 +147,6 @@ ADComputeFiniteStrain::computeQpIncrements(ADRankTwoTensor & total_strain_increm
       const ADReal C1_squared =
           p + 3.0 * Utility::pow<2>(p) * (1.0 - (p + q)) / Utility::pow<2>(p + q) -
           2.0 * Utility::pow<3>(p) * (1.0 - (p + q)) / Utility::pow<3>(p + q);
-      mooseAssert(C1_squared >= 0.0,
-                  "Cannot take square root of a negative number. This may happen when elements "
-                  "become heavily distorted.");
       const ADReal C1 = std::sqrt(C1_squared);
 
       ADReal C2;


### PR DESCRIPTION
See current failure on idaholab/blackbear#250. Test passes in opt
(with no asserts) and fails in debugging modes because of the assert.
It's much better not to assert and instead to insert a NaN into the
residual vector. PETSc will quite naturally cut the lambda in the
line search when it gets a NaN in its fnorm testing which is exactly
what we want here. We want to reduce the Newton step such that we
stay within physical bounds. Right now we don't do that and instead
we just abort. There's absolutely no need for that
