### PR TITLE
Fix exodiff compatibility with Exodus 8

### DIFF
--- a/framework/contrib/exodiff/exo_entity.C
+++ b/framework/contrib/exodiff/exo_entity.C
@@ -573,7 +573,7 @@ get_index(int file_id, EXOTYPE exo_type, size_t id, const char * label)
 size_t
 get_num_entities(int file_id, EXOTYPE exo_type)
 {
-  int inquiry = 0;
+  ex_inquiry inquiry = EX_INQ_INVALID;
   switch (exo_type)
   {
     case EX_ELEM_BLOCK:


### PR DESCRIPTION
Refs #18768

## Reason

When libMesh has been compiled to use Exodus 8 instead of Exodus 5, the version of exodiff distributed with Moose fails to compile against the included exodusII.h, because of an Exodus API change which makes one of the arguments to `ex_inquire_int` slightly stricter about what it accepts.

## Design

Updating to a newer exodiff might break Exodus 5 compatibility, so we just tweak this version of exodiff: instead of passing an `int` as an `ex_inquiry`, we pass an `ex_inquiry` with the same data.

## Impact

No change for Exodus 5 users; Exodus 8 users can compile Moose now.