### PR TITLE
Add autotools to build deps for all archs

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_3
+  - moose-mpich 4.0.1 build_4
 
 moose_python:
   - python 3.9

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,7 +1,7 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
-{% set build = 8 %}
+{% set build = 9 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_3
+  - moose-mpich 4.0.1 build_4
 
 moose_petsc:
   - moose-petsc 3.16.5

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.06.06" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -3,7 +3,7 @@
 #   petsc/
 #   libmesh-vtk/
 #   libmesh/
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.1" %}
 
@@ -30,10 +30,10 @@ requirements:
     - {{ base_mpifort }}
     - {{ moose_hdf5 }}
     - {{ moose_ld64 }}          # [osx]
-    - autoconf                  # [unix]
-    - automake                  # [unix]
-    - libtool                   # [unix]
-    - make                      # [unix]
+    - autoconf
+    - automake
+    - libtool
+    - make
     - gnuconfig                 # [arm64]
     - openssl <3
   host: []

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -55,6 +55,7 @@ requirements:
     - {{ moose_mesalib }}       # [linux]
     - openssl <3
     - mpi 1.0 mpich
+    - cmake
 
 test:
   commands:

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_3
+  - moose-mpich 4.0.1 build_4
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,7 +1,7 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
-{% set build = 4 %}
+{% set build = 5 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}


### PR DESCRIPTION
Adding autotools back into the build/runtime dependency chain for
all arches.

Refs #21514
