### PR TITLE
Patch Yum mirror and bad exits in Docker builds

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -50,7 +50,7 @@ chown -R dev:dev /home/dev
 # Install managed packages and clear cache
 #-----------------------------------------------------------------------------#
 COPY docker_ci/install_packages.sh docker_ci/apt_installs.sh docker_ci/yum_installs.sh ./
-RUN ./install_packages.sh; rm *.sh
+RUN ./install_packages.sh || exit 1; rm *.sh
 
 #-----------------------------------------------------------------------------#
 # Install mpich-3.3 to system path
@@ -81,7 +81,9 @@ F77FLAGS='' ; \
 make -j ${MOOSE_JOBS} ; \
 make install ; \
 # Cleanup
-cd ../../ ; rm -rf mpich-3.3*
+cd ../../ ; rm -rf mpich-3.3* ; \
+# Ensure mpich was installed by checking for binary
+if [ ! -f $(which mpicc) ]; then exit 1; fi
 
 ENV CC=mpicc \
 CXX=mpicxx \
@@ -94,14 +96,15 @@ WORKDIR ${MOOSE_DIR}
 #-----------------------------------------------------------------------------#
 ARG PETSC_REV
 ARG PETSC_OPTIONS
+ENV PETSC_DIR=/usr/local
 COPY scripts/update_and_rebuild_petsc.sh ${MOOSE_DIR}/scripts/update_and_rebuild_petsc.sh
 COPY scripts/configure_petsc.sh ${MOOSE_DIR}/scripts/configure_petsc.sh
 RUN git clone https://gitlab.com/petsc/petsc.git ; \
 cd petsc && git checkout ${PETSC_REV} && cd .. ; \
-PETSC_PREFIX=/usr/local ./scripts/update_and_rebuild_petsc.sh ${PETSC_OPTIONS} ; \
-rm -rf petsc/* petsc/.* || true
-
-ENV PETSC_DIR=/usr/local
+PETSC_PREFIX=$PETSC_DIR ./scripts/update_and_rebuild_petsc.sh ${PETSC_OPTIONS} ; \
+rm -rf petsc/* petsc/.* || true ; \
+# Ensure PETSc was installed based on present of library directory
+if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
@@ -121,7 +124,9 @@ git checkout ${LIBMESH_REV} ; \
 git submodule update --init ; \
 cd .. ; \
 METHODS="${LIBMESH_METHODS}" ./scripts/update_and_rebuild_libmesh.sh ${LIBMESH_OPTIONS} ; \
-rm -rf libmesh/* libmesh/.* || true
+rm -rf libmesh/* libmesh/.* || true ; \
+# Ensure Libmesh was installed via include directory
+if [ ! -d $LIBMESH_DIR/include/libmesh ]; then exit 1; fi
 
 #-----------------------------------------------------------------------------#
 # Copy and build MOOSE framework, test, and optionally modules
@@ -133,7 +138,9 @@ COPY --chown=dev:dev . ${MOOSE_DIR}
 
 ARG BUILD_MODULES
 ARG MOOSE_METHODS=opt
-RUN ./docker_ci/build_moose.sh
+RUN ./docker_ci/build_moose.sh ; \
+# Ensure a MOOSE test binary was built
+if [ ! -f $MOOSE_DIR/test/moose_test* ]; then exit 1; fi
 
 #-----------------------------------------------------------------------------#
 # Add needed env vars to /etc/environment

--- a/docker_ci/apt_installs.sh
+++ b/docker_ci/apt_installs.sh
@@ -11,6 +11,9 @@
 # This script is used in docker_ci/Dockerfile to setup
 # the base container environment for Debian-based images
 
+# Want to exit if there's an errror
+set -e
+
 export DEBIAN_FRONTEND=noninteractive
 
 # Update package lists

--- a/docker_ci/install_packages.sh
+++ b/docker_ci/install_packages.sh
@@ -19,6 +19,11 @@ for MGR in "${MGR_ARY[@]}"; do
     # Run matching install
     if [ $(command -v $MGR | grep -c $MGR) -gt 0 ]; then
         ./${MGR}_installs.sh
+
+        if [ $? -ne 0 ]; then
+            printf "Error with $MGR package installs.  Aborting build\n"
+            exit 1
+        fi
     fi
 done
 

--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -11,9 +11,13 @@
 # This script is used in docker_ci/Dockerfile to setup
 # the base container environment for Red Hat-based images
 
+# Want to exit if there's an errror
+set -e
+
 # Per https://stackoverflow.com/a/70930049, we need these commands for Yum mirrors
+# Per https://serverfault.com/a/1093928, switch to vault.epel.cloud
 sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
-sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-*
 
 # Update package lists
 yum update -y


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
The Yum mirror `vault.centos.org` kept timing out on our builds.  It was noted that these non-graceful exits didn't cause the Docker build to fail and by extension the Jenkins pipeline, yielding useless MOOSE images.

## Design
<!--A concise description (design) of the enhancement.-->
All files referred to are in the directory `docker_ci`.  The Yum mirror `vault.centos.org` has been replaced with `vault.epel.cloud`.  In both package manager install shell scripts `apt_installs.sh` and `yum_installs.sh`, `set -e` has been specified to force an exit for the script at the first non-zero exit within.  In `install_packages.sh`, this exit code is captured and acted upon if non-zero.  From here, to ensure Docker builds fail when they should, the following changes were made to `Dockerfile`.
1. Add `|| exit 1` to running `install_packages.sh`
1. Check for `mpicc` on system path after building MPICH
1. Check for PETSc library directory to verify it installed
1. Check for the Libmesh include directory to verify it installed
1. Check for a MOOSE test binary to ensure everything built

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No changes to source.  This impacts Docker builds by ensuring the builds fail when something goes wrong along the way.  Closes #20448.
<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
