### PR TITLE
Use simpler memory fencing for Perfgraph

### DIFF
--- a/framework/include/utils/PerfGraph.h
+++ b/framework/include/utils/PerfGraph.h
@@ -147,12 +147,18 @@ public:
   /**
    * Set the time limit before a message prints
    */
-  void setLiveTimeLimit(Real time_limit) { _live_print_time_limit = time_limit; }
+  void setLiveTimeLimit(Real time_limit)
+  {
+    _live_print_time_limit.store(time_limit, std::memory_order_relaxed);
+  }
 
   /**
    * Sert the memory limit before a message prints
    */
-  void setLiveMemoryLimit(unsigned int mem_limit) { _live_print_mem_limit = mem_limit; }
+  void setLiveMemoryLimit(unsigned int mem_limit)
+  {
+    _live_print_mem_limit.store(mem_limit, std::memory_order_relaxed);
+  }
 
   /**
    * Gets a PerfGraph result pertaining to a section
@@ -397,10 +403,10 @@ protected:
   std::condition_variable _finished_section;
 
   /// The time limit before a message is printed (in seconds)
-  Real _live_print_time_limit;
+  std::atomic<Real> _live_print_time_limit;
 
   /// The memory limit before a message is printed (in MB)
-  unsigned int _live_print_mem_limit;
+  std::atomic<unsigned int> _live_print_mem_limit;
 
   /// The object that is doing live printing
   const std::unique_ptr<PerfGraphLivePrint> _live_print;

--- a/framework/include/utils/PerfGraphLivePrint.h
+++ b/framework/include/utils/PerfGraphLivePrint.h
@@ -80,10 +80,10 @@ private:
   bool _should_print;
 
   /// Limit (in seconds) before printing
-  Real & _time_limit;
+  std::atomic<Real> & _time_limit;
 
   /// Limit (in MB)
-  unsigned int & _mem_limit;
+  std::atomic<unsigned int> & _mem_limit;
 
   /// This is one beyond the last thing on the stack
   unsigned int _stack_level;

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -160,20 +160,21 @@ PerfGraph::addToExecutionList(const PerfID id,
   section_increment._memory = memory;
   section_increment._beginning_num_printed = _console.numPrinted();
 
-  // This will synchronize the above memory changes with the
-  // atomic_thread_fence in the printing thread
-  std::atomic_thread_fence(std::memory_order_release);
-
-  // All of the above memory operations will be seen by the
-  // printing thread before the printing thread sees this new value
-
+  // A note about this next section of code:
+  // It is only EVER run on the main thread - and therefore there can be
+  // no race conditions.  All that is important here is that the print
+  // thread always sees a consistent value for _execution_list_end
   auto next_execution_list_end = _execution_list_end + 1;
 
   // Are we at the end of our circular buffer?
   if (next_execution_list_end >= MAX_EXECUTION_LIST_SIZE)
     next_execution_list_end = 0;
 
-  _execution_list_end.store(next_execution_list_end, std::memory_order_relaxed);
+  // This "release" will synchronize the above memory changes with the
+  // "acquire" in the printing thread
+  // All of the above memory operations will be seen by the
+  // printing thread before the printing thread sees this new value
+  _execution_list_end.store(next_execution_list_end, std::memory_order_release);
 }
 
 void

--- a/framework/src/utils/PerfGraphLivePrint.C
+++ b/framework/src/utils/PerfGraphLivePrint.C
@@ -325,8 +325,11 @@ PerfGraphLivePrint::start()
           this->_currently_destructing = _perf_graph._destructing;
 
           // The end will be one past the last
+          // This "acquire" synchronizes with the "release" in the PerfGraph
+          // to ensure that all of the writes to the execution list have been
+          // published to this thread for the "end" we're reading
           this->_current_execution_list_end =
-              _perf_graph._execution_list_end.load(std::memory_order_relaxed);
+              _perf_graph._execution_list_end.load(std::memory_order_acquire);
 
           // Save off the number of things currently printed to the console
           this->_console_num_printed = _console.numPrinted();
@@ -354,10 +357,6 @@ PerfGraphLivePrint::start()
     _current_execution_list_last = static_cast<long int>(_current_execution_list_end) - 1 >= 0
                                        ? _current_execution_list_end - 1
                                        : MAX_EXECUTION_LIST_SIZE;
-
-    // This will synchronize with the thread_fence in addToExecutionList() so that all of the below
-    // reads, will be reading synchronized memory
-    std::atomic_thread_fence(std::memory_order_acquire);
 
     // Only happens if nothing has been added
     if (_current_execution_list_end == 0 && _last_execution_list_end == _current_execution_list_end)


### PR DESCRIPTION
Hopefully will be easier for threading tools to see what's going on

BIG NOTE: I think that the previous implementation of this was _correct_ and more performant... but it was definitely more complicated and ripe for failure if someone modified it incorrectly.

closes #19443
