### PR TITLE
Remove derivative of specific heat from NS kernels

### DIFF
--- a/modules/navier_stokes/doc/content/source/fvkernels/INSFVEnergyTimeDerivative.md
+++ b/modules/navier_stokes/doc/content/source/fvkernels/INSFVEnergyTimeDerivative.md
@@ -5,13 +5,33 @@
 The `INSFVEnergyTimeDerivative` kernel implements a time derivative for the domain $\Omega$ given by
 
 \begin{equation}
-\underbrace{\rho c_p \frac{\partial u}{\partial t}}_{\textrm{INSFVEnergyTimeDerivative}} +
+\underbrace{\rho c_p \frac{\partial T}{\partial t}}_{\textrm{INSFVEnergyTimeDerivative}} +
 \sum_{i=1}^n \beta_i = 0 \in \Omega.
 \end{equation}
-where $\rho$ is the material density, $c_p$ is the specific heat, and the second term on the left hand side corresponds to the strong forms of
-other kernels.
+where $\rho$ is the material density, $c_p$ is the specific heat, $T$ is the fluid temperature and the
+second term on the left hand side corresponds to the strong forms of other kernels.
 
 The Jacobian is computed with automatic differentiation.
+
+## Implementation
+
+The derivative is obtained from the definition of the fluid energy. The isobaric and isochoric heat
+capacities being equal for incompressible fluids,
+
+\begin{equation}
+U(T(t), p(t)) = \rho(T(t), p(t)) \int_0^T(t) dT cp(T(t), p(t))
+\end{equation}
+
+we take the partial derivative with regards to time:
+
+\begin{equation}
+\frac{\partial U}{\partial t} = \frac{\partial \rho(T, p)}{\partial t} \int_0^T dT cp(T, p) + \rho(T, p) \frac{\partial T}{\partial t} cp(T, p)
+\end{equation}
+
+The variation of the kinetic energy is not considered in this kernel.
+
+!alert note
+The specific energy, $u = \int_0^T dT cp(T, p)$, is currently approximated as $c_p T$.
 
 !syntax parameters /FVKernels/INSFVEnergyTimeDerivative
 

--- a/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyTimeDerivative.md
+++ b/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyTimeDerivative.md
@@ -13,8 +13,7 @@ for the fluid phase and
 \end{equation}
 for the solid phase, where $\epsilon$ is the porosity, $\rho_{f/s}$ the fluid/solid material density, $c_{pf/s}$ the fluid/solid specific heat and $T_{f/s}$ the fluid/solid temperature.
 
-The time derivatives of density and the specific heat capacity are ignored if [!param](/FVKernels/PINSFVEnergyTimeDerivative/drho_dt)
-and [!param](/FVKernels/PINSFVEnergyTimeDerivative/dcp_dt) are not provided. For incompressible flows, the former should not be provided.
+The time derivative of the density is ignored if [!param](/FVKernels/PINSFVEnergyTimeDerivative/drho_dt) is not provided. For incompressible flows, the former should not be provided.
 
 The variation of the kinetic energy is not considered in this kernel.
 

--- a/modules/navier_stokes/include/fvkernels/INSFVEnergyTimeDerivative.h
+++ b/modules/navier_stokes/include/fvkernels/INSFVEnergyTimeDerivative.h
@@ -24,6 +24,4 @@ protected:
   const Moose::Functor<ADReal> & _rho;
   /// the heat conductivity
   const Moose::Functor<ADReal> & _cp;
-  /// the time derivative of the heat conductivity
-  const Moose::Functor<ADReal> & _cp_dot;
 };

--- a/modules/navier_stokes/src/actions/NSFVAction.C
+++ b/modules/navier_stokes/src/actions/NSFVAction.C
@@ -984,18 +984,7 @@ NSFVAction::addINSEnergyTimeKernels()
     params.set<MooseFunctorName>(NS::porosity) = _porosity_name;
     if (_problem->hasFunctor(NS::time_deriv(_density_name), /*thread_id=*/0))
       params.set<MooseFunctorName>(NS::time_deriv(NS::density)) = NS::time_deriv(_density_name);
-    if (_problem->hasFunctor(NS::time_deriv(_specific_heat_name), /*thread_id=*/0))
-      params.set<MooseFunctorName>(NS::time_deriv(NS::cp)) = NS::time_deriv(_specific_heat_name);
     params.set<bool>("is_solid") = false;
-  }
-  else
-  {
-    // check if the name of the specific heat is just a constant, if it is,
-    // we automatically assign a zero timederivative
-    if (MooseUtils::parsesToReal(_specific_heat_name))
-      params.set<MooseFunctorName>(NS::time_deriv(NS::cp)) = "0";
-    else
-      params.set<MooseFunctorName>(NS::time_deriv(NS::cp)) = NS::time_deriv(_specific_heat_name);
   }
 
   _problem->addFVKernel(kernel_type, kernel_name, params);
@@ -2071,7 +2060,6 @@ NSFVAction::addWCNSEnergyTimeKernels()
   params.set<MooseFunctorName>(NS::density) = _density_name;
   params.set<MooseFunctorName>(NS::time_deriv(NS::density)) = NS::time_deriv(_density_name);
   params.set<MooseFunctorName>(NS::cp) = _specific_heat_name;
-  params.set<MooseFunctorName>(NS::time_deriv(NS::cp)) = NS::time_deriv(_specific_heat_name);
 
   if (_porous_medium_treatment)
   {

--- a/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVEnergyTimeDerivative.C
@@ -22,16 +22,13 @@ INSFVEnergyTimeDerivative::validParams()
       "Adds the time derivative term to the incompressible Navier-Stokes energy equation.");
   params.addRequiredParam<MooseFunctorName>(NS::density, "Density");
   params.addRequiredParam<MooseFunctorName>(NS::cp, "Specific heat capacity");
-  params.addRequiredParam<MooseFunctorName>(NS::time_deriv(NS::cp),
-                                            "Specific heat capacity time derivative functor");
   return params;
 }
 
 INSFVEnergyTimeDerivative::INSFVEnergyTimeDerivative(const InputParameters & params)
   : FVTimeKernel(params),
     _rho(getFunctor<ADReal>(getParam<MooseFunctorName>(NS::density))),
-    _cp(getFunctor<ADReal>(getParam<MooseFunctorName>(NS::cp))),
-    _cp_dot(getFunctor<ADReal>(getParam<MooseFunctorName>(NS::time_deriv(NS::cp))))
+    _cp(getFunctor<ADReal>(getParam<MooseFunctorName>(NS::cp)))
 {
   if (!dynamic_cast<INSFVEnergyVariable *>(&_var))
     paramError("variable", "The supplied variable should be of INSFVEnergyVariable type.");
@@ -41,6 +38,5 @@ ADReal
 INSFVEnergyTimeDerivative::computeQpResidual()
 {
   const auto & elem_arg = makeElemArg(_current_elem);
-  return _rho(elem_arg) * _cp(elem_arg) * FVTimeKernel::computeQpResidual() +
-         _rho(elem_arg) * _cp_dot(elem_arg) * _var(elem_arg);
+  return _rho(elem_arg) * _cp(elem_arg) * FVTimeKernel::computeQpResidual();
 }

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyTimeDerivative.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyTimeDerivative.C
@@ -25,8 +25,6 @@ PINSFVEnergyTimeDerivative::validParams()
   params.addRequiredParam<MooseFunctorName>(NS::density, "Density");
   params.addParam<MooseFunctorName>(NS::time_deriv(NS::density), "Density time derivative functor");
   params.addRequiredParam<MooseFunctorName>(NS::cp, "Specific heat capacity");
-  params.addParam<MooseFunctorName>(NS::time_deriv(NS::cp),
-                                    "Specific heat capacity time derivative functor");
   params.addRequiredParam<MooseFunctorName>(NS::porosity, "Porosity");
 
   params.addRequiredParam<bool>("is_solid", "Whether this kernel acts on the solid temperature");
@@ -45,8 +43,6 @@ PINSFVEnergyTimeDerivative::PINSFVEnergyTimeDerivative(const InputParameters & p
                  ? &getFunctor<ADReal>(NS::time_deriv(NS::density))
                  : nullptr),
     _cp(getFunctor<ADReal>(NS::cp)),
-    _cp_dot(isParamValid(NS::time_deriv(NS::cp)) ? &getFunctor<ADReal>(NS::time_deriv(NS::cp))
-                                                 : nullptr),
     _eps(getFunctor<ADReal>(NS::porosity)),
     _is_solid(getParam<bool>("is_solid")),
     _scaling(getParam<Real>("scaling")),
@@ -65,8 +61,6 @@ PINSFVEnergyTimeDerivative::computeQpResidual()
     auto time_derivative = _rho(elem_arg) * _cp(elem_arg) * FVTimeKernel::computeQpResidual();
     if (_rho_dot)
       time_derivative += (*_rho_dot)(elem_arg)*_cp(elem_arg) * _var(elem_arg);
-    if (_cp_dot)
-      time_derivative += _rho(elem_arg) * (*_cp_dot)(elem_arg)*_var(elem_arg);
 
     return _scaling * (_is_solid ? 1 - _eps(elem_arg) : _eps(elem_arg)) * time_derivative;
   }

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-transient.i
@@ -129,7 +129,6 @@ velocity_interp_method='rc'
     type = INSFVEnergyTimeDerivative
     variable = T_fluid
     cp = ${cp}
-    dcp_dt = 0.0
     rho = ${rho}
   []
   [energy_advection]

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/transient-lid-driven-with-energy.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/transient-lid-driven-with-energy.i
@@ -154,7 +154,6 @@ advected_interp_method = 'average'
     variable = T
     rho = ${rho}
     cp = 'cp'
-    dcp_dt = 0.0
   []
   [temp_conduction]
     type = FVDiffusion

--- a/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient.i
@@ -161,7 +161,6 @@ velocity_interp_method='rc'
     type = PINSFVEnergyTimeDerivative
     variable = T_fluid
     cp = ${cp}
-    dcp_dt = 'dcp_dt'
     rho = ${rho}
     drho_dt = 'drho_dt'
     is_solid = false

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/dirichlet_bcs_mdot.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/dirichlet_bcs_mdot.i
@@ -144,7 +144,6 @@ inlet_velocity = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -239,8 +238,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/dirichlet_bcs_velocity.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/dirichlet_bcs_velocity.i
@@ -143,7 +143,6 @@ inlet_velocity = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -229,8 +228,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_direct.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_direct.i
@@ -148,7 +148,6 @@ inlet_velocity = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -288,8 +287,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot-action.i
@@ -96,8 +96,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k mu dcp_dt'
-    prop_values = '${cp} ${k} ${mu} 0'
+    prop_names = 'cp k mu'
+    prop_values = '${cp} ${k} ${mu}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot.i
@@ -152,7 +152,6 @@ inlet_velocity = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -296,8 +295,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity-action.i
@@ -100,8 +100,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k mu dcp_dt'
-    prop_values = '${cp} ${k} ${mu} 0'
+    prop_names = 'cp k mu'
+    prop_values = '${cp} ${k} ${mu}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity.i
@@ -147,7 +147,6 @@ inlet_velocity = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -285,8 +284,8 @@ inlet_velocity = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-action.i
@@ -76,8 +76,8 @@ inlet_v = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt mu'
-    prop_values = '${cp} ${k} 0 ${mu}'
+    prop_names = 'cp k mu'
+    prop_values = '${cp} ${k} ${mu}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient.i
@@ -165,7 +165,6 @@ inlet_v = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion
@@ -249,8 +248,8 @@ inlet_v = 0.001
 [Materials]
   [const_functor]
     type = ADGenericFunctorMaterial
-    prop_names = 'cp k dcp_dt'
-    prop_values = '${cp} ${k} 0'
+    prop_names = 'cp k'
+    prop_values = '${cp} ${k}'
   []
   [rho]
     type = RhoFromPTFunctorMaterial

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/materials/2d-transient.i
@@ -139,7 +139,6 @@ inlet_v = 0.001
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = dcp_dt
   []
   [temp_conduction]
     type = FVDiffusion

--- a/modules/navier_stokes/test/tests/postprocessors/rayleigh/natural_convection.i
+++ b/modules/navier_stokes/test/tests/postprocessors/rayleigh/natural_convection.i
@@ -129,7 +129,6 @@ l = 4
     cp = cp
     rho = rho
     drho_dt = drho_dt
-    dcp_dt = 0
   []
   [temp_conduction]
     type = FVDiffusion


### PR DESCRIPTION
If h = cp T with cp constant it doesnt matter
For our future formulation of h = int(cp dT) then it ll matter

Refs #21245