### PR TITLE
Enable parallel execution in FlowChannel1Phase

### DIFF
--- a/modules/thermal_hydraulics/test/tests/closures/none_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/closures/none_1phase/tests
@@ -3,7 +3,6 @@
     type = 'Exodiff'
     input = 'phy.test.i'
     exodiff = 'phy.test_out.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
   [enumeration_option]
@@ -12,7 +11,6 @@
     cli_args = "GlobalParams/closures=none"
     allow_deprecated = False
     expect_err = 'The closures system now uses objects created in the input file'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/closures/simple_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/closures/simple_1phase/tests
@@ -11,7 +11,6 @@
     cli_args = "GlobalParams/closures=simple Components/pipe/f=0"
     allow_deprecated = False
     expect_err = 'The closures system now uses objects created in the input file'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/deprecated/tests
+++ b/modules/thermal_hydraulics/test/tests/components/deprecated/tests
@@ -4,7 +4,6 @@
     type = 'RunException'
     input = 'free_boundary.i'
     expect_err = "Deprecated component. Use FreeBoundary1Phase or FreeBoundary2Phase instead."
-    max_parallel = 1
     ad_indexing_type = 'global'
     design = 'FreeBoundary.md'
     requirement = 'The system shall report an error if the FreeBoundary component is used.'
@@ -22,7 +21,6 @@
     type = 'RunException'
     input = 'solid_wall.i'
     expect_err = "Deprecated component. Use SolidWall1Phase or SolidWall2Phase instead."
-    max_parallel = 1
     ad_indexing_type = 'global'
     design = 'SolidWall.md'
     requirement = 'The system shall report an error if the SolidWall component is used.'
@@ -49,7 +47,6 @@
     type = 'RunException'
     input = 'heat_source_volumetric.i'
     expect_err = "Deprecated component. Use HeatSourceVolumetric1Phase or HeatSourceVolumetric2Phase instead."
-    max_parallel = 1
     ad_indexing_type = 'global'
     design = 'HeatSourceVolumetric.md'
     requirement = 'The system shall report an error if the HeatSourceVolumetric component is used.'

--- a/modules/thermal_hydraulics/test/tests/components/elbow_pipe_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/elbow_pipe_1phase/tests
@@ -4,7 +4,6 @@
     input = 'phy.position.i'
     exodiff = 'phy.position_out.e'
     custom_cmp = 'phy.position.exodiff'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/flow_channel_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/flow_channel_1phase/tests
@@ -5,7 +5,6 @@
     input = 'phy.f_fn.3eqn.i'
     csvdiff = 'phy.f_fn.3eqn_out.csv'
     rel_err = 1e-10
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -14,7 +13,6 @@
     input = 'phy.par_fn.i'
     csvdiff = 'phy.par_fn_out.csv'
     rel_err = 1e-10
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -25,7 +23,6 @@
     custom_cmp = 'phy.sub_discretization.exodiff'
     # matching geometry at t=0
     recover = false
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 

--- a/modules/thermal_hydraulics/test/tests/components/form_loss_from_external_app_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/form_loss_from_external_app_1phase/tests
@@ -5,7 +5,6 @@
     exodiff = 'phy.form_loss_1phase.master_out_slave0.e'
     rel_err = 1e-10
     recover = false
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/form_loss_from_function_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/form_loss_from_function_1phase/tests
@@ -4,7 +4,6 @@
     input = 'phy.form_loss_1phase.i'
     csvdiff = 'phy.form_loss_1phase_out.csv'
     rel_err = 1e-3
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/free_boundary_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/free_boundary_1phase/tests
@@ -7,7 +7,6 @@
     cli_args = 'Outputs/out_mass/type=CSV Outputs/out_mass/execute_postprocessors_on=final Outputs/out_mass/show=mass_conservation'
     abs_zero = 1e-10
     rel_err = 1e-15
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
   [phy:momentum_1phase]
@@ -18,7 +17,6 @@
     abs_zero = 1e-6
     rel_err = 1e-15
     prereq = 'phy:mass_1phase'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
   [phy:energy_1phase]
@@ -29,7 +27,6 @@
     abs_zero = 1e-2
     rel_err = 1e-15
     prereq = 'phy:momentum_1phase'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/heat_source_volumetric_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/heat_source_volumetric_1phase/tests
@@ -5,7 +5,6 @@
     input = 'phy.conservation.1phase.i'
     csvdiff = 'phy.conservation.1phase_out.csv'
     abs_zero = 1e-9
-    max_parallel = 1
     # because output has execute_on = 'final'
     recover = false
     ad_indexing_type = 'global'

--- a/modules/thermal_hydraulics/test/tests/components/inlet_density_velocity_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/inlet_density_velocity_1phase/tests
@@ -4,7 +4,6 @@
     type = 'Exodiff'
     input = 'phy.densityvelocity_3eqn.i'
     exodiff = 'phy.densityvelocity_3eqn_out.e'
-    max_parallel = 1
     recover = false
     ad_indexing_type = 'global'
   []
@@ -14,7 +13,6 @@
     type = 'CSVDiff'
     input = 'clg.densityvelocity_3eqn.i'
     csvdiff = 'clg.densityvelocity_3eqn_out.csv'
-    max_parallel = 1
     rel_err = 1e-5
     ad_indexing_type = 'global'
   []

--- a/modules/thermal_hydraulics/test/tests/components/inlet_mass_flow_rate_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/inlet_mass_flow_rate_1phase/tests
@@ -4,7 +4,6 @@
     input = 'phy.massflowrate_3eqn.i'
     exodiff = 'phy.massflowrate_3eqn.e'
     group = 'inlet_mass_flow_rate outlet pipe 1phase'
-    max_parallel = 1
     max_time = 1000
     ad_indexing_type = 'global'
   []
@@ -12,7 +11,6 @@
     type = 'Exodiff'
     input = 'phy.reversed_flow.i'
     exodiff = 'phy.reversed_flow.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -20,14 +18,12 @@
     type = 'CSVDiff'
     input = 'clg.ctrl_m_dot_3eqn_rdg.i'
     csvdiff = 'clg.ctrl_m_dot_3eqn_rdg_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
   [clg:ctrl_T_3eqn_rdg]
     type = 'CSVDiff'
     input = 'clg.ctrl_T_3eqn_rdg.i'
     csvdiff = 'clg.ctrl_T_3eqn_rdg_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 

--- a/modules/thermal_hydraulics/test/tests/components/inlet_stagnation_p_t_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/inlet_stagnation_p_t_1phase/tests
@@ -4,7 +4,6 @@
     type = 'Exodiff'
     input = 'phy.stagnation_p_T_steady_3eqn.i'
     exodiff = 'phy.stagnation_p_T_steady_3eqn_out.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -12,7 +11,6 @@
     type = 'Exodiff'
     input = 'phy.stagnation_p_T_transient_3eqn.i'
     exodiff = 'phy.stagnation_p_T_transient_3eqn_out.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -20,7 +18,6 @@
     type = 'Exodiff'
     input = 'phy.p0T0_3eqn.i'
     exodiff = 'phy.p0T0_3eqn.e'
-    max_parallel = 1
     max_time = 500
     group = 'inlet_p0_T0 outlet pipe 1phase'
     ad_indexing_type = 'global'
@@ -30,7 +27,6 @@
     type = 'CSVDiff'
     input = 'clg.ctrl_p0_3eqn.i'
     csvdiff = 'clg.ctrl_p0_3eqn_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -38,7 +34,6 @@
     type = 'CSVDiff'
     input = 'clg.ctrl_T0_3eqn.i'
     csvdiff = 'clg.ctrl_T0_3eqn_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/inlet_velocity_t_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/inlet_velocity_t_1phase/tests
@@ -4,7 +4,6 @@
     input = 'phy.velocity_t_3eqn.i'
     exodiff = 'phy.velocity_t_3eqn.e'
     custom_cmp = 'rdg_1phase.exodiff'
-    max_parallel = 1
     group = 'outlet pipe 1phase rdg'
     max_time = 600
     ad_indexing_type = 'global'
@@ -13,14 +12,12 @@
     type = 'Exodiff'
     input = 'phy.reversed_flow.i'
     exodiff = 'phy.reversed_flow.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
   [clg:velocity_t_3eqn]
     type = 'CSVDiff'
     input = 'clg.velocity_t_3eqn.i'
     csvdiff = 'clg.velocity_t_3eqn_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/components/outlet_1phase/phy.solidwall_outlet_3eqn.exodiff
+++ b/modules/thermal_hydraulics/test/tests/components/outlet_1phase/phy.solidwall_outlet_3eqn.exodiff
@@ -1,0 +1,6 @@
+COORDINATES
+TIME STEPS
+ELEMENT VARIABLES
+	vel floor 1.e-5
+	T
+	p

--- a/modules/thermal_hydraulics/test/tests/components/outlet_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/outlet_1phase/tests
@@ -3,11 +3,10 @@
     type = 'Exodiff'
     input = 'phy.solidwall_outlet_3eqn.i'
     exodiff = 'phy.solidwall_outlet_3eqn.e'
+    custom_cmp = 'phy.solidwall_outlet_3eqn.exodiff'
     group = 'solid_wall outlet pipe 1phase'
-    abs_zero = 1e-7
     # see #530 why
     max_threads = 1
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 
@@ -15,7 +14,6 @@
     type = 'CSVDiff'
     input = 'clg.ctrl_p_3eqn.i'
     csvdiff = 'clg.ctrl_p_3eqn_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 

--- a/modules/thermal_hydraulics/test/tests/components/solid_wall_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/solid_wall_1phase/tests
@@ -4,7 +4,6 @@
     type = 'Exodiff'
     input = 'phy.3eqn.i'
     exodiff = 'phy.3eqn_out.e'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 

--- a/modules/thermal_hydraulics/test/tests/components/supersonic_inlet/tests
+++ b/modules/thermal_hydraulics/test/tests/components/supersonic_inlet/tests
@@ -3,7 +3,6 @@
     type = 'RunException'
     input = 'err.i'
     expect_err = "This component is not implemented for single-phase flow."
-    max_parallel = 1
     ad_indexing_type = 'global'
     design = 'SupersonicInlet.md'
     requirement = 'The system shall report an error if the SupersonicInlet component is used.'

--- a/modules/thermal_hydraulics/test/tests/controls/copy_postprocessor_value_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/copy_postprocessor_value_control/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/delay_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/delay_control/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 

--- a/modules/thermal_hydraulics/test/tests/controls/dependency/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/dependency/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/get_function_value_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/get_function_value_control/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/pid_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/pid_control/tests
@@ -4,7 +4,6 @@
     input = 'test.i'
     csvdiff = 'test_out.csv'
     rel_err = 1e-4
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/set_bool_value_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/set_bool_value_control/tests
@@ -4,7 +4,6 @@
     input = 'test.i'
     csvdiff = 'test_out.csv'
     allow_test_objects = true
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/set_component_real_value_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/set_component_real_value_control/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/set_real_value_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/set_real_value_control/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/thm_solve_postprocessor_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/thm_solve_postprocessor_control/tests
@@ -3,6 +3,5 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
   []
 []

--- a/modules/thermal_hydraulics/test/tests/controls/unit_trip_control/tests
+++ b/modules/thermal_hydraulics/test/tests/controls/unit_trip_control/tests
@@ -4,7 +4,6 @@
     input = 'test.i'
     csvdiff = 'no_latch.csv'
     cli_args = 'Outputs/file_base=no_latch'
-    max_parallel = 1
     group = 'controls'
     requirement = 'The system shall provide a unit trip component that report true if the trip condition was met and false otherwise.'
     design = 'UnitTripControl.md'
@@ -16,7 +15,6 @@
     input = 'test.i'
     csvdiff = 'latch.csv'
     cli_args = 'ControlLogic/trip_ctrl/latch=true Outputs/file_base=latch'
-    max_parallel = 1
     requirement = 'The system shall provide a unit trip component that stays in tripped state after the trip happened.'
     design = 'UnitTripControl.md'
     issues = '#619'

--- a/modules/thermal_hydraulics/test/tests/misc/adapt/single_block.i
+++ b/modules/thermal_hydraulics/test/tests/misc/adapt/single_block.i
@@ -77,7 +77,7 @@
   num_steps = 5
   abort_on_solve_fail = true
 
-  solve_type = 'PJFNK'
+  solve_type = 'NEWTON'
   line_search = 'basic'
   nl_rel_tol = 1e-9
   nl_abs_tol = 1e-8

--- a/modules/thermal_hydraulics/test/tests/misc/adapt/tests
+++ b/modules/thermal_hydraulics/test/tests/misc/adapt/tests
@@ -3,7 +3,7 @@
     type = 'Exodiff'
     input = 'single_block.i'
     exodiff = 'single_block_out.e-s005'
-    abs_zero = 1e-8
+    abs_zero = 1e-7
     recover = false
     max_parallel = 1
     ad_indexing_type = 'global'

--- a/modules/thermal_hydraulics/test/tests/postprocessors/flow_boundary_flux_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/postprocessors/flow_boundary_flux_1phase/tests
@@ -3,7 +3,6 @@
     type = 'CSVDiff'
     input = 'test.i'
     csvdiff = 'test_out.csv'
-    max_parallel = 1
     ad_indexing_type = 'global'
   []
 []


### PR DESCRIPTION
- fixing `SlopeReconstruction1DInterface` so it works only with values it owns
- enabling tests to run in parallel

Refs #19899