### PR TITLE
Update libmesh submodule

### DIFF
--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -31,7 +31,7 @@ if [[ $target_platform == osx-arm64 ]]; then
     cd ../timpi
     ./bootstrap
     cd ../netcdf/netcdf*
-    autoreconf
+    autoreconf -f -i
     cd ../../../
 fi
 

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -3,7 +3,7 @@
 #   template/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.08.05" %}
+{% set version = "2022.08.23" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.08.05 build_0
+ - moose-libmesh 2022.08.23 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=fd99dadd91eb3f4155e7767613fc37ecf1bd75f3
+ARG LIBMESH_REV=5fb5bc70cf1b8894b363e5678171ff90c10472bc
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -964,10 +964,3 @@ extern const TagName PREVIOUS_NL_SOLUTION_TAG;
   {                                                                                                \
     __VA_ARGS__                                                                                    \
   }
-
-template <typename T>
-auto
-index_range(const T & sizable)
-{
-  return IntRange<decltype(sizable.size())>(0, sizable.size());
-}

--- a/modules/doc/content/newsletter/2022_08.md
+++ b/modules/doc/content/newsletter/2022_08.md
@@ -75,6 +75,14 @@ each of these quantities.
   many corner cases
 - Fix `TET10` numbering with `TetgenIO`
 
+### `2022.08.23` Update
+- More test coverage in examples
+- Comment clarifications
+- Build system, version control improvements
+- Support in `MeshTools::build_square` for quad shell elements
+- Minor bug fixes
+- Much more generic `index_range()` support
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
Summary of changes:

- More test coverage in examples
- Comment clarifications
- Build system, version control improvements
- Support in `MeshTools::build_square` for quad shell elements
- Minor bug fixes
- Much more generic `index_range()` support