### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,9 +2,9 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.08.23" %}
+{% set version = "2022.09.09" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - {{ moose_petsc }}
     - {{ moose_libmesh_vtk }}
     - pkg-config
+    - packaging
     - setuptools <60
 
 test:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.08.23 build_1
+ - moose-libmesh 2022.09.09 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.08.23 build_1
+ - moose-libmesh 2022.09.09 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=5fb5bc70cf1b8894b363e5678171ff90c10472bc
+ARG LIBMESH_REV=1eef758792bff86e26258972ab9dc60533161964
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2022_09.md
+++ b/modules/doc/content/newsletter/2022_09.md
@@ -9,6 +9,35 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2022.09.09` Update
+- Performance logging via `PerfLog` has been added to more of the
+  `ExodusII` interface.
+- The `Parameters` class `print_helper()` has been overloaded to
+  handle nested vector-of-vectors-of-vectors parameters, so
+  `Parameter<T>::print()` can now operate with that type as `T`.
+- `ExodusII::write_added_sides()` support, which can be turned on to
+  automatically generate "side elements" in output, useful for
+  visualization of `SIDE_DISCONTINUOUS` data fields which are
+  discontinuous on true elements' edges and vertices.
+- Overloads for `TypeTensor` and `TypeVector` classes in the
+  template metafunctions `RawType` and `ReplaceAlgebraicType`.
+- A new `TensorTraits` class, for easier writing of generic algorithms
+  that can handle scalar, vector, and tensor classes.
+- Code refactoring and bug fixes, including
+
+  - Fixed preconditioner reuse in the `PetscNonlinearSolver`
+    interface when combined with Adaptive Mesh Refinement
+  - Fixed the `Poly2TriTriangulator` refinement code behavior when
+    it is told not to refine at all.
+  - Fixed `MeshedHole` boundary orientation issues, thereby fixing a
+    bug when `Poly2TriTriangulator` is required to refine a hole
+    boundary initially defined by another mesh.
+  - Fixed fragile `SIDE_DISCONTINUOUS` behavior when combined with
+    other variable types on a `HEX27`.
+
+- More test coverage
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
- Performance logging via `PerfLog` has been added to more of the `ExodusII` interface.
- The `Parameters` class `print_helper()` has been overloaded to handle nested vector-of-vectors-of-vectors parameters, so `Parameter<T>::print()` can now operate with that type as `T`.
- `ExodusII::write_added_sides()` support, which can be turned on to automatically generate "side elements" in output, useful for visualization of `SIDE_DISCONTINUOUS` data fields which are discontinuous on true elements' edges and vertices.
- Overloads for `TypeTensor` and `TypeVector` classes in the template metafunctions `RawType` and `ReplaceAlgebraicType`.
- A new `TensorTraits` class, for easier writing of generic algorithms that can handle scalar, vector, and tensor classes.
- Code refactoring and bug fixes, including

  - Fixed preconditioner reuse in the `PetscNonlinearSolver` interface when combined with Adaptive Mesh Refinement
  - Fixed the `Poly2TriTriangulator` refinement code behavior when it is told not to refine at all.
  - Fixed `MeshedHole` boundary orientation issues, thereby fixing a bug when `Poly2TriTriangulator` is required to refine a hole boundary initially defined by another mesh.
  - Fixed fragile `SIDE_DISCONTINUOUS` behavior when combined with other variable types on a `HEX27`.

- More test coverage