### PR TITLE
Don't do nonlocal in regular Jacobian thread

### DIFF
--- a/test/tests/userobjects/shape_element_user_object/jacobian.i
+++ b/test/tests/userobjects/shape_element_user_object/jacobian.i
@@ -76,9 +76,6 @@
 [Executioner]
   type = Transient
   solve_type = NEWTON
-  petsc_options = '-snes_test_display'
-  petsc_options_iname = '-snes_type'
-  petsc_options_value = 'test'
   dt = 0.1
   num_steps = 2
 []

--- a/test/tests/userobjects/shape_element_user_object/tests
+++ b/test/tests/userobjects/shape_element_user_object/tests
@@ -79,4 +79,48 @@
       detail = 'for a full physics test.'
     []
   []
+  [diagonal]
+    requirement = 'The system shall error if a user attempts to use nonlocal residual objects without appropriate coupling specified in a preconditioning object. These residual objects include'
+    [kernels]
+      type = RunException
+      input = 'jacobian.i'
+      expect_err = 'Nonlocal kernels only supported for non-diagonal coupling'
+      detail = 'kernels'
+      cli_args = "Preconditioning/active='' Executioner/solve_type=PJFNK"
+      allow_warnings = true
+      recover = false
+      max_threads = 1
+    []
+    [bcs]
+      type = RunException
+      input = 'shape_side_uo_jac_test.i'
+      expect_err = 'Nonlocal boundary conditions only supported for non-diagonal coupling'
+      detail = 'boundary conditions'
+      cli_args = "Preconditioning/active='' Executioner/solve_type=PJFNK"
+      allow_warnings = true
+      recover = false
+      max_threads = 1
+    []
+  []
+  [automatic_scaling]
+    requirement = 'The system shall be able to perform automatic scaling in the presence of nonlocal residual objects such as'
+    [kernels]
+      type = RunApp
+      input = 'jacobian.i'
+      detail = 'kernels'
+      cli_args = 'Executioner/automatic_scaling=true'
+      allow_warnings = true
+      recover = false
+      max_threads = 1
+    []
+    [bcs]
+      type = RunApp
+      input = 'shape_side_uo_physics_test.i'
+      detail = 'boundary conditions'
+      cli_args = 'Executioner/automatic_scaling=true'
+      allow_warnings = true
+      recover = false
+      max_threads = 1
+    []
+  []
 []


### PR DESCRIPTION
Based on coverage and module testing, we don't need this.
Additionally it actually makes automatic scaling break for real inputs
because it leads to querying global dof indices for variables that don't
have global character, e.g. 'w' in phase field

This fixes the automatic scaling error reported in #20484