### PR TITLE
Suppress execute_on

### DIFF
--- a/modules/heat_conduction/src/userobjects/GapFluxModelBase.C
+++ b/modules/heat_conduction/src/userobjects/GapFluxModelBase.C
@@ -15,6 +15,12 @@ GapFluxModelBase::validParams()
 {
   InputParameters params = InterfaceUserObjectBase::validParams();
   params.addClassDescription("Gap flux model base class");
+
+  // UOs of this type should not be executed by MOOSE, but only called through
+  // ModularGapConductanceConstraint
+  params.set<ExecFlagEnum>("execute_on") = EXEC_CUSTOM;
+  params.suppressParameter<ExecFlagEnum>("execute_on");
+
   return params;
 }
 


### PR DESCRIPTION
Turns out it was only `GapFluxModelBase`. In `DiscreteElementUserObject` I had already suppressed this parameter.

Closes #20918