### PR TITLE
Fixup #18395

### DIFF
--- a/framework/include/variables/MooseVariableField.h
+++ b/framework/include/variables/MooseVariableField.h
@@ -336,6 +336,8 @@ public:
   virtual const DoFValue & nodalVectorTagValue(TagID tag) const = 0;
 
   void meshChanged() override;
+  void residualSetup() override;
+  void jacobianSetup() override;
 
 protected:
   using FunctorArg = typename Moose::ADType<OutputType>::type;

--- a/framework/src/variables/MooseVariableField.C
+++ b/framework/src/variables/MooseVariableField.C
@@ -235,6 +235,26 @@ MooseVariableField<OutputType>::meshChanged()
   _current_elem_side_qp_functor_elem_side = std::make_pair(nullptr, libMesh::invalid_uint);
 }
 
+template <typename OutputType>
+void
+MooseVariableField<OutputType>::residualSetup()
+{
+  _current_elem_qp_functor_elem = nullptr;
+  _current_elem_side_qp_functor_elem_side = std::make_pair(nullptr, libMesh::invalid_uint);
+  MooseVariableFieldBase::residualSetup();
+  Moose::Functor<typename Moose::ADType<OutputType>::type>::residualSetup();
+}
+
+template <typename OutputType>
+void
+MooseVariableField<OutputType>::jacobianSetup()
+{
+  _current_elem_qp_functor_elem = nullptr;
+  _current_elem_side_qp_functor_elem_side = std::make_pair(nullptr, libMesh::invalid_uint);
+  MooseVariableFieldBase::jacobianSetup();
+  Moose::Functor<typename Moose::ADType<OutputType>::type>::jacobianSetup();
+}
+
 template class MooseVariableField<Real>;
 template class MooseVariableField<RealVectorValue>;
 template class MooseVariableField<RealEigenVector>;

--- a/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/tests
@@ -45,5 +45,6 @@
     requirement = 'The system shall be able to model natural convection using a weakly compressible implementation.'
     ad_indexing_type = 'global'
     method = '!dbg'
+    valgrind = 'none'
   []
 []


### PR DESCRIPTION
Make sure to clear cache data on residual and Jacobian setup because, for example, there might be a single element on a partition and if we don't clear then we will never re-evaluate our functor