### PR TITLE
Protect against mixed positive and negative extrusion heights in FancyExtruderGenerator

### DIFF
--- a/framework/src/meshgenerators/FancyExtruderGenerator.C
+++ b/framework/src/meshgenerators/FancyExtruderGenerator.C
@@ -162,6 +162,19 @@ FancyExtruderGenerator::FancyExtruderGenerator(const InputParameters & parameter
         elevation_extra_swap_pairs[elevation_extra_swaps[k]] = elevation_extra_swaps[k + 1];
     }
   }
+
+  bool has_negative_entry = false;
+  bool has_positive_entry = false;
+  for (const auto & h : _heights)
+  {
+    if (h > 0.0)
+      has_positive_entry = true;
+    else
+      has_negative_entry = true;
+  }
+
+  if (has_negative_entry && has_positive_entry)
+    paramError("heights", "Cannot have both positive and negative heights!");
 }
 
 std::unique_ptr<MeshBase>

--- a/test/tests/meshgenerators/fancy_extruder_generator/tests
+++ b/test/tests/meshgenerators/fancy_extruder_generator/tests
@@ -61,4 +61,13 @@
     design = 'FancyExtruderGenerator.md'
     issues = '#18087'
   []
+  [mixed_extrude]
+    type = RunException
+    input = gen_extrude.i
+    cli_args = 'Mesh/extrude/heights="1 2 -3" --mesh-only'
+    expect_err = "Cannot have both positive and negative heights!"
+    requirement = "The system shall error if missing a consistent positive or negative extrusion direction."
+    design = "FancyExtruderGenerator.md"
+    issues = "#21273"
+  []
 []


### PR DESCRIPTION
I also figure it's probably an error to have a zero extrusion height, but didn't add that. Happy to tack that on if the reviewer thinks that's an error.

Closes #21273