### PR TITLE
Add zlib-devel to Docker Yum installs for Rocky Linux

### DIFF
--- a/docker_ci/yum_installs.sh
+++ b/docker_ci/yum_installs.sh
@@ -60,7 +60,8 @@ yum install -y \
   emacs \
   gtest \
   sudo \
-  file
+  file \
+  zlib-devel
 
 # Clear cache
 yum clean all


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
I boldly assumed that Rocky Linux installing all of the same Yum packages as CentOS meant the whole build would work, so I'm sorry about causing PR spam.  It turns out that CentOS natively has `zlib-devel` installed, whereas Rocky Linux doesn't, and it's needed for LibMesh.

## Design
<!--A concise description (design) of the enhancement.-->
I have added `zlib-devel` to `docker_ci/yum_installs.sh`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
This enables Docker builds using Rocky Linux as a base.  Closes #20632.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
