### PR TITLE
[WIP] Mirror PSPG in finite volume

### DIFF
--- a/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
+++ b/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
@@ -77,6 +77,8 @@ protected:
 
   using Moose::FunctorBase<T>::evaluateGradient;
   GradientType evaluateGradient(const Moose::ElemArg & elem_arg, unsigned int) const override;
+  GradientType evaluateGradient(const Moose::ElemFromFaceArg & elem_from_face_arg,
+                                unsigned int) const override;
 
 private:
   /**
@@ -230,36 +232,12 @@ PiecewiseByBlockLambdaFunctor<T>::evaluate(const Moose::SingleSidedFaceArg & fac
 
 template <typename T>
 typename PiecewiseByBlockLambdaFunctor<T>::ValueType
-PiecewiseByBlockLambdaFunctor<T>::evaluate(const Moose::FaceArg & face, unsigned int state) const
+PiecewiseByBlockLambdaFunctor<T>::evaluate(const Moose::FaceArg & face,
+                                           unsigned int libmesh_dbg_var(state)) const
 {
   using namespace Moose::FV;
-
-  mooseAssert(face.fi,
-              "We must have a non-null face_info in order to prepare our ElemFromFace tuples");
-  static const typename libMesh::TensorTools::IncrementRank<T>::type example_gradient(0);
-
-  switch (face.limiter_type)
-  {
-    case LimiterType::CentralDifference:
-    case LimiterType::Upwind:
-    {
-      const auto elem_from_face = face.elemFromFace();
-      const auto neighbor_from_face = face.neighborFromFace();
-      const auto & upwind_elem = face.elem_is_upwind ? elem_from_face : neighbor_from_face;
-      const auto & downwind_elem = face.elem_is_upwind ? neighbor_from_face : elem_from_face;
-      auto limiter_obj =
-          Limiter<typename LimiterValueType<T>::value_type>::build(face.limiter_type);
-      return interpolate(*limiter_obj,
-                         evaluate(upwind_elem, state),
-                         evaluate(downwind_elem, state),
-                         &example_gradient,
-                         *face.fi,
-                         face.elem_is_upwind);
-    }
-
-    default:
-      mooseError("Unsupported limiter type in PiecewiseByBlockLambdaFunctor::evaluate(FaceArg)");
-  }
+  mooseAssert(state == 0, "Only current time state supported.");
+  return interpolate(*this, face);
 }
 
 template <typename T>
@@ -294,4 +272,16 @@ PiecewiseByBlockLambdaFunctor<T>::evaluateGradient(const Moose::ElemArg & elem_a
                                                    unsigned int) const
 {
   return Moose::FV::greenGaussGradient(elem_arg, *this, true, _mesh);
+}
+
+template <typename T>
+typename PiecewiseByBlockLambdaFunctor<T>::GradientType
+PiecewiseByBlockLambdaFunctor<T>::evaluateGradient(
+    const Moose::ElemFromFaceArg & elem_from_face_arg, unsigned int) const
+{
+  const auto elem_arg = elem_from_face_arg.makeElem();
+  if (elem_arg.elem)
+    return Moose::FV::greenGaussGradient(elem_arg, *this, true, _mesh);
+  else
+    return GradientType(0);
 }

--- a/framework/src/limiters/Limiter.C
+++ b/framework/src/limiters/Limiter.C
@@ -66,6 +66,18 @@ limiterType(const InterpMethod interp_method)
     case InterpMethod::Upwind:
       return LimiterType::Upwind;
 
+    case InterpMethod::VanLeer:
+      return LimiterType::VanLeer;
+
+    case InterpMethod::MinMod:
+      return LimiterType::MinMod;
+
+    case InterpMethod::SOU:
+      return LimiterType::SOU;
+
+    case InterpMethod::QUICK:
+      return LimiterType::QUICK;
+
     default:
       mooseError("Unrecognized interpolation method type.");
   }

--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumAdvection.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumAdvection.h
@@ -11,6 +11,7 @@
 
 #include "INSFVAdvectionKernel.h"
 #include "INSFVMomentumResidualObject.h"
+#include "PiecewiseByBlockLambdaFunctor.h"
 
 /**
  * An advection kernel that implements interpolation schemes specific to Navier-Stokes flow
@@ -29,6 +30,9 @@ protected:
 
   /// Density
   const Moose::Functor<ADReal> & _rho;
+
+  /// Our local momentum functor
+  const PiecewiseByBlockLambdaFunctor<ADReal> _rho_u;
 
   /// The a coefficient for the element
   ADReal _ae = 0;

--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumBoussinesq.h
@@ -9,25 +9,23 @@
 
 #pragma once
 
-#include "FVElementalKernel.h"
+#include "INSFVElementalKernel.h"
 #include "INSFVMomentumResidualObject.h"
 
 /**
  * Imposes a Boussinesq force on the momentum equation. Useful for modeling natural convection
  * within an incompressible formulation of the Navier-Stokes equations
  */
-class INSFVMomentumBoussinesq : public FVElementalKernel, public INSFVMomentumResidualObject
+class INSFVMomentumBoussinesq : public INSFVElementalKernel
 {
 public:
   static InputParameters validParams();
   INSFVMomentumBoussinesq(const InputParameters & params);
 
-  void gatherRCData(const Elem &) override {}
-  void gatherRCData(const FaceInfo &) override {}
+  using INSFVElementalKernel::gatherRCData;
+  void gatherRCData(const Elem &) override;
 
 protected:
-  ADReal computeQpResidual() override;
-
   /// Fluid temperature
   const Moose::Functor<ADReal> & _temperature;
   /// The gravity vector

--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumGravity.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumGravity.h
@@ -9,24 +9,22 @@
 
 #pragma once
 
-#include "FVElementalKernel.h"
+#include "INSFVElementalKernel.h"
 #include "INSFVMomentumResidualObject.h"
 
 /**
  * Imposes a gravitational force on the momentum equation in Rhie-Chow (incompressible) contexts
  */
-class INSFVMomentumGravity : public FVElementalKernel, public INSFVMomentumResidualObject
+class INSFVMomentumGravity : public INSFVElementalKernel
 {
 public:
   static InputParameters validParams();
   INSFVMomentumGravity(const InputParameters & params);
 
-  void gatherRCData(const Elem &) override {}
-  void gatherRCData(const FaceInfo &) override {}
+  using INSFVElementalKernel::gatherRCData;
+  void gatherRCData(const Elem &) override;
 
 protected:
-  ADReal computeQpResidual() override;
-
   /// The gravity vector
   const RealVectorValue _gravity;
 

--- a/modules/navier_stokes/include/fvkernels/INSFVMomentumPressure.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVMomentumPressure.h
@@ -9,25 +9,19 @@
 
 #pragma once
 
-#include "FVElementalKernel.h"
+#include "INSFVElementalKernel.h"
 #include "INSFVMomentumResidualObject.h"
 
-class INSFVMomentumPressure : public FVElementalKernel, public INSFVMomentumResidualObject
+class INSFVMomentumPressure : public INSFVElementalKernel
 {
 public:
   static InputParameters validParams();
   INSFVMomentumPressure(const InputParameters & params);
 
-  // This object neither contributes to the A coefficients nor to the B (source) coefficients
-  void gatherRCData(const Elem &) override {}
-  void gatherRCData(const FaceInfo &) override {}
+  using INSFVElementalKernel::gatherRCData;
+  void gatherRCData(const Elem &) override;
 
 protected:
-  ADReal computeQpResidual() override;
-
   /// The pressure variable
   const MooseVariableFVReal * const _p_var;
-
-  /// index x|y|z
-  const unsigned int _index;
 };

--- a/modules/navier_stokes/include/fvkernels/PINSFVMomentumBoussinesq.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVMomentumBoussinesq.h
@@ -21,9 +21,10 @@ public:
   static InputParameters validParams();
   PINSFVMomentumBoussinesq(const InputParameters & params);
 
-protected:
-  ADReal computeQpResidual() override;
+  using INSFVMomentumBoussinesq::gatherRCData;
+  void gatherRCData(const Elem & elem) override;
 
+protected:
   /// the porosity
   const Moose::Functor<ADReal> & _eps;
 };

--- a/modules/navier_stokes/include/fvkernels/PINSFVMomentumGravity.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVMomentumGravity.h
@@ -21,9 +21,10 @@ public:
   static InputParameters validParams();
   PINSFVMomentumGravity(const InputParameters & params);
 
-protected:
-  ADReal computeQpResidual() override;
+  using INSFVMomentumGravity::gatherRCData;
+  void gatherRCData(const Elem & elem) override;
 
+protected:
   /// the porosity
   const Moose::Functor<ADReal> & _eps;
 };

--- a/modules/navier_stokes/include/fvkernels/PINSFVMomentumPressure.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVMomentumPressure.h
@@ -20,9 +20,10 @@ public:
   static InputParameters validParams();
   PINSFVMomentumPressure(const InputParameters & params);
 
-protected:
-  ADReal computeQpResidual() override;
+  using INSFVMomentumPressure::gatherRCData;
+  void gatherRCData(const Elem & elem) override;
 
+protected:
   /// the porosity
   const Moose::Functor<ADReal> & _eps;
 };

--- a/modules/navier_stokes/include/userobjects/INSFVRhieChowInterpolator.h
+++ b/modules/navier_stokes/include/userobjects/INSFVRhieChowInterpolator.h
@@ -196,6 +196,11 @@ private:
   /// application solving precursor advection, and another application has computed the fluid flow
   /// field
   bool _a_data_provided;
+
+  const Real _rc_scale_factor;
+
+  std::vector<const Moose::Functor<ADReal> *> _rhos;
+  std::vector<const Moose::Functor<ADReal> *> _mus;
 };
 
 inline const Moose::FunctorBase<ADReal> & INSFVRhieChowInterpolator::epsilon(THREAD_ID) const

--- a/modules/navier_stokes/include/userobjects/INSFVRhieChowInterpolator.h
+++ b/modules/navier_stokes/include/userobjects/INSFVRhieChowInterpolator.h
@@ -201,6 +201,13 @@ private:
 
   std::vector<const Moose::Functor<ADReal> *> _rhos;
   std::vector<const Moose::Functor<ADReal> *> _mus;
+  std::vector<const Moose::Functor<ADReal> *> _T_fluids;
+  const bool _has_boussinesq;
+  const bool _has_gravity;
+  const Real _alpha_b;
+  const Real _ref_temp;
+  const RealVectorValue _gravity;
+  const Real _gravity_mag;
 };
 
 inline const Moose::FunctorBase<ADReal> & INSFVRhieChowInterpolator::epsilon(THREAD_ID) const

--- a/modules/navier_stokes/src/fvkernels/INSFVEnergyAdvection.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVEnergyAdvection.C
@@ -35,18 +35,12 @@ INSFVEnergyAdvection::INSFVEnergyAdvection(const InputParameters & params)
 ADReal
 INSFVEnergyAdvection::computeQpResidual()
 {
-  ADReal adv_quant_interface;
-
-  const auto elem_face = elemFromFace();
-  const auto neighbor_face = neighborFromFace();
-
   const auto v = _rc_vel_provider.getVelocity(_velocity_interp_method, *_face_info, _tid);
-  Moose::FV::interpolate(_advected_interp_method,
-                         adv_quant_interface,
-                         _adv_quant(elem_face),
-                         _adv_quant(neighbor_face),
-                         v,
-                         *_face_info,
-                         true);
+  const auto adv_quant_interface =
+      Moose::FV::interpolate(_adv_quant,
+                             Moose::FV::makeFace(*_face_info,
+                                                 limiterType(_advected_interp_method),
+                                                 MetaPhysicL::raw_value(v) * _normal > 0,
+                                                 faceArgSubdomains()));
   return _normal * v * adv_quant_interface;
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMassAdvection.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMassAdvection.C
@@ -34,18 +34,12 @@ INSFVMassAdvection::INSFVMassAdvection(const InputParameters & params)
 ADReal
 INSFVMassAdvection::computeQpResidual()
 {
-  ADReal rho_interface;
-
-  const auto elem_face = elemFromFace();
-  const auto neighbor_face = neighborFromFace();
-
   const auto v = _rc_vel_provider.getVelocity(_velocity_interp_method, *_face_info, _tid);
-  Moose::FV::interpolate(_advected_interp_method,
-                         rho_interface,
-                         _rho(elem_face),
-                         _rho(neighbor_face),
-                         v,
-                         *_face_info,
-                         true);
+  const auto rho_interface =
+      Moose::FV::interpolate(_rho,
+                             Moose::FV::makeFace(*_face_info,
+                                                 limiterType(_advected_interp_method),
+                                                 MetaPhysicL::raw_value(v) * _normal > 0,
+                                                 faceArgSubdomains()));
   return _normal * v * rho_interface;
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumAdvection.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumAdvection.C
@@ -81,13 +81,13 @@ INSFVMomentumAdvection::gatherRCData(const FaceInfo & fi)
   const auto saved_velocity_interp_method = _velocity_interp_method;
   _velocity_interp_method = Moose::FV::InterpMethod::Average;
   // Fill-in the coefficients _ae and _an (but without multiplication by A)
-  computeQpResidual();
+  const auto strong_residual = computeQpResidual();
   _velocity_interp_method = saved_velocity_interp_method;
 
   if (_face_type == FaceInfo::VarFaceNeighbors::ELEM ||
       _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-    _rc_uo.addToA(&fi.elem(), _index, _ae * (fi.faceArea() * fi.faceCoord()));
+    _rc_uo.addToA(&fi.elem(), _index, strong_residual);
   if (_face_type == FaceInfo::VarFaceNeighbors::NEIGHBOR ||
       _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-    _rc_uo.addToA(fi.neighborPtr(), _index, _an * (fi.faceArea() * fi.faceCoord()));
+    _rc_uo.addToA(fi.neighborPtr(), _index, -strong_residual);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumDiffusion.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumDiffusion.C
@@ -64,23 +64,6 @@ INSFVMomentumDiffusion::computeStrongResidual()
   const auto dudn = gradUDotNormal();
   const auto face_mu = _mu(face);
 
-  if (_face_type == FaceInfo::VarFaceNeighbors::ELEM ||
-      _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-  {
-    const auto dof_number = _face_info->elem().dof_number(_sys.number(), _var.number(), 0);
-    // A gradient is a linear combination of degrees of freedom so it's safe to straight-up index
-    // into the derivatives vector at the dof we care about
-    _ae = dudn.derivatives()[dof_number];
-    _ae *= -face_mu;
-  }
-  if (_face_type == FaceInfo::VarFaceNeighbors::NEIGHBOR ||
-      _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-  {
-    const auto dof_number = _face_info->neighbor().dof_number(_sys.number(), _var.number(), 0);
-    _an = dudn.derivatives()[dof_number];
-    _an *= face_mu;
-  }
-
   return -face_mu * dudn;
 }
 
@@ -94,12 +77,13 @@ INSFVMomentumDiffusion::gatherRCData(const FaceInfo & fi)
   _normal = fi.normal();
   _face_type = fi.faceType(_var.name());
 
-  processResidual(computeStrongResidual() * (fi.faceArea() * fi.faceCoord()));
+  const auto strong_residual = computeStrongResidual();
+  processResidual(strong_residual * (fi.faceArea() * fi.faceCoord()));
 
   if (_face_type == FaceInfo::VarFaceNeighbors::ELEM ||
       _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-    _rc_uo.addToA(&fi.elem(), _index, _ae * (fi.faceArea() * fi.faceCoord()));
+    _rc_uo.addToA(&fi.elem(), _index, strong_residual);
   if (_face_type == FaceInfo::VarFaceNeighbors::NEIGHBOR ||
       _face_type == FaceInfo::VarFaceNeighbors::BOTH)
-    _rc_uo.addToA(fi.neighborPtr(), _index, _an * (fi.faceArea() * fi.faceCoord()));
+    _rc_uo.addToA(fi.neighborPtr(), _index, -strong_residual);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumGravity.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumGravity.C
@@ -15,8 +15,7 @@ registerMooseObject("NavierStokesApp", INSFVMomentumGravity);
 InputParameters
 INSFVMomentumGravity::validParams()
 {
-  InputParameters params = FVElementalKernel::validParams();
-  params += INSFVMomentumResidualObject::validParams();
+  InputParameters params = INSFVElementalKernel::validParams();
   params.addClassDescription(
       "Computes a body force due to gravity in Rhie-Chow based simulations.");
   params.addRequiredParam<RealVectorValue>("gravity", "Direction of the gravity vector");
@@ -25,15 +24,19 @@ INSFVMomentumGravity::validParams()
 }
 
 INSFVMomentumGravity::INSFVMomentumGravity(const InputParameters & params)
-  : FVElementalKernel(params),
-    INSFVMomentumResidualObject(*this),
+  : INSFVElementalKernel(params),
     _gravity(getParam<RealVectorValue>("gravity")),
     _rho(getFunctor<ADReal>(NS::density))
 {
 }
 
-ADReal
-INSFVMomentumGravity::computeQpResidual()
+void
+INSFVMomentumGravity::gatherRCData(const Elem & elem)
 {
-  return -_rho(makeElemArg(_current_elem)) * _gravity(_index);
+  const auto strong_residual = -_rho(makeElemArg(&elem)) * _gravity(_index);
+  const auto dof_number = elem.dof_number(_sys.number(), _var.number(), 0);
+
+  _rc_uo.addToA(&elem, _index, strong_residual);
+
+  processResidual(strong_residual * _assembly.elementVolume(&elem), dof_number);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMomentumTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMomentumTimeDerivative.C
@@ -32,11 +32,10 @@ INSFVMomentumTimeDerivative::INSFVMomentumTimeDerivative(const InputParameters &
 void
 INSFVMomentumTimeDerivative::gatherRCData(const Elem & elem)
 {
-  const auto residual = _rho * _var.dot(makeElemArg(&elem)) * _assembly.elementVolume(&elem);
+  const auto strong_residual = _rho * _var.dot(makeElemArg(&elem));
   const auto dof_number = elem.dof_number(_sys.number(), _var.number(), 0);
-  const Real a = residual.derivatives()[dof_number];
 
-  _rc_uo.addToA(&elem, _index, a);
+  _rc_uo.addToA(&elem, _index, strong_residual);
 
-  processResidual(residual, dof_number);
+  processResidual(strong_residual * _assembly.elementVolume(&elem), dof_number);
 }

--- a/modules/navier_stokes/src/fvkernels/PINSFVMomentumBoussinesq.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVMomentumBoussinesq.C
@@ -32,8 +32,15 @@ PINSFVMomentumBoussinesq::PINSFVMomentumBoussinesq(const InputParameters & param
                "variable, of variable type PINSFVSuperficialVelocityVariable.");
 }
 
-ADReal
-PINSFVMomentumBoussinesq::computeQpResidual()
+void
+PINSFVMomentumBoussinesq::gatherRCData(const Elem & elem)
 {
-  return _eps(makeElemArg(_current_elem)) * INSFVMomentumBoussinesq::computeQpResidual();
+  const auto strong_residual = _eps(makeElemArg(&elem)) * _alpha(makeElemArg(&elem)) *
+                               _gravity(_index) * _rho *
+                               (_temperature(makeElemArg(&elem)) - _ref_temperature);
+  const auto dof_number = elem.dof_number(_sys.number(), _var.number(), 0);
+
+  _rc_uo.addToA(&elem, _index, strong_residual);
+
+  processResidual(strong_residual * _assembly.elementVolume(&elem), dof_number);
 }

--- a/modules/navier_stokes/src/fvkernels/PINSFVMomentumGravity.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVMomentumGravity.C
@@ -27,8 +27,14 @@ PINSFVMomentumGravity::PINSFVMomentumGravity(const InputParameters & params)
 {
 }
 
-ADReal
-PINSFVMomentumGravity::computeQpResidual()
+void
+PINSFVMomentumGravity::gatherRCData(const Elem & elem)
 {
-  return _eps(makeElemArg(_current_elem)) * INSFVMomentumGravity::computeQpResidual();
+  const auto strong_residual =
+      -_rho(makeElemArg(&elem)) * _eps(makeElemArg(&elem)) * _gravity(_index);
+  const auto dof_number = elem.dof_number(_sys.number(), _var.number(), 0);
+
+  _rc_uo.addToA(&elem, _index, strong_residual);
+
+  processResidual(strong_residual * _assembly.elementVolume(&elem), dof_number);
 }


### PR DESCRIPTION
For our `boussinesq.i` input in `navier_stokes/test/tests/finite_volume/ins`, here is a table of convergence and conditioning results with an 8x8 mesh, first-order `upwind` for advection, and no scaling applied to any variables

| method | Ra | final iteration condition number | number of nls |
| --- | --- | --- | --- |
| average | 1e1 | 1.2e4 | 3 |
| average | 1e2 | 2.4e4 | 4 |
| average | 1e3 | 2.4e5  | 5 |
| average | 1e4 | 1.4e7 | 6 |
| average | 1e5 | 7.4e8 | 7 |
| average | 1e6 | 3.6e10 | 12 |
| rc | 1e1 | 1.7e3 | 3 |
| rc | 1e2 | 4.4e3 | 4 |
| rc | 1e3 | 2.4e5 | 5 |
| rc | 1e4 | 1.5e7 | 6 |
| rc | 1e5 | 7.8e8 | 7 |
| rc | 1e6 | 3.8e10 | 14 |
| brought back b | 1e1 | 1.7e3 | 3 |
| brought back b | 1e2 | 4.4e3 | 4 |
| brought back b | 1e3 | 2.4e5 | 5 |
| brought back b | 1e4 | 1.4e7 | 6 |
| brought back b | 1e5 | 7.5e8 | 7 |
| brought back b | 1e6 | 3.7e10 | 14 |
| pspg | 1e1 | 8.9e3 | 3 |
| pspg | 1e2 | 1.8e4 | 4 |
| pspg | 1e3 | 2.3e5 | 5 |
| pspg | 1e4 | 1.3e7 | 6 |
| pspg | 1e5 | 6.9e8 | 16 |
| pspg | 1e6 | 1.0e9 | DNC |

With second-order upwind:

| method | Ra | final iteration condition number | number of nls |
| --- | --- | --- | --- |
| average | 1e1 | 1.1e4 | 4 |
| average | 1e2 | 2.4e4 | 5 |
| average | 1e3 | 2.5e5  | 5 |
| average | 1e4 | 1.6e7 | 7 |
| average | 1e5 | 9.2e8 | 9 |
| average | 1e6 | 1.8e15| DNC |
| rc | 1e1 | 5.0e9 | DNC |
| rc | 1e2 | 8.9e5 | 9 |
| rc | 1e3 | 2.1e6 | 9 |
| rc | 1e4 | 2.7e16 | DNC |
| rc | 1e5 | 2.3e15 | DNC |
| rc | 1e6 | 1.6e18 | DNC |
| brought back b | 1e1 | 3.4e5 | 12 |
| brought back b | 1e2 | 8.7e5 | 7 |
| brought back b | 1e3 | 3.5e6 | 10 |
| brought back b | 1e4 | 1.8e18 | DNC |
| brought back b | 1e5 | 8.8e17 | DNC |
| brought back b | 1e6 | 1.3e13 | DNC |
| pspg | 1e1 | 9.0e3 | 4 |
| pspg | 1e2 | 1.7e4 | 5 |
| pspg | 1e3 | 2.4e5 | 6 |
| pspg | 1e4 | 1.5e7 | 8 |
| pspg | 1e5 | 8.3e8 | 12 |
| pspg | 1e6 | 3.8e10 | DNC |

Finite element with `pspg`

| method | Ra | final iteration condition number | number of nls |
| --- | --- | --- | --- |
| supg | 1e1 | 2.4e3 | 3 |
| supg | 1e2 | 2.6e3 | 3 |
| supg | 1e3 | 4.2e4 | 5 |
| supg | 1e4 | 3.6e6 | 6 |
| supg | 1e5 | 1.7e8 | 8 | 
| supg | 1e6 | 4.5e14 | DNC |
| no supg | 1e1 | 2.4e3 | 3 |
| no supg | 1e2 | 2.6e3 | 3 |
| no supg | 1e3 | 4.2e4 | 5 |
| no supg | 1e4 | 4.0e6 | 7 |
| no supg | 1e5 | 2.4e8 | 9 |
| no supg | 1e6 | 5.1e13 | DNC |