### PR TITLE
Install examples

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -25,7 +25,6 @@ $INSTALLABLE_DIRS$(STACK) := $(INSTALLABLE_DIRS)
 
 # install target related stuff
 share_install_dir := $(share_dir)/$(APPLICATION_NAME)
-tests_install_dir := $(share_install_dir)/test
 docs_install_dir := $(share_install_dir)/doc
 
 #
@@ -411,10 +410,10 @@ $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend
 	@$(codesign)
 
 ###### install stuff #############
-
+INSTALLABLE_DIRS ?= test/tests
 docs_dir := $(APPLICATION_DIR)/doc
 bindst = $(bin_install_dir)/$(notdir $(app_EXEC))
-binlink = $(tests_install_dir)/$(notdir $(app_EXEC))
+binlink = $(share_install_dir)/$(notdir $(app_EXEC))
 
 lib_install_targets = $(foreach lib,$(applibs),$(dir $(lib))install_lib_$(notdir $(lib)))
 ifneq ($(app_test_LIB),)
@@ -429,6 +428,7 @@ install_$(APPLICATION_NAME)_tests: all
 	do \
 		base_dir=$$(basename $$dir); \
 		rm -rf $(share_install_dir)/$$base_dir; \
+		mkdir -p $(share_install_dir)/$$base_dir; \
 		cp -R $(APPLICATION_DIR)/$$dir $(share_install_dir)/$$base_dir; \
 		if [ -e $(APPLICATION_DIR)/testroot ]; \
 		then \
@@ -455,7 +455,7 @@ install_lib_%: % all
 	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
 
 $(binlink): all install_$(APPLICATION_NAME)_tests
-	@ln -s ../../../bin/$(notdir $(app_EXEC)) $@
+	ln -sf ../../bin/$(notdir $(app_EXEC)) $@
 
 install_$(APPLICATION_NAME)_docs:
 ifeq ($(MOOSE_SKIP_DOCS),)

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -5,7 +5,15 @@
 # This variable is used to determine whether a C++ header revision file is generated for use
 # in your application. You can turn it on/off by changing it in your application Makefile.
 GEN_REVISION ?= yes
-INSTALLABLE_DIRS ?= tests
+
+# Set a default to install the main application's tests if one isn't set in the Makefile
+ifeq ($(INSTALLABLE_DIRS),)
+  ifneq ($(wildcard $(APPLICATION_DIR)/test/.),)
+    INSTALLABLE_DIRS := test/tests
+  else
+    INSTALLABLE_DIRS := tests
+  endif
+endif
 
 # list of application-wide excluded source files
 excluded_srcfiles :=

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -5,6 +5,7 @@
 # This variable is used to determine whether a C++ header revision file is generated for use
 # in your application. You can turn it on/off by changing it in your application Makefile.
 GEN_REVISION ?= yes
+INSTALLABLE_DIRS ?= tests
 
 # list of application-wide excluded source files
 excluded_srcfiles :=
@@ -410,7 +411,6 @@ $(app_EXEC): $(app_LIBS) $(mesh_library) $(main_object) $(app_test_LIB) $(depend
 	@$(codesign)
 
 ###### install stuff #############
-INSTALLABLE_DIRS ?= test/tests
 docs_dir := $(APPLICATION_DIR)/doc
 bindst = $(bin_install_dir)/$(notdir $(app_EXEC))
 binlink = $(share_install_dir)/$(notdir $(app_EXEC))

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1215,6 +1215,21 @@ private:
    */
   PerfGraph & createRecoverablePerfGraph();
 
+  /**
+   * Handles the copy_inputs input parameter logic: Checks to see whether the passed argument is
+   * valid (a readable installed directory) and recursively copies those files into a read/writable
+   * location for the user.
+   * @return a Boolean value used to indicate whether the application should exit early
+   */
+  bool copyInputs();
+
+  /**
+   * Handles the run input parameter logic: Checks to see whether a directory exists in user space
+   * and launches the TestHarness to process the given directory.
+   * @return a Boolean value used to indicate whether the application should exit early
+   */
+  bool runInputs();
+
   /// General storage for custom RestartableData that can be added to from outside applications
   std::unordered_map<RestartableDataMapName, std::pair<RestartableDataMap, std::string>>
       _restartable_meta_data;

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -97,9 +97,8 @@ std::string runTestsExecutable();
 /// the first testroot file found.
 std::string findTestRoot();
 
-/// Returns the directory of any installed tests - or the empty string if none
-/// are found.
-std::string installedTestsDir(const std::string & app_name);
+/// Returns the directory of any installed inputs or the empty string if none are found.
+std::string installedInputsDir(const std::string & app_name, const std::string & dir_name);
 
 /// Returns the directory of any installed docs/site.
 std::string docsDir(const std::string & app_name);

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -395,7 +395,7 @@ install_exodiff: all
 	@cp $(MOOSE_DIR)/framework/contrib/exodiff/exodiff $(bin_install_dir)
 
 install_harness:
-	@echo "Installing test harness"
+	@echo "Installing TestHarness"
 	@rm -rf $(python_install_dir)
 	@mkdir -p $(python_install_dir)
 	@mkdir -p $(moose_share_dir)/bin

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1428,18 +1428,13 @@ MooseApp::copyInputs()
     auto binname = appBinaryName();
     if (binname == "")
       mooseError("could not locate installed tests to run (unresolved binary/app name)");
+
     auto src_dir = MooseUtils::installedInputsDir(binname, dir_to_copy);
-    if (src_dir == "")
-      mooseError("couldn't locate any installed tests to copy");
-    if (!MooseUtils::checkFileReadable(src_dir, false, false))
-      mooseError(
-          "You don't have permissions to read/copy tests from their current installed location: \"",
-          src_dir,
-          "\"");
     auto dst_dir = binname + "_" + dir_to_copy;
     auto cmdname = Moose::getExecutableName();
     if (cmdname.find_first_of("/") != std::string::npos)
       cmdname = cmdname.substr(cmdname.find_first_of("/") + 1, std::string::npos);
+
     if (MooseUtils::pathExists(dst_dir))
       mooseError(
           "The directory \"./",
@@ -1458,7 +1453,7 @@ MooseApp::copyInputs()
     int ret = system(cmd.c_str());
     if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)
       mooseError("Failed to copy the requested directory.");
-    Moose::out << "Directory successfully copied into ./" << dst_dir << "\n";
+    Moose::out << "Directory successfully copied into ./" << dst_dir << '\n';
     return true;
   }
   return false;

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -149,13 +149,22 @@ MooseApp::validParams()
       "syntax", "--syntax", false, "Dumps the associated Action syntax paths ONLY");
   params.addCommandLineParam<bool>("run_tests", "--tests", false, "run all tests");
   params.addCommandLineParam<bool>(
-      "copy_tests", "--copy-tests", false, "copy installed tests to an [appname]_tests dir");
+      "copy_tests", "--copy-tests", false, "copy installed tests to an <appname>_tests dir");
   params.addCommandLineParam<bool>(
       "show_docs", "--docs", false, "print url/path to the documentation website");
   params.addCommandLineParam<bool>("check_input",
                                    "--check-input",
                                    false,
                                    "Check the input file (i.e. requires -i <filename>) and quit.");
+  params.addCommandLineParam<std::string>("copy_inputs",
+                                          "--copy-inputs <dir>",
+                                          "Copies installed inputs (e.g. tests, examples, etc.) to "
+                                          "an directory named  <appname>_<dir>.");
+  params.addCommandLineParam<std::string>("run",
+                                          "--run <dir>",
+                                          "Runs the inputs in the specified directory copied to a "
+                                          "user-writable location by \"--copy-inputs\"");
+
   params.addCommandLineParam<bool>(
       "list_constructed_objects",
       "--list-constructed-objects",
@@ -1371,79 +1380,8 @@ MooseApp::run()
     return;
   }
 
-  if (getParam<bool>("copy_tests"))
+  if (copyInputs() || runInputs())
   {
-    auto binname = appBinaryName();
-    if (binname == "")
-      mooseError("could not locate installed tests to run (unresolved binary/app name)");
-    auto src_dir = MooseUtils::installedTestsDir(binname);
-    if (src_dir == "")
-      mooseError("couldn't locate any installed tests to copy");
-    if (!MooseUtils::checkFileReadable(src_dir, false, false))
-      mooseError(
-          "You don't have permissions to read/copy tests from their current installed location: \"",
-          src_dir,
-          "\"");
-    auto dst_dir = binname + "_tests";
-    auto cmdname = Moose::getExecutableName();
-    if (cmdname.find_first_of("/") != std::string::npos)
-      cmdname = cmdname.substr(cmdname.find_first_of("/") + 1, std::string::npos);
-    if (MooseUtils::pathExists(dst_dir))
-      mooseError("The tests directory \"./",
-                 dst_dir,
-                 "\" already exists.\nTo update/recopy tests, rename (\"mv ",
-                 dst_dir,
-                 " new_dir_name\") or remove (\"rm -r ",
-                 dst_dir,
-                 "\") the existing directory.\nThen re-run \"",
-                 cmdname,
-                 " --copy-tests\".");
-
-    std::string cmd = "cp -R " + src_dir + " " + dst_dir;
-    int ret = system(cmd.c_str());
-    if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)
-      mooseError("Failed to copy the tests.");
-    Moose::out << "Tests successfully copied into ./" << dst_dir << "\n";
-    _ready_to_exit = true;
-    return;
-  }
-
-  if (isParamValid("run_tests") && getParam<bool>("run_tests"))
-  {
-    std::string args;
-    for (int i = 2; i < _sys_info->argc(); i++)
-      args += " " + std::string(*(_sys_info->argv() + i));
-    auto cmd = MooseUtils::runTestsExecutable() + args;
-    if (MooseUtils::findTestRoot() == "")
-    {
-      // run installed tests instead of cwd tests
-      auto binname = appBinaryName();
-      if (binname == "")
-        mooseError("could not locate installed tests to run (unresolved binary/app name)");
-      auto dir = MooseUtils::installedTestsDir(binname);
-      if (dir == "")
-        mooseError("no could not find any tests to run");
-
-      auto cmdname = Moose::getExecutableName();
-      if (cmdname.find_first_of("/") != std::string::npos)
-        cmdname = cmdname.substr(cmdname.find_first_of("/") + 1, std::string::npos);
-      if (!MooseUtils::checkFileWriteable(MooseUtils::pathjoin(dir, "testroot"), false))
-        mooseError(
-            "You don't have permissions to run tests at their current installed location.\nRun \"",
-            cmdname,
-            " --copy-tests\" to copy the tests to a \"./",
-            binname,
-            "_tests\" directory.\nChange into that directory and try \"",
-            cmdname,
-            " --tests\" again.");
-
-      int ret = chdir(dir.c_str());
-      if (ret != 0)
-        mooseError("Failed to change to testing directory ", dir);
-    }
-    int ret = system(cmd.c_str());
-    if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)
-      mooseError("Tests failed");
     _ready_to_exit = true;
     return;
   }
@@ -1470,6 +1408,120 @@ MooseApp::run()
     // Output to stderr, so it is easier for peacock to get the result
     Moose::err << "Syntax OK" << std::endl;
   }
+}
+
+bool
+MooseApp::copyInputs()
+{
+  std::string dir_to_copy = "tests";
+  bool copy_param_valid = false;
+
+  if (isParamValid("copy_inputs"))
+  {
+    // Get command line argument following --copy-inputs on command line
+    dir_to_copy = getParam<std::string>("copy_inputs");
+    copy_param_valid = true;
+  }
+
+  if (getParam<bool>("copy_tests") || copy_param_valid)
+  {
+    auto binname = appBinaryName();
+    if (binname == "")
+      mooseError("could not locate installed tests to run (unresolved binary/app name)");
+    auto src_dir = MooseUtils::installedInputsDir(binname, dir_to_copy);
+    if (src_dir == "")
+      mooseError("couldn't locate any installed tests to copy");
+    if (!MooseUtils::checkFileReadable(src_dir, false, false))
+      mooseError(
+          "You don't have permissions to read/copy tests from their current installed location: \"",
+          src_dir,
+          "\"");
+    auto dst_dir = binname + "_" + dir_to_copy;
+    auto cmdname = Moose::getExecutableName();
+    if (cmdname.find_first_of("/") != std::string::npos)
+      cmdname = cmdname.substr(cmdname.find_first_of("/") + 1, std::string::npos);
+    if (MooseUtils::pathExists(dst_dir))
+      mooseError(
+          "The directory \"./",
+          dst_dir,
+          "\" already exists.\nTo update/recopy the contents of this directory, rename (\"mv ",
+          dst_dir,
+          " new_dir_name\") or remove (\"rm -r ",
+          dst_dir,
+          "\") the existing directory.\nThen re-run \"",
+          cmdname,
+          " --copy-inputs ",
+          dir_to_copy,
+          "\".");
+
+    std::string cmd = "cp -R " + src_dir + " " + dst_dir;
+    int ret = system(cmd.c_str());
+    if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)
+      mooseError("Failed to copy the requested directory.");
+    Moose::out << "Directory successfully copied into ./" << dst_dir << "\n";
+    return true;
+  }
+  return false;
+}
+
+bool
+MooseApp::runInputs()
+{
+  std::string dir_to_run = "tests";
+  bool run_param_valid = false;
+  int skip_args = 2;
+
+  if (isParamValid("run"))
+  {
+    // Get command line argument following --run on command line
+    dir_to_run = getParam<std::string>("run");
+    run_param_valid = true;
+    skip_args = 3;
+  }
+
+  if ((isParamValid("run_tests") && getParam<bool>("run_tests")) || run_param_valid)
+  {
+    std::string args;
+    for (int i = skip_args; i < _sys_info->argc(); i++)
+      args += " " + std::string(*(_sys_info->argv() + i));
+    auto cmd = MooseUtils::runTestsExecutable() + args;
+
+    std::string working_dir;
+    if (MooseUtils::findTestRoot() == "")
+    {
+      // run installed tests instead of cwd tests
+      auto binname = appBinaryName();
+      if (binname == "")
+        mooseError("could not locate installed tests to run (unresolved binary/app name)");
+
+      working_dir = MooseUtils::installedInputsDir(binname, dir_to_run);
+      if (working_dir == "")
+        mooseError("could not find any directory to run");
+
+      auto cmdname = Moose::getExecutableName();
+      if (cmdname.find_first_of("/") != std::string::npos)
+        cmdname = cmdname.substr(cmdname.find_first_of("/") + 1, std::string::npos);
+      if (!MooseUtils::checkFileWriteable(MooseUtils::pathjoin(working_dir, "testroot"), false))
+        mooseError("You don't have permissions to run contents of directory at their current "
+                   "installed location.\nRun \"",
+                   cmdname,
+                   " --copy-inputs <dir>\" to copy the contents of <dir> to a \"./",
+                   binname,
+                   "_<dir>\" directory.\nChange into that directory and try \"",
+                   cmdname,
+                   " --run <dir>\" again.");
+
+      int ret = chdir(working_dir.c_str());
+      if (ret != 0)
+        mooseError("Failed to change directory into ", working_dir);
+    }
+    Moose::out << "Working Directory: " << working_dir << "\nRunning Command: " << cmd << std::endl;
+    int ret = system(cmd.c_str());
+    if (WIFEXITED(ret) && WEXITSTATUS(ret) != 0)
+      mooseError("Run failed");
+    return true;
+  }
+  return false;
 }
 
 void

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -91,10 +91,12 @@ installedInputsDir(const std::string & app_name, const std::string & dir_name)
   std::string installed_path =
       pathjoin(Moose::getExecutablePath(), "..", "share", app_name, dir_name);
 
-  auto testroot = pathjoin(installed_path, "testroot");
-  if (pathExists(testroot) && checkFileReadable(testroot))
-    return installed_path;
-  return "";
+  auto test_root = pathjoin(installed_path, "testroot");
+  if (!pathExists(installed_path))
+    mooseError("Couldn't locate any installed inputs to copy in path: ", installed_path);
+
+  checkFileReadable(test_root);
+  return installed_path;
 }
 
 std::string

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -67,6 +67,7 @@ runTestsExecutable()
   // TODO: maybe no path prefix - just moose_test_runner here?
   return pathjoin(Moose::getExecutablePath(), "moose_test_runner");
 }
+
 std::string
 findTestRoot()
 {
@@ -82,9 +83,13 @@ findTestRoot()
 }
 
 std::string
-installedTestsDir(const std::string & app_name)
+installedInputsDir(const std::string & app_name, const std::string & dir_name)
 {
-  std::string installed_path = pathjoin(Moose::getExecutablePath(), "../share", app_name, "test");
+  // See moose.mk for a detailed explanation of the assumed installed application
+  // layout. Installed inputs are expected to be installed in "share/<app_name>/<folder>".
+  // The binary, which has a defined location will be in "bin", a peer directory to "share".
+  std::string installed_path =
+      pathjoin(Moose::getExecutablePath(), "..", "share", app_name, dir_name);
 
   auto testroot = pathjoin(installed_path, "testroot");
   if (pathExists(testroot) && checkFileReadable(testroot))
@@ -95,8 +100,12 @@ installedTestsDir(const std::string & app_name)
 std::string
 docsDir(const std::string & app_name)
 {
-  std::string installed_path = pathjoin(Moose::getExecutablePath(), "../share", app_name, "doc");
-  auto docfile = pathjoin(installed_path, "css/moose.css");
+  // See moose.mk for a detailed explanation of the assumed installed application
+  // layout. Installed docs are expected to be installed in "share/<app_name>/doc".
+  // The binary, which has a defined location will be in "bin", a peer directory to "share".
+  std::string installed_path = pathjoin(Moose::getExecutablePath(), "..", "share", app_name, "doc");
+
+  auto docfile = pathjoin(installed_path, "css", "moose.css");
   if (pathExists(docfile) && checkFileReadable(docfile))
     return installed_path;
   return "";

--- a/modules/doc/content/application_development/build_system.md
+++ b/modules/doc/content/application_development/build_system.md
@@ -208,3 +208,49 @@ when building MOOSE or a MOOSE-based application.
 
 - `framework/conf_var.mk.in` - This file is where you put your new expansion expressions. Typically these
   are in the form of "@VARAIBLE@".
+
+### Make Install
+
+MOOSE's build system has the ability to create installed binaries suitable for use with the conda package manager, or installation on a shared computing resource such as Sawtooth. The `install` target will copy binary and required libraries to a file tree based on the prefix you configured with (set by the variable `PREFIX` or the `--prefix` argument.
+
+```
+$ cd moose/framework
+$ ./configure --prefix=<installation path>
+$ make
+$ make install
+```
+
+Additionally each application may wish to make an one or more file structures available for end users to install into their own environment. This allows for end-users to install and run the application test suite, examples, tutorials, or other inputs of interest. To customize what is available for installation, the application developer will define the list of directories in their application make file. For example:
+
+```
+INSTALLABLE_DIRS := test/tests examples
+```
+
+These paths should be relative to the root location of the application.
+
+!alert warning
+Make sure that installed paths do not include source code. This could result in an accidental export of information for those cleared for only binary access.
+
+### Copying and Running Installed Inputs
+
+Once an application has been installed, end users that have access to those binaries can install or copy those paths to their home directories and also run the tests using the test harness using convenient command line parameters.
+
+Example:
+
+```
+$ cd <user writable location>
+$ export PATH=$PATH:<prefix>/bin  # See instructions for HPC computers below
+$ bison-opt --copy-inputs <installable input type>  # e.g. tests, examples, etc.
+$ bison-opt --run <installable input type>
+
+```
+
+Where `<installable input type>` is one of the installable directories as defined by the application developers (i.e. `tests`, `examples`, `tutorials`, etc.)
+
+When using INL HPC systems to run your input, you will load a module that will set your path correctly
+
+Example:
+
+```
+$ module load use.moose <app name> # e.g bison
+```

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -250,6 +250,7 @@ class TestHarness:
         checks = {}
         checks['platform'] = util.getPlatforms()
         checks['submodules'] = util.getInitializedSubmodules(self.run_tests_dir)
+        checks['installed'] = util.checkInstalled(self.run_tests_dir)
         checks['exe_objects'] = None # This gets calculated on demand
         checks['registered_apps'] = None # This gets extracted on demand
 

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -315,6 +315,14 @@ class Tester(MooseObject):
         cmd = self.getCommand(options)
         cwd = self.getTestDir()
 
+        # Verify that the working directory is available right before we execute.
+        if not os.path.exists(cwd):
+            # Timers must be used since they are directly indexed in the Job class
+            timer.start()
+            self.setStatus(self.fail, 'WORKING DIRECTORY NOT FOUND')
+            timer.stop()
+            return
+
         self.process = None
         try:
             f = SpooledTemporaryFile(max_size=1000000) # 1M character buffer
@@ -637,12 +645,10 @@ class Tester(MooseObject):
             if missing:
                 reasons['requires'] = ', '.join(['no {}'.format(p) for p in missing])
 
-        # Verify working_directory is relative and available
+        # Verify working_directory is relative. We'll check to make sure it's available just in time.
         if self.specs['working_directory']:
             if self.specs['working_directory'][:1] == os.path.sep:
                 self.setStatus(self.fail, 'ABSOLUTE PATH DETECTED')
-            elif not os.path.exists(self.getTestDir()):
-                self.setStatus(self.fail, 'WORKING DIRECTORY NOT FOUND')
 
         ##### The below must be performed last to register all above caveats #####
         # Remove any matching user supplied caveats from accumulated checkRunnable caveats that

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -82,6 +82,7 @@ class Tester(MooseObject):
         params.addParam('asio',          ['ALL'], "A test that runs only if ASIO is available ('ALL', 'TRUE', 'FALSE')")
         params.addParam('fparser_jit',   ['ALL'], "A test that runs only if FParser JIT is available ('ALL', 'TRUE', 'FALSE')")
         params.addParam('libpng',        ['ALL'], "A test that runs only if libpng is available ('ALL', 'TRUE', 'FALSE')")
+        params.addParam('installed',     ['ALL'], "A test that runs only if it is installed ('ALL', 'TRUE', 'FALSE')")
 
         params.addParam('depend_files',  [], "A test that only runs if all depend files exist (files listed are expected to be relative to the base directory, not the test directory")
         params.addParam('env_vars',      [], "A test that only runs if all the environment variables listed exist")
@@ -533,7 +534,7 @@ class Tester(MooseObject):
         # PETSc and SLEPc is being explicitly checked above
         local_checks = ['platform', 'compiler', 'mesh_mode', 'ad_mode', 'ad_indexing_type', 'method', 'library_mode', 'dtk', 'unique_ids', 'vtk', 'tecplot',
                         'petsc_debug', 'curl', 'superlu', 'mumps', 'strumpack', 'cxx11', 'asio', 'unique_id', 'slepc', 'petsc_version_release', 'boost', 'fparser_jit',
-                        'parmetis', 'chaco', 'party', 'ptscotch', 'threading', 'libpng']
+                        'parmetis', 'chaco', 'party', 'ptscotch', 'threading', 'libpng', 'installed']
         for check in local_checks:
             test_platforms = set()
             operator_display = '!='

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -657,6 +657,33 @@ def getInitializedSubmodules(root_dir):
     # This ignores submodules that have a '-' at the beginning which means they are not initialized
     return re.findall(r'^[ +]\S+ (\S+)', output, flags=re.MULTILINE)
 
+def checkInstalled(root_dir):
+    """
+    Returns a set containing 'ALL' and whether or not the TestHarness
+    is running in an "installed" directory. Since we don't have a fool-proof
+    way of knowing whether a binary is installed or not... Actually we really
+    don't have even a "bad" way of telling. People can install tests just about
+    anywhere that they can write too so we'll see all sorts of good and bad
+    practices. So, for now, let's just detect whether or not we are in a Git
+    repository since usually installed tests won't be in a git area.
+
+    - If somebody tarballs MOOSE up, this report an incorrect result
+    - If somebody installs tests into their git repository, this report an incorrect results
+
+    Neither of these cases a significant risk.
+    """
+
+    option_set = set(['ALL'])
+
+    # If we are in a git repo assume we are not installed
+    output = str(runCommand("git submodule status", cwd=root_dir))
+    if output.startswith("ERROR"):
+        option_set.add('TRUE')
+    else:
+        option_set.add('FALSE')
+
+    return option_set
+
 def addObjectsFromBlock(objs, node, block_name):
     """
     Utility function that iterates over a dictionary and adds keys

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,6 @@ APPLICATION_NAME   := moose_test
 BUILD_EXEC         := yes
 BUILD_TEST_OBJECTS_LIB := no
 GEN_REVISION       := no
-INSTALLABLE_DIRS   := tests
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,7 @@ APPLICATION_NAME   := moose_test
 BUILD_EXEC         := yes
 BUILD_TEST_OBJECTS_LIB := no
 GEN_REVISION       := no
-INSTALLABLE_DIRS   := tests examples
+INSTALLABLE_DIRS   := tests
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ APPLICATION_NAME   := moose_test
 BUILD_EXEC         := yes
 BUILD_TEST_OBJECTS_LIB := no
 GEN_REVISION       := no
+INSTALLABLE_DIRS   := tests examples
 include            $(FRAMEWORK_DIR)/app.mk
 
 ###############################################################################

--- a/test/tests/make_install/tests
+++ b/test/tests/make_install/tests
@@ -14,7 +14,7 @@
     requirement = 'The system shall support the ability to "install" inputs:'
     [setup_fake_test_structure]
       type = 'RunCommand'
-      command = 'rm -rf moose_test_tests; rm -rf ../../../share/moose_test; mkdir -p ../../../share/moose_test/tests; cp -R ../kernels/2d_diffusion ../../../share/moose_test/tests/; cp ../../testroot ../../../share/moose_test/tests/'
+      command = 'rm -rf moose_test_tests; rm -rf ../../../share/moose_test; mkdir -p ../../../share/moose_test/tests/version; cp ../misc/version/tests ../../../share/moose_test/tests/version; cp ../../testroot ../../../share/moose_test/tests/'
       installed = False
 
       detail = 'from a pre-determined user-readable location;'
@@ -22,8 +22,8 @@
 
     [copy_tests]
       type = 'RunApp'
-      input = 'DUMMY'
       cli_args = "--copy-inputs tests"
+      no_additional_cli_args = True
       expect_out = 'Directory successfully copied'
       installed = False
       prereq = 'test_copy_install/setup_fake_test_structure'
@@ -35,7 +35,7 @@
       type = 'CheckFiles'
       input = 'DUMMY'
       should_execute = False
-      check_files = 'moose_test_tests/testroot moose_test_tests/2d_diffusion/tests'
+      check_files = 'moose_test_tests/testroot moose_test_tests/version/tests'
       installed = False
       prereq = 'test_copy_install/copy_tests'
 
@@ -44,8 +44,8 @@
 
     [copy_warn_overwrite]
       type = 'RunException'
-      input = 'DUMMY'
       cli_args = "--copy-inputs tests"
+      no_additional_cli_args = True
       expect_err = 'The directory \S+ already exists.'
       installed = False
       prereq = 'test_copy_install/check_files'
@@ -53,12 +53,25 @@
       detail = 'able to report an error if overwriting may occur using a MOOSE-based binary;'
     []
 
+    [link_exec_installed]
+      type = 'RunCommand'
+      command = 'ln -s ../../../moose_test-opt .'
+      working_directory = "./moose_test_tests"
+      installed = False
+      method = opt
+      prereq = 'test_copy_install/copy_warn_overwrite'
+
+      detail = 'able to link a binary to an installed location;'
+    []
+
     [run]
       type = 'RunApp'
       cli_args = "--run tests"
+      working_directory = "./moose_test_tests"
       no_additional_cli_args = True
       installed = False
-      prereq = 'test_copy_install/copy_warn_overwrite'
+      method = opt
+      prereq = 'test_copy_install/link_exec_installed'
 
       detail = 'able to successfully launch the TestHarness using a MOOSE-based binary;'
     []

--- a/test/tests/make_install/tests
+++ b/test/tests/make_install/tests
@@ -1,0 +1,75 @@
+# Copying tests with the binary is intended to copy from an installed location
+# (i.e. after "make install"). The logic in the binary however attempts to find
+# installed tests relative to the binary location, which is also installed
+# through "make install". If we run it from the non-installed version of the binary
+# it'll look for tests in <bin location>/../share/moose_test/tests/. To get
+# line coverage, we'll just copy a file to that area.
+# See application_development/build_system.md for more information.
+
+[Tests]
+  issues = '#19022'
+  design = 'MooseApp.md'
+
+  [test_copy_install]
+    requirement = 'The system shall support the ability to "install" inputs:'
+    [setup_fake_test_structure]
+      type = 'RunCommand'
+      command = 'rm -rf moose_test_tests; rm -rf ../../../share/moose_test; mkdir -p ../../../share/moose_test/tests; cp -R ../kernels/2d_diffusion ../../../share/moose_test/tests/; cp ../../testroot ../../../share/moose_test/tests/'
+      installed = False
+
+      detail = 'from a pre-determined user-readable location;'
+    []
+
+    [copy_tests]
+      type = 'RunApp'
+      input = 'DUMMY'
+      cli_args = "--copy-inputs tests"
+      expect_out = 'Directory successfully copied'
+      installed = False
+      prereq = 'test_copy_install/setup_fake_test_structure'
+
+      detail = 'copied using a MOOSE-based binary;'
+    []
+
+    [check_files]
+      type = 'CheckFiles'
+      input = 'DUMMY'
+      should_execute = False
+      check_files = 'moose_test_tests/testroot moose_test_tests/2d_diffusion/tests'
+      installed = False
+      prereq = 'test_copy_install/copy_tests'
+
+      detail = 'verifying a successful copy operation;'
+    []
+
+    [copy_warn_overwrite]
+      type = 'RunException'
+      input = 'DUMMY'
+      cli_args = "--copy-inputs tests"
+      expect_err = 'The directory \S+ already exists.'
+      installed = False
+      prereq = 'test_copy_install/check_files'
+
+      detail = 'able to report an error if overwriting may occur using a MOOSE-based binary;'
+    []
+
+    [run]
+      type = 'RunApp'
+      cli_args = "--run tests"
+      no_additional_cli_args = True
+      installed = False
+      prereq = 'test_copy_install/copy_warn_overwrite'
+
+      detail = 'able to successfully launch the TestHarness using a MOOSE-based binary;'
+    []
+
+    [tear_down]
+      type = 'RunCommand'
+      command = 'rm -rf ../../../share/; rm -rf moose_test_tests'
+      prereq = 'test_copy_install/run'
+      installed = False
+
+      detail = 'and cleaned up from a user-readable location.'
+    []
+  []
+[]

--- a/test/tests/parser/multiple_inputs/tests
+++ b/test/tests/parser/multiple_inputs/tests
@@ -23,7 +23,7 @@
     [three_inputs_error]
       type = 'RunException'
       input = 'diffusion1a.i diffusion1c.i diffusion1d.i'
-      expect_err = 'test/tests/parser/multiple_inputs/diffusion1d.i:3: unused parameter '
+      expect_err = '/diffusion1d.i:3: unused parameter '
                    '\'BCs/right/invalid_param\''
       detail = 'while locating input errors in the correct file'
     []

--- a/test/tests/usability/tests
+++ b/test/tests/usability/tests
@@ -1,21 +1,21 @@
 [Tests]
-  # These tests intentionally use 'command' to demonstrate the command-line usability.
   issues = "#16410"
   design = "sqa/non_functional.md"
   collections = USABILITY
   [command-line]
     requirement = "The system will be operated using a command-line interface that"
     [empty]
-      type = RunCommand
-      method = opt
-      command = "../../moose_test-opt"
+      type = RunApp
+      no_additional_cli_args = True
+      expect_out = "Usage: \S+"
 
-      detail = "reports the available options in non are provided and"
+      detail = "reports the available options when none are provided and"
     []
     [flags]
-      type = RunCommand
-      method = opt
-      command = "../../moose_test-opt --help"
+      type = RunApp
+      cli_args = "--help"
+      no_additional_cli_args = True
+      expect_out = "Usage: \S+"
 
       detail = "accepts defined command-line flags."
     []
@@ -23,37 +23,32 @@
   [input]
     requirement = "The system will be operated using"
     [input_file]
-      type = RunCommand
-      method = opt
-      command = "../../moose_test-opt -i input.i"
+      type = RunApp
+      input = 'input.i'
 
       detail = "an input file and"
     []
     [command_line]
-      type = RunCommand
-      method = opt
-      command = "../../moose_test-opt -i input.i Mesh/uniform_refine=1"
+      type = RunApp
+      input = 'input.i'
+      cli_args = "Mesh/uniform_refine=1"
 
       detail = "command-line options."
     []
   []
 
-  # The following tests do not use RunCommand, but use the 'command' parameter to demonstrate
-  # the actual command being run for usability. The application of mpiexec by RunApp/Exception
-  # is not designed to be used with 'command', so 'max_parallel' is set to one.
   [message]
-    type = RunApp
-    method = opt
-    command = "../../moose_test-opt -i input.i invalid_command=1"
-    expect_out = "unused parameter 'invalid_command'"
+    type = RunException
+    input = 'input.i'
+    cli_args = "invalid_command=1"
+    expect_err = "unused parameter 'invalid_command'"
     max_parallel = 1
 
     requirement = "The system shall return usage messages when unidentified arguments or incorrectly used arguments are passed."
   []
   [diagnostic]
     type = RunException
-    method = opt
-    command = "../../moose_test-opt -i bad.i"
+    input = 'bad.i'
     expect_err = "bad.i:13: missing closing '\[\]' for section"
     max_parallel = 1
 
@@ -61,8 +56,7 @@
   []
   [normal]
     type = RunApp
-    method = opt
-    command = "../../moose_test-opt -i input.i"
+    input = 'input.i'
     expect_out = "Framework Information"
     max_parallel = 1
 


### PR DESCRIPTION
This is a first rough take at supporting installing more than just the "tests" directory. I think there are many more improvements that could be added, but this may be good enough to get us started considering how critical this is. I'm happy to attempt to address 😉 whatever I can, but here are some thoughts:

- Really don't like the shell loop in the Makefile. This needs to be converted to a proper Make dependency for each installable directory instead
- Not my bug, but I noticed that you cannot run `make install` before running `make`. We are missing a dependency in there. It appears that the doc installer kicks off before the binary is built. Shouldn't be too bad to track this down.
- Probably needs some more documentation. This will be used by binary users who have no idea what may be available to copy so perhaps we need a way to help the user know what the valid arguments are for a given application. I don't want to bake this into the binary and the only place it exists right now is the main Makefile which we don't parse (and probably don't want to). Need to think more about what to do to help the user. 


This PR shouldn't break any of the install targets as I have not yet removed the existing `--copy-tests` and `--tests` CLI options. Those two default to the old behavior. To get an application or module to install more than one directory you need to specify the **relative paths with respect to the root of your repository** in your `Makefile`:

e.g.
`INSTALLABLE_DIRS := test/tests examples problems`

Note: Do not quote the above line, it'll turn it into a string which doesn't allow the shell loop to loop over it. This goes back to the first improvement that could be implemented (later?), in turning each installed directory into a Makefile target instead of just looping over a variable. If the above line doesn't exist then we default to just `test/tests`.
