### PR TITLE
Fixup threading for ElementSubdomainModifier

### DIFF
--- a/framework/include/userobject/ElementSubdomainModifier.h
+++ b/framework/include/userobject/ElementSubdomainModifier.h
@@ -23,7 +23,7 @@ public:
   virtual void initialSetup() override;
   virtual void initialize() override;
   virtual void execute() override;
-  virtual void threadJoin(const UserObject & /*uo*/) override{};
+  virtual void threadJoin(const UserObject & /*uo*/) override;
   virtual void finalize() override;
 
 protected:

--- a/framework/src/userobject/ElementSubdomainModifier.C
+++ b/framework/src/userobject/ElementSubdomainModifier.C
@@ -107,6 +107,21 @@ ElementSubdomainModifier::execute()
 }
 
 void
+ElementSubdomainModifier::threadJoin(const UserObject & in_uo)
+{
+  // Join the data from uo into _this_ object:
+  const ElementSubdomainModifier & uo = static_cast<const ElementSubdomainModifier &>(in_uo);
+
+  _moved_elems.insert(_moved_elems.end(), uo._moved_elems.begin(), uo._moved_elems.end());
+
+  _moved_displaced_elems.insert(_moved_displaced_elems.end(),
+                                uo._moved_displaced_elems.begin(),
+                                uo._moved_displaced_elems.end());
+
+  _moved_nodes.insert(uo._moved_nodes.begin(), uo._moved_nodes.end());
+}
+
+void
 ElementSubdomainModifier::finalize()
 {
   /*


### PR DESCRIPTION
Implements `threadJoin()`

closes #20243