### PR TITLE
Fixes memory issue with parallel study buffer and mpi send buffer object

### DIFF
--- a/modules/ray_tracing/include/utils/ParallelStudy.h
+++ b/modules/ray_tracing/include/utils/ParallelStudy.h
@@ -1099,12 +1099,12 @@ ParallelStudy<WorkType, ParallelDataType>::moveWorkToBuffer(const work_iterator 
   // Can move directly into the work buffer on thread 0 when we're not executing work
   if (!_currently_executing_work && tid == 0)
   {
-    if (_work_buffer->capacity() < _work_buffer->capacity() + size)
-      _work_buffer->setCapacity(_work_buffer->capacity() + size);
+    if (_work_buffer->capacity() < _work_buffer->size() + size)
+      _work_buffer->setCapacity(_work_buffer->size() + size);
     _local_work_started += size;
   }
   else
-    _temp_threaded_work[tid].reserve(_temp_threaded_work[tid].capacity() + size);
+    _temp_threaded_work[tid].reserve(_temp_threaded_work[tid].size() + size);
 
   // Move the objects
   if (!_currently_executing_work && tid == 0)
@@ -1142,8 +1142,8 @@ ParallelStudy<WorkType, ParallelDataType>::moveContinuingWorkToBuffer(const work
     moveWorkError(MoveWorkError::CONTINUING_DURING_EXECUTING_WORK);
 
   const auto size = std::distance(begin, end);
-  if (_work_buffer->capacity() < _work_buffer->capacity() + size)
-    _work_buffer->setCapacity(_work_buffer->capacity() + size);
+  if (_work_buffer->capacity() < _work_buffer->size() + size)
+    _work_buffer->setCapacity(_work_buffer->size() + size);
 
   for (auto it = begin; it != end; ++it)
     _work_buffer->move(*it);

--- a/modules/ray_tracing/include/utils/ReceiveBuffer.h
+++ b/modules/ray_tracing/include/utils/ReceiveBuffer.h
@@ -295,8 +295,8 @@ ReceiveBuffer<Object, Context>::cleanupRequests()
           _buffers_received++;
           _objects_received += objects->size();
 
-          if (_buffer.capacity() < _buffer.capacity() + objects->size())
-            _buffer.setCapacity(_buffer.capacity() + objects->size());
+          if (_buffer.capacity() < _buffer.size() + objects->size())
+            _buffer.setCapacity(_buffer.size() + objects->size());
 
           for (auto & object : *objects)
             _buffer.move(object);


### PR DESCRIPTION

Closes #21414

## Reason
Change code logic so that affected buffers do not grow every time they are used, only when needed.

## Design
Several calls to capacity() simply needed to be changed to size()

## Impact
Users running very large simulations in HPC environment may see less memory build with the new code.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
