### PR TITLE
Only patch Yum mirrors for CentOS Docker builds.  Fixes #20617.

### DIFF
--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -14,10 +14,13 @@
 # Want to exit if there's an errror
 set -e
 
-# Per https://stackoverflow.com/a/70930049, we need these commands for Yum mirrors
-# Per https://serverfault.com/a/1093928, switch to vault.epel.cloud
-sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
-sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-*
+# Only want to mess with mirrors for CentOS
+if [ $(ls /etc/yum.repos.d | grep -c CentOS) -gt 0 ]; then
+  # Per https://stackoverflow.com/a/70930049, we need these commands for Yum mirrors
+  # Per https://serverfault.com/a/1093928, switch to vault.epel.cloud
+  sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+  sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-*
+fi
 
 # Update package lists
 yum update -y


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
We want to start building on Rocky Linux, which uses Yum like CentOS.  For that to work, we need an if-guard around the CentOS-specific `sed` commands in `docker_ci/yum_installs.sh`. 

## Design
I added an if-guard so that those `sed` statements only fire off if there's an occurrence of `CentOS` under directory `/etc/yum.repos.d`.  Having verified that the same packages all install with Rocky Linux, this should do the trick.

## Impact
No impact to the framework.  Just allows other distros that use Yum to build with Docker.  Closes #20617.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
