### PR TITLE
Subdomain setup fix in ComputeElemAuxBcsThread 

### DIFF
--- a/framework/src/loops/ComputeElemAuxBcsThread.C
+++ b/framework/src/loops/ComputeElemAuxBcsThread.C
@@ -59,6 +59,7 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
     const Elem * elem = belem->_elem;
     unsigned short int side = belem->_side;
     BoundaryID boundary_id = belem->_bnd_id;
+    SubdomainID last_did = Elem::invalid_subdomain_id;
 
     // need to update the boundary ID in assembly
     _problem.setCurrentBoundaryID(boundary_id, _tid);
@@ -74,6 +75,12 @@ ComputeElemAuxBcsThread<AuxKernelType>::operator()(const ConstBndElemRange & ran
 
       if (iter != boundary_kernels.end() && !(iter->second.empty()))
       {
+        auto did = elem->subdomain_id();
+        if (did != last_did)
+        {
+          _problem.subdomainSetup(did, _tid);
+          last_did = did;
+        }
         _problem.setCurrentSubdomainID(elem, _tid);
         _problem.prepare(elem, _tid);
         _problem.reinitElemFace(elem, side, boundary_id, _tid);


### PR DESCRIPTION
Fixes a threading failure exposed by the recent thermal expansion eigentrain PR (#20982).

Closes #21018