### PR TITLE
Use github actions for stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale pull requests
+
+on:
+  schedule:
+  - cron: '36 5 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+        stale-pr-label: 'no-pr-activity'
+        days-before-pr-stale: 30
+        days-before-pr-close: 3


### PR DESCRIPTION
Label PRs older than 30 days with no activity as stale.

Close PRs labeled as stale if they continue to not have activity
after 3 days.

Closes #20475
