### PR TITLE
fix ExtraNodesetGenerator.C for mesh dimension lower than spatial dimension 

### DIFF
--- a/framework/src/meshgenerators/ExtraNodesetGenerator.C
+++ b/framework/src/meshgenerators/ExtraNodesetGenerator.C
@@ -111,7 +111,7 @@ ExtraNodesetGenerator::generate()
                  " has too many components. Did you maybe forget to separate multiple coordinates "
                  "with a ';'?");
 
-    for (unsigned int j = 0; j < dim; ++j)
+    for (unsigned int j = 0; j < c.size(); ++j)
       p(j) = c[j];
 
     // locate candidate element


### PR DESCRIPTION
close #18781 
