### PR TITLE
Update petsc to  3.16

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.03.02" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.03.02 build_0
+  - moose-libmesh 2022.03.02 build_1
 
 SHORT_VTK_NAME:
   - 9.1
@@ -14,7 +14,7 @@ moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0 build_4
 
 moose_petsc:
-  - moose-petsc 3.15.1 build_7
+  - moose-petsc 3.16.5 build_0
 
 moose_mpich:
   - moose-mpich 3.4.2 build_3

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -16,7 +16,6 @@ export CXXFLAGS=$(echo ${CXXFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export FFLAGS=$(echo ${FFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export FCFLAGS="$FFLAGS"
 export HYDRA_LAUNCHER=fork
-#export LIBS="-lmpifort -lgfortran"
 
 if [[ $(uname) == Darwin ]]; then
     if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -16,7 +16,7 @@ export CXXFLAGS=$(echo ${CXXFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export FFLAGS=$(echo ${FFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
 export FCFLAGS="$FFLAGS"
 export HYDRA_LAUNCHER=fork
-export LIBS="-lmpifort -lgfortran"
+#export LIBS="-lmpifort -lgfortran"
 
 if [[ $(uname) == Darwin ]]; then
     if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
@@ -57,7 +57,6 @@ configure_petsc \
     FFLAGS="$FFLAGS" \
     FCFLAGS="$FCFLAGS" \
     LDFLAGS="$LDFLAGS" \
-    LIBS="$LIBS" \
     --prefix=$PREFIX || (cat configure.log && exit 1)
 
 # Verify that gcc_ext isn't linked

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 7 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "3.15.1" %}
+{% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}
 
 package:
@@ -50,7 +50,7 @@ test:
     - pkg-config --libs PETSc
 
 about:
-  home: http://www.mcs.anl.gov/petsc/
+  home: https://petsc.org
   summary: 'PETSc: Portable, Extensible Toolkit for Scientific Computation'
   license: BSD 2-Clause
   license_file: LICENSE

--- a/python/TestHarness/suppressions/errors.supp
+++ b/python/TestHarness/suppressions/errors.supp
@@ -189,3 +189,16 @@
    fun:*boost*math*
    ...
 }
+{
+   hypre_leaks
+   Memcheck:Leak
+   fun:hypre_HostMalloc
+   fun:hypre_MAlloc_core
+   fun:hypre_CAlloc
+   fun:hypre_IntArrayCreate
+   fun:hypre_BoomerAMGCoarseParmsHost
+   fun:hypre_BoomerAMGCoarseParms
+   fun:hypre_BoomerAMGSetup
+   fun:HYPRE_BoomerAMGSetup
+   fun:PCSetUp_HYPRE
+}


### PR DESCRIPTION
It is time to update PETSc. New PETSc will make maintenance easier.  For example, I can patch new PETSc but not old PETSc.