### PR TITLE
Remove valgrind for ambient convection tests

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/tests
@@ -185,6 +185,7 @@
     issues = '#16948'
     ad_indexing_type = 'global'
     design = 'NSFVEnergyAmbientConvection.md'
+    valgrind = none
   []
   [ambient-convection-action]
     type = 'CSVDiff'
@@ -194,6 +195,7 @@
     issues = '#19472'
     ad_indexing_type = 'global'
     design = 'NSFVEnergyAmbientConvection.md'
+    valgrind = none
   []
   [triangles]
     requirement = 'The system shall be able to run incompressible Navier-Stokes channel-flow simulations with'


### PR DESCRIPTION
The action one is timing out on next. Heavy valgrind is already
an hour and a half. I don't think we need to run valgrind on
every test