### PR TITLE
Update VTK to version 9.1

### DIFF
--- a/conda/libmesh-vtk/build.sh
+++ b/conda/libmesh-vtk/build.sh
@@ -19,18 +19,23 @@ cmake .. -G "Ninja" \
     -DCMAKE_PREFIX_PATH:PATH=${VTK_PREFIX} \
     -DCMAKE_INSTALL_PREFIX:PATH=${VTK_PREFIX} \
     -DCMAKE_INSTALL_RPATH:PATH=${VTK_PREFIX}/lib \
-    -DBUILD_DOCUMENTATION:BOOL=OFF \
-    -DBUILD_TESTING:BOOL=OFF \
-    -DBUILD_EXAMPLES:BOOL=OFF \
+    -DVTK_BUILD_DOCUMENTATION:BOOL=OFF \
+    -DVTK_BUILD_TESTING:BOOL=OFF \
+    -DVTK_BUILD_EXAMPLES:BOOL=OFF \
     -DBUILD_SHARED_LIBS:BOOL=ON \
-    -DVTK_Group_MPI:BOOL=ON \
-    -DVTK_Group_Rendering:BOOL=OFF \
-    -DVTK_Group_Qt:BOOL=OFF \
-    -DVTK_Group_Views:BOOL=OFF \
-    -DVTK_Group_Web:BOOL=OFF \
+    -DVTK_USE_MPI:BOOL=ON \
+    -DVTK_GROUP_ENABLE_Rendering:STRING=DONT_WANT \
+    -DVTK_GROUP_ENABLE_Qt::STRING=NO \
+    -DVTK_GROUP_ENABLE_Views:STRING=NO \
+    -DVTK_GROUP_ENABLE_Web:STRING=NO \
     -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}
 
 ninja install -v
+
+# VTK 9.1 now places libs in lib64 when installed on linux, linking to the "expected" location of lib
+if [[ $(uname) == Linux ]]; then
+    ln -s ${VTK_PREFIX}/lib64 ${VTK_PREFIX}/lib
+fi
 
 # Set LIBMESH_DIR environment variable for those that need it
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,9 +1,9 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 8 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set vtk_version = "6.3.0" %}
-{% set friendly_version = "6.3" %}
-{% set sha256 = "92a493354c5fa66bea73b5fc014154af5d9f3f6cee8d20a826f4cd5d4b0e8a5e" %}
+{% set vtk_version = "9.1.0" %}
+{% set friendly_version = "9.1" %}
+{% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}
 
 package:
   name: moose-libmesh-vtk

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2021.10.27" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,19 +2,19 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.10.27 build_3
+  - moose-libmesh 2021.10.27 build_4
+
+SHORT_VTK_NAME:
+  - 9.1
+
+vtk_version:
+  - 9.1.0
+
+moose_libmesh_vtk:
+  - moose-libmesh-vtk 9.1.0 build_0
 
 moose_petsc:
   - moose-petsc 3.15.1 build_3
-
-SHORT_VTK_NAME:
-  - 6.3
-
-vtk_version:
-  - 6.3.0
-
-moose_libmesh_vtk:
-  - moose-libmesh-vtk 6.3.0 build_8
 
 moose_mpich:
   - moose-mpich 3.3.2 build_8


### PR DESCRIPTION
After the issue referenced in #19327 and a bug report with VTK, it was found that updating to 9.1 should fix possible rounding errors experienced on VTK <=9.0 on ARM64 platforms.  

refs #18954

Related bug report: https://gitlab.kitware.com/vtk/vtk/-/issues/18373
