### PR TITLE
Slightly loosen exodiff tolerance for fixed point, nonlinear test

### DIFF
--- a/test/tests/executioners/fixed_point/tests
+++ b/test/tests/executioners/fixed_point/tests
@@ -18,6 +18,7 @@
       exodiff = 'nonlinear_fixed_point_out.e'
 
       detail = "nonlinear problems."
+      rel_err = 7e-6
     []
   []
 


### PR DESCRIPTION
Refs CIVET failure [here](https://civet.inl.gov/job/938512/) and the original PR #13033