### PR TITLE
Fix up PerfGraph when creating sub-apps 

### DIFF
--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -303,6 +303,8 @@ MultiApp::createApps()
   if (!_has_an_app)
     return;
 
+  TIME_SECTION("createApps", 2, "Instantiating Sub-Apps", false);
+
   // Read commandLine arguments that will be used when creating apps
   readCommandLineArguments();
 


### PR DESCRIPTION
Turns off live printing during sub-app creation.  The sub-apps should be doing their own printing if they are taking a long time to set up.

closes #20874 #19114
