### PR TITLE
 Specializations of MooseADWrapper for std::array and MooseUtils::SemiDynamicVector

### DIFF
--- a/framework/include/utils/MooseADWrapper.h
+++ b/framework/include/utils/MooseADWrapper.h
@@ -46,10 +46,22 @@ struct MooseADWrapperStruct<std::vector<T>, is_ad>
 };
 
 // std::array and MooseUtils::SemidynamicVector support
-template <template <typename, std::size_t> class W, typename T, std::size_t N, bool is_ad>
-struct MooseADWrapperStruct<W<T, N>, is_ad>
+template <typename T, std::size_t N, bool is_ad>
+struct MooseADWrapperStruct<std::array<T, N>, is_ad>
 {
-  typedef W<typename MooseADWrapperStruct<T, is_ad>::type, N> type;
+  typedef std::array<typename MooseADWrapperStruct<T, is_ad>::type, N> type;
+};
+
+namespace MooseUtils
+{
+template <typename, std::size_t>
+class SemidynamicVector;
+}
+
+template <typename T, std::size_t N, bool is_ad>
+struct MooseADWrapperStruct<MooseUtils::SemidynamicVector<T, N>, is_ad>
+{
+  typedef MooseUtils::SemidynamicVector<typename MooseADWrapperStruct<T, is_ad>::type, N> type;
 };
 
 template <typename T, bool is_ad>


### PR DESCRIPTION
refs #20364

## Reason
Reestablish compatibility with Fastor

## Design
Specializations of MooseADWrapper for std::array and MooseUtils::SemiDynamicVector

## Impact
no
