### PR TITLE
Fix distributed mesh failures caused by #21543

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -999,7 +999,7 @@ MooseMesh::cacheInfo()
   _higher_d_elem_side_to_lower_d_elem.clear();
 
   // TODO: Thread this!
-  for (const auto & elem : getMesh().element_ptr_range())
+  for (const auto & elem : getMesh().active_local_element_ptr_range())
   {
     SubdomainID subdomain_id = elem->subdomain_id();
     const Elem * ip_elem = elem->interior_parent();

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -999,9 +999,8 @@ MooseMesh::cacheInfo()
   _higher_d_elem_side_to_lower_d_elem.clear();
 
   // TODO: Thread this!
-  for (const auto & elem : getMesh().active_local_element_ptr_range())
+  for (const auto & elem : getMesh().element_ptr_range())
   {
-    SubdomainID subdomain_id = elem->subdomain_id();
     const Elem * ip_elem = elem->interior_parent();
 
     if (ip_elem)
@@ -1017,6 +1016,16 @@ MooseMesh::cacheInfo()
       }
     }
 
+    for (unsigned int nd = 0; nd < elem->n_nodes(); ++nd)
+    {
+      Node & node = *elem->node_ptr(nd);
+      _block_node_list[node.id()].insert(elem->subdomain_id());
+    }
+  }
+
+  for (const auto & elem : getMesh().active_local_element_ptr_range())
+  {
+    SubdomainID subdomain_id = elem->subdomain_id();
     for (unsigned int side = 0; side < elem->n_sides(); side++)
     {
       std::vector<BoundaryID> boundaryids = getBoundaryIDs(elem, side);
@@ -1033,12 +1042,6 @@ MooseMesh::cacheInfo()
         if (neighbor_subdomain_id != subdomain_id)
           _sub_to_neighbor_subs[subdomain_id].insert(neighbor_subdomain_id);
       }
-    }
-
-    for (unsigned int nd = 0; nd < elem->n_nodes(); ++nd)
-    {
-      Node & node = *elem->node_ptr(nd);
-      _block_node_list[node.id()].insert(elem->subdomain_id());
     }
   }
 


### PR DESCRIPTION
This looks like a bug. It shows up with distributed mesh because it may access invalid neighbor of a non-local elements.

Need @roystgnr and @lindsayad and civet to confirm. 
