### PR TITLE
Allow variables to be used when initing neighbor stateful props

### DIFF
--- a/framework/include/loops/ProjectMaterialProperties.h
+++ b/framework/include/loops/ProjectMaterialProperties.h
@@ -64,4 +64,14 @@ protected:
   const MaterialWarehouse & _materials;
   /// Discrete materials warehouse
   const MaterialWarehouse & _discrete_materials;
+
+private:
+  bool shouldComputeInternalSide(const Elem & /*elem*/, const Elem & /*neighbor*/) const override;
 };
+
+inline bool
+ProjectMaterialProperties::shouldComputeInternalSide(const Elem & /*elem*/,
+                                                     const Elem & /*neighbor*/) const
+{
+  return true;
+}

--- a/framework/src/loops/ComputeMaterialsObjectThread.C
+++ b/framework/src/loops/ComputeMaterialsObjectThread.C
@@ -172,19 +172,6 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
   if (_need_internal_side_material)
   {
     const Elem * neighbor = elem->neighbor_ptr(side);
-    const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();
-
-    // When looping over elements and then sides, we need to make sure that we not duplicate effort,
-    // e.g. if a face is shared by element 1 and element 2, then we do not want to do compute work
-    // both when we are visiting element 1 *and* then later when visiting element 2. Our rule is to
-    // only compute when we are visting the element that has the lower element id when element and
-    // neighbor are of the same adaptivity level, and then if they are not of the same level, then
-    // we only compute when we are visiting the finer element
-    const bool should_continue =
-        (neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) ||
-        (neighbor->level() < elem->level());
-    if (!should_continue)
-      return;
 
     _fe_problem.reinitElemNeighborAndLowerD(elem, side, _tid);
     unsigned int face_n_points = _assembly[_tid]->qRuleFace()->n_points();

--- a/framework/src/loops/ComputeMaterialsObjectThread.C
+++ b/framework/src/loops/ComputeMaterialsObjectThread.C
@@ -173,6 +173,13 @@ ComputeMaterialsObjectThread::onInternalSide(const Elem * elem, unsigned int sid
   {
     const Elem * neighbor = elem->neighbor_ptr(side);
     const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();
+
+    // When looping over elements and then sides, we need to make sure that we not duplicate effort,
+    // e.g. if a face is shared by element 1 and element 2, then we do not want to do compute work
+    // both when we are visiting element 1 *and* then later when visiting element 2. Our rule is to
+    // only compute when we are visting the element that has the lower element id when element and
+    // neighbor are of the same adaptivity level, and then if they are not of the same level, then
+    // we only compute when we are visiting the finer element
     const bool should_continue =
         (neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) ||
         (neighbor->level() < elem->level());

--- a/framework/src/loops/ComputeResidualThread.C
+++ b/framework/src/loops/ComputeResidualThread.C
@@ -254,32 +254,25 @@ ComputeResidualThread::onInternalSide(const Elem * elem, unsigned int side)
     // Pointer to the neighbor we are currently working on.
     const Elem * neighbor = elem->neighbor_ptr(side);
 
-    // Get the global id of the element and the neighbor
-    const dof_id_type elem_id = elem->id(), neighbor_id = neighbor->id();
+    _fe_problem.reinitElemNeighborAndLowerD(elem, side, _tid);
 
-    if ((neighbor->active() && (neighbor->level() == elem->level()) && (elem_id < neighbor_id)) ||
-        (neighbor->level() < elem->level()))
+    // Set up Sentinels so that, even if one of the reinitMaterialsXXX() calls throws, we
+    // still remember to swap back during stack unwinding.
+    SwapBackSentinel face_sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
+    _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
+
+    SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
+    _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
+
+    const auto & dgks = _dg_warehouse->getActiveBlockObjects(_subdomain, _tid);
+    for (const auto & dg_kernel : dgks)
+      if (dg_kernel->hasBlocks(neighbor->subdomain_id()))
+        dg_kernel->computeResidual();
+
     {
-      _fe_problem.reinitElemNeighborAndLowerD(elem, side, _tid);
-
-      // Set up Sentinels so that, even if one of the reinitMaterialsXXX() calls throws, we
-      // still remember to swap back during stack unwinding.
-      SwapBackSentinel face_sentinel(_fe_problem, &FEProblem::swapBackMaterialsFace, _tid);
-      _fe_problem.reinitMaterialsFace(elem->subdomain_id(), _tid);
-
-      SwapBackSentinel neighbor_sentinel(_fe_problem, &FEProblem::swapBackMaterialsNeighbor, _tid);
-      _fe_problem.reinitMaterialsNeighbor(neighbor->subdomain_id(), _tid);
-
-      const auto & dgks = _dg_warehouse->getActiveBlockObjects(_subdomain, _tid);
-      for (const auto & dg_kernel : dgks)
-        if (dg_kernel->hasBlocks(neighbor->subdomain_id()))
-          dg_kernel->computeResidual();
-
-      {
-        Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
-        _fe_problem.addResidualNeighbor(_tid);
-        _fe_problem.addResidualLower(_tid);
-      }
+      Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+      _fe_problem.addResidualNeighbor(_tid);
+      _fe_problem.addResidualLower(_tid);
     }
   }
 }

--- a/framework/src/vectorpostprocessors/WorkBalance.C
+++ b/framework/src/vectorpostprocessors/WorkBalance.C
@@ -233,6 +233,12 @@ public:
   ElemSideBuilder _elem_side_builder;
 
   std::unique_ptr<PetscExternalPartitioner> _petsc_partitioner;
+
+private:
+  bool shouldComputeInternalSide(const Elem & /*elem*/, const Elem & /*neighbor*/) const override
+  {
+    return true;
+  }
 };
 
 class WBNodeLoop : public ThreadedNodeLoop<ConstNodeRange, ConstNodeRange::const_iterator>

--- a/test/include/materials/VarCouplingMaterial.h
+++ b/test/include/materials/VarCouplingMaterial.h
@@ -28,6 +28,6 @@ protected:
   const VariableValue & _var;
   Real _base;
   Real _coef;
-  MaterialProperty<Real> & _diffusion;
-  const MaterialProperty<Real> * const _diffusion_old;
+  MaterialProperty<Real> & _coupled_prop;
+  const MaterialProperty<Real> * const _coupled_prop_old;
 };

--- a/test/src/materials/VarCouplingMaterial.C
+++ b/test/src/materials/VarCouplingMaterial.C
@@ -21,12 +21,16 @@ VarCouplingMaterial::validParams()
   params.addParam<bool>(
       "declare_old", false, "When True the old value for the material property is declared.");
   params.addParam<TagName>("tag", Moose::SOLUTION_TAG, "The solution vector to be coupled in");
+  params.addParam<bool>("use_tag",
+                        true,
+                        "Whether the coupled value should come from a tag. If false, then we use "
+                        "an ordinary coupled value.");
   return params;
 }
 
 VarCouplingMaterial::VarCouplingMaterial(const InputParameters & parameters)
   : Material(parameters),
-    _var(coupledVectorTagValue("var", "tag")),
+    _var(getParam<bool>("use_tag") ? coupledVectorTagValue("var", "tag") : coupledValue("var")),
     _base(getParam<Real>("base")),
     _coef(getParam<Real>("coef")),
     _diffusion(declareProperty<Real>("diffusion")),

--- a/test/tests/dgkernels/stateful-coupled-var/test.i
+++ b/test/tests/dgkernels/stateful-coupled-var/test.i
@@ -1,0 +1,73 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  xmin = 0
+  xmax = 1
+  ymin = 0
+  ymax = 1
+  elem_type = QUAD4
+[]
+
+[Variables]
+  [u]
+    order = FIRST
+    family = MONOMIAL
+  []
+[]
+
+[Functions]
+  [exact_fn]
+    type = ParsedGradFunction
+    value = pow(e,-x-(y*y))
+    grad_x = -pow(e,-x-(y*y))
+    grad_y = -2*y*pow(e,-x-(y*y))
+  []
+[]
+
+[Kernels]
+  [diff]
+    type = Diffusion
+    variable = u
+  []
+[]
+
+[DGKernels]
+  [dg_diff]
+    type = DGDiffusion
+    variable = u
+    epsilon = -1
+    sigma = 6
+    diff = diffusion
+  []
+[]
+
+[Materials]
+  [coupled_mat]
+    type = VarCouplingMaterial
+    var = u
+    declare_old = true
+    use_tag = false
+  []
+[]
+
+[BCs]
+  [all]
+    type = DGFunctionDiffusionDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    function = exact_fn
+    epsilon = -1
+    sigma = 6
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/dgkernels/stateful-coupled-var/tests
+++ b/test/tests/dgkernels/stateful-coupled-var/tests
@@ -1,0 +1,9 @@
+[Tests]
+  issues = '#19735'
+  design = 'Materials/index.md'
+  [run]
+    type = RunApp
+    input = test.i
+    requirement = 'The system shall be able to use variables when initializing stateful material properties on neighbor materials used for the discontinuous Galerkin method.'
+  []
+[]


### PR DESCRIPTION
Previously we did not reinit the variables so you would get a bad access
if you used a variable when initializing the neighbor version of
stateful material properties. I'm honestly a little surprised we never
hit this before

Closes #19735
