### PR TITLE
Make all cloned repos marked as safe for Git in Docker builds

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -51,6 +51,13 @@ COPY docker_ci/install_packages.sh docker_ci/apt_installs.sh docker_ci/yum_insta
 RUN ./install_packages.sh || exit 1; rm *.sh
 
 #-----------------------------------------------------------------------------#
+# Ensure all local repos are marked as safe for all users
+#-----------------------------------------------------------------------------#
+RUN for CURR_USR in root dev; do \
+    sudo -u $CURR_USR /bin/bash -c "printf '[safe]\n\tdirectory = *\n' > ~/.gitconfig" ; \
+done
+
+#-----------------------------------------------------------------------------#
 # Install mpich-3.3 to system path
 #-----------------------------------------------------------------------------#
 RUN curl -L -O http://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz ; \


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
Per the liked issue this closes, Git no longer tolerates having repos copied between users or operated on by a different user without the directory being marked as safe.  Since we trust our upstream repositories and our environment, this added security is overkill and cumbersome.

## Design
In the image build, once user `dev` is added and package manager installs are in place to have `sudo` available, each user's `~/.gitconfig` is set to the following, which marks all local repos as safe for the given user.
```
[safe]
        directory = *
```
## Impact
This doesn't touch the source.  We need to be able to run Git commands on copied repositories downstream, so it makes sense to couch the arrangement upstream with a simple catch-all.  Closes #20906.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
