### PR TITLE
Nodal constraint sparsity

### DIFF
--- a/test/tests/constraints/equal_value_boundary_constraint/equal_value_boundary_constraint_test.i
+++ b/test/tests/constraints/equal_value_boundary_constraint/equal_value_boundary_constraint_test.i
@@ -21,6 +21,9 @@
   [../]
 []
 
+[Problem]
+  error_on_jacobian_nonzero_reallocation = true
+[]
 
 [BCs]
   [./left]


### PR DESCRIPTION
This fixes the issue identified in #21159 where `NodalConstraint`s write a bunch of explicit zero Jacobian entries which are not accounted for in the sparsity structure of the global Jacobian.  The fix is just to cache the non-zero diagonal entries *only* for that block of the Jacobian.

Closes #21159 
