### PR TITLE
Error with better messages

### DIFF
--- a/python/TestHarness/tests/test_FailedJSON.py
+++ b/python/TestHarness/tests/test_FailedJSON.py
@@ -1,0 +1,51 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import os, sys, io
+import unittest
+import mock
+import TestHarness
+from contextlib import redirect_stdout
+
+class TestHarnessTester(unittest.TestCase):
+    @mock.patch.object(TestHarness.util, 'runCommand')
+    def mocked_output(self, mocked, expect_fail, mocked_return):
+        MOOSE_DIR = os.getenv('MOOSE_DIR')
+        os.chdir(f'{MOOSE_DIR}/test')
+        out = io.StringIO()
+        with redirect_stdout(out):
+            mocked_return.return_value=f'{mocked}'
+            harness = TestHarness.TestHarness(['', '-i', 'required_objects'], MOOSE_DIR)
+            if expect_fail:
+                with self.assertRaises(SystemExit):
+                    harness.findAndRunTests()
+            else:
+                harness.findAndRunTests()
+        return out.getvalue()
+
+    def testGoodJSONOutput(self):
+        """
+        Test for good json output
+        """
+        out = self.mocked_output('**START JSON DATA**\n{}**END JSON DATA**\n', False)
+        self.assertRegex(out, r'.*?AnalyticalIndicator not found in executable')
+
+    def testBadJSONOutput(self):
+        """
+        Test for bad json output
+        """
+        out = self.mocked_output('**START JSON DATA**\n{badjson}**END JSON DATA**\n', True)
+        self.assertRegex(out, r'.*?produced invalide JSON output')
+
+    def testBadIndex(self):
+        """
+        Test for general bad output (unable to split)
+        """
+        out = self.mocked_output('bad output\n', True)
+        self.assertRegex(out, r'.*?produced an error during execution')

--- a/python/TestHarness/tests/test_FailedJSON.py
+++ b/python/TestHarness/tests/test_FailedJSON.py
@@ -41,7 +41,7 @@ class TestHarnessTester(unittest.TestCase):
         Test for bad json output
         """
         out = self.mocked_output('**START JSON DATA**\n{badjson}**END JSON DATA**\n', True)
-        self.assertRegex(out, r'.*?produced invalide JSON output')
+        self.assertRegex(out, r'.*?produced invalid JSON output')
 
     def testBadIndex(self):
         """

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -241,7 +241,7 @@
   [do_last]
     type = PythonUnitTest
     input = test_DoLast.py
-    requirement = "TestHarnes shall perform a test after all other tests have passed if specified to do so"
+    requirement = "TestHarness shall perform a test after all other tests have passed if specified to do so"
     issues = '#15230'
   []
   [test_failed_json]

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -244,4 +244,10 @@
     requirement = "TestHarnes shall perform a test after all other tests have passed if specified to do so"
     issues = '#15230'
   []
+  [test_failed_json]
+    type = PythonUnitTest
+    input = test_FailedJSON.py
+    requirement = "TestHarness shall test for a valid json output dump"
+    issues = '#21967'
+  []
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -12,6 +12,7 @@ import subprocess
 from mooseutils import colorText
 from collections import OrderedDict
 import json
+import sys
 
 TERM_COLS = int(os.getenv('MOOSE_TERM_COLS', '110'))
 TERM_FORMAT = os.getenv('MOOSE_TERM_FORMAT', 'njcst')
@@ -797,9 +798,17 @@ def getExeJSON(exe):
     Extracts the JSON from the dump
     """
     output = runCommand("%s --json" % exe)
-    output = output.split('**START JSON DATA**\n')[1]
-    output = output.split('**END JSON DATA**\n')[0]
-    return json.loads(output)
+    try:
+        output = output.split('**START JSON DATA**\n')[1]
+        output = output.split('**END JSON DATA**\n')[0]
+        results = json.loads(output)
+    except IndexError:
+        print(f'{exe} --json, produced an error during execution')
+        sys.exit(1)
+    except json.decoder.JSONDecodeError:
+        print(f'{exe} --json, produced invalide JSON output')
+        sys.exit(1)
+    return results
 
 def getExeObjects(exe):
     """

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -806,7 +806,7 @@ def getExeJSON(exe):
         print(f'{exe} --json, produced an error during execution')
         sys.exit(1)
     except json.decoder.JSONDecodeError:
-        print(f'{exe} --json, produced invalide JSON output')
+        print(f'{exe} --json, produced invalid JSON output')
         sys.exit(1)
     return results
 

--- a/python/peacock/CheckRequirements.py
+++ b/python/peacock/CheckRequirements.py
@@ -7,10 +7,15 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+from platform import python_version
+
 def print_error(msg):
-    print("\nError starting peacock: %s\n" % msg)
-    print("You need to use the miniconda module. Run:")
-    print("\tmodule load miniconda")
+    python_short = '.'.join(python_version().split('.')[:2])
+    print(f"\nError starting peacock: {msg}"
+           "\n\nYou may need to either create or load an environment providing PyQt, VTK, etc"
+           "\nWe provide a conda package with the required dependencies:"
+           f"\n\n\tmamba create -n peacock moose-peacock python={python_short}"
+           "\n\tmamba activate peacock\n\nThen run peacock again\n")
 
 class ErrorObserver(object):
     """

--- a/python/peacock/CheckRequirements.py
+++ b/python/peacock/CheckRequirements.py
@@ -12,8 +12,8 @@ from platform import python_version
 def print_error(msg):
     python_short = '.'.join(python_version().split('.')[:2])
     print(f"\nError starting peacock: {msg}"
-           "\n\nYou may need to either create or load an environment providing PyQt, VTK, etc"
-           "\nWe provide a conda package with the required dependencies:"
+           "\n\nYou may need to either create or load an environment providing PyQt, VTK, etc."
+           "\nThe MOOSE development team provides a conda package with the required dependencies:"
            f"\n\n\tmamba create -n peacock moose-peacock python={python_short}"
            "\n\tmamba activate peacock\n\nThen run peacock again\n")
 


### PR DESCRIPTION
Return proper error when application can't report registered objects.
Return an actual solution when running Peacock without proper dependencies.
Add unittest to test for proper json dumps.

Closes #21967
