### PR TITLE
Enable HDF5 download fallback support on Intel macOS

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.03.28" %}
 

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.03.28 build_1
+  - moose-libmesh 2022.03.28 build_2
 
 SHORT_VTK_NAME:
   - 9.1
@@ -14,7 +14,7 @@ moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0 build_6
 
 moose_petsc:
-  - moose-petsc 3.16.5 build_1
+  - moose-petsc 3.16.5 build_2
 
 moose_mpich:
   - moose-mpich 4.0.1 build_1

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -43,6 +43,7 @@ HDF5_DIR=""
 HDF5DIR=""
 HDF5_ROOT=""
 HDF5_STR=""
+HDF5_FORTRAN_STR=""
 
 source $PETSC_DIR/configure_petsc.sh
 configure_petsc \

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -74,11 +74,11 @@ function configure_petsc()
     unset IFS
   fi
 
-  # If HDF5 is not found locally, download it via PETSc (except for Darwin)
+  # If HDF5 is not found locally, download it via PETSc (except on Apple Silicon)
   if [ -z "$HDF5_STR" ]; then
-    if [[ $(uname) == Darwin ]]; then
-      # HDF5 currently doesn't configure properly on macOS due to a gfortran io
-      # buffer bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102992
+    if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]]; then
+      # HDF5 currently doesn't build properly via PETSc download on macOS Apple
+      # Silicon machines due to a build system reconfiguration that is needed.
       # So, we won't be downloading it by default for now if it isn't found.
       # Instead, if a user has it installed somewhere, we'll note the variable
       # they need to set.
@@ -86,6 +86,7 @@ function configure_petsc()
       echo "INFO: Set HDF5_DIR to the location of HDF5 and re-run this script, if desired."
     else
       HDF5_STR="--download-hdf5=1"
+      HDF5_FORTRAN_STR="--download-hdf5-fortran-bindings=0"
       echo "INFO: HDF5 library not detected, opting to download via PETSc..."
     fi
   fi
@@ -94,6 +95,7 @@ function configure_petsc()
   python ./configure --download-hypre=1 \
       --with-shared-libraries=$SHARED \
       "$HDF5_STR" \
+      "$HDF5_FORTRAN_STR" \
       "$MAKE_NP_STR" \
       --with-debugging=no \
       --download-fblaslapack=1 \


### PR DESCRIPTION
[PETSc 3.16 disabled HDF5 fortran bindings by default](https://petsc.org/main/docs/changes/316/), so the gfortran bug in macOS is no longer an issue.

Refs #20033

Tag @roystgnr 
