### PR TITLE
Libmesh update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.04.07" %}
+{% set version = "2022.05.12" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -2,7 +2,7 @@
 ## Any changes made will require additional changes to any item above that.
 
 moose_libmesh:
-  - moose-libmesh 2022.04.07 build_1
+  - moose-libmesh 2022.05.12 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=c4ce6d1e397bf58401cf12edf1caa9aa61f0f175
+ARG LIBMESH_REV=5a7a9bd0e7295628f465c3bb4e42563b8b8c1a9c
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/src/constraints/EqualValueBoundaryConstraint.C
+++ b/framework/src/constraints/EqualValueBoundaryConstraint.C
@@ -11,7 +11,7 @@
 #include "EqualValueBoundaryConstraint.h"
 #include "MooseMesh.h"
 
-#include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/null_output_iterator.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_elem.h"
 #include "libmesh/parallel_node.h"
@@ -170,12 +170,12 @@ EqualValueBoundaryConstraint::updateConstrainedNodes()
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   nodes_to_ghost.begin(),
                                                   nodes_to_ghost.end(),
-                                                  mesh_inserter_iterator<Node>(_mesh.getMesh()));
+                                                  null_output_iterator<Node>());
 
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   primary_elems_to_ghost.begin(),
                                                   primary_elems_to_ghost.end(),
-                                                  mesh_inserter_iterator<Elem>(_mesh.getMesh()));
+                                                  null_output_iterator<Elem>());
 
     _mesh.update(); // Rebuild node_to_elem_map
 

--- a/modules/doc/content/newsletter/2022_05.md
+++ b/modules/doc/content/newsletter/2022_05.md
@@ -9,6 +9,37 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2022.05.06` Update
+
+- More internal memory management uses smart pointers rather than raw
+  `new` and `delete`
+- `MeshBase`, `ExodusII`, and mesh stitching now support element sets
+  (which unlike subdomains specified with `subdomain_id`, can overlap)
+- Mesh stitching is now possible (via automatically temporarily
+  serializing) a `DistributedMesh`.  This is useful when building a
+  smaller mesh in serial but distributing it before it gets enlarged
+  by refinement or extrusion.
+- Triangulation improvements:
+  - Support for specifying a fixed level of uniform refinement on each
+    outer and/or hole boundary, then optionally disallowing further refinement
+  - Mesh holes can be specified using other Mesh objects, for easier
+    stitching later.
+- `Abaqus` mesh file input now supports `TRI6` and `QUAD8` elements
+- Support for more than 65,535 variables in a `System`
+- `Node` and `Elem` `packed_range` code now always unpacks to a mesh
+  - This enables use of the more-efficient NBX communication
+    algorithms, the `push_` and `pull_` `parallel_vector_data` methods
+    in `timpi/parallel_sync.h`, with ranges of nodes and elements
+- Improvements to `reduced_basis` code
+- Various bug fixes and interface updates
+  - Updating deprecated `ExodusII` API uses
+  - Compatibility with `PETSc` 3.17
+  - Fix Eigen use of C++17-deprecated call
+
+- MetaPhysicL updates, for additional unit testing, better
+  compatibility with some compilers and compiler warning settings, and
+  support for `std::isinf()`.
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/tensor_mechanics/src/constraints/NodalFrictionalConstraint.C
+++ b/modules/tensor_mechanics/src/constraints/NodalFrictionalConstraint.C
@@ -14,7 +14,7 @@
 #include "Assembly.h"
 #include "SystemBase.h"
 
-#include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/null_output_iterator.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_elem.h"
 #include "libmesh/parallel_node.h"
@@ -137,12 +137,12 @@ NodalFrictionalConstraint::updateConstrainedNodes()
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   nodes_to_ghost.begin(),
                                                   nodes_to_ghost.end(),
-                                                  mesh_inserter_iterator<Node>(_mesh.getMesh()));
+                                                  null_output_iterator<Node>());
 
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   primary_elems_to_ghost.begin(),
                                                   primary_elems_to_ghost.end(),
-                                                  mesh_inserter_iterator<Elem>(_mesh.getMesh()));
+                                                  null_output_iterator<Elem>());
 
     _mesh.update(); // Rebuild node_to_elem_map
 

--- a/modules/tensor_mechanics/src/constraints/NodalStickConstraint.C
+++ b/modules/tensor_mechanics/src/constraints/NodalStickConstraint.C
@@ -14,7 +14,7 @@
 #include "Assembly.h"
 #include "SystemBase.h"
 
-#include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/null_output_iterator.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_elem.h"
 #include "libmesh/parallel_node.h"
@@ -118,12 +118,12 @@ NodalStickConstraint::updateConstrainedNodes()
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   nodes_to_ghost.begin(),
                                                   nodes_to_ghost.end(),
-                                                  mesh_inserter_iterator<Node>(_mesh.getMesh()));
+                                                  null_output_iterator<Node>());
 
     _mesh.getMesh().comm().allgather_packed_range(&_mesh.getMesh(),
                                                   primary_elems_to_ghost.begin(),
                                                   primary_elems_to_ghost.end(),
-                                                  mesh_inserter_iterator<Elem>(_mesh.getMesh()));
+                                                  null_output_iterator<Elem>());
 
     _mesh.update(); // Rebuild node_to_elem_map
 


### PR DESCRIPTION
* More smart pointers for internal memory management
* MeshBase and ExodusII support for element sets
* Triangulation improvements:
  * Support for specifying or disallowing boundary refinement
  * Mesh holes can be specified using other Mesh objects
* Mesh stitching is now possible on (serialized) DistributedMesh
* Support for more than 65,535 variables in a System
* Various bug fixes and interface updates
  * Updating deprecated ExodusII API uses
  * Compatibility with PETSc 3.17
  * Fix Eigen use of C++17-deprecated call

* MetaPhysicL updates
  * Don't do potentially different sign comparison in sparsity_trim
  * DynamicSparseNumberArray<long long> comm tests
  * Add missing headers, inline keywords

Nothing super-urgent here; I mostly want the triangulation improvements so I can put in the Moose interfaces to them ASAP, and I want to make sure none of the internal changes are affecting any of the more extensive Moose app tests.