### PR TITLE
Adapt more kernels to functors

### DIFF
--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
@@ -25,7 +25,7 @@ protected:
   ADReal computeQpResidual() override;
 
   /// Fluid temperature
-  const ADVariableValue & _temperature;
+  const Moose::Functor<ADReal> & _temperature;
   /// The gravity vector
   const RealVectorValue _gravity;
   /// The thermal expansion coefficient

--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
@@ -24,10 +24,12 @@ public:
 protected:
   ADReal computeQpResidual() override;
 
+  /// Fluid temperature
   const ADVariableValue & _temperature;
+  /// The gravity vector
   const RealVectorValue _gravity;
   /// The thermal expansion coefficient
-  const ADMaterialProperty<Real> & _alpha;
+  const Moose::Functor<ADReal> & _alpha;
   /// Reference temperature at which the value of _rho was measured
   const Real _ref_temperature;
   /// the density

--- a/modules/navier_stokes/include/fvkernels/PINSFVEnergyAmbientConvection.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVEnergyAmbientConvection.h
@@ -27,9 +27,9 @@ protected:
   /// the convective heat transfer coefficient
   const Moose::Functor<ADReal> & _h_solid_fluid;
   /// fluid temperature
-  const ADVariableValue & _temp_fluid;
+  const Moose::Functor<ADReal> & _temp_fluid;
   /// solid temperature
-  const ADVariableValue & _temp_solid;
+  const Moose::Functor<ADReal> & _temp_solid;
   /// whether this kernel is being used for a solid or a fluid temperature
   const bool _is_solid;
 };

--- a/modules/navier_stokes/include/fvkernels/PINSFVEnergyAmbientConvection.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVEnergyAmbientConvection.h
@@ -25,7 +25,7 @@ protected:
   ADReal computeQpResidual() override;
 
   /// the convective heat transfer coefficient
-  const ADMaterialProperty<Real> & _h_solid_fluid;
+  const Moose::Functor<ADReal> & _h_solid_fluid;
   /// fluid temperature
   const ADVariableValue & _temp_fluid;
   /// solid temperature

--- a/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
@@ -21,8 +21,7 @@ INSFVEnergyTimeDerivative::validParams()
       "Adds the time derivative term to the incompressible Navier-Stokes energy equation.");
   params.addRequiredParam<Real>(NS::density, "The value for the density");
   params.declareControllable(NS::density);
-  params.addParam<MooseFunctorName>(
-      "cp_name", NS::cp, "The name of the specific heat capacity");
+  params.addParam<MooseFunctorName>("cp_name", NS::cp, "The name of the specific heat capacity");
   return params;
 }
 

--- a/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
@@ -21,7 +21,7 @@ INSFVEnergyTimeDerivative::validParams()
       "Adds the time derivative term to the incompressible Navier-Stokes energy equation.");
   params.addRequiredParam<Real>(NS::density, "The value for the density");
   params.declareControllable(NS::density);
-  params.addParam<MaterialPropertyName>(
+  params.addParam<MooseFunctorName>(
       "cp_name", NS::cp, "The name of the specific heat capacity");
   return params;
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
@@ -19,10 +19,10 @@ INSFVMomentumBoussinesq::validParams()
   params.addClassDescription("Computes a body force for natural convection buoyancy.");
   params.addRequiredCoupledVar(NS::T_fluid, "temperature variable");
   params.addRequiredParam<RealVectorValue>("gravity", "Direction of the gravity vector");
-  params.addParam<MaterialPropertyName>("alpha_name",
-                                        NS::alpha_boussinesq,
-                                        "The name of the thermal expansion coefficient"
-                                        "this is of the form rho = rho*(1-alpha (T-T_ref))");
+  params.addParam<MooseFunctorName>("alpha_name",
+                                    NS::alpha_boussinesq,
+                                    "The name of the thermal expansion coefficient"
+                                    "this is of the form rho = rho*(1-alpha (T-T_ref))");
   params.addRequiredParam<Real>("ref_temperature", "The value for the reference temperature.");
   MooseEnum momentum_component("x=0 y=1 z=2");
   params.addRequiredParam<MooseEnum>(
@@ -38,7 +38,7 @@ INSFVMomentumBoussinesq::INSFVMomentumBoussinesq(const InputParameters & params)
   : FVElementalKernel(params),
     _temperature(adCoupledValue(NS::T_fluid)),
     _gravity(getParam<RealVectorValue>("gravity")),
-    _alpha(getADMaterialProperty<Real>("alpha_name")),
+    _alpha(getFunctor<ADReal>("alpha_name")),
     _ref_temperature(getParam<Real>("ref_temperature")),
     _rho(getParam<Real>(NS::density)),
     _index(getParam<MooseEnum>("momentum_component"))
@@ -53,5 +53,5 @@ INSFVMomentumBoussinesq::INSFVMomentumBoussinesq(const InputParameters & params)
 ADReal
 INSFVMomentumBoussinesq::computeQpResidual()
 {
-  return _alpha[_qp] * _gravity(_index) * _rho * (_temperature[_qp] - _ref_temperature);
+  return _alpha(_current_elem) * _gravity(_index) * _rho * (_temperature[_qp] - _ref_temperature);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
@@ -17,7 +17,7 @@ INSFVMomentumBoussinesq::validParams()
 {
   InputParameters params = FVElementalKernel::validParams();
   params.addClassDescription("Computes a body force for natural convection buoyancy.");
-  params.addRequiredCoupledVar(NS::T_fluid, "temperature variable");
+  params.addRequiredParam<MooseFunctorName>(NS::T_fluid, "temperature variable");
   params.addRequiredParam<RealVectorValue>("gravity", "Direction of the gravity vector");
   params.addParam<MooseFunctorName>("alpha_name",
                                     NS::alpha_boussinesq,
@@ -36,7 +36,7 @@ INSFVMomentumBoussinesq::validParams()
 
 INSFVMomentumBoussinesq::INSFVMomentumBoussinesq(const InputParameters & params)
   : FVElementalKernel(params),
-    _temperature(adCoupledValue(NS::T_fluid)),
+    _temperature(getFunctor<ADReal>(NS::T_fluid)),
     _gravity(getParam<RealVectorValue>("gravity")),
     _alpha(getFunctor<ADReal>("alpha_name")),
     _ref_temperature(getParam<Real>("ref_temperature")),
@@ -53,5 +53,6 @@ INSFVMomentumBoussinesq::INSFVMomentumBoussinesq(const InputParameters & params)
 ADReal
 INSFVMomentumBoussinesq::computeQpResidual()
 {
-  return _alpha(_current_elem) * _gravity(_index) * _rho * (_temperature[_qp] - _ref_temperature);
+  return _alpha(_current_elem) * _gravity(_index) * _rho *
+         (_temperature(_current_elem) - _ref_temperature);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumBoussinesq.C
@@ -17,7 +17,7 @@ INSFVMomentumBoussinesq::validParams()
 {
   InputParameters params = FVElementalKernel::validParams();
   params.addClassDescription("Computes a body force for natural convection buoyancy.");
-  params.addRequiredParam<MooseFunctorName>(NS::T_fluid, "temperature variable");
+  params.addRequiredParam<MooseFunctorName>(NS::T_fluid, "the fluid temperature");
   params.addRequiredParam<RealVectorValue>("gravity", "Direction of the gravity vector");
   params.addParam<MooseFunctorName>("alpha_name",
                                     NS::alpha_boussinesq,

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyAmbientConvection.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyAmbientConvection.C
@@ -18,7 +18,7 @@ PINSFVEnergyAmbientConvection::validParams()
   InputParameters params = FVElementalKernel::validParams();
   params.addClassDescription("Implements the solid-fluid ambient convection term in the porous "
                              "media Navier Stokes energy equation.");
-  params.addRequiredParam<MaterialPropertyName>(
+  params.addRequiredParam<MooseFunctorName>(
       "h_solid_fluid",
       "Name of the convective heat "
       "transfer coefficient. This coefficient should include the influence of porosity.");
@@ -30,7 +30,7 @@ PINSFVEnergyAmbientConvection::validParams()
 
 PINSFVEnergyAmbientConvection::PINSFVEnergyAmbientConvection(const InputParameters & parameters)
   : FVElementalKernel(parameters),
-    _h_solid_fluid(getADMaterialProperty<Real>("h_solid_fluid")),
+    _h_solid_fluid(getFunctor<ADReal>("h_solid_fluid")),
     _temp_fluid(adCoupledValue(NS::T_fluid)),
     _temp_solid(adCoupledValue(NS::T_solid)),
     _is_solid(getParam<bool>("is_solid"))
@@ -41,7 +41,7 @@ ADReal
 PINSFVEnergyAmbientConvection::computeQpResidual()
 {
   if (_is_solid)
-    return -_h_solid_fluid[_qp] * (_temp_fluid[_qp] - _temp_solid[_qp]);
+    return -_h_solid_fluid(_current_elem) * (_temp_fluid[_qp] - _temp_solid[_qp]);
   else
-    return _h_solid_fluid[_qp] * (_temp_fluid[_qp] - _temp_solid[_qp]);
+    return _h_solid_fluid(_current_elem) * (_temp_fluid[_qp] - _temp_solid[_qp]);
 }

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyAmbientConvection.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyAmbientConvection.C
@@ -23,16 +23,16 @@ PINSFVEnergyAmbientConvection::validParams()
       "Name of the convective heat "
       "transfer coefficient. This coefficient should include the influence of porosity.");
   params.addRequiredParam<bool>("is_solid", "Whether this kernel acts on the solid temperature");
-  params.addRequiredCoupledVar(NS::T_fluid, "Fluid temperature");
-  params.addRequiredCoupledVar(NS::T_solid, "Solid temperature");
+  params.addRequiredParam<MooseFunctorName>(NS::T_fluid, "Fluid temperature");
+  params.addRequiredParam<MooseFunctorName>(NS::T_solid, "Solid temperature");
   return params;
 }
 
 PINSFVEnergyAmbientConvection::PINSFVEnergyAmbientConvection(const InputParameters & parameters)
   : FVElementalKernel(parameters),
     _h_solid_fluid(getFunctor<ADReal>("h_solid_fluid")),
-    _temp_fluid(adCoupledValue(NS::T_fluid)),
-    _temp_solid(adCoupledValue(NS::T_solid)),
+    _temp_fluid(getFunctor<ADReal>(NS::T_fluid)),
+    _temp_solid(getFunctor<ADReal>(NS::T_solid)),
     _is_solid(getParam<bool>("is_solid"))
 {
 }
@@ -41,7 +41,9 @@ ADReal
 PINSFVEnergyAmbientConvection::computeQpResidual()
 {
   if (_is_solid)
-    return -_h_solid_fluid(_current_elem) * (_temp_fluid[_qp] - _temp_solid[_qp]);
+    return -_h_solid_fluid(_current_elem) *
+           (_temp_fluid(_current_elem) - _temp_solid(_current_elem));
   else
-    return _h_solid_fluid(_current_elem) * (_temp_fluid[_qp] - _temp_solid[_qp]);
+    return _h_solid_fluid(_current_elem) *
+           (_temp_fluid(_current_elem) - _temp_solid(_current_elem));
 }

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyTimeDerivative.C
@@ -27,10 +27,8 @@ PINSFVEnergyTimeDerivative::validParams()
   params.addRequiredParam<MooseFunctorName>(NS::cp, "Specific heat capacity");
   params.addParam<MooseFunctorName>(NS::time_deriv(NS::cp),
                                     "Specific heat capacity time derivative functor");
+  params.addRequiredParam<MooseFunctorName>(NS::porosity, "Porosity");
 
-  params.addRequiredParam<MooseFunctorName>(NS::porosity, "Porosity variable");
-  params.addParam<MaterialPropertyName>("porosity_prop_name",
-                                        "A name for a porosity material property.");
   params.addRequiredParam<bool>("is_solid", "Whether this kernel acts on the solid temperature");
   params.addRangeCheckedParam<Real>("scaling",
                                     1,

--- a/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
@@ -19,10 +19,10 @@ PINSFVMomentumFriction::validParams()
   params.addClassDescription(
       "Computes a friction force term on fluid in porous media in the "
       "Navier Stokes i-th momentum equation in Rhie-Chow (incompressible) contexts.");
-  params.addParam<MaterialPropertyName>("Darcy_name",
-                                        "Name of the Darcy coefficients material property.");
-  params.addParam<MaterialPropertyName>("Forchheimer_name",
-                                        "Name of the Forchheimer coefficients material property.");
+  params.addParam<MooseFunctorName>("Darcy_name",
+                                    "Name of the Darcy coefficients material property.");
+  params.addParam<MooseFunctorName>("Forchheimer_name",
+                                    "Name of the Forchheimer coefficients material property.");
   params.addParam<MooseFunctorName>(NS::porosity, NS::porosity, "Porosity variable.");
   params.addRequiredParam<MooseFunctorName>(NS::density, "The density.");
   MooseEnum momentum_component("x=0 y=1 z=2");

--- a/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVMomentumFriction.C
@@ -19,11 +19,10 @@ PINSFVMomentumFriction::validParams()
   params.addClassDescription(
       "Computes a friction force term on fluid in porous media in the "
       "Navier Stokes i-th momentum equation in Rhie-Chow (incompressible) contexts.");
-  params.addParam<MooseFunctorName>("Darcy_name",
-                                    "Name of the Darcy coefficients material property.");
+  params.addParam<MooseFunctorName>("Darcy_name", "Name of the Darcy coefficients property.");
   params.addParam<MooseFunctorName>("Forchheimer_name",
-                                    "Name of the Forchheimer coefficients material property.");
-  params.addParam<MooseFunctorName>(NS::porosity, NS::porosity, "Porosity variable.");
+                                    "Name of the Forchheimer coefficients property.");
+  params.addParam<MooseFunctorName>(NS::porosity, NS::porosity, "the porosity");
   params.addRequiredParam<MooseFunctorName>(NS::density, "The density.");
   MooseEnum momentum_component("x=0 y=1 z=2");
   params.addRequiredParam<MooseEnum>(

--- a/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/boussinesq.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/boussinesq/boussinesq.i
@@ -252,15 +252,10 @@ temp_ref=${fparse hot_temp / 2.}
 []
 
 [Materials]
-  [const]
-    type = ADGenericConstantMaterial
-    prop_names = 'alpha_b'
-    prop_values = '${alpha}'
-  []
   [const_functor]
     type = ADGenericConstantFunctorMaterial
-    prop_names = 'cp k'
-    prop_values = '${cp} ${k}'
+    prop_names = 'alpha_b cp k'
+    prop_values = '${alpha} ${cp} ${k}'
   []
   [ins_fv]
     type = INSFVMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-boussinesq.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-boussinesq.i
@@ -259,7 +259,7 @@ velocity_interp_method='rc'
 
 [Materials]
   [constants]
-    type = ADGenericConstantMaterial
+    type = ADGenericConstantFunctorMaterial
     prop_names = 'h_cv alpha_b'
     prop_values = '1e-3 8e-4'
   []

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-effective.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-effective.i
@@ -249,7 +249,7 @@ velocity_interp_method='rc'
 
 [Materials]
   [constants]
-    type = ADGenericConstantMaterial
+    type = ADGenericConstantFunctorMaterial
     prop_names = 'h_cv'
     prop_values = '1'
   []

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated.i
@@ -249,7 +249,7 @@ velocity_interp_method='rc'
 
 [Materials]
   [constants]
-    type = ADGenericConstantMaterial
+    type = ADGenericConstantFunctorMaterial
     prop_names = 'h_cv'
     prop_values = '1'
   []

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-transient.i
@@ -277,7 +277,7 @@ velocity_interp_method='rc'
 
 [Materials]
   [constants]
-    type = ADGenericConstantMaterial
+    type = ADGenericConstantFunctorMaterial
     prop_names = 'h_cv'
     prop_values = '${h_fs}'
   []

--- a/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient.i
@@ -295,7 +295,7 @@ velocity_interp_method='rc'
 
 [Materials]
   [constants]
-    type = ADGenericConstantMaterial
+    type = ADGenericConstantFunctorMaterial
     prop_names = 'h_cv'
     prop_values = '${h_fs}'
   []


### PR DESCRIPTION
i was thinking we could survive with regular material properties for the elemental kernels. I was wrong.

Basically, all the Pgh materials expect properties from a GeneralFluidProps. But we only define the Functor version of this. The regular version requires a non-functor variable material, which we no longer have in FV. 

So functors for everyone!