### PR TITLE
Put back coloring context teardown 

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -944,6 +944,7 @@ colorAdjacencyMatrix(PetscScalar * adjacency_matrix,
 
   MatDestroy(&A);
   MatColoringDestroy(&mc);
+  ISColoringDestroy(&iscoloring);
 }
 
 void


### PR DESCRIPTION
Fixes an erroneously removed tear down of the PETSc coloring context.

Refs #19197