### PR TITLE
Fix Jenkins post exception handling for Slack

### DIFF
--- a/docker_ci/Jenkinsfile
+++ b/docker_ci/Jenkinsfile
@@ -99,8 +99,8 @@ pipeline {
                 try {
                     // Send message build was successful
                     slackSend color: 'good', message: "Successful build of ${SLACK_SFX}"
-                } catch (Exception e) {
-                    echo "${SLACK_ERR}" + e.toString() // Slack not required to build
+                } catch (java.lang.NoSuchMethodError ex) {
+                    echo "${SLACK_ERR}" // Slack not required to build
                 }
             }
         }
@@ -115,8 +115,8 @@ pipeline {
 
                     // Send message build failed
                     slackSend color: 'danger', message: "Failed to build ${SLACK_SFX}"
-                } catch (Exception e) {
-                    echo "${SLACK_ERR}" + e.toString() // Slack not required to build
+                } catch (java.lang.NoSuchMethodError ex) {
+                    echo "${SLACK_ERR}" // Slack not required to build
                 }
             }
         }


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
If someone wants to set up MOOSE with Jenkins and doesn't have the `slackSend` plugin installed, their pipelines will fail.  Also, it's just bad practice to leave things broken when the fix is known.

## Design
Changed exception type in `post` from `Exception` to `java.lang.NoSuchMethodError`, because what's thrown when `slackSend` isn't available.

## Impact
Jenkins pipelines will not fail in the absence of the `slackSend` plugin.  Closes #19319.
