### PR TITLE
Remove 2022 summer workshop announcement from website homepage

### DIFF
--- a/modules/doc/content/upcoming_training.md
+++ b/modules/doc/content/upcoming_training.md
@@ -1,11 +1,9 @@
-!alert! note title=Upcoming Training prefix=False center-title=True
+<!-- !alert! note title=Upcoming Training prefix=False center-title=True -->
 
-!style! halign=center style=font-size:110%;font-weight:200;margin-bottom:10px
+<!-- !style! halign=center style=font-size:110%;font-weight:200;margin-bottom:10px -->
 
-Idaho National Laboratory (INL) will be hosting a MOOSE workshop June 6th and 7th, 2022 from 8:30 a.m. to 4:30 p.m MT in Idaho Falls, ID. The workshop will be offered both in-person and virtually. Attendance to the workshop is free of charge, but you must register by filling out the Google form at [bit.ly/3rVLuNL](https://bit.ly/3rVLuNL).
+<!-- remove all comments, and place training information below this line -->
 
-For questions regarding the training, please contact Cody Permann (cody.permann@inl.gov).
+<!-- !style-end! -->
 
-!style-end!
-
-!alert-end!
+<!-- !alert-end! -->


### PR DESCRIPTION
remove training no longer relevant.
