### PR TITLE
AD domain integral

### DIFF
--- a/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
+++ b/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
@@ -143,4 +143,6 @@ protected:
   bool _incremental;
   /// Whether to convert the J-integral to a stress intensity factor (K) --deprecated
   bool _convert_J_to_K;
+  /// Whether to create automatic differentiation objects from the action
+  const bool _use_ad;
 };

--- a/modules/tensor_mechanics/include/materials/EshelbyTensor.h
+++ b/modules/tensor_mechanics/include/materials/EshelbyTensor.h
@@ -12,16 +12,18 @@
 #include "Material.h"
 #include "DerivativeMaterialInterface.h"
 #include "RankTwoTensorForward.h"
+#include "MooseTypes.h"
 
 /**
  * EshelbyTensor defines a strain increment and rotation increment, for finite strains.
  */
-class EshelbyTensor : public DerivativeMaterialInterface<Material>
+template <bool is_ad>
+class EshelbyTensorTempl : public DerivativeMaterialInterface<Material>
 {
 public:
   static InputParameters validParams();
 
-  EshelbyTensor(const InputParameters & parameters);
+  EshelbyTensorTempl(const InputParameters & parameters);
 
   virtual void initialSetup() override;
   virtual void initQpStatefulProperties() override;
@@ -41,7 +43,7 @@ protected:
   MaterialProperty<RankTwoTensor> * _eshelby_tensor_dissipation;
 
   /// The stress tensor
-  const MaterialProperty<RankTwoTensor> & _stress;
+  const GenericMaterialProperty<RankTwoTensor, is_ad> & _stress;
 
   /// The old stress tensor
   const MaterialProperty<RankTwoTensor> & _stress_old;
@@ -54,3 +56,6 @@ protected:
   const bool _has_temp;
   const OptionalMaterialProperty<RankTwoTensor> & _total_deigenstrain_dT;
 };
+
+typedef EshelbyTensorTempl<false> EshelbyTensor;
+typedef EshelbyTensorTempl<true> ADEshelbyTensor;

--- a/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
+++ b/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
@@ -12,16 +12,18 @@
 #include "Material.h"
 #include "DerivativeMaterialInterface.h"
 #include "RankTwoTensorForward.h"
+#include "MooseTypes.h"
 
 /**
  * StrainEnergyDensity calculates the strain energy density.
  */
-class StrainEnergyDensity : public DerivativeMaterialInterface<Material>
+template <bool is_ad>
+class StrainEnergyDensityTempl : public DerivativeMaterialInterface<Material>
 {
 public:
   static InputParameters validParams();
 
-  StrainEnergyDensity(const InputParameters & parameters);
+  StrainEnergyDensityTempl(const InputParameters & parameters);
 
   virtual void initialSetup() override;
 
@@ -37,14 +39,17 @@ protected:
   const MaterialProperty<Real> & _strain_energy_density_old;
 
   ///{@ Current and old values of stress
-  const MaterialProperty<RankTwoTensor> & _stress;
+  const GenericMaterialProperty<RankTwoTensor, is_ad> & _stress;
   const MaterialProperty<RankTwoTensor> & _stress_old;
   ///@}
 
   /// Current value of mechanical strain which includes elastic and
   /// inelastic components of the strain
-  const MaterialProperty<RankTwoTensor> & _mechanical_strain;
+  const GenericMaterialProperty<RankTwoTensor, is_ad> & _mechanical_strain;
 
   /// Current value of the strain increment for incremental models
-  const OptionalMaterialProperty<RankTwoTensor> & _strain_increment;
+  const GenericMaterialProperty<RankTwoTensor, is_ad> * _strain_increment;
 };
+
+typedef StrainEnergyDensityTempl<false> StrainEnergyDensity;
+typedef StrainEnergyDensityTempl<true> ADStrainEnergyDensity;

--- a/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
+++ b/modules/tensor_mechanics/include/materials/StrainEnergyDensity.h
@@ -48,7 +48,7 @@ protected:
   const GenericMaterialProperty<RankTwoTensor, is_ad> & _mechanical_strain;
 
   /// Current value of the strain increment for incremental models
-  const GenericMaterialProperty<RankTwoTensor, is_ad> * _strain_increment;
+  const GenericOptionalMaterialProperty<RankTwoTensor, is_ad> & _strain_increment;
 };
 
 typedef StrainEnergyDensityTempl<false> StrainEnergyDensity;

--- a/modules/tensor_mechanics/include/materials/StrainEnergyRateDensity.h
+++ b/modules/tensor_mechanics/include/materials/StrainEnergyRateDensity.h
@@ -39,7 +39,7 @@ private:
   const std::string _base_name;
 
   /// The strain energy density material property
-  GenericMaterialProperty<Real, is_ad> & _strain_energy_rate_density;
+  MaterialProperty<Real> & _strain_energy_rate_density;
 
   /// Current and old values of stress
   const GenericMaterialProperty<RankTwoTensor, is_ad> & _stress;

--- a/modules/tensor_mechanics/src/actions/DomainIntegralAction.C
+++ b/modules/tensor_mechanics/src/actions/DomainIntegralAction.C
@@ -834,23 +834,24 @@ DomainIntegralAction::act()
       params.set<std::vector<SubdomainName>>("block") = {_blocks};
       _problem->addMaterial(mater_type_name, mater_name, params);
 
-      std::string mater_name2;
-      const std::string mater_type_name2(ad_prepend + "EshelbyTensor");
-      mater_name2 = ad_prepend + "EshelbyTensor";
+      {
+        std::string mater_name;
+        const std::string mater_type_name(ad_prepend + "EshelbyTensor");
+        mater_name = ad_prepend + "EshelbyTensor";
 
-      InputParameters params2 = _factory.getValidParams(mater_type_name2);
-      _displacements = getParam<std::vector<VariableName>>("displacements");
-      params2.set<std::vector<VariableName>>("displacements") = _displacements;
-      params2.set<std::vector<SubdomainName>>("block") = {_blocks};
+        InputParameters params = _factory.getValidParams(mater_type_name);
+        _displacements = getParam<std::vector<VariableName>>("displacements");
+        params.set<std::vector<VariableName>>("displacements") = _displacements;
+        params.set<std::vector<SubdomainName>>("block") = {_blocks};
 
-      if (have_c_integral)
-        params2.set<bool>("compute_dissipation") = true;
+        if (have_c_integral)
+          params.set<bool>("compute_dissipation") = true;
 
-      if (_temp != "")
-        params2.set<std::vector<VariableName>>("temperature") = {_temp};
+        if (_temp != "")
+          params.set<std::vector<VariableName>>("temperature") = {_temp};
 
-      _problem->addMaterial(mater_type_name2, mater_name2, params2);
-
+        _problem->addMaterial(mater_type_name, mater_name, params);
+      }
       // Strain energy rate density needed for C(t)/C* integral
       if (have_c_integral)
       {

--- a/modules/tensor_mechanics/src/materials/EshelbyTensor.C
+++ b/modules/tensor_mechanics/src/materials/EshelbyTensor.C
@@ -12,9 +12,11 @@
 #include "MooseMesh.h"
 
 registerMooseObject("TensorMechanicsApp", EshelbyTensor);
+registerMooseObject("TensorMechanicsApp", ADEshelbyTensor);
 
+template <bool is_ad>
 InputParameters
-EshelbyTensor::validParams()
+EshelbyTensorTempl<is_ad>::validParams()
 {
   InputParameters params = Material::validParams();
   params.addClassDescription("Computes the Eshelby tensor as a function of "
@@ -36,7 +38,8 @@ EshelbyTensor::validParams()
   return params;
 }
 
-EshelbyTensor::EshelbyTensor(const InputParameters & parameters)
+template <bool is_ad>
+EshelbyTensorTempl<is_ad>::EshelbyTensorTempl(const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _compute_dissipation(getParam<bool>("compute_dissipation")),
@@ -49,7 +52,7 @@ EshelbyTensor::EshelbyTensor(const InputParameters & parameters)
         _compute_dissipation
             ? &declareProperty<RankTwoTensor>(_base_name + "Eshelby_tensor_dissipation")
             : nullptr),
-    _stress(getMaterialProperty<RankTwoTensor>(_base_name + "stress")),
+    _stress(getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "stress")),
     _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
     _grad_disp(3),
     _grad_disp_old(3),
@@ -86,8 +89,9 @@ EshelbyTensor::EshelbyTensor(const InputParameters & parameters)
   }
 }
 
+template <bool is_ad>
 void
-EshelbyTensor::initialSetup()
+EshelbyTensorTempl<is_ad>::initialSetup()
 {
   if (_has_temp && !_total_deigenstrain_dT)
     mooseError("EshelbyTensor Error: To include thermal strain term in Fracture integral "
@@ -95,13 +99,15 @@ EshelbyTensor::initialSetup()
                "total_deigenstrain_dT using ThermalFractureIntegral material model.");
 }
 
+template <bool is_ad>
 void
-EshelbyTensor::initQpStatefulProperties()
+EshelbyTensorTempl<is_ad>::initQpStatefulProperties()
 {
 }
 
+template <bool is_ad>
 void
-EshelbyTensor::computeQpProperties()
+EshelbyTensorTempl<is_ad>::computeQpProperties()
 {
   // Deformation gradient
   auto F = RankTwoTensor::initializeFromRows(
@@ -113,7 +119,7 @@ EshelbyTensor::computeQpProperties()
   RankTwoTensor FinvT(F.inverse().transpose());
 
   // 1st Piola-Kirchoff Stress (P):
-  RankTwoTensor P = detF * _stress[_qp] * FinvT;
+  RankTwoTensor P = detF * MetaPhysicL::raw_value(_stress[_qp]) * FinvT;
 
   // HTP = H^T * P = H^T * detF * sigma * FinvT;
   RankTwoTensor HTP = H.transpose() * P;
@@ -143,7 +149,8 @@ EshelbyTensor::computeQpProperties()
 
   if (_has_temp)
   {
-    const Real sigma_alpha = _stress[_qp].doubleContraction(_total_deigenstrain_dT[_qp]);
+    const Real sigma_alpha =
+        MetaPhysicL::raw_value(_stress[_qp]).doubleContraction(_total_deigenstrain_dT[_qp]);
     _J_thermal_term_vec[_qp] = sigma_alpha * _grad_temp[_qp];
   }
   else

--- a/modules/tensor_mechanics/src/materials/StrainEnergyDensity.C
+++ b/modules/tensor_mechanics/src/materials/StrainEnergyDensity.C
@@ -12,9 +12,11 @@
 #include "MooseMesh.h"
 
 registerMooseObject("TensorMechanicsApp", StrainEnergyDensity);
+registerMooseObject("TensorMechanicsApp", ADStrainEnergyDensity);
 
+template <bool is_ad>
 InputParameters
-StrainEnergyDensity::validParams()
+StrainEnergyDensityTempl<is_ad>::validParams()
 {
   InputParameters params = Material::validParams();
   params.addClassDescription("Computes the strain energy density using a combination of the "
@@ -30,20 +32,26 @@ StrainEnergyDensity::validParams()
   return params;
 }
 
-StrainEnergyDensity::StrainEnergyDensity(const InputParameters & parameters)
+template <bool is_ad>
+StrainEnergyDensityTempl<is_ad>::StrainEnergyDensityTempl(const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
     _strain_energy_density(declareProperty<Real>(_base_name + "strain_energy_density")),
     _strain_energy_density_old(getMaterialPropertyOld<Real>(_base_name + "strain_energy_density")),
-    _stress(getMaterialProperty<RankTwoTensor>(_base_name + "stress")),
+    _stress(getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "stress")),
     _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress")),
-    _mechanical_strain(getMaterialProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
-    _strain_increment(getOptionalMaterialProperty<RankTwoTensor>(_base_name + "strain_increment"))
+    _mechanical_strain(
+        getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "mechanical_strain")),
+    _strain_increment(
+        (isParamValid("incremental") && getParam<bool>("incremental"))
+            ? &getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "strain_increment")
+            : nullptr)
 {
 }
 
+template <bool is_ad>
 void
-StrainEnergyDensity::initialSetup()
+StrainEnergyDensityTempl<is_ad>::initialSetup()
 {
   // optional error checking
   if (isParamValid("incremental"))
@@ -57,21 +65,28 @@ StrainEnergyDensity::initialSetup()
                  "incremental.");
   }
 }
-
+template <bool is_ad>
 void
-StrainEnergyDensity::initQpStatefulProperties()
+StrainEnergyDensityTempl<is_ad>::initQpStatefulProperties()
 {
   _strain_energy_density[_qp] = 0.0;
 }
 
+template <bool is_ad>
 void
-StrainEnergyDensity::computeQpProperties()
+StrainEnergyDensityTempl<is_ad>::computeQpProperties()
 {
 
   if (_strain_increment)
-    _strain_energy_density[_qp] = _strain_energy_density_old[_qp] +
-                                  _stress[_qp].doubleContraction(_strain_increment[_qp]) / 2.0 +
-                                  _stress_old[_qp].doubleContraction(_strain_increment[_qp]) / 2.0;
+    _strain_energy_density[_qp] =
+        _strain_energy_density_old[_qp] +
+        MetaPhysicL::raw_value(_stress[_qp])
+                .doubleContraction(MetaPhysicL::raw_value((*_strain_increment)[_qp])) /
+            2.0 +
+        _stress_old[_qp].doubleContraction(MetaPhysicL::raw_value((*_strain_increment)[_qp])) / 2.0;
   else
-    _strain_energy_density[_qp] = _stress[_qp].doubleContraction((_mechanical_strain)[_qp]) / 2.0;
+    _strain_energy_density[_qp] =
+        MetaPhysicL::raw_value(_stress[_qp])
+            .doubleContraction((MetaPhysicL::raw_value(_mechanical_strain[_qp]))) /
+        2.0;
 }

--- a/modules/tensor_mechanics/src/materials/StrainEnergyDensity.C
+++ b/modules/tensor_mechanics/src/materials/StrainEnergyDensity.C
@@ -43,9 +43,7 @@ StrainEnergyDensityTempl<is_ad>::StrainEnergyDensityTempl(const InputParameters 
     _mechanical_strain(
         getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "mechanical_strain")),
     _strain_increment(
-        (isParamValid("incremental") && getParam<bool>("incremental"))
-            ? &getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "strain_increment")
-            : nullptr)
+        getGenericOptionalMaterialProperty<RankTwoTensor, is_ad>(_base_name + "strain_increment"))
 {
 }
 
@@ -81,9 +79,9 @@ StrainEnergyDensityTempl<is_ad>::computeQpProperties()
     _strain_energy_density[_qp] =
         _strain_energy_density_old[_qp] +
         MetaPhysicL::raw_value(_stress[_qp])
-                .doubleContraction(MetaPhysicL::raw_value((*_strain_increment)[_qp])) /
+                .doubleContraction(MetaPhysicL::raw_value(_strain_increment[_qp])) /
             2.0 +
-        _stress_old[_qp].doubleContraction(MetaPhysicL::raw_value((*_strain_increment)[_qp])) / 2.0;
+        _stress_old[_qp].doubleContraction(MetaPhysicL::raw_value(_strain_increment[_qp])) / 2.0;
   else
     _strain_energy_density[_qp] =
         MetaPhysicL::raw_value(_stress[_qp])

--- a/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
+++ b/modules/tensor_mechanics/src/materials/StrainEnergyRateDensity.C
@@ -38,8 +38,7 @@ StrainEnergyRateDensityTempl<is_ad>::StrainEnergyRateDensityTempl(
     const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
-    _strain_energy_rate_density(
-        declareGenericProperty<Real, is_ad>(_base_name + "strain_energy_rate_density")),
+    _strain_energy_rate_density(declareProperty<Real>(_base_name + "strain_energy_rate_density")),
     _stress(getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "stress")),
     _strain_rate(getGenericMaterialProperty<RankTwoTensor, is_ad>(_base_name + "strain_rate")),
     _num_models(getParam<std::vector<MaterialName>>("inelastic_models").size())
@@ -78,7 +77,7 @@ StrainEnergyRateDensityTempl<is_ad>::computeQpProperties()
   for (unsigned int i = 0; i < _inelastic_models.size(); ++i)
   {
     _inelastic_models[i]->setQp(_qp);
-    _strain_energy_rate_density[_qp] =
-        _inelastic_models[i]->computeStrainEnergyRateDensity(_stress, _strain_rate);
+    _strain_energy_rate_density[_qp] = MetaPhysicL::raw_value(
+        _inelastic_models[i]->computeStrainEnergyRateDensity(_stress, _strain_rate));
   }
 }

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/c_int_surfbreak_ellip_crack_sym_mm_ad.i
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/c_int_surfbreak_ellip_crack_sym_mm_ad.i
@@ -1,0 +1,162 @@
+[GlobalParams]
+  order = FIRST
+  family = LAGRANGE
+  displacements = 'disp_x disp_y disp_z'
+  volumetric_locking_correction = true
+[]
+
+[Mesh]
+  file = c_integral_coarse.e
+  partitioner = centroid
+  centroid_partitioner_direction = z
+[]
+
+[AuxVariables]
+  [SED]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [resid_z]
+  []
+[]
+
+[Functions]
+  [rampConstantUp]
+    type = PiecewiseLinear
+    x = '0. 0.1 100.0'
+    y = '0. 1 1'
+    scale_factor = -68.95 #MPa
+  []
+  [dts]
+    type = PiecewiseLinear
+    x = '0   1'
+    y = '1   400000'
+  []
+[]
+
+[Modules/TensorMechanics/Master]
+  [master]
+    strain = FINITE
+    add_variables = true
+    incremental = true
+    generate_output = 'stress_xx stress_yy stress_zz vonmises_stress'
+    use_automatic_differentiation = true
+  []
+[]
+
+[AuxKernels]
+  [SED]
+    type = MaterialRealAux
+    variable = SED
+    property = strain_energy_density
+    execute_on = timestep_end
+  []
+[]
+
+[BCs]
+  [crack_y]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = 6
+    value = 0.0
+  []
+  [no_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 12
+    value = 0.0
+  []
+  [no_x]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  []
+  [Pressure]
+    [Side1]
+      boundary = 5
+      function = rampConstantUp
+    [] # BCs
+  []
+[]
+
+[Materials]
+  [elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 206800
+    poissons_ratio = 0.0
+  []
+  [radial_return_stress]
+    type = ADComputeMultipleInelasticStress
+    inelastic_models = 'powerlawcrp'
+  []
+  [powerlawcrp]
+    type = ADPowerLawCreepStressUpdate
+    coefficient = 3.125e-21 # 7.04e-17 #
+    n_exponent = 4.0
+    m_exponent = 0.0
+    activation_energy = 0.0
+    # max_inelastic_increment = 0.01
+  []
+[]
+
+[DomainIntegral]
+  integrals = CIntegral
+  boundary = 1001
+  crack_direction_method = CurvedCrackFront
+  crack_end_direction_method = CrackDirectionVector
+  crack_direction_vector_end_1 = '0.0 1.0 0.0'
+  crack_direction_vector_end_2 = '1.0 0.0 0.0'
+  radius_inner = '12.5 25.0 37.5'
+  radius_outer = '25.0 37.5 50.0'
+  intersecting_boundary = '1 2'
+  symmetry_plane = 2
+  incremental = true
+  inelastic_models = 'powerlawcrp'
+  use_automatic_differentiation = true
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'NEWTON'
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -pc_svd_monitor '
+                  '-snes_linesearch_monitor -snes_ksp_ew'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
+
+  nl_max_its = 20
+  nl_abs_tol = 1e-3
+  nl_rel_tol = 1e-11
+
+  start_time = 0.0
+  end_time = 401
+
+  [TimeStepper]
+    type = FunctionDT
+    function = dts
+    min_dt = 1.0
+  []
+[]
+
+[Postprocessors]
+  [_dt]
+    type = TimestepSize
+  []
+  [nl_its]
+    type = NumNonlinearIterations
+  []
+  [lin_its]
+    type = NumLinearIterations
+  []
+  [react_z]
+    type = NodalSum
+    variable = resid_z
+    boundary = 5
+  []
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_1_0002.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_1_0002.csv
@@ -1,0 +1,1 @@
+c_int_surfbreak_ellip_crack_sym_mm_out_C_1_0002.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_2_0002.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_2_0002.csv
@@ -1,0 +1,1 @@
+c_int_surfbreak_ellip_crack_sym_mm_out_C_2_0002.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_3_0002.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_3_0002.csv
@@ -1,0 +1,1 @@
+c_int_surfbreak_ellip_crack_sym_mm_out_C_3_0002.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_1_0001.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_1_0001.csv
@@ -1,0 +1,1 @@
+j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_1_0001.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_2_0001.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_2_0001.csv
@@ -1,0 +1,1 @@
+j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_2_0001.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_3_0001.csv
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/gold/j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_3_0001.csv
@@ -1,0 +1,1 @@
+j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_3_0001.csv

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm_ad.i
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/j_int_surfbreak_ellip_crack_sym_mm_cm_ad.i
@@ -1,0 +1,147 @@
+[GlobalParams]
+  order = FIRST
+  family = LAGRANGE
+  displacements = 'disp_x disp_y disp_z'
+  volumetric_locking_correction = true
+[]
+
+[Mesh]
+  file = ellip_crack_4sym_norad_mm.e
+  partitioner = centroid
+  centroid_partitioner_direction = z
+[]
+
+[AuxVariables]
+  [SED]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [resid_z]
+  []
+[]
+
+[Functions]
+  [rampConstantUp]
+    type = PiecewiseLinear
+    x = '0. 1.'
+    y = '0. 0.1'
+    scale_factor = -689.5 #MPa
+  []
+[]
+
+[DomainIntegral]
+  integrals = JIntegral
+  boundary = 1001
+  crack_direction_method = CrackMouth
+  crack_mouth_boundary = 11
+  crack_end_direction_method = CrackDirectionVector
+  crack_direction_vector_end_1 = '0.0 1.0 0.0'
+  crack_direction_vector_end_2 = '1.0 0.0 0.0'
+  radius_inner = '12.5 25.0 37.5'
+  radius_outer = '25.0 37.5 50.0'
+  intersecting_boundary = '1 2'
+  symmetry_plane = 2
+  position_type = angle
+  incremental = true
+  use_automatic_differentiation = true
+[]
+
+[Modules/TensorMechanics/Master]
+  [master]
+    strain = FINITE
+    add_variables = true
+    incremental = true
+    generate_output = 'stress_xx stress_yy stress_zz vonmises_stress'
+    use_automatic_differentiation = true
+  []
+[]
+
+[AuxKernels]
+  [SED]
+    type = MaterialRealAux
+    variable = SED
+    property = strain_energy_density
+    execute_on = timestep_end
+  []
+[]
+
+[BCs]
+  [crack_y]
+    type = ADDirichletBC
+    variable = disp_z
+    boundary = 6
+    value = 0.0
+  []
+  [no_y]
+    type = ADDirichletBC
+    variable = disp_y
+    boundary = 12
+    value = 0.0
+  []
+  [no_x]
+    type = ADDirichletBC
+    variable = disp_x
+    boundary = 1
+    value = 0.0
+  []
+  [Pressure]
+    [Side1]
+      boundary = 5
+      function = rampConstantUp
+    []
+  [] # BCs
+[]
+
+[Materials]
+  [elasticity_tensor]
+    type = ADComputeIsotropicElasticityTensor
+    youngs_modulus = 206800
+    poissons_ratio = 0.3
+  []
+  [elastic_stress]
+    type = ADComputeFiniteStrainElasticStress
+  []
+[]
+
+[Executioner]
+
+  type = Transient
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -pc_svd_monitor '
+                  '-snes_linesearch_monitor -snes_ksp_ew'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type'
+  petsc_options_value = 'lu       NONZERO'
+
+  nl_max_its = 20
+  nl_abs_tol = 1e-5
+  nl_rel_tol = 1e-11
+
+  start_time = 0.0
+  dt = 1
+
+  end_time = 1
+  num_steps = 1
+[]
+
+[Postprocessors]
+  [_dt]
+    type = TimestepSize
+  []
+  [nl_its]
+    type = NumNonlinearIterations
+  []
+  [lin_its]
+    type = NumLinearIterations
+  []
+  [react_z]
+    type = NodalSum
+    variable = resid_z
+    boundary = 5
+  []
+[]
+
+[Outputs]
+  execute_on = 'timestep_end'
+  file_base = j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out
+  exodus = true
+  csv = true
+[]

--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/tests
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/tests
@@ -1,42 +1,86 @@
 [Tests]
-design = 'syntax/DomainIntegral/index.md'
-issues = '#2717'
- [./j_ellip]
- design = 'syntax/DomainIntegral/index.md'
-   type = 'CSVDiff'
-   input = 'j_int_surfbreak_ellip_crack_sym_mm.i'
-   csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_out_J_1_0001.csv j_int_surfbreak_ellip_crack_sym_mm_out_J_2_0001.csv j_int_surfbreak_ellip_crack_sym_mm_out_J_3_0001.csv'
-   max_parallel = 1
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the J integral for surface breaking elliptical cracks.'
- [../]
- [./J_ellip_cm]
-   type = 'CSVDiff'
-   input = 'j_int_surfbreak_ellip_crack_sym_mm_cm.i'
-   csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_1_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_2_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_3_0001.csv'
-   max_parallel = 1
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the J integral for surface breaking elliptical cracks using the crack mouth specification.'
- [../]
- [./j_ellip_cfp]
-   type = 'CSVDiff'
-   input = 'j_int_surfbreak_ellip_crack_sym_mm_cfp.i'
-   csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_1_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_2_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_3_0001.csv'
-   max_parallel = 1
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the J integral for surface breaking elliptical cracks with crack face pressure.'
- [../]
- [./J_ellip_cm_cfp]
-   type = 'CSVDiff'
-   input = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm.i'
-   csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_1_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_2_0001.csv j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_3_0001.csv'
-   max_parallel = 1
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the J integral for surface breaking elliptical cracks with crack face pressure and crack mouth boundary specified.'
- [../]
- [./c_int_surfbreak_ellip_crack_sym_mm]
-   design = 'syntax/DomainIntegral/index.md'
-   type = 'CSVDiff'
-   input = 'c_int_surfbreak_ellip_crack_sym_mm.i'
-   csvdiff = 'c_int_surfbreak_ellip_crack_sym_mm_out_C_1_0002.csv c_int_surfbreak_ellip_crack_sym_mm_out_C_2_0002.csv c_int_surfbreak_ellip_crack_sym_mm_out_C_3_0002.csv'
-   max_parallel = 1
-   heavy = true
-   requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals including the C integral for surface breaking elliptical cracks.'
- [../]
+  design = 'syntax/DomainIntegral/index.md'
+  issues = '#2717'
+  [j_ellip]
+    design = 'syntax/DomainIntegral/index.md'
+    type = 'CSVDiff'
+    input = 'j_int_surfbreak_ellip_crack_sym_mm.i'
+    csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_out_J_1_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_out_J_2_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_out_J_3_0001.csv'
+    max_parallel = 1
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the J integral for surface breaking elliptical cracks.'
+  []
+  [J_ellip_cm]
+    type = 'CSVDiff'
+    input = 'j_int_surfbreak_ellip_crack_sym_mm_cm.i'
+    csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_1_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_2_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cm_out_J_3_0001.csv'
+    max_parallel = 1
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the J integral for surface breaking elliptical cracks using the crack '
+                  'mouth specification.'
+  []
+  [J_ellip_cm_ad]
+    type = 'CSVDiff'
+    input = 'j_int_surfbreak_ellip_crack_sym_mm_cm_ad.i'
+    csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_1_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_2_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_3_0001.csv'
+    max_parallel = 1
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the J integral for surface breaking elliptical cracks using the crack '
+                  'mouth specification computing the system Jacobian via automatic differentiation.'
+  []
+  [j_ellip_cfp]
+    type = 'CSVDiff'
+    input = 'j_int_surfbreak_ellip_crack_sym_mm_cfp.i'
+    csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_1_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_2_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cfp_out_J_3_0001.csv'
+    max_parallel = 1
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the J integral for surface breaking elliptical cracks with crack face '
+                  'pressure.'
+  []
+  [J_ellip_cm_cfp]
+    type = 'CSVDiff'
+    input = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm.i'
+    csvdiff = 'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_1_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_2_0001.csv '
+              'j_int_surfbreak_ellip_crack_sym_mm_cfp_cm_out_J_3_0001.csv'
+    max_parallel = 1
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the J integral for surface breaking elliptical cracks with crack face '
+                  'pressure and crack mouth boundary specified.'
+  []
+  [c_int_surfbreak_ellip_crack_sym_mm]
+    design = 'syntax/DomainIntegral/index.md'
+    type = 'CSVDiff'
+    input = 'c_int_surfbreak_ellip_crack_sym_mm.i'
+    csvdiff = 'c_int_surfbreak_ellip_crack_sym_mm_out_C_1_0002.csv '
+              'c_int_surfbreak_ellip_crack_sym_mm_out_C_2_0002.csv '
+              'c_int_surfbreak_ellip_crack_sym_mm_out_C_3_0002.csv'
+    max_parallel = 1
+    heavy = true
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the C integral for surface breaking elliptical cracks.'
+  []
+
+  [c_int_surfbreak_ellip_crack_sym_mm_ad]
+    design = 'syntax/DomainIntegral/index.md'
+    type = 'CSVDiff'
+    input = 'c_int_surfbreak_ellip_crack_sym_mm_ad.i'
+    csvdiff = 'c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_1_0002.csv '
+              'c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_2_0002.csv '
+              'c_int_surfbreak_ellip_crack_sym_mm_ad_out_C_3_0002.csv'
+    max_parallel = 1
+    heavy = true
+    requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
+                  'including the C integral for surface breaking elliptical cracks using automatic '
+                  'differentiation.'
+    rel_err = 1.0e-4
+  []
 []

--- a/modules/tensor_mechanics/test/tests/multi_power_law/power_law_creep.i
+++ b/modules/tensor_mechanics/test/tests/multi_power_law/power_law_creep.i
@@ -28,7 +28,7 @@
 
 [AuxKernels]
   [strain_energy_rate_density]
-    type = ADMaterialRealAux
+    type = MaterialRealAux
     variable = strain_energy_rate_density
     property = strain_energy_rate_density
     execute_on = timestep_end

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/ad_rate_model_weak_plane.i
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/ad_rate_model_weak_plane.i
@@ -18,117 +18,117 @@
 []
 
 [AuxVariables]
-  [./SERD]
+  [SERD]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [Variables]
-  [./strain_zz]
+  [strain_zz]
   []
 []
 
 [Functions]
-  [./rampConstantUp]
+  [rampConstantUp]
     type = PiecewiseLinear
     x = '0. 1.'
     y = '0. 1.'
     scale_factor = -100
-  [../]
+  []
 []
 
 [Modules/TensorMechanics/Master]
-  [./master]
+  [master]
     strain = FINITE
     add_variables = true
     incremental = true
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress strain_xx strain_yy'
     planar_formulation = WEAK_PLANE_STRESS
     use_automatic_differentiation = true
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./SERD]
-    type = ADMaterialRealAux
+  [SERD]
+    type = MaterialRealAux
     variable = SERD
     property = strain_energy_rate_density
     execute_on = timestep_end
-  [../]
+  []
 []
 
 [BCs]
-  [./no_x]
+  [no_x]
     type = ADDirichletBC
     variable = disp_x
     boundary = 'left'
     value = 0.0
-  [../]
-  [./no_y]
+  []
+  [no_y]
     type = ADDirichletBC
     variable = disp_y
     boundary = 'bottom'
     value = 0.0
-  [../]
-  [./Pressure]
-    [./top]
+  []
+  [Pressure]
+    [top]
       boundary = 'top'
       function = rampConstantUp
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ADComputeIsotropicElasticityTensor
     youngs_modulus = 206800
     poissons_ratio = 0.0
-  [../]
-  [./radial_return_stress]
+  []
+  [radial_return_stress]
     type = ADComputeMultipleInelasticStress
     inelastic_models = 'powerlawcrp'
-  [../]
-  [./powerlawcrp]
+  []
+  [powerlawcrp]
     type = ADPowerLawCreepStressUpdate
     coefficient = 3.125e-21 # 7.04e-17 #
     n_exponent = 4.0
     m_exponent = 0.0
     activation_energy = 0.0
     # max_inelastic_increment = 0.01
-  [../]
-  [./strain_energy_rate_density]
+  []
+  [strain_energy_rate_density]
     type = ADStrainEnergyRateDensity
     inelastic_models = 'powerlawcrp'
-  [../]
+  []
 []
 
 [Executioner]
-   type = Transient
+  type = Transient
 
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 
   line_search = 'none'
 
-   l_max_its = 50
-   nl_max_its = 20
-   nl_abs_tol = 3e-7
-   nl_rel_tol = 1e-12
-   l_tol = 1e-2
+  l_max_its = 50
+  nl_max_its = 20
+  nl_abs_tol = 3e-7
+  nl_rel_tol = 1e-12
+  l_tol = 1e-2
 
-   start_time = 0.0
-   dt = 1
+  start_time = 0.0
+  dt = 1
 
-   end_time = 1
-   num_steps = 1
+  end_time = 1
+  num_steps = 1
 []
 
 [Postprocessors]
-  [./SERD]
+  [SERD]
     type = ElementAverageValue
     variable = SERD
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/tests
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/tests
@@ -1,95 +1,94 @@
 [Tests]
- issues = '#10972'
- [./incr_elas]
-   type = 'CSVDiff'
-   input = 'incr_model.i'
-   csvdiff = 'incr_model_out.csv'
-   rel_err = 1e-6
-   abs_zero = 1e-8
-   design = 'StrainEnergyDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy density '
-                 'incrementally in materials with elastic stress and finite '
-                 'strain.'
- [../]
- [./incr_chk1]
-   type = 'RunException'
-   input = 'incr_model.i'
-   cli_args = 'Materials/strain_energy_density/incremental=false'
-   design = 'StrainEnergyDensity.md'
-   expect_err = 'StrainEnergyDensity: Specified incremental = false, but material model is incremental.'
-   requirement = 'Moose shall be capable of informing a user when they '
-                 'incorrectly choose not to use the incremental strain '
-                 'energy density formulation with an incremental material '
-                 'model.'
- [../]
- [./tot_elas]
-   type = 'CSVDiff'
-   input = 'tot_model.i'
-   csvdiff = 'tot_model_out.csv'
-   rel_err = 1e-6
-   design = 'StrainEnergyDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy density '
-                 'for materials with elastic stress and small strain.'
- [../]
- [./tot_chk1]
-   type = 'RunException'
-   input = 'tot_model.i'
-   cli_args = 'Materials/strain_energy_density/incremental=true'
-   design = 'StrainEnergyDensity.md'
-   expect_err = "StrainEnergyDensity: Specified incremental = true, but material model is not incremental."
-   requirement = 'Moose shall be capable of informing a user when they '
-                 'incorrectly choose to use the incremental strain energy '
-                 'density formulation in a material utilizing small strain.'
- [../]
- [./incr_elas_plas]
-   type = 'CSVDiff'
-   input = 'incr_model_elas_plas.i'
-   csvdiff = 'incr_model_elas_plas_out.csv'
-   rel_err = 1e-6
-   design = 'StrainEnergyDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy density '
-                 'incrementally in materials with inelastic stress and '
-                 'isotropic plasticity.'
- [../]
- [./rate_model]
-   type = 'CSVDiff'
-   input = 'rate_model.i'
-   csvdiff = 'rate_model_out.csv'
-   rel_err = 1e-6
-   abs_zero = 1e-8
-   design = 'StrainEnergyRateDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy rate density '
-                 'with elastic stress and finite strain.'
- [../]
- [./rate_model_small]
-   type = 'CSVDiff'
-   input = 'rate_model_small.i'
-   csvdiff = 'rate_model_small_out.csv'
-   rel_err = 1e-6
-   design = 'StrainEnergyRateDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy rate density '
-                 'when using small strain assumptions.'
- [../]
+  issues = '#10972'
+  [incr_elas]
+    type = 'CSVDiff'
+    input = 'incr_model.i'
+    csvdiff = 'incr_model_out.csv'
+    rel_err = 1e-6
+    abs_zero = 1e-8
+    design = 'StrainEnergyDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy density incrementally in '
+                  'materials with elastic stress and finite strain.'
+  []
+  [incr_chk1]
+    type = 'RunException'
+    input = 'incr_model.i'
+    cli_args = 'Materials/strain_energy_density/incremental=false'
+    design = 'StrainEnergyDensity.md'
+    expect_err = 'StrainEnergyDensity: Specified incremental = false, but material model is '
+                 'incremental.'
+    requirement = 'Moose shall be capable of informing a user when they incorrectly choose not to '
+                  'use the incremental strain energy density formulation with an incremental '
+                  'material model.'
+  []
+  [tot_elas]
+    type = 'CSVDiff'
+    input = 'tot_model.i'
+    csvdiff = 'tot_model_out.csv'
+    rel_err = 1e-6
+    design = 'StrainEnergyDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy density for materials with '
+                  'elastic stress and small strain.'
+  []
+  [tot_chk1]
+    type = 'RunException'
+    input = 'tot_model.i'
+    cli_args = 'Materials/strain_energy_density/incremental=true'
+    design = 'StrainEnergyDensity.md'
+    expect_err = "StrainEnergyDensity: Specified incremental = true, but material model is not "
+                 "incremental."
+    requirement = 'Moose shall be capable of informing a user when they incorrectly choose to use '
+                  'the incremental strain energy density formulation in a material utilizing small '
+                  'strain.'
+  []
+  [incr_elas_plas]
+    type = 'CSVDiff'
+    input = 'incr_model_elas_plas.i'
+    csvdiff = 'incr_model_elas_plas_out.csv'
+    rel_err = 1e-6
+    design = 'StrainEnergyDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy density incrementally in '
+                  'materials with inelastic stress and isotropic plasticity.'
+  []
+  [rate_model]
+    type = 'CSVDiff'
+    input = 'rate_model.i'
+    csvdiff = 'rate_model_out.csv'
+    rel_err = 1e-6
+    abs_zero = 1e-8
+    design = 'StrainEnergyRateDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy rate density with elastic '
+                  'stress and finite strain.'
+  []
+  [rate_model_small]
+    type = 'CSVDiff'
+    input = 'rate_model_small.i'
+    csvdiff = 'rate_model_small_out.csv'
+    rel_err = 1e-6
+    design = 'StrainEnergyRateDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy rate density when using small '
+                  'strain assumptions.'
+  []
 
- [./ad_rate_model_weak_plane]
-   type = 'CSVDiff'
-   input = 'ad_rate_model_weak_plane.i'
-   csvdiff = 'ad_rate_model_weak_plane_out.csv'
-   rel_err = 1e-6
-   abs_zero = 1e-8
-   design = 'StrainEnergyRateDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy rate density '
-                 'when using automatic differentiation and weak plane stress.'
- [../]
+  [ad_rate_model_weak_plane]
+    type = 'CSVDiff'
+    input = 'ad_rate_model_weak_plane.i'
+    csvdiff = 'ad_rate_model_weak_plane_out.csv'
+    rel_err = 1e-6
+    abs_zero = 1e-8
+    design = 'StrainEnergyRateDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy rate density when using '
+                  'automatic differentiation and weak plane stress.'
+  []
 
- [./nonAD_rate_model_weak_plane]
-   type = 'CSVDiff'
-   input = 'nonAD_rate_model_weak_plane.i'
-   csvdiff = 'nonAD_rate_model_weak_plane_out.csv'
-   rel_err = 1e-6
-   abs_zero = 1e-8
-   design = 'StrainEnergyRateDensity.md'
-   requirement = 'Moose shall be capable of calculating strain energy rate density '
-                 'when using hand-coded Jacobian and weak plane stress.'
- [../]
+  [nonAD_rate_model_weak_plane]
+    type = 'CSVDiff'
+    input = 'nonAD_rate_model_weak_plane.i'
+    csvdiff = 'nonAD_rate_model_weak_plane_out.csv'
+    rel_err = 1e-6
+    abs_zero = 1e-8
+    design = 'StrainEnergyRateDensity.md'
+    requirement = 'Moose shall be capable of calculating strain energy rate density when using '
+                  'hand-coded Jacobian and weak plane stress.'
+  []
 []

--- a/modules/tensor_mechanics/test/tests/strain_energy_density/tot_model.i
+++ b/modules/tensor_mechanics/test/tests/strain_energy_density/tot_model.i
@@ -17,129 +17,129 @@
 []
 
 [AuxVariables]
-  [./SED]
+  [SED]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [Functions]
-  [./rampConstantUp]
+  [rampConstantUp]
     type = PiecewiseLinear
     x = '0. 1.'
     y = '0. 1.'
     scale_factor = -100
-  [../]
+  []
 []
 
 [Modules/TensorMechanics/Master]
-  [./master]
+  [master]
     strain = SMALL
     add_variables = true
     incremental = false
     generate_output = 'stress_xx stress_yy stress_zz vonmises_stress strain_xx strain_yy strain_zz'
     planar_formulation = PLANE_STRAIN
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./SED]
+  [SED]
     type = MaterialRealAux
     variable = SED
     property = strain_energy_density
     execute_on = timestep_end
-  [../]
+  []
 []
 
 [BCs]
-  [./no_x]
+  [no_x]
     type = DirichletBC
     variable = disp_x
     boundary = 'left'
     value = 0.0
-  [../]
-  [./no_y]
+  []
+  [no_y]
     type = DirichletBC
     variable = disp_y
     boundary = 'bottom'
     value = 0.0
-  [../]
-  [./Pressure]
-    [./top]
+  []
+  [Pressure]
+    [top]
       boundary = 'top'
       function = rampConstantUp
-    [../]
-  [../]
+    []
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 30e+6
     poissons_ratio = 0.3
-  [../]
-  [./elastic_stress]
+  []
+  [elastic_stress]
     type = ComputeLinearElasticStress
-  [../]
-  [./strain_energy_density]
+  []
+  [strain_energy_density]
     type = StrainEnergyDensity
     incremental = false
-  [../]
+  []
 []
 
 [Executioner]
-   type = Transient
+  type = Transient
 
   petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
   petsc_options_value = '201                hypre    boomeramg      4'
 
   line_search = 'none'
 
-   l_max_its = 50
-   nl_max_its = 20
-   nl_abs_tol = 3e-7
-   nl_rel_tol = 1e-12
-   l_tol = 1e-2
+  l_max_its = 50
+  nl_max_its = 20
+  nl_abs_tol = 3e-7
+  nl_rel_tol = 1e-12
+  l_tol = 1e-2
 
-   start_time = 0.0
-   dt = 1
+  start_time = 0.0
+  dt = 1
 
-   end_time = 1
-   num_steps = 1
+  end_time = 1
+  num_steps = 1
 []
 
 [Postprocessors]
-  [./epxx]
+  [epxx]
     type = ElementalVariableValue
     variable = strain_xx
     elementid = 0
-  [../]
-  [./epyy]
+  []
+  [epyy]
     type = ElementalVariableValue
     variable = strain_yy
     elementid = 0
-  [../]
-  [./epzz]
+  []
+  [epzz]
     type = ElementalVariableValue
     variable = strain_zz
     elementid = 0
-  [../]
-  [./sigxx]
+  []
+  [sigxx]
     type = ElementAverageValue
     variable = stress_xx
-  [../]
-  [./sigyy]
+  []
+  [sigyy]
     type = ElementAverageValue
     variable = stress_yy
-  [../]
-  [./sigzz]
+  []
+  [sigzz]
     type = ElementAverageValue
     variable = stress_zz
-  [../]
-  [./SED]
+  []
+  [SED]
     type = ElementAverageValue
     variable = SED
-  [../]
+  []
 []
 
 [Outputs]


### PR DESCRIPTION

## Reason
Some models in the tensor mechanics module benefit significantly from the use of automatic differentiation, especially those involving plastic behavior. Because of this, it's necessary to convert the domain integral action and its associated objects to templated AD.

## Design
Typical templated AD. Also make objects that do not intervene in the residual (for now) non-AD.

## Impact
Allow more capabilities for AD simulations within the tensor mechanics module. This particular capability is needed in fracture mechanics applications.

Refs. #15517