### PR TITLE
Added in citation to the JOSS article 'The MOOSE geochemistry module'

### DIFF
--- a/modules/doc/content/citing.md
+++ b/modules/doc/content/citing.md
@@ -230,6 +230,25 @@ The following papers present the governing equations of the MOOSE Porous Flow mo
 }
 ```
 
+### Geochemistry Module
+
+The following paper introduces the MOOSE Geochemistry module, along with discussions of its capabilities and implementation details:
+
+```
+@article{Wilkins2021,
+  doi = {10.21105/joss.03314},
+  url = {https://doi.org/10.21105/joss.03314},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {68},
+  pages = {3314},
+  author = {Andy Wilkins and Christopher P. Green and Logan Harbour and Robert Podgorney},
+  title = {The MOOSE geochemistry module},
+  journal = {Journal of Open Source Software}
+}
+```
+
 ### XFEM
 
 The following papers document various aspects of the MOOSE XFEM module.

--- a/modules/geochemistry/doc/content/bib/geochemistry.bib
+++ b/modules/geochemistry/doc/content/bib/geochemistry.bib
@@ -1,3 +1,16 @@
+@article{Wilkins2021,
+  doi = {10.21105/joss.03314},
+  url = {https://doi.org/10.21105/joss.03314},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {68},
+  pages = {3314},
+  author = {Andy Wilkins and Christopher P. Green and Logan Harbour and Robert Podgorney},
+  title = {The MOOSE geochemistry module},
+  journal = {Journal of Open Source Software}
+}
+
 @book{bethke_2007,
     author = "Bethke, Craig M.",
     place = "Cambridge",


### PR DESCRIPTION
closes #19521

## Reason
Update reference list with newly-published JOSS geochemistry paper

## Design
Added in reference to https://doi.org/10.21105/joss.03314 to `citing.md` and into the `geochemistry.bib` file

## Impact
Up-to-date bibliography

