### PR TITLE
[WIP] Enable on-the-fly FV code with auxes

### DIFF
--- a/framework/src/variables/MooseVariableDataFV.C
+++ b/framework/src/variables/MooseVariableDataFV.C
@@ -962,6 +962,11 @@ MooseVariableDataFV<OutputType>::setDofValue(const OutputData & value, unsigned 
   if (_need_ad_u)
     for (const auto qp : make_range(_ad_u.size()))
       _ad_u[qp] = value;
+
+  // We need to update the current local solution such that aux kernels that use on-the-fly
+  // evaluation of aux variables have up-to-date solution vector information
+  if (_var.kind() == Moose::VAR_AUXILIARY)
+    insert(const_cast<NumericVector<Number> &>(*_sys.currentSolution()));
 }
 
 template <typename OutputType>


### PR DESCRIPTION
On-the-fly variable evaluation relies on querying the solution
vector. If we have a chain of aux kernels we have to make sure that
the first aux ends up updating the solution vector or else a second
aux kernel that relies on on-the-fly evaluation of the variable won't
receive up-to-date information

@tanoret 