### PR TITLE
Use two ghost layers in FVLimitedVectorAdvection

### DIFF
--- a/test/src/fvkernels/FVLimitedVectorAdvection.C
+++ b/test/src/fvkernels/FVLimitedVectorAdvection.C
@@ -27,6 +27,7 @@ FVLimitedVectorAdvection::validParams()
   params.addRequiredParam<unsigned int>(
       "component",
       "The component at which we will index the evaluated vector functor to populate our residual");
+  params.set<unsigned short>("ghost_layers") = 2;
   return params;
 }
 


### PR DESCRIPTION
For higher-order advection schemes we need two layers. References
distributed mesh failures on next post #20504