### PR TITLE
allow doc flags to be set by env var

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -461,7 +461,7 @@ install_$(APPLICATION_NAME)_docs:
 ifeq ($(MOOSE_SKIP_DOCS),)
 	@echo "Installing docs"
 	@mkdir -p $(docs_install_dir)
-	@if [ -f "$(docs_dir)/moosedocs.py" ]; then cd $(docs_dir) && ./moosedocs.py build --destination $(docs_install_dir); fi
+	@if [ -f "$(docs_dir)/moosedocs.py" ]; then cd $(docs_dir) && ./moosedocs.py build $(MOOSE_DOCS_FLAGS) --destination $(docs_install_dir); fi
 else
 	@echo "Skipping docs installation."
 endif


### PR DESCRIPTION


<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
This will allow things like --hide-source from issue #19019
to be set from packaging scripts, etc.

## Design
Just add an env var to the makefile docs build target.

## Impact
No impact - just extra optional env var.

