### PR TITLE
Raise tolerance for wcns test, refs #16809

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/tests
@@ -8,7 +8,7 @@
     method = "!dbg"
     requirement = 'The system shall be able to use realistic fluid properties in a weakly compressible flow simulation'
     ad_indexing_type = 'global'
-    rel_err = 5e-5
+    rel_err = 7e-5
     # The non-linear tolerance is actually fairly tight, but the variable values
     # are small at the no-slip boundary conditions, and this leads to absolute diffs of around 1e-15,
     # triggering the default relative tolerance error criterion


### PR DESCRIPTION
This came up again, at 5.8e-5. I remember cutting it close last time so let's make the same mistake again and cut it at 7e-5 :)

(these diffs are still in the 10^-15 absolute btw)