### PR TITLE
Return a hash for a given library

### DIFF
--- a/modules/doc/content/python/index.md
+++ b/modules/doc/content/python/index.md
@@ -17,6 +17,7 @@ with MOOSE and [python/source/index.md] links to the source code documentation.
 | [combine_csv.md] | Tool for combining CSV files together. |
 | [moosesqa/index.md] | Tools for managing SQA documentation. |
 | [ReporterReader.md] | Tool for reading [JSON](JSONOutput.md) output of [Reporter](Reporters/index.md) data |
+| [module_hash.md] | Tool for generating a hash suffix for our contribution modules. |
 
 ## Setup
 

--- a/modules/doc/content/python/module_hash/module_hash.md
+++ b/modules/doc/content/python/module_hash/module_hash.md
@@ -1,0 +1,100 @@
+# Module Hash Tool
+
+The `module_hash.py` tool provides a method for suggesting a unique naming suffix for our contribution modules within our continuous integration environment.
+
+The idea is to utilize git blob/commit hashes on specific items involved with updating or modifying any contribution library. Dependencies are taking into consideration; a change to PETSc requires a change to libMesh and therefore a new hash is generated for libMesh as well as PETSc.
+
+The configuration file responsible for tracking changes is in yaml format:
+
+```yaml
+packages:
+  petsc:
+    - petsc
+    - conda/petsc/meta.yaml
+    - scripts/configure_petsc.sh
+    - scripts/update_and_rebuild_petsc.sh
+  libmesh:
+    - libmesh
+    - conda/libmesh/meta.yaml
+    - scripts/configure_libmesh.sh
+    - scripts/update_and_rebuild_libmesh.sh
+zip_keys:
+  - petsc
+  - libmesh
+```
+
+`zip_keys` is present in order to produce an ordered list (a dependency chain) `['petsc', 'libmesh']`. As configured here, libMesh is set to depend on PETSc.
+
+`packages` contain each contribution, and each contribution contains items that will be used to ultimately generate a hash using `git ls-tree`:
+
+```bash
+git ls-tree HEAD MOOSE_DIR/petsc
+git ls-tree HEAD MOOSE_DIR/conda/petsc/meta.yaml
+...etc
+```
+
+In order to support history, the module hash tool will perform a `git show <COMMIT>:module_hash.yaml` to understand any additions/subtractions that were being tracked at that time. That same `<COMMIT>` will then be used during `git ls-tree COMMIT` operations.
+
+If the provided `<COMMIT>` does not produce valid results (module_hash.yaml does not exist at that time in history), then `arbitrary` will be produced, as the tool will not understand what to track.
+
+### Syntax
+
+```bash
+❯ ./module_hash.py -h
+usage: module_hash.py [-h] [-q] [-i] library [commit]
+
+Supplies a hash for a given library
+
+positional arguments:
+  library            choose from: petsc, libmesh
+  commit             default HEAD
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -q, --quiet        Do not print warnings
+  -i, --influential  List influential files involved with hash generation then exit
+```
+
+### Examples
+
+Basic usage, defaulting to HEAD:
+
+```bash
+❯ ./module_hash.py petsc
+8328006
+
+❯ ./module_hash.py libmesh
+ae2fdf1
+```
+
+Example arbitrary return:
+
+```bash
+❯ ./module_hash.py libmesh abc123
+warning: commit abc123 does not contain module_hash.yaml
+arbitrary
+
+❯ ./module_hash.py libmesh abc123 --quiet
+arbitrary
+```
+
+Relative history support:
+
+```bash
+❯ ./module_hash.py libmesh HEAD~1
+ae2fdf1
+
+❯ ./module_hash.py libmesh HEAD~2
+warning: commit HEAD~2 does not contain module_hash.yaml
+arbitrary
+```
+
+Demonstrating dependency tracking. Because the module hash tool uses `git ls-tree`, the change must be committed to take effect.
+
+```bash
+❯ echo "" >> ../conda/petsc/meta.yaml
+❯ git add ../conda/petsc/meta.yaml
+❯ git commit -m "a change to petsc"
+❯ ./module_hash.py libmesh
+bf57cd8
+```

--- a/scripts/module_hash.py
+++ b/scripts/module_hash.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+"""
+Generate hash based on vetted versions of libraries as listed in
+module_hash.yaml's (zip_keys)
+"""
+
+import os
+import sys
+import argparse
+import hashlib
+import subprocess
+import yaml
+
+MOOSE_DIR = os.environ.get('MOOSE_DIR',
+                           os.path.abspath(os.path.join(os.path.dirname(
+                               os.path.realpath(__file__)), '..')))
+
+# Load resource file so argparse 'choices' can function properly
+YAML_FILE = os.path.relpath(os.path.join(MOOSE_DIR, "scripts", "module_hash.yaml"))
+try:
+    with open(f'{YAML_FILE}', 'r', encoding='utf-8') as rc_file:
+        ENTITIES = yaml.safe_load(rc_file)['zip_keys']
+
+except FileNotFoundError:
+    print(f'fatal: {YAML_FILE} not found')
+    sys.exit(1)
+
+except yaml.scanner.ScannerError:
+    print(f'fatal: {YAML_FILE} parsing error')
+    sys.exit(1)
+
+def tell(quiet, message, and_exit=None):
+    """ print a message to stdout and conditionally exit with code """
+    if not quiet:
+        print(message)
+    if and_exit is not None:
+        sys.exit(and_exit)
+
+def parse_args():
+    """ parse arguments """
+    parser = argparse.ArgumentParser(description='Supplies a hash for a given library')
+    parser.add_argument('library', metavar='library', choices=ENTITIES,
+                        help=f'choose from: {", ".join(ENTITIES)}')
+    parser.add_argument('commit', nargs='?', metavar='commit', default='HEAD',
+                        help='default %(default)s')
+    parser.add_argument('-q', '--quiet', action='store_true', default=False,
+                        help='Do not print warnings')
+    parser.add_argument('-i', '--influential', action='store_true', default=False,
+                        help='List influential files involved with hash generation '
+                        'then exit')
+    return parser.parse_args()
+
+def git_hash(args, entity):
+    """ use git ls-tree HEAD|HASH ABSPATH, to supply hash """
+    _stmp = ''
+    try:
+        out = subprocess.check_output(['git', 'ls-tree', args.commit,
+                                       os.path.join(MOOSE_DIR, entity)],
+                                      encoding='utf-8',
+                                      stderr=subprocess.DEVNULL)
+        _stmp = out.split()[2]
+
+    # file does not exist in repo (git does not error for this scenario)
+    except IndexError:
+        tell(args.quiet, f'warning: {entity} does not exist')
+        tell(False, 'arbitrary', 0)
+
+    # commit was not found in git
+    except subprocess.CalledProcessError:
+        tell(args.quiet, f'warning: {args.commit} is not a valid git commit')
+        tell(False, 'arbitrary', 0)
+
+    return _stmp
+
+def read_yamlfile(args):
+    """ read module_hash.yaml file at specified commit """
+    _meta = {}
+    try:
+        out = subprocess.check_output(['git', 'show',
+                                       f'{args.commit}:./{YAML_FILE}'],
+                                      encoding='utf-8',
+                                      stderr=subprocess.DEVNULL)
+        _meta = yaml.safe_load(out)
+    except subprocess.CalledProcessError:
+        # Resource file does not exist at specified commit
+        message = f'commit {args.commit} does not contain {YAML_FILE}'
+        if args.influential:
+            tell(False, f'fatal: {message}', 1)
+        tell(args.quiet, f'warning: {message}')
+        tell(False, 'arbitrary', 0)
+    return _meta
+
+def build_list(args):
+    """ return list of files associated with supplied library """
+    _dtmp = read_yamlfile(args)
+    _ltmp = []
+    for group_entity in ENTITIES:
+        if group_entity in _dtmp['packages']:
+            for entity in _dtmp['packages'][group_entity]:
+                _ltmp.append(entity)
+        if group_entity == args.library:
+            break
+    return _ltmp
+
+def main():
+    """ print hash for supplied library """
+    args = parse_args()
+    hash_tree = []
+    entity_list = []
+    for an_entity in build_list(args):
+        entity_list.append(os.path.abspath(os.path.join(MOOSE_DIR, an_entity)))
+        hash_tree.append(git_hash(args, an_entity))
+    if args.influential:
+        print('\n'.join(entity_list))
+    else:
+        print(hashlib.md5(''.join(hash_tree).encode('utf-8')).hexdigest()[:7])
+
+if __name__ == '__main__':
+    main()

--- a/scripts/module_hash.yaml
+++ b/scripts/module_hash.yaml
@@ -1,0 +1,14 @@
+packages:
+  petsc:
+    - petsc
+    - conda/petsc/meta.yaml
+    - scripts/configure_petsc.sh
+    - scripts/update_and_rebuild_petsc.sh
+  libmesh:
+    - libmesh
+    - conda/libmesh/meta.yaml
+    - scripts/configure_libmesh.sh
+    - scripts/update_and_rebuild_libmesh.sh
+zip_keys:
+  - petsc
+  - libmesh

--- a/scripts/tests/test_modulehash.py
+++ b/scripts/tests/test_modulehash.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import os
+import sys
+import unittest
+import yaml
+import subprocess # for assertRaises
+import mooseutils
+
+MOOSE_DIR = mooseutils.git_root_dir()
+YAML_FILE = os.path.relpath(os.path.join(MOOSE_DIR, "scripts", "module_hash.yaml"))
+
+# TODO: Replace with an actual commit hash which contains module_hash.yaml
+COMMIT = 'FIXME'
+
+# The following represent the current output of module_hash.py petsc|libmesh
+HASH_TABLE = {'petsc': '8328006', 'libmesh' :'ae2fdf1'}
+
+try:
+    with open(f'{YAML_FILE}', 'r', encoding='utf-8') as rc_file:
+        RAW = yaml.safe_load(rc_file)
+        ENTITIES = RAW['packages']
+        LIBRARIES = RAW['zip_keys']
+
+except FileNotFoundError:
+    print(f'fatal: {YAML_FILE} not found')
+    sys.exit(1)
+
+except yaml.scanner.ScannerError:
+    print(f'fatal: {YAML_FILE} parsing error')
+    sys.exit(1)
+
+sys.path.insert(0, os.path.join(MOOSE_DIR, 'scripts'))
+from module_hash import main
+
+@classmethod
+def setUpClass(cls):
+    cls.flag = False
+
+class Test(unittest.TestCase):
+    def read_yaml(self):
+        # Read the module_hash.yaml file at 'COMMIT' time in history
+        out = mooseutils.check_output(['git', 'show',
+                                       f'{COMMIT}:./{os.path.basename(YAML_FILE)}'],
+                                      cwd=os.path.join(MOOSE_DIR, 'scripts'))
+        return yaml.safe_load(out)
+
+    def testExpectedOutputArbitrary(self):
+        # Verify a non existent hash generates 'arbitrary'
+        for library in LIBRARIES:
+            out = mooseutils.check_output(['./module_hash.py', library, 'abc1234', '--quiet'],
+                                          cwd=os.path.join(MOOSE_DIR, 'scripts'))
+            self.assertEqual('arbitrary\n', out)
+
+        # Verify a non existent hash generates a warning, and prints 'arbitrary'
+        for library in LIBRARIES:
+            out = mooseutils.check_output(['./module_hash.py', library, 'abc1234'],
+                                          cwd=os.path.join(MOOSE_DIR, 'scripts'))
+            self.assertIn('warning: commit abc1234 does not contain module_hash.yaml\narbitrary\n', out)
+
+        # Verify a non existent hash fatally errors when invoked with --influential
+        for library in LIBRARIES:
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                out = mooseutils.check_output(['./module_hash.py', library, 'abc1234', '--influential'],
+                                              cwd=os.path.join(MOOSE_DIR, 'scripts'))
+            e = cm.exception
+            self.assertIn('warning: commit abc1234 does not contain module_hash.yaml\narbitrary\n', out)
+
+    def testEntitiesHEAD(self):
+        # Verify that module_hashes.py reports valid control files for HEAD
+        _ltmp = set([])
+        _unit_tmp = set([])
+        for library in LIBRARIES:
+            out = mooseutils.check_output(['./module_hash.py', library, '--influential'],
+                                          cwd=os.path.join(mooseutils.git_root_dir(), 'scripts'))
+            _ltmp.update(out.split())
+        for library in LIBRARIES:
+            _unit_tmp.update([f'{os.path.join(MOOSE_DIR, x)}' for x in ENTITIES[library]])
+
+        if _ltmp.difference(_unit_tmp) or len(_ltmp) is not len(_unit_tmp):
+            self.fail(f'Difference in control files: {_ltmp.difference(_unit_tmp)}')
+
+    def testExpectedOutputHASH(self):
+        # TODO: When module_hash.yaml has entered git history, uncomment the following test
+        #       and replace COMMIT='FIXME' with a proper hash containing module_hash.yaml
+
+        # # Verify a vetted hash reports correctly for all involved libraries
+        # for library in LIBRARIES:
+        #     out = mooseutils.check_output(['./module_hash.py', library, COMMIT, '--quiet'],
+        #                                   cwd=os.path.join(mooseutils.git_root_dir(), 'scripts'))
+        #     self.assertIn(HASH_TABLE[library], out)
+        return
+
+    def testEntitiesHASH(self):
+        # TODO: When module_hash.yaml has entered git history, uncomment the following test
+        #       and replace COMMIT='FIXME' with a proper hash containing module_hash.yaml
+
+        # # Verify a vetted hash reports proper control files
+        # hashed_list = self.read_yaml()
+        # _ltmp = set([])
+        # _unit_tmp = set([])
+        # for library in LIBRARIES:
+        #     out = mooseutils.check_output(['./module_hash.py', library, COMMIT, '--influential'],
+        #                                   cwd=os.path.join(mooseutils.git_root_dir(), 'scripts'))
+        #     _ltmp.update(out.split())
+        # for library in LIBRARIES:
+        #     _unit_tmp.update([f'{os.path.join(MOOSE_DIR, x)}' for x in hashed_list['packages'][library]])
+
+        # if _ltmp.difference(_unit_tmp) or len(_ltmp) is not len(_unit_tmp):
+        #     self.fail(f'Difference in control files: {_ltmp.difference(_unit_tmp)}')
+        return
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, buffer=True)

--- a/scripts/tests/tests
+++ b/scripts/tests/tests
@@ -38,6 +38,7 @@
     type = PythonUnitTest
     input = test_modulehash.py
     issues = '#20336'
+    design = 'python/index.md'
     requirement = "The system shall include a utility for generating a unique hash that represents a moose environment module"
   []
 []

--- a/scripts/tests/tests
+++ b/scripts/tests/tests
@@ -34,4 +34,10 @@
     design = 'python/index.md'
     requirement = "The system shall include a utility for counting the number of lines for unique contributor."
   []
+  [module_hash]
+    type = PythonUnitTest
+    input = test_modulehash.py
+    issues = '#20336'
+    requirement = "The system shall include a utility for generating a unique hash that represents a moose environment module"
+  []
 []


### PR DESCRIPTION
A simple script to produce a hash based on several key files involved when
building the vetted libraries; PETSc and libMesh.

Closes #20335

