### PR TITLE
Add `skip_coordinate_collapsing` param to all MultiAppTransfers

### DIFF
--- a/framework/src/transfers/MultiAppMeshFunctionTransfer.C
+++ b/framework/src/transfers/MultiAppMeshFunctionTransfer.C
@@ -42,7 +42,6 @@ MultiAppMeshFunctionTransfer::validParams()
       false,
       "Whether or not to error in the case that a target point is not found in the source domain.");
   MultiAppTransfer::addBBoxFactorParam(params);
-  MultiAppTransfer::addSkipCoordCollapsingParam(params);
   return params;
 }
 

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -46,8 +46,6 @@ MultiAppPostprocessorInterpolationTransfer::validParams()
                         "Radius to use for radial_basis interpolation.  If negative "
                         "then the radius is taken as the max distance between "
                         "points.");
-
-  MultiAppTransfer::addSkipCoordCollapsingParam(params);
   return params;
 }
 

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -46,6 +46,7 @@ MultiAppTransfer::validParams()
   params.addParam<bool>("displaced_target_mesh",
                         false,
                         "Whether or not to use the displaced mesh for the target mesh.");
+  addSkipCoordCollapsingParam(params);
   return params;
 }
 

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -73,9 +73,6 @@ MultiAppUserObjectTransfer::validParams()
                         false,
                         "When True, a from_multiapp transfer will work by finding the nearest "
                         "(using the `location`) sub-app and query that for the value to transfer");
-
-  MultiAppTransfer::addSkipCoordCollapsingParam(params);
-
   return params;
 }
 


### PR DESCRIPTION
@GiudGiud was right in his review that we should add this for all transfers. I ran into a need for it for `MultiAppInterpolationTransfer` when debugging a failing Sabertooth test. Might as well just add it for everyone

Refs #21788