### PR TITLE
Create the moose-seacas package

### DIFF
--- a/conda/seacas/LICENSE
+++ b/conda/seacas/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 1988-2017, National Technology & Engineering Solutions
+of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+NTESS, the U.S. Government retains certain rights in this software.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of NTESS nor the names of its contributors may
+      be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/conda/seacas/build.sh
+++ b/conda/seacas/build.sh
@@ -6,27 +6,26 @@ export INSTALL_PATH=${PREFIX}/seacas
 export BUILD=YES
 export GNU_PARALLEL=NO
 export H5VERSION=V112
+export JOBS=${MOOSE_JOBS:-2}
 
-# If on macOS, set COMPILER to clang and don't enable X11
+# If on macOS, set COMPILER to clang
 if [[ $(uname) == Darwin ]]; then
     export COMPILER=clang
-    X11_STR="-DTPL_ENABLE_X11=OFF"
 else
     export COMPILER=gcc
-    X11_STR="-DTPL_ENABLE_X11=ON"
 fi
 
 # Install third party libraries
 ./install-tpl.sh
 
-# Setup build location and configure there
+# Setup build location and configure there.
+# Disable X11 support, as xorg-libx11 is not adequate and causes build failures on macOS or Linux.
 mkdir build
 cd build
-../cmake-config $X11_STR
+../cmake-config -DTPL_ENABLE_X11=OFF
 
 # Make and install
-CORES=${MOOSE_JOBS:-2}
-make -j $CORES
+make -j $JOBS
 make install
 
 # Set a SEACAS_DIR environment variable for users who might need it, and add SEACAS bins to the PATH.

--- a/conda/seacas/build.sh
+++ b/conda/seacas/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eu
+
+# Configure and build options
+export INSTALL_PATH=${PREFIX}/seacas
+export BUILD=YES
+export GNU_PARALLEL=NO
+export H5VERSION=V112
+
+# If on macOS, set COMPILER to clang and don't enable X11
+if [[ $(uname) == Darwin ]]; then
+    export COMPILER=clang
+    X11_STR="-DTPL_ENABLE_X11=OFF"
+else
+    export COMPILER=gcc
+    X11_STR="-DTPL_ENABLE_X11=ON"
+fi
+
+# Install third party libraries
+./install-tpl.sh
+
+# Setup build location and configure there
+mkdir build
+cd build
+../cmake-config $X11_STR
+
+# Make and install
+CORES=${MOOSE_JOBS:-2}
+make -j $CORES
+make install
+
+# Set a SEACAS_DIR environment variable for users who might need it, and add SEACAS bins to the PATH.
+# Given SEACAS has its own HDF5, place the bin dir at the end of the PATH, to give priority to
+#   moose-mpich HDF5 bins if the user has both packages installed.
+mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
+cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+export SEACAS_DIR=${PREFIX}/seacas
+export PATH=\${PATH}:${PREFIX}/seacas/bin
+EOF
+cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+unset SEACAS_DIR
+export PATH=\${PATH%":${PREFIX}/seacas/bin"}
+EOF

--- a/conda/seacas/build.sh
+++ b/conda/seacas/build.sh
@@ -11,18 +11,21 @@ export JOBS=${MOOSE_JOBS:-2}
 # If on macOS, set COMPILER to clang
 if [[ $(uname) == Darwin ]]; then
     export COMPILER=clang
+    BUILD_LD_EXT=dylib
 else
     export COMPILER=gcc
+    BUILD_LD_EXT=so
 fi
 
 # Install third party libraries
 ./install-tpl.sh
 
 # Setup build location and configure there.
-# Disable X11 support, as xorg-libx11 is not adequate and causes build failures on macOS or Linux.
 mkdir build
 cd build
-../cmake-config -DTPL_ENABLE_X11=OFF
+../cmake-config \
+    -DTPL_X11_LIBRARIES=${BUILD_PREFIX}/lib/libX11.${BUILD_LD_EXT} \
+    -DTPL_X11_INCLUDE_DIRS=${BUILD_PREFIX}/include
 
 # Make and install
 make -j $JOBS

--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -1,0 +1,16 @@
+#### Darwin SDK SYSROOT
+CONDA_BUILD_SYSROOT:                                        # [osx]
+  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX11.3.sdk                                     # [arm64]
+
+macos_min_version:                                          # [osx]
+  - 10.12                                                   # [not arm64 and osx]
+  - 11.3                                                    # [arm64]
+
+macos_machine:                                              # [osx]
+  - x86_64-apple-darwin13.4.0                               # [not arm64 and osx]
+  - arm64-apple-darwin20.0.0                                # [arm64]
+
+MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
+  - 10.12                                                   # [not arm64 and osx]
+  - 11.3                                                    # [arm64]

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,0 +1,56 @@
+{% set build = "0" %}
+{% set seacas_version = "2022.05.16" %}
+{% set seacas_git_rev = "v2022-05-16" %}
+{% set strbuild = "build_" + build|string %}
+
+package:
+  name: moose-seacas
+  version: {{ seacas_version }}
+
+source:
+  git_url: https://github.com/sandialabs/seacas
+  git_rev: {{ seacas_git_rev }}
+  patches:
+    - use-curl-instead-of-wget.patch
+
+build:
+  number: {{ build }}
+  string: {{ strbuild }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - cmake
+    - make
+    - automake
+  run:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - python 3
+
+test:
+  commands:
+    - exodiff --version
+    - algebra
+    - explore
+    - grepos
+    - gjoin -v
+    - python $PREFIX/seacas/lib/tests/test_exodus3.py
+
+about:
+  home: https://github.com/sandialabs/seacas
+  license: BSD 3-clause
+  license_file: LICENSE
+  summary: >
+    The Sandia Engineering Analysis Code Access System (SEACAS) is a suite of
+    preprocessing, postprocessing, translation, and utility applications supporting
+    finite element analysis software using the Exodus database file format.
+
+extra:
+  recipe-maintainers:
+    - cticenhour
+    - milljm
+    - loganharbour

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
+    - xorg-libx11
     - cmake
     - make
     - automake
@@ -32,6 +33,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
+    - xorg-libx11
     - python 3
 
 test:
@@ -42,6 +44,7 @@ test:
     - grepos
     - gjoin -v
     - python $PREFIX/seacas/lib/tests/test_exodus3.py
+    - blot --help || test $? -eq 1
 
 about:
   home: https://github.com/sandialabs/seacas

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -16,6 +16,8 @@ source:
 build:
   number: {{ build }}
   string: {{ strbuild }}
+  script_env:
+    - MOOSE_JOBS
 
 requirements:
   build:

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,3 +1,4 @@
+# MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
 {% set seacas_version = "2022.05.16" %}
 {% set seacas_git_rev = "v2022-05-16" %}

--- a/conda/seacas/use-curl-instead-of-wget.patch
+++ b/conda/seacas/use-curl-instead-of-wget.patch
@@ -1,0 +1,21 @@
+diff --git a/install-tpl.sh b/install-tpl.sh
+index d4601be6a..8fbc554e5 100755
+--- a/install-tpl.sh
++++ b/install-tpl.sh
+@@ -215,7 +215,6 @@ fi
+ # Check that cmake, git, wget exist at the beginning instead of erroring out later on...
+ check_exec cmake
+ check_exec git
+-check_exec wget
+
+ if [ "$NEEDS_SZIP" == "YES" ]
+ then
+@@ -418,7 +417,7 @@ then
+         elif [ "${H5VERSION}" == "V110" ]; then
+             wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
+         elif [ "${H5VERSION}" == "V112" ]; then
+-            wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
++            curl --insecure -L -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
+         elif [ "${H5VERSION}" == "V113" ]; then
+             wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
+         elif [ "${H5VERSION}" == "develop" ]; then


### PR DESCRIPTION
## Reason
[SEACAS](https://github.com/sandialabs/seacas) was historically a part of our [old MOOSE package](https://github.com/idaholab/package_builder/blob/master/build_from_source/template/seacas-tools). While it generally saw light use, some members of the application teams have requested that it be restored.

## Design
A basic SEACAS installation, using most of the defaults (minus GNU parallel ~~and X11 support~~), should be available as part of a conda package named `moose-seacas`. It should ideally be interoperable and able to sit side-by-side with `moose-mpich/petsc/libmesh`. While SEACAS does build it's own copy of a serial HDF5, containing it within `$CONDA_PREFIX/seacas` and adding it to the `PATH` in such a way as to prioritize the HDF5 installation provided by `moose-mpich` should be sufficient for most user cases.

## Impact
This will add a new package for users who need Exodus manipulation options.
