### PR TITLE
Properly setting ADReal for junction residuals to zero

### DIFF
--- a/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
+++ b/modules/thermal_hydraulics/src/userobjects/ADVolumeJunctionBaseUserObject.C
@@ -52,7 +52,7 @@ void
 ADVolumeJunctionBaseUserObject::initialize()
 {
   _flux.assign(_n_connections, std::vector<ADReal>(_n_flux_eq, 0.0));
-  std::fill(_residual.begin(), _residual.end(), 0.0);
+  std::fill(_residual.begin(), _residual.end(), ADReal(0.0, DNDerivativeType()));
   _connection_indices.clear();
 }
 


### PR DESCRIPTION
`std::fill(..., ..., 0.)` on `ADReal` only sets the value part to zero. It does
not touch the derivatives part. This patch fixes the problem.

Refs #19899
