### PR TITLE
Rename perf_graph in tests to avoid Outputs/perf_graph=true clobbering

### DIFF
--- a/modules/phase_field/examples/grain_growth/grain_growth_3D.i
+++ b/modules/phase_field/examples/grain_growth/grain_growth_3D.i
@@ -343,7 +343,7 @@
 [Outputs]
   exodus = true
   csv = true
-  [./perf_graph]
+  [./pg]
     type = PerfGraphOutput
     execute_on = 'initial final'  # Default is "final"
     level = 2                     # Default is 1

--- a/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_remapping_test.i
+++ b/modules/phase_field/test/tests/grain_tracker_test/grain_tracker_remapping_test.i
@@ -273,7 +273,7 @@
 [Outputs]
   csv = true
   exodus = true
-  [./perf_graph]
+  [./pg]
     type = PerfGraphOutput
     level = 2                     # Default is 1
   [../]


### PR DESCRIPTION
refs #20400

After this, we should be able to test all modules in moose with `-t`.

Hopefully a more useful fix will come in the future.