### PR TITLE
Temporary fixes in MOOSE for nodal normals threading failures

### DIFF
--- a/framework/include/userobject/NodalNormalsPreprocessor.h
+++ b/framework/include/userobject/NodalNormalsPreprocessor.h
@@ -15,6 +15,8 @@
 
 #include "libmesh/fe_type.h"
 
+#include <mutex>
+
 class AuxiliarySystem;
 
 /**
@@ -54,4 +56,11 @@ protected:
   BoundaryID _corner_boundary_id;
 
   const VariablePhiGradient & _grad_phi;
+
+private:
+  static std::mutex _nodal_normals_mutex;
+
+  // For access to mutex
+  friend class NodalNormalsCorner;
+  friend class NodalNormalsEvaluator;
 };

--- a/framework/src/userobject/NodalNormalsCorner.C
+++ b/framework/src/userobject/NodalNormalsCorner.C
@@ -13,10 +13,9 @@
 #include "AuxiliarySystem.h"
 #include "MooseMesh.h"
 #include "MooseVariableFE.h"
+#include "NodalNormalsPreprocessor.h"
 
 #include "libmesh/numeric_vector.h"
-
-Threads::spin_mutex nodal_normals_corner_mutex;
 
 registerMooseObject("MooseApp", NodalNormalsCorner);
 
@@ -40,7 +39,7 @@ NodalNormalsCorner::NodalNormalsCorner(const InputParameters & parameters)
 void
 NodalNormalsCorner::execute()
 {
-  Threads::spin_mutex::scoped_lock lock(nodal_normals_corner_mutex);
+  std::scoped_lock lock(NodalNormalsPreprocessor::_nodal_normals_mutex);
   NumericVector<Number> & sln = _aux.solution();
 
   // Get a reference to our BoundaryInfo object

--- a/framework/src/userobject/NodalNormalsEvaluator.C
+++ b/framework/src/userobject/NodalNormalsEvaluator.C
@@ -12,8 +12,7 @@
 // MOOSE includes
 #include "AuxiliarySystem.h"
 #include "MooseVariableFE.h"
-
-Threads::spin_mutex nodal_normals_evaluator_mutex;
+#include "NodalNormalsPreprocessor.h"
 
 registerMooseObject("MooseApp", NodalNormalsEvaluator);
 
@@ -47,7 +46,7 @@ NodalNormalsEvaluator::execute()
                                                Moose::VarFieldType::VAR_FIELD_STANDARD)
                                   .number()) > 0)
     {
-      Threads::spin_mutex::scoped_lock lock(nodal_normals_evaluator_mutex);
+      std::scoped_lock lock(NodalNormalsPreprocessor::_nodal_normals_mutex);
 
       dof_id_type dof_x =
           _current_node->dof_number(_aux.number(),

--- a/framework/src/userobject/NodalNormalsPreprocessor.C
+++ b/framework/src/userobject/NodalNormalsPreprocessor.C
@@ -18,7 +18,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/quadrature.h"
 
-Threads::spin_mutex nodal_normals_preprocessor_mutex;
+std::mutex NodalNormalsPreprocessor::_nodal_normals_mutex;
 
 registerMooseObject("MooseApp", NodalNormalsPreprocessor);
 
@@ -153,7 +153,7 @@ NodalNormalsPreprocessor::execute()
 
           for (unsigned int qp = 0; qp < _qrule->n_points(); qp++)
           {
-            Threads::spin_mutex::scoped_lock lock(nodal_normals_preprocessor_mutex);
+            std::scoped_lock lock(_nodal_normals_mutex);
 
             sln.add(dof_x, _JxW[qp] * _grad_phi[i][qp](0));
             sln.add(dof_y, _JxW[qp] * _grad_phi[i][qp](1));


### PR DESCRIPTION
Refs failures on libmesh/libmesh#3171. This will be fixed in libMesh by
libmesh/libmesh#3176, but until then we should have a fix in MOOSE
