### PR TITLE
Elem::centroid() -> Elem::vertex_average()

### DIFF
--- a/framework/src/meshgenerators/PlaneIDMeshGenerator.C
+++ b/framework/src/meshgenerators/PlaneIDMeshGenerator.C
@@ -77,12 +77,12 @@ PlaneIDMeshGenerator::generate()
   const Real tol = getParam<Real>("tolerance");
   for (auto & elem : mesh->active_element_ptr_range())
   {
-    const int layer_id = getPlaneID(elem->centroid());
+    const int layer_id = getPlaneID(elem->vertex_average());
     for (unsigned int i = 0; i < elem->n_nodes(); ++i)
     {
-      const Point & p = elem->point(i) - (elem->point(i) - elem->centroid()) * tol;
+      const Point & p = elem->point(i) - (elem->point(i) - elem->vertex_average()) * tol;
       if (getPlaneID(p) != layer_id)
-        mooseError("Element at ", elem->centroid(), " is cut by the planes");
+        mooseError("Element at ", elem->vertex_average(), " is cut by the planes");
     }
     elem->set_extra_integer(extra_id_index, layer_id);
   }


### PR DESCRIPTION
## Reason
This makes code clearer and fixes compilation with --disable-deprecated libMesh builds.

## Design
libMesh deprecated Elem::centroid() due to its misleading name - that
method was actually returning a vertex average for most elements, even
when that average was not the true centroid.

For this application it looks like vertex_average() (which is faster
than a true_centroid() calculation in general) should work correctly;
let's request it explicitly.

## Impact
No negative impact; libMesh::Elem::centroid() is currently a deprecated shim to vertex_average() anyway.

Refs #13921