### PR TITLE
Help!  Code duplication.  Sad.

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -153,6 +153,8 @@ public:
   virtual Moose::CoordinateSystemType getCoordSystem(SubdomainID sid) const override;
   virtual void setCoordSystem(const std::vector<SubdomainName> & blocks,
                               const MultiMooseEnum & coord_sys);
+  virtual void setCoordSystem(const std::vector<SubdomainID> & blocks,
+                              const MultiMooseEnum & coord_sys);
   void setAxisymmetricCoordAxis(const MooseEnum & rz_coord_axis);
 
   /**

--- a/framework/include/userobject/CoupledVarSubdomainModifier.h
+++ b/framework/include/userobject/CoupledVarSubdomainModifier.h
@@ -9,19 +9,19 @@
 
 #pragma once
 
-#include "ThresholdElementSubdomainModifier.h"
+#include "ElementSubdomainModifier.h"
 
-class CoupledVarThresholdElementSubdomainModifier : public ThresholdElementSubdomainModifier
+class CoupledVarSubdomainModifier : public ElementSubdomainModifier
 {
 public:
   static InputParameters validParams();
 
-  CoupledVarThresholdElementSubdomainModifier(const InputParameters & parameters);
+  CoupledVarSubdomainModifier(const InputParameters & parameters);
 
 protected:
-  virtual Real computeValue() const override;
+  virtual SubdomainID computeSubdomainID() const override;
 
 private:
-  /// The coupled variable used in the criterion
+  /// The coupled variable that defines the Subdomain ID
   const VariableValue & _v;
 };

--- a/framework/include/userobject/ElementSubdomainAndBoundaryModifier.h
+++ b/framework/include/userobject/ElementSubdomainAndBoundaryModifier.h
@@ -1,0 +1,65 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ElementSubdomainModifier.h"
+
+class ElementSubdomainAndBoundaryModifier : public ElementSubdomainModifier
+{
+public:
+  static InputParameters validParams();
+
+  ElementSubdomainAndBoundaryModifier(const InputParameters & parameters);
+
+  virtual void initialSetup() override;
+
+protected:
+  // The ID of the moving boundary that this object creates/modifies.
+  BoundaryID movingBoundaryID() const
+  {
+    if (!_moving_boundary_specified)
+      mooseError("no moving boundary specified");
+    return _moving_boundary_id;
+  }
+
+  // The name of the moving boundary that this object creates/modifies.
+  const BoundaryName movingBoundaryName() const
+  {
+    if (!_moving_boundary_specified)
+      mooseError("no moving boundary specified");
+    return _moving_boundary_name;
+  }
+
+  void updateBoundaryInfo(MooseMesh & mesh, const std::vector<const Elem *> & moved_elems) override;
+
+private:
+  // Set the name of the moving boundary. Create the nodeset/sideset if not exist.
+  void setMovingBoundaryName(MooseMesh & mesh);
+
+  // Remove ghosted element sides
+  void pushBoundarySideInfo(
+      MooseMesh & mesh,
+      std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>> &
+          elems_to_push);
+
+  // Remove ghosted boundary nodes
+  void pushBoundaryNodeInfo(
+      MooseMesh & mesh,
+      std::unordered_map<processor_id_type, std::vector<dof_id_type>> & nodes_to_push);
+
+  /// Whether a moving boundary name is provided
+  const bool _moving_boundary_specified;
+
+  /// The name of the moving boundary
+  BoundaryName _moving_boundary_name;
+
+  /// The Id of the moving boundary
+  BoundaryID _moving_boundary_id;
+};

--- a/framework/include/userobject/ElementSubdomainModifier.h
+++ b/framework/include/userobject/ElementSubdomainModifier.h
@@ -20,7 +20,6 @@ public:
 
   ElementSubdomainModifier(const InputParameters & parameters);
 
-  virtual void initialSetup() override;
   virtual void initialize() override;
   virtual void execute() override;
   virtual void threadJoin(const UserObject & /*uo*/) override{};
@@ -29,22 +28,6 @@ public:
 protected:
   // Compute the subdomain ID of the current element
   virtual SubdomainID computeSubdomainID() = 0;
-
-  // The ID of the moving boundary that this object creates/modifies.
-  BoundaryID movingBoundaryID() const
-  {
-    if (!_moving_boundary_specified)
-      mooseError("no moving boundary specified");
-    return _moving_boundary_id;
-  }
-
-  // The name of the moving boundary that this object creates/modifies.
-  const BoundaryName movingBoundaryName() const
-  {
-    if (!_moving_boundary_specified)
-      mooseError("no moving boundary specified");
-    return _moving_boundary_name;
-  }
 
   // Range of the elements who changed their subdomain ID
   ConstElemRange & movedElemsRange() const { return *_moved_elems_range; }
@@ -55,28 +38,14 @@ protected:
   // Pointer to the displaced problem
   DisplacedProblem * _displaced_problem;
 
-private:
-  // Set the name of the moving boundary. Create the nodeset/sideset if not exist.
-  void setMovingBoundaryName(MooseMesh & mesh);
-
   // Update the moving boundary (both the underlying sideset and nodeset)
-  void updateBoundaryInfo(MooseMesh & mesh, const std::vector<const Elem *> & moved_elems);
+  virtual void updateBoundaryInfo(MooseMesh & mesh, const std::vector<const Elem *> & moved_elems);
 
+private:
   // Helper function to add nodes on a side of an element to a set
   void recordNodeIdsOnElemSide(const Elem * elem,
                                const unsigned short int side,
                                std::set<dof_id_type> & node_ids);
-
-  // Remove ghosted element sides
-  void pushBoundarySideInfo(
-      MooseMesh & mesh,
-      std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>> &
-          elems_to_push);
-
-  // Remove ghosted boundary nodes
-  void pushBoundaryNodeInfo(
-      MooseMesh & mesh,
-      std::unordered_map<processor_id_type, std::vector<dof_id_type>> & nodes_to_push);
 
   // Helper function to build the range of moved elements
   void buildMovedElemsRange();
@@ -104,13 +73,4 @@ private:
 
   // Whether to re-apply ICs on moved elements and moved nodes
   const bool _apply_ic;
-
-  /// Whether a moving boundary name is provided
-  const bool _moving_boundary_specified;
-
-  /// The name of the moving boundary
-  BoundaryName _moving_boundary_name;
-
-  /// The Id of the moving boundary
-  BoundaryID _moving_boundary_id;
 };

--- a/framework/include/userobject/ElementSubdomainModifier.h
+++ b/framework/include/userobject/ElementSubdomainModifier.h
@@ -27,7 +27,7 @@ public:
 
 protected:
   // Compute the subdomain ID of the current element
-  virtual SubdomainID computeSubdomainID() = 0;
+  virtual SubdomainID computeSubdomainID() const = 0;
 
   // Range of the elements who changed their subdomain ID
   ConstElemRange & movedElemsRange() const { return *_moved_elems_range; }

--- a/framework/include/userobject/ThresholdElementSubdomainModifier.h
+++ b/framework/include/userobject/ThresholdElementSubdomainModifier.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include "ElementSubdomainModifier.h"
+#include "ElementSubdomainAndBoundaryModifier.h"
 #include "MooseEnum.h"
 
-class ThresholdElementSubdomainModifier : public ElementSubdomainModifier
+class ThresholdElementSubdomainModifier : public ElementSubdomainAndBoundaryModifier
 {
 public:
   static InputParameters validParams();

--- a/framework/include/userobject/ThresholdElementSubdomainModifier.h
+++ b/framework/include/userobject/ThresholdElementSubdomainModifier.h
@@ -20,10 +20,10 @@ public:
   ThresholdElementSubdomainModifier(const InputParameters & parameters);
 
 protected:
-  virtual SubdomainID computeSubdomainID() override;
+  virtual SubdomainID computeSubdomainID() const override;
 
   /// Compute the value used in the criterion
-  virtual Real computeValue() = 0;
+  virtual Real computeValue() const = 0;
 
 private:
   /// Threshold to modify the element subdomain ID

--- a/framework/src/userobject/CoupledVarSubdomainModifier.C
+++ b/framework/src/userobject/CoupledVarSubdomainModifier.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "CoupledVarSubdomainModifier.h"
+
+#include "libmesh/quadrature.h"
+
+registerMooseObject("MooseApp", CoupledVarSubdomainModifier);
+
+InputParameters
+CoupledVarSubdomainModifier::validParams()
+{
+  InputParameters params = ElementSubdomainModifier::validParams();
+  params.addClassDescription(
+      "Sets the element subdomain ID equal to that defined by the coupled_var");
+  params.addRequiredCoupledVar("coupled_var",
+                               "Coupled variable whose value sets the subdomain ID.  The value of "
+                               "coupled_var rounded to the nearest unsigned integer is used");
+  return params;
+}
+
+CoupledVarSubdomainModifier::CoupledVarSubdomainModifier(const InputParameters & parameters)
+  : ElementSubdomainModifier(parameters), _v(coupledValue("coupled_var"))
+{
+}
+
+SubdomainID
+CoupledVarSubdomainModifier::computeSubdomainID() const
+{
+  Real avg_val = 0;
+
+  for (unsigned int qp = 0; qp < _qrule->n_points(); ++qp)
+    avg_val += _v[qp] * _JxW[qp] * _coord[qp];
+  avg_val /= _current_elem_volume;
+
+  if (avg_val <= 0)
+    return 0;
+  else if (avg_val >= std::numeric_limits<SubdomainID>::max())
+    return std::numeric_limits<SubdomainID>::max() - 1;
+  return static_cast<SubdomainID>(std::lround(avg_val));
+}

--- a/framework/src/userobject/CoupledVarThresholdElementSubdomainModifier.C
+++ b/framework/src/userobject/CoupledVarThresholdElementSubdomainModifier.C
@@ -29,7 +29,7 @@ CoupledVarThresholdElementSubdomainModifier::CoupledVarThresholdElementSubdomain
 }
 
 Real
-CoupledVarThresholdElementSubdomainModifier::computeValue()
+CoupledVarThresholdElementSubdomainModifier::computeValue() const
 {
   Real avg_val = 0;
 

--- a/framework/src/userobject/ElementSubdomainAndBoundaryModifier.C
+++ b/framework/src/userobject/ElementSubdomainAndBoundaryModifier.C
@@ -1,0 +1,174 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElementSubdomainAndBoundaryModifier.h"
+
+#include "libmesh/remote_elem.h"
+
+InputParameters
+ElementSubdomainAndBoundaryModifier::validParams()
+{
+  InputParameters params = ElementSubdomainModifier::validParams();
+  params.addClassDescription("Modify element subdomain ID, and optionally a mesh boundary. This "
+                             "userobject only runs on the undisplaced mesh, and it will "
+                             "modify both the undisplaced and the displaced mesh.");
+  params.addParam<BoundaryName>(
+      "moving_boundary_name",
+      "Optional boundary to modify when an element is moved. A boundary "
+      "with the provided name will be created if it does not already exist");
+  return params;
+}
+
+ElementSubdomainAndBoundaryModifier::ElementSubdomainAndBoundaryModifier(
+    const InputParameters & parameters)
+  : ElementSubdomainModifier(parameters),
+    _moving_boundary_specified(isParamValid("moving_boundary_name"))
+{
+}
+
+void
+ElementSubdomainAndBoundaryModifier::initialSetup()
+{
+  if (_moving_boundary_specified)
+  {
+    _moving_boundary_name = getParam<BoundaryName>("moving_boundary_name");
+    setMovingBoundaryName(_mesh);
+    if (_displaced_problem)
+      setMovingBoundaryName(_displaced_problem->mesh());
+  }
+}
+
+void
+ElementSubdomainAndBoundaryModifier::setMovingBoundaryName(MooseMesh & mesh)
+{
+  // We only need one boundary to modify. Create a dummy vector just to use the API.
+  const std::vector<BoundaryID> boundary_ids = mesh.getBoundaryIDs({{_moving_boundary_name}}, true);
+  mooseAssert(boundary_ids.size() == 1, "Expect exactly one boundary ID.");
+  _moving_boundary_id = boundary_ids[0];
+  mesh.setBoundaryName(_moving_boundary_id, _moving_boundary_name);
+  mesh.getMesh().get_boundary_info().sideset_name(_moving_boundary_id) = _moving_boundary_name;
+  mesh.getMesh().get_boundary_info().nodeset_name(_moving_boundary_id) = _moving_boundary_name;
+}
+
+void
+ElementSubdomainAndBoundaryModifier::updateBoundaryInfo(
+    MooseMesh & mesh, const std::vector<const Elem *> & moved_elems)
+{
+  if (!_moving_boundary_specified)
+    return;
+
+  BoundaryInfo & bnd_info = mesh.getMesh().get_boundary_info();
+
+  // save the removed ghost sides and associated nodes to sync across processors
+  std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
+      ghost_sides_to_remove;
+  std::unordered_map<processor_id_type, std::vector<dof_id_type>> ghost_nodes_to_remove;
+
+  // The logic below updates the side set and the node set associated with the moving boundary.
+  std::set<dof_id_type> added_nodes, removed_nodes;
+  for (auto elem : moved_elems)
+  {
+    // First loop over all the sides of the element
+    for (auto side : elem->side_index_range())
+    {
+      const Elem * neighbor = elem->neighbor_ptr(side);
+      if (neighbor && neighbor != libMesh::remote_elem)
+      {
+        // If the neighbor has a different subdomain ID, then this side should be added to
+        // the moving boundary
+        if (neighbor->subdomain_id() != elem->subdomain_id())
+          bnd_info.add_side(elem, side, _moving_boundary_id);
+        // Otherwise remove this side and the neighbor side from the boundary.
+        else
+        {
+          bnd_info.remove_side(elem, side);
+          unsigned int neighbor_side = neighbor->which_neighbor_am_i(elem);
+          bnd_info.remove_side(neighbor, neighbor_side);
+          if (neighbor->processor_id() != this->processor_id())
+            ghost_sides_to_remove[neighbor->processor_id()].emplace_back(neighbor->id(),
+                                                                         neighbor_side);
+        }
+      }
+    }
+
+    // Then loop over all the nodes of the element
+    for (auto node : elem->node_index_range())
+    {
+      // Find the point neighbors
+      std::set<const Elem *> neighbor_set;
+      elem->find_point_neighbors(elem->node_ref(node), neighbor_set);
+      for (auto neighbor : neighbor_set)
+        if (neighbor != libMesh::remote_elem)
+        {
+          // If the neighbor has a different subdomain ID, then this node should be added to
+          // the moving boundary
+          if (neighbor->subdomain_id() != elem->subdomain_id())
+            added_nodes.insert(elem->node_id(node));
+          // Otherwise remove this node from the boundary.
+          else
+          {
+            removed_nodes.insert(elem->node_id(node));
+            if (neighbor->processor_id() != this->processor_id())
+              ghost_nodes_to_remove[neighbor->processor_id()].push_back(elem->node_id(node));
+          }
+        }
+    }
+  }
+
+  // make sure to remove nodes that are not in the add set
+  std::set<dof_id_type> nodes_to_remove;
+  std::set_difference(removed_nodes.begin(),
+                      removed_nodes.end(),
+                      added_nodes.begin(),
+                      added_nodes.end(),
+                      std::inserter(nodes_to_remove, nodes_to_remove.end()));
+  for (auto node_id : nodes_to_remove)
+    mesh.getMesh().get_boundary_info().remove_node(mesh.nodePtr(node_id), _moving_boundary_id);
+  // synchronize boundary information across processors
+  pushBoundarySideInfo(mesh, ghost_sides_to_remove);
+  pushBoundaryNodeInfo(mesh, ghost_nodes_to_remove);
+  mesh.getMesh().get_boundary_info().parallel_sync_side_ids();
+  mesh.getMesh().get_boundary_info().parallel_sync_node_ids();
+  mesh.update();
+}
+
+void
+ElementSubdomainAndBoundaryModifier::pushBoundarySideInfo(
+    MooseMesh & mesh,
+    std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>> &
+        elems_to_push)
+{
+  auto elem_action_functor =
+      [&mesh, this](processor_id_type,
+                    const std::vector<std::pair<dof_id_type, unsigned int>> & received_elem) {
+        // remove the side
+        for (const auto & pr : received_elem)
+          mesh.getMesh().get_boundary_info().remove_side(
+              mesh.getMesh().elem_ptr(pr.first), pr.second, _moving_boundary_id);
+      };
+
+  Parallel::push_parallel_vector_data(
+      mesh.getMesh().get_boundary_info().comm(), elems_to_push, elem_action_functor);
+}
+
+void
+ElementSubdomainAndBoundaryModifier::pushBoundaryNodeInfo(
+    MooseMesh & mesh,
+    std::unordered_map<processor_id_type, std::vector<dof_id_type>> & nodes_to_push)
+{
+  auto node_action_functor = [&mesh, this](processor_id_type,
+                                           const std::vector<dof_id_type> & received_nodes) {
+    for (const auto & pr : received_nodes)
+      mesh.getMesh().get_boundary_info().remove_node(mesh.getMesh().node_ptr(pr),
+                                                     _moving_boundary_id);
+  };
+
+  Parallel::push_parallel_vector_data(
+      mesh.getMesh().get_boundary_info().comm(), nodes_to_push, node_action_functor);
+}

--- a/framework/src/userobject/ElementSubdomainModifier.C
+++ b/framework/src/userobject/ElementSubdomainModifier.C
@@ -8,13 +8,6 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ElementSubdomainModifier.h"
-#include "DisplacedProblem.h"
-
-#include "libmesh/parallel_algebra.h"
-#include "libmesh/parallel.h"
-#include "libmesh/dof_map.h"
-#include "libmesh/remote_elem.h"
-#include "libmesh/parallel_ghost_sync.h"
 
 InputParameters
 ElementSubdomainModifier::validParams()
@@ -26,10 +19,6 @@ ElementSubdomainModifier::validParams()
   params.addParam<bool>("apply_initial_conditions",
                         true,
                         "Whether to apply initial conditions on the moved nodes and elements");
-  params.addParam<BoundaryName>(
-      "moving_boundary_name",
-      "Boundary to modify when an element is moved. A boundary with the provided name will be "
-      "created if not already exists on the mesh.");
   params.set<bool>("use_displaced_mesh") = false;
   params.suppressParameter<bool>("use_displaced_mesh");
   return params;
@@ -38,33 +27,8 @@ ElementSubdomainModifier::validParams()
 ElementSubdomainModifier::ElementSubdomainModifier(const InputParameters & parameters)
   : ElementUserObject(parameters),
     _displaced_problem(_fe_problem.getDisplacedProblem().get()),
-    _apply_ic(getParam<bool>("apply_initial_conditions")),
-    _moving_boundary_specified(isParamValid("moving_boundary_name"))
+    _apply_ic(getParam<bool>("apply_initial_conditions"))
 {
-}
-
-void
-ElementSubdomainModifier::initialSetup()
-{
-  if (_moving_boundary_specified)
-  {
-    _moving_boundary_name = getParam<BoundaryName>("moving_boundary_name");
-    setMovingBoundaryName(_mesh);
-    if (_displaced_problem)
-      setMovingBoundaryName(_displaced_problem->mesh());
-  }
-}
-
-void
-ElementSubdomainModifier::setMovingBoundaryName(MooseMesh & mesh)
-{
-  // We only need one boundary to modify. Create a dummy vector just to use the API.
-  const std::vector<BoundaryID> boundary_ids = mesh.getBoundaryIDs({{_moving_boundary_name}}, true);
-  mooseAssert(boundary_ids.size() == 1, "Expect exactly one boundary ID.");
-  _moving_boundary_id = boundary_ids[0];
-  mesh.setBoundaryName(_moving_boundary_id, _moving_boundary_name);
-  mesh.getMesh().get_boundary_info().sideset_name(_moving_boundary_id) = _moving_boundary_name;
-  mesh.getMesh().get_boundary_info().nodeset_name(_moving_boundary_id) = _moving_boundary_name;
 }
 
 void
@@ -156,85 +120,10 @@ ElementSubdomainModifier::finalize()
 }
 
 void
-ElementSubdomainModifier::updateBoundaryInfo(MooseMesh & mesh,
-                                             const std::vector<const Elem *> & moved_elems)
+ElementSubdomainModifier::updateBoundaryInfo(MooseMesh & /*mesh*/,
+                                             const std::vector<const Elem *> & /*moved_elems*/)
 {
-  if (!_moving_boundary_specified)
-    return;
-
-  BoundaryInfo & bnd_info = mesh.getMesh().get_boundary_info();
-
-  // save the removed ghost sides and associated nodes to sync across processors
-  std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>>
-      ghost_sides_to_remove;
-  std::unordered_map<processor_id_type, std::vector<dof_id_type>> ghost_nodes_to_remove;
-
-  // The logic below updates the side set and the node set associated with the moving boundary.
-  std::set<dof_id_type> added_nodes, removed_nodes;
-  for (auto elem : moved_elems)
-  {
-    // First loop over all the sides of the element
-    for (auto side : elem->side_index_range())
-    {
-      const Elem * neighbor = elem->neighbor_ptr(side);
-      if (neighbor && neighbor != libMesh::remote_elem)
-      {
-        // If the neighbor has a different subdomain ID, then this side should be added to
-        // the moving boundary
-        if (neighbor->subdomain_id() != elem->subdomain_id())
-          bnd_info.add_side(elem, side, _moving_boundary_id);
-        // Otherwise remove this side and the neighbor side from the boundary.
-        else
-        {
-          bnd_info.remove_side(elem, side);
-          unsigned int neighbor_side = neighbor->which_neighbor_am_i(elem);
-          bnd_info.remove_side(neighbor, neighbor_side);
-          if (neighbor->processor_id() != this->processor_id())
-            ghost_sides_to_remove[neighbor->processor_id()].emplace_back(neighbor->id(),
-                                                                         neighbor_side);
-        }
-      }
-    }
-
-    // Then loop over all the nodes of the element
-    for (auto node : elem->node_index_range())
-    {
-      // Find the point neighbors
-      std::set<const Elem *> neighbor_set;
-      elem->find_point_neighbors(elem->node_ref(node), neighbor_set);
-      for (auto neighbor : neighbor_set)
-        if (neighbor != libMesh::remote_elem)
-        {
-          // If the neighbor has a different subdomain ID, then this node should be added to
-          // the moving boundary
-          if (neighbor->subdomain_id() != elem->subdomain_id())
-            added_nodes.insert(elem->node_id(node));
-          // Otherwise remove this node from the boundary.
-          else
-          {
-            removed_nodes.insert(elem->node_id(node));
-            if (neighbor->processor_id() != this->processor_id())
-              ghost_nodes_to_remove[neighbor->processor_id()].push_back(elem->node_id(node));
-          }
-        }
-    }
-  }
-
-  // make sure to remove nodes that are not in the add set
-  std::set<dof_id_type> nodes_to_remove;
-  std::set_difference(removed_nodes.begin(),
-                      removed_nodes.end(),
-                      added_nodes.begin(),
-                      added_nodes.end(),
-                      std::inserter(nodes_to_remove, nodes_to_remove.end()));
-  for (auto node_id : nodes_to_remove)
-    mesh.getMesh().get_boundary_info().remove_node(mesh.nodePtr(node_id), _moving_boundary_id);
-  // synchronize boundary information across processors
-  pushBoundarySideInfo(mesh, ghost_sides_to_remove);
-  pushBoundaryNodeInfo(mesh, ghost_nodes_to_remove);
-  mesh.getMesh().get_boundary_info().parallel_sync_side_ids();
-  mesh.getMesh().get_boundary_info().parallel_sync_node_ids();
-  mesh.update();
+  return;
 }
 
 void
@@ -244,41 +133,6 @@ ElementSubdomainModifier::recordNodeIdsOnElemSide(const Elem * elem,
 {
   for (unsigned int i = 0; i < elem->side_ptr(side)->n_nodes(); ++i)
     node_ids.insert(elem->side_ptr(side)->node_id(i));
-}
-
-void
-ElementSubdomainModifier::pushBoundarySideInfo(
-    MooseMesh & mesh,
-    std::unordered_map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned int>>> &
-        elems_to_push)
-{
-  auto elem_action_functor =
-      [&mesh, this](processor_id_type,
-                    const std::vector<std::pair<dof_id_type, unsigned int>> & received_elem) {
-        // remove the side
-        for (const auto & pr : received_elem)
-          mesh.getMesh().get_boundary_info().remove_side(
-              mesh.getMesh().elem_ptr(pr.first), pr.second, _moving_boundary_id);
-      };
-
-  Parallel::push_parallel_vector_data(
-      mesh.getMesh().get_boundary_info().comm(), elems_to_push, elem_action_functor);
-}
-
-void
-ElementSubdomainModifier::pushBoundaryNodeInfo(
-    MooseMesh & mesh,
-    std::unordered_map<processor_id_type, std::vector<dof_id_type>> & nodes_to_push)
-{
-  auto node_action_functor = [&mesh, this](processor_id_type,
-                                           const std::vector<dof_id_type> & received_nodes) {
-    for (const auto & pr : received_nodes)
-      mesh.getMesh().get_boundary_info().remove_node(mesh.getMesh().node_ptr(pr),
-                                                     _moving_boundary_id);
-  };
-
-  Parallel::push_parallel_vector_data(
-      mesh.getMesh().get_boundary_info().comm(), nodes_to_push, node_action_functor);
 }
 
 void

--- a/framework/src/userobject/ElementSubdomainModifier.C
+++ b/framework/src/userobject/ElementSubdomainModifier.C
@@ -9,6 +9,7 @@
 
 #include "ElementSubdomainModifier.h"
 
+#include "libmesh/string_to_enum.h"
 InputParameters
 ElementSubdomainModifier::validParams()
 {
@@ -102,6 +103,13 @@ ElementSubdomainModifier::finalize()
   // Apply initial condition for the newly moved elements and boundary nodes
   buildMovedElemsRange();
   buildMovedBndNodesRange();
+
+  // This does not work because _mesh.meshSubdomains() does not contain the new subdomains
+  // MultiMooseEnum blah("COORD_XYZ");
+  //_fe_problem.setCoordSystem({}, blah);
+  MultiMooseEnum blah("COORD_XYZ");
+  std::vector<SubdomainID> asdf({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  _fe_problem.setCoordSystem(asdf, blah);
 
   if (_apply_ic)
   {

--- a/framework/src/userobject/ThresholdElementSubdomainModifier.C
+++ b/framework/src/userobject/ThresholdElementSubdomainModifier.C
@@ -41,7 +41,7 @@ ThresholdElementSubdomainModifier::ThresholdElementSubdomainModifier(
 }
 
 SubdomainID
-ThresholdElementSubdomainModifier::computeSubdomainID()
+ThresholdElementSubdomainModifier::computeSubdomainID() const
 {
   Real criterion = computeValue();
 

--- a/framework/src/userobject/ThresholdElementSubdomainModifier.C
+++ b/framework/src/userobject/ThresholdElementSubdomainModifier.C
@@ -12,7 +12,7 @@
 InputParameters
 ThresholdElementSubdomainModifier::validParams()
 {
-  InputParameters params = ElementSubdomainModifier::validParams();
+  InputParameters params = ElementSubdomainAndBoundaryModifier::validParams();
 
   params.addRequiredParam<Real>("threshold",
                                 "The value above (or below) which to change the element subdomain");
@@ -30,7 +30,7 @@ ThresholdElementSubdomainModifier::validParams()
 
 ThresholdElementSubdomainModifier::ThresholdElementSubdomainModifier(
     const InputParameters & parameters)
-  : ElementSubdomainModifier(parameters),
+  : ElementSubdomainAndBoundaryModifier(parameters),
     _threshold(getParam<Real>("threshold")),
     _criterion_type(getParam<MooseEnum>("criterion_type").getEnum<CriterionType>()),
     _subdomain_id(getParam<SubdomainID>("subdomain_id")),

--- a/test/tests/userobjects/coupled_var_subdomain/coupled_var_subdomain.i
+++ b/test/tests/userobjects/coupled_var_subdomain/coupled_var_subdomain.i
@@ -1,0 +1,60 @@
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 1
+    nx = 10
+    xmin = -1
+    xmax = 1
+  []
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[ICs]
+  [u]
+    type = FunctionIC
+    variable = u
+    function = '10 * x'
+  []
+[]
+
+[Kernels]
+  [u]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = -1E5
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 1E5
+  []
+[]
+
+[UserObjects]
+  [coupled_var_subdomain]
+    type = CoupledVarSubdomainModifier
+    coupled_var = u
+    execute_on = 'INITIAL TIMESTEP_END'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
Refs #19072

Here you see a MeshModifier that defines SubdomainID using a Function.  **Almost all the code is more-or-less directly copied from PiecewiseConstant and its subclasses.  Oh dear.**

1. What i'd like: to define SubdomainID using a MOOSE Function.  I can't get this to work because _fe_problem is not defined when creating the mesh, so i can't use `getFunction`.
2. Alternatively, i could define SubdomainID using the same user interface as a Piecewise Function.  PiecewiseConstant is probably least prone to user errors.  That's what this PR essentially does.  But ideally, i'd like to use `PiecewiseConstant::value` to define subdomainID without all this code duplication, so perhaps i'd like to inherit from PiecewiseConstant, but the best i could get was MOOSE exiting with error "add_mesh_generator is not registered to build Function derived objects".

It'd be great if someone could suggest a way around my problems, or suggest a different approach.

Don't focus on the details of the current code - i'll tidy and test it later if no one can think of a better approach.

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
