### PR TITLE
Add magnitude and function name interfaces. Refs #19555

### DIFF
--- a/framework/include/ics/FunctionIC.h
+++ b/framework/include/ics/FunctionIC.h
@@ -36,8 +36,7 @@ public:
   FunctionIC(const InputParameters & parameters);
 
   /**
-   * Get the function name
-   * @return function name
+   * @returns The function name
    */
   const FunctionName functionName() const;
 

--- a/framework/include/ics/FunctionIC.h
+++ b/framework/include/ics/FunctionIC.h
@@ -35,6 +35,12 @@ public:
 
   FunctionIC(const InputParameters & parameters);
 
+  /**
+   * Get the function name
+   * @return function name
+   */
+  const FunctionName functionName() const;
+
 protected:
   /**
    * Evaluate the function at the current quadrature point and time step.

--- a/framework/include/ics/IntegralPreservingFunctionIC.h
+++ b/framework/include/ics/IntegralPreservingFunctionIC.h
@@ -25,10 +25,9 @@ public:
   virtual void initialSetup() override;
 
   /**
-   * Get the magnitude of the function
-   * @return magnitude
+   * @returns The magnitude of the function
    */
-  virtual Real magnitude() const { return _magnitude; }
+  Real magnitude() const { return _magnitude; }
 
 protected:
   virtual Real value(const Point & p) override;

--- a/framework/include/ics/IntegralPreservingFunctionIC.h
+++ b/framework/include/ics/IntegralPreservingFunctionIC.h
@@ -24,6 +24,12 @@ public:
 
   virtual void initialSetup() override;
 
+  /**
+   * Get the magnitude of the function
+   * @return magnitude
+   */
+  virtual Real magnitude() const { return _magnitude; }
+
 protected:
   virtual Real value(const Point & p) override;
 

--- a/framework/src/ics/FunctionIC.C
+++ b/framework/src/ics/FunctionIC.C
@@ -45,3 +45,9 @@ FunctionIC::gradient(const Point & p)
 {
   return _scaling * _func.gradient(_t, p);
 }
+
+const FunctionName
+FunctionIC::functionName() const
+{
+  return _func.name();
+}

--- a/framework/src/ics/IntegralPreservingFunctionIC.C
+++ b/framework/src/ics/IntegralPreservingFunctionIC.C
@@ -48,5 +48,5 @@ IntegralPreservingFunctionIC::value(const Point & p)
   if (std::abs(_integral) < libMesh::TOLERANCE)
     mooseError("The integral of '" + _pp_name + "' cannot be zero!");
 
-  return _magnitude * _func.value(_t, p) / _integral;
+  return magnitude() * _func.value(_t, p) / _integral;
 }


### PR DESCRIPTION
Adds necessary APIs for Cardinal to set up these ICs automatically, with a subsequent IC that depends on the function provided to the `IntegralPreservingFunctionIC`.

Closes #19555