### PR TITLE
Some THM cleanup

### DIFF
--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/syntax/Closures/index.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/syntax/Closures/index.md
@@ -6,8 +6,8 @@ as friction factors and heat transfer coefficients.
 
 ## Objects and Associated Actions
 
-!syntax list /Components objects=True actions=False subsystems=False
+!syntax list /Closures objects=True actions=False subsystems=False
 
-!syntax list /Components objects=False actions=False subsystems=True
+!syntax list /Closures objects=False actions=False subsystems=True
 
-!syntax list /Components objects=False actions=True subsystems=False
+!syntax list /Closures objects=False actions=True subsystems=False

--- a/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/syntax/ControlLogic/index.md
+++ b/modules/thermal_hydraulics/doc/content/modules/thermal_hydraulics/syntax/ControlLogic/index.md
@@ -1,1 +1,25 @@
-!template load file=stubs/moose_system.md.template name=ControlLogic syntax=/ControlLogic
+# ControlLogic System
+
+The `ControlLogic` system is an extension of MOOSE's [Controls system](syntax/Controls/index.md).
+Standard MOOSE `Control`s can be created within a `[ControlLogic]` block or a
+`[Controls]` block. `THMControl`s, however, which have additional functionality,
+can only be created within a `[ControlLogic]` block.
+
+While MOOSE `Control`s work "directly" with controllable parameters,
+`THMControl`s can work with an additional layer, +control data+. A `THMControl` can:
+
+- Declare new control data
+- Retrieve control data declared elsewhere
+- Change control data values
+- Set controllable parameters in MOOSE objects using control data
+
+The main advantage of this additional capability is to chain control operations together,
+which is useful for composing realistic control systems.
+
+## Objects and Associated Actions
+
+!syntax list /ControlLogic objects=True actions=False subsystems=False
+
+!syntax list /ControlLogic objects=False actions=False subsystems=True
+
+!syntax list /ControlLogic objects=False actions=True subsystems=False

--- a/modules/thermal_hydraulics/include/base/FlowModelSinglePhase.h
+++ b/modules/thermal_hydraulics/include/base/FlowModelSinglePhase.h
@@ -33,6 +33,9 @@ protected:
   /// Numerical flux user object name
   const UserObjectName _numerical_flux_name;
 
+  /// Scaling factors for each solution variable (rhoA, rhouA, rhoEA)
+  const std::vector<Real> _scaling_factors;
+
 public:
   static const std::string DENSITY;
   static const std::string FRICTION_FACTOR_DARCY;

--- a/modules/thermal_hydraulics/include/components/Component.h
+++ b/modules/thermal_hydraulics/include/components/Component.h
@@ -362,13 +362,6 @@ protected:
   void checkMutuallyExclusiveParameters(const std::vector<std::string> & params,
                                         bool need_one_specified = true) const;
 
-  /**
-   * Logs an error for the model type not being implemented for the component
-   *
-   * @param[in] model   model type
-   */
-  void logModelNotImplementedError(const THM::FlowModelID & model) const;
-
   /// Pointer to a parent component (used in composed components)
   Component * _parent;
 

--- a/modules/thermal_hydraulics/include/components/Component.h
+++ b/modules/thermal_hydraulics/include/components/Component.h
@@ -363,41 +363,6 @@ protected:
                                         bool need_one_specified = true) const;
 
   /**
-   * Checks that an rDG parameter was provided
-   *
-   * @param[in] param   parameter name
-   */
-  void checkRDGRequiredParameter(const std::string & param) const;
-
-  /**
-   * Checks that a 1-phase parameter was provided
-   *
-   * @param[in] param   parameter name
-   */
-  void check1PhaseRequiredParameter(const std::string & param) const;
-
-  /**
-   * Checks that a 2-phase parameter was provided
-   *
-   * @param[in] param   parameter name
-   */
-  void check2PhaseRequiredParameter(const std::string & param) const;
-
-  /**
-   * Checks that a 7-equation (2-phase plus phase interaction) parameter was provided
-   *
-   * @param[in] param   parameter name
-   */
-  void check7EqnRequiredParameter(const std::string & param) const;
-
-  /**
-   * Checks that a 7-equation (2-phase plus phase interaction) + NCG parameter was provided
-   *
-   * @param[in] param   parameter name
-   */
-  void check7EqnNCGRequiredParameter(const std::string & param) const;
-
-  /**
    * Logs an error for the model type not being implemented for the component
    *
    * @param[in] model   model type

--- a/modules/thermal_hydraulics/src/base/FlowModelSinglePhase.C
+++ b/modules/thermal_hydraulics/src/base/FlowModelSinglePhase.C
@@ -40,6 +40,9 @@ FlowModelSinglePhase::validParams()
   params.addRequiredParam<UserObjectName>("numerical_flux", "Numerical flux user object name");
   params.addRequiredParam<MooseEnum>("rdg_slope_reconstruction",
                                      "Slope reconstruction type for rDG");
+  params.addRequiredParam<std::vector<Real>>(
+      "scaling_factor_1phase",
+      "Scaling factors for each single phase variable (rhoA, rhouA, rhoEA)");
   return params;
 }
 
@@ -48,7 +51,8 @@ registerMooseObject("ThermalHydraulicsApp", FlowModelSinglePhase);
 FlowModelSinglePhase::FlowModelSinglePhase(const InputParameters & params)
   : FlowModel(params),
     _rdg_slope_reconstruction(params.get<MooseEnum>("rdg_slope_reconstruction")),
-    _numerical_flux_name(params.get<UserObjectName>("numerical_flux"))
+    _numerical_flux_name(params.get<UserObjectName>("numerical_flux")),
+    _scaling_factors(getParam<std::vector<Real>>("scaling_factor_1phase"))
 {
 }
 
@@ -63,12 +67,11 @@ FlowModelSinglePhase::addVariables()
   FlowModel::addCommonVariables();
 
   const std::vector<SubdomainName> & subdomains = _flow_channel.getSubdomainNames();
-  std::vector<Real> scaling_factor = _sim.getParam<std::vector<Real>>("scaling_factor_1phase");
 
   // Nonlinear variables
-  _sim.addSimVariable(true, RHOA, _fe_type, subdomains, scaling_factor[0]);
-  _sim.addSimVariable(true, RHOUA, _fe_type, subdomains, scaling_factor[1]);
-  _sim.addSimVariable(true, RHOEA, _fe_type, subdomains, scaling_factor[2]);
+  _sim.addSimVariable(true, RHOA, _fe_type, subdomains, _scaling_factors[0]);
+  _sim.addSimVariable(true, RHOUA, _fe_type, subdomains, _scaling_factors[1]);
+  _sim.addSimVariable(true, RHOEA, _fe_type, subdomains, _scaling_factors[2]);
 
   _solution_vars = {RHOA, RHOUA, RHOEA};
   _derivative_vars = _solution_vars;

--- a/modules/thermal_hydraulics/src/base/HeatConductionModel.C
+++ b/modules/thermal_hydraulics/src/base/HeatConductionModel.C
@@ -21,6 +21,8 @@ HeatConductionModel::validParams()
   InputParameters params = MooseObject::validParams();
   params.addPrivateParam<THMProblem *>("_thm_problem");
   params.addPrivateParam<HeatStructureBase *>("_hs");
+  params.addRequiredParam<Real>("scaling_factor_temperature",
+                                "Scaling factor for solid temperature variable.");
   params.registerBase("THM:heat_conduction_model");
   return params;
 }
@@ -47,7 +49,7 @@ void
 HeatConductionModel::addVariables()
 {
   const auto & subdomain_names = _hs.getSubdomainNames();
-  const Real & scaling_factor = _sim.getParam<Real>("scaling_factor_temperature");
+  const Real & scaling_factor = getParam<Real>("scaling_factor_temperature");
 
   _sim.addSimVariable(true, TEMPERATURE, _fe_type, subdomain_names, scaling_factor);
 }

--- a/modules/thermal_hydraulics/src/components/Component.C
+++ b/modules/thermal_hydraulics/src/components/Component.C
@@ -167,43 +167,6 @@ Component::checkMutuallyExclusiveParameters(const std::vector<std::string> & par
 }
 
 void
-Component::checkRDGRequiredParameter(const std::string & param) const
-{
-  if (!_pars.isParamSetByUser(param))
-    logError("The parameter '", param, "' must be provided when using rDG");
-}
-
-void
-Component::check1PhaseRequiredParameter(const std::string & param) const
-{
-  if (!isParamValid(param))
-    logError("The parameter '", param, "' must be provided for single-phase flow");
-}
-
-void
-Component::check2PhaseRequiredParameter(const std::string & param) const
-{
-  if (!isParamValid(param))
-    logError("The parameter '", param, "' must be provided for two-phase flow");
-}
-
-void
-Component::check7EqnRequiredParameter(const std::string & param) const
-{
-  if (!isParamValid(param))
-    logError("The parameter '", param, "' must be provided for the 7-equation model");
-}
-
-void
-Component::check7EqnNCGRequiredParameter(const std::string & param) const
-{
-  if (!isParamValid(param))
-    logError("The parameter '",
-             param,
-             "' must be provided for the 7-equation model with non-condensable gas");
-}
-
-void
 Component::logModelNotImplementedError(const THM::FlowModelID & model) const
 {
   if (model == THM::FM_SINGLE_PHASE)

--- a/modules/thermal_hydraulics/src/components/Component.C
+++ b/modules/thermal_hydraulics/src/components/Component.C
@@ -165,16 +165,3 @@ Component::checkMutuallyExclusiveParameters(const std::vector<std::string> & par
       logError("Only one of the parameters ", params_list_string, " can be provided");
   }
 }
-
-void
-Component::logModelNotImplementedError(const THM::FlowModelID & model) const
-{
-  if (model == THM::FM_SINGLE_PHASE)
-    logError("This component is not implemented for single-phase flow");
-  else if (model == THM::FM_TWO_PHASE)
-    logError("This component is not implemented for two-phase flow");
-  else if (model == THM::FM_TWO_PHASE_NCG)
-    logError("This component is not implemented for two-phase flow with non-condensable gases");
-  else
-    logError("This component is not implemented for model type '", model, "'");
-}

--- a/modules/thermal_hydraulics/src/components/FlowChannel1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannel1Phase.C
@@ -30,6 +30,11 @@ FlowChannel1Phase::validParams()
       "rdg_slope_reconstruction",
       SlopeReconstruction1DInterface<true>::getSlopeReconstructionMooseEnum("None"),
       "Slope reconstruction type for rDG spatial discretization");
+  std::vector<Real> sf_1phase(3, 1.0);
+  params.addParam<std::vector<Real>>(
+      "scaling_factor_1phase",
+      sf_1phase,
+      "Scaling factors for each single phase variable (rhoA, rhouA, rhoEA)");
 
   params.declareControllable("initial_p initial_T initial_vel D_h");
 
@@ -63,10 +68,9 @@ FlowChannel1Phase::buildFlowModel()
   InputParameters pars = _factory.getValidParams(class_name);
   pars.set<THMProblem *>("_thm_problem") = &_sim;
   pars.set<FlowChannelBase *>("_flow_channel") = this;
-  pars.set<UserObjectName>("fp") = _fp_name;
   pars.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
-  pars.set<MooseEnum>("rdg_slope_reconstruction") = _rdg_slope_reconstruction;
   pars.set<bool>("output_vector_velocity") = _sim.getVectorValuedVelocity();
+  pars.applyParameters(parameters());
   return _factory.create<FlowModel>(class_name, name(), pars, 0);
 }
 

--- a/modules/thermal_hydraulics/src/components/GateValve1Phase.C
+++ b/modules/thermal_hydraulics/src/components/GateValve1Phase.C
@@ -43,9 +43,6 @@ GateValve1Phase::check() const
 {
   FlowJunction1Phase::check();
 
-  if (_flow_model_id != THM::FM_SINGLE_PHASE)
-    logModelNotImplementedError(_flow_model_id);
-
   // Check that there are exactly 2 connections
   checkNumberOfConnections(2);
 

--- a/modules/thermal_hydraulics/src/components/HeatStructureBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureBase.C
@@ -38,6 +38,8 @@ HeatStructureBase::validParams()
   InputParameters params = Component2D::validParams();
   params.addPrivateParam<std::string>("component_type", "heat_struct");
   params.addParam<FunctionName>("initial_T", "Initial temperature [K]");
+  params.addParam<Real>(
+      "scaling_factor_temperature", 1.0, "Scaling factor for solid temperature variable.");
   return params;
 }
 
@@ -53,6 +55,7 @@ HeatStructureBase::buildModel()
   InputParameters pars = _factory.getValidParams(class_name);
   pars.set<THMProblem *>("_thm_problem") = &_sim;
   pars.set<HeatStructureBase *>("_hs") = this;
+  pars.applyParameters(parameters());
   return _factory.create<HeatConductionModel>(class_name, name(), pars, 0);
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
@@ -63,6 +63,7 @@ HeatStructureFromFile3D::buildModel()
   InputParameters pars = _factory.getValidParams(class_name);
   pars.set<THMProblem *>("_thm_problem") = &_sim;
   pars.set<HeatStructureBase *>("_hs") = this;
+  pars.applyParameters(parameters());
   return _factory.create<HeatConductionModel>(class_name, name(), pars, 0);
 }
 

--- a/modules/thermal_hydraulics/src/components/SupersonicInlet.C
+++ b/modules/thermal_hydraulics/src/components/SupersonicInlet.C
@@ -33,7 +33,7 @@ SupersonicInlet::check() const
 {
   FlowBoundary1Phase::check();
 
-  logModelNotImplementedError(_flow_model_id);
+  logError("This component is deprecated.");
 }
 
 void

--- a/modules/thermal_hydraulics/src/components/VolumeJunction1Phase.C
+++ b/modules/thermal_hydraulics/src/components/VolumeJunction1Phase.C
@@ -81,9 +81,6 @@ VolumeJunction1Phase::check() const
 {
   FlowJunction1Phase::check();
 
-  if (_flow_model_id != THM::FM_SINGLE_PHASE)
-    logModelNotImplementedError(_flow_model_id);
-
   bool ics_set =
       _sim.hasInitialConditionsFromFile() ||
       (isParamValid("initial_p") && isParamValid("initial_T") && isParamValid("initial_vel_x") &&

--- a/modules/thermal_hydraulics/src/problems/THMProblem.C
+++ b/modules/thermal_hydraulics/src/problems/THMProblem.C
@@ -17,10 +17,6 @@ THMProblem::validParams()
 {
   InputParameters params = FEProblem::validParams();
 
-  // default scaling factors
-  params.addParam<Real>(
-      "scaling_factor_temperature", 1.0, "Scaling factor for solid temperature variable.");
-
   params.addParam<bool>("2nd_order_mesh", false, "Use 2nd order elements in the mesh");
 
   params.addParam<FileName>("initial_from_file",

--- a/modules/thermal_hydraulics/src/problems/THMProblem.C
+++ b/modules/thermal_hydraulics/src/problems/THMProblem.C
@@ -18,28 +18,10 @@ THMProblem::validParams()
   InputParameters params = FEProblem::validParams();
 
   // default scaling factors
-  std::vector<Real> sf_2phase(7, 1.);
-  params.addParam<std::vector<Real>>("scaling_factor_2phase",
-                                     sf_2phase,
-                                     "Scaling factors for each variable of 7eqn 2phase model "
-                                     "(alpha_l, arhoA_l, arhouA_l, arhoEA_l, "
-                                     "arhoA_v, arhouA_v, arhoEA_v");
-  params.addParam<std::vector<Real>>(
-      "scaling_factor_ncgs", "Scaling factor(s) for the non-condensable gas equations, if any");
   params.addParam<Real>(
       "scaling_factor_temperature", 1.0, "Scaling factor for solid temperature variable.");
 
   params.addParam<bool>("2nd_order_mesh", false, "Use 2nd order elements in the mesh");
-
-  // bounds
-  std::vector<Real> alpha_vapor_bounds(2, 0);
-  alpha_vapor_bounds[0] = 0.0001;
-  alpha_vapor_bounds[1] = 0.9999;
-  params.addParam<std::vector<Real>>(
-      "alpha_vapor_bounds", alpha_vapor_bounds, "Bounds imposed on the vapor volume fraction");
-  params.addParam<Real>("volume_fraction_remapper_exponential_region_width",
-                        1e-6,
-                        "Width of the exponential regions in the volume fraction remapper");
 
   params.addParam<FileName>("initial_from_file",
                             "The name of an exodus file with initial conditions");

--- a/modules/thermal_hydraulics/src/problems/THMProblem.C
+++ b/modules/thermal_hydraulics/src/problems/THMProblem.C
@@ -18,11 +18,6 @@ THMProblem::validParams()
   InputParameters params = FEProblem::validParams();
 
   // default scaling factors
-  std::vector<Real> sf_1phase(3, 1.0);
-  params.addParam<std::vector<Real>>(
-      "scaling_factor_1phase",
-      sf_1phase,
-      "Scaling factors for each single phase variable (rhoA, rhouA, rhoEA)");
   std::vector<Real> sf_2phase(7, 1.);
   params.addParam<std::vector<Real>>("scaling_factor_2phase",
                                      sf_2phase,

--- a/modules/thermal_hydraulics/test/include/components/InletFunction1Phase.h
+++ b/modules/thermal_hydraulics/test/include/components/InletFunction1Phase.h
@@ -21,9 +21,6 @@ public:
 
   virtual void addMooseObjects() override;
 
-protected:
-  virtual void check() const override;
-
 public:
   static InputParameters validParams();
 };

--- a/modules/thermal_hydraulics/test/src/components/InletFunction1Phase.C
+++ b/modules/thermal_hydraulics/test/src/components/InletFunction1Phase.C
@@ -31,15 +31,6 @@ InletFunction1Phase::InletFunction1Phase(const InputParameters & params)
 }
 
 void
-InletFunction1Phase::check() const
-{
-  FlowBoundary1Phase::check();
-
-  if (_flow_model_id != THM::FM_SINGLE_PHASE)
-    logModelNotImplementedError(_flow_model_id);
-}
-
-void
 InletFunction1Phase::addMooseObjects()
 {
   ExecFlagEnum execute_on(MooseUtils::getDefaultExecFlagEnum());

--- a/modules/thermal_hydraulics/test/tests/components/supersonic_inlet/tests
+++ b/modules/thermal_hydraulics/test/tests/components/supersonic_inlet/tests
@@ -2,7 +2,7 @@
   [not_implemented]
     type = 'RunException'
     input = 'err.i'
-    expect_err = "This component is not implemented for single-phase flow."
+    expect_err = "This component is deprecated."
     ad_indexing_type = 'global'
     design = 'SupersonicInlet.md'
     requirement = 'The system shall report an error if the SupersonicInlet component is used.'

--- a/modules/thermal_hydraulics/test/tests/misc/initial_from_file/flow_channel/steady_state.i
+++ b/modules/thermal_hydraulics/test/tests/misc/initial_from_file/flow_channel/steady_state.i
@@ -1,6 +1,5 @@
 [GlobalParams]
   scaling_factor_1phase = '1. 1.e-2 1.e-4'
-  scaling_factor_temperature = 1e-2
 
   initial_T = 500
   initial_p = 6.e6

--- a/modules/thermal_hydraulics/test/tests/misc/initial_from_file/flow_channel/test.i
+++ b/modules/thermal_hydraulics/test/tests/misc/initial_from_file/flow_channel/test.i
@@ -2,7 +2,6 @@
 
 [GlobalParams]
   scaling_factor_1phase = '1. 1.e-2 1.e-4'
-  scaling_factor_temperature = 1e-2
 
   closures = simple_closures
 


### PR DESCRIPTION
This PR:

- Fixes/adds some THM system documentation
- Removes model-specific (like 2-phase) check methods from `Component`
- Moves model-specific parameters from `THMProblem` to the respective components

