### PR TITLE
Make temperature required in GapFluxModels

### DIFF
--- a/modules/heat_conduction/src/userobjects/GapFluxModelConduction.C
+++ b/modules/heat_conduction/src/userobjects/GapFluxModelConduction.C
@@ -18,7 +18,7 @@ GapFluxModelConduction::validParams()
 {
   InputParameters params = GapFluxModelBase::validParams();
   params.addClassDescription("Gap flux model for varying gap conductance");
-  params.addCoupledVar("temperature", "The name of the temperature variable");
+  params.addRequiredCoupledVar("temperature", "The name of the temperature variable");
   params.addRequiredParam<Real>("gap_conductivity", "Gap conductivity value");
   params.addParam<FunctionName>(
       "gap_conductivity_function",

--- a/modules/heat_conduction/src/userobjects/GapFluxModelRadiation.C
+++ b/modules/heat_conduction/src/userobjects/GapFluxModelRadiation.C
@@ -18,7 +18,7 @@ GapFluxModelRadiation::validParams()
   InputParameters params = GapFluxModelBase::validParams();
   params.addClassDescription("Gap flux model for heat conduction across a gap due to radiation, "
                              "based on the diffusion approximation.");
-  params.addCoupledVar("temperature", "The name of the temperature variable");
+  params.addRequiredCoupledVar("temperature", "The name of the temperature variable");
   params.addParam<Real>("stefan_boltzmann", 5.670373e-8, "Stefan-Boltzmann constant");
   params.addRangeCheckedParam<Real>("primary_emissivity",
                                     1,

--- a/modules/heat_conduction/src/userobjects/GapFluxModelRadiative.C
+++ b/modules/heat_conduction/src/userobjects/GapFluxModelRadiative.C
@@ -17,7 +17,7 @@ GapFluxModelRadiative::validParams()
 {
   InputParameters params = GapFluxModelBase::validParams();
   params.addClassDescription("Gap flux demonstration model for radiative heat conductance");
-  params.addCoupledVar("T", "Temperature");
+  params.addRequiredCoupledVar("temperature", "The name of the temperature variable");
   params.addParam<Real>("sigma", 5.670373e-8, "Stefan-Boltzmann constant");
   params.addRequiredRangeCheckedParam<MaterialPropertyName>(
       "primary_emissivity",
@@ -32,8 +32,8 @@ GapFluxModelRadiative::validParams()
 
 GapFluxModelRadiative::GapFluxModelRadiative(const InputParameters & parameters)
   : GapFluxModelBase(parameters),
-    _primary_T(adCoupledNeighborValue("T")),
-    _secondary_T(adCoupledValue("T")),
+    _primary_T(adCoupledNeighborValue("temperature")),
+    _secondary_T(adCoupledValue("temperature")),
     _sigma(getParam<Real>("sigma")),
     _primary_emissivity(getNeighborADMaterialProperty<Real>("primary_emissivity")),
     _secondary_emissivity(getADMaterialProperty<Real>("secondary_emissivity"))

--- a/modules/heat_conduction/src/userobjects/GapFluxModelSimple.C
+++ b/modules/heat_conduction/src/userobjects/GapFluxModelSimple.C
@@ -16,7 +16,7 @@ GapFluxModelSimple::validParams()
 {
   InputParameters params = GapFluxModelBase::validParams();
   params.addClassDescription("Gap flux model with a constant conductance");
-  params.addCoupledVar("temperature", "The name of the temperature variable");
+  params.addRequiredCoupledVar("temperature", "The name of the temperature variable");
   params.addRequiredParam<Real>("k", "Gap conductance");
   params.addParam<Real>("min_gap",
                         1e-6,

--- a/modules/heat_conduction/test/tests/gap_heat_transfer_mortar/gap_heat_transfer_radiation_test.i
+++ b/modules/heat_conduction/test/tests/gap_heat_transfer_mortar/gap_heat_transfer_radiation_test.i
@@ -77,7 +77,7 @@
     type = GapFluxModelRadiative
     secondary_emissivity = 0.5
     primary_emissivity = 0.5
-    T = temp
+    temperature = temp
     boundary = 3
   []
   [simple]


### PR DESCRIPTION
This makes temperature required coupled variables for several GapFluxModels. This avoids difficult to understand errors when temperature is tried before being defined. Also, changing one instance of `T` to `temperature` to be consistent.
 Ref #20658
