### PR TITLE
Remove boundary conditions parameters from addBCAction, 

### DIFF
--- a/framework/src/actions/AddBCAction.C
+++ b/framework/src/actions/AddBCAction.C
@@ -19,7 +19,6 @@ InputParameters
 AddBCAction::validParams()
 {
   InputParameters params = MooseObjectAction::validParams();
-  params += BoundaryCondition::validParams();
   params.addClassDescription("Add a BoundaryCondition object to the simulation.");
   return params;
 }


### PR DESCRIPTION
I think that was added by mistake. This was creating parameter confusion for https://github.com/idaholab/moose/discussions/19929#discussioncomment-1893437

refs #14135 the original issue for that code
