### PR TITLE
Libmesh update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2021.11.11" %}
+{% set version = "2021.12.15" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.11.11 build_1
+  - moose-libmesh 2021.12.15 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/modules/doc/content/newsletter/2021_12.md
+++ b/modules/doc/content/newsletter/2021_12.md
@@ -9,4 +9,20 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+- More flexibility in transient adjoint calculations with libMesh::TimeSolver classes
+- Automatic support for TIMPI+MetaPhysicL integration, which enables easier
+  parallel communication when using Moose Automatic Differentiation
+- Compatibility with stricter GCC 11 warnings, avoidance of GCC 11
+  optimization flag problems
+- Optimizations (and for IsoGeometric Analysis problems, fixes) for
+  calculations on element edges, including projections onto higher
+  order elements with edge-based degrees of freedom
+- Configure option to require HDF5 detection, to ease building with newer
+  ExodusII library versions
+- Bug fixes in Reduced Basis code, conversion of meshes to second
+  order while preserving element integers
+- Support for converting spline-node-based IsoGeometric Analysis
+  meshes into unconstrained C0 rational Bernstein-Bezier form
+- Side element construction caching class, optimizations
+
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
Summary of libMesh changes:
  - SolutionHistory based on HistoryData
  - add documentation misc 14
  - Automatic support for configuring MetaPhysicL to use TIMPI
  - Fix "make coverage -j"
  - Refactor unsteady adjoint operation order
  - Fixes + workarounds for GCC 11 warnings, runtime error
  - Mapping fixes, optimizations
  - Add ExodusII_IO::get_nodeset_data_indices()
  - RBEIMEvaluation fix
  - Add --enable-hdf5-required option to configure
  - Add helper for building element sides that minimizes construction
  - MeshTools::clear_spline_nodes() support
  - Fix all_second_order() bug with extra integers
  - EIM fix
  - poly2tri submodule in contrib