### PR TITLE
Swap-back sentinels for boundary aux kernels

### DIFF
--- a/framework/src/loops/ComputeElemAuxBcsThread.C
+++ b/framework/src/loops/ComputeElemAuxBcsThread.C
@@ -94,10 +94,9 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
         // Set up Sentinel class so that, even if reinitMaterialsFace() throws, we
         // still remember to swap back during stack unwinding.
         SwapBackSentinel sentinel(_problem, &FEProblem::swapBackMaterialsFace, _tid);
-        std::unique_ptr<SwapBackSentinel> neighbor_sentinel =
-            compute_interface ? std::make_unique<SwapBackSentinel>(
-                                    _problem, &FEProblem::swapBackMaterialsNeighbor, _tid)
-                              : nullptr;
+        SwapBackSentinel neighbor_sentinel(
+            _problem, &FEProblem::swapBackMaterialsNeighbor, _tid, compute_interface);
+
         if (_need_materials)
         {
           std::set<unsigned int> needed_mat_props;

--- a/framework/src/loops/ComputeElemAuxBcsThread.C
+++ b/framework/src/loops/ComputeElemAuxBcsThread.C
@@ -91,6 +91,13 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
             neighbor && neighbor->active() &&
             _problem.getInterfaceMaterialsWarehouse().hasActiveBoundaryObjects(boundary_id, _tid);
 
+        // Set up Sentinel class so that, even if reinitMaterialsFace() throws, we
+        // still remember to swap back during stack unwinding.
+        SwapBackSentinel sentinel(_problem, &FEProblem::swapBackMaterialsFace, _tid);
+        std::unique_ptr<SwapBackSentinel> neighbor_sentinel =
+            compute_interface ? std::make_unique<SwapBackSentinel>(
+                                    _problem, &FEProblem::swapBackMaterialsNeighbor, _tid)
+                              : nullptr;
         if (_need_materials)
         {
           std::set<unsigned int> needed_mat_props;
@@ -117,12 +124,7 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
           aux->compute();
 
         if (_need_materials)
-        {
-          _problem.swapBackMaterialsFace(_tid);
-          if (compute_interface)
-            _problem.swapBackMaterialsNeighbor(_tid);
           _problem.clearActiveMaterialProperties(_tid);
-        }
       }
 
       // update the solution vector


### PR DESCRIPTION
If an exception gets thrown out of reinitMaterialsXXX or callees of reinitMaterialsXXX then none of the remaining code in ComputeElemAuxBcsThread::operator() will get executed, e.g. in the old way, _problem.swapBackMaterialsXXX would never get called. However, the C++ language is nice enough that, even though it won't execute any following lines of code, it will destroy any scope-local variables, like these SwapBackSentinels. And in the destructors of SwapBackSentinel we call problem.swapBackMaterialsXXX.

This swap-back is necessary for stateful material properties ... essentially if you don't swap-back after swapping then you'll be likely to be operating on material properties in the future that aren't "stateful"; e.g. you'll be working with some null, uninitialized dummy quantity. This was the case here ... the sifgrs property never got swapped back so you wound up operating on some dummy quantity that had never been initialized/properly-sized 