### PR TITLE
Avoid allocating large dense matrix in EBSDReader

### DIFF
--- a/modules/tensor_mechanics/include/utils/EulerAngles.h
+++ b/modules/tensor_mechanics/include/utils/EulerAngles.h
@@ -29,7 +29,7 @@ public:
   // default constructor
   EulerAngles();
   // Quaternions to Euler Angles
-  EulerAngles(Eigen::Quaternion<Real> & q);
+  EulerAngles(const Eigen::Quaternion<Real> & q);
 
   operator RealVectorValue() const { return RealVectorValue(phi1, Phi, phi2); }
 

--- a/modules/tensor_mechanics/src/utils/EulerAngles.C
+++ b/modules/tensor_mechanics/src/utils/EulerAngles.C
@@ -18,7 +18,7 @@ EulerAngles::EulerAngles()
   phi2 = 0.0;
 }
 
-EulerAngles::EulerAngles(Eigen::Quaternion<Real> & q)
+EulerAngles::EulerAngles(const Eigen::Quaternion<Real> & q)
 {
   phi1 = std::atan2((q.x() * q.z() + q.w() * q.y()), -(-q.w() * q.x() + q.y() * q.z())) *
          (180.0 / libMesh::pi);


### PR DESCRIPTION
This should address the scalability issues reported by @frombs 
The algorithm now constructs `Q*w*Q^T` directly without constructing the `Q` and `w` matrices.

Closes #15418