### PR TITLE
Continue Cleanup of install tests

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -7,7 +7,7 @@
 GEN_REVISION ?= yes
 
 # Set a default to install the main application's tests if one isn't set in the Makefile
-ifeq ($(INSTALLABLE_DIRS),)
+ifndef INSTALLABLE_DIRS
   ifneq ($(wildcard $(APPLICATION_DIR)/test/.),)
     INSTALLABLE_DIRS := test/tests
   else
@@ -28,7 +28,6 @@ $APPLICATION_NAME$(STACK) := $(APPLICATION_NAME)
 $DEPEND_MODULES$(STACK) := $(DEPEND_MODULES)
 $GEN_REVISION$(STACK) := $(GEN_REVISION)
 $BUILD_EXEC$(STACK) := $(BUILD_EXEC)
-$INSTALLABLE_DIRS$(STACK) := $(INSTALLABLE_DIRS)
 
 -include $(APPLICATION_DIR)/$(APPLICATION_NAME).mk
 
@@ -44,7 +43,6 @@ APPLICATION_NAME := $($APPLICATION_NAME$(STACK))
 DEPEND_MODULES := $($DEPEND_MODULES$(STACK))
 GEN_REVISION := $($GEN_REVISION$(STACK))
 BUILD_EXEC := $($BUILD_EXEC$(STACK))
-INSTALLABLE_DIRS := $($INSTALLABLE_DIRS$(STACK))
 STACK := $(basename $(STACK))
 
 ifneq ($(SUFFIX),)

--- a/framework/include/parser/CommandLine.h
+++ b/framework/include/parser/CommandLine.h
@@ -93,6 +93,18 @@ public:
   bool search(const std::string & option_name, std::vector<T> & argument);
 
   /**
+   * Returns an iterator to the underlying argument vector to the position of the option or
+   * end if the option is not on the command line.
+   */
+  std::vector<std::string>::const_iterator find(const std::string & option_name) const;
+
+  // Return an iterator to the beginning of the container of CLI options
+  std::vector<std::string>::const_iterator begin() const;
+
+  // Return an iterator to the beginning of the container of CLI options
+  std::vector<std::string>::const_iterator end() const;
+
+  /**
    * Print the usage info for this command line
    */
   void printUsage() const;

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -241,6 +241,13 @@ std::string stripExtension(const std::string & s);
 std::pair<std::string, std::string> splitFileName(std::string full_file);
 
 /**
+ * Returns the current working directory as a string. If there's a problem
+ * obtaining the current working directory, this function just returns an
+ * empty string. It doesn't not throw.
+ */
+std::string getCurrentWorkingDir();
+
+/**
  * Recursively make directories
  * @param dir_name A complete path
  * @param throw_on_failure True to throw instead of error out when creating a directory is failed.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -74,7 +74,6 @@
 #include <cstdlib> // for system()
 #include <chrono>
 #include <thread>
-#include <filesystem>
 
 #define QUOTE(macro) stringifyName(macro)
 
@@ -1474,14 +1473,7 @@ MooseApp::runInputs()
     }
 
     auto cmd = MooseUtils::runTestsExecutable() + test_args;
-    std::filesystem::path working_dir;
-    try
-    {
-      working_dir = std::filesystem::current_path();
-    }
-    catch (...)
-    {
-    }
+    auto working_dir = MooseUtils::getCurrentWorkingDir();
 
     if (MooseUtils::findTestRoot() == "")
     {

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -195,6 +195,37 @@ CommandLine::addOption(const std::string & name, Option cli_opt)
   _cli_options[name] = cli_opt;
 }
 
+std::vector<std::string>::const_iterator
+CommandLine::find(const std::string & option_name) const
+{
+  auto pos = _cli_options.find(option_name);
+  auto it = _args.end();
+
+  if (pos != _cli_options.end())
+  {
+    for (const auto & search_string : pos->second.cli_switch)
+    {
+      auto it = std::find(_args.begin(), _args.end(), search_string);
+      if (it != _args.end())
+        return it;
+    }
+  }
+
+  return it;
+}
+
+std::vector<std::string>::const_iterator
+CommandLine::begin() const
+{
+  return _args.begin();
+}
+
+std::vector<std::string>::const_iterator
+CommandLine::end() const
+{
+  return _args.end();
+}
+
 bool
 CommandLine::search(const std::string & option_name)
 {

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -422,6 +422,19 @@ splitFileName(std::string full_file)
   return std::pair<std::string, std::string>(path, file);
 }
 
+std::string
+getCurrentWorkingDir()
+{
+  // Note: At the time of creating this method, our minimum compiler still
+  // does not support <filesystem>. Additionally, the inclusion of that header
+  // requires an additional library to be linked so for now, we'll just
+  // use the Unix standard library to get us the cwd().
+  constexpr unsigned int BUF_SIZE = 1024;
+  char buffer[BUF_SIZE];
+
+  return getcwd(buffer, BUF_SIZE) != nullptr ? buffer : "";
+}
+
 void
 makedirs(const std::string & dir_name, bool throw_on_failure)
 {

--- a/modules/doc/content/application_development/build_system.md
+++ b/modules/doc/content/application_development/build_system.md
@@ -214,9 +214,10 @@ when building MOOSE or a MOOSE-based application.
 MOOSE's build system has the ability to create installed binaries suitable for use with the conda package manager, or installation on a shared computing resource such as Sawtooth. The `install` target will copy binary and required libraries to a file tree based on the prefix you configured with (set by the variable `PREFIX` or the `--prefix` argument.
 
 ```
-$ cd moose/framework
+$ cd moose
 $ ./configure --prefix=<installation path>
-$ make
+$ cd <application_dir>
+$ make [make options]
 $ make install
 ```
 
@@ -241,13 +242,13 @@ Example:
 $ cd <user writable location>
 $ export PATH=$PATH:<prefix>/bin  # See instructions for HPC computers below
 $ bison-opt --copy-inputs <installable input type>  # e.g. tests, examples, etc.
-$ bison-opt --run <installable input type>
+$ bison-opt --run
 
 ```
 
 Where `<installable input type>` is one of the installable directories as defined by the application developers (i.e. `tests`, `examples`, `tutorials`, etc.)
 
-When using INL HPC systems to run your input, you will load a module that will set your path correctly
+When using INL HPC systems to run your input, you will load a module that will set your path correctly.
 
 Example:
 

--- a/test/tests/make_install/tests
+++ b/test/tests/make_install/tests
@@ -76,7 +76,7 @@
 
     [run]
       type = 'RunApp'
-      cli_args = "--run tests"
+      cli_args = "--run"
       working_directory = "../../../make_install_test/moose_test_tests"
       no_additional_cli_args = True
       installed = False


### PR DESCRIPTION
1) Removing old --copy-tests and --tests options
2) Getting rid of convoluted logic to run tests in system installed location
3) Introducing the first C++17 filesystem usage
4) Remove the first C++17 filesystem usage 😢 

refs #19022
