### PR TITLE
Have SideIntegralVariablePostprocessor use Guillaume's new API

### DIFF
--- a/framework/include/postprocessors/SideDiffusiveFluxIntegral.h
+++ b/framework/include/postprocessors/SideDiffusiveFluxIntegral.h
@@ -32,10 +32,11 @@ public:
   SideDiffusiveFluxIntegralTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpIntegral() override;
+  Real computeQpIntegral() override;
+  Real computeFaceInfoIntegral(const FaceInfo * fi) override;
 
-  MaterialPropertyName _diffusivity;
-  const GenericMaterialProperty<T, is_ad> & _diffusion_coef;
+  const GenericMaterialProperty<T, is_ad> * const _diffusion_coef;
+  const Moose::Functor<Moose::GenericType<T, is_ad>> * const _functor_diffusion_coef;
 
 private:
   /// Routine to get the diffusive flux with a Real diffusivity

--- a/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
+++ b/framework/include/postprocessors/SideIntegralVariablePostprocessor.h
@@ -27,7 +27,8 @@ public:
   SideIntegralVariablePostprocessor(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpIntegral() override;
+  Real computeQpIntegral() override;
+  Real computeFaceInfoIntegral(const FaceInfo * fi) override;
 
   /// Holds the solution at current quadrature points
   const VariableValue & _u;

--- a/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
@@ -12,9 +12,6 @@
 
 #include "metaphysicl/raw_type.h"
 
-using namespace Moose;
-using namespace FV;
-
 registerMooseObject("MooseApp", SideDiffusiveFluxIntegral);
 registerMooseObject("MooseApp", ADSideDiffusiveFluxIntegral);
 registerMooseObject("MooseApp", SideVectorDiffusivityFluxIntegral);
@@ -54,7 +51,7 @@ SideDiffusiveFluxIntegralTempl<is_ad, T>::SideDiffusiveFluxIntegralTempl(
                         ? &getGenericMaterialProperty<T, is_ad>("diffusivity")
                         : nullptr),
     _functor_diffusion_coef(isParamValid("functor_diffusivity")
-                                ? &getFunctor<GenericType<T, is_ad>>("functor_diffusivity")
+                                ? &getFunctor<Moose::GenericType<T, is_ad>>("functor_diffusivity")
                                 : nullptr)
 {
   if (_fv && !isParamValid("functor_diffusivity"))
@@ -69,14 +66,15 @@ Real
 SideDiffusiveFluxIntegralTempl<is_ad, T>::computeFaceInfoIntegral(const FaceInfo * const fi)
 {
   // Get the gradient of the variable on the face
-  const auto grad_u = MetaPhysicL::raw_value(
-      _fv_variable->gradient(makeCDFace(*fi, faceArgSubdomains(*_fv_variable, *fi))));
+  const auto grad_u = MetaPhysicL::raw_value(_fv_variable->gradient(
+      Moose::FV::makeCDFace(*fi, Moose::FV::faceArgSubdomains(*_fv_variable, *fi))));
   ;
 
   // FIXME Get the diffusion coefficient on the face, see #16809
-  return -diffusivityGradientProduct(grad_u,
-                                     MetaPhysicL::raw_value((*_functor_diffusion_coef)(makeCDFace(
-                                         *fi, faceArgSubdomains(*_functor_diffusion_coef, *fi))))) *
+  return -diffusivityGradientProduct(
+             grad_u,
+             MetaPhysicL::raw_value((*_functor_diffusion_coef)(Moose::FV::makeCDFace(
+                 *fi, Moose::FV::faceArgSubdomains(*_functor_diffusion_coef, *fi))))) *
          (_fv_variable->hasBlocks(fi->elemSubdomainID()) ? fi->normal() : Point(-fi->normal()));
 }
 

--- a/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
@@ -8,8 +8,12 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SideDiffusiveFluxIntegral.h"
+#include "MathFVUtils.h"
 
 #include "metaphysicl/raw_type.h"
+
+using namespace Moose;
+using namespace FV;
 
 registerMooseObject("MooseApp", SideDiffusiveFluxIntegral);
 registerMooseObject("MooseApp", ADSideDiffusiveFluxIntegral);
@@ -29,9 +33,14 @@ InputParameters
 SideDiffusiveFluxIntegralTempl<is_ad, T>::validParams()
 {
   InputParameters params = SideIntegralVariablePostprocessor::validParams();
-  params.addRequiredParam<MaterialPropertyName>(
+  params.addParam<MaterialPropertyName>(
       "diffusivity",
-      "The name of the diffusivity material property that will be used in the flux computation.");
+      "The name of the diffusivity material property that will be used in the flux computation. "
+      "This must be provided if the variable is of finite element type");
+  params.addParam<MooseFunctorName>(
+      "functor_diffusivity",
+      "The name of the diffusivity functor that will be used in the flux computation. This must be "
+      "provided if the variable is of finite volume type");
   params.addClassDescription(
       "Computes the integral of the diffusive flux over the specified boundary");
   return params;
@@ -41,31 +50,43 @@ template <bool is_ad, typename T>
 SideDiffusiveFluxIntegralTempl<is_ad, T>::SideDiffusiveFluxIntegralTempl(
     const InputParameters & parameters)
   : SideIntegralVariablePostprocessor(parameters),
-    _diffusivity(getParam<MaterialPropertyName>("diffusivity")),
-    _diffusion_coef(getGenericMaterialProperty<T, is_ad>(_diffusivity))
+    _diffusion_coef(isParamValid("diffusivity")
+                        ? &getGenericMaterialProperty<T, is_ad>("diffusivity")
+                        : nullptr),
+    _functor_diffusion_coef(isParamValid("functor_diffusivity")
+                                ? &getFunctor<GenericType<T, is_ad>>("functor_diffusivity")
+                                : nullptr)
 {
+  if (_fv && !isParamValid("functor_diffusivity"))
+    mooseError(
+        "For a finite volume variable, the parameter 'functor_diffusivity' must be provided");
+  if (!_fv && !isParamValid("diffusivity"))
+    mooseError("For a finite element variable, the parameter 'diffusivity' must be provided");
+}
+
+template <bool is_ad, typename T>
+Real
+SideDiffusiveFluxIntegralTempl<is_ad, T>::computeFaceInfoIntegral(const FaceInfo * const fi)
+{
+  // Get the gradient of the variable on the face
+  const auto grad_u = MetaPhysicL::raw_value(
+      _fv_variable->gradient(makeCDFace(*fi, faceArgSubdomains(*_fv_variable, *fi))));
+  ;
+
+  // FIXME Get the diffusion coefficient on the face, see #16809
+  return -diffusivityGradientProduct(grad_u,
+                                     MetaPhysicL::raw_value((*_functor_diffusion_coef)(makeCDFace(
+                                         *fi, faceArgSubdomains(*_functor_diffusion_coef, *fi))))) *
+         (_fv_variable->hasBlocks(fi->elemSubdomainID()) ? fi->normal() : Point(-fi->normal()));
 }
 
 template <bool is_ad, typename T>
 Real
 SideDiffusiveFluxIntegralTempl<is_ad, T>::computeQpIntegral()
 {
-  if (_fv)
-  {
-    // Get the face info
-    const FaceInfo * const fi = _mesh.faceInfo(_current_elem, _current_side);
-    mooseAssert(fi, "We should have a face info");
-
-    // Get the gradient of the variable on the face
-    const auto & grad_u = MetaPhysicL::raw_value(_fv_variable->adGradSln(*fi));
-
-    // FIXME Get the diffusion coefficient on the face, see #16809
-    return -diffusivityGradientProduct(grad_u, MetaPhysicL::raw_value(_diffusion_coef[_qp])) *
-           _normals[_qp];
-  }
-  else
-    return -diffusivityGradientProduct(_grad_u[_qp], MetaPhysicL::raw_value(_diffusion_coef[_qp])) *
-           _normals[_qp];
+  return -diffusivityGradientProduct(_grad_u[_qp],
+                                     MetaPhysicL::raw_value((*_diffusion_coef)[_qp])) *
+         _normals[_qp];
 }
 
 template <bool is_ad, typename T>

--- a/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
+++ b/framework/src/postprocessors/SideDiffusiveFluxIntegral.C
@@ -68,14 +68,12 @@ SideDiffusiveFluxIntegralTempl<is_ad, T>::computeFaceInfoIntegral(const FaceInfo
   // Get the gradient of the variable on the face
   const auto grad_u = MetaPhysicL::raw_value(_fv_variable->gradient(
       Moose::FV::makeCDFace(*fi, Moose::FV::faceArgSubdomains(*_fv_variable, *fi))));
-  ;
 
-  // FIXME Get the diffusion coefficient on the face, see #16809
   return -diffusivityGradientProduct(
              grad_u,
              MetaPhysicL::raw_value((*_functor_diffusion_coef)(Moose::FV::makeCDFace(
                  *fi, Moose::FV::faceArgSubdomains(*_functor_diffusion_coef, *fi))))) *
-         (_fv_variable->hasBlocks(fi->elemSubdomainID()) ? fi->normal() : Point(-fi->normal()));
+         _normals[_qp];
 }
 
 template <bool is_ad, typename T>

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -36,17 +36,18 @@ SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(
     _fv(_fv_variable)
 {
   addMooseVariableDependency(&mooseVariableField());
+
+  _qp_integration = !_fv;
+}
+
+Real
+SideIntegralVariablePostprocessor::computeFaceInfoIntegral(const FaceInfo * const fi)
+{
+  return MetaPhysicL::raw_value(_fv_variable->getBoundaryFaceValue(*fi));
 }
 
 Real
 SideIntegralVariablePostprocessor::computeQpIntegral()
 {
-  if (_fv)
-  {
-    const FaceInfo * const fi = _mesh.faceInfo(_current_elem, _current_side);
-    mooseAssert(fi, "We should have an fi");
-    return MetaPhysicL::raw_value(_fv_variable->getBoundaryFaceValue(*fi));
-  }
-  else
-    return _u[_qp];
+  return _u[_qp];
 }

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -8,8 +8,12 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SideIntegralVariablePostprocessor.h"
+#include "MathFVUtils.h"
 
 #include "metaphysicl/raw_type.h"
+
+using namespace Moose;
+using namespace FV;
 
 registerMooseObject("MooseApp", SideIntegralVariablePostprocessor);
 
@@ -43,7 +47,8 @@ SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(
 Real
 SideIntegralVariablePostprocessor::computeFaceInfoIntegral(const FaceInfo * const fi)
 {
-  return MetaPhysicL::raw_value(_fv_variable->getBoundaryFaceValue(*fi));
+  return MetaPhysicL::raw_value(
+      (*_fv_variable)(makeCDFace(*fi, faceArgSubdomains(*_fv_variable, *fi))));
 }
 
 Real

--- a/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
+++ b/framework/src/postprocessors/SideIntegralVariablePostprocessor.C
@@ -12,9 +12,6 @@
 
 #include "metaphysicl/raw_type.h"
 
-using namespace Moose;
-using namespace FV;
-
 registerMooseObject("MooseApp", SideIntegralVariablePostprocessor);
 
 InputParameters
@@ -47,8 +44,8 @@ SideIntegralVariablePostprocessor::SideIntegralVariablePostprocessor(
 Real
 SideIntegralVariablePostprocessor::computeFaceInfoIntegral(const FaceInfo * const fi)
 {
-  return MetaPhysicL::raw_value(
-      (*_fv_variable)(makeCDFace(*fi, faceArgSubdomains(*_fv_variable, *fi))));
+  return MetaPhysicL::raw_value((*_fv_variable)(
+      Moose::FV::makeCDFace(*fi, Moose::FV::faceArgSubdomains(*_fv_variable, *fi))));
 }
 
 Real

--- a/test/include/postprocessors/NonFunctorSideDiffusiveFluxIntegral.h
+++ b/test/include/postprocessors/NonFunctorSideDiffusiveFluxIntegral.h
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+// MOOSE includes
+#include "SideIntegralPostprocessor.h"
+#include "MooseVariableInterface.h"
+
+template <bool is_ad>
+class NonFunctorSideDiffusiveFluxIntegralTempl : public SideIntegralPostprocessor,
+                                                 public MooseVariableInterface<Real>
+{
+public:
+  static InputParameters validParams();
+
+  NonFunctorSideDiffusiveFluxIntegralTempl(const InputParameters & parameters);
+
+protected:
+  Real computeQpIntegral() override;
+
+  const VariableValue & _u;
+  const VariableGradient & _grad_u;
+  const bool _fv;
+
+  const GenericMaterialProperty<Real, is_ad> & _diffusion_coef;
+
+private:
+  /// Routine to get the diffusive flux with a Real diffusivity
+  RealVectorValue diffusivityGradientProduct(const RealVectorValue & grad_u, Real diffusivity);
+};
+
+typedef NonFunctorSideDiffusiveFluxIntegralTempl<false> NonFunctorSideDiffusiveFluxIntegral;
+typedef NonFunctorSideDiffusiveFluxIntegralTempl<true> ADNonFunctorSideDiffusiveFluxIntegral;

--- a/test/src/postprocessors/NonFunctorSideDiffusiveFluxIntegral.C
+++ b/test/src/postprocessors/NonFunctorSideDiffusiveFluxIntegral.C
@@ -1,0 +1,83 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "NonFunctorSideDiffusiveFluxIntegral.h"
+#include "MathFVUtils.h"
+
+#include "metaphysicl/raw_type.h"
+
+using namespace Moose;
+using namespace FV;
+
+registerMooseObject("MooseTestApp", NonFunctorSideDiffusiveFluxIntegral);
+registerMooseObject("MooseTestApp", ADNonFunctorSideDiffusiveFluxIntegral);
+
+template <bool is_ad>
+InputParameters
+NonFunctorSideDiffusiveFluxIntegralTempl<is_ad>::validParams()
+{
+  InputParameters params = SideIntegralPostprocessor::validParams();
+  params.addRequiredCoupledVar("variable",
+                               "The name of the variable which this postprocessor integrates");
+  params.addParam<MaterialPropertyName>(
+      "diffusivity",
+      "The name of the diffusivity material property that will be used in the flux computation. "
+      "This must be provided if the variable is of finite element type");
+  return params;
+}
+
+template <bool is_ad>
+NonFunctorSideDiffusiveFluxIntegralTempl<is_ad>::NonFunctorSideDiffusiveFluxIntegralTempl(
+    const InputParameters & parameters)
+  : SideIntegralPostprocessor(parameters),
+    MooseVariableInterface<Real>(this,
+                                 false,
+                                 "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
+    _u(coupledValue("variable")),
+    _grad_u(coupledGradient("variable")),
+    _fv(_fv_variable),
+    _diffusion_coef(getGenericMaterialProperty<Real, is_ad>("diffusivity"))
+{
+  addMooseVariableDependency(&mooseVariableField());
+}
+
+template <bool is_ad>
+Real
+NonFunctorSideDiffusiveFluxIntegralTempl<is_ad>::computeQpIntegral()
+{
+  if (_fv)
+  {
+    // Get the face info
+    const FaceInfo * const fi = _mesh.faceInfo(_current_elem, _current_side);
+    mooseAssert(fi, "We should have a face info");
+
+    // Get the gradient of the variable on the face
+    const auto & grad_u = MetaPhysicL::raw_value(_fv_variable->adGradSln(*fi));
+
+    // FIXME Get the diffusion coefficient on the face, see #16809
+    return -diffusivityGradientProduct(grad_u, MetaPhysicL::raw_value(_diffusion_coef[_qp])) *
+           _normals[_qp];
+  }
+  else
+    return -diffusivityGradientProduct(_grad_u[_qp], MetaPhysicL::raw_value(_diffusion_coef[_qp])) *
+           _normals[_qp];
+}
+
+template <bool is_ad>
+RealVectorValue
+NonFunctorSideDiffusiveFluxIntegralTempl<is_ad>::diffusivityGradientProduct(
+    const RealVectorValue & grad_u, const Real diffusivity)
+{
+  return grad_u * diffusivity;
+}
+
+template class NonFunctorSideDiffusiveFluxIntegralTempl<false>;
+template class NonFunctorSideDiffusiveFluxIntegralTempl<true>;

--- a/test/tests/materials/piecewise_by_block_material/test.i
+++ b/test/tests/materials/piecewise_by_block_material/test.i
@@ -70,7 +70,7 @@
 [Postprocessors]
   # to trigger on boundary element computations
   [flux]
-    type = ADSideDiffusiveFluxIntegral
+    type = ADNonFunctorSideDiffusiveFluxIntegral
     boundary = left
     variable = v
     diffusivity = 'coeff'

--- a/test/tests/postprocessors/side_diffusive_flux_average/side_diffusive_flux_average_fv.i
+++ b/test/tests/postprocessors/side_diffusive_flux_average/side_diffusive_flux_average_fv.i
@@ -6,60 +6,52 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = CONSTANT
     family = MONOMIAL
     fv = true
-  [../]
+  []
 []
 
 [FVKernels]
-  [./diff]
+  [diff]
     type = FVDiffusion
     variable = u
     coeff = 1
-  [../]
+  []
 []
 
 [FVBCs]
-  [./left]
+  [left]
     type = FVDirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = FVDirichletBC
     variable = u
     boundary = right
     value = 1
-  [../]
+  []
 []
 
 [Materials]
-  [./mat_props]
-    type = GenericConstantMaterial
-    block = 0
-    prop_names = diffusivity
-    prop_values = 2
-  [../]
-
-  [./mat_props_bnd]
-    type = GenericConstantMaterial
-    boundary = right
+  [mat_props]
+    type = GenericFunctorMaterial
     prop_names = diffusivity
     prop_values = 1
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./avg_flux_right]
+  [avg_flux_right]
     # Computes flux integral on the boundary, which should be -1
     type = SideDiffusiveFluxAverage
     variable = u
     boundary = right
-    diffusivity = diffusivity
-  [../]
+    functor_diffusivity = diffusivity
+  []
 []
 
 [Executioner]

--- a/test/tests/postprocessors/side_diffusive_flux_integral/side_diffusive_flux_integral_fv.i
+++ b/test/tests/postprocessors/side_diffusive_flux_integral/side_diffusive_flux_integral_fv.i
@@ -6,74 +6,65 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = CONSTANT
     family = MONOMIAL
     fv = true
-  [../]
+  []
 []
 
 [FVKernels]
-  [./diff]
+  [diff]
     type = FVDiffusion
     variable = u
     coeff = 1
-  [../]
+  []
 []
 
 [FVBCs]
-  [./left]
+  [left]
     type = FVDirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = FVDirichletBC
     variable = u
     boundary = right
     value = 1
-  [../]
+  []
 []
 
 [Materials]
-  [./mat_props]
-    type = GenericConstantMaterial
-    block = 0
-    prop_names = diffusivity
-    prop_values = 2
-  [../]
-
-  [./mat_props_bnd]
-    type = GenericConstantMaterial
-    boundary = right
+  [mat_props]
+    type = GenericFunctorMaterial
     prop_names = diffusivity
     prop_values = 1
-  [../]
+  []
 
-  [./mat_props_vector]
-    type = GenericConstantVectorMaterial
-    boundary = 'right top'
+  [mat_props_vector]
+    type = GenericVectorFunctorMaterial
     prop_names = diffusivity_vec
     prop_values = '1 1.5 1'
-  [../]
+  []
 []
 
 [Postprocessors]
   inactive = 'avg_flux_top'
-  [./avg_flux_right]
+  [avg_flux_right]
     # Computes flux integral on the boundary, which should be -1
     type = SideDiffusiveFluxAverage
     variable = u
     boundary = right
-    diffusivity = diffusivity
-  [../]
-  [./avg_flux_top]
+    functor_diffusivity = diffusivity
+  []
+  [avg_flux_top]
     type = SideVectorDiffusivityFluxIntegral
     variable = u
     boundary = top
-    diffusivity = diffusivity_vec
-  [../]
+    functor_diffusivity = diffusivity_vec
+  []
 []
 
 [Executioner]

--- a/test/tests/postprocessors/side_diffusive_flux_integral/tests
+++ b/test/tests/postprocessors/side_diffusive_flux_integral/tests
@@ -32,7 +32,7 @@
       type = 'Exodiff'
       input = 'side_diffusive_flux_integral_fv.i'
       exodiff = 'side_diffusive_flux_integral_fv_vector.e'
-      cli_args = "Outputs/file_base=side_diffusive_flux_integral_fv_vector Postprocessors/avg_flux_right/type=SideVectorDiffusivityFluxIntegral Postprocessors/avg_flux_right/diffusivity=diffusivity_vec Postprocessors/inactive=''"
+      cli_args = "Outputs/file_base=side_diffusive_flux_integral_fv_vector Postprocessors/avg_flux_right/type=SideVectorDiffusivityFluxIntegral Postprocessors/avg_flux_right/functor_diffusivity=diffusivity_vec Postprocessors/inactive=''"
       ad_indexing_type = 'global'
       detail = 'with a vector diffusivity.'
     []


### PR DESCRIPTION
The getFaceInfos API in SideUserObject robustly gets the correct
face information regardless of whether `_current_elem` and `_current_side`
are the correct keys for retrieving the face information (e.g. the
neighbor and its corresponding side may be the correct key)

Refs #16585