### PR TITLE
Bump conda package MPICH to 4.0.2

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_4
+  - moose-mpich 4.0.2 build_0
 
 moose_python:
   - python 3.9

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -1,7 +1,7 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
-{% set build = 9 %}
+{% set build = 10 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_4
+  - moose-mpich 4.0.2 build_0
 
 moose_petsc:
   - moose-petsc 3.16.5

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.06.06" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -1,23 +1,23 @@
 #### Compilers
 base_mpich:
-  - mpich 4.0.1                                            # [linux]
-  - mpich 4.0.1                                            # [not arm64 and osx]
-  - mpich 4.0.1                                            # [arm64]
+  - mpich 4.0.2                                            # [linux]
+  - mpich 4.0.2                                            # [not arm64 and osx]
+  - mpich 4.0.2                                            # [arm64]
 
 base_mpicc:
-  - mpich-mpicc 4.0.1                                      # [linux]
-  - mpich-mpicc 4.0.1                                      # [not arm64 and osx]
-  - mpich-mpicc 4.0.1                                      # [arm64]
+  - mpich-mpicc 4.0.2                                      # [linux]
+  - mpich-mpicc 4.0.2                                      # [not arm64 and osx]
+  - mpich-mpicc 4.0.2                                      # [arm64]
 
 base_mpicxx:
-  - mpich-mpicxx 4.0.1                                     # [linux]
-  - mpich-mpicxx 4.0.1                                     # [not arm64 and osx]
-  - mpich-mpicxx 4.0.1                                     # [arm64]
+  - mpich-mpicxx 4.0.2                                     # [linux]
+  - mpich-mpicxx 4.0.2                                     # [not arm64 and osx]
+  - mpich-mpicxx 4.0.2                                     # [arm64]
 
 base_mpifort:
-  - mpich-mpifort 4.0.1                                     # [linux]
-  - mpich-mpifort 4.0.1                                     # [not arm64 and osx]
-  - mpich-mpifort 4.0.1                                     # [arm64]
+  - mpich-mpifort 4.0.2                                     # [linux]
+  - mpich-mpifort 4.0.2                                     # [not arm64 and osx]
+  - mpich-mpifort 4.0.2                                     # [arm64]
 
 moose_ld64:                                                 # [osx]
   - ld64 609                                                # [not arm64 and osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -3,9 +3,9 @@
 #   petsc/
 #   libmesh-vtk/
 #   libmesh/
-{% set build = 4 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "4.0.1" %}
+{% set version = "4.0.2" %}
 
 package:
   name: moose-mpich
@@ -61,6 +61,7 @@ requirements:
     - {{ moose_mesalib }}       # [linux]
     - openssl <3
     - mpi 1.0 mpich
+    - clang-format-12
 
 test:
   commands:

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.1 build_4
+  - moose-mpich 4.0.2 build_0
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -1,7 +1,7 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
-{% set build = 5 %}
+{% set build = 6 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.5" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}


### PR DESCRIPTION
This is to test if increasing MPICH version to 4.0.2 causes issues with the wider ecosystem. 

Also adds `clang-format-12` to `moose-mpich` runtime dependencies. 


Closes #21553 
Closes #21554
