### PR TITLE
Exodus IsoGeometric Analysis prerequisites

### DIFF
--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -69,9 +69,10 @@ AddVariableAction::AddVariableAction(InputParameters params)
 MooseEnum
 AddVariableAction::getNonlinearVariableFamilies()
 {
-  return MooseEnum("LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
-                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC",
-                   "LAGRANGE");
+  return MooseEnum(
+      "LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
+      "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC RATIONAL_BERNSTEIN",
+      "LAGRANGE");
 }
 
 MooseEnum

--- a/framework/src/loops/MaxQpsThread.C
+++ b/framework/src/loops/MaxQpsThread.C
@@ -85,9 +85,12 @@ MaxQpsThread::operator()(const ConstElemRange & range)
     // NOTE: user might specify higher order rule for faces, thus possibly ending up with more qps
     // than in the volume
     auto qrule_face = assem.attachQRuleFace(dim, *side_fe);
-    side_fe->reinit(elem, side);
-    if (qrule_face->n_points() > _max)
-      _max = qrule_face->n_points();
+    if (dim > 0) // side reinit in 0D makes no sense, but we may have NodeElems
+    {
+      side_fe->reinit(elem, side);
+      if (qrule_face->n_points() > _max)
+        _max = qrule_face->n_points();
+    }
 
     // In initial conditions nodes are enumerated as pretend quadrature points
     // using the _qp index to access coupled variables. In order to be able to

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -48,7 +48,7 @@ MooseVariableBase::validParams()
                              "Order of the FE shape function to use for this variable (additional "
                              "orders not listed here are allowed, depending on the family).");
 
-  MooseEnum family { AddVariableAction::getNonlinearVariableFamilies() };
+  MooseEnum family{AddVariableAction::getNonlinearVariableFamilies()};
 
   params.addParam<MooseEnum>(
       "family", family, "Specifies the family of FE shape functions to use for this variable.");

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -8,6 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "MooseVariableBase.h"
+
+#include "AddVariableAction.h"
 #include "SubProblem.h"
 #include "SystemBase.h"
 #include "MooseMesh.h"
@@ -46,10 +48,8 @@ MooseVariableBase::validParams()
                              "Order of the FE shape function to use for this variable (additional "
                              "orders not listed here are allowed, depending on the family).");
 
-  MooseEnum family(
-      "LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
-      "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC RATIONAL_BERNSTEIN",
-      "LAGRANGE");
+  MooseEnum family { AddVariableAction::getNonlinearVariableFamilies() };
+
   params.addParam<MooseEnum>(
       "family", family, "Specifies the family of FE shape functions to use for this variable.");
 

--- a/framework/src/variables/MooseVariableBase.C
+++ b/framework/src/variables/MooseVariableBase.C
@@ -46,9 +46,10 @@ MooseVariableBase::validParams()
                              "Order of the FE shape function to use for this variable (additional "
                              "orders not listed here are allowed, depending on the family).");
 
-  MooseEnum family("LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
-                   "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC",
-                   "LAGRANGE");
+  MooseEnum family(
+      "LAGRANGE MONOMIAL HERMITE SCALAR HIERARCHIC CLOUGH XYZ SZABAB BERNSTEIN "
+      "L2_LAGRANGE L2_HIERARCHIC NEDELEC_ONE LAGRANGE_VEC MONOMIAL_VEC RATIONAL_BERNSTEIN",
+      "LAGRANGE");
   params.addParam<MooseEnum>(
       "family", family, "Specifies the family of FE shape functions to use for this variable.");
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -260,6 +260,7 @@ class TestHarness:
             checks['petsc_version'] = 'N/A'
             checks['petsc_version_release'] = 'N/A'
             checks['slepc_version'] = 'N/A'
+            checks['exodus_version'] = 'N/A'
             checks['library_mode'] = set(['ALL'])
             checks['mesh_mode'] = set(['ALL'])
             checks['ad_mode'] = set(['ALL'])
@@ -291,6 +292,7 @@ class TestHarness:
             checks['petsc_version'] = util.getPetscVersion(self.libmesh_dir)
             checks['petsc_version_release'] = util.getLibMeshConfigOption(self.libmesh_dir, 'petsc_version_release')
             checks['slepc_version'] = util.getSlepcVersion(self.libmesh_dir)
+            checks['exodus_version'] = util.getExodusVersion(self.libmesh_dir)
             checks['library_mode'] = util.getSharedOption(self.libmesh_dir)
             checks['mesh_mode'] = util.getLibMeshConfigOption(self.libmesh_dir, 'mesh_mode')
             checks['ad_mode'] = util.getMooseConfigOption(self.moose_dir, 'ad_mode')

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -53,6 +53,7 @@ class Tester(MooseObject):
         params.addParam('petsc_version', ['ALL'], "A list of petsc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
         params.addParam('petsc_version_release', ['ALL'], "A test that runs against PETSc master if FALSE ('ALL', 'TRUE', 'FALSE')")
         params.addParam('slepc_version', [], "A list of slepc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
+        params.addParam('exodus_version', ['ALL'], "A list of Exodus versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
         params.addParam('mesh_mode',     ['ALL'], "A list of mesh modes for which this test will run ('DISTRIBUTED', 'REPLICATED')")
         params.addParam('min_ad_size',   None, "A minimum AD size for which this test will run")
         params.addParam('ad_mode',       ['ALL'], "A list of AD modes for which this test will run ('SPARSE', 'NONSPARSE')")
@@ -520,6 +521,14 @@ class Tester(MooseObject):
                 reasons['slepc_version'] = 'using SLEPc ' + str(checks['slepc_version']) + ' REQ: ' + slepc_version
             elif slepc_version == None:
                 reasons['slepc_version'] = 'SLEPc is not installed'
+
+        # Check for ExodusII versions
+        (exodus_status, exodus_version) = util.checkExodusVersion(checks, self.specs)
+        if not exodus_status:
+            if checks['exodus_version'] != None:
+                reasons['exodus_version'] = 'using ExodusII ' + str(checks['exodus_version']) + ' REQ: ' + exodus_version
+            else:
+                reasons['exodus_version'] = 'Exodus version not detected. REQ: ' + exodus_version
 
         # PETSc and SLEPc is being explicitly checked above
         local_checks = ['platform', 'compiler', 'mesh_mode', 'ad_mode', 'ad_indexing_type', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot',

--- a/python/TestHarness/tests/test_ExtraInfo.py
+++ b/python/TestHarness/tests/test_ExtraInfo.py
@@ -33,7 +33,7 @@ class TestHarnessTester(TestHarnessTestCase):
                    'PETSC_DEBUG', 'LIBRARY_MODE', 'PETSC_VERSION',
                    'CURL', 'THREADING', 'SLEPC', 'VTK', 'UNIQUE_ID',
                    'COMPILER', 'FPARSER_JIT', 'PARMETIS', 'CHACO',
-                   'PARTY', 'PTSCOTCH']
+                   'PARTY', 'PTSCOTCH', 'EXODUS_VERSION']
 
         # Verify all special TestHarness 'checks' are printed. We
         # will use the --ignore feature to force the test to run

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -118,6 +118,12 @@ LIBMESH_OPTIONS = {
   'slepc_subminor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_SLEPC_VERSION_SUBMINOR\s+(\d+)',
                      'default'   : '1'
                    },
+  'exodus_major' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_EXODUS_VERSION_MAJOR\s+(\d+)',
+                     'default'   : '1'
+                   },
+  'exodus_minor' :  { 're_option' : r'#define\s+LIBMESH_DETECTED_EXODUS_VERSION_MINOR\s+(\d+)',
+                     'default'   : '1'
+                   },
   'dof_id_bytes' : { 're_option' : r'#define\s+LIBMESH_DOF_ID_BYTES\s+(\d+)',
                      'default'   : '4'
                    },
@@ -449,6 +455,15 @@ def getSlepcVersion(libmesh_dir):
 
     return major_version.pop() + '.' + minor_version.pop() + '.' + subminor_version.pop()
 
+def getExodusVersion(libmesh_dir):
+    major_version = getLibMeshConfigOption(libmesh_dir, 'exodus_major')
+    minor_version = getLibMeshConfigOption(libmesh_dir, 'exodus_minor')
+    if len(major_version) != 1 or len(minor_version) != 1:
+      return None
+
+    return major_version.pop() + '.' + minor_version.pop()
+
+
 def checkLogicVersionSingle(checks, iversion, package):
     logic, version = re.search(r'(.*?)(\d\S+)', iversion).groups()
     if logic == '' or logic == '=':
@@ -513,6 +528,21 @@ def checkSlepcVersion(checks, test):
 
     version_string = ' '.join(test['slepc_version'])
     return (checkVersion(checks, version_string, 'slepc_version'), version_string)
+
+# Break down exodus version logic in a new define
+def checkExodusVersion(checks, test):
+    version_string = ' '.join(test['exodus_version'])
+
+    # If any version of Exodus works, return true immediately
+    if 'ALL' in set(test['exodus_version']):
+        return (True, version_string)
+
+    # Exodus not installed or version could not be detected (e.g. old libMesh)
+    if checks['exodus_version'] == None:
+       return (False, version_string)
+
+    return (checkVersion(checks, version_string, 'exodus_version'), version_string)
+
 
 def getIfAsioExists(moose_dir):
     option_set = set(['ALL'])

--- a/test/tests/test_harness/extra_info
+++ b/test/tests/test_harness/extra_info
@@ -8,6 +8,7 @@
     petsc_version_release = true
     petsc_debug = true
     slepc_version = '>=3.7.4'
+    exodus_version = '>=8.0'
     library_mode = 'DYNAMIC'
     mesh_mode = 'distributed'
     dtk = true


### PR DESCRIPTION
## Reason

Testing Moose with the upcoming IGA support in ExodusII revealed a few incompatibilities that need to be fixed for that feature to work.

## Design

We now make sure to skip side reinits on 0-D NodeElem elements (which have no sides, but which are critical in C1+ IGA simulations as libMesh uses NodeElem to represent spline nodes and store unconstrained degrees of freedom there).

We now have `RATIONAL_BERNSTEIN` as a selectable nonlinear variable type, so we can actually use IGA basis functions on IGA elements.

We now have the ability to set a restricted `exodus_version` on new Moose tests, so upcoming IGA tests, which require a very recent version of ExodusII to be enabled in libMesh, will be skipped when Moose has been compiled against an older incompatible ExodusII library.

## Impact

New features, no impact to existing use cases.

Refs #18768 