### PR TITLE
Allow warnings in hard mortar contact test

### DIFF
--- a/modules/contact/test/tests/bouncing-block-contact/grid-sequencing/tests
+++ b/modules/contact/test/tests/bouncing-block-contact/grid-sequencing/tests
@@ -23,5 +23,6 @@
     partial = True
     mesh_mode = replicated # Fix when mortar segment mesh is distributed
     rel_err = 2e-5
+    allow_warnings = True # This is a difficult problem that can result in poor mortar projections that emit warnings
   []
 []


### PR DESCRIPTION
Antonio recently changed an exception for invalid mortar orientations
to a warning, which in contact module testing has the effect of
turning a cut timestep into a hard failure unless we allow warnings.
We just saw this in CI parallel testing (which I'm going to invalidate
so linking here would be ineffectual)

Refs #17696