### PR TITLE
Add names to functor base

### DIFF
--- a/framework/include/base/MooseFunctor.h
+++ b/framework/include/base/MooseFunctor.h
@@ -271,10 +271,13 @@ public:
 
   virtual ~FunctorBase() = default;
   FunctorBase() : _clearance_schedule({EXEC_ALWAYS}) {}
-  FunctorBase(const std::set<ExecFlagType> & clearance_schedule)
-    : _clearance_schedule(clearance_schedule)
+  FunctorBase(const std::set<ExecFlagType> & clearance_schedule, const MooseFunctorName & name)
+    : _clearance_schedule(clearance_schedule), _functor_name(name)
   {
   }
+
+  /// Return the functor name
+  const MooseFunctorName & fname() const { return _functor_name; }
 
   ///@{
   /**
@@ -382,7 +385,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const ElemArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element gradient not implemented for functor " + fname());
   }
 
   /**
@@ -393,7 +396,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const ElemFromFaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element (obtained from a face) gradient not implemented for functor " + fname());
   }
 
   /**
@@ -404,7 +407,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const FaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Face gradient not implemented for functor " + fname());
   }
 
   /**
@@ -415,7 +418,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const SingleSidedFaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("One-sided face gradient not implemented for functor " + fname());
   }
 
   /**
@@ -426,7 +429,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const ElemQpArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element quadrature point gradient not implemented for functor " + fname());
   }
 
   /**
@@ -437,7 +440,7 @@ protected:
    */
   virtual GradientType evaluateGradient(const ElemSideQpArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element side quadrature point gradient not implemented for functor " + fname());
   }
 
   /**
@@ -446,7 +449,7 @@ protected:
    */
   virtual DotType evaluateDot(const ElemArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element time derivative not implemented for functor " + fname());
   }
 
   /**
@@ -457,7 +460,8 @@ protected:
    */
   virtual DotType evaluateDot(const ElemFromFaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element (obtained from a face) time derivative not implemented for functor " +
+               fname());
   }
 
   /**
@@ -468,7 +472,7 @@ protected:
    */
   virtual DotType evaluateDot(const FaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Face time derivative not implemented for functor " + fname());
   }
 
   /**
@@ -479,7 +483,7 @@ protected:
    */
   virtual DotType evaluateDot(const SingleSidedFaceArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("One-sided face time derivative not implemented for functor " + fname());
   }
 
   /**
@@ -490,7 +494,7 @@ protected:
    */
   virtual DotType evaluateDot(const ElemQpArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element quadrature point time derivative not implemented for functor " + fname());
   }
 
   /**
@@ -501,7 +505,8 @@ protected:
    */
   virtual DotType evaluateDot(const ElemSideQpArg &, unsigned int) const
   {
-    mooseError("not implemented");
+    mooseError("Element side quadrature point time derivative not implemented for functor " +
+               fname());
   }
 
 private:
@@ -576,6 +581,9 @@ private:
 
   /// Map from single-sided-face arguments to their cached evaluations
   mutable std::map<SingleSidedFaceArg, ValueType> _ssf_arg_to_value;
+
+  /// name of the functor
+  const MooseFunctorName _functor_name;
 };
 
 template <typename T>

--- a/framework/include/base/MooseFunctor.h
+++ b/framework/include/base/MooseFunctor.h
@@ -586,7 +586,7 @@ private:
   mutable std::map<SingleSidedFaceArg, ValueType> _ssf_arg_to_value;
 
   /// name of the functor
-  const MooseFunctorName _functor_name;
+  MooseFunctorName _functor_name;
 };
 
 template <typename T>

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -226,7 +226,7 @@ void serialEnd(const libMesh::Parallel::Communicator & comm, bool warn = true);
 bool hasExtension(const std::string & filename, std::string ext, bool strip_exodus_ext = false);
 
 /**
- * Removes any file extension from the fiven string s (i.e. any ".[extension]" suffix of s) and
+ * Removes any file extension from the given string s (i.e. any ".[extension]" suffix of s) and
  * returns the result.
  */
 std::string stripExtension(const std::string & s);
@@ -1031,3 +1031,8 @@ public:
  * find, erase, length algorithm for removing a substring from a string
  */
 void removeSubstring(std::string & main, const std::string & sub);
+
+/**
+ * find, erase, length algorithm for removing a substring from a copy of a string
+ */
+std::string removeSubstring(const std::string & main, const std::string & sub);

--- a/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
+++ b/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
@@ -103,9 +103,6 @@ private:
   /// Functors that will evaluate elements at side quadrature points
   std::unordered_map<SubdomainID, ElemSideQpFn> _elem_side_qp_functor;
 
-  /// The name of this object
-  std::string _name;
-
   /// The mesh that this functor operates on
   const MooseMesh & _mesh;
 };
@@ -118,7 +115,7 @@ PiecewiseByBlockLambdaFunctor<T>::PiecewiseByBlockLambdaFunctor(
     const std::set<ExecFlagType> & clearance_schedule,
     const MooseMesh & mesh,
     const std::set<SubdomainID> & block_ids)
-  : Moose::FunctorBase<T>(clearance_schedule), _name(name), _mesh(mesh)
+  : Moose::FunctorBase<T>(clearance_schedule, name), _mesh(mesh)
 {
   setFunctor(mesh, block_ids, my_lammy);
 }
@@ -139,7 +136,7 @@ PiecewiseByBlockLambdaFunctor<T>::setFunctor(const MooseMesh & mesh,
     auto pr = _elem_functor.emplace(block_id, my_lammy);
     if (!pr.second)
       mooseError("No insertion for the functor material property '",
-                 _name,
+                 this->fname(),
                  "' for block id ",
                  block_id,
                  ". Another material must already declare this property on that block.");
@@ -180,7 +177,7 @@ PiecewiseByBlockLambdaFunctor<T>::subdomainErrorMessage(const SubdomainID sub_id
   mooseError("The provided subdomain ID ",
              std::to_string(sub_id),
              " doesn't exist in the map for lambda functor '",
-             _name,
+             this->fname(),
              "'! This is likely because you did not provide a functor material "
              "definition on that subdomain");
 }

--- a/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
+++ b/framework/include/utils/PiecewiseByBlockLambdaFunctor.h
@@ -115,7 +115,7 @@ PiecewiseByBlockLambdaFunctor<T>::PiecewiseByBlockLambdaFunctor(
     const std::set<ExecFlagType> & clearance_schedule,
     const MooseMesh & mesh,
     const std::set<SubdomainID> & block_ids)
-  : Moose::FunctorBase<T>(clearance_schedule, name), _mesh(mesh)
+  : Moose::FunctorBase<T>(name, clearance_schedule), _mesh(mesh)
 {
   setFunctor(mesh, block_ids, my_lammy);
 }
@@ -136,7 +136,7 @@ PiecewiseByBlockLambdaFunctor<T>::setFunctor(const MooseMesh & mesh,
     auto pr = _elem_functor.emplace(block_id, my_lammy);
     if (!pr.second)
       mooseError("No insertion for the functor material property '",
-                 this->fname(),
+                 this->functorName(),
                  "' for block id ",
                  block_id,
                  ". Another material must already declare this property on that block.");
@@ -177,7 +177,7 @@ PiecewiseByBlockLambdaFunctor<T>::subdomainErrorMessage(const SubdomainID sub_id
   mooseError("The provided subdomain ID ",
              std::to_string(sub_id),
              " doesn't exist in the map for lambda functor '",
-             this->fname(),
+             this->functorName(),
              "'! This is likely because you did not provide a functor material "
              "definition on that subdomain");
 }

--- a/framework/include/utils/VectorComponentFunctor.h
+++ b/framework/include/utils/VectorComponentFunctor.h
@@ -26,7 +26,9 @@ public:
   using VectorFunctor = Moose::FunctorBase<VectorArg>;
 
   VectorComponentFunctor(const VectorFunctor & vector, const unsigned int component)
-    : _vector(vector), _component(component)
+    : Moose::FunctorBase<T>(vector.functorName() + "_" + std::to_string(component)),
+      _vector(vector),
+      _component(component)
   {
   }
 

--- a/framework/src/functions/Function.C
+++ b/framework/src/functions/Function.C
@@ -30,7 +30,8 @@ FunctionTempl<T>::FunctionTempl(const InputParameters & parameters)
     UserObjectInterface(this),
     Restartable(this, "Functions"),
     MeshChangedInterface(parameters),
-    ScalarCoupleable(this)
+    ScalarCoupleable(this),
+    Moose::FunctorBase<T>(name())
 {
 }
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3209,7 +3209,7 @@ MooseMesh::buildFaceInfo() const
       //
       //  * when the following two (CURRENTLY ONE ACTUALLY) conditions are met:
       //
-      //     - WE AREN'T ACTULLY DOING THIS CHECK RIGHT NOW. SHOULD WE BE? WE DON'T
+      //     - WE AREN'T ACTUALLY DOING THIS CHECK RIGHT NOW. SHOULD WE BE? WE DON'T
       //       DO IT FOR DGKERNELS OR INTERFACE KERNELS
       //       the neighbor is active - this means we aren't looking at a face
       //       between an active element and an inactive (pre-refined version)

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -19,6 +19,7 @@
 #include "Assembly.h"
 #include "MooseObjectName.h"
 #include "RelationshipManager.h"
+#include "MooseUtils.h"
 
 #include "libmesh/equation_systems.h"
 #include "libmesh/system.h"
@@ -1031,7 +1032,7 @@ SubProblem::initialSetup()
     for (const auto & pr : functors)
       if (pr.second->wrapsNull())
         mooseError("No functor ever provided with name '",
-                   pr.first,
+                   removeSubstring(pr.first, "wraps_"),
                    "', which was requested by '",
                    MooseUtils::join(libmesh_map_find(_functor_to_requestors, pr.first), ","),
                    "'.");
@@ -1042,7 +1043,7 @@ SubProblem::hasFunctor(const std::string & name, const THREAD_ID tid) const
 {
   mooseAssert(tid < _functors.size(), "Too large a thread ID");
   auto & functors = _functors[tid];
-  return (functors.find(name) != functors.end());
+  return (functors.find("wraps_" + name) != functors.end());
 }
 
 Moose::CoordinateSystemType

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -1355,3 +1355,14 @@ removeSubstring(std::string & main, const std::string & sub)
   for (std::string::size_type i = main.find(sub); i != std::string::npos; i = main.find(sub))
     main.erase(i, n);
 }
+
+std::string
+removeSubstring(const std::string & main, const std::string & sub)
+{
+  std::string copy_main = main;
+  std::string::size_type n = sub.length();
+  for (std::string::size_type i = copy_main.find(sub); i != std::string::npos;
+       i = copy_main.find(sub))
+    copy_main.erase(i, n);
+  return copy_main;
+}

--- a/framework/src/variables/MooseVariableField.C
+++ b/framework/src/variables/MooseVariableField.C
@@ -25,6 +25,7 @@ MooseVariableField<OutputType>::validParams()
 template <typename OutputType>
 MooseVariableField<OutputType>::MooseVariableField(const InputParameters & parameters)
   : MooseVariableFieldBase(parameters),
+    Moose::FunctorBase<typename Moose::ADType<OutputType>::type>(name()),
     MeshChangedInterface(parameters),
     _time_integrator(_sys.getTimeIntegrator())
 {

--- a/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
+++ b/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
@@ -58,16 +58,16 @@ public:
   using ElemSideQpArg = Moose::ElemSideQpArg;
 
   CellCenteredMapFunctor(const MooseMesh & mesh, const std::string & name)
-    : _mesh(mesh), _name(name)
+    : Moose::FunctorBase<T>(name), _mesh(mesh)
   {
   }
 
   CellCenteredMapFunctor(const MooseMesh & mesh,
                          const std::set<SubdomainID> & sub_ids,
                          const std::string & name)
-    : _mesh(mesh),
-      _sub_ids(sub_ids == mesh.meshSubdomains() ? std::set<SubdomainID>() : sub_ids),
-      _name(name)
+    : Moose::FunctorBase<T>(name),
+      _mesh(mesh),
+      _sub_ids(sub_ids == mesh.meshSubdomains() ? std::set<SubdomainID>() : sub_ids)
   {
   }
 
@@ -81,9 +81,6 @@ private:
   /// on all subdomains
   const std::set<SubdomainID> _sub_ids;
 
-  /// The name of this functor
-  const std::string _name;
-
   ValueType evaluate(const ElemArg & elem_arg, unsigned int) const override final
   {
     const Elem * const elem = elem_arg.elem;
@@ -96,16 +93,16 @@ private:
     {
       if (!_sub_ids.empty() && !_sub_ids.count(elem->subdomain_id()))
         mooseError("Attempted to evaluate CellCenteredMapFunctor '",
-                   _name,
+                   this->functorName(),
                    "' with an element subdomain id of '",
                    elem->subdomain_id(),
                    "' but that subdomain id is not one of the subdomain ids the functor is "
                    "restricted to.");
       else
-        ::mooseError("Attempted access into CellCenteredMapFunctor '",
-                     _name,
-                     "' with a key that does not yet exist in the map. Make sure to fill your "
-                     "CellCenteredMapFunctor for all elements you will attempt to access later.");
+        mooseError("Attempted access into CellCenteredMapFunctor '",
+                   this->functorName(),
+                   "' with a key that does not yet exist in the map. Make sure to fill your "
+                   "CellCenteredMapFunctor for all elements you will attempt to access later.");
     }
   }
 

--- a/modules/navier_stokes/include/utils/VectorCompositeFunctor.h
+++ b/modules/navier_stokes/include/utils/VectorCompositeFunctor.h
@@ -32,10 +32,11 @@ public:
   using ElemQpArg = Moose::ElemQpArg;
   using ElemSideQpArg = Moose::ElemSideQpArg;
 
-  VectorCompositeFunctor(const FunctorBase<T> & x_comp,
+  VectorCompositeFunctor(const MooseFunctorName & name,
+                         const FunctorBase<T> & x_comp,
                          const FunctorBase<T> & y_comp,
                          const FunctorBase<T> & z_comp)
-    : _x_comp(x_comp), _y_comp(y_comp), _z_comp(z_comp)
+    : Moose::FunctorBase<VectorValue<T>>(name), _x_comp(x_comp), _y_comp(y_comp), _z_comp(z_comp)
   {
   }
 

--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -238,6 +238,7 @@ INSFVRhieChowInterpolator::fillARead()
         w_comp = &_zero_functor;
 
       _a_aux[tid] = std::make_unique<VectorCompositeFunctor<ADReal>>(
+          "RC_a_coeffs",
           UserObject::_subproblem.getFunctor<ADReal>(deduceFunctorName("a_u"), tid, name()),
           *v_comp,
           *w_comp);

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -30,7 +30,7 @@ class TestFunctor : public FunctorBase<T>
 public:
   using typename FunctorBase<T>::ValueType;
 
-  TestFunctor() = default;
+  TestFunctor() : FunctorBase<T>("test"){};
 
 private:
   ValueType evaluate(const ElemArg &, unsigned int) const override final { return 0; }


### PR DESCRIPTION
We could take over the variable name from the coupleable API ?
It has a name() function as well, hence my fname()

I'm not sure it's a good idea though, would force people to come look into our functor stuff (though really not very often do you debug the name() function)
