### PR TITLE
Working on distributed merge for PolyCrystalUserObjectBase

### DIFF
--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -310,20 +310,7 @@ public:
 
     FeatureData duplicate() const { return FeatureData(*this); }
 
-#ifndef __INTEL_COMPILER
-    /**
-     * 2016-07-14
-     * The INTEL compiler we are currently using (2013 with GCC 4.8) appears to have a bug
-     * introduced by the addition of the Point member in this structure. Even though it supports
-     * move semantics on other non-POD types like libMesh::BoundingBox, it fails to compile this
-     * class with the "centroid" member. Specifically, it supports the move operation into the
-     * vector type but fails to work with the bracket operator on std::map and the std::sort
-     * algorithm used in this class. It does work with std::map::emplace() but that syntax is much
-     * less appealing and still doesn't work around the issue. For now, I'm allowing the copy
-     * constructor to be called where it shouldn't so that this class works under the Intel compiler
-     * but there may be a degradation in performance in that case. */
   private:
-#endif
     ///@{
     /**
      * We do not expect these objects to ever be copied. This is important since they are stored in

--- a/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
+++ b/modules/phase_field/include/userobjects/PolycrystalUserObjectBase.h
@@ -98,7 +98,10 @@ protected:
                                              FeatureData *& feature,
                                              Status & status,
                                              unsigned int & new_id) override;
+  virtual void prepareDataForTransfer() override;
   virtual void mergeSets() override;
+  virtual processor_id_type numberOfDistributedMergeHelpers() const override;
+  virtual void restoreOriginalDataStructures(std::vector<std::list<FeatureData>> & orig) override;
 
   /**
    * Builds a dense adjacency matrix based on the discovery of grain neighbors and halos
@@ -157,6 +160,9 @@ protected:
   static const unsigned int HALO_THICKNESS;
 
 private:
+  /// The number of chunks (for merging the features together)
+  processor_id_type _num_chunks;
+
   /// A vector indicating which op is assigned to each grain (by index of the grain)
   std::vector<unsigned int> _grain_idx_to_op;
 

--- a/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
+++ b/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
@@ -218,9 +218,9 @@ PolycrystalUserObjectBase::prepareDataForTransfer()
   _num_chunks = std::min(_app.n_processors(), total_items);
 
   /**
-   * Here we are resizing our datastructures that we normally size upon construction. This is too
+   * Here we are resizing our data structures that we normally size upon construction. This is to
    * support the parallel merge capability that's in the FeatureFloodCount class. We'll need to undo
-   * this latter, there are a few assumptions built on the sizes of these data structures.
+   * this later, there are a few assumptions built on the sizes of these data structures.
    *
    * See FeatureFloodCount::consolidateMergedFeatures for the "un-sizing" of these structures.
    */
@@ -288,7 +288,7 @@ void
 PolycrystalUserObjectBase::mergeSets()
 {
   // When working with _distribute_merge_work all of the maps will be empty except for one
-  for (MooseIndex(_maps_size) map_num = 0; map_num < _partial_feature_sets.size(); ++map_num)
+  for (const auto map_num : index_range(_partial_feature_sets))
   {
     /**
      * With initial conditions we know the grain IDs of every grain (even partial grains). We can

--- a/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
+++ b/modules/phase_field/src/userobjects/PolycrystalUserObjectBase.C
@@ -68,7 +68,8 @@ PolycrystalUserObjectBase::PolycrystalUserObjectBase(const InputParameters & par
     _op_num(_vars.size()),
     _coloring_algorithm(getParam<MooseEnum>("coloring_algorithm")),
     _colors_assigned(false),
-    _output_adjacency_matrix(getParam<bool>("output_adjacency_matrix"))
+    _output_adjacency_matrix(getParam<bool>("output_adjacency_matrix")),
+    _num_chunks(FeatureFloodCount::invalid_proc_id)
 {
   mooseAssert(_single_map_mode, "Do not turn off single_map_mode with this class");
 }
@@ -155,6 +156,92 @@ PolycrystalUserObjectBase::execute()
   }
 }
 
+processor_id_type
+PolycrystalUserObjectBase::numberOfDistributedMergeHelpers() const
+{
+  mooseAssert(_num_chunks != FeatureFloodCount::invalid_proc_id,
+              "prepareDataForTransfer() hasn't been called yet");
+
+  return _num_chunks;
+}
+
+void
+PolycrystalUserObjectBase::prepareDataForTransfer()
+{
+  FeatureFloodCount::prepareDataForTransfer();
+
+  /**
+   * With this class, all of the partial features are crammed into a single "outer" entry in our
+   * data structure because we don't know the variable assignments during the initial condition
+   * (that is the whole point of this class!). However, what we do know is _the_ feature number
+   * that each piece belongs to, which is even more useful for merging. However, with extensive
+   * testing on larger problems, even ordering optimally ordering these pieces is far too much
+   * work for a single core to process. In order create a scalable algorithm, we'll first order
+   * our data, then break it into complete chunks for several processors to work on concurrently.
+   *
+   * After sorting the data structure, it'll look something like this on some rank:
+   * _partial_feature_sets (showing the unique_id and fake variable number):
+   * 0     0 0 0 1 1 1 3 4 4 4 4 4 6 6 ...
+   *
+   * We may very well have gaps in our numbering. This is a local view on one rank.
+   * We'd like to transform the data into something like the following
+   * 0     0 0 0 1 1 1         <- First 3 items here (even when we don't have all features)
+   * 1     3 4 4 4 4 4         <- Next 3 items here
+   * 2     6 6 ...             <- Next 3 or remainder (linear partitioning)
+   *
+   * The way to break up this work is to simply break it into min(n_features, n_procs) chunks.
+   * e.g. If we have 70 features and 8 cores, we'll partition the work into 8 chunks. In the
+   * odd case where we have more processors than features (e.g. 100 processors merging 10 features),
+   * we'll use end up using a subset of the available cores.
+   *
+   * To get all this started we just need the number of features, but we don't normally know
+   * that until we've merged everything together... sigh... Wait! We can fall back on our
+   * sorted data structure though and figure out before we sort and merge. We'll need
+   * one more parallel communication, that won't hurt anything, right?!
+   */
+  _partial_feature_sets[0].sort();
+
+  // Get the largest ID seen on any rank
+  auto largest_id = _partial_feature_sets[0].back()._id;
+  _communicator.max(largest_id);
+  mooseAssert(largest_id != invalid_size_t, "Largest ID should not be invalid");
+
+  /**
+   * With this class there are no guarentees that our IDs have a contiguous zero-based numbering.
+   * However, for many of the common derived classes they do (generated grain structures).
+   * If we have holes in our numbering, we might not get an even partition, but it shouldn't break.
+   * We just need the best guess at a total number (before we can actually count) which should
+   * be bounded by the largest_id + 1.
+   */
+  auto total_items = largest_id + 1;
+
+  _num_chunks = std::min(_app.n_processors(), total_items);
+
+  /**
+   * Here we are resizing our datastructures that we normally size upon construction. This is too
+   * support the parallel merge capability that's in the FeatureFloodCount class. We'll need to undo
+   * this latter, there are a few assumptions built on the sizes of these data structures.
+   *
+   * See FeatureFloodCount::consolidateMergedFeatures for the "un-sizing" of these structures.
+   */
+  _partial_feature_sets.resize(_num_chunks);
+  _feature_counts_per_map.resize(_num_chunks);
+
+  for (auto it = _partial_feature_sets[0].begin(); it != _partial_feature_sets[0].end();
+       /* No increment on it*/)
+  {
+    auto chunk = MooseUtils::linearPartitionChunk(total_items, _num_chunks, it->_id);
+
+    if (chunk)
+    {
+      _partial_feature_sets[chunk].emplace_back(std::move(*it));
+      it = _partial_feature_sets[0].erase(it); // it is incremented here!
+    }
+    else
+      ++it;
+  }
+}
+
 void
 PolycrystalUserObjectBase::finalize()
 {
@@ -200,29 +287,47 @@ PolycrystalUserObjectBase::finalize()
 void
 PolycrystalUserObjectBase::mergeSets()
 {
-  /**
-   * With initial conditions we know the grain IDs of every grain (even partial grains). We can use
-   * this information to put all mergeable features adjacent to one and other in the list so that
-   * merging is simply O(n).
-   */
-  _partial_feature_sets[0].sort();
-
-  auto it1 = _partial_feature_sets[0].begin();
-  auto it_end = _partial_feature_sets[0].end();
-  while (it1 != it_end)
+  // When working with _distribute_merge_work all of the maps will be empty except for one
+  for (MooseIndex(_maps_size) map_num = 0; map_num < _partial_feature_sets.size(); ++map_num)
   {
-    auto it2 = it1;
-    if (++it2 == it_end)
-      break;
+    /**
+     * With initial conditions we know the grain IDs of every grain (even partial grains). We can
+     * use this information to put all mergeable features adjacent to one and other in the list so
+     * that merging is simply O(n).
+     */
+    _partial_feature_sets[map_num].sort();
 
-    if (areFeaturesMergeable(*it1, *it2))
+    auto it1 = _partial_feature_sets[map_num].begin();
+    auto it_end = _partial_feature_sets[map_num].end();
+    while (it1 != it_end)
     {
-      it1->merge(std::move(*it2));
-      _partial_feature_sets[0].erase(it2);
+      auto it2 = it1;
+      if (++it2 == it_end)
+        break;
+
+      if (areFeaturesMergeable(*it1, *it2))
+      {
+        it1->merge(std::move(*it2));
+        _partial_feature_sets[map_num].erase(it2);
+      }
+      else
+        ++it1; // Only increment if we have a mismatch
     }
-    else
-      ++it1; // Only increment if we have a mismatch
   }
+}
+
+void
+PolycrystalUserObjectBase::restoreOriginalDataStructures(std::vector<std::list<FeatureData>> & orig)
+{
+  // Move all the data back into the first list
+  auto & master_list = orig[0];
+  for (MooseIndex(_maps_size) map_num = 1; map_num < orig.size(); ++map_num)
+  {
+    master_list.splice(master_list.end(), orig[map_num]);
+    orig[map_num].clear();
+  }
+
+  orig.resize(1);
 }
 
 bool


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

The PolycrystalUserObjectBase class currently only supports serial merging. This is because we don't have several separate variable maps that make it trivial to parallelize. 

## Design
<!--A concise description (design) of the enhancement.-->

There is still a fairly easy way to partition the work since we can order partial feature discovery in a known way for the merge step (e.g. by feature ID). This requires some clever resizing of data structures and populating them with work and just linking back into existing `FeatureFloodCount` logic that can already parallelize the merge step. All of the work should be contained within the `communicateAndMerge` steps with some "unrolling and re-rolling" of the data to partition it among several ranks.


## Impact
<!--Will the enhancement change existing APIs or add something new?-->

This will greatly speedup (more than 10x) Polycrystal-type simulations ICs.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->

