### PR TITLE
Move to repo root in post_checkout for Docker autobuild

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,5 @@
 /conda @loganharbour @milljm @cticenhour
 /docker_ci @loganharbour
-/hooks @loganharbour
 /m4 @lindsayad
 
 /COPYING @permcody

--- a/docker_ci/hooks/post_checkout
+++ b/docker_ci/hooks/post_checkout
@@ -8,6 +8,9 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+# Move to root of the repo; we start in docker_ci
+cd ..
+
 # Docker autobuild will initialize submodules; we don't want
 # them in the final image because we end up cloing libmesh
 # and PETSc seperately, and large_media can be cloned


### PR DESCRIPTION
Refs #20614

Result of the current hook:

```
Executing post_checkout hook...
error: pathspec 'large_media' did not match any file(s) known to git.
error: pathspec 'libmesh' did not match any file(s) known to git.
error: pathspec 'petsc' did not match any file(s) known to git.
post_checkout hook failed! (1)
```

This is because we're sitting in `docker_ci` and not the repo root.