### PR TITLE
Data folder registration/installation

### DIFF
--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -97,7 +97,7 @@
 #define registerADMooseObjectRenamed(app, orig_class, time, new_class)                             \
   registerMooseObjectRenamed(app, orig_class, time, new_class)
 
-#define registerDataFilePath() Registry::addDataFilePath(__FILE__)
+#define registerDataFilePath() Registry::addDataFilePathFromApp(__FILE__)
 
 struct RegistryEntry;
 class Factory;
@@ -191,6 +191,9 @@ public:
 
   /// addKnownLabel whitelists a label as valid for purposes of the checkLabels function.
   static char addKnownLabel(const std::string & label);
+
+  /// register search paths for built-in data files based on the app file name
+  static void addDataFilePathFromApp(const std::string & path);
 
   /// register search paths for built-in data files
   static void addDataFilePath(const std::string & path);

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -86,6 +86,8 @@ std::string runTestsExecutable();
 /// the first testroot file found.
 std::string findTestRoot();
 
+std::string getInstalledDir(const std::string & app_name, const std::string & dir_name);
+
 /// Returns the directory of any installed inputs or the empty string if none are found.
 std::string installedInputsDir(const std::string & app_name,
                                const std::string & dir_name,

--- a/framework/src/base/Registry.C
+++ b/framework/src/base/Registry.C
@@ -110,16 +110,22 @@ Registry::addKnownLabel(const std::string & label)
 }
 
 void
-Registry::addDataFilePath(const std::string & fullpath)
+Registry::addDataFilePathFromApp(const std::string & fullpath)
 {
-  auto & dfp = getRegistry()._data_file_paths;
-
   // split the *App.C filename from its containing directory
   const auto path = MooseUtils::splitFileName(fullpath).first;
 
   // This works for both build/unity_src/ and src/base/ as the *App.C file location,
   // in case __FILE__ doesn't get overriden in unity build
   const auto data_dir = MooseUtils::pathjoin(path, "../../data");
+
+  addDataFilePath(data_dir);
+}
+
+void
+Registry::addDataFilePath(const std::string & data_dir)
+{
+  auto & dfp = getRegistry()._data_file_paths;
 
   // if the data directory exists and hasn't been added before, add it
   if (MooseUtils::pathIsDirectory(data_dir) &&

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -84,23 +84,27 @@ findTestRoot()
 }
 
 std::string
-installedInputsDir(const std::string & app_name,
-                   const std::string & dir_name,
-                   const std::string & extra_error_msg)
+getInstalledDir(const std::string & app_name, const std::string & dir_name)
 {
   // See moose.mk for a detailed explanation of the assumed installed application
   // layout. Installed inputs are expected to be installed in "share/<app_name>/<folder>".
   // The binary, which has a defined location will be in "bin", a peer directory to "share".
-  std::string installed_path =
-      pathjoin(Moose::getExecutablePath(), "..", "share", app_name, dir_name);
+  return pathjoin(Moose::getExecutablePath(), "..", "share", app_name, dir_name);
+}
 
-  auto test_root = pathjoin(installed_path, "testroot");
+std::string
+installedInputsDir(const std::string & app_name,
+                   const std::string & dir_name,
+                   const std::string & extra_error_msg)
+{
+  std::string installed_path = getInstalledDir(app_name, dir_name);
   if (!pathExists(installed_path))
     mooseError("Couldn't locate any installed inputs to copy in path: ",
                installed_path,
                '\n',
                extra_error_msg);
 
+  auto test_root = pathjoin(installed_path, "testroot");
   checkFileReadable(test_root);
   return installed_path;
 }
@@ -108,10 +112,7 @@ installedInputsDir(const std::string & app_name,
 std::string
 docsDir(const std::string & app_name)
 {
-  // See moose.mk for a detailed explanation of the assumed installed application
-  // layout. Installed docs are expected to be installed in "share/<app_name>/doc".
-  // The binary, which has a defined location will be in "bin", a peer directory to "share".
-  std::string installed_path = pathjoin(Moose::getExecutablePath(), "..", "share", app_name, "doc");
+  std::string installed_path = getInstalledDir(app_name, "doc");
 
   auto docfile = pathjoin(installed_path, "css", "moose.css");
   if (pathExists(docfile) && checkFileReadable(docfile))


### PR DESCRIPTION
Refer to #21187.

A small improvement on `MooseUtils::pathjoin` was added in here.

This PR does not add the capability of `app-opt --print-registered-data-folders` and let `make install` to copy those folders. A side note is that we possibly need to differentiate the data folders and test folders.