### PR TITLE
Rename pid_aux to output_process_domains for user friendliness

### DIFF
--- a/framework/src/actions/SetupDebugAction.C
+++ b/framework/src/actions/SetupDebugAction.C
@@ -40,11 +40,16 @@ SetupDebugAction::validParams()
   params.addParam<bool>("show_mesh_meta_data", false, "Print out the available mesh meta data");
   params.addParam<bool>(
       "show_reporters", false, "Print out information about the declared and requested Reporters");
-  params.addParam<bool>(
+  params.addDeprecatedParam<bool>(
       "pid_aux",
+      "Add a AuxVariable named \"pid\" that shows the processors and partitioning",
+      "pid_aux is deprecated, use output_process_domains");
+  params.addParam<bool>(
+      "output_process_domains",
       false,
-      "Add a AuxVariable named \"pid\" that shows the processors and partitioning");
-  params.addParam<bool>("show_functors", false, "Whether to output the problem functors");
+      "Add a AuxVariable named \"pid\" that shows the partitioning for each process");
+  params.addParam<bool>(
+      "show_functors", false, "Whether to print information about the functors in the problem");
 
   params.addClassDescription(
       "Adds various debugging type Output objects to the simulation system.");
@@ -106,10 +111,11 @@ SetupDebugAction::act()
   }
 
   // Add pid aux
-  if (getParam<bool>("pid_aux"))
+  if (getParam<bool>("output_process_domains") ||
+      (isParamValid("pid_aux") && getParam<bool>("pid_aux")))
   {
     if (_problem->hasVariable("pid"))
-      paramError("pid_aux", "Variable with the name \"pid\" already exists");
+      paramError("output_process_domains", "Variable with the name \"pid\" already exists");
 
     auto fe_type = FEType(CONSTANT, MONOMIAL);
     auto type = AddAuxVariableAction::variableType(fe_type);

--- a/test/tests/meshgenerators/break_mesh_by_block_generator/hanging_nodes_parallel.i
+++ b/test/tests/meshgenerators/break_mesh_by_block_generator/hanging_nodes_parallel.i
@@ -67,7 +67,7 @@
 []
 
 [Debug]
-  pid_aux = true
+  output_process_domains = true
 []
 
 [Problem]

--- a/test/tests/misc/debug_pid_aux/debug_pid_aux.i
+++ b/test/tests/misc/debug_pid_aux/debug_pid_aux.i
@@ -12,7 +12,7 @@
 []
 
 [Debug]
-  pid_aux = true
+  output_process_domains = true
 []
 
 [Problem]

--- a/test/tests/partitioners/single_rank_partitioner/single_rank_partitioner.i
+++ b/test/tests/partitioners/single_rank_partitioner/single_rank_partitioner.i
@@ -45,7 +45,7 @@
 []
 
 [Debug]
-  pid_aux = true
+  output_process_domains = true
 []
 
 [Outputs]


### PR DESCRIPTION
~~need to amend for SQA, placeholder~~

The logic is that pid_aux is a fine name if you already know a lot about moose and how this action will do its fine. 
It's not if you're new to MOOSE and are not sure how one would output process domains

If we say "show_" is only for console output, then maybe we could switch to "output_process_domains"
But as we are moving to more GUI intergration I could see "show" for exodus output