### PR TITLE
Enhance `hit find` command with wildcard and value matching support

### DIFF
--- a/framework/contrib/hit/braceexpr.h
+++ b/framework/contrib/hit/braceexpr.h
@@ -74,6 +74,7 @@ class BraceExpander;
 class Evaler
 {
 public:
+  virtual ~Evaler() {}
   virtual std::string eval(Field * n, const std::list<std::string> & args, BraceExpander & exp) = 0;
 };
 

--- a/framework/contrib/hit/main.cc
+++ b/framework/contrib/hit/main.cc
@@ -615,8 +615,9 @@ common(int argc, char ** argv)
 int
 subtract(int argc, char ** argv)
 {
-  Flags flags("hit subtract left.i right.i\n  Subtract left.i from right.i by removing all "
-              "parameters listed in left.i from right.i.\n");
+  Flags flags(
+      "hit subtract base.i remove.i\n  Build the input base.i minus remove.i by removing all "
+      "parameters listed in remove.i from base.i.\n");
   flags.add("h", "print help");
   flags.add("help", "print help");
   auto positional = parseOpts(argc, argv, flags);
@@ -633,18 +634,18 @@ subtract(int argc, char ** argv)
   if (!left || !right)
     return 1;
 
-  std::cerr << "Subtracting:\n    " << positional[0] << "\nfrom:\n    " << positional[1] << '\n';
+  std::cerr << "Subtracting:\n    " << positional[1] << "\nfrom:\n    " << positional[0] << '\n';
 
-  hit::GatherParamWalker::ParamMap left_params;
-  hit::GatherParamWalker left_walker(left_params);
-  hit::RemoveParamWalker right_walker(left_params);
-  hit::RemoveEmptySectionWalker right_section_walker;
+  hit::GatherParamWalker::ParamMap right_params;
+  hit::GatherParamWalker right_walker(right_params);
+  hit::RemoveParamWalker left_walker(right_params);
+  hit::RemoveEmptySectionWalker left_section_walker;
 
-  left->walk(&left_walker);
   right->walk(&right_walker);
-  right->walk(&right_section_walker);
+  left->walk(&left_walker);
+  left->walk(&left_section_walker);
 
-  std::cout << right->render();
+  std::cout << left->render();
 
   return 0;
 }

--- a/framework/contrib/hit/main.cc
+++ b/framework/contrib/hit/main.cc
@@ -529,9 +529,6 @@ merge(int argc, char ** argv)
     return 1;
   }
 
-  std::string fname(flags.val("output"));
-  std::ofstream output(fname);
-
   hit::Node * root = nullptr;
   for (int i = 0; i < positional.size(); i++)
   {
@@ -545,7 +542,14 @@ merge(int argc, char ** argv)
       root = hit::parse(fname, input);
   }
 
-  output << root->render();
+  std::string fname(flags.val("output"));
+  if (fname == "-")
+    std::cout << root->render();
+  else
+  {
+    std::ofstream output(fname);
+    output << root->render();
+  }
 
   return 0;
 }
@@ -580,7 +584,7 @@ diff(int argc, char ** argv)
     return 1;
   }
 
-  bool use_color = flags.have("C");
+  bool use_color = flags.have("C") || flags.have("color");
 
   // terminal colors
   std::string color_red = use_color ? "\33[31m" : "";

--- a/framework/contrib/hit/main.cc
+++ b/framework/contrib/hit/main.cc
@@ -218,6 +218,7 @@ findParam(int argc, char ** argv)
       "hit find [flags] <parameter-pathern> <file>...\n  Specify '-' as a file name to accept "
       "input from stdin.\n  A pattern has the form param[=value] and wildcards (*,?) may be used");
   flags.add("f", "only show file name");
+  flags.add("i", "case insensitive matches");
   flags.add("h", "print help");
   flags.add("help", "print help");
   auto positional = parseOpts(argc, argv, flags);
@@ -229,6 +230,10 @@ findParam(int argc, char ** argv)
   }
 
   const bool file_only = flags.have("f");
+  const bool case_insensitive = flags.have("i");
+
+  if (case_insensitive)
+    positional[0] = hit::lower(positional[0]);
 
   auto equal_sign = positional[0].find('=');
   std::string param(positional[0], 0, equal_sign);
@@ -264,12 +269,12 @@ findParam(int argc, char ** argv)
 
     // search parameters
     for (const auto & p : params)
-      if (globCompare(p.first, param))
+      if (globCompare(case_insensitive ? hit::lower(p.first) : p.first, param))
       {
         auto n = p.second;
         auto v = n->strVal();
         // if a value was given, make sure it matches, too
-        if (value && !globCompare(v, *value))
+        if (value && !globCompare(case_insensitive ? hit::lower(v) : v, *value))
           continue;
         n_matches++;
 

--- a/framework/contrib/hit/main.cc
+++ b/framework/contrib/hit/main.cc
@@ -417,7 +417,7 @@ diff(int argc, char ** argv)
   flags.add("v", "verbose diff");
   flags.add("C", "output color");
   flags.add("color", "output color");
-  flags.add("common", "show common parts on bothe sides");
+  flags.add("common", "show common parts on both sides");
   flags.add("h", "print help");
   flags.add("help", "print help");
   flags.addVector("left", "Left hand inputs");

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -57,6 +57,9 @@ namespace hit
 
 const std::string default_indent = "  ";
 
+// lower converts all characters in str to their lower-case versions.
+std::string lower(const std::string & str);
+
 /// toBool converts the given val to a boolean value which is stored in dst.  It returns true if
 /// val was successfully converted to a boolean and returns false otherwise.
 bool toBool(const std::string & val, bool * dst);

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -105,7 +105,7 @@ public:
   ParseError(const std::string & msg);
 };
 
-/// Walker is an interface that can be implemented to perform operations that traverse ag
+/// Walker is an interface that can be implemented to perform operations that traverse a
 /// parsed hit node tree.  Implementing classes are passed to the Node::walk function.
 class Walker
 {

--- a/framework/contrib/hit/parse.h
+++ b/framework/contrib/hit/parse.h
@@ -97,7 +97,7 @@ class Error : public std::exception
 {
 public:
   Error(const std::string & msg);
-  virtual const char * what() const throw() override;
+  virtual const char * what() const noexcept override;
   std::string msg;
 };
 
@@ -113,6 +113,8 @@ public:
 class Walker
 {
 public:
+  virtual ~Walker() {}
+
   /// walk is called when the walker is passed into a Node::walk function for each relevant node in
   /// the hit (sub)tree.  fullpath is the fully-qualified (absolute) path to the hit node
   /// where each section header is a path-element.  nodepath is the path for the node of interest -

--- a/framework/doc/content/hit.md
+++ b/framework/doc/content/hit.md
@@ -6,7 +6,7 @@ block hierarchies. To deal with HIT files we provide the `hit` executable, which
 is automatically built under `framework/contrib/hit`. This command line tool
 offers multiple functions for
 
-- Finding parameters across many input files in a contect sensitive way
+- Finding parameters across many input files in a context sensitive way
 - Validating input files
 - Formatting input files according to a user defined style
 - Merging input files
@@ -14,14 +14,14 @@ offers multiple functions for
 - Extracting common portions of input files
 - Subtracting out common portions of input files
 
-## `hit find` - Seaching for parameters
+## `hit find` - Searching for parameters
 
 ```
 hit find [-i] [-v] [-p additional_pattern [...] --] main_pattern files ...
 ```
 
 `hit find` looks for a full parameter path that can be specified with wildcards
-as `main_pattern`. `*` will match an arbitrary set of characters and `?` with
+as `main_pattern`. `*` will match an arbitrary set of characters and `?` will
 match a single character. In the input
 
 ```
@@ -37,7 +37,7 @@ the main pattern `Kernels/*/variable` will match the variable line, as will
 `Kernels/*/variable=a`, `*iable=?`, and `*/diff/*=a`, but `Kernels/*/variable=b`
 will not match.
 
-An `!=` operator is also available for negative matching. In the exaple above
+An `!=` operator is also available for negative matching. In the example above
 `Kernels/*/variable!=b` will match the variable line.
 
 The `-i` option will turn all matching case insensitive (useful to match
@@ -46,7 +46,7 @@ MooseEnum values).
 The `-v` option will list all files that do not have a single match, which can
 be used to check for the absence of patterns.
 
-The `-p` option will match additional parameters inside the blocks mathced by
+The `-p` option will match additional parameters inside the blocks matched by
 the main pattern. For example `hit find -p type=Diffusion -- Kernels/*/variable=a`
 will match the snippet above, and any kernel acting on the variable `a` that has
 `type = Diffusion` (and so would `hit find -p type!=NeumannBC -- Kernels/*/variable=a`)
@@ -179,7 +179,7 @@ common settings into a single input file.
 ## `hit subtract` - Removing common parameters parameters
 
 ```
-hit subtract common_parameters.i simulation_1_full.i > simulation_1.i
+hit subtract simulation_1_full.i common_parameters.i > simulation_1.i
 ```
 
 removes the parameters in `common_parameters.i` from `simulation_1_full.i`,

--- a/framework/doc/content/hit.md
+++ b/framework/doc/content/hit.md
@@ -1,0 +1,189 @@
+the# The `hit` command
+
+*Hierarchial Input Text* (HIT) is the file format that MOOSE input files (and
+`tests` specs) are built upon. HIT is a key-value pair syntax with multilevel
+block hierarchies. To deal with HIT files we provide the `hit` executable, which
+is automatically built under `framework/contrib/hit`. This command line tool
+offers multiple functions for
+
+- Finding parameters across many input files in a contect sensitive way
+- Validating input files
+- Formatting input files according to a user defined style
+- Merging input files
+- Diffing input files
+- Extracting common portions of input files
+- Subtracting out common portions of input files
+
+## `hit find` - Seaching for parameters
+
+```
+hit find [-i] [-v] [-p additional_pattern [...] --] main_pattern files ...
+```
+
+`hit find` looks for a full parameter path that can be specified with wildcards
+as `main_pattern`. `*` will match an arbitrary set of characters and `?` with
+match a single character. In the input
+
+```
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = a
+  []
+[]
+```
+
+the main pattern `Kernels/*/variable` will match the variable line, as will
+`Kernels/*/variable=a`, `*iable=?`, and `*/diff/*=a`, but `Kernels/*/variable=b`
+will not match.
+
+An `!=` operator is also available for negative matching. In the exaple above
+`Kernels/*/variable!=b` will match the variable line.
+
+The `-i` option will turn all matching case insensitive (useful to match
+MooseEnum values).
+
+The `-v` option will list all files that do not have a single match, which can
+be used to check for the absence of patterns.
+
+The `-p` option will match additional parameters inside the blocks mathced by
+the main pattern. For example `hit find -p type=Diffusion -- Kernels/*/variable=a`
+will match the snippet above, and any kernel acting on the variable `a` that has
+`type = Diffusion` (and so would `hit find -p type!=NeumannBC -- Kernels/*/variable=a`)
+
+### Examples
+
+```
+hit find Outputs/file_base **/*.i
+```
+
+Will find all inputs that contain the `file_base` parameter in the `[Outputs]` block.
+
+```
+hit find Outputs/file_base **/*.i
+```
+
+```
+hit find -v Modules/TensorMechanics/Master/* **/*.i
+```
+
+Will find all files that do not (`-v`) contain use of the TensorMechanics master
+action.
+
+```
+hit find BCs/*/boundary=left **/*.i
+```
+
+Will find all boundary conditions that are applied to just the `left` sideset.
+
+```
+hit find BCs/*/boundary!=left **/*.i
+```
+
+Will find all boundary conditions that are *not* applied to just the `left` sideset.
+
+```
+hit find -p type=FunctionDirichletBC -- BCs/*/boundary=\*right\* **/*.i
+```
+
+Will find all `FunctionDirichletBC`s that are applied to the `right` sideset
+(and possibly others). This will also match `boundary=inner_right` so some
+filtering of the results with `grep` may be necessary.
+
+```
+hit find -i -p formulation=mortar mortar_approach -- Contact/*/model=coulomb **/*.i
+```
+
+Will find all inputs that contain a `Contact` action block with `model = COULOMB`
+(case insensitive match using `-i`) and have the `formulation` parameter set to
+`mortar` *and* have also specified a `mortar_approach` parameter (with whatever
+value). Not that multiple arguments are supplied to the `-p` parameter and the
+list is terminated with a double dash `--`, after which the main pattern and the
+list of files to search follow.
+
+## `hit format` - Formatting input files
+
+```
+hit format [-i] [-style file] input
+```
+
+The format subcommand will reformat a valid HIT file into a cannonical form with
+a consistent indentation and potentially sorted sections and parameters. The
+name of the file to be formatted is given as the `input` parameter. When
+specifying `-` as the filename the input is taken from stdin.
+
+The formatted input will be output to terminal unless the `-i` option is supplied,
+which enables inplace formatting of the supplied `input` file.
+
+The formatting style can be user defined using the `-style` parameter. The
+argument is the name of a style file of the format:
+
+```
+    [format]
+        indent_string = "  "
+        line_length = 100
+        canonical_section_markers = true
+
+        [sorting]
+            [pattern]
+                section = "[^/]+/[^/]+"
+                order = "type"
+            []
+            [pattern]
+                section = ""
+                order = "Mesh ** Executioner Outputs"
+            []
+        []
+    []
+```
+
+where all fields are optional and the sorting section is also optional.  If the
+sorting section is present, you can have as many patterns as you want, but each
+pattern section must have 'section' and 'order' fields.
+
+## `hit merge` - Combining input files
+
+```
+hit merge -output outfile.i infile1.i infile2.i ...
+```
+
+will produce a single file `outfile.i` that is a merge of the `infile*.i` inputs
+(which would result in the same MOOSE simulation as the multiple input files).
+
+## `hit diff` - Highlighting differences between input files
+
+```
+hit diff left.i right.i
+```
+
+or
+
+```
+hit diff -left left1.i left2.i ... -right right1.i right2.i ...
+```
+
+performs a diff on the left and right files (in the second example merging all
+left and right files respectively first). This diff is not sensitive to order,
+formatting, or comments in the input files.
+
+## `hit common` - Extract common parameters between inputs
+
+```
+hit common file1.i file2.i ... > common_parameters.i
+```
+
+Will extract all parameters that are common to the specified input files (and
+have the same values). This can be used as the **first step** in factoring out
+common settings into a single input file.
+
+## `hit subtract` - Removing common parameters parameters
+
+```
+hit subtract common_parameters.i simulation_1_full.i > simulation_1.i
+```
+
+removes the parameters in `common_parameters.i` from `simulation_1_full.i`,
+creating `simulation_1.i`. This is the **second step** in factoring out common
+parameters from a set of input files. The resulting file can be run as
+`./mooseapp-opt -i common.i simulation_1.i` and will result in the same
+simulation as `./mooseapp-opt -i simulation_1_full.i`.

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -49,6 +49,9 @@ hit_objects   := $(patsubst %.cc, %.$(obj-suffix), $(hit_srcfiles))
 hit_LIB       := $(HIT_DIR)/libhit-$(METHOD).la
 # dependency files
 hit_deps      := $(patsubst %.cc, %.$(obj-suffix).d, $(hit_srcfiles))
+# hit command line tool
+hit_CLI_srcfiles := $(HIT_DIR)/main.cc
+hit_CLI          := $(HIT_DIR)/hit
 
 #
 # hit python bindings
@@ -85,9 +88,10 @@ else
 endif
 
 
-hit $(pyhit_LIB): $(pyhit_srcfiles)
+hit $(pyhit_LIB) $(hit_CLI): $(pyhit_srcfiles) $(hit_CLI_srcfiles)
 	@echo "Building and linking "$@"..."
 	@bash -c '(cd "$(HIT_DIR)" && $(libmesh_CXX) -std=c++11 -w -fPIC -lstdc++ -shared $^ $(pyhit_COMPILEFLAGS) $(DYNAMIC_LOOKUP) -o $(pyhit_LIB))'
+	@bash -c '(cd "$(HIT_DIR)" && make)'
 
 #
 # gtest

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -384,7 +384,7 @@ moose_share_dir = $(share_dir)/moose
 python_install_dir = $(moose_share_dir)/python
 bin_install_dir = $(PREFIX)/bin
 
-install: install_libs install_bin install_harness install_exodiff install_adreal_monolith
+install: install_libs install_bin install_harness install_exodiff install_adreal_monolith install_hit
 
 install_adreal_monolith: ADRealMonolithic.h
 	@ mkdir -p $(moose_include_dir)
@@ -407,6 +407,10 @@ install_harness:
 	@cp -f $(MOOSE_DIR)/framework/include/base/MooseConfig.h $(moose_include_dir)/
 	@cp -f $(HIT_DIR)/hit.so $(python_install_dir)/
 	@echo "libmesh_install_dir = '$(LIBMESH_DIR)'" > $(moose_share_dir)/moose_config.py
+
+install_hit: all
+	@echo "Installing HIT"
+	@cp $(MOOSE_DIR)/framework/contrib/hit/hit $(bin_install_dir)
 
 lib_install_suffix = lib/$(APPLICATION_NAME)
 lib_install_dir = $(PREFIX)/$(lib_install_suffix)

--- a/test/tests/misc/hit_cli/gold/additional_pattern
+++ b/test/tests/misc/hit_cli/gold/additional_pattern
@@ -1,0 +1,2 @@
+input1.i:21 BCs/left/value = 0
+1 match found.

--- a/test/tests/misc/hit_cli/gold/additional_pattern_negative
+++ b/test/tests/misc/hit_cli/gold/additional_pattern_negative
@@ -1,0 +1,4 @@
+input2.i:16 PostProcessor/max/value = 1
+input2.i:21 PostProcessor/min/value = 1
+input2.i:26 PostProcessor/min2/value = 1
+3 matches found.

--- a/test/tests/misc/hit_cli/gold/diff_color
+++ b/test/tests/misc/hit_cli/gold/diff_color
@@ -1,0 +1,57 @@
+Left hand side:
+    input1.i
+
+Right hand side:
+    input2.i
+
+Parameters removed left -> right:
+[31m
+        [BCs]
+          [left]
+            type = DirichletBC
+            value = 0
+            variable = u
+          []
+          [right]
+            type = NeumannBC
+            value = 0
+            variable = v
+          []
+        []
+        [Kernels]
+          [diff_u]
+            type = Diffusion
+            variable = u
+          []
+          [diff_v]
+            type = Diffusion
+            variable = v
+          []
+        []
+
+[39mParameters added left -> right:
+[32m
+        [Outputs]
+          [out]
+            type = Exodus
+          []
+        []
+        [PostProcessor]
+          [max]
+            mode = MAX
+            type = Calculation
+            value = 1
+          []
+          [min]
+            mode = min
+            type = Calculation
+            value = 1
+          []
+        []
+
+[39mParameters with differing values:
+
+    [33mPostProcessor/min2/value[34m (input1.i:34)[39m has differing values
+      '[31m0[39m' -> '[32m1[39m'
+
+

--- a/test/tests/misc/hit_cli/gold/diff_common
+++ b/test/tests/misc/hit_cli/gold/diff_common
@@ -1,0 +1,15 @@
+Left hand side:
+    input1.i
+
+Right hand side:
+    input2.i
+
+Common parameters:
+
+        [PostProcessor]
+          [min2]
+            mode = MIN
+            type = Calculation
+          []
+        []
+

--- a/test/tests/misc/hit_cli/gold/diff_vanilla
+++ b/test/tests/misc/hit_cli/gold/diff_vanilla
@@ -1,0 +1,57 @@
+Left hand side:
+    input1.i
+
+Right hand side:
+    input2.i
+
+Parameters removed left -> right:
+
+        [BCs]
+          [left]
+            type = DirichletBC
+            value = 0
+            variable = u
+          []
+          [right]
+            type = NeumannBC
+            value = 0
+            variable = v
+          []
+        []
+        [Kernels]
+          [diff_u]
+            type = Diffusion
+            variable = u
+          []
+          [diff_v]
+            type = Diffusion
+            variable = v
+          []
+        []
+
+Parameters added left -> right:
+
+        [Outputs]
+          [out]
+            type = Exodus
+          []
+        []
+        [PostProcessor]
+          [max]
+            mode = MAX
+            type = Calculation
+            value = 1
+          []
+          [min]
+            mode = min
+            type = Calculation
+            value = 1
+          []
+        []
+
+Parameters with differing values:
+
+    PostProcessor/min2/value (input1.i:34) has differing values
+      '0' -> '1'
+
+

--- a/test/tests/misc/hit_cli/gold/diff_verbose
+++ b/test/tests/misc/hit_cli/gold/diff_verbose
@@ -1,0 +1,33 @@
+Left hand side:
+    input1.i
+
+Right hand side:
+    input2.i
+
+Parameters removed left -> right:
+BCs/left/type (input1.i:19) is missing on the right.
+BCs/left/value (input1.i:21) is missing on the right.
+BCs/left/variable (input1.i:20) is missing on the right.
+BCs/right/type (input1.i:24) is missing on the right.
+BCs/right/value (input1.i:26) is missing on the right.
+BCs/right/variable (input1.i:25) is missing on the right.
+Kernels/diff_u/type (input1.i:8) is missing on the right.
+Kernels/diff_u/variable (input1.i:9) is missing on the right.
+Kernels/diff_v/type (input1.i:12) is missing on the right.
+Kernels/diff_v/variable (input1.i:13) is missing on the right.
+
+Parameters added left -> right:
+Outputs/out/type (input2.i:8) is missing on the left.
+PostProcessor/max/mode (input2.i:15) is missing on the left.
+PostProcessor/max/type (input2.i:14) is missing on the left.
+PostProcessor/max/value (input2.i:16) is missing on the left.
+PostProcessor/min/mode (input2.i:20) is missing on the left.
+PostProcessor/min/type (input2.i:19) is missing on the left.
+PostProcessor/min/value (input2.i:21) is missing on the left.
+
+Parameters with differing values:
+
+    PostProcessor/min2/value (input1.i:34) has differing values
+      '0' -> '1'
+
+

--- a/test/tests/misc/hit_cli/gold/diff_verbose_color
+++ b/test/tests/misc/hit_cli/gold/diff_verbose_color
@@ -1,0 +1,33 @@
+Left hand side:
+    input1.i
+
+Right hand side:
+    input2.i
+
+Parameters removed left -> right:
+[31m[31mBCs/left/type[34m (input1.i:19)[39m is missing on the right.
+[31mBCs/left/value[34m (input1.i:21)[39m is missing on the right.
+[31mBCs/left/variable[34m (input1.i:20)[39m is missing on the right.
+[31mBCs/right/type[34m (input1.i:24)[39m is missing on the right.
+[31mBCs/right/value[34m (input1.i:26)[39m is missing on the right.
+[31mBCs/right/variable[34m (input1.i:25)[39m is missing on the right.
+[31mKernels/diff_u/type[34m (input1.i:8)[39m is missing on the right.
+[31mKernels/diff_u/variable[34m (input1.i:9)[39m is missing on the right.
+[31mKernels/diff_v/type[34m (input1.i:12)[39m is missing on the right.
+[31mKernels/diff_v/variable[34m (input1.i:13)[39m is missing on the right.
+
+[39mParameters added left -> right:
+[32m[32mOutputs/out/type[34m (input2.i:8)[39m is missing on the left.
+[32mPostProcessor/max/mode[34m (input2.i:15)[39m is missing on the left.
+[32mPostProcessor/max/type[34m (input2.i:14)[39m is missing on the left.
+[32mPostProcessor/max/value[34m (input2.i:16)[39m is missing on the left.
+[32mPostProcessor/min/mode[34m (input2.i:20)[39m is missing on the left.
+[32mPostProcessor/min/type[34m (input2.i:19)[39m is missing on the left.
+[32mPostProcessor/min/value[34m (input2.i:21)[39m is missing on the left.
+
+[39mParameters with differing values:
+
+    [33mPostProcessor/min2/value[34m (input1.i:34)[39m has differing values
+      '[31m0[39m' -> '[32m1[39m'
+
+

--- a/test/tests/misc/hit_cli/gold/merge
+++ b/test/tests/misc/hit_cli/gold/merge
@@ -31,6 +31,21 @@
   [min2]
     type = Calculation
     mode = MIN
-    value = 0
+    value = 1
+  []
+  [max]
+    type = Calculation
+    mode = MAX
+    value = 1
+  []
+  [min]
+    type = Calculation
+    mode = min
+    value = 1
+  []
+[]
+[Outputs]
+  [out]
+    type = Exodus
   []
 []

--- a/test/tests/misc/hit_cli/gold/parameter_does_not_exist
+++ b/test/tests/misc/hit_cli/gold/parameter_does_not_exist
@@ -1,0 +1,2 @@
+input2.i
+1 match found.

--- a/test/tests/misc/hit_cli/gold/parameter_exists
+++ b/test/tests/misc/hit_cli/gold/parameter_exists
@@ -1,0 +1,3 @@
+input1.i:9 Kernels/diff_u/variable = u
+input1.i:13 Kernels/diff_v/variable = v
+2 matches found.

--- a/test/tests/misc/hit_cli/gold/positive_pattern
+++ b/test/tests/misc/hit_cli/gold/positive_pattern
@@ -1,0 +1,2 @@
+input1.i:9 Kernels/diff_u/variable = u
+1 match found.

--- a/test/tests/misc/hit_cli/hit_wrapper.py
+++ b/test/tests/misc/hit_cli/hit_wrapper.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import subprocess
+
+if len(sys.argv) < 2:
+    print("Usage:\nhit_wrapper.py gold_output [hit arguments]\n")
+
+MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', '..')))
+hit = os.path.join(MOOSE_DIR, 'framework', 'contrib', 'hit', 'hit')
+if not os.path.exists(hit):
+    print('Failed to locate hit executable.')
+    sys.exit(1)
+
+gold_file = sys.argv[1]
+hit_args = sys.argv[2:]
+
+with open(gold_file, 'rb') as f:
+    gold = f.read()
+
+out = subprocess.check_output([hit] + hit_args)
+
+if out == gold:
+    sys.exit(0)
+
+print("Output:\n", out, "\ndoes not match gold:\n", gold)
+sys.exit(1)

--- a/test/tests/misc/hit_cli/hit_wrapper.py
+++ b/test/tests/misc/hit_cli/hit_wrapper.py
@@ -19,7 +19,8 @@ hit_args = sys.argv[2:]
 with open(gold_file, 'rb') as f:
     gold = f.read()
 
-out = subprocess.check_output([hit] + hit_args)
+result = subprocess.run([hit] + hit_args, capture_output=True)
+out = result.stdout
 
 if out == gold:
     sys.exit(0)

--- a/test/tests/misc/hit_cli/hit_wrapper.py
+++ b/test/tests/misc/hit_cli/hit_wrapper.py
@@ -2,13 +2,20 @@
 
 import sys
 import os
+import shutil
 import subprocess
 
 if len(sys.argv) < 2:
     print("Usage:\nhit_wrapper.py gold_output [hit arguments]\n")
 
-MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', '..')))
+CWD = os.path.dirname(os.path.realpath(__file__))
+MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(CWD, '..', '..', '..', '..')))
+
+# in place compiled hit
 hit = os.path.join(MOOSE_DIR, 'framework', 'contrib', 'hit', 'hit')
+if not os.path.exists(hit):
+    # installed hit
+    hit = os.path.abspath(os.path.join(CWD, '../../../../../../bin/hit'))
 if not os.path.exists(hit):
     print('Failed to locate hit executable.')
     sys.exit(1)
@@ -19,14 +26,18 @@ hit_args = sys.argv[2:]
 with open(gold_file, 'rb') as f:
     gold = f.read()
 
-try:
-    out = subprocess.check_output([hit] + hit_args, stderr=subprocess.STDOUT)
-except subprocess.CalledProcessError as err:
-    return_code = err.returncode
-    out = err.output
+command = [hit] + hit_args
+print("Running: ", ' '.join(command))
+
+p = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE)
+p.wait()
+print("hit returned ", p.returncode)
+out = p.communicate()[0]
 
 if out == gold:
+    print("Passed.")
     sys.exit(0)
 
 print("Output:\n", out, "\ndoes not match gold:\n", gold)
+print(sys.version)
 sys.exit(1)

--- a/test/tests/misc/hit_cli/hit_wrapper.py
+++ b/test/tests/misc/hit_cli/hit_wrapper.py
@@ -19,8 +19,11 @@ hit_args = sys.argv[2:]
 with open(gold_file, 'rb') as f:
     gold = f.read()
 
-result = subprocess.run([hit] + hit_args, capture_output=True)
-out = result.stdout
+try:
+    out = subprocess.check_output([hit] + hit_args, stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as err:
+    return_code = err.returncode
+    out = err.output
 
 if out == gold:
     sys.exit(0)

--- a/test/tests/misc/hit_cli/input1.i
+++ b/test/tests/misc/hit_cli/input1.i
@@ -1,0 +1,28 @@
+#
+# This is not a valid MOOSE input, it is only used for testing the HIT command
+# line utility.
+#
+
+[Kernels]
+  [diff_u]
+    type = Diffusion
+    variable = u
+  []
+  [diff_v]
+    type = Diffusion
+    variable = v
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    value = 0
+  []
+  [right]
+    type = NeumannBC
+    variable = v
+    value = 0
+  []
+[]

--- a/test/tests/misc/hit_cli/input2.i
+++ b/test/tests/misc/hit_cli/input2.i
@@ -1,0 +1,28 @@
+#
+# This is not a valid MOOSE input, it is only used for testing the HIT command
+# line utility.
+#
+
+[Outputs]
+  [out]
+    type = Exodus
+  []
+[]
+
+[PostProcessor]
+  [max]
+    type = Calculation
+    mode = MAX
+    value = 1
+  []
+  [min]
+    type = Calculation
+    mode = min
+    value = 1
+  []
+  [min2]
+    type = Calculation
+    mode = MIN
+    value = 1
+  []
+[]

--- a/test/tests/misc/hit_cli/tests
+++ b/test/tests/misc/hit_cli/tests
@@ -3,7 +3,7 @@
   design = 'hit.md'
 
   [find]
-    requirement = 'The hit find command shall be able to find'
+    requirement = 'The `hit find` command shall be able to find'
     [parameter_exists]
       type = RunCommand
       command = './hit_wrapper.py gold/parameter_exists find Kernels/\*/variable input1.i input2.i'
@@ -29,13 +29,51 @@
 
     [additional_pattern]
       type = RunCommand
-      command = './hit_wrapper.py gold/additional_pattern find -p type=DirichletBC -- \*/value input1.i input2.i'
+      command = './hit_wrapper.py gold/additional_pattern find -p type=DirichletBC -- \*/value '
+                'input1.i input2.i'
       detail = 'parameters with additional pattern constraints,'
     []
     [additional_pattern_negative]
       type = RunCommand
-      command = './hit_wrapper.py gold/additional_pattern_negative find -p type!=DirichletBC -- \*/value input1.i input2.i'
-      detail = 'parameters with additional pattern constraints,'
+      command = './hit_wrapper.py gold/additional_pattern_negative find -p type!=DirichletBC -- '
+                '\*/value input1.i input2.i'
+      detail = 'parameters with additional pattern constraints.'
+    []
+  []
+
+  [merge]
+    type = RunCommand
+    command = './hit_wrapper.py gold/merge merge -output - input1.i input2.i'
+    requirement = 'The `hit merge` command shall be able to combine input files.'
+  []
+
+  [diff]
+    requirement = 'The `hit diff` command shall be able to'
+    [vanilla]
+      type = RunCommand
+      command = './hit_wrapper.py gold/diff_vanilla diff input1.i input2.i'
+      detail = 'show differences between input files,'
+    []
+    [color]
+      type = RunCommand
+      command = './hit_wrapper.py gold/diff_color diff -color input1.i input2.i'
+      detail = 'show differences between input files marked up using terminal colors,'
+    []
+    [verbose]
+      type = RunCommand
+      command = './hit_wrapper.py gold/diff_verbose diff -v input1.i input2.i'
+      detail = 'show differences between input files with verbose explanations,'
+    []
+    [verbose_color]
+      type = RunCommand
+      command = './hit_wrapper.py gold/diff_verbose_color diff -v -color input1.i input2.i'
+      detail = 'show differences between input files with verbose explanations marked up using '
+               'terminal colors,'
+    []
+    [common]
+      type = RunCommand
+      command = './hit_wrapper.py gold/diff_common diff -common input1.i input2.i'
+      detail = 'show common parameters/value pairs between input files,'
     []
   []
 []

--- a/test/tests/misc/hit_cli/tests
+++ b/test/tests/misc/hit_cli/tests
@@ -37,7 +37,7 @@
       type = RunCommand
       command = './hit_wrapper.py gold/additional_pattern_negative find -p type!=DirichletBC -- '
                 '\*/value input1.i input2.i'
-      detail = 'parameters with additional pattern constraints.'
+      detail = 'parameters with additional inverted pattern constraints.'
     []
   []
 

--- a/test/tests/misc/hit_cli/tests
+++ b/test/tests/misc/hit_cli/tests
@@ -1,0 +1,41 @@
+[Tests]
+  issues = '#19001'
+  design = 'hit.md'
+
+  [find]
+    requirement = 'The hit find command shall be able to find'
+    [parameter_exists]
+      type = RunCommand
+      command = './hit_wrapper.py gold/parameter_exists find Kernels/\*/variable input1.i input2.i'
+      detail = 'files with specific parameters,'
+    []
+    [parameter_does_not_exist]
+      type = RunCommand
+      command = './hit_wrapper.py gold/parameter_does_not_exist find -v Kernels/\*/variable input1.i '
+                'input2.i'
+      detail = 'files not containing a specified parameter,'
+    []
+
+    [positive_pattern]
+      type = RunCommand
+      command = './hit_wrapper.py gold/positive_pattern find Kernels/\*/variable=u input1.i'
+      detail = 'parameters set to an exact specified value,'
+    []
+    [negative_pattern]
+      type = RunCommand
+      command = './hit_wrapper.py gold/positive_pattern find Kernels/\*/variable!=v input1.i'
+      detail = 'parameters not set to an exact specified value,'
+    []
+
+    [additional_pattern]
+      type = RunCommand
+      command = './hit_wrapper.py gold/additional_pattern find -p type=DirichletBC -- \*/value input1.i input2.i'
+      detail = 'parameters with additional pattern constraints,'
+    []
+    [additional_pattern_negative]
+      type = RunCommand
+      command = './hit_wrapper.py gold/additional_pattern_negative find -p type!=DirichletBC -- \*/value input1.i input2.i'
+      detail = 'parameters with additional pattern constraints,'
+    []
+  []
+[]


### PR DESCRIPTION
Example output for 

```
hit find 'Kernels/*/type=*Diff*' test/tests/*/*.i
```

```
test/tests/coord_type/coord_type_rz.i:15 Kernels/diff/type = Diffusion
test/tests/coord_type/coord_type_rz_integrated.i:36 Kernels/diff_u/type = Diffusion
test/tests/performance/input.i:15 Kernels/diff/type = Diffusion
test/tests/phi_zero/simple_transient_diffusion.i:22 Kernels/diff/type = CoefDiffusion
test/tests/system_interfaces/input.i:15 Kernels/diff/type = Diffusion
test/tests/tag/2d_diffusion_dg_tag.i:71 Kernels/diff/type = Diffusion
test/tests/tag/2d_diffusion_matrix_tag_test.i:27 Kernels/diff/type = Diffusion
test/tests/tag/2d_diffusion_matrix_tag_test.i:33 Kernels/diff1/type = Diffusion
test/tests/tag/2d_diffusion_matrix_tag_test.i:40 Kernels/diff2/type = Diffusion
test/tests/tag/2d_diffusion_matrix_tag_test.i:46 Kernels/diff3/type = Diffusion
test/tests/tag/2d_diffusion_tag_matrix.i:31 Kernels/diff/type = Diffusion
test/tests/tag/2d_diffusion_tag_vector.i:31 Kernels/diff/type = Diffusion
test/tests/tag/controls-tagging.i:25 Kernels/diff/type = Diffusion
test/tests/tag/eigen_tag.i:32 Kernels/diff/type = Diffusion
test/tests/tag/tag_ad_kernels.i:15 Kernels/diff/type = ADDiffusion
test/tests/tag/tag_dirac_kernels.i:35 Kernels/diff_u/type = Diffusion
test/tests/tag/tag_dirac_kernels.i:49 Kernels/diff_v/type = Diffusion
test/tests/tag/tag_interface_kernels.i:48 Kernels/diff_u/type = CoeffParamDiffusion
test/tests/tag/tag_interface_kernels.i:56 Kernels/diff_v/type = CoeffParamDiffusion
test/tests/tag/tag_neumann.i:15 Kernels/diff/type = Diffusion
test/tests/tag/tag_nodal_kernels.i:17 Kernels/diff/type = Diffusion
test/tests/test_harness/500_num_steps.i:14 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csv_validation_tester_01.i:37 Kernels/diff/type = Diffusion
test/tests/test_harness/csvdiff.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_floor.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_global_floor.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_global_relative.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_not_logic.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_relative.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_comparison_removed_field.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_diff_gold.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_missing_field_comparison.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_spec_override_global_floor.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_spec_override_global_relative.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_spec_override_specific_floor.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/csvdiff_spec_override_specific_relative.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/exception_transient.i:25 Kernels/diff/type = Diffusion
test/tests/test_harness/exodiff.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/exodiff_diff_gold.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/good.i:15 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/long_running.i:16 Kernels/diff/type = CoefDiffusion
test/tests/test_harness/output_csv_and_exodus.i:15 Kernels/diff/type = CoefDiffusion
test/tests/thewarehouse/test1.i:21 Kernels/diff/type = CoefDiffusion
test/tests/usability/bad.i:13: missing closing '[]' for section
test/tests/usability/input.i:15 Kernels/diff/type = Diffusion
45 matches found.
```

Closes #19001