### PR TITLE
Demonstrate first/second order gap heat transfer with FV

### DIFF
--- a/framework/include/constraints/MortarConstraintBase.h
+++ b/framework/include/constraints/MortarConstraintBase.h
@@ -150,6 +150,15 @@ protected:
   /// The shape function gradients corresponding to the primary interior primal variable
   const VariableTestGradient & _grad_test_primary;
 
+  /// the higher-dimensional secondary face element
+  const Elem * const & _interior_secondary_elem;
+
+  /// the higher-dimensional primary face element
+  const Elem * const & _interior_primary_elem;
+
+  /// the lower-dimensional secondary element
+  const Elem * const & _lower_secondary_elem;
+
   /// The primary face lower dimensional element (not the mortar element!). The mortar element
   /// lives on the secondary side of the mortar interface and *may* correspond to \p
   /// _lower_secondary_elem under the very specific circumstance that the nodes on the primary side

--- a/framework/include/constraints/MortarConstraintBase.h
+++ b/framework/include/constraints/MortarConstraintBase.h
@@ -106,10 +106,10 @@ protected:
   MooseVariable * const _var;
 
   /// Reference to the secondary variable
-  MooseVariable & _secondary_var;
+  MooseVariableField<Real> & _secondary_var;
 
   /// Reference to the primary variable
-  MooseVariable & _primary_var;
+  MooseVariableField<Real> & _primary_var;
 
   /// Whether to compute primal residuals
   const bool _compute_primal_residuals;

--- a/framework/include/functions/Function.h
+++ b/framework/include/functions/Function.h
@@ -155,6 +155,7 @@ private:
   using ElemSideQpArg = Moose::ElemSideQpArg;
   using FaceArg = Moose::FaceArg;
   using SingleSidedFaceArg = Moose::SingleSidedFaceArg;
+  using ElemPointArg = Moose::ElemPointArg;
 
   ValueType evaluate(const ElemArg & elem, unsigned int state) const override final;
   ValueType evaluate(const ElemFromFaceArg & elem_from_face,
@@ -163,6 +164,7 @@ private:
   ValueType evaluate(const SingleSidedFaceArg & face, unsigned int state) const override final;
   ValueType evaluate(const ElemQpArg & qp, unsigned int state) const override final;
   ValueType evaluate(const ElemSideQpArg & elem_side_qp, unsigned int state) const override final;
+  ValueType evaluate(const ElemPointArg & elem_point, unsigned int state) const override final;
 
   GradientType evaluateGradient(const ElemArg & elem, unsigned int state) const override final;
   GradientType evaluateGradient(const ElemFromFaceArg & elem_from_face,
@@ -173,6 +175,8 @@ private:
   GradientType evaluateGradient(const ElemQpArg & qp, unsigned int state) const override final;
   GradientType evaluateGradient(const ElemSideQpArg & elem_side_qp,
                                 unsigned int state) const override final;
+  GradientType evaluateGradient(const ElemPointArg & elem_point,
+                                unsigned int state) const override final;
 
   DotType evaluateDot(const ElemArg & elem, unsigned int state) const override final;
   DotType evaluateDot(const ElemFromFaceArg & elem_from_face,
@@ -181,6 +185,7 @@ private:
   DotType evaluateDot(const SingleSidedFaceArg & face, unsigned int state) const override final;
   DotType evaluateDot(const ElemQpArg & qp, unsigned int state) const override final;
   DotType evaluateDot(const ElemSideQpArg & elem_side_qp, unsigned int state) const override final;
+  DotType evaluateDot(const ElemPointArg & elem_point, unsigned int state) const override final;
 
   /**
    * Compute \p _current_elem_qp_functor_xyz if we are on a new element

--- a/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
+++ b/framework/include/relationshipmanagers/AugmentSparsityOnInterface.h
@@ -17,6 +17,7 @@
 #include "libmesh/mesh_base.h"
 
 using libMesh::boundary_id_type;
+using libMesh::CouplingMatrix;
 using libMesh::Elem;
 using libMesh::GhostingFunctor;
 using libMesh::MeshBase;
@@ -70,6 +71,32 @@ public:
 protected:
   virtual void internalInitWithMesh(const MeshBase &) override;
 
+  /**
+   * Ghost the mortar interface couplings of the provided element
+   */
+  void ghostMortarInterfaceCouplings(const processor_id_type p,
+                                     const Elem * const elem,
+                                     map_type & coupled_elements);
+
+  /**
+   * Query the mortar interface couplings of the query element. If a lower dimensional secondary
+   * element is found, then we search for its point neighbors, which we ghost, as well as all of the
+   * mortar interface couplings of the point neighbors. This kind of ghosting is required for mortar
+   * nodal auxiliary kernels
+   */
+  void ghostLowerDSecondaryElemPointNeighbors(const processor_id_type p,
+                                              const Elem * const query_elem,
+                                              map_type & coupled_elements);
+
+  void ghostHigherDNeighbors(const processor_id_type p,
+                             const Elem * const query_elem,
+                             map_type & coupled_elements);
+
+  /**
+   * fill boundary id, subdomain id, and mortar mesh generation object data members
+   */
+  void fillDataMembers();
+
   BoundaryName _primary_boundary_name;
   BoundaryName _secondary_boundary_name;
   SubdomainName _primary_subdomain_name;
@@ -79,7 +106,26 @@ protected:
   /// the matrix sparsity pattern
   const bool _is_coupling_functor;
 
-  /// Whether to ghost point neighbors of secondary lower subdomain elements and consequently their
-  /// cross mortar interface counterparts
+  /// Whether to ghost point neighbors of secondary lower subdomain elements and their
+  /// cross mortar interface counterparts for applications such as mortar nodal auxiliary kernels
   const bool _ghost_point_neighbors;
+
+  /// Whether we should ghost higher-dimensional neighbors. This is necessary when we are doing
+  /// second order mortar with finite volume primal variables, because in order for the method to be
+  /// second order we must use cell gradients, which couples in the neighbor cells
+  const bool _ghost_higher_d_neighbors;
+
+  /// Whether this ghosting functor is being called while we are sill in the mesh generation phase
+  bool _generating_mesh = true;
+
+  BoundaryID _primary_boundary_id = Moose::INVALID_BOUNDARY_ID;
+  BoundaryID _secondary_boundary_id = Moose::INVALID_BOUNDARY_ID;
+  SubdomainID _primary_subdomain_id = Moose::INVALID_BLOCK_ID;
+  SubdomainID _secondary_subdomain_id = Moose::INVALID_BLOCK_ID;
+
+  /// the mortar mesh generation object
+  const AutomaticMortarGeneration * _amg = nullptr;
+
+  // null matrix for generating full variable coupling
+  const CouplingMatrix * const _null_mat = nullptr;
 };

--- a/framework/include/utils/ArrayComponentFunctor.h
+++ b/framework/include/utils/ArrayComponentFunctor.h
@@ -76,6 +76,12 @@ private:
     return _array(elem_side_qp, state)[_component];
   }
 
+  ValueType evaluate(const Moose::ElemPointArg & elem_point,
+                     const unsigned int state) const override final
+  {
+    return _array(elem_point, state)[_component];
+  }
+
   using Moose::FunctorBase<T>::evaluateGradient;
   GradientType evaluateGradient(const Moose::ElemArg & elem,
                                 const unsigned int state) const override final

--- a/framework/include/utils/VectorComponentFunctor.h
+++ b/framework/include/utils/VectorComponentFunctor.h
@@ -78,6 +78,12 @@ private:
     return _vector(elem_side_qp, state)(_component);
   }
 
+  ValueType evaluate(const Moose::ElemPointArg & elem_point,
+                     const unsigned int state) const override final
+  {
+    return _vector(elem_point, state)(_component);
+  }
+
   using Moose::FunctorBase<T>::evaluateGradient;
   GradientType evaluateGradient(const Moose::ElemArg & elem_arg,
                                 const unsigned int state) const override final

--- a/framework/include/utils/VectorCompositeFunctor.h
+++ b/framework/include/utils/VectorCompositeFunctor.h
@@ -32,6 +32,7 @@ public:
   using SingleSidedFaceArg = Moose::SingleSidedFaceArg;
   using ElemQpArg = Moose::ElemQpArg;
   using ElemSideQpArg = Moose::ElemSideQpArg;
+  using ElemPointArg = Moose::ElemPointArg;
 
   VectorCompositeFunctor(const MooseFunctorName & name,
                          const FunctorBase<T> & x_comp,
@@ -94,6 +95,13 @@ private:
   {
     return {
         _x_comp(elem_side_qp, state), _y_comp(elem_side_qp, state), _z_comp(elem_side_qp, state)};
+  }
+
+  ValueType evaluate(const ElemPointArg & elem_point_arg, unsigned int state) const override final
+  {
+    return {_x_comp(elem_point_arg, state),
+            _y_comp(elem_point_arg, state),
+            _z_comp(elem_point_arg, state)};
   }
 
   using Moose::FunctorBase<VectorValue<T>>::evaluateGradient;

--- a/framework/include/variables/MooseVariableFV.h
+++ b/framework/include/variables/MooseVariableFV.h
@@ -134,10 +134,7 @@ public:
   {
     // mooseError("computeNodalValues not supported by MooseVariableFVBase");
   }
-  virtual const std::vector<dof_id_type> & dofIndicesLower() const override final
-  {
-    mooseError("dofIndicesLower not supported by MooseVariableFVBase");
-  }
+  virtual const std::vector<dof_id_type> & dofIndicesLower() const override final;
 
   unsigned int numberOfDofs() const override final { return _element_data->numberOfDofs(); }
 
@@ -750,6 +747,14 @@ MooseVariableFV<OutputType>::setActiveTags(const std::set<TagID> & vtags)
 {
   _element_data->setActiveTags(vtags);
   _neighbor_data->setActiveTags(vtags);
+}
+
+template <typename OutputType>
+const std::vector<dof_id_type> &
+MooseVariableFV<OutputType>::dofIndicesLower() const
+{
+  static const std::vector<dof_id_type> empty;
+  return empty;
 }
 
 template <>

--- a/framework/include/variables/MooseVariableField.h
+++ b/framework/include/variables/MooseVariableField.h
@@ -362,9 +362,11 @@ protected:
 
   using ElemQpArg = Moose::ElemQpArg;
   using ElemSideQpArg = Moose::ElemSideQpArg;
+  using ElemPointArg = Moose::ElemPointArg;
 
   ValueType evaluate(const ElemQpArg & elem_qp, unsigned int state) const override final;
   ValueType evaluate(const ElemSideQpArg & elem_side_qp, unsigned int state) const override final;
+  ValueType evaluate(const ElemPointArg & elem_point, unsigned int state) const override final;
 
   GradientType evaluateGradient(const ElemQpArg & elem_qp, unsigned int state) const override final;
   GradientType evaluateGradient(const ElemSideQpArg & elem_side_qp,

--- a/framework/src/constraints/MortarConstraintBase.C
+++ b/framework/src/constraints/MortarConstraintBase.C
@@ -37,6 +37,8 @@ MortarConstraintBase::validParams()
                                       obj_params.get<SubdomainName>("secondary_subdomain");
                                   rm_params.set<SubdomainName>("primary_subdomain") =
                                       obj_params.get<SubdomainName>("primary_subdomain");
+                                  rm_params.set<bool>("ghost_higher_d_neighbors") =
+                                      obj_params.get<bool>("ghost_higher_d_neighbors");
                                 });
 
   params.addParam<VariableName>("secondary_variable", "Primal variable on secondary surface.");
@@ -100,6 +102,9 @@ MortarConstraintBase::MortarConstraintBase(const InputParameters & parameters)
     _test_primary(_primary_var.phiFaceNeighbor()),
     _grad_test_secondary(_secondary_var.gradPhiFace()),
     _grad_test_primary(_primary_var.gradPhiFaceNeighbor()),
+    _interior_secondary_elem(_assembly.elem()),
+    _interior_primary_elem(_assembly.neighbor()),
+    _lower_secondary_elem(_assembly.lowerDElem()),
     _lower_primary_elem(_assembly.neighborLowerDElem()),
     _displaced(getParam<bool>("use_displaced_mesh"))
 {

--- a/framework/src/constraints/MortarConstraintBase.C
+++ b/framework/src/constraints/MortarConstraintBase.C
@@ -80,11 +80,11 @@ MortarConstraintBase::MortarConstraintBase(const InputParameters & parameters)
              : nullptr),
     _secondary_var(
         isParamValid("secondary_variable")
-            ? _subproblem.getStandardVariable(_tid, parameters.getMooseType("secondary_variable"))
-            : _subproblem.getStandardVariable(_tid, parameters.getMooseType("primary_variable"))),
+            ? _sys.getActualFieldVariable<Real>(_tid, parameters.getMooseType("secondary_variable"))
+            : _sys.getActualFieldVariable<Real>(_tid, parameters.getMooseType("primary_variable"))),
     _primary_var(
         isParamValid("primary_variable")
-            ? _subproblem.getStandardVariable(_tid, parameters.getMooseType("primary_variable"))
+            ? _sys.getActualFieldVariable<Real>(_tid, parameters.getMooseType("primary_variable"))
             : _secondary_var),
 
     _compute_primal_residuals(getParam<bool>("compute_primal_residuals")),

--- a/framework/src/functions/Function.C
+++ b/framework/src/functions/Function.C
@@ -243,6 +243,13 @@ FunctionTempl<T>::evaluate(const ElemSideQpArg & elem_side_qp, const unsigned in
 }
 
 template <typename T>
+typename FunctionTempl<T>::ValueType
+FunctionTempl<T>::evaluate(const ElemPointArg & elem_point_arg, const unsigned int state) const
+{
+  return value(getTime(state), elem_point_arg.point);
+}
+
+template <typename T>
 typename FunctionTempl<T>::GradientType
 FunctionTempl<T>::evaluateGradient(const ElemArg & elem_arg, const unsigned int state) const
 {
@@ -299,6 +306,14 @@ FunctionTempl<T>::evaluateGradient(const ElemSideQpArg & elem_side_qp,
 }
 
 template <typename T>
+typename FunctionTempl<T>::GradientType
+FunctionTempl<T>::evaluateGradient(const ElemPointArg & elem_point_arg,
+                                   const unsigned int state) const
+{
+  return gradient(getTime(state), elem_point_arg.point);
+}
+
+template <typename T>
 typename FunctionTempl<T>::DotType
 FunctionTempl<T>::evaluateDot(const ElemArg & elem_arg, const unsigned int state) const
 {
@@ -351,6 +366,13 @@ FunctionTempl<T>::evaluateDot(const ElemSideQpArg & elem_side_qp, const unsigned
   mooseAssert(qp < _current_elem_side_qp_functor_xyz.size(),
               "The requested " << qp << " is outside our xyz size");
   return timeDerivative(getTime(state), _current_elem_side_qp_functor_xyz[qp]);
+}
+
+template <typename T>
+typename FunctionTempl<T>::DotType
+FunctionTempl<T>::evaluateDot(const ElemPointArg & elem_point_arg, const unsigned int state) const
+{
+  return timeDerivative(getTime(state), elem_point_arg.point);
 }
 
 template <typename T>

--- a/framework/src/interfaces/MortarConsumerInterface.C
+++ b/framework/src/interfaces/MortarConsumerInterface.C
@@ -41,6 +41,8 @@ MortarConsumerInterface::validParams()
             obj_params.get<SubdomainName>("primary_subdomain");
         rm_params.set<bool>("ghost_point_neighbors") =
             obj_params.get<bool>("ghost_point_neighbors");
+        rm_params.set<bool>("ghost_higher_d_neighbors") =
+            obj_params.get<bool>("ghost_higher_d_neighbors");
       });
 
   params.addRequiredParam<BoundaryName>("primary_boundary",
@@ -80,6 +82,13 @@ MortarConsumerInterface::validParams()
                         false,
                         "Whether we should ghost point neighbors of secondary face elements, and "
                         "consequently also their mortar interface couples.");
+
+  params.addParam<bool>(
+      "ghost_higher_d_neighbors",
+      false,
+      "Whether we should ghost higher-dimensional neighbors. This is necessary when we are doing "
+      "second order mortar with finite volume primal variables, because in order for the method to "
+      "be second order we must use cell gradients, which couples in the neighbor cells.");
 
   return params;
 }

--- a/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
+++ b/framework/src/relationshipmanagers/AugmentSparsityOnInterface.C
@@ -34,10 +34,18 @@ AugmentSparsityOnInterface::validParams()
                                          "The name of the primary lower dimensional subdomain.");
   params.addRequiredParam<SubdomainName>("secondary_subdomain",
                                          "The name of the secondary lower dimensional subdomain.");
-  params.addParam<bool>("ghost_point_neighbors",
-                        false,
-                        "Whether we should ghost point neighbors of secondary face elements, and "
-                        "consequently also their mortar interface couples.");
+  params.addParam<bool>(
+      "ghost_point_neighbors",
+      false,
+      "Whether we should ghost point neighbors of secondary lower-dimensional elements and "
+      "also their mortar interface couples for applications such as mortar nodal auxiliary "
+      "kernels.");
+  params.addParam<bool>(
+      "ghost_higher_d_neighbors",
+      false,
+      "Whether we should ghost higher-dimensional neighbors. This is necessary when we are doing "
+      "second order mortar with finite volume primal variables, because in order for the method to "
+      "be second order we must use cell gradients, which couples in the neighbor cells.");
   return params;
 }
 
@@ -48,7 +56,8 @@ AugmentSparsityOnInterface::AugmentSparsityOnInterface(const InputParameters & p
     _primary_subdomain_name(getParam<SubdomainName>("primary_subdomain")),
     _secondary_subdomain_name(getParam<SubdomainName>("secondary_subdomain")),
     _is_coupling_functor(isType(Moose::RelationshipManagerType::COUPLING)),
-    _ghost_point_neighbors(getParam<bool>("ghost_point_neighbors"))
+    _ghost_point_neighbors(getParam<bool>("ghost_point_neighbors")),
+    _ghost_higher_d_neighbors(getParam<bool>("ghost_higher_d_neighbors"))
 {
 }
 
@@ -59,7 +68,8 @@ AugmentSparsityOnInterface::AugmentSparsityOnInterface(const AugmentSparsityOnIn
     _primary_subdomain_name(other._primary_subdomain_name),
     _secondary_subdomain_name(other._secondary_subdomain_name),
     _is_coupling_functor(other._is_coupling_functor),
-    _ghost_point_neighbors(other._ghost_point_neighbors)
+    _ghost_point_neighbors(other._ghost_point_neighbors),
+    _ghost_higher_d_neighbors(other._ghost_higher_d_neighbors)
 {
 }
 
@@ -86,35 +96,189 @@ AugmentSparsityOnInterface::getInfo() const
 }
 
 void
+AugmentSparsityOnInterface::ghostMortarInterfaceCouplings(const processor_id_type p,
+                                                          const Elem * const elem,
+                                                          map_type & coupled_elements)
+{
+  // Look up elem in the mortar_interface_coupling data structure.
+  const auto & mic = _amg->mortarInterfaceCoupling();
+  auto find_it = mic.find(elem->id());
+  if (find_it == mic.end())
+    return;
+
+  const auto & coupled_set = find_it->second;
+
+  for (const auto coupled_elem_id : coupled_set)
+  {
+    const Elem * coupled_elem = _mesh->elem_ptr(coupled_elem_id);
+    mooseAssert(coupled_elem,
+                "The coupled element with id " << coupled_elem_id << " doesn't exist!");
+
+    if (coupled_elem->processor_id() != p)
+      coupled_elements.insert(std::make_pair(coupled_elem, _null_mat));
+  }
+}
+
+void
+AugmentSparsityOnInterface::ghostLowerDSecondaryElemPointNeighbors(const processor_id_type p,
+                                                                   const Elem * const query_elem,
+                                                                   map_type & coupled_elements)
+{
+  // I hypothesize that node processor ids are tied to higher dimensional element processor
+  // ids over lower dimensional element processor ids based on debugging experience.
+  // Consequently we need to be checking for higher dimensional elements and whether they are
+  // along our secondary boundary. From there we will query the AMG object's
+  // mortar-interface-coupling container to get the secondary lower-dimensional element, and
+  // then we will ghost it's point neighbors and their mortar interface couples
+
+  // It's possible that one higher-dimensional element could have multiple lower-dimensional
+  // elements from multiple sides. Morever, even if there is only one lower-d element per
+  // higher-d element, the unordered_multimap that holds the coupling information can have
+  // duplicate key-value pairs if there are multiple mortar segments per secondary face. So to
+  // prevent attempting to insert into the coupled elements map multiple times with the same
+  // element, we'll keep track of the elements we've handled. We're going to use a tree-based
+  // set here since the number of lower-d elements handled should never exceed the number of
+  // element sides (which is small)
+  std::set<dof_id_type> secondary_lower_elems_handled;
+  const BoundaryInfo & binfo = _mesh->get_boundary_info();
+  for (auto side : query_elem->side_index_range())
+  {
+    if (!binfo.has_boundary_id(query_elem, side, _secondary_boundary_id))
+      // We're not a higher-dimensional element along the secondary face, or at least this
+      // side isn't
+      continue;
+
+    const auto & mic = _amg->mortarInterfaceCoupling();
+    auto find_it = mic.find(query_elem->id());
+    if (find_it == mic.end())
+      continue;
+
+    const auto & coupled_set = find_it->second;
+    for (const auto coupled_elem_id : coupled_set)
+    {
+      auto * const coupled_elem = _mesh->elem_ptr(coupled_elem_id);
+
+      if (coupled_elem->subdomain_id() != _secondary_subdomain_id)
+      {
+        // We support higher-d-secondary to higher-d-primary coupling now, e.g.
+        // if we get here, coupled_elem is not actually a secondary lower elem; it's a
+        // primary higher-d elem
+        mooseAssert(coupled_elem->dim() == query_elem->dim(), "These should be matching dim");
+        continue;
+      }
+
+      auto insert_pr = secondary_lower_elems_handled.insert(coupled_elem_id);
+
+      // If insertion didn't happen, then we've already handled this element
+      if (!insert_pr.second)
+        continue;
+
+      // We've already ghosted the secondary lower-d element itself if it needed to be
+      // outside of the _ghost_point_neighbors logic. But now we must make sure to ghost the
+      // point neighbors of the secondary lower-d element and their mortar interface
+      // couplings
+      std::set<const Elem *> secondary_lower_elem_point_neighbors;
+      coupled_elem->find_point_neighbors(secondary_lower_elem_point_neighbors);
+
+      for (const Elem * const neigh : secondary_lower_elem_point_neighbors)
+      {
+        if (neigh->processor_id() != p)
+          coupled_elements.emplace(neigh, _null_mat);
+
+        ghostMortarInterfaceCouplings(p, neigh, coupled_elements);
+      }
+    } // end iteration over mortar interface couplings
+
+    // We actually should have added all the lower-dimensional elements associated with the
+    // higher-dimensional element, so we can stop iterating over sides
+    return;
+
+  } // end for side_index_range
+}
+
+void
+AugmentSparsityOnInterface::ghostHigherDNeighbors(const processor_id_type p,
+                                                  const Elem * const query_elem,
+                                                  map_type & coupled_elements)
+{
+  // The coupling is this for second order FV: secondary lower dimensional elem dofs will depend on
+  // higher-d secondary elem neighbor primal dofs and higher-d primary elem neighbor primal dofs.
+  // Higher dimensional primal dofs only depend on the secondary lower dimensional LM dofs for the
+  // current FV gap heat transfer use cases
+
+  if (query_elem->subdomain_id() != _secondary_subdomain_id)
+    return;
+
+  const BoundaryInfo & binfo = _mesh->get_boundary_info();
+  const auto which_side = query_elem->interior_parent()->which_side_am_i(query_elem);
+  if (!binfo.has_boundary_id(query_elem->interior_parent(), which_side, _secondary_boundary_id))
+    return;
+
+  const auto & mic = _amg->mortarInterfaceCoupling();
+  auto find_it = mic.find(query_elem->id());
+  if (find_it == mic.end())
+    // Perhaps no projection onto primary
+    return;
+
+  const auto & lower_d_coupled_set = find_it->second;
+  for (const auto coupled_elem_id : lower_d_coupled_set)
+  {
+    auto * const coupled_elem = _mesh->elem_ptr(coupled_elem_id);
+    if (coupled_elem->dim() == query_elem->dim())
+      // lower-d-elem
+      continue;
+
+    std::vector<const Elem *> active_neighbors;
+
+    for (auto s : coupled_elem->side_index_range())
+    {
+      const Elem * const neigh = coupled_elem->neighbor_ptr(s);
+
+      if (!neigh || neigh == remote_elem)
+        continue;
+
+      // With any kind of neighbor, we need to couple to all the
+      // active descendants on our side.
+      neigh->active_family_tree_by_neighbor(active_neighbors, coupled_elem);
+
+      for (const auto & neighbor : active_neighbors)
+        if (neighbor->processor_id() != p)
+          coupled_elements.emplace(neighbor, _null_mat);
+    }
+  }
+}
+
+void
+AugmentSparsityOnInterface::fillDataMembers()
+{
+  // We ask the user to pass boundary names instead of ids to our constraint object.  However, We
+  // are unable to get the boundary ids from boundary names until we've attached the MeshBase object
+  // to the MooseMesh
+  _generating_mesh = !_moose_mesh->getMeshPtr();
+  _primary_boundary_id = _generating_mesh ? Moose::INVALID_BOUNDARY_ID
+                                          : _moose_mesh->getBoundaryID(_primary_boundary_name);
+  _secondary_boundary_id = _generating_mesh ? Moose::INVALID_BOUNDARY_ID
+                                            : _moose_mesh->getBoundaryID(_secondary_boundary_name);
+  _primary_subdomain_id = _generating_mesh ? Moose::INVALID_BLOCK_ID
+                                           : _moose_mesh->getSubdomainID(_primary_subdomain_name);
+  _secondary_subdomain_id = _generating_mesh
+                                ? Moose::INVALID_BLOCK_ID
+                                : _moose_mesh->getSubdomainID(_secondary_subdomain_name);
+
+  _amg = _app.getExecutioner() ? &_app.getExecutioner()->feProblem().getMortarInterface(
+                                     std::make_pair(_primary_boundary_id, _secondary_boundary_id),
+                                     std::make_pair(_primary_subdomain_id, _secondary_subdomain_id),
+                                     _use_displaced_mesh)
+                               : nullptr;
+}
+
+void
 AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & range_begin,
                                        const MeshBase::const_element_iterator & range_end,
                                        const processor_id_type p,
                                        map_type & coupled_elements)
 {
-  // We ask the user to pass boundary names instead of ids to our constraint object.  However, We
-  // are unable to get the boundary ids from boundary names until we've attached the MeshBase object
-  // to the MooseMesh
-  bool generating_mesh = !_moose_mesh->getMeshPtr();
-  auto primary_boundary_id = generating_mesh ? Moose::INVALID_BOUNDARY_ID
-                                             : _moose_mesh->getBoundaryID(_primary_boundary_name);
-  auto secondary_boundary_id = generating_mesh
-                                   ? Moose::INVALID_BOUNDARY_ID
-                                   : _moose_mesh->getBoundaryID(_secondary_boundary_name);
-  auto primary_subdomain_id = generating_mesh
-                                  ? Moose::INVALID_BLOCK_ID
-                                  : _moose_mesh->getSubdomainID(_primary_subdomain_name);
-  auto secondary_subdomain_id = generating_mesh
-                                    ? Moose::INVALID_BLOCK_ID
-                                    : _moose_mesh->getSubdomainID(_secondary_subdomain_name);
-
-  const AutomaticMortarGeneration * const amg =
-      _app.getExecutioner() ? &_app.getExecutioner()->feProblem().getMortarInterface(
-                                  std::make_pair(primary_boundary_id, secondary_boundary_id),
-                                  std::make_pair(primary_subdomain_id, secondary_subdomain_id),
-                                  _use_displaced_mesh)
-                            : nullptr;
-
-  const CouplingMatrix * const null_mat = libmesh_nullptr;
+  fillDataMembers();
 
   // If we're on a dynamic mesh or we have not yet constructed the mortar mesh, we need to ghost the
   // entire interface because we don't know a priori what elements will project onto what. We *do
@@ -123,21 +287,21 @@ AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & 
   // element at a time (and then below we do a loop over all the mesh's active elements). It's
   // perhaps faster in this case to deal with mallocs coming out of MatSetValues, especially if the
   // mesh displacements are relatively small
-  if ((!amg || _use_displaced_mesh) && !_is_coupling_functor)
+  if ((!_amg || _use_displaced_mesh) && !_is_coupling_functor)
   {
     for (const Elem * const elem : _mesh->active_element_ptr_range())
     {
-      if (generating_mesh)
+      if (_generating_mesh)
       {
         // We are still generating the mesh, so it's possible we don't even have the right boundary
         // ids created yet! So we actually ghost all boundary elements and all lower dimensional
         // elements who have parents on a boundary
         if (elem->on_boundary())
-          coupled_elements.insert(std::make_pair(elem, null_mat));
+          coupled_elements.insert(std::make_pair(elem, _null_mat));
         else if (const Elem * const ip = elem->interior_parent())
         {
           if (ip->on_boundary())
-            coupled_elements.insert(std::make_pair(elem, null_mat));
+            coupled_elements.insert(std::make_pair(elem, _null_mat));
         }
       }
       else
@@ -145,16 +309,16 @@ AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & 
         // We've finished generating our mesh so we can be selective and only ghost elements lying
         // in our lower-dimensional subdomains and their interior parents
 
-        mooseAssert(primary_boundary_id != Moose::INVALID_BOUNDARY_ID,
+        mooseAssert(_primary_boundary_id != Moose::INVALID_BOUNDARY_ID,
                     "Primary boundary id should exist by now. If you're using a MeshModifier "
                     "please use the corresponding MeshGenerator instead");
-        mooseAssert(secondary_boundary_id != Moose::INVALID_BOUNDARY_ID,
+        mooseAssert(_secondary_boundary_id != Moose::INVALID_BOUNDARY_ID,
                     "Secondary boundary id should exist by now. If you're using a MeshModifier "
                     "please use the corresponding MeshGenerator instead");
-        mooseAssert(primary_subdomain_id != Moose::INVALID_BLOCK_ID,
+        mooseAssert(_primary_subdomain_id != Moose::INVALID_BLOCK_ID,
                     "Primary subdomain id should exist by now. If you're using a MeshModifier "
                     "please use the corresponding MeshGenerator instead");
-        mooseAssert(secondary_subdomain_id != Moose::INVALID_BLOCK_ID,
+        mooseAssert(_secondary_subdomain_id != Moose::INVALID_BLOCK_ID,
                     "Secondary subdomain id should exist by now. If you're using a MeshModifier "
                     "please use the corresponding MeshGenerator instead");
 
@@ -163,15 +327,15 @@ AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & 
 
         for (auto side : elem->side_index_range())
           if ((elem->processor_id() != p) &&
-              (binfo.has_boundary_id(elem, side, primary_boundary_id) ||
-               binfo.has_boundary_id(elem, side, secondary_boundary_id)))
-            coupled_elements.insert(std::make_pair(elem, null_mat));
+              (binfo.has_boundary_id(elem, side, _primary_boundary_id) ||
+               binfo.has_boundary_id(elem, side, _secondary_boundary_id)))
+            coupled_elements.insert(std::make_pair(elem, _null_mat));
 
         // Lower dimensional subdomain elements
-        if ((elem->processor_id() != p) && (elem->subdomain_id() == primary_subdomain_id ||
-                                            elem->subdomain_id() == secondary_subdomain_id))
+        if ((elem->processor_id() != p) && (elem->subdomain_id() == _primary_subdomain_id ||
+                                            elem->subdomain_id() == _secondary_subdomain_id))
         {
-          coupled_elements.insert(std::make_pair(elem, null_mat));
+          coupled_elements.insert(std::make_pair(elem, _null_mat));
 
 #ifndef NDEBUG
           // let's do some safety checks
@@ -180,8 +344,8 @@ AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & 
                       "We should have set interior parents for all of our lower-dimensional mortar "
                       "subdomains");
           auto side = ip->which_side_am_i(elem);
-          auto bnd_id = elem->subdomain_id() == primary_subdomain_id ? primary_boundary_id
-                                                                     : secondary_boundary_id;
+          auto bnd_id = elem->subdomain_id() == _primary_subdomain_id ? _primary_boundary_id
+                                                                      : _secondary_boundary_id;
           mooseAssert(_mesh->get_boundary_info().has_boundary_id(ip, side, bnd_id),
                       "The interior parent for the lower-dimensional element does not lie on the "
                       "boundary");
@@ -192,109 +356,18 @@ AugmentSparsityOnInterface::operator()(const MeshBase::const_element_iterator & 
   }
   // For a static mesh (or for determining a sparsity pattern approximation on a displaced mesh) we
   // can just ghost the coupled elements determined during mortar mesh generation
-  else if (amg)
+  else if (_amg)
   {
-    auto ghost_mortar_interface_couplings =
-        [this, p, &coupled_elements, null_mat, amg](const Elem * const elem_arg)
-    {
-      // Look up elem_arg in the mortar_interface_coupling data structure.
-      const auto & mic = amg->mortarInterfaceCoupling();
-      auto find_it = mic.find(elem_arg->id());
-      if (find_it == mic.end())
-        return;
-
-      const auto & coupled_set = find_it->second;
-
-      for (const auto coupled_elem_id : coupled_set)
-      {
-        const Elem * coupled_elem = _mesh->elem_ptr(coupled_elem_id);
-        mooseAssert(coupled_elem,
-                    "The coupled element with id " << coupled_elem_id << " doesn't exist!");
-
-        if (coupled_elem->processor_id() != p)
-          coupled_elements.insert(std::make_pair(coupled_elem, null_mat));
-      }
-    };
-
     for (const Elem * const elem : as_range(range_begin, range_end))
     {
-      ghost_mortar_interface_couplings(elem);
+      ghostMortarInterfaceCouplings(p, elem, coupled_elements);
 
       if (_ghost_point_neighbors)
-      {
-        // I hypothesize that node processor ids are tied to higher dimensional element processor
-        // ids over lower dimensional element processor ids based on debugging experience.
-        // Consequently we need to be checking for higher dimensional elements and whether they are
-        // along our secondary boundary. From there we will query the AMG object's
-        // mortar-interface-coupling container to get the secondary lower-dimensional element, and
-        // then we will ghost it's point neighbors and their mortar interface couples
-
-        // It's possible that one higher-dimensional element could have multiple lower-dimensional
-        // elements from multiple sides. Morever, even if there is only one lower-d element per
-        // higher-d element, the unordered_multimap that holds the coupling information can have
-        // duplicate key-value pairs if there are multiple mortar segments per secondary face. So to
-        // prevent attempting to insert into the coupled elements map multiple times with the same
-        // element, we'll keep track of the elements we've handled. We're going to use a tree-based
-        // set here since the number of lower-d elements handled should never exceed the number of
-        // element sides (which is small)
-        std::set<dof_id_type> secondary_lower_elems_handled;
-        const BoundaryInfo & binfo = _mesh->get_boundary_info();
-        for (auto side : elem->side_index_range())
-        {
-          if (!binfo.has_boundary_id(elem, side, secondary_boundary_id))
-            // We're not a higher-dimensional element along the secondary face, or at least this
-            // side isn't
-            continue;
-
-          const auto & mic = amg->mortarInterfaceCoupling();
-          auto find_it = mic.find(elem->id());
-          if (find_it == mic.end())
-            continue;
-
-          const auto & coupled_set = find_it->second;
-          for (const auto coupled_elem_id : coupled_set)
-          {
-            auto * const coupled_elem = _mesh->elem_ptr(coupled_elem_id);
-
-            if (coupled_elem->subdomain_id() != secondary_subdomain_id)
-            {
-              // We support higher-d-secondary to higher-d-primary coupling now, e.g.
-              // if we get here, coupled_elem is not actually a secondary lower elem; it's a
-              // primary higher-d elem
-              mooseAssert(coupled_elem->dim() == elem->dim(), "These should be matching dim");
-              continue;
-            }
-
-            auto insert_pr = secondary_lower_elems_handled.insert(coupled_elem_id);
-
-            // If insertion didn't happen, then we've already handled this element
-            if (!insert_pr.second)
-              continue;
-
-            // We've already ghosted the secondary lower-d element itself if it needed to be
-            // outside of the _ghost_point_neighbors logic. But now we must make sure to ghost the
-            // point neighbors of the secondary lower-d element and their mortar interface
-            // couplings
-            std::set<const Elem *> secondary_lower_elem_point_neighbors;
-            coupled_elem->find_point_neighbors(secondary_lower_elem_point_neighbors);
-
-            for (const Elem * const neigh : secondary_lower_elem_point_neighbors)
-            {
-              if (neigh->processor_id() != p)
-                coupled_elements.emplace(neigh, null_mat);
-
-              ghost_mortar_interface_couplings(neigh);
-            }
-          } // end iteration over multimap
-
-          // We actually should have added all the lower-dimensional elements associated with the
-          // higher-dimensional element, so we can stop iterating over sides
-          break;
-
-        } // end for side_index_range
-      }   // end if ghost_point_neighbors
-    }     // end for loop over input range
-  }       // end if amg
+        ghostLowerDSecondaryElemPointNeighbors(p, elem, coupled_elements);
+      if (_ghost_higher_d_neighbors)
+        ghostHigherDNeighbors(p, elem, coupled_elements);
+    } // end for loop over input range
+  }   // end if _amg
 }
 
 bool
@@ -306,7 +379,8 @@ AugmentSparsityOnInterface::operator>=(const RelationshipManager & other) const
         _secondary_boundary_name == asoi->_secondary_boundary_name &&
         _primary_subdomain_name == asoi->_primary_subdomain_name &&
         _secondary_subdomain_name == asoi->_secondary_subdomain_name &&
-        (_ghost_point_neighbors >= asoi->_ghost_point_neighbors) && baseGreaterEqual(*asoi))
+        _ghost_point_neighbors >= asoi->_ghost_point_neighbors &&
+        _ghost_higher_d_neighbors >= asoi->_ghost_higher_d_neighbors && baseGreaterEqual(*asoi))
       return true;
   }
   return false;

--- a/framework/src/variables/MooseVariableField.C
+++ b/framework/src/variables/MooseVariableField.C
@@ -333,6 +333,16 @@ MooseVariableField<OutputType>::evaluateDot(const ElemSideQpArg &, unsigned int)
 
 #endif
 
+template <typename OutputType>
+typename MooseVariableField<OutputType>::ValueType
+MooseVariableField<OutputType>::evaluate(const ElemPointArg & elem_point,
+                                         const unsigned int state) const
+{
+  return (*this)(elem_point.makeElem(), state) +
+         (elem_point.point - elem_point.elem->vertex_average()) *
+             this->gradient(elem_point.makeElem(), state);
+}
+
 template <>
 typename MooseVariableField<RealEigenVector>::ValueType
 MooseVariableField<RealEigenVector>::evaluate(const ElemQpArg &, unsigned int) const
@@ -347,6 +357,15 @@ MooseVariableField<RealEigenVector>::evaluate(const ElemSideQpArg &, unsigned in
 {
   mooseError(
       "MooseVariableField::evaluate(ElemSideQpArg &, unsigned int) overload not implemented for "
+      "array variables");
+}
+
+template <>
+typename MooseVariableField<RealEigenVector>::ValueType
+MooseVariableField<RealEigenVector>::evaluate(const ElemPointArg &, unsigned int) const
+{
+  mooseError(
+      "MooseVariableField::evaluate(ElemPointArg &, unsigned int) overload not implemented for "
       "array variables");
 }
 

--- a/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
+++ b/modules/navier_stokes/include/utils/CellCenteredMapFunctor.h
@@ -56,6 +56,7 @@ public:
   using SingleSidedFaceArg = Moose::SingleSidedFaceArg;
   using ElemQpArg = Moose::ElemQpArg;
   using ElemSideQpArg = Moose::ElemSideQpArg;
+  using ElemPointArg = Moose::ElemPointArg;
 
   CellCenteredMapFunctor(const MooseMesh & mesh, const std::string & name)
     : Moose::FunctorBase<T>(name), _mesh(mesh)
@@ -159,6 +160,13 @@ private:
       return neighbor_value +
              this->gradient(neighbor_arg) * (fi.faceCentroid() - fi.neighborCentroid());
     }
+  }
+
+  ValueType evaluate(const ElemPointArg & elem_point, const unsigned int state) const override final
+  {
+    return (*this)(elem_point.makeElem(), state) +
+           (elem_point.point - elem_point.elem->vertex_average()) *
+               this->gradient(elem_point.makeElem(), state);
   }
 
   using Moose::FunctorBase<T>::evaluateGradient;

--- a/test/include/constraints/GapHeatConductanceTest.h
+++ b/test/include/constraints/GapHeatConductanceTest.h
@@ -28,4 +28,5 @@ protected:
   const ADMaterialProperty<Real> & _primary_gap_conductance;
   const FunctionTempl<Real> & _secondary_mms_function;
   const FunctionTempl<Real> & _primary_mms_function;
+  const bool _functor_evals_for_primal;
 };

--- a/test/src/constraints/GapHeatConductanceTest.C
+++ b/test/src/constraints/GapHeatConductanceTest.C
@@ -118,10 +118,14 @@ GapHeatConductanceTest::computeJacobian(Moose::MortarType mortar_type)
       *_lower_primary_elem, *_lower_primary_elem->interior_parent(), *_lower_secondary_elem);
   const auto & secondary_ip_lowerd_map =
       amg().getSecondaryIpToLowerElementMap(*_lower_secondary_elem);
-  const std::vector<const MooseVariable *> var_array = {&_secondary_var, &_primary_var};
+  const std::array<const MooseVariableField<Real> *, 2> secondary_side_var_array = {
+      &_secondary_var};
+  const std::array<const MooseVariableField<Real> *, 2> primary_side_var_array = {&_primary_var};
 
-  trimInteriorNodeDerivatives(secondary_ip_lowerd_map, var_array, residuals, true);
-  trimInteriorNodeDerivatives(primary_ip_lowerd_map, var_array, residuals, false);
+  if (_secondary_var.feType().family == LAGRANGE)
+    trimInteriorNodeDerivatives(secondary_ip_lowerd_map, secondary_side_var_array, residuals, true);
+  if (_primary_var.feType().family == LAGRANGE)
+    trimInteriorNodeDerivatives(primary_ip_lowerd_map, primary_side_var_array, residuals, false);
   _assembly.processUnconstrainedResidualsAndJacobian(
       residuals, dof_indices, _vector_tags, _matrix_tags, scaling_factor);
 

--- a/test/src/constraints/GapHeatConductanceTest.C
+++ b/test/src/constraints/GapHeatConductanceTest.C
@@ -11,6 +11,8 @@
 #include "Function.h"
 #include "Assembly.h"
 
+using namespace Moose;
+
 registerMooseObject("MooseTestApp", GapHeatConductanceTest);
 
 InputParameters
@@ -29,6 +31,10 @@ GapHeatConductanceTest::validParams()
       "secondary_mms_function", 0, "An mms function to apply to the secondary side");
   params.addParam<FunctionName>(
       "primary_mms_function", 0, "An mms function to apply to the primary side");
+  params.addParam<bool>("functor_evals_for_primal",
+                        false,
+                        "Whether to perform elem-point functor evaluations of the primal variables "
+                        "as opposed to indexing pre-evaluated quadrature point data");
   return params;
 }
 
@@ -37,24 +43,25 @@ GapHeatConductanceTest::GapHeatConductanceTest(const InputParameters & parameter
     _secondary_gap_conductance(getADMaterialProperty<Real>("secondary_gap_conductance")),
     _primary_gap_conductance(getNeighborADMaterialProperty<Real>("primary_gap_conductance")),
     _secondary_mms_function(getFunction<Real>("secondary_mms_function")),
-    _primary_mms_function(getFunctionByName<Real>(getParam<FunctionName>("primary_mms_function")))
+    _primary_mms_function(getFunctionByName<Real>(getParam<FunctionName>("primary_mms_function"))),
+    _functor_evals_for_primal(getParam<bool>("functor_evals_for_primal"))
 {
 }
 
 ADReal
-GapHeatConductanceTest::computeQpResidual(Moose::MortarType type)
+GapHeatConductanceTest::computeQpResidual(MortarType type)
 {
   switch (type)
   {
-    case Moose::MortarType::Secondary:
+    case MortarType::Secondary:
       return (_lambda[_qp] + _secondary_mms_function.value(_t, _phys_points_secondary[_qp])) *
              _test_secondary[_i][_qp];
 
-    case Moose::MortarType::Primary:
+    case MortarType::Primary:
       return (-_lambda[_qp] + _primary_mms_function.value(_t, _phys_points_primary[_qp])) *
              _test_primary[_i][_qp];
 
-    case Moose::MortarType::Lower:
+    case MortarType::Lower:
     {
       ADReal heat_transfer_coeff(0);
       auto gap = (_phys_points_secondary[_qp] - _phys_points_primary[_qp]).norm();
@@ -64,8 +71,16 @@ GapHeatConductanceTest::computeQpResidual(Moose::MortarType type)
       heat_transfer_coeff =
           (0.5 * (_secondary_gap_conductance[_qp] + _primary_gap_conductance[_qp])) / gap;
 
-      return _test[_i][_qp] *
-             (_lambda[_qp] - heat_transfer_coeff * (_u_secondary[_qp] - _u_primary[_qp]));
+      const auto u_secondary =
+          _functor_evals_for_primal
+              ? _secondary_var(
+                    ElemPointArg({_interior_secondary_elem, _phys_points_secondary[_qp], false}))
+              : _u_secondary[_qp];
+      const auto u_primary = _functor_evals_for_primal
+                                 ? _primary_var(ElemPointArg(
+                                       {_interior_primary_elem, _phys_points_primary[_qp], false}))
+                                 : _u_primary[_qp];
+      return _test[_i][_qp] * (_lambda[_qp] - heat_transfer_coeff * (u_secondary - u_primary));
     }
 
     default:
@@ -74,12 +89,12 @@ GapHeatConductanceTest::computeQpResidual(Moose::MortarType type)
 }
 
 void
-GapHeatConductanceTest::computeJacobian(Moose::MortarType mortar_type)
+GapHeatConductanceTest::computeJacobian(MortarType mortar_type)
 {
   std::vector<DualReal> residuals;
   size_t test_space_size = 0;
-  typedef Moose::ConstraintJacobianType JType;
-  typedef Moose::MortarType MType;
+  typedef ConstraintJacobianType JType;
+  typedef MortarType MType;
   std::vector<JType> jacobian_types;
   std::vector<dof_id_type> dof_indices;
   Real scaling_factor = 1;
@@ -164,15 +179,10 @@ GapHeatConductanceTest::computeJacobian(Moose::MortarType mortar_type)
 
       // Derivatives are offset by the variable number
       std::vector<size_t> ad_offsets{
-          Moose::adOffset(jvar, _sys.getMaxVarNDofsPerElem(), Moose::ElementType::Element),
-          Moose::adOffset(jvar,
-                          _sys.getMaxVarNDofsPerElem(),
-                          Moose::ElementType::Neighbor,
-                          _sys.system().n_vars()),
-          Moose::adOffset(jvar,
-                          _sys.getMaxVarNDofsPerElem(),
-                          Moose::ElementType::Lower,
-                          _sys.system().n_vars())};
+          adOffset(jvar, _sys.getMaxVarNDofsPerElem(), ElementType::Element),
+          adOffset(
+              jvar, _sys.getMaxVarNDofsPerElem(), ElementType::Neighbor, _sys.system().n_vars()),
+          adOffset(jvar, _sys.getMaxVarNDofsPerElem(), ElementType::Lower, _sys.system().n_vars())};
       std::vector<size_t> shape_space_sizes{jvariable.dofIndices().size(),
                                             jvariable.dofIndicesNeighbor().size(),
                                             jvariable.dofIndicesLower().size()};

--- a/test/tests/mortar/convergence-studies/fv-gap-conductance/gap-conductance.i
+++ b/test/tests/mortar/convergence-studies/fv-gap-conductance/gap-conductance.i
@@ -1,0 +1,214 @@
+[Problem]
+  error_on_jacobian_nonzero_reallocation = true
+[]
+
+[Mesh]
+  [left_block]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 1
+    ymin = 0
+    ymax = 1
+    nx = 2
+    ny = 2
+    elem_type = QUAD4
+  []
+  [left_block_sidesets]
+    type = RenameBoundaryGenerator
+    input = left_block
+    old_boundary = '0 1 2 3'
+    new_boundary = 'lb_bottom lb_right lb_top lb_left'
+  []
+  [left_block_id]
+    type = SubdomainIDGenerator
+    input = left_block_sidesets
+    subdomain_id = 1
+  []
+  [right_block]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 2
+    xmax = 3
+    ymin = 0
+    ymax = 1
+    nx = 2
+    ny = 2
+    elem_type = QUAD4
+  []
+  [right_block_id]
+    type = SubdomainIDGenerator
+    input = right_block
+    subdomain_id = 2
+  []
+  [right_block_change_boundary_id]
+    type = RenameBoundaryGenerator
+    input = right_block_id
+    old_boundary = '0 1 2 3'
+    new_boundary = '100 101 102 103'
+  []
+  [combined]
+    type = MeshCollectionGenerator
+    inputs = 'left_block_id right_block_change_boundary_id'
+  []
+  [block_rename]
+    type = RenameBlockGenerator
+    input = combined
+    old_block = '1 2'
+    new_block = 'left_block right_block'
+  []
+  [right_right_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = block_rename
+    new_boundary = rb_right
+    block = right_block
+    normal = '1 0 0'
+  []
+  [right_left_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = right_right_sideset
+    new_boundary = rb_left
+    block = right_block
+    normal = '-1 0 0'
+  []
+  [right_top_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = right_left_sideset
+    new_boundary = rb_top
+    block = right_block
+    normal = '0 1 0'
+  []
+  [right_bottom_sideset]
+    type = SideSetsAroundSubdomainGenerator
+    input = right_top_sideset
+    new_boundary = rb_bottom
+    block = right_block
+    normal = '0 -1 0'
+  []
+  [secondary]
+    input = right_bottom_sideset
+    type = LowerDBlockFromSidesetGenerator
+    sidesets = 'lb_right'
+    new_block_id = '10001'
+    new_block_name = 'secondary_lower'
+  []
+  [primary]
+    input = secondary
+    type = LowerDBlockFromSidesetGenerator
+    sidesets = 'rb_left'
+    new_block_id = '10000'
+    new_block_name = 'primary_lower'
+  []
+[]
+
+[Variables]
+  [T]
+    block = 'left_block right_block'
+    type = MooseVariableFVReal
+  []
+  [lambda]
+    block = 'secondary_lower'
+    family = MONOMIAL
+    order = CONSTANT
+  []
+[]
+
+[FVBCs]
+  [neumann]
+    type = FVFunctionDirichletBC
+    function = exact_soln_primal
+    variable = T
+    boundary = 'lb_bottom lb_top lb_left rb_bottom rb_right rb_top'
+  []
+[]
+
+[FVKernels]
+  [conduction]
+    type = FVDiffusion
+    variable = T
+    block = 'left_block right_block'
+    coeff = 1
+  []
+  [sink]
+    type = FVReaction
+    variable = T
+    block = 'left_block right_block'
+  []
+  [forcing_function]
+    type = FVBodyForce
+    variable = T
+    function = forcing_function
+    block = 'left_block right_block'
+  []
+[]
+
+[Functions]
+  [forcing_function]
+    type = ParsedFunction
+    value = ''
+  []
+  [exact_soln_primal]
+    type = ParsedFunction
+    value = ''
+  []
+  [exact_soln_lambda]
+    type = ParsedFunction
+    value = ''
+  []
+  [mms_secondary]
+    type = ParsedFunction
+    value = ''
+  []
+  [mms_primary]
+    type = ParsedFunction
+    value = ''
+  []
+[]
+
+[Constraints]
+  [mortar]
+    type = GapHeatConductanceTest
+    primary_boundary = rb_left
+    secondary_boundary = lb_right
+    primary_subdomain = primary_lower
+    secondary_subdomain = secondary_lower
+    secondary_variable = T
+    variable = lambda
+    secondary_gap_conductance = 1
+    primary_gap_conductance = 1
+    secondary_mms_function = mms_secondary
+    primary_mms_function = mms_primary
+  []
+[]
+
+[Executioner]
+  solve_type = NEWTON
+  type = Steady
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre    boomeramg'
+[]
+
+[Outputs]
+  csv = true
+[]
+
+[Postprocessors]
+  [L2lambda]
+    type = ElementL2Error
+    variable = lambda
+    function = exact_soln_lambda
+    execute_on = 'timestep_end'
+    block = 'secondary_lower'
+  []
+  [L2u]
+    type = ElementL2Error
+    variable = T
+    function = exact_soln_primal
+    execute_on = 'timestep_end'
+    block = 'left_block right_block'
+  []
+  [h]
+    type = AverageElementSize
+    block = 'left_block right_block'
+  []
+[]

--- a/test/tests/mortar/convergence-studies/fv-gap-conductance/lm-spatial.py
+++ b/test/tests/mortar/convergence-studies/fv-gap-conductance/lm-spatial.py
@@ -1,0 +1,53 @@
+import mms
+import unittest
+from mooseutils import fuzzyEqual, fuzzyAbsoluteEqual
+import sympy
+
+class TestGapConductance(unittest.TestCase):
+    def __init__(self, methodName='runTest'):
+        super(TestGapConductance, self).__init__(methodName)
+        exact_soln = 'x**4 + 2*y**4 +x*y**3'
+        f, exact = mms.evaluate('-div(grad(T)) + T', exact_soln, variable='T')
+
+        x,y = sympy.symbols('x y')
+
+        u = eval(str(exact).replace('R.x','x').replace('R.y','y'))
+
+        u_secondary = u.subs(x,1)
+        u_primary = u.subs(x,2)
+        lm = u_secondary - u_primary
+
+        du_dx = sympy.diff(u, x)
+
+        # flux = n * -grad_u = nx * -du_dx
+        # n_secondary = 1
+        # n_primary = -1
+        flux_secondary = -du_dx.subs(x,1)
+
+        flux_primary = -1 * -du_dx.subs(x,2)
+
+        mms_secondary = flux_secondary - lm
+        mms_primary = flux_primary + lm
+
+        self.function_args = [
+            "Functions/forcing_function/value=\'" + mms.fparser(f) + "\'",
+            "Functions/exact_soln_primal/value=\'" + mms.fparser(exact) + "\'",
+            "Functions/exact_soln_lambda/value=\'" + mms.fparser(lm) + "\'",
+            "Functions/mms_secondary/value=\'" + mms.fparser(mms_secondary) + "\'",
+            "Functions/mms_primary/value=\'" + mms.fparser(mms_primary) + "\'"]
+
+
+    def test(self):
+        labels = ['L2lambda', 'L2u']
+        df1 = mms.run_spatial('gap-conductance.i', 6, "--error", "--error-unused", "--error-deprecated", *self.function_args, y_pp=labels)
+
+        fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
+        fig.plot(df1, label=labels, marker='o', markersize=8, num_fitted_points=3, slope_precision=1)
+        fig.save('gap-conductance.png')
+        for key,value in fig.label_to_slope.items():
+            print("%s, %f" % (key, value))
+            self.assertTrue(fuzzyAbsoluteEqual(value, 1., .1))
+
+
+if __name__ == '__main__':
+    unittest.main(__name__, verbosity=2)

--- a/test/tests/mortar/convergence-studies/fv-gap-conductance/tests
+++ b/test/tests/mortar/convergence-studies/fv-gap-conductance/tests
@@ -1,12 +1,25 @@
 [Tests]
   design = 'Constraints/index.md'
   issues = '#21599'
-  [p0p0]
-    type = PythonUnitTest
-    input = 'lm-spatial.py'
-    test_case = 'TestGapConductance'
-    requirement = 'The system shall be able to perform gap heat transfer to couple conduction equations, on either side of the mortar interface, discretized with the finite volume method.'
-    required_python_packages = 'sympy pandas matplotlib'
-    method = '!dbg'
+  [fv]
+    requirement = 'The system shall be able to perform gap heat transfer to couple conduction equations, on either side of the mortar interface, discretized with the finite volume method with'
+    [first_order]
+      type = PythonUnitTest
+      input = 'lm-spatial.py'
+      test_case = 'TestGapConductanceFirstOrder'
+      detail = 'first order accuracy'
+      required_python_packages = 'sympy pandas matplotlib'
+      method = '!dbg'
+      ad_indexing_type = 'global'
+    []
+    [second_order]
+      type = PythonUnitTest
+      input = 'lm-spatial.py'
+      test_case = 'TestGapConductanceSecondOrder'
+      detail = 'second order accuracy'
+      required_python_packages = 'sympy pandas matplotlib'
+      method = '!dbg'
+      ad_indexing_type = 'global'
+    []
   []
 []

--- a/test/tests/mortar/convergence-studies/fv-gap-conductance/tests
+++ b/test/tests/mortar/convergence-studies/fv-gap-conductance/tests
@@ -1,0 +1,12 @@
+[Tests]
+  design = 'Constraints/index.md'
+  issues = '#21599'
+  [p0p0]
+    type = PythonUnitTest
+    input = 'lm-spatial.py'
+    test_case = 'TestGapConductance'
+    requirement = 'The system shall be able to perform gap heat transfer to couple conduction equations, on either side of the mortar interface, discretized with the finite volume method.'
+    required_python_packages = 'sympy pandas matplotlib'
+    method = '!dbg'
+  []
+[]

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -103,6 +103,7 @@ TEST(MooseFunctorTest, testArgs)
   auto elem_from_face = ElemFromFaceArg({elem.get(), &fi, false, INVALID_BLOCK_ID});
   auto elem_qp = std::make_tuple(elem.get(), 0, &qrule);
   auto elem_side_qp = std::make_tuple(elem.get(), 0, 0, &qrule);
+  auto elem_point = ElemPointArg({elem.get(), Point(0), false});
 
   // Test not-implemented errors
   {
@@ -125,6 +126,7 @@ TEST(MooseFunctorTest, testArgs)
     test_dot(elem_from_face);
     test_dot(elem_qp);
     test_dot(elem_side_qp);
+    test_dot(elem_point);
 
     auto test_gradient = [&test](const auto & arg)
     {
@@ -145,6 +147,7 @@ TEST(MooseFunctorTest, testArgs)
     test_gradient(elem_from_face);
     test_gradient(elem_qp);
     test_gradient(elem_side_qp);
+    test_gradient(elem_point);
   }
 
   auto zero_gradient_test = [](const auto & functor, const auto & arg)
@@ -164,6 +167,7 @@ TEST(MooseFunctorTest, testArgs)
     EXPECT_EQ(cf(elem_from_face), 2);
     EXPECT_EQ(cf(elem_qp), 2);
     EXPECT_EQ(cf(elem_side_qp), 2);
+    EXPECT_EQ(cf(elem_point), 2);
 
     zero_gradient_test(cf, elem_arg);
     zero_gradient_test(cf, elem_from_face);
@@ -172,6 +176,7 @@ TEST(MooseFunctorTest, testArgs)
     zero_gradient_test(cf, elem_from_face);
     zero_gradient_test(cf, elem_qp);
     zero_gradient_test(cf, elem_side_qp);
+    zero_gradient_test(cf, elem_point);
 
     EXPECT_EQ(cf.dot(elem_arg), 0);
     EXPECT_EQ(cf.dot(elem_from_face), 0);
@@ -180,6 +185,7 @@ TEST(MooseFunctorTest, testArgs)
     EXPECT_EQ(cf.dot(elem_from_face), 0);
     EXPECT_EQ(cf.dot(elem_qp), 0);
     EXPECT_EQ(cf.dot(elem_side_qp), 0);
+    EXPECT_EQ(cf.dot(elem_point), 0);
   }
 
   const char * argv[2] = {"foo", "\0"};
@@ -228,6 +234,7 @@ TEST(MooseFunctorTest, testArgs)
     EXPECT_EQ(vec_comp(elem_from_face), 0);
     EXPECT_EQ(vec_comp(elem_qp), 0);
     EXPECT_EQ(vec_comp(elem_side_qp), 0);
+    EXPECT_EQ(vec_comp(elem_point), 0);
 
     bool found_internal = false;
     for (const auto & mesh_fi : all_fi)
@@ -277,15 +284,18 @@ TEST(MooseFunctorTest, testArgs)
     test_null_error(elem_from_face);
     test_null_error(elem_qp);
     test_null_error(elem_side_qp);
+    test_null_error(elem_point);
   }
 
   // Test PiecewiseByBlockLambdaFunctor
   {
     // Test subdomain error
     {
-      auto dummy_lammy = [](const auto &, const auto &) -> Real { return 0; };
+      auto dummy_lammy = [](const auto &, const auto &) -> Real { return 2; };
       PiecewiseByBlockLambdaFunctor<Real> errorful(
           "errorful", dummy_lammy, {EXEC_ALWAYS}, *mesh, {});
+      PiecewiseByBlockLambdaFunctor<Real> errorfree(
+          "errorfree", dummy_lammy, {EXEC_ALWAYS}, *mesh, mesh->meshSubdomains());
 
       auto test_sub_error = [&errorful](const auto & arg)
       {
@@ -309,6 +319,8 @@ TEST(MooseFunctorTest, testArgs)
       test_sub_error(elem_from_face);
       test_sub_error(elem_qp);
       test_sub_error(elem_side_qp);
+      test_sub_error(elem_point);
+      EXPECT_EQ(errorfree(elem_point), 2);
     }
 
     // Test functions

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -40,6 +40,7 @@ private:
   ValueType evaluate(const SingleSidedFaceArg &, unsigned int) const override final { return 0; }
   ValueType evaluate(const ElemQpArg &, unsigned int) const override final { return 0; }
   ValueType evaluate(const ElemSideQpArg &, unsigned int) const override final { return 0; }
+  ValueType evaluate(const ElemPointArg &, unsigned int) const override final { return 0; }
 };
 
 template <typename T>

--- a/unit/src/ParsedFunctionTest.C
+++ b/unit/src/ParsedFunctionTest.C
@@ -125,6 +125,17 @@ TEST_F(ParsedFunctionTest, basicConstructor)
   dot_traditional = f.timeDerivative(0, xyz[0]);
   dot_functor = f_wrapped.dot(elem_side_qp, 0);
   test_eq();
+
+  // Test elem_point overloads
+  const Point test_point(0.5, 0.5, 0.5);
+  const auto elem_point = Moose::ElemPointArg{elem, test_point, false};
+  f_traditional = f.value(0, test_point);
+  f_functor = f_wrapped(elem_point, 0);
+  gradient_traditional = f.gradient(0, test_point);
+  gradient_functor = f_wrapped.gradient(elem_point, 0);
+  dot_traditional = f.timeDerivative(0, test_point);
+  dot_functor = f_wrapped.dot(elem_point, 0);
+  test_eq();
 }
 
 TEST_F(ParsedFunctionTest, advancedConstructor)


### PR DESCRIPTION
To-do in follow-on PR
- Add production-level FV object for mortar-based gap heat transfer in heat conduction module

Refs #21599