### PR TITLE
Add packaging to moose-libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.08.23" %}
 {% set vtk_friendly_version = "9.1" %}
@@ -30,12 +30,14 @@ requirements:
     - {{ moose_libmesh_vtk }}
     - pkg-config
     - libpng
+    - packaging
   run:
     - {{ moose_mpich }}
     - {{ moose_petsc }}
     - {{ moose_libmesh_vtk }}
     - pkg-config
     - setuptools <60
+    - packaging
 
 test:
   commands:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.08.23 build_1
+ - moose-libmesh 2022.08.23 build_2
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.08.23 build_1
+ - moose-libmesh 2022.08.23 build_2
 
 moose_python:
  - python 3.9


### PR DESCRIPTION
moose-libmesh is the first package which requires python. So adding it here.

TODO: Lets scrutnize this a bit even if it passes. I want to make sure by adding this, moose-tools (and all its python versions) is easilly installed after installing this moose-libmesh package.

Closes #22040
