### PR TITLE
Rename temporary copy of index_range overload

### DIFF
--- a/framework/include/utils/MathFVUtils.h
+++ b/framework/include/utils/MathFVUtils.h
@@ -649,7 +649,7 @@ containerInterpolate(const FunctorBase<T> & functor, const FaceArg & face)
   if (face.limiter_type == LimiterType::Upwind ||
       face.limiter_type == LimiterType::CentralDifference)
   {
-    for (const auto i : index_range(ret))
+    for (const auto i : index_range_temp(ret))
     {
       const auto &component_upwind = phi_upwind[i], component_downwind = phi_downwind[i];
       std::tie(coeff_upwind, coeff_downwind) = interpCoeffs(*limiter,
@@ -664,7 +664,7 @@ containerInterpolate(const FunctorBase<T> & functor, const FaceArg & face)
   else
   {
     const auto grad_phi_upwind = functor.gradient(upwind_arg);
-    for (const auto i : index_range(ret))
+    for (const auto i : index_range_temp(ret))
     {
       const auto &component_upwind = phi_upwind[i], component_downwind = phi_downwind[i];
       const auto & grad = grad_phi_upwind[i];

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -967,7 +967,7 @@ extern const TagName PREVIOUS_NL_SOLUTION_TAG;
 
 template <typename T>
 auto
-index_range(const T & sizable)
+index_range_temp(const T & sizable)
 {
   return IntRange<decltype(sizable.size())>(0, sizable.size());
 }

--- a/framework/src/materials/FunctorADConverter.C
+++ b/framework/src/materials/FunctorADConverter.C
@@ -56,32 +56,32 @@ FunctorADConverterTempl<T>::FunctorADConverterTempl(const InputParameters & para
 
   // Check input names for overlaps, before possibly hitting a harder to
   // interpret error at functor definition
-  for (const auto i : index_range(reg_props_in))
-    for (const auto j : index_range(reg_props_in))
+  for (const auto i : index_range_temp(reg_props_in))
+    for (const auto j : index_range_temp(reg_props_in))
       if (reg_props_in[i] == ad_props_out[j])
         paramError("reg_props_in",
                    "Functor names may not overlap between reg_props_in and ad_props_out");
 
-  for (const auto i : index_range(reg_props_in))
-    for (const auto j : index_range(ad_props_in))
+  for (const auto i : index_range_temp(reg_props_in))
+    for (const auto j : index_range_temp(ad_props_in))
       if (reg_props_in[i] == reg_props_out[j])
         paramError("reg_props_in",
                    "Functor names may not overlap between reg_props_in and reg_props_out");
 
-  for (const auto i : index_range(ad_props_in))
-    for (const auto j : index_range(ad_props_in))
+  for (const auto i : index_range_temp(ad_props_in))
+    for (const auto j : index_range_temp(ad_props_in))
       if (ad_props_in[i] == reg_props_out[j])
         paramError("ad_props_in",
                    "Functor names may not overlap between ad_props_in and reg_props_out");
 
-  for (const auto i : index_range(ad_props_in))
-    for (const auto j : index_range(reg_props_in))
+  for (const auto i : index_range_temp(ad_props_in))
+    for (const auto j : index_range_temp(reg_props_in))
       if (ad_props_in[i] == ad_props_out[j])
         paramError("ad_props_in",
                    "Functor names may not overlap between ad_props_in and ad_props_out");
 
   // Define the AD functors
-  for (const auto i : index_range(reg_props_in))
+  for (const auto i : index_range_temp(reg_props_in))
   {
     const auto & reg_functor = getFunctor<T>(reg_props_in[i]);
     addFunctorProperty<typename Moose::ADType<T>::type>(
@@ -91,7 +91,7 @@ FunctorADConverterTempl<T>::FunctorADConverterTempl(const InputParameters & para
   }
 
   // Define the regular functors
-  for (const auto i : index_range(ad_props_in))
+  for (const auto i : index_range_temp(ad_props_in))
   {
     const auto & ad_functor = getFunctor<typename Moose::ADType<T>::type>(ad_props_in[i]);
     addFunctorProperty<T>(reg_props_out[i],

--- a/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
+++ b/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
@@ -117,7 +117,7 @@ LowerDBlockFromSidesetGenerator::generate()
     std::unordered_map<processor_id_type, decltype(elements_to_send)> push_element_data;
     std::unordered_map<processor_id_type, decltype(connected_nodes)> push_node_data;
 
-    for (const auto pid : index_range(mesh->comm()))
+    for (const auto pid : index_range_temp(mesh->comm()))
       // Don't need to send to self
       if (pid != mesh->processor_id() && need_boundary_elems[pid])
       {

--- a/framework/src/variables/MooseVariableDataFV.C
+++ b/framework/src/variables/MooseVariableDataFV.C
@@ -787,11 +787,11 @@ MooseVariableDataFV<OutputType>::setDofValue(const OutputData & value, unsigned 
 
   auto & u = _vector_tag_u[_solution_tag];
   // Update the qp values as well
-  for (const auto qp : index_range(u))
+  for (const auto qp : index_range_temp(u))
     u[qp] = value;
 
   if (_need_ad_u)
-    for (const auto qp : index_range(_ad_u))
+    for (const auto qp : index_range_temp(_ad_u))
       _ad_u[qp] = value;
 }
 

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -2156,7 +2156,7 @@ FeatureFloodCount::FeatureData::mergeBBoxes(std::vector<BoundingBox> & bboxes,
   {
     std::ostringstream oss;
     oss << "LHS BBoxes:\n";
-    for (const auto i : index_range(_bboxes))
+    for (const auto i : index_range_temp(_bboxes))
       oss << "Max: " << _bboxes[i].max() << " Min: " << _bboxes[i].min() << '\n';
 
     ::mooseError("No Bounding Boxes Expanded - This is a catastrophic error!\n", oss.str());

--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -128,7 +128,7 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
                "if using extruded geometry");
 
   Real base_pitch = 0.0;
-  for (const auto i : index_range(_inputs))
+  for (const auto i : index_range_temp(_inputs))
   {
     auto pin = _inputs[i];
     if (i == 0)
@@ -204,7 +204,7 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
     _duct_block_names = getParam<std::vector<std::vector<std::string>>>("duct_block_names");
     if (_duct_region_ids.size() != _duct_block_names.size())
       mooseError("The size of duct_block_names must match the size of duct_region_ids");
-    for (const auto i : index_range(_duct_region_ids))
+    for (const auto i : index_range_temp(_duct_region_ids))
       if (_duct_region_ids[i].size() != _duct_block_names[i].size())
         mooseError("The size of duct_block_names must match the size of duct_region_ids");
   }

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -101,9 +101,9 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
     {
       // Found dummy assembly in input assembly names
       make_empty = true;
-      for (const auto i : index_range(_pattern))
+      for (const auto i : index_range_temp(_pattern))
       {
-        for (const auto j : index_range(_pattern[i]))
+        for (const auto j : index_range_temp(_pattern[i]))
         {
           // Found dummy assembly in input lattice definition
           if (_pattern[i][j] == empty_pattern_loc)

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -148,7 +148,7 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
     _block_names = getParam<std::vector<std::vector<std::string>>>("block_names");
     if (_region_ids.size() != _block_names.size())
       mooseError("The size of block_names must match the size of region_ids");
-    for (const auto i : index_range(_region_ids))
+    for (const auto i : index_range_temp(_region_ids))
       if (_region_ids[i].size() != _block_names[i].size())
         mooseError("The size of block_names must match the size of region_ids");
   }
@@ -170,7 +170,7 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
   // Use special block id to designate TRI elements
   unsigned int pin_block_id_tri = pin_block_id_start - 1;
 
-  for (const auto i : index_range(_intervals))
+  for (const auto i : index_range_temp(_intervals))
   {
     const auto block_name = "RGMB_PIN" + std::to_string(_pin_type) + "_R" + std::to_string(i);
     const auto block_id = pin_block_id_start + i;

--- a/modules/stochastic_tools/src/reporters/EvaluateSurrogate.C
+++ b/modules/stochastic_tools/src/reporters/EvaluateSurrogate.C
@@ -59,14 +59,14 @@ EvaluateSurrogate::EvaluateSurrogate(const InputParameters & parameters)
     paramError("evaluate_std",
                "Nmber of entries must be 1 or equal to the number of entries in 'model'.");
   _doing_std.resize(_model.size());
-  for (const auto i : index_range(_model))
+  for (const auto i : index_range_temp(_model))
     _doing_std[i] = estd.size() == 1 ? estd[0] == "true" : estd[i] == "true";
 
   _real_values.resize(_model.size(), nullptr);
   _real_std.resize(_model.size(), nullptr);
   _vector_real_values.resize(_model.size(), nullptr);
   _vector_real_std.resize(_model.size(), nullptr);
-  for (const auto i : index_range(_model))
+  for (const auto i : index_range_temp(_model))
   {
     const std::string rtype = _response_types.size() == 1 ? _response_types[0] : _response_types[i];
     if (rtype == "real")
@@ -95,7 +95,7 @@ EvaluateSurrogate::execute()
   for (const auto ind : make_range(_sampler.getNumberOfLocalRows()))
   {
     const std::vector<Real> data = _sampler.getNextLocalRow();
-    for (const auto m : index_range(_model))
+    for (const auto m : index_range_temp(_model))
     {
       if (_real_values[m] && _real_std[m])
         (*_real_values[m])[ind] = _model[m]->evaluate(data, (*_real_std[m])[ind]);

--- a/modules/stochastic_tools/src/surrogates/NearestPointSurrogate.C
+++ b/modules/stochastic_tools/src/surrogates/NearestPointSurrogate.C
@@ -47,7 +47,7 @@ NearestPointSurrogate::evaluate(const std::vector<Real> & x, std::vector<Real> &
 
   unsigned int idx = findNearestPoint(x);
 
-  for (const auto & r : index_range(y))
+  for (const auto & r : index_range_temp(y))
     y[r] = _sample_results[r][idx];
 }
 

--- a/modules/tensor_mechanics/src/materials/crystal_plasticity/CrystalPlasticityStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/crystal_plasticity/CrystalPlasticityStressUpdateBase.C
@@ -163,7 +163,7 @@ CrystalPlasticityStressUpdateBase::getSlipSystems()
     for (const auto i : make_range(_number_slip_systems))
     {
       // directly grab the raw data and scale it by the unit cell dimension
-      for (const auto j : index_range(_reader.getData(i)))
+      for (const auto j : index_range_temp(_reader.getData(i)))
       {
         if (j < LIBMESH_DIM)
           _slip_plane_normal[i](j) = _reader.getData(i)[j] / _unit_cell_dimension[j];

--- a/test/src/userobjects/DGDiffusionDomainUserObject.C
+++ b/test/src/userobjects/DGDiffusionDomainUserObject.C
@@ -72,7 +72,7 @@ DGDiffusionDomainUserObject::executeOnElement()
   auto & local_integrals = _elem_integrals[_current_elem->id()];
   local_integrals.resize(_test.size());
 
-  for (const auto i : index_range(_test))
+  for (const auto i : index_range_temp(_test))
     for (const auto qp : make_range(qRule().n_points()))
       local_integrals[i] += JxW()[qp] * coord()[qp] * _diff[qp] * _grad_u[qp] * _grad_test[i][qp];
 }
@@ -84,7 +84,7 @@ DGDiffusionDomainUserObject::executeOnBoundary()
   mooseAssert(local_integrals.size() == _test_face.size(),
               "These should be equal or we're in trouble.");
 
-  for (const auto i : index_range(_test_face))
+  for (const auto i : index_range_temp(_test_face))
     for (const auto qp : make_range(qRule().n_points()))
     {
       mooseAssert(_diff_face[qp] == _diff_face_by_name[qp], "API sanity check");
@@ -117,7 +117,7 @@ DGDiffusionDomainUserObject::executeOnInternalSide()
     mooseAssert(local_integrals.size() == _test_face.size(),
                 "These should be equal or we're in trouble.");
 
-    for (const auto i : index_range(_test_face))
+    for (const auto i : index_range_temp(_test_face))
       for (const auto qp : make_range(qRule().n_points()))
       {
         Real r = 0.0;
@@ -138,7 +138,7 @@ DGDiffusionDomainUserObject::executeOnInternalSide()
     if (local_integrals.size() < _test_face_neighbor.size())
       local_integrals.resize(_test_face_neighbor.size());
 
-    for (const auto i : index_range(_test_face_neighbor))
+    for (const auto i : index_range_temp(_test_face_neighbor))
       for (const auto qp : make_range(qRule().n_points()))
       {
         Real r = 0.0;
@@ -173,7 +173,7 @@ void
 DGDiffusionDomainUserObject::threadJoin(const UserObject & y)
 {
   const DGDiffusionDomainUserObject & dg_uo = dynamic_cast<const DGDiffusionDomainUserObject &>(y);
-  for (const auto i : index_range(_elem_integrals))
+  for (const auto i : index_range_temp(_elem_integrals))
   {
     auto & my_local_integrals = _elem_integrals[i];
     auto & their_local_integrals = dg_uo._elem_integrals[i];

--- a/test/src/userobjects/InterfaceDomainUserObject.C
+++ b/test/src/userobjects/InterfaceDomainUserObject.C
@@ -66,7 +66,7 @@ InterfaceDomainUserObject::initialize()
 void
 InterfaceDomainUserObject::executeOnElement()
 {
-  for (const auto i : index_range(_test))
+  for (const auto i : index_range_temp(_test))
   {
     auto & integral = _nodal_integrals[_current_elem->node_ref(i).id()];
     for (const auto qp : make_range(qRule().n_points()))
@@ -81,7 +81,7 @@ InterfaceDomainUserObject::executeOnBoundary()
   if (!_robin_bnd_ids.count(_current_boundary_id))
     return;
 
-  for (const auto i : index_range(_test_face))
+  for (const auto i : index_range_temp(_test_face))
   {
     auto & integral = _nodal_integrals[_current_elem->node_ref(i).id()];
     for (const auto qp : make_range(qRule().n_points()))
@@ -95,7 +95,7 @@ InterfaceDomainUserObject::executeOnInterface()
   mooseAssert(_interface_bnd_ids.count(_current_boundary_id),
               "We should only get called if shouldExecuteOnInterface returns true");
 
-  for (const auto i : index_range(_test_face))
+  for (const auto i : index_range_temp(_test_face))
   {
     auto & integral = _nodal_integrals[_current_elem->node_ref(i).id()];
     for (const auto qp : make_range(qRule().n_points()))


### PR DESCRIPTION
libMesh CI (and any other MOOSE build against libMesh master) doesn't
like trying to build MOOSE with the same index_range overload in both
libMesh and MOOSE.  (added in #21910 here and https://github.com/libMesh/libmesh/pull/3378 there)

Refs #21910

Refs #21316 (indirectly)

This lets us build again against libMesh master locally for me, hopefully it will do the same for libMesh CI failures like https://civet.inl.gov/job/1152677/