### PR TITLE
Remove default function gradient/curl etc return 0 implementations

### DIFF
--- a/framework/include/functions/ConstantFunction.h
+++ b/framework/include/functions/ConstantFunction.h
@@ -28,6 +28,7 @@ public:
 
   virtual Real value(Real t, const Point & p) const override;
   virtual Real timeDerivative(Real t, const Point & p) const override;
+  virtual RealVectorValue gradient(Real t, const Point & p) const override;
 
 protected:
   const Real & _value;

--- a/framework/src/functions/ConstantFunction.C
+++ b/framework/src/functions/ConstantFunction.C
@@ -40,3 +40,9 @@ ConstantFunction::timeDerivative(Real /*t*/, const Point & /*p*/) const
 {
   return 0;
 }
+
+RealVectorValue
+ConstantFunction::gradient(Real /*t*/, const Point & /*p*/) const
+{
+  return RealVectorValue(0);
+}

--- a/framework/src/functions/Function.C
+++ b/framework/src/functions/Function.C
@@ -43,6 +43,7 @@ template <typename T>
 Real
 FunctionTempl<T>::value(Real /*t*/, const Point & /*p*/) const
 {
+  mooseError("value method not implemented");
   return 0.0;
 }
 
@@ -50,6 +51,7 @@ template <typename T>
 RealGradient
 FunctionTempl<T>::gradient(Real /*t*/, const Point & /*p*/) const
 {
+  mooseError("gradient method not implemented");
   return RealGradient(0, 0, 0);
 }
 
@@ -57,7 +59,7 @@ template <typename T>
 Real
 FunctionTempl<T>::timeDerivative(Real /*t*/, const Point & /*p*/) const
 {
-  mooseError("timeDerivative method not defined for function ", name());
+  mooseError("timeDerivative method not implemented");
   return 0;
 }
 
@@ -65,6 +67,7 @@ template <typename T>
 RealVectorValue
 FunctionTempl<T>::vectorValue(Real /*t*/, const Point & /*p*/) const
 {
+  mooseError("vectorValue method not implemented");
   return RealVectorValue(0, 0, 0);
 }
 
@@ -72,6 +75,7 @@ template <typename T>
 RealVectorValue
 FunctionTempl<T>::vectorCurl(Real /*t*/, const Point & /*p*/) const
 {
+  mooseError("vectorCurl method not implemented");
   return RealVectorValue(0, 0, 0);
 }
 
@@ -79,7 +83,7 @@ template <typename T>
 Real
 FunctionTempl<T>::integral() const
 {
-  mooseError("Integral method not defined for function ", name());
+  mooseError("Integral method not implemented for function ", name());
   return 0;
 }
 
@@ -87,7 +91,7 @@ template <typename T>
 Real
 FunctionTempl<T>::average() const
 {
-  mooseError("Average method not defined for function ", name());
+  mooseError("Average method not implemented for function ", name());
   return 0;
 }
 

--- a/test/include/functions/MTPiecewiseConst1D.h
+++ b/test/include/functions/MTPiecewiseConst1D.h
@@ -19,4 +19,6 @@ public:
   MTPiecewiseConst1D(const InputParameters & parameters);
 
   virtual Real value(Real t, const Point & p) const;
+
+  virtual RealGradient gradient(Real, const Point &) const { return 0; };
 };

--- a/test/include/functions/MTPiecewiseConst2D.h
+++ b/test/include/functions/MTPiecewiseConst2D.h
@@ -19,4 +19,6 @@ public:
   MTPiecewiseConst2D(const InputParameters & parameters);
 
   virtual Real value(Real t, const Point & p) const;
+
+  virtual RealGradient gradient(Real, const Point &) const { return 0; };
 };

--- a/test/include/functions/MTPiecewiseConst3D.h
+++ b/test/include/functions/MTPiecewiseConst3D.h
@@ -19,4 +19,6 @@ public:
   MTPiecewiseConst3D(const InputParameters & parameters);
 
   virtual Real value(Real t, const Point & p) const;
+
+  virtual RealGradient gradient(Real, const Point &) const { return 0; };
 };


### PR DESCRIPTION
Separating this from #19118 to be able to merge that one faster

From there I saw a failure in a bunch of apps, probably not bugs just to adapt to the new design
https://civet.inl.gov/job/859887/
https://civet.inl.gov/job/859886/
@cticenhour where's ELK?
@andrsd I can make a pr to thm, I ll check on relap
@joshuahansel I'll patch sockeye