### PR TITLE
Make stork script a bit more backwards compatible with older git

### DIFF
--- a/scripts/stork.sh
+++ b/scripts/stork.sh
@@ -124,7 +124,7 @@ if [[ "$kind" == "app" ]]; then
     cp $MOOSE_DIR/.gitignore $dir/
 
     dir="$PWD/$dir"
-    (cd $dir && git init && git branch -m main && git add * .clang-format .gitignore && git commit -m"Initial files")
+    (cd $dir && git init && git add * .clang-format .gitignore && git commit -m "Initial files" && git branch -m main)
 
     echo "MOOSE app created in '$dir'"
     echo ""


### PR DESCRIPTION
Closes #22110 

@jiangwen84 give this change a try on sawtooth and let me know if it fixes your problem. For older git versions, the order of these commands mattered. 
