### PR TITLE
Remove unnecessary gpHandler access from GP surrogate

### DIFF
--- a/modules/stochastic_tools/src/surrogates/GaussianProcess.C
+++ b/modules/stochastic_tools/src/surrogates/GaussianProcess.C
@@ -25,10 +25,7 @@ GaussianProcess::validParams()
 GaussianProcess::GaussianProcess(const InputParameters & parameters)
   : SurrogateModel(parameters),
     CovarianceInterface(parameters),
-    _gp_handler(
-        isParamValid("trainer")
-            ? dynamic_cast<GaussianProcessTrainer &>(getSurrogateTrainer("trainer")).gpHandler()
-            : setModelData<StochasticTools::GaussianProcessHandler>("_gp_handler")),
+    _gp_handler(setModelData<StochasticTools::GaussianProcessHandler>("_gp_handler")),
     _training_params(getModelData<RealEigenMatrix>("_training_params"))
 {
 }


### PR DESCRIPTION
Refs. #20501

## Reason
Since the GPHandler is already a restartable data, there is no need for the lookup through the trainer within the surrogate. 

## Design
Simplify the constructor of the GaussianProcess.

## Impact
Will allow more flexible GP-based active learners in STM.