### PR TITLE
Use an ordered set based on ID for secondary to msm container

### DIFF
--- a/framework/include/constraints/AutomaticMortarGeneration.h
+++ b/framework/include/constraints/AutomaticMortarGeneration.h
@@ -29,13 +29,13 @@
 namespace libMesh
 {
 class MeshBase;
-class Elem;
 class System;
 }
 class GetPot;
 
 // Using statements
 using libMesh::boundary_id_type;
+using libMesh::CompareDofObjectsByID;
 using libMesh::dof_id_type;
 using libMesh::Elem;
 using libMesh::MeshBase;
@@ -301,7 +301,7 @@ public:
   bool incorrectEdgeDropping() const { return !_correct_edge_dropping; }
 
   using MortarFilterIter =
-      std::unordered_map<const Elem *, std::unordered_set<Elem *>>::const_iterator;
+      std::unordered_map<const Elem *, std::set<Elem *, CompareDofObjectsByID>>::const_iterator;
 
   /**
    * @return A vector of iterators that point to the lower dimensional secondary elements and their
@@ -313,7 +313,7 @@ public:
   /**
    * @return the lower dimensional secondary elements and their associated mortar segment elements
    */
-  const std::unordered_map<const Elem *, std::unordered_set<Elem *>> &
+  const std::unordered_map<const Elem *, std::set<Elem *, CompareDofObjectsByID>> &
   secondariesToMortarSegments() const
   {
     return _secondary_elems_to_mortar_segments;
@@ -419,7 +419,8 @@ private:
   /// We maintain a mapping from lower-dimensional secondary elements in the original mesh to (sets
   /// of) elements in mortar_segment_mesh.  This allows us to quickly determine which elements need
   /// to be split.
-  std::unordered_map<const Elem *, std::unordered_set<Elem *>> _secondary_elems_to_mortar_segments;
+  std::unordered_map<const Elem *, std::set<Elem *, CompareDofObjectsByID>>
+      _secondary_elems_to_mortar_segments;
 
   /**
    * Helper function responsible for projecting secondary nodes

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -901,24 +901,13 @@ AutomaticMortarGeneration::buildMortarSegmentMesh3d()
       result_set.init(&ret_index[0], &out_dist_sqr[0]);
       kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParams(10));
 
-      struct CompareElemsByID
-      {
-        bool operator()(const Elem * a, const Elem * b) const
-        {
-          libmesh_assert(a);
-          libmesh_assert(b);
-
-          return a->id() < b->id();
-        }
-      };
-
       // Initialize list of processed primary elements, we don't want to revisit processed elements
-      std::set<const Elem *, CompareElemsByID> processed_primary_elems;
+      std::set<const Elem *, CompareDofObjectsByID> processed_primary_elems;
 
       // Initialize candidate set and flag for switching between coarse screening and breadth-first
       // search
       bool primary_elem_found = false;
-      std::set<const Elem *, CompareElemsByID> primary_elem_candidates;
+      std::set<const Elem *, CompareDofObjectsByID> primary_elem_candidates;
 
       // Loop candidate nodes (returned by Nanoflann) and add all adjoining elems to candidate set
       for (auto r : make_range(result_set.size()))

--- a/modules/contact/test/tests/bouncing-block-contact/frictionless-weighted-gap.i
+++ b/modules/contact/test/tests/bouncing-block-contact/frictionless-weighted-gap.i
@@ -122,7 +122,7 @@ offset = 1e-2
   l_max_its = 30
   nl_max_its = 20
   line_search = 'none'
-  snesmf_reuse_base = false
+  snesmf_reuse_base = true
 []
 
 [Debug]

--- a/modules/contact/test/tests/bouncing-block-contact/ping-ponging/mortar-no-ping-pong_weighted.i
+++ b/modules/contact/test/tests/bouncing-block-contact/ping-ponging/mortar-no-ping-pong_weighted.i
@@ -92,7 +92,7 @@ offset = 1e-2
   dt = 5
   dtmin = 5
   solve_type = 'PJFNK'
-  petsc_options = '-snes_converged_reason -ksp_converged_reason'
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_ksp_ew'
   petsc_options_iname = '-pc_type -mat_mffd_err -pc_factor_shift_type'
   petsc_options_value = 'lu       1e-5          NONZERO'
   l_max_its = 30
@@ -100,6 +100,7 @@ offset = 1e-2
   nl_abs_tol = 1e-10
   nl_rel_tol = 1e-10
   line_search = 'none'
+  snesmf_reuse_base = true
 []
 
 [Debug]

--- a/modules/contact/test/tests/mechanical-small-problem/frictionless-nodal-lm-mortar-disp.i
+++ b/modules/contact/test/tests/mechanical-small-problem/frictionless-nodal-lm-mortar-disp.i
@@ -127,8 +127,6 @@
   dtmin = 1
   petsc_options_iname = '-pc_type -snes_linesearch_type -pc_factor_shift_type -pc_factor_shift_amount'
   petsc_options_value = 'lu       basic                 NONZERO               1e-15'
-  # function is too noisy
-  snesmf_reuse_base = false
 []
 
 [Outputs]

--- a/modules/contact/test/tests/mechanical-small-problem/mortar-mech.i
+++ b/modules/contact/test/tests/mechanical-small-problem/mortar-mech.i
@@ -135,8 +135,6 @@
   dtmin = 1
   petsc_options_iname = '-pc_type -snes_linesearch_type -pc_factor_shift_type -pc_factor_shift_amount'
   petsc_options_value = 'lu       basic                 NONZERO               1e-15'
-  # This function is too noisy
-  snesmf_reuse_base = false
 []
 
 [Outputs]


### PR DESCRIPTION
I ran into occasional failures about reusing the base for matrix-free computations on CIVET and in repeated running locally (strangely only when running valgrind (which I should note never errored, it just was the only thing that helped trigger the libMesh failed assertion)). After some bisecting I tracked the change to moving from a vector sequence based on the msm ids to an unordered set based only the msm pointers. Because the msm mesh is rebuilt upon ever residual evaluation the address space used by the msm elements is liable to change and so the hashing and consequently the container iteration order is liable to change. This is what led to the reuse base errors. Because I always expect the number of mortar segments per secondary to be relatively small I think it makes cpu sense to switch to an ordered container and this has the happy side-effect of making the container iteration order deterministic.

Perhaps here is a good place to point out that while the secondary to msm container is an unordered_map, the secondary element pointers do not change from residual to residual and hence the hashing and container iteration order do not change, so that is why we have never seen an issue related to that "unordered-ness" before

Refs #20017