### PR TITLE
Block restrict homogenization integral

### DIFF
--- a/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
+++ b/modules/tensor_mechanics/src/actions/TensorMechanicsAction.C
@@ -495,6 +495,7 @@ TensorMechanicsAction::act()
       params.set<MultiMooseEnum>("constraint_types") = _constraint_types;
       params.set<std::vector<FunctionName>>("targets") = _targets;
       params.set<bool>("large_kinematics") = _lk_large_kinematics;
+      params.set<std::vector<SubdomainName>>("block") = _subdomain_names;
       params.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_LINEAR};
 
       _problem->addUserObject("HomogenizationConstraintIntegral", _integrator_name, params);

--- a/modules/tensor_mechanics/test/tests/lagrangian/action/homogenization_block.i
+++ b/modules/tensor_mechanics/test/tests/lagrangian/action/homogenization_block.i
@@ -1,0 +1,75 @@
+[Mesh]
+  use_displaced_mesh = false
+  [msh]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 4
+    ny = 4
+    nz = 4
+  []
+  [A]
+    type = SubdomainBoundingBoxGenerator
+    input = msh
+    bottom_left = '0 0 0'
+    top_right = '1 1 1'
+    block_id = 0
+    block_name = A
+  []
+  [B]
+    type = SubdomainBoundingBoxGenerator
+    input = A
+    bottom_left = '0 0 0'
+    top_right = '0.25 0.25 0.5'
+    block_id = 1
+    block_name = B
+  []
+[]
+
+[Variables]
+  [x]
+    block = 'B'
+  []
+[]
+
+[Modules]
+  [TensorMechanics]
+    [Master]
+      displacements = 'disp_x disp_y disp_z'
+      [all]
+        displacements = 'disp_x disp_y disp_z'
+        strain = FINITE
+        add_variables = true
+        new_system = true
+        formulation = TOTAL
+        volumetric_locking_correction = true
+        block = 'A'
+        constraint_types = 'stress strain strain stress stress strain stress stress strain'
+        targets = '0 0 0 0 0 0 0 0 0'
+      []
+    []
+  []
+[]
+
+[Materials]
+  [stress]
+    type = ComputeLagrangianLinearElasticStress
+    block = 'A'
+  []
+  [C1]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 2e5
+    poissons_ratio = 0.3
+    block = 'A'
+  []
+[]
+
+[Kernels]
+  [blah]
+    type = NullKernel
+    variable = x
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/modules/tensor_mechanics/test/tests/lagrangian/action/tests
+++ b/modules/tensor_mechanics/test/tests/lagrangian/action/tests
@@ -1,6 +1,6 @@
 [Tests]
-  issues = '#20281'
   [./without_correction]
+    issues = '#20281'
     type = RunApp
     input = 'simple_test.i'
     design = 'source/actions/TensorMechanicsAction.md'
@@ -8,11 +8,19 @@
     cli_args = "Modules/TensorMechanics/Master/all/volumetric_locking_correction=false"
   [../]
   [./with_correction]
+    issues = '#20281'
     type = RunException
     input = 'simple_test.i'
     design = 'source/actions/TensorMechanicsAction.md'
     requirement = "Cannot run second order problem with stabilization"
     cli_args = "Modules/TensorMechanics/Master/all/volumetric_locking_correction=true"
     expect_err = "Volumetric locking correction should not be used for higher-order elements."
+  [../]
+  [./homogenization_block_restriction]
+    issues = '#21716'
+    type = RunApp
+    input = 'homogenization_block.i'
+    design = 'source/actions/TensorMechanicsAction.md'
+    requirement = "Homogenization system can be block restricted"
   [../]
 []


### PR DESCRIPTION
Block restrict the homogenization user object to correctly restrict the entire system the specified blocks the user provides as part of the TensorMechanicsAction.

closes #21716
