### PR TITLE
Adding Lead and LeadBismuth Fluid properties

### DIFF
--- a/modules/fluid_properties/doc/content/bib/fluid_properties.bib
+++ b/modules/fluid_properties/doc/content/bib/fluid_properties.bib
@@ -303,3 +303,13 @@ from 0 to 1000 C, 0 to 5000 bar, and 0 to 1 X$_{NaCl}$}},
   year = {1979}
 }
 
+@techreport{Fazio,
+  author = {Fazio Concetta and Sobolev V.P. and Aerts A. and Gavrilov S. and Lambrinou K. and Schuurmans P. and Gessi, A. and Agostini P. and Ciampichetti A. and Martinelli
+  L. and Gosse S. and Balbaud-Celerier F. and Courouau J.L. and Terlain A. and Li N. and Glasbrenner H. and Neuhausen J. and Heinitz S. and Zanini L. and Dai Y. and Jolkkonen
+   M. and Kurata Y. and Obara T. and Thiolliere N. and Martin-Munoz F.J. and Heinzel A. and Weisenburger A. and Mueller G. and Schumacher G. and Jianu A. and Pacio J. and Marocco
+   L. and Stieglitz R. and Wetzel T. and Daubner M. and Litfin K. and Vogt J.B. and Proriol-Serre I. and Gorse D. and Eckert S. and Stefani F. and Buchenau D. and Wondrak T. & Hwang},
+  title = {Handbook on Lead-bismuth Eutectic Alloy and Lead Properties, Materials Compatibility, Thermal- hydraulics and Technologies},
+  institution = {Nuclear Energy Agency of the OECD},
+  number = {NEA--7268},
+  year = {2015}
+}

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
@@ -1,0 +1,57 @@
+# LeadBismuthFluidProperties
+
+!syntax description /FluidProperties/LeadBismuthFluidProperties
+
+Formulation for Molten Lead that is heated above 398 Kelvin and is below 1300 Kelvin, based off prior experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead Properties, Materials Compatibility, Thermal- hydraulics and Technologies [!citep](Fazio).
+
+Density, enthalpy, internal energy, viscosity, thermal conductivity and isobaric specific heat.
+calculated using the formulations provided in [!citep](Fazio).
+
+The formulations used from the handbook are all based off of pressure and temperature dependence,
+with only using temperature as a variable in its calculations.
+
+The handbook also assumes that isochoric specific heat is the same as isobaric specific heat,
+as the fluid is considered incompressible.
+
+## Uncertainties of Lead Fluid Properties
+
+Table for LeadBismuthFluidProperties Uncertainties:
+
+
+| Properties | Range/ Uncertainties|
+| :------------- | :------------- |
+| Density | .8% |
+| Viscosity | 8% |
+| Thermal Conductivity | 15% |
+| Isobaric Specific Heat | 7% |
+
+## Properties Associated Equations and Figure #  
+
+Table of properties, equations and citation of where in [!citep](Fazio).
+
+| Properties | Equations| Figure # |
+| :------------- | :------------- | :------------- |
+| Melting point $(T_{mo}, K)$ | 398 |  2.1  |
+| Boilling Point (K) | 1300 |  6.2.1  |
+| Density $(\rho, kg/m^3)$ | $11065 - 1.2793T$ |  2.30  |
+| Viscosity $(\mu, Pa \times s)$ | $4.94 \times 10^{-4} \times e^{\frac{754.1}{temperature}}$ |  2.83  |
+| Specific Volume (v, m^3) | $\frac{1}{\rho}$ |  NA  |
+| Specific enthalpy (h, J) | $164.8(T - T_{mo}) - 1.97 \times 10^{-2}(T^2 - T_{mo}^2) + 4.167 \times 10^6(T^3 - T_{mo}^3) + 4.56 \times 10^5(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.55  |
+| Thermal Conductivity $(k, \frac {W}{m * K})$ | $3.284 + 1.617 \times 10^{-2}T - 2.305 \times 10^{-6}T^2$ |  2.91  |
+| Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $164.8 - 3.94 * 10^{-2}T + 1.25 \times 10^{-5}T^2 - \frac{4.56 * 10^5}{T^2}$ |  Table 2.19.3  |
+| Bulk Modules $(\frac{N}{m^2})$ | $(38.02 - 1.296 \times 10^{-2}T + 1.320 \times 10^{-6}T^2)10^9$ |  2.44  |
+| Speed of Sound  (c) | $\sqrt{\frac {Bulk Modules}{\rho}}$ |  NA  |
+
+## Range of validity
+
+The LeadFluidProperties UserObject is valid for:
+
+ 698 K $\le$ T $\le$ 1300 K
+
+!syntax parameters /FluidProperties/LeadBismuthFluidProperties
+
+!syntax inputs /FluidProperties/LeadBismuthFluidProperties
+
+!syntax children /FluidProperties/LeadBismuthFluidProperties
+
+!bibtex bibliography

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
@@ -2,51 +2,38 @@
 
 !syntax description /FluidProperties/LeadBismuthFluidProperties
 
-Formulation for Molten Lead that is heated above 398 Kelvin and is below 1300 Kelvin, based off prior experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead Properties, Materials Compatibility, Thermal- hydraulics and Technologies [!citep](Fazio).
+These properties are based on experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead
+Properties, Materials Compatibility, Thermal-hydraulics and Technologies [!citep](Fazio). 
+Most properties only depend on temperature, the fluid is considered incompressible.
 
-Density, enthalpy, internal energy, viscosity, thermal conductivity and isobaric specific heat.
-calculated using the formulations provided in [!citep](Fazio).
-
-The formulations used from the handbook are all based off of pressure and temperature dependence,
-with only using temperature as a variable in its calculations.
-
-The handbook also assumes that isochoric specific heat is the same as isobaric specific heat,
-as the fluid is considered incompressible.
-
-## Uncertainties of Lead Fluid Properties
-
-Table for LeadBismuthFluidProperties Uncertainties:
-
-
-| Properties | Range/ Uncertainties|
-| :------------- | :------------- |
-| Density | .8% |
-| Viscosity | 8% |
-| Thermal Conductivity | 15% |
-| Isobaric Specific Heat | 7% |
-
-## Properties Associated Equations and Figure #  
-
-Table of properties, equations and citation of where in [!citep](Fazio).
-
-| Properties | Equations| Figure # |
-| :------------- | :------------- | :------------- |
-| Melting point $(T_{mo}, K)$ | 398 |  2.1  |
-| Boilling Point (K) | 1300 |  6.2.1  |
-| Density $(\rho, kg/m^3)$ | $11065 - 1.2793T$ |  2.30  |
+!table caption=Table of properties and references to the equations in [!citep](Fazio).
+| Properties                     | Equations| Equation # |
+| :----------------------------- | :------------- | :------------- |
+| Melting point $(T_{mo}, K)$    | 398 |  2.1  |
+| Density $(\rho, kg/m^3)$       | $11065 - 1.2793T$ |  2.30  |
 | Viscosity $(\mu, Pa \times s)$ | $4.94 \times 10^{-4} \times e^{\frac{754.1}{temperature}}$ |  2.83  |
-| Specific Volume (v, m^3) | $\frac{1}{\rho}$ |  NA  |
-| Specific enthalpy (h, J) | $164.8(T - T_{mo}) - 1.97 \times 10^{-2}(T^2 - T_{mo}^2) + 4.167 \times 10^6(T^3 - T_{mo}^3) + 4.56 \times 10^5(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.55  |
+| Specific enthalpy (h, J)       | $164.8(T - T_{mo}) - 1.97 \times 10^{-2}(T^2 - T_{mo}^2) + 4.167 \times 10^6(T^3 - T_{mo}^3) + 4.56 \times 10^5(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.55  |
 | Thermal Conductivity $(k, \frac {W}{m * K})$ | $3.284 + 1.617 \times 10^{-2}T - 2.305 \times 10^{-6}T^2$ |  2.91  |
 | Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $164.8 - 3.94 * 10^{-2}T + 1.25 \times 10^{-5}T^2 - \frac{4.56 * 10^5}{T^2}$ |  Table 2.19.3  |
 | Bulk Modules $(\frac{N}{m^2})$ | $(38.02 - 1.296 \times 10^{-2}T + 1.320 \times 10^{-6}T^2)10^9$ |  2.44  |
-| Speed of Sound  (c) | $\sqrt{\frac {Bulk Modules}{\rho}}$ |  NA  |
+| Speed of Sound  (c)            | $1855 - 0.212 T$ | Table 2.19.3 |
 
 ## Range of validity
 
-The LeadFluidProperties UserObject is valid for:
+The properties defined in `LeadBismuthFluidProperties` from [!citep](Fazio) are valid for:
 
- 698 K $\le$ T $\le$ 1300 K
+400 K $\le$ T $\le$ 1100 K
+
+## Uncertainties of Lead Bismuth Eutectic Fluid Properties
+
+The reported uncertainties in [!citep](Fazio) for lead-bismuth eutectic fluid properties are:
+
+| Properties     | Range/ Uncertainties|
+| :------------- | :------------- |
+| Density        | .8% |
+| Viscosity      |  8% |
+| Thermal Conductivity | 15% |
+| Isobaric Specific Heat | 7% |
 
 !syntax parameters /FluidProperties/LeadBismuthFluidProperties
 

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadBismuthFluidProperties.md
@@ -4,19 +4,20 @@
 
 These properties are based on experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead
 Properties, Materials Compatibility, Thermal-hydraulics and Technologies [!citep](Fazio). 
-Most properties only depend on temperature, the fluid is considered incompressible.
+Most properties only depend on temperature; the fluid is considered incompressible.
+The fluid properties are summarized in Table [tab:leadbi], which reports the formulas used and their origin. 
 
-!table caption=Table of properties and references to the equations in [!citep](Fazio).
-| Properties                     | Equations| Equation # |
+!table id=tab:leadbi caption=Table of properties and references to the equations in [!citep](Fazio).
+| Properties                     | Equations| Equation/Table # |
 | :----------------------------- | :------------- | :------------- |
-| Melting point $(T_{mo}, K)$    | 398 |  2.1  |
-| Density $(\rho, kg/m^3)$       | $11065 - 1.2793T$ |  2.30  |
-| Viscosity $(\mu, Pa \times s)$ | $4.94 \times 10^{-4} \times e^{\frac{754.1}{temperature}}$ |  2.83  |
-| Specific enthalpy (h, J)       | $164.8(T - T_{mo}) - 1.97 \times 10^{-2}(T^2 - T_{mo}^2) + 4.167 \times 10^6(T^3 - T_{mo}^3) + 4.56 \times 10^5(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.55  |
-| Thermal Conductivity $(k, \frac {W}{m * K})$ | $3.284 + 1.617 \times 10^{-2}T - 2.305 \times 10^{-6}T^2$ |  2.91  |
-| Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $164.8 - 3.94 * 10^{-2}T + 1.25 \times 10^{-5}T^2 - \frac{4.56 * 10^5}{T^2}$ |  Table 2.19.3  |
-| Bulk Modules $(\frac{N}{m^2})$ | $(38.02 - 1.296 \times 10^{-2}T + 1.320 \times 10^{-6}T^2)10^9$ |  2.44  |
-| Speed of Sound  (c)            | $1855 - 0.212 T$ | Table 2.19.3 |
+| Melting point, $T_{mo}$ (K)    | 398 | Equation 2.1  |
+| Density, $\rho$ (kg/m^3)       | $11065 - 1.2793T$ | Equation 2.30  |
+| Viscosity, $\mu$ (Pa-s)        | $4.94 \times 10^{-4} \times e^{\frac{754.1}{T}}$ | Equation 2.83  |
+| Specific enthalpy, $h$ (J)     | $164.8(T - T_{mo}) - 1.97 \times 10^{-2}(T^2 - T_{mo}^2) + 4.167 \times 10^6(T^3 - T_{mo}^3) + 4.56 \times 10^5(\frac{1}{T} -\frac{1}{T_{mo}})$ | Equation 2.55  |
+| Thermal Conductivity, $k$ (W/m-K)        | $3.284 + 1.617 \times 10^{-2}T - 2.305 \times 10^{-6}T^2$ | Equation 2.91  |
+| Isobaric Specific Heat, $cp$ (J/kg-K)    | $164.8 - 3.94 \times 10^{-2}T + 1.25 \times 10^{-5}T^2 - \frac{4.56 \times 10^5}{T^2}$ |  Table 2.19.3  |
+| Isentropic Bulk Modulus, $B_S$ (N/m$^2$) | $(38.02 - 1.296 \times 10^{-2}T + 1.320 \times 10^{-6}T^2)10^9$ | Equation 2.44  |
+| Speed of Sound, $c$ (m/s)                | $1855 - 0.212 T$ | Table 2.19.3 |
 
 ## Range of validity
 
@@ -30,7 +31,7 @@ The reported uncertainties in [!citep](Fazio) for lead-bismuth eutectic fluid pr
 
 | Properties     | Range/ Uncertainties|
 | :------------- | :------------- |
-| Density        | .8% |
+| Density        | 0.8% |
 | Viscosity      |  8% |
 | Thermal Conductivity | 15% |
 | Isobaric Specific Heat | 7% |

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
@@ -1,0 +1,56 @@
+# LeadFluidProperties
+
+!syntax description /FluidProperties/LeadFluidProperties
+
+ Formulation for Molten Lead that is heated above 600 Kelvin and is below 1800 Kelvin, based off prior experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead Properties, Materials Compatibility, Thermal- hydraulics and Technologies [!citep](Fazio).
+
+Density, enthalpy, internal energy, viscosity, thermal conductivity and isobaric specific heat.
+calculated using the formulations provided in [!citep](Fazio).
+
+The formulations used from the handbook are all based off of pressure and temperature dependence,
+with only using temperature as a variable in its calculations.
+
+The handbook also assumes that isochoric specific heat is the same as isobaric specific heat,
+as the fluid is considered incompressible.
+
+## Uncertainties of Lead Fluid Properties
+
+Table for LeadFluidProperties Uncertainties:
+
+| Properties | Uncertainties|
+| :------------- | :------------- |
+| Density | 1% |
+| Viscosity | 5% |
+| Thermal Conductivity | 15% |
+| Isobaric Specific Heat | 5% |
+
+## Properties Associated Equations and Reference
+
+Table of properties, equations and citation of where in [!citep](Fazio).
+
+| Properties | Equations| Figure # |
+| :------------- | :------------- | :------------- |
+| Melting point $(T_{mo}, K)$ | 600 |  2.1  |
+| Boilling Point (K) | 1750 |  6.2.1  |
+| Density $(\rho, kg/m^3)$ | $11441 - 1.2795T$ |  2.28  |
+| Viscosity $(\mu, Pa \times s)$ | $4.55 \times 10^{-4} \times e^{\frac{1069}{temperature}}$ |  2.81  |
+| Specific Volume (v, m^3) | $\frac{1}{\rho}$ |  NA  |
+| Specific enthalpy (h, J) | $176.2(T - T_{mo}) - 2.4615 \times 10^{-2}(T^2 - T_{mo}^2) + 5.147 \times 10^6(T^3 - T_{mo}^3) + 1.524 \times 10^6(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.53  |
+| Thermal Conductivity $(k, \frac {W}{m * K})$ | $9.2 + 0.011T$ |  2.89  |
+| Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $176.2 - 4.923* 10^{-2} \times T + 1.544 \times 10^-5 \times T^2 - \frac{1.524 * 10^6}{T^2}$ |  Table 2.19.1  |
+| Bulk Modules $(\frac{N}{m^2})$ | $(43.50 - 1.552 \times 10^{-2}T + 1.622 \times 10^{-6}T^2)10^9$ |  2.42  |
+| Speed of Sound  (c) | $\sqrt{\frac {Bulk Modules}{\rho}}$ |  NA  |
+
+## Range of validity
+
+The properties defined by `LeadFluidProperties` are valid for:
+
+ - 600 K $\le$ T $\le$ 1800 K
+
+!syntax parameters /FluidProperties/LeadFluidProperties
+
+!syntax inputs /FluidProperties/LeadFluidProperties
+
+!syntax children /FluidProperties/LeadFluidProperties
+
+!bibtex bibliography

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
@@ -4,19 +4,20 @@
 
 These properties are based on experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead
 Properties, Materials Compatibility, Thermal-hydraulics and Technologies [!citep](Fazio).
-Most properties only depend on temperature, the fluid is considered incompressible.
+Most properties only depend on temperature; the fluid is considered incompressible.
+The fluid properties are summarized in Table [tab:lead], which reports the formulas used and their origin. 
 
-!table caption=Table of properties and references to the equations in [!citep](Fazio).
-| Properties                     | Equation       | Equation # |
+!table id=tab:lead caption=Table of properties and references to the equations in [!citep](Fazio).
+| Properties                     | Equation       | Equation/Table # |
 | :----------------------------- | :------------- | :------------- |
-| Melting point $(T_{mo}, K)$    | 600            |  2.1  |
-| Density $(\rho, kg/m^3)$       | $11441 - 1.2795T$ |  2.28  |
-| Viscosity $(\mu, Pa \times s)$ | $4.55 \times 10^{-4} \times e^{\frac{1069}{temperature}}$ |  2.81  |
-| Specific enthalpy (h, J)       | $176.2(T - T_{mo}) - 2.4615 \times 10^{-2}(T^2 - T_{mo}^2) + 5.147 \times 10^6(T^3 - T_{mo}^3) + 1.524 \times 10^6(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.53  |
-| Thermal Conductivity $(k, \frac {W}{m * K})$ | $9.2 + 0.011T$ |  2.89  |
-| Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $176.2 - 4.923* 10^{-2} \times T + 1.544 \times 10^-5 \times T^2 - \frac{1.524 * 10^6}{T^2}$ |  Table 2.19.1  |
-| Bulk Modulus $(\frac{N}{m^2})$ | $(43.50 - 1.552 \times 10^{-2}T + 1.622 \times 10^{-6}T^2)10^9$ |  2.42  |
-| Speed of Sound (c, m/s)           | $1953 - 0.246 T$ | Table 2.19.1 |
+| Melting point, $T_{mo}$ (K)    | 600            | Equation 2.1  |
+| Density, $\rho$ (kg/m^3)       | $11441 - 1.2795T$ | Equation 2.28  |
+| Viscosity, $\mu$ (Pa-s)        | $4.55 \times 10^{-4} \times e^{\frac{1069}{T}}$ | Equation 2.81  |
+| Specific enthalpy, $h$ (J)     | $176.2(T - T_{mo}) - 2.4615 \times 10^{-2}(T^2 - T_{mo}^2) + 5.147 \times 10^6(T^3 - T_{mo}^3) + 1.524 \times 10^6(\frac{1}{T} -\frac{1}{T_{mo}})$ | Equation 2.53  |
+| Thermal Conductivity, $k$ (W/m-K)        | $9.2 + 0.011T$ | Equation 2.89  |
+| Isobaric Specific Heat, $cp$ (J/kg-K)    | $176.2 - 4.923\times 10^{-2} \times T + 1.544 \times 10^{-5} \times T^2 - \frac{1.524 \times 10^6}{T^2}$ |  Table 2.19.1  |
+| Isentropic Bulk Modulus, $B_S$ (N/m$^2$) | $(43.50 - 1.552 \times 10^{-2}T + 1.622 \times 10^{-6}T^2)10^9$ | Equation 2.42  |
+| Speed of Sound, $c$ (m/s)                | $1953 - 0.246 T$ | Table 2.19.1 |
 
 ## Range of validity
 

--- a/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/userobjects/LeadFluidProperties.md
@@ -2,50 +2,38 @@
 
 !syntax description /FluidProperties/LeadFluidProperties
 
- Formulation for Molten Lead that is heated above 600 Kelvin and is below 1800 Kelvin, based off prior experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead Properties, Materials Compatibility, Thermal- hydraulics and Technologies [!citep](Fazio).
+These properties are based on experiments reported in the Handbook on Lead-bismuth Eutectic Alloy and Lead
+Properties, Materials Compatibility, Thermal-hydraulics and Technologies [!citep](Fazio).
+Most properties only depend on temperature, the fluid is considered incompressible.
 
-Density, enthalpy, internal energy, viscosity, thermal conductivity and isobaric specific heat.
-calculated using the formulations provided in [!citep](Fazio).
-
-The formulations used from the handbook are all based off of pressure and temperature dependence,
-with only using temperature as a variable in its calculations.
-
-The handbook also assumes that isochoric specific heat is the same as isobaric specific heat,
-as the fluid is considered incompressible.
-
-## Uncertainties of Lead Fluid Properties
-
-Table for LeadFluidProperties Uncertainties:
-
-| Properties | Uncertainties|
-| :------------- | :------------- |
-| Density | 1% |
-| Viscosity | 5% |
-| Thermal Conductivity | 15% |
-| Isobaric Specific Heat | 5% |
-
-## Properties Associated Equations and Reference
-
-Table of properties, equations and citation of where in [!citep](Fazio).
-
-| Properties | Equations| Figure # |
-| :------------- | :------------- | :------------- |
-| Melting point $(T_{mo}, K)$ | 600 |  2.1  |
-| Boilling Point (K) | 1750 |  6.2.1  |
-| Density $(\rho, kg/m^3)$ | $11441 - 1.2795T$ |  2.28  |
+!table caption=Table of properties and references to the equations in [!citep](Fazio).
+| Properties                     | Equation       | Equation # |
+| :----------------------------- | :------------- | :------------- |
+| Melting point $(T_{mo}, K)$    | 600            |  2.1  |
+| Density $(\rho, kg/m^3)$       | $11441 - 1.2795T$ |  2.28  |
 | Viscosity $(\mu, Pa \times s)$ | $4.55 \times 10^{-4} \times e^{\frac{1069}{temperature}}$ |  2.81  |
-| Specific Volume (v, m^3) | $\frac{1}{\rho}$ |  NA  |
-| Specific enthalpy (h, J) | $176.2(T - T_{mo}) - 2.4615 \times 10^{-2}(T^2 - T_{mo}^2) + 5.147 \times 10^6(T^3 - T_{mo}^3) + 1.524 \times 10^6(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.53  |
+| Specific enthalpy (h, J)       | $176.2(T - T_{mo}) - 2.4615 \times 10^{-2}(T^2 - T_{mo}^2) + 5.147 \times 10^6(T^3 - T_{mo}^3) + 1.524 \times 10^6(\frac{1}{T} -\frac{1}{T_{mo}})$ |  2.53  |
 | Thermal Conductivity $(k, \frac {W}{m * K})$ | $9.2 + 0.011T$ |  2.89  |
 | Isobaric Specific Heat $(cp, \frac{J}{kg * K})$ | $176.2 - 4.923* 10^{-2} \times T + 1.544 \times 10^-5 \times T^2 - \frac{1.524 * 10^6}{T^2}$ |  Table 2.19.1  |
-| Bulk Modules $(\frac{N}{m^2})$ | $(43.50 - 1.552 \times 10^{-2}T + 1.622 \times 10^{-6}T^2)10^9$ |  2.42  |
-| Speed of Sound  (c) | $\sqrt{\frac {Bulk Modules}{\rho}}$ |  NA  |
+| Bulk Modulus $(\frac{N}{m^2})$ | $(43.50 - 1.552 \times 10^{-2}T + 1.622 \times 10^{-6}T^2)10^9$ |  2.42  |
+| Speed of Sound (c, m/s)           | $1953 - 0.246 T$ | Table 2.19.1 |
 
 ## Range of validity
 
 The properties defined by `LeadFluidProperties` are valid for:
 
  - 600 K $\le$ T $\le$ 1800 K
+
+## Uncertainties of Lead Fluid Properties
+
+The reported uncertainties in [!citep](Fazio) for lead fluid properties are:
+
+| Properties | Uncertainties |
+| :------------- | :------------- |
+| Density | 1% |
+| Viscosity | 5% |
+| Thermal Conductivity | 15% |
+| Isobaric Specific Heat | 5% |
 
 !syntax parameters /FluidProperties/LeadFluidProperties
 

--- a/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
@@ -12,7 +12,7 @@
 #include "SinglePhaseFluidProperties.h"
 
 /**
- * Fluid properties for 2LiF-BeF2 (LeadBismuth) \cite richard.
+ *  Fluid properties for (Lead) \cite Fazio.
  */
 class LeadBismuthFluidProperties : public SinglePhaseFluidProperties
 {
@@ -37,6 +37,7 @@ public:
    * @param[in] e   specific internal energy (J/kg)
    * @return pressure (Pa)
    */
+  using SinglePhaseFluidProperties::p_from_v_e;
   virtual Real p_from_v_e(Real v, Real e) const override;
 
   /**
@@ -180,6 +181,11 @@ public:
    */
   virtual void
   rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
 
   /**
    * Specific volume from pressure and temperature
@@ -189,7 +195,6 @@ public:
    * @return specific volume (m$^3$/kg)
    */
   virtual Real v_from_p_T(Real p, Real T) const override;
-  virtual DualReal v_from_p_T(const DualReal & p, const DualReal & T) const override;
 
   /**
    * Specific volume and its derivatives from pressure and temperature
@@ -334,6 +339,23 @@ public:
    */
   virtual void
   mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+
+  /**
+   * Bulk Modulus from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return Bulk Modules (N/m^2)
+   */
+  virtual Real bulk_modulus_from_p_T(Real p, Real T) const;
+  /**
+   * Speed of Sound from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return [out] c speed of sound (m/s)
+   */
+  virtual Real c_from_v_e(Real v, Real e) const override;
 
 private:
   const Real _T_mo;

--- a/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
@@ -12,7 +12,7 @@
 #include "SinglePhaseFluidProperties.h"
 
 /**
- *  Fluid properties for (Lead) \cite Fazio.
+ *  Fluid properties for 2LiF-BeF2 (LeadBismuth) \cite richard.
  */
 class LeadBismuthFluidProperties : public SinglePhaseFluidProperties
 {
@@ -23,322 +23,72 @@ public:
 
   LeadBismuthFluidProperties(const InputParameters & parameters);
 
-  /**
-   * Fluid name
-   *
-   * @return "LeadBismuth"
-   */
   virtual std::string fluidName() const override;
+  Real molarMass() const override;
 
-  /**
-   * Pressure from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return pressure (Pa)
-   */
   using SinglePhaseFluidProperties::p_from_v_e;
-  virtual Real p_from_v_e(Real v, Real e) const override;
+  Real p_from_v_e(Real v, Real e) const override;
+  void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
 
-  /**
-   * Pressure and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v        specific volume (m$^3$/kg)
-   * @param[in] e        specific internal energy (J/kg)
-   * @param[out] p       pressure (Pa)
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
-   */
-  virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
-
-  /**
-   * Temperature from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return temperature (K)
-   */
-  virtual Real T_from_v_e(Real v, Real e) const override;
-
-  /**
-   * Temperature and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v        specific volume (m$^3$/kg)
-   * @param[in] e        specific internal energy (J/kg)
-   * @param[out] T       temperature (K)
-   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
-   */
-  virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
+  Real T_from_v_e(Real v, Real e) const override;
+  void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
 
   /**
    * Temperature from pressure and density
    *
-   * @param[in] p   pressure (Pa)
-   * @param[in] rho density (kg/m$^3$)
+   * @param[in] p     pressure (Pa)
+   * @param[in] rho   (kg/m$^3$)
    * @return[out] temperature (K)
    */
-  virtual Real T_from_p_rho(Real p, Real rho) const;
+  Real T_from_p_rho(Real p, Real rho) const;
+  void T_from_p_rho(Real pressure, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
 
-  /**
-   * Density and its derivatives from pressure and temperature
-   * @param[in] p          pressure (Pa)
-   * @param[in] rho       density (kg/m$^3$)
-   * @param[out] T          temperature (K)
-   * @param[out] dT_dp   derivative of temperature w.r.t. temperature
-   * @param[out] dT_drho   derivative of temperature w.r.t. density
-   */
-  virtual void
-  T_from_p_rho(Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const;
+  Real cp_from_v_e(Real v, Real e) const override;
+  void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
 
-  /**
-   * Isobaric specific heat from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return isobaric specific heat (J/kg.K)
-   */
-  virtual Real cp_from_v_e(Real v, Real e) const override;
+  Real cv_from_v_e(Real v, Real e) const override;
+  void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
 
-  /**
-   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v       specific volume (m$^3$/kg)
-   * @param[in] e       specific internal energy (J/kg)
-   * @param[out] cp     isobaric specific heat (J/kg.K)
-   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
-   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
-   */
-  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
+  Real mu_from_v_e(Real v, Real e) const override;
+  void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
 
-  /**
-   * Isochoric specific heat from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return isochoric specific heat (J/kg.K)
-   */
-  virtual Real cv_from_v_e(Real v, Real e) const override;
+  Real k_from_v_e(Real v, Real e) const override;
+  void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
 
-  /**
-   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v       specific volume (m$^3$/kg)
-   * @param[in] e       specific internal energy (J/kg)
-   * @param[out] cv     isochoric specific heat (J/kg.K)
-   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
-   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
-   */
-  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+  Real rho_from_p_T(Real p, Real T) const override;
+  void rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  void rho_from_p_T(const DualReal & p,
+                    const DualReal & T,
+                    DualReal & rho,
+                    DualReal & drho_dp,
+                    DualReal & drho_dT) const override;
 
-  /**
-   * Isobaric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isochoric specific heat (J/kg.K)
-   */
-  virtual Real cv_from_p_T(Real p, Real T) const override;
-  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
+  Real v_from_p_T(Real p, Real T) const override;
+  void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
 
-  /**
-   * Dynamic viscosity from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return dynamic viscosity (Pa.s)
-   */
-  virtual Real mu_from_v_e(Real v, Real e) const override;
-  virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
+  Real h_from_v_e(Real v, Real e) const;
+  void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
 
-  /**
-   * Thermal conductivity from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return thermal conductivity (W/m.K)
-   */
-  virtual Real k_from_v_e(Real v, Real e) const override;
-  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
+  Real h_from_p_T(Real p, Real T) const override;
+  void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  /**
-   * Density from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return density (kg/m$^3$)
-   */
-  virtual Real rho_from_p_T(Real p, Real T) const override;
+  Real e_from_p_T(Real p, Real T) const override;
+  void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
 
-  /**
-   * Density and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
-   * @param[out] rho       density (kg/m$^3$)
-   * @param[out] drho_dp   derivative of density w.r.t. pressure
-   * @param[out] drho_dT   derivative of density w.r.t. temperature
-   */
-  virtual void
-  rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
-  virtual void rho_from_p_T(const DualReal & p,
-                            const DualReal & T,
-                            DualReal & rho,
-                            DualReal & drho_dp,
-                            DualReal & drho_dT) const override;
+  Real e_from_p_rho(Real p, Real rho) const override;
+  void e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
 
-  /**
-   * Specific volume from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific volume (m$^3$/kg)
-   */
-  virtual Real v_from_p_T(Real p, Real T) const override;
+  Real cv_from_p_T(Real p, Real T) const override;
+  void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
 
-  /**
-   * Specific volume and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
-   * @param[out] v         specific volume (m$^3$/kg)
-   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
-   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
-   */
-  virtual void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
+  Real cp_from_p_T(Real p, Real T) const override;
+  void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
 
-  /**
-   * Specific enthalpy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific enthalpy (J/kg)
-   */
-  virtual Real h_from_v_e(Real v, Real e) const;
-  virtual void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
+  Real k_from_p_T(Real p, Real T) const override;
+  void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  /**
-   * Pressure from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return specific enthalpy (J/kg)
-   */
-  virtual Real h_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Specific enthalpy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] h       specific enthalpy (J/kg)
-   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
-   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
-   */
-  virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
-
-  /**
-   * Specific internal energy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific internal energy (J/kg)
-   */
-  virtual Real e_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Density and its derivatives from pressure and temperature
-   * @param[in] p          pressure (Pa)
-   * @param[in] rho       density (kg/m$^3$)
-   * @param[out] e       specific internal energy (J/kg)
-   */
-  virtual Real e_from_p_rho(Real p, Real rho) const override;
-
-  /**
-   * Specific internal energy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] e       specific internal energy (J/kg)
-   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
-   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
-   */
-  virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
-
-  /**
-   * Isobaric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isobaric specific heat (J/kg/.K)
-   */
-  virtual Real cp_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Isobaric specific heat capacity and its derivatives from pressure and temperature
-   *
-   * @param[in] p       pressure (Pa)
-   * @param[in] T       temperature (K)
-   * @param[out] cp     isobaric specific heat (J/kg/K)
-   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
-   */
-  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
-
-  /**
-   * Isochoric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isochoric specific heat (J/kg.K)
-   */
-
-  /**
-   * Molar mass
-   *
-   * @return molar mass (kg/mol)
-   */
-  virtual Real molarMass() const override;
-
-  /**
-   * Thermal conductivity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return thermal conductivity  (W/m.K)
-   */
-  virtual Real k_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Thermal conductivity and its derivatives wrt pressure and temperature
-   *
-   * @param p           pressure (Pa)
-   * @param T           temperature (K)
-   * @param[out]  k     thermal conductivity  (W/m.K)
-   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
-   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
-   */
-  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  /**
-   * Dynamic viscosity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return dynamic viscosity (Pa.s)
-   */
-  virtual Real mu_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Dynamic viscosity and its derivatives wrt pressure and temperature
-   *
-   * @param p             pressure (Pa)
-   * @param T             temperature (K)
-   * @param[out] mu       viscosity (Pa.s)
-   * @param[out] dmu_dp   derivative of viscosity wrt pressure
-   * @param[out] dmu_dT   derivative of viscosity wrt temperature
-   */
-  virtual void
-  mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  Real mu_from_p_T(Real p, Real T) const override;
+  void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
    * Bulk Modulus from pressure and temperature
@@ -347,17 +97,13 @@ public:
    * @param T   temperature (K)
    * @return Bulk Modules (N/m^2)
    */
-  virtual Real bulk_modulus_from_p_T(Real p, Real T) const;
-  /**
-   * Speed of Sound from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return [out] c speed of sound (m/s)
-   */
-  virtual Real c_from_v_e(Real v, Real e) const override;
+  Real bulk_modulus_from_p_T(Real p, Real T) const;
+
+  Real c_from_v_e(Real v, Real e) const override;
+  DualReal c_from_v_e(const DualReal & v, const DualReal & e) const override;
 
 private:
+  /// Melting temperature of 2LiF-BeF2
   const Real _T_mo;
 };
 #pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
@@ -36,12 +36,12 @@ public:
   /**
    * Temperature from pressure and density
    *
-   * @param[in] p     pressure (Pa)
-   * @param[in] rho   (kg/m$^3$)
-   * @return[out] temperature (K)
+   * @param p     pressure (Pa)
+   * @param rho   (kg/m$^3$)
+   * @return temperature (K)
    */
   Real T_from_p_rho(Real p, Real rho) const;
-  void T_from_p_rho(Real pressure, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
+  void T_from_p_rho(Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
 
   Real cp_from_v_e(Real v, Real e) const override;
   void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;

--- a/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
@@ -91,7 +91,7 @@ public:
   void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
-   * Bulk Modulus from pressure and temperature
+   * Isentropic bulk modulus from pressure and temperature
    *
    * @param p   pressure (Pa)
    * @param T   temperature (K)

--- a/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadBismuthFluidProperties.h
@@ -1,0 +1,341 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "SinglePhaseFluidProperties.h"
+
+/**
+ * Fluid properties for 2LiF-BeF2 (LeadBismuth) \cite richard.
+ */
+class LeadBismuthFluidProperties : public SinglePhaseFluidProperties
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+public:
+  static InputParameters validParams();
+
+  LeadBismuthFluidProperties(const InputParameters & parameters);
+
+  /**
+   * Fluid name
+   *
+   * @return "LeadBismuth"
+   */
+  virtual std::string fluidName() const override;
+
+  /**
+   * Pressure from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return pressure (Pa)
+   */
+  virtual Real p_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Pressure and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v        specific volume (m$^3$/kg)
+   * @param[in] e        specific internal energy (J/kg)
+   * @param[out] p       pressure (Pa)
+   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
+   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
+   */
+  virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
+
+  /**
+   * Temperature from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return temperature (K)
+   */
+  virtual Real T_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Temperature and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v        specific volume (m$^3$/kg)
+   * @param[in] e        specific internal energy (J/kg)
+   * @param[out] T       temperature (K)
+   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
+   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
+   */
+  virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
+
+  /**
+   * Temperature from pressure and density
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] rho density (kg/m$^3$)
+   * @return[out] temperature (K)
+   */
+  virtual Real T_from_p_rho(Real p, Real rho) const;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   * @param[in] p          pressure (Pa)
+   * @param[in] rho       density (kg/m$^3$)
+   * @param[out] T          temperature (K)
+   * @param[out] dT_dp   derivative of temperature w.r.t. temperature
+   * @param[out] dT_drho   derivative of temperature w.r.t. density
+   */
+  virtual void
+  T_from_p_rho(Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const;
+
+  /**
+   * Isobaric specific heat from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return isobaric specific heat (J/kg.K)
+   */
+  virtual Real cp_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cp     isobaric specific heat (J/kg.K)
+   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
+   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
+   */
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
+
+  /**
+   * Isochoric specific heat from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return isochoric specific heat (J/kg.K)
+   */
+  virtual Real cv_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cv     isochoric specific heat (J/kg.K)
+   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
+   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
+   */
+  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+
+  /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isochoric specific heat (J/kg.K)
+   */
+  virtual Real cv_from_p_T(Real p, Real T) const override;
+  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
+
+  /**
+   * Dynamic viscosity from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return dynamic viscosity (Pa.s)
+   */
+  virtual Real mu_from_v_e(Real v, Real e) const override;
+  virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
+
+  /**
+   * Thermal conductivity from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return thermal conductivity (W/m.K)
+   */
+  virtual Real k_from_v_e(Real v, Real e) const override;
+  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
+
+  /**
+   * Density from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return density (kg/m$^3$)
+   */
+  virtual Real rho_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] rho       density (kg/m$^3$)
+   * @param[out] drho_dp   derivative of density w.r.t. pressure
+   * @param[out] drho_dT   derivative of density w.r.t. temperature
+   */
+  virtual void
+  rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+
+  /**
+   * Specific volume from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific volume (m$^3$/kg)
+   */
+  virtual Real v_from_p_T(Real p, Real T) const override;
+  virtual DualReal v_from_p_T(const DualReal & p, const DualReal & T) const override;
+
+  /**
+   * Specific volume and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] v         specific volume (m$^3$/kg)
+   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
+   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
+   */
+  virtual void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
+
+  /**
+   * Specific enthalpy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific enthalpy (J/kg)
+   */
+  virtual Real h_from_v_e(Real v, Real e) const;
+  virtual void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
+
+  /**
+   * Pressure from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return specific enthalpy (J/kg)
+   */
+  virtual Real h_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] h       specific enthalpy (J/kg)
+   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
+   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
+   */
+  virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
+
+  /**
+   * Specific internal energy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific internal energy (J/kg)
+   */
+  virtual Real e_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   * @param[in] p          pressure (Pa)
+   * @param[in] rho       density (kg/m$^3$)
+   * @param[out] e       specific internal energy (J/kg)
+   */
+  virtual Real e_from_p_rho(Real p, Real rho) const override;
+
+  /**
+   * Specific internal energy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] e       specific internal energy (J/kg)
+   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
+   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
+   */
+  virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
+
+  /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isobaric specific heat (J/kg/.K)
+   */
+  virtual Real cp_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Isobaric specific heat capacity and its derivatives from pressure and temperature
+   *
+   * @param[in] p       pressure (Pa)
+   * @param[in] T       temperature (K)
+   * @param[out] cp     isobaric specific heat (J/kg/K)
+   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
+   */
+  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+
+  /**
+   * Isochoric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isochoric specific heat (J/kg.K)
+   */
+
+  /**
+   * Molar mass
+   *
+   * @return molar mass (kg/mol)
+   */
+  virtual Real molarMass() const override;
+
+  /**
+   * Thermal conductivity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return thermal conductivity  (W/m.K)
+   */
+  virtual Real k_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Thermal conductivity and its derivatives wrt pressure and temperature
+   *
+   * @param p           pressure (Pa)
+   * @param T           temperature (K)
+   * @param[out]  k     thermal conductivity  (W/m.K)
+   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
+   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
+   */
+  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
+
+  /**
+   * Dynamic viscosity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return dynamic viscosity (Pa.s)
+   */
+  virtual Real mu_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Dynamic viscosity and its derivatives wrt pressure and temperature
+   *
+   * @param p             pressure (Pa)
+   * @param T             temperature (K)
+   * @param[out] mu       viscosity (Pa.s)
+   * @param[out] dmu_dp   derivative of viscosity wrt pressure
+   * @param[out] dmu_dT   derivative of viscosity wrt temperature
+   */
+  virtual void
+  mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+
+private:
+  const Real _T_mo;
+};
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
@@ -24,324 +24,76 @@ public:
   LeadFluidProperties(const InputParameters & parameters);
 
   virtual std::string fluidName() const override;
-  /**
-   * Pressure from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return pressure (Pa)
-   */
+  Real molarMass() const override;
+
   using SinglePhaseFluidProperties::p_from_v_e;
-  virtual Real p_from_v_e(Real v, Real e) const override;
+  Real p_from_v_e(Real v, Real e) const override;
+  void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
 
-  /**
-   * Pressure and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v        specific volume (m$^3$/kg)
-   * @param[in] e        specific internal energy (J/kg)
-   * @param[out] p       pressure (Pa)
-   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
-   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
-   */
-  virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
-
-  /**
-   * Temperature from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return temperature (K)
-   */
   using SinglePhaseFluidProperties::T_from_v_e;
-  virtual Real T_from_v_e(Real v, Real e) const override;
-
-  /**
-   * Temperature and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v        specific volume (m$^3$/kg)
-   * @param[in] e        specific internal energy (J/kg)
-   * @param[out] T       temperature (K)
-   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
-   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
-   */
-  virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
+  Real T_from_v_e(Real v, Real e) const override;
+  void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
 
   /**
    * Temperature from pressure and density
    *
-   * @param[in] p   pressure (Pa)
-   * @param[in] rho   (kg/m$^3$)
+   * @param[in] p     pressure (Pa)
+   * @param[in] rho   density (kg/m$^3$)
    * @return[out] temperature (K)
    */
-  virtual Real T_from_p_rho(Real p, Real rho) const;
+  Real T_from_p_rho(Real p, Real rho) const;
+  void T_from_p_rho(Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
 
-  /**
-   * Density and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] rho       density (kg/m$^3$)
-   * @param[out] T          temperature (K)
-   * @param[out] dT_dp   derivative of temperature w.r.t. temperature
-   * @param[out] dT_drho   derivative of temperature w.r.t. density
-   */
-  virtual void
-  T_from_p_rho(Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const;
+  Real cp_from_v_e(Real v, Real e) const override;
+  void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
 
-  /**
-   * Isobaric specific heat from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return isobaric specific heat (J/kg.K)
-   */
-  virtual Real cp_from_v_e(Real v, Real e) const override;
+  Real cv_from_v_e(Real v, Real e) const override;
+  void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
 
-  /**
-   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v       specific volume (m$^3$/kg)
-   * @param[in] e       specific internal energy (J/kg)
-   * @param[out] cp     isobaric specific heat (J/kg.K)
-   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
-   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
-   */
-  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
+  Real cv_from_p_T(Real p, Real T) const override;
+  void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
 
-  /**
-   * Isochoric specific heat from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return isochoric specific heat (J/kg.K)
-   */
-  virtual Real cv_from_v_e(Real v, Real e) const override;
+  Real mu_from_v_e(Real v, Real e) const override;
+  void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
 
-  /**
-   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v       specific volume (m$^3$/kg)
-   * @param[in] e       specific internal energy (J/kg)
-   * @param[out] cv     isochoric specific heat (J/kg.K)
-   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
-   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
-   */
-  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+  Real k_from_v_e(Real v, Real e) const override;
+  void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
 
-  /**
-   * Isobaric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isochoric specific heat (J/kg.K)
-   */
-  virtual Real cv_from_p_T(Real p, Real T) const override;
-  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
-
-  /**
-   * Dynamic viscosity from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return dynamic viscosity (Pa.s)
-   */
-  virtual Real mu_from_v_e(Real v, Real e) const override;
-  virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
-
-  /**
-   * Thermal conductivity from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return thermal conductivity (W/m.K)
-   */
-  virtual Real k_from_v_e(Real v, Real e) const override;
-  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
-
-  /**
-   * Density from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return density (kg/m$^3$)
-   */
   using SinglePhaseFluidProperties::rho_from_p_T;
-  virtual Real rho_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Density and its derivatives from pressure and temperature
-   *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
-   * @param[out] rho       density (kg/m$^3$)
-   * @param[out] drho_dp   derivative of density w.r.t. pressure
-   * @param[out] drho_dT   derivative of density w.r.t. temperature
-   */
-  virtual void rho_from_p_T(
+  Real rho_from_p_T(Real p, Real T) const override;
+  void rho_from_p_T(
       Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
-  virtual void rho_from_p_T(const DualReal & p,
-                            const DualReal & T,
-                            DualReal & rho,
-                            DualReal & drho_dp,
-                            DualReal & drho_dT) const override;
+  void rho_from_p_T(const DualReal & p,
+                    const DualReal & T,
+                    DualReal & rho,
+                    DualReal & drho_dp,
+                    DualReal & drho_dT) const override;
 
-  /**
-   * Specific volume from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific volume (m$^3$/kg)
-   */
-  virtual Real v_from_p_T(Real p, Real T) const override;
+  Real v_from_p_T(Real p, Real T) const override;
 
-  /**
-   * Specific volume and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @param[out] v         specific volume (m$^3$/kg)
-   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
-   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
-   */
-  virtual void
+  void
   v_from_p_T(Real pressure, Real temerature, Real & v, Real & dv_dp, Real & dv_dT) const override;
 
-  /**
-   * Specific enthalpy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific enthalpy (J/kg)
-   */
-  virtual Real h_from_p_T(Real p, Real T) const override;
+  Real h_from_p_T(Real p, Real T) const override;
+  void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
 
-  /**
-   * Specific enthalpy and its derivatives from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @param[out] h       specific enthalpy (J/kg)
-   * @param[out] dh_dv   derivative of specific enthalpy w.r.t. specific volume
-   * @param[out] dh_de   derivative of specific enthalpy w.r.t. specific energy
-   */
-  virtual void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
+  Real h_from_v_e(Real v, Real e) const;
+  void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
 
-  /**
-   * Specific enthalpy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] h       specific enthalpy (J/kg)
-   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
-   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
-   */
-  virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
+  Real e_from_p_T(Real p, Real T) const override;
 
-  /**
-   * Specific enthalpy and its derivatives from pressure and temperature
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @param[out] h       specific enthalpy (J/kg)
-   */
-  virtual Real h_from_v_e(Real v, Real e) const;
+  Real e_from_p_rho(Real p, Real rho) const override;
+  void e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
+  void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
 
-  /**
-   * Specific internal energy from pressure and temperature
-   *
-   * @param[in] p   pressure (Pa)
-   * @param[in] T   temperature (K)
-   * @return specific internal energy (J/kg)
-   */
-  virtual Real e_from_p_T(Real p, Real T) const override;
+  Real cp_from_p_T(Real p, Real T) const override;
+  void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
 
-  /**
-   * Specific enthalpy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @return specific internal energy (J/kg)
-   */
-  virtual Real e_from_p_rho(Real p, Real rho) const override;
-  virtual void
-  e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
+  Real k_from_p_T(Real p, Real T) const override;
+  void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
 
-  /**
-   * Specific internal energy and its derivatives from pressure and temperature
-   *
-   * @param[in] p        pressure (Pa)
-   * @param[in] T        temperature (K)
-   * @param[out] e       specific internal energy (J/kg)
-   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
-   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
-   */
-  virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
-
-  /**
-   * Isobaric specific heat capacity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return isobaric specific heat (J/kg/.K)
-   */
-  virtual Real cp_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Isobaric specific heat capacity and its derivatives from pressure and temperature
-   *
-   * @param[in] p       pressure (Pa)
-   * @param[in] T       temperature (K)
-   * @param[out] cp     isobaric specific heat (J/kg/K)
-   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
-   */
-  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
-
-  /**
-   * Molar mass
-   *
-   * @return molar mass (kg/mol)
-   */
-  virtual Real molarMass() const override;
-
-  /**
-   * Thermal conductivity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return thermal conductivity  (W/m.K)
-   */
-  virtual Real k_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Thermal conductivity and its derivatives wrt pressure and temperature
-   *
-   * @param p           pressure (Pa)
-   * @param T           temperature (K)
-   * @param[out]  k     thermal conductivity  (W/m.K)
-   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
-   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
-   */
-  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
-
-  /**
-   * Dynamic viscosity from pressure and temperature
-   *
-   * @param p   pressure (Pa)
-   * @param T   temperature (K)
-   * @return dynamic viscosity (Pa.s)
-   */
-  virtual Real mu_from_p_T(Real p, Real T) const override;
-
-  /**
-   * Dynamic viscosity and its derivatives wrt pressure and temperature
-   *
-   * @param p             pressure (Pa)
-   * @param T             temperature (K)
-   * @param[out] mu       viscosity (Pa.s)
-   * @param[out] dmu_dp   derivative of viscosity wrt pressure
-   * @param[out] dmu_dT   derivative of viscosity wrt temperature
-   */
-  virtual void
-  mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+  Real mu_from_p_T(Real p, Real T) const override;
+  void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
    * Bulk Modulus from pressure and temperature
@@ -350,28 +102,13 @@ public:
    * @param T   temperature (K)
    * @return Bulk Modules (N/m^2)
    */
-  virtual Real bulk_modulus_from_p_T(Real p, Real T) const;
-  /**
-   * Speed of Sound from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @return [out] c speed of sound (m/s)
-   */
-  virtual Real c_from_v_e(Real v, Real e) const override;
+  Real bulk_modulus_from_p_T(Real p, Real T) const;
 
-  /**
-   * Speed of Sound from specific volume and specific internal energy
-   *
-   * @param[in] v   specific volume (m$^3$/kg)
-   * @param[in] e   specific internal energy (J/kg)
-   * @param [out] c speed of sound (m/s)
-   * @param[out] dc_dv   derivative of speed of sound wrt specific volume
-   * @param[out] dc_de   derivative of speed of sound wrt specific specific internal energy
-   */
-  virtual DualReal c_from_v_e(const DualReal & v, const DualReal & e) const override;
+  Real c_from_v_e(Real v, Real e) const override;
+  DualReal c_from_v_e(const DualReal & v, const DualReal & e) const override;
 
 private:
+  /// Melting temperature of Lead
   const Real _T_mo;
 };
 #pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
@@ -37,9 +37,9 @@ public:
   /**
    * Temperature from pressure and density
    *
-   * @param[in] p     pressure (Pa)
-   * @param[in] rho   density (kg/m$^3$)
-   * @return[out] temperature (K)
+   * @param p     pressure (Pa)
+   * @param rho   density (kg/m$^3$)
+   * @return temperature (K)
    */
   Real T_from_p_rho(Real p, Real rho) const;
   void T_from_p_rho(Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
@@ -61,8 +61,7 @@ public:
 
   using SinglePhaseFluidProperties::rho_from_p_T;
   Real rho_from_p_T(Real p, Real T) const override;
-  void rho_from_p_T(
-      Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  void rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const override;
   void rho_from_p_T(const DualReal & p,
                     const DualReal & T,
                     DualReal & rho,
@@ -71,8 +70,7 @@ public:
 
   Real v_from_p_T(Real p, Real T) const override;
 
-  void
-  v_from_p_T(Real pressure, Real temerature, Real & v, Real & dv_dp, Real & dv_dT) const override;
+  void v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const override;
 
   Real h_from_p_T(Real p, Real T) const override;
   void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;

--- a/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
@@ -1,0 +1,352 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "SinglePhaseFluidProperties.h"
+
+/**
+ * Fluid properties for 2LiF-BeF2 (Lead) \cite richard.
+ */
+class LeadFluidProperties : public SinglePhaseFluidProperties
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+public:
+  static InputParameters validParams();
+
+  LeadFluidProperties(const InputParameters & parameters);
+
+  virtual std::string fluidName() const override;
+
+  /**
+   * Pressure from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return pressure (Pa)
+   */
+  virtual Real p_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Pressure and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v        specific volume (m$^3$/kg)
+   * @param[in] e        specific internal energy (J/kg)
+   * @param[out] p       pressure (Pa)
+   * @param[out] dp_dv   derivative of pressure w.r.t. specific volume
+   * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
+   */
+  virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
+  virtual void p_from_v_e(const DualReal & v,
+                          const DualReal & e,
+                          DualReal & p,
+                          DualReal & dp_dv,
+                          DualReal & dp_de) const override;
+
+  /**
+   * Temperature from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return temperature (K)
+   */
+  virtual Real T_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Temperature and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v        specific volume (m$^3$/kg)
+   * @param[in] e        specific internal energy (J/kg)
+   * @param[out] T       temperature (K)
+   * @param[out] dT_dv   derivative of temperature w.r.t. specific volume
+   * @param[out] dT_de   derivative of temperature w.r.t. specific internal energy
+   */
+  virtual void T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const override;
+
+  /**
+   * Temperature from pressure and density
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] rho   (kg/m$^3$)
+   * @return[out] temperature (K)
+   */
+  virtual Real T_from_p_rho(Real p, Real rho) const;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] rho       density (kg/m$^3$)
+   * @param[out] T          temperature (K)
+   * @param[out] dT_dp   derivative of temperature w.r.t. temperature
+   * @param[out] dT_drho   derivative of temperature w.r.t. density
+   */
+  virtual void
+  T_from_p_rho(Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const;
+
+  /**
+   * Isobaric specific heat from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return isobaric specific heat (J/kg.K)
+   */
+  virtual Real cp_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isobaric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cp     isobaric specific heat (J/kg.K)
+   * @param[out] dcp_dv derivative of isobaric specific heat w.r.t. specific volume
+   * @param[out] dcp_de derivative of isobaric specific heat w.r.t. specific internal energy
+   */
+  virtual void cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const override;
+
+  /**
+   * Isochoric specific heat from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return isochoric specific heat (J/kg.K)
+   */
+  virtual Real cv_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Isochoric specific heat and its derivatives from specific volume and specific internal energy
+   *
+   * @param[in] v       specific volume (m$^3$/kg)
+   * @param[in] e       specific internal energy (J/kg)
+   * @param[out] cv     isochoric specific heat (J/kg.K)
+   * @param[out] dcv_dv derivative of isochoric specific heat w.r.t. specific volume
+   * @param[out] dcv_de derivative of isochoric specific heat w.r.t. specific internal energy
+   */
+  virtual void cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const override;
+
+  /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isochoric specific heat (J/kg.K)
+   */
+  virtual Real cv_from_p_T(Real p, Real T) const override;
+  virtual void cv_from_p_T(Real p, Real T, Real & cv, Real & dcp_dp, Real & dcp_dT) const override;
+
+  /**
+   * Dynamic viscosity from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return dynamic viscosity (Pa.s)
+   */
+  virtual Real mu_from_v_e(Real v, Real e) const override;
+  virtual void mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const override;
+
+  /**
+   * Thermal conductivity from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return thermal conductivity (W/m.K)
+   */
+  virtual Real k_from_v_e(Real v, Real e) const override;
+  virtual void k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const override;
+
+  /**
+   * Density from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return density (kg/m$^3$)
+   */
+  virtual Real rho_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Density and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] rho       density (kg/m$^3$)
+   * @param[out] drho_dp   derivative of density w.r.t. pressure
+   * @param[out] drho_dT   derivative of density w.r.t. temperature
+   */
+  virtual void rho_from_p_T(
+      Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const override;
+  virtual void rho_from_p_T(const DualReal & p,
+                            const DualReal & T,
+                            DualReal & rho,
+                            DualReal & drho_dp,
+                            DualReal & drho_dT) const override;
+
+  /**
+   * Specific volume from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific volume (m$^3$/kg)
+   */
+  virtual Real v_from_p_T(Real p, Real T) const override;
+  virtual DualReal v_from_p_T(const DualReal & pressure,
+                              const DualReal & temperature) const override;
+
+  /**
+   * Specific volume and its derivatives from pressure and temperature
+   *
+   * @param[in] p          pressure (Pa)
+   * @param[in] T          temperature (K)
+   * @param[out] v         specific volume (m$^3$/kg)
+   * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
+   * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
+   */
+  virtual void
+  v_from_p_T(Real pressure, Real temerature, Real & v, Real & dv_dp, Real & dv_dT) const override;
+
+  /**
+   * Specific enthalpy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific enthalpy (J/kg)
+   */
+  virtual Real h_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @param[out] h       specific enthalpy (J/kg)
+   * @param[out] dh_dv   derivative of specific enthalpy w.r.t. specific volume
+   * @param[out] dh_de   derivative of specific enthalpy w.r.t. specific energy
+   */
+  virtual void h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] h       specific enthalpy (J/kg)
+   * @param[out] dh_dp   derivative of specific enthalpy w.r.t. pressure
+   * @param[out] dh_dT   derivative of specific enthalpy w.r.t. temperature
+   */
+  virtual void h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const override;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @param[out] h       specific enthalpy (J/kg)
+   */
+  virtual Real h_from_v_e(Real v, Real e) const;
+
+  /**
+   * Specific internal energy from pressure and temperature
+   *
+   * @param[in] p   pressure (Pa)
+   * @param[in] T   temperature (K)
+   * @return specific internal energy (J/kg)
+   */
+  virtual Real e_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Specific enthalpy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @return specific internal energy (J/kg)
+   */
+  virtual Real e_from_p_rho(Real p, Real rho) const override;
+
+  /**
+   * Specific internal energy and its derivatives from pressure and temperature
+   *
+   * @param[in] p        pressure (Pa)
+   * @param[in] T        temperature (K)
+   * @param[out] e       specific internal energy (J/kg)
+   * @param[out] de_dp   derivative of specific internal energy w.r.t. pressure
+   * @param[out] de_dT   derivative of specific internal energy w.r.t. temperature
+   */
+  virtual void e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const override;
+
+  /**
+   * Isobaric specific heat capacity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return isobaric specific heat (J/kg/.K)
+   */
+  virtual Real cp_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Isobaric specific heat capacity and its derivatives from pressure and temperature
+   *
+   * @param[in] p       pressure (Pa)
+   * @param[in] T       temperature (K)
+   * @param[out] cp     isobaric specific heat (J/kg/K)
+   * @param[out] dcp_dp derivative of isobaric specific heat w.r.t. pressure (J/kg/K/Pa)
+   */
+  virtual void cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const override;
+
+  /**
+   * Molar mass
+   *
+   * @return molar mass (kg/mol)
+   */
+  virtual Real molarMass() const override;
+
+  /**
+   * Thermal conductivity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return thermal conductivity  (W/m.K)
+   */
+  virtual Real k_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Thermal conductivity and its derivatives wrt pressure and temperature
+   *
+   * @param p           pressure (Pa)
+   * @param T           temperature (K)
+   * @param[out]  k     thermal conductivity  (W/m.K)
+   * @param[out]  dk_dp derivative of thermal conductivity wrt pressure
+   * @param[out]  dk_dT derivative of thermal conductivity wrt temperature
+   */
+  virtual void k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const override;
+
+  /**
+   * Dynamic viscosity from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return dynamic viscosity (Pa.s)
+   */
+  virtual Real mu_from_p_T(Real p, Real T) const override;
+
+  /**
+   * Dynamic viscosity and its derivatives wrt pressure and temperature
+   *
+   * @param p             pressure (Pa)
+   * @param T             temperature (K)
+   * @param[out] mu       viscosity (Pa.s)
+   * @param[out] dmu_dp   derivative of viscosity wrt pressure
+   * @param[out] dmu_dT   derivative of viscosity wrt temperature
+   */
+  virtual void
+  mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+
+private:
+  const Real _T_mo;
+};
+#pragma GCC diagnostic pop

--- a/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
@@ -12,7 +12,7 @@
 #include "SinglePhaseFluidProperties.h"
 
 /**
- * Fluid properties for 2LiF-BeF2 (Lead) \cite richard.
+ * Fluid properties for (Lead) \cite Fazio.
  */
 class LeadFluidProperties : public SinglePhaseFluidProperties
 {
@@ -24,7 +24,6 @@ public:
   LeadFluidProperties(const InputParameters & parameters);
 
   virtual std::string fluidName() const override;
-
   /**
    * Pressure from specific volume and specific internal energy
    *
@@ -32,6 +31,7 @@ public:
    * @param[in] e   specific internal energy (J/kg)
    * @return pressure (Pa)
    */
+  using SinglePhaseFluidProperties::p_from_v_e;
   virtual Real p_from_v_e(Real v, Real e) const override;
 
   /**
@@ -44,11 +44,6 @@ public:
    * @param[out] dp_de   derivative of pressure w.r.t. specific internal energy
    */
   virtual void p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & dp_de) const override;
-  virtual void p_from_v_e(const DualReal & v,
-                          const DualReal & e,
-                          DualReal & p,
-                          DualReal & dp_dv,
-                          DualReal & dp_de) const override;
 
   /**
    * Temperature from specific volume and specific internal energy
@@ -57,6 +52,7 @@ public:
    * @param[in] e   specific internal energy (J/kg)
    * @return temperature (K)
    */
+  using SinglePhaseFluidProperties::T_from_v_e;
   virtual Real T_from_v_e(Real v, Real e) const override;
 
   /**
@@ -168,6 +164,7 @@ public:
    * @param[in] T   temperature (K)
    * @return density (kg/m$^3$)
    */
+  using SinglePhaseFluidProperties::rho_from_p_T;
   virtual Real rho_from_p_T(Real p, Real T) const override;
 
   /**
@@ -195,14 +192,12 @@ public:
    * @return specific volume (m$^3$/kg)
    */
   virtual Real v_from_p_T(Real p, Real T) const override;
-  virtual DualReal v_from_p_T(const DualReal & pressure,
-                              const DualReal & temperature) const override;
 
   /**
-   * Specific volume and its derivatives from pressure and temperature
+   * Specific volume and its derivatives from specific volume and specific internal energy
    *
-   * @param[in] p          pressure (Pa)
-   * @param[in] T          temperature (K)
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
    * @param[out] v         specific volume (m$^3$/kg)
    * @param[out] dv_dp     derivative of specific volume w.r.t. pressure
    * @param[out] dv_dT     derivative of specific volume w.r.t. temperature
@@ -220,7 +215,7 @@ public:
   virtual Real h_from_p_T(Real p, Real T) const override;
 
   /**
-   * Specific enthalpy and its derivatives from pressure and temperature
+   * Specific enthalpy and its derivatives from specific volume and specific internal energy
    *
    * @param[in] v   specific volume (m$^3$/kg)
    * @param[in] e   specific internal energy (J/kg)
@@ -267,6 +262,8 @@ public:
    * @return specific internal energy (J/kg)
    */
   virtual Real e_from_p_rho(Real p, Real rho) const override;
+  virtual void
+  e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
 
   /**
    * Specific internal energy and its derivatives from pressure and temperature
@@ -345,6 +342,34 @@ public:
    */
   virtual void
   mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
+
+  /**
+   * Bulk Modulus from pressure and temperature
+   *
+   * @param p   pressure (Pa)
+   * @param T   temperature (K)
+   * @return Bulk Modules (N/m^2)
+   */
+  virtual Real bulk_modulus_from_p_T(Real p, Real T) const;
+  /**
+   * Speed of Sound from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @return [out] c speed of sound (m/s)
+   */
+  virtual Real c_from_v_e(Real v, Real e) const override;
+
+  /**
+   * Speed of Sound from specific volume and specific internal energy
+   *
+   * @param[in] v   specific volume (m$^3$/kg)
+   * @param[in] e   specific internal energy (J/kg)
+   * @param [out] c speed of sound (m/s)
+   * @param[out] dc_dv   derivative of speed of sound wrt specific volume
+   * @param[out] dc_de   derivative of speed of sound wrt specific specific internal energy
+   */
+  virtual DualReal c_from_v_e(const DualReal & v, const DualReal & e) const override;
 
 private:
   const Real _T_mo;

--- a/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/LeadFluidProperties.h
@@ -96,7 +96,7 @@ public:
   void mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_drho, Real & dmu_dT) const override;
 
   /**
-   * Bulk Modulus from pressure and temperature
+   * Isentropic bulk modulus from pressure and temperature
    *
    * @param p   pressure (Pa)
    * @param T   temperature (K)

--- a/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
@@ -1,0 +1,330 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "LeadBismuthFluidProperties.h"
+
+registerMooseObject("FluidPropertiesApp", LeadBismuthFluidProperties);
+
+InputParameters
+LeadBismuthFluidProperties::validParams()
+{
+  InputParameters params = SinglePhaseFluidProperties::validParams();
+  params.addParam<Real>("T_mo", 398, "Melting Point of LeadBismuth");
+  // params.addRangeCheckedParam<Real>(
+  //     "drho_dp",
+  //     1.7324E-7,
+  //     "drho_dp > 0.0",
+  //     "derivative of density with respect to pressure (at constant temperature)");
+  // params.addClassDescription("Fluid properties for LeadBismuth");
+  return params;
+}
+
+LeadBismuthFluidProperties::LeadBismuthFluidProperties(const InputParameters & parameters)
+  : SinglePhaseFluidProperties(parameters), _T_mo(getParam<Real>("T_mo"))
+// _drho_dp(getParam<Real>("drho_dp")),
+// _drho_dT(-0.4884),
+// _p_atm(101325.0),
+// _cp(2416.0),
+// _c0(2413.0),
+// _dp_dT_at_constant_v(-_drho_dT / _drho_dp)
+{
+}
+
+std::string
+LeadBismuthFluidProperties::fluidName() const
+{
+  return "LeadBismuth";
+}
+
+Real
+LeadBismuthFluidProperties::molarMass() const
+{
+  return 233.99;
+}
+
+Real
+LeadBismuthFluidProperties::p_from_v_e(Real v, Real e) const
+{
+  Real h = h_from_v_e(v, e);
+  return (h - e) / v;
+}
+
+void
+LeadBismuthFluidProperties::p_from_v_e(
+    Real v, Real e, Real & /*p*/, Real & dp_dv, Real & dp_de) const
+{
+  Real h, dh_dv, dh_de;
+  h_from_v_e(v, e, h, dh_dv, dh_de);
+  dp_dv = (v * dh_dv - h + e) / v / v;
+  dp_de = (dh_de - 1) / v;
+}
+
+Real
+LeadBismuthFluidProperties::T_from_v_e(Real v, Real /*e*/) const
+{
+  return (1 / v - 11065) * -1 / 1.293;
+}
+
+void
+LeadBismuthFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const
+{
+  T = T_from_v_e(v, e);
+  // Returning straight derivatives since no pressure dependence
+  dT_de = 0;
+  dT_dv = 1 / v / v / 1.293;
+}
+//
+Real
+LeadBismuthFluidProperties::cp_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 164.8 - 3.94e-2 * temperature + 1.25e-5 * temperature * temperature -
+         4.56e+5 / temperature / temperature;
+}
+
+void
+LeadBismuthFluidProperties::cp_from_v_e(
+    Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  cp = cp_from_v_e(v, e);
+  dcp_dv = -3.94e-2 * dT_dv + 2 * dT_dv * 1.25e-5 * temperature +
+           2 * dT_dv * 4.56e+5 / temperature / temperature / temperature;
+
+  dcp_de = -3.94e-2 * dT_de + 2 * dT_de * 1.25e-5 * temperature +
+           2 * dT_de * 4.56e+5 / temperature / temperature / temperature;
+}
+Real
+LeadBismuthFluidProperties::cv_from_v_e(Real v, Real e) const
+{
+  return cp_from_v_e(v, e);
+}
+
+void
+LeadBismuthFluidProperties::cv_from_v_e(
+    Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const
+{
+  Real cp, dcp_dv, dcp_de;
+  cp_from_v_e(v, e, cp, dcp_dv, dcp_de);
+  cv = cv_from_v_e(v, e);
+  dcv_dv = dcp_dv;
+  dcv_de = dcp_de;
+}
+
+Real
+LeadBismuthFluidProperties::cv_from_p_T(Real p, Real T) const
+{
+  return cp_from_p_T(p, T);
+}
+
+void
+LeadBismuthFluidProperties::cv_from_p_T(
+    Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const
+{
+  Real cp, dcp_dp, dcp_dT;
+  cp_from_p_T(p, T, cp, dcp_dp, dcp_dT);
+  cv = cv_from_p_T(p, T);
+  dcv_dp = dcp_dp;
+  dcv_dT = dcp_dT;
+}
+
+Real
+LeadBismuthFluidProperties::mu_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 4.94e-4 * std::exp(754.1 / temperature);
+}
+
+void
+LeadBismuthFluidProperties::mu_from_v_e(
+    Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  mu = mu_from_v_e(v, e);
+  dmu_dv = dT_dv * -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
+  dmu_de = dT_de * -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
+}
+
+Real
+LeadBismuthFluidProperties::k_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 3.284 + 1.67e-2 * temperature - 2.305e-6 * temperature * temperature;
+}
+
+void
+LeadBismuthFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  k = k_from_v_e(v, e);
+  dk_dv = 1.67e-2 * dT_dv - 2 * 2.305e-6 * dT_dv * temperature;
+  dk_de = 1.67e-2 * dT_de - 2 * 2.305e-6 * dT_de * temperature;
+}
+
+Real
+LeadBismuthFluidProperties::rho_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 11065 - 1.293 * temperature;
+}
+
+void
+LeadBismuthFluidProperties::rho_from_p_T(
+    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+{
+  rho = rho_from_p_T(pressure, temperature);
+  drho_dp = 0;
+  drho_dT = -1.293;
+}
+
+Real
+LeadBismuthFluidProperties::v_from_p_T(Real pressure, Real temperature) const
+{
+  return 1.0 / rho_from_p_T(pressure, temperature);
+}
+
+void
+LeadBismuthFluidProperties::v_from_p_T(
+    Real pressure, Real temperature, Real & v, Real & dv_dp, Real & dv_dT) const
+{
+  v = v_from_p_T(pressure, temperature);
+  dv_dp = 0;
+  dv_dT = 1.293 / MathUtils::pow(11065 - 1.293 * temperature, 2);
+}
+
+Real
+LeadBismuthFluidProperties::h_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 164.8 * (temperature - _T_mo) - 1.97e-2 * (temperature * temperature - _T_mo * _T_mo) +
+         4.167e-6 * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
+         4.56e+5 * (1 / temperature - 1 / _T_mo);
+}
+
+void
+LeadBismuthFluidProperties::h_from_p_T(
+    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+{
+  h = h_from_p_T(pressure, temperature);
+  dh_dp = 0;
+  dh_dT = 164.8 + 2 * 1.97e-2 * temperature + 3 * 4.167e-6 * temperature * temperature -
+          4.56e+5 / temperature / temperature;
+}
+
+Real
+LeadBismuthFluidProperties::h_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 164.8 * (temperature - _T_mo) - 1.97e-2 * (temperature * temperature - _T_mo * _T_mo) +
+         4.167e-6 * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
+         4.56e+5 * (1 / temperature - 1 / _T_mo);
+}
+
+void
+LeadBismuthFluidProperties::h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  h = h_from_v_e(v, e);
+  dh_dv = 164.8 * dT_dv + 2 * dT_dv * 1.97e-2 * temperature +
+          3 * 4.167e-6 * temperature * temperature * dT_dv -
+          4.56e+5 / temperature / temperature * dT_dv;
+  dh_de = 164.8 * dT_de + 2 * dT_de * 1.97e-2 * temperature +
+          3 * 4.167e-6 * temperature * temperature * dT_de -
+          4.56e+5 / temperature / temperature * dT_de;
+}
+
+Real
+LeadBismuthFluidProperties::e_from_p_T(Real p, Real T) const
+{
+  // definition of h = e + p * v
+  Real v = v_from_p_T(p, T);
+  Real h = h_from_p_T(p, T);
+  return h - p * v;
+}
+
+void
+LeadBismuthFluidProperties::e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const
+{
+  Real dh_dp, dv_dp, dh_dT, dv_dT, v, h;
+  h_from_p_T(p, T, h, dh_dp, dh_dT);
+  v_from_p_T(p, T, v, dv_dp, dv_dT);
+  e = h_from_p_T(v, e);
+  de_dp = dh_dp - v - dv_dp * p;
+  de_dT = dh_dT - dv_dT * p;
+}
+
+Real
+LeadBismuthFluidProperties::e_from_p_rho(Real p, Real rho) const
+{
+  return e_from_p_T(p, T_from_p_rho(p, rho));
+}
+
+Real
+LeadBismuthFluidProperties::T_from_p_rho(Real /*pressure*/, Real rho) const
+{
+  return (rho - 11065) / -1.293;
+}
+
+void
+LeadBismuthFluidProperties::T_from_p_rho(
+    Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const
+{
+  temperature = T_from_p_rho(pressure, rho);
+  dT_dp = 0;
+  dT_drho = 1 / -1.293;
+}
+
+Real
+LeadBismuthFluidProperties::cp_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 164.8 - 3.94e-2 * temperature + 1.25e-5 * temperature * temperature -
+         4.56e+5 / temperature / temperature;
+}
+
+void
+LeadBismuthFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0;
+  dcp_dT =
+      -3.94e-2 + 2 * 1.25e-5 * temperature + 2 * 4.56e+5 / temperature / temperature / temperature;
+}
+
+Real
+LeadBismuthFluidProperties::mu_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 4.94e-4 * std::exp(754.1 / temperature);
+}
+
+void
+LeadBismuthFluidProperties::mu_from_p_T(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = mu_from_p_T(pressure, temperature);
+  dmu_dp = 0;
+  dmu_dT = -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
+}
+
+Real
+LeadBismuthFluidProperties::k_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 3.284 + 1.67e-2 * temperature - 2.305e-6 * temperature * temperature;
+}
+
+void
+LeadBismuthFluidProperties::k_from_p_T(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = k_from_p_T(pressure, temperature);
+  dk_dp = 0;
+  dk_dT = 1.67e-2 - 2 * 2.305e-6 * temperature;
+}

--- a/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
@@ -15,7 +15,7 @@ InputParameters
 LeadBismuthFluidProperties::validParams()
 {
   InputParameters params = SinglePhaseFluidProperties::validParams();
-  params.addParam<Real>("T_mo", 398, "Melting Point of Lead Bismuth (K)");
+  params.addParam<Real>("T_mo", 398, "Melting Point (K)");
   params.addClassDescription("Fluid properties for Lead Bismuth eutectic 2LiF-BeF2");
 
   return params;
@@ -35,7 +35,7 @@ LeadBismuthFluidProperties::fluidName() const
 Real
 LeadBismuthFluidProperties::molarMass() const
 {
-  return 233.99;
+  return 2.3399e-1;
 }
 
 Real
@@ -93,23 +93,20 @@ LeadBismuthFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, R
 Real
 LeadBismuthFluidProperties::cp_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 164.8 - 3.94e-2 * temperature + 1.25e-5 * temperature * temperature -
-         4.56e+5 / temperature / temperature;
+  Real T = T_from_v_e(v, e);
+  return 164.8 - 3.94e-2 * T + 1.25e-5 * T * T - 4.56e+5 / T / T;
 }
 
 void
 LeadBismuthFluidProperties::cp_from_v_e(
     Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   cp = cp_from_v_e(v, e);
-  dcp_dv = -3.94e-2 * dT_dv + 2 * dT_dv * 1.25e-5 * temperature +
-           2 * dT_dv * 4.56e+5 / temperature / temperature / temperature;
+  dcp_dv = -3.94e-2 * dT_dv + 2 * dT_dv * 1.25e-5 * T + 2 * dT_dv * 4.56e+5 / T / T / T;
 
-  dcp_de = -3.94e-2 * dT_de + 2 * dT_de * 1.25e-5 * temperature +
-           2 * dT_de * 4.56e+5 / temperature / temperature / temperature;
+  dcp_de = -3.94e-2 * dT_de + 2 * dT_de * 1.25e-5 * T + 2 * dT_de * 4.56e+5 / T / T / T;
 }
 Real
 LeadBismuthFluidProperties::cv_from_v_e(Real v, Real e) const
@@ -172,113 +169,109 @@ LeadBismuthFluidProperties::cv_from_p_T(
 Real
 LeadBismuthFluidProperties::mu_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 4.94e-4 * std::exp(754.1 / temperature);
+  Real T = T_from_v_e(v, e);
+  return 4.94e-4 * std::exp(754.1 / T);
 }
 
 void
 LeadBismuthFluidProperties::mu_from_v_e(
     Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   mu = mu_from_v_e(v, e);
-  dmu_dv = dT_dv * -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
-  dmu_de = dT_de * -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
+  dmu_dv = dT_dv * -754.1 * 4.94e-4 * exp(754.1 / T) / T / T;
+  dmu_de = dT_de * -754.1 * 4.94e-4 * exp(754.1 / T) / T / T;
 }
 
 Real
 LeadBismuthFluidProperties::k_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 3.284 + 1.617e-2 * temperature - 2.305e-6 * temperature * temperature;
+  Real T = T_from_v_e(v, e);
+  return 3.284 + 1.617e-2 * T - 2.305e-6 * T * T;
 }
 
 void
 LeadBismuthFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   k = k_from_v_e(v, e);
-  dk_dv = 1.617e-2 * dT_dv - 2 * 2.305e-6 * dT_dv * temperature;
-  dk_de = 1.617e-2 * dT_de - 2 * 2.305e-6 * dT_de * temperature;
+  dk_dv = 1.617e-2 * dT_dv - 2 * 2.305e-6 * dT_dv * T;
+  dk_de = 1.617e-2 * dT_de - 2 * 2.305e-6 * dT_de * T;
 }
 
 Real
-LeadBismuthFluidProperties::rho_from_p_T(Real /*pressure*/, Real temperature) const
+LeadBismuthFluidProperties::rho_from_p_T(Real /*p*/, Real T) const
 {
-  return 11065 - 1.293 * temperature;
+  return 11065 - 1.293 * T;
 }
 
 void
 LeadBismuthFluidProperties::rho_from_p_T(
-    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+    Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
-  rho = rho_from_p_T(pressure, temperature);
+  rho = rho_from_p_T(p, T);
   drho_dp = 0;
   drho_dT = -1.293;
 }
 
 void
-LeadBismuthFluidProperties::rho_from_p_T(const DualReal & pressure,
-                                         const DualReal & temperature,
+LeadBismuthFluidProperties::rho_from_p_T(const DualReal & p,
+                                         const DualReal & T,
                                          DualReal & rho,
                                          DualReal & drho_dp,
                                          DualReal & drho_dT) const
 {
-  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
+  rho = SinglePhaseFluidProperties::rho_from_p_T(p, T);
   drho_dp = 0;
   drho_dT = -1.293;
 }
 
 Real
-LeadBismuthFluidProperties::v_from_p_T(Real pressure, Real temperature) const
+LeadBismuthFluidProperties::v_from_p_T(Real p, Real T) const
 {
-  return 1.0 / rho_from_p_T(pressure, temperature);
+  return 1.0 / rho_from_p_T(p, T);
 }
 
 void
-LeadBismuthFluidProperties::v_from_p_T(
-    Real pressure, Real temperature, Real & v, Real & dv_dp, Real & dv_dT) const
+LeadBismuthFluidProperties::v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const
 {
-  v = v_from_p_T(pressure, temperature);
+  v = v_from_p_T(p, T);
   dv_dp = 0;
-  dv_dT = 1.293 / MathUtils::pow(11065 - 1.293 * temperature, 2);
+  dv_dT = 1.293 / MathUtils::pow(11065 - 1.293 * T, 2);
 }
 
 Real
-LeadBismuthFluidProperties::h_from_p_T(Real /*pressure*/, Real temperature) const
+LeadBismuthFluidProperties::h_from_p_T(Real /*p*/, Real T) const
 {
   // see 2.55 in 2005 NEA Lead Handbook
   // 4.167e-6 is replaced by 1.25e-5/3 for accuracy
-  return 164.8 * (temperature - _T_mo) - 1.97e-2 * (temperature * temperature - _T_mo * _T_mo) +
-         (1.25e-5 / 3) * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
-         4.56e+5 * (1 / temperature - 1 / _T_mo);
+  return 164.8 * (T - _T_mo) - 1.97e-2 * (T * T - _T_mo * _T_mo) +
+         (1.25e-5 / 3) * (T * T * T - _T_mo * _T_mo * _T_mo) + 4.56e+5 * (1 / T - 1 / _T_mo);
 }
 
 void
-LeadBismuthFluidProperties::h_from_p_T(
-    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+LeadBismuthFluidProperties::h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const
 {
-  h = h_from_p_T(pressure, temperature);
+  h = h_from_p_T(p, T);
   dh_dp = 0;
-  dh_dT = cp_from_p_T(pressure, temperature);
+  dh_dT = cp_from_p_T(p, T);
 }
 
 Real
 LeadBismuthFluidProperties::h_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 164.8 * (temperature - _T_mo) - 1.97e-2 * (temperature * temperature - _T_mo * _T_mo) +
-         (1.25e-5 / 3) * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
-         4.56e+5 * (1 / temperature - 1 / _T_mo);
+  Real T = T_from_v_e(v, e);
+  return 164.8 * (T - _T_mo) - 1.97e-2 * (T * T - _T_mo * _T_mo) +
+         (1.25e-5 / 3) * (T * T * T - _T_mo * _T_mo * _T_mo) + 4.56e+5 * (1 / T - 1 / _T_mo);
 }
 
 void
 LeadBismuthFluidProperties::h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   h = h_from_v_e(v, e);
   Real cp = cp_from_v_e(v, e);
   dh_dv = cp * dT_dv;
@@ -313,74 +306,71 @@ LeadBismuthFluidProperties::e_from_p_rho(Real p, Real rho) const
 
 void
 LeadBismuthFluidProperties::e_from_p_rho(
-    Real pressure, Real rho, Real & e, Real & de_dp, Real & de_drho) const
+    Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const
 {
   Real T, dT_dp, dT_drho;
-  T_from_p_rho(pressure, rho, T, dT_dp, dT_drho);
+  T_from_p_rho(p, rho, T, dT_dp, dT_drho);
   Real de_dp_T, de_dT;
-  e_from_p_T(pressure, T, e, de_dp_T, de_dT);
+  e_from_p_T(p, T, e, de_dp_T, de_dT);
   de_dp = de_dp_T * 1 + de_dT * dT_dp;
   de_drho = de_dT * dT_drho;
 }
 
 Real
-LeadBismuthFluidProperties::T_from_p_rho(Real /*pressure*/, Real rho) const
+LeadBismuthFluidProperties::T_from_p_rho(Real /*p*/, Real rho) const
 {
   return (rho - 11065) / -1.293;
 }
 
 void
 LeadBismuthFluidProperties::T_from_p_rho(
-    Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const
+    Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const
 {
-  temperature = T_from_p_rho(pressure, rho);
+  T = T_from_p_rho(p, rho);
   dT_dp = 0;
   dT_drho = 1 / -1.293;
 }
 
 Real
-LeadBismuthFluidProperties::cp_from_p_T(Real /*pressure*/, Real temperature) const
+LeadBismuthFluidProperties::cp_from_p_T(Real /*p*/, Real T) const
 {
-  return 164.8 - 3.94e-2 * temperature + 1.25e-5 * temperature * temperature -
-         4.56e+5 / temperature / temperature;
+  return 164.8 - 3.94e-2 * T + 1.25e-5 * T * T - 4.56e+5 / T / T;
 }
 
 void
 LeadBismuthFluidProperties::cp_from_p_T(
-    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+    Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const
 {
-  cp = cp_from_p_T(pressure, temperature);
+  cp = cp_from_p_T(p, T);
   dcp_dp = 0;
-  dcp_dT =
-      -3.94e-2 + 2 * 1.25e-5 * temperature + 2 * 4.56e+5 / temperature / temperature / temperature;
+  dcp_dT = -3.94e-2 + 2 * 1.25e-5 * T + 2 * 4.56e+5 / T / T / T;
 }
 
 Real
-LeadBismuthFluidProperties::mu_from_p_T(Real /*pressure*/, Real temperature) const
+LeadBismuthFluidProperties::mu_from_p_T(Real /*p*/, Real T) const
 {
-  return 4.94e-4 * std::exp(754.1 / temperature);
+  return 4.94e-4 * std::exp(754.1 / T);
 }
 
 void
 LeadBismuthFluidProperties::mu_from_p_T(
-    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+    Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const
 {
-  mu = mu_from_p_T(pressure, temperature);
+  mu = mu_from_p_T(p, T);
   dmu_dp = 0;
-  dmu_dT = -754.1 * 4.94e-4 * exp(754.1 / temperature) / temperature / temperature;
+  dmu_dT = -754.1 * 4.94e-4 * exp(754.1 / T) / T / T;
 }
 
 Real
-LeadBismuthFluidProperties::k_from_p_T(Real /*pressure*/, Real temperature) const
+LeadBismuthFluidProperties::k_from_p_T(Real /*p*/, Real T) const
 {
-  return 3.284 + 1.617e-2 * temperature - 2.305e-6 * temperature * temperature;
+  return 3.284 + 1.617e-2 * T - 2.305e-6 * T * T;
 }
 
 void
-LeadBismuthFluidProperties::k_from_p_T(
-    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+LeadBismuthFluidProperties::k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const
 {
-  k = k_from_p_T(pressure, temperature);
+  k = k_from_p_T(p, T);
   dk_dp = 0;
-  dk_dT = 1.617e-2 - 2 * 2.305e-6 * temperature;
+  dk_dT = 1.617e-2 - 2 * 2.305e-6 * T;
 }

--- a/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
@@ -15,8 +15,8 @@ InputParameters
 LeadBismuthFluidProperties::validParams()
 {
   InputParameters params = SinglePhaseFluidProperties::validParams();
-  params.addParam<Real>("T_mo", 398, "Melting Point of LeadBismuth (K)");
-  params.addClassDescription("Fluid properties for LeadBismuth 2LiF-BeF2");
+  params.addParam<Real>("T_mo", 398, "Melting Point of Lead Bismuth (K)");
+  params.addClassDescription("Fluid properties for Lead Bismuth eutectic 2LiF-BeF2");
 
   return params;
 }

--- a/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadBismuthFluidProperties.C
@@ -16,23 +16,13 @@ LeadBismuthFluidProperties::validParams()
 {
   InputParameters params = SinglePhaseFluidProperties::validParams();
   params.addParam<Real>("T_mo", 398, "Melting Point of LeadBismuth");
-  // params.addRangeCheckedParam<Real>(
-  //     "drho_dp",
-  //     1.7324E-7,
-  //     "drho_dp > 0.0",
-  //     "derivative of density with respect to pressure (at constant temperature)");
-  // params.addClassDescription("Fluid properties for LeadBismuth");
+  params.addClassDescription("Fluid properties for LeadBismuth");
+
   return params;
 }
 
 LeadBismuthFluidProperties::LeadBismuthFluidProperties(const InputParameters & parameters)
   : SinglePhaseFluidProperties(parameters), _T_mo(getParam<Real>("T_mo"))
-// _drho_dp(getParam<Real>("drho_dp")),
-// _drho_dT(-0.4884),
-// _p_atm(101325.0),
-// _cp(2416.0),
-// _c0(2413.0),
-// _dp_dT_at_constant_v(-_drho_dT / _drho_dp)
 {
 }
 
@@ -46,6 +36,21 @@ Real
 LeadBismuthFluidProperties::molarMass() const
 {
   return 233.99;
+}
+
+Real
+LeadBismuthFluidProperties::bulk_modulus_from_p_T(Real /*p*/, Real T) const
+{
+  return (38.02 - 1.296e-2 * T + 1.320 - 6 * T * T) * MathUtils::pow(10, 9);
+}
+
+Real
+LeadBismuthFluidProperties::c_from_v_e(Real v, Real e) const
+{
+  Real Temperature = T_from_v_e(v, e);
+  Real pressure = p_from_v_e(v, e);
+  return std::sqrt(bulk_modulus_from_p_T(pressure, Temperature) /
+                   rho_from_p_T(pressure, Temperature));
 }
 
 Real
@@ -181,6 +186,18 @@ LeadBismuthFluidProperties::rho_from_p_T(
     Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
   rho = rho_from_p_T(pressure, temperature);
+  drho_dp = 0;
+  drho_dT = -1.293;
+}
+
+void
+LeadBismuthFluidProperties::rho_from_p_T(const DualReal & pressure,
+                                         const DualReal & temperature,
+                                         DualReal & rho,
+                                         DualReal & drho_dp,
+                                         DualReal & drho_dT) const
+{
+  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
   drho_dp = 0;
   drho_dT = -1.293;
 }

--- a/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
@@ -15,7 +15,7 @@ InputParameters
 LeadFluidProperties::validParams()
 {
   InputParameters params = SinglePhaseFluidProperties::validParams();
-  params.addParam<Real>("T_mo", 600.6, "Melting Point of Lead (K)");
+  params.addParam<Real>("T_mo", 600.6, "Melting Point (K)");
   params.addClassDescription("Fluid properties for Lead");
 
   return params;
@@ -35,7 +35,7 @@ LeadFluidProperties::fluidName() const
 Real
 LeadFluidProperties::molarMass() const
 {
-  return 207.2;
+  return 2.072e-1;
 }
 
 Real
@@ -48,15 +48,15 @@ LeadFluidProperties::bulk_modulus_from_p_T(Real /*p*/, Real T) const
 Real
 LeadFluidProperties::c_from_v_e(Real v, Real e) const
 {
-  auto temperature = T_from_v_e(v, e);
-  return 1953 - 0.246 * temperature;
+  auto T = T_from_v_e(v, e);
+  return 1953 - 0.246 * T;
 }
 
 DualReal
 LeadFluidProperties::c_from_v_e(const DualReal & v, const DualReal & e) const
 {
-  DualReal temperature = SinglePhaseFluidProperties::T_from_v_e(v, e);
-  return 1953 - 0.246 * temperature;
+  DualReal T = SinglePhaseFluidProperties::T_from_v_e(v, e);
+  return 1953 - 0.246 * T;
 }
 
 Real
@@ -79,95 +79,91 @@ LeadFluidProperties::p_from_v_e(Real v, Real e, Real & p, Real & dp_dv, Real & d
 Real
 LeadFluidProperties::mu_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 4.55e-4 * std::exp(1069 / temperature);
+  Real T = T_from_v_e(v, e);
+  return 4.55e-4 * std::exp(1069 / T);
 }
 
 void
 LeadFluidProperties::mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   mu = mu_from_v_e(v, e);
-  dmu_dv = dT_dv * -1069 * 4.55e-4 * exp(1069 / temperature) / temperature / temperature;
-  dmu_de = dT_de * -1069 * 4.55e-4 * exp(1069 / temperature) / temperature / temperature;
+  dmu_dv = dT_dv * -1069 * 4.55e-4 * exp(1069 / T) / T / T;
+  dmu_de = dT_de * -1069 * 4.55e-4 * exp(1069 / T) / T / T;
 }
 
 Real
 LeadFluidProperties::k_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 0.011 * temperature + 9.2;
+  Real T = T_from_v_e(v, e);
+  return 0.011 * T + 9.2;
 }
 
 void
 LeadFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   k = k_from_v_e(v, e);
   dk_dv = 0.011 * dT_dv;
   dk_de = 0.011 * dT_de;
 }
 
 Real
-LeadFluidProperties::rho_from_p_T(Real /*pressure*/, Real temperature) const
+LeadFluidProperties::rho_from_p_T(Real /*p*/, Real T) const
 {
-  return 11441 - 1.2795 * temperature;
+  return 11441 - 1.2795 * T;
 }
 
 void
-LeadFluidProperties::rho_from_p_T(
-    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+LeadFluidProperties::rho_from_p_T(Real p, Real T, Real & rho, Real & drho_dp, Real & drho_dT) const
 {
-  rho = rho_from_p_T(pressure, temperature);
+  rho = rho_from_p_T(p, T);
   drho_dp = 0;
   drho_dT = -1.2795;
 }
 
 void
-LeadFluidProperties::rho_from_p_T(const DualReal & pressure,
-                                  const DualReal & temperature,
+LeadFluidProperties::rho_from_p_T(const DualReal & p,
+                                  const DualReal & T,
                                   DualReal & rho,
                                   DualReal & drho_dp,
                                   DualReal & drho_dT) const
 {
-  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
+  rho = SinglePhaseFluidProperties::rho_from_p_T(p, T);
   drho_dp = 0;
   drho_dT = -1.2795;
 }
 
 Real
-LeadFluidProperties::v_from_p_T(Real pressure, Real temperature) const
+LeadFluidProperties::v_from_p_T(Real p, Real T) const
 {
-  return 1.0 / rho_from_p_T(pressure, temperature);
+  return 1.0 / rho_from_p_T(p, T);
 }
 
 void
-LeadFluidProperties::v_from_p_T(
-    Real pressure, Real temperature, Real & v, Real & dv_dp, Real & dv_dT) const
+LeadFluidProperties::v_from_p_T(Real p, Real T, Real & v, Real & dv_dp, Real & dv_dT) const
 {
-  v = v_from_p_T(pressure, temperature);
+  v = v_from_p_T(p, T);
   dv_dp = 0;
-  dv_dT = 1.2795 / MathUtils::pow(11441 - 1.2795 * temperature, 2);
+  dv_dT = 1.2795 / MathUtils::pow(11441 - 1.2795 * T, 2);
 }
 
 Real
-LeadFluidProperties::h_from_p_T(Real /*pressure*/, Real temperature) const
+LeadFluidProperties::h_from_p_T(Real /*p*/, Real T) const
 {
   // see 2.53 in 2005 NEA Lead Handbook
   // 5.1467e-6 is replaced by 1.544e-5/3 for accuracy
-  return 176.2 * (temperature - _T_mo) - 2.4615e-2 * (temperature * temperature - _T_mo * _T_mo) +
-         (1.544e-5 / 3) * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
-         1.524e+6 * (1 / temperature - 1 / _T_mo);
+  return 176.2 * (T - _T_mo) - 2.4615e-2 * (T * T - _T_mo * _T_mo) +
+         (1.544e-5 / 3) * (T * T * T - _T_mo * _T_mo * _T_mo) + 1.524e+6 * (1 / T - 1 / _T_mo);
 }
 
 void
-LeadFluidProperties::h_from_p_T(
-    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+LeadFluidProperties::h_from_p_T(Real p, Real T, Real & h, Real & dh_dp, Real & dh_dT) const
 {
-  h = h_from_p_T(pressure, temperature);
-  Real cp = cp_from_p_T(pressure, temperature);
+  h = h_from_p_T(p, T);
+  Real cp = cp_from_p_T(p, T);
   dh_dp = 0;
   dh_dT = cp;
 }
@@ -175,17 +171,16 @@ LeadFluidProperties::h_from_p_T(
 Real
 LeadFluidProperties::h_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 176.2 * (temperature - _T_mo) - 2.4615e-2 * (temperature * temperature - _T_mo * _T_mo) +
-         (1.544e-5 / 3) * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
-         1.524e+6 * (1 / temperature - 1 / _T_mo);
+  Real T = T_from_v_e(v, e);
+  return 176.2 * (T - _T_mo) - 2.4615e-2 * (T * T - _T_mo * _T_mo) +
+         (1.544e-5 / 3) * (T * T * T - _T_mo * _T_mo * _T_mo) + 1.524e+6 * (1 / T - 1 / _T_mo);
 }
 
 void
 LeadFluidProperties::h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   h = h_from_v_e(v, e);
   Real cp = cp_from_v_e(v, e);
   dh_dv = cp * dT_dv;
@@ -221,12 +216,6 @@ LeadFluidProperties::e_from_p_rho(Real p, Real rho) const
 void
 LeadFluidProperties::e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const
 {
-  // e = e_from_p_rho(p, rho);
-  // Real epsilon = 1e-8;
-  // Real e_p_plus = e_from_p_rho(p * (1 + epsilon), rho);
-  // Real e_rho_plus = e_from_p_rho(p, rho * (1 + epsilon));
-  // de_dp = (e_p_plus - e) / epsilon / p;
-  // de_drho = (e_rho_plus - e) / epsilon / rho;
   Real T, dT_dp, dT_drho;
   T_from_p_rho(p, rho, T, dT_dp, dT_drho);
   Real de_dp_T, de_dT;
@@ -236,16 +225,15 @@ LeadFluidProperties::e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real
 }
 
 Real
-LeadFluidProperties::T_from_p_rho(Real /*pressure*/, Real rho) const
+LeadFluidProperties::T_from_p_rho(Real /*p*/, Real rho) const
 {
   return (rho - 11441) / -1.2795;
 }
 
 void
-LeadFluidProperties::T_from_p_rho(
-    Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const
+LeadFluidProperties::T_from_p_rho(Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const
 {
-  temperature = T_from_p_rho(pressure, rho);
+  T = T_from_p_rho(p, rho);
   dT_dp = 0;
   dT_drho = 1 / -1.2795;
 }
@@ -260,47 +248,40 @@ void
 LeadFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const
 {
   T = T_from_v_e(v, e);
-  // Returning straight derivatives since no pressure dependence
   dT_de = 0;
   dT_dv = 1. / v / v / 1.2795;
 }
 
 Real
-LeadFluidProperties::cp_from_p_T(Real /*pressure*/, Real temperature) const
+LeadFluidProperties::cp_from_p_T(Real /*p*/, Real T) const
 {
-  return 176.2 - 4.923e-2 * temperature + 1.544e-5 * temperature * temperature -
-         1.524e+6 / temperature / temperature;
+  return 176.2 - 4.923e-2 * T + 1.544e-5 * T * T - 1.524e+6 / T / T;
 }
 
 void
-LeadFluidProperties::cp_from_p_T(
-    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+LeadFluidProperties::cp_from_p_T(Real p, Real T, Real & cp, Real & dcp_dp, Real & dcp_dT) const
 {
-  cp = cp_from_p_T(pressure, temperature);
+  cp = cp_from_p_T(p, T);
   dcp_dp = 0;
-  dcp_dT = -4.923e-2 + 2 * 1.544e-5 * temperature +
-           2 * 1.524e6 / temperature / temperature / temperature;
+  dcp_dT = -4.923e-2 + 2 * 1.544e-5 * T + 2 * 1.524e6 / T / T / T;
 }
 
 Real
 LeadFluidProperties::cp_from_v_e(Real v, Real e) const
 {
-  Real temperature = T_from_v_e(v, e);
-  return 176.2 - 4.923e-2 * temperature + 1.544e-5 * temperature * temperature -
-         1.524e6 / temperature / temperature;
+  Real T = T_from_v_e(v, e);
+  return 176.2 - 4.923e-2 * T + 1.544e-5 * T * T - 1.524e6 / T / T;
 }
 
 void
 LeadFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
 {
-  Real temperature, dT_dv, dT_de;
-  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  Real T, dT_dv, dT_de;
+  T_from_v_e(v, e, T, dT_dv, dT_de);
   cp = cp_from_v_e(v, e);
-  dcp_dv = -4.923e-2 * dT_dv + 2 * dT_dv * 1.544e-5 * temperature +
-           2 * dT_dv * 1.524e+6 / temperature / temperature / temperature;
+  dcp_dv = -4.923e-2 * dT_dv + 2 * dT_dv * 1.544e-5 * T + 2 * dT_dv * 1.524e+6 / T / T / T;
 
-  dcp_de = -4.923e-2 * dT_de + 2 * dT_de * 1.544e-5 * temperature +
-           2 * dT_de * 1.524e+6 / temperature / temperature / temperature;
+  dcp_de = -4.923e-2 * dT_de + 2 * dT_de * 1.544e-5 * T + 2 * dT_de * 1.524e+6 / T / T / T;
 }
 
 Real
@@ -360,31 +341,29 @@ LeadFluidProperties::cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real 
 }
 
 Real
-LeadFluidProperties::mu_from_p_T(Real /*pressure*/, Real temperature) const
+LeadFluidProperties::mu_from_p_T(Real /*p*/, Real T) const
 {
-  return 4.55e-4 * std::exp(1069 / temperature);
+  return 4.55e-4 * std::exp(1069 / T);
 }
 
 void
-LeadFluidProperties::mu_from_p_T(
-    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+LeadFluidProperties::mu_from_p_T(Real p, Real T, Real & mu, Real & dmu_dp, Real & dmu_dT) const
 {
-  mu = mu_from_p_T(pressure, temperature);
+  mu = mu_from_p_T(p, T);
   dmu_dp = 0;
-  dmu_dT = -1069 * 4.55e-4 * std::exp(1069 / temperature) / temperature / temperature;
+  dmu_dT = -1069 * 4.55e-4 * std::exp(1069 / T) / T / T;
 }
 
 Real
-LeadFluidProperties::k_from_p_T(Real /*pressure*/, Real temperature) const
+LeadFluidProperties::k_from_p_T(Real /*p*/, Real T) const
 {
-  return 0.011 * temperature + 9.2;
+  return 0.011 * T + 9.2;
 }
 
 void
-LeadFluidProperties::k_from_p_T(
-    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+LeadFluidProperties::k_from_p_T(Real p, Real T, Real & k, Real & dk_dp, Real & dk_dT) const
 {
-  k = k_from_p_T(pressure, temperature);
+  k = k_from_p_T(p, T);
   dk_dp = 0;
   dk_dT = 0.011;
 }

--- a/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
@@ -16,23 +16,13 @@ LeadFluidProperties::validParams()
 {
   InputParameters params = SinglePhaseFluidProperties::validParams();
   params.addParam<Real>("T_mo", 600.6, "Melting Point of Lead");
-  // params.addRangeCheckedParam<Real>(
-  //     "drho_dp",
-  //     1.7324E-7,
-  //     "drho_dp > 0.0",
-  //     "derivative of density with respect to pressure (at constant temperature)");
-  // params.addClassDescription("Fluid properties for Lead");
+  params.addClassDescription("Fluid properties for Lead");
+
   return params;
 }
 
 LeadFluidProperties::LeadFluidProperties(const InputParameters & parameters)
   : SinglePhaseFluidProperties(parameters), _T_mo(getParam<Real>("T_mo"))
-// _drho_dp(getParam<Real>("drho_dp")),
-// _drho_dT(-0.4884),
-// _p_atm(101325.0),
-// _cp(2416.0),
-// _c0(2413.0),
-// _dp_dT_at_constant_v(-_drho_dT / _drho_dp)
 {
 }
 
@@ -46,6 +36,30 @@ Real
 LeadFluidProperties::molarMass() const
 {
   return 207.2;
+}
+
+Real
+LeadFluidProperties::bulk_modulus_from_p_T(Real /*p*/, Real T) const
+{
+  return (43.50 - 1.552e-2 * T + 1.622e-6 * T * T) * 10e8;
+}
+
+Real
+LeadFluidProperties::c_from_v_e(Real v, Real e) const
+{
+  Real Temperature = T_from_v_e(v, e);
+  Real pressure = p_from_v_e(v, e);
+  return std::sqrt(bulk_modulus_from_p_T(pressure, Temperature) /
+                   rho_from_p_T(pressure, Temperature));
+}
+
+DualReal
+LeadFluidProperties::c_from_v_e(const DualReal & v, const DualReal & e) const
+{
+  auto Temperature = T_from_v_e(v, e);
+  auto pressure = p_from_v_e(v, e);
+  return std::sqrt(bulk_modulus_from_p_T(pressure.value(), Temperature.value()) /
+                   rho_from_p_T(pressure, Temperature));
 }
 
 Real
@@ -196,7 +210,7 @@ LeadFluidProperties::e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & d
   Real dh_dp, dv_dp, dh_dT, dv_dT, v, h;
   h_from_p_T(p, T, h, dh_dp, dh_dT);
   v_from_p_T(p, T, v, dv_dp, dv_dT);
-  e = h_from_p_T(v, e);
+  e = e_from_p_T(p, T);
   de_dp = dh_dp - v - dv_dp * p;
   de_dT = dh_dT - dv_dT * p;
 }
@@ -205,6 +219,17 @@ Real
 LeadFluidProperties::e_from_p_rho(Real p, Real rho) const
 {
   return e_from_p_T(p, T_from_p_rho(p, rho));
+}
+
+void
+LeadFluidProperties::e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const
+{
+  e = e_from_p_rho(p, rho);
+  Real epsilon = 1e-8;
+  Real e_p_plus = e_from_p_rho(p * (1 + epsilon), rho);
+  Real e_rho_plus = e_from_p_rho(p, rho * (1 + epsilon));
+  de_dp = (e_p_plus - e) / epsilon / p;
+  de_drho = (e_rho_plus - e) / epsilon / rho;
 }
 
 Real
@@ -250,8 +275,8 @@ LeadFluidProperties::cp_from_p_T(
 {
   cp = cp_from_p_T(pressure, temperature);
   dcp_dp = 0;
-  dcp_dT = -4.923e-2 + 2 * 1.55e-5 * temperature +
-           2 * 1.524e+6 / temperature / temperature / temperature;
+  dcp_dT = -4.923e-2 + 2 * 1.544e-5 * temperature +
+           2 * 1.524e6 / temperature / temperature / temperature;
 }
 
 Real
@@ -259,7 +284,7 @@ LeadFluidProperties::cp_from_v_e(Real v, Real e) const
 {
   Real temperature = T_from_v_e(v, e);
   return 176.2 - 4.923e-2 * temperature + 1.544e-5 * temperature * temperature -
-         1.524e+6 / temperature / temperature;
+         1.524e6 / temperature / temperature;
 }
 
 void
@@ -268,10 +293,10 @@ LeadFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real 
   Real temperature, dT_dv, dT_de;
   T_from_v_e(v, e, temperature, dT_dv, dT_de);
   cp = cp_from_v_e(v, e);
-  dcp_dv = -4.923e-2 * dT_dv + 2 * dT_dv * 1.554e-5 * temperature +
+  dcp_dv = -4.923e-2 * dT_dv + 2 * dT_dv * 1.544e-5 * temperature +
            2 * dT_dv * 1.524e+6 / temperature / temperature / temperature;
 
-  dcp_de = -4.923e-2 * dT_de + 2 * dT_de * 1.554e-5 * temperature +
+  dcp_de = -4.923e-2 * dT_de + 2 * dT_de * 1.544e-5 * temperature +
            2 * dT_de * 1.524e+6 / temperature / temperature / temperature;
 }
 
@@ -302,7 +327,7 @@ LeadFluidProperties::cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real 
 {
   Real cp, dcp_dp, dcp_dT;
   cp_from_p_T(p, T, cp, dcp_dp, dcp_dT);
-  cv = cv_from_p_T(p, T);
+  cv = cp;
   dcv_dp = dcp_dp;
   dcv_dT = dcp_dT;
 }

--- a/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
+++ b/modules/fluid_properties/src/userobjects/LeadFluidProperties.C
@@ -1,0 +1,338 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "LeadFluidProperties.h"
+
+registerMooseObject("FluidPropertiesApp", LeadFluidProperties);
+
+InputParameters
+LeadFluidProperties::validParams()
+{
+  InputParameters params = SinglePhaseFluidProperties::validParams();
+  params.addParam<Real>("T_mo", 600.6, "Melting Point of Lead");
+  // params.addRangeCheckedParam<Real>(
+  //     "drho_dp",
+  //     1.7324E-7,
+  //     "drho_dp > 0.0",
+  //     "derivative of density with respect to pressure (at constant temperature)");
+  // params.addClassDescription("Fluid properties for Lead");
+  return params;
+}
+
+LeadFluidProperties::LeadFluidProperties(const InputParameters & parameters)
+  : SinglePhaseFluidProperties(parameters), _T_mo(getParam<Real>("T_mo"))
+// _drho_dp(getParam<Real>("drho_dp")),
+// _drho_dT(-0.4884),
+// _p_atm(101325.0),
+// _cp(2416.0),
+// _c0(2413.0),
+// _dp_dT_at_constant_v(-_drho_dT / _drho_dp)
+{
+}
+
+std::string
+LeadFluidProperties::fluidName() const
+{
+  return "Lead";
+}
+
+Real
+LeadFluidProperties::molarMass() const
+{
+  return 207.2;
+}
+
+Real
+LeadFluidProperties::p_from_v_e(Real v, Real e) const
+{
+  Real h = h_from_v_e(v, e);
+  return (h - e) / v;
+}
+
+void
+LeadFluidProperties::p_from_v_e(Real v, Real e, Real & /*p*/, Real & dp_dv, Real & dp_de) const
+{
+  Real h, dh_dv, dh_de;
+  h_from_v_e(v, e, h, dh_dv, dh_de);
+  dp_dv = (v * dh_dv - h + e) / v / v;
+  dp_de = (dh_de - 1) / v;
+}
+
+Real
+LeadFluidProperties::mu_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 4.55e-4 * std::exp(1069 / temperature);
+}
+
+void
+LeadFluidProperties::mu_from_v_e(Real v, Real e, Real & mu, Real & dmu_dv, Real & dmu_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  mu = mu_from_v_e(v, e);
+  dmu_dv = dT_dv * -1069 * 4.55e-4 * exp(1069 / temperature) / temperature / temperature;
+  dmu_de = dT_de * -1069 * 4.55e-4 * exp(1069 / temperature) / temperature / temperature;
+}
+
+Real
+LeadFluidProperties::k_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 0.011 * temperature + 9.2;
+}
+
+void
+LeadFluidProperties::k_from_v_e(Real v, Real e, Real & k, Real & dk_dv, Real & dk_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  k = k_from_v_e(v, e);
+  dk_dv = 0.011 * dT_dv;
+  dk_de = 0.011 * dT_de;
+}
+
+Real
+LeadFluidProperties::rho_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 11441 - 1.2795 * temperature;
+}
+
+void
+LeadFluidProperties::rho_from_p_T(
+    Real pressure, Real temperature, Real & rho, Real & drho_dp, Real & drho_dT) const
+{
+  rho = rho_from_p_T(pressure, temperature);
+  drho_dp = 0;
+  drho_dT = -1.2795;
+}
+
+void
+LeadFluidProperties::rho_from_p_T(const DualReal & pressure,
+                                  const DualReal & temperature,
+                                  DualReal & rho,
+                                  DualReal & drho_dp,
+                                  DualReal & drho_dT) const
+{
+  rho = SinglePhaseFluidProperties::rho_from_p_T(pressure, temperature);
+  drho_dp = 0;
+  drho_dT = -1.2795;
+}
+
+Real
+LeadFluidProperties::v_from_p_T(Real pressure, Real temperature) const
+{
+  return 1.0 / rho_from_p_T(pressure, temperature);
+}
+
+void
+LeadFluidProperties::v_from_p_T(
+    Real pressure, Real temperature, Real & v, Real & dv_dp, Real & dv_dT) const
+{
+  v = v_from_p_T(pressure, temperature);
+  dv_dp = 0;
+  dv_dT = -1.2795 / MathUtils::pow(11441 - 1.2795 * temperature, 2);
+}
+
+Real
+LeadFluidProperties::h_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 176.2 * (temperature - _T_mo) - 2.4615e-2 * (temperature * temperature - _T_mo * _T_mo) +
+         5.147e-6 * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
+         1.524e+6 * (1 / temperature - 1 / _T_mo);
+}
+
+void
+LeadFluidProperties::h_from_p_T(
+    Real pressure, Real temperature, Real & h, Real & dh_dp, Real & dh_dT) const
+{
+  h = h_from_p_T(pressure, temperature);
+  dh_dp = 0;
+  dh_dT = 176.2 + 2 * 2.4615e-2 * temperature + 3 * 5.147e-6 * temperature * temperature -
+          1.524e+6 / temperature / temperature;
+}
+
+Real
+LeadFluidProperties::h_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 176.2 * (temperature - _T_mo) - 2.4615e-2 * (temperature * temperature - _T_mo * _T_mo) +
+         5.147e-6 * (temperature * temperature * temperature - _T_mo * _T_mo * _T_mo) +
+         1.524e+6 * (1 / temperature - 1 / _T_mo);
+}
+
+void
+LeadFluidProperties::h_from_v_e(Real v, Real e, Real & h, Real & dh_dv, Real & dh_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  h = h_from_v_e(v, e);
+  dh_dv = 176.2 * dT_dv + 2 * dT_dv * 2.4615e-2 * temperature +
+          3 * 5.147e-6 * temperature * temperature * dT_dv -
+          1.524e+6 / temperature / temperature / dT_dv;
+  dh_de = 176.2 * dT_de + 2 * dT_de * 2.4615e-2 * temperature +
+          3 * 5.147e-6 * temperature * temperature * dT_de -
+          1.524e+6 / temperature / temperature / dT_de;
+}
+
+Real
+LeadFluidProperties::e_from_p_T(Real p, Real T) const
+{
+  // definition of h = e + p * v
+  Real v = v_from_p_T(p, T);
+  Real h = h_from_p_T(p, T);
+  return h - p * v;
+}
+
+void
+LeadFluidProperties::e_from_p_T(Real p, Real T, Real & e, Real & de_dp, Real & de_dT) const
+{
+  Real dh_dp, dv_dp, dh_dT, dv_dT, v, h;
+  h_from_p_T(p, T, h, dh_dp, dh_dT);
+  v_from_p_T(p, T, v, dv_dp, dv_dT);
+  e = h_from_p_T(v, e);
+  de_dp = dh_dp - v - dv_dp * p;
+  de_dT = dh_dT - dv_dT * p;
+}
+
+Real
+LeadFluidProperties::e_from_p_rho(Real p, Real rho) const
+{
+  return e_from_p_T(p, T_from_p_rho(p, rho));
+}
+
+Real
+LeadFluidProperties::T_from_p_rho(Real /*pressure*/, Real rho) const
+{
+  return (rho - 11441) / -1.2795;
+}
+
+void
+LeadFluidProperties::T_from_p_rho(
+    Real pressure, Real rho, Real & temperature, Real & dT_dp, Real & dT_drho) const
+{
+  temperature = T_from_p_rho(pressure, rho);
+  dT_dp = 0;
+  dT_drho = 1 / -1.2795;
+}
+
+Real
+LeadFluidProperties::T_from_v_e(Real v, Real /*e*/) const
+{
+  return (1 / v - 11441) * -1 / 1.2795;
+}
+
+void
+LeadFluidProperties::T_from_v_e(Real v, Real e, Real & T, Real & dT_dv, Real & dT_de) const
+{
+  T = T_from_v_e(v, e);
+  // Returning straight derivatives since no pressure dependence
+  dT_de = 0;
+  dT_dv = 1 / v / v / 1.2795;
+}
+
+Real
+LeadFluidProperties::cp_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 176.2 - 4.923e-2 * temperature + 1.544e-5 * temperature * temperature -
+         1.524e+6 / temperature / temperature;
+}
+
+void
+LeadFluidProperties::cp_from_p_T(
+    Real pressure, Real temperature, Real & cp, Real & dcp_dp, Real & dcp_dT) const
+{
+  cp = cp_from_p_T(pressure, temperature);
+  dcp_dp = 0;
+  dcp_dT = -4.923e-2 + 2 * 1.55e-5 * temperature +
+           2 * 1.524e+6 / temperature / temperature / temperature;
+}
+
+Real
+LeadFluidProperties::cp_from_v_e(Real v, Real e) const
+{
+  Real temperature = T_from_v_e(v, e);
+  return 176.2 - 4.923e-2 * temperature + 1.544e-5 * temperature * temperature -
+         1.524e+6 / temperature / temperature;
+}
+
+void
+LeadFluidProperties::cp_from_v_e(Real v, Real e, Real & cp, Real & dcp_dv, Real & dcp_de) const
+{
+  Real temperature, dT_dv, dT_de;
+  T_from_v_e(v, e, temperature, dT_dv, dT_de);
+  cp = cp_from_v_e(v, e);
+  dcp_dv = -4.923e-2 * dT_dv + 2 * dT_dv * 1.554e-5 * temperature +
+           2 * dT_dv * 1.524e+6 / temperature / temperature / temperature;
+
+  dcp_de = -4.923e-2 * dT_de + 2 * dT_de * 1.554e-5 * temperature +
+           2 * dT_de * 1.524e+6 / temperature / temperature / temperature;
+}
+
+Real
+LeadFluidProperties::cv_from_v_e(Real v, Real e) const
+{
+  return cp_from_v_e(v, e);
+}
+
+void
+LeadFluidProperties::cv_from_v_e(Real v, Real e, Real & cv, Real & dcv_dv, Real & dcv_de) const
+{
+  Real cp, dcp_dv, dcp_de;
+  cp_from_v_e(v, e, cp, dcp_dv, dcp_de);
+  cv = cv_from_v_e(v, e);
+  dcv_dv = dcp_dv;
+  dcv_de = dcp_de;
+}
+
+Real
+LeadFluidProperties::cv_from_p_T(Real p, Real T) const
+{
+  return cp_from_p_T(p, T);
+}
+
+void
+LeadFluidProperties::cv_from_p_T(Real p, Real T, Real & cv, Real & dcv_dp, Real & dcv_dT) const
+{
+  Real cp, dcp_dp, dcp_dT;
+  cp_from_p_T(p, T, cp, dcp_dp, dcp_dT);
+  cv = cv_from_p_T(p, T);
+  dcv_dp = dcp_dp;
+  dcv_dT = dcp_dT;
+}
+
+Real
+LeadFluidProperties::mu_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 4.55e-4 * std::exp(1069 / temperature);
+}
+
+void
+LeadFluidProperties::mu_from_p_T(
+    Real pressure, Real temperature, Real & mu, Real & dmu_dp, Real & dmu_dT) const
+{
+  mu = mu_from_p_T(pressure, temperature);
+  dmu_dp = 0;
+  dmu_dT = -1069 * 4.55e-4 * std::exp(1069 / temperature) / temperature / temperature;
+}
+
+Real
+LeadFluidProperties::k_from_p_T(Real /*pressure*/, Real temperature) const
+{
+  return 0.011 * temperature + 9.2;
+}
+
+void
+LeadFluidProperties::k_from_p_T(
+    Real pressure, Real temperature, Real & k, Real & dk_dp, Real & dk_dT) const
+{
+  k = k_from_p_T(pressure, temperature);
+  dk_dp = 0;
+  dk_dT = 0.011;
+}

--- a/modules/fluid_properties/unit/include/LeadBismuthFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/LeadBismuthFluidPropertiesTest.h
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+#include "LeadBismuthFluidProperties.h"
+
+class LeadBismuthFluidPropertiesTest : public MooseObjectUnitTest
+{
+public:
+  LeadBismuthFluidPropertiesTest() : MooseObjectUnitTest("FluidPropertiesApp") { buildObjects(); }
+
+protected:
+  void buildObjects()
+  {
+    InputParameters uo_pars = _factory.getValidParams("LeadBismuthFluidProperties");
+    _fe_problem->addUserObject("LeadBismuthFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<LeadBismuthFluidProperties>("fp");
+  }
+
+  const LeadBismuthFluidProperties * _fp;
+};

--- a/modules/fluid_properties/unit/include/LeadFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/LeadFluidPropertiesTest.h
@@ -1,0 +1,29 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseObjectUnitTest.h"
+#include "LeadFluidProperties.h"
+
+class LeadFluidPropertiesTest : public MooseObjectUnitTest
+{
+public:
+  LeadFluidPropertiesTest() : MooseObjectUnitTest("FluidPropertiesApp") { buildObjects(); }
+
+protected:
+  void buildObjects()
+  {
+    InputParameters uo_pars = _factory.getValidParams("LeadFluidProperties");
+    _fe_problem->addUserObject("LeadFluidProperties", "fp", uo_pars);
+    _fp = &_fe_problem->getUserObject<LeadFluidProperties>("fp");
+  }
+
+  const LeadFluidProperties * _fp;
+};

--- a/modules/fluid_properties/unit/src/FlinakFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/FlinakFluidPropertiesTest.C
@@ -111,8 +111,7 @@ TEST_F(FlinakFluidPropertiesTest, specificInternalEnergy)
   ABS_TEST(_fp->e_from_p_T(p, T), e, REL_TOL_SAVED_VALUE);
   DERIV_TEST(_fp->e_from_p_T, p, T, REL_TOL_DERIVATIVE);
 
-  ABS_TEST(
-      _fp->e_from_p_rho(p, _fp->rho_from_p_T(p, T)), e, REL_TOL_SAVED_VALUE);
+  ABS_TEST(_fp->e_from_p_rho(p, _fp->rho_from_p_T(p, T)), e, REL_TOL_SAVED_VALUE);
 }
 
 /**

--- a/modules/fluid_properties/unit/src/LeadBismuthFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadBismuthFluidPropertiesTest.C
@@ -20,7 +20,7 @@ TEST_F(LeadBismuthFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), 
  */
 TEST_F(LeadBismuthFluidPropertiesTest, molarMass)
 {
-  ABS_TEST(_fp->molarMass(), 233.99, REL_TOL_SAVED_VALUE);
+  REL_TEST(_fp->molarMass(), 2.3399e-1, REL_TOL_SAVED_VALUE);
 }
 
 /**
@@ -28,21 +28,22 @@ TEST_F(LeadBismuthFluidPropertiesTest, molarMass)
  */
 TEST_F(LeadBismuthFluidPropertiesTest, properties)
 {
-  const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const Real tol = REL_TOL_SAVED_VALUE;
   const std::vector<Real> pressures = {1e5, 1e6, 5e6};
   const std::vector<Real> temperatures = {400, 500, 700};
 
   // Solutions : obtained from running the property object itself
   // Verified visually against the reference
   const std::vector<Real> rho_refs = {10547.8, 10418.5, 10159.9};
-  const std::vector<Real> h_refs = {296.41, 15029.6, 43909.3};
-  const std::vector<Real> e_refs = {286.93, 14933.6, 43417.2};
-  const std::vector<Real> k_refs = {9.3832, 10.7927, 13.4736};
+  const std::vector<Real> h_refs = {296.410190117253, 15029.57685678392, 43909.33876154583};
+  const std::vector<Real> e_refs = {286.9295401238894, 14933.59374981075, 43417.2079334865};
+  const std::vector<Real> k_refs = {9.3832, 10.79275, 13.47355};
   const std::vector<Real> c_refs = {1770.2, 1749, 1706.6};
   const std::vector<Real> E_refs = {3.30472e+10, 3.187e+10, 2.95948e+10};
-  const std::vector<Real> cp_refs = {148.19, 146.401, 142.414};
-  const std::vector<Real> cv_refs = {131.481, 126.109, 115.606};
-  const std::vector<Real> mu_refs = {0.00325447, 0.00223218, 0.00145073};
+  const std::vector<Real> cp_refs = {148.19, 146.401, 142.4143877551021};
+  const std::vector<Real> cv_refs = {131.481010510397, 126.1085687634637, 115.6060997100004};
+  const std::vector<Real> mu_refs = {
+      0.003254472610814353, 0.002232183463848443, 0.001450728657307528};
 
   for (auto i : make_range(pressures.size()))
   {
@@ -56,39 +57,45 @@ TEST_F(LeadBismuthFluidPropertiesTest, properties)
     // Density
     REL_TEST(_fp->rho_from_p_T(p, T), rho_refs[i], tol);
 
+    // Specific volume
+    REL_TEST(_fp->v_from_p_T(p, T), 1. / rho_refs[i], tol);
+
+    // Pressure
+    REL_TEST(_fp->p_from_v_e(v, e), p, 1e5 * tol);
+
     // Enthalpy
-    ABS_TEST(_fp->h_from_p_T(p, T), h_refs[i], 100 * tol);
-    ABS_TEST(_fp->h_from_v_e(v, e), h_refs[i], 100 * tol);
+    REL_TEST(_fp->h_from_p_T(p, T), h_refs[i], tol);
+    REL_TEST(_fp->h_from_v_e(v, e), h_refs[i], tol);
 
     // Specific energy
-    ABS_TEST(_fp->e_from_p_T(p, T), e_refs[i], 10 * tol);
-    ABS_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], 10 * tol);
+    REL_TEST(_fp->e_from_p_T(p, T), e_refs[i], tol);
+    REL_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], tol);
 
     // Temperature
-    ABS_TEST(_fp->T_from_v_e(v, e), T, tol);
-    ABS_TEST(_fp->T_from_p_rho(p, rho), T, tol);
+    REL_TEST(_fp->T_from_v_e(v, e), T, tol);
+    REL_TEST(_fp->T_from_p_rho(p, rho), T, tol);
 
     // Thermal conductivity (function of T only)
-    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], 10.0 * tol);
-    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], 10.0 * tol);
+    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], tol);
+    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], tol);
 
     // Bulk modulus
-    REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_refs[i], 10.0 * tol);
+    REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_refs[i], tol);
 
     // Speed of sound
-    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], 10.0 * tol);
+    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], tol);
 
     // Isobaric specific heat
-    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], 10.0 * tol);
-    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], 10.0 * tol);
+    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], tol);
+    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], tol);
 
     // Isochoric specific heat
-    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], 10.0 * tol);
-    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], 10.0 * tol);
+    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], tol);
+    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], tol);
 
     // Dynamic viscosity
-    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], 10.0 * tol);
-    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], 10.0 * tol);
+    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], tol);
+    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], tol);
   }
 }
 

--- a/modules/fluid_properties/unit/src/LeadBismuthFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadBismuthFluidPropertiesTest.C
@@ -1,0 +1,128 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "LeadBismuthFluidPropertiesTest.h"
+#include "SinglePhaseFluidPropertiesTestUtils.h"
+
+/**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(LeadBismuthFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "LeadBismuth"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(LeadBismuthFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_fp->molarMass(), 233.99, REL_TOL_SAVED_VALUE);
+}
+
+/**
+ * Verify calculation of the LeadBismuth fluid properties
+ */
+TEST_F(LeadBismuthFluidPropertiesTest, properties)
+{
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> pressures = {1e5, 1e6, 5e6};
+  const std::vector<Real> temperatures = {400, 500, 700};
+
+  // Solutions : obtained from running the property object itself
+  // Verified visually against the reference
+  const std::vector<Real> rho_refs = {10547.8, 10418.5, 10159.9};
+  const std::vector<Real> h_refs = {296.41, 15029.6, 43909.3};
+  const std::vector<Real> e_refs = {286.93, 14933.6, 43417.2};
+  const std::vector<Real> k_refs = {9.3832, 10.7927, 13.4736};
+  const std::vector<Real> c_refs = {1770.2, 1749, 1706.6};
+  const std::vector<Real> E_refs = {3.30472e+10, 3.187e+10, 2.95948e+10};
+  const std::vector<Real> cp_refs = {148.19, 146.401, 142.414};
+  const std::vector<Real> cv_refs = {131.481, 126.109, 115.606};
+  const std::vector<Real> mu_refs = {0.00325447, 0.00223218, 0.00145073};
+
+  for (auto i : make_range(pressures.size()))
+  {
+    // Obtain variable sets
+    const Real p = pressures[i];
+    const Real T = temperatures[i];
+    const Real rho = _fp->rho_from_p_T(p, T);
+    const Real v = 1. / rho;
+    const Real e = _fp->e_from_p_T(p, T);
+
+    // Density
+    REL_TEST(_fp->rho_from_p_T(p, T), rho_refs[i], tol);
+
+    // Enthalpy
+    ABS_TEST(_fp->h_from_p_T(p, T), h_refs[i], 100 * tol);
+    ABS_TEST(_fp->h_from_v_e(v, e), h_refs[i], 100 * tol);
+
+    // Specific energy
+    ABS_TEST(_fp->e_from_p_T(p, T), e_refs[i], 10 * tol);
+    ABS_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], 10 * tol);
+
+    // Temperature
+    ABS_TEST(_fp->T_from_v_e(v, e), T, tol);
+    ABS_TEST(_fp->T_from_p_rho(p, rho), T, tol);
+
+    // Thermal conductivity (function of T only)
+    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], 10.0 * tol);
+    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], 10.0 * tol);
+
+    // Bulk modulus
+    REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_refs[i], 10.0 * tol);
+
+    // Speed of sound
+    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], 10.0 * tol);
+
+    // Isobaric specific heat
+    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], 10.0 * tol);
+    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], 10.0 * tol);
+
+    // Isochoric specific heat
+    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], 10.0 * tol);
+    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], 10.0 * tol);
+
+    // Dynamic viscosity
+    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], 10.0 * tol);
+    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], 10.0 * tol);
+  }
+}
+
+/**
+ * Verify calculation of the derivatives of LeadBismuth properties by comparing with finite
+ * differences
+ */
+TEST_F(LeadBismuthFluidPropertiesTest, derivatives)
+{
+  const Real tol = REL_TOL_DERIVATIVE;
+
+  const Real p = 30.0e6;
+  const Real T = 300.0;
+  const Real rho = _fp->rho_from_p_T(p, T);
+  const Real v = 1. / rho;
+  const Real e = _fp->e_from_p_T(p, T);
+
+  DERIV_TEST(_fp->rho_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->e_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->v_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->h_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->k_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->cp_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->cv_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->mu_from_p_T, p, T, tol);
+
+  DERIV_TEST(_fp->p_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->mu_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->k_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->h_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->T_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->cv_from_v_e, v, e, tol);
+
+  DERIV_TEST(_fp->T_from_p_rho, p, rho, tol);
+  DERIV_TEST(_fp->e_from_p_rho, p, rho, tol);
+}

--- a/modules/fluid_properties/unit/src/LeadFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadFluidPropertiesTest.C
@@ -1,0 +1,128 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "LeadFluidPropertiesTest.h"
+#include "SinglePhaseFluidPropertiesTestUtils.h"
+
+/**
+ * Test that the fluid name is correctly returned
+ */
+TEST_F(LeadFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "Lead"); }
+
+/**
+ * Test that the molar mass is correctly returned
+ */
+TEST_F(LeadFluidPropertiesTest, molarMass)
+{
+  ABS_TEST(_fp->molarMass(), 207.2, REL_TOL_SAVED_VALUE);
+}
+
+/**
+ * Verify calculation of the Lead fluid properties
+ */
+TEST_F(LeadFluidPropertiesTest, properties)
+{
+  const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const std::vector<Real> pressures = {1e5, 1e6, 5e6};
+  const std::vector<Real> temperatures = {700, 800, 1000};
+
+  // Solutions : obtained from running the property object itself
+  // Verified visually against the reference
+  const std::vector<Real> rho_refs = {10545.4, 10417.4, 10161.5};
+  const std::vector<Real> h_refs = {14622, 29147.4, 57656.6};
+  const std::vector<Real> e_refs = {14612.5, 29051.4, 57164.5};
+  const std::vector<Real> k_refs = {16.9, 18, 20.2};
+  const std::vector<Real> E_refs = {3.34308e+10, 3.21221e+10, 2.9602e+10};
+  const std::vector<Real> c_refs = {1780.8, 1756.2, 1707};
+  const std::vector<Real> cp_refs = {146.194, 144.316, 140.886};
+  const std::vector<Real> cv_refs = {119.492, 114.732, 106.102};
+  const std::vector<Real> mu_refs = {0.00209528, 0.00173116, 0.00132517};
+
+  for (auto i : make_range(pressures.size()))
+  {
+    // Obtain variable sets
+    const Real p = pressures[i];
+    const Real T = temperatures[i];
+    const Real rho = _fp->rho_from_p_T(p, T);
+    const Real v = 1. / rho;
+    const Real e = _fp->e_from_p_T(p, T);
+
+    // Density
+    REL_TEST(_fp->rho_from_p_T(p, T), rho_refs[i], 10 * tol);
+
+    // Enthalpy
+    ABS_TEST(_fp->h_from_p_T(p, T), h_refs[i], 100 * tol);
+    ABS_TEST(_fp->h_from_v_e(v, e), h_refs[i], 100 * tol);
+
+    // Specific energy
+    ABS_TEST(_fp->e_from_p_T(p, T), e_refs[i], 50 * tol);
+    ABS_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], 50 * tol);
+
+    // Temperature
+    ABS_TEST(_fp->T_from_v_e(v, e), T, tol);
+    ABS_TEST(_fp->T_from_p_rho(p, rho), T, tol);
+
+    // Thermal conductivity (function of T only)
+    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], 10 * tol);
+    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], 10 * tol);
+
+    // Bulk modulus
+    REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_refs[i], tol);
+
+    // Speed of sound
+    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], 10 * tol);
+
+    // Isobaric specific heat
+    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], 10 * tol);
+    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], 10 * tol);
+
+    // Isochoric specific heat
+    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], 10 * tol);
+    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], 10 * tol);
+
+    // Dynamic viscosity
+    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], 10 * tol);
+    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], 10 * tol);
+  }
+}
+
+/**
+ * Verify calculation of the derivatives of lead properties by comparing with finite
+ * differences
+ */
+TEST_F(LeadFluidPropertiesTest, derivatives)
+{
+  const Real tol = REL_TOL_DERIVATIVE;
+
+  const Real p = 30.0e6;
+  const Real T = 300.0;
+  const Real rho = _fp->rho_from_p_T(p, T);
+  const Real v = 1. / rho;
+  const Real e = _fp->e_from_p_T(p, T);
+
+  DERIV_TEST(_fp->rho_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->e_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->v_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->h_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->k_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->cp_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->cv_from_p_T, p, T, tol);
+  DERIV_TEST(_fp->mu_from_p_T, p, T, tol);
+
+  DERIV_TEST(_fp->p_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->mu_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->k_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->h_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->T_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->cp_from_v_e, v, e, tol);
+  DERIV_TEST(_fp->cv_from_v_e, v, e, tol);
+
+  DERIV_TEST(_fp->T_from_p_rho, p, rho, tol);
+  DERIV_TEST(_fp->e_from_p_rho, p, rho, tol);
+}

--- a/modules/fluid_properties/unit/src/LeadFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/LeadFluidPropertiesTest.C
@@ -20,7 +20,7 @@ TEST_F(LeadFluidPropertiesTest, fluidName) { EXPECT_EQ(_fp->fluidName(), "Lead")
  */
 TEST_F(LeadFluidPropertiesTest, molarMass)
 {
-  ABS_TEST(_fp->molarMass(), 207.2, REL_TOL_SAVED_VALUE);
+  REL_TEST(_fp->molarMass(), 2.072e-1, REL_TOL_SAVED_VALUE);
 }
 
 /**
@@ -28,21 +28,22 @@ TEST_F(LeadFluidPropertiesTest, molarMass)
  */
 TEST_F(LeadFluidPropertiesTest, properties)
 {
-  const Real tol = REL_TOL_EXTERNAL_VALUE;
+  const Real tol = REL_TOL_SAVED_VALUE;
   const std::vector<Real> pressures = {1e5, 1e6, 5e6};
   const std::vector<Real> temperatures = {700, 800, 1000};
 
   // Solutions : obtained from running the property object itself
   // Verified visually against the reference
-  const std::vector<Real> rho_refs = {10545.4, 10417.4, 10161.5};
-  const std::vector<Real> h_refs = {14622, 29147.4, 57656.6};
-  const std::vector<Real> e_refs = {14612.5, 29051.4, 57164.5};
+  const std::vector<Real> rho_refs = {10545.35, 10417.4, 10161.5};
+  const std::vector<Real> h_refs = {14622.0302715953, 29147.42408111911, 57656.59741445244};
+  const std::vector<Real> e_refs = {14612.54741896357, 29051.43083904335, 57164.54407587054};
   const std::vector<Real> k_refs = {16.9, 18, 20.2};
-  const std::vector<Real> E_refs = {3.34308e+10, 3.21221e+10, 2.9602e+10};
+  const std::vector<Real> E_refs = {3.343078e+10, 3.212208e+10, 2.9602e+10};
   const std::vector<Real> c_refs = {1780.8, 1756.2, 1707};
-  const std::vector<Real> cp_refs = {146.194, 144.316, 140.886};
-  const std::vector<Real> cv_refs = {119.492, 114.732, 106.102};
-  const std::vector<Real> mu_refs = {0.00209528, 0.00173116, 0.00132517};
+  const std::vector<Real> cp_refs = {146.1943959183673, 144.31635, 140.886};
+  const std::vector<Real> cv_refs = {119.4919995682616, 114.7318265760007, 106.1017358488117};
+  const std::vector<Real> mu_refs = {
+      0.002095275392729136, 0.001731160754658103, 0.001325171837844852};
 
   for (auto i : make_range(pressures.size()))
   {
@@ -54,41 +55,47 @@ TEST_F(LeadFluidPropertiesTest, properties)
     const Real e = _fp->e_from_p_T(p, T);
 
     // Density
-    REL_TEST(_fp->rho_from_p_T(p, T), rho_refs[i], 10 * tol);
+    REL_TEST(_fp->rho_from_p_T(p, T), rho_refs[i], tol);
+
+    // Specific volume
+    REL_TEST(_fp->v_from_p_T(p, T), 1. / rho_refs[i], tol);
+
+    // Pressure
+    REL_TEST(_fp->p_from_v_e(v, e), p, 1e5 * tol);
 
     // Enthalpy
-    ABS_TEST(_fp->h_from_p_T(p, T), h_refs[i], 100 * tol);
-    ABS_TEST(_fp->h_from_v_e(v, e), h_refs[i], 100 * tol);
+    REL_TEST(_fp->h_from_p_T(p, T), h_refs[i], tol);
+    REL_TEST(_fp->h_from_v_e(v, e), h_refs[i], tol);
 
     // Specific energy
-    ABS_TEST(_fp->e_from_p_T(p, T), e_refs[i], 50 * tol);
-    ABS_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], 50 * tol);
+    REL_TEST(_fp->e_from_p_T(p, T), e_refs[i], tol);
+    REL_TEST(_fp->e_from_p_rho(p, rho), e_refs[i], tol);
 
     // Temperature
-    ABS_TEST(_fp->T_from_v_e(v, e), T, tol);
-    ABS_TEST(_fp->T_from_p_rho(p, rho), T, tol);
+    REL_TEST(_fp->T_from_v_e(v, e), T, tol);
+    REL_TEST(_fp->T_from_p_rho(p, rho), T, tol);
 
     // Thermal conductivity (function of T only)
-    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], 10 * tol);
-    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], 10 * tol);
+    REL_TEST(_fp->k_from_p_T(p, T), k_refs[i], tol);
+    REL_TEST(_fp->k_from_v_e(v, e), k_refs[i], tol);
 
     // Bulk modulus
     REL_TEST(_fp->bulk_modulus_from_p_T(p, T), E_refs[i], tol);
 
     // Speed of sound
-    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], 10 * tol);
+    REL_TEST(_fp->c_from_v_e(v, e), c_refs[i], tol);
 
     // Isobaric specific heat
-    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], 10 * tol);
-    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], 10 * tol);
+    REL_TEST(_fp->cp_from_p_T(p, T), cp_refs[i], tol);
+    REL_TEST(_fp->cp_from_v_e(v, e), cp_refs[i], tol);
 
     // Isochoric specific heat
-    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], 10 * tol);
-    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], 10 * tol);
+    REL_TEST(_fp->cv_from_p_T(p, T), cv_refs[i], tol);
+    REL_TEST(_fp->cv_from_v_e(v, e), cv_refs[i], tol);
 
     // Dynamic viscosity
-    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], 10 * tol);
-    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], 10 * tol);
+    REL_TEST(_fp->mu_from_p_T(p, T), mu_refs[i], tol);
+    REL_TEST(_fp->mu_from_v_e(v, e), mu_refs[i], tol);
   }
 }
 


### PR DESCRIPTION
Used the known equations from "Handbook on Lead-bismuth Eutectic Alloy and Lead Properties "(2015). Added the known formulations for Rho, mu, cp, k and h. While adding other formulation that are needed.  