### PR TITLE
Restore MooseDocs functionality for Python 3.10 on Darwin

### DIFF
--- a/python/MooseDocs/base/executioners.py
+++ b/python/MooseDocs/base/executioners.py
@@ -188,7 +188,8 @@ class Executioner(mixins.ConfigObject, mixins.TranslatorObject):
 
         # The method for spawning processes changed to "spawn" for macOS in python 3.9. Currently,
         # MooseDocs does not work with this combination.
-        if (platform.python_version() >= '3.9') and (platform.system() == 'Darwin'):
+        # Ints are used for the second comparison because simple string comparison is inadequate against 3.9 for >= 3.10
+        if (platform.python_version_tuple()[0] >= '3') and (int(platform.python_version_tuple()[1]) >= 9) and (platform.system() == 'Darwin'):
             self._ctx = multiprocessing.get_context('fork')
         else:
             self._ctx = multiprocessing.get_context()


### PR DESCRIPTION
A currently incompatible process spawning start method was selected for Python 3.10 on Darwin due to a faulty string comparison in `executioners.py`. This was fixed up by using `platform.python_version_tuple()` and using an int comparison for the minor release version. 

Closes #21767 
