### PR TITLE
'constant' is deprecated in Pressure BC

### DIFF
--- a/modules/tensor_mechanics/src/actions/PressureAction.C
+++ b/modules/tensor_mechanics/src/actions/PressureAction.C
@@ -89,10 +89,7 @@ PressureAction::act()
     if (_has_save_in_vars[i])
       params.set<std::vector<AuxVariableName>>("save_in") = _save_in_vars[i];
 
-    if (_use_ad)
-      params.set<Real>("constant") = getParam<Real>("factor");
-    else
-      params.set<Real>("factor") = getParam<Real>("factor");
+    params.set<Real>("factor") = getParam<Real>("factor");
     _problem->addBoundaryCondition(kernel_name, unique_kernel_name, params);
   }
 }


### PR DESCRIPTION
(#15915)

I missed this earlier. `constant` is deprecated in the action, so, to avoid deprecation errors, we can set the `factor` parameter always.
