### PR TITLE
Remove reference to temporary warning

### DIFF
--- a/test/src/userobjects/ReporterSpecialTypeTest.C
+++ b/test/src/userobjects/ReporterSpecialTypeTest.C
@@ -30,7 +30,7 @@ ReporterSpecialTypeTest::ReporterSpecialTypeTest(const InputParameters & params)
   getReporterValue<Real>("pp_reporter");
   getReporterValue<VectorPostprocessorValue>("vpp_reporter");
 
-  for (const std::string & name : {"pp_reporter", "vpp_reporter"})
+  for (const auto & name : {"pp_reporter", "vpp_reporter"})
     if (isPostprocessor(name) || isVectorPostprocessor(name))
       mooseError("Is a special type");
 }


### PR DESCRIPTION
We're binding a reference to a temporary because we actually construct a
string from a const char *. By changing this to `auto` we actually
create a reference to const char * instead of to a string, avoiding the
implicit copy

Refs #19394
