### PR TITLE
Unveil November 2021 news

### DIFF
--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -21,7 +21,8 @@ perform the following command:
 conda update --all
 ```
 
-where the appropriate versions and build in the update output should be:
+where the appropriate versions and build numbers in the update output should be at least the 
+following:
 
 ```
 Package                  Version            Build
@@ -31,8 +32,9 @@ moose-mpich              3.3.2              build_8
 moose-petsc              3.15.1             build_3
 ```
 
-If any issues with the new packages are experienced, please open a new
-[Discussions post](https://github.com/idaholab/moose/discussions)!
+Versions and build numbers will increment over time as MOOSE is updated, and the above represents 
+the version/build when compatibility was first enabled. If any issues with the new packages are 
+experienced, please open a new [Discussions post](https://github.com/idaholab/moose/discussions)!
 
 ## Legacy Input Parameter Deprecation
 

--- a/modules/doc/content/newsletter/2021_11.md
+++ b/modules/doc/content/newsletter/2021_11.md
@@ -1,10 +1,5 @@
 # MOOSE Newsletter (November 2021)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in December 2021
-for a complete description of all MOOSE changes.
-!alert-end!
-
 ## MOOSE Conda Packages Now Compatible with Xcode Newer Than 12.4, MacOS Monterey
 
 Conda package updates for `moose-mpich`, `moose-petsc`, and `moose-libmesh` were
@@ -148,7 +143,7 @@ with most configurations (see the documentation for more details).
 - Reduced Basis support for Empirical Interpolation Method
   incorporation of integral terms on element sides.
 - API support for selecting SVD as a preconditioner type
-- Improvements to the ``calculator'' app, for visualizing projections
+- Improvements to the "calculator" app, for visualizing projections
   of parsed functions on meshes (and, optionally, pre-existing
   solutions), to allow it to optionally noutput numeric integrals
   instead.

--- a/modules/doc/content/newsletter/2021_12.md
+++ b/modules/doc/content/newsletter/2021_12.md
@@ -1,0 +1,12 @@
+# MOOSE Newsletter (December 2021)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in January 2022
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -7,6 +7,7 @@ provided below.
 
 ## 2021
 
+- [November, 2021](2021_11.md)
 - [October, 2021](2021_10.md)
 - [September, 2021](2021_09.md)
 - [August, 2021](2021_08.md)


### PR DESCRIPTION
It is now December, so we should make November visible. Also add in-progress page for December, and fix typo in November news.

Refs #11447
