### PR TITLE
Add ability to print clean cyclic graph

### DIFF
--- a/framework/include/interfaces/DependencyResolverInterface.h
+++ b/framework/include/interfaces/DependencyResolverInterface.h
@@ -17,6 +17,7 @@
 
 // MOOSE includes
 #include "DependencyResolver.h"
+#include "MooseUtils.h"
 
 /**
  * Interface for sorting dependent vectors of objects.
@@ -120,10 +121,10 @@ DependencyResolverInterface::cyclicDependencyError(CyclicDependencyException<T2>
   std::ostringstream oss;
 
   oss << header << ":\n";
-  const auto & adjacency_lists = e.getCyclicDependencies();
-  for (const auto & [object, object_adjacencies] : adjacency_lists)
-    for (const auto & adjacent_object : object_adjacencies)
-      oss << static_cast<T>(object)->name() << " -> " << static_cast<T>(adjacent_object)->name()
-          << "\n";
+  const auto cycle = e.getCyclicDependencies();
+  std::vector<std::string> names(cycle.size());
+  for (const auto i : index_range(cycle))
+    names[i] = static_cast<T>(cycle[i])->name();
+  oss << MooseUtils::join(names, " <- ");
   mooseError(oss.str());
 }

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -99,7 +99,15 @@ Syntax::clearTaskDependencies()
 const std::vector<std::string> &
 Syntax::getSortedTask()
 {
-  return _tasks.getSortedValues();
+  try
+  {
+    return _tasks.getSortedValues();
+  }
+  catch (CyclicDependencyException<std::string> & e)
+  {
+    const auto cycle = e.getCyclicDependencies();
+    mooseError("Cyclic graph detected: ", MooseUtils::join(cycle, " <- "));
+  }
 }
 
 const std::vector<std::vector<std::string>> &

--- a/framework/src/parser/Syntax.C
+++ b/framework/src/parser/Syntax.C
@@ -106,7 +106,7 @@ Syntax::getSortedTask()
   catch (CyclicDependencyException<std::string> & e)
   {
     const auto cycle = e.getCyclicDependencies();
-    mooseError("Cyclic graph detected: ", MooseUtils::join(cycle, " <- "));
+    mooseError("Cyclic dependencies detected: ", MooseUtils::join(cycle, " <- "));
   }
 }
 

--- a/unit/src/SyntaxTest.C
+++ b/unit/src/SyntaxTest.C
@@ -116,3 +116,21 @@ TEST_F(SyntaxTest, deprecatedCustomMessage)
   const std::string message = _syntax.deprecatedActionSyntaxMessage("TopBlock");
   EXPECT_EQ(message, "Replace [TopBlock] with [NewBlock].");
 }
+
+TEST(CyclicSyntaxTest, cyclic)
+{
+  Syntax syntax;
+  syntax.registerTaskName("a");
+  syntax.registerTaskName("b");
+  syntax.addDependency("a", "b");
+  syntax.addDependency("b", "a");
+  try
+  {
+    syntax.getSortedTask();
+    FAIL() << "missing expected error";
+  }
+  catch (std::runtime_error & e)
+  {
+    EXPECT_TRUE(std::string(e.what()).find("a <- b") != std::string::npos);
+  }
+}


### PR DESCRIPTION
Example:

```
add_partitioner <- init_sam_simulation <- build_mesh <- finish_input_file_output
<- sam_check_quadrature <- check_legacy_params <- setup_executioner_params <-
meta_action <- dynamic_object_registration <- common_output <- set_global_params
<- setup_recover_file_base <- check_copy_nodal_vars <- setup_mesh <-
add_geometric_rm <- add_partitioner
```

Refs #21108