### PR TITLE
Disable valgrind for long domain integral test 

### DIFF
--- a/modules/tensor_mechanics/test/tests/j_integral_vtest/tests
+++ b/modules/tensor_mechanics/test/tests/j_integral_vtest/tests
@@ -30,6 +30,8 @@
               'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_2_0001.csv '
               'j_int_surfbreak_ellip_crack_sym_mm_cm_ad_out_J_3_0001.csv'
     max_parallel = 1
+    valgrind = 'none'
+    method = 'opt'
     requirement = 'The Domain Integral Action shall compute all of the fracture domain integrals '
                   'including the J integral for surface breaking elliptical cracks using the crack '
                   'mouth specification computing the system Jacobian via automatic differentiation.'


### PR DESCRIPTION
A test is timing out for the valgrind recipe. Disabling valgrind testing on one test. It becomes slightly slower when running the problem with AD, thereby the difference with the non-AD counterpart.

(#15517)