### PR TITLE
Add python 3.10 to supported conda versions

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,11 +1,6 @@
 moose_mpich:
   - moose-mpich 4.0.2 build_0
 
-moose_python:
-  - python 3.9
-  - python 3.8
-  - python 3.7                                              # [not arm64]
-
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
   - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]

--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -1,4 +1,5 @@
 moose_python:
+  - python 3.10
   - python 3.9
   - python 3.8
   - python 3.7                                             # [not arm64]

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.06.23" %}
+{% set version = "2022.07.18" %}
 
 package:
   name: moose-peacock

--- a/conda/pyhit/conda_build_config.yaml
+++ b/conda/pyhit/conda_build_config.yaml
@@ -1,4 +1,5 @@
 moose_python:
+  - python 3.10
   - python 3.9
   - python 3.8
   - python 3.7                                              # [not arm64]

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.06.23" %}
+{% set version = "2022.07.18" %}
 
 package:
   name: moose-pyhit

--- a/conda/tools/conda_build_config.yaml
+++ b/conda/tools/conda_build_config.yaml
@@ -1,4 +1,5 @@
 moose_python:
+  - python 3.10
   - python 3.9
   - python 3.8
   - python 3.7                                             # [not arm64]

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   template/ (must contain any python major.minor version this
 #              package is building. Usually the latest version.)
 {% set build = 0 %}
-{% set version = "2022.06.16" %}
+{% set version = "2022.07.18" %}
 
 package:
   name: moose-tools


### PR DESCRIPTION
Also remove python versions from libmesh-vtk config, as python dependence is no longer required for that package

Closes #21695
