### PR TITLE
Use NaNInterface in IdealGasFluidProperties. 

### DIFF
--- a/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/IdealGasFluidProperties.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "SinglePhaseFluidProperties.h"
+#include "NaNInterface.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
@@ -18,7 +19,7 @@
  * Ideal gas fluid properties
  * Default parameters are for air at atmospheric pressure and temperature
  */
-class IdealGasFluidProperties : public SinglePhaseFluidProperties
+class IdealGasFluidProperties : public SinglePhaseFluidProperties, public NaNInterface
 {
 public:
   static InputParameters validParams();


### PR DESCRIPTION
This adds the `NaNInterface` to `IdealGasFluidProperties`.

## Reason
Reduce user confusion when NaNs don't cause convergence problems.

## Design
Add interface to properties.

## Impact
No expected changes.


Closes #19180
