### PR TITLE
Restrict IGA tests to vtk 9.1 for now

### DIFF
--- a/modules/tensor_mechanics/examples/cframe_iga/tests
+++ b/modules/tensor_mechanics/examples/cframe_iga/tests
@@ -3,7 +3,8 @@
     type = XMLDiff
     input = 'cframe_iga.i'
     exodus_version = '>=8.0'
-    vtk_version = '>=9.0'
+    # Set to >=9.0 once #21449 is resolved
+    vtk_version = '>=9.1'
     max_parallel = 1 # number of VTK output files changes with num processes, so we are sticking w/ one for now
     xmldiff = 'cframe_iga_out_001.pvtu cframe_iga_out_001_0.vtu'
   []

--- a/test/tests/meshgenerators/file_mesh_generator/tests
+++ b/test/tests/meshgenerators/file_mesh_generator/tests
@@ -28,7 +28,8 @@
     expect_out = 'Solve Converged'
     recover = false
     exodus_version = '>=8.0'
-    vtk_version = '>=9.0'
+    # Set to >=9.0 once #21449 is resolved
+    vtk_version = '>=9.1'
     max_parallel = 1
     vtk = true
     xmldiff = '2d_diffusion_iga_out_002.pvtu 2d_diffusion_iga_out_002_0.vtu'
@@ -44,7 +45,8 @@
     expect_out = 'Solve Converged'
     recover = false
     exodus_version = '>=8.0'
-    vtk_version = '>=9.0'
+    # Set to >=9.0 once #21449 is resolved
+    vtk_version = '>=9.1'
     max_parallel = 1
     vtk = true
     xmldiff = '2d_diffusion_iga_nosplines_out_002.pvtu 2d_diffusion_iga_nosplines_out_002_0.vtu'
@@ -60,7 +62,8 @@
     expect_out = 'Solve Converged'
     recover = false
     exodus_version = '>=8.0'
-    vtk_version = '>=9.0'
+    # Set to >=9.0 once #21449 is resolved
+    vtk_version = '>=9.1'
     max_parallel = 1
     vtk = true
     xmldiff = '3d_steady_diffusion_iga_out_001.pvtu 3d_steady_diffusion_iga_out_001_0.vtu'


### PR DESCRIPTION
Refs #21449

These should be removed once #21449 is resolved.

~~I've verified that these do work with VTK 9.1... so @roystgnr let me know what I can do to help.~~ This may not be true

This'll fix next for now.