### PR TITLE
Revert mark mortar constraint variable as active in fe_problem

### DIFF
--- a/framework/include/utils/MortarUtils.h
+++ b/framework/include/utils/MortarUtils.h
@@ -97,15 +97,6 @@ loopOverMortarSegments(const Iterators & secondary_elems_to_mortar_segments,
   // The element Jacobian times weights
   const auto & JxW_msm = assembly.jxWMortar();
 
-  // Set required variables
-  std::set<MooseVariableFieldBase *> needed_moose_vars;
-  for (const auto & consumer : consumers)
-  {
-    const auto & mv_deps = consumer->getMooseVariableDependencies();
-    needed_moose_vars.insert(mv_deps.begin(), mv_deps.end());
-  }
-  fe_problem.setActiveElementalMooseVariables(needed_moose_vars, /*tid=*/tid);
-
   // Set required material properties
   std::set<unsigned int> needed_mat_props;
   for (const auto & consumer : consumers)


### PR DESCRIPTION
These lines of code make assessment cases leveraging mortar constraints to model gap heat transfer fail. It appears that problem variables (temperature) are not properly initialized when reinitializing face materials (e.g. creep/thermal expansion) from the mortar constraint loop. The ultimate cause of this issue is not known to me, but it's not straightforward to reproduce in a MOOSE regression test unfortunately.

Tagging @lindsayad who has more insight into what the cause can be.

Refs #19444.