### PR TITLE
Enables libmesh preconditioner reuse capability

### DIFF
--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -430,7 +430,6 @@ in this example.
 
 There are two differences between
 `reuse_preconditioner` and 
-`reuse_preconditioner_max_linear_its`
 and setting up preconditioner reuse directly in PETSc with the 
 `snes_lag_preconditioner_persists` and `-snes_lag_preconditioner` options:
 1. `-snes_lag_preconditioner X` will recalculate a new preconditioner

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -368,7 +368,7 @@ expensive may be good candidates for computing the residual and Jacobian togethe
 
 ## Reusing preconditioners id=reuse_preconditioners
 
-The simple version of GRMES and other iterative methods converge only very
+The simple version of GMRES and other iterative methods converge only very
 slowly.  To improve convergence, PETSc and other iterative solver packages
 apply a [preconditioner](https://en.wikipedia.org/wiki/Preconditioner) to the
 system of equations/sparse matrix before applying the iterative solver.

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -431,7 +431,7 @@ in this example.
 There are two differences between
 `reuse_preconditioner` and 
 setting up preconditioner reuse directly in PETSc with the 
-`snes_lag_preconditioner_persists` and `-snes_lag_preconditioner` options:
+`-snes_lag_preconditioner_persists` and `-snes_lag_preconditioner` options:
 1. `-snes_lag_preconditioner X` will recalculate a new preconditioner
    every X linear iterations, regardless of the progress of the linear solve.
    `reuse_preconditioner_max_linear_its = X` will continue to reuse

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -430,7 +430,7 @@ in this example.
 
 There are two differences between
 `reuse_preconditioner` and 
-and setting up preconditioner reuse directly in PETSc with the 
+setting up preconditioner reuse directly in PETSc with the 
 `snes_lag_preconditioner_persists` and `-snes_lag_preconditioner` options:
 1. `-snes_lag_preconditioner X` will recalculate a new preconditioner
    every X linear iterations, regardless of the progress of the linear solve.

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -427,3 +427,44 @@ when the cost of solving the linearized system is a large fraction of
 the total simulation time.  As such, it can be especially beneficial
 when using an expensive preconditioner, like a direct solver, as shown
 in this example.
+
+There are two differences between
+`reuse_preconditioner` and 
+`reuse_preconditioner_max_linear_its`
+and setting up preconditioner reuse directly in PETSc with the 
+`snes_lag_preconditioner_persists` and `-snes_lag_preconditioner` options:
+1. `-snes_lag_preconditioner X` will recalculate a new preconditioner
+   every X linear iterations, regardless of the progress of the linear solve.
+   `reuse_preconditioner_max_linear_its = X` will continue to reuse
+   the same preconditioner until the number of linear iterations 
+   required to solve the linearized equations exceeds X.
+2. By default libmesh deletes the PETSc `SNES` instance after each time
+   step.  This means that regardless of how the reuse options are set,
+   the solver cannot retain the preconditioner across time steps.  The
+   `reuse_preconditioner` alters this behavior to retain the `SNES`
+   instance so that preconditioner reuse can be carried across time
+   steps.
+
+Preconditioner reuse is also different from modified Newton methods,
+which can be configured with the PETSc `-snes_lag_jacobian` and
+`-snes_lag_jacobian_persists` options.  Preconditioner reuse
+affects how PETSc solves the linearized system of equations formed
+at each nonlinear iteration.  Ideally, if the reused preconditioner
+achieves the requested `l_tol` precision before iterating more than
+`l_max_its` times, preconditioner reuse will not affect the
+convergence of the nonlinear iterations compared to a case with the 
+reuse option off.  As described above,
+preconditioner reuse aims to decrease the time required to solve
+the linearized equations at each nonlinear iteration by reducing the
+number of times the solver needs to setup the potentially-expensive
+linear preconditioner.
+
+By contrast, modified Newton methods will affect the nonlinear
+convergence of the system without affecting how PETSc solves the
+linearized system of equations.  The goal of 
+modified Newton methods is to reduce the time required to solve
+the nonlinear equations by forming a new Jacobian matrix less often.
+
+Put another way, preconditioner reuse aims to speed up solving the
+linear system of equations while modified Newton methods aim to 
+accelerate solving the nonlinear equations.

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -369,7 +369,7 @@ expensive may be good candidates for computing the residual and Jacobian togethe
 ## Reusing preconditioners id=reuse_preconditioners
 
 The simple version of GRMES and other iterative methods converge only very
-slowly.  To improve convergence PETSc and other iterative solver packages
+slowly.  To improve convergence, PETSc and other iterative solver packages
 apply a [preconditioner](https://en.wikipedia.org/wiki/Preconditioner) to the
 system of equations/sparse matrix before applying the iterative solver.
 
@@ -421,14 +421,10 @@ configure PETSc and MOOSE to solve the equations with this combination:
   nl_abs_tol = 1e-10
 ```
 
-This solver strategy can be very efficient when solving a problem on a 
-desktop or workstation computer (i.e. not on a cluster).  However, it
-is a heuristic -- the efficiency of the approach and the optimal value
-of `reuse_preconditioner_max_its` will vary greatly depending on the type of
-physics you are solving and on how quickly the structure of the problem
-changes from load step to load step.
-
-On larger machines reusing the AMG preconditioner provided by BoomerAMG
-may be a way to increase the efficiency of the overall simulation.  Again,
-this is a heuristic and the effectiveness of the approach and good values
-of `reuse_preconditioner_max_its` are going to vary.
+This solver strategy can be very effective when the system Jacobian
+does not change very much from nonlinear iteration to nonlinear iteration
+and/or from time step to time step.  The heuristic is also most effective
+when the cost of solving the linearized system is a large fraction of
+the total simulation time.  As such, it can be especially beneficial
+when using an expensive preconditioner, like a direct solver, as shown
+in this example.

--- a/framework/doc/content/source/systems/NonlinearSystem.md
+++ b/framework/doc/content/source/systems/NonlinearSystem.md
@@ -375,7 +375,8 @@ system of equations/sparse matrix before applying the iterative solver.
 
 A great number of preconditioners exist, but 
 [multigrid](https://en.wikipedia.org/wiki/Multigrid_method)
-methods are often among the best choices.  
+methods are often among the best choices for problems without 
+significant hyperbolic character.  
 The [HYPRE](application_development/hypre.md optional=true) package, 
 specifically the 
 BoomerAMG preconditioner, is often a good choice for a preconditioner to
@@ -395,13 +396,13 @@ Setting
 
 ```
   reuse_preconditioner = true
-  reuse_preconditioner_max_its = 20
+  reuse_preconditioner_max_linear_its = 20
 ```
 
 in the `[Executioner]` block will reuse the same preconditioner until
 the number of linear iterations required to solve the linearized system of
 equations exceeds 20.   If the number of linear iterations exceeds 
-`reuse_preconditioner_max_its`
+`reuse_preconditioner_max_linear_its`
 the system does not immediately stop iterating on the current linearized
 system.  Instead it will continue until it either successfully solves
 the current system or reaches `l_max_its`.  It will then form a new 
@@ -409,14 +410,14 @@ preconditioner for the next nonlinear iteration.
 
 Using these parameters in combination with a direct factorization of the
 system can be very efficient.  The following is an example of how to
-configure PETSc and MOOSE to solve the equations with this combination:
+direct PETSc and MOOSE to solve the equations with this combination:
 
 ```
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_package -ksp_type'
   petsc_options_value = 'lu superlu_dist gmres'
 
   reuse_preconditioner = true
-  reuse_preconditioner_max_its = 20
+  reuse_preconditioner_max_linear_its = 20
 ```
 
 This solver strategy can be very effective when the system Jacobian

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -130,8 +130,10 @@ FEProblemSolve::validParams()
                         false,
                         "If true reuse the previously calculated "
                         "preconditioner for the linearized "
-                        "system across multiple solvers, "
-                        "controlled by reuse_preconditioner_max_its");
+                        "system across multiple solves "
+                        "spanning nonlinear iterations and time steps. "
+                        "The preconditioner resets as controlled by "
+                        "reuse_preconditioner_max_its");
   params.addParam<unsigned int>("reuse_preconditioner_max_its",
                                 25,
                                 "Reuse the previously calculated "

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -133,8 +133,8 @@ FEProblemSolve::validParams()
                         "system across multiple solves "
                         "spanning nonlinear iterations and time steps. "
                         "The preconditioner resets as controlled by "
-                        "reuse_preconditioner_max_its");
-  params.addParam<unsigned int>("reuse_preconditioner_max_its",
+                        "reuse_preconditioner_max_linear_its");
+  params.addParam<unsigned int>("reuse_preconditioner_max_linear_its",
                                 25,
                                 "Reuse the previously calculated "
                                 "preconditioner for the linear system "
@@ -146,7 +146,7 @@ FEProblemSolve::validParams()
                               "snesmf_reuse_base compute_initial_residual_before_preset_bcs "
                               "num_grids nl_div_tol nl_abs_div_tol residual_and_jacobian_together "
                               "n_max_nonlinear_pingpong reuse_preconditioner "
-                              "reuse_preconditioner_max_its",
+                              "reuse_preconditioner_max_linear_its",
                               "Solver");
   params.addParamNamesToGroup(
       "automatic_scaling compute_scaling_once off_diagonals_in_auto_scaling "
@@ -201,8 +201,8 @@ FEProblemSolve::FEProblemSolve(Executioner & ex)
 
   es.parameters.set<bool>("reuse preconditioner") = getParam<bool>("reuse_preconditioner");
 
-  es.parameters.set<unsigned int>("reuse preconditioner maximum iterations") =
-      getParam<unsigned int>("reuse_preconditioner_max_its");
+  es.parameters.set<unsigned int>("reuse preconditioner maximum linear iterations") =
+      getParam<unsigned int>("reuse_preconditioner_max_linear_its");
 
   _nl._compute_initial_residual_before_preset_bcs =
       getParam<bool>("compute_initial_residual_before_preset_bcs");

--- a/framework/src/executioners/FEProblemSolve.C
+++ b/framework/src/executioners/FEProblemSolve.C
@@ -126,11 +126,25 @@ FEProblemSolve::validParams()
                         false,
                         "Whether to compute the residual and Jacobian together.");
 
+  params.addParam<bool>("reuse_preconditioner",
+                        false,
+                        "If true reuse the previously calculated "
+                        "preconditioner for the linearized "
+                        "system across multiple solvers, "
+                        "controlled by reuse_preconditioner_max_its");
+  params.addParam<unsigned int>("reuse_preconditioner_max_its",
+                                25,
+                                "Reuse the previously calculated "
+                                "preconditioner for the linear system "
+                                "until the number of linear iterations "
+                                "exceeds this number");
+
   params.addParamNamesToGroup("solve_type l_tol l_abs_tol l_max_its nl_max_its nl_max_funcs "
                               "nl_abs_tol nl_rel_tol nl_abs_step_tol nl_rel_step_tol "
                               "snesmf_reuse_base compute_initial_residual_before_preset_bcs "
                               "num_grids nl_div_tol nl_abs_div_tol residual_and_jacobian_together "
-                              "n_max_nonlinear_pingpong",
+                              "n_max_nonlinear_pingpong reuse_preconditioner "
+                              "reuse_preconditioner_max_its",
                               "Solver");
   params.addParamNamesToGroup(
       "automatic_scaling compute_scaling_once off_diagonals_in_auto_scaling "
@@ -182,6 +196,11 @@ FEProblemSolve::FEProblemSolve(Executioner & ex)
 
   es.parameters.set<Real>("nonlinear solver relative step tolerance") =
       getParam<Real>("nl_rel_step_tol");
+
+  es.parameters.set<bool>("reuse preconditioner") = getParam<bool>("reuse_preconditioner");
+
+  es.parameters.set<unsigned int>("reuse preconditioner maximum iterations") =
+      getParam<unsigned int>("reuse_preconditioner_max_its");
 
   _nl._compute_initial_residual_before_preset_bcs =
       getParam<bool>("compute_initial_residual_before_preset_bcs");

--- a/modules/tensor_mechanics/test/tests/preconditioner_reuse/convergence.i
+++ b/modules/tensor_mechanics/test/tests/preconditioner_reuse/convergence.i
@@ -139,7 +139,7 @@
   l_max_its = 100
 
   reuse_preconditioner = false
-  reuse_preconditioner_max_its = 20
+  reuse_preconditioner_max_linear_its = 20
 
   nl_max_its = 10
   nl_rel_tol = 1e-8

--- a/modules/tensor_mechanics/test/tests/preconditioner_reuse/convergence.i
+++ b/modules/tensor_mechanics/test/tests/preconditioner_reuse/convergence.i
@@ -1,0 +1,164 @@
+# Simple 3D test
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+  large_kinematics = true
+[]
+
+[Variables]
+  [disp_x]
+  []
+  [disp_y]
+  []
+  [disp_z]
+  []
+[]
+
+[Mesh]
+  [msh]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 4
+    ny = 4
+    nz = 4
+  []
+[]
+
+[Kernels]
+  [sdx]
+    type = TotalLagrangianStressDivergence
+    variable = disp_x
+    component = 0
+  []
+  [sdy]
+    type = TotalLagrangianStressDivergence
+    variable = disp_y
+    component = 1
+  []
+  [sdz]
+    type = TotalLagrangianStressDivergence
+    variable = disp_z
+    component = 2
+  []
+[]
+
+[Functions]
+  [pullx]
+    type = ParsedFunction
+    value = '4000 * t'
+  []
+  [pully]
+    type = ParsedFunction
+    value = '-2000 * t'
+  []
+  [pullz]
+    type = ParsedFunction
+    value = '3000 * t'
+  []
+  [lambda_function]
+    type = ParsedFunction
+    value = '1000.0*(t+1.0)'
+  []
+[]
+
+[BCs]
+  [leftx]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_x
+    value = 0.0
+  []
+  [lefty]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_y
+    value = 0.0
+  []
+  [leftz]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_z
+    value = 0.0
+  []
+  [pull_x]
+    type = FunctionNeumannBC
+    boundary = right
+    variable = disp_x
+    function = pullx
+  []
+  [pull_y]
+    type = FunctionNeumannBC
+    boundary = top
+    variable = disp_y
+    function = pully
+  []
+  [pull_z]
+    type = FunctionNeumannBC
+    boundary = right
+    variable = disp_z
+    function = pullz
+  []
+[]
+
+[Materials]
+  [compute_stress]
+    type = ComputeNeoHookeanStress
+    lambda = lambda
+    mu = 67000.0
+  []
+  [lambda]
+    type = GenericFunctionMaterial
+    prop_names = lambda
+    prop_values = lambda_function
+  []
+  [compute_strain]
+    type = ComputeLagrangianStrain
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'newton'
+  line_search = none
+
+  petsc_options = ''
+  petsc_options_iname = '-pc_type -ksp_type'
+  petsc_options_value = 'lu gmres'
+  l_tol = 1e-8
+  l_max_its = 100
+
+  reuse_preconditioner = false
+  reuse_preconditioner_max_its = 20
+
+  nl_max_its = 10
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  start_time = 0.0
+  dt = 1.0
+  dtmin = 1.0
+  end_time = 10.0
+[]
+
+[Reporters/iteration_info]
+  type = IterationInfo
+[]
+
+[Outputs]
+  exodus = false
+  [./csv]
+    type = CSV
+    file_base = base_case
+  [../]
+[]

--- a/modules/tensor_mechanics/test/tests/preconditioner_reuse/gold/base_case.csv
+++ b/modules/tensor_mechanics/test/tests/preconditioner_reuse/gold/base_case.csv
@@ -1,0 +1,12 @@
+time,iteration_info/num_fixed_point_iterations,iteration_info/num_linear_iterations,iteration_info/num_nonlinear_iterations,iteration_info/time,iteration_info/timestep
+0,0,0,0,0,0
+1,1,4,4,1,1
+2,1,4,4,2,2
+3,1,4,4,3,3
+4,1,4,4,4,4
+5,1,3,3,5,5
+6,1,3,3,6,6
+7,1,3,3,7,7
+8,1,3,3,8,8
+9,1,3,3,9,9
+10,1,3,3,10,10

--- a/modules/tensor_mechanics/test/tests/preconditioner_reuse/gold/reuse_case.csv
+++ b/modules/tensor_mechanics/test/tests/preconditioner_reuse/gold/reuse_case.csv
@@ -1,0 +1,12 @@
+time,iteration_info/num_fixed_point_iterations,iteration_info/num_linear_iterations,iteration_info/num_nonlinear_iterations,iteration_info/time,iteration_info/timestep
+0,0,0,0,0,0
+1,1,29,4,1,1
+2,1,47,4,2,2
+3,1,56,4,3,3
+4,1,64,4,4,4
+5,1,52,3,5,5
+6,1,55,3,6,6
+7,1,58,3,7,7
+8,1,42,3,8,8
+9,1,16,3,9,9
+10,1,20,3,10,10

--- a/modules/tensor_mechanics/test/tests/preconditioner_reuse/tests
+++ b/modules/tensor_mechanics/test/tests/preconditioner_reuse/tests
@@ -1,0 +1,20 @@
+[Tests]
+  issues = '#21868'
+  design = 'NonlinearSystem.md'
+  [without_reuse]
+    type = CSVDiff
+    input = convergence.i
+    csvdiff = base_case.csv
+    requirement = 'Convergence matches previous version of MOOSE without the '
+                  'preconditioner reuse system'
+  []
+  [with_reuse]
+    type = CSVDiff
+    input = convergence.i
+    cli_args = "Executioner/reuse_preconditioner=true Outputs/csv/file_base=reuse_case"
+    csvdiff = reuse_case.csv
+    requirement = 'Preconditioner is reused until the linear iterations exceed '
+                  'the value of reuse_preconditioner_max_its upon which the '
+                  'system recalculates the preconditioner'
+  []
+[]

--- a/test/tests/preconditioners/reuse/convergence.i
+++ b/test/tests/preconditioners/reuse/convergence.i
@@ -1,6 +1,6 @@
 # Simple 3D test with diffusion, setup to make sure
 # there is a sensible difference in the linear iteration
-# counts with resuse versus without resuse
+# counts with re-use versus without re-use
 
 [Variables]
   [u]
@@ -85,6 +85,14 @@
   dt = 1.0
   dtmin = 1.0
   end_time = 10.0
+
+  [./Adaptivity]
+    interval = 5
+    max_h_level = 1
+    start_time = 11.0
+    stop_time = 6.0
+  [../]
+
 []
 
 [Reporters/iteration_info]

--- a/test/tests/preconditioners/reuse/convergence.i
+++ b/test/tests/preconditioners/reuse/convergence.i
@@ -75,7 +75,7 @@
   l_max_its = 100
 
   reuse_preconditioner = false
-  reuse_preconditioner_max_its = 10
+  reuse_preconditioner_max_linear_its = 10
 
   nl_max_its = 10
   nl_rel_tol = 1e-8

--- a/test/tests/preconditioners/reuse/convergence.i
+++ b/test/tests/preconditioners/reuse/convergence.i
@@ -1,0 +1,100 @@
+# Simple 3D test with diffusion, setup to make sure
+# there is a sensible difference in the linear iteration
+# counts with resuse versus without resuse
+
+[Variables]
+  [u]
+  []
+[]
+
+[Mesh]
+  [msh]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 4
+    ny = 4
+    nz = 4
+  []
+[]
+
+[Kernels]
+  [diffusion]
+    type = FunctionDiffusion
+    variable = u
+    function = 'arg'
+  []
+  [time]
+    type = TimeDerivative
+    variable = u
+  []
+  [body_force]
+    type = BodyForce
+    variable = u
+    function = body
+  []
+[]
+
+[Functions]
+  [body]
+    type = ParsedFunction
+    value = 100*sin(t)
+  []
+  [arg]
+    type = ParsedFunction
+    value = 'x*y*z*cos(t)+1'
+  []
+[]
+
+[BCs]
+  [fix_concentration]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = u
+    value = 0.0
+  []
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'newton'
+  line_search = none
+
+  petsc_options = ''
+  petsc_options_iname = '-pc_type -ksp_type'
+  petsc_options_value = 'lu gmres'
+  l_tol = 1e-8
+  l_max_its = 100
+
+  reuse_preconditioner = false
+  reuse_preconditioner_max_its = 10
+
+  nl_max_its = 10
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  start_time = 0.0
+  dt = 1.0
+  dtmin = 1.0
+  end_time = 10.0
+[]
+
+[Reporters/iteration_info]
+  type = IterationInfo
+[]
+
+[Outputs]
+  exodus = false
+  [./csv]
+    type = CSV
+    file_base = base_case
+  [../]
+[]

--- a/test/tests/preconditioners/reuse/gold/base_case.csv
+++ b/test/tests/preconditioners/reuse/gold/base_case.csv
@@ -1,0 +1,12 @@
+time,iteration_info/num_fixed_point_iterations,iteration_info/num_linear_iterations,iteration_info/num_nonlinear_iterations,iteration_info/time,iteration_info/timestep
+0,0,0,0,0,0
+1,1,1,1,1,1
+2,1,1,1,2,2
+3,1,1,1,3,3
+4,1,1,1,4,4
+5,1,1,1,5,5
+6,1,1,1,6,6
+7,1,1,1,7,7
+8,1,1,1,8,8
+9,1,1,1,9,9
+10,1,1,1,10,10

--- a/test/tests/preconditioners/reuse/gold/mesh_case.csv
+++ b/test/tests/preconditioners/reuse/gold/mesh_case.csv
@@ -1,0 +1,12 @@
+time,iteration_info/num_fixed_point_iterations,iteration_info/num_linear_iterations,iteration_info/num_nonlinear_iterations,iteration_info/time,iteration_info/timestep
+0,0,0,0,0,0
+1,1,1,1,1,1
+2,1,11,1,2,2
+3,1,1,1,3,3
+4,1,9,1,4,4
+5,1,14,1,5,5
+6,1,1,1,6,6
+7,1,5,1,7,7
+8,1,10,1,8,8
+9,1,16,1,9,9
+10,1,1,1,10,10

--- a/test/tests/preconditioners/reuse/gold/reuse_case.csv
+++ b/test/tests/preconditioners/reuse/gold/reuse_case.csv
@@ -1,0 +1,12 @@
+time,iteration_info/num_fixed_point_iterations,iteration_info/num_linear_iterations,iteration_info/num_nonlinear_iterations,iteration_info/time,iteration_info/timestep
+0,0,0,0,0,0
+1,1,1,1,1,1
+2,1,11,1,2,2
+3,1,1,1,3,3
+4,1,9,1,4,4
+5,1,14,1,5,5
+6,1,1,1,6,6
+7,1,5,1,7,7
+8,1,10,1,8,8
+9,1,16,1,9,9
+10,1,1,1,10,10

--- a/test/tests/preconditioners/reuse/tests
+++ b/test/tests/preconditioners/reuse/tests
@@ -1,0 +1,20 @@
+[Tests]
+  issues = '#21868'
+  design = 'NonlinearSystem.md'
+  [without_reuse]
+    type = CSVDiff
+    input = convergence.i
+    csvdiff = base_case.csv
+    requirement = 'Convergence matches previous version of MOOSE without the '
+                  'preconditioner reuse system'
+  []
+  [with_reuse]
+    type = CSVDiff
+    input = convergence.i
+    cli_args = "Executioner/reuse_preconditioner=true Outputs/csv/file_base=reuse_case"
+    csvdiff = reuse_case.csv
+    requirement = 'Preconditioner is reused until the linear iterations exceed '
+                  'the value of reuse_preconditioner_max_its upon which the '
+                  'system recalculates the preconditioner'
+  []
+[]

--- a/test/tests/preconditioners/reuse/tests
+++ b/test/tests/preconditioners/reuse/tests
@@ -17,4 +17,12 @@
                   'the value of reuse_preconditioner_max_its upon which the '
                   'system recalculates the preconditioner'
   []
+  [mesh_refinement]
+    type = CSVDiff
+    input = convergence.i
+    cli_args = "Executioner/reuse_preconditioner=true Outputs/csv/file_base=mesh_case Executioner/Adaptivity/start_time=5.0"
+    csvdiff = "mesh_case.csv"
+    requirement = 'A new preconditioner is formed if the system of equations changes '
+                  'for example here through mesh refinement'
+  []
 []


### PR DESCRIPTION
This closes #21868, adding an option for preconditioner reuse to MOOSE.

## Reason
See issue for details, but this can be a good trick to effective decrease the computational cost of problems where the linear solve is a large portion of the run time.

## Design
Adds two new options to the executioner block:
- `reuse_preconditioner` -- enables preconditioner reuse
- `reuse_preconditioner_max_its` -- the heuristic: reuse the same preconditioner until the linear solve requires more iterations than this target.

## Impact
New feature.