### PR TITLE
Use dualnumber_decl.h to get its declarations

### DIFF
--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -24,6 +24,7 @@
 #include "libmesh/int_range.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/metaphysicl_version.h"
+#include "metaphysicl/dualnumber_decl.h"
 #include "metaphysicl/dynamic_std_array_wrapper.h"
 #include "timpi/standard_type.h"
 
@@ -50,29 +51,6 @@ class Communicator;
 }
 }
 class MultiMooseEnum;
-namespace MetaPhysicL
-{
-#if METAPHYSICL_MAJOR_VERSION < 1
-template <typename, typename>
-class DualNumber;
-#else
-#include "metaphysicl/dualnumber_forward.h"
-#endif
-}
-namespace std
-{
-#if METAPHYSICL_MAJOR_VERSION < 1
-template <typename T, typename D>
-MetaPhysicL::DualNumber<T, D> abs(const MetaPhysicL::DualNumber<T, D> & in);
-template <typename T, typename D>
-MetaPhysicL::DualNumber<T, D> abs(MetaPhysicL::DualNumber<T, D> && in);
-#else
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(const MetaPhysicL::DualNumber<T, D, asd> & in);
-template <typename T, typename D, bool asd>
-MetaPhysicL::DualNumber<T, D, asd> abs(MetaPhysicL::DualNumber<T, D, asd> && in);
-#endif
-}
 
 namespace MooseUtils
 {


### PR DESCRIPTION
## Reason

This ensures compatibility of MetaPhysicL declarations and MetaPhysicL configuration.

## Design

Get declarations from dualnumber_decl.h instead of trying to duplicate them.

## Impact

This should fix #21203.
