### PR TITLE
Remove far-away replicated mesh ghosted elements from VFR boundary ghosting

### DIFF
--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -459,7 +459,8 @@ INSFVRhieChowInterpolator::ghostADataOnBoundary(const BoundaryID boundary_id)
   for (auto elem_id : _moose_mesh.getBoundaryActiveSemiLocalElemIds(boundary_id))
   {
     const auto & elem = _moose_mesh.elemPtr(elem_id);
-    if (elem->processor_id() != this->processor_id())
+    // no need to ghost if locally owned or far from local process
+    if (elem->processor_id() != this->processor_id() && elem->is_semilocal(this->processor_id()))
       // Adding to the a coefficient will make sure the final result gets communicated
       addToA(elem, 0, 0);
   }
@@ -468,7 +469,9 @@ INSFVRhieChowInterpolator::ghostADataOnBoundary(const BoundaryID boundary_id)
   for (auto neighbor_id : _moose_mesh.getBoundaryActiveNeighborElemIds(boundary_id))
   {
     const auto & neighbor = _moose_mesh.queryElemPtr(neighbor_id);
-    if (neighbor->processor_id() != this->processor_id())
+    // no need to ghost if locally owned or far from local process
+    if (neighbor->processor_id() != this->processor_id() &&
+        neighbor->is_semilocal(this->processor_id()))
       // Adding to the a coefficient will make sure the final result gets communicated
       addToA(neighbor, 0, 0);
   }


### PR DESCRIPTION
refs #21991

elem->is_semilocal isnt quite what we said would be semilocal but it s exactly what I want. 

Basically should semilocal be all of the domain when using replicated meshes, or should it be just local + ghosted?

This goes to show this naming thing is not settled yet.

Either way i need this to fix the VTB Pronghorn MSR input

EDIT:
local + ghosted should be all of the replicated domain, so I m not clear up there. 
Maybe local + 1 layer (eg neighbors of those elements are local), which is what is_semilocal is giving me, is a better name for what we want here