### PR TITLE
Call base class single-parameter version of set()

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1035,17 +1035,14 @@ InputParameters::set(const std::string & name, bool quiet_mode)
   checkParamName(name);
   checkConsistentType<T>(name);
 
-  if (!this->have_parameter<T>(name))
-    _values[name] = new Parameter<T>;
-
-  set_attributes(name, false);
+  T & result = this->Parameters::set<T>(name);
 
   if (quiet_mode)
     _params[name]._set_by_add_param = true;
 
   setHelper<T>(name);
 
-  return cast_ptr<Parameter<T> *>(_values[name])->set();
+  return result;
 }
 
 template <typename T, typename... Ts>


### PR DESCRIPTION
I'm not sure if this even compiles, but if it does, it would also get libMesh/libmesh#3291 closer to passing.

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
Allow the `Parameters` class in libmesh to switch to `unique_ptr`s for storage.

## Design
<!--A concise description (design) of the enhancement.-->
This duplicates less of the `Parameters::set()` function by simply calling that function.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Hopefully no impact in MOOSE
