### PR TITLE
Output n_constrained_dofs

### DIFF
--- a/framework/include/reporters/MeshInfo.h
+++ b/framework/include/reporters/MeshInfo.h
@@ -57,6 +57,7 @@ protected:
   unsigned int & _num_dofs;
   unsigned int & _num_dofs_nl;
   unsigned int & _num_dofs_aux;
+  unsigned int & _num_dofs_constrained;
   unsigned int & _num_elem;
   unsigned int & _num_node;
   unsigned int & _num_local_dofs;

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -147,6 +147,12 @@ outputSystemInformationHelper(std::stringstream & oss, System & system)
     oss << std::setw(console_field_width) << "  Num DOFs: " << system.n_dofs() << '\n'
         << std::setw(console_field_width) << "  Num Local DOFs: " << system.n_local_dofs() << '\n';
 
+    if (system.n_constrained_dofs())
+    {
+      oss << std::setw(console_field_width) << "  Num Constrained DOFs: " << system.n_constrained_dofs() << '\n'
+          << std::setw(console_field_width) << "  Local Constrained DOFs: " << system.n_local_constrained_dofs() << '\n';
+    }
+
     std::streampos begin_string_pos = oss.tellp();
     std::streampos curr_string_pos = begin_string_pos;
     oss << std::setw(console_field_width) << "  Variables: ";

--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -149,8 +149,10 @@ outputSystemInformationHelper(std::stringstream & oss, System & system)
 
     if (system.n_constrained_dofs())
     {
-      oss << std::setw(console_field_width) << "  Num Constrained DOFs: " << system.n_constrained_dofs() << '\n'
-          << std::setw(console_field_width) << "  Local Constrained DOFs: " << system.n_local_constrained_dofs() << '\n';
+      oss << std::setw(console_field_width)
+          << "  Num Constrained DOFs: " << system.n_constrained_dofs() << '\n'
+          << std::setw(console_field_width)
+          << "  Local Constrained DOFs: " << system.n_local_constrained_dofs() << '\n';
     }
 
     std::streampos begin_string_pos = oss.tellp();

--- a/framework/src/reporters/MeshInfo.C
+++ b/framework/src/reporters/MeshInfo.C
@@ -40,7 +40,8 @@ MeshInfo::MeshInfo(const InputParameters & parameters)
     _num_dofs(declareHelper<unsigned int>("num_dofs", REPORTER_MODE_REPLICATED)),
     _num_dofs_nl(declareHelper<unsigned int>("num_dofs_nonlinear", REPORTER_MODE_REPLICATED)),
     _num_dofs_aux(declareHelper<unsigned int>("num_dofs_auxiliary", REPORTER_MODE_REPLICATED)),
-    _num_dofs_constrained(declareHelper<unsigned int>("num_dofs_constrained", REPORTER_MODE_REPLICATED)),
+    _num_dofs_constrained(
+        declareHelper<unsigned int>("num_dofs_constrained", REPORTER_MODE_REPLICATED)),
     _num_elem(declareHelper<unsigned int>("num_elements", REPORTER_MODE_REPLICATED)),
     _num_node(declareHelper<unsigned int>("num_nodes", REPORTER_MODE_REPLICATED)),
     _num_local_dofs(declareHelper<unsigned int>("num_local_dofs", REPORTER_MODE_DISTRIBUTED)),

--- a/framework/src/reporters/MeshInfo.C
+++ b/framework/src/reporters/MeshInfo.C
@@ -40,6 +40,7 @@ MeshInfo::MeshInfo(const InputParameters & parameters)
     _num_dofs(declareHelper<unsigned int>("num_dofs", REPORTER_MODE_REPLICATED)),
     _num_dofs_nl(declareHelper<unsigned int>("num_dofs_nonlinear", REPORTER_MODE_REPLICATED)),
     _num_dofs_aux(declareHelper<unsigned int>("num_dofs_auxiliary", REPORTER_MODE_REPLICATED)),
+    _num_dofs_constrained(declareHelper<unsigned int>("num_dofs_constrained", REPORTER_MODE_REPLICATED)),
     _num_elem(declareHelper<unsigned int>("num_elements", REPORTER_MODE_REPLICATED)),
     _num_node(declareHelper<unsigned int>("num_nodes", REPORTER_MODE_REPLICATED)),
     _num_local_dofs(declareHelper<unsigned int>("num_local_dofs", REPORTER_MODE_DISTRIBUTED)),
@@ -80,6 +81,10 @@ MeshInfo::execute()
   _num_dofs_nl = _nonlinear_system.n_dofs();
   _num_dofs_aux = _aux_system.n_dofs();
   _num_dofs = _equation_systems.n_dofs();
+  _num_dofs_constrained = 0;
+  for (auto s : make_range(_equation_systems.n_systems()))
+    _num_dofs_constrained += _equation_systems.get_system(s).n_constrained_dofs();
+
   _num_node = _mesh.n_nodes();
   _num_elem = _mesh.n_elem();
   _num_local_dofs_nl = _nonlinear_system.n_local_dofs();

--- a/test/tests/reporters/mesh_info/gold/mesh_info_out.json
+++ b/test/tests/reporters/mesh_info/gold/mesh_info_out.json
@@ -23,6 +23,9 @@
                 "num_dofs_auxiliary": {
                     "type": "unsigned int"
                 },
+                "num_dofs_constrained": {
+                    "type": "unsigned int"
+                },
                 "num_dofs_local_auxiliary": {
                     "type": "unsigned int"
                 },
@@ -71,6 +74,7 @@
                 "local_subdomains": null,
                 "num_dofs": 0,
                 "num_dofs_auxiliary": 0,
+                "num_dofs_constrained": 0,
                 "num_dofs_local_auxiliary": 0,
                 "num_dofs_local_nonlinear": 0,
                 "num_dofs_nonlinear": 0,
@@ -267,6 +271,7 @@
                 ],
                 "num_dofs": 221,
                 "num_dofs_auxiliary": 100,
+                "num_dofs_constrained": 0,
                 "num_dofs_local_auxiliary": 50,
                 "num_dofs_local_nonlinear": 66,
                 "num_dofs_nonlinear": 121,

--- a/test/tests/reporters/mesh_info/gold/mesh_info_out.json.1
+++ b/test/tests/reporters/mesh_info/gold/mesh_info_out.json.1
@@ -23,6 +23,9 @@
                 "num_dofs_auxiliary": {
                     "type": "unsigned int"
                 },
+                "num_dofs_constrained": {
+                    "type": "unsigned int"
+                },
                 "num_dofs_local_auxiliary": {
                     "type": "unsigned int"
                 },
@@ -59,6 +62,7 @@
                 "local_subdomains": null,
                 "num_dofs": 0,
                 "num_dofs_auxiliary": 0,
+                "num_dofs_constrained": 0,
                 "num_dofs_local_auxiliary": 0,
                 "num_dofs_local_nonlinear": 0,
                 "num_dofs_nonlinear": 0,
@@ -251,6 +255,7 @@
                 ],
                 "num_dofs": 221,
                 "num_dofs_auxiliary": 100,
+                "num_dofs_constrained": 0,
                 "num_dofs_local_auxiliary": 50,
                 "num_dofs_local_nonlinear": 55,
                 "num_dofs_nonlinear": 121,


### PR DESCRIPTION

## Reason
Additional output of numbers of constrained DoFs, when those exist

## Design
MeshInfo and ConsoleUtils have additional output when DoF constraints exist.

## Impact
Additional screen output and MeshInfo output

Closes #20909