### PR TITLE
Update libMesh to a version with ExodusII IsoGeometric Analysis support

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2021.09.15" %}
+{% set version = "2021.10.27" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - 2021.09.15 build_0
+  - 2021.10.27 build_0
 
 moose_petsc:
   - 3.15.1 build_2

--- a/modules/doc/content/newsletter/2021_10.md
+++ b/modules/doc/content/newsletter/2021_10.md
@@ -101,7 +101,7 @@ Some examples of MOOSE mortar constraints (previously available only in 2D) incl
 
 ## libMesh-level Changes
 
-- Support for Tri7 triangles (like Tri6 plus with one mid-element
+- Support for Tri7 triangles (like Tri6 plus one mid-element
   node) and Tet14 tetrahedra (like Tri10 plus one mid-face node on
   each face)
 - Reduced Basis EIM updates

--- a/modules/doc/content/newsletter/2021_10.md
+++ b/modules/doc/content/newsletter/2021_10.md
@@ -101,4 +101,23 @@ Some examples of MOOSE mortar constraints (previously available only in 2D) incl
 
 ## libMesh-level Changes
 
+- Support for Tri7 triangles (like Tri6 plus with one mid-element
+  node) and Tet14 tetrahedra (like Tri10 plus one mid-face node on
+  each face)
+- Reduced Basis EIM updates
+- SIDE\_HIERARCHIC finite element (shapes defined on sides and
+  discontinuous between sides) support for triangles
+- LOG\_CALL() macro to simplify exception-safe PerfLog support in more
+  use cases.
+- Refactoring and simplification of the finite-difference-method
+  fallback for calculating shape function gradients on finite element
+  types without analytic gradient implementations
+- ExodusII\_IO::get\_sideset\_data\_indices() accessor method
+- Fixed file handle leaks in some ExodusII use cases, leaks which
+  triggered errors when running with ExodusII version 8.11
+- Read support for new IsoGeometric Analysis extensions to ExodusII
+- Assorted bug fixes for distcheck, clang warnings,
+  non-double-precision configurations, Elem::permute(), other minor
+  issues. 
+
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
Summary of changes:

  - Tri7 and Tet14 element support
  - Reduced Basis EIM updates
  - SIDE_HIERARCHIC FE support on triangles
  - LOG_CALL() macro
  - Refactored FE derivatives FDM fallback
  - ExodusII_IO::get_sideset_data_indices() accessor
  - Fix file leak/error with some ExodusII version 8 use cases
  - ExodusII IsoGeometric Analysis file support
  - Bug fixes for distcheck, clang warnings, non-double FP,
    Elem::permute(), etc.

Refs #0

Refs #18768 - this brings in read support for Exodus IGA files

Marking this as Do Not Merge at first, since there's a chance I'll want to slip in another libMesh PR first, but I'd like to at least make sure that CI here doesn't have any problem with the changes so far.