### PR TITLE
Use std::make_unique, not libmesh_make_unique

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1214,7 +1214,7 @@ MooseApp::addExecutorParams(const std::string & type,
                             const std::string & name,
                             const InputParameters & params)
 {
-  _executor_params[name] = std::make_pair(type, libmesh_make_unique<InputParameters>(params));
+  _executor_params[name] = std::make_pair(type, std::make_unique<InputParameters>(params));
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -540,9 +540,9 @@ FEProblemBase::getEvaluableElementRange()
       const auto & sys = _eq.get_system(i);
       dof_maps[i] = &sys.get_dof_map();
     }
-    _evaluable_local_elem_range = std::make_unique<ConstElemRange>(
-        _mesh.getMesh().multi_evaluable_elements_begin(dof_maps),
-        _mesh.getMesh().multi_evaluable_elements_end(dof_maps));
+    _evaluable_local_elem_range =
+        std::make_unique<ConstElemRange>(_mesh.getMesh().multi_evaluable_elements_begin(dof_maps),
+                                         _mesh.getMesh().multi_evaluable_elements_end(dof_maps));
   }
   return *_evaluable_local_elem_range;
 }

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -540,7 +540,7 @@ FEProblemBase::getEvaluableElementRange()
       const auto & sys = _eq.get_system(i);
       dof_maps[i] = &sys.get_dof_map();
     }
-    _evaluable_local_elem_range = libmesh_make_unique<ConstElemRange>(
+    _evaluable_local_elem_range = std::make_unique<ConstElemRange>(
         _mesh.getMesh().multi_evaluable_elements_begin(dof_maps),
         _mesh.getMesh().multi_evaluable_elements_end(dof_maps));
   }
@@ -552,8 +552,8 @@ FEProblemBase::getNonlinearEvaluableElementRange()
 {
   if (!_nl_evaluable_local_elem_range)
     _nl_evaluable_local_elem_range =
-        libmesh_make_unique<ConstElemRange>(_mesh.getMesh().evaluable_elements_begin(_nl->dofMap()),
-                                            _mesh.getMesh().evaluable_elements_end(_nl->dofMap()));
+        std::make_unique<ConstElemRange>(_mesh.getMesh().evaluable_elements_begin(_nl->dofMap()),
+                                         _mesh.getMesh().evaluable_elements_end(_nl->dofMap()));
   return *_nl_evaluable_local_elem_range;
 }
 

--- a/modules/thermal_hydraulics/src/base/THMMesh.C
+++ b/modules/thermal_hydraulics/src/base/THMMesh.C
@@ -62,7 +62,7 @@ THMMesh::effectiveSpatialDimension() const
 std::unique_ptr<MooseMesh>
 THMMesh::safeClone() const
 {
-  return libmesh_make_unique<THMMesh>(*this);
+  return std::make_unique<THMMesh>(*this);
 }
 
 void

--- a/modules/thermal_hydraulics/src/controls/ParsedFunctionControl.C
+++ b/modules/thermal_hydraulics/src/controls/ParsedFunctionControl.C
@@ -40,7 +40,7 @@ ParsedFunctionControl::buildFunction()
     if (isParamValid("_tid"))
       tid = getParam<THREAD_ID>("_tid");
 
-    _function_ptr = libmesh_make_unique<THMParsedFunctionWrapper>(
+    _function_ptr = std::make_unique<THMParsedFunctionWrapper>(
         *_sim, _pfb_feproblem, _function, _vars, _vals, tid);
   }
 }

--- a/modules/thermal_hydraulics/src/controls/UnitTripControl.C
+++ b/modules/thermal_hydraulics/src/controls/UnitTripControl.C
@@ -47,7 +47,7 @@ UnitTripControl::buildConditionFunction()
     if (isParamValid("_tid"))
       tid = getParam<THREAD_ID>("_tid");
 
-    _condition_ptr = libmesh_make_unique<THMParsedFunctionWrapper>(
+    _condition_ptr = std::make_unique<THMParsedFunctionWrapper>(
         *_sim, _pfb_feproblem, _condition, _vars, _vals, tid);
   }
 }

--- a/modules/thermal_hydraulics/src/functions/THMParsedFunctionWrapper.C
+++ b/modules/thermal_hydraulics/src/functions/THMParsedFunctionWrapper.C
@@ -29,8 +29,8 @@ THMParsedFunctionWrapper::THMParsedFunctionWrapper(Simulation & sim,
 {
   initialize();
 
-  _function_ptr = std::make_unique<ParsedFunction<Real, RealGradient>>(
-      _function_str, &_vars, &_initial_vals);
+  _function_ptr =
+      std::make_unique<ParsedFunction<Real, RealGradient>>(_function_str, &_vars, &_initial_vals);
 
   for (auto & v : _vars)
     _addr.push_back(&_function_ptr->getVarAddress(v));

--- a/modules/thermal_hydraulics/src/functions/THMParsedFunctionWrapper.C
+++ b/modules/thermal_hydraulics/src/functions/THMParsedFunctionWrapper.C
@@ -29,7 +29,7 @@ THMParsedFunctionWrapper::THMParsedFunctionWrapper(Simulation & sim,
 {
   initialize();
 
-  _function_ptr = libmesh_make_unique<ParsedFunction<Real, RealGradient>>(
+  _function_ptr = std::make_unique<ParsedFunction<Real, RealGradient>>(
       _function_str, &_vars, &_initial_vals);
 
   for (auto & v : _vars)

--- a/test/src/materials/LinearInterpolationMaterial.C
+++ b/test/src/materials/LinearInterpolationMaterial.C
@@ -40,9 +40,9 @@ LinearInterpolationMaterial::LinearInterpolationMaterial(const InputParameters &
 {
   if (_use_poly_fit)
   {
-    _poly_fit = libmesh_make_unique<PolynomialFit>(getParam<std::vector<Real>>("independent_vals"),
-                                                   getParam<std::vector<Real>>("dependent_vals"),
-                                                   4);
+    _poly_fit = std::make_unique<PolynomialFit>(getParam<std::vector<Real>>("independent_vals"),
+                                                getParam<std::vector<Real>>("dependent_vals"),
+                                                4);
 
     _poly_fit->generate();
   }
@@ -52,8 +52,8 @@ LinearInterpolationMaterial::LinearInterpolationMaterial(const InputParameters &
     {
 
       _linear_interp =
-          libmesh_make_unique<LinearInterpolation>(getParam<std::vector<Real>>("independent_vals"),
-                                                   getParam<std::vector<Real>>("dependent_vals"));
+          std::make_unique<LinearInterpolation>(getParam<std::vector<Real>>("independent_vals"),
+                                                getParam<std::vector<Real>>("dependent_vals"));
     }
     catch (std::domain_error & e)
     {

--- a/test/src/partitioner/PartitionerWeightTest.C
+++ b/test/src/partitioner/PartitionerWeightTest.C
@@ -31,7 +31,7 @@ PartitionerWeightTest::PartitionerWeightTest(const InputParameters & params)
 std::unique_ptr<Partitioner>
 PartitionerWeightTest::clone() const
 {
-  return libmesh_make_unique<PartitionerWeightTest>(_pars);
+  return std::make_unique<PartitionerWeightTest>(_pars);
 }
 
 dof_id_type

--- a/unit/include/ParsedFunctionTest.h
+++ b/unit/include/ParsedFunctionTest.h
@@ -38,7 +38,7 @@ protected:
     mesh_params.set<unsigned int>("nz") = 2;
     mesh_params.set<MooseEnum>("parallel_type") = "REPLICATED";
 
-    _mesh = libmesh_make_unique<GeneratedMesh>(mesh_params);
+    _mesh = std::make_unique<GeneratedMesh>(mesh_params);
     _mesh->setMeshBase(_mesh->buildMeshBaseObject());
     _mesh->buildMesh();
 
@@ -46,7 +46,7 @@ protected:
     problem_params.set<MooseMesh *>("mesh") = _mesh.get();
     problem_params.set<std::string>("_object_name") = "FEProblem";
     problem_params.set<std::string>("_type") = "FEProblem";
-    _fe_problem = libmesh_make_unique<FEProblem>(problem_params);
+    _fe_problem = std::make_unique<FEProblem>(problem_params);
   }
 
   ParsedFunction<Real> * fptr(MooseParsedFunction & f)


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
`libmesh_make_unique` was originally a shim for older compilers; it has long since become unnecessary and has recently become deprecated.

## Design
`std::make_unique` is a drop-in-replacement

## Impact
No API changes

Refs #13921


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
