### PR TITLE
Pin openssl to 1.x for now and bump min macOS to 10.12

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 5 %}
+{% set build = 6 %}
 {% set strbuild = "build_" + build|string %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.03.28" %}
 

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.03.28" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.03.28 build_0
+  - moose-libmesh 2022.03.28 build_1
 
 SHORT_VTK_NAME:
   - 9.1
@@ -266,11 +266,11 @@ pin_run_as_build:
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.11.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.11                                                   # [not arm64 and osx]
+  - 10.12                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -278,5 +278,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.11                                                   # [not arm64 and osx]
+  - 10.12                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -195,24 +195,24 @@ zip_keys:
 
 #### Compilers
 base_mpich:
-  - mpich 4.0.1 h846660c_100                               # [linux]
-  - mpich 4.0.1 hd33e60e_100                               # [not arm64 and osx]
-  - mpich 4.0.1 hd4b5bf3_100                               # [arm64]
+  - mpich 4.0.1 h846660c_100                                # [linux]
+  - mpich 4.0.1 hd33e60e_100                                # [not arm64 and osx]
+  - mpich 4.0.1 hd4b5bf3_100                                # [arm64]
 
 base_mpicc:
-  - mpich-mpicc 4.0.1 hb600da9_100                         # [linux]
-  - mpich-mpicc 4.0.1 h4fd26ce_100                         # [not arm64 and osx]
-  - mpich-mpicc 4.0.1 haad7f49_100                         # [arm64]
+  - mpich-mpicc 4.0.1 hb600da9_100                          # [linux]
+  - mpich-mpicc 4.0.1 h4fd26ce_100                          # [not arm64 and osx]
+  - mpich-mpicc 4.0.1 haad7f49_100                          # [arm64]
 
 base_mpicxx:
-  - mpich-mpicxx 4.0.1 h166bdaf_100                        # [linux]
-  - mpich-mpicxx 4.0.1 h5eb16cf_100                        # [not arm64 and osx]
-  - mpich-mpicxx 4.0.1 h1c322ee_100                        # [arm64]
+  - mpich-mpicxx 4.0.1 h166bdaf_100                         # [linux]
+  - mpich-mpicxx 4.0.1 h5eb16cf_100                         # [not arm64 and osx]
+  - mpich-mpicxx 4.0.1 h1c322ee_100                         # [arm64]
 
 base_mpifort:
-  - mpich-mpifort 4.0.1 h924138e_100                       # [linux]
-  - mpich-mpifort 4.0.1 hbb4e6a2_100                       # [not arm64 and osx]
-  - mpich-mpifort 4.0.1 h3e96240_100                       # [arm64]
+  - mpich-mpifort 4.0.1 h924138e_100                        # [linux]
+  - mpich-mpifort 4.0.1 hbb4e6a2_100                        # [not arm64 and osx]
+  - mpich-mpifort 4.0.1 h3e96240_100                        # [arm64]
 
 moose_ld64:                                                 # [osx]
   - ld64 609 h4dfd969_10                                    # [not arm64 and osx]

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -11,7 +11,7 @@ vtk_version:
   - 9.1.0
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0 build_5
+  - moose-libmesh-vtk 9.1.0 build_6
 
 moose_petsc:
   - moose-petsc 3.16.5 build_1

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -214,6 +214,10 @@ base_mpifort:
   - mpich-mpifort 4.0.1 hbb4e6a2_100                       # [not arm64 and osx]
   - mpich-mpifort 4.0.1 h3e96240_100                       # [arm64]
 
+moose_ld64:                                                 # [osx]
+  - ld64 609 h4dfd969_10                                    # [not arm64 and osx]
+  - ld64_osx-arm64 609 h7c97014_10                          # [arm64]
+
 #### Support Libraries (libMesh and VTK)
 moose_libglu:                                               # [linux]
   - libglu 9.0.0 hf484d3e_1000                              # [linux]

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -14,10 +14,10 @@ moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0 build_5
 
 moose_petsc:
-  - moose-petsc 3.16.5 build_0
+  - moose-petsc 3.16.5 build_1
 
 moose_mpich:
-  - moose-mpich 4.0.1 build_0
+  - moose-mpich 4.0.1 build_1
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 moose_python:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -37,8 +37,7 @@ requirements:
     - automake                  # [osx]
     - libtool                   # [osx]
     - make                      # [osx]
-    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
-    - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
+    - openssl <3
     - mpi 1.0 mpich
 test:
   commands:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ base_mpicc }}
     - {{ base_mpicxx }}
     - {{ base_mpifort }}
+    - {{ moose_ld64 }}          # [osx]
     - autoconf                  # [unix]
     - automake                  # [unix]
     - libtool                   # [unix]
@@ -33,6 +34,7 @@ requirements:
     - {{ base_mpicc }}
     - {{ base_mpicxx }}
     - {{ base_mpifort }}
+    - {{ moose_ld64 }}          # [osx]
     - autoconf                  # [osx]
     - automake                  # [osx]
     - libtool                   # [osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.1" %}
 
@@ -37,6 +37,7 @@ requirements:
     - automake                  # [osx]
     - libtool                   # [osx]
     - make                      # [osx]
+    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
     - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
     - mpi 1.0 mpich
 test:

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - libtool                   # [osx]
     - make                      # [osx]
     - openssl <3
+    - setuptools <60
     - mpi 1.0 mpich
 test:
   commands:

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -64,7 +64,7 @@ configure_petsc \
     FFLAGS="$FFLAGS" \
     FCFLAGS="$FCFLAGS" \
     LDFLAGS="$LDFLAGS" \
-    --prefix=$PREFIX || (cat configure.log && exit 1)
+    --prefix=$PREFIX/petsc || (cat configure.log && exit 1)
 
 # Verify that gcc_ext isn't linked
 for f in $PETSC_ARCH/lib/petsc/conf/petscvariables $PETSC_ARCH/lib/pkgconfig/PETSc.pc; do
@@ -91,7 +91,7 @@ sedinplace "s%${BUILD_PREFIX}/bin/python%/usr/bin/env python%g" $PETSC_ARCH/lib/
 for path in $PETSC_DIR $BUILD_PREFIX; do
     for f in $(grep -l "${path}" $PETSC_ARCH/include/petsc*.h); do
         echo "Fixing ${path} in $f"
-        sedinplace s%$path%\${PREFIX}%g $f
+        sedinplace s%$path%\${PREFIX}/petsc%g $f
     done
 done
 
@@ -105,28 +105,40 @@ make check MPIEXEC="${RECIPE_DIR}/mpiexec.sh"
 make install
 
 # Remove unneeded files
-rm -f ${PREFIX}/lib/petsc/conf/configure-hash
-find $PREFIX/lib/petsc -name '*.pyc' -delete
+rm -f ${PREFIX}/petsc/lib/petsc/conf/configure-hash
+find $PREFIX/petsc/lib/petsc -name '*.pyc' -delete
 
 # Replace ${BUILD_PREFIX} after installation,
 # otherwise 'make install' above may fail
-for f in $(grep -l "${BUILD_PREFIX}" -R "${PREFIX}/lib/petsc"); do
+for f in $(grep -l "${BUILD_PREFIX}" -R "${PREFIX}/petsc/lib/petsc"); do
   echo "Fixing ${BUILD_PREFIX} in $f"
-  sedinplace s%${BUILD_PREFIX}%${PREFIX}%g $f
+  sedinplace s%${BUILD_PREFIX}%${PREFIX}/petsc%g $f
 done
 
 echo "Removing example files"
-du -hs $PREFIX/share/petsc/examples/src
-rm -fr $PREFIX/share/petsc/examples/src
+du -hs $PREFIX/petsc/share/petsc/examples/src
+rm -fr $PREFIX/petsc/share/petsc/examples/src
 echo "Removing data files"
-du -hs $PREFIX/share/petsc/datafiles/*
-rm -fr $PREFIX/share/petsc/datafiles
+du -hs $PREFIX/petsc/share/petsc/datafiles/*
+rm -fr $PREFIX/petsc/share/petsc/datafiles
 
 # Set PETSC_DIR environment variable for those that need it
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
-export PETSC_DIR=${PREFIX}
+if [ "x\$PKG_CONFIG_PATH" != "x" ]; then
+  export petsc_pkg_config_path=\$PKG_CONFIG_PATH
+  export PKG_CONFIG_PATH=${PREFIX}/petsc/lib/pkgconfig:\$PKG_CONFIG_PATH
+else
+  export PKG_CONFIG_PATH=${PREFIX}/petsc/lib/pkgconfig
+fi
+export PETSC_DIR=${PREFIX}/petsc
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+if [ "x\$petsc_pkg_config_path" != "x" ]; then
+  export PKG_CONFIG_PATH=\$petsc_pkg_config_path
+  unset petsc_pkg_config_path
+else
+  unset PKG_CONFIG_PATH
+fi
 unset PETSC_DIR
 EOF

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -24,8 +24,7 @@ requirements:
     - cython
 
   run:
-    - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
-    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
+    - openssl <3
     - python
 
 test:

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 
   run:
     - openssl <3
+    - setuptools <60
     - python
 
 test:

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = "2022.03.15" %}
 
 package:
@@ -25,6 +25,7 @@ requirements:
 
   run:
     - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
+    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
     - python
 
 test:

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.03.15" %}
+{% set version = "2022.03.30" %}
 
 package:
   name: moose-tools
@@ -15,6 +15,7 @@ requirements:
   build:
     - {{ moose_python }}
     - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
+    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
 
   run:
     - {{ moose_mpich }}
@@ -37,6 +38,7 @@ requirements:
     - {{ moose_sympy }}
     - {{ moose_deepdiff }}
     - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
+    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
     - clang-tools
     - python
 

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -14,8 +14,6 @@ build:
 requirements:
   build:
     - {{ moose_python }}
-    - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
-    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
 
   run:
     - {{ moose_mpich }}
@@ -37,8 +35,7 @@ requirements:
     - {{ moose_mako }}
     - {{ moose_sympy }}
     - {{ moose_deepdiff }}
-    - {{ pin_compatible('setuptools', lower_bound='58', upper_bound='60') }}
-    - {{ pin_compatible('openssl', lower_bound='1', upper_bound='3') }}
+    - openssl <3
     - clang-tools
     - python
 

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - {{ moose_sympy }}
     - {{ moose_deepdiff }}
     - openssl <3
+    - setuptools <60
     - clang-tools
     - python
 


### PR DESCRIPTION
We have an issue with secure renegotiation with our CI server. Pinning openssl will allow CI to continue.

Bumping the minimum macOS to Sierra (10.12) in order to fixup threading issues on Mac in framework and BISON

Closes #20668
Closes #20680

