### PR TITLE
Add conda package update to November news

### DIFF
--- a/modules/doc/content/getting_started/installation/m1_monterey.md
+++ b/modules/doc/content/getting_started/installation/m1_monterey.md
@@ -1,83 +1,107 @@
 # Process for building moose-mpich and then MOOSE on ARM64 (M1, Monterey)
 
-NOTE: This assumes that you have miniforge3 installed. (https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh). The MOOSE installation instructions for conda can be used to do this.
+!alert! construction title=Work In Progress
+This document is intended to be a living one, as M1 support is added and the current
+"best practice" of installing it improved. As of Nov 3 2021, full package support
+(i.e., `moose-mpich` + `moose-petsc` + `moose-libmesh`) is not yet available.
+!alert-end!
 
-1. Download MacOSX 11.3 SDK (https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz)
+!alert! note title=Miniforge3
+This guide assumes that you have miniforge3 installed. Download the newest release
+[using this link](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh).
+Then the [MOOSE installation instructions for conda](conda.md) can be used to perform
+the installation.
+!alert-end!
 
-2. Extract the SDK and place it in /opt/
+1. Download MacOSX 11.3 SDK [via GitHub](https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz).
+
+2. Extract the SDK and place it in `/opt/`
 
 3. Set up conda build environment:
 
-```
-conda create -n build -y
-conda activate build
-mamba install boa
-```
+   ```
+   conda deactivate
+   conda install mamba
+   conda create -n build -y
+   conda activate build
+   mamba install boa
+   ```
 
-Deactivate and re-activate to ensure environment is in the proper state:
+   Deactivate and re-activate to ensure environment is in the proper state:
 
-```
-conda deactivate
-conda activate build
-```
+   ```
+   conda deactivate
+   conda activate build
+   ```
 
 4. Build moose-mpich and moose-tools locally (make sure build environment is activated) and init submodules
 
-```
-cd ~/projects/moose/conda
-conda mambabuild mpich
-conda mambabuild tools
-cd ..
-git submodule update --init --recursive petsc libmesh
-```
+   ```
+   cd ~/projects/moose/conda
+   conda mambabuild mpich
+   conda mambabuild tools
+   cd ..
+   git submodule update --init --recursive petsc libmesh
+   ```
 
 5. Create development environment and build PETSc:
 
-```
-conda deactivate
-conda create -n testing -y
-conda activate testing
-mamba install -c ~/miniforge3/envs/build/conda-bld moose-mpich moose-tools cmake
-```
+   ```
+   conda deactivate
+   conda create -n testing -y
+   conda activate testing
+   mamba install -c ~/miniforge3/envs/build/conda-bld moose-mpich moose-tools cmake
+   ```
 
-IMPORTANT: Close and re-open the Terminal
+   !alert! tip
+   IMPORTANT: Close and re-open the Terminal so that the environment variables
+   can be properly set upon activation
+   !alert-end!
 
+   ```
+   conda activate testing
+   cd ~/projects/moose
+   scripts/updata_and_rebuild_petsc.sh --enable-shared-libraries=0 --download-mumps=0
+   ```
 
-```
-conda activate testing
-cd ~/projects/moose
-scripts/updata_and_rebuild_petsc.sh --enable-shared-libraries=0 --download-mumps=0
-```
-
-The modified configure options are necessary for the current build to succeed.
-FBLASLAPACK fails if shared libraries are enabled, and the `-lmpiseq` library cannot
-be currently found in the current `moose-mpich` build on Monterey.
+   The modified configure options are necessary for the current build to succeed.
+   FBLASLAPACK fails if shared libraries are enabled, and the `-lmpiseq` library
+   cannot be currently found in the current `moose-mpich` build on Monterey.
 
 6. When PETSc completes, libmesh and its dependencies need to be bootstrapped for ARM64 on MacOS:
 
-```
-cd libmesh
-git submodule update --recursive
-./bootstrap
-cd contrib/metaphysicl
-./bootstrap
-cd ../timpi
-./bootstrap
-cd ../netcdf/netcdf*
-autoreconf
-cd ../../../.. # to get back to moose
-```
+   ```
+   cd libmesh
+   git submodule update --recursive
+   ./bootstrap
+   cd contrib/metaphysicl
+   ./bootstrap
+   cd ../timpi
+   ./bootstrap
+   cd ../netcdf/netcdf*
+   autoreconf
+   cd ../../../.. # to get back to moose
+   ```
 
 7. Then run the libmesh script as normal:
 
-```
-scripts/update_and_rebuild_libmesh.sh
-```
+   ```
+   scripts/update_and_rebuild_libmesh.sh
+   ```
 
 8. Build and test MOOSE:
 
+   ```
+   cd test
+   make -j8
+   ./run_tests -j8
+   ```
+
+!alert! warning title=Failing tests
+This method of building MOOSE *will* result in many failing tests. Currently (as
+of Nov 3 2021), many of these tests fail with the following error:
+
 ```
-cd test
-make -j8
-./run_tests -j8
+dyld[75720]: symbol not found in flat namespace '_petsc_allreduce_ct'
 ```
+!alert-end!

--- a/modules/doc/content/newsletter/2021_10.md
+++ b/modules/doc/content/newsletter/2021_10.md
@@ -123,6 +123,4 @@ Some examples of MOOSE mortar constraints (previously available only in 2D) incl
 - Read support for new IsoGeometric Analysis extensions to ExodusII
 - Assorted bug fixes for distcheck, clang warnings,
   non-double-precision configurations, Elem::permute(), other minor
-  issues. 
-
-## Bug Fixes and Minor Enhancements
+  issues.

--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -5,6 +5,40 @@ This MOOSE Newsletter edition is in progress. Please check back in December 2021
 for a complete description of all MOOSE changes.
 !alert-end!
 
+## MOOSE Conda Packages Now Compatible with Xcode Newer Than 12.4, MacOS Monterey
+
+Conda package updates for `moose-mpich`, `moose-petsc`, and `moose-libmesh` were
+merged in [#19230](https://github.com/idaholab/moose/pull/19230), and they enable
+full MacOS Big Sur compatibility for previously unsupported Xcode and Command Line
+Tools versions 12.5, 13, and 13.1. This update also enables support for MacOS Monterey.
+The Clang compiler has also been updated to 12.0.1.
+
+!alert! note title=Intel Macs Only
+This update only applies to Intel Macs. Official M1 Apple Silicon support is on
+the way! Track the MOOSE issue [#18954](https://github.com/idaholab/moose/issues/18954)
+if interested in new developments.
+!alert-end!
+
+To download the new packages, please activate your MOOSE conda environment and
+perform the following command:
+
+```
+conda update --all
+```
+
+where the appropriate versions and build in the update output should be:
+
+```
+Package                  Version            Build
+=====================================================
+moose-libmesh            2021.10.27         build_1
+moose-mpich              3.3.2              build_8
+moose-petsc              3.15.1             build_3
+```
+
+If any issues with the new packages are experienced, please open a new
+[Discussions post](https://github.com/idaholab/moose/discussions)!
+
 ## MOOSE Improvements
 
 ## libMesh-level Changes


### PR DESCRIPTION
Adds conda package update details to November newsletter, and improves formatting and info on experimental M1 Apple Silicon build instructions.

Refs #19230
Refs #18954
