### PR TITLE
Expand isParamValid for Vectors of MooseEnum

### DIFF
--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -320,6 +320,12 @@ InputParameters::isParamValid(const std::string & name) const
 {
   if (have_parameter<MooseEnum>(name))
     return get<MooseEnum>(name).isValid();
+  else if (have_parameter<std::vector<MooseEnum>>(name))
+  {
+    for (auto it = get<std::vector<MooseEnum>>(name).begin(); it != get<std::vector<MooseEnum>>(name).end(); ++it)
+      if (!it->isValid()) return false;
+    return true;
+  }
   else if (have_parameter<MultiMooseEnum>(name))
     return get<MultiMooseEnum>(name).isValid();
   else if (have_parameter<ExecFlagEnum>(name))

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -322,8 +322,11 @@ InputParameters::isParamValid(const std::string & name) const
     return get<MooseEnum>(name).isValid();
   else if (have_parameter<std::vector<MooseEnum>>(name))
   {
-    for (auto it = get<std::vector<MooseEnum>>(name).begin(); it != get<std::vector<MooseEnum>>(name).end(); ++it)
-      if (!it->isValid()) return false;
+    for (auto it = get<std::vector<MooseEnum>>(name).begin();
+         it != get<std::vector<MooseEnum>>(name).end();
+         ++it)
+      if (!it->isValid())
+        return false;
     return true;
   }
   else if (have_parameter<MultiMooseEnum>(name))

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -9,6 +9,7 @@
 
 // MOOSE includes
 #include "InputParameters.h"
+#include "MooseEnum.h"
 #include "MultiMooseEnum.h"
 #include "Conversion.h"
 #include "gtest/gtest.h"
@@ -180,6 +181,27 @@ TEST(InputParameters, applyParameter)
   p2.set<MultiMooseEnum>("enum") = "bar";
   p1.applyParameter(p2, "enum");
   EXPECT_TRUE(p1.get<MultiMooseEnum>("enum").contains("bar"));
+}
+
+TEST(InputParameters, applyParametersVector)
+{
+  MooseEnum types("foo bar");
+
+  InputParameters p1 = emptyInputParameters();
+  p1.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1,types), "testing");
+
+  InputParameters p2 = emptyInputParameters();
+  p2.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1,types), "testing");
+
+  MooseEnum set("foo bar", "bar");
+  p2.set<std::vector<MooseEnum>>("enum") = std::vector<MooseEnum>(1,set);
+
+  EXPECT_FALSE(p1.isParamValid("enum"));
+  EXPECT_TRUE(p2.isParamValid("enum"));
+
+  p1.applyParameters(p2);
+
+  EXPECT_TRUE(p1.get<std::vector<MooseEnum>>("enum")[0]=="bar");
 }
 
 TEST(InputParameters, applyParameters)

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -188,20 +188,20 @@ TEST(InputParameters, applyParametersVector)
   MooseEnum types("foo bar");
 
   InputParameters p1 = emptyInputParameters();
-  p1.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1,types), "testing");
+  p1.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1, types), "testing");
 
   InputParameters p2 = emptyInputParameters();
-  p2.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1,types), "testing");
+  p2.addRequiredParam<std::vector<MooseEnum>>("enum", std::vector<MooseEnum>(1, types), "testing");
 
   MooseEnum set("foo bar", "bar");
-  p2.set<std::vector<MooseEnum>>("enum") = std::vector<MooseEnum>(1,set);
+  p2.set<std::vector<MooseEnum>>("enum") = std::vector<MooseEnum>(1, set);
 
   EXPECT_FALSE(p1.isParamValid("enum"));
   EXPECT_TRUE(p2.isParamValid("enum"));
 
   p1.applyParameters(p2);
 
-  EXPECT_TRUE(p1.get<std::vector<MooseEnum>>("enum")[0]=="bar");
+  EXPECT_TRUE(p1.get<std::vector<MooseEnum>>("enum")[0] == "bar");
 }
 
 TEST(InputParameters, applyParameters)


### PR DESCRIPTION
This PR expands the logic within `isParamValid` to confirm that all entries within a vector of MooseEnum objects are valid. Confirming that all entries are valid allows `applyParameters` to correctly determine if a required parameter has been defined.

Closes #21530