### PR TITLE
Default non-HDF5 Exodus output even w/HDF5 enabled

### DIFF
--- a/framework/include/outputs/Exodus.h
+++ b/framework/include/outputs/Exodus.h
@@ -191,4 +191,7 @@ private:
 
   /// Flag to output discontinuous format in Exodus
   bool _discontinuous;
+
+  /// Flag to output HDF5 format (when available) in Exodus
+  bool _write_hdf5;
 };

--- a/framework/src/actions/MeshOnlyAction.C
+++ b/framework/src/actions/MeshOnlyAction.C
@@ -71,6 +71,9 @@ MeshOnlyAction::act()
 
     Exodus::setOutputDimensionInExodusWriter(exio, *mesh_ptr);
 
+    // Default to non-HDF5 output for wider compatibility
+    exio.set_hdf5_writing(false);
+
     exio.write(mesh_file);
   }
   else if (mesh_file.find(".cpr") + 4 == mesh_file.size())

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -723,6 +723,10 @@ AutomaticMortarGeneration::buildMortarSegmentMesh()
   if (_debug)
   {
     ExodusII_IO mortar_segment_mesh_writer(*_mortar_segment_mesh);
+
+    // Default to non-HDF5 output for wider compatibility
+    mortar_segment_mesh_writer.set_hdf5_writing(false);
+
     mortar_segment_mesh_writer.write("mortar_segment_mesh.e");
   }
 
@@ -1140,6 +1144,10 @@ AutomaticMortarGeneration::buildMortarSegmentMesh3d()
         msm_el->subdomain_id()++;
 
     ExodusII_IO mortar_segment_mesh_writer(*_mortar_segment_mesh);
+
+    // Default to non-HDF5 output for wider compatibility
+    mortar_segment_mesh_writer.set_hdf5_writing(false);
+
     mortar_segment_mesh_writer.write("mortar_segment_mesh.e");
 
     // Undo increment
@@ -2192,8 +2200,15 @@ AutomaticMortarGeneration::writeGeometryToFile()
   _nodal_normals_system->solution->close();
 
   std::set<std::string> sys_names = {"nodal_geometry"};
+
   // Write the nodal normals to file
-  ExodusII_IO(_mesh).write_equation_systems("nodal_geometry_only.e", nodal_normals_es, &sys_names);
+  ExodusII_IO nodal_normals_writer(_mesh);
+
+  // Default to non-HDF5 output for wider compatibility
+  nodal_normals_writer.set_hdf5_writing(false);
+
+  nodal_normals_writer.write_equation_systems(
+      "nodal_geometry_only.e", nodal_normals_es, &sys_names);
 }
 
 std::vector<AutomaticMortarGeneration::MortarFilterIter>

--- a/framework/src/outputs/Exodus.C
+++ b/framework/src/outputs/Exodus.C
@@ -19,6 +19,7 @@
 #include "LockFile.h"
 
 #include "libmesh/exodusII_io.h"
+#include "libmesh/libmesh_config.h" // LIBMESH_HAVE_HDF5
 
 registerMooseObject("MooseApp", Exodus);
 
@@ -69,6 +70,14 @@ Exodus::validParams()
   params.addParam<bool>(
       "discontinuous", false, "Enables discontinuous output format for Exodus files.");
 
+  // Flag for outputting Exodus data in HDF5 format (when libMesh is
+  // configured with HDF5 support).  libMesh wants to do so by default
+  // (for backwards compatibility with libMesh HDF5 users), but we
+  // want to avoid this by default (for backwards compatibility with
+  // most Moose users and to avoid generating regression test gold
+  // files that non-HDF5 Moose builds can't read)
+  params.addParam<bool>("write_hdf5", false, "Enables HDF5 output format for Exodus files.");
+
   // Need a layer of geometric ghosting for mesh serialization
   params.addRelationshipManager("MooseGhostPointNeighbors",
                                 Moose::RelationshipManagerType::GEOMETRIC);
@@ -88,7 +97,8 @@ Exodus::Exodus(const InputParameters & parameters)
                                        : false),
     _overwrite(getParam<bool>("overwrite")),
     _output_dimension(getParam<MooseEnum>("output_dimension").getEnum<OutputDimension>()),
-    _discontinuous(getParam<bool>("discontinuous"))
+    _discontinuous(getParam<bool>("discontinuous")),
+    _write_hdf5(getParam<bool>("write_hdf5"))
 {
   if (isParamValid("use_problem_dimension"))
   {
@@ -199,6 +209,20 @@ Exodus::outputSetup()
   // Create the ExodusII_IO object
   _exodus_io_ptr = std::make_unique<ExodusII_IO>(_es_ptr->get_mesh());
   _exodus_initialized = false;
+
+  if (_write_hdf5)
+  {
+#ifndef LIBMESH_HAVE_HDF5
+    mooseError("Moose input requested HDF Exodus output, but libMesh was built without HDF5.");
+#endif
+
+    // This is redundant unless the libMesh default changes
+    _exodus_io_ptr->set_hdf5_writing(true);
+  }
+  else
+  {
+    _exodus_io_ptr->set_hdf5_writing(false);
+  }
 
   // Increment file number and set appending status, append if all the following conditions are met:
   //   (1) If the application is recovering (not restarting)

--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -51,8 +51,13 @@ class RunParallel(Scheduler):
             job_output = job.getOutput()
             output = tester.processResults(tester.getMooseDir(), self.options, job_output)
 
+            # If the tester requested to be skipped at the last minute, report that.
+            if tester.isSkip():
+                output += '\n' + "#"*80 + '\nTester skipped, reason: ' + tester.getStatusMessage() + '\n'
+            elif tester.isFail():
+                output += '\n' + "#"*80 + '\nTester failed, reason: ' + tester.getStatusMessage() + '\n'
             # If the tester has not yet failed, append additional information to output
-            if not tester.isFail():
+            else:
                 # Read the output either from the temporary file or redirected files
                 if tester.hasRedirectedOutput(self.options):
                     redirected_output = util.getOutputFromFiles(tester, self.options)
@@ -64,8 +69,6 @@ class RunParallel(Scheduler):
                         output += '\n' + "#"*80 + '\nTester failed, reason: ' + tester.getStatusMessage() + '\n'
 
                 self.setSuccessfulMessage(tester)
-            else:
-                output += '\n' + "#"*80 + '\nTester failed, reason: ' + tester.getStatusMessage() + '\n'
         except Exception as e:
             output += 'Python exception encountered:\n\n' + traceback.format_exc()
             tester.setStatus(tester.error, 'PYTHON EXCEPTION')

--- a/python/TestHarness/testers/RunCommand.py
+++ b/python/TestHarness/testers/RunCommand.py
@@ -27,7 +27,9 @@ class RunCommand(Tester):
         return self.command
 
     def processResults(self, moose_dir, options, output):
-        if self.exit_code != 0 :
+        if self.exit_code == 77 :
+            self.setStatus(self.skip)
+        elif self.exit_code != 0 :
             self.setStatus(self.fail, 'CODE %d' % self.exit_code)
 
         return output

--- a/test/tests/outputs/exodus/tests
+++ b/test/tests/outputs/exodus/tests
@@ -9,6 +9,16 @@
     requirement = "The system shall support ExodusII output."
   [../]
 
+  [./hdf5]
+    type = 'RunCommand'
+    prereq = 'basic'
+    command = 'if ! type h5dump >/dev/null 2>&1; then return 77; fi;
+               if h5dump exodus_out.e >/dev/null 2>&1; then return 1; fi;
+               return 0'
+
+    requirement = "The system ExodusII output shall not use HDF5 unless requested."
+  [../]
+
   [./input]
     # Moose runs with the output_input = true
     # \TODO Find a method for comparing files with and without information records

--- a/test/tests/outputs/exodus/tests
+++ b/test/tests/outputs/exodus/tests
@@ -12,9 +12,9 @@
   [./hdf5]
     type = 'RunCommand'
     prereq = 'basic'
-    command = 'if ! type h5dump >/dev/null 2>&1; then return 77; fi;
-               if h5dump exodus_out.e >/dev/null 2>&1; then return 1; fi;
-               return 0'
+    command = 'if ! type h5dump >/dev/null 2>&1; then echo "Could not run h5dump to test for HDF5"; exit 77; fi;
+               if h5dump exodus_out.e >/dev/null 2>&1; then echo "h5dump found HDF5 where it should not be"; exit 1; fi;
+               exit 0'
 
     requirement = "The system ExodusII output shall not use HDF5 unless requested."
   [../]


### PR DESCRIPTION
## Reason
Current Moose builds with HDF5 are a "roach motel" - you can check in (a new Exodus file) any time you like, but you can never leave (because you just unwittingly wrote an HDF5 file and now it won't work with non-HDF5 Moose builds).

## Design
The Moose Exodus class now has a "write_hdf5" parameter, defaulting to false, determining whether HDF5 should be written instead of old NetCDF3.

## Impact
Users who really want to write HDF5 output will now have to set this parameter.  (there may not be any of those - we really wanted *read* support for HDF5 but we don't yet have IGA Exodus *output* so there's no obvious use case for *write* support)

Refs #20033

Pinging @loganharbour and @cticenhour; sorry for the delay with this.