### PR TITLE
output the number of adjacent grains for each grain

### DIFF
--- a/0createCode.sh
+++ b/0createCode.sh
@@ -1,0 +1,6 @@
+cp ~/projects/moose/modules/phase_field/src/materials/GBEvolution.C ~/projects/moose/modules/phase_field/src/materials/GBAnisotropyEvolution.C
+
+cp ~/projects/moose/modules/phase_field/include/materials/GBEvolution.h ~/projects/moose/modules/phase_field/include/materials/GBAnisotropyEvolution.h
+
+code ~/projects/moose/modules/phase_field/src/materials/GBAnisotropyEvolution.C
+code ~/projects/moose/modules/phase_field/include/materials/GBAnisotropyEvolution.h

--- a/modules/phase_field/include/materials/ComputePolycrystalGBAnisotropy.h
+++ b/modules/phase_field/include/materials/ComputePolycrystalGBAnisotropy.h
@@ -1,0 +1,39 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "GrainTracker.h"
+#include "EulerAngleProvider.h"
+
+class ComputePolycrystalGBAnisotropy : public Material
+{
+public:
+  static InputParameters validParams();
+
+  ComputePolycrystalGBAnisotropy(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  /// Grain tracker object
+  const GrainTracker & _grain_tracker;
+
+  /// object providing the Euler angles
+  const EulerAngleProvider & _euler;
+  
+  /// Number of order parameters
+  const unsigned int _op_num;
+
+  /// Order parameters
+  const std::vector<const VariableValue *> _vals;
+
+  MaterialProperty<Real> & _delta_theta; // GB mobility
+};

--- a/modules/phase_field/include/materials/GBAnisotropyEvolution.h
+++ b/modules/phase_field/include/materials/GBAnisotropyEvolution.h
@@ -1,0 +1,31 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GBAnisotropyEvolutionBase.h"
+
+/**
+ * Grain boundary energy parameters for isotropic uniform grain boundary energies
+ */
+
+class GBAnisotropyEvolution : public GBAnisotropyEvolutionBase
+                                  //  public ComputePolycrystalGBAnisotropy
+{
+public:
+  static InputParameters validParams();
+
+  GBAnisotropyEvolution(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  Real _GBEnergy;
+};
+

--- a/modules/phase_field/include/materials/GBAnisotropyEvolutionBase.h
+++ b/modules/phase_field/include/materials/GBAnisotropyEvolutionBase.h
@@ -1,0 +1,53 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "DerivativeMaterialInterface.h"
+
+class GBAnisotropyEvolutionBase : public DerivativeMaterialInterface<Material>
+{
+public:
+  static InputParameters validParams();
+
+  GBAnisotropyEvolutionBase(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  Real _f0s;
+  Real _wGB;
+  Real _length_scale;
+  Real _time_scale;
+  Real _GBmob0;
+  Real _GBEnergy;
+  Real _Q;
+  Real _GBMobility;
+  Real _molar_vol;
+
+  const VariableValue & _T;
+
+  MaterialProperty<Real> & _sigma;
+  MaterialProperty<Real> & _M_GB;
+  MaterialProperty<Real> & _kappa;
+  MaterialProperty<Real> & _gamma;
+  MaterialProperty<Real> & _L;
+  MaterialProperty<Real> * _dLdT;
+  MaterialProperty<Real> & _l_GB;
+  MaterialProperty<Real> & _mu;
+  MaterialProperty<Real> & _entropy_diff;
+  MaterialProperty<Real> & _molar_volume;
+  MaterialProperty<Real> & _act_wGB;
+
+  const MaterialProperty<Real> & _delta_theta;
+
+  const Real _kb;
+  const Real _JtoeV;
+};

--- a/modules/phase_field/include/materials/GBAnisotropyMisorientation.h
+++ b/modules/phase_field/include/materials/GBAnisotropyMisorientation.h
@@ -1,0 +1,69 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+
+// Forward Declarations
+
+/**
+ * Function[kappa, gamma, m, L] = parameters (sigma, mob, w_GB, sigma0)
+ * Parameter determination method is elaborated in Phys. Rev. B, 78(2), 024113, 2008, by N. Moelans
+ * This material uses Algorithm 1 from the paper to determine parameters for constant GB width
+ */
+class GBAnisotropyMisorientation : public Material
+{
+public:
+  static InputParameters validParams();
+
+  GBAnisotropyMisorientation(const InputParameters & parameters);
+
+private:
+  virtual void computeQpProperties();
+
+  const unsigned int _mesh_dimension;
+
+  const Real _wGB;
+  const Real _length_scale;
+  const Real _time_scale;
+  const Real _M_V;
+
+  const VariableValue & _T;
+
+  Real _sigma; // 二维矩阵
+  Real _mob;
+  Real _Q;
+  Real _kappa;
+  Real _gamma;
+  Real _a;
+  Real _g2;
+
+  MaterialProperty<Real> & _sigma_gb;
+  MaterialProperty<Real> & _mob_gb;
+  MaterialProperty<Real> & _kappa_gb;
+  MaterialProperty<Real> & _gamma_gb;
+  MaterialProperty<Real> & _L_gb;
+  MaterialProperty<Real> & _mu_gb;
+
+  MaterialProperty<Real> & _molar_volume;
+  MaterialProperty<Real> & _entropy_diff;
+  MaterialProperty<Real> & _act_wGB;
+
+  const Real _kb;
+  const Real _JtoeV;
+  Real _mu_qp;
+
+  const unsigned int _op_num;
+
+  const std::vector<const VariableValue *> _vals;
+  const std::vector<const VariableGradient *> _grad_vals;
+
+  const MaterialProperty<Real> & _delta_theta;
+};

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -83,6 +83,15 @@ public:
   /// Returns the variable representing the passed in feature
   virtual unsigned int getFeatureVar(unsigned int feature_id) const;
 
+  /// Returns the feature ID representing the passed in feature (Grain ID)
+  virtual unsigned int getFeatureID(unsigned int feature_id) const;
+
+  /// Create a vector<unsigned int> including adjacent feature ID for one feature
+  std::vector<unsigned int> createAdjacentGrainMap(int num_feature);
+
+  /// Returns the number of adjacent grains for grain ID
+  virtual unsigned int getAdjacentGrainNum(unsigned int feature_id) const;
+
   /// Returns the number of coupled varaibles
   std::size_t numCoupledVars() const { return _n_vars; }
 
@@ -159,9 +168,11 @@ public:
 
     FeatureData(std::size_t var_index,
                 Status status,
+                std::vector<unsigned int> adjacent_grain_id = std::vector<unsigned int>(), // a vector including all adjacent feature ID for one feature
                 unsigned int id = invalid_id,
                 std::vector<BoundingBox> bboxes = {BoundingBox()})
       : _var_index(var_index),
+        _adjacent_grain_id(adjacent_grain_id), // initialize
         _id(id),
         _bboxes(bboxes), // Assume at least one bounding box
         _min_entity_id(DofObject::invalid_id),
@@ -287,6 +298,9 @@ public:
     /// The vector of bounding boxes completely enclosing this feature
     /// (multiple used with periodic constraints)
     std::vector<BoundingBox> _bboxes;
+
+    /// The vecor of adjacent feature ID for this feature 
+    std::vector<unsigned int> _adjacent_grain_id;
 
     /// Original processor/local ids
     std::list<std::pair<processor_id_type, unsigned int>> _orig_ids;

--- a/modules/phase_field/include/vectorpostprocessors/FeatureVolumeVectorPostprocessor.h
+++ b/modules/phase_field/include/vectorpostprocessors/FeatureVolumeVectorPostprocessor.h
@@ -54,7 +54,9 @@ protected:
   /// A reference to the feature flood count object
   const FeatureFloodCount & _feature_counter;
 
+  VectorPostprocessorValue & _feature_id;
   VectorPostprocessorValue & _var_num;
+  VectorPostprocessorValue & _adjacent_num;
   VectorPostprocessorValue & _feature_volumes;
   VectorPostprocessorValue & _intersects_bounds;
   VectorPostprocessorValue & _intersects_specified_bounds;

--- a/modules/phase_field/src/materials/ComputePolycrystalGBAnisotropy.C
+++ b/modules/phase_field/src/materials/ComputePolycrystalGBAnisotropy.C
@@ -1,0 +1,88 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ComputePolycrystalGBAnisotropy.h"
+
+
+registerMooseObject("PhaseFieldApp", ComputePolycrystalGBAnisotropy);
+
+InputParameters
+ComputePolycrystalGBAnisotropy::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription(
+      "Compute of grain boundary energy and grain boundary mobility based on misorientation");
+  params.addRequiredParam<UserObjectName>(
+      "grain_tracker", "Name of GrainTracker user object that provides Grain ID according to element ID");
+  params.addRequiredParam<UserObjectName>("euler_angle_provider",
+                                          "Name of Euler angle provider user object");  
+  params.addRequiredCoupledVarWithAutoBuild(
+      "v", "var_name_base", "op_num", "Array of coupled variables");
+  return params;   
+}
+
+ComputePolycrystalGBAnisotropy::ComputePolycrystalGBAnisotropy(const InputParameters & parameters)
+  : Material(parameters),
+    _grain_tracker(getUserObject<GrainTracker>("grain_tracker")),
+    _euler(getUserObject<EulerAngleProvider>("euler_angle_provider")),
+    _op_num(coupledComponents("v")),
+    _vals(coupledValues("v")),
+    _delta_theta(declareProperty<Real>("delta_theta"))
+{
+}
+
+void
+ComputePolycrystalGBAnisotropy::computeQpProperties()
+{
+  // Get list of active order parameters from grain tracker, std::vector<unsigned int>
+  const auto & op_to_grains = _grain_tracker.getVarToFeatureVector(_current_elem->id());
+
+  unsigned int num_grain_id = 0; // the number of vaild graid IDs
+  std::vector<std::vector<unsigned int>> grainID_varibaleIndex; // Create a vector of grain IDs to order parameter indices
+  grainID_varibaleIndex.clear();
+
+  for (MooseIndex(op_to_grains) op_index = 0; op_index < op_to_grains.size(); ++op_index)
+  {
+    auto grain_id = op_to_grains[op_index];
+
+    if (grain_id == FeatureFloodCount::invalid_id)
+      continue;    
+    
+    grainID_varibaleIndex[num_grain_id][0] = grain_id;
+    grainID_varibaleIndex[num_grain_id][1] = op_index; 
+    num_grain_id++;
+  }
+  
+  if (grainID_varibaleIndex.size() == 1) // inside the grain 
+    _delta_theta[_qp] = 0; // the misorientation 
+  else // on the grain boudary
+  {
+    Real sum_val = 0;
+    Real sum_delta_theta = 0;
+    Real Val = 0.0;
+    for (unsigned int i = 0; i < grainID_varibaleIndex.size(); ++i)
+    {
+      for (unsigned int j = i+1; j < grainID_varibaleIndex.size(); ++j)
+      {
+        const RealVectorValue angles_i = _euler.getEulerAngles(grainID_varibaleIndex[i][0]); // Get the sequence of Euler angles for grain i
+        const RealVectorValue angles_j = _euler.getEulerAngles(grainID_varibaleIndex[j][0]);
+
+        unsigned int m = grainID_varibaleIndex[i][1]; // Get the order parameter index of grain i
+        unsigned int n = grainID_varibaleIndex[j][1];
+
+        Val = (100000.0 * ((*_vals[m])[_qp]) * ((*_vals[m])[_qp]) + 0.01) *
+              (100000.0 * ((*_vals[n])[_qp]) * ((*_vals[n])[_qp]) + 0.01); // eta_i^2 * eta_j^2
+
+        sum_val += Val;
+        sum_delta_theta += std::abs(angles_i(0)-angles_j(0))*Val; // misorientation for only considering phi_1
+      }
+    }
+    _delta_theta[_qp] = sum_delta_theta / sum_val;
+  } 
+}

--- a/modules/phase_field/src/materials/GBAnisotropyEvolution.C
+++ b/modules/phase_field/src/materials/GBAnisotropyEvolution.C
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GBAnisotropyEvolution.h"
+
+registerMooseObject("PhaseFieldApp", GBAnisotropyEvolution);
+
+InputParameters
+GBAnisotropyEvolution::validParams()
+{
+  InputParameters params = GBAnisotropyEvolutionBase::validParams();
+  params.addRequiredParam<Real>("GBenergy", "Grain boundary energy in J/m^2");
+  return params;
+}
+
+
+GBAnisotropyEvolution::GBAnisotropyEvolution(const InputParameters & parameters)
+  : GBAnisotropyEvolutionBase(parameters), _GBEnergy(getParam<Real>("GBenergy"))
+{
+}
+
+void
+GBAnisotropyEvolution::computeQpProperties()
+{
+  // eV/nm^2
+  this->_sigma[this->_qp] = _GBEnergy * this->_JtoeV * (this->_length_scale * this->_length_scale);
+
+  GBAnisotropyEvolutionBase::computeQpProperties();
+}

--- a/modules/phase_field/src/materials/GBAnisotropyEvolutionBase.C
+++ b/modules/phase_field/src/materials/GBAnisotropyEvolutionBase.C
@@ -1,0 +1,132 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GBAnisotropyEvolutionBase.h"
+
+registerMooseObject("PhaseFieldApp", GBAnisotropyEvolutionBase);
+
+InputParameters
+GBAnisotropyEvolutionBase::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription(
+      "Computes necessary material properties for the isotropic grain growth model");
+  params.addRequiredCoupledVar("T", "Temperature in Kelvin");
+  params.addParam<Real>("f0s", 0.125, "The GB energy constant ");
+  params.addRequiredParam<Real>("wGB", "Diffuse GB width in the length scale of the model");
+  params.addParam<Real>("length_scale", 1.0e-9, "Length scale in m, where default is nm");
+  params.addParam<Real>("time_scale", 1.0e-9, "Time scale in s, where default is ns");
+  params.addParam<Real>(
+      "GBMobility",
+      -1,
+      "GB mobility input in m^4/(J*s), that overrides the temperature dependent calculation");
+  params.addParam<Real>("GBmob0", 0, "Grain boundary mobility prefactor in m^4/(J*s)");
+  params.addParam<Real>("Q", 0, "Grain boundary migration activation energy in eV");
+  params.addParam<Real>("molar_volume",
+                        24.62e-6,
+                        "Molar volume in m^3/mol, needed for temperature gradient driving force");
+  params.addRequiredParam<Real>("GBenergy", "Grain boundary energy in J/m^2");                      
+  return params;
+}
+
+GBAnisotropyEvolutionBase::GBAnisotropyEvolutionBase(const InputParameters & parameters)
+  : DerivativeMaterialInterface<Material>(parameters),
+    _f0s(getParam<Real>("f0s")),
+    _wGB(getParam<Real>("wGB")),
+    _length_scale(getParam<Real>("length_scale")),
+    _time_scale(getParam<Real>("time_scale")),
+    _GBmob0(getParam<Real>("GBmob0")),
+    _Q(getParam<Real>("Q")),
+    _GBMobility(getParam<Real>("GBMobility")),
+    _molar_vol(getParam<Real>("molar_volume")),
+    _T(coupledValue("T")), 
+    _GBEnergy(getParam<Real>("GBenergy")), //
+    _sigma(declareProperty<Real>("sigma")),
+    _M_GB(declareProperty<Real>("M_GB")),
+    _kappa(declareProperty<Real>("kappa_op")),
+    _gamma(declareProperty<Real>("gamma_asymm")),
+    _L(declareProperty<Real>("L")),
+    _dLdT(parameters.hasDefaultCoupledValue("T")
+              ? nullptr
+              : &declarePropertyDerivative<Real>("L", getVar("T", 0)->name())),
+    _l_GB(declareProperty<Real>("l_GB")),
+    _mu(declareProperty<Real>("mu")),
+    _entropy_diff(declareProperty<Real>("entropy_diff")),
+    _molar_volume(declareProperty<Real>("molar_volume")),
+    _act_wGB(declareProperty<Real>("act_wGB")),
+    _kb(8.617343e-5),     // Boltzmann constant in eV/K
+    _JtoeV(6.24150974e18), // Joule to eV conversion
+    _delta_theta(getMaterialProperty<Real>("delta_theta"))
+{
+  if (_GBMobility == -1 && _GBmob0 == 0)
+    mooseError("Either a value for GBMobility or for GBmob0 and Q must be provided");
+}
+
+void
+GBAnisotropyEvolutionBase::computeQpProperties()
+{
+  const Real length_scale4 = _length_scale * _length_scale * _length_scale * _length_scale;
+
+  // GB mobility Derivative
+  Real dM_GBdT;
+
+  const Real delta_theta_HGB = 15; // the misorientation corresponding to the transition angle between low and high angle grain boudaries
+
+  // Grain boundary mobility according to the sigmoidal law 
+  const Real & GBmobi0_HGB = _GBmob0; // the grain boudary mobility of a high angle grain boundary
+  const Real B = 5;
+  const Real n = 4;
+
+  // Grain boundary energy according to the Read-Shockley law;
+  const Real & GBEnergy_HGB = _GBEnergy; // the grain boudary energy of a high angle grain boundary  
+
+  Real _GBmob0_theta = GBmobi0_HGB;
+  _sigma[_qp] = GBEnergy_HGB * _JtoeV * (_length_scale * _length_scale);
+  
+  if (_delta_theta[_qp] > 0)
+  {
+    _GBmob0_theta = GBmobi0_HGB * (1- std::exp(-B * std::pow(_delta_theta[_qp] / delta_theta_HGB,n))) + GBmobi0_HGB; 
+    if (_delta_theta[_qp] < 15)
+      _sigma[_qp] = (GBEnergy_HGB * _delta_theta[_qp] / delta_theta_HGB * std::log(1 - std::log(_delta_theta[_qp] / delta_theta_HGB)) + 1 ) * _JtoeV * (_length_scale * _length_scale);
+    else
+      _sigma[_qp] = (GBEnergy_HGB * 15.0 / delta_theta_HGB * std::log(1 - std::log(15.0 / delta_theta_HGB)) + 1) * _JtoeV * (_length_scale * _length_scale);
+  }
+
+  if (_GBMobility < 0)
+  {
+    // Convert to lengthscale^4/(eV*timescale);
+    const Real M0 = _GBmob0_theta * _time_scale / (_JtoeV * length_scale4); // _GBmob0_theta
+
+    _M_GB[_qp] = M0 * std::exp(-_Q / (_kb * _T[_qp]));
+    dM_GBdT = MetaPhysicL::raw_value(_M_GB[_qp] * _Q / (_kb * _T[_qp] * _T[_qp]));
+  }
+  else
+  {
+    // Convert to lengthscale^4/(eV*timescale)
+    _M_GB[_qp] = _GBMobility * _time_scale / (_JtoeV * length_scale4);
+    dM_GBdT = 0.0;
+  }
+
+  // in the length scale of the system
+  _l_GB[_qp] = _wGB;
+
+  _L[_qp] = 4.0 / 3.0 * _M_GB[_qp] / _l_GB[_qp];
+  if (_dLdT)
+    (*_dLdT)[_qp] = MetaPhysicL::raw_value(4.0 / 3.0 * dM_GBdT / _l_GB[_qp]);
+  _kappa[_qp] = 3.0 / 4.0 * _sigma[_qp] * _l_GB[_qp];
+  _gamma[_qp] = 1.5;
+  _mu[_qp] = 3.0 / 4.0 * 1.0 / _f0s * _sigma[_qp] / _l_GB[_qp];
+
+  // J/(K mol) converted to eV(K mol)
+  _entropy_diff[_qp] = 8.0e3 * _JtoeV;
+
+  // m^3/mol converted to ls^3/mol
+  _molar_volume[_qp] = _molar_vol / (_length_scale * _length_scale * _length_scale);
+  _act_wGB[_qp] = 0.5e-9 / _length_scale;
+}

--- a/modules/phase_field/src/materials/GBAnisotropyMisorientation.C
+++ b/modules/phase_field/src/materials/GBAnisotropyMisorientation.C
@@ -1,0 +1,138 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "GBAnisotropyMisorientation.h"
+
+registerMooseObject("PhaseFieldApp", GBAnisotropyMisorientation);
+
+InputParameters
+GBAnisotropyMisorientation::validParams()
+{
+  InputParameters params = Material::validParams();
+  params.addClassDescription(
+      "Compute of material parameters for multi-order paramater phase field models based on misorientation");
+  params.addCoupledVar("T", 300.0, "Temperature in Kelvin");
+  params.addRequiredParam<Real>("wGB", "Diffuse GB width in nm");
+  params.addParam<Real>("length_scale", 1.0e-9, "Length scale in m, where default is nm");
+  params.addParam<Real>("time_scale", 1.0e-9, "Time scale in s, where default is ns");
+  params.addParam<Real>("molar_volume_value",
+                        7.11e-6,
+                        "molar volume of material in m^3/mol, by default it's the value of copper");
+  params.addRequiredCoupledVarWithAutoBuild(
+      "v", "var_name_base", "op_num", "Array of coupled variables");
+  return params;
+}
+
+GBAnisotropyMisorientation::GBAnisotropyMisorientation(const InputParameters & parameters)
+  : Material(parameters), 
+    _mesh_dimension(_mesh.dimension()),
+    _wGB(getParam<Real>("wGB")),
+    _length_scale(getParam<Real>("length_scale")),
+    _time_scale(getParam<Real>("time_scale")),
+    _M_V(getParam<Real>("molar_volume_value")),
+    _T(coupledValue("T")),
+    _sigma_gb(declareProperty<Real>("sigma")),
+    _mob_gb(declareProperty<Real>("M_GB")),
+    _kappa_gb(declareProperty<Real>("kappa_op")),
+    _gamma_gb(declareProperty<Real>("gamma_asymm")), // gamma
+    _L_gb(declareProperty<Real>("L")),
+    _mu_gb(declareProperty<Real>("mu")),
+    _molar_volume(declareProperty<Real>("molar_volume")),
+    _entropy_diff(declareProperty<Real>("entropy_diff")),
+    _act_wGB(declareProperty<Real>("act_wGB")),
+    _kb(8.617343e-5),      // Boltzmann constant in eV/K
+    _JtoeV(6.24150974e18), // Joule to eV conversion
+    _mu_qp(0.0),
+    _op_num(coupledComponents("v")),
+    _vals(coupledValues("v")),
+    _grad_vals(coupledGradients("v")),
+    _delta_theta(getMaterialProperty<Real>("delta_theta"))
+{
+
+}
+
+void
+GBAnisotropyMisorientation::computeQpProperties()
+{
+  Real sigma_init; //
+  Real g2 = 0.0; 
+  Real f_interf = 0.0; // f_{0, \text { interf }}(\gamma)}
+  Real a_0 = 0.75; // a_init(gamma_init) or a_k
+  Real a_star = 0.0; // a*(kappa*, gamma*)
+  Real kappa_star = 0.0; 
+  Real gamma_star = 0.0;
+  Real y = 0.0; // 1/gamma
+  Real yyy = 0.0; // 1/gamma^3
+
+
+  const Real & delta_theta_HGB = 15;
+  // Grain boundary mobility according to the sigmoidal law 
+  const Real & GBmobi0_HGB = 2.5e-6 * std::exp(- 0.23 / (_kb * 450)); // the grain boudary mobility of a high angle grain boundary
+  const Real B = 5;
+  const Real n = 4;
+
+  // Grain boundary energy according to the Read-Shockley law;
+  const Real & GBEnergy_HGB = 0.708; // the grain boudary energy of a high angle grain boundary  
+
+  _mob = GBmobi0_HGB; // GBmobi0_HGB;
+  _sigma = GBEnergy_HGB; //GBEnergy_HGB
+  
+  if (_delta_theta[_qp] > 0)
+  {
+    _mob = GBmobi0_HGB * ((1- std::exp(-B * std::pow(_delta_theta[_qp] / delta_theta_HGB, n))) * 4 + 1 );  // 
+    if (_delta_theta[_qp] < 15)
+      _sigma = GBEnergy_HGB * ( _delta_theta[_qp] / delta_theta_HGB * (1 - std::log(_delta_theta[_qp] / delta_theta_HGB)) * 4 + 1);
+    else
+      _sigma = GBEnergy_HGB * (15.0 / delta_theta_HGB * (1 - std::log(15.0 / delta_theta_HGB)) * 4 + 1);
+  }    
+
+      // Convert units of mobility and energy
+  _sigma *= _JtoeV * (_length_scale * _length_scale); // eV/nm^2
+
+  _mob *= _time_scale / (_JtoeV * (_length_scale * _length_scale * _length_scale * _length_scale)); // Convert to nm^4/(eV*ns);                                    
+
+  // 设置初始晶界能和局部自由能密度函数的前置因子
+  _mu_qp = 6.0 * _sigma / _wGB; // 3/4 * 0.125 * sigma / l, model coefficient
+
+  // 对于晶粒m-晶粒n的晶界
+  a_star = a_0; // 0.75
+  a_0 = 0.0; // a_0 = sqrt*(f_{0, interf}(gamma)) / g(gamma)
+
+  while (std::abs(a_0 - a_star) > 1.0e-9) // whie (a_0 != a*)
+  {
+    a_0 = a_star;
+    kappa_star = a_0 * _wGB * _sigma; // (eq-36b)
+    g2 = _sigma * _sigma / (kappa_star * _mu_qp); // (eq-12)
+    y = -5.288 * g2 * g2 * g2 * g2 - 0.09364 * g2 * g2 * g2 + 9.965 * g2 * g2 - 8.183 * g2 +
+        2.007; // g^{-1} ??
+    gamma_star = 1 / y; // gamma* = g^{-1}
+    yyy = y * y * y;
+    f_interf = 0.05676 * yyy * yyy - 0.2924 * yyy * y * y + 0.6367 * yyy * y - 0.7749 * yyy +
+                0.6107 * y * y - 0.4324 * y + 0.2792; // f_interf(gamma*)
+    a_star = std::sqrt(f_interf / g2);
+  }
+
+   _kappa = kappa_star; // upper triangle stores the discrete set of kappa values
+  _gamma = gamma_star; // lower triangle stores the discrete set of gamma values
+
+  _a = a_star; // upper triangle stores "a" data. a*
+  _g2 = g2;     // lower triangle stores "g2" data. (eq-12)
+
+  _sigma_gb[_qp] = _sigma;
+  _mob_gb[_qp] = _mob;
+  _kappa_gb[_qp] = _kappa;
+  _gamma_gb[_qp] = _gamma;
+  _L_gb[_qp] = _mob * std::exp(-_Q / (_kb * _T[_qp])) * _mu_qp * _g2 / _sigma;
+  _mu_gb[_qp] = _mu_qp;
+
+  _molar_volume[_qp] =
+      _M_V / (_length_scale * _length_scale * _length_scale); // m^3/mol converted to ls^3/mol
+  _entropy_diff[_qp] = 9.5 * _JtoeV;                          // J/(K mol) converted to eV(K mol)
+  _act_wGB[_qp] = 0.5e-9 / _length_scale;                     // 0.5 nm
+}


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
In the evolution of grain growth, output the number of grains adjacent to each grain, that is, the topology information of grain growth simulation.

## Design
<!--A concise description (design) of the enhancement.-->
1. In `FeatureFloodCount`, add `adjacent_grain_id` in `FeatureData` to store the ID of adjacent grains for each grain, and create `createAdjacentGrainMap` to build `adjacent_grain_id`.
2. In `FeatureFloodCount`, get the number of adjacent grains through `getAdjacentGrainNum`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No effect on related code.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
