### PR TITLE
A small fix for creating multiple subapps of a MultiApp

### DIFF
--- a/framework/src/actions/CheckLegacyParamsAction.C
+++ b/framework/src/actions/CheckLegacyParamsAction.C
@@ -28,6 +28,11 @@ CheckLegacyParamsAction::CheckLegacyParamsAction(InputParameters params) : Actio
 void
 CheckLegacyParamsAction::act()
 {
+  // no need to do the check for sub-apps other than the zero-th of a MultiApp
+  // which helps when a MultiApp spawns lots of sub-apps.
+  if (_app.multiAppNumber() > 0)
+    return;
+
   // Not a big fan of testing objects within the object itself... but this is a temp object
   // and this is the easiest way to do it. MooseTestApp uses this parameter for the test
   const bool for_test = _app.parameters().have_parameter<bool>("test_check_legacy_params") &&


### PR DESCRIPTION
This almost remove the time spent in this action of checking legacy params in #20657. The CPU time for setting up in my case drops from 8min 58sec to 5min 36sec. Note that this is only part of the fix for #20657. Also this fix is temporary and should be gone all together with this action in the future.