### PR TITLE
Allow setting thermal conductivity components as function of temperature

### DIFF
--- a/framework/include/auxkernels/MaterialRealTensorValueAux.h
+++ b/framework/include/auxkernels/MaterialRealTensorValueAux.h
@@ -12,10 +12,16 @@
 // MOOSE includes
 #include "MaterialAuxBase.h"
 
+// Forward Declarations
+template <bool>
+class MaterialRealTensorValueAuxTempl;
+typedef MaterialRealTensorValueAuxTempl<false> MaterialRealTensorValueAux;
+
 /**
  * AuxKernel for outputting a RealTensorValue material property component to an AuxVariable
  */
-class MaterialRealTensorValueAux : public MaterialAuxBase<RealTensorValue>
+template <bool is_ad>
+class MaterialRealTensorValueAuxTempl : public MaterialAuxBaseTempl<RankTwoTensor, is_ad>
 {
 public:
   static InputParameters validParams();
@@ -24,7 +30,7 @@ public:
    * Class constructor
    * @param parameters The input parameters for this AuxKernel
    */
-  MaterialRealTensorValueAux(const InputParameters & parameters);
+  MaterialRealTensorValueAuxTempl(const InputParameters & parameters);
 
 protected:
   virtual Real getRealValue() override;
@@ -35,3 +41,5 @@ protected:
   /// The column index to output
   unsigned int _col;
 };
+
+typedef MaterialRealTensorValueAuxTempl<true> ADMaterialRealTensorValueAux;

--- a/framework/src/auxkernels/MaterialRealTensorValueAux.C
+++ b/framework/src/auxkernels/MaterialRealTensorValueAux.C
@@ -10,11 +10,13 @@
 #include "MaterialRealTensorValueAux.h"
 
 registerMooseObject("MooseApp", MaterialRealTensorValueAux);
+registerMooseObject("MooseApp", ADMaterialRealTensorValueAux);
 
+template <bool is_ad>
 InputParameters
-MaterialRealTensorValueAux::validParams()
+MaterialRealTensorValueAuxTempl<is_ad>::validParams()
 {
-  InputParameters params = MaterialAuxBase<>::validParams();
+  InputParameters params = MaterialAuxBaseTempl<RankTwoTensor, is_ad>::validParams();
   params.addClassDescription("Object for extracting a component of a rank two tensor material "
                              "property to populate an auxiliary variable.");
   params.addParam<unsigned int>("row", 0, "The row component to consider for this kernel");
@@ -22,10 +24,12 @@ MaterialRealTensorValueAux::validParams()
   return params;
 }
 
-MaterialRealTensorValueAux::MaterialRealTensorValueAux(const InputParameters & parameters)
-  : MaterialAuxBase<RealTensorValue>(parameters),
-    _row(getParam<unsigned int>("row")),
-    _col(getParam<unsigned int>("column"))
+template <bool is_ad>
+MaterialRealTensorValueAuxTempl<is_ad>::MaterialRealTensorValueAuxTempl(
+    const InputParameters & parameters)
+  : MaterialAuxBaseTempl<RankTwoTensor, is_ad>(parameters),
+    _row(this->template getParam<unsigned int>("row")),
+    _col(this->template getParam<unsigned int>("column"))
 {
   if (_row > LIBMESH_DIM)
     mooseError(
@@ -38,8 +42,12 @@ MaterialRealTensorValueAux::MaterialRealTensorValueAux(const InputParameters & p
                " dimensional problems");
 }
 
+template <bool is_ad>
 Real
-MaterialRealTensorValueAux::getRealValue()
+MaterialRealTensorValueAuxTempl<is_ad>::getRealValue()
 {
-  return _prop[_qp](_row, _col);
+  return MetaPhysicL::raw_value(this->_prop[this->_qp](_row, _col));
 }
+
+template class MaterialRealTensorValueAuxTempl<false>;
+template class MaterialRealTensorValueAuxTempl<true>;

--- a/modules/heat_conduction/doc/content/source/materials/AnisoHeatConductionMaterial.md
+++ b/modules/heat_conduction/doc/content/source/materials/AnisoHeatConductionMaterial.md
@@ -4,29 +4,36 @@
 
 ## Description
 
-The material model AnisoHeatConductionMaterial is used to model a material with anisotropic thermal properties. The thermal conductivity $k$ is represented as a rank two tensor:  
+The material model AnisoHeatConductionMaterial is used to model a material with anisotropic thermal properties. The thermal conductivity $k$ is represented as a rank two tensor:
 \begin{equation}
   \begin{bmatrix}
   k_{11} & k_{12} & k_{13}\\
-  k_{21} & k_{22} & k_{23}\\ 
-  k_{31} & k_{32} & k_{33}\\ 
+  k_{21} & k_{22} & k_{23}\\
+  k_{31} & k_{32} & k_{33}\\
   \end{bmatrix}
   \label{eq:aeqn}
 \end{equation}
 
-It is mandatory for the user to supply the parameter `thermal_conductivity` as a vector with nine element '$k_{11}$ $k_{21}$ $k_{31}$ $k_{12}$ $k_{22}$ $k_{32}$ $k_{13}$ $k_{23}$ $k_{33}$'. The thermal conductivity can be set as a function of temperature ($T$) by providing the parameters `thermal_conductivity_temperature_coefficient_function` ($\alpha$) and the `reference_temperature` ($T_{ref}$). The thermal conductivity as a function of temperature $k(T)$ is expressed as:
+The user can provide the thermal conductivity by setting the parameter `thermal_conductivity` as a vector with nine element '$k_{11}$ $k_{21}$ $k_{31}$ $k_{12}$ $k_{22}$ $k_{32}$ $k_{13}$ $k_{23}$ $k_{33}$'. If the parameter `thermal_conductivity` is supplied by the user, the thermal conductivity can be set as a function of temperature ($T$) by providing the parameters `thermal_conductivity_temperature_coefficient_function` ($\alpha$) and the `reference_temperature` ($T_{ref}$). The thermal conductivity as a function of temperature $k(T)$ is then expressed as:
 
 \begin{equation}
  k(T) = k_{o} (1 + \alpha (T - T_{ref}) )
 \end{equation}
 
-where $k_{o}$ is the thermal conductivity based on the user supplied vector. The specific heat capacity $C_p$ can be supplied either as a constant value or as a function using the parameter `specific_heat`.
+where $k_{o}$ is the thermal conductivity based on the user supplied vector.
+
+
+Another way, by which the user can provide thermal conductivity, is by providing the indivifual components `k_11`, `k_22` and `k_33` which can be either a constant value or a function of temperature.  Note that if `k_22` or `k_33` are not provided then their values will be set equal to that of `k_11`. Of the three parameters `k_11`, `k_22` and `k_33`, `k_11` is mandatory and the latter two are optional.
+
+The specific heat capacity $C_p$ can be supplied either as a constant value or as a function using the parameter `specific_heat`.
 
 It should be noted that in some analyses the thermal conductivity could potentially depend on other variables (e.g. solute concentration). The user should provide off diagonal Jacobian contributions in these analyses.
 
 ## Example Input Syntax
 
 !listing /test/tests/heat_conduction_ortho/heat_conduction_ortho.i block=Materials/heat
+
+!listing /test/tests/heat_conduction_ortho/heat_conduction_ortho_components.i block=Materials/heat
 
 !syntax parameters /Materials/AnisoHeatConductionMaterial
 

--- a/modules/heat_conduction/include/materials/AnisoHeatConductionMaterial.h
+++ b/modules/heat_conduction/include/materials/AnisoHeatConductionMaterial.h
@@ -26,7 +26,6 @@ public:
   AnisoHeatConductionMaterialTempl(const InputParameters & parameters);
 
 protected:
-  virtual void initQpStatefulProperties() override;
   virtual void computeQpProperties() override;
 
   const unsigned int _dim;
@@ -39,10 +38,14 @@ protected:
 
   const std::string _base_name;
 
-  const RankTwoTensor _user_provided_thermal_conductivity;
+  const std::vector<GenericReal<is_ad>> * _user_provided_thermal_conductivity_vector;
   GenericMaterialProperty<RankTwoTensor, is_ad> & _thermal_conductivity;
   MaterialProperty<RankTwoTensor> & _dthermal_conductivity_dT;
   const Function * const _thermal_conductivity_temperature_coefficient_function;
+
+  const Function * const _k_11_function;
+  const Function * const _k_22_function;
+  const Function * const _k_33_function;
 
   GenericMaterialProperty<Real, is_ad> & _specific_heat;
   MaterialProperty<Real> & _dspecific_heat_dT;

--- a/modules/heat_conduction/src/materials/AnisoHeatConductionMaterial.C
+++ b/modules/heat_conduction/src/materials/AnisoHeatConductionMaterial.C
@@ -28,12 +28,15 @@ AnisoHeatConductionMaterialTempl<is_ad>::validParams()
   params.addParam<Real>(
       "reference_temperature", 293.0, "Reference temperature for thermal conductivity in Kelvin.");
   params.addParam<std::string>("base_name", "Material property base name.");
-  params.addRequiredParam<std::vector<Real>>("thermal_conductivity",
-                                             "The thermal conductivity tensor values");
+  params.addParam<std::vector<Real>>("thermal_conductivity",
+                                     "The thermal conductivity tensor values");
   params.addParam<FunctionName>(
       "thermal_conductivity_temperature_coefficient_function",
       "",
       "Temperature coefficient for thermal conductivity as a function of temperature.");
+  params.addParam<FunctionName>("k_11", "", "k_11 component of thermal conductivity tensor.");
+  params.addParam<FunctionName>("k_22", "", "k_22 component of thermal conductivity tensor.");
+  params.addParam<FunctionName>("k_33", "", "k_33 component of thermal conductivity tensor.");
   params.addRequiredParam<FunctionName>("specific_heat",
                                         "Specific heat as a function of temperature.");
   params.addClassDescription("General-purpose material model for anisotropic heat conduction");
@@ -53,7 +56,10 @@ AnisoHeatConductionMaterialTempl<is_ad>::AnisoHeatConductionMaterialTempl(
     _T_name(getVar("temperature", 0)->name()),
     _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
 
-    _user_provided_thermal_conductivity(getParam<std::vector<Real>>("thermal_conductivity")),
+    _user_provided_thermal_conductivity_vector(
+        isParamValid("thermal_conductivity")
+            ? &getParam<std::vector<GenericReal<is_ad>>>("thermal_conductivity")
+            : nullptr),
     _thermal_conductivity(
         declareGenericProperty<RankTwoTensor, is_ad>(_base_name + "thermal_conductivity")),
     _dthermal_conductivity_dT(
@@ -62,20 +68,14 @@ AnisoHeatConductionMaterialTempl<is_ad>::AnisoHeatConductionMaterialTempl(
         getParam<FunctionName>("thermal_conductivity_temperature_coefficient_function") != ""
             ? &getFunction("thermal_conductivity_temperature_coefficient_function")
             : nullptr),
-
+    _k_11_function(getParam<FunctionName>("k_11") != "" ? &getFunction("k_11") : nullptr),
+    _k_22_function(getParam<FunctionName>("k_22") != "" ? &getFunction("k_22") : nullptr),
+    _k_33_function(getParam<FunctionName>("k_33") != "" ? &getFunction("k_33") : nullptr),
     _specific_heat(declareGenericProperty<Real, is_ad>(_base_name + "specific_heat")),
     _dspecific_heat_dT(declarePropertyDerivative<Real>(_base_name + "specific_heat", _T_name)),
     _specific_heat_function(&getFunction("specific_heat")),
     _ad_q_point(is_ad ? &_assembly.adQPoints() : nullptr)
 {
-}
-
-template <bool is_ad>
-void
-AnisoHeatConductionMaterialTempl<is_ad>::initQpStatefulProperties()
-{
-  _thermal_conductivity[_qp] = _user_provided_thermal_conductivity;
-  DerivativeMaterialInterface::initQpStatefulProperties();
 }
 
 template <>
@@ -98,22 +98,70 @@ AnisoHeatConductionMaterialTempl<is_ad>::computeQpProperties()
 {
   const auto & temp_qp = _T[_qp];
   const auto & p = genericQPoints();
+  GenericRankTwoTensor<is_ad> thermal_conductivity_tensor;
+  RankTwoTensor dthermal_conductivity_tensor_dt;
+  if (_user_provided_thermal_conductivity_vector && _k_11_function)
+    mooseError("Either thermal_conductivity or k_11 parameter should be provided by the user in " +
+               _name + ". Both cannot be provided.");
 
-  if (_thermal_conductivity_temperature_coefficient_function)
+  if (_user_provided_thermal_conductivity_vector)
   {
+    thermal_conductivity_tensor =
+        GenericRankTwoTensor<is_ad>(*_user_provided_thermal_conductivity_vector);
 
-    _thermal_conductivity[_qp] =
-        _user_provided_thermal_conductivity *
-        (1.0 + _thermal_conductivity_temperature_coefficient_function->value(temp_qp, p) *
-                   (temp_qp - _ref_temp));
-    _dthermal_conductivity_dT[_qp] =
-        _user_provided_thermal_conductivity *
-        _thermal_conductivity_temperature_coefficient_function->timeDerivative(
-            MetaPhysicL::raw_value(temp_qp), _q_point[_qp]) *
-        MetaPhysicL::raw_value(temp_qp - _ref_temp);
+    if (_thermal_conductivity_temperature_coefficient_function)
+    {
+
+      _thermal_conductivity[_qp] =
+          thermal_conductivity_tensor *
+          (1.0 + _thermal_conductivity_temperature_coefficient_function->value(temp_qp, p) *
+                     (temp_qp - _ref_temp));
+      _dthermal_conductivity_dT[_qp] =
+          MetaPhysicL::raw_value(thermal_conductivity_tensor) *
+          _thermal_conductivity_temperature_coefficient_function->timeDerivative(
+              MetaPhysicL::raw_value(temp_qp), _q_point[_qp]) *
+          MetaPhysicL::raw_value(temp_qp - _ref_temp);
+    }
+    else
+      _thermal_conductivity[_qp] = thermal_conductivity_tensor;
   }
+  else if (_k_11_function)
+  {
+    thermal_conductivity_tensor(0, 0) = _k_11_function->value(temp_qp, p);
+    dthermal_conductivity_tensor_dt(0, 0) =
+        _k_11_function->timeDerivative(MetaPhysicL::raw_value(temp_qp), _q_point[_qp]);
+
+    if (_k_22_function)
+    {
+      thermal_conductivity_tensor(1, 1) = _k_22_function->value(temp_qp, p);
+      dthermal_conductivity_tensor_dt(1, 1) =
+          _k_22_function->timeDerivative(MetaPhysicL::raw_value(temp_qp), _q_point[_qp]);
+    }
+    else
+    {
+      thermal_conductivity_tensor(1, 1) = _k_11_function->value(temp_qp, p);
+      dthermal_conductivity_tensor_dt(1, 1) = dthermal_conductivity_tensor_dt(0, 0);
+    }
+
+    if (_k_33_function)
+    {
+      thermal_conductivity_tensor(2, 2) = _k_33_function->value(temp_qp, p);
+      dthermal_conductivity_tensor_dt(2, 2) =
+          _k_33_function->timeDerivative(MetaPhysicL::raw_value(temp_qp), _q_point[_qp]);
+    }
+    else
+    {
+      thermal_conductivity_tensor(2, 2) = _k_11_function->value(temp_qp, p);
+      dthermal_conductivity_tensor_dt(2, 2) = dthermal_conductivity_tensor_dt(0, 0);
+    }
+
+    _thermal_conductivity[_qp] = thermal_conductivity_tensor;
+    _dthermal_conductivity_dT[_qp] = dthermal_conductivity_tensor_dt;
+  }
+
   else
-    _thermal_conductivity[_qp] = _user_provided_thermal_conductivity;
+    mooseError("Either thermal_conductivity or k_11 parameter must be provided by the user in " +
+               _name);
 
   _specific_heat[_qp] = _specific_heat_function->value(temp_qp, p);
   _dspecific_heat_dT[_qp] =

--- a/modules/heat_conduction/test/tests/heat_conduction_ortho/gold/heat_conduction_ortho_components_out.csv
+++ b/modules/heat_conduction/test/tests/heat_conduction_ortho/gold/heat_conduction_ortho_components_out.csv
@@ -1,0 +1,3 @@
+time,thermal_conductivity_x,thermal_conductivity_y,thermal_conductivity_z
+0,0,0,0
+1,110,220,330

--- a/modules/heat_conduction/test/tests/heat_conduction_ortho/heat_conduction_ortho_components.i
+++ b/modules/heat_conduction/test/tests/heat_conduction_ortho/heat_conduction_ortho_components.i
@@ -1,0 +1,147 @@
+# The temperature is set at 273K and the thermal conductivity components
+# are computed as functions of temperature.
+# k_xx = (273 - 173) * 1.0 + 10.0 = 110.0
+# k_yy = (273 - 173) * 2.0 + 20.0 = 220.0
+# k_zz = (273 - 173) * 1.0 + 30.0 = 330.0
+# Same values of thermal conductivity components are calculated by Moose.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 3
+  nx = 1
+  ny = 1
+  nz = 1
+[]
+
+[Variables]
+  [temperature]
+    initial_condition = 273.0
+  []
+[]
+
+[AuxVariables]
+  [thermal_conductivity_x]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [thermal_conductivity_y]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+  [thermal_conductivity_z]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[Functions]
+  [k_xx]
+    type = ParsedFunction
+    value = '(t-173.0)*1.0+10.0' # t is used as temperature
+  []
+  [k_yy]
+    type = ParsedFunction
+    value = '(t-173.0)*2.0+20.0' # t is used as temperature
+  []
+  [k_zz]
+    type = ParsedFunction
+    value = '(t-173.0)*3.0+30.0' # t is used as temperature
+  []
+[]
+
+[Kernels]
+  [heat]
+    type = AnisoHeatConduction
+    variable = temperature
+  []
+[]
+
+[AuxKernels]
+  [thermal_conductivity_x]
+    type = MaterialRealTensorValueAux
+    variable = thermal_conductivity_x
+    property = thermal_conductivity
+    execute_on = timestep_end
+  []
+  [thermal_conductivity_y]
+    type = MaterialRealTensorValueAux
+    variable = thermal_conductivity_y
+    property = thermal_conductivity
+    row = 1
+    column = 1
+    execute_on = timestep_end
+  []
+  [thermal_conductivity_z]
+    type = MaterialRealTensorValueAux
+    variable = thermal_conductivity_z
+    property = thermal_conductivity
+    row = 2
+    column = 2
+    execute_on = timestep_end
+  []
+[]
+
+[BCs]
+  [temperatures]
+    type = DirichletBC
+    variable = temperature
+    boundary = left
+    value = 273.0
+  []
+  [neum]
+    type = NeumannBC
+    variable = temperature
+    boundary = right
+    value = 0.0
+  []
+[]
+
+[Materials]
+  [heat]
+    type = AnisoHeatConductionMaterial
+    specific_heat = 0.116
+    k_11 = k_xx
+    k_22 = k_yy
+    k_33 = k_zz
+    temperature = temperature
+  []
+  [density]
+    type = GenericConstantMaterial
+    prop_names = 'density'
+    prop_values = 0.283
+  []
+[]
+
+[Executioner]
+  type = Steady
+
+  petsc_options_iname = '-pc_type -ksp_gmres_restart'
+  petsc_options_value = 'lu       101'
+  line_search = 'none'
+
+  nl_abs_tol = 1e-11
+  nl_rel_tol = 1e-10
+  l_max_its = 20
+[]
+
+[Outputs]
+  csv = true
+[]
+
+[Postprocessors]
+  [thermal_conductivity_x]
+    type = ElementAverageValue
+    variable = thermal_conductivity_x
+    execute_on = 'initial timestep_end'
+  []
+  [thermal_conductivity_y]
+    type = ElementAverageValue
+    variable = thermal_conductivity_y
+    execute_on = 'initial timestep_end'
+  []
+  [thermal_conductivity_z]
+    type = ElementAverageValue
+    variable = thermal_conductivity_z
+    execute_on = 'initial timestep_end'
+  []
+[]

--- a/modules/heat_conduction/test/tests/heat_conduction_ortho/tests
+++ b/modules/heat_conduction/test/tests/heat_conduction_ortho/tests
@@ -8,4 +8,13 @@
     issues = '#2674'
     requirement = 'The system shall allow the use of an anisotropic heat conduction material set by postprocessors.'
   [../]
+  [./therm_cond_components]
+    type = 'CSVDiff'
+    input = 'heat_conduction_ortho_components.i'
+    csvdiff = 'heat_conduction_ortho_components_out.csv'
+    max_parallel = 1
+    design = 'AnisoHeatConductionMaterial.md'
+    issues = '#22027'
+    requirement = 'The system shall calculated the individual components of thermal conductivity tensor as function of temperature'
+  [../]
 []


### PR DESCRIPTION
Ref: #22027

<!--
#22027 
-->

## Reason
User may want to set individual components of thermal conductivity tensor as different functions of temperature.

## Design
The current model AnisoHeatConductionMaterial will be updated to allow user to input individual components. The user will set the components using input parameters which will be functions of temperature; functions will be defined in the input file.

## Impact
This update will not change the existing functionality of the code.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
