### PR TITLE
Disable issue checking in stalebot (#20475)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,8 +20,9 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity in the last 30 days. It will be closed in 3 days if no further activity occurs. Thank you for your contributions.'
         stale-pr-label: 'stale'
         days-before-pr-stale: 30
         days-before-pr-close: 3
+        days-before-issue-stale: -1
         operations-per-run: 100


### PR DESCRIPTION
We originally thought only defining PR messages and other parameters would be enough to disable issue checks. This is not the case (as seen in our [most recent action log](https://github.com/idaholab/moose/actions/runs/1984899133)), and does eat up our permitted number of operations without any gain. The stalebot will determine an issue is stale and attempt to apply a message and label. Since those aren't defined, it just skips. However 3 operations are still "performed". 

This PR disables issue checking by setting `days-before-issue-stale` to `-1` based on discussion from one of the stalebot developers at: https://github.com/actions/stale/issues/688

This PR also adjusts the PR message to contain our set days before stale and closure, for developer information.

Refs #20475
