### PR TITLE
Speed up LayeredBase construction

### DIFF
--- a/framework/include/userobject/LayeredBase.h
+++ b/framework/include/userobject/LayeredBase.h
@@ -154,4 +154,7 @@ private:
 
   /// List of SubdomainIDs, if given
   std::vector<SubdomainID> _layer_bounding_blocks;
+
+  /// whether the max/min coordinate in the direction is known from user input
+  bool _has_direction_max_min;
 };

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -112,52 +112,52 @@ LayeredBase::LayeredBase(const InputParameters & parameters)
     _has_direction_max_min = true;
   }
   else
-    mooseError("One of 'bounds' or 'num_layers' must be specified for ", _layered_base_name);
+    mooseError("One of 'bounds' or 'num_layers' must be specified");
 
   if (!_interval_based && _sample_type == 1)
-    mooseError("'sample_type = interpolate' not supported with 'bounds' in ", _layered_base_name);
+    mooseError("'sample_type = interpolate' not supported with 'bounds'");
 
-  bool layer_bounding_block = _layered_base_params.isParamValid("layer_bounding_block");
-  bool block = _layered_base_params.isParamValid("block");
-  bool direction_min = _layered_base_params.isParamValid("direction_min");
-  bool direction_max = _layered_base_params.isParamValid("direction_max");
+  bool has_layer_bounding_block = _layered_base_params.isParamValid("layer_bounding_block");
+  bool has_block = _layered_base_params.isParamValid("block");
+  bool has_direction_min = _layered_base_params.isParamValid("direction_min");
+  bool has_direction_max = _layered_base_params.isParamValid("direction_max");
 
-  if (_has_direction_max_min && direction_min)
-    mooseWarning("'direction_min' is unused when providing 'bounds' in ", _layered_base_name);
+  if (_has_direction_max_min && has_direction_min)
+    mooseWarning("'direction_min' is unused when providing 'bounds'");
 
-  if (_has_direction_max_min && direction_max)
-    mooseWarning("'direction_max' is unused when providing 'bounds' in ", _layered_base_name);
+  if (_has_direction_max_min && has_direction_max)
+    mooseWarning("'direction_max' is unused when providing 'bounds'");
 
-  if (layer_bounding_block && block)
-    mooseError("'layer_bounding_block' and 'block' cannot both be set in ", _layered_base_name);
+  if (has_layer_bounding_block && has_block)
+    mooseError("'layer_bounding_block' and 'block' cannot both be set");
 
-  // can only specify one of layer_bounding_block, block, or the pair direction_max/min
-  if ((layer_bounding_block || block) && (direction_min || direction_max))
-    mooseError("Only one of 'layer_bounding_block', 'block', and the pair 'direction_max' and "
-               "'direction_min' can be provided in ",
-               _layered_base_name);
+  // can only specify one of layer_bounding_block or the pair direction_max/min
+  if (has_layer_bounding_block && (has_direction_min || has_direction_max))
+    mooseError("Only one of 'layer_bounding_block' and the pair 'direction_max' and "
+               "'direction_min' can be provided");
 
   // if either one of direction_min or direction_max is specified, must provide the other one
-  if (direction_min != direction_max)
+  if (has_direction_min != has_direction_max)
     mooseError("If providing the layer max/min directions, both 'direction_max' and "
                "'direction_min' must be specified.");
 
-  if (layer_bounding_block)
+  if (has_layer_bounding_block)
     _layer_bounding_blocks = _layered_base_subproblem.mesh().getSubdomainIDs(
         _layered_base_params.get<std::vector<SubdomainName>>("layer_bounding_block"));
 
-  if (block)
+  if (has_block)
     _layer_bounding_blocks = _layered_base_subproblem.mesh().getSubdomainIDs(
         _layered_base_params.get<std::vector<SubdomainName>>("block"));
 
-  if (direction_min && direction_max)
+  // specifying the direction max/min overrides anything set with the 'block'
+  if (has_direction_min && has_direction_max)
   {
     _direction_min = parameters.get<Real>("direction_min");
     _direction_max = parameters.get<Real>("direction_max");
     _has_direction_max_min = true;
 
     if (_direction_max <= _direction_min)
-      mooseError("'direction_max' must be larger than 'direction_min' in ", _layered_base_name);
+      mooseError("'direction_max' must be larger than 'direction_min'");
   }
 
   _layer_values.resize(_num_layers);

--- a/framework/src/userobject/LayeredBase.C
+++ b/framework/src/userobject/LayeredBase.C
@@ -90,7 +90,7 @@ LayeredBase::LayeredBase(const InputParameters & parameters)
 {
   if (_layered_base_params.isParamValid("num_layers") &&
       _layered_base_params.isParamValid("bounds"))
-    mooseError("'bounds' and 'num_layers' cannot both be set in ", _layered_base_name);
+    mooseError("'bounds' and 'num_layers' cannot both be set");
 
   if (_layered_base_params.isParamValid("num_layers"))
   {
@@ -128,9 +128,6 @@ LayeredBase::LayeredBase(const InputParameters & parameters)
   if (_has_direction_max_min && has_direction_max)
     mooseWarning("'direction_max' is unused when providing 'bounds'");
 
-  if (has_layer_bounding_block && has_block)
-    mooseError("'layer_bounding_block' and 'block' cannot both be set");
-
   // can only specify one of layer_bounding_block or the pair direction_max/min
   if (has_layer_bounding_block && (has_direction_min || has_direction_max))
     mooseError("Only one of 'layer_bounding_block' and the pair 'direction_max' and "
@@ -144,8 +141,7 @@ LayeredBase::LayeredBase(const InputParameters & parameters)
   if (has_layer_bounding_block)
     _layer_bounding_blocks = _layered_base_subproblem.mesh().getSubdomainIDs(
         _layered_base_params.get<std::vector<SubdomainName>>("layer_bounding_block"));
-
-  if (has_block)
+  else if (has_block)
     _layer_bounding_blocks = _layered_base_subproblem.mesh().getSubdomainIDs(
         _layered_base_params.get<std::vector<SubdomainName>>("block"));
 

--- a/test/tests/userobjects/layered_average/tests
+++ b/test/tests/userobjects/layered_average/tests
@@ -37,7 +37,7 @@
     [bounds_and_interp]
       type = 'RunException'
       input = 'layered_average_bounds.i'
-      expect_err = "'sample_type = interpolate' not supported with 'bounds' in"
+      expect_err = "'sample_type = interpolate' not supported with 'bounds'"
       cli_args = 'UserObjects/average/sample_type=interpolate'
 
       detail = "sample interpolate and"
@@ -46,7 +46,7 @@
     [no_bounds_or_num_layers]
       type = 'RunException'
       input = 'layered_average_bounds_error.i'
-      expect_err = "One of 'bounds' or 'num_layers' must be specified for"
+      expect_err = "One of 'bounds' or 'num_layers' must be specified"
 
       detail = "if neither the bounds or number of layers are set."
     []

--- a/test/tests/userobjects/nearest_point_layered_average/tests
+++ b/test/tests/userobjects/nearest_point_layered_average/tests
@@ -78,4 +78,54 @@
     design = 'NearestRadiusLayeredAverage.md'
     issues = '#18931'
   []
+
+  [error_duplicate_block]
+    type = RunException
+    input = 'nearest_point_layered_average.i'
+    cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/layer_bounding_block='0' UserObjects/npla/block='0'"
+    expect_err = "'layer_bounding_block' and 'block' cannot both be set in npla"
+    requirement = 'The system shall error if both means of specifying bounding blocks are provided'
+    design = 'NearestPointLayeredAverage.md'
+    issues = '#19122'
+  []
+
+  [error_duplicate_block_specs]
+    type = RunException
+    input = 'nearest_point_layered_average.i'
+    cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/layer_bounding_block='0' UserObjects/npla/direction_min=0.0 UserObjects/npla/direction_max=1.0"
+    expect_err = "Only one of 'layer_bounding_block', 'block', and the pair 'direction_max' and 'direction_min' can be provided in npla"
+    requirement = 'The system shall error if user-set direction bounds conflict with block-type bound specifications'
+    design = 'NearestPointLayeredAverage.md'
+    issues = '#19122'
+  []
+
+  [error_missing_bound]
+    type = RunException
+    input = 'nearest_point_layered_average.i'
+    cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/direction_max=1.0"
+    expect_err = "If providing the layer max/min directions, both 'direction_max' and 'direction_min' must be specified"
+    requirement = 'The system shall error if a direction bound is missing'
+    design = 'NearestPointLayeredAverage.md'
+    issues = '#19122'
+  []
+
+  [error_invalid_bounds]
+    type = RunException
+    input = 'nearest_point_layered_average.i'
+    cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/direction_max=0.0 UserObjects/npla/direction_min=1.0"
+    expect_err = "'direction_max' must be larger than 'direction_min' in npla"
+    requirement = 'The system shall error if the maximum bound is lower than the minimum bound'
+    design = 'NearestPointLayeredAverage.md'
+    issues = '#19122'
+  []
+
+  [test_with_automatic_bounds]
+    type = 'Exodiff'
+    input = 'nearest_point_layered_average.i'
+    cli_args = "UserObjects/npla/points='0.25 0 0.25 0.75 0 0.25 0.25 0 0.75 0.75 0 0.75' UserObjects/npla/direction_min=0.0 UserObjects/npla/direction_max=1.0"
+    exodiff = 'nearest_point_layered_average_out.e'
+    requirement = 'The system shall allow specification of direction bounds to skip bounding box calculation'
+    design = 'NearestPointLayeredAverage.md'
+    issues = '#1878'
+  []
 []

--- a/test/tests/userobjects/nearest_point_layered_average/tests
+++ b/test/tests/userobjects/nearest_point_layered_average/tests
@@ -83,7 +83,7 @@
     type = RunException
     input = 'nearest_point_layered_average.i'
     cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/layer_bounding_block='0' UserObjects/npla/block='0'"
-    expect_err = "'layer_bounding_block' and 'block' cannot both be set in npla"
+    expect_err = "'layer_bounding_block' and 'block' cannot both be set"
     requirement = 'The system shall error if both means of specifying bounding blocks are provided'
     design = 'NearestPointLayeredAverage.md'
     issues = '#19122'
@@ -93,7 +93,7 @@
     type = RunException
     input = 'nearest_point_layered_average.i'
     cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/layer_bounding_block='0' UserObjects/npla/direction_min=0.0 UserObjects/npla/direction_max=1.0"
-    expect_err = "Only one of 'layer_bounding_block', 'block', and the pair 'direction_max' and 'direction_min' can be provided in npla"
+    expect_err = "Only one of 'layer_bounding_block' and the pair 'direction_max' and 'direction_min' can be provided"
     requirement = 'The system shall error if user-set direction bounds conflict with block-type bound specifications'
     design = 'NearestPointLayeredAverage.md'
     issues = '#19122'
@@ -113,7 +113,7 @@
     type = RunException
     input = 'nearest_point_layered_average.i'
     cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/direction_max=0.0 UserObjects/npla/direction_min=1.0"
-    expect_err = "'direction_max' must be larger than 'direction_min' in npla"
+    expect_err = "'direction_max' must be larger than 'direction_min'"
     requirement = 'The system shall error if the maximum bound is lower than the minimum bound'
     design = 'NearestPointLayeredAverage.md'
     issues = '#19122'

--- a/test/tests/userobjects/nearest_point_layered_average/tests
+++ b/test/tests/userobjects/nearest_point_layered_average/tests
@@ -79,16 +79,6 @@
     issues = '#18931'
   []
 
-  [error_duplicate_block]
-    type = RunException
-    input = 'nearest_point_layered_average.i'
-    cli_args = "UserObjects/npla/points='0.25 0 0.25' UserObjects/npla/layer_bounding_block='0' UserObjects/npla/block='0'"
-    expect_err = "'layer_bounding_block' and 'block' cannot both be set"
-    requirement = 'The system shall error if both means of specifying bounding blocks are provided'
-    design = 'NearestPointLayeredAverage.md'
-    issues = '#19122'
-  []
-
   [error_duplicate_block_specs]
     type = RunException
     input = 'nearest_point_layered_average.i'


### PR DESCRIPTION
This PR allows the `_direction_max`/`_direction_min` for the layers in `LayeredBase` objects to be either:

- inferred from the already known bounds (if the user directly provides `bounds`)
- provided by the user if instead using `num_layers` to specify the layers

This is needed for anyone using meshes with ~1 million elements with either many points and/or many threads. 
Try changing the mesh in the `nearest_point_layered_average.i` test to have 2 million elements. I put in some timers in the `NearestPointBase` constructor and got these runtime estimates for **each nearest point** for **each thread**:

| User Settings for `NearestPointLayeredAverage` | runtime (microseconds) |
|-|-|
| none | 405474 |
| `block = '0'` | 118896 |
| with this PR | 128 |

For a mesh with ~2 million elements, with ~500 nearest points and ~48 threads per node, the previous approach gives a total setup time of:

- 500 points * 48 threads * 118896 microseconds = 48 minutes

This PR drops the setup time to:

- 500 points * 48 threads * 128 microseconds = 3 seconds

which gives a factor of 960x speedup. The speedup is at least linear with the number of mesh elements, so for our 24 million full core meshes, the speedup is more like 11520x.

## Design
Allowed the `getBounds()` call to be skipped if we already know the bounds. Also added tests to make sure the correct combination of parameters is set.

## Impact
Hugely speed up Cardinal initializations.

Closes #19122