### PR TITLE
Print longest running DAGs along with Jobs

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -734,8 +734,7 @@ class TestHarness:
                 if len(sorted_tups) == 0 or float(sorted_tups[0][0].getTiming()) == 0:
                     print('No jobs were completed.')
 
-                # The TestHarness receives completed jobs serially out of order, when we want
-                # to work with groups (can't use self.test_table).
+                # The TestHarness receives individual jobs out of order (can't realistically use self.test_table)
                 tester_dirs = {}
                 dag_table = []
                 for jobs, dag, thread_lock in self.scheduler.retrieveDAGs():
@@ -752,6 +751,7 @@ class TestHarness:
                 if sorted_table[0:self.options.longest_jobs]:
                     print(f'\n{self.options.longest_jobs} longest running spec files:')
                     print(('-' * (util.TERM_COLS)))
+                    # We can't use util.formatResults, as we are representing a group of testers
                     for group in sorted_table[0:self.options.longest_jobs]:
                         print(str(group[0]).ljust((util.TERM_COLS - (len(group[1]) + 4)), ' '), f'[{group[1]}s]')
 

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -745,15 +745,17 @@ class TestHarness:
                             total_time += tester.getTiming()
                     tester_dirs[tester.getTestDir()] = (tester_dirs.get(tester.getTestDir(), 0) + total_time)
                 for k, v in tester_dirs.items():
-                    dag_table.append([f'{os.path.sep}'.join(k.split(os.path.sep)[-2:]), f'{v:.3f}'])
+                    rel_spec_path = f'{os.path.sep}'.join(k.split(os.path.sep)[-2:])
+                    dag_table.append([f'{rel_spec_path}{os.path.sep}{self._infiles[0]}', f'{v:.3f}'])
 
                 sorted_table = sorted(dag_table, key=lambda dag_table: float(dag_table[1]), reverse=True)
                 if sorted_table[0:self.options.longest_jobs]:
-                    print(f'\n{self.options.longest_jobs} longest running spec files:')
+                    print(f'\n{self.options.longest_jobs} longest running folders:')
                     print(('-' * (util.TERM_COLS)))
                     # We can't use util.formatResults, as we are representing a group of testers
                     for group in sorted_table[0:self.options.longest_jobs]:
                         print(str(group[0]).ljust((util.TERM_COLS - (len(group[1]) + 4)), ' '), f'[{group[1]}s]')
+                    print('\n')
 
             # Perform any write-to-disc operations
             self.writeResults()

--- a/python/TestHarness/schedulers/Job.py
+++ b/python/TestHarness/schedulers/Job.py
@@ -273,7 +273,7 @@ class Job(object):
         """ Return active time """
         m = re.search(r"Active time=(\S+)", self.__joined_out)
         if m != None:
-            return m.group(1)
+            return float(m.group(1))
 
     def getSolveTime(self):
         """ Return solve time """

--- a/python/TestHarness/schedulers/Scheduler.py
+++ b/python/TestHarness/schedulers/Scheduler.py
@@ -133,6 +133,10 @@ class Scheduler(MooseObject):
         """ return all the jobs the scheduler was tasked to perform work for """
         return self.__scheduled_jobs
 
+    def retrieveDAGs(self):
+        """ return all the dags containing the jobs the scueduler was tasked to perform work for """
+        return self.__dag_bank
+
     def schedulerError(self):
         """ boolean if the scheduler prematurely exited """
         return self.__error_state and not self.maxFailures()


### PR DESCRIPTION
When using the --longest-jobs option, append also the longest running DAGs

Closes #20916

