### PR TITLE
Adjust stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,3 +24,4 @@ jobs:
         stale-pr-label: 'stale'
         days-before-pr-stale: 30
         days-before-pr-close: 3
+        operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
This PR:
- Increases `operations-per-run` to 100. Up to 3 operations are performed for a newly-stale PR (label, msg, check for closure), and 1 on a stale PR (check for closure). This change sets the operation limit high enough to capture ~33 newly stale PRs at once, which should be more than enough. 
  - Prior to this change, [we were running out of operations](https://github.com/idaholab/moose/actions/runs/1975480263) before we make it through all PRs that need to be evaluated. 
- Updates to `actions/stale@v5`, which introduces more readable and colorful log output over `v3` (originally introduced in `v4`) and updates the Node.js runtime used to 16 instead of 12. 12 is EOL at the end of April. 

Refs #20475
