### PR TITLE
Save XFEM nodal points as Point, not Node

### DIFF
--- a/modules/xfem/include/userobjects/NodeValueAtXFEMInterface.h
+++ b/modules/xfem/include/userobjects/NodeValueAtXFEMInterface.h
@@ -77,7 +77,7 @@ protected:
   MooseMesh & _mesh;
 
   /// The nodes to evaluate at
-  std::vector<Node> _nodes;
+  std::vector<Point> _nodes;
 
   /// Pointer to PointLocatorBase object
   std::unique_ptr<PointLocatorBase> _pl;


### PR DESCRIPTION
Refs #13921

## Reason

This avoids us calling a Node copy constructor which has been deprecated within libMesh (because it does a slicing copy, which is in fact what we want to do here, but which is too often a mistake).

## Design

Changing the saved data type from Node to Point calls the desired constructor automatically (and is clearer about intent, and saves a little RAM).

## Impact
If any user subclasses of `NodeValueAtXFEMInterface` try to declare iterators etc. to the protected `_nodes` member using the old data type, those subclasses will need to be updated.  If not, this should have no impact (except trivial RAM savings) on users with standard libMesh builds, and it should fix compilation for users of libMesh `--disable-deprecated` builds.