### PR TITLE
Additional forward compatibility InputParameters updates

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -1403,9 +1403,14 @@ template <typename T>
 void
 InputParameters::checkConsistentType(const std::string & name) const
 {
-  // Do we have a parameter with the same name but a different type?
+  // If we don't currently have the Parameter, can't be any inconsistency
   InputParameters::const_iterator it = _values.find(name);
-  if (it != _values.end() && dynamic_cast<const Parameter<T> *>(it->second) == NULL)
+  if (it == _values.end())
+    return;
+
+  // Now, if we already have the Parameter, but it doesn't have the
+  // right type, throw an error.
+  if (!this->Parameters::have_parameter<T>(name))
     mooseError("Attempting to set parameter \"",
                name,
                "\" with type (",

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -1051,6 +1051,39 @@ public:
   using Parent::_dynamic_n;
 };
 
+/**
+ * The MooseUtils::get() specializations are used to support making
+ * forwards-compatible code changes from dumb pointers to smart pointers.
+ * The same line of code, e.g.
+ *
+ * libMesh::Parameters::Value * value = MooseUtils::get(map_iter->second);
+ *
+ * will then work regardless of whether map_iter->second is a dumb pointer
+ * or a smart pointer. Note that the smart pointer get() functions are const
+ * so they can be (ab)used to get a non-const pointer to the underlying
+ * resource. We are simply following this convention here.
+ */
+template <typename T>
+T *
+get(const std::unique_ptr<T> & u)
+{
+  return u.get();
+}
+
+template <typename T>
+T *
+get(T * p)
+{
+  return p;
+}
+
+template <typename T>
+T *
+get(const std::shared_ptr<T> & s)
+{
+  return s.get();
+}
+
 } // MooseUtils namespace
 
 /**

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1256,10 +1256,9 @@ MooseApp::recursivelyCreateExecutors(const std::string & current_executor_name,
 
   for (const auto & param : params)
   {
-    if (dynamic_cast<InputParameters::Parameter<ExecutorName> *>(param.second))
+    if (params.have_parameter<ExecutorName>(param.first))
     {
-      const auto & dependency_name =
-          static_cast<InputParameters::Parameter<ExecutorName> *>(param.second)->get();
+      const auto & dependency_name = params.get<ExecutorName>(param.first);
 
       possible_roots.remove(dependency_name);
 

--- a/framework/src/outputs/formatters/InputFileFormatter.C
+++ b/framework/src/outputs/formatters/InputFileFormatter.C
@@ -93,11 +93,12 @@ InputFileFormatter::printParams(const std::string & /*prefix*/,
       // of course we are in dump mode
       if (!_dump_mode && iter.first == "active")
       {
-        libMesh::Parameters::Parameter<std::vector<std::string>> * val =
-            dynamic_cast<libMesh::Parameters::Parameter<std::vector<std::string>> *>(iter.second);
-        const std::vector<std::string> & active = val->get();
-        if (val != NULL && active.size() == 1 && active[0] == "__all__")
-          continue;
+        if (params.have_parameter<std::vector<std::string>>(iter.first))
+        {
+          const auto & active = params.get<std::vector<std::string>>(iter.first);
+          if (active.size() == 1 && active[0] == "__all__")
+            continue;
+        }
       }
 
       // Mark it as "seen"
@@ -106,12 +107,10 @@ InputFileFormatter::printParams(const std::string & /*prefix*/,
       // Don't print type if it is blank
       if (iter.first == "type")
       {
-        libMesh::Parameters::Parameter<std::string> * val =
-            dynamic_cast<libMesh::Parameters::Parameter<std::string> *>(iter.second);
-        if (val)
+        if (params.have_parameter<std::string>(iter.first))
         {
-          const std::string & active = val->get();
-          if (val != NULL && active == "")
+          const auto & active = params.get<std::string>(iter.first);
+          if (active == "")
             continue;
         }
       }

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -101,24 +101,13 @@ YAMLFormatter::printParams(const std::string & prefix,
     if (!group_name.empty())
       oss << "'" << group_name << "'";
 
-    {
-      InputParameters::Parameter<MooseEnum> * enum_type =
-          dynamic_cast<InputParameters::Parameter<MooseEnum> *>(iter.second);
-      if (enum_type)
-        oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
-    }
-    {
-      InputParameters::Parameter<MultiMooseEnum> * enum_type =
-          dynamic_cast<InputParameters::Parameter<MultiMooseEnum> *>(iter.second);
-      if (enum_type)
-        oss << "\n" << indent << "    options: " << enum_type->get().getRawNames();
-    }
-    {
-      InputParameters::Parameter<std::vector<MooseEnum>> * enum_type =
-          dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum>> *>(iter.second);
-      if (enum_type)
-        oss << "\n" << indent << "    options: " << (enum_type->get())[0].getRawNames();
-    }
+    if (params.have_parameter<MooseEnum>(name))
+      oss << "\n" << indent << "    options: " << params.get<MooseEnum>(name).getRawNames();
+    if (params.have_parameter<MultiMooseEnum>(name))
+      oss << "\n" << indent << "    options: " << params.get<MultiMooseEnum>(name).getRawNames();
+    if (params.have_parameter<std::vector<MooseEnum>>(name))
+      oss << "\n"
+          << indent << "    options: " << params.get<std::vector<MooseEnum>>(name)[0].getRawNames();
 
     oss << "\n" << indent << "    description: |\n      " << indent << doc << std::endl;
   }
@@ -161,13 +150,14 @@ YAMLFormatter::buildOutputString(
     std::ostringstream & output,
     const std::iterator_traits<InputParameters::iterator>::value_type & p)
 {
+  libMesh::Parameters::Value * val = MooseUtils::get(p.second);
+
   // Account for Point
-  InputParameters::Parameter<Point> * ptr0 =
-      dynamic_cast<InputParameters::Parameter<Point> *>(p.second);
+  InputParameters::Parameter<Point> * ptr0 = dynamic_cast<InputParameters::Parameter<Point> *>(val);
 
   // Account for RealVectorValues
   InputParameters::Parameter<RealVectorValue> * ptr1 =
-      dynamic_cast<InputParameters::Parameter<RealVectorValue> *>(p.second);
+      dynamic_cast<InputParameters::Parameter<RealVectorValue> *>(val);
 
   // Output the Point components
   if (ptr0)

--- a/framework/src/parser/CommandLine.C
+++ b/framework/src/parser/CommandLine.C
@@ -115,9 +115,8 @@ CommandLine::addCommandLineOptionsFromParams(InputParameters & params)
       syntax = params.getSyntax(orig_name);
     cli_opt.cli_syntax = syntax;
     cli_opt.required = false;
-    InputParameters::Parameter<bool> * bool_type =
-        dynamic_cast<InputParameters::Parameter<bool> *>(it.second);
-    if (bool_type)
+
+    if (params.have_parameter<bool>(orig_name))
       cli_opt.argument_type = CommandLine::NONE;
     else
       cli_opt.argument_type = CommandLine::REQUIRED;
@@ -135,44 +134,37 @@ CommandLine::populateInputParams(InputParameters & params)
 
     if (search(orig_name))
     {
-      auto * string_type = dynamic_cast<InputParameters::Parameter<std::string> *>(it.second);
-      if (string_type)
+      if (params.have_parameter<std::string>(orig_name))
       {
         search(orig_name, params.set<std::string>(orig_name));
         continue;
       }
 
-      auto * string_vector_type =
-          dynamic_cast<InputParameters::Parameter<std::vector<std::string>> *>(it.second);
-      if (string_vector_type)
+      if (params.have_parameter<std::vector<std::string>>(orig_name))
       {
         search(orig_name, params.set<std::vector<std::string>>(orig_name));
         continue;
       }
 
-      auto * real_type = dynamic_cast<InputParameters::Parameter<Real> *>(it.second);
-      if (real_type)
+      if (params.have_parameter<Real>(orig_name))
       {
         search(orig_name, params.set<Real>(orig_name));
         continue;
       }
 
-      auto * uint_type = dynamic_cast<InputParameters::Parameter<unsigned int> *>(it.second);
-      if (uint_type)
+      if (params.have_parameter<unsigned int>(orig_name))
       {
         search(orig_name, params.set<unsigned int>(orig_name));
         continue;
       }
 
-      auto * int_type = dynamic_cast<InputParameters::Parameter<int> *>(it.second);
-      if (int_type)
+      if (params.have_parameter<int>(orig_name))
       {
         search(orig_name, params.set<int>(orig_name));
         continue;
       }
 
-      auto * bool_type = dynamic_cast<InputParameters::Parameter<bool> *>(it.second);
-      if (bool_type)
+      if (params.have_parameter<bool>(orig_name))
       {
         search(orig_name, params.set<bool>(orig_name));
         continue;

--- a/framework/src/parser/Parser.C
+++ b/framework/src/parser/Parser.C
@@ -1232,7 +1232,7 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
       // parser.
 
       InputParameters::Parameter<OutFileBase> * scalar_p =
-          dynamic_cast<InputParameters::Parameter<OutFileBase> *>(it.second);
+          dynamic_cast<InputParameters::Parameter<OutFileBase> *>(MooseUtils::get(it.second));
       if (scalar_p)
       {
         std::string input_file_name = getPrimaryFileName();
@@ -1250,8 +1250,8 @@ Parser::extractParams(const std::string & prefix, InputParameters & p)
                    full_name,
                    "' is a private parameter and should not be used in an input file.");
 
-      auto par = it.second;
-      auto short_name = it.first;
+      auto & short_name = it.first;
+      libMesh::Parameters::Value * par = MooseUtils::get(it.second);
 
 #define setscalarvaltype(ptype, base, range)                                                       \
   else if (par->type() == demangle(typeid(ptype).name()))                                          \

--- a/framework/src/problems/DumpObjectsProblem.C
+++ b/framework/src/problems/DumpObjectsProblem.C
@@ -173,12 +173,14 @@ DumpObjectsProblem::stringifyParameters(const InputParameters & parameters)
       else
       {
         // special treatment for some types
-        auto param_bool = dynamic_cast<InputParameters::Parameter<bool> *>(value_pair.second);
 
         // parameter value
         std::string param_value;
-        if (param_bool)
-          param_value = param_bool->get() ? "true" : "false";
+        if (parameters.have_parameter<bool>(param_name))
+        {
+          const bool & b = parameters.get<bool>(param_name);
+          param_value = b ? "true" : "false";
+        }
         else
         {
           std::stringstream ss;

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -294,7 +294,9 @@ dataStore(std::ostream & stream, libMesh::Parameters & p, void * context)
 
 #define storescalar(ptype)                                                                         \
   else if (it->second->type() == demangle(typeid(ptype).name())) storeHelper(                      \
-      stream, (dynamic_cast<libMesh::Parameters::Parameter<ptype> *>(it->second))->get(), context)
+      stream,                                                                                      \
+      (dynamic_cast<libMesh::Parameters::Parameter<ptype> *>(MooseUtils::get(it->second)))->get(), \
+      context)
 
     if (false)
       ;

--- a/framework/src/utils/InputParameterWarehouse.C
+++ b/framework/src/utils/InputParameterWarehouse.C
@@ -74,7 +74,7 @@ InputParameterWarehouse::addInputParameters(const std::string & name,
   for (libMesh::Parameters::iterator map_iter = ptr->begin(); map_iter != ptr->end(); ++map_iter)
   {
     const std::string & name = map_iter->first;
-    libMesh::Parameters::Value * value = map_iter->second;
+    libMesh::Parameters::Value * value = MooseUtils::get(map_iter->second);
 
     if (ptr->isControllable(name))
       for (const auto & object_name : object_names)

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -459,12 +459,13 @@ InputParameters::mooseObjectSyntaxVisibility() const
 #define dynamicCastRangeCheck(type, up_type, long_name, short_name, param, oss)                    \
   do                                                                                               \
   {                                                                                                \
+    libMesh::Parameters::Value * val = MooseUtils::get(param);                                     \
     InputParameters::Parameter<type> * scalar_p =                                                  \
-        dynamic_cast<InputParameters::Parameter<type> *>(param);                                   \
+        dynamic_cast<InputParameters::Parameter<type> *>(val);                                     \
     if (scalar_p)                                                                                  \
       rangeCheck<type, up_type>(long_name, short_name, scalar_p, oss);                             \
     InputParameters::Parameter<std::vector<type>> * vector_p =                                     \
-        dynamic_cast<InputParameters::Parameter<std::vector<type>> *>(param);                      \
+        dynamic_cast<InputParameters::Parameter<std::vector<type>> *>(val);                        \
     if (vector_p)                                                                                  \
       rangeCheck<type, up_type>(long_name, short_name, vector_p, oss);                             \
   } while (0)
@@ -829,7 +830,7 @@ InputParameters::applyParameter(const InputParameters & common,
   if (local_exist && common_exist && common_valid && (!local_valid || !local_set) &&
       (!common_priv || !local_priv))
   {
-    delete _values[common_name];
+    remove(common_name);
     _values[common_name] = common._values.find(common_name)->second->clone();
     set_attributes(common_name, false);
   }

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -236,10 +236,12 @@ std::string
 JsonSyntaxTree::buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p,
                              bool & out_of_range_allowed)
 {
+  libMesh::Parameters::Value * val = MooseUtils::get(p.second);
+
   std::string options;
   {
     InputParameters::Parameter<MooseEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<MooseEnum> *>(p.second);
+        dynamic_cast<InputParameters::Parameter<MooseEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
@@ -248,7 +250,7 @@ JsonSyntaxTree::buildOptions(const std::iterator_traits<InputParameters::iterato
   }
   {
     InputParameters::Parameter<MultiMooseEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<MultiMooseEnum> *>(p.second);
+        dynamic_cast<InputParameters::Parameter<MultiMooseEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
@@ -257,7 +259,7 @@ JsonSyntaxTree::buildOptions(const std::iterator_traits<InputParameters::iterato
   }
   {
     InputParameters::Parameter<ExecFlagEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<ExecFlagEnum> *>(p.second);
+        dynamic_cast<InputParameters::Parameter<ExecFlagEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
@@ -266,7 +268,7 @@ JsonSyntaxTree::buildOptions(const std::iterator_traits<InputParameters::iterato
   }
   {
     InputParameters::Parameter<std::vector<MooseEnum>> * enum_type =
-        dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum>> *>(p.second);
+        dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum>> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = (enum_type->get())[0].isOutOfRangeAllowed();
@@ -280,14 +282,15 @@ std::string
 JsonSyntaxTree::buildOutputString(
     const std::iterator_traits<InputParameters::iterator>::value_type & p)
 {
+  libMesh::Parameters::Value * val = MooseUtils::get(p.second);
+
   // Account for Point
   std::stringstream str;
-  InputParameters::Parameter<Point> * ptr0 =
-      dynamic_cast<InputParameters::Parameter<Point> *>(p.second);
+  InputParameters::Parameter<Point> * ptr0 = dynamic_cast<InputParameters::Parameter<Point> *>(val);
 
   // Account for RealVectorValues
   InputParameters::Parameter<RealVectorValue> * ptr1 =
-      dynamic_cast<InputParameters::Parameter<RealVectorValue> *>(p.second);
+      dynamic_cast<InputParameters::Parameter<RealVectorValue> *>(val);
 
   // Output the Point components
   if (ptr0)
@@ -301,7 +304,7 @@ JsonSyntaxTree::buildOutputString(
 
   // General case, call the print operator
   else
-    p.second->print(str);
+    val->print(str);
 
   // remove additional '\n' possibly generated in output (breaks JSON parsing)
   std::string tmp_str = str.str();

--- a/unit/src/ControllableItemTest.C
+++ b/unit/src/ControllableItemTest.C
@@ -19,7 +19,7 @@ get_value(const std::string & name, const InputParameters & params)
   for (libMesh::Parameters::const_iterator map_iter = params.begin(); map_iter != params.end();
        ++map_iter)
     if (name == map_iter->first)
-      return map_iter->second;
+      return MooseUtils::get(map_iter->second);
   return nullptr;
 }
 }

--- a/unit/src/ControllableParameterTest.C
+++ b/unit/src/ControllableParameterTest.C
@@ -20,7 +20,7 @@ get_value(const std::string & name, const InputParameters & params)
   for (libMesh::Parameters::const_iterator map_iter = params.begin(); map_iter != params.end();
        ++map_iter)
     if (name == map_iter->first)
-      return map_iter->second;
+      return MooseUtils::get(map_iter->second);
   return nullptr;
 }
 }


### PR DESCRIPTION
* Update InputParameters::checkConsistentType()
* To allow the use of std::unique_ptrs in the Parameters class, avoid
  code that explicitly casts or otherwise refers to dumb pointers.

Refs libMesh/libmesh#3291
Reasoning and Impact as described in #21032

