### PR TITLE
Enable PETSc shared libraries on Apple Silicon

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_0
+  - moose-mpich 4.0.2 build_1
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
 #   template/
-{% set build = 10 %}
+{% set build = 11 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,8 +1,8 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_0
+  - moose-mpich 4.0.2 build_1
 
 moose_petsc:
-  - moose-petsc 3.16.5
+  - moose-petsc 3.16.6
 
 moose_libmesh_vtk:
   - moose-libmesh-vtk 9.1.0

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,7 +1,7 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.06.06" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -21,7 +21,7 @@ base_mpifort:
 
 moose_ld64:                                                 # [osx]
   - ld64 609                                                # [not arm64 and osx]
-  - ld64_osx-arm64 609                                      # [arm64]
+  - ld64_osx-arm64 530                                      # [arm64]
 
 moose_hdf5:
   - hdf5 1.12.1 mpi_mpich_hfd824e9_4                        # [not arm64 and osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -4,7 +4,7 @@
 #   libmesh-vtk/
 #   libmesh/
 #   template/
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_0
+  - moose-mpich 4.0.2 build_1
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -2,9 +2,9 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   libmesh/
 #   template/
-{% set build = 6 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "3.16.5" %}
+{% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}
 
 package:

--- a/conda/petsc/run_tests.sh
+++ b/conda/petsc/run_tests.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-export PETSC_DIR=${PREFIX}
-
-pkg-config --cflags PETSc | grep -v isystem

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.06.06 build_3
+ - moose-libmesh 2022.06.06 build_4
 
 moose_python:
  - python 3.9

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -24,12 +24,6 @@ function configure_petsc()
     echo "$PETSC_DIR=PETSC_DIR does not exist"
     exit 1
   fi
-  # Apple Silicon has an issue building shared libraries
-  if [[ `uname -p` == "arm" ]]; then
-    SHARED=0
-  else
-    SHARED=1
-  fi
 
   # Use --with-make-np if MOOSE_JOBS is given
   MAKE_NP_STR=""
@@ -60,8 +54,7 @@ function configure_petsc()
     # Set path delimiter
     IFS=:
     for p in $HDF5_PATHS; do
-      # When first instance of hdf5 header is found, report finding, set HDF5_STR,
-      # and break
+      # When first instance of hdf5 header is found, report finding, set HDF5_STR, and break
       loc=$(find "$p" -name 'hdf5.h' -print -quit 2>/dev/null)
       if [ ! -z "$loc" ]; then
         echo "INFO: HDF5 header location was found at: $loc"
@@ -80,37 +73,40 @@ function configure_petsc()
     HDF5_STR="--download-hdf5=1"
     HDF5_FORTRAN_STR="--download-hdf5-fortran-bindings=0"
     echo "INFO: HDF5 library not detected, opting to download via PETSc..."
-    # If on Apple Silicon (arm64), PETSc needs to be patched using git in order
-    # to properly configure HDF5
-    if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]]; then
-      echo "INFO: Apple Silicon detected, checking for ARM patches..."
-      # Check to see if patch marker file exists in PETSC_DIR. If not, perform
-      # patch and create patch marker file. If so, skip patch and report.
-      patch_file=$(find "$PETSC_DIR" -name '.patched' -print -quit 2>/dev/null)
-      if [ -z "$patch_file" ]; then
+  fi
+
+  # If manually building PETSc on Apple Silicon (arm64), several adjustments need to be made to
+  # properly configure PETSc for this platform
+  MUMPS_ARM_STR=""
+  if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]] && [[ $PETSC_ARCH == arch-moose ]]; then
+    echo "INFO: Apple Silicon detected, checking to see if PETSc ARM patches need to be applied..."
+    # First check to see if patch marker file exists in PETSC_DIR due to a previous build. If not,
+    # perform patch and create patch marker file. If so, skip patch and report.
+    patch_file=$(find "$PETSC_DIR" -name '.patched' -print -quit 2>/dev/null)
+    if [ -z "$patch_file" ]; then
+      # If an HDF5 download is requested, patch PETSc to properly configure it
+      if [ "$HDF5_STR" == "--download-hdf5=1" ]; then
          echo "INFO: Patching PETSc to support HDF5 download and installation on ARM..."
          git apply $PETSC_DIR/../scripts/apple-silicon-hdf5-autogen.patch
          touch $PETSC_DIR/.patched
-      elif [ ! -z "$patch_file" ]; then
-         echo "INFO: ARM patches already applied, proceeding to PETSc configure..."
+      else
+        echo "INFO: No ARM patches required, proceeding to PETSc configure..."
       fi
+    elif [ ! -z "$patch_file" ]; then
+      echo "INFO: Applicable ARM patches already applied, proceeding to PETSc configure..."
     fi
-  fi
-
-  # For Apple Silicon (arm64) manual builds be sure to set FFLAGS for mumps to use the proper arch,
-  # otherwise it will fail to build correctly
-  MUMPS_STR=""
-  if [[ `uname -p` == "arm" ]] && [[ $(uname) == Darwin ]] && [[ $PETSC_ARCH == arch-moose ]]; then
-    MUMPS_STR="FFLAGS="-march=armv8.3-a""
+    # Finally, be sure to set FFLAGS for mumps to use the proper arch, otherwise it will fail to
+    # build correctly
+    MUMPS_ARM_STR="FFLAGS="-march=armv8.3-a""
   fi
 
   cd $PETSC_DIR
   python ./configure --download-hypre=1 \
-      --with-shared-libraries=$SHARED \
+      --with-shared-libraries=1 \
       "$HDF5_STR" \
       "$HDF5_FORTRAN_STR" \
       "$MAKE_NP_STR" \
-      "$MUMPS_STR" \
+      "$MUMPS_ARM_STR" \
       --with-debugging=no \
       --download-fblaslapack=1 \
       --download-metis=1 \


### PR DESCRIPTION
This PR:

- Updates PETSc to 3.16.6 with a patch that allows shared library support with fblaslapack on Apple Silicon platforms. For more info see https://gitlab.com/petsc/petsc/-/merge_requests/5447, and thanks @fdkong! 
- Re-organizes `configure_petsc.sh` to place all Apple Silicon related modifications in the same location within the script.
- After the above update and patch, conda build fails at codesigning PETSc dylibs on Apple Silicon. There appears to have been a bug with cctools/ld64 on this platform (see https://github.com/conda-forge/cctools-and-ld64-feedstock/issues/50 for an example using gfortran and cctools/ld64) that might have been patched but is still experienced with the `ld64 609` package used by `moose-mpich 4.0.2 build_0`. Downgrading to `ld64 530` seems to work around this for now.
- `conda/petsc/run_tests.sh` was also removed since it was not used in the petsc meta.yaml testing procedure (and was superseded by a current pkg-config test) 

Refs #18954
