### PR TITLE
PerfGraph Live Tweaks

### DIFF
--- a/framework/include/utils/PerfGraph.h
+++ b/framework/include/utils/PerfGraph.h
@@ -302,7 +302,8 @@ protected:
         _print_stack_level(0),
         _num_dots(0),
         _time(std::chrono::seconds(0)),
-        _memory(0)
+        _memory(0),
+        _beginning_num_printed(0)
     {
     }
 
@@ -323,6 +324,9 @@ protected:
 
     /// Either the starting memory or final memory depending on _state
     long int _memory;
+
+    /// The _console numPrinted() at the time this section was created
+    unsigned long long int _beginning_num_printed;
   };
 
   /**

--- a/framework/include/utils/PerfGraphLivePrint.h
+++ b/framework/include/utils/PerfGraphLivePrint.h
@@ -116,6 +116,9 @@ private:
   /// The output count from the console the last time we printed
   unsigned long long int _last_num_printed;
 
+  /// The current output count from the console
+  unsigned long long int _console_num_printed;
+
   /// Whether or not printing happened in this iteration
   bool _printed;
 };

--- a/framework/include/utils/PerfGraphLivePrint.h
+++ b/framework/include/utils/PerfGraphLivePrint.h
@@ -121,4 +121,7 @@ private:
 
   /// Whether or not printing happened in this iteration
   bool _printed;
+
+  /// Whether or not the top thing on the stack is set to print dots
+  bool _stack_top_print_dots;
 };

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -178,6 +178,7 @@ PerfGraph::addToExecutionList(const PerfID id,
   section_increment._state = state;
   section_increment._time = time;
   section_increment._memory = memory;
+  section_increment._beginning_num_printed = _console.numPrinted();
 
   // This will synchronize the above memory changes with the
   // atomic_thread_fence in the printing thread

--- a/framework/src/utils/PerfGraphLivePrint.C
+++ b/framework/src/utils/PerfGraphLivePrint.C
@@ -25,6 +25,7 @@ PerfGraphLivePrint::PerfGraphLivePrint(PerfGraph & perf_graph, MooseApp & app)
     _last_execution_list_end(0),
     _last_printed_increment(NULL),
     _last_num_printed(0),
+    _console_num_printed(0),
     _printed(false)
 {
 }
@@ -32,7 +33,24 @@ PerfGraphLivePrint::PerfGraphLivePrint(PerfGraph & perf_graph, MooseApp & app)
 void
 PerfGraphLivePrint::printLiveMessage(PerfGraph::SectionIncrement & section_increment)
 {
+  // If this section is just started - but other stuff has printed before we got to print its message
+  // just mark it as printed and return (i.e. - don't print it)
+  if (section_increment._state == PerfGraph::IncrementState::STARTED && section_increment._beginning_num_printed != _console_num_printed)
+  {
+    section_increment._state = PerfGraph::IncrementState::PRINTED;
+    _last_printed_increment = &section_increment;
+    return;
+  }
+
   auto & section_info = _perf_graph_registry.sectionInfo(section_increment._id);
+
+  // If we're not printing dots - we shouldn't be printing the message at all
+  if (!section_info._print_dots)
+  {
+    section_increment._state = PerfGraph::IncrementState::PRINTED;
+    _last_printed_increment = &section_increment;
+    return;
+  }
 
   // If the live_message is empty - just print the name
   const auto message =
@@ -67,7 +85,8 @@ PerfGraphLivePrint::printLiveMessage(PerfGraph::SectionIncrement & section_incre
     if (!section_info._print_dots)
       _console << '\n';
 
-    section_increment._num_dots = 0;
+    // The 6 is for "Still "
+    section_increment._num_dots = 6;
   }
   else // Just print the message
   {
@@ -81,6 +100,12 @@ PerfGraphLivePrint::printLiveMessage(PerfGraph::SectionIncrement & section_incre
   }
 
   section_increment._state = PerfGraph::IncrementState::PRINTED;
+
+  // Get the message to the screen
+  _console << std::flush;
+
+  // Keep track of where we printed in the console
+  section_increment._beginning_num_printed = _console.numPrinted();
 
   _last_printed_increment = &section_increment;
 
@@ -114,17 +139,21 @@ PerfGraphLivePrint::printStats(PerfGraph::SectionIncrement & section_increment_s
   // Do we need to print "Finished"?
   // This happens after something else printed in-between when this increment started and finished
   if (!section_info_start._print_dots ||
-      (_last_printed_increment && _last_printed_increment != &section_increment_start))
+      (_last_printed_increment && _last_printed_increment != &section_increment_start) ||
+      (section_increment_start._beginning_num_printed != _console_num_printed)) // This means someone _else_ printed
   {
-    if ((_last_printed_increment &&
+    // If we had printed some dots - we need to finish the line
+    if ((section_increment_start._beginning_num_printed == _console_num_printed) &&
+        (_last_printed_increment &&
          _last_printed_increment->_state == PerfGraph::IncrementState::PRINTED &&
          _perf_graph_registry.sectionInfo(_last_printed_increment->_id)._print_dots))
       _console << '\n';
-    const std::string finished("Finished ");
-    _console << std::string(2 * section_increment_start._print_stack_level, ' ') << finished
+
+    _console << std::string(2 * section_increment_start._print_stack_level, ' ') << "Finished "
              << message;
 
-    num_horizontal_chars += finished.size();
+    // 9 is for "Finished "
+    num_horizontal_chars += 9;
   }
   else
     num_horizontal_chars += section_increment_start._num_dots;
@@ -187,7 +216,8 @@ PerfGraphLivePrint::printStackUpToLast()
   {
     auto & section = _print_thread_stack[s];
 
-    if (section._state == PerfGraph::IncrementState::STARTED) // Hasn't been printed at all
+    // Hasn't been printed at all and nothing else has been printed since this started
+    if (section._state == PerfGraph::IncrementState::STARTED)
       printLiveMessage(section);
 
     // Note: this will reset the state of a "continued" section to "printed" - so that it can be
@@ -199,9 +229,18 @@ PerfGraphLivePrint::printStackUpToLast()
 void
 PerfGraphLivePrint::inSamePlace()
 {
-  // If someone else printed since, then we need to start over
-  if (_last_num_printed != _console.numPrinted())
+  // If someone else printed since, then we need to start over, and set everything on the stack to printed
+  // Everything is set to printed because if something printed and we're still in the same place
+  // then we need to NOT print out the beginning message
+  if (_last_num_printed != _console_num_printed)
+  {
     _last_printed_increment = nullptr;
+
+    for (unsigned int s = 0; s < _stack_level; s++)
+      _print_thread_stack[s]._state = PerfGraph::IncrementState::PRINTED;
+
+    return;
+  }
 
   // Only print if there is something to print!
   if (_stack_level > 0)
@@ -298,6 +337,9 @@ PerfGraphLivePrint::start()
       this->_current_execution_list_end =
           _perf_graph._execution_list_end.load(std::memory_order_relaxed);
 
+      // Save off the number of things currently printed to the console
+      this->_console_num_printed = _console.numPrinted();
+
       // If we are destructing or there is new work to do... allow moving on
       return this->_currently_destructing ||
              this->_last_execution_list_end != this->_current_execution_list_end;
@@ -345,13 +387,7 @@ PerfGraphLivePrint::start()
     // it, modifying the stack and printing anything that needs printing
     iterateThroughExecutionList();
 
-    // Make sure that everything comes out on the console
-    if (_printed)
-    {
-      if (_should_print)
-        _console << std::flush;
-      _last_num_printed = _console.numPrinted();
-    }
+    _last_num_printed = _console.numPrinted();
 
     _last_execution_list_end = _current_execution_list_end;
   }

--- a/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
+++ b/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
@@ -34,7 +34,7 @@
 
 [Problem]
   type = SlowProblem
-  seconds_to_sleep = 7
+  seconds_to_sleep = 4
 []
 
 [Executioner]
@@ -45,5 +45,6 @@
 []
 
 [Outputs]
+  perf_graph_live_time_limit = 1
   exodus = true
 []


### PR DESCRIPTION
@YaqiWang noticed some undesireable behavior from Perf Graph Live... this is some tweaks to address that.

Main things:
- If something is set not to print dots - it won't ever print the message (only the "Finished" message could possibly be shown)
- If something has printed to the Console since the last time Live woke up - Live won't print anything (the idea being that if they are seeing any progress at all - then there is no reason for Live to do anything.
- "Context" (scopes above the one being printed) are no longer printed.
closes #18818