### PR TITLE
Fix deprecated code uses

### DIFF
--- a/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
@@ -86,7 +86,7 @@ CoarseMeshExtraElementIDGenerator::generate()
   MeshSerializer tm(*coarse_mesh);
 
   // build a point_locator on coarse mesh
-  UniquePtr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE_ELEMENTS, *coarse_mesh);
+  std::unique_ptr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE_ELEMENTS, *coarse_mesh);
   point_locator->enable_out_of_mesh_mode();
 
   // loop through fine mesh elements and get element's centroid

--- a/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
@@ -118,7 +118,7 @@ CoarseMeshExtraElementIDGenerator::generate()
     {
       // Get the node: we need to manually move it towards the centroid to
       // ensure that nothing weird happes due to round-off
-      Node current_node = elem->node_ref(n);
+      Point current_node = elem->point(n);
       current_node.add_scaled(current_node, -aeps);
       current_node.add_scaled(centroid, aeps);
 

--- a/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoarseMeshExtraElementIDGenerator.C
@@ -86,7 +86,8 @@ CoarseMeshExtraElementIDGenerator::generate()
   MeshSerializer tm(*coarse_mesh);
 
   // build a point_locator on coarse mesh
-  std::unique_ptr<PointLocatorBase> point_locator = PointLocatorBase::build(TREE_ELEMENTS, *coarse_mesh);
+  std::unique_ptr<PointLocatorBase> point_locator =
+      PointLocatorBase::build(TREE_ELEMENTS, *coarse_mesh);
   point_locator->enable_out_of_mesh_mode();
 
   // loop through fine mesh elements and get element's centroid

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -730,21 +730,21 @@ PatternedHexMeshGenerator::generate()
     MooseMesh::changeBoundaryId(*out_mesh, OUTER_SIDESET_ID, _external_boundary_id, false);
   if (!_external_boundary_name.empty())
   {
-    out_mesh->boundary_info->sideset_name(
+    out_mesh->get_boundary_info().sideset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
-    out_mesh->boundary_info->nodeset_name(
+    out_mesh->get_boundary_info().nodeset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
   }
   // assign sideset and nodeset maps
-  auto & new_sideset_map = out_mesh->boundary_info->set_sideset_name_map();
-  auto & new_nodeset_map = out_mesh->boundary_info->set_nodeset_name_map();
+  auto & new_sideset_map = out_mesh->get_boundary_info().set_sideset_name_map();
+  auto & new_nodeset_map = out_mesh->get_boundary_info().set_nodeset_name_map();
   for (unsigned int i = 0; i < meshes.size(); i++)
   {
-    const auto input_sideset_map = meshes[i]->boundary_info->get_sideset_name_map();
+    const auto input_sideset_map = meshes[i]->get_boundary_info().get_sideset_name_map();
     new_sideset_map.insert(input_sideset_map.begin(), input_sideset_map.end());
-    const auto input_nodeset_map = meshes[i]->boundary_info->get_nodeset_name_map();
+    const auto input_nodeset_map = meshes[i]->get_boundary_info().get_nodeset_name_map();
     new_nodeset_map.insert(input_nodeset_map.begin(), input_nodeset_map.end());
   }
 

--- a/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
@@ -535,10 +535,10 @@ PolygonConcentricCircleMeshGeneratorBase::generate()
         _has_rings ? (_ring_intervals.front() > 1 ? 2 : 1) : (_background_intervals > 1 ? 2 : 1);
     for (unsigned int i = 0; i < _interface_boundary_names.size(); i++)
     {
-      mesh0->get_boundary_info().sideset_name(i + interface_id_shift + _interface_boundary_id_shift) =
-          _interface_boundary_names[i];
-      mesh0->get_boundary_info().nodeset_name(i + interface_id_shift + _interface_boundary_id_shift) =
-          _interface_boundary_names[i];
+      mesh0->get_boundary_info().sideset_name(
+          i + interface_id_shift + _interface_boundary_id_shift) = _interface_boundary_names[i];
+      mesh0->get_boundary_info().nodeset_name(
+          i + interface_id_shift + _interface_boundary_id_shift) = _interface_boundary_names[i];
     }
   }
   return dynamic_pointer_cast<MeshBase>(mesh0);

--- a/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
@@ -522,10 +522,10 @@ PolygonConcentricCircleMeshGeneratorBase::generate()
     MooseMesh::changeBoundaryId(*mesh0, OUTER_SIDESET_ID, _external_boundary_id, false);
   if (!_external_boundary_name.empty())
   {
-    mesh0->boundary_info->sideset_name(
+    mesh0->get_boundary_info().sideset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
-    mesh0->boundary_info->nodeset_name(
+    mesh0->get_boundary_info().nodeset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
   }
@@ -535,9 +535,9 @@ PolygonConcentricCircleMeshGeneratorBase::generate()
         _has_rings ? (_ring_intervals.front() > 1 ? 2 : 1) : (_background_intervals > 1 ? 2 : 1);
     for (unsigned int i = 0; i < _interface_boundary_names.size(); i++)
     {
-      mesh0->boundary_info->sideset_name(i + interface_id_shift + _interface_boundary_id_shift) =
+      mesh0->get_boundary_info().sideset_name(i + interface_id_shift + _interface_boundary_id_shift) =
           _interface_boundary_names[i];
-      mesh0->boundary_info->nodeset_name(i + interface_id_shift + _interface_boundary_id_shift) =
+      mesh0->get_boundary_info().nodeset_name(i + interface_id_shift + _interface_boundary_id_shift) =
           _interface_boundary_names[i];
     }
   }

--- a/modules/reactor/src/meshgenerators/SimpleHexagonGenerator.C
+++ b/modules/reactor/src/meshgenerators/SimpleHexagonGenerator.C
@@ -144,10 +144,10 @@ SimpleHexagonGenerator::generate()
     MooseMesh::changeBoundaryId(*mesh, OUTER_SIDESET_ID, _external_boundary_id, false);
   if (!_external_boundary_name.empty())
   {
-    mesh->boundary_info->sideset_name(
+    mesh->get_boundary_info().sideset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
-    mesh->boundary_info->nodeset_name(
+    mesh->get_boundary_info().nodeset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
   }


### PR DESCRIPTION
Another round of upgrades for deprecated-by-libMesh code that slipped into Moose.  A couple of these APIs will be progressing from "deprecated" to "removed" shortly, too.

Refs #13921