### PR TITLE
Removed calls to ADMaterial

### DIFF
--- a/framework/include/materials/ADPiecewiseLinearInterpolationMaterial.h
+++ b/framework/include/materials/ADPiecewiseLinearInterpolationMaterial.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "LinearInterpolation.h"
 #include "DerivativeMaterialPropertyNameInterface.h"
 
@@ -17,7 +17,7 @@
  * This material uses a LinearInterpolation object to define the dependence
  * of the material's value on a variable.
  */
-class ADPiecewiseLinearInterpolationMaterial : public ADMaterial,
+class ADPiecewiseLinearInterpolationMaterial : public Material,
                                                public DerivativeMaterialPropertyNameInterface
 {
 public:

--- a/framework/src/materials/ADPiecewiseLinearInterpolationMaterial.C
+++ b/framework/src/materials/ADPiecewiseLinearInterpolationMaterial.C
@@ -16,7 +16,7 @@ registerMooseObject("MooseApp", ADPiecewiseLinearInterpolationMaterial);
 InputParameters
 ADPiecewiseLinearInterpolationMaterial::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Compute a property using a piecewise linear interpolation to define "
                              "its dependence on a variable");
   params.addRequiredParam<std::string>("property",
@@ -38,7 +38,7 @@ ADPiecewiseLinearInterpolationMaterial::validParams()
 
 ADPiecewiseLinearInterpolationMaterial::ADPiecewiseLinearInterpolationMaterial(
     const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _prop_name(getParam<std::string>("property")),
     _coupled_var(adCoupledValue("variable")),
     _scale_factor(getParam<Real>("scale_factor")),

--- a/modules/heat_conduction/test/include/materials/ADConvectiveHeatFluxTest.h
+++ b/modules/heat_conduction/test/include/materials/ADConvectiveHeatFluxTest.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
-class ADConvectiveHeatFluxTest : public ADMaterial
+class ADConvectiveHeatFluxTest : public Material
 {
 public:
   ADConvectiveHeatFluxTest(const InputParameters & parameters);

--- a/modules/heat_conduction/test/include/materials/ADThermalConductivityTest.h
+++ b/modules/heat_conduction/test/include/materials/ADThermalConductivityTest.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // Forward Declarations
-class ADThermalConductivityTest : public ADMaterial
+class ADThermalConductivityTest : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/heat_conduction/test/src/materials/ADConvectiveHeatFluxTest.C
+++ b/modules/heat_conduction/test/src/materials/ADConvectiveHeatFluxTest.C
@@ -14,13 +14,13 @@ registerMooseObject("HeatConductionTestApp", ADConvectiveHeatFluxTest);
 InputParameters
 ADConvectiveHeatFluxTest::validParams()
 {
-  auto params = ADMaterial::validParams();
+  auto params = Material::validParams();
   params.addRequiredCoupledVar("temperature", "Coupled temperature");
   return params;
 }
 
 ADConvectiveHeatFluxTest::ADConvectiveHeatFluxTest(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _temperature(adCoupledValue("temperature")),
     _t_inf(declareADProperty<Real>("T_inf")),
     _htc(declareADProperty<Real>("htc"))

--- a/modules/heat_conduction/test/src/materials/ADThermalConductivityTest.C
+++ b/modules/heat_conduction/test/src/materials/ADThermalConductivityTest.C
@@ -14,7 +14,7 @@ registerMooseObject("HeatConductionTestApp", ADThermalConductivityTest);
 InputParameters
 ADThermalConductivityTest::validParams()
 {
-  auto params = ADMaterial::validParams();
+  auto params = Material::validParams();
   params.addRequiredCoupledVar("temperature", "Coupled temperature");
   params.addRequiredCoupledVar(
       "c", "Coupled variable used to help verify automatic differentiation capability");
@@ -22,7 +22,7 @@ ADThermalConductivityTest::validParams()
 }
 
 ADThermalConductivityTest::ADThermalConductivityTest(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _diffusivity(declareADProperty<Real>("thermal_conductivity")),
     _temperature(adCoupledValue("temperature")),
     _c(adCoupledValue("c"))

--- a/modules/misc/include/materials/ADDensity.h
+++ b/modules/misc/include/materials/ADDensity.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
-class ADDensity : public ADMaterial
+class ADDensity : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/misc/src/materials/ADDensity.C
+++ b/modules/misc/src/materials/ADDensity.C
@@ -14,7 +14,7 @@ registerMooseObject("MiscApp", ADDensity);
 InputParameters
 ADDensity::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Creates density AD material property");
   params.addCoupledVar(
       "displacements",
@@ -24,7 +24,7 @@ ADDensity::validParams()
 }
 
 ADDensity::ADDensity(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _coord_system(getBlockCoordSystem()),
     _initial_density(getParam<Real>("density")),
     _disp_r(coupledComponents("displacements") ? adCoupledValue("displacements", 0) : _ad_zero),

--- a/modules/misc/test/include/materials/ADSoretCoeffTest.h
+++ b/modules/misc/test/include/materials/ADSoretCoeffTest.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
-class ADSoretCoeffTest : public ADMaterial
+class ADSoretCoeffTest : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/misc/test/src/materials/ADSoretCoeffTest.C
+++ b/modules/misc/test/src/materials/ADSoretCoeffTest.C
@@ -14,14 +14,14 @@ registerMooseObject("MiscTestApp", ADSoretCoeffTest);
 InputParameters
 ADSoretCoeffTest::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar("coupled_var", "A coupled variable");
   params.addRequiredCoupledVar("temperature", "The coupled temperature variable");
   return params;
 }
 
 ADSoretCoeffTest::ADSoretCoeffTest(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _coupled_var(adCoupledValue("coupled_var")),
     _temp(adCoupledValue("temperature")),
     _soret_coeff(declareADProperty<Real>("soret_coefficient"))

--- a/modules/navier_stokes/include/materials/INSADMaterial.h
+++ b/modules/navier_stokes/include/materials/INSADMaterial.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 class INSADObjectTracker;
 
-class INSADMaterial : public ADMaterial
+class INSADMaterial : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/navier_stokes/src/materials/INSADMaterial.C
+++ b/modules/navier_stokes/src/materials/INSADMaterial.C
@@ -19,7 +19,7 @@ registerMooseObject("NavierStokesApp", INSADMaterial);
 InputParameters
 INSADMaterial::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("This is the material class used to compute some of the strong "
                              "residuals for the INS equations.");
   params.addRequiredCoupledVar("velocity", "The velocity");
@@ -30,7 +30,7 @@ INSADMaterial::validParams()
 }
 
 INSADMaterial::INSADMaterial(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _velocity(adCoupledVectorValue("velocity")),
     _grad_velocity(adCoupledVectorGradient("velocity")),
     _grad_p(adCoupledGradient(NS::pressure)),

--- a/modules/phase_field/include/materials/ADMathFreeEnergy.h
+++ b/modules/phase_field/include/materials/ADMathFreeEnergy.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "DerivativeMaterialPropertyNameInterface.h"
 
 /**
  * Material class that creates the math free energy and its derivatives
  * for use with ADSplitCHParsed. \f$ F = \frac14(1 + c)^2(1 - c)^2 \f$.
  */
-class ADMathFreeEnergy : public ADMaterial, public DerivativeMaterialPropertyNameInterface
+class ADMathFreeEnergy : public Material, public DerivativeMaterialPropertyNameInterface
 {
 public:
   static InputParameters validParams();

--- a/modules/phase_field/src/materials/ADMathFreeEnergy.C
+++ b/modules/phase_field/src/materials/ADMathFreeEnergy.C
@@ -14,7 +14,7 @@ registerMooseObject("PhaseFieldApp", ADMathFreeEnergy);
 InputParameters
 ADMathFreeEnergy::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Material that implements the math free energy and its derivatives: "
                              "\n$F = 1/4(1 + c)^2(1 - c)^2$");
   params.addParam<MaterialPropertyName>("f_name", "F", "function property name");
@@ -23,7 +23,7 @@ ADMathFreeEnergy::validParams()
 }
 
 ADMathFreeEnergy::ADMathFreeEnergy(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _c(adCoupledValue("c")),
     _f_name(getParam<MaterialPropertyName>("f_name")),
     _prop_F(declareADProperty<Real>(_f_name)),

--- a/modules/phase_field/test/include/materials/ADTestDerivativeFunction.h
+++ b/modules/phase_field/test/include/materials/ADTestDerivativeFunction.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "DerivativeMaterialPropertyNameInterface.h"
 
 /**
  * Material class that creates the math free energy and its derivatives
  * for use with ADSplitCHParsed. \f$ F = \frac14(1 + c)^2(1 - c)^2 \f$.
  */
-class ADTestDerivativeFunction : public ADMaterial, public DerivativeMaterialPropertyNameInterface
+class ADTestDerivativeFunction : public Material, public DerivativeMaterialPropertyNameInterface
 {
 public:
   static InputParameters validParams();

--- a/modules/phase_field/test/src/materials/ADTestDerivativeFunction.C
+++ b/modules/phase_field/test/src/materials/ADTestDerivativeFunction.C
@@ -14,7 +14,7 @@ registerMooseObject("PhaseFieldTestApp", ADTestDerivativeFunction);
 InputParameters
 ADTestDerivativeFunction::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription(
       "Material that implements the a function of one variable and its first derivative.");
   MooseEnum functionEnum("F1 F2 F3");
@@ -29,7 +29,7 @@ ADTestDerivativeFunction::validParams()
 }
 
 ADTestDerivativeFunction::ADTestDerivativeFunction(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _function(getParam<MooseEnum>("function").template getEnum<FunctionEnum>()),
     _op(adCoupledValues("op")),
     _f_name(getParam<MaterialPropertyName>("f_name")),

--- a/modules/tensor_mechanics/include/materials/ADComputeIncrementalShellStrain.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeIncrementalShellStrain.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "DenseMatrix.h"
-#include "ADMaterial.h"
+#include "Material.h"
 #include "ADRankTwoTensorForward.h"
 
 namespace libMesh
@@ -18,7 +18,7 @@ namespace libMesh
 class QGauss;
 }
 
-class ADComputeIncrementalShellStrain : public ADMaterial
+class ADComputeIncrementalShellStrain : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/ADComputeIsotropicElasticityTensorShell.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeIsotropicElasticityTensorShell.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 #define usingComputeIsotropicElasticityTensorShellMembers usingMaterialMembers
 
@@ -18,7 +18,7 @@ namespace libMesh
 class QGauss;
 }
 
-class ADComputeIsotropicElasticityTensorShell : public ADMaterial
+class ADComputeIsotropicElasticityTensorShell : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/ADComputeShellStress.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeShellStress.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "ADComputeIsotropicElasticityTensorShell.h"
 #include "ADRankTwoTensorForward.h"
 #include "ADRankFourTensorForward.h"
@@ -21,7 +21,7 @@ namespace libMesh
 class QGauss;
 }
 
-class ADComputeShellStress : public ADMaterial
+class ADComputeShellStress : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeStrainBase.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "ADRankTwoTensorForward.h"
 
 /**
  * ADADComputeStrainBase is the base class for strain tensors
  */
-class ADComputeStrainBase : public ADMaterial
+class ADComputeStrainBase : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/ADComputeStressBase.h
+++ b/modules/tensor_mechanics/include/materials/ADComputeStressBase.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "Function.h"
 #include "ADRankTwoTensorForward.h"
 #include "ADRankFourTensorForward.h"
@@ -17,7 +17,7 @@
 /**
  * ADComputeStressBase is the base class for stress tensors
  */
-class ADComputeStressBase : public ADMaterial
+class ADComputeStressBase : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
+++ b/modules/tensor_mechanics/include/materials/ADSmearedCrackSofteningBase.h
@@ -11,7 +11,7 @@
 
 #include "Conversion.h"
 #include "InputParameters.h"
-#include "ADMaterial.h"
+#include "Material.h"
 
 /**
  * ADSmearedCrackSofteningBase is the base class for a set of models that define the
@@ -19,7 +19,7 @@
  * These models are called by ADComputeSmearedCrackingStress, so they
  * must have the compute=false flag set in the parameter list.
  */
-class ADSmearedCrackSofteningBase : public ADMaterial
+class ADSmearedCrackSofteningBase : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/include/materials/HillConstants.h
+++ b/modules/tensor_mechanics/include/materials/HillConstants.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 #include "Function.h"
 #include "RotationTensor.h"
 
@@ -17,7 +17,7 @@
  * This class defines a Hill tensor material object with a given base name.
  */
 
-class HillConstants : public ADMaterial
+class HillConstants : public Material
 {
 public:
   static InputParameters validParams();

--- a/modules/tensor_mechanics/src/materials/ADComputeIncrementalShellStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeIncrementalShellStrain.C
@@ -27,7 +27,7 @@ registerMooseObject("TensorMechanicsApp", ADComputeIncrementalShellStrain);
 InputParameters
 ADComputeIncrementalShellStrain::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Compute a small strain increment for the shell.");
   params.addRequiredCoupledVar(
       "rotations", "The rotations appropriate for the simulation geometry and coordinate system");
@@ -45,7 +45,7 @@ ADComputeIncrementalShellStrain::validParams()
 }
 
 ADComputeIncrementalShellStrain::ADComputeIncrementalShellStrain(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _nrot(coupledComponents("rotations")),
     _ndisp(coupledComponents("displacements")),
     _rot_num(_nrot),

--- a/modules/tensor_mechanics/src/materials/ADComputeIsotropicElasticityTensorShell.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeIsotropicElasticityTensorShell.C
@@ -22,7 +22,7 @@ registerMooseObject("TensorMechanicsApp", ADComputeIsotropicElasticityTensorShel
 InputParameters
 ADComputeIsotropicElasticityTensorShell::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Compute a plane stress isotropic elasticity tensor.");
   params.addRequiredRangeCheckedParam<Real>("poissons_ratio",
                                             "poissons_ratio >= -1.0 & poissons_ratio < 0.5",
@@ -36,7 +36,7 @@ ADComputeIsotropicElasticityTensorShell::validParams()
 
 ADComputeIsotropicElasticityTensorShell::ADComputeIsotropicElasticityTensorShell(
     const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _poissons_ratio(getParam<Real>("poissons_ratio")),
     _youngs_modulus(getParam<Real>("youngs_modulus"))
 {

--- a/modules/tensor_mechanics/src/materials/ADComputeShellStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeShellStress.C
@@ -24,7 +24,7 @@ registerMooseObject("TensorMechanicsApp", ADComputeShellStress);
 InputParameters
 ADComputeShellStress::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Compute in-plane stress using elasticity for shell");
   params.addRequiredParam<std::string>("through_thickness_order",
                                        "Quadrature order in out of plane direction");
@@ -32,7 +32,7 @@ ADComputeShellStress::validParams()
 }
 
 ADComputeShellStress::ADComputeShellStress(const InputParameters & parameters)
-  : ADMaterial(parameters)
+  : Material(parameters)
 {
   // get number of quadrature points along thickness based on order
   std::unique_ptr<QGauss> t_qrule = std::make_unique<QGauss>(

--- a/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStrainBase.C
@@ -15,7 +15,7 @@
 InputParameters
 ADComputeStrainBase::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar(
       "displacements",
       "The displacements appropriate for the simulation geometry and coordinate system");
@@ -35,7 +35,7 @@ ADComputeStrainBase::validParams()
 }
 
 ADComputeStrainBase::ADComputeStrainBase(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _ndisp(coupledComponents("displacements")),
     _disp(adCoupledValues("displacements")),
     _grad_disp(adCoupledGradients("displacements")),

--- a/modules/tensor_mechanics/src/materials/ADComputeStressBase.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeStressBase.C
@@ -14,7 +14,7 @@
 InputParameters
 ADComputeStressBase::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addParam<std::string>("base_name",
                                "Optional parameter that allows the user to define "
                                "multiple mechanics material systems on the same "
@@ -28,7 +28,7 @@ ADComputeStressBase::validParams()
 }
 
 ADComputeStressBase::ADComputeStressBase(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _mechanical_strain(getADMaterialProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
     _stress(declareADProperty<RankTwoTensor>(_base_name + "stress")),

--- a/modules/tensor_mechanics/src/materials/ADSmearedCrackSofteningBase.C
+++ b/modules/tensor_mechanics/src/materials/ADSmearedCrackSofteningBase.C
@@ -24,6 +24,6 @@ ADSmearedCrackSofteningBase::validParams()
 }
 
 ADSmearedCrackSofteningBase::ADSmearedCrackSofteningBase(const InputParameters & parameters)
-  : ADMaterial(parameters)
+  : Material(parameters)
 {
 }

--- a/modules/tensor_mechanics/src/materials/HillConstants.C
+++ b/modules/tensor_mechanics/src/materials/HillConstants.C
@@ -14,7 +14,7 @@ registerMooseObject("TensorMechanicsApp", HillConstants);
 InputParameters
 HillConstants::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addClassDescription("Build and rotate the Hill Tensor. It can be used with other Hill "
                              "plasticity and creep materials.");
   params.addParam<std::string>("base_name",
@@ -43,7 +43,7 @@ HillConstants::validParams()
 }
 
 HillConstants::HillConstants(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _use_large_rotation(getParam<bool>("use_large_rotation")),
     _rotation_total_hill(_use_large_rotation

--- a/modules/tensor_mechanics/test/tests/ad_elastic/finite_elastic.i
+++ b/modules/tensor_mechanics/test/tests/ad_elastic/finite_elastic.i
@@ -46,25 +46,25 @@
 
 [BCs]
   [./symmy]
-    type = DirichletBC
+    type = ADDirichletBC
     variable = disp_y
     boundary = bottom
     value = 0
   [../]
   [./symmx]
-    type = DirichletBC
+    type = ADDirichletBC
     variable = disp_x
     boundary = left
     value = 0
   [../]
   [./symmz]
-    type = DirichletBC
+    type = ADDirichletBC
     variable = disp_z
     boundary = back
     value = 0
   [../]
   [./tdisp]
-    type = DirichletBC
+    type = ADDirichletBC
     variable = disp_z
     boundary = front
     value = 0.1

--- a/test/include/materials/ADCheckGlobalToDerivativeMap.h
+++ b/test/include/materials/ADCheckGlobalToDerivativeMap.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 /**
  * Test object for verifying that \p globalDofIndexToDerivative generates a correct mapping from
  * global dof indices to derivatives for Jacobians
  */
-class ADCheckGlobalToDerivativeMap : public ADMaterial
+class ADCheckGlobalToDerivativeMap : public Material
 {
 public:
   static InputParameters validParams();

--- a/test/include/materials/ADCoupledMaterial.h
+++ b/test/include/materials/ADCoupledMaterial.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 /**
  * A material that couples a material property
  */
-class ADCoupledMaterial : public ADMaterial
+class ADCoupledMaterial : public Material
 {
 public:
   static InputParameters validParams();

--- a/test/include/materials/ADStateful.h
+++ b/test/include/materials/ADStateful.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
-class ADStateful : public ADMaterial
+class ADStateful : public Material
 {
 public:
   static InputParameters validParams();

--- a/test/include/materials/ADStatefulMaterial.h
+++ b/test/include/materials/ADStatefulMaterial.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 /**
  * Stateful material class that defines a few properties.
  */
-class ADStatefulMaterial : public ADMaterial
+class ADStatefulMaterial : public Material
 {
 public:
   static InputParameters validParams();

--- a/test/src/materials/ADCoupledMaterial.C
+++ b/test/src/materials/ADCoupledMaterial.C
@@ -14,7 +14,7 @@ registerMooseObject("MooseTestApp", ADCoupledMaterial);
 InputParameters
 ADCoupledMaterial::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar("coupled_var", "A coupledvariable");
   params.addRequiredParam<MaterialPropertyName>("ad_mat_prop",
                                                 "Name of the ad property this material defines");
@@ -24,7 +24,7 @@ ADCoupledMaterial::validParams()
 }
 
 ADCoupledMaterial::ADCoupledMaterial(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _ad_mat_prop(declareADProperty<Real>(getParam<MaterialPropertyName>("ad_mat_prop"))),
     _regular_mat_prop(declareProperty<Real>(getParam<MaterialPropertyName>("regular_mat_prop"))),
     _coupled_var(adCoupledValue("coupled_var"))

--- a/test/src/materials/ADStateful.C
+++ b/test/src/materials/ADStateful.C
@@ -14,7 +14,7 @@ registerMooseObject("MooseTestApp", ADStateful);
 InputParameters
 ADStateful::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
 
   params.addRequiredParam<MaterialPropertyName>("property_name",
                                                 "Name of porosity material property");
@@ -23,7 +23,7 @@ ADStateful::validParams()
 }
 
 ADStateful::ADStateful(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     _property(declareADProperty<Real>("property_name")),
     _property_old(getMaterialPropertyOld<Real>("property_name"))
 {

--- a/test/src/materials/ADStatefulMaterial.C
+++ b/test/src/materials/ADStatefulMaterial.C
@@ -14,14 +14,14 @@ registerMooseObject("MooseTestApp", ADStatefulMaterial);
 InputParameters
 ADStatefulMaterial::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addParam<Real>("initial_diffusivity", 0.5, "The Initial Diffusivity");
   params.addRequiredCoupledVar("u", "The coupled variable");
   return params;
 }
 
 ADStatefulMaterial::ADStatefulMaterial(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
 
     // Get a parameter value for the diffusivity
     _initial_diffusivity(getParam<Real>("initial_diffusivity")),

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/include/materials/PackedColumn.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // A helper class from MOOSE that linear interpolates x,y data
 #include "LinearInterpolation.h"
@@ -20,7 +20,7 @@
  * use by other objects in the calculation such as Kernels and
  * BoundaryConditions.
  */
-class PackedColumn : public ADMaterial
+class PackedColumn : public Material
 {
 public:
   static InputParameters validParams();

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/src/materials/PackedColumn.C
@@ -16,7 +16,7 @@ registerMooseObject("DarcyThermoMechApp", PackedColumn);
 InputParameters
 PackedColumn::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar("temperature", "The temperature (C) of the fluid.");
 
   // Add a parameter to get the radius of the spheres in the column
@@ -90,7 +90,7 @@ PackedColumn::validParams()
 }
 
 PackedColumn::PackedColumn(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     // Get the one parameter from the input file
     _input_radius(getFunction("radius")),
     _input_porosity(getFunction("porosity")),

--- a/tutorials/darcy_thermo_mech/step09_mechanics/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/include/materials/PackedColumn.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // A helper class from MOOSE that linear interpolates x,y data
 #include "LinearInterpolation.h"
@@ -20,7 +20,7 @@
  * use by other objects in the calculation such as Kernels and
  * BoundaryConditions.
  */
-class PackedColumn : public ADMaterial
+class PackedColumn : public Material
 {
 public:
   static InputParameters validParams();

--- a/tutorials/darcy_thermo_mech/step09_mechanics/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/src/materials/PackedColumn.C
@@ -16,7 +16,7 @@ registerMooseObject("DarcyThermoMechApp", PackedColumn);
 InputParameters
 PackedColumn::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar("temperature", "The temperature (C) of the fluid.");
 
   // Add a parameter to get the radius of the spheres in the column
@@ -106,7 +106,7 @@ PackedColumn::validParams()
 }
 
 PackedColumn::PackedColumn(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     // Get the one parameter from the input file
     _input_radius(getFunction("radius")),
     _input_porosity(getFunction("porosity")),

--- a/tutorials/darcy_thermo_mech/step10_multiapps/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/include/materials/PackedColumn.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // A helper class from MOOSE that linear interpolates x,y data
 #include "LinearInterpolation.h"
@@ -20,7 +20,7 @@
  * use by other objects in the calculation such as Kernels and
  * BoundaryConditions.
  */
-class PackedColumn : public ADMaterial
+class PackedColumn : public Material
 {
 public:
   static InputParameters validParams();

--- a/tutorials/darcy_thermo_mech/step10_multiapps/src/materials/PackedColumn.C
+++ b/tutorials/darcy_thermo_mech/step10_multiapps/src/materials/PackedColumn.C
@@ -16,7 +16,7 @@ registerMooseObject("DarcyThermoMechApp", PackedColumn);
 InputParameters
 PackedColumn::validParams()
 {
-  InputParameters params = ADMaterial::validParams();
+  InputParameters params = Material::validParams();
   params.addRequiredCoupledVar("temperature", "The temperature (C) of the fluid.");
 
   // Add a parameter to get the radius of the spheres in the column
@@ -117,7 +117,7 @@ PackedColumn::validParams()
 }
 
 PackedColumn::PackedColumn(const InputParameters & parameters)
-  : ADMaterial(parameters),
+  : Material(parameters),
     // Get the one parameter from the input file
     _input_radius(getFunction("radius")),
     _input_porosity(getFunction("porosity")),

--- a/tutorials/tutorial01_app_development/step09_mat_props/include/materials/PackedColumn.h
+++ b/tutorials/tutorial01_app_development/step09_mat_props/include/materials/PackedColumn.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // A helper class from MOOSE that linearly interpolates abscissa-ordinate pairs
 #include "LinearInterpolation.h"
@@ -10,7 +10,7 @@
  * diameter in accordance with Pamuk and Ozdemir (2012). This also provides a specified dynamic
  * viscosity of the fluid in the medium.
  */
-class PackedColumn : public ADMaterial
+class PackedColumn : public Material
 {
 public:
   static InputParameters validParams();

--- a/tutorials/tutorial01_app_development/step10_auxkernels/include/materials/PackedColumn.h
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/include/materials/PackedColumn.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ADMaterial.h"
+#include "Material.h"
 
 // A helper class from MOOSE that linearly interpolates abscissa-ordinate pairs
 #include "LinearInterpolation.h"
@@ -10,7 +10,7 @@
  * diameter in accordance with Pamuk and Ozdemir (2012). This also provides a specified dynamic
  * viscosity of the fluid in the medium.
  */
-class PackedColumn : public ADMaterial
+class PackedColumn : public Material
 {
 public:
   static InputParameters validParams();

--- a/unit/src/ADTypesTest.C
+++ b/unit/src/ADTypesTest.C
@@ -8,7 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "Moose.h"
-#include "ADMaterial.h"
+#include "Material.h"
 #include "DenseMatrix.h"
 
 #include "libmesh/dense_vector.h"


### PR DESCRIPTION
ADMaterial.h can be used interchangeably with Material.h, and leads to confusion on when to use which. Really, all calls to ADMaterial can just be Material (I think), so make it so.

closes #19091 
