### PR TITLE
Configure libMesh to require C++17

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2021.11.11" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.11.11 build_0
+  - moose-libmesh 2021.11.11 build_1
 
 SHORT_VTK_NAME:
   - 9.1

--- a/scripts/configure_libmesh.sh
+++ b/scripts/configure_libmesh.sh
@@ -52,7 +52,7 @@ function configure_libmesh()
                --disable-maintainer-mode \
                --enable-petsc-hypre-required \
                --enable-metaphysicl-required \
-               --with-cxx-std-min=2014 \
+               --with-cxx-std-min=2017 \
                --without-gdb-command \
                --with-methods="${METHODS}" \
                --prefix="${LIBMESH_DIR}" \


### PR DESCRIPTION
Logan recommended giving this a push through CI to see what screams at
us, before we go whole hog and start allowing C++14-incompatible code in
libMesh and MOOSE, as per the discussion in
https://github.com/libMesh/MetaPhysicL/pull/5

In theory we're already requesting C++17 from every compiler that
supports it, which should be everything in the current Moose test suite
except "Minimum gcc version", and we'll have to update that from gcc 5
to gcc 7.

Refs #0

## Reason
C++17 is excellent.  Parallel algorithms and execution policies!  Spherical associated Legendre polynomials in the standard library!  Compile-time constexpr if and constexpr lambdas!  Inline variables!  Structured binding declarations!  Map/set merge!  

## Design
libMesh currently assumes we would like C++17; instead it will now be told that we demand C++17, and it will give an error at configure-time in `update_and_rebuild_libmesh.sh` if we don't have it, so we'll be safe to write C++17 code without users getting a much more confusing error message much later.

## Impact
Users without C++17-compatible compilers will have to install one (even RHEL6, released in 2010, now has this as a standard option) or build one (two have been freely available since 2018).  We will have to update the minimum gcc version we support.