### PR TITLE
Improve error checking in mesh generators

### DIFF
--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -172,4 +172,32 @@ bool isCoPlanar(const std::vector<Point> vec_pts);
  * @param input mesh over which to compute the next free block id
  */
 SubdomainID getNextFreeSubdomainID(MeshBase & input_mesh);
+
+/**
+ * Whether a particular subdomain ID exists in the mesh
+ * @param input mesh over which to determine subdomain IDs
+ * @param subdomain ID
+ */
+bool hasSubdomainID(MeshBase & input_mesh, const SubdomainID & id);
+
+/**
+ * Whether a particular subdomain name exists in the mesh
+ * @param input mesh over which to determine subdomain names
+ * @param subdomain name
+ */
+bool hasSubdomainName(MeshBase & input_mesh, const SubdomainName & name);
+
+/**
+ * Whether a particular boundary ID exists in the mesh
+ * @param input mesh over which to determine boundary IDs
+ * @param boundary ID
+ */
+bool hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id);
+
+/**
+ * Whether a particular boundary name exists in the mesh
+ * @param input mesh over which to determine boundary names
+ * @param boundary name
+ */
+bool hasBoundaryName(MeshBase & input_mesh, const BoundaryName & name);
 }

--- a/framework/src/meshgenerators/BlockDeletionGenerator.C
+++ b/framework/src/meshgenerators/BlockDeletionGenerator.C
@@ -48,11 +48,8 @@ BlockDeletionGenerator::generate()
         MooseMeshUtils::getSubdomainIDs(*_input, getParam<std::vector<SubdomainName>>("block"));
 
   // Check that the block ids/names exist in the mesh
-  std::set<SubdomainID> mesh_blocks;
-  _input->subdomain_ids(mesh_blocks);
-
   for (std::size_t i = 0; i < _block_ids.size(); ++i)
-    if (_block_ids[i] == Moose::INVALID_BLOCK_ID || !mesh_blocks.count(_block_ids[i]))
+    if (!MooseMeshUtils::hasSubdomainID(*_input, _block_ids[i]))
     {
       if (isParamValid("block"))
         paramError("block",

--- a/framework/src/meshgenerators/BoundaryDeletionGenerator.C
+++ b/framework/src/meshgenerators/BoundaryDeletionGenerator.C
@@ -45,7 +45,9 @@ BoundaryDeletionGenerator::generate()
   {
     auto bid = MooseMeshUtils::getBoundaryID(name, *mesh);
     if (bid == BoundaryInfo::invalid_id)
-      paramError("boundary_names", name, " is not a valid boundary name");
+      paramError("boundary_names", "The boundary '",
+                                   name,
+                                   "' was not found in the mesh");
 
     mesh->get_boundary_info().remove_id(bid);
   }

--- a/framework/src/meshgenerators/BoundaryDeletionGenerator.C
+++ b/framework/src/meshgenerators/BoundaryDeletionGenerator.C
@@ -45,9 +45,7 @@ BoundaryDeletionGenerator::generate()
   {
     auto bid = MooseMeshUtils::getBoundaryID(name, *mesh);
     if (bid == BoundaryInfo::invalid_id)
-      paramError("boundary_names", "The boundary '",
-                                   name,
-                                   "' was not found in the mesh");
+      paramError("boundary_names", "The boundary '", name, "' was not found in the mesh");
 
     mesh->get_boundary_info().remove_id(bid);
   }

--- a/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
+++ b/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
@@ -54,9 +54,7 @@ BreakBoundaryOnSubdomainGenerator::generate()
     {
       // check that the boundary exists in the mesh
       if (!MooseMeshUtils::hasBoundaryName(*mesh, boundary_name))
-        paramError("boundaries", "The boundary '",
-                                 boundary_name,
-                                 "' was not found in the mesh");
+        paramError("boundaries", "The boundary '", boundary_name, "' was not found in the mesh");
 
       breaking_boundary_ids.insert(boundary_info.get_id_by_name(boundary_name));
     }

--- a/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
+++ b/framework/src/meshgenerators/BreakBoundaryOnSubdomainGenerator.C
@@ -51,7 +51,15 @@ BreakBoundaryOnSubdomainGenerator::generate()
   {
     auto & boundary_names = getParam<std::vector<BoundaryName>>("boundaries");
     for (auto & boundary_name : boundary_names)
+    {
+      // check that the boundary exists in the mesh
+      if (!MooseMeshUtils::hasBoundaryName(*mesh, boundary_name))
+        paramError("boundaries", "The boundary '",
+                                 boundary_name,
+                                 "' was not found in the mesh");
+
       breaking_boundary_ids.insert(boundary_info.get_id_by_name(boundary_name));
+    }
   }
   else
   {

--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -86,7 +86,8 @@ BreakMeshByBlockGenerator::generate()
   // Handle block restrictions
   if (_block_pairs_restricted)
   {
-    for (const auto block_name_pair : getParam<std::vector<std::vector<SubdomainName>>>("block_pairs"))
+    for (const auto block_name_pair :
+         getParam<std::vector<std::vector<SubdomainName>>>("block_pairs"))
     {
       if (block_name_pair.size() != 2)
         paramError("block_pairs",
@@ -95,9 +96,7 @@ BreakMeshByBlockGenerator::generate()
       // check that the blocks exist in the mesh
       for (const auto & name : block_name_pair)
         if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-          paramError("block_pairs", "The block '",
-                                   name,
-                                   "' was not found in the mesh");
+          paramError("block_pairs", "The block '", name, "' was not found in the mesh");
 
       const auto block_pair = MooseMeshUtils::getSubdomainIDs(*mesh, block_name_pair);
       std::pair<SubdomainID, SubdomainID> pair = std::make_pair(
@@ -112,9 +111,7 @@ BreakMeshByBlockGenerator::generate()
     // check that the blocks exist in the mesh
     for (const auto & name : getParam<std::vector<SubdomainName>>("surrounding_blocks"))
       if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-        paramError("surrounding_blocks", "The block '",
-                                 name,
-                                 "' was not found in the mesh");
+        paramError("surrounding_blocks", "The block '", name, "' was not found in the mesh");
 
     const auto surrounding_block_ids = MooseMeshUtils::getSubdomainIDs(
         *mesh, getParam<std::vector<SubdomainName>>("surrounding_blocks"));

--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -86,11 +86,19 @@ BreakMeshByBlockGenerator::generate()
   // Handle block restrictions
   if (_block_pairs_restricted)
   {
-    for (auto block_name_pair : getParam<std::vector<std::vector<SubdomainName>>>("block_pairs"))
+    for (const auto block_name_pair : getParam<std::vector<std::vector<SubdomainName>>>("block_pairs"))
     {
       if (block_name_pair.size() != 2)
-        paramError("block_pair",
+        paramError("block_pairs",
                    "Each row of 'block_pairs' must have a size of two (block names).");
+
+      // check that the blocks exist in the mesh
+      for (const auto & name : block_name_pair)
+        if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+          paramError("block_pairs", "The block '",
+                                   name,
+                                   "' was not found in the mesh");
+
       const auto block_pair = MooseMeshUtils::getSubdomainIDs(*mesh, block_name_pair);
       std::pair<SubdomainID, SubdomainID> pair = std::make_pair(
           std::min(block_pair[0], block_pair[1]), std::max(block_pair[0], block_pair[1]));
@@ -101,6 +109,13 @@ BreakMeshByBlockGenerator::generate()
   }
   else if (_surrounding_blocks_restricted)
   {
+    // check that the blocks exist in the mesh
+    for (const auto & name : getParam<std::vector<SubdomainName>>("surrounding_blocks"))
+      if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+        paramError("surrounding_blocks", "The block '",
+                                 name,
+                                 "' was not found in the mesh");
+
     const auto surrounding_block_ids = MooseMeshUtils::getSubdomainIDs(
         *mesh, getParam<std::vector<SubdomainName>>("surrounding_blocks"));
     std::copy(surrounding_block_ids.begin(),

--- a/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
+++ b/framework/src/meshgenerators/BreakMeshByBlockGenerator.C
@@ -86,7 +86,7 @@ BreakMeshByBlockGenerator::generate()
   // Handle block restrictions
   if (_block_pairs_restricted)
   {
-    for (const auto block_name_pair :
+    for (const auto & block_name_pair :
          getParam<std::vector<std::vector<SubdomainName>>>("block_pairs"))
     {
       if (block_name_pair.size() != 2)

--- a/framework/src/meshgenerators/ExplodeMeshGenerator.C
+++ b/framework/src/meshgenerators/ExplodeMeshGenerator.C
@@ -9,6 +9,7 @@
 
 #include "ExplodeMeshGenerator.h"
 #include "CastUniquePointer.h"
+#include "MooseMeshUtils.h"
 
 #include "libmesh/partitioner.h"
 

--- a/framework/src/meshgenerators/ExplodeMeshGenerator.C
+++ b/framework/src/meshgenerators/ExplodeMeshGenerator.C
@@ -20,8 +20,7 @@ ExplodeMeshGenerator::validParams()
   InputParameters params = MeshGenerator::validParams();
   params.addClassDescription("Break all element-element interfaces in the specified subdomains.");
   params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
-  params.addParam<std::vector<SubdomainID>>("subdomains",
-                                            "The list of subdomain IDs to explode.");
+  params.addParam<std::vector<SubdomainID>>("subdomains", "The list of subdomain IDs to explode.");
   params.addRequiredParam<BoundaryName>(
       "interface_name", "The boundary name containing all broken element-element interfaces.");
   return params;

--- a/framework/src/meshgenerators/ExplodeMeshGenerator.C
+++ b/framework/src/meshgenerators/ExplodeMeshGenerator.C
@@ -21,7 +21,7 @@ ExplodeMeshGenerator::validParams()
   params.addClassDescription("Break all element-element interfaces in the specified subdomains.");
   params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
   params.addParam<std::vector<SubdomainID>>("subdomains",
-                                            "The list of subdomain names to explode.");
+                                            "The list of subdomain IDs to explode.");
   params.addRequiredParam<BoundaryName>(
       "interface_name", "The boundary name containing all broken element-element interfaces.");
   return params;
@@ -39,6 +39,11 @@ std::unique_ptr<MeshBase>
 ExplodeMeshGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
+
+  // check that the subdomain IDs exist in the mesh
+  for (const auto & id : _subdomains)
+    if (!MooseMeshUtils::hasSubdomainID(*mesh, id))
+      paramError("subdomains", "The block ID '", id, "' was not found in the mesh");
 
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
   if (boundary_info.get_id_by_name(_interface_name) != Moose::INVALID_BOUNDARY_ID)

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -76,9 +76,7 @@ MeshExtruderGenerator::generate()
   // check that the existing_subdomains exist in the mesh
   for (const auto & id : _existing_subdomains)
     if (!MooseMeshUtils::hasSubdomainID(*source_mesh, id))
-      paramError("existing_subdomains", "The block ID '",
-                                        id,
-                                        "' was not found in the mesh");
+      paramError("existing_subdomains", "The block ID '", id, "' was not found in the mesh");
 
   if (source_mesh->mesh_dimension() == 3)
     mooseError("You cannot extrude a 3D mesh !");

--- a/framework/src/meshgenerators/MeshExtruderGenerator.C
+++ b/framework/src/meshgenerators/MeshExtruderGenerator.C
@@ -73,6 +73,13 @@ MeshExtruderGenerator::generate()
 
   auto dest_mesh = buildMeshBaseObject();
 
+  // check that the existing_subdomains exist in the mesh
+  for (const auto & id : _existing_subdomains)
+    if (!MooseMeshUtils::hasSubdomainID(*source_mesh, id))
+      paramError("existing_subdomains", "The block ID '",
+                                        id,
+                                        "' was not found in the mesh");
+
   if (source_mesh->mesh_dimension() == 3)
     mooseError("You cannot extrude a 3D mesh !");
 

--- a/framework/src/meshgenerators/ParsedGenerateSideset.C
+++ b/framework/src/meshgenerators/ParsedGenerateSideset.C
@@ -135,9 +135,7 @@ ParsedGenerateSideset::generate()
     const auto subdomains = getParam<std::vector<SubdomainName>>("included_subdomains");
     for (const auto & name : subdomains)
       if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-        paramError("included_subdomains", "The block '",
-                                          name,
-                                          "' was not found in the mesh");
+        paramError("included_subdomains", "The block '", name, "' was not found in the mesh");
 
     _included_ids = MooseMeshUtils::getSubdomainIDs(*mesh, subdomains);
   }
@@ -148,9 +146,7 @@ ParsedGenerateSideset::generate()
     const auto subdomains = getParam<std::vector<SubdomainName>>("included_neighbors");
     for (const auto & name : subdomains)
       if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-        paramError("included_neighbors", "The block '",
-                                         name,
-                                         "' was not found in the mesh");
+        paramError("included_neighbors", "The block '", name, "' was not found in the mesh");
 
     _included_neighbor_ids = MooseMeshUtils::getSubdomainIDs(*mesh, subdomains);
   }

--- a/framework/src/meshgenerators/ParsedGenerateSideset.C
+++ b/framework/src/meshgenerators/ParsedGenerateSideset.C
@@ -130,11 +130,30 @@ ParsedGenerateSideset::generate()
 
   // Get the boundary ids from the names
   if (parameters().isParamValid("included_subdomains"))
-    _included_ids = MooseMeshUtils::getSubdomainIDs(
-        *mesh, getParam<std::vector<SubdomainName>>("included_subdomains"));
+  {
+    // check that the subdomains exist in the mesh
+    const auto subdomains = getParam<std::vector<SubdomainName>>("included_subdomains");
+    for (const auto & name : subdomains)
+      if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+        paramError("included_subdomains", "The block '",
+                                          name,
+                                          "' was not found in the mesh");
+
+    _included_ids = MooseMeshUtils::getSubdomainIDs(*mesh, subdomains);
+  }
+
   if (parameters().isParamValid("included_neighbors"))
-    _included_neighbor_ids = MooseMeshUtils::getSubdomainIDs(
-        *mesh, getParam<std::vector<SubdomainName>>("included_neighbors"));
+  {
+    // check that the subdomains exist in the mesh
+    const auto subdomains = getParam<std::vector<SubdomainName>>("included_neighbors");
+    for (const auto & name : subdomains)
+      if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+        paramError("included_neighbors", "The block '",
+                                         name,
+                                         "' was not found in the mesh");
+
+    _included_neighbor_ids = MooseMeshUtils::getSubdomainIDs(*mesh, subdomains);
+  }
 
   // Get the BoundaryIDs from the mesh
   std::vector<boundary_id_type> boundary_ids =

--- a/framework/src/meshgenerators/ParsedSubdomainMeshGenerator.C
+++ b/framework/src/meshgenerators/ParsedSubdomainMeshGenerator.C
@@ -97,9 +97,7 @@ ParsedSubdomainMeshGenerator::generate()
     // check that the subdomains exist in the mesh
     for (const auto & name : excluded_subdomains)
       if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-        paramError("excluded_subdomains", "The block '",
-                                          name,
-                                          "' was not found in the mesh");
+        paramError("excluded_subdomains", "The block '", name, "' was not found in the mesh");
 
     _excluded_ids = MooseMeshUtils::getSubdomainIDs(*mesh, excluded_subdomains);
   }

--- a/framework/src/meshgenerators/RefineBlockGenerator.C
+++ b/framework/src/meshgenerators/RefineBlockGenerator.C
@@ -56,14 +56,12 @@ RefineBlockGenerator::generate()
   _input->subdomain_ids(mesh_blocks);
 
   for (std::size_t i = 0; i < block_ids.size(); ++i)
-    if (block_ids[i] == Moose::INVALID_BLOCK_ID || !mesh_blocks.count(block_ids[i]))
-    {
-      if (isParamValid("block"))
-        paramError("block",
-                   "The block '",
-                   getParam<std::vector<SubdomainName>>("block")[i],
-                   "' was not found within the mesh");
-    }
+    if (!MooseMeshUtils::hasSubdomainID(*_input, block_ids[i]))
+      paramError("block",
+                 "The block '",
+                 getParam<std::vector<SubdomainName>>("block")[i],
+                 "' was not found within the mesh");
+
   std::unique_ptr<MeshBase> mesh = std::move(_input);
   int max = *std::max_element(_refinement.begin(), _refinement.end());
 

--- a/framework/src/meshgenerators/RefineBlockGenerator.C
+++ b/framework/src/meshgenerators/RefineBlockGenerator.C
@@ -63,11 +63,6 @@ RefineBlockGenerator::generate()
                    "The block '",
                    getParam<std::vector<SubdomainName>>("block")[i],
                    "' was not found within the mesh");
-      else
-        paramError("block_id",
-                   "The block '",
-                   getParam<SubdomainID>("block_id"),
-                   "' was not found within the mesh");
     }
   std::unique_ptr<MeshBase> mesh = std::move(_input);
   int max = *std::max_element(_refinement.begin(), _refinement.end());

--- a/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
+++ b/framework/src/meshgenerators/SideSetsAroundSubdomainGenerator.C
@@ -69,14 +69,13 @@ SideSetsAroundSubdomainGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
-  // Extract the block ID
-  /*std::vector<subdomain_id_type> blocks;
   std::vector<SubdomainName> block_names = getParam<std::vector<SubdomainName>>("block");
-  blocks.resize(block_names.size());
-  for (unsigned int i = 0; i < block_names.size(); i++)
-  blocks[i] = mesh->get_id_by_name(block_names[i]);*/
-  auto blocks =
-      MooseMeshUtils::getSubdomainIDs(*mesh, getParam<std::vector<SubdomainName>>("block"));
+  // check that the blocks exist in the mesh
+  for (const auto & name : block_names)
+    if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+      paramError("block", "The block '", name, "' was not found in the mesh");
+
+  auto blocks = MooseMeshUtils::getSubdomainIDs(*mesh, block_names);
   std::set<subdomain_id_type> block_ids(blocks.begin(), blocks.end());
 
   // Create the boundary IDs from the list of names provided (the true flag creates ids from unknown

--- a/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
@@ -49,26 +49,20 @@ SideSetsBetweenSubdomainsGenerator::SideSetsBetweenSubdomainsGenerator(
 std::unique_ptr<MeshBase>
 SideSetsBetweenSubdomainsGenerator::generate()
 {
-  auto primary_block = isParamValid("primary_block") ?
-                       getParam<std::vector<SubdomainName>>("primary_block") :
-                       getParam<std::vector<SubdomainName>>("master_block");
+  auto primary_block = isParamValid("primary_block")
+                           ? getParam<std::vector<SubdomainName>>("primary_block")
+                           : getParam<std::vector<SubdomainName>>("master_block");
 
   auto paired_block = getParam<std::vector<SubdomainName>>("paired_block");
 
   // Check that the block ids/names exist in the mesh
   for (const auto & b : primary_block)
     if (!MooseMeshUtils::hasSubdomainName(*_input, b))
-      paramError("primary_block",
-                 "The block '",
-                 b,
-                 "' was not found within the mesh");
+      paramError("primary_block", "The block '", b, "' was not found within the mesh");
 
   for (const auto & b : paired_block)
     if (!MooseMeshUtils::hasSubdomainName(*_input, b))
-      paramError("paired_block",
-                 "The block '",
-                 b,
-                 "' was not found within the mesh");
+      paramError("paired_block", "The block '", b, "' was not found within the mesh");
 
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
@@ -76,8 +70,8 @@ SideSetsBetweenSubdomainsGenerator::generate()
   if (!mesh->is_prepared())
     mesh->find_neighbors();
 
-  std::vector<subdomain_id_type> vec_primary_ids = MooseMeshUtils::getSubdomainIDs(
-      *mesh, primary_block);
+  std::vector<subdomain_id_type> vec_primary_ids =
+      MooseMeshUtils::getSubdomainIDs(*mesh, primary_block);
   std::set<subdomain_id_type> primary_ids(vec_primary_ids.begin(), vec_primary_ids.end());
 
   std::vector<subdomain_id_type> vec_paired_ids =

--- a/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
+++ b/framework/src/meshgenerators/SideSetsBetweenSubdomainsGenerator.C
@@ -49,6 +49,27 @@ SideSetsBetweenSubdomainsGenerator::SideSetsBetweenSubdomainsGenerator(
 std::unique_ptr<MeshBase>
 SideSetsBetweenSubdomainsGenerator::generate()
 {
+  auto primary_block = isParamValid("primary_block") ?
+                       getParam<std::vector<SubdomainName>>("primary_block") :
+                       getParam<std::vector<SubdomainName>>("master_block");
+
+  auto paired_block = getParam<std::vector<SubdomainName>>("paired_block");
+
+  // Check that the block ids/names exist in the mesh
+  for (const auto & b : primary_block)
+    if (!MooseMeshUtils::hasSubdomainName(*_input, b))
+      paramError("primary_block",
+                 "The block '",
+                 b,
+                 "' was not found within the mesh");
+
+  for (const auto & b : paired_block)
+    if (!MooseMeshUtils::hasSubdomainName(*_input, b))
+      paramError("paired_block",
+                 "The block '",
+                 b,
+                 "' was not found within the mesh");
+
   std::unique_ptr<MeshBase> mesh = std::move(_input);
 
   // Make sure that the mesh is prepared
@@ -56,13 +77,11 @@ SideSetsBetweenSubdomainsGenerator::generate()
     mesh->find_neighbors();
 
   std::vector<subdomain_id_type> vec_primary_ids = MooseMeshUtils::getSubdomainIDs(
-      *mesh,
-      isParamValid("primary_block") ? getParam<std::vector<SubdomainName>>("primary_block")
-                                    : getParam<std::vector<SubdomainName>>("master_block"));
+      *mesh, primary_block);
   std::set<subdomain_id_type> primary_ids(vec_primary_ids.begin(), vec_primary_ids.end());
 
   std::vector<subdomain_id_type> vec_paired_ids =
-      MooseMeshUtils::getSubdomainIDs(*mesh, getParam<std::vector<SubdomainName>>("paired_block"));
+      MooseMeshUtils::getSubdomainIDs(*mesh, paired_block);
   std::set<subdomain_id_type> paired_ids(vec_paired_ids.begin(), vec_paired_ids.end());
 
   std::vector<BoundaryName> boundary_names = getParam<std::vector<BoundaryName>>("new_boundary");

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -69,9 +69,7 @@ SubdomainBoundingBoxGenerator::generate()
     {
       // check that the subdomain exists in the mesh
       if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
-        paramError("restricted_subdomains", "The block '",
-                                            name,
-                                            "' was not found in the mesh");
+        paramError("restricted_subdomains", "The block '", name, "' was not found in the mesh");
 
       restricted_ids.insert(MooseMeshUtils::getSubdomainID(name, *mesh));
     }

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -11,6 +11,7 @@
 #include "Conversion.h"
 #include "CastUniquePointer.h"
 #include "MooseUtils.h"
+#include "MooseMeshUtils.h"
 
 #include "libmesh/elem.h"
 

--- a/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SubdomainBoundingBoxGenerator.C
@@ -67,11 +67,13 @@ SubdomainBoundingBoxGenerator::generate()
     auto names = getParam<std::vector<SubdomainName>>("restricted_subdomains");
     for (auto & name : names)
     {
-      SubdomainID id = Moose::INVALID_BLOCK_ID;
-      std::istringstream ss(name);
-      if (!(ss >> id) || !ss.eof())
-        id = mesh->get_id_by_name(name);
-      restricted_ids.insert(id);
+      // check that the subdomain exists in the mesh
+      if (!MooseMeshUtils::hasSubdomainName(*mesh, name))
+        paramError("restricted_subdomains", "The block '",
+                                            name,
+                                            "' was not found in the mesh");
+
+      restricted_ids.insert(MooseMeshUtils::getSubdomainID(name, *mesh));
     }
   }
 

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -332,7 +332,7 @@ hasSubdomainID(MeshBase & input_mesh, const SubdomainID & id)
 bool
 hasSubdomainName(MeshBase & input_mesh, const SubdomainName & name)
 {
-  auto id = getSubdomainID(name, input_mesh);
+  const auto id = getSubdomainID(name, input_mesh);
   return hasSubdomainID(input_mesh, id);
 }
 

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -326,6 +326,12 @@ hasSubdomainID(MeshBase & input_mesh, const SubdomainID & id)
 {
   std::set<SubdomainID> mesh_blocks;
   input_mesh.subdomain_ids(mesh_blocks);
+
+  // On a distributed mesh we may have sideset IDs that only exist on
+  // other processors
+  if (!input_mesh.is_replicated())
+    input_mesh.comm().set_union(mesh_blocks);
+
   return mesh_blocks.count(id) && (id != Moose::INVALID_BLOCK_ID);
 }
 
@@ -341,6 +347,12 @@ hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id)
 {
   const libMesh::BoundaryInfo & boundary_info = input_mesh.get_boundary_info();
   std::set<libMesh::boundary_id_type> boundary_ids = boundary_info.get_boundary_ids();
+
+  // On a distributed mesh we may have boundary IDs that only exist on
+  // other processors
+  if (!input_mesh.is_replicated())
+    input_mesh.comm().set_union(boundary_ids);
+
   return boundary_ids.count(id) && (id != Moose::INVALID_BOUNDARY_ID);
 }
 

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -320,4 +320,34 @@ getNextFreeSubdomainID(MeshBase & input_mesh)
     return highest_subdomain_id + 1;
   }
 }
+
+bool
+hasSubdomainID(MeshBase & input_mesh, const SubdomainID & id)
+{
+  std::set<SubdomainID> mesh_blocks;
+  input_mesh.subdomain_ids(mesh_blocks);
+  return mesh_blocks.count(id) && (id != Moose::INVALID_BLOCK_ID);
+}
+
+bool
+hasSubdomainName(MeshBase & input_mesh, const SubdomainName & name)
+{
+  auto id = getSubdomainID(name, input_mesh);
+  return hasSubdomainID(input_mesh, id);
+}
+
+bool
+hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id)
+{
+  const libMesh::BoundaryInfo & boundary_info = input_mesh.get_boundary_info();
+  std::set<libMesh::boundary_id_type> boundary_ids = boundary_info.get_boundary_ids();
+  return boundary_ids.count(id) && (id != Moose::INVALID_BOUNDARY_ID);
+}
+
+bool
+hasBoundaryName(MeshBase & input_mesh, const BoundaryName & name)
+{
+  auto id = getBoundaryID(name, input_mesh);
+  return hasBoundaryID(input_mesh, id);
+}
 }

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -347,7 +347,7 @@ hasBoundaryID(MeshBase & input_mesh, const BoundaryID & id)
 bool
 hasBoundaryName(MeshBase & input_mesh, const BoundaryName & name)
 {
-  auto id = getBoundaryID(name, input_mesh);
+  const auto id = getBoundaryID(name, input_mesh);
   return hasBoundaryID(input_mesh, id);
 }
 }

--- a/test/tests/meshgenerators/block_deletion_generator/tests
+++ b/test/tests/meshgenerators/block_deletion_generator/tests
@@ -38,7 +38,7 @@
       input = block_deletion_test1.i
       cli_args = "Mesh/ed0/block=50"
       expect_err = "The block '50' was not found within the mesh"
-      requirement = 'blocks and erroring if a block does not exist.'
+      detail = 'blocks and erroring if a block does not exist.'
     []
   []
 []

--- a/test/tests/meshgenerators/block_deletion_generator/tests
+++ b/test/tests/meshgenerators/block_deletion_generator/tests
@@ -2,7 +2,7 @@
   [block_deletion]
     design = 'meshgenerators/BlockDeletionGenerator.md'
     requirement = 'The system shall be capable of deleting '
-    issues = '#11640 #17052'
+    issues = '#11640 #17052 #22117'
     [all_by_block_ids]
       type = 'Exodiff'
       input = 'block_deletion_test1.i'
@@ -32,6 +32,13 @@
       cli_args = '--mesh-only'
       recover = false
       detail = 'blocks and assigning the new boundary even if the input mesh is not prepared.'
+    []
+    [missing_block]
+      type = RunException
+      input = block_deletion_test1.i
+      cli_args = "Mesh/ed0/block=50"
+      expect_err = "The block '50' was not found within the mesh"
+      requirement = 'blocks and erroring if a block does not exist.'
     []
   []
 []

--- a/test/tests/meshgenerators/boundary_deletion_generator/tests
+++ b/test/tests/meshgenerators/boundary_deletion_generator/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [./boundary_deletion_test]
+  [boundary_deletion_test]
     type = JSONDiff
     input = 'boundary_deletion.i'
     jsondiff = 'boundary_deletion_out.json'
@@ -7,5 +7,14 @@
     requirement = 'The system shall have the capability to remove boundaries in an existing mesh.'
     design = 'meshgenerators/BoundaryDeletionGenerator.md'
     issues = '#11174'
-  [../]
+  []
+  [invalid_boundary]
+    type = RunException
+    input = boundary_deletion.i
+    cli_args = "Mesh/boundary_removal/boundary_names='missing'"
+    expect_err = "The boundary 'missing' was not found in the mesh"
+    requirement = "The system shall error if deleting a non-existent boundary"
+    design = 'meshgenerators/BoundaryDeletionGenerator.md'
+    issues = '#22117'
+  []
 []

--- a/test/tests/meshgenerators/boundary_deletion_generator/tests
+++ b/test/tests/meshgenerators/boundary_deletion_generator/tests
@@ -13,7 +13,7 @@
     input = boundary_deletion.i
     cli_args = "Mesh/boundary_removal/boundary_names='missing'"
     expect_err = "The boundary 'missing' was not found in the mesh"
-    requirement = "The system shall error if deleting a non-existent boundary"
+    requirement = "The system shall error if attempting to delete a non-existent boundary"
     design = 'meshgenerators/BoundaryDeletionGenerator.md'
     issues = '#22117'
   []

--- a/test/tests/meshgenerators/break_boundary_on_subdomain/tests
+++ b/test/tests/meshgenerators/break_boundary_on_subdomain/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#7887 #11640'
+  issues = '#7887 #11640 #22117'
   design = 'meshgenerators/BreakBoundaryOnSubdomainGenerator.md'
 
   [boundary_type]
@@ -24,7 +24,15 @@
       mesh_mode = 'REPLICATED'
       recover = false
 
-      detail = 'on internal boundaries.'
+      detail = 'on internal boundaries, and'
+    []
+
+    [invalid_boundary]
+      type = RunException
+      input = break_boundary_on_subdomain.i
+      cli_args = 'Mesh/break_boundary/boundaries="missing"'
+      expect_err = "The boundary 'missing' was not found in the mesh"
+      detail = 'error when the boundary does not exist in the mesh.'
     []
   []
 []

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/tests
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/tests
@@ -231,6 +231,8 @@
     cli_args = 'Mesh/split/block_pairs="0 missing;2 3"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = "The system shall error if the mesh does not contain the specified block pair"
+    design = 'meshgenerators/BreakMeshByBlockGenerator.md'
+    issues = '#22117'
   []
 
   [invalid_surrounding_block]

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/tests
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/tests
@@ -231,6 +231,7 @@
     cli_args = 'Mesh/split/block_pairs="0 missing;2 3"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = "The system shall error if the mesh does not contain the specified block pair"
+    mesh_mode = 'REPLICATED'
     design = 'meshgenerators/BreakMeshByBlockGenerator.md'
     issues = '#22117'
   []
@@ -241,6 +242,7 @@
     cli_args = 'Mesh/split/surrounding_blocks="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = "The system shall error if the mesh does not contain the specified surrounding block"
+    mesh_mode = 'REPLICATED'
     design = 'meshgenerators/BreakMeshByBlockGenerator.md'
     issues = '#22117'
   []

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/tests
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/tests
@@ -241,5 +241,7 @@
     cli_args = 'Mesh/split/surrounding_blocks="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = "The system shall error if the mesh does not contain the specified surrounding block"
+    design = 'meshgenerators/BreakMeshByBlockGenerator.md'
+    issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/tests
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/tests
@@ -2,7 +2,7 @@
   [break_mesh_by_blocks_generator]
     requirement = 'The system shall be able to create separate blocks in a mesh'
     design = 'meshgenerators/BreakMeshByBlockGenerator.md'
-    issues = '#11640'
+    issues = '#11640 #22117'
 
     [3d_auto_test]
       type = 'Exodiff'
@@ -223,5 +223,21 @@
     min_parallel = 12
     max_parallel = 12
     recover = false
+  []
+
+  [invalid_block_pair]
+    type = RunException
+    input = break_mesh_block_pairs_restricted.i
+    cli_args = 'Mesh/split/block_pairs="0 missing;2 3"'
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = "The system shall error if the mesh does not contain the specified block pair"
+  []
+
+  [invalid_surrounding_block]
+    type = RunException
+    input = break_mesh_block_restricted.i
+    cli_args = 'Mesh/split/surrounding_blocks="missing"'
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = "The system shall error if the mesh does not contain the specified surrounding block"
   []
 []

--- a/test/tests/meshgenerators/explode_mesh_generator/tests
+++ b/test/tests/meshgenerators/explode_mesh_generator/tests
@@ -30,5 +30,7 @@
     cli_args = 'Mesh/explode/subdomains="100"'
     expect_err = "The block ID '100' was not found in the mesh"
     requirement = "The system shall error if the subdomain to explode was not found in the mesh"
+    design = 'meshgenerators/ExplodeMeshGenerator.md'
+    issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/explode_mesh_generator/tests
+++ b/test/tests/meshgenerators/explode_mesh_generator/tests
@@ -3,7 +3,7 @@
     requirement = 'The system shall have the ability to break all element-element interfaces within '
                   'given subdomains both'
     design = 'meshgenerators/ExplodeMeshGenerator.md'
-    issues = '#21060'
+    issues = '#21060 #22117'
     [2D]
       type = 'Exodiff'
       input = '2D.i'
@@ -22,5 +22,13 @@
       mesh_mode = 'REPLICATED'
       detail = 'in 3D.'
     []
+  []
+
+  [invalid_subdomain]
+    type = RunException
+    input = 2D.i
+    cli_args = 'Mesh/explode/subdomains="100"'
+    expect_err = "The block ID '100' was not found in the mesh"
+    requirement = "The system shall error if the subdomain to explode was not found in the mesh"
   []
 []

--- a/test/tests/meshgenerators/mesh_extruder_generator/tests
+++ b/test/tests/meshgenerators/mesh_extruder_generator/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'meshgenerators/MeshExtruderGenerator.md'
-  issues = '#11640 #14037'
+  issues = '#11640 #14037 #22117'
 
   [extruder]
     requirement = 'The system shall have the capability of extruding a lower dimensional mesh to '
@@ -61,5 +61,13 @@
 
       detail = 'while making sure to preserve existing side set names.'
     []
+  []
+
+  [invalid_existing_subdomain]
+    type = RunException
+    input = extrude_remap_layer1.i
+    cli_args = 'Mesh/extrude/existing_subdomains="1 2 800"'
+    expect_err = "The block ID '800' was not found in the mesh"
+    requirement = "The system shall error if the existing subdomain does not exist in the mesh"
   []
 []

--- a/test/tests/meshgenerators/parsed_generate_sideset/parsed_generate_sideset.i
+++ b/test/tests/meshgenerators/parsed_generate_sideset/parsed_generate_sideset.i
@@ -21,7 +21,7 @@
     type = ParsedGenerateSideset
     input = subdomains
     combinatorial_geometry = 'z < 1'
-    included_subdomain_ids = '1'
+    included_subdomains = '1'
     normal = '1 0 0'
     new_sideset_name = interior
   []

--- a/test/tests/meshgenerators/parsed_generate_sideset/tests
+++ b/test/tests/meshgenerators/parsed_generate_sideset/tests
@@ -30,7 +30,7 @@
     input = parsed_generate_sideset.i
     cli_args = 'Mesh/sideset/included_subdomains="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
-    requirement = 'The system shall error if the included subdomains do not exist in the mesh.'
+    requirement = 'The system shall error if one of the included subdomains does not exist in the mesh.'
     issues = '#22117'
   []
 
@@ -39,7 +39,7 @@
     input = parsed_generate_sideset.i
     cli_args = 'Mesh/sideset/included_neighbors="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
-    requirement = 'The system shall error if the included neighbors do not exist in the mesh.'
+    requirement = 'The system shall error if one of the included neighbors does not exist in the mesh.'
     issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/parsed_generate_sideset/tests
+++ b/test/tests/meshgenerators/parsed_generate_sideset/tests
@@ -31,6 +31,7 @@
     cli_args = 'Mesh/sideset/included_subdomains="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = 'The system shall error if one of the included subdomains does not exist in the mesh.'
+    mesh_mode = 'REPLICATED'
     design = 'meshgenerators/ParsedGenerateSideset.md'
     issues = '#22117'
   []
@@ -41,6 +42,7 @@
     cli_args = 'Mesh/sideset/included_neighbors="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = 'The system shall error if one of the included neighbors does not exist in the mesh.'
+    mesh_mode = 'REPLICATED'
     design = 'meshgenerators/ParsedGenerateSideset.md'
     issues = '#22117'
   []

--- a/test/tests/meshgenerators/parsed_generate_sideset/tests
+++ b/test/tests/meshgenerators/parsed_generate_sideset/tests
@@ -24,4 +24,22 @@
     design = 'meshgenerators/ParsedGenerateSideset.md'
     issues = '#15651'
   [../]
+
+  [invalid_included_subdomains]
+    type = RunException
+    input = parsed_generate_sideset.i
+    cli_args = 'Mesh/sideset/included_subdomains="missing"'
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = 'The system shall error if the included subdomains do not exist in the mesh.'
+    issues = '#22117'
+  []
+
+  [invalid_included_neighbors]
+    type = RunException
+    input = parsed_generate_sideset.i
+    cli_args = 'Mesh/sideset/included_neighbors="missing"'
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = 'The system shall error if the included neighbors do not exist in the mesh.'
+    issues = '#22117'
+  []
 []

--- a/test/tests/meshgenerators/parsed_generate_sideset/tests
+++ b/test/tests/meshgenerators/parsed_generate_sideset/tests
@@ -31,6 +31,7 @@
     cli_args = 'Mesh/sideset/included_subdomains="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = 'The system shall error if one of the included subdomains does not exist in the mesh.'
+    design = 'meshgenerators/ParsedGenerateSideset.md'
     issues = '#22117'
   []
 
@@ -40,6 +41,7 @@
     cli_args = 'Mesh/sideset/included_neighbors="missing"'
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = 'The system shall error if one of the included neighbors does not exist in the mesh.'
+    design = 'meshgenerators/ParsedGenerateSideset.md'
     issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
+++ b/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
@@ -11,4 +11,12 @@
     design = 'meshgenerators/ParsedSubdomainMeshGenerator.md'
     issues = '#11640'
   [../]
+  [invalid_excluded_subdomain]
+    type = RunException
+    input = parsed_subdomain_mg.i
+    cli_args = "Mesh/subdomains2/excluded_subdomains='missing'"
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = 'The system shall error if subdomains are specified that do not exist in the mesh.'
+    issues = '#22117'
+  []
 []

--- a/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
+++ b/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
@@ -16,7 +16,7 @@
     input = parsed_subdomain_mg.i
     cli_args = "Mesh/subdomains2/excluded_subdomains='missing'"
     expect_err = "The block 'missing' was not found in the mesh"
-    requirement = 'The system shall error if subdomains are specified that do not exist in the mesh.'
+    requirement = 'The system shall error if a specified subdomain does not exist in the mesh.'
     issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
+++ b/test/tests/meshgenerators/parsed_subdomain_mesh_generator/tests
@@ -17,6 +17,7 @@
     cli_args = "Mesh/subdomains2/excluded_subdomains='missing'"
     expect_err = "The block 'missing' was not found in the mesh"
     requirement = 'The system shall error if a specified subdomain does not exist in the mesh.'
+    design = 'meshgenerators/ParsedSubdomainMeshGenerator.md'
     issues = '#22117'
   []
 []

--- a/test/tests/meshgenerators/refine_block_generator/tests
+++ b/test/tests/meshgenerators/refine_block_generator/tests
@@ -36,6 +36,6 @@
     input = test_single.i
     cli_args = 'Mesh/refine/block="missing"'
     expect_err = "The block 'missing' was not found within the mesh"
-    requirement = "The system shall error if refining a block that does not exist in the mesh."
+    requirement = "The system shall error if attempting to refine a block that does not exist in the mesh."
   []
 []

--- a/test/tests/meshgenerators/refine_block_generator/tests
+++ b/test/tests/meshgenerators/refine_block_generator/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#18686'
+  issues = '#18686 #22117'
   design = 'meshgenerators/RefineBlockGenerator.md'
 
   [generate]
@@ -29,5 +29,13 @@
       recover = false
       detail = 'multiple blocks within a multi-domain mesh, with neighbor refinement enabled'
     []
+  []
+
+  [invalid_block]
+    type = RunException
+    input = test_single.i
+    cli_args = 'Mesh/refine/block="missing"'
+    expect_err = "The block 'missing' was not found within the mesh"
+    requirement = "The system shall error if refining a block that does not exist in the mesh."
   []
 []

--- a/test/tests/meshgenerators/sideset_around_subdomain_generator/tests
+++ b/test/tests/meshgenerators/sideset_around_subdomain_generator/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'meshgenerators/SideSetsAroundSubdomainGenerator.md'
-  issues = '#11640'
+  issues = '#11640 #22117'
 
   [group]
     requirement = 'The system shall have the ability to create new mesh side sets around subdomains:'
@@ -44,5 +44,13 @@
 
       detail = 'around two blocks within a domain.'
     []
+  []
+
+  [invalid_block]
+    type = RunException
+    input = around.i
+    cli_args = 'Mesh/block_2/block="missing"'
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = "The system shall error if the subdomain to create sidesets around does not exist in the mesh"
   []
 []

--- a/test/tests/meshgenerators/sidesets_between_subdomains_generator/tests
+++ b/test/tests/meshgenerators/sidesets_between_subdomains_generator/tests
@@ -47,5 +47,21 @@
 
       detail = 'between two subdomains in an unprepared mesh.'
     []
+
+    [invalid_primary_block]
+      type = RunException
+      input = sideset_between_subdomains.i
+      cli_args = "Mesh/central_boundary/primary_block='missing'"
+      expect_err = "The block 'missing' was not found within the mesh"
+      detail = 'only when both the primary and paired blocks exist in the mesh.'
+    []
+
+    [invalid_paired_block]
+      type = RunException
+      input = sideset_between_subdomains.i
+      cli_args = "Mesh/central_boundary/paired_block='missing'"
+      expect_err = "The block 'missing' was not found within the mesh"
+      detail = 'only when both the primary and paired blocks exist in the mesh.'
+    []
   []
 []

--- a/test/tests/meshgenerators/sidesets_between_subdomains_generator/tests
+++ b/test/tests/meshgenerators/sidesets_between_subdomains_generator/tests
@@ -53,7 +53,7 @@
       input = sideset_between_subdomains.i
       cli_args = "Mesh/central_boundary/primary_block='missing'"
       expect_err = "The block 'missing' was not found within the mesh"
-      detail = 'only when both the primary and paired blocks exist in the mesh.'
+      detail = 'only when the primary block exists in the mesh.'
     []
 
     [invalid_paired_block]
@@ -61,7 +61,7 @@
       input = sideset_between_subdomains.i
       cli_args = "Mesh/central_boundary/paired_block='missing'"
       expect_err = "The block 'missing' was not found within the mesh"
-      detail = 'only when both the primary and paired blocks exist in the mesh.'
+      detail = 'only when the paired block exists in the mesh.'
     []
   []
 []

--- a/test/tests/meshgenerators/subdomain_bounding_box_generator/tests
+++ b/test/tests/meshgenerators/subdomain_bounding_box_generator/tests
@@ -54,4 +54,16 @@
     mesh_mode = 'REPLICATED'
     recover = false
   [../]
+
+  [invalid_restricted_subdomain]
+    type = RunException
+    input = subdomain_bounding_box_generator_restricted.i
+    cli_args = "Mesh/subdomains2/restricted_subdomains='missing'"
+    expect_err = "The block 'missing' was not found in the mesh"
+    requirement = 'The system shall error if a restricted subdomain does not exist in the mesh'
+    design = 'meshgenerators/SubdomainBoundingBoxGenerator.md'
+    issues = '#22117'
+    mesh_mode = 'REPLICATED'
+    recover = false
+  []
 []

--- a/test/tests/meshgenerators/subdomain_bounding_box_generator/tests
+++ b/test/tests/meshgenerators/subdomain_bounding_box_generator/tests
@@ -60,7 +60,7 @@
     input = subdomain_bounding_box_generator_restricted.i
     cli_args = "Mesh/subdomains2/restricted_subdomains='missing'"
     expect_err = "The block 'missing' was not found in the mesh"
-    requirement = 'The system shall error if a restricted subdomain does not exist in the mesh'
+    requirement = 'The system shall error if a restricted subdomain of the bounding box subdomain generation does not exist in the mesh'
     design = 'meshgenerators/SubdomainBoundingBoxGenerator.md'
     issues = '#22117'
     mesh_mode = 'REPLICATED'


### PR DESCRIPTION
This adds extra error checks on user input for boundary IDs/names in the mesh generators. This does not address every occurence where the user provides a boundary/sideset ID/name, but I thought it better to split into smaller PRs since there's a decent amount here already.

Refs #22117

