### PR TITLE
Update libMesh submodule

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 2 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.03.28" %}
+{% set version = "2022.04.07" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.03.28 build_2
+  - moose-libmesh 2022.04.07 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -107,7 +107,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=ec3954e32a5f6b4d71853a8c007896417aebce58
+ARG LIBMESH_REV=c4ce6d1e397bf58401cf12edf1caa9aa61f0f175
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -13,6 +13,7 @@
 #include "libmesh/libmesh_common.h"
 #include "XTermConstants.h"
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -22,6 +23,13 @@ template <typename>
 class NumericVector;
 template <typename>
 class SparseMatrix;
+
+// This was deprecated in libMesh a year ago!  It was obsolete 5 years
+// ago!  How are 6 apps in CI still using it!?
+#ifdef LIBMESH_ENABLE_DEPRECATED
+template <typename T>
+using UniquePtr = std::unique_ptr<T>;
+#endif
 }
 
 using namespace libMesh;

--- a/modules/doc/content/newsletter/2022_04.md
+++ b/modules/doc/content/newsletter/2022_04.md
@@ -9,6 +9,25 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2022.04.07` Update
+
+- Deprecated shims to C++11 features
+  - `libmesh_make_unique` should be replaced by `std::make_unique`
+  - `UniquePtr` should be replaced by `std::unique_ptr`
+  - `std::is_sorted` and `std::iota` alternatives are deprecated
+- Updated many string APIs to take `std::string_view`
+- ExodusII updates
+  - Always get sideset + nodeset data indices
+  - `set_hdf_writing()` is now runtime-configurable
+- Parallel (TIMPI) support for communication and reductions of
+  `NumberArray`, so `ADReal` can now be used with `MPI` in both sparse
+  and non-sparse configurations
+- Assorted warning fixes, bug fixes
+  - Another small memory leak with Exodus attributes is fixed
+  - `MeshFunction::set_subdomain_ids()` now works
+  - TIMPI `Packing` for data types which were failing with large
+    subtypes now communicate correctly
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
Summary of libMesh changes:
  * Free all the attributes we retrieve with ex_get_attributes
  * Deprecate libmesh_make_unique
  * Use string_view, std::move(string) where appropriate.
  * Use C++17 merge where appropriate
  * Remove long-deprecated UniquePtr shim
  * Remove long-deprecated overload MeshTools::find_boundary_nodes()
  * ExodusII: Always get sideset+nodeset data indices
  * More C++17 structured bindings
  * ExodusII set_hdf5_writing(bool) option
  * Deprecate non-std:: is_sorted, iota
  * Modern C++ parameter passing
  * Fix clang warnings
  * Fix MeshFunction::set_subdomain_ids()

TIMPI submodule changes:
  * Append to user $LIBS, don't override $LIBS
  * Fixes for Packing<> bug w/ large nested data types, inc. ADReal

MetaPhysicL changes:
  * Parallel (TIMPI) support for NumberArray
  * Fixes for configure with strict compiler options
  * Fixes in some unit tests

Some seriously important bugfixes here; the only thing that might be
newsletter worthy is that communication and reduction operations on
ADReal ought to be working smoothly now.