### PR TITLE
Changed unused param check to default to Error instead of warning

### DIFF
--- a/examples/ex09_stateful_materials/ex09.i
+++ b/examples/ex09_stateful_materials/ex09.i
@@ -57,8 +57,6 @@
     variable = convected
     boundary = 'right'
     value = 1
-
-    some_var = diffused
   [../]
 
   [./left_diffused]

--- a/examples/ex15_actions/ex15.i
+++ b/examples/ex15_actions/ex15.i
@@ -37,8 +37,6 @@
     variable = convected
     boundary = 'right'
     value = 1
-
-    some_var = diffused
   [../]
 
   [./left_diffused]

--- a/examples/ex19_dampers/ex19.i
+++ b/examples/ex19_dampers/ex19.i
@@ -45,7 +45,6 @@
   # Use a constant damping parameter
   [./diffusion_damp]
     type = ConstantDamper
-    variable = diffusion
     damping = 0.9
   [../]
 []

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -354,7 +354,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _null_executor(NULL),
     _use_nonlinear(true),
     _use_eigen_value(false),
-    _enable_unused_check(WARN_UNUSED),
+    _enable_unused_check(ERROR_UNUSED),
     _factory(*this),
     _error_overridden(false),
     _ready_to_exit(false),
@@ -1184,16 +1184,7 @@ MooseApp::restore(std::shared_ptr<Backup> backup, bool for_restart)
 void
 MooseApp::setCheckUnusedFlag(bool warn_is_error)
 {
-  /**
-   * _enable_unused_check is initialized to WARN_UNUSED. If an application chooses to promote
-   * this value to ERROR_UNUSED programmatically prior to running the simulation, we certainly
-   * don't want to allow it to fall back. Therefore, we won't set it if it's already at the
-   * highest value (i.e. error). If however a developer turns it off, it can still be turned on.
-   */
-  if (_enable_unused_check != ERROR_UNUSED || warn_is_error)
-    _enable_unused_check = warn_is_error ? ERROR_UNUSED : WARN_UNUSED;
-  else
-    mooseInfo("Ignoring request to turn off or warn about unused parameters.\n");
+  _enable_unused_check = warn_is_error ? ERROR_UNUSED : WARN_UNUSED;
 }
 
 void

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1019,7 +1019,7 @@ class TestHarness:
         parser.add_argument('--error', action='store_true', help='Run the tests with warnings as errors (Pass "--error" to executable)')
         parser.add_argument('--error-unused', action='store_true', help='Run the tests with errors on unused parameters (Pass "--error-unused" to executable)')
         parser.add_argument('--error-deprecated', action='store_true', help='Run the tests with errors on deprecations')
-
+        parser.add_argument('--warn-unused',action='store_true', help='Run the tests without errors on unused parameters (Pass "--warn-unused" to executable)')
         # Option to use for passing unwrapped options to the executable
         parser.add_argument('--cli-args', nargs='?', type=str, dest='cli_args', help='Append the following list of arguments to the command line (Encapsulate the command in quotes)')
 

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -161,8 +161,11 @@ class RunApp(Tester):
         if '--error' not in cli_args and (not specs["allow_warnings"] or options.error):
             cli_args.append('--error')
 
-        if '--error-unused' not in cli_args and (not specs["allow_unused"] or options.error_unused):
+        if '--error-unused' not in cli_args and options.error_unused:
             cli_args.append('--error-unused')
+
+        if '--error-unused' not in cli_args and '--warn-unused' not in cli_args and (specs["allow_unused"] or options.warn_unused):
+            cli_args.append('--warn-unused')
 
         if '--error-override' not in cli_args and not specs["allow_override"]:
             cli_args.append('--error-override')

--- a/test/tests/fvkernels/mms/skewness-correction/adv-diff-react/skewed.i
+++ b/test/tests/fvkernels/mms/skewness-correction/adv-diff-react/skewed.i
@@ -14,8 +14,6 @@ diff=1.1
     initial_condition = 1
     type = MooseVariableFVReal
     face_interp_method = 'skewness-corrected'
-    cache_face_gradients = false
-    cache_face_values = true
   []
 []
 

--- a/test/tests/fvkernels/mms/skewness-correction/two_term_extrapol/advection-outflow.i
+++ b/test/tests/fvkernels/mms/skewness-correction/two_term_extrapol/advection-outflow.i
@@ -16,8 +16,6 @@ a=1
   [./v]
     type = MooseVariableFVReal
     face_interp_method = 'skewness-corrected'
-    cache_face_gradients = false
-    cache_face_values = true
   [../]
 []
 

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -640,23 +640,41 @@
   [../]
 
   [./unused_param_test]
+    type = 'RunException'
+    expect_err = "unused parameter 'Mesh/unused_param'"
+    input = 'unused_param_test.i'
+
+    requirement = 'The system shall report an error when an unused parameter is provided through the input file or an Action.'
+    issues = '#709 #759 #4101'
+  [../]
+
+  [./unused_param_test_cli]
+    type = 'RunException'
+    expect_err = "unused parameter 'Executioner/unused_param'"
+    input = 'unused_param_test.i'
+    cli_args = 'Executioner/unused_param=true'
+
+    requirement = 'The system shall report an error when an unused parameter is supplied on the command line.'
+    issues = '#709 #759 #4101'
+  [../]
+
+  [./unused_param_test_warn]
     type = 'RunApp'
     expect_out = "unused parameter 'Mesh/unused_param'"
     input = 'unused_param_test.i'
     allow_unused = true
 
-    requirement = 'The system shall report a warning when an unused parameter is provided through the input file or an Action.'
+    requirement = 'The system shall include the option to report a warning instead of an error for an unused parameter set in input.'
     issues = '#709 #759 #4101'
   [../]
-
-  [./unused_param_test_cli]
+  
+  [./unused_param_test_warn_cli]
     type = 'RunApp'
-    expect_out = "unused parameter 'Executioner/unused_param'"
+    expect_out = "unused parameter 'Mesh/unused_param'"
     input = 'unused_param_test.i'
-    cli_args = 'Executioner/unused_param=true'
-    allow_unused = true
+    cli_args = '--warn-unused'
 
-    requirement = 'The system shall report a warning when an unused parameter is supplied on the command line.'
+    requirement = 'The system shall include the option to report a warning instead of an error for an unused parameter set in command line arguments'
     issues = '#709 #759 #4101'
   [../]
 

--- a/test/tests/misc/jacobian/simple.i
+++ b/test/tests/misc/jacobian/simple.i
@@ -37,7 +37,6 @@
   [./diffu]
     type = WrongJacobianDiffusion
     variable = u
-    error = factor
     jfactor = 0.0
   [../]
   [./diffu2]


### PR DESCRIPTION
Remade onto new branch as rebases were not cooperating.

Closes #20567

Supersedes #20568 and #21291 