### PR TITLE
Use conda-forge parallel HDF5 and use Qt/Python within moose-libmesh-vtk

### DIFF
--- a/conda/libmesh-vtk/build.sh
+++ b/conda/libmesh-vtk/build.sh
@@ -9,6 +9,14 @@ if [[ $mpi == "openmpi" ]]; then
 elif [[ $mpi == "moose-mpich" ]]; then
   export HYDRA_LAUNCHER=fork
 fi
+
+# Qt is enabled in VTK by default, but currently doesn't exist on M1 Macs.
+# So, it is disabled if building on that platform.
+QT="YES"
+if [[ $(uname) == Darwin ]] && [[ $(uname -p) == arm ]]; then
+  QT="NO"
+fi
+
 export CC=mpicc CXX=mpicxx
 mkdir -p build
 cd build
@@ -19,23 +27,35 @@ cmake .. -G "Ninja" \
     -DCMAKE_PREFIX_PATH:PATH=${VTK_PREFIX} \
     -DCMAKE_INSTALL_PREFIX:PATH=${VTK_PREFIX} \
     -DCMAKE_INSTALL_RPATH:PATH=${VTK_PREFIX}/lib \
+    -DCMAKE_INSTALL_LIBDIR=lib \
     -DVTK_BUILD_DOCUMENTATION:BOOL=OFF \
     -DVTK_BUILD_TESTING:BOOL=OFF \
     -DVTK_BUILD_EXAMPLES:BOOL=OFF \
     -DBUILD_SHARED_LIBS:BOOL=ON \
     -DVTK_USE_MPI:BOOL=ON \
-    -DVTK_GROUP_ENABLE_Rendering:STRING=DONT_WANT \
-    -DVTK_GROUP_ENABLE_Qt::STRING=NO \
+    -DVTK_WRAP_PYTHON:BOOL=ON \
+    -DVTK_GROUP_ENABLE_Rendering:STRING=YES \
+    -DVTK_GROUP_ENABLE_Qt::STRING=${QT} \
     -DVTK_GROUP_ENABLE_Views:STRING=NO \
     -DVTK_GROUP_ENABLE_Web:STRING=NO \
     -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}
 
 ninja install -v -j ${MOOSE_JOBS:-2}
 
-# VTK 9.1 now places libs in lib64 when installed on linux, linking to the "expected" location of lib
-if [[ $(uname) == Linux ]]; then
-    ln -s ${VTK_PREFIX}/lib64 ${VTK_PREFIX}/lib
-fi
+# Create a symlink between the VTK python module/deps and conda python
+VTK_SP_DIR=${VTK_PREFIX}/lib/python3.*/site-packages
+ln -s ${VTK_SP_DIR}/vtk.py ${SP_DIR}/vtk.py
+ln -s ${VTK_SP_DIR}/vtkmodules ${SP_DIR}/vtkmodules
+ln -s ${VTK_SP_DIR}/mpi4py ${SP_DIR}/mpi4py
+
+# In case pkg_resources needs to be able to find VTK
+cat > $SP_DIR/vtk-$PKG_VERSION.egg-info <<FAKE_EGG
+Metadata-Version: 2.1
+Name: vtk
+Version: $PKG_VERSION
+Summary: VTK is an open-source toolkit for 3D computer graphics, image processing, and visualization
+Platform: UNKNOWN
+FAKE_EGG
 
 # Set VTK environment variables for those that need it
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 6 %}
+{% set build = 7 %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,6 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
 {% set build = 6 %}
-{% set strbuild = "build_" + build|string %}
 {% set vtk_version = "9.1.0" %}
 {% set friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}
@@ -15,7 +14,6 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ strbuild }}
   skip: true  # [win]
   script_env:
     - MOOSE_JOBS
@@ -23,6 +21,8 @@ build:
 requirements:
   build:
     - {{ moose_mpich }}
+    - {{ moose_python }}
+    - {{ moose_pyqt }}         # [not arm64]
     - cmake
     - ninja
     - {{ moose_libglu }}       # [linux]
@@ -37,6 +37,8 @@ requirements:
 
   run:
     - {{ moose_mpich }}
+    - {{ moose_python }}
+    - {{ moose_pyqt }}         # [not arm64]
     - {{ moose_libglu }}       # [linux]
     - {{ moose_mesalib }}      # [linux]
     - {{ moose_libxt }}        # [linux]
@@ -51,6 +53,9 @@ test:
   commands:
     - test -f $PREFIX/libmesh-vtk/lib/libvtkCommonCore-{{ friendly_version }}.dylib # [osx]
     - test -f $PREFIX/libmesh-vtk/lib/libvtkCommonCore-{{ friendly_version }}.so    # [linux]
+  imports:
+    - PyQt5  # [not arm64]
+    - vtk
 
 about:
   home: http://www.vtk.org/

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.04.07" %}
 

--- a/conda/mpich/build.sh
+++ b/conda/mpich/build.sh
@@ -13,8 +13,8 @@ ACTIVATION_CXXFLAGS=${TEMP_CXXFLAGS%%-fdebug-prefix-map*}-std=c++17
 # Set MPICH environment variables for those that need it, and set CXXFLAGS using our ACTIVATION_CXXFLAGS variable
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
-export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 C_INCLUDE_PATH=${PREFIX}/include MOOSE_NO_CODESIGN=true MPIHOME=${PREFIX} CXXFLAGS="$ACTIVATION_CXXFLAGS"
+export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77 C_INCLUDE_PATH=${PREFIX}/include MOOSE_NO_CODESIGN=true MPIHOME=${PREFIX} CXXFLAGS="$ACTIVATION_CXXFLAGS" HDF5_DIR=${PREFIX}
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
-unset CC CXX FC F90 F77 C_INCLUDE_PATH MOOSE_NO_CODESIGN MPIHOME CXXFLAGS
+unset CC CXX FC F90 F77 C_INCLUDE_PATH MOOSE_NO_CODESIGN MPIHOME CXXFLAGS HDF5_DIR
 EOF

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.04.07 build_0
+  - moose-libmesh 2022.04.07 build_1
 
 SHORT_VTK_NAME:
   - 9.1
@@ -14,10 +14,10 @@ moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0
 
 moose_petsc:
-  - moose-petsc 3.16.5 build_2
+  - moose-petsc 3.16.5 build_3
 
 moose_mpich:
-  - moose-mpich 4.0.1 build_1
+  - moose-mpich 4.0.1 build_2
 
 #### MOOSE_TOOLS stuff (order is important, must match python version order)
 moose_python:

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -24,17 +24,14 @@ moose_python:
   - python 3.9
   - python 3.8
   - python 3.7                                             # [not arm64]
-  - python 3.6                                             # [not arm64]
 
 moose_vtk:
   - vtk 9.1.0 qt_py39h5247bde_203                          # [not arm64 and osx]
   - vtk 9.1.0 qt_py38hf8e4d4e_203                          # [not arm64 and osx]
   - vtk 9.1.0 qt_py37hd791b3b_203                          # [not arm64 and osx]
-  - vtk 9.0.3 no_osmesa_py36h79fd37d_104                   # [not arm64 and osx]
   - vtk 9.0.3 no_osmesa_py39h801044d_100                   # [linux]
   - vtk 9.0.3 no_osmesa_py38h3850a3d_100                   # [linux]
   - vtk 9.0.3 no_osmesa_py37h7b56ff3_100                   # [linux]
-  - vtk 9.0.3 no_osmesa_py36hfa3a401_100                   # [linux]
   - vtk 9.0.3 no_osmesa_py39h8e4790f_105                   # [arm64]
   - vtk 9.0.3 no_osmesa_py38hb8cbb7a_105                   # [arm64]
 
@@ -42,11 +39,9 @@ moose_numpy:
   - numpy 1.22.1 py39h9d9ce41_0                            # [not arm64 and osx]
   - numpy 1.22.1 py38h9d72dae_0                            # [not arm64 and osx]
   - numpy 1.21.5 py37h3c8089f_0                            # [not arm64 and osx]
-  - numpy 1.19.5 py36h08b5fde_2                            # [not arm64 and osx]
   - numpy 1.21.1 py39hdbf815f_0                            # [linux]
   - numpy 1.21.1 py38h9894fe3_0                            # [linux]
   - numpy 1.21.1 py37h038b26d_0                            # [linux]
-  - numpy 1.19.5 py36hfc0c790_2                            # [linux]
   - numpy 1.21.3 py39h1f3b974_0                            # [arm64]
   - numpy 1.21.3 py38hbf7bb01_0                            # [arm64]
 
@@ -54,21 +49,17 @@ moose_pyqt:                                                # [not arm64]
   - pyqt 5.12.3 py39h6e9494a_8                             # [not arm64 and osx]
   - pyqt 5.12.3 py38h50d1736_8                             # [not arm64 and osx]
   - pyqt 5.12.3 py37hf985489_8                             # [not arm64 and osx]
-  - pyqt 5.12.3 py36h79c6626_7                             # [not arm64 and osx]
   - pyqt 5.12.3 py39hf3d152e_7                             # [linux]
   - pyqt 5.12.3 py38h578d9bd_7                             # [linux]
   - pyqt 5.12.3 py37h89c1867_7                             # [linux]
-  - pyqt 5.12.3 py36h5fab9bb_7                             # [linux]
 
 moose_matplotlib:
   - matplotlib 3.5.1 py39h6e9494a_0                        # [not arm64 and osx]
   - matplotlib 3.5.1 py38h50d1736_0                        # [not arm64 and osx]
   - matplotlib 3.5.1 py37hf985489_0                        # [not arm64 and osx]
-  - matplotlib 3.3.4 py36h79c6626_0                        # [not arm64 and osx]
   - matplotlib 3.4.2 py39hf3d152e_0                        # [linux]
   - matplotlib 3.4.2 py38h578d9bd_0                        # [linux]
   - matplotlib 3.4.2 py37h89c1867_0                        # [linux]
-  - matplotlib 3.3.4 py36h5fab9bb_0                        # [linux]
   - matplotlib 3.4.3 py39hdf13c20_0                        # [arm64]
   - matplotlib 3.4.3 py38h150bfb4_0                        # [arm64]
 
@@ -76,11 +67,9 @@ moose_pandas:
   - pandas 1.4.0 py39h4d6be9b_0                             # [not arm64 and osx]
   - pandas 1.4.0 py38ha53d530_0                             # [not arm64 and osx]
   - pandas 1.3.5 py37h5b83a90_0                             # [not arm64 and osx]
-  - pandas 1.1.5 py36h2be6da3_0                             # [not arm64 and osx]
   - pandas 1.3.1 py39hde0f152_0                             # [linux]
   - pandas 1.3.1 py38h1abd341_0                             # [linux]
   - pandas 1.3.1 py37h219a48f_0                             # [linux]
-  - pandas 1.1.5 py36h284efc9_0                             # [linux]
   - pandas 1.3.4 py39h7f752ed_0                             # [arm64]
   - pandas 1.3.4 py38h3777fb4_0                             # [arm64]
 
@@ -88,11 +77,9 @@ moose_pyyaml:
   - pyyaml 6.0 py39h89e85a6_3                               # [not arm64 and osx]
   - pyyaml 6.0 py38h96a0964_3                               # [not arm64 and osx]
   - pyyaml 6.0 py37h271585c_3                               # [not arm64 and osx]
-  - pyyaml 5.4.1 py36hfa26744_1                             # [not arm64 and osx]
   - pyyaml 5.4.1 py39h3811e60_0                             # [linux]
   - pyyaml 5.4.1 py38h497a2fe_0                             # [linux]
   - pyyaml 5.4.1 py37h5e8e339_0                             # [linux]
-  - pyyaml 5.4.1 py36h8f6f2f9_0                             # [linux]
   - pyyaml 6.0 py39h5161555_0                               # [arm64]
   - pyyaml 6.0 py38hea4295b_0                               # [arm64]
 
@@ -100,11 +87,9 @@ moose_pybtex:
   - pybtex 0.24.0 pyhd8ed1ab_2                              # [not arm64 and osx]
   - pybtex 0.24.0 pyhd8ed1ab_2                              # [not arm64 and osx]
   - pybtex 0.24.0 pyhd8ed1ab_2                              # [not arm64 and osx]
-  - pybtex 0.24.0 pyhd8ed1ab_2                              # [not arm64 and osx]
   - pybtex 0.24.0 py39hf3d152e_0                            # [linux]
   - pybtex 0.24.0 py38h578d9bd_0                            # [linux]
   - pybtex 0.24.0 py37h89c1867_0                            # [linux]
-  - pybtex 0.24.0 py36h5fab9bb_0                            # [linux]
   - pybtex 0.24.0 py39h2804cbe_0                            # [arm64]
   - pybtex 0.24.0 py38h10201cd_0                            # [arm64]
 
@@ -112,11 +97,9 @@ moose_mock:
   - mock 4.0.3 py39h6e9494a_2                               # [not arm64 and osx]
   - mock 4.0.3 py38h50d1736_2                               # [not arm64 and osx]
   - mock 4.0.3 py37hf985489_2                               # [not arm64 and osx]
-  - mock 4.0.3 py36h79c6626_1                               # [not arm64 and osx]
   - mock 4.0.3 py39hf3d152e_1                               # [linux]
   - mock 4.0.3 py38h578d9bd_1                               # [linux]
   - mock 4.0.3 py37h89c1867_1                               # [linux]
-  - mock 4.0.3 py36h5fab9bb_1                               # [linux]
   - mock 4.0.3 py39h2804cbe_1                               # [arm64]
   - mock 4.0.3 py38h10201cd_1                               # [arm64]
 
@@ -124,11 +107,9 @@ moose_lxml:
   - lxml 4.7.1 py39hf41e7f8_0                               # [not arm64 and osx]
   - lxml 4.7.1 py38h6ea4786_0                               # [not arm64 and osx]
   - lxml 4.6.3 py37h250624f_0                               # [not arm64 and osx]
-  - lxml 4.6.3 py36habcf893_0                               # [not arm64 and osx]
   - lxml 4.6.3 py39h107f48f_0                               # [linux]
   - lxml 4.6.3 py38hf1fe3a4_0                               # [linux]
   - lxml 4.6.3 py37h77fd288_0                               # [linux]
-  - lxml 4.6.3 py36h04a5ba7_0                               # [linux]
   - lxml 4.6.3 py39h3757d6e_0                               # [arm64]
   - lxml 4.6.3 py38hd4105a3_0                               # [arm64]
 
@@ -136,11 +117,9 @@ moose_scikit_image:
   - scikit-image 0.19.1 py39h4d6be9b_0                      # [not arm64 and osx]
   - scikit-image 0.19.1 py38ha53d530_0                      # [not arm64 and osx]
   - scikit-image 0.19.1 py37h5b83a90_0                      # [not arm64 and osx]
-  - scikit-image 0.17.2 py36h2be6da3_4                      # [not arm64 and osx]
   - scikit-image 0.18.2 py39hde0f152_0                      # [linux]
   - scikit-image 0.18.2 py38h1abd341_0                      # [linux]
   - scikit-image 0.18.2 py37h219a48f_0                      # [linux]
-  - scikit-image 0.17.2 py36h284efc9_4                      # [linux]
   - scikit-image 0.18.3 py39h7f752ed_0                      # [arm64]
   - scikit-image 0.18.3 py38h3777fb4_0                      # [arm64]
 
@@ -148,11 +127,9 @@ moose_sympy:
   - sympy 1.9 py39h6e9494a_1                                # [not arm64 and osx]
   - sympy 1.9 py38h50d1736_1                                # [not arm64 and osx]
   - sympy 1.9 py37hf985489_0                                # [not arm64 and osx]
-  - sympy 1.8 py36h79c6626_0                                # [not arm64 and osx]
   - sympy 1.9 py39hf3d152e_0                                # [linux]
   - sympy 1.9 py38h578d9bd_0                                # [linux]
   - sympy 1.9 py37h89c1867_0                                # [linux]
-  - sympy 1.8 py36h5fab9bb_0                                # [linux]
   - sympy 1.9 py39h2804cbe_0                                # [arm64]
   - sympy 1.9 py38h10201cd_0                                # [arm64]
 
@@ -257,9 +234,6 @@ mpi:
 
 pin_run_as_build:
   moose_mpich: x.x.x
-  moose_libblas: x.x.x
-  moose_libcblas: x.x.x
-  moose_liblapack: x.x.x
   moose_petsc: x.x.x
   moose_libmesh_vtk: x.x.x
   moose_python: x.x

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -11,7 +11,7 @@ vtk_version:
   - 9.1.0
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0 build_6
+  - moose-libmesh-vtk 9.1.0
 
 moose_petsc:
   - moose-petsc 3.16.5 build_2
@@ -24,16 +24,6 @@ moose_python:
   - python 3.9
   - python 3.8
   - python 3.7                                             # [not arm64]
-
-moose_vtk:
-  - vtk 9.1.0 qt_py39h5247bde_203                          # [not arm64 and osx]
-  - vtk 9.1.0 qt_py38hf8e4d4e_203                          # [not arm64 and osx]
-  - vtk 9.1.0 qt_py37hd791b3b_203                          # [not arm64 and osx]
-  - vtk 9.0.3 no_osmesa_py39h801044d_100                   # [linux]
-  - vtk 9.0.3 no_osmesa_py38h3850a3d_100                   # [linux]
-  - vtk 9.0.3 no_osmesa_py37h7b56ff3_100                   # [linux]
-  - vtk 9.0.3 no_osmesa_py39h8e4790f_105                   # [arm64]
-  - vtk 9.0.3 no_osmesa_py38hb8cbb7a_105                   # [arm64]
 
 moose_numpy:
   - numpy 1.22.1 py39h9d9ce41_0                            # [not arm64 and osx]
@@ -158,7 +148,6 @@ moose_yaml:
 
 zip_keys:
   - moose_python
-  - moose_vtk
   - moose_numpy
   - moose_pyqt                                              # [not arm64]
   - moose_matplotlib

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -228,6 +228,11 @@ moose_mesa_libgl:                                           # [linux]
 moose_xorg_x11:                                             # [linux]
   - xorg-x11-proto-devel-cos7-x86_64 2018.4 h9b0a68f_1105   # [linux]
 
+moose_hdf5:
+  - hdf5 1.12.1 mpi_mpich_hfd824e9_4                        # [not arm64 and osx]
+  - hdf5 1.12.1 mpi_mpich_h08b82f9_4                        # [linux]
+  - hdf5 1.12.1 mpi_mpich_hfc22502_3                        # [arm64]
+
 #### build/run pining
 mpi:
   - moose-mpich

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ base_mpicc }}
     - {{ base_mpicxx }}
     - {{ base_mpifort }}
+    - {{ moose_hdf5 }}
     - {{ moose_ld64 }}          # [osx]
     - autoconf                  # [unix]
     - automake                  # [unix]
@@ -34,6 +35,7 @@ requirements:
     - {{ base_mpicc }}
     - {{ base_mpicxx }}
     - {{ base_mpifort }}
+    - {{ moose_hdf5 }}
     - {{ moose_ld64 }}          # [osx]
     - autoconf                  # [osx]
     - automake                  # [osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.1" %}
 

--- a/conda/petsc/build.sh
+++ b/conda/petsc/build.sh
@@ -36,15 +36,6 @@ else
     FCFLAGS="${FCFLAGS} -I$PREFIX/include"
 fi
 
-# Set empty HDF5 variables for the configure PETSc script, since we want to use
-# the downloaded PETSc HDF5. This is to avoid an "unbound variable" error in
-# scripts/configure_petsc.sh
-HDF5_DIR=""
-HDF5DIR=""
-HDF5_ROOT=""
-HDF5_STR=""
-HDF5_FORTRAN_STR=""
-
 source $PETSC_DIR/configure_petsc.sh
 configure_petsc \
     --COPTFLAGS=-O3 \

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,5 +1,5 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -17,9 +17,7 @@ requirements:
 
   run:
     - {{ moose_mpich }}
-    - {{ moose_vtk }}
     - {{ moose_numpy }}
-    - {{ moose_pyqt }}           # [not arm64]
     - {{ moose_matplotlib }}
     - {{ moose_pandas }}
     - {{ moose_livereload }}
@@ -43,7 +41,6 @@ requirements:
 test:
   imports:
     - numpy
-    - PyQt5                      # [not arm64]
     - matplotlib
     - pandas
     - livereload
@@ -54,7 +51,6 @@ test:
     - lxml
     - skimage
     - sympy
-    - vtk
     - pylatexenc
     - jinja2
     - deepdiff

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.03.30" %}
+{% set version = "2022.04.18" %}
 
 package:
   name: moose-tools

--- a/framework/doc/content/sqa/framework_srs.md
+++ b/framework/doc/content/sqa/framework_srs.md
@@ -78,7 +78,7 @@ behaviors of each user-defined object.
 - 4 GB of RAM for optimized compilation (8 GB for debug compilation), 2 GB per core execution
 - 100 GB disk space
 - C++17 compatible compiler (GCC, Clang)
-- Python 3.6+
+- Python 3.7+
 - Git
 !! minimum-requirements-finish
 !template-end!

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -75,6 +75,7 @@ function configure_petsc()
   fi
 
   # If HDF5 is not found locally, download it via PETSc (except on Apple Silicon)
+  HDF5_FORTRAN_STR=""
   if [ -z "$HDF5_STR" ]; then
     if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]]; then
       # HDF5 currently doesn't build properly via PETSc download on macOS Apple


### PR DESCRIPTION
This PR tests changes to the moose packages to facilitate removal of PyQt5 and serial VTK dependencies within `moose-tools` as well as use a parallel HDF5 from conda-forge that is compatible with PETSc/libMesh on all platforms (including M1). This should remove occasional library collisions that have been affecting those who use Peacock and HDF5 with the conda environment. 

This PR also removes Python 3.6 from the conda packages.

Refs #20736
Closes #20876 
