### PR TITLE
Name both ids and names if shared for RenameBoundaryGenerator. 

### DIFF
--- a/framework/doc/content/source/meshgenerators/RenameBoundaryGenerator.md
+++ b/framework/doc/content/source/meshgenerators/RenameBoundaryGenerator.md
@@ -17,6 +17,10 @@ The following will change the name for the boundary "meaningless" to "interior" 
 []
 ```
 
+For the special case where the original boundary name and ID are the same, this mesh generator
+will convert *both* to the new boundary name/ID. For instance, if the mesh contains a boundary
+named `3` that also has an ID of `3`, this mesh generator will convert both the name and ID.
+
 ## Merging Boundaries
 
 When using the `RenameBoundaryGenerator` to merge boundaries, the result is not necessarily independent of ordering.

--- a/framework/src/meshgenerators/RenameBoundaryGenerator.C
+++ b/framework/src/meshgenerators/RenameBoundaryGenerator.C
@@ -218,7 +218,13 @@ RenameBoundaryGenerator::generate()
 
       // Preserve the old boundary name if there was one
       if (old_boundary_names[i].size())
-        new_names[id] = old_boundary_names[i];
+      {
+        // if the name was the same as the ID, change the name as well
+        if (old_boundary_names[i] == std::to_string(old_boundary_ids[i]))
+          new_names[id] = std::to_string(new_boundary_ids[i]);
+        else
+          new_names[id] = old_boundary_names[i];
+      }
     }
     // If the user input a name, we will use the ID that it is coming from for the
     // "new" name if the new name does not name a current boundary. If the name does

--- a/test/tests/meshgenerators/rename_boundary_generator/gold/name_and_id_out.json
+++ b/test/tests/meshgenerators/rename_boundary_generator/gold/name_and_id_out.json
@@ -1,0 +1,91 @@
+{
+    "reporters": {
+        "mesh_info": {
+            "type": "MeshInfo",
+            "values": {
+                "sideset_elems": {
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                }
+            }
+        }
+    },
+    "time_steps": [
+        {
+            "mesh_info": {
+                "sideset_elems": null
+            },
+            "time": 0.0,
+            "time_step": 0
+        },
+        {
+            "mesh_info": {
+                "sideset_elems": [
+                    {
+                        "id": 0,
+                        "name": "bottom",
+                        "sides": [
+                            {
+                                "elem_id": 0,
+                                "side": 0
+                            }
+                        ]
+                    },
+                    {
+                        "id": 1,
+                        "name": "right",
+                        "sides": [
+                            {
+                                "elem_id": 0,
+                                "side": 1
+                            },
+                            {
+                                "elem_id": 2,
+                                "side": 1
+                            }
+                        ]
+                    },
+                    {
+                        "id": 2,
+                        "name": "top",
+                        "sides": [
+                            {
+                                "elem_id": 1,
+                                "side": 2
+                            },
+                            {
+                                "elem_id": 2,
+                                "side": 2
+                            }
+                        ]
+                    },
+                    {
+                        "id": 3,
+                        "name": "left",
+                        "sides": [
+                            {
+                                "elem_id": 1,
+                                "side": 3
+                            }
+                        ]
+                    },
+                    {
+                        "id": 101,
+                        "name": "101",
+                        "sides": [
+                            {
+                                "elem_id": 0,
+                                "side": 3
+                            },
+                            {
+                                "elem_id": 1,
+                                "side": 0
+                            }
+                        ]
+                    }
+                ]
+            },
+            "time": 1.0,
+            "time_step": 1
+        }
+    ]
+}

--- a/test/tests/meshgenerators/rename_boundary_generator/name_and_id.i
+++ b/test/tests/meshgenerators/rename_boundary_generator/name_and_id.i
@@ -34,6 +34,8 @@
   # We compare by element numbers, which are not consistent in parallel
   # if this is true
   allow_renumbering = false
+
+  parallel_type = replicated
 []
 
 [Reporters/mesh_info]

--- a/test/tests/meshgenerators/rename_boundary_generator/name_and_id.i
+++ b/test/tests/meshgenerators/rename_boundary_generator/name_and_id.i
@@ -1,0 +1,57 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 2
+    ny = 2
+    xmin = 0
+    xmax = 4
+    ymin = 0
+    ymax = 4
+  []
+  [SubdomainBoundingBox]
+    type = SubdomainBoundingBoxGenerator
+    input = gmg
+    block_id = 1
+    bottom_left = '0 0 0'
+    top_right = '2 2 2'
+  []
+  [ed0]
+    type = BlockDeletionGenerator
+    input = SubdomainBoundingBox
+    block = 1
+
+    # this makes a new boundary with an ID of 100 and a name of "100"
+    new_boundary = '100'
+  []
+  [rename_both_id_and_name]
+    type = RenameBoundaryGenerator
+    input = ed0
+    old_boundary = '100' # this is both an ID and a name, which we want to both rename
+    new_boundary = '101'
+  []
+
+  # We compare by element numbers, which are not consistent in parallel
+  # if this is true
+  allow_renumbering = false
+[]
+
+[Reporters/mesh_info]
+  type = MeshInfo
+  items = sideset_elems
+[]
+
+[Outputs]
+  [out]
+    type = JSON
+    execute_system_information_on = NONE
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'meshgenerators/RenameBoundaryGenerator.md'
-  issues = '#11640 #14128 #16885'
+  issues = '#11640 #14128 #16885 #21268'
 
   [rename]
     requirement = 'The system shall be able to rename or renumber mesh boundaries by:'

--- a/test/tests/meshgenerators/rename_boundary_generator/tests
+++ b/test/tests/meshgenerators/rename_boundary_generator/tests
@@ -57,7 +57,14 @@
                   Outputs/file_base=mixed_out'
       jsondiff = 'mixed_out.json'
 
-      detail = 'and by identifying boundaries by both id and name.'
+      detail = 'identifying boundaries by both id and name,'
+    []
+
+    [identical_name_and_id]
+      type = JSONDiff
+      input = 'name_and_id.i'
+      jsondiff = 'name_and_id_out.json'
+      detail = 'and by changing both id and name for old boundaries where the id and name match.'
     []
   []
 


### PR DESCRIPTION
Closes #21268
