### PR TITLE
HPC Docs

### DIFF
--- a/modules/doc/content/getting_started/installation/hpc_install_moose.md
+++ b/modules/doc/content/getting_started/installation/hpc_install_moose.md
@@ -2,7 +2,7 @@
 
 The following instructions aims at setting up a baseline single-user environment for building MOOSE based applications in a job scheduling capable environment.
 
-If instead, you are here interested in allowing MOOSE-based development to be made avaialable to multiple users, please see our [Multi-User](getting_started/installation/cluster.md) setup instructions (requires administrative rights). Normal users: please ingore the previous sentence, and continue on...
+If instead, you are here interested in allowing MOOSE-based development to be made available to multiple users, please see our [Multi-User](getting_started/installation/cluster.md) setup instructions (requires administrative rights). Normal users: please ignore the previous sentence, and continue on...
 
 ## Pre-Reqs
 

--- a/modules/doc/content/getting_started/installation/index.md
+++ b/modules/doc/content/getting_started/installation/index.md
@@ -8,6 +8,7 @@ To install the MOOSE Framework, click the link below that corresponds to your op
 - Advanced Instructions:
 
   - [installation/hpc_install_moose.md]
+  - [installation/inl_hpc_install_moose.md]
   - [installation/manual_installation_gcc.md]
   - [installation/manual_installation_llvm.md]
   - [installation/manual_installation_linux_lldb.md]

--- a/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
@@ -1,0 +1,138 @@
+# INL HPC Cluster
+
+This page aims at simplifying the installation process on INL computing clusters.
+The [general cluster instructions](hpc_install_moose.md) may also be used, but these
+instructions will save some steps. There are multiple options for installing / using
+MOOSE and MOOSE applications.
+
+!alert note
+Falcon is planned to be decommissioned this January 2022.
+
+!alert warning
+Do not mix installation workflows except when specified here.
+
+## Option 1: Loading an application directly (easy, users only)
+
+You may load pre-built binaries for MOOSE
+and the applications you have access to by running: `module load use.moose moose-apps <app_name>`.
+Pre-built executables are then added in the `PATH` environment variable, and can be called
+directly in any folder with: `app_name-opt -i <input_file>`.
+
+## Option 2: Modules + source-based installation (medium, for developers)
+
+### Step 1: load some compilers
+
+In order to compile MOOSE and its applications, we first need to load compilers & compiling tools.
+The following modules are recommended for each of INL's clusters:
+
+- Falcon: `module load use.moose MVAPICH2 CMake`
+
+- Lemhi: `module load use.moose mvapich2 cmake PETSc`
+
+- Sawtooth: `module load use.moose mvapich2 cmake PETSc`
+
+
+!alert note
+If you use HPC modules, you will need to load them every time you log in! One solution is to
+modify the `.bashrc` file and add these `module load` commands there.
+
+### Step 1a: make sure those compilers are used
+
+Depending on how the MPI modules were built (and 99% of the time, this is not needed),
+it may be that the compilers loaded will not be automatically used when compiling.
+To make sure of this, we export those environment variables.
+
+```
+  export CC=mpicc CXX=mpicxx FC=mpif90
+```
+
+!alert note
+You will need to export those environment variables every time you log in. One solution is to
+modify the `.bashrc` file and add these `export` commands there. Make sure the `export` are placed
+after all `module load` commands, as these sometimes overwrite environment variables.
+
+### Step 2: module-load or download MOOSE dependencies
+
+PETSc may be obtained directly from HPC modules pre-installed on each machine:
+
+- Falcon: `module load use.moose PETSc`
+
+- Lemhi: `module load use.moose PETSc` (no need if you loaded PETSc earlier)
+
+- Sawtooth: `module load use.moose PETSc` (no need if you loaded PETSc earlier)
+
+
+!alert note
+For some MOOSE applications (Griffin & others), the latest version of `PETSc` is required, in which case
+you will need to run the `update_and_rebuild_petsc.sh` script.
+
+- libMesh
+
+
+LibMesh does not have pre-built modules as it is very frequently updated. In order to install, or update,
+libMesh, you will need to run the `update_and_rebuild_libmesh.sh` script.
+
+```
+  cd scripts
+  MOOSE_JOBS=6 ./update_and_rebuild_libmesh.sh
+```
+
+### Step 4: download and install MOOSE and the application you need
+
+MOOSE may be classically obtained from its [GitHub repository](https://github.com/idaholab/moose).
+Many open-source MOOSE applications may also be obtained from GitHub, while others will require
+officially requesting access through the [NCRC](ncrc/ncrc_ondemand.md). Please then follow the
+associated instructions for installation.
+
+## Option 3: Installation solely from source (medium-hard, for developers)
+
+### Step 1: load some compilers
+
+In order to compile MOOSE and its applications, we first need to load compilers & compiling tools.
+The following modules are recommended for each of INL's clusters:
+
+- Falcon: `module load use.moose MVAPICH2 CMake`
+
+- Lemhi: `module load use.moose mvapich2 cmake`
+
+- Sawtooth: `module load use.moose mvapich2 cmake`
+
+
+!alert note
+If you use HPC modules, you will need to load them every time you log in! One solution is to
+modify the `.bashrc` file and add these `module load` commands there.
+
+### Step 1a: See Option 2: Step 1a
+
+### Step 2: download and install MOOSE dependencies
+
+MOOSE dependencies, mainly PETSc and libMesh, may be obtained using the `update_and_rebuild_...`
+scripts, as is detailed in these [instructions](hpc_install_moose.md). These scripts currently
+should be run on the head node, as the compute nodes do not have access to the internet.
+Please make sure to `export MOOSE_JOBS=6` to control the number of cores used for installation.
+
+```
+  cd scripts
+  export MOOSE_JOBS=6
+  ./update_and_rebuild_petsc.sh
+  ./update_and_rebuild_libmesh.sh
+```
+
+### Step 4: see Option 2: Step 4
+
+## Option 4: conda installation (not recommended, light users)
+
+!alert warning
+The [conda-based installation](conda.md) is not recommended for INL HPC, as it does not use
+optimized, architecture-specific compilers. However, if you are not seeking performance,
+and will not use more than one node (to limit the attrition of computational resources),
+you are free to use them.
+
+!alert note
+If you want to use MPI with a conda installation, you will likely need to use the `mpiexec / mpirun`
+in the conda package, not another one from a module.
+
+!alert note
+Do not use the `miniconda/anaconda` HPC module. Download and install your own conda. If you get permission
+errors when trying to install conda packages, it is likely the HPC conda module is being used.
+`module unload miniconda` should be ran to remove it.

--- a/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_install_moose.md
@@ -34,9 +34,11 @@ The following modules are recommended for each of INL's clusters:
 
 !alert note
 If you use HPC modules, you will need to load them every time you log in! One solution is to
-modify the `.bashrc` file and add these `module load` commands there.
+add the `module load` commands to your `~/.bashrc` file. Adding commands to that file means 
+they would run every time you log in. However, modifying your `~/.bashrc` may cause unintended 
+consequences while using other applications or services if the modules are not unloaded first.
 
-### Step 1a: make sure those compilers are used
+### Step 1a: Make sure those compilers are used
 
 Depending on how the MPI modules were built (and 99% of the time, this is not needed),
 it may be that the compilers loaded will not be automatically used when compiling.
@@ -77,7 +79,7 @@ libMesh, you will need to run the `update_and_rebuild_libmesh.sh` script.
   MOOSE_JOBS=6 ./update_and_rebuild_libmesh.sh
 ```
 
-### Step 4: download and install MOOSE and the application you need
+### Step 3: download and install MOOSE and the application you need
 
 MOOSE may be classically obtained from its [GitHub repository](https://github.com/idaholab/moose).
 Many open-source MOOSE applications may also be obtained from GitHub, while others will require
@@ -100,7 +102,9 @@ The following modules are recommended for each of INL's clusters:
 
 !alert note
 If you use HPC modules, you will need to load them every time you log in! One solution is to
-modify the `.bashrc` file and add these `module load` commands there.
+add the `module load` commands to your `~/.bashrc` file. Adding commands to that file means 
+they would run every time you log in. However, modifying your `~/.bashrc` may cause unintended 
+consequences while using other applications or services if the modules are not unloaded first.
 
 ### Step 1a: See Option 2: Step 1a
 
@@ -126,7 +130,9 @@ Please make sure to `export MOOSE_JOBS=6` to control the number of cores used fo
 The [conda-based installation](conda.md) is not recommended for INL HPC, as it does not use
 optimized, architecture-specific compilers. However, if you are not seeking performance,
 and will not use more than one node (to limit the attrition of computational resources),
-you are free to use them.
+you are free to use them. However, use caution when installing conda as running `conda init` may
+have uninted consequences while using other applications or services as it makes changes to your
+`~/.bashrc`.
 
 !alert note
 If you want to use MPI with a conda installation, you will likely need to use the `mpiexec / mpirun`
@@ -136,3 +142,4 @@ in the conda package, not another one from a module.
 Do not use the `miniconda/anaconda` HPC module. Download and install your own conda. If you get permission
 errors when trying to install conda packages, it is likely the HPC conda module is being used.
 `module unload miniconda` should be ran to remove it.
+


### PR DESCRIPTION
## Reason
Adding additional documentation for accessing moose on HPC clusters per Refs #20071 

## Design
An updated documentation page for access MOOSE in HPC.

## Impact
Better documentation hopefully provides for less issues.

This includes all of @GiudGiud 's additions from https://github.com/GiudGiud/moose/commit/b11e25aa6971c46dc414b29ddc66eb3578a83bbd with a few modifications, mostly around altering one's `~/.bashrc` and the possible implications of that with other HPC services.

Refs #20071