### PR TITLE
Restoring the ability to swap between underlying containers

### DIFF
--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -139,13 +139,14 @@ public:
   public:
     /**
      * The primary underlying container type used to hold the data in each FeatureData.
-     * Supported types are std::set<dof_id_type> (with minor adjustmnets)
-     * or std::vector<dof_id_type>.
+     * Supported types are std::set<dof_id_type> or std::vector<dof_id_type>.
      *
-     * Note: Testing has shown that the vector container is nearly 10x faster. There's really
-     * no reason to use sets.
+     * Note: Testing has shown that vector container _may_ be slightly faster, but I
+     * believe much more data needs to be gathered to be sure. Perhaps more work could be performed
+     * to keep sorted sets to eliminate any extra work we do by occasionally performing a linear
+     * find or resorting the vector could help. For now, vector it is.
      */
-    using container_type = std::set<dof_id_type>;
+    using container_type = std::vector<dof_id_type>;
 
     FeatureData() : FeatureData(std::numeric_limits<std::size_t>::max(), Status::INACTIVE) {}
 
@@ -759,6 +760,21 @@ private:
   static inline void reserve(std::vector<T> & container, std::size_t size)
   {
     container.reserve(size);
+  }
+
+  template <class T>
+  static inline bool contains(std::set<T> & container, const T & item)
+  {
+    return container.find(item) != container.end();
+  }
+
+  template <class T>
+  static inline bool contains(std::vector<T> & container, const T & item)
+  {
+    for (const auto & cont_item : container)
+      if (item == cont_item)
+        return true;
+    return false;
   }
 
   /// The data structure for maintaining entities to flood during discovery

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -1706,7 +1706,7 @@ FeatureFloodCount::visitNeighborsHelper(const T * curr_entity,
 
         if (topological_neighbor || disjoint_only)
           feature->_disjoint_halo_ids.insert(feature->_disjoint_halo_ids.end(), entity_id);
-        else if (feature->_local_ids.find(entity_id) == feature->_local_ids.end())
+        else if (!FeatureFloodCount::contains(feature->_local_ids, entity_id))
           feature->_halo_ids.insert(feature->_halo_ids.end(), entity_id);
       }
       else


### PR DESCRIPTION
This PR just fixes a capability that was added a few years ago and has been a little neglected,
(e.g. making the data structures in the FeatureFloodCount object agnostic to the container type).
This could be used to do various performance analysis to continue to work on optimizations in the
future. It turns out there was only a single regression that was easy to resolve.

More importantly, I'm going to go ahead and flip the storage container from set to vector as even
though my testing is showing very little difference, vector does seem to consistently be a tiny bit
faster. More testing is needed.

## Reason
<!--Why do you need this feature or what is the enhancement?-->

Fixing a few lines of code to enable future performance optimization testing.

## Design
<!--A concise description (design) of the enhancement.-->

Container type in FeatureFloodCount has been abstracted out so that it can be toggled 
with a single line of code.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

None


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
