### PR TITLE
Increase perf graph test sleep time

### DIFF
--- a/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
+++ b/test/tests/utils/perf_graph_live_print/perf_graph_live_print.i
@@ -34,7 +34,7 @@
 
 [Problem]
   type = SlowProblem
-  seconds_to_sleep = 4
+  seconds_to_sleep = 8
 []
 
 [Executioner]


### PR DESCRIPTION
We just had a failure on [next testing](https://civet.inl.gov/job/936661/) because the Slowness text didn't show up on a valgrind test target run
