### PR TITLE
Add proxy variable for max/min in postprocessors

### DIFF
--- a/framework/doc/content/source/postprocessors/ElementExtremeValue.md
+++ b/framework/doc/content/source/postprocessors/ElementExtremeValue.md
@@ -2,7 +2,12 @@
 
 !syntax description /Postprocessors/ElementExtremeValue
 
-The corresponding postprocessor that find extreme values of noodal variables
+You can optionally provide a [!param](/Postprocessors/ElementExtremeValue/proxy_variable),
+which will change the behavior of this postprocessor to
+find the quadrature point at which the proxy variable reaches the max/min value,
+and then return the value of the specified variable at that point.
+
+The corresponding postprocessor that find extreme values of nodal variables
 evaluated at nodes is [NodalExtremeValue](NodalExtremeValue.md)
 
 ## Example Input File Syntax

--- a/framework/doc/content/source/postprocessors/NodalExtremeValue.md
+++ b/framework/doc/content/source/postprocessors/NodalExtremeValue.md
@@ -2,6 +2,11 @@
 
 !syntax description /Postprocessors/NodalExtremeValue
 
+You can optionally provide a [!param](/Postprocessors/ElementExtremeValue/proxy_variable),
+which will change the behavior of this postprocessor to
+find the node at which the proxy variable reaches the max/min value,
+and then return the value of the specified variable at that node.
+
 The corresponding postprocessor that find extreme values of variables evaluated
 inside elements (at quadrature points) is
 [ElementExtremeValue](ElementExtremeValue.md)

--- a/framework/include/postprocessors/ElementExtremeValue.h
+++ b/framework/include/postprocessors/ElementExtremeValue.h
@@ -18,7 +18,7 @@ class ElementExtremeValue;
 template <>
 InputParameters validParams<ElementExtremeValue>();
 
-/// A postprocessor for collecting the nodal min or max value
+/// A postprocessor for collecting the elemental min or max value
 class ElementExtremeValue : public ElementVariablePostprocessor
 {
 public:
@@ -48,7 +48,19 @@ protected:
   /// The extreme value type
   ExtremeType _type;
 
-  /// The extreme value
+  /**
+   * The value of the variable at the point at which the proxy variable
+   * reaches the max/min value.
+   */
   Real _value;
+
+  /**
+   * A proxy variable used to find the quadrature point at
+   * which to evaluate the variable. If not provided, defaults to the variable.
+   */
+  const VariableValue & _proxy_variable;
+
+  /// Extreme value of the proxy variable
+  Real _proxy_value;
 };
 

--- a/framework/include/postprocessors/ElementExtremeValue.h
+++ b/framework/include/postprocessors/ElementExtremeValue.h
@@ -63,4 +63,3 @@ protected:
   /// Extreme value of the proxy variable
   Real _proxy_value;
 };
-

--- a/framework/include/postprocessors/NodalExtremeValue.h
+++ b/framework/include/postprocessors/NodalExtremeValue.h
@@ -45,7 +45,19 @@ protected:
   /// The extreme value type ("min" or "max")
   ExtremeType _type;
 
-  /// The extreme value
+  /**
+   * The value of the variable at the point at which the proxy variable
+   * reaches the max/min value.
+   */
   Real _value;
+
+  /**
+   * A proxy variable used to find the quadrature point at
+   * which to evaluate the variable. If not provided, defaults to the variable.
+   */
+  const VariableValue & _proxy_variable;
+
+  /// Extreme value of the proxy variable
+  Real _proxy_value;
 };
 

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -143,9 +143,21 @@ public:
     _communicator.min(value);
   }
 
+  /**
+   * Gather the parallel value of a variable according to which process has the parallel
+   * maximum of the provided value.
+   * @param[in] value process with maximum value will be selected
+   * @param[in] proxy value to be obtained on process with maximum value
+   */
   template <typename T1, typename T2>
   void gatherProxyValueMax(T1 & value, T2 & proxy);
 
+  /**
+   * Gather the parallel value of a variable according to which process has the parallel
+   * minimum of the provided value.
+   * @param[in] value process with minimum value will be selected
+   * @param[in] proxy value to be obtained on process with minimum value
+   */
   template <typename T1, typename T2>
   void gatherProxyValueMin(T1 & value, T2 & proxy);
 
@@ -200,7 +212,7 @@ template <typename T1, typename T2>
 void
 UserObject::gatherProxyValueMax(T1 & value, T2 & proxy)
 {
-  unsigned int rank;
+  processor_id_type rank;
   _communicator.maxloc(value, rank);
   _communicator.broadcast(proxy, rank);
 }
@@ -209,7 +221,7 @@ template <typename T1, typename T2>
 void
 UserObject::gatherProxyValueMin(T1 & value, T2 & proxy)
 {
-  unsigned int rank;
+  processor_id_type rank;
   _communicator.minloc(value, rank);
   _communicator.broadcast(proxy, rank);
 }

--- a/framework/include/userobject/UserObject.h
+++ b/framework/include/userobject/UserObject.h
@@ -146,6 +146,9 @@ public:
   template <typename T1, typename T2>
   void gatherProxyValueMax(T1 & value, T2 & proxy);
 
+  template <typename T1, typename T2>
+  void gatherProxyValueMin(T1 & value, T2 & proxy);
+
   void setPrimaryThreadCopy(UserObject * primary);
 
   UserObject * primaryThreadCopy() { return _primary_thread_copy; }
@@ -199,5 +202,14 @@ UserObject::gatherProxyValueMax(T1 & value, T2 & proxy)
 {
   unsigned int rank;
   _communicator.maxloc(value, rank);
+  _communicator.broadcast(proxy, rank);
+}
+
+template <typename T1, typename T2>
+void
+UserObject::gatherProxyValueMin(T1 & value, T2 & proxy)
+{
+  unsigned int rank;
+  _communicator.minloc(value, rank);
   _communicator.broadcast(proxy, rank);
 }

--- a/framework/src/postprocessors/ElementExtremeValue.C
+++ b/framework/src/postprocessors/ElementExtremeValue.C
@@ -33,7 +33,8 @@ ElementExtremeValue::validParams()
 
   params.addCoupledVar("proxy_variable",
                        "The name of the variable to use to identify the location at which "
-                       "the variable value should be taken");
+                       "the variable value should be taken; if not provided, this defaults "
+                       "to the 'variable'.");
 
   params.addClassDescription(
       "Finds either the min or max elemental value of a variable over the domain.");
@@ -44,7 +45,6 @@ ElementExtremeValue::validParams()
 ElementExtremeValue::ElementExtremeValue(const InputParameters & parameters)
   : ElementVariablePostprocessor(parameters),
     _type((ExtremeType)(int)parameters.get<MooseEnum>("value_type")),
-    _value(_type == 0 ? -std::numeric_limits<Real>::max() : std::numeric_limits<Real>::max()),
     _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u)
 {
 }
@@ -56,10 +56,12 @@ ElementExtremeValue::initialize()
   {
     case MAX:
       _proxy_value = -std::numeric_limits<Real>::max(); // start w/ the min
+      _value = -std::numeric_limits<Real>::max();
       break;
 
     case MIN:
       _proxy_value = std::numeric_limits<Real>::max(); // start w/ the max
+      _value = std::numeric_limits<Real>::max();
       break;
   }
 }

--- a/framework/src/postprocessors/ElementExtremeValue.C
+++ b/framework/src/postprocessors/ElementExtremeValue.C
@@ -31,8 +31,12 @@ ElementExtremeValue::validParams()
                              "returns the maximum value. 'min' returns "
                              "the minimum value.");
 
+  params.addCoupledVar("proxy_variable",
+                       "The name of the variable to use to identify the location at which "
+                       "the variable value should be taken");
+
   params.addClassDescription(
-      "Finds either the min or max elemental value of a a variable over the domain.");
+      "Finds either the min or max elemental value of a variable over the domain.");
 
   return params;
 }
@@ -40,7 +44,8 @@ ElementExtremeValue::validParams()
 ElementExtremeValue::ElementExtremeValue(const InputParameters & parameters)
   : ElementVariablePostprocessor(parameters),
     _type((ExtremeType)(int)parameters.get<MooseEnum>("value_type")),
-    _value(_type == 0 ? -std::numeric_limits<Real>::max() : std::numeric_limits<Real>::max())
+    _value(_type == 0 ? -std::numeric_limits<Real>::max() : std::numeric_limits<Real>::max()),
+    _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u)
 {
 }
 
@@ -50,11 +55,11 @@ ElementExtremeValue::initialize()
   switch (_type)
   {
     case MAX:
-      _value = -std::numeric_limits<Real>::max(); // start w/ the min
+      _proxy_value = -std::numeric_limits<Real>::max(); // start w/ the min
       break;
 
     case MIN:
-      _value = std::numeric_limits<Real>::max(); // start w/ the max
+      _proxy_value = std::numeric_limits<Real>::max(); // start w/ the max
       break;
   }
 }
@@ -65,11 +70,19 @@ ElementExtremeValue::computeQpValue()
   switch (_type)
   {
     case MAX:
-      _value = std::max(_value, _u[_qp]);
+      if (_proxy_variable[_qp] > _proxy_value)
+      {
+        _proxy_value = _proxy_variable[_qp];
+        _value = _u[_qp];
+      }
       break;
 
     case MIN:
-      _value = std::min(_value, _u[_qp]);
+      if (_proxy_variable[_qp] < _proxy_value)
+      {
+        _proxy_value = _proxy_variable[_qp];
+        _value = _u[_qp];
+      }
       break;
   }
 }
@@ -80,10 +93,10 @@ ElementExtremeValue::getValue()
   switch (_type)
   {
     case MAX:
-      gatherMax(_value);
+      gatherProxyValueMax(_proxy_value, _value);
       break;
     case MIN:
-      gatherMin(_value);
+      gatherProxyValueMin(_proxy_value, _value);
       break;
   }
 
@@ -98,10 +111,18 @@ ElementExtremeValue::threadJoin(const UserObject & y)
   switch (_type)
   {
     case MAX:
-      _value = std::max(_value, pps._value);
+      if (pps._proxy_value > _proxy_value)
+      {
+        _proxy_value = pps._proxy_value;
+        _value = pps._value;
+      }
       break;
     case MIN:
-      _value = std::min(_value, pps._value);
+      if (pps._proxy_value < _proxy_value)
+      {
+        _proxy_value = pps._proxy_value;
+        _value = pps._value;
+      }
       break;
   }
 }

--- a/framework/src/postprocessors/NodalExtremeValue.C
+++ b/framework/src/postprocessors/NodalExtremeValue.C
@@ -34,14 +34,14 @@ NodalExtremeValue::validParams()
 
   params.addCoupledVar("proxy_variable",
                        "The name of the variable to use to identify the location at which "
-                       "the variable value should be taken");
+                       "the variable value should be taken; if not provided, this defaults "
+                       "to the 'variable'.");
   return params;
 }
 
 NodalExtremeValue::NodalExtremeValue(const InputParameters & parameters)
   : NodalVariablePostprocessor(parameters),
     _type((ExtremeType)(int)parameters.get<MooseEnum>("value_type")),
-    _value(_type == 0 ? -std::numeric_limits<Real>::max() : std::numeric_limits<Real>::max()),
     _proxy_variable(isParamValid("proxy_variable") ? coupledValue("proxy_variable") : _u)
 {
 }
@@ -53,10 +53,12 @@ NodalExtremeValue::initialize()
   {
     case MAX:
       _proxy_value = -std::numeric_limits<Real>::max(); // start w/ the min
+      _value = -std::numeric_limits<Real>::max();
       break;
 
     case MIN:
       _proxy_value = std::numeric_limits<Real>::max(); // start w/ the max
+      _value = std::numeric_limits<Real>::max();
       break;
   }
 }

--- a/test/tests/postprocessors/element_extreme_value/element_proxy_extreme_value.i
+++ b/test/tests/postprocessors/element_extreme_value/element_proxy_extreme_value.i
@@ -1,0 +1,113 @@
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 40
+[]
+
+[AuxVariables]
+  [u]
+  []
+  [w]
+  []
+  [v_x]
+  []
+  [v_y]
+  []
+[]
+
+[AuxKernels]
+  [u]
+    type = FunctionAux
+    variable = u
+    function = u
+  []
+  [w]
+    type = FunctionAux
+    variable = w
+    function = w
+  []
+  [v_x]
+    type = FunctionAux
+    variable = v_x
+    function = v_x
+  []
+  [v_y]
+    type = FunctionAux
+    variable = v_y
+    function = v_y
+  []
+[]
+
+[Functions]
+  [u] # reaches a maximum value at (0.5, 0.6)
+    type = ParsedFunction
+    value = 'sin(pi*x)*sin(pi*y/1.2)'
+  []
+  [w] # reaches a minium value at (0.7, 0.8)
+    type = ParsedFunction
+    value = '-sin(pi*x/1.4)*sin(pi*y/1.6)'
+  []
+
+  [v_x]
+    type = ParsedFunction
+    value = 'x'
+  []
+  [v_y]
+    type = ParsedFunction
+    value = 'y'
+  []
+[]
+
+[Postprocessors]
+  # because we set v_x and v_y equal to the x and y coordinates, these two postprocessors
+  # should just return the point at which u reaches a maximum value
+  [max_v_from_proxy_x]
+    type = ElementExtremeValue
+    variable = v_x
+    proxy_variable = u
+    value_type = max
+  []
+  [max_v_from_proxy_y]
+    type = ElementExtremeValue
+    variable = v_y
+    proxy_variable = u
+    value_type = max
+  []
+
+  # because we set v_x and v_y equal to the x and y coordinates, these two postprocessors
+  # should just return the point at which w reaches a minimum value
+  [min_v_from_proxy_x]
+    type = ElementExtremeValue
+    variable = v_x
+    proxy_variable = w
+    value_type = min
+  []
+  [min_v_from_proxy_y]
+    type = ElementExtremeValue
+    variable = v_y
+    proxy_variable = w
+    value_type = min
+  []
+[]
+
+[Executioner]
+  type = Steady
+
+  # increase the quadrature order to get more quadrature points so that were closer
+  # to hitting the expect max/min
+  [Quadrature]
+    type = GAUSS
+    order = SECOND
+  []
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/test/tests/postprocessors/element_extreme_value/gold/element_proxy_extreme_value_out.csv
+++ b/test/tests/postprocessors/element_extreme_value/gold/element_proxy_extreme_value_out.csv
@@ -1,0 +1,3 @@
+time,max_v_from_proxy_x,max_v_from_proxy_y,min_v_from_proxy_x,min_v_from_proxy_y
+0,0,0,0,0
+1,0.49471687836487,0.59471687836487,0.69471687836487,0.79471687836487

--- a/test/tests/postprocessors/element_extreme_value/tests
+++ b/test/tests/postprocessors/element_extreme_value/tests
@@ -1,12 +1,21 @@
 [Tests]
   design = 'ElementExtremeValue.md'
-  issues = '#2776'
 
-  [./elemental_extreme]
+  [elemental_extreme]
     type = 'Exodiff'
     input = 'element_extreme_value.i'
     exodiff = 'element_extreme_value_out.e'
+    issues = '#2776'
 
-    requirement = 'The system shall compute the the extreme (min/max) values of an elemental field variable over the domain.'
-  [../]
+    requirement = 'The system shall compute the extreme (min/max) values of an elemental field variable over the domain.'
+  []
+
+  [proxy_elemental_extreme]
+    type = 'CSVDiff'
+    input = 'element_proxy_extreme_value.i'
+    csvdiff = 'element_proxy_extreme_value_out.csv'
+    issues = '#18936'
+
+    requirement = 'The system shall compute the value of a variable at the point where a proxy variable reaches the extreme (max/min) value over the domain.'
+  []
 []

--- a/test/tests/postprocessors/nodal_extreme_value/gold/nodal_proxy_extreme_value_out.csv
+++ b/test/tests/postprocessors/nodal_extreme_value/gold/nodal_proxy_extreme_value_out.csv
@@ -1,0 +1,3 @@
+time,max_v_from_proxy_x,max_v_from_proxy_y,min_v_from_proxy_x,min_v_from_proxy_y
+0,0,0,0,0
+1,0.49471687836487,0.59471687836487,0.69471687836487,0.79471687836487

--- a/test/tests/postprocessors/nodal_extreme_value/nodal_proxy_extreme_value.i
+++ b/test/tests/postprocessors/nodal_extreme_value/nodal_proxy_extreme_value.i
@@ -1,0 +1,113 @@
+[Problem]
+  type = FEProblem
+  solve = false
+[]
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 40
+  ny = 40
+[]
+
+[AuxVariables]
+  [u]
+  []
+  [w]
+  []
+  [v_x]
+  []
+  [v_y]
+  []
+[]
+
+[AuxKernels]
+  [u]
+    type = FunctionAux
+    variable = u
+    function = u
+  []
+  [w]
+    type = FunctionAux
+    variable = w
+    function = w
+  []
+  [v_x]
+    type = FunctionAux
+    variable = v_x
+    function = v_x
+  []
+  [v_y]
+    type = FunctionAux
+    variable = v_y
+    function = v_y
+  []
+[]
+
+[Functions]
+  [u] # reaches a maximum value at (0.5, 0.6)
+    type = ParsedFunction
+    value = 'sin(pi*x)*sin(pi*y/1.2)'
+  []
+  [w] # reaches a minium value at (0.7, 0.8)
+    type = ParsedFunction
+    value = '-sin(pi*x/1.4)*sin(pi*y/1.6)'
+  []
+
+  [v_x]
+    type = ParsedFunction
+    value = 'x'
+  []
+  [v_y]
+    type = ParsedFunction
+    value = 'y'
+  []
+[]
+
+[Postprocessors]
+  # because we set v_x and v_y equal to the x and y coordinates, these two postprocessors
+  # should just return the point at which u reaches a maximum value
+  [max_v_from_proxy_x]
+    type = ElementExtremeValue
+    variable = v_x
+    proxy_variable = u
+    value_type = max
+  []
+  [max_v_from_proxy_y]
+    type = ElementExtremeValue
+    variable = v_y
+    proxy_variable = u
+    value_type = max
+  []
+
+  # because we set v_x and v_y equal to the x and y coordinates, these two postprocessors
+  # should just return the point at which w reaches a minimum value
+  [min_v_from_proxy_x]
+    type = ElementExtremeValue
+    variable = v_x
+    proxy_variable = w
+    value_type = min
+  []
+  [min_v_from_proxy_y]
+    type = ElementExtremeValue
+    variable = v_y
+    proxy_variable = w
+    value_type = min
+  []
+[]
+
+[Executioner]
+  type = Steady
+
+  # increase the quadrature order to get more quadrature points so that were closer
+  # to hitting the expect max/min
+  [Quadrature]
+    type = GAUSS
+    order = SECOND
+  []
+[]
+
+[Outputs]
+  exodus = true
+  csv = true
+[]

--- a/test/tests/postprocessors/nodal_extreme_value/tests
+++ b/test/tests/postprocessors/nodal_extreme_value/tests
@@ -1,12 +1,20 @@
 [Tests]
   design = 'NodalExtremeValue.md'
-  issues = '#2026'
 
-  [./nodal_extreme]
+  [nodal_extreme]
     type = 'Exodiff'
     input = 'nodal_extreme_pps_test.i'
     exodiff = 'nodal_extreme_pps_test_out.e'
+    issues = '#2026'
 
-    requirement = 'The system shall compute the the extreme (min/max) values of a nodal field variable over the domain.'
-  [../]
+    requirement = 'The system shall compute the extreme (min/max) values of a nodal field variable over the domain.'
+  []
+  [nodal_extreme_proxy]
+    type = 'CSVDiff'
+    input = 'nodal_proxy_extreme_value.i'
+    csvdiff = 'nodal_proxy_extreme_value_out.csv'
+    issues = '#18936'
+
+    requirement = 'The system shall compute the value of a variable at the point at which a proxy variable reaches the extreme (min/max) value.'
+  []
 []


### PR DESCRIPTION
This PR adds an optional `proxy_variable` to the `NodalExtremeValue` and `ElementExtremeValue` postprocessors that finds the value of the `variable` at the point in the domain at which the `proxy_variable` reaches its max/min value. If not specified, the proxy variable is taken equal to the `variable`, such that behavior is unchanged from the default usage of these postprocessors.

## Impact
No expected impact. Changes are compatible with previous behavior.

Closes #18936
