### PR TITLE
Protect against concurrent read/write for SectionIncrements

### DIFF
--- a/framework/include/utils/PerfGraph.h
+++ b/framework/include/utils/PerfGraph.h
@@ -399,6 +399,9 @@ protected:
   /// The mutex to use with a condition_variable predicate to guard _destructing
   std::mutex _destructing_mutex;
 
+  /// A mutex to prevent concurrent thread reading and writing of section increment data
+  std::mutex _section_increment_mutex;
+
   /// The condition_variable to wake the print thread
   std::condition_variable _finished_section;
 

--- a/framework/src/utils/PerfGraph.C
+++ b/framework/src/utils/PerfGraph.C
@@ -154,11 +154,14 @@ PerfGraph::addToExecutionList(const PerfID id,
 {
   auto & section_increment = _execution_list[_execution_list_end];
 
-  section_increment._id = id;
-  section_increment._state = state;
-  section_increment._time = time;
-  section_increment._memory = memory;
-  section_increment._beginning_num_printed = _console.numPrinted();
+  {
+    std::lock_guard<std::mutex> lock(_section_increment_mutex);
+    section_increment._id = id;
+    section_increment._state = state;
+    section_increment._time = time;
+    section_increment._memory = memory;
+    section_increment._beginning_num_printed = _console.numPrinted();
+  }
 
   // A note about this next section of code:
   // It is only EVER run on the main thread - and therefore there can be
@@ -174,7 +177,7 @@ PerfGraph::addToExecutionList(const PerfID id,
   // "acquire" in the printing thread
   // All of the above memory operations will be seen by the
   // printing thread before the printing thread sees this new value
-  _execution_list_end.store(next_execution_list_end, std::memory_order_release);
+  _execution_list_end.store(next_execution_list_end, std::memory_order_relaxed);
 }
 
 void

--- a/framework/src/utils/PerfGraphLivePrint.C
+++ b/framework/src/utils/PerfGraphLivePrint.C
@@ -251,6 +251,7 @@ PerfGraphLivePrint::iterateThroughExecutionList()
 
     auto & section_increment = _execution_list[p];
 
+    std::lock_guard<std::mutex> lock(_perf_graph._section_increment_mutex);
     // New section, add to the stack
     if (section_increment._state == PerfGraph::IncrementState::STARTED)
     {
@@ -330,7 +331,7 @@ PerfGraphLivePrint::start()
           // to ensure that all of the writes to the execution list have been
           // published to this thread for the "end" we're reading
           this->_current_execution_list_end =
-              _perf_graph._execution_list_end.load(std::memory_order_acquire);
+              _perf_graph._execution_list_end.load(std::memory_order_relaxed);
 
           // Save off the number of things currently printed to the console
           this->_console_num_printed = _console.numPrinted();


### PR DESCRIPTION
Removes the thread sanitizer errors reported [here](https://github.com/idaholab/moose/discussions/19443#discussioncomment-2240054)

To reproduce:
```
cd test/tests/geomsearch/3d_moving_penetration_smoothing
TSAN_OPTIONS=history_size=7 ../../../moose_test-devel -i pl_test3nns.i
```

The crux of the matter is that, at run-time, there is no guarantee that the `release` (consequently changed to `relaxed` in this PR) will occur before the `acquire` (consequently changed to `relaxed` in this PR), and if it does not there is no sychronizes-with relationship between the two. See the run-time section of [Pershing](https://preshing.com/20130823/the-synchronizes-with-relation/).