### PR TITLE
Avoid deprecated direct boundary_info use

### DIFF
--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -226,10 +226,10 @@ PeripheralRingMeshGenerator::generate()
   // Assign customized external boundary name
   if (!_external_boundary_name.empty())
   {
-    mesh->boundary_info->sideset_name(
+    mesh->get_boundary_info().sideset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
-    mesh->boundary_info->nodeset_name(
+    mesh->get_boundary_info().nodeset_name(
         _external_boundary_id > 0 ? _external_boundary_id : (boundary_id_type)OUTER_SIDESET_ID) =
         _external_boundary_name;
   }

--- a/modules/thermal_hydraulics/src/components/FlowBoundary1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FlowBoundary1Phase.C
@@ -37,7 +37,7 @@ FlowBoundary1Phase::setupMesh()
 
     // create a nodeset/sideset corresponding to the node of the connected pipe end
     const BoundaryID boundary_id = _mesh.getNextBoundaryId();
-    _mesh.getMesh().boundary_info->add_node(_node, boundary_id);
+    _mesh.getMesh().get_boundary_info().add_node(_node, boundary_id);
     _mesh.setBoundaryName(boundary_id, name());
   }
 }

--- a/modules/thermal_hydraulics/src/components/FlowJunction.C
+++ b/modules/thermal_hydraulics/src/components/FlowJunction.C
@@ -29,6 +29,8 @@ FlowJunction::setupMesh()
 
   const BoundaryID boundary_id = _mesh.getNextBoundaryId();
 
+  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+
   for (const auto & connection : getConnections())
   {
     const std::string & comp_name = connection._geometrical_component_name;
@@ -38,7 +40,7 @@ FlowJunction::setupMesh()
       const GeometricalFlowComponent & gc = getComponentByName<GeometricalFlowComponent>(comp_name);
       for (auto && conn : gc.getConnections(connection._end_type))
         // add connection's node to nodeset of all nodes connected to this zero-D component
-        _mesh.getMesh().boundary_info->add_node(conn._node, boundary_id);
+        boundary_info.add_node(conn._node, boundary_id);
     }
   }
 

--- a/modules/thermal_hydraulics/src/components/HeatStructureBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureBase.C
@@ -128,6 +128,8 @@ HeatStructureBase::build2DMesh()
     _outer_heat_node_ids.push_back(node_ids[i][_total_elem_number]);
   }
 
+  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+
   // create elements from nodes
   elem_ids.resize(_n_elem);
   unsigned int i = 0;
@@ -154,12 +156,12 @@ HeatStructureBase::build2DMesh()
           // exterior axial boundaries (all radial sections)
           if (i == 0)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 0, _start_bc_id[0]);
+            boundary_info.add_side(elem, 0, _start_bc_id[0]);
             _start_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 0));
           }
           if (i == _n_elem - 1)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 2, _end_bc_id[0]);
+            boundary_info.add_side(elem, 2, _end_bc_id[0]);
             _end_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 2));
           }
 
@@ -167,9 +169,9 @@ HeatStructureBase::build2DMesh()
           if (_names.size() > 1)
           {
             if (i == 0)
-              _mesh.getMesh().boundary_info->add_side(elem, 0, _radial_start_bc_id[j_section]);
+              boundary_info.add_side(elem, 0, _radial_start_bc_id[j_section]);
             if (i == _n_elem - 1)
-              _mesh.getMesh().boundary_info->add_side(elem, 2, _radial_end_bc_id[j_section]);
+              boundary_info.add_side(elem, 2, _radial_end_bc_id[j_section]);
           }
 
           // interior axial boundaries (per radial section)
@@ -177,19 +179,18 @@ HeatStructureBase::build2DMesh()
               i_section != _n_sections - 1 && i == i_section_end)
           {
             const unsigned int k = i_section * _number_of_hs + j_section;
-            _mesh.getMesh().boundary_info->add_side(
-                elem, 2, _interior_axial_per_radial_section_bc_id[k]);
+            boundary_info.add_side(elem, 2, _interior_axial_per_radial_section_bc_id[k]);
           }
 
           // exterior radial boundaries (all axial sections)
           if (j == 0)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 1, _inner_bc_id[0]);
+            boundary_info.add_side(elem, 1, _inner_bc_id[0]);
             _inner_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 1));
           }
           if (j == _total_elem_number - 1)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 3, _outer_bc_id[0]);
+            boundary_info.add_side(elem, 3, _outer_bc_id[0]);
             _outer_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 3));
           }
 
@@ -197,9 +198,9 @@ HeatStructureBase::build2DMesh()
           if (_n_sections > 1 && _axial_region_names.size() == _n_sections)
           {
             if (j == 0)
-              _mesh.getMesh().boundary_info->add_side(elem, 1, _axial_inner_bc_id[i_section]);
+              boundary_info.add_side(elem, 1, _axial_inner_bc_id[i_section]);
             if (j == _total_elem_number - 1)
-              _mesh.getMesh().boundary_info->add_side(elem, 3, _axial_outer_bc_id[i_section]);
+              boundary_info.add_side(elem, 3, _axial_outer_bc_id[i_section]);
           }
 
           // interior radial boundaries (all axial sections)
@@ -210,7 +211,7 @@ HeatStructureBase::build2DMesh()
               j_section_begin += _n_part_elems[jj_section];
 
             if (j == j_section_begin)
-              _mesh.getMesh().boundary_info->add_side(elem, 1, _inner_radial_bc_id[j_section - 1]);
+              boundary_info.add_side(elem, 1, _inner_radial_bc_id[j_section - 1]);
           }
 
           j++;
@@ -256,6 +257,8 @@ HeatStructureBase::build2DMesh2ndOrder()
     _outer_heat_node_ids.push_back(node_ids[i][_total_elem_number * 2]);
   }
 
+  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+
   // create elements from nodes
   elem_ids.resize(_n_elem);
   unsigned int i = 0;
@@ -281,39 +284,39 @@ HeatStructureBase::build2DMesh2ndOrder()
 
           if (i == 0)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 0, _start_bc_id[0]);
+            boundary_info.add_side(elem, 0, _start_bc_id[0]);
             _start_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 0));
           }
           if (i == _n_elem - 1)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 2, _end_bc_id[0]);
+            boundary_info.add_side(elem, 2, _end_bc_id[0]);
             _end_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 2));
           }
           if (_names.size() > 1)
           {
             if (i == 0)
-              _mesh.getMesh().boundary_info->add_side(elem, 0, _radial_start_bc_id[j_section]);
+              boundary_info.add_side(elem, 0, _radial_start_bc_id[j_section]);
             if (i == _n_elem - 1)
-              _mesh.getMesh().boundary_info->add_side(elem, 2, _radial_end_bc_id[j_section]);
+              boundary_info.add_side(elem, 2, _radial_end_bc_id[j_section]);
           }
 
           if (j == 0)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 3, _inner_bc_id[0]);
+            boundary_info.add_side(elem, 3, _inner_bc_id[0]);
             _inner_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 3));
           }
           if (j == _total_elem_number - 1)
           {
-            _mesh.getMesh().boundary_info->add_side(elem, 1, _outer_bc_id[0]);
+            boundary_info.add_side(elem, 1, _outer_bc_id[0]);
             _outer_bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem->id(), 1));
           }
 
           if (_n_sections > 1 && _axial_region_names.size() == _n_sections)
           {
             if (j == 0)
-              _mesh.getMesh().boundary_info->add_side(elem, 1, _axial_inner_bc_id[i_section]);
+              boundary_info.add_side(elem, 1, _axial_inner_bc_id[i_section]);
             if (j == _total_elem_number - 1)
-              _mesh.getMesh().boundary_info->add_side(elem, 3, _axial_outer_bc_id[i_section]);
+              boundary_info.add_side(elem, 3, _axial_outer_bc_id[i_section]);
           }
 
           // interior radial boundaries
@@ -324,7 +327,7 @@ HeatStructureBase::build2DMesh2ndOrder()
               j_section_begin += _n_part_elems[jj_section];
 
             if (j == j_section_begin)
-              _mesh.getMesh().boundary_info->add_side(elem, 1, _inner_radial_bc_id[j_section - 1]);
+              boundary_info.add_side(elem, 1, _inner_radial_bc_id[j_section - 1]);
           }
 
           j++;

--- a/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
@@ -174,6 +174,8 @@ HeatStructureFromFile3D::buildMesh()
     new_ids_to_names.emplace(bc_id, sideset_name);
   }
 
+  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+
   for (auto e : index_range(exio_helper.elem_list))
   {
     int ex_elem_id = exio_helper.elem_num_map[exio_helper.elem_list[e] - 1];
@@ -186,7 +188,7 @@ HeatStructureFromFile3D::buildMesh()
     unsigned int side_index = static_cast<unsigned int>(raw_side_index - side_index_offset);
     int mapped_side = conv.get_side_map(side_index);
     unsigned int bc_id = thm_bc_id_map[exio_helper.id_list[e]];
-    _mesh.getMesh().boundary_info->add_side(elem, mapped_side, bc_id);
+    boundary_info.add_side(elem, mapped_side, bc_id);
   }
   for (const auto & pr : new_ids_to_names)
     _mesh.setBoundaryName(pr.first, genName(_name, pr.second));


### PR DESCRIPTION
Refs #13921

## Reason
Builds against a `--disable-deprecated` libMesh regressed again

## Design
Use `get_boundary_info()`, don't directly access the member.

## Impact
No impact here.  Though that accessor has been around since 2014 and direct access has been deprecated for a year and a half, and yet when later I remove direct access entirely I'm guessing there will be some shock.
