### PR TITLE
Various SQA documentation fixes

### DIFF
--- a/framework/doc/content/sqa/framework_rtm.md
+++ b/framework/doc/content/sqa/framework_rtm.md
@@ -18,6 +18,7 @@
 !template-end!
 
 !template! item key=pre-test
+!! pre-test-begin
 Ideally all testing should be performed on a clean test machine following
 one of the supported configurations setup by the test system engineer. Testing
 may be performed on local workstations and cluster systems containing supported
@@ -35,6 +36,7 @@ git submodule foreach 'git clean -xfd'
 All tests must pass in accordance with the type of test being performed. This list
 can be found in the [Software Test Plan](sqa/framework_stp.md).
 
+!! pre-test-finish
 !template-end!
 
 !template item key=functional-requirements

--- a/framework/doc/content/sqa/framework_sdd.md
+++ b/framework/doc/content/sqa/framework_sdd.md
@@ -1,6 +1,7 @@
 !template load file=sdd.md.template category=framework project=Framework
 
 !template! item key=introduction
+!! introduction-begin
 Frameworks are a software development construct aiming to simplify the creation of specific classes
 of applications through abstraction of low-level details. The main object of creating a framework is
 to provide an interface to application developers that saves time and provides advanced capabilities
@@ -55,9 +56,11 @@ input files for driving a simulation, run the application, and analyze the resul
 through MOOSE are primarily through the command-line interface and through a customizable block-based
 input file.
 
+!! introduction-finish
 !template-end!
 
 !template! item key=system-purpose
+!! system-purpose-begin
 The Software Design Description provided here is description of each object in the system. The pluggable
 architecture of the framework makes [!ac](MOOSE) and [!ac](MOOSE)-based applications straightforward
 to develop as each piece of end-user (developer) code that goes into the system follows a well-defined
@@ -65,9 +68,11 @@ interface for the underlying systems that those object plug into. These descript
 through developer-supplied "markdown" files that are required for all new objects that are developed
 as part of the framework, modules and derivative applications. More information about the design
 documentation can be found in [framework/documenting.md].
+!! system-purpose-finish
 !template-end!
 
 !template! item key=system-scope
+!! system-scope-begin
 The purpose of this software is to provide several libraries that can be used to build an application
 based upon the framework. Additionally, several utilities are provided
 for assisting developers and users in end-to-end [!ac](FEM) analysis. A brief overview of the major
@@ -86,9 +91,11 @@ components are listed here:
 | tutorials | Step by step guides to building up an application using [!ac](MOOSE)'s pluggable systems |
 | unit | An application for unit testing individual classes or methods of C++ code |
 
+!! system-scope-finish
 !template-end!
 
 !template! item key=dependencies-and-limitations
+!! dependencies-and-limitations-begin
 The [!ac](MOOSE) platform has several dependencies on other software packages and has scope that
 is constantly evolving based upon funding, resources, priorities, and lab direction. However, the
 software is open-source and many features and even bugs can be offloaded to developers with appropriate
@@ -109,13 +116,16 @@ specific packages to be installed prior to using MOOSE, which can be found on th
        caption=A diagram of the MOOSE code platform.
        style=width=50%;
 
+!! dependencies-and-limitations-finish
 !template-end!
 
 !template! item key=definitions
+!! definitions-begin
 - +Pull (Merge) Request+: A proposed change to the software (e.g. usually a code change, but may also include documentation, requirements, design, and/or testing).
 - +Baseline+: A specification or product (e.g., project plan, maintenance and operations (M&O) plan, requirements, or design) that has been formally reviewed and agreed upon, that thereafter serves as the basis for use and further development, and that can be changed only by using an approved change control process (NQA-1, 2009).
 - +Validation+: Confirmation, through the provision of objective evidence (e.g., acceptance test), that the requirements for a specific intended use or application have been fulfilled (24765:2010(E), 2010).
 - +Verification+: (1) The process of: evaluating a system or component to determine whether the products of a given development phase satisfy the conditions imposed at the start of that phase. (2) Formal proof of program correctness (e.g., requirements, design, implementation reviews, system tests) (24765:2010(E), 2010).
+!! definitions-finish
 !template-end!
 
 !template! item key=acronyms
@@ -123,13 +133,16 @@ specific packages to be installed prior to using MOOSE, which can be found on th
 !template-end!
 
 !template! item key=design-stakeholders
+!! design-stakeholders-begin
 Stakeholders for [!ac](MOOSE) include several of the funding sources including [!ac](DOE-NE)
 and the [!ac](INL). However, Since [!ac](MOOSE) is an open-source project, several universities,
 companies, and foreign governments have an interest in the development and maintenance of the
 [!ac](MOOSE) project.
+!! design-stakeholders-finish
 !template-end!
 
 !template! item key=stakeholder-design-concerns
+!! stakeholder-design-concerns-begin
 Concerns from many of the stakeholders are similar. These concerns include correctness, stability,
 and performance. The mitigation plan for each of these can be addressed. For correctness, [!ac](MOOSE)
 development requires either regression or unit testing for all new code added to the repository.
@@ -138,9 +151,11 @@ other verification methods such as [MMS](python/mms.md optional=True). For stabi
 multiple branches to incorporate several layers of testing both internally and for dependent
 applications. Finally, performance tests are also performed as part of the the normal testing suite
 to monitor code change impacts to performance.
+!! stakeholder-design-concerns-finish
 !template-end!
 
 !template! item key=system-design
+!! system-design-begin
 The MOOSE framework itself is composed of a wide range of pluggable systems. Each system is generally
 composed of a single or small set of C++ objects intended to be specialized by a Developer to solve a
 specific problem. To accomplish this design goal, MOOSE uses several modern object-oriented design
@@ -151,15 +166,17 @@ section. Additionally, up-to-date documentation extracted from the source is mai
 mooseframework.org documentation site after every successful merge to MOOSE's stable branch. After
 these objects are created, the can be registered with the framework and used immediately in a MOOSE
 input file.
+!! system-design-finish
 !template-end!
 
 !template! item key=system-structure
+!! system-structure-begin
 The MOOSE framework architecture consists of a core and several pluggable systems. The core of MOOSE
 consists of a number of key objects responsible for setting up and managing the user-defined objects
 of a finite element simulation. This core set of objects has limited extendability and exist for
 every simulation configuration that the framework is capable of running.
 
-!syntax list subsystems=True actions=False objects=False
+!syntax complete subsystems=False actions=False objects=False
 
 The MooseApp is the top-level object used to hold all of the other objects in a simulation. In a
 normal simulation a single MooseApp object is created and "run()". This object uses it's Factory
@@ -172,36 +189,45 @@ MOOSE's pluggable systems are documented on the mooseframework.org wiki. Each of
 set of defined polymorphic interfaces and are designed to accomplish a specific task within the
 simulation. The design of these systems is fluid and is managed through agile methods and ticket
 request system on the Github.org website.
+!! system-structure-finish
 !template-end!
 
 !template! item key=data-design-and-control
+!! data-design-and-control-begin
 At a high level, the system is designed to process [!ac](HIT) input files to construct several
 objects that will constitute an [!ac](FE) simulation. Some of the objects in the simulation may
 in turn load other file-based resources to complete the simulation. Examples include meshes
 or data files. The system will then assemble systems of equations and solve them using the
 libraries of the [Code Platform](#dependencies-and-limitations). The system can then output the
 solution in one or more supported output formats commonly used for visualization.
+!! data-design-and-control-finish
 !template-end!
 
 !template! item key=human-machine-interface-design
+!! human-machine-interface-design-begin
 MOOSE is a command-line driven program. All interaction with MOOSE and MOOSE-based codes is
 ultimately done through the command line. This is typical for [!ac](HPC) applications that use
 the [!ac](MPI) interface for running on super computing clusters. Optional GUIs may be used
 to assist in creating input files and launching executables on the command line.
+!! human-machine-interface-design-finish
 !template-end!
 
 !template! item key=system-design-interface
+!! system-design-interface-begin
 All external system interaction is performed either through file [!ac](I/O) or through local
 [!ac](API) calls. Neither the framework, nor the modules are designed to interact
 with any external system directly through remote procedure calls. Any code to code coupling
 performed using the framework are done directly through API calls either in
 a static binary or after loading shared libraries.
+!! system-design-interface-finish
 !template-end!
 
 !template! item key=security-structure
+!! security-structure-begin
 The framework does not require any elevated privileges to operate and does not
 run any stateful services, daemons or other network programs. Distributed runs rely on the
 [!ac](MPI) library.
+!! security-structure-finish
 !template-end!
 
 !template! item key=requirements-cross-reference

--- a/framework/doc/content/sqa/framework_srs.md
+++ b/framework/doc/content/sqa/framework_srs.md
@@ -9,6 +9,7 @@
 !template-end!
 
 !template! item key=system-context
+!! system-context-begin
 [!ac](MOOSE) is a command-line driven application. This is typical for a high-performance software
 that is designed to run across several nodes of a cluster system. As such, all of the usage
 of the software is through any standard terminal program generally available on all supported
@@ -21,16 +22,20 @@ which may be launched from the command line and writes out various result files 
        id=usage_diagram
        caption=Usage of [!ac](MOOSE) and [!ac](MOOSE)-based applications.
        style=width:50%;
+!! system-context-finish
 !template-end!
 
 !template! item key=system-functions
+!! system-functions-begin
 Since [!ac](MOOSE) is a command-line driven application, all functionality provided in the framework
 is operated through the use of standard UNIX command line flags and the extendable MOOSE input file.
 The framework is completely extendable so individual design pages should be consulted for specific
 behaviors of each user-defined object.
+!! system-functions-finish
 !template-end!
 
 !template! item key=user-characteristics
+!! user-characteristics-begin
 
 - +Framework Developers+: These are the core developers of the framework. They will be responsible
   for following and enforcing the appropriate software development standards. They will be
@@ -46,6 +51,7 @@ behaviors of each user-defined object.
   they perform.  These users may interact with developers of the system requesting new features and
   reporting bugs found and will typically make heavy use of the input file format.
 
+!! user-characteristics-finish
 !template-end!
 
 !template! item key=assumptions-and-dependencies
@@ -53,10 +59,12 @@ behaviors of each user-defined object.
 !template-end!
 
 !template! item key=definitions
+!! definitions-begin
 - +Verification+: (1) The process of: evaluating a system or component to determine whether the
   products of a given development phase satisfy the conditions imposed at the start of that
   phase. (2) Formal proof of program correctness (e.g., requirements, design, implementation reviews,
   system tests) [!citep](ISO-systems-software).
+!! definitions-finish
 !template-end!
 
 !template! item key=acronyms
@@ -64,6 +72,7 @@ behaviors of each user-defined object.
 !template-end!
 
 !template! item key=minimum-requirements
+!! minimum-requirements-begin
 - A [!ac](POSIX) compliant Unix including the two most recent versions of MacOS and most current
   versions of Linux.
 - 4 GB of RAM for optimized compilation (8 GB for debug compilation), 2 GB per core execution
@@ -71,6 +80,7 @@ behaviors of each user-defined object.
 - C++17 compatible compiler (GCC, Clang)
 - Python 3.6+
 - Git
+!! minimum-requirements-finish
 !template-end!
 
 !template item key=functional-requirements
@@ -86,14 +96,17 @@ behaviors of each user-defined object.
 !sqa requirements link=False collections=SYSTEM category=framework
 
 !template! item key=human-system-integration
+!! human-system-integration-begin
 [!ac](MOOSE) is a command line driven application which conforms to all standard terminal
 behaviors. Specific human system interaction accommodations shall be a function of the end-user's
 terminal. MOOSE does support optional coloring within the terminal's ability to display color,
 which may be disabled.
+!! human-system-integration-finish
 !template-end!
 
 
 !template! item key=maintainability
+!! maintainability-begin
 - The latest working version (defined as the version that passes all tests in the current regression
   test suite) shall be publicly available at all times through the repository host provider.
 - Flaws identified in the system shall be reported and tracked in a ticket or issue based system. The
@@ -103,26 +116,34 @@ which may be disabled.
   (within two business days).
 - The core framework in its entirety will be made publicly available under the [!ac](LGPL)
   version 2.0 license.
+!! maintainability-finish
 !template-end!
 
 
 !template item key=reliability
+!! reliability-begin
 The regression test suite will cover at least 80% of all lines of code at all times. Known
 regressions will be recorded and tracked (see [#maintainability]) to an independent and
 satisfactory resolution.
+!! reliability-finish
 !template-end!
 
 !template item key=information-management
+!! information-management-begin
 The core framework in its entirety will be made publicly available on an appropriate repository
 hosting site. Backups and security services will be provided by the hosting service.
+!! information-management-finish
 !template-end!
 
 !template item key=verification
+!! verification-begin
 The regression test suite will employ several verification tests using comparison against known
 analytical solutions, the method of manufactured solutions, and convergence rate analysis.
+!! verification-finish
 !template-end!
 
 !template! item key=system-modes
+!! system-modes-begin
 [!ac](MOOSE) applications normally run in normal execution  mode when an input file is supplied. However
 there are a few other modes that can be triggered with various command line flags as indicated here:
 
@@ -143,35 +164,48 @@ there are a few other modes that can be triggered with various command line flag
 The list of system-modes may not be extensive as the system is designed to be extendable to end-user applications.
 The complete list of command line options for applications can be obtained by running the executable with
 zero arguments. See the [command line usage](command_line_usage.md optional=True).
+!! system-modes-finish
 !template-end!
 
 !template! item key=physical-characteristics
+!! physical-characteristics-begin
 [!ac](MOOSE) is software only with no associated physical media. See [#system-requirements] for a description
 of the minimum required hardware necessary for running a [!ac](MOOSE)-based application.
+!! physical-characteristics-finish
 !template-end!
 
 !template! item key=environmental-conditions
+!! environmental-conditions-begin
 Not Applicable
+!! environmental-conditions-finish
 !template-end!
 
 !template! item key=system-security
+!! system-security-begin
 [!ac](MOOSE) based applications have no requirements or special needs related to system-security. The framework
 is designed to run completely in user-space with no elevated privileges required nor recommended.
+!! system-security-finish
 !template-end!
 
 !template! item key=policies-and-regulations
+!! policies-and-regulations-begin
 [!ac](MOOSE)-based applications must comply with all export control restrictions.
+!! policies-and-regulations-finish
 !template-end!
 
 !template! item key=system-life-cycle
+!! system-life-cycle-begin
 [!ac](MOOSE)-based development follows various agile methods. The system is continuously built and deployed in
 a piecemeal fashion since objects within the system are more or less independent. Every new object requires a test,
 which in turn requires an associated requirement and design description. Some [!ac](MOOSE)-based development
 teams follow the [!ac](NQA-1) standards.
+!! system-life-cycle-finish
 !template-end!
 
 !template! item key=packaging
+!! packaging-begin
 No special requirements are needed for packaging or shipping any media containing [!ac](MOOSE) source code. However,
 some [!ac](MOOSE)-based applications maybe be export controlled in which case all export control restrictions must
 be adhered to when packaging and shipping media.
+!! packaging-finish
 !template-end!

--- a/framework/doc/content/templates/sqa/app_rtm.md.template
+++ b/framework/doc/content/templates/sqa/app_rtm.md.template
@@ -1,4 +1,4 @@
-!template load file=framework_rtm.md project={{app}}
+!template load file=rtm.md.template project={{app}}
 
 !template! item key=pre-intro
 !alert! note
@@ -9,9 +9,21 @@ This document serves as an addendum to [framework_rtm.md] and captures informati
 !alert-end!
 !template-end!
 
+!template item key=minimum_requirements
+!include sqa/minimum_requirements.md
+
+!template item key=system-purpose
+!include sqa/system_purpose.md
+
+!template item key=system-scope
+!include sqa/system_scope.md
+
 !template item key=assumptions-and-dependencies
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](RTM) for {{app}} is dependent upon the files listed at the beginning of this document.
+
+!template item key=pre-test
+!include framework_rtm.md start=pre-test-begin end=pre-test-finish
 
 !template! item key=functional-requirements
 !sqa requirements link=True collections=FUNCTIONAL category={{category}}

--- a/framework/doc/content/templates/sqa/app_sdd.md.template
+++ b/framework/doc/content/templates/sqa/app_sdd.md.template
@@ -1,4 +1,4 @@
-!template load file=framework_sdd.md project={{app}}
+!template load file=sdd.md.template category={{category}} project={{app}}
 
 !template! item key=pre-intro
 !alert! note
@@ -9,6 +9,47 @@ This document serves as an addendum to [framework_sdd.md] and captures informati
 !alert-end!
 !template-end!
 
-!template! item key=requirements-cross-reference
+!template item key=introduction
+!include framework_sdd.md start=introduction-begin end=introduction-finish
+
+!template item key=system-purpose
+!include framework_sdd.md start=system-purpose-begin end=system-purpose-finish
+
+!template item key=system-scope
+!include framework_sdd.md start=system-scope-begin end=system-scope-finish
+
+!template item key=dependencies-and-limitations
+!include framework_sdd.md start=dependencies-and-limitations-begin end=dependencies-and-limitations-finish
+
+!template item key=definitions
+!include framework_sdd.md start=definitions-begin end=definitions-finish
+
+!template item key=acronyms
+!acronym list
+
+!template item key=design-stakeholders
+!include framework_sdd.md start=design-stakeholders-begin end=design-stakeholders-finish
+
+!template item key=stakeholder-design-concerns
+!include framework_sdd.md start=stakeholder-design-concerns-begin end=stakeholder-design-concerns-finish
+
+!template item key=system-design
+!include framework_sdd.md start=system-design-begin end=system-design-finish
+
+!template item key=system-structure
+!include framework_sdd.md start=system-structure-begin end=system-structure-finish
+
+!template item key=data-design-and-control
+!include framework_sdd.md start=data-design-and-control-begin end=data-design-and-control-finish
+
+!template item key=human-machine-interface-design
+!include framework_sdd.md start=human-machine-interface-design-begin end=human-machine-interface-design-finish
+
+!template item key=system-design-interface
+!include framework_sdd.md start=system-design-interface-begin end=system-design-interface-finish
+
+!template item key=security-structure
+!include framework_sdd.md start=security-structure-begin end=security-structure-finish
+
+!template item key=requirements-cross-reference
 !sqa cross-reference category={{category}}
-!template-end!

--- a/framework/doc/content/templates/sqa/app_srs.md.template
+++ b/framework/doc/content/templates/sqa/app_srs.md.template
@@ -1,4 +1,4 @@
-!template load file=framework_srs.md project={{app}}
+!template load file=srs.md.template project={{app}}
 
 !template! item key=pre-intro
 !alert! note
@@ -9,6 +9,78 @@ This document serves as an addendum to [framework_srs.md] and captures informati
 !alert-end!
 !template-end!
 
+!template item key=system-purpose
+!include sqa/system_purpose.md
+
+!template item key=system-scope
+!include sqa/system_scope.md
+
+!template item key=system-context
+!include sqa/framework_srs.md start=system-context-begin end=system-context-finish
+
+!template item key=system-functions
+!include sqa/framework_srs.md start=system-functions-begin end=system-functions-finish
+
+!template item key=user-characteristics
+!include sqa/framework_srs.md start=user-characteristics-begin end=user-characteristics-finish
+
 !template item key=assumptions-and-dependencies
 The {{app}} application is developed using MOOSE and is based on various modules, as such
 the [!ac](SRS) for {{app}} is dependent upon the files listed at the beginning of this document.
+
+!template item key=definitions
+!include sqa/framework_srs.md start=definitions-begin end=definitions-finish
+
+!template item key=acronyms
+!acronym list
+
+!template item key=minimum-requirements
+!include sqa/framework_srs.md start=minimum-requirements-begin end=minimum-requirements-finish
+
+!template item key=functional-requirements
+!sqa requirements link=False collections=FUNCTIONAL category={{category}}
+
+!template item key=usability-requirements
+!sqa requirements link=False collections=USABILITY category={{category}}
+
+!template item key=performance-requirements
+!sqa requirements link=False collections=PERFORMANCE category={{category}}
+
+!template item key=system-interfaces-requirements
+!sqa requirements link=False collections=SYSTEM category={{category}}
+
+!template item key=human-system-integration
+!include sqa/framework_srs.md start=human-system-integration-begin end=human-system-integration-finish
+
+!template item key=maintainability
+!include sqa/framework_srs.md start=maintainability-begin end=maintainability-finish
+
+!template item key=reliability
+!include sqa/framework_srs.md start=reliability-begin end=reliability-finish
+
+!template item key=information-management
+!include sqa/framework_srs.md start=information-management-begin end=information-management-finish
+
+!template item key=verification
+!include sqa/framework_srs.md start=verification-begin end=verification-finish
+
+!template item key=system-modes
+!include sqa/framework_srs.md start=system-modes-begin end=system-modes-finish
+
+!template item key=physical-characteristics
+!include sqa/framework_srs.md start=physical-characteristics-begin end=physical-characteristics-finish
+
+!template item key=environmental-conditions
+!include sqa/framework_srs.md start=environmental-conditions-begin end=environmental-conditions-finish
+
+!template item key=system-security
+!include sqa/framework_srs.md start=system-security-begin end=system-security-finish
+
+!template item key=policies-and-regulations
+!include sqa/framework_srs.md start=policies-and-regulations-begin end=policies-and-regulations-finish
+
+!template item key=system-life-cycle
+!include sqa/framework_srs.md start=system-life-cycle-begin end=system-life-cycle-finish
+
+!template item key=packaging
+!include sqa/framework_srs.md start=packaging-begin end=packaging-finish

--- a/modules/contact/doc/config.yml
+++ b/modules/contact/doc/config.yml
@@ -2,7 +2,10 @@ Content:
     - framework/doc/content
     - modules/contact/doc/content
     - modules/tensor_mechanics/doc/content
-
+    - utility:
+        root_dir: ${MOOSE_DIR}/modules/doc/content
+        content:
+            - help/finite_element_concepts/nodal_patch_recovery.md            
 Renderer:
     type: MooseDocs.base.MaterializeRenderer
 

--- a/modules/contact/doc/sqa_reports.yml
+++ b/modules/contact/doc/sqa_reports.yml
@@ -18,12 +18,13 @@ Documents:
     configuration_management_plan: sqa/inl_records.md#configuration_management_plan
     asset_management_plan: sqa/inl_records.md#asset_management_plan
     verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
-    log_software_requirements_specification: WARNING
-    log_software_design_description: WARNING
-    log_software_test_plan: WARNING
-    log_requirements_traceablity_matrix: WARNING
-    log_verification_validation_report: WARNING
-    log_failure_analysis_report: WARNING
+    software_requirements_specification: sqa/contact_srs.md
+    software_design_description: sqa/contact_sdd.md
+    software_test_plan: sqa/contact_stp.md
+    requirements_traceablity_matrix: sqa/contact_rtm.md
+    verification_validation_report: sqa/contact_vvr.md
+    failure_analysis_report: sqa/contact_far.md
+    software_library_list: sqa/contact_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
     log_user_manual: WARNING

--- a/modules/doc/config.yml
+++ b/modules/doc/config.yml
@@ -142,6 +142,8 @@ Extensions:
             ray_tracing: !include modules/ray_tracing/doc/sqa_ray_tracing.yml
             fsi: !include modules/fsi/doc/sqa_fsi.yml
             thermal_hydraulics: !include modules/thermal_hydraulics/doc/sqa_thermal_hydraulics.yml
+            porous_flow: !include modules/porous_flow/doc/sqa_porous_flow.yml
+            level_set: !include modules/level_set/doc/sqa_level_set.yml
 
         requirement-groups:
             dgkernels: DGKernel Objects

--- a/modules/doc/content/application_development/debugging.md
+++ b/modules/doc/content/application_development/debugging.md
@@ -4,7 +4,7 @@ At some point while developing a MOOSE-based application you will probably need 
 
 In particular, if you ever see a "Segfault" or a "Signal 11" that means it's time to pull out the debugger.  Any debugger will automatically stop once a segfault is reached, showing you exactly where the invalid memory access occurred.
 
-For a good tutorial on debugging [see Example 21](/ex21_debugging.md)
+For a good tutorial on debugging [see Example 21](/ex21_debugging.md optional=True)
 
 ## Debug Executable
 

--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -11,9 +11,9 @@ and an experimental [WSL](installation/windows10.md) option is available.
 
 !include installation/install_conda_moose.md
 
-!include getting_started/installation/clone_moose.md
+!include getting_started/installation/clone_moose.md optional=True
 
-!include getting_started/installation/test_moose.md
+!include getting_started/installation/test_moose.md optional=True
 
 Head back over to the [getting_started/installation/index.md optional=True] page to continue your tour of MOOSE.
 

--- a/modules/doc/content/help/faq/index.md
+++ b/modules/doc/content/help/faq/index.md
@@ -9,7 +9,7 @@
 - [How do I build my own libMesh with VTK?](faq/faq_build_libmesh-vtk.md)
 - [How do I build my own PETSc?](faq/faq_build_petsc.md)
 - [Where is the stiffness matrix?](help/faq/what_is_fem.md)
-- [How do I execute MOOSE in parallel?](getting_started/examples_and_tutorials/tutorial01_app_development/step07_parallel.md)
+- [How do I execute MOOSE in parallel?](getting_started/examples_and_tutorials/tutorial01_app_development/step07_parallel.md optional=True)
 
 
 ### Mailing lists:

--- a/modules/doc/content/python/TestHarness.md
+++ b/modules/doc/content/python/TestHarness.md
@@ -141,7 +141,7 @@ The "prereq" parameter is still honored when using "parallel_scheduling = True".
 
 #### PYTHONPATH
 
-PYTHONPATH instructs python to include the designated paths while attempting to import python modules. +While normally not needing to be set+, sometimes it is necessary. For example, when testing the TestHarness (unittests). Another use-case, is when a developer wants to utilize the moosedocs system for creating [moose documentation](MooseDocs/index.md) (the website you are using right now).
+PYTHONPATH instructs python to include the designated paths while attempting to import python modules. +While normally not needing to be set+, sometimes it is necessary. For example, when testing the TestHarness (unittests). Another use-case, is when a developer wants to utilize the moosedocs system for creating [moose documentation](MooseDocs/index.md optional=True) (the website you are using right now).
 
 In either case, when you need to modify PYTHONPATH for MOOSE related development, you will almost always want to point it at `moose/python`.
 

--- a/modules/level_set/doc/config.yml
+++ b/modules/level_set/doc/config.yml
@@ -23,4 +23,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/level_set/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            level_set: !include modules/level_set/doc/sqa_level_set.yml

--- a/modules/level_set/doc/content/modules/level_set/sqa/index.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/index.md
@@ -1,0 +1,4 @@
+!template load file=sqa/app_index.md.template category=level_set app=Level Set
+
+!template item key=sqa-report
+!sqa report category={{category}}

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_far.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_far.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_far.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_rtm.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_rtm.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_rtm.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_sdd.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_sdd.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sdd.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_sll.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_sll.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sll.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_srs.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_srs.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_srs.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_stp.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_stp.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_stp.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/content/modules/level_set/sqa/level_set_vvr.md
+++ b/modules/level_set/doc/content/modules/level_set/sqa/level_set_vvr.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_vvr.md.template category=level_set app=Level Set

--- a/modules/level_set/doc/sqa_level_set.yml
+++ b/modules/level_set/doc/sqa_level_set.yml
@@ -1,0 +1,8 @@
+directories:
+    - ${MOOSE_DIR}/modules/level_set/test/tests
+specs:
+    - tests
+dependencies:
+    - framework
+repo: moose
+reports: !include ${MOOSE_DIR}/modules/level_set/doc/sqa_reports.yml

--- a/modules/level_set/doc/sqa_reports.yml
+++ b/modules/level_set/doc/sqa_reports.yml
@@ -17,12 +17,13 @@ Documents:
     configuration_management_plan: sqa/inl_records.md#configuration_management_plan
     asset_management_plan: sqa/inl_records.md#asset_management_plan
     verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
-    log_software_requirements_specification: WARNING
-    log_software_design_description: WARNING
-    log_software_test_plan: WARNING
-    log_requirements_traceablity_matrix: WARNING
-    log_verification_validation_report: WARNING
-    log_failure_analysis_report: WARNING
+    software_requirements_specification: sqa/level_set_srs.md
+    software_design_description: sqa/level_set_sdd.md
+    software_test_plan: sqa/level_set_stp.md
+    requirements_traceablity_matrix: sqa/level_set_rtm.md
+    verification_validation_report: sqa/level_set_vvr.md
+    failure_analysis_report: sqa/level_set_far.md
+    software_library_list: sqa/level_set_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
     log_user_manual: WARNING

--- a/modules/level_set/test/tests/functions/olsson_bubble/tests
+++ b/modules/level_set/test/tests/functions/olsson_bubble/tests
@@ -5,7 +5,7 @@
     input = olsson_bubble.i
     exodiff = olsson_bubble_out.e
     issues = '#8465'
-    requirement = "The level set module shall include the bubble function defined in [cite!olsson2005conservative]."
+    requirement = "The level set module shall include the bubble function defined in [!cite](olsson2005conservative)."
   [../]
   [./adjac]
     type = PetscJacobianTester

--- a/modules/level_set/test/tests/functions/olsson_plane/tests
+++ b/modules/level_set/test/tests/functions/olsson_plane/tests
@@ -5,6 +5,6 @@
     type = Exodiff
     input = olsson_plane.i
     exodiff = olsson_plane_out.e
-    requirement = "The level set module shall include the plane function defined in [cite!olsson2005conservative]."
+    requirement = "The level set module shall include the plane function defined in [!cite](olsson2005conservative)."
   []
 []

--- a/modules/level_set/test/tests/functions/olsson_vortex/tests
+++ b/modules/level_set/test/tests/functions/olsson_vortex/tests
@@ -5,13 +5,13 @@
     type = Exodiff
     input = olsson_vortex.i
     exodiff = olsson_vortex_out.e
-    requirement = "The level set module shall include the vortex function defined in [cite!olsson2005conservative] with an instantaneous reverse feature."
+    requirement = "The level set module shall include the vortex function defined in [!cite](olsson2005conservative) with an instantaneous reverse feature."
   [../]
   [./cosine]
     type = Exodiff
     input = olsson_vortex.i
     cli_args = "Functions/velocity_func/reverse_type=cosine Outputs/file_base=olsson_vortex_cosine_out"
     exodiff = olsson_vortex_cosine_out.e
-    requirement = "The level set module shall include the vortex function defined in [cite!olsson2005conservative] with an cosine reverse feature."
+    requirement = "The level set module shall include the vortex function defined in [!cite](olsson2005conservative) with an cosine reverse feature."
   [../]
 []

--- a/modules/level_set/test/tests/kernels/olsson_reinitialization/tests
+++ b/modules/level_set/test/tests/kernels/olsson_reinitialization/tests
@@ -5,7 +5,7 @@
     type = Exodiff
     input = olsson_1d.i
     exodiff = olsson_1d_out.e
-    requirement = "The level set module shall include the reinitialization scheme presented by [cite!olsson2005conservative]."
+    requirement = "The level set module shall include the reinitialization scheme presented by [!cite](olsson2005conservative)."
     valgrind = HEAVY
   [../]
 []

--- a/modules/navier_stokes/doc/config.yml
+++ b/modules/navier_stokes/doc/config.yml
@@ -29,4 +29,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/navier_stokes/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            navier_stokes: !include modules/navier_stokes/doc/sqa_navier_stokes.yml

--- a/modules/navier_stokes/doc/sqa_reports.yml
+++ b/modules/navier_stokes/doc/sqa_reports.yml
@@ -18,12 +18,13 @@ Documents:
     configuration_management_plan: sqa/inl_records.md#configuration_management_plan
     asset_management_plan: sqa/inl_records.md#asset_management_plan
     verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
-    log_software_requirements_specification: WARNING
-    log_software_design_description: WARNING
-    log_software_test_plan: WARNING
-    log_requirements_traceablity_matrix: WARNING
-    log_verification_validation_report: WARNING
-    log_failure_analysis_report: WARNING
+    software_requirements_specification: sqa/navier_stokes_srs.md
+    software_design_description: sqa/navier_stokes_sdd.md
+    software_test_plan: sqa/navier_stokes_stp.md
+    requirements_traceablity_matrix: sqa/navier_stokes_rtm.md
+    verification_validation_report: sqa/navier_stokes_vvr.md
+    failure_analysis_report: sqa/navier_stokes_far.md
+    software_library_list: sqa/navier_stokes_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
     log_user_manual: WARNING

--- a/modules/porous_flow/doc/config.yml
+++ b/modules/porous_flow/doc/config.yml
@@ -29,4 +29,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/porous_flow/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            porous_flow: !include modules/porous_flow/doc/sqa_porous_flow.yml

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/index.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/index.md
@@ -1,0 +1,4 @@
+!template load file=sqa/app_index.md.template category=porous_flow app=Porous Flow
+
+!template item key=sqa-report
+!sqa report category={{category}}

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_far.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_far.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_far.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_rtm.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_rtm.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_rtm.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_sdd.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_sdd.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sdd.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_sll.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_sll.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sll.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_srs.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_srs.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_srs.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_stp.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_stp.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_stp.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_vvr.md
+++ b/modules/porous_flow/doc/content/modules/porous_flow/sqa/porous_flow_vvr.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_vvr.md.template category=porous_flow app=Porous Flow

--- a/modules/porous_flow/doc/sqa_porous_flow.yml
+++ b/modules/porous_flow/doc/sqa_porous_flow.yml
@@ -1,0 +1,8 @@
+directories:
+    - ${MOOSE_DIR}/modules/porous_flow/test/tests
+specs:
+    - tests
+dependencies:
+    - framework
+repo: moose
+reports: !include ${MOOSE_DIR}/modules/porous_flow/doc/sqa_reports.yml

--- a/modules/porous_flow/doc/sqa_reports.yml
+++ b/modules/porous_flow/doc/sqa_reports.yml
@@ -18,12 +18,13 @@ Documents:
     configuration_management_plan: sqa/inl_records.md#configuration_management_plan
     asset_management_plan: sqa/inl_records.md#asset_management_plan
     verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
-    log_software_requirements_specification: WARNING
-    log_software_design_description: WARNING
-    log_software_test_plan: WARNING
-    log_requirements_traceablity_matrix: WARNING
-    log_verification_validation_report: WARNING
-    log_failure_analysis_report: WARNING
+    software_requirements_specification: sqa/porous_flow_srs.md
+    software_design_description: sqa/porous_flow_sdd.md
+    software_test_plan: sqa/porous_flow_stp.md
+    requirements_traceablity_matrix: sqa/porous_flow_rtm.md
+    verification_validation_report: sqa/porous_flow_vvr.md
+    failure_analysis_report: sqa/porous_flow_far.md
+    software_library_list: sqa/porous_flow_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
     log_user_manual: WARNING

--- a/modules/porous_flow/test/tests/dirackernels/tests
+++ b/modules/porous_flow/test/tests/dirackernels/tests
@@ -5,7 +5,7 @@
     csvdiff = 'squarepulse1.csv'
     threading = '!pthreads'
     requirement = 'PorousFlowSquarePulsePointSource shall provide a constant mass point source/sink between two specified times'
-    design = 'porous_flow/tests/dirackernels/dirackernels_tests.md porous_flow/sinks.md PorousFlowSquarePulsePointSource'
+    design = 'porous_flow/tests/dirackernels/dirackernels_tests.md porous_flow/sinks.md PorousFlowSquarePulsePointSource.md'
     issues = '#6990'
   [../]
   [./frompps]
@@ -14,7 +14,7 @@
     csvdiff = 'frompps.csv'
     threading = '!pthreads'
     requirement = 'The system shall provide a mass point source/sink computed by a postprocessor'
-    design = 'porous_flow/tests/dirackernels/dirackernels_tests.md porous_flow/sinks.md PorousFlowPointSourceFromPostprocessor'
+    design = 'porous_flow/tests/dirackernels/dirackernels_tests.md porous_flow/sinks.md PorousFlowPointSourceFromPostprocessor.md'
     issues = '#15132'
   [../]
   [./hfrompps]
@@ -23,7 +23,7 @@
     csvdiff = 'hfrompps.csv'
     threading = '!pthreads'
     requirement = 'The system shall provide an enthalphy point source computed by a postprocessor'
-    design = 'porous_flow/sinks.md PorousFlowPointEnthalpySourceFromPostprocessor'
+    design = 'porous_flow/sinks.md PorousFlowPointEnthalpySourceFromPostprocessor.md'
     issues = '#15742'
   [../]
   [./theis1]
@@ -42,7 +42,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to accurately simulate drawdown in 2D groundwater systems, to agree with the Theis solution'
     design = 'porous_flow/tests/dirackernels/dirackernels_tests.md porous_flow/sinks.md PorousFlowSquarePulsePointSource.md'
-    issues = '#6990 13155'
+    issues = '#6990 #13155'
   [../]
   [./theis2]
     type = 'CSVDiff'

--- a/modules/porous_flow/test/tests/fluidstate/tests
+++ b/modules/porous_flow/test/tests/fluidstate/tests
@@ -108,7 +108,7 @@
     csvdiff = "waterncg_ic_out.csv"
     threading = '!pthreads'
     requirement = 'PorousFlow shall calculate the initial value of total mass fraction corresponding to the specified gas saturation in a water and NCG system'
-    design = 'PorousFlowWaterNCGIC.md'
+    design = 'PorousFlowFluidStateWaterNCGIC.md'
     issues = '#9377'
   [../]
   [./brineco2_ic]
@@ -117,7 +117,7 @@
     csvdiff = "brineco2_ic_out.csv"
     threading = '!pthreads'
     requirement = 'PorousFlow shall calculate the initial value of total mass fraction corresponding to the specified gas saturation in a brine and CO2 system'
-    design = 'PorousFlowBrineCO2IC.md'
+    design = 'PorousFlowFluidStateBrineCO2IC.md'
     issues = '#9377'
   [../]
   [./water_vapor_2phase]

--- a/modules/porous_flow/test/tests/hysteresis/tests
+++ b/modules/porous_flow/test/tests/hysteresis/tests
@@ -28,7 +28,7 @@
     input = 'except04.i'
     expect_err = 'Each previous_turning_point must lie in the range [0.0, 1.0]'
     match_literal = true
-    requirement = 'An error shall be thrown if the hysteretic turning points do not lie in the range [0, 1]'
+    requirement = 'An error shall be thrown if the hysteretic turning points do not lie in the range \[0, 1\]'
     design = 'PorousFlowHysteresisOrder.md'
     issues = '#16021'
   [../]
@@ -37,7 +37,7 @@
     input = 'except05.i'
     expect_err = 'Each previous_turning_point must lie in the range [0.0, 1.0]'
     match_literal = true
-    requirement = 'An error shall be thrown if the hysteretic turning points do not lie in the range [0, 1]'
+    requirement = 'An error shall be thrown if the hysteretic turning points do not lie in the range \[0, 1\]'
     design = 'PorousFlowHysteresisOrder.md'
     issues = '#16021'
   [../]

--- a/modules/porous_flow/test/tests/pressure_pulse/tests
+++ b/modules/porous_flow/test/tests/pressure_pulse/tests
@@ -159,7 +159,7 @@
     csvdiff = 'pressure_pulse_1d_adaptivity_out.csv'
     rel_err = 1.0E-5
     threading = '!pthreads'
-    issues = '#6845 14035'
+    issues = '#6845 #14035'
     design = 'porous_flow/tests/pressure_pulse/pressure_pulse_tests.md'
     requirement = 'PorousFlow shall correctly simulate the transient evolution of a pressure pulse when mesh adaptivity is included'
   [../]

--- a/modules/porous_flow/test/tests/sinks/tests
+++ b/modules/porous_flow/test/tests/sinks/tests
@@ -7,7 +7,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s02]
     type = 'CSVDiff'
@@ -17,7 +17,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, when the source/sink strength is multiplied by the mobility'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s03]
     type = 'CSVDiff'
@@ -27,7 +27,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, unsaturated flow, when the source/sink strength is multiplied by the relative permeability'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s04]
     type = 'CSVDiff'
@@ -37,7 +37,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model source/sink boundary condition for single-phase, single-component flow, when the boundary flux is a piecewise-linear function of porepressure'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s05]
     type = 'CSVDiff'
@@ -47,7 +47,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model source/sink boundary condition for single-phase, single-component flow, when the boundary flux is a half-gaussian function of porepressure'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s06]
     type = 'CSVDiff'
@@ -57,7 +57,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model source/sink boundary condition for single-phase, single-component flow, when the boundary flux is a half-cubic function of porepressure'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s07]
     type = 'CSVDiff'
@@ -67,7 +67,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, multi-component, fully-saturated flow'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s08]
     type = 'CSVDiff'
@@ -77,7 +77,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for multi-phase, multi-component flow'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s09]
     type = CSVDiff
@@ -87,7 +87,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition that holds porepressures fixed and extracts fluid components from boundaries at a rate prescribed by the flow within the model at the boundary - viz, the sink should behave like a free boundary'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s09_fully_saturated]
     type = CSVDiff
@@ -97,7 +97,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition that holds porepressures fixed and extracts fluid components from boundaries at a rate prescribed by the flow within the model at the boundary - viz, the sink should behave like a free boundary, and this feature shall be compatible with the fully-saturated formalism within PorousFlow'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
 
   [./s10_left]
@@ -108,7 +108,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the left-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s10_right]
     type = Exodiff
@@ -118,7 +118,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the right-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s10_top]
     type = Exodiff
@@ -128,7 +128,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the top-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s10_bottom]
     type = Exodiff
@@ -138,7 +138,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the bottom-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s10_front]
     type = Exodiff
@@ -148,7 +148,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the front-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s10_back]
     type = Exodiff
@@ -158,7 +158,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition for single-phase, single-component, fully-saturated flow, and the source/sink shall remove fluid from the correct node in a mesh: the back-side nodes in this case'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./s11]
     type = Exodiff
@@ -246,7 +246,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a free boundary condition for multi-phase, multi-component fluids, and a clear example showing how this is possible shall be given'
     issues = '#7333'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
   [./PorousFlowPiecewiseLinearSink_BC_eg1]
     type = 'CSVDiff'
@@ -255,7 +255,7 @@
     threading = '!pthreads'
     requirement = 'PorousFlow shall be able to model a source/sink boundary condition, and a clear example showing how these boundary conditions can be used to fix porepressures shall be given'
     issues = '#12769'
-    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/doc/tests/sinks.tex'
+    design = 'porous_flow/tests/sinks/sinks_tests.md porous_flow/boundaries.md porous_flow/sinks.md'
   [../]
 
   [./outflow_except1]

--- a/modules/ray_tracing/doc/config.yml
+++ b/modules/ray_tracing/doc/config.yml
@@ -23,4 +23,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/ray_tracing/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            ray_tracing: !include modules/ray_tracing/doc/sqa_ray_tracing.yml

--- a/modules/ray_tracing/doc/content/sqa/index.md
+++ b/modules/ray_tracing/doc/content/sqa/index.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_index.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_index.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_far.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_far.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_far.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_far.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_rtm.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_rtm.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_rtm.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_rtm.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_sdd.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_sdd.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sdd.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_sdd.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_sll.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_sll.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sll.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_sll.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_srs.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_srs.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_srs.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_srs.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_stp.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_stp.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_stp.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_stp.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/content/sqa/ray_tracing_vvr.md
+++ b/modules/ray_tracing/doc/content/sqa/ray_tracing_vvr.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_vvr.md.template app=RayTracingApp category=ray_tracing
+!template load file=sqa/app_vvr.md.template app=Ray Tracing category=ray_tracing

--- a/modules/ray_tracing/doc/sqa_reports.yml
+++ b/modules/ray_tracing/doc/sqa_reports.yml
@@ -8,17 +8,24 @@ Applications:
             - ${MOOSE_DIR}/framework/doc/remove.yml
 
 Documents:
+    software_quality_plan: sqa/inl_records.md#software_quality_plan
+    enterprise_architecture_entry: sqa/inl_records.md#enterprise_architecture_entry
+    safety_software_determination: sqa/inl_records.md#safety_software_determination
+    quality_level_determination: sqa/inl_records.md#quality_level_determination
+    configuration_management_plan: sqa/inl_records.md#configuration_management_plan
+    asset_management_plan: sqa/inl_records.md#asset_management_plan
+    verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
     software_requirements_specification: sqa/ray_tracing_srs.md
     software_design_description: sqa/ray_tracing_sdd.md
     software_test_plan: sqa/ray_tracing_stp.md
     requirements_traceablity_matrix: sqa/ray_tracing_rtm.md
-    verification_validation_plan: sqa/ray_tracing_vvr.md
+    verification_validation_report: sqa/ray_tracing_vvr.md
     failure_analysis_report: sqa/ray_tracing_far.md
     software_library_list: sqa/ray_tracing_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
-    log_default: WARNING
-    show_warning: false
+    log_user_manual: WARNING
+    log_theory_manual: WARNING
 
 Requirements:
     ray_tracing:

--- a/modules/rdg/doc/content/sqa/index.md
+++ b/modules/rdg/doc/content/sqa/index.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_index.md.template app=RdgApp category=rdg
+!template load file=sqa/app_index.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_far.md
+++ b/modules/rdg/doc/content/sqa/rdg_far.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_far.md.template app=RdgApp category=rdg
+!template load file=sqa/app_far.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_rtm.md
+++ b/modules/rdg/doc/content/sqa/rdg_rtm.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_rtm.md.template app=RdgApp category=rdg
+!template load file=sqa/app_rtm.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_sdd.md
+++ b/modules/rdg/doc/content/sqa/rdg_sdd.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sdd.md.template app=RdgApp category=rdg
+!template load file=sqa/app_sdd.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_sll.md
+++ b/modules/rdg/doc/content/sqa/rdg_sll.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sll.md.template app=RdgApp category=rdg
+!template load file=sqa/app_sll.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_srs.md
+++ b/modules/rdg/doc/content/sqa/rdg_srs.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_srs.md.template app=RdgApp category=rdg
+!template load file=sqa/app_srs.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_stp.md
+++ b/modules/rdg/doc/content/sqa/rdg_stp.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_stp.md.template app=RdgApp category=rdg
+!template load file=sqa/app_stp.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/rdg/doc/content/sqa/rdg_vvr.md
+++ b/modules/rdg/doc/content/sqa/rdg_vvr.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_vvr.md.template app=RdgApp category=rdg
+!template load file=sqa/app_vvr.md.template app=Reconstructed Discontinuous Galerkin category=rdg

--- a/modules/reactor/doc/config.yml
+++ b/modules/reactor/doc/config.yml
@@ -19,4 +19,9 @@ Extensions:
         shortcuts: !include framework/doc/globals.yml
     MooseDocs.extensions.acronym:
         acronyms: !include framework/doc/acronyms.yml
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/reactor/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            reactor: !include modules/reactor/doc/sqa_reactor.yml

--- a/modules/reactor/doc/content/modules/reactor/sqa/index.md
+++ b/modules/reactor/doc/content/modules/reactor/sqa/index.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_index.md.template category=reactor app=ReactorApp
+!template load file=sqa/app_index.md.template category=reactor app=Reactor

--- a/modules/reactor/doc/content/modules/reactor/sqa/reactor_far.md
+++ b/modules/reactor/doc/content/modules/reactor/sqa/reactor_far.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_far.md.template category=reactor app=Reactor

--- a/modules/reactor/doc/content/modules/reactor/sqa/reactor_sll.md
+++ b/modules/reactor/doc/content/modules/reactor/sqa/reactor_sll.md
@@ -1,0 +1,1 @@
+!template load file=sqa/app_sll.md.template category=reactor app=Reactor

--- a/modules/reactor/doc/sqa_reactor.yml
+++ b/modules/reactor/doc/sqa_reactor.yml
@@ -2,3 +2,7 @@ directories:
     - ${MOOSE_DIR}/modules/reactor/test/tests
 specs:
     - tests
+dependencies:
+    - framework
+repo: moose
+reports: !include ${MOOSE_DIR}/modules/reactor/doc/sqa_reports.yml

--- a/modules/reactor/doc/sqa_reports.yml
+++ b/modules/reactor/doc/sqa_reports.yml
@@ -18,17 +18,17 @@ Documents:
     configuration_management_plan: sqa/inl_records.md#configuration_management_plan
     asset_management_plan: sqa/inl_records.md#asset_management_plan
     verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
-    log_software_requirements_specification: WARNING
-    log_software_design_description: WARNING
-    log_software_test_plan: WARNING
-    log_requirements_traceablity_matrix: WARNING
-    log_verification_validation_report: WARNING
-    log_failure_analysis_report: WARNING
+    software_requirements_specification: sqa/reactor_srs.md
+    software_design_description: sqa/reactor_sdd.md
+    software_test_plan: sqa/reactor_stp.md
+    requirements_traceablity_matrix: sqa/reactor_rtm.md
+    verification_validation_report: sqa/reactor_vvr.md
+    failure_analysis_report: sqa/reactor_far.md
+    software_library_list: sqa/reactor_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
     log_user_manual: WARNING
     log_theory_manual: WARNING
-    log_software_library_list: WARNING
 
 Requirements:
     reactor:

--- a/modules/thermal_hydraulics/doc/config.yml
+++ b/modules/thermal_hydraulics/doc/config.yml
@@ -61,4 +61,15 @@ Extensions:
             project-name-abbrev: THM
             bin-opt: thermal_hydraulics-opt
             bin-dbg: thermal_hydraulics-dbg
-    MooseDocs.extensions.sqa: disable
+    MooseDocs.extensions.sqa:
+        active: True
+        reports: !include modules/thermal_hydraulics/doc/sqa_reports.yml
+        categories:
+            framework: !include framework/doc/sqa_framework.yml
+            thermal_hydraulics: !include modules/thermal_hydraulics/doc/sqa_thermal_hydraulics.yml
+            fluid_properties: !include modules/fluid_properties/doc/sqa_fluid_properties.yml
+            heat_conduction: !include modules/heat_conduction/doc/sqa_heat_conduction.yml
+            misc: !include modules/misc/doc/sqa_misc.yml
+            navier_stokes: !include modules/navier_stokes/doc/sqa_navier_stokes.yml
+            ray_tracing: !include modules/ray_tracing/doc/sqa_ray_tracing.yml
+            rdg: !include modules/rdg/doc/sqa_rdg.yml

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/index.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/index.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_index.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_index.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_far.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_far.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_far.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_far.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_rtm.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_rtm.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_rtm.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_rtm.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_sdd.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_sdd.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sdd.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_sdd.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_sll.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_sll.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_sll.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_sll.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_srs.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_srs.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_srs.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_srs.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_stp.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_stp.md
@@ -1,2 +1,2 @@
 
-!template load file=sqa/app_stp.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_stp.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_vvr.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/sqa/thermal_hydraulics_vvr.md
@@ -1,1 +1,1 @@
-!template load file=sqa/app_vvr.md.template app=ThermalHydraulicsApp category=thermal_hydraulics
+!template load file=sqa/app_vvr.md.template app=Thermal Hydraulics category=thermal_hydraulics

--- a/modules/thermal_hydraulics/doc/sqa_reports.yml
+++ b/modules/thermal_hydraulics/doc/sqa_reports.yml
@@ -12,17 +12,24 @@ Applications:
         show_warning: false
 
 Documents:
+    software_quality_plan: sqa/inl_records.md#software_quality_plan
+    enterprise_architecture_entry: sqa/inl_records.md#enterprise_architecture_entry
+    safety_software_determination: sqa/inl_records.md#safety_software_determination
+    quality_level_determination: sqa/inl_records.md#quality_level_determination
+    configuration_management_plan: sqa/inl_records.md#configuration_management_plan
+    asset_management_plan: sqa/inl_records.md#asset_management_plan
+    verification_validation_plan: sqa/inl_records.md#verification_and_validation_plan
     software_requirements_specification: sqa/thermal_hydraulics_srs.md
     software_design_description: sqa/thermal_hydraulics_sdd.md
     software_test_plan: sqa/thermal_hydraulics_stp.md
     requirements_traceablity_matrix: sqa/thermal_hydraulics_rtm.md
-    verification_validation_plan: sqa/thermal_hydraulics_vvr.md
+    verification_validation_report: sqa/thermal_hydraulics_vvr.md
     failure_analysis_report: sqa/thermal_hydraulics_far.md
     software_library_list: sqa/thermal_hydraulics_sll.md
     communication_and_contact_information: sqa/framework_cci.md
     software_coding_standards: sqa/framework_scs.md
-    log_default: WARNING
-    show_warning: false
+    log_user_manual: WARNING
+    log_theory_manual: WARNING
 
 Requirements:
     thermal_hydraulics:

--- a/python/MooseDocs/extensions/heading.py
+++ b/python/MooseDocs/extensions/heading.py
@@ -35,11 +35,13 @@ class HeadingExtension(Extension):
 
     def postTokenize(self, page, ast):
         func = lambda n: (n.name == 'Heading')
+        level = 100
         for node in moosetree.iterate(ast.root, func):
             id_ = node.get('id') or node.text('-').lower()
             node['id'] = id_
-            if page['title'] is None:
+            if page['title'] is None or node['level'] < level:
                 page['title'] = node.copy()
+                level = node['level']
             if id_ not in page['headings']:
                 page['headings'][id_] = node.copy()
 

--- a/python/MooseDocs/extensions/include.py
+++ b/python/MooseDocs/extensions/include.py
@@ -36,13 +36,16 @@ class IncludeCommand(command.CommandComponent):
     def defaultSettings():
         settings = command.CommandComponent.defaultSettings()
         settings.update(common.extractContentSettings())
+        settings['optional'] = (False, "Toggle the include as optional when the file doesn't exist.")
         return settings
 
     def createToken(self, parent, info, page, settings):
         """
         Tokenize the included content and create dependency between pages.
         """
-        include_page = self.translator.findPage(info['subcommand'])
+        include_page = self.translator.findPage(info['subcommand'], throw_on_zero=not settings['optional'])
+        if include_page is None and settings['optional']:
+            return parent
         content, line = common.extractContent(self.reader.read(include_page), settings)
 
         self.reader.tokenize(parent, content, page, line=line)


### PR DESCRIPTION
Four things:

- Adding SQA documents and configuration files for delinquent apps.
- Making module SRS, SDD, and RTM templates reference the base template instead of the framework, still including the documentation for the framework version.
- The SLL had an erroneous link text for the dependent SLL's because "References" was treated as the top-level heading. So I changed the extension to use the first level 1 heading for the autolink
- Making some links in the getting_started and help pages so apps can include that content more easily.

Refs #15968
Closes #20434