### PR TITLE
More info in NS param checking, more selective checking

### DIFF
--- a/modules/navier_stokes/include/actions/NSFVAction.h
+++ b/modules/navier_stokes/include/actions/NSFVAction.h
@@ -316,6 +316,18 @@ private:
   /// Checks that sufficient Rhie Chow coefficients have been defined for the given dimension, used
   /// for scalar or temperature advection by auxiliary variables
   void checkRhieChowFunctorsDefined();
+  /// Check that two parameters are the same size
+  void checkSizeFriendParams(const unsigned int param_vector_1_size,
+                             const unsigned int param_vector_2_size,
+                             const std::string & param_name_1,
+                             const std::string & param_name_2,
+                             const std::string & object_name_1) const;
+  /// Check that a parameter is of the expected size
+  void checkSizeParam(const unsigned int param_vector_size,
+                      const std::string & param_name,
+                      const unsigned int size_wanted,
+                      const std::string & object_name,
+                      const std::string & size_source_explanation) const;
 
   /// List to show which advected scalar field variable needs to be created within
   /// this action
@@ -353,8 +365,11 @@ NSFVAction::checkBlockwiseConsistency(const std::string block_param_name,
       const std::vector<T> & param_vector = _pars.get<std::vector<T>>(param_name);
       if (block_names.size() != param_vector.size())
         paramError(param_name,
-                   "The number of entries in '" + param_name +
-                       "' is not the same as the number of blocks in '" + block_param_name + "'!");
+                   "The number of entries in '" + param_name + "' (" +
+                       std::to_string(param_vector.size()) +
+                       ") is not the same as the number of blocks"
+                       " (" +
+                       std::to_string(block_names.size()) + ") in '" + block_param_name + "'!");
     }
   }
   else

--- a/modules/navier_stokes/src/actions/NSFVAction.C
+++ b/modules/navier_stokes/src/actions/NSFVAction.C
@@ -2350,17 +2350,24 @@ NSFVAction::checkICParameterErrors()
 void
 NSFVAction::checkBoundaryParameterErrors()
 {
-  if (_outlet_boundaries.size() != _momentum_outlet_types.size())
-    paramError("momentum_outlet_types",
-               "Size is not the same as the number of outlet boundaries in 'outlet_boundaries'");
+  checkSizeFriendParams(_outlet_boundaries.size(),
+                        _momentum_outlet_types.size(),
+                        "outlet_boundaries",
+                        "momentum_outlet_types",
+                        "outlet boundaries");
 
-  if (_wall_boundaries.size() > 0 && _wall_boundaries.size() != _momentum_wall_types.size())
-    paramError("momentum_wall_types",
-               "Size is not the same as the number of wall boundaries in 'wall_boundaries'");
+  if (_wall_boundaries.size() > 0)
+    checkSizeFriendParams(_wall_boundaries.size(),
+                          _momentum_wall_types.size(),
+                          "wall_boundaries",
+                          "momentum_wall_types",
+                          "wall boundaries");
 
-  if (_inlet_boundaries.size() != _momentum_inlet_types.size())
-    paramError("momentum_inlet_types",
-               "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'");
+  checkSizeFriendParams(_inlet_boundaries.size(),
+                        _momentum_inlet_types.size(),
+                        "inlet_boundaries",
+                        "momentum_inlet_types",
+                        "inlet boundaries");
 
   unsigned int num_dir_dependent_bcs = 0;
   unsigned int num_flux_bc_postprocessors = 0;
@@ -2372,15 +2379,17 @@ NSFVAction::checkBoundaryParameterErrors()
       num_flux_bc_postprocessors += 1;
   }
 
-  if (_momentum_inlet_function.size() != num_dir_dependent_bcs * _dim)
-    paramError("momentum_inlet_function",
-               "Size is not the same as the number of direction dependent boundaries in "
-               "'inlet_boundaries' times the mesh dimension");
+  checkSizeParam(_momentum_inlet_function.size(),
+                 "momentum_inlet_function",
+                 num_dir_dependent_bcs * _dim,
+                 "direction dependent directions",
+                 "'inlet_boundaries' times the mesh dimension");
 
-  if (_flux_inlet_pps.size() != num_flux_bc_postprocessors)
-    paramError("flux_inlet_pps",
-               "The number of flux postprocessors is not equal to the number of flux types in "
-               "'inlet_boundaries'!");
+  checkSizeParam(_flux_inlet_pps.size(),
+                 "flux_inlet_pps",
+                 num_flux_bc_postprocessors,
+                 "flux types",
+                 "'inlet_boundaries'");
 
   unsigned int num_pressure_outlets = 0;
   for (unsigned int enum_ind = 0; enum_ind < _outlet_boundaries.size(); ++enum_ind)
@@ -2388,9 +2397,11 @@ NSFVAction::checkBoundaryParameterErrors()
         _momentum_outlet_types[enum_ind] == "fixed-pressure-zero-gradient")
       num_pressure_outlets += 1;
 
-  if (_pressure_function.size() != num_pressure_outlets)
-    paramError("pressure_function",
-               "Size is not the same as the number of pressure outlet boundaries!");
+  checkSizeParam(_pressure_function.size(),
+                 "pressure_function",
+                 num_pressure_outlets,
+                 "pressure outlet boundaries",
+                 "'fixed-pressure/fixed-pressure-zero-gradient'");
 
   if (_compressibility == "incompressible" && _has_flow_equations)
     if (num_pressure_outlets == 0 && !(getParam<bool>("pin_pressure")))
@@ -2399,17 +2410,23 @@ NSFVAction::checkBoundaryParameterErrors()
 
   if (_has_energy_equation)
   {
-    if (_inlet_boundaries.size() != _energy_inlet_types.size())
-      paramError("energy_inlet_types",
-                 "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'");
+    checkSizeFriendParams(_inlet_boundaries.size(),
+                          _energy_inlet_types.size(),
+                          "inlet_boundaries",
+                          "energy_inlet_types",
+                          "inlet boundaries");
 
-    if (_energy_inlet_types.size() != _energy_inlet_function.size())
-      paramError("energy_inlet_function",
-                 "Size is not the same as the number of boundaries in 'energy_inlet_types'");
+    checkSizeFriendParams(_energy_inlet_types.size(),
+                          _energy_inlet_function.size(),
+                          "energy_inlet_types",
+                          "energy_inlet_function",
+                          "boundaries");
 
-    if (_wall_boundaries.size() != _energy_wall_types.size())
-      paramError("energy_wall_types",
-                 "Size is not the same as the number of wall boundaries in 'wall_boundaries'");
+    checkSizeFriendParams(_wall_boundaries.size(),
+                          _energy_wall_types.size(),
+                          "wall_boundaries",
+                          "energy_wall_types",
+                          "wall boundaries");
 
     unsigned int num_fixed_energy_walls = 0;
     for (unsigned int enum_ind = 0; enum_ind < _energy_wall_types.size(); ++enum_ind)
@@ -2417,23 +2434,28 @@ NSFVAction::checkBoundaryParameterErrors()
           _energy_wall_types[enum_ind] == "heatflux")
         num_fixed_energy_walls += 1;
 
-    if (_wall_boundaries.size() > 0 && (_energy_wall_function.size() != num_fixed_energy_walls))
-      paramError("energy_wall_function",
-                 "Size " + std::to_string(_energy_wall_function.size()) +
-                     " is not the same as the number of Dirichlet/Neumann conditions in "
-                     "'energy_wall_types' (" +
-                     std::to_string(num_fixed_energy_walls) + ")");
+    if (_wall_boundaries.size() > 0)
+      checkSizeParam(_energy_wall_function.size(),
+                     "energy_wall_function",
+                     num_fixed_energy_walls,
+                     "Dirichlet/Neumann conditions",
+                     "'energy_wall_types'");
   }
   if (_has_scalar_equation)
   {
-    if (_inlet_boundaries.size() != _passive_scalar_inlet_types.size())
-      paramError("passive_scalar_inlet_types",
-                 "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'");
-
-    if (_passive_scalar_inlet_types.size() != _passive_scalar_inlet_function.size())
-      paramError(
-          "passive_scalar_inlet_function",
-          "Size is not the same as the number of boundaries in 'passive_scalar_inlet_types'");
+    if (_inlet_boundaries.size())
+    {
+      checkSizeFriendParams(_inlet_boundaries.size(),
+                            _passive_scalar_inlet_types.size(),
+                            "inlet_boundaries",
+                            "passive_scalar_inlet_types",
+                            "inlet boundaries");
+      checkSizeFriendParams(_passive_scalar_inlet_types.size(),
+                            _passive_scalar_inlet_function.size(),
+                            "passive_scalar_inlet_types",
+                            "passive_scalar_inlet_function",
+                            "boundaries");
+    }
   }
 }
 
@@ -2543,6 +2565,37 @@ NSFVAction::checkDependentParameterError(const std::string main_parameter,
       paramError(param,
                  "This parameter should not be given by the user with the corresponding " +
                      main_parameter + " setting!");
+}
+
+void
+NSFVAction::checkSizeFriendParams(const unsigned int param_vector_1_size,
+                                  const unsigned int param_vector_2_size,
+                                  const std::string & param_name_1,
+                                  const std::string & param_name_2,
+                                  const std::string & object_name_1) const
+{
+  // param 1 is the reference
+  if (param_vector_1_size != param_vector_2_size)
+    paramError(param_name_2,
+               "Size (" + std::to_string(param_vector_2_size) +
+                   ") is not the same as the "
+                   "number of " +
+                   object_name_1 + " in '" + param_name_1 + "' (" +
+                   std::to_string(param_vector_1_size) + ")");
+}
+
+void
+NSFVAction::checkSizeParam(const unsigned int param_vector_size,
+                           const std::string & param_name,
+                           const unsigned int size_wanted,
+                           const std::string & object_name,
+                           const std::string & size_source_explanation) const
+{
+  if (param_vector_size != size_wanted)
+    paramError(param_name,
+               "Size (" + std::to_string(param_vector_size) +
+                   ") is not the same as the number of " + object_name + " in " +
+                   size_source_explanation + " (" + std::to_string(size_wanted) + ")");
 }
 
 void

--- a/modules/navier_stokes/test/tests/finite_volume/ins/action/errors/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/action/errors/tests
@@ -6,7 +6,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of momentum inlet types does not match the number of inlet boundaries.'
     cli_args = "Modules/NavierStokesFV/momentum_inlet_types=''"
-    expect_err = "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of inlet boundaries in 'inlet_boundaries' \(1\)"
     ad_indexing_type = 'global'
   []
   [momentum-inlet-function-error]
@@ -14,7 +14,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of momentum inlet functions does not match the number of inlet boundaries times the dimension of the mesh.'
     cli_args = "Modules/NavierStokesFV/momentum_inlet_function='1'"
-    expect_err = "Size is not the same as the number of direction dependent boundaries in 'inlet_boundaries' times the mesh dimension"
+    expect_err = "Size \(1\) is not the same as the number of direction dependent directions in 'inlet_boundaries' times the mesh dimension \(2\)"
     ad_indexing_type = 'global'
   []
   [momentum-outlet-error]
@@ -22,7 +22,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of momentum outlet types does not match the number of outlet boundaries.'
     cli_args = "Modules/NavierStokesFV/momentum_outlet_types=''"
-    expect_err = "Size is not the same as the number of outlet boundaries in 'outlet_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of outlet boundaries in 'outlet_boundaries' \(1\)"
     ad_indexing_type = 'global'
   []
   [pressure-outlet-function-error]
@@ -30,7 +30,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of pressure outlet functions is not the same the pressure outlet boundaries.'
     cli_args = "Modules/NavierStokesFV/pressure_function=''"
-    expect_err = "Size is not the same as the number of pressure outlet boundaries!"
+    expect_err = "Size \(0\) is not the same as the number of pressure outlet boundaries in 'fixed-pressure/fixed-pressure-zero-gradient' \(1\)"
     ad_indexing_type = 'global'
   []
   [momentum-wall-error]
@@ -38,7 +38,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of momentum wall types does not match the number of wall boundaries.'
     cli_args = "Modules/NavierStokesFV/momentum_wall_types=''"
-    expect_err = "Size is not the same as the number of wall boundaries in 'wall_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of wall boundaries in 'wall_boundaries' \(2\)"
     ad_indexing_type = 'global'
   []
   [energy-inlet-error]
@@ -46,7 +46,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of energy inlet types does not match the number of inlet boundaries.'
     cli_args = "Modules/NavierStokesFV/energy_inlet_types=''"
-    expect_err = "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of inlet boundaries in 'inlet_boundaries' \(1\)"
     ad_indexing_type = 'global'
   []
   [passive-scalar-inlet-error]
@@ -54,7 +54,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of passive scalar inlet types does not match the number of inlet boundaries.'
     cli_args = "Modules/NavierStokesFV/passive_scalar_inlet_types=''"
-    expect_err = "Size is not the same as the number of inlet boundaries in 'inlet_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of inlet boundaries in 'inlet_boundaries' \(1\)"
     ad_indexing_type = 'global'
   []
   [passive-scalar-inlet-function-error]
@@ -62,7 +62,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of passive scalar inlet functions does not match the number of inlet boundaries.'
     cli_args = "Modules/NavierStokesFV/passive_scalar_inlet_function=''"
-    expect_err = "Size is not the same as the number of boundaries in 'passive_scalar_inlet_types'"
+    expect_err = "Size \(0\) is not the same as the number of boundaries in 'passive_scalar_inlet_types' \(1\)"
     ad_indexing_type = 'global'
   []
   [energy-wall-error]
@@ -70,7 +70,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of energy wall types does not match the number of wall boundaries.'
     cli_args = "Modules/NavierStokesFV/energy_wall_types=''"
-    expect_err = "Size is not the same as the number of wall boundaries in 'wall_boundaries'"
+    expect_err = "Size \(0\) is not the same as the number of wall boundaries in 'wall_boundaries' \(2\)"
     ad_indexing_type = 'global'
   []
   [energy-wall-function-action-error]
@@ -78,7 +78,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of energy wall functions does not match the number of energy wall types.'
     cli_args = "Modules/NavierStokesFV/energy_wall_function=''"
-    expect_err = "Size 0 is not the same as the number of Dirichlet/Neumann conditions in 'energy_wall_types' \(2\)"
+    expect_err = "Size \(0\) is not the same as the number of Dirichlet/Neumann conditions in 'energy_wall_types' \(2\)"
     ad_indexing_type = 'global'
   []
   [scalar-ic-error]


### PR DESCRIPTION
This fixes errors in MSFR with the new conditions on when to check the inlet BCs for scalars
