### PR TITLE
Change C++ standard set by moose-mpich to C++17

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.01.19" %}
 

--- a/conda/mpich/build.sh
+++ b/conda/mpich/build.sh
@@ -18,6 +18,14 @@ if [[ $HOST == arm64-apple-darwin20.0.0 ]]; then
     ./autogen.sh
 fi
 
+# In order to set a CXXFLAGS during moose-mpich activation with the proper C++
+# standard (as clang and gcc from conda-forge still default to C++14), we extract
+# what moose_cxx gives us here, before we unset it. The  "-fdebug-prefix-map"
+# flags are also removed, as they are specific to the conda build process.
+TEMP_CXXFLAGS=${CXXFLAGS%%-fdebug-prefix-map*}
+# Finally, swap "-std=c++14" with "-std=c++17" to set our basic standard requirement.
+ACTIVATION_CXXFLAGS=${TEMP_CXXFLAGS/-std=c++14/-std=c++17}
+
 unset LDFLAGS CPPFLAGS CFLAGS CXXFLAGS FFLAGS FCFLAGS F90 F77
 export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export LIBRARY_PATH="$PREFIX/lib"
@@ -87,11 +95,11 @@ CORES=$(echo "${CPU_COUNT:-2} / 2" | bc)
 make -j $CORES
 make install
 
-# Set PETSC_DIR environment variable for those that need it
+# Set MPICH environment variables for those that need it, and set CXXFLAGS using our ACTIVATION_CXXFLAGS variable
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
-export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 C_INCLUDE_PATH=${PREFIX}/include MOOSE_NO_CODESIGN=true MPIHOME=${PREFIX}
+export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 C_INCLUDE_PATH=${PREFIX}/include MOOSE_NO_CODESIGN=true MPIHOME=${PREFIX} CXXFLAGS="$ACTIVATION_CXXFLAGS"
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
-unset CC CXX FC F90 F77 C_INCLUDE_PATH MOOSE_NO_CODESIGN MPIHOME
+unset CC CXX FC F90 F77 C_INCLUDE_PATH MOOSE_NO_CODESIGN MPIHOME CXXFLAGS
 EOF

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.01.19 build_2
+  - moose-libmesh 2022.01.19 build_3
 
 SHORT_VTK_NAME:
   - 9.1
@@ -11,13 +11,13 @@ vtk_version:
   - 9.1.0
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0 build_3
+  - moose-libmesh-vtk 9.1.0 build_4
 
 moose_petsc:
-  - moose-petsc 3.15.1 build_6
+  - moose-petsc 3.15.1 build_7
 
 moose_mpich:
-  - moose-mpich 3.4.2 build_2
+  - moose-mpich 3.4.2 build_3
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 moose_python:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.4.2" %}
 

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 6 %}
+{% set build = 7 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.15.1" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}


### PR DESCRIPTION
This PR sets the C++ standard for `moose-mpich` at C++17 using `CXXFLAGS`.  This is done by extracting `CXXFLAGS` from Clang/GCC during conda build, cleaning up unneeded conda build flags, and replacing `-std=c++14` with `-std=c++17` using bash shell parameter expansions. 

`CXXFLAGS` as set by this new package (`moose-mpich-3.4.2-build_3`): 
```
% echo $CXXFLAGS
-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -isystem /Users/user/miniconda3/envs/test/include
```
`CXXFLAGS` as set by the current package (`moose-mpich-3.4.2-build_2`)
```
echo $CXXFLAGS
-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -isystem /Users/user/miniconda3/envs/moose/include
```

Refs #19417 

Tag @roystgnr @loganharbour @milljm @dschwen 