### PR TITLE
Make make_install tests more robust

### DIFF
--- a/test/tests/make_install/tests
+++ b/test/tests/make_install/tests
@@ -14,7 +14,12 @@
     requirement = 'The system shall support the ability to "install" inputs:'
     [setup_fake_test_structure]
       type = 'RunCommand'
-      command = 'rm -rf moose_test_tests; rm -rf ../../../share/moose_test; mkdir -p ../../../share/moose_test/tests/version; cp ../misc/version/tests ../../../share/moose_test/tests/version; cp ../../testroot ../../../share/moose_test/tests/'
+      command = 'rm -rf ../../../make_install_test;
+                 rm -rf ../../../share/moose_test;
+                 mkdir -p ../../../share/moose_test/tests/version;
+                 cp ../misc/version/tests ../../../share/moose_test/tests/version;
+                 cp ../../testroot ../../../share/moose_test/tests/;
+                 mkdir -p ../../../make_install_test'
       installed = False
 
       detail = 'from a pre-determined user-readable location;'
@@ -23,6 +28,7 @@
     [copy_tests]
       type = 'RunApp'
       cli_args = "--copy-inputs tests"
+      working_directory = '../../../make_install_test'
       no_additional_cli_args = True
       expect_out = 'Directory successfully copied'
       installed = False
@@ -33,6 +39,7 @@
 
     [check_files]
       type = 'CheckFiles'
+      working_directory = '../../../make_install_test'
       input = 'DUMMY'
       should_execute = False
       check_files = 'moose_test_tests/testroot moose_test_tests/version/tests'
@@ -44,6 +51,7 @@
 
     [copy_warn_overwrite]
       type = 'RunException'
+      working_directory = '../../../make_install_test'
       cli_args = "--copy-inputs tests"
       no_additional_cli_args = True
       expect_err = 'The directory \S+ already exists.'
@@ -55,10 +63,12 @@
 
     [link_exec_installed]
       type = 'RunCommand'
-      command = 'ln -s ../../../moose_test-opt .'
-      working_directory = "./moose_test_tests"
+      command = 'for bin in `ls ../../test/moose_test-*`
+                 do
+                 ln -sf $bin .
+                 done'
+      working_directory = '../../../make_install_test/moose_test_tests'
       installed = False
-      method = opt
       prereq = 'test_copy_install/copy_warn_overwrite'
 
       detail = 'able to link a binary to an installed location;'
@@ -67,10 +77,9 @@
     [run]
       type = 'RunApp'
       cli_args = "--run tests"
-      working_directory = "./moose_test_tests"
+      working_directory = "../../../make_install_test/moose_test_tests"
       no_additional_cli_args = True
       installed = False
-      method = opt
       prereq = 'test_copy_install/link_exec_installed'
 
       detail = 'able to successfully launch the TestHarness using a MOOSE-based binary;'
@@ -78,7 +87,8 @@
 
     [tear_down]
       type = 'RunCommand'
-      command = 'rm -rf ../../../share/; rm -rf moose_test_tests'
+      command = 'rm -rf ../../../share/;
+                 rm -rf ../../../make_install_test'
       prereq = 'test_copy_install/run'
       installed = False
 


### PR DESCRIPTION
1) Moving the copied test structure outside of the main test root. This prevents any side effects
   from an unexpected termination or any other failure of the tear down step followed by a subsequent
   relaunch of the test suite.
2) Removing the method=opt restriction, which triggered the original failure by causing the tear down
   step to be skipped during a normal test run. Instead I'm just going to link all versions of the
   binary into the installed directory and allow this to run in all modes.

closes #19022