### PR TITLE
1-numbering option for ElementPropertyFileRead

### DIFF
--- a/modules/tensor_mechanics/doc/content/source/userobjects/ElementPropertyReadFile.md
+++ b/modules/tensor_mechanics/doc/content/source/userobjects/ElementPropertyReadFile.md
@@ -15,6 +15,9 @@ element ID is performed. In +grain+ mode the centroid of the passed in element
 is taken and the grain ID is determined as the ID of the Voronoi center closest
 to the element centroid.
 
+The `blocks_zero_numbered` parameter indicates whether the block numbers start
+with zero (`true`) or one (`false`).
+
 !syntax parameters /UserObjects/ElementPropertyReadFile
 
 !syntax inputs /UserObjects/ElementPropertyReadFile

--- a/modules/tensor_mechanics/doc/content/source/userobjects/ElementPropertyReadFile.md
+++ b/modules/tensor_mechanics/doc/content/source/userobjects/ElementPropertyReadFile.md
@@ -15,8 +15,9 @@ element ID is performed. In +grain+ mode the centroid of the passed in element
 is taken and the grain ID is determined as the ID of the Voronoi center closest
 to the element centroid.
 
-The `blocks_zero_numbered` parameter indicates whether the block numbers start
-with zero (`true`) or one (`false`).
+The [!param](/UserObjects/ElementPropertyReadFile/use_zero_based_block_indexing)
+parameter indicates whether the block numbers start with zero (`true`)
+or one (`false`).
 
 !syntax parameters /UserObjects/ElementPropertyReadFile
 

--- a/modules/tensor_mechanics/include/userobjects/ElementPropertyReadFile.h
+++ b/modules/tensor_mechanics/include/userobjects/ElementPropertyReadFile.h
@@ -89,6 +89,8 @@ protected:
   unsigned int _rand_seed;
   ///Type of grain structure - non-periodic default
   MooseEnum _rve_type;
+  /// Do the block numbers start with zero or one?
+  bool _block_zero;
 
   MooseMesh & _mesh;
   std::vector<Point> _center;

--- a/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
+++ b/modules/tensor_mechanics/src/userobjects/ElementPropertyReadFile.C
@@ -35,7 +35,8 @@ ElementPropertyReadFile::validParams()
       "rve_type",
       MooseEnum("periodic none", "none"),
       "Periodic or non-periodic grain distribution: Default is non-periodic");
-  params.addParam<bool>("blocks_zero_numbered", true, "Are the blocks numbered starting at zero?");
+  params.addParam<bool>(
+      "use_zero_based_block_indexing", true, "Are the blocks numbered starting at zero?");
   return params;
 }
 
@@ -49,7 +50,7 @@ ElementPropertyReadFile::ElementPropertyReadFile(const InputParameters & paramet
     _read_type(getParam<MooseEnum>("read_type").getEnum<ReadType>()),
     _rand_seed(getParam<unsigned int>("rand_seed")),
     _rve_type(getParam<MooseEnum>("rve_type")),
-    _block_zero(getParam<bool>("blocks_zero_numbered")),
+    _block_zero(getParam<bool>("use_zero_based_block_indexing")),
     _mesh(_fe_problem.mesh())
 {
   _nelem = _mesh.nElem();


### PR DESCRIPTION
Adds an input parameter that lets ElementPropertyFileRead make sense of mesh with block ids starting from 1.  Defaults to original 0-numbered behavior.

Closes #20288