### PR TITLE
Add back secondary-primary coupling for penalty mortar

### DIFF
--- a/framework/include/constraints/AutomaticMortarGeneration.h
+++ b/framework/include/constraints/AutomaticMortarGeneration.h
@@ -337,6 +337,11 @@ public:
   }
 
 private:
+  /**
+   * build the \p _mortar_interface_coupling data
+   */
+  void buildCouplingInformation();
+
   MooseApp & _app;
 
   // Reference to the mesh stored in equation_systems.

--- a/framework/include/constraints/AutomaticMortarGeneration.h
+++ b/framework/include/constraints/AutomaticMortarGeneration.h
@@ -256,7 +256,8 @@ public:
   /**
    * @return The mortar interface coupling
    */
-  const std::unordered_multimap<dof_id_type, dof_id_type> & mortarInterfaceCoupling() const
+  const std::unordered_map<dof_id_type, std::unordered_set<dof_id_type>> &
+  mortarInterfaceCoupling() const
   {
     return _mortar_interface_coupling;
   }
@@ -419,7 +420,7 @@ private:
   /// explicitly declared when there is no primary_elem for a given
   /// mortar segment and you are using e.g.  a P^1-P^0 discretization
   /// which does not induce the coupling automatically.
-  std::unordered_multimap<dof_id_type, dof_id_type> _mortar_interface_coupling;
+  std::unordered_map<dof_id_type, std::unordered_set<dof_id_type>> _mortar_interface_coupling;
 
   /// Container for storing the nodal normal vector associated with each secondary node.
   std::unordered_map<const Node *, Point> _secondary_node_to_nodal_normal;

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -754,6 +754,13 @@ AutomaticMortarGeneration::buildMortarSegmentMesh()
     // PrimaryLower
     _mortar_interface_coupling.insert(
         std::make_pair(primary_elem->interior_parent()->id(), secondary_elem->id()));
+
+    // SecondaryPrimary
+    _mortar_interface_coupling.insert(std::make_pair(secondary_elem->interior_parent()->id(),
+                                                     primary_elem->interior_parent()->id()));
+    // PrimarySecondary
+    _mortar_interface_coupling.insert(std::make_pair(primary_elem->interior_parent()->id(),
+                                                     secondary_elem->interior_parent()->id()));
   }
 }
 
@@ -1180,6 +1187,13 @@ AutomaticMortarGeneration::buildMortarSegmentMesh3d()
     // PrimaryLower
     _mortar_interface_coupling.insert(
         std::make_pair(primary_elem->interior_parent()->id(), secondary_elem->id()));
+
+    // SecondaryPrimary
+    _mortar_interface_coupling.insert(std::make_pair(secondary_elem->interior_parent()->id(),
+                                                     primary_elem->interior_parent()->id()));
+    // PrimarySecondary
+    _mortar_interface_coupling.insert(std::make_pair(primary_elem->interior_parent()->id(),
+                                                     secondary_elem->interior_parent()->id()));
   }
 
   // Print mortar segment mesh statistics

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -1168,8 +1168,8 @@ AutomaticMortarGeneration::buildCouplingInformation()
     if (secondary_elem->processor_id() != _mesh.processor_id())
       // We want to keep information for nonlocal secondary element point neighbors for mortar nodal
       // aux kernels
-      _mortar_interface_coupling.emplace(secondary_elem->id(),
-                                         secondary_elem->interior_parent()->id());
+      _mortar_interface_coupling[secondary_elem->id()].insert(
+          secondary_elem->interior_parent()->id());
 
     // LowerPrimary
     coupling_info[secondary_elem->processor_id()].emplace_back(
@@ -1177,8 +1177,8 @@ AutomaticMortarGeneration::buildCouplingInformation()
     if (secondary_elem->processor_id() != _mesh.processor_id())
       // We want to keep information for nonlocal secondary element point neighbors for mortar nodal
       // aux kernels
-      _mortar_interface_coupling.emplace(secondary_elem->id(),
-                                         primary_elem->interior_parent()->id());
+      _mortar_interface_coupling[secondary_elem->id()].insert(
+          primary_elem->interior_parent()->id());
 
     // SecondaryLower
     coupling_info[secondary_elem->interior_parent()->processor_id()].emplace_back(
@@ -1203,7 +1203,7 @@ AutomaticMortarGeneration::buildCouplingInformation()
              const std::vector<std::pair<dof_id_type, dof_id_type>> & coupling_info)
   {
     for (auto [i, j] : coupling_info)
-      _mortar_interface_coupling.emplace(i, j);
+      _mortar_interface_coupling[i].insert(j);
   };
   TIMPI::push_parallel_vector_data(_mesh.comm(), coupling_info, action_functor);
 }

--- a/test/tests/mortar/continuity-3d-non-conforming/continuity_penalty_sphere_hex8.i
+++ b/test/tests/mortar/continuity-3d-non-conforming/continuity_penalty_sphere_hex8.i
@@ -23,6 +23,7 @@
 
 [Problem]
   kernel_coverage_check = false
+  error_on_jacobian_nonzero_reallocation = true
 []
 
 [Variables]


### PR DESCRIPTION
At one point we removed the secondary-primary (and vice versa)
coupling because all of our constraints were LM based. But with
penalty we need that coupling restored in order to avoid
new-nonzero reallocations

Closes #21569