### PR TITLE
Fix mirror spec for Yum in Docker CentOS

### DIFF
--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -11,6 +11,10 @@
 # This script is used in docker_ci/Dockerfile to setup
 # the base container environment for Red Hat-based images
 
+# Per https://stackoverflow.com/a/70930049, we need these commands for Yum mirrors
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 # Update package lists
 yum update -y
 


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Our downstream pipelines are being failed by an issue with Yum in Docker for CentOS when trying to install Perl packages for assessing code coverage.  Basically, per the issue linked at the bottom of this comment, the `appstream` repository immediately times out, even on the base image `centos:8`.

## Design
<!--A concise description (design) of the enhancement.-->
In `docker_ci/yum_installs.sh`, the lines from [this](https://stackoverflow.com/a/70930049) StackOverflow answer have been added before the package manager is first invoked.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No change to the source, just ensuring Yum will work for CentOS Docker builds.  Closes #20194.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
