### PR TITLE
Fixup newsletter rendering

### DIFF
--- a/modules/doc/content/newsletter/2021_06.md
+++ b/modules/doc/content/newsletter/2021_06.md
@@ -8,7 +8,7 @@ later files adding and overwriting parameters. This allows users to factor out
 common parameters (e.g. solver options, postprocessors, outputs) from a set of
 similar input files
 
- ```
+```
  ./mooseapp-opt -i common_parameters.i simulation_1.i
 ```
 
@@ -40,7 +40,7 @@ the `hit` commandline tool.
 - active\_local\_subdomain\_set mesh iterators
 - MeshFunction::set\_subdomain\_ids() option
 - GenericProjector made more flexible, for solution transfer use
-- SIDE\_HIERARCHIC finite element type added, for varaibles defined on
+- SIDE\_HIERARCHIC finite element type added, for variables defined on
   interfaces between elements.
 - Minor bug fixes, compatibility fixes
 

--- a/modules/doc/content/newsletter/2021_07.md
+++ b/modules/doc/content/newsletter/2021_07.md
@@ -19,22 +19,22 @@ number natural convection simulations.
 
 ## libMesh-level changes
 
-  - Mimic stl and boost constructors in our allocators
-  - Try changing max order for L2 families
-  - Add LumpedMassMatrix class
-  - Test custom FE reinit
-  - `$LIBMESH_BENCHMARK` selection of benchmarking examples
-  - RB: skip reinit when there are no DOFs on Elem
-  - Command-line override of default Metis-vs-Parmetis
-  - init_names() at more points
-  - Fix FE side unit tests with --enable-complex
-  - Begin contains_vertex_of with node equality tests
-  - chunked_mapvector storage option
-  - Weaken partitioner_test for SFC on 8+ processors
-  - Bugfix for PR libmesh/libmesh#2940
-  - Revert "interior_parent fix on distributed refined multi-elem_dim meshes"
-  - interior_parent fix on distributed refined multi-elem_dim meshes
-  - RB EIM update
-  - Fix for deprecated warning in SLEPc not-quite-3.15
-  - Use pool allocator in mapvector
-  - Check for gdb in command line in print_trace when compiling with no gdb backtrace by default
+- Mimic stl and boost constructors in our allocators
+- Try changing max order for L2 families
+- Add LumpedMassMatrix class
+- Test custom FE reinit
+- `$LIBMESH_BENCHMARK` selection of benchmarking examples
+- RB: skip reinit when there are no DOFs on Elem
+- Command-line override of default Metis-vs-Parmetis
+- init_names() at more points
+- Fix FE side unit tests with --enable-complex
+- Begin contains_vertex_of with node equality tests
+- chunked_mapvector storage option
+- Weaken partitioner_test for SFC on 8+ processors
+- Bugfix for PR libmesh/libmesh#2940
+- Revert "interior_parent fix on distributed refined multi-elem_dim meshes"
+- interior_parent fix on distributed refined multi-elem_dim meshes
+- RB EIM update
+- Fix for deprecated warning in SLEPc not-quite-3.15
+- Use pool allocator in mapvector
+- Check for gdb in command line in print_trace when compiling with no gdb backtrace by default


### PR DESCRIPTION
Fixes up incorrect spacing in June and July 2021 newsletters, missed during review. Also fixes spelling typo. 

Refs #18275 

@GiudGiud could you give this a quick review? 