### PR TITLE
Use default arg `Communicator::get_unique_tag()` everywhere

### DIFF
--- a/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
+++ b/framework/src/meshgenerators/ElementDeletionGeneratorBase.C
@@ -140,8 +140,8 @@ ElementDeletionGeneratorBase::generate()
           queries[pid].push_back(std::make_pair(elem->id(), n));
     }
 
-    Parallel::MessageTag queries_tag = mesh->comm().get_unique_tag(42),
-                         replies_tag = mesh->comm().get_unique_tag(6 * 9);
+    const auto queries_tag = mesh->comm().get_unique_tag(),
+               replies_tag = mesh->comm().get_unique_tag();
 
     std::vector<Parallel::Request> query_requests(my_n_proc - 1), reply_requests(my_n_proc - 1);
 

--- a/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
+++ b/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
@@ -143,8 +143,8 @@ SideSetsAroundSubdomainGenerator::generate()
 
   if (!mesh->is_serial())
   {
-    Parallel::MessageTag queries_tag = mesh->comm().get_unique_tag(867),
-                         replies_tag = mesh->comm().get_unique_tag(5309);
+    const auto queries_tag = mesh->comm().get_unique_tag(),
+               replies_tag = mesh->comm().get_unique_tag();
 
     std::vector<Parallel::Request> side_requests(my_n_proc - 1), reply_requests(my_n_proc - 1);
 

--- a/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
@@ -106,8 +106,8 @@ SideSetsBetweenSubdomainsGenerator::generate()
 
   if (!mesh->is_serial())
   {
-    Parallel::MessageTag queries_tag = mesh->comm().get_unique_tag(867),
-                         replies_tag = mesh->comm().get_unique_tag(5309);
+    const auto queries_tag = mesh->comm().get_unique_tag(),
+               replies_tag = mesh->comm().get_unique_tag();
 
     std::vector<Parallel::Request> side_requests(my_n_proc - 1), reply_requests(my_n_proc - 1);
 

--- a/modules/ray_tracing/include/utils/ParallelStudy.h
+++ b/modules/ray_tracing/include/utils/ParallelStudy.h
@@ -391,7 +391,7 @@ ParallelStudy<WorkType, ParallelDataType>::ParallelStudy(
     _clicks_per_root_communication(params.get<unsigned int>("clicks_per_root_communication")),
     _clicks_per_receive(params.get<unsigned int>("clicks_per_receive")),
 
-    _parallel_data_buffer_tag(Parallel::MessageTag(100)),
+    _parallel_data_buffer_tag(comm.get_unique_tag()),
     _parallel_data_pools(libMesh::n_threads()),
     _temp_threaded_work(libMesh::n_threads()),
     _work_buffer(createWorkBuffer()),
@@ -819,7 +819,7 @@ ParallelStudy<WorkType, ParallelDataType>::harmExecute()
   // Work completed by each processor
   std::vector<unsigned long long int> work_completed_per_proc(comm().size(), 0);
   // Tag for sending work finished
-  Parallel::MessageTag work_completed_requests_tag = Parallel::MessageTag(21000);
+  const auto work_completed_requests_tag = comm().get_unique_tag();
 
   // Get the amount of work that was started in the whole domain
   comm().sum(_local_work_started, _total_work_started, work_started_request);


### PR DESCRIPTION
Closes #19968

Easy one for you @roystgnr 