### PR TITLE
More coordinate transform robustification

### DIFF
--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -262,7 +262,7 @@ public:
   /**
    * @return Number of Global Apps in this MultiApp
    */
-  unsigned int numGlobalApps() { return _total_num_apps; }
+  unsigned int numGlobalApps() const { return _total_num_apps; }
 
   /**
    * @return Number of Apps on local processor.
@@ -287,12 +287,6 @@ public:
   bool hasLocalApp(unsigned int global_app) const;
 
   /**
-   * @return the local app number corresponding to the supplied global app number. We will assert
-   * that we have the local app before computing the local app number
-   */
-  unsigned int localAppNumber(unsigned int global_app) const;
-
-  /**
    * Get the local MooseApp object
    * @param local_app The local app number
    */
@@ -303,7 +297,7 @@ public:
    * @param app The global app number you want the position for.
    * @return the position
    */
-  const Point & position(unsigned int app) { return _positions[app]; }
+  const Point & position(unsigned int app) const { return _positions[app]; }
 
   /**
    * "Reset" the App corresponding to the global App number

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -1149,13 +1149,3 @@ MultiApp::addAssociatedTransfer(MultiAppTransfer & transfer)
 {
   _associated_transfers.push_back(&transfer);
 }
-
-unsigned int
-MultiApp::localAppNumber(const unsigned int global_app) const
-{
-  mooseAssert(
-      hasLocalApp(global_app),
-      "We must have the local app in order for this computation to make sense and be valid");
-
-  return cast_int<unsigned int>(global_app - _first_local_app);
-}

--- a/framework/src/transfers/MultiAppGeometricInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppGeometricInterpolationTransfer.C
@@ -465,11 +465,7 @@ MultiAppGeometricInterpolationTransfer::execute()
 
           auto & to_solution = getToMultiApp()->appTransferVector(i, _to_var_name);
 
-          interpolateTargetPoints(to_problem,
-                                  to_var,
-                                  to_solution,
-                                  *_to_transforms[getToMultiApp()->localAppNumber(i)],
-                                  idi);
+          interpolateTargetPoints(to_problem, to_var, to_solution, *_to_transforms[i], idi);
         }
       }
 
@@ -489,8 +485,7 @@ MultiAppGeometricInterpolationTransfer::execute()
                                                            Moose::VarKindType::VAR_ANY,
                                                            Moose::VarFieldType::VAR_FIELD_STANDARD);
 
-          fillSourceInterpolationPoints(
-              from_problem, from_var, *_from_transforms[getFromMultiApp()->localAppNumber(i)], idi);
+          fillSourceInterpolationPoints(from_problem, from_var, *_from_transforms[i], idi);
         }
       }
 

--- a/framework/src/transfers/MultiAppNearestNodeTransfer.C
+++ b/framework/src/transfers/MultiAppNearestNodeTransfer.C
@@ -127,7 +127,9 @@ MultiAppNearestNodeTransfer::execute()
       unsigned int sys_num = to_sys->number();
       unsigned int var_num = to_sys->variable_number(_to_var_name);
       MeshBase * to_mesh = &_to_meshes[i_to]->getMesh();
-      const auto & to_transform = *_to_transforms[i_to];
+      const auto to_global_num =
+          _current_direction == FROM_MULTIAPP ? 0 : _to_local2global_map[i_to];
+      const auto & to_transform = *_to_transforms[to_global_num];
       auto & fe_type = to_sys->variable_type(var_num);
       bool is_constant = fe_type.order == CONSTANT;
       bool is_to_nodal = fe_type.family == LAGRANGE;
@@ -380,7 +382,9 @@ MultiAppNearestNodeTransfer::execute()
           System & from_sys = from_var.sys().system();
           unsigned int from_sys_num = from_sys.number();
           unsigned int from_var_num = from_sys.variable_number(from_var.name());
-          const auto & from_transform = *_from_transforms[i_local_from];
+          const auto from_global_num =
+              _current_direction == TO_MULTIAPP ? 0 : _from_local2global_map[i_local_from];
+          const auto & from_transform = *_from_transforms[from_global_num];
 
           for (unsigned int i_node = 0; i_node < local_entities[i_local_from].size(); i_node++)
           {

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -117,11 +117,9 @@ MultiAppPostprocessorInterpolationTransfer::execute()
         {
           if (getFromMultiApp()->hasLocalApp(i) && getFromMultiApp()->isRootProcessor())
           {
-            const auto local_app_number = getFromMultiApp()->localAppNumber(i);
             // Evaluation of the _from_transform at the origin yields the transformed position of
             // the from multi-app
-            src_pts.push_back(
-                to_coord_transform.mapBack((*_from_transforms[local_app_number])(Point(0))));
+            src_pts.push_back(to_coord_transform.mapBack((*_from_transforms[i])(Point(0))));
             src_vals.push_back(getFromMultiApp()->appPostprocessorValue(i, _postprocessor));
           }
         }

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -243,6 +243,7 @@ MultiAppProjectionTransfer::execute()
   {
     for (unsigned int i_to = 0; i_to < _to_problems.size(); i_to++)
     {
+      // Indexing into the coordinate transforms vector
       const auto to_global_num =
           _current_direction == FROM_MULTIAPP ? 0 : _to_local2global_map[i_to];
       MeshBase & to_mesh = _to_meshes[i_to]->getMesh();

--- a/framework/src/transfers/MultiAppProjectionTransfer.C
+++ b/framework/src/transfers/MultiAppProjectionTransfer.C
@@ -243,6 +243,8 @@ MultiAppProjectionTransfer::execute()
   {
     for (unsigned int i_to = 0; i_to < _to_problems.size(); i_to++)
     {
+      const auto to_global_num =
+          _current_direction == FROM_MULTIAPP ? 0 : _to_local2global_map[i_to];
       MeshBase & to_mesh = _to_meshes[i_to]->getMesh();
 
       LinearImplicitSystem & system = *_proj_sys[i_to];
@@ -268,7 +270,7 @@ MultiAppProjectionTransfer::execute()
             for (unsigned int qp = 0; qp < qrule.n_points() && !qp_hit; qp++)
             {
               Point qpt = xyz[qp];
-              if (bboxes[from0 + i_from].contains_point((*_to_transforms[i_to])(qpt)))
+              if (bboxes[from0 + i_from].contains_point((*_to_transforms[to_global_num])(qpt)))
                 qp_hit = true;
             }
           }
@@ -283,7 +285,7 @@ MultiAppProjectionTransfer::execute()
             for (unsigned int qp = 0; qp < qrule.n_points(); qp++)
             {
               Point qpt = xyz[qp];
-              outgoing_qps[i_proc].push_back((*_to_transforms[i_to])(qpt));
+              outgoing_qps[i_proc].push_back((*_to_transforms[to_global_num])(qpt));
             }
           }
         }
@@ -376,10 +378,12 @@ MultiAppProjectionTransfer::execute()
       {
         if (local_bboxes[i_from].contains_point(qpt))
         {
+          const auto from_global_num =
+              _current_direction == TO_MULTIAPP ? 0 : _from_local2global_map[i_from];
           outgoing_evals_ids[pid][qp].first =
-              (*local_meshfuns[i_from])(_from_transforms[i_from]->mapBack(qpt));
+              (*local_meshfuns[i_from])(_from_transforms[from_global_num]->mapBack(qpt));
           if (_current_direction == FROM_MULTIAPP)
-            outgoing_evals_ids[pid][qp].second = _from_local2global_map[i_from];
+            outgoing_evals_ids[pid][qp].second = from_global_num;
         }
       }
     }

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -69,7 +69,7 @@ MultiAppTransfer::addSkipCoordCollapsingParam(InputParameters & params)
 {
   params.addParam<bool>(
       "skip_coordinate_collapsing",
-      false,
+      true,
       "Whether to skip coordinate collapsing (translation and rotation are still performed, only "
       "XYZ, RZ etc collapsing is skipped) when performing mapping and inverse "
       "mapping coordinate transformation operations. This parameter should only "

--- a/framework/src/transfers/MultiAppUserObjectTransfer.C
+++ b/framework/src/transfers/MultiAppUserObjectTransfer.C
@@ -167,7 +167,7 @@ MultiAppUserObjectTransfer::execute()
               getToMultiApp()->problemBase().getUserObjectBase(_user_object_name);
           mooseAssert(_from_transforms.size() == 1, "This should have size 1");
           const auto & from_transform = *_from_transforms[0];
-          const auto & to_transform = *_to_transforms[getToMultiApp()->localAppNumber(i)];
+          const auto & to_transform = *_to_transforms[i];
 
           if (is_nodal)
           {
@@ -330,9 +330,7 @@ MultiAppUserObjectTransfer::execute()
                   continue;
 
                 BoundingBox app_box = getFromMultiApp()->getBoundingBox(
-                    i,
-                    _displaced_source_mesh,
-                    _from_transforms[getFromMultiApp()->localAppNumber(i)].get());
+                    i, _displaced_source_mesh, _from_transforms[i].get());
 
                 if (app_box.contains_point(transformed_node))
                   ++node_found_in_sub_app;
@@ -395,9 +393,7 @@ MultiAppUserObjectTransfer::execute()
                   continue;
 
                 BoundingBox app_box = getFromMultiApp()->getBoundingBox(
-                    i,
-                    _displaced_source_mesh,
-                    _from_transforms[getFromMultiApp()->localAppNumber(i)].get());
+                    i, _displaced_source_mesh, _from_transforms[i].get());
 
                 if (app_box.contains_point(point))
                   ++elem_found_in_sub_app;
@@ -440,8 +436,7 @@ MultiAppUserObjectTransfer::execute()
             if (sub_app == static_cast<unsigned int>(-1))
               continue;
 
-            const auto & from_transform =
-                *_from_transforms[getFromMultiApp()->localAppNumber(sub_app)];
+            const auto & from_transform = *_from_transforms[sub_app];
             const auto & user_object = _multi_app->appUserObjectBase(sub_app, _user_object_name);
 
             dof_id_type dof = node->dof_number(to_sys_num, to_var_num, 0);
@@ -505,8 +500,7 @@ MultiAppUserObjectTransfer::execute()
             if (sub_app == static_cast<unsigned int>(-1))
               continue;
 
-            const auto & from_transform =
-                *_from_transforms[getFromMultiApp()->localAppNumber(sub_app)];
+            const auto & from_transform = *_from_transforms[sub_app];
             const auto & user_object =
                 getFromMultiApp()->appUserObjectBase(sub_app, _user_object_name);
 
@@ -600,11 +594,8 @@ MultiAppUserObjectTransfer::findSubAppToTransferFrom(const Point & p)
 
     for (unsigned int i = 0; i < _multi_app->numGlobalApps(); i++)
     {
-      if (!_multi_app->hasLocalApp(i))
-        continue;
-
       // Obtain the possibly transformed app position by querying the transform with the origin
-      const auto app_position = (*_from_transforms[getFromMultiApp()->localAppNumber(i)])(Point(0));
+      const auto app_position = (*_from_transforms[i])(Point(0));
 
       auto distance = (p - app_position).norm();
 
@@ -632,8 +623,8 @@ MultiAppUserObjectTransfer::findSubAppToTransferFrom(const Point & p)
     if (!_multi_app->hasLocalApp(i))
       continue;
 
-    BoundingBox app_box = _multi_app->getBoundingBox(
-        i, _displaced_source_mesh, _from_transforms[getFromMultiApp()->localAppNumber(i)].get());
+    BoundingBox app_box =
+        _multi_app->getBoundingBox(i, _displaced_source_mesh, _from_transforms[i].get());
 
     if (_skip_bbox_check || app_box.contains_point(p))
       return static_cast<unsigned int>(i);

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -525,6 +525,9 @@ MultiAppCoordTransform::hasNonTranslationTransformation() const
           return true;
       }
 
+  if (_skip_coordinate_collapsing)
+    return false;
+
   if ((_our_app_transform._coord_type == Moose::COORD_XYZ &&
        (_destination_app_transform->_coord_type == Moose::COORD_RZ ||
         _destination_app_transform->_coord_type == Moose::COORD_RSPHERICAL)) ||

--- a/test/tests/transfers/coord_transform/rz-xyz/3d-xyz.i
+++ b/test/tests/transfers/coord_transform/rz-xyz/3d-xyz.i
@@ -66,6 +66,7 @@
     source_variable = u
     variable = v
     execute_on = 'timestep_end'
+    skip_coordinate_collapsing = false
   []
   [from_sub]
     type = MultiAppNearestNodeTransfer
@@ -73,5 +74,6 @@
     source_variable = u
     variable = v
     execute_on = 'timestep_end'
+    skip_coordinate_collapsing = false
   []
 []

--- a/unit/src/MooseCoordTest.C
+++ b/unit/src/MooseCoordTest.C
@@ -123,6 +123,10 @@ TEST(MooseCoordTest, testCoordCollapse)
   MultiAppCoordTransform rz(single_app_rz);
   MultiAppCoordTransform rsph(single_app_rsph);
 
+  const std::string return_mapping_error_message(
+      "Coordinate collapsing occurred in going to the reference space. There is no unique return "
+      "mapping");
+
   const Real sqrt2 = std::sqrt(2.);
   const Real sqrt3 = std::sqrt(3.);
   const Point xyz_pt(1, 1, 1);
@@ -133,6 +137,17 @@ TEST(MooseCoordTest, testCoordCollapse)
     EXPECT_TRUE(absoluteFuzzyEqual(pt(0), sqrt2));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(1), 1.));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(2), 0.));
+    EXPECT_TRUE(xyz.hasNonTranslationTransformation());
+    try
+    {
+      xyz.mapBack(pt);
+      EXPECT_TRUE(false);
+    }
+    catch (std::runtime_error & e)
+    {
+      std::string error_message(e.what());
+      EXPECT_TRUE(error_message.find(return_mapping_error_message) != std::string::npos);
+    }
   }
   {
     xyz.setDestinationCoordTransform(single_app_rsph);
@@ -140,6 +155,17 @@ TEST(MooseCoordTest, testCoordCollapse)
     EXPECT_TRUE(absoluteFuzzyEqual(pt(0), sqrt3));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(1), 0.));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(2), 0.));
+    EXPECT_TRUE(xyz.hasNonTranslationTransformation());
+    try
+    {
+      xyz.mapBack(pt);
+      EXPECT_TRUE(false);
+    }
+    catch (std::runtime_error & e)
+    {
+      std::string error_message(e.what());
+      EXPECT_TRUE(error_message.find(return_mapping_error_message) != std::string::npos);
+    }
   }
   {
     rz.setDestinationCoordTransform(single_app_rsph);
@@ -147,6 +173,17 @@ TEST(MooseCoordTest, testCoordCollapse)
     EXPECT_TRUE(absoluteFuzzyEqual(pt(0), sqrt2));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(1), 0.));
     EXPECT_TRUE(absoluteFuzzyEqual(pt(2), 0.));
+    EXPECT_TRUE(rz.hasNonTranslationTransformation());
+    try
+    {
+      rz.mapBack(pt);
+      EXPECT_TRUE(false);
+    }
+    catch (std::runtime_error & e)
+    {
+      std::string error_message(e.what());
+      EXPECT_TRUE(error_message.find(return_mapping_error_message) != std::string::npos);
+    }
   }
 }
 

--- a/unit/src/MooseCoordTest.C
+++ b/unit/src/MooseCoordTest.C
@@ -42,7 +42,7 @@ TEST(MooseCoordTest, testRotations)
     try
     {
       transform.setUpDirection(up_direction);
-      EXPECT_TRUE(false);
+      FAIL();
     }
     catch (std::runtime_error & e)
     {
@@ -88,7 +88,7 @@ TEST(MooseCoordTest, testRotations)
     try
     {
       transform.setRotation(alpha, beta, gamma);
-      EXPECT_TRUE(false);
+      FAIL();
     }
     catch (std::runtime_error & e)
     {
@@ -141,7 +141,7 @@ TEST(MooseCoordTest, testCoordCollapse)
     try
     {
       xyz.mapBack(pt);
-      EXPECT_TRUE(false);
+      FAIL();
     }
     catch (std::runtime_error & e)
     {
@@ -159,7 +159,7 @@ TEST(MooseCoordTest, testCoordCollapse)
     try
     {
       xyz.mapBack(pt);
-      EXPECT_TRUE(false);
+      FAIL();
     }
     catch (std::runtime_error & e)
     {
@@ -177,7 +177,7 @@ TEST(MooseCoordTest, testCoordCollapse)
     try
     {
       rz.mapBack(pt);
-      EXPECT_TRUE(false);
+      FAIL();
     }
     catch (std::runtime_error & e)
     {


### PR DESCRIPTION
- Make skipping coordinate collapsing the default
- Create multiapp transform objects for every app in the multiapp, not just the local ones. This allows querying the (possibly transformed) position of every app, which is necessary for some of our transfer logic, including the `nearest_sub_app = true` logic in `MultiAppUserObjectTransfer`. The bug there was discovered by @vincentlaboure. @vincentlaboure I think this makes your HTTR test look good again, but can you double check?
