### PR TITLE
Insert dependencies from discrete materials

### DIFF
--- a/framework/include/materials/Material.h
+++ b/framework/include/materials/Material.h
@@ -131,6 +131,25 @@ public:
   const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name);
   ///@}
 
+  /**
+   * Retrieve the discrete material with a given parameter key named "name"
+   */
+  MaterialBase & getMaterial(const std::string & name)
+  {
+    return getMaterialByName(parameters().get<MaterialName>(name));
+  }
+
+  /**
+   * Retrieve the discrete material named "name".
+   *
+   * @param no_warn If true, suppress warning about retrieving the material potentially during its
+   * calculation. If you don't know what this is/means, then you don't need it.
+   * @param no_dep Use no_dep = true if no dependency resolution for the material is required. Using
+   * no_dep = false is useful for discrete materials.
+   */
+  MaterialBase &
+  getMaterialByName(const std::string & name, bool no_warn = false, bool no_dep = false);
+
   ///@{ Optional material property getters
   template <typename T, bool is_ad>
   const GenericOptionalMaterialProperty<T, is_ad> &

--- a/framework/include/vectorpostprocessors/MaterialVectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/MaterialVectorPostprocessor.h
@@ -58,4 +58,3 @@ private:
   /// properties are scalar or not.
   std::vector<std::string> _prop_names;
 };
-

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -148,6 +148,26 @@ Material::computeConstantOption()
   return co;
 }
 
+MaterialBase &
+Material::getMaterialByName(const std::string & name, bool no_warn, bool no_dep)
+{
+  if (!no_dep && _mi_feproblem.getCurrentExecuteOnFlag() != EXEC_INITIAL)
+    mooseError("To ensure dependency resolution, discrete materials must be retrieved during "
+               "initial setup. This is a code problem.");
+
+  MaterialBase & discrete_mat = MaterialPropertyInterface::getMaterialByName(name, no_warn);
+
+  if (!no_dep)
+  {
+    // Insert the materials requested by the discrete material into the host material who
+    // retrieves this discrete material
+    const auto & discrete_requested = discrete_mat.getRequestedItems();
+    _requested_props.insert(discrete_requested.begin(), discrete_requested.end());
+  }
+
+  return discrete_mat;
+}
+
 void
 Material::resolveOptionalProperties()
 {

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -854,6 +854,15 @@ FEProblemBase::initialSetup()
 
       // Call initialSetup on all material objects
       _all_materials.initialSetup(tid);
+
+      // Discrete materials may insert additional dependencies on materials during the initial
+      // setup. Therefore we resolve the dependencies once more, now with the additional
+      // dependencies due to discrete materials.
+      if (_discrete_materials.hasActiveObjects())
+      {
+        _materials.sort(tid);
+        _interface_materials.sort(tid);
+      }
     }
 
     {

--- a/modules/tensor_mechanics/include/userobjects/LinearViscoelasticityManager.h
+++ b/modules/tensor_mechanics/include/userobjects/LinearViscoelasticityManager.h
@@ -32,11 +32,13 @@ public:
 
   LinearViscoelasticityManager(const InputParameters & parameters);
 
+  virtual void initialSetup() override;
+
 protected:
-  virtual void initialize() override;
+  virtual void initialize() override {}
   virtual void execute() override;
-  virtual void threadJoin(const UserObject & /*uo*/) override{};
-  virtual void finalize() override{};
+  virtual void threadJoin(const UserObject & /*uo*/) override {}
+  virtual void finalize() override {}
 
   std::string _stress_name;
   /*
@@ -56,5 +58,5 @@ protected:
   /// Name of the viscoelastic model to update
   std::string _viscoelastic_model_name;
   /// Pointer to the viscoelastic model to update
-  std::shared_ptr<LinearViscoelasticityBase> _viscoelastic_model;
+  LinearViscoelasticityBase * _viscoelastic_model;
 };

--- a/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeMultipleInelasticStress.C
@@ -79,10 +79,7 @@ ADComputeMultipleInelasticStress::ADComputeMultipleInelasticStress(
                            : std::vector<Real>(_num_models, true)),
     _cycle_models(getParam<bool>("cycle_models")),
     _material_timestep_limit(declareProperty<Real>(_base_name + "material_timestep_limit")),
-    _is_elasticity_tensor_guaranteed_isotropic(false),
-    _damage_model(isParamValid("damage_model")
-                      ? dynamic_cast<DamageBaseTempl<true> *>(&getMaterial("damage_model"))
-                      : nullptr)
+    _is_elasticity_tensor_guaranteed_isotropic(false)
 {
   if (_inelastic_weights.size() != _num_models)
     paramError("combined_inelastic_strain_weights",
@@ -102,6 +99,10 @@ ADComputeMultipleInelasticStress::initQpStatefulProperties()
 void
 ADComputeMultipleInelasticStress::initialSetup()
 {
+  _damage_model = isParamValid("damage_model")
+                      ? dynamic_cast<DamageBaseTempl<true> *>(&getMaterial("damage_model"))
+                      : nullptr;
+
   _is_elasticity_tensor_guaranteed_isotropic =
       this->hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC);
 

--- a/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeMultipleInelasticStress.C
@@ -96,10 +96,7 @@ ComputeMultipleInelasticStress::ComputeMultipleInelasticStress(const InputParame
     _cycle_models(getParam<bool>("cycle_models")),
     _material_timestep_limit(declareProperty<Real>(_base_name + "material_timestep_limit")),
     _identity_symmetric_four(RankFourTensor::initIdentitySymmetricFour),
-    _all_models_isotropic(true),
-    _damage_model(isParamValid("damage_model")
-                      ? dynamic_cast<DamageBaseTempl<false> *>(&getMaterial("damage_model"))
-                      : nullptr)
+    _all_models_isotropic(true)
 {
   if (_inelastic_weights.size() != _num_models)
     mooseError(
@@ -120,6 +117,10 @@ ComputeMultipleInelasticStress::initQpStatefulProperties()
 void
 ComputeMultipleInelasticStress::initialSetup()
 {
+  _damage_model = isParamValid("damage_model")
+                      ? dynamic_cast<DamageBaseTempl<false> *>(&getMaterial("damage_model"))
+                      : nullptr;
+
   _is_elasticity_tensor_guaranteed_isotropic =
       hasGuaranteedMaterialProperty(_elasticity_tensor_name, Guarantee::ISOTROPIC);
 

--- a/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
+++ b/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
@@ -44,7 +44,12 @@ StrainEnergyRateDensityTempl<is_ad>::StrainEnergyRateDensityTempl(
     _strain_rate(getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "strain_rate")),
     _num_models(getParam<std::vector<MaterialName>>("inelastic_models").size())
 {
+}
 
+template <bool is_ad>
+void
+StrainEnergyRateDensityTempl<is_ad>::initialSetup()
+{
   std::vector<MaterialName> models = getParam<std::vector<MaterialName>>("inelastic_models");
 
   // Store inelastic models as generic StressUpdateBase.
@@ -56,12 +61,6 @@ StrainEnergyRateDensityTempl<is_ad>::StrainEnergyRateDensityTempl(
     if (inelastic_model_stress_update)
       _inelastic_models.push_back(inelastic_model_stress_update);
   }
-}
-
-template <bool is_ad>
-void
-StrainEnergyRateDensityTempl<is_ad>::initialSetup()
-{
 }
 
 template <bool is_ad>

--- a/modules/tensor_mechanics/src/userobjects/LinearViscoelasticityManager.C
+++ b/modules/tensor_mechanics/src/userobjects/LinearViscoelasticityManager.C
@@ -49,6 +49,18 @@ LinearViscoelasticityManager::LinearViscoelasticityManager(const InputParameters
 }
 
 void
+LinearViscoelasticityManager::initialSetup()
+{
+  MaterialBase * test = &getMaterialByName(_viscoelastic_model_name, /*no_warn =*/true);
+  if (!test)
+    mooseError(_viscoelastic_model_name + " does not exist");
+
+  _viscoelastic_model = dynamic_cast<LinearViscoelasticityBase *>(test);
+  if (!_viscoelastic_model)
+    mooseError(_viscoelastic_model_name + " is not a LinearViscoelasticityBase object");
+}
+
+void
 LinearViscoelasticityManager::execute()
 {
   if (_mi_feproblem.getCurrentExecuteOnFlag() == EXEC_TIMESTEP_BEGIN)
@@ -56,19 +68,4 @@ LinearViscoelasticityManager::execute()
     for (unsigned int _qp = 0; _qp < _qrule->n_points(); ++_qp)
       _viscoelastic_model->recomputeQpApparentProperties(_qp);
   }
-}
-
-void
-LinearViscoelasticityManager::initialize()
-{
-  std::shared_ptr<MaterialBase> test =
-      _mi_feproblem.getMaterial(_viscoelastic_model_name, _material_data_type, _mi_tid, true);
-
-  if (!test)
-    mooseError(_viscoelastic_model_name + " does not exist");
-
-  _viscoelastic_model = std::dynamic_pointer_cast<LinearViscoelasticityBase>(test);
-
-  if (!_viscoelastic_model)
-    mooseError(_viscoelastic_model_name + " is not a LinearViscoelasticityBase object");
 }

--- a/test/include/materials/NewtonMaterial.h
+++ b/test/include/materials/NewtonMaterial.h
@@ -25,8 +25,10 @@ public:
   NewtonMaterial(const InputParameters & parameters);
   virtual ~NewtonMaterial(){};
 
+  virtual void initialSetup() override;
+
 protected:
-  void computeQpProperties();
+  void computeQpProperties() override;
 
 private:
   const Real & _tol;
@@ -35,5 +37,5 @@ private:
   MaterialProperty<Real> & _p;
   std::vector<unsigned int> _prop_ids;
   unsigned int _max_iterations;
-  MaterialBase & _discrete;
+  MaterialBase * _discrete;
 };

--- a/test/src/materials/NewtonMaterial.C
+++ b/test/src/materials/NewtonMaterial.C
@@ -38,9 +38,14 @@ NewtonMaterial::NewtonMaterial(const InputParameters & parameters)
     _f(getMaterialProperty<Real>(getParam<std::string>("f_name"))),
     _f_prime(getMaterialProperty<Real>(getParam<std::string>("f_prime_name"))),
     _p(declareProperty<Real>(getParam<std::string>("p_name"))),
-    _max_iterations(getParam<unsigned int>("max_iterations")),
-    _discrete(getMaterial("material"))
+    _max_iterations(getParam<unsigned int>("max_iterations"))
 {
+}
+
+void
+NewtonMaterial::initialSetup()
+{
+  _discrete = &getMaterial("material");
 }
 
 // MOOSEDOCS_START
@@ -52,7 +57,7 @@ NewtonMaterial::computeQpProperties()
   // Newton iteration for find p
   for (unsigned int i = 0; i < _max_iterations; ++i)
   {
-    _discrete.computePropertiesAtQp(_qp);
+    _discrete->computePropertiesAtQp(_qp);
     _p[_qp] -= _f[_qp] / _f_prime[_qp];
     if (std::abs(_f[_qp]) < _tol)
       break;

--- a/test/src/materials/RecomputeMaterial.C
+++ b/test/src/materials/RecomputeMaterial.C
@@ -26,6 +26,7 @@ RecomputeMaterial::validParams()
   params.addRequiredParam<std::string>("p_name",
                                        "The name of the independant variable for the function");
   params.addParam<Real>("constant", 0, "The constant to add to the f equation.");
+  params.set<bool>("compute") = false;
   return params;
 }
 

--- a/test/tests/materials/discrete/recompute_boundary_error.i
+++ b/test/tests/materials/discrete/recompute_boundary_error.i
@@ -5,48 +5,46 @@
     nx = 10
     ny = 1
   []
-  [./left_domain]
+  [left_domain]
     input = gen
     type = SubdomainBoundingBoxGenerator
     bottom_left = '0 0 0'
     top_right = '0.5 1 0'
     block_id = 10
-  [../]
+  []
 []
 
-
 [Variables]
-  [./u]
+  [u]
     initial_condition = 2
-  [../]
+  []
 []
 
 [Kernels]
-  [./diff]
-    type = MatDiffusionTest
+  [diff]
+    type = Diffusion
     variable = u
-    prop_name = 'p'
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 2
-  [../]
-  [./right]
+  []
+  [right]
     type = DirichletBC
     variable = u
     boundary = right
     value = 3
-  [../]
+  []
 []
 
 [Materials]
 
-  [./recompute_props]
+  [recompute_props]
     type = RecomputeMaterial
     boundary = 'left'
     f_name = 'f'
@@ -54,9 +52,9 @@
     p_name = 'p'
     outputs = all
     output_properties = 'f f_prime p'
-  [../]
+  []
 
-  [./newton]
+  [newton]
     type = NewtonMaterial
     boundary = 'left right'
     outputs = all
@@ -64,15 +62,15 @@
     f_prime_name = 'f_prime'
     p_name = 'p'
     material = 'recompute_props'
-  [../]
+  []
 
-  [./left]
+  [left]
     type = GenericConstantMaterial
-    prop_names =  'f f_prime'
+    prop_names = 'f f_prime'
     prop_values = '1 0.5    '
     block = '10 0'
     outputs = all
-  [../]
+  []
 []
 
 [Executioner]


### PR DESCRIPTION
Currently when we retrieve a discrete materials, we touch nothing about its dependencies. This leads to a weird situation where, when a discrete material is called by its hosting material, its dependencies may have not been evaluated. To avoid this situation, I propose to add the materials requested by the discrete material into the hosting material trying to retrieve the discrete material. I am now restricting the retrieval of discrete materials to the initial setup, so that we only need one more dependency resolution after the initial setup.

close #18726