### PR TITLE
Enforce same order/family 

### DIFF
--- a/framework/src/auxkernels/TagVectorAux.C
+++ b/framework/src/auxkernels/TagVectorAux.C
@@ -33,6 +33,11 @@ TagVectorAux::TagVectorAux(const InputParameters & parameters)
   auto & execute_on = getParam<ExecFlagEnum>("execute_on");
   if (execute_on.size() != 1 || !execute_on.contains(EXEC_TIMESTEP_END))
     mooseError("execute_on for TagVectorAux must be set to EXEC_TIMESTEP_END");
+
+  if (getVar("v", 0)->feType() != _var.feType())
+    paramError("variable",
+               "The AuxVariable this AuxKernel is acting on has to have the same order and family "
+               "as the variable 'v'");
 }
 
 Real

--- a/test/tests/tag/tests
+++ b/test/tests/tag/tests
@@ -38,6 +38,15 @@
       detail = 'multiple numeric matrices simultaneously.'
     []
   []
+  [tag_vector_error]
+    type = 'RunException'
+    input = '2d_diffusion_tag_vector.i'
+    expect_err = 'The AuxVariable this AuxKernel is acting on has to have the same order and family '
+                 'as the variable \'v\''
+    cli_args = 'Mesh/square/second=true Variables/u/order=SECOND'
+    requirement = 'The system shall throw an error when the variable orders and families for the '
+                  'tagged and the auxiliary output variables do not match.'
+  []
 
   [systems]
     requirement = 'The system shall support filling in labeled or "tagged" vectors or matrices from:'
@@ -107,7 +116,8 @@
     type = 'Exodiff'
     input = 'controls-tagging.i'
     exodiff = 'controls-tagging_out.e'
-    requirement = 'Cached Active object state will be maintained correctly even when objects\' active state changes during runtime.'
+    requirement = 'Cached Active object state will be maintained correctly even when objects\' '
+                  'active state changes during runtime.'
     issues = '#15515'
   []
 []


### PR DESCRIPTION
Closes #18847

The real crime here, however, seems to me is that MOOSE lets you couple a lower order AUxVariable on an higher order element and will just happily give you junk on the extra high order nodes that the low order variable has no DOFs on. 👀 

IMO this should just be a framework level error...