### PR TITLE
Add conda_recipe generator into moose repo

### DIFF
--- a/conda/empty_shell/meta.yaml
+++ b/conda/empty_shell/meta.yaml
@@ -1,0 +1,26 @@
+{% set build = "<BUILD>" %}
+{% set version = "<VERSION>" %}
+{% set strbuild = "build_" + build|string %}
+
+package:
+  name: <PREFIX_PACKAGE_WITH><FORMATTED_APPLICATION>
+  version: {{ version }}
+
+source:
+  path: .
+
+build:
+  number: {{ build }}  # [linux,osx]
+  string: {{ strbuild }}
+  skip: true # [win]
+
+about:
+  home: https://mooseframework.org/
+  license: LGPL 2.1
+  summary: 'The Multiphysics Object-Oriented Simulation Environment (MOOSE) is a finite-element, multiphysics framework primarily developed by Idaho National Laboratory. This superficial module (moose) if a future placeholder for binary releases of MOOSE.'
+
+extra:
+  recipe-maintainers:
+    - milljm
+    - cticenhour
+    - loganharbour

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export REPO=$1
+export MOOSE_JOBS=${MOOSE_JOBS:-$2}
+export TEMPLATE=template
+if [ -n "$3" ]; then
+    export TEMPLATE=empty_shell
+fi
+
+function create_tmp()
+{
+    if [ -z "$TMP_DIR" ]; then DO_TRAP="True"; fi
+    # Protect running build
+    umask 077
+    if [ `uname` == "Darwin" ]; then
+        TMP_DIR=${TMP_DIR:-`mktemp -d -t $APPLICATION`}
+    else
+        TMP_DIR=${TMP_DIR:-`mktemp -d -t $APPLICATION.XXXXXXXX`}
+    fi
+    if [ -z "$CIVET_HOME" ] && [ -n "$DO_TRAP" ]; then
+        trap 'rm -rf "$TMP_DIR"' EXIT
+    fi
+    if [ -d "$TMP_DIR/$RECIPES" ]; then
+        rm "$TMP_DIR/$RECIPES/"*
+    fi
+    mkdir -p "$TMP_DIR/$RECIPES"
+}
+
+function create_env()
+{
+    conda create -p $TMP_DIR/_env -q -y
+    source activate $TMP_DIR/_env
+    export CONDARC=$TMP_DIR/.condarc
+    export CONDA_ENVS_PATH=$TMP_DIR/_env/.envs
+    conda config --env --set ssl_verify false
+    conda config --env --set channel_priority strict
+    conda config --env --add envs_dirs $TMP_DIR/_env/.envs
+    conda config --env --add pkgs_dirs $TMP_DIR/_env/.pkgs
+    conda config --env --set changeps1 false
+    conda config --env --set always_yes true
+    conda config --env --add channels conda-forge
+    conda config --env --add channels https://conda.software.inl.gov/public
+    conda install conda-build mamba boa
+}
+
+function clean_repo()
+{
+    printf "Cleaning repo\n"
+    if [ $(git -C "$REPO" status | grep -c -i "^untracked files:") -ge 1 ] && [ -z "$CIVET_HOME" ]; then
+        read -p "Untracked files in $APPLICATION. Press Enter to delete files and continue. CTRL-C to Cancel. "
+    fi
+    git -C "$REPO" clean -xfd &>/dev/null
+    git -C "$REPO" submodule foreach --recursive git clean -xfd &>/dev/null
+    git -C "$SCRIPT_DIR" clean -xfd &> /dev/null
+}
+
+function string_replace()
+{
+    printf "Creating recipes at $TMP_DIR/$RECIPES\n"
+    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE IS_MOOSE TMP_DIR RECIPES SKIP_DOCS SUBMODULES EXTRA_SUBMODULES PREFIX_PACKAGE_WITH)
+    for sfile in `find $SCRIPT_DIR/$TEMPLATE -type l`; do
+        cat "$sfile" > "$TMP_DIR/$RECIPES/$(basename $sfile)"
+    done
+    for cfile in `find $SCRIPT_DIR/$TEMPLATE -type f`; do
+        cp "$cfile" "$TMP_DIR/$RECIPES"
+        for THIS in "${REPLACE[@]}"; do
+            if [ `uname ` == "Darwin" ]; then
+                sed -i '' -e "s|\<${THIS}\>|${!THIS}|g" "$TMP_DIR/$RECIPES/$(basename $cfile)"
+            else
+                sed -i'' -e "s|<${THIS}>|${!THIS}|g" "$TMP_DIR/$RECIPES/$(basename $cfile)"
+            fi
+        done
+    done
+}
+
+function conda_build()
+{
+    if [ -z "$CIVET_HOME" ]; then
+        printf "Installing everything necessary to a temporary location (including Conda)\n"
+        create_tmp
+        printf "TEMP DIR: $TMP_DIR\n"
+        create_env
+        clean_repo
+        string_replace || exit 1
+        cd "$TMP_DIR/$RECIPES" || exit 1
+        mkdir -p "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
+        conda mambabuild . --output-folder "${SCRIPT_DIR}/packages/${APPLICATION}" || exit 1
+        printf "Built: ${SCRIPT_DIR}/packages/${APPLICATION}/${ARCH}/${PREFIX_PACKAGE_WITH}${FORMATTED_APPLICATION}-${VERSION}-build_${BUILD}.tar.bz2\n"
+    else
+        TMP_DIR="$BUILD_ROOT"
+        clean_repo
+        create_tmp || exit 1
+        string_replace || exit 1
+    fi
+}
+
+if ! `type conda &>/dev/null` || ! `type activate &>/dev/null`; then
+    printf "Conda not installed. Or not properly available (activate not available).\n"
+    exit 1
+elif [ -z "$2" ]; then
+    printf "Supply possitional arguments:\n\t$0 /path/to/application jobs\n\nExample:\n\t$0 /home/user/moose 24\n"
+    exit 1
+elif ! [ -d "$1" ]; then
+    printf "$1 not found\n"
+    exit 1
+fi
+if [ "$(uname)" == "Darwin" ]; then
+    ARCH="osx-64"
+else
+    ARCH="linux-64"
+fi
+# We are building moose
+if [ "$(basename "$REPO" .git)" == "moose" ]; then
+    export IS_MOOSE='/modules'
+    export MOOSE=''
+    export EXECUTABLE='combined'
+    export PREFIX_PACKAGE_WITH=''
+    export MOOSE_SKIP_DOCS='true'
+else
+    export IS_MOOSE=''
+    export MOOSE='/moose'
+    export PREFIX_PACKAGE_WITH=${PREFIX_PACKAGE_WITH:-'ncrc-'}
+fi
+SKIP_DOCS='False'
+if [ -n "$MOOSE_SKIP_DOCS" ]; then
+    printf "Influential environment variable: MOOSE_SKIP_DOCS detected.\n"
+    export SKIP_DOCS="True"
+fi
+SUBMODULES="False"
+if [ -n "$EXTRA_SUBMODULES" ]; then
+    printf "Influential environment variable: EXTRA_SUBMODULES detected.\n"
+    export SUBMODULES="True"
+fi
+export APPLICATION=$(basename "$REPO" .git)
+export FORMATTED_APPLICATION=$(echo $APPLICATION | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+export RECIPES=".recipes/$APPLICATION"
+export EXECUTABLE=${EXECUTABLE:-$APPLICATION}
+export VERSION=$(git -C "$REPO" log -1 --date=format:"%Y_%m_%d" --pretty=format:"%ad")
+export BUILD=0
+conda_build
+exit 0

--- a/conda/generate_recipe.sh
+++ b/conda/generate_recipe.sh
@@ -57,7 +57,7 @@ function clean_repo()
 function string_replace()
 {
     printf "Creating recipes at $TMP_DIR/$RECIPES\n"
-    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE IS_MOOSE TMP_DIR RECIPES SKIP_DOCS SUBMODULES EXTRA_SUBMODULES PREFIX_PACKAGE_WITH)
+    REPLACE=(APPLICATION FORMATTED_APPLICATION EXECUTABLE REPO BUILD VERSION MOOSE_JOBS MOOSE IS_MOOSE TMP_DIR RECIPES SKIP_DOCS PREFIX_PACKAGE_WITH)
     for sfile in `find $SCRIPT_DIR/$TEMPLATE -type l`; do
         cat "$sfile" > "$TMP_DIR/$RECIPES/$(basename $sfile)"
     done
@@ -125,11 +125,6 @@ SKIP_DOCS='False'
 if [ -n "$MOOSE_SKIP_DOCS" ]; then
     printf "Influential environment variable: MOOSE_SKIP_DOCS detected.\n"
     export SKIP_DOCS="True"
-fi
-SUBMODULES="False"
-if [ -n "$EXTRA_SUBMODULES" ]; then
-    printf "Influential environment variable: EXTRA_SUBMODULES detected.\n"
-    export SUBMODULES="True"
 fi
 export APPLICATION=$(basename "$REPO" .git)
 export FORMATTED_APPLICATION=$(echo $APPLICATION | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -1,5 +1,14 @@
-## Dependencies are listed in descending order.
-## Any changes made will require additional changes to any item above that.
+## Dependencies are listed in descending order. Generally speaking any
+## changes made will require additional changes to items listed above
+## your change (except where otherwise noted)
+
+# NCRC dependency
+moose_tools:
+  - moose-tools 2022.04.18
+
+# NCRC default Python
+moose_ncrc_python:
+  - python 3.9
 
 moose_libmesh:
   - moose-libmesh 2022.04.07 build_1

--- a/conda/template/build.sh
+++ b/conda/template/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eux
+export APPLICATION=<APPLICATION>
+export MOOSE_JOBS=<MOOSE_JOBS>
+export SKIP_DOCS=<SKIP_DOCS>
+export O_WORKDIR=`pwd`
+export INSTALL_DIR=${PREFIX}/${APPLICATION}
+
+#### APPLICATION
+export EXTERNAL_FLAGS="-Wl,-headerpad_max_install_names"
+export PYTHONPATH=${O_WORKDIR}<MOOSE>/python
+if [ "$SKIP_DOCS" == "True" ]; then
+    export MOOSE_SKIP_DOCS="True"
+fi
+cd ${O_WORKDIR}<MOOSE>
+./configure --prefix=${INSTALL_DIR}
+cd ${O_WORKDIR}<IS_MOOSE>
+make -j <MOOSE_JOBS>
+make install -j <MOOSE_JOBS>
+cd ${PREFIX}/bin
+ln -s ${INSTALL_DIR}/bin/<EXECUTABLE>-opt .
+ln -s ${INSTALL_DIR}/bin/moose_test_runner .
+cd ${PREFIX}/share
+ln -s ${INSTALL_DIR}/share/<APPLICATION> .
+mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
+cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+export MOOSE_ADFPARSER_JIT_INCLUDE=${INSTALL_DIR}/include/moose/ADRealMonolithic.h
+export <FORMATTED_APPLICATION>_DOCS=${INSTALL_DIR}/share/<APPLICATION>/doc/index.html
+export NCRC_APP=<FORMATTED_APPLICATION>
+EOF
+cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+unset MOOSE_ADFPARSER_JIT_INCLUDE
+unset <FORMATTED_APPLICATION>_DOCS
+unset NCRC_APP
+EOF
+if [ ${APPLICATION} == "moose" ]; then
+    cat <<EOF >> "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+alias moose-opt="combined-opt"
+EOF
+    cat <<EOF >> "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+unalias moose-opt
+EOF
+fi

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,0 +1,1 @@
+../mpich/conda_build_config.yaml

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -1,0 +1,41 @@
+{% set build = "<BUILD>" %}
+{% set version = "<VERSION>" %}
+{% set strbuild = "build_" + build|string %}
+
+package:
+  name: <PREFIX_PACKAGE_WITH><FORMATTED_APPLICATION>
+  version: {{ version }}
+
+source:
+  path: <REPO>
+
+build:
+  number: {{ build }}  # [linux,osx]
+  string: {{ strbuild }}
+  skip: true # [win]
+
+requirements:
+  build:
+    - {{ moose_ncrc_python }}
+    - {{ moose_libmesh }}
+    - {{ moose_tools }}
+
+  run:
+    - {{ moose_ncrc_python }}
+    - {{ moose_libmesh }}
+    - {{ moose_tools }}
+
+test:
+  commands:
+    - <EXECUTABLE>-opt --help
+
+about:
+  home: https://mooseframework.org/
+  license: LGPL 2.1
+  summary: 'The Multiphysics Object-Oriented Simulation Environment (MOOSE) is a finite-element, multiphysics framework primarily developed by Idaho National Laboratory. This superficial module (moose) if a future placeholder for binary releases of MOOSE.'
+
+extra:
+  recipe-maintainers:
+    - milljm
+    - cticenhour
+    - loganharbour


### PR DESCRIPTION
Bring the contents of hpcgitlab:idaholab/conda_recipes into the public
moose namespace. This allows for minimal maintenance when building the
NCRC apps.

closes #21002

Additional Tasks associated with this PR

- [x]  moose/conda/generate_recipe.sh /path/to/moose
- [x]  moose/conda/generate_recipe.sh /path/to/repo
