### PR TITLE
Do depth-first-search with new edge for cycle catching

### DIFF
--- a/framework/include/utils/DependencyResolver.h
+++ b/framework/include/utils/DependencyResolver.h
@@ -142,7 +142,6 @@ public:
   };
 
 private:
-  bool isCyclic();
   bool depthFirstSearch(const T & node);
 
   /**
@@ -283,20 +282,6 @@ DependencyResolver<T>::depthFirstSearch(const T & root)
   }
 
   root_color_it->second = BLACK;
-
-  return false;
-}
-
-template <typename T>
-bool
-DependencyResolver<T>::isCyclic()
-{
-  for (auto & pr : _colors)
-    pr.second = WHITE;
-
-  for (auto & [key, color] : _colors)
-    if (color == WHITE && depthFirstSearch(key))
-      return true;
 
   return false;
 }


### PR DESCRIPTION
Per #20657 the dependency resolver is very slow when inserting new dependencies. In one of @jortensi's inputs I saw over 100 seconds spent in `RattlesnakeApp::addActionTasks`. With this change we do a depth-first search based on the new key we're adding in the model of https://www.geeksforgeeks.org/detect-cycle-direct-graph-using-colors/. This reduces the time spent in that method to .12 seconds.