### PR TITLE
Fixed a non-deterministic test

### DIFF
--- a/modules/thermal_hydraulics/test/tests/interfaces/discrete_line_segment_interface/tests
+++ b/modules/thermal_hydraulics/test/tests/interfaces/discrete_line_segment_interface/tests
@@ -20,7 +20,7 @@
       type = RunException
       input = 'discrete_line_segment_interface.i'
       cli_args = "AuxKernels/ax_coord_aux/length=5.0"
-      expect_err = "ax_coord_aux: The point \(x,y,z\)=\( 4.07033, -1.21099, -2.64835\) has an invalid axial coordinate \(5.5\). Valid axial coordinates are in the range \(0,5\)."
+      expect_err = "ax_coord_aux: The point \(x,y,z\)=\(.*\) has an invalid axial coordinate \(.*\). Valid axial coordinates are in the range \(0,5\)."
       allow_test_objects = true
 
       detail = 'if an invalid axial coordinate is provided.'


### PR DESCRIPTION
This fix is intended to address the failure https://civet.inl.gov/job/1169599/. I was never able to reproduce the failure locally (tried large number of times). I believe the failure was due to points getting executed in different orders and thus that the tested error message should be more general; however, I noticed that the output shown in https://civet.inl.gov/job/1169599/ did not show any error at all, not just that it was at the wrong point, which might invalidate my theory.

Refs #21818
