### PR TITLE
Libmesh update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Do not use jinja templating (A physical change to this file is required to trigger a build)
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.05.12" %}
+{% set version = "2022.06.06" %}
 
 package:
   name: moose-libmesh

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -11,7 +11,7 @@ moose_ncrc_python:
   - python 3.9
 
 moose_libmesh:
-  - moose-libmesh 2022.05.12 build_0
+  - moose-libmesh 2022.06.06 build_0
 
 SHORT_VTK_NAME:
   - 9.1

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=5a7a9bd0e7295628f465c3bb4e42563b8b8c1a9c
+ARG LIBMESH_REV=4747096de5d6c69ed79f28e38ce45c76546364c3
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2022_05.md
+++ b/modules/doc/content/newsletter/2022_05.md
@@ -45,6 +45,31 @@ for a complete description of all MOOSE changes.
   compatibility with some compilers and compiler warning settings, and
   support for `std::isinf()`.
 
+### `2022.05.27` Update
+
+- Even more internal smart pointers.  This includes changes to the
+  `Parameters` class that may require downstream changes to match;
+  compatibility in Moose itself has already been fixed.
+- When trying to combine a low-order `Elem` with an incompatibly
+  higher order `FE` type, the mistake is now always reported with
+  comprehensible error message, even in non-debugging-mode builds.
+- When a parsed function is used and the parser returns an error, we
+  now check and report details even in non-debugging-mode builds, and
+  we print the failing parsed expression.
+- The last use of C++17-deprecated std::iterator has been fixed;
+  a few compilers outside CI were giving us warnings about it.
+- We put support for input meshes that themselves have holes into
+  MeshedHole, so you can mesh with holes while your hole has holes.
+- Bug fixes for some triangulator use cases.
+- Support for Laplace mesh smoothing of an unpartitioned mesh.
+- Compatibility fixes for some `PETSc` 3.17 configurations.
+
+- MetaPhysicL updates, for evaluating `pow(negative DualNumber,
+  integer)` operations without throwing floating point exceptions,
+  and also evaluating binary functions faster in general when mixing
+  DualNumber and non-DualNumber parameter types.
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/modules/doc/content/newsletter/2022_05.md
+++ b/modules/doc/content/newsletter/2022_05.md
@@ -45,30 +45,33 @@ for a complete description of all MOOSE changes.
   compatibility with some compilers and compiler warning settings, and
   support for `std::isinf()`.
 
-### `2022.05.27` Update
+### `2022.06.01` Update
 
 - Even more internal smart pointers.  This includes changes to the
   `Parameters` class that may require downstream changes to match;
   compatibility in Moose itself has already been fixed.
 - When trying to combine a low-order `Elem` with an incompatibly
   higher order `FE` type, the mistake is now always reported with
-  comprehensible error message, even in non-debugging-mode builds.
+  comprehensible error message, even in builds with assertions
+  disabled.
 - When a parsed function is used and the parser returns an error, we
-  now check and report details even in non-debugging-mode builds, and
-  we print the failing parsed expression.
+  now check and report details even in builds with assertions
+  disabled, and we print the failing parsed expression.
 - The last use of C++17-deprecated std::iterator has been fixed;
   a few compilers outside CI were giving us warnings about it.
 - We put support for input meshes that themselves have holes into
-  MeshedHole, so you can mesh with holes while your hole has holes.
+  `MeshedHole`, so you can mesh with holes while your hole has holes.
 - Bug fixes for some triangulator use cases.
 - Support for Laplace mesh smoothing of an unpartitioned mesh.
 - Compatibility fixes for some `PETSc` 3.17 configurations.
-
+- `configure --enable-xdr-required` option to get a configure-time
+  error when XDR I/O is unavailable.
 - MetaPhysicL updates, for evaluating `pow(negative DualNumber,
   integer)` operations without throwing floating point exceptions,
   and also evaluating binary functions faster in general when mixing
-  DualNumber and non-DualNumber parameter types.
-
+  DualNumber and non-DualNumber parameter types.  Disable some
+  MetaPhysicL optimizations when using older clang++ compilers that
+  were having trouble with them.
 
 ## PETSc-level Changes
 

--- a/scripts/configure_libmesh.sh
+++ b/scripts/configure_libmesh.sh
@@ -50,6 +50,7 @@ function configure_libmesh()
                --enable-hdf5 \
                --enable-petsc-hypre-required \
                --enable-metaphysicl-required \
+               --enable-xdr-required \
                --with-cxx-std-min=2014 \
                --without-gdb-command \
                --with-methods="${METHODS}" \

--- a/tutorials/tutorial03_verification/app/test/tests/step03_analytical/1d_analytical.i
+++ b/tutorials/tutorial03_verification/app/test/tests/step03_analytical/1d_analytical.i
@@ -62,8 +62,8 @@
     vars = 'k    rho  cp  T0  qs'
     vals = '80.2 7800 450 300 7e5'
     value = 'T0 + '
-            'qs/k*(2*sqrt(k/(rho*cp)*t/pi)*exp(-x^2/(4*k/(rho*cp)*t)) - '
-            'x*(1-erf(x/(2*sqrt(k/(rho*cp)*t)))))'
+            'qs/k*(2*sqrt(k/(rho*cp)*t/pi)*exp(-x^2/(4*k/(rho*cp)*(t+1e-50))) - '
+            'x*(1-erf(x/(2*sqrt(k/(rho*cp)*(t+1e-50))))))'
   []
 []
 


### PR DESCRIPTION
- Even more internal smart pointers.  This includes changes to the `Parameter` class that may require downstream changes to match; compatibility in Moose itself has already been fixed.
- When trying to combine a low-order `Elem` with an incompatibly higher order `FE` type, the mistake is now always reported with
  comprehensible error message, even in non-debugging-mode builds.
- When a parsed function is used and the parser returns an error, we now check and report details even in non-debugging-mode builds.
- The last use of C++17-deprecated std::iterator has been fixed; a few compilers outside CI were giving us warnings about it.
- We put support for input meshes that themselves have holes into MeshedHole, so you can mesh with holes while your hole has holes.
- Bug fixes for some triangulator use cases.
- Compatibility fixes for some `PETSc` 3.17 configurations.

- MetaPhysicL updates, for evaluating `pow(negative DualNumber, integer)` operations without throwing floating point exceptions, and also evaluating binary functions faster in general when mixing DualNumber and non-DualNumber parameter types.

I mostly need this for the triangulator fixes, but the MetaPhysicL updates fix a Moose-user-reported bug.  I also want to get that `Parameters` change into Moose CI, to be completely sure it doesn't affect anything that we didn't previously catch via libMesh CI.