### PR TITLE
Update AD version to use exception instead of assert

### DIFF
--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteStrain.C
@@ -148,9 +148,12 @@ ADComputeFiniteStrain::computeQpIncrements(ADRankTwoTensor & total_strain_increm
       const ADReal C1_squared =
           p + 3.0 * Utility::pow<2>(p) * (1.0 - (p + q)) / Utility::pow<2>(p + q) -
           2.0 * Utility::pow<3>(p) * (1.0 - (p + q)) / Utility::pow<3>(p + q);
-      mooseAssert(C1_squared >= 0.0,
-                  "Cannot take square root of a negative number. This may happen when elements "
-                  "become heavily distorted.");
+      if (C1_squared <= 0.0)
+        mooseException(
+            "Cannot take square root of a number less than or equal to zero in the calculation of "
+            "C1 for the Rashid approximation for the rotation tensor. This zero or negative number "
+            "may occur when elements become heavily distorted.");
+
       const ADReal C1 = std::sqrt(C1_squared);
 
       ADReal C2;
@@ -169,9 +172,12 @@ ADComputeFiniteStrain::computeQpIncrements(ADRankTwoTensor & total_strain_increm
 
       const ADReal C3_test =
           (p * q * (3.0 - q) + Utility::pow<3>(p) + Utility::pow<2>(q)) / Utility::pow<3>(p + q);
-      mooseAssert(C3_test >= 0.0,
-                  "Cannot take square root of a negative number. This may happen when elements "
-                  "become heavily distorted.");
+      if (C3_test <= 0.0)
+        mooseException(
+            "Cannot take square root of a number less than or equal to zero in the calculation of "
+            "C3_test for the Rashid approximation for the rotation tensor. This zero or negative "
+            "number may occur when elements become heavily distorted.");
+
       const ADReal C3 = 0.5 * std::sqrt(C3_test); // sin theta_a/(2 sqrt(q))
 
       // Calculate incremental rotation. Note that this value is the transpose of that from Rashid,

--- a/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/3d_bar.i
+++ b/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/3d_bar.i
@@ -32,57 +32,57 @@
 []
 
 [Modules/TensorMechanics/Master]
-  [./all]
+  [all]
     strain = FINITE
     add_variables = true
     use_finite_deform_jacobian = true
     volumetric_locking_correction = false
     use_automatic_differentiation = true
-  [../]
+  []
 []
 
 [Materials]
-  [./stress]
+  [stress]
     type = ADComputeFiniteStrainElasticStress
-  [../]
-  [./elasticity_tensor]
+  []
+  [elasticity_tensor]
     type = ADComputeElasticityTensor
     fill_method = symmetric9
     C_ijkl = '1.684e5 0.176e5 0.176e5 1.684e5 0.176e5 1.684e5 0.754e5 0.754e5 0.754e5'
-  [../]
+  []
 []
 
 [BCs]
- [./fix_corner_x]
+ [fix_corner_x]
    type = ADDirichletBC
    variable = disp_x
    boundary = 101
    value = 0
- [../]
- [./fix_corner_y]
+ []
+ [fix_corner_y]
    type = ADDirichletBC
    variable = disp_y
    boundary = 101
    value = 0
- [../]
- [./fix_side_y]
+ []
+ [fix_side_y]
    type = ADDirichletBC
    variable = disp_y
    boundary = 102
    value = 0
- [../]
- [./fix_z]
+ []
+ [fix_z]
    type = ADDirichletBC
    variable = disp_z
    boundary = back
    value = 0
- [../]
- [./move_z]
+ []
+ [move_z]
    type = ADFunctionDirichletBC
    variable = disp_z
    boundary = front
    function = 't'
- [../]
+ []
 []
 
 [Executioner]
@@ -105,10 +105,10 @@
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/bending_jacobian.i
+++ b/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/bending_jacobian.i
@@ -35,51 +35,51 @@
 []
 
 [Modules/TensorMechanics/Master]
-  [./all]
+  [all]
     strain = FINITE
     add_variables = true
     use_finite_deform_jacobian = true
     volumetric_locking_correction = false
     use_automatic_differentiation = true
-  [../]
+  []
 []
 
 [Materials]
-  [./stress]
+  [stress]
     type = ADComputeFiniteStrainElasticStress
-  [../]
-  [./elasticity_tensor]
+  []
+  [elasticity_tensor]
     type = ADComputeElasticityTensor
     fill_method = symmetric9
     C_ijkl = '1.684e5 0.176e5 0.176e5 1.684e5 0.176e5 1.684e5 0.754e5 0.754e5 0.754e5'
-  [../]
+  []
 []
 
 [BCs]
- [./fix_corner_x]
+ [fix_corner_x]
    type = ADDirichletBC
    variable = disp_x
    boundary = 101
    value = 0
- [../]
- [./fix_corner_y]
+ []
+ [fix_corner_y]
    type = ADDirichletBC
    variable = disp_y
    boundary = 101
    value = 0
- [../]
- [./fix_y]
+ []
+ [fix_y]
    type = ADDirichletBC
    variable = disp_y
    boundary = 102
    value = 0
- [../]
- [./move_y]
+ []
+ [move_y]
    type = ADFunctionDirichletBC
    variable = disp_y
    boundary = 103
    function = '-t'
- [../]
+ []
 []
 
 [Executioner]
@@ -102,10 +102,10 @@
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Outputs]

--- a/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/tests
+++ b/modules/tensor_mechanics/test/tests/ad_finite_strain_jacobian/tests
@@ -1,14 +1,14 @@
 [Tests]
   design = '/ADComputeFiniteStrain.md'
-  [./bending]
+  [bending]
     type = Exodiff
     input = 'bending_jacobian.i'
     exodiff = 'bending_jacobian_out.e'
     issues = '#7228 #13260'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    bar bending simulation in 2D using AD and match non-AD methods'
-  [../]
-  [./bending_Bbar]
+  []
+  [bending_Bbar]
     type = Exodiff
     input = 'bending_jacobian.i'
     exodiff = 'bending_jacobian_bbar_out.e'
@@ -18,16 +18,16 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    bar bending simulation in 2D using a volumetric locking correction using AD and
                    match non-AD methods'
-  [../]
-  [./3d_bar]
+  []
+  [3d_bar]
     type = Exodiff
     input = '3d_bar.i'
     exodiff = '3d_bar_out.e'
     issues = '#7228 #13260'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D using AD and match non-AD methods'
-  [../]
-  [./3d_bar_Bbar]
+  []
+  [3d_bar_Bbar]
     type = Exodiff
     input = '3d_bar.i'
     exodiff = '3d_bar_out.e'
@@ -37,9 +37,9 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    tensile test simulation in 3D using a volumetric locking correction using AD and
                    match non-AD methods'
-  [../]
+  []
 
-  [./bending-jac]
+  [bending-jac]
     type = PetscJacobianTester
     input = 'bending_jacobian.i'
     run_sim = 'True'
@@ -49,8 +49,8 @@
     issues = '#12650 #13260'
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    bar bending simulation in 2D using AD and calculate perfect Jacobians'
-  [../]
-  [./bending_Bbar-jac]
+  []
+  [bending_Bbar-jac]
     type = PetscJacobianTester
     input = 'bending_jacobian.i'
     cli_args = 'GlobalParams/volumetric_locking_correction=true'
@@ -62,8 +62,8 @@
     requirement = 'Finite strain methods in Tensor Mechanics should be able to adequately simulate a
                    bar bending simulation in 2D using a volumetric locking correction using AD and
                    calculate perfect Jacobians'
-  [../]
-  [./3d_bar-jac]
+  []
+  [3d_bar-jac]
     type = PetscJacobianTester
     input = '3d_bar.i'
     prereq = '3d_bar'
@@ -75,8 +75,8 @@
                    tensile test simulation in 3D using AD and calculate perfect Jacobians'
     valgrind = 'none' # too slow especially after #14547
     cli_args = 'Executioner/num_steps=1'
-  [../]
-  [./3d_bar_Bbar-jac]
+  []
+  [3d_bar_Bbar-jac]
     type = PetscJacobianTester
     input = '3d_bar.i'
     cli_args = 'GlobalParams/volumetric_locking_correction=true Executioner/num_steps=1'
@@ -89,5 +89,22 @@
                    tensile test simulation in 3D using a volumetric locking correction using AD and
                    calculate perfect Jacobians'
     valgrind = 'none' # too slow especially after #14547
-  [../]
+  []
+
+  [bending_exception]
+    type = 'RunException'
+    input = bending_jacobian.i
+    cli_args = 'BCs/move_y/function="-100*t"'
+    expect_err = 'Cannot take square root of a number less than or equal to '
+                 'zero in the calculation of C3_test for the Rashid '
+                 'approximation for the rotation tensor. This zero or '
+                 'negative number may occur when elements become heavily distorted.'
+    issues = '#19067'
+    requirement = 'Finite strain methods in Tensor Mechanics, using the auto '
+                  'differentiation capabilities, shall cut the timestep through '
+                  ' a mooseException when the loading conditions deform the '
+                  'elements so much as to produce a negative number under the '
+                  'square root term in the Rashid approximation for the '
+                  'rotation tensor calcuation'
+  []
 []


### PR DESCRIPTION
Propagates the change from #19069 to the AD version of ComputeFiniteStrain

Refs #19067
