### PR TITLE
Fixup mastodon broken sqa docs

### DIFF
--- a/test/tests/outputs/residuals_output/tests
+++ b/test/tests/outputs/residuals_output/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'Outputs/index.md'
+  design = 'syntax/Outputs/index.md'
   issues = '#22056'
   [./no_linear_residuals]
     type = 'RunApp'


### PR DESCRIPTION
@socratesgorilla @GiudGiud Use of `Outputs/index.md` instead of `syntax/Outputs/index.md` as the design page for the new `residuals_output` tests broke Mastodon SQA docs (as they have their own `Outputs/index.md` page for a special output action). This PR fixes that up. 

See https://civet.inl.gov/job/1180883/ for reference.

Refs #22129

