### PR TITLE
Add Abaqus UMAT interface for the new Lagrangian mechanics kernels

### DIFF
--- a/modules/tensor_mechanics/include/materials/abaqus/AbaqusUMATStress.h
+++ b/modules/tensor_mechanics/include/materials/abaqus/AbaqusUMATStress.h
@@ -24,16 +24,11 @@ class AbaqusUMATStressBase</*new_system = */ false> : public ComputeStressBase
 public:
   static InputParameters validParams() { return ComputeStressBase::validParams(); }
 
-  AbaqusUMATStressBase(const InputParameters & params)
-    : ComputeStressBase(params),
-      _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "stress"))
-  {
-  }
+  AbaqusUMATStressBase(const InputParameters & params) : ComputeStressBase(params) {}
 
 protected:
   virtual void computeQpStress() { computeQpStressHelper(); }
   virtual void computeQpStressHelper() = 0;
-  const MaterialProperty<RankTwoTensor> & _stress_old;
 };
 
 // Shim for the new system
@@ -43,16 +38,11 @@ class AbaqusUMATStressBase</*new_system = */ true> : public ComputeLagrangianObj
 public:
   static InputParameters validParams() { return ComputeLagrangianObjectiveStress::validParams(); }
 
-  AbaqusUMATStressBase(const InputParameters & params)
-    : ComputeLagrangianObjectiveStress(params),
-      _stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "cauchy_stress"))
-  {
-  }
+  AbaqusUMATStressBase(const InputParameters & params) : ComputeLagrangianObjectiveStress(params) {}
 
 protected:
   virtual void computeQpSmallStress() { computeQpStressHelper(); }
   virtual void computeQpStressHelper() = 0;
-  const MaterialProperty<RankTwoTensor> & _stress_old;
 };
 
 /**
@@ -239,8 +229,9 @@ protected:
   std::vector<Real> _aqDPRED;
 
   void initQpStatefulProperties() override;
-  void computeQpStressHelper();
+  void computeQpStressHelper() override;
 
+  const MaterialProperty<RankTwoTensor> & _stress_old;
   const MaterialProperty<RankTwoTensor> & _total_strain_old;
   const OptionalMaterialProperty<RankTwoTensor> & _strain_increment;
 
@@ -292,7 +283,6 @@ protected:
   using AbaqusUMATStressBase<new_system>::_t;
   using AbaqusUMATStressBase<new_system>::_dt;
   using AbaqusUMATStressBase<new_system>::_t_step;
-  using AbaqusUMATStressBase<new_system>::_stress_old;
 };
 
 typedef AbaqusUMATStressTempl<false> AbaqusUMATStress;

--- a/modules/tensor_mechanics/src/materials/abaqus/AbaqusUMATStress.C
+++ b/modules/tensor_mechanics/src/materials/abaqus/AbaqusUMATStress.C
@@ -60,6 +60,8 @@ AbaqusUMATStressTempl<new_system>::AbaqusUMATStressTempl(const InputParameters &
     _aqSTATEV(_aqNSTATV),
     _aqPROPS(this->template getParam<std::vector<Real>>("constant_properties")),
     _aqNPROPS(_aqPROPS.size()),
+    _stress_old(this->template getMaterialPropertyOld<RankTwoTensor>(
+        _base_name + (new_system ? "cauchy_stress" : "stress"))),
     _total_strain_old(
         this->template getMaterialPropertyOld<RankTwoTensor>(_base_name + "total_strain")),
     _strain_increment(

--- a/modules/tensor_mechanics/test/tests/umat/elastic_hardening/elastic_new_system.i
+++ b/modules/tensor_mechanics/test/tests/umat/elastic_hardening/elastic_new_system.i
@@ -1,0 +1,96 @@
+# Testing the UMAT Interface - linear elastic model using the large strain formulation.
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 3
+    xmin = -0.5
+    xmax = 0.5
+    ymin = -0.5
+    ymax = 0.5
+    zmin = -0.5
+    zmax = 0.5
+  []
+[]
+
+[Functions]
+  [top_pull]
+    type = ParsedFunction
+    value = t/100
+  []
+[]
+
+[Modules/TensorMechanics/Master]
+  [all]
+    add_variables = true
+    strain = FINITE
+    new_system = true
+    volumetric_locking_correction = true
+  []
+[]
+
+[BCs]
+  [y_pull_function]
+    type = FunctionDirichletBC
+    variable = disp_y
+    boundary = top
+    function = top_pull
+  []
+  [x_bot]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  []
+  [y_bot]
+    type = DirichletBC
+    variable = disp_y
+    boundary = bottom
+    value = 0.0
+  []
+  [z_bot]
+    type = DirichletBC
+    variable = disp_z
+    boundary = front
+    value = 0.0
+  []
+[]
+
+[Materials]
+  [umat]
+    type = ComputeLagrangianAbaqusUMATStress
+    constant_properties = '1000 0.3'
+    plugin = '../../../plugins/elastic'
+    num_state_vars = 0
+    use_one_based_indexing = true
+    objective_rate = jaumann
+    large_kinematics = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'NEWTON'
+
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+
+  line_search = 'none'
+
+  l_max_its = 100
+  nl_max_its = 100
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-10
+  l_tol = 1e-9
+  start_time = 0.0
+  num_steps = 30
+  dt = 1.0
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/modules/tensor_mechanics/test/tests/umat/elastic_hardening/tests
+++ b/modules/tensor_mechanics/test/tests/umat/elastic_hardening/tests
@@ -8,8 +8,7 @@
     exodiff = 'linear_strain_hardening_out.e'
     library_mode = 'DYNAMIC'
     valgrind = 'NONE'
-    requirement = 'The system shall provide an interface to use Abaqus UMAT materials as '
-                  'constitutive models, with support for stateful properties'
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials as constitutive models, with support for stateful properties'
   []
 
   [total_strain_error]
@@ -29,21 +28,18 @@
     exodiff = 'elastic_out.e'
     library_mode = 'DYNAMIC'
     valgrind = 'NONE'
-    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in '
-                  'Fortran77 as constitutive models, with support for finite strain elastic material '
-                  'models'
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in Fortran77 as constitutive models, with support for finite strain elastic material models'
   []
 
   [elastic_small]
     type = 'Exodiff'
     input = 'elastic.i'
-    cli_args = "Materials/active='umat' Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/incremental=true Outputs/file_base=elastic_small"
+    cli_args = "Materials/active='umat' Modules/TensorMechanics/Master/all/strain=SMALL "
+               "Modules/TensorMechanics/Master/all/incremental=true Outputs/file_base=elastic_small"
     exodiff = 'elastic_small.e'
     library_mode = 'DYNAMIC'
     valgrind = 'NONE'
-    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in '
-                  'Fortran77 as constitutive models, with support for small strain elastic material '
-                  'models'
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in Fortran77 as constitutive models, with support for small strain elastic material models'
   []
 
   [elastic_C]
@@ -53,26 +49,23 @@
     exodiff = 'elastic_out.e'
     library_mode = 'DYNAMIC'
     valgrind = 'NONE'
-    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in '
-                  'C/C++ as constitutive models, with support for finite strain elastic material '
-                  'models'
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials written in C/C++ as constitutive models, with support for finite strain elastic material models'
   []
   [elastic_reference]
     type = 'Exodiff'
     input = 'elastic.i'
     cli_args = "Materials/active='elastic stress'"
     exodiff = 'elastic_out.e'
-    requirement = 'The Abaqus UMAT interface shall produce the same results as the built-in MOOSE '
-                  'material models for finite strain elasticity'
+    requirement = 'The Abaqus UMAT interface shall produce the same results as the built-in MOOSE material models for finite strain elasticity'
   []
 
   [elastic_small_reference]
     type = 'Exodiff'
     input = 'elastic.i'
-    cli_args = "Materials/active='elastic stress' Materials/stress/type=ComputeLinearElasticStress Modules/TensorMechanics/Master/all/strain=SMALL Outputs/file_base=elastic_small"
+    cli_args = "Materials/active='elastic stress' Materials/stress/type=ComputeLinearElasticStress "
+               "Modules/TensorMechanics/Master/all/strain=SMALL Outputs/file_base=elastic_small"
     exodiff = 'elastic_small.e'
-    requirement = 'The Abaqus UMAT interface shall produce the same results as the built-in MOOSE '
-                  'material models for small strain elasticity'
+    requirement = 'The Abaqus UMAT interface shall produce the same results as the built-in MOOSE material models for small strain elasticity'
   []
 
   [elastic_incremental]
@@ -82,8 +75,17 @@
     exodiff = 'elastic_out.e'
     library_mode = 'DYNAMIC'
     valgrind = 'NONE'
-    requirement = 'The system shall provide an interface to use Abaqus UMAT materials as '
-                  'constitutive models, with support for incremental strain elastic material models'
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials as constitutive models, with support for incremental strain elastic material models'
     issues = '#18843'
+  []
+
+  [elastic_new_system_vlc]
+    type = PetscJacobianTester
+    input = 'elastic_new_system.i'
+    run_sim = true
+    ratio_tol = 5E-7
+    difference_tol = 1E10
+    requirement = 'The system shall provide an interface to use Abaqus UMAT materials through the new Lagrangian mechanics kernels, and the Jacobian should be exact with volumetric locking correction'
+    issues = '#21842'
   []
 []


### PR DESCRIPTION
Template AbaqusUMATStress to support the new system.
Added a regression test to demonstrate that the new system gives exact Jacobian with volumetric locking correction (assuming the UMAT's DDSDDE is exact).

ref #21842