### PR TITLE
Lagrangian kernels can mix small strain models

### DIFF
--- a/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
+++ b/modules/tensor_mechanics/src/materials/ComputeLinearElasticStress.C
@@ -29,7 +29,12 @@ ComputeLinearElasticStress::ComputeLinearElasticStress(const InputParameters & p
 void
 ComputeLinearElasticStress::initialSetup()
 {
-  if (hasBlockMaterialProperty<RankTwoTensor>(_base_name + "strain_increment"))
+  // _base_name + "unstabilized_deformation_gradient" is only declared if we're
+  // using the Lagrangian kernels.  It's okay to invoke this small strain
+  // material if you are using that kernel system and the
+  // ComputeLagrangianWrappedStress wrapper
+  if (hasBlockMaterialProperty<RankTwoTensor>(_base_name + "strain_increment") &&
+      !hasBlockMaterialProperty<RankTwoTensor>(_base_name + "unstabilized_deformation_gradient"))
     mooseError("This linear elastic stress calculation only works for small strains; use "
                "ComputeFiniteStrainElasticStress for simulations using incremental and finite "
                "strains.");

--- a/modules/tensor_mechanics/test/tests/lagrangian/materials/kinematic_check/strain_check.i
+++ b/modules/tensor_mechanics/test/tests/lagrangian/materials/kinematic_check/strain_check.i
@@ -1,0 +1,115 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 3
+  ny = 3
+  nz = 3
+  elem_type = HEX8
+[]
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+  large_kinematics = true
+[]
+
+[Modules/TensorMechanics/Master]
+  [all]
+    new_system = true
+    formulation = TOTAL
+    strain = FINITE
+    add_variables = true
+    generate_output = 'cauchy_stress_xx cauchy_stress_yy cauchy_stress_zz cauchy_stress_xy'
+  []
+[]
+
+[Functions]
+  [tdisp]
+    type = ParsedFunction
+    value = '0.5 * t'
+  []
+  [tdisp_quer]
+    type = ParsedFunction
+    value = '0.5 * y * t'
+  []
+[]
+
+[BCs]
+  [bottom_y]
+    type = DirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0
+  []
+  [bottom_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = bottom
+    value = 0
+  []
+  [bottom_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = bottom
+    value = 0
+  []
+  [left_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0
+  []
+  [right_x]
+    type = DirichletBC
+    variable = disp_x
+    boundary = right
+    value = 0
+  []
+  [front_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = front
+    value = 0
+  []
+  [back_z]
+    type = DirichletBC
+    variable = disp_z
+    boundary = back
+    value = 0
+  []
+  [tdisp]
+    type = FunctionDirichletBC
+    variable = disp_y
+    boundary = top
+    function = tdisp
+  []
+[]
+
+[Materials]
+  [elasticity]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 30
+    poissons_ratio = 0.4
+  []
+  [stress]
+    type = ComputeLagrangianWrappedStress
+  []
+  [stress_base]
+    type = ComputeLinearElasticStress
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+    petsc_options_iname = '-pc_type'
+    petsc_options_value = 'lu'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = Newton
+  end_time = 1
+  dt = 0.25
+[]

--- a/modules/tensor_mechanics/test/tests/lagrangian/materials/kinematic_check/tests
+++ b/modules/tensor_mechanics/test/tests/lagrangian/materials/kinematic_check/tests
@@ -1,0 +1,9 @@
+[Tests]
+  issues = '#21720'
+  design = 'source/materials/lagrangian/ComputeLagrangianWrappedStress.md'
+  [./runs_with_small_strain_model]
+    type = RunApp
+    input = 'strain_check.i'
+    requirement = "The Lagrangian kernels can use a small strain elastic update with a large kinematics formulation"
+  [../]
+[]


### PR DESCRIPTION
The Lagrangian kernels can use small deformation material models in conjunction with large deformation kinematics using the ComputeLagrangianWrappedStress object.  Currently, ComputeLinearElasticStress throws an error and doesn't allow the kernel to use it in a large deformation context.

This suppresses that error when using the Lagrangian kernels.

closes #21720