### PR TITLE
Always clone rms

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1045,6 +1045,15 @@ private:
   void createMeshGeneratorOrder();
 
   /**
+   * @return whether we have created any clones for the provided template relationship manager and
+   * mesh yet. This may be false for instance when we are in the initial add relationship manager
+   * stage and haven't attempted attaching any relationship managers to the mesh or dof map yet
+   * (which is when we generate the clones). It's also maybe possible that we've created a clone of
+   * a given \p template_rm but not for the provided mesh so we return false in that case as well
+   */
+  bool hasRMClone(const RelationshipManager & template_rm, const MeshBase & mesh) const;
+
+  /**
    * Return the ghosting functor clone originally created from the provided template relationship
    * manager (the relationship manager stored by the \p MooseApp) and mesh
    */

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1054,11 +1054,11 @@ private:
   bool hasRMClone(const RelationshipManager & template_rm, const MeshBase & mesh) const;
 
   /**
-   * Return the ghosting functor clone originally created from the provided template relationship
-   * manager (the relationship manager stored by the \p MooseApp) and mesh
+   * Return the relationship manager clone originally created from the provided template
+   * relationship manager and mesh
    */
-  GhostingFunctor & getRMClone(const RelationshipManager & template_rm,
-                               const MeshBase & mesh) const;
+  RelationshipManager & getRMClone(const RelationshipManager & template_rm,
+                                   const MeshBase & mesh) const;
 
   /**
    * Take an input relationship manager, clone it, and then initialize it with provided mesh and
@@ -1067,11 +1067,11 @@ private:
    * @param mesh The mesh to use for initialization
    * @param dof_map An optional parameter that, if provided, will be used to help init the cloned
    * relationship manager
-   * @return the cloned and initialized ghosting functor/relationship manager
+   * @return a reference to the cloned and initialized relationship manager
    */
-  std::shared_ptr<GhostingFunctor> createRMFromTemplate(const RelationshipManager & template_rm,
-                                                        MeshBase & mesh,
-                                                        const DofMap * dof_map = nullptr);
+  RelationshipManager & createRMFromTemplateAndInit(const RelationshipManager & template_rm,
+                                                    MeshBase & mesh,
+                                                    const DofMap * dof_map = nullptr);
 
   /// Where the restartable data is held (indexed on tid)
   RestartableDataMaps _restartable_data;
@@ -1148,7 +1148,7 @@ private:
   /// Map from a template relationship manager to a map in which the key-value pairs represent the \p
   /// MeshBase object and the clone of the template relationship manager, e.g. the top-level map key
   std::map<const RelationshipManager *,
-           std::map<const MeshBase *, std::shared_ptr<GhostingFunctor>>>
+           std::map<const MeshBase *, std::unique_ptr<RelationshipManager>>>
       _template_to_clones;
 
   // Allow FEProblemBase to set the recover/restart state, so make it a friend

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1044,6 +1044,26 @@ private:
    */
   void createMeshGeneratorOrder();
 
+  /**
+   * Return the ghosting functor clone originally created from the provided template relationship
+   * manager (the relationship manager stored by the \p MooseApp) and mesh
+   */
+  GhostingFunctor & getRMClone(const RelationshipManager & template_rm,
+                               const MeshBase & mesh) const;
+
+  /**
+   * Take an input relationship manager, clone it, and then initialize it with provided mesh and
+   * optional \p dof_map
+   * @param template_rm The relationship manager template from which we will clone
+   * @param mesh The mesh to use for initialization
+   * @param dof_map An optional parameter that, if provided, will be used to help init the cloned
+   * relationship manager
+   * @return the cloned and initialized ghosting functor/relationship manager
+   */
+  std::shared_ptr<GhostingFunctor> createRMFromTemplate(const RelationshipManager & template_rm,
+                                                        MeshBase & mesh,
+                                                        const DofMap * dof_map = nullptr);
+
   /// Where the restartable data is held (indexed on tid)
   RestartableDataMaps _restartable_data;
 
@@ -1115,6 +1135,12 @@ private:
 
   /// Memory profiling
   bool _heap_profiling = false;
+
+  /// Map from a template relationship manager to a map in which the key-value pairs represent the \p
+  /// MeshBase object and the clone of the template relationship manager, e.g. the top-level map key
+  std::map<const RelationshipManager *,
+           std::map<const MeshBase *, std::shared_ptr<GhostingFunctor>>>
+      _template_to_clones;
 
   // Allow FEProblemBase to set the recover/restart state, so make it a friend
   friend class FEProblemBase;

--- a/framework/include/relationshipmanagers/RelationshipManager.h
+++ b/framework/include/relationshipmanagers/RelationshipManager.h
@@ -122,6 +122,8 @@ public:
    */
   bool useDisplacedMesh() const { return _use_displaced_mesh; }
 
+  const DofMap * dofMap() { return _dof_map; }
+
 protected:
   /**
    * Called before this RM is attached.  Only called once

--- a/framework/include/utils/CastUniquePointer.h
+++ b/framework/include/utils/CastUniquePointer.h
@@ -14,12 +14,29 @@
  * New GitHub Repo here: https://github.com/friedmud/unique_ptr_cast
  */
 
-
 #include <memory>
 
 template <typename T_DEST, typename T_SRC, typename T_DELETER>
 std::unique_ptr<T_DEST, T_DELETER>
 dynamic_pointer_cast(std::unique_ptr<T_SRC, T_DELETER> & src)
+{
+  if (!src)
+    return std::unique_ptr<T_DEST, T_DELETER>(nullptr);
+
+  T_DEST * dest_ptr = dynamic_cast<T_DEST *>(src.get());
+  if (!dest_ptr)
+    return std::unique_ptr<T_DEST, T_DELETER>(nullptr);
+
+  std::unique_ptr<T_DEST, T_DELETER> dest_temp(dest_ptr, std::move(src.get_deleter()));
+
+  src.release();
+
+  return dest_temp;
+}
+
+template <typename T_DEST, typename T_SRC, typename T_DELETER>
+std::unique_ptr<T_DEST, T_DELETER>
+dynamic_pointer_cast(std::unique_ptr<T_SRC, T_DELETER> && src)
 {
   if (!src)
     return std::unique_ptr<T_DEST, T_DELETER>(nullptr);
@@ -53,3 +70,20 @@ dynamic_pointer_cast(std::unique_ptr<T_SRC> & src)
   return dest_temp;
 }
 
+template <typename T_DEST, typename T_SRC>
+std::unique_ptr<T_DEST>
+dynamic_pointer_cast(std::unique_ptr<T_SRC> && src)
+{
+  if (!src)
+    return std::unique_ptr<T_DEST>(nullptr);
+
+  T_DEST * dest_ptr = dynamic_cast<T_DEST *>(src.get());
+  if (!dest_ptr)
+    return std::unique_ptr<T_DEST>(nullptr);
+
+  std::unique_ptr<T_DEST> dest_temp(dest_ptr);
+
+  src.release();
+
+  return dest_temp;
+}


### PR DESCRIPTION
Also continue the very slow march to make relationship manager code more
readable which hopefully also means less liable to bug-ridden. This
change came about because on Jacob's 3D mortar PR he has a test that
collects two meshes into a single one using the
`MeshCollectionGenerator`. We were failing an assertion when running
with distributed mesh because a relationship manager/ghosting functor
was using the incorrect `MeshBase` object. To avoid this we should
always clone and make sure we're initializing with the correct mesh

Refs #18203