### PR TITLE
Make GeneralizedPlaneStrain UO execute at nonlinear 

### DIFF
--- a/modules/tensor_mechanics/src/actions/GeneralizedPlaneStrainAction.C
+++ b/modules/tensor_mechanics/src/actions/GeneralizedPlaneStrainAction.C
@@ -147,8 +147,6 @@ GeneralizedPlaneStrainAction::act()
     if (parameters().isParamSetByUser("pressure_factor"))
       params.set<Real>("pressure_factor") = getParam<Real>("pressure_factor");
 
-    params.set<ExecFlagEnum>("execute_on") = EXEC_LINEAR;
-
     _problem->addUserObject(uo_type, uo_name, params);
   }
 

--- a/modules/tensor_mechanics/src/userobjects/GeneralizedPlaneStrainUserObject.C
+++ b/modules/tensor_mechanics/src/userobjects/GeneralizedPlaneStrainUserObject.C
@@ -49,7 +49,7 @@ GeneralizedPlaneStrainUserObject::validParams()
       "pressure_factor",
       "Scale factor applied to prescribed out-of-plane pressure (both material and function)");
   params.addParam<std::string>("base_name", "Material properties base name");
-  params.set<ExecFlagEnum>("execute_on") = EXEC_LINEAR;
+  params.set<ExecFlagEnum>("execute_on") = {EXEC_LINEAR, EXEC_NONLINEAR};
 
   return params;
 }


### PR DESCRIPTION
Jacobian_mult is obviously computed at NONLINEAR, e.g. in ComputeMultipleInelasticStress, so
there is a need to extend the execution of this UO now that we want it to use a Jacobian
tensor instead of just the elasticity tensor.

Closes #21780