### PR TITLE
Limit mortar continuity test to run only in serial 

### DIFF
--- a/test/tests/mortar/continuity-3d-non-conforming/tests
+++ b/test/tests/mortar/continuity-3d-non-conforming/tests
@@ -5,7 +5,9 @@
     type = 'Exodiff'
     input = 'continuity_sphere_hex8.i'
     exodiff = 'continuity_sphere_hex8_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a HEX8 mesh with curved geometry, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a HEX8 mesh with curved geometry, e.g. the primal '
+                  'variable values across the mortar interface shall be the same.'
     map = False
     partial = True
     ad_indexing_type = global
@@ -17,26 +19,31 @@
     # heavy = True
     input = 'continuity_sphere_hex27.i'
     exodiff = 'continuity_sphere_hex27_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a HEX27 mesh with curved geometry, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a HEX27 mesh with curved geometry, e.g. the '
+                  'primal variable values across the mortar interface shall be the same.'
     map = False
     partial = True
     ad_indexing_type = global
     min_parallel = 2
   []
   [continuity_sphere_hex27-debug-mesh]
-  type = 'Exodiff'
-  input = 'continuity_sphere_hex27.i'
-  exodiff = 'mortar_segment_mesh.e'
-  cli_args = 'Constraints/mortar/debug_mesh=true Outputs/exodus=false'
-  requirement = 'MOOSE shall generate a debug mortar mesh the parameter debug_mesh is passed to a mortar constraint'
-  min_ad_size = 200
-  max_parallel = 1 # Serial needed for debugging mesh
-[]
+    type = 'Exodiff'
+    input = 'continuity_sphere_hex27.i'
+    exodiff = 'mortar_segment_mesh.e'
+    cli_args = 'Constraints/mortar/debug_mesh=true Outputs/exodus=false'
+    requirement = 'MOOSE shall generate a debug mortar mesh the parameter debug_mesh is passed to a '
+                  'mortar constraint'
+    min_ad_size = 200
+    max_parallel = 1 # Serial needed for debugging mesh
+  []
   [continuity_tet4]
     type = 'Exodiff'
     input = 'continuity_tet4.i'
     exodiff = 'continuity_tet4_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a TET4 conforming mesh, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a TET4 conforming mesh, e.g. the primal variable '
+                  'values across the mortar interface shall be the same.'
     map = False
     partial = True
     ad_indexing_type = global
@@ -46,7 +53,9 @@
     min_ad_size = 100
     input = 'continuity_tet10.i'
     exodiff = 'continuity_tet10_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a TET10 conforming mesh, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a TET10 conforming mesh, e.g. the primal variable '
+                  'values across the mortar interface shall be the same.'
     map = False
     partial = True
     ad_indexing_type = global
@@ -55,7 +64,9 @@
     type = 'Exodiff'
     input = 'continuity_non_conforming_tet.i'
     exodiff = 'continuity_non_conforming_tet_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a TET4 non-conforming mesh, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a TET4 non-conforming mesh, e.g. the primal '
+                  'variable values across the mortar interface shall be the same.'
     map = False
     partial = True
     ad_indexing_type = global
@@ -64,9 +75,12 @@
     type = 'Exodiff'
     input = 'continuity_mixed.i'
     exodiff = 'continuity_mixed_out.e'
-    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test case using the mortar method on a mesh with mixed element types, e.g. the primal variable values across the mortar interface shall be the same.'
+    requirement = 'MOOSE shall be able to produce the expected result for a solution continuity test '
+                  'case using the mortar method on a mesh with mixed element types, e.g. the primal '
+                  'variable values across the mortar interface shall be the same.'
     map = False
     partial = True
+    max_parallel = 1
     ad_indexing_type = global
   []
 []


### PR DESCRIPTION
Temporarily disable parallel runs of a mortar test that is failing on the `next` branch.

Refs. #13080
