### PR TITLE
Updates to allow manual build of conda packages on M1

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - autoconf                                          # [arm64]
     - automake                                          # [arm64]
     - make                                              # [arm64]
+    - m4                                                # [arm64]
     - pkg-config
     - {{ moose_cctools }}                               # [osx]
     - {{ moose_ld64 }}                                  # [osx]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.01.19" %}
 

--- a/conda/mpich/build.sh
+++ b/conda/mpich/build.sh
@@ -24,7 +24,8 @@ export LIBRARY_PATH="$PREFIX/lib"
 
 if [[ $(uname) == Darwin ]]; then
     if [[ $target_platform == osx-arm64 ]]; then
-        TUNING="-I$PREFIX/include"
+        CTUNING="-mcpu=apple-a12 -I$PREFIX/include"
+        FTUNING="-march=armv8.3-a -I$PREFIX/include"
         OPTIONS="--disable-opencl --enable-cxx --enable-fortran"
         export pac_cv_f77_accepts_F=yes
         export pac_cv_f77_flibs_valid=unknown
@@ -59,13 +60,15 @@ if [[ $(uname) == Darwin ]]; then
         export pac_cv_prog_fc_works=yes
         export pac_MOD='mod'
     else
-        TUNING="-march=core2 -mtune=haswell -I$PREFIX/include"
+        CTUNING="-march=core2 -mtune=haswell -I$PREFIX/include"
+        FTUNING="-march=core2 -mtune=haswell -I$PREFIX/include"
         OPTIONS=""
     fi
     SHARED="clang"
 else
     SHARED="gcc"
-    TUNING="-march=nocona -mtune=haswell -I$PREFIX/include"
+    CTUNING="-march=nocona -mtune=haswell -I$PREFIX/include"
+    FTUNING="-march=nocona -mtune=haswell -I$PREFIX/include"
     OPTIONS=""
 fi
 
@@ -77,8 +80,8 @@ fi
             --enable-two-level-namespace \
             --with-device=ch3 \
             CC="${CC}" CXX="${CXX}" FC="${FC}" F77="${FC}" F90="" \
-            CFLAGS="${TUNING}" CXXFLAGS="${TUNING}" FFLAGS="${TUNING}" LDFLAGS="${LDFLAGS}" \
-            FCFLAGS="${TUNING}" F90FLAGS="" F77FLAGS="" \
+            CFLAGS="${CTUNING}" CXXFLAGS="${CTUNING}" FFLAGS="${FTUNING}" LDFLAGS="${LDFLAGS}" \
+            FCFLAGS="${FTUNING}" F90FLAGS="" F77FLAGS="" \
             ${OPTIONS}
 
 make -j"${CPU_COUNT:-1}"

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.01.19 build_0
+  - moose-libmesh 2022.01.19 build_1
 
 SHORT_VTK_NAME:
   - 9.1
@@ -11,13 +11,13 @@ vtk_version:
   - 9.1.0
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0 build_1
+  - moose-libmesh-vtk 9.1.0 build_2
 
 moose_petsc:
-  - moose-petsc 3.15.1 build_4
+  - moose-petsc 3.15.1 build_5
 
 moose_mpich:
-  - moose-mpich 3.4.2 build_0
+  - moose-mpich 3.4.2 build_1
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 moose_python:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.4.2" %}
 

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -5,57 +5,64 @@ export PATH=/bin:$PATH
 export PETSC_DIR=$SRC_DIR
 export PETSC_ARCH=arch-conda-c-opt
 
-if [[ $mpi == "openmpi" ]]; then
-  export OMPI_MCA_plm=isolated
-  export OMPI_MCA_rmaps_base_oversubscribe=yes
-  export OMPI_MCA_btl_vader_single_copy_mechanism=none
-elif [[ $mpi == "moose-mpich" ]]; then
-  export HYDRA_LAUNCHER=fork
-fi
+export CC=$(basename "$CC")
+export CXX=$(basename "$CXX")
+export FC=$(basename "$FC")
 
-unset CFLAGS CPPFLAGS CXXFLAGS FFLAGS LIBS LDFLAGS
-if [[ $(uname) == Darwin ]]; then
-    if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
-        LDFLAGS="-Wl,-rpath,$PREFIX/lib"
-        CTUNING="-mcpu=apple-a12"
-        FTUNING="-march=armv8.3-a"
-    else
-        CTUNING="-march=core2 -mtune=haswell"
-        FTUNING="-I$PREFIX/include"
-    fi
-    LDFLAGS="${LDFLAGS:-} -Wl,-headerpad-max-install-names"
-    export LIBRARY_PATH="$PREFIX/lib"
+# feed-stock recommendation
+# scrub debug-prefix-map args, which cause problems in pkg-config
+export CFLAGS=$(echo ${CFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+export CXXFLAGS=$(echo ${CXXFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+export FFLAGS=$(echo ${FFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+export FCFLAGS="$FFLAGS"
+export HYDRA_LAUNCHER=fork
+export LIBS="-lmpifort -lgfortran"
+
+if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
+    CFLAGS="${CFLAGS} -mcpu=apple-a12"
+    CXXFLAGS="${CXXFLAGS} -mcpu=apple-a12"
+    FFLAGS="${FFLAGS} -march=armv8.3-a"
+    FCFLAGS="${FCFLAGS} -march=armv8.3-a"
+    shared=0
+elif [[ $(uname) == Darwin ]]; then
+    CFLAGS="${CFLAGS} -march=core2 -mtune=haswell"
+    CXXFLAGS="${CXXFLAGS} -march=core2 -mtune=haswell"
+    FFLAGS="${FFLAGS} -I$PREFIX/include"
+    FCFLAGS="${FCFLAGS} -I$PREFIX/include"
+    LDFLAGS="${LDFLAGS} -Wl,-headerpad-max-install-names"
+    shared=1
 else
-    CTUNING="-march=nocona -mtune=haswell"
-    FTUNING="-I$PREFIX/include"
+    CFLAGS="${CFLAGS} -march=nocona -mtune=haswell"
+    CXXFLAGS="${CXXFLAGS} -march=nocona -mtune=haswell"
+    FFLAGS="${FFLAGS} -I$PREFIX/include"
+    FCFLAGS="${FCFLAGS} -I$PREFIX/include"
+    shared=1
 fi
-
-# for MPI discovery
-export C_INCLUDE_PATH=$PREFIX/include
-export CPLUS_INCLUDE_PATH=$PREFIX/include
-export FPATH_INCLUDE_PATH=$PREFIX/include
 
 source $PETSC_DIR/configure_petsc.sh
 configure_petsc \
-       --download-slepc=0 \
-       --COPTFLAGS=-O3 \
-       --CXXOPTFLAGS=-O3 \
-       --FOPTFLAGS=-O3 \
-       --with-x=0 \
-       --with-ssl=0 \
-       AR="${AR:-ar}" \
-       CC="mpicc" \
-       CXX="mpicxx" \
-       FC="mpifort" \
-       F90="mpifort" \
-       F77="mpifort" \
-       CFLAGS="${CTUNING}" \
-       CXXFLAGS="${CTUNING}" \
-       FFLAGS="${FTUNING}" \
-       FCFLAGS="${FTUNING}" \
-       LDFLAGS="${LDFLAGS:-}" \
-       --prefix=$PREFIX \
-       $* || (cat configure.log && exit 1)
+    --download-slepc=0 \
+    --COPTFLAGS=-O3 \
+    --CXXOPTFLAGS=-O3 \
+    --FOPTFLAGS=-O3 \
+    --with-x=0 \
+    --with-ssl=0 \
+    --with-shared-libraries=$shared \
+    CC="$CC" \
+    CXX="$CXX" \
+    FC="$FC" \
+    F90="$F90" \
+    F77="$F77" \
+    AR="$AR" \
+    RANLIB="$RANLIB" \
+    CFLAGS="$CFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    CPPFLAGS="$CPPFLAGS" \
+    FFLAGS="$FFLAGS" \
+    FCFLAGS="$FCFLAGS" \
+    LDFLAGS="$LDFLAGS" \
+    LIBS="$LIBS" \
+    --prefix=$PREFIX || (cat configure.log && exit 1)
 
 # Verify that gcc_ext isn't linked
 for f in $PETSC_ARCH/lib/petsc/conf/petscvariables $PETSC_ARCH/lib/pkgconfig/PETSc.pc; do

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -23,20 +23,17 @@ if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
     CXXFLAGS="${CXXFLAGS} -mcpu=apple-a12"
     FFLAGS="${FFLAGS} -march=armv8.3-a"
     FCFLAGS="${FCFLAGS} -march=armv8.3-a"
-    shared=0
 elif [[ $(uname) == Darwin ]]; then
     CFLAGS="${CFLAGS} -march=core2 -mtune=haswell"
     CXXFLAGS="${CXXFLAGS} -march=core2 -mtune=haswell"
     FFLAGS="${FFLAGS} -I$PREFIX/include"
     FCFLAGS="${FCFLAGS} -I$PREFIX/include"
     LDFLAGS="${LDFLAGS} -Wl,-headerpad-max-install-names"
-    shared=1
 else
     CFLAGS="${CFLAGS} -march=nocona -mtune=haswell"
     CXXFLAGS="${CXXFLAGS} -march=nocona -mtune=haswell"
     FFLAGS="${FFLAGS} -I$PREFIX/include"
     FCFLAGS="${FCFLAGS} -I$PREFIX/include"
-    shared=1
 fi
 
 source $PETSC_DIR/configure_petsc.sh
@@ -47,7 +44,6 @@ configure_petsc \
     --FOPTFLAGS=-O3 \
     --with-x=0 \
     --with-ssl=0 \
-    --with-shared-libraries=$shared \
     CC="$CC" \
     CXX="$CXX" \
     FC="$FC" \

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -16,15 +16,15 @@ fi
 unset CFLAGS CPPFLAGS CXXFLAGS FFLAGS LIBS LDFLAGS
 if [[ $(uname) == Darwin ]]; then
     if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
-        LDFLAGS="${LDFLAGS:-} -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
-        CTUNING="-march=armv8.3-a -I$PREFIX/include"
-        FTUNING="-march=armv8.3-a -I$PREFIX/include"
-        export LIBRARY_PATH="$PREFIX/lib"
+        LDFLAGS="-Wl,-rpath,$PREFIX/lib"
+        CTUNING="-mcpu=apple-a12"
+        FTUNING="-march=armv8.3-a"
     else
         CTUNING="-march=core2 -mtune=haswell"
         FTUNING="-I$PREFIX/include"
     fi
     LDFLAGS="${LDFLAGS:-} -Wl,-headerpad-max-install-names"
+    export LIBRARY_PATH="$PREFIX/lib"
 else
     CTUNING="-march=nocona -mtune=haswell"
     FTUNING="-I$PREFIX/include"
@@ -37,6 +37,7 @@ export FPATH_INCLUDE_PATH=$PREFIX/include
 
 source $PETSC_DIR/configure_petsc.sh
 configure_petsc \
+       --download-slepc=0 \
        --COPTFLAGS=-O3 \
        --CXXOPTFLAGS=-O3 \
        --FOPTFLAGS=-O3 \
@@ -53,7 +54,8 @@ configure_petsc \
        FFLAGS="${FTUNING}" \
        FCFLAGS="${FTUNING}" \
        LDFLAGS="${LDFLAGS:-}" \
-       --prefix=$PREFIX || (cat configure.log && exit 1)
+       --prefix=$PREFIX \
+       $* || (cat configure.log && exit 1)
 
 # Verify that gcc_ext isn't linked
 for f in $PETSC_ARCH/lib/petsc/conf/petscvariables $PETSC_ARCH/lib/pkgconfig/PETSc.pc; do

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -38,7 +38,6 @@ fi
 
 source $PETSC_DIR/configure_petsc.sh
 configure_petsc \
-    --download-slepc=0 \
     --COPTFLAGS=-O3 \
     --CXXOPTFLAGS=-O3 \
     --FOPTFLAGS=-O3 \

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -18,17 +18,18 @@ export FCFLAGS="$FFLAGS"
 export HYDRA_LAUNCHER=fork
 export LIBS="-lmpifort -lgfortran"
 
-if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
-    CFLAGS="${CFLAGS} -mcpu=apple-a12"
-    CXXFLAGS="${CXXFLAGS} -mcpu=apple-a12"
-    FFLAGS="${FFLAGS} -march=armv8.3-a"
-    FCFLAGS="${FCFLAGS} -march=armv8.3-a"
-elif [[ $(uname) == Darwin ]]; then
-    CFLAGS="${CFLAGS} -march=core2 -mtune=haswell"
-    CXXFLAGS="${CXXFLAGS} -march=core2 -mtune=haswell"
-    FFLAGS="${FFLAGS} -I$PREFIX/include"
-    FCFLAGS="${FCFLAGS} -I$PREFIX/include"
-    LDFLAGS="${LDFLAGS} -Wl,-headerpad-max-install-names"
+if [[ $(uname) == Darwin ]]; then
+    if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
+        CFLAGS="${CFLAGS} -mcpu=apple-a12"
+        CXXFLAGS="${CXXFLAGS} -mcpu=apple-a12"
+        FFLAGS="${FFLAGS} -march=armv8.3-a"
+        FCFLAGS="${FCFLAGS} -march=armv8.3-a"
+    else
+        CFLAGS="${CFLAGS} -march=core2 -mtune=haswell"
+        CXXFLAGS="${CXXFLAGS} -march=core2 -mtune=haswell"
+        FFLAGS="${FFLAGS} -I$PREFIX/include"
+        FCFLAGS="${FCFLAGS} -I$PREFIX/include"
+    fi
 else
     CFLAGS="${CFLAGS} -march=nocona -mtune=haswell"
     CXXFLAGS="${CXXFLAGS} -march=nocona -mtune=haswell"

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -13,6 +13,7 @@ source:
   - path: ../../scripts/configure_petsc.sh
   - patches:
       - arm64_framework.patch           # [arm64]
+      - no-cppflags-in-pkgconfig-cflags.patch
 
 build:
   number: {{ build }}

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 4 %}
+{% set build = 5 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.15.1" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/petsc/no-cppflags-in-pkgconfig-cflags.patch
+++ b/conda/petsc/no-cppflags-in-pkgconfig-cflags.patch
@@ -1,0 +1,13 @@
+diff --git a/config/PETSc/Configure.py b/config/PETSc/Configure.py
+index 64738da03e..ecc4a7d937 100644
+--- a/config/PETSc/Configure.py
++++ b/config/PETSc/Configure.py
+@@ -186,7 +186,7 @@ class Configure(config.base.Configure):
+       fd.write('Name: PETSc\n')
+       fd.write('Description: Library to solve ODEs and algebraic equations\n')
+       fd.write('Version: %s\n' % self.petscdir.version)
+-      fd.write('Cflags: ' + ' '.join([self.setCompilers.CPPFLAGS] + cflags_inc) + '\n')
++      fd.write('Cflags: ' + ' '.join(cflags_inc) + '\n')
+       fd.write('Libs: '+self.libraries.toStringNoDupes(['-L${libdir}', self.petsclib], with_rpath=False)+'\n')
+       # Remove RPATH flags from library list.  User can add them using
+       # pkg-config --variable=ldflag_rpath and pkg-config --libs-only-L

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -24,11 +24,17 @@ function configure_petsc()
     echo "$PETSC_DIR=PETSC_DIR does not exist"
     exit 1
   fi
+  # Apple Silicon has an issue building shared libraries
+  if [[ `uname -p` == "arm" ]]; then
+    SHARED=0
+  else
+    SHARED=1
+  fi
 
   cd $PETSC_DIR
   python ./configure --download-hypre=1 \
+      --with-shared-libraries=$SHARED \
       --with-debugging=no \
-      --with-shared-libraries=1 \
       --download-fblaslapack=1 \
       --download-metis=1 \
       --download-ptscotch=1 \
@@ -44,7 +50,7 @@ function configure_petsc()
       --with-fortran-bindings=0 \
       --with-sowing=0 \
       --with-64-bit-indices \
-      $*
+      "$@"
 
   return $?
 }


### PR DESCRIPTION
This PR provides the settings and configuration necessary for local builds of `moose-mpich`, `moose-libmesh-vtk`, `moose-petsc`, `moose-libmesh`, and `moose-tools` on M1 Apple Silicon. This *does not* mean they are ready for regular use, as we cannot yet test them across the full range of CIVET configurations normal for such macOS packages.

All MOOSE tests for these local packages pass with `opt` in both framework and unit tests as of the current next branch. Four geochemistry tests remain broken (see below for a results summary), and extended testing on heavy tests (in general) still needs to be performed.  

```
Modules:
geochemistry/test:equilibrium_models.ph_constraint .......................... FAILED (EXPECTED OUTPUT MISSING)
geochemistry/test:equilibrium_models.seawater_no_precip ..................... FAILED (EXPECTED OUTPUT MISSING)
geochemistry/test:time_dependent_reactions.flushing ........................................... FAILED (CRASH)
geochemistry/test:time_dependent_reactions.mixing_seawater_step2 ............................ FAILED (CSVDIFF)
--------------------------------------------------------------------------------------------------------------
Ran 4526 tests in 652.0 seconds. Average test time 0.9 seconds, maximum test time 29.7 seconds.
4522 passed, 366 skipped, 0 pending, 4 FAILED
```

Refs #18954
