### PR TITLE
Fixes tests too heavy for valgrind

### DIFF
--- a/modules/tensor_mechanics/test/tests/lagrangian/total/convergence/L/tests
+++ b/modules/tensor_mechanics/test/tests/lagrangian/total/convergence/L/tests
@@ -6,11 +6,13 @@
     input = 'large.i'
     csvdiff = 'large_out.csv'
     requirement = "Quadratic convergence in 3D for PresetBCs on a complicated geometry, SMP matches FDP."
+    valgrind = HEAVY
   [../]
   [./L-small]
     type = CSVDiff
     input = 'small.i'
     csvdiff = 'small_out.csv'
     requirement = "Quadratic convergence in 3D for PresetBCs on a complicated geometry, SMP matches FDP."
+    valgrind = HEAVY
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/lagrangian/updated/convergence/L/tests
+++ b/modules/tensor_mechanics/test/tests/lagrangian/updated/convergence/L/tests
@@ -6,11 +6,13 @@
     input = 'large.i'
     csvdiff = 'large_out.csv'
     requirement = "Quadratic convergence in 3D for PresetBCs on a complicated geometry for small deformations, SMP matches FDP."
+    valgrind = HEAVY
   [../]
   [./L-small]
     type = CSVDiff
     input = 'small.i'
     csvdiff = 'small_out.csv'
     requirement = "Quadratic convergence in 3D for PresetBCs on a complicated geometry for large deformations, SMP matches FDP."
+    valgrind = HEAVY
   [../]
 []


### PR DESCRIPTION
Adds valgrind=HEAVY for four tests for the new `tensor_mechanics` kernels that are too new  costly to run with valgrind.