### PR TITLE
Remove executable symlinks

### DIFF
--- a/test/tests/mortar/continuity-3d-non-conforming/moose_test-dbg
+++ b/test/tests/mortar/continuity-3d-non-conforming/moose_test-dbg
@@ -1,1 +1,0 @@
-../../../moose_test-dbg

--- a/test/tests/mortar/continuity-3d-non-conforming/moose_test-opt
+++ b/test/tests/mortar/continuity-3d-non-conforming/moose_test-opt
@@ -1,1 +1,0 @@
-../../../moose_test-opt


### PR DESCRIPTION
Some executable symlinks were accidentally left in during the creation of #19092. This PR removes those symlinks from the repo. 

Tagging @recuero @lindsayad 



