### PR TITLE
Change two deprecations in old eigenvalue executioners into info

### DIFF
--- a/framework/src/executioners/InversePowerMethod.C
+++ b/framework/src/executioners/InversePowerMethod.C
@@ -48,7 +48,7 @@ InversePowerMethod::InversePowerMethod(const InputParameters & parameters)
   if (_l_tol < 0.0)
     paramError("l_tol", "l_tol<0!");
 
-  mooseDeprecated(
+  mooseInfo(
       "'InversePowerMethod' executioner is deprecated in favor of 'Eigenvalue' executioner.\n",
       "Few parameters such as 'bx_norm', 'k0', 'xdiff', 'max_power_iterations', "
       "'min_power_iterations', 'eig_check_tol', 'sol_check_tol', and 'output_before_normalization' "

--- a/framework/src/executioners/NonlinearEigen.C
+++ b/framework/src/executioners/NonlinearEigen.C
@@ -34,7 +34,7 @@ NonlinearEigen::NonlinearEigen(const InputParameters & parameters)
     _free_l_tol(getParam<Real>("free_l_tol")),
     _output_after_pi(getParam<bool>("output_after_power_iterations"))
 {
-  mooseDeprecated(
+  mooseInfo(
       "'NonlinearEigen' executioner is deprecated in favor of 'Eigenvalue' executioner.\n",
       "Few parameters such as 'bx_norm', 'k0', 'free_l_tol', 'output_before_normalization' and "
       "'output_after_power_iterations' are no longer supported.\n",


### PR DESCRIPTION
Due to performance issues probably related with #20095, we cannot finish the transition yet from `NonlinearEigen` to `Eigenvalue`. Several of our users complained about the degraded performance. Thus need to turn this deprecation temporarily into an information.  