### PR TITLE
Dont bypass threads during initial stateful computation

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -838,13 +838,7 @@ FEProblemBase::initialSetup()
                                        _bnd_material_props,
                                        _neighbor_material_props,
                                        _assembly);
-      /**
-       * The ComputeMaterialObjectThread object now allocates memory as needed for the material
-       * storage system.
-       * This cannot be done with threads. The first call to this object bypasses threading by
-       * calling the object directly. The subsequent call can be called with threads.
-       */
-      cmt(elem_range, true);
+      Threads::parallel_reduce(elem_range, cmt);
 
       if (_material_props.hasStatefulProperties() || _bnd_material_props.hasStatefulProperties() ||
           _neighbor_material_props.hasStatefulProperties())


### PR DESCRIPTION
Once upon a time it seems ComputeMaterialsObjectThread was not thread-safe but now it seems to be. In [idaholab/bison#3236](https://hpcgitlab.hpc.inl.gov/idaholab/bison/-/merge_requests/3236/) we were failing an initial aux variable exodiff because aux kernels running on thread ID 1 were retrieving porosity values that had not been initialized on thread ID 1 