### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2021.12.15" %}
+{% set version = "2022.01.19" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2021.12.15 build_1
+  - moose-libmesh 2022.01.19 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/modules/doc/content/newsletter/2022_01.md
+++ b/modules/doc/content/newsletter/2022_01.md
@@ -32,7 +32,7 @@ moose-petsc              3.15.1             build_4
 
 ## libMesh-level Changes
 
-- Make 1CompareDofObjectsByID` available to all. This is useful for building sets
+- Make `CompareDofObjectsByID` available to all. This is useful for building sets
   of node and element pointers that have more deterministic ordering than if the
   set was ordered based on the pointer addresses
 - Make use of `std::condition_variable` for `_get_array`. Eliminates helgrind

--- a/modules/doc/content/newsletter/2022_01.md
+++ b/modules/doc/content/newsletter/2022_01.md
@@ -32,6 +32,23 @@ moose-petsc              3.15.1             build_4
 
 ## libMesh-level Changes
 
+- Make 1CompareDofObjectsByID` available to all. This is useful for building sets
+  of node and element pointers that have more deterministic ordering than if the
+  set was ordered based on the pointer addresses
+- Make use of `std::condition_variable` for `_get_array`. Eliminates helgrind
+  errors during multi-thread access to `PetscVector::get`
+- Update to TIMPI 1.8.2
+- Nanoflann update to 1.4.1
+- Use get_unique_tag() for a few more MessageTags
+- Remove caching from FE<CLOUGH>
+- Higher precision when printing assert failures
+- resolve warning of expectedly unbinned entries.
+- Clear input data structure before using
+- Don't unnecessarily compute the Jacobian for ComputeResidualandJacobian. This
+  optimization will likely be leveraged in MOOSE in order to compute the residual
+  and Jacobian simultaneously, avoiding duplicate variable and material property
+  reinitialization.
+
 ## Bug Fixes and Minor Enhancements
 
 - A boolean parameter `extrap` was added to [PiecewiseLinear.md], which when set

--- a/scripts/configure_libmesh.sh
+++ b/scripts/configure_libmesh.sh
@@ -45,7 +45,6 @@ function configure_libmesh()
   ../configure --enable-silent-rules \
                --enable-unique-id \
                --disable-warnings \
-               --enable-glibcxx-debugging \
                --with-thread-model=openmp \
                --disable-maintainer-mode \
                --enable-petsc-hypre-required \


### PR DESCRIPTION
Summary of changes:
  - Make CompareDofObjectsByID available to all
  - Make use of std::condition_variable for _get_array
  - Update to TIMPI 1.8.2
  - Check processor id of point neighbors
  - Nanoflann update to 1.4.1
  - Update to TIMPI 1.8.1
  - Use get_unique_tag() for a few more MessageTags
  - Remove caching from FE<CLOUGH>
  - Higher precision when printing assert failures
  - resolve warning of expectedly unbinned entries.
  - Clear input data structure before using
  - Don't unnecessarily compute the Jacobian for ComputeResidualandJacobian
