### PR TITLE
Error if user requests nonsense with MooseVariableConstMonomial

### DIFF
--- a/framework/src/variables/MooseVariableConstMonomial.C
+++ b/framework/src/variables/MooseVariableConstMonomial.C
@@ -13,6 +13,7 @@
 #include "Assembly.h"
 
 #include "libmesh/quadrature.h"
+#include "libmesh/enum_to_string.h"
 
 registerMooseObject("MooseApp", MooseVariableConstMonomial);
 
@@ -29,6 +30,12 @@ MooseVariableConstMonomial::validParams()
 MooseVariableConstMonomial::MooseVariableConstMonomial(const InputParameters & parameters)
   : MooseVariable(parameters)
 {
+  if (_fe_type.order != CONSTANT || _fe_type.family != MONOMIAL)
+    mooseError("This type is only meant for a CONSTANT "
+               "MONOMIAL finite element basis. You have requested a ",
+               Utility::enum_to_string(_fe_type.family),
+               " family and order ",
+               Utility::enum_to_string(Order(_fe_type.order)));
 }
 
 void

--- a/test/tests/variables/fe_monomial_const/tests
+++ b/test/tests/variables/fe_monomial_const/tests
@@ -30,4 +30,13 @@
       detail = 'in three dimensions.'
     []
   []
+
+  [bad_order]
+    type = 'RunException'
+    input = 'monomial-const-1d.i'
+    expect_err = "This type is only meant for a CONSTANT MONOMIAL finite element basis\. You have requested a MONOMIAL family and order FIRST"
+    cli_args = "Variables/u/type=MooseVariableConstMonomial Variables/u/order=FIRST"
+    issues = '#9836'
+    requirement = 'The system shall error if a user requests a constant monomial finite element variable type with either a non-monomial family or non-constant order.'
+  []
 []


### PR DESCRIPTION
A user may explicitly request a `MooseVariableConstMonomial`
variable type but with values for family and order that don't make
sense. We should help them out in that case