### PR TITLE
Manually flip images

### DIFF
--- a/framework/include/utils/ImageSampler.h
+++ b/framework/include/utils/ImageSampler.h
@@ -14,6 +14,7 @@
 #include "ConsoleStream.h"
 
 #include "libmesh/bounding_box.h"
+#include <array>
 
 // VTK includes
 #ifdef LIBMESH_HAVE_VTK
@@ -92,13 +93,6 @@ protected:
    */
   void vtkMagnitude();
 
-  /**
-   * Perform image flipping
-   *
-   * Flip the image along the x, y, and/or z axis. If multiple flips occur, they happen in order.
-   */
-  void vtkFlip();
-
 private:
 #ifdef LIBMESH_HAVE_VTK
 
@@ -122,18 +116,6 @@ private:
 
   /// Pointer to the magnitude filter
   vtkSmartPointer<vtkImageMagnitude> _magnitude_filter;
-
-  /// Pointers to image flipping filter.  May be used for x, y, or z.
-  vtkSmartPointer<vtkImageFlip> _flip_filter;
-#endif
-
-/**
- * Helper method for flipping image
- * @param axis Flag for determing the flip axis: "x=0", "y=1", "z=2"
- * @return A smart pointer the flipping filter
- */
-#ifdef LIBMESH_HAVE_VTK
-  vtkSmartPointer<vtkImageFlip> imageFlip(const int & axis);
 #endif
 
   /// Origin of image
@@ -161,4 +143,7 @@ private:
 
   /// Create a console stream object for this helper class
   ConsoleStream _is_console;
+
+  /// image flip
+  std::array<bool, 3> _flip;
 };


### PR DESCRIPTION
The `vtkImageFlip` filter is subtly broken on Apple Silicon, giving weird off by one results. Using it is overkill anyways, and just doing the flip in voxel space is less code.

Refs #18954