### PR TITLE
Add getIterations(), setMinIterations(), and setMaxIterations() in NestedSolve.h.

### DIFF
--- a/framework/include/utils/NestedSolve.h
+++ b/framework/include/utils/NestedSolve.h
@@ -85,14 +85,17 @@ public:
     NOT_CONVERGED
   };
 
-  /**
-   * Get the solver state
-   */
+  /// Get the solver state
   const State & getState() const { return _state; }
+  /// Get the number of iterations from the last solve
+  const std::size_t & getIterations() { return _n_iterations; };
 
 protected:
   /// current solver state
   State _state;
+
+  /// number of nested iterations
+  std::size_t _n_iterations;
 
   ///@{ Deduce the Jacobian type from the solution type
   template <typename T>
@@ -303,7 +306,7 @@ NestedSolve::nonlinear(V & guess, T compute)
   CorrespondingJacobian<V> jacobian;
   sizeItems(guess, residual, jacobian);
 
-  std::size_t n_iterations = 0;
+  _n_iterations = 0;
   compute(guess, residual, jacobian);
 
   // compute first residual norm for relative convergence checks
@@ -331,16 +334,16 @@ NestedSolve::nonlinear(V & guess, T compute)
   };
 
   // perform non-linear iterations
-  while (n_iterations < _max_iterations)
+  while (_n_iterations < _max_iterations)
   {
     // check convergence
-    if (n_iterations >= _min_iterations && is_converged())
+    if (_n_iterations >= _min_iterations && is_converged())
       return;
 
     // solve and apply next increment
     linear(jacobian, delta, residual);
     guess -= delta;
-    n_iterations++;
+    _n_iterations++;
 
     // compute residual and jacobian for the next iteration
     compute(guess, residual, jacobian);

--- a/framework/src/utils/NestedSolve.C
+++ b/framework/src/utils/NestedSolve.C
@@ -38,7 +38,8 @@ NestedSolve::NestedSolve()
     _absolute_tolerance_square(Utility::pow<2>(absoluteToleranceDefault())),
     _min_iterations(minIterationsDefault()),
     _max_iterations(maxIterationsDefault()),
-    _state(State::NONE)
+    _state(State::NONE),
+    _n_iterations(0)
 {
 }
 
@@ -47,7 +48,8 @@ NestedSolve::NestedSolve(const InputParameters & params)
     _absolute_tolerance_square(Utility::pow<2>(params.get<Real>("absolute_tolerance"))),
     _min_iterations(params.get<unsigned int>("min_iterations")),
     _max_iterations(params.get<unsigned int>("max_iterations")),
-    _state(State::NONE)
+    _state(State::NONE),
+    _n_iterations(0)
 {
 }
 


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
By showing the nested Newton iteration number at each quadrature point, we can tell which points are difficult to solve. This helps with debugging. By adding the set_iteration methods, the users are able to supply the minimum or maximum nested iteration numbers in the input file. These numbers are passed into a material source file which constructs a solver object.

## Design
A slight change to the `n_iterations` variable in the NestedSolve.h will be made. `n_iterations` will be made a protected member variable and a getter function for the last number of iterations will be added. `setMinIterations` and `setMaxIterations` functions will be added to overwrite the default iterations.

## Impact
Added capability.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
Closes #18980