### PR TITLE
Avoid relying on to-be-deprecated MeshBase iterators

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -282,14 +282,18 @@ public:
   /**
    * Calls local_nodes_begin/end() on the underlying libMesh mesh object.
    */
-  MeshBase::const_node_iterator localNodesBegin();
-  MeshBase::const_node_iterator localNodesEnd();
+  MeshBase::node_iterator localNodesBegin();
+  MeshBase::node_iterator localNodesEnd();
+  MeshBase::const_node_iterator localNodesBegin() const;
+  MeshBase::const_node_iterator localNodesEnd() const;
 
   /**
    * Calls active_local_nodes_begin/end() on the underlying libMesh mesh object.
    */
-  MeshBase::const_element_iterator activeLocalElementsBegin();
-  const MeshBase::const_element_iterator activeLocalElementsEnd();
+  MeshBase::element_iterator activeLocalElementsBegin();
+  const MeshBase::element_iterator activeLocalElementsEnd();
+  MeshBase::const_element_iterator activeLocalElementsBegin() const;
+  const MeshBase::const_element_iterator activeLocalElementsEnd() const;
 
   /**
    * Calls n_nodes/elem() on the underlying libMesh mesh object.

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2455,26 +2455,50 @@ MooseMesh::sideWithBoundaryID(const Elem * const elem, const BoundaryID boundary
   return getMesh().get_boundary_info().side_with_boundary_id(elem, boundary_id);
 }
 
-MeshBase::const_node_iterator
+MeshBase::node_iterator
 MooseMesh::localNodesBegin()
 {
   return getMesh().local_nodes_begin();
 }
 
-MeshBase::const_node_iterator
+MeshBase::node_iterator
 MooseMesh::localNodesEnd()
 {
   return getMesh().local_nodes_end();
 }
 
-MeshBase::const_element_iterator
+MeshBase::const_node_iterator
+MooseMesh::localNodesBegin() const
+{
+  return getMesh().local_nodes_begin();
+}
+
+MeshBase::const_node_iterator
+MooseMesh::localNodesEnd() const
+{
+  return getMesh().local_nodes_end();
+}
+
+MeshBase::element_iterator
 MooseMesh::activeLocalElementsBegin()
 {
   return getMesh().active_local_elements_begin();
 }
 
-const MeshBase::const_element_iterator
+const MeshBase::element_iterator
 MooseMesh::activeLocalElementsEnd()
+{
+  return getMesh().active_local_elements_end();
+}
+
+MeshBase::const_element_iterator
+MooseMesh::activeLocalElementsBegin() const
+{
+  return getMesh().active_local_elements_begin();
+}
+
+const MeshBase::const_element_iterator
+MooseMesh::activeLocalElementsEnd() const
 {
   return getMesh().active_local_elements_end();
 }

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -756,7 +756,7 @@ MultiAppNearestNodeTransfer::getLocalEntitiesAndComponents(
 {
   mooseAssert(mesh, "mesh should not be a nullptr");
   mooseAssert(local_entities.empty(), "local_entities should be empty");
-  const MeshBase & mesh_base = mesh->getMesh();
+  MeshBase & mesh_base = mesh->getMesh();
 
   if (isParamValid("source_boundary"))
   {
@@ -846,7 +846,7 @@ MultiAppNearestNodeTransfer::getLocalEntities(
     MooseMesh * mesh, std::vector<std::pair<Point, DofObject *>> & local_entities, bool is_nodal)
 {
   mooseAssert(local_entities.empty(), "local_entities should be empty");
-  const MeshBase & mesh_base = mesh->getMesh();
+  MeshBase & mesh_base = mesh->getMesh();
 
   if (isParamValid("source_boundary"))
   {
@@ -889,7 +889,7 @@ const std::vector<Node *> &
 MultiAppNearestNodeTransfer::getTargetLocalNodes(const unsigned int to_problem_id)
 {
   _target_local_nodes.clear();
-  const MeshBase & to_mesh = _to_meshes[to_problem_id]->getMesh();
+  MeshBase & to_mesh = _to_meshes[to_problem_id]->getMesh();
 
   if (isParamValid("target_boundary"))
   {


### PR DESCRIPTION

## Reason
The non-const-correct libMesh::MeshBase iterators will hopefully soon be deprecated by https://github.com/libMesh/libmesh/pull/3164 - once they are we'll need to avoid making use of the current ability to get access to non-const Node and Elem objects from a const mesh.

## Design
Add non-const iterator shims to MooseMesh, and fix the transfer class where we were incorrectly taking a const reference to a non-const Mesh we wanted non-const pointers from later.

## Impact
No impact to users.

When we eventually eliminate the deprecated iterators from libMesh in a year or two, there may be other downstream changes needed.  Hopefully they'll all be as tiny as this PR turned out to be - no changes to test classes or unit tests or examples, and only a handful of declaration changes in one framework class!