### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -1,9 +1,9 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
-{% set build = 4 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.06.06" %}
+{% set version = "2022.08.05" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.06.06 build_4
+ - moose-libmesh 2022.08.05 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=4747096de5d6c69ed79f28e38ce45c76546364c3
+ARG LIBMESH_REV=fd99dadd91eb3f4155e7767613fc37ecf1bd75f3
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2022_08.md
+++ b/modules/doc/content/newsletter/2022_08.md
@@ -9,6 +9,40 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2022.08.05` Update
+- Support reading/writing extra node integers and extra element
+  integers in XDR and XDA files.
+- Support inverted 1D element orientations when reconstructing mesh
+  neighbors.
+- `--deny_re` command line option for unit test driver, to allow more
+  options for running subsets of the full unit test suite.
+- `Eigen` upgrade to 3.4.0; now via a git submodule to make future
+  upgrades easier and more efficient.
+- More internal use of smart pointers for memory management and
+  exception safety.
+- `MetaPhysicL` update to 1.4.0, fixing an intermittent bug in the test
+  suite
+- `TIMPI` update to 1.8.5, giving better compiler error messages for
+  certain user errors, more parallel unit testing, and warning fixes
+  for new compilers.
+- Additional features for `Poly2TriTriangulator`, including
+  triangulation of id-defined subsets of outer boundaries, and
+  verification of boundary non-intersection.
+- New `TriangulatorInterface::Hole::contains()` API
+- Improved `DistributedMesh` cached object count tracking when deleting
+  objects.
+- `BoundaryInfo::renumber_id()`, now supporting automatic handling of
+  id-to-name maps.
+- `SIDE_HIERARCHIC` finite-element space support for `TET14` geometric
+  elements.
+- New `MeshBase::reinit_ghosting_functors()` API
+- `reconnect_nodes()` API typedef, to enable forward compatibility
+  with future data structure changes.
+- Memory leak fix in `fparser`
+- Fixes for `Poly2TriTriangulator` use with `DistributedMesh`, and for
+  many corner cases
+- Fix `TET10` numbering with `TetgenIO`
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
- Support reading/writing extra node integers and extra element integers in XDR and XDA files.
- Support inverted 1D element orientations when reconstructing mesh neighbors.
- `--deny_re` command line option for unit test driver, to allow more options for running subsets of the full unit test suite.
- `Eigen` upgrade to 3.4.0; now via a git submodule to make future upgrades easier and more efficient.
- More internal use of smart pointers for memory management and exception safety.
- `MetaPhysicL` update to 1.4.0, fixing an intermittent bug in the test suite
- `TIMPI` update to 1.8.5, giving better compiler error messages for certain user errors, more parallel unit testing, and warning fixes for new compilers.
- Additional features for `Poly2TriTriangulator`, including triangulation of id-defined subsets of outer boundaries, and verification of boundary non-intersection.
- New `TriangulatorInterface::Hole::contains()` API
- Improved `DistributedMesh` cached object count tracking when deleting objects.
- `BoundaryInfo::renumber_id()`, now supporting automatic handling of id-to-name maps.
- `SIDE_HIERARCHIC` finite-element space support for `TET14` geometric elements.
- New `MeshBase::reinit_ghosting_functors()` API
- `reconnect_nodes()` API typedef, to enable forward compatibility with future data structure changes.
- Memory leak fix in `fparser`
- Fixes for `Poly2TriTriangulator` use with `DistributedMesh`, and for many corner cases
- Fix `TET10` numbering with `TetgenIO`
