### PR TITLE
Fixup remaining failures on M1 Apple Silicon

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 7 %}
+{% set build = 8 %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -69,3 +69,4 @@ about:
 extra:
   recipe-maintainers:
     - milljm
+    - cticenhour

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -52,3 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - milljm
+    - cticenhour

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.05.12" %}
 

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   build:
     - libtool                                           # [arm64]
     - autoconf                                          # [arm64]
-    - automake                                          # [arm64]
+    - automake 1.16.1                                   # [arm64]
     - make                                              # [arm64]
     - m4                                                # [arm64]
     - pkg-config

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -11,7 +11,7 @@ moose_ncrc_python:
   - python 3.9
 
 moose_libmesh:
-  - moose-libmesh 2022.05.12 build_0
+  - moose-libmesh 2022.05.12 build_1
 
 SHORT_VTK_NAME:
   - 9.1
@@ -23,10 +23,10 @@ moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0
 
 moose_petsc:
-  - moose-petsc 3.16.5 build_3
+  - moose-petsc 3.16.5 build_4
 
 moose_mpich:
-  - moose-mpich 4.0.1 build_2
+  - moose-mpich 4.0.1 build_3
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 moose_python:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.1" %}
 

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - {{ moose_hdf5 }}
     - {{ moose_ld64 }}          # [osx]
     - autoconf                  # [osx]
-    - automake                  # [osx]
+    - automake 1.16.1           # [osx]
     - libtool                   # [osx]
     - make                      # [osx]
     - openssl <3

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -61,3 +61,4 @@ about:
 extra:
   recipe-maintainers:
     - milljm
+    - cticenhour

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -60,3 +60,4 @@ about:
 extra:
   recipe-maintainers:
     - milljm
+    - cticenhour

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -63,3 +63,4 @@ about:
 extra:
   recipe-maintainers:
     - milljm
+    - cticenhour

--- a/modules/geochemistry/test/tests/equilibrium_models/seawater_no_precip.i
+++ b/modules/geochemistry/test/tests/equilibrium_models/seawater_no_precip.i
@@ -24,4 +24,3 @@
     piecewise_linear_interpolation = true # for comparison with GWB
   []
 []
-

--- a/modules/geochemistry/test/tests/time_dependent_reactions/flushing.i
+++ b/modules/geochemistry/test/tests/time_dependent_reactions/flushing.i
@@ -44,7 +44,7 @@
   ramp_max_ionic_strength_initial = 0 # max_ionic_strength in such a simple problem does not need ramping
   stoichiometric_ionic_str_using_Cl_only = true
   execute_console_output_on = '' # only CSV output for this test
-  abs_tol = 1E-13
+  abs_tol = 1E-12
 []
 
 [Executioner]

--- a/modules/geochemistry/test/tests/time_dependent_reactions/tests
+++ b/modules/geochemistry/test/tests/time_dependent_reactions/tests
@@ -180,6 +180,7 @@ e- = 0.5*H2O - 1*H+ - 0.25*O2(aq);  Eh = 0.7722V'
     type = CSVDiff
     input = 'mixing_seawater_step2.i'
     csvdiff = 'mixing_seawater_step2_out.csv'
+    rel_err = 1.4E-5
     requirement = "The geochemistry module shall be able to record molalities as AuxVariables in order to assist with fluid-mixing problems, including the case with precipitates"
     issues = '#15330'
     design = 'pickup.md'

--- a/scripts/apple-silicon-hdf5-autogen.patch
+++ b/scripts/apple-silicon-hdf5-autogen.patch
@@ -1,0 +1,14 @@
+diff --git a/config/BuildSystem/config/packages/hdf5.py b/config/BuildSystem/config/packages/hdf5.py
+index f218d22bea..53451365aa 100644
+--- a/config/BuildSystem/config/packages/hdf5.py
++++ b/config/BuildSystem/config/packages/hdf5.py
+@@ -85,6 +85,9 @@ class Configure(config.package.GNUPackage):
+     self.addToArgs(args,'LIBS',self.libraries.toStringNoDupes(self.dlib))
+     return args
+
++  def preInstall(self):
++    self.executeShellCommand('HDF5_ACLOCAL=$(which aclocal) HDF5_AUTOHEADER=$(which autoheader) HDF5_AUTOMAKE=$(which automake) HDF5_AUTOCONF=$(which autoconf) HDF5_LIBTOOL=$(which libtool) HDF5_M4=$(which m4) ./autogen.sh',cwd=self.packageDir,log=self.log)
++
+   def configureLibrary(self):
+     if hasattr(self.compilers, 'FC') and self.argDB['download-hdf5-fortran-bindings']:
+       # PETSc does not need the Fortran interface, but some users will call the Fortran interface

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -74,21 +74,26 @@ function configure_petsc()
     unset IFS
   fi
 
-  # If HDF5 is not found locally, download it via PETSc (except on Apple Silicon)
+  # If HDF5 is not found locally, download it via PETSc
   HDF5_FORTRAN_STR=""
   if [ -z "$HDF5_STR" ]; then
+    HDF5_STR="--download-hdf5=1"
+    HDF5_FORTRAN_STR="--download-hdf5-fortran-bindings=0"
+    echo "INFO: HDF5 library not detected, opting to download via PETSc..."
+    # If on Apple Silicon (arm64), PETSc needs to be patched using git in order
+    # to properly configure HDF5
     if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]]; then
-      # HDF5 currently doesn't build properly via PETSc download on macOS Apple
-      # Silicon machines due to a build system reconfiguration that is needed.
-      # So, we won't be downloading it by default for now if it isn't found.
-      # Instead, if a user has it installed somewhere, we'll note the variable
-      # they need to set.
-      echo "INFO: HDF5 library not detected; HDF5 related PETSc features will not be enabled."
-      echo "INFO: Set HDF5_DIR to the location of HDF5 and re-run this script, if desired."
-    else
-      HDF5_STR="--download-hdf5=1"
-      HDF5_FORTRAN_STR="--download-hdf5-fortran-bindings=0"
-      echo "INFO: HDF5 library not detected, opting to download via PETSc..."
+      echo "INFO: Apple Silicon detected, checking for ARM patches..."
+      # Check to see if patch marker file exists in PETSC_DIR. If not, perform
+      # patch and create patch marker file. If so, skip patch and report.
+      patch_file=$(find "$PETSC_DIR" -name '.patched' -print -quit 2>/dev/null)
+      if [ -z "$patch_file" ]; then
+         echo "INFO: Patching PETSc to support HDF5 download and installation on ARM..."
+         git apply $PETSC_DIR/../scripts/apple-silicon-hdf5-autogen.patch
+         touch $PETSC_DIR/.patched
+      elif [ ! -z "$patch_file" ]; then
+         echo "INFO: ARM patches already applied, proceeding to PETSc configure..."
+      fi
     fi
   fi
 

--- a/scripts/update_and_rebuild_libmesh.sh
+++ b/scripts/update_and_rebuild_libmesh.sh
@@ -131,6 +131,18 @@ if [ -z "$PETSC_DIR" ]; then
   fi
 fi
 
+# If on osx-arm64, bootstrap libmesh and its contribs
+if [[ $(uname) == Darwin  ]] && [[ $(uname -m) == arm64 ]]; then
+    ./bootstrap
+    cd contrib/metaphysicl
+    ./bootstrap
+    cd ../timpi
+    ./bootstrap
+    cd ../netcdf/netcdf*
+    autoreconf
+    cd ../../../
+fi
+
 # If we're not going fast, remove the build directory and reconfigure
 if [ -z "$go_fast" ]; then
   if [[ -n "$LIBMESH_BUILD_DIR" ]]; then


### PR DESCRIPTION
This PR aims to fixup the remaining broken module tests and failing recipe steps on M1 Apple Silicon, in final preparation for official support. This PR also enables HDF5 support on M1 Macs.

Refs #18954
Closes #20736 
