### PR TITLE
Libmesh update

### DIFF
--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -75,6 +75,7 @@ fi
 source $SRC_DIR/configure_libmesh.sh
 export INSTALL_BINARY="${SRC_DIR}/build-aux/install-sh -C"
 METHODS="opt oprof devel dbg" configure_libmesh --prefix=${PREFIX}/libmesh \
+                                                --with-future-timpi-dir=${PREFIX}/libmesh \
                                                 --with-vtk-lib=${BUILD_PREFIX}/libmesh-vtk/lib \
                                                 --with-vtk-include=${BUILD_PREFIX}/libmesh-vtk/include/vtk-${SHORT_VTK_NAME} \
                                                 $*

--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -74,11 +74,10 @@ fi
 
 source $SRC_DIR/configure_libmesh.sh
 export INSTALL_BINARY="${SRC_DIR}/build-aux/install-sh -C"
-METHODS="opt oprof devel dbg" configure_libmesh --prefix=${PREFIX}/libmesh \
-                                                --with-future-timpi-dir=${PREFIX}/libmesh \
-                                                --with-vtk-lib=${BUILD_PREFIX}/libmesh-vtk/lib \
-                                                --with-vtk-include=${BUILD_PREFIX}/libmesh-vtk/include/vtk-${SHORT_VTK_NAME} \
-                                                $*
+LIBMESH_DIR=${PREFIX}/libmesh METHODS="opt oprof devel dbg" \
+  configure_libmesh --with-vtk-lib=${BUILD_PREFIX}/libmesh-vtk/lib \
+                    --with-vtk-include=${BUILD_PREFIX}/libmesh-vtk/include/vtk-${SHORT_VTK_NAME} \
+                    $*
 
 make -j $CPU_COUNT
 make install

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2021.11.10" %}
+{% set version = "2021.11.11" %}
 
 package:
   name: moose-libmesh

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 4 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2021.10.27" %}
+{% set version = "2021.11.10" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.11.10 build_0
+  - moose-libmesh 2021.11.11 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.10.27 build_4
+  - moose-libmesh 2021.11.10 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -43,17 +43,27 @@ If any issues with the new packages are experienced, please open a new
 
 ## libMesh-level Changes
 
-- Exodus IGA fix for multiblock files
-- fix vector-index out of range
-- Update TIMPI submodule
-- Use more macros from autoconf submodule
-- Dual shape function modification
-- IGA files need RATIONAL\_BERNSTEIN mapping even for w=1.0
-- Fix Apple M1 JIT
-- Initialize version\_number in Xdr class.
-- RB update: Enable EIM on element sides
-- Add SVD in preconditioner type
-- Only write Xdr header info on proc 0
-- Calculator app improvements
+- Changes to dual shape function initialization to enable edge
+  dropping and 3D mortar problems.
+- Refactored autoconf compiler option selection, to allow for testing
+  of submodules with stricter compiler settings.
+- Reduced Basis support for Empirical Interpolation Method
+  incorporation of integral terms on element sides.
+- API support for selecting SVD as a preconditioner type
+- Improvements to the ``calculator'' app, for visualizing projections
+  of parsed functions on meshes (and, optionally, pre-existing
+  solutions), to allow it to optionally noutput numeric integrals
+  instead.
+- Fix (or at least workaround for a compiler bug) for broken JIT
+  parsed function compilation on Apple M1 compilers. 
+- Fix for broken TIMPI communication of standard library structured
+  classes of large strings.
+- Fix for potential leak of TIMPI derived data types, causing valgrind
+  errors in some use cases.
+- Assorted minor bugfixes: for Exodus IGA reads of files with multiple
+  element blocks, for Exodus IGA files with homogeneous (implicit)
+  element weights, for element quality calculations on infinite hexes,
+  and for Xdr header writes and a potentially uninitialized Xdr
+  version variable.
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -43,13 +43,14 @@ If any issues with the new packages are experienced, please open a new
 
 ## libMesh-level Changes
 
+- Exodus IGA fix for multiblock files
 - fix vector-index out of range
 - Update TIMPI submodule
 - Use more macros from autoconf submodule
 - Dual shape function modification
-- IGA files need RATIONAL_BERNSTEIN mapping even for w=1.0
+- IGA files need RATIONAL\_BERNSTEIN mapping even for w=1.0
 - Fix Apple M1 JIT
-- Initialize version_number in Xdr class.
+- Initialize version\_number in Xdr class.
 - RB update: Enable EIM on element sides
 - Add SVD in preconditioner type
 - Only write Xdr header info on proc 0

--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -43,4 +43,16 @@ If any issues with the new packages are experienced, please open a new
 
 ## libMesh-level Changes
 
+- fix vector-index out of range
+- Update TIMPI submodule
+- Use more macros from autoconf submodule
+- Dual shape function modification
+- IGA files need RATIONAL_BERNSTEIN mapping even for w=1.0
+- Fix Apple M1 JIT
+- Initialize version_number in Xdr class.
+- RB update: Enable EIM on element sides
+- Add SVD in preconditioner type
+- Only write Xdr header info on proc 0
+- Calculator app improvements
+
 ## Bug Fixes and Minor Enhancements

--- a/scripts/configure_libmesh.sh
+++ b/scripts/configure_libmesh.sh
@@ -19,8 +19,14 @@ function configure_libmesh()
     echo "SRC_DIR is not set for configure_libmesh"
     exit 1
   fi
+
   if [ ! -d "$SRC_DIR" ]; then
     echo "$SRC_DIR=SRC_DIR does not exist"
+    exit 1
+  fi
+
+  if [ -z "$LIBMESH_DIR" ]; then
+    echo "$LIBMESH_DIR is not set for configure_libmesh"
     exit 1
   fi
 
@@ -49,6 +55,8 @@ function configure_libmesh()
                --with-cxx-std-min=2014 \
                --without-gdb-command \
                --with-methods="${METHODS}" \
+               --prefix="${LIBMESH_DIR}" \
+               --with-future-timpi-dir="${LIBMESH_DIR}" \
                INSTALL="${INSTALL_BINARY}" \
                $*
 

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -164,6 +164,7 @@ if [ -z "$go_fast" ]; then
 
   source $SCRIPT_DIR/configure_libmesh.sh
   SRC_DIR=${SCRIPT_DIR}/../libmesh configure_libmesh --prefix=$LIBMESH_DIR \
+                                                     --with-future-timpi-dir=$LIBMESH_DIR \
                                                      $DISABLE_TIMESTAMPS \
                                                      $VTK_OPTIONS \
                                                      $* | tee -a "$SCRIPT_DIR/$DIAGNOSTIC_LOG" || exit 1

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -163,9 +163,7 @@ if [ -z "$go_fast" ]; then
   fi
 
   source $SCRIPT_DIR/configure_libmesh.sh
-  SRC_DIR=${SCRIPT_DIR}/../libmesh configure_libmesh --prefix=$LIBMESH_DIR \
-                                                     --with-future-timpi-dir=$LIBMESH_DIR \
-                                                     $DISABLE_TIMESTAMPS \
+  SRC_DIR=${SCRIPT_DIR}/../libmesh configure_libmesh $DISABLE_TIMESTAMPS \
                                                      $VTK_OPTIONS \
                                                      $* | tee -a "$SCRIPT_DIR/$DIAGNOSTIC_LOG" || exit 1
 else


### PR DESCRIPTION
Summary of changes:

- Exodus IGA fix for multiblock files
- fix vector-index out of range
- Update TIMPI submodule
- Use more macros from autoconf submodule
- Dual shape function modification
- IGA files need RATIONAL\_BERNSTEIN mapping even for w=1.0
- Fix Apple M1 JIT
- Initialize version\_number in Xdr class.
- RB update: Enable EIM on element sides
- Add SVD in preconditioner type
- Only write Xdr header info on proc 0
- Calculator app improvements

Refs #0

Refs #18768 - the bugfix here gets multi-subdomain Exodus IGA files working

This also cherry-picks the previous updates necessary for #19349 - I'm hoping that whatever's causing problems there is in the *non*-libMesh-update commits.