### PR TITLE
Add December 2021 newsletter

### DIFF
--- a/modules/doc/content/newsletter/2021_12.md
+++ b/modules/doc/content/newsletter/2021_12.md
@@ -1,12 +1,5 @@
 # MOOSE Newsletter (December 2021)
 
-!alert! construction title=In Progress
-This MOOSE Newsletter edition is in progress. Please check back in January 2022
-for a complete description of all MOOSE changes.
-!alert-end!
-
-## MOOSE Improvements
-
 ## libMesh-level Changes
 
 - More flexibility in transient adjoint calculations with libMesh::TimeSolver classes
@@ -24,5 +17,3 @@ for a complete description of all MOOSE changes.
 - Support for converting spline-node-based IsoGeometric Analysis
   meshes into unconstrained C0 rational Bernstein-Bezier form
 - Side element construction caching class, optimizations
-
-## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/2022_01.md
+++ b/modules/doc/content/newsletter/2022_01.md
@@ -1,0 +1,12 @@
+# MOOSE Newsletter (January 2022)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in February 2022
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/index.md
+++ b/modules/doc/content/newsletter/index.md
@@ -7,6 +7,7 @@ provided below.
 
 ## 2021
 
+- [December, 2021](2021_12.md)
 - [November, 2021](2021_11.md)
 - [October, 2021](2021_10.md)
 - [September, 2021](2021_09.md)


### PR DESCRIPTION
Also adds placeholder for January 2022.

@idaholab/moose-ccb Last call for any additions to the December 2021 newsletter. This one ended up being a bit light, so giving one more notice to add content. 

Refs #11447
