### PR TITLE
WIP: Read read bubble coordinates in "initialSetup" instead of constructor

### DIFF
--- a/modules/phase_field/include/ics/SmoothCircleFromFileIC.h
+++ b/modules/phase_field/include/ics/SmoothCircleFromFileIC.h
@@ -26,9 +26,11 @@ public:
 
   SmoothCircleFromFileIC(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
+
 protected:
-  virtual void computeCircleRadii();
-  virtual void computeCircleCenters();
+  virtual void computeCircleRadii() override;
+  virtual void computeCircleCenters() override;
 
   enum COLS
   {
@@ -44,4 +46,7 @@ protected:
   MooseUtils::DelimitedFileReader _txt_reader;
   std::vector<std::string> _col_names;
   unsigned int _n_circles;
+
+private:
+  void readBubbleCoordinates();
 };

--- a/modules/phase_field/src/ics/SmoothCircleFromFileIC.C
+++ b/modules/phase_field/src/ics/SmoothCircleFromFileIC.C
@@ -27,6 +27,9 @@ SmoothCircleFromFileIC::SmoothCircleFromFileIC(const InputParameters & parameter
     _file_name(getParam<FileName>("file_name")),
     _txt_reader(_file_name, &_communicator),
     _n_circles(0)
+{}
+
+void SmoothCircleFromFileIC::readBubbleCoordinates()
 {
   // Read names and vectors from file
   _txt_reader.read();
@@ -61,6 +64,12 @@ SmoothCircleFromFileIC::SmoothCircleFromFileIC(const InputParameters & parameter
     mooseError("No column in ", _file_name, " labeled 'z'.");
   if (_col_map[R] == -1)
     mooseError("No column in ", _file_name, " labeled 'r'.");
+}
+
+void SmoothCircleFromFileIC::initialSetup()
+{
+  readBubbleCoordinates();
+  SmoothCircleBaseIC::initialSetup();
 }
 
 void


### PR DESCRIPTION
Use case:

A coordinate file might be generated by a subapp on "initial". The file
won't exist when IC C++ object is constructed

