### PR TITLE
Fix QColor type in Peacock PostprocessViewer

### DIFF
--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -4,6 +4,18 @@ moose_python:
   - python 3.8
   - python 3.7                                             # [not arm64]
 
+moose_pyqt:
+  - pyqt 5.15.7
+
+moose_qt:
+  - qt-main 5.15.4
+
+moose_matplotlib:
+  - matplotlib 3.5.2
+
+moose_pandas:
+  - pandas 1.4.3
+
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!
 openssl:

--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -13,8 +13,8 @@ moose_qt:
 moose_matplotlib:
   - matplotlib 3.5.2
 
-moose_pandas:
-  - pandas 1.4.3
+moose_vtk:
+  - vtk 9.1.0
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -21,8 +21,8 @@ requirements:
     - {{ moose_pyqt }}
     - {{ moose_qt }}
     - {{ moose_matplotlib }}
-    - {{ moose_pandas }}
-    - {{ moose_pandas }}
+    - {{ moose_vtk }}
+    - pandas
     - python
     - openssl
     - setuptools

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.07.18" %}
+{% set version = "2022.10.04" %}
 
 package:
   name: moose-peacock
@@ -10,6 +10,7 @@ source:
 
 build:
   number: {{ build }}
+  pin_depends: strict
 
 requirements:
   build:
@@ -17,10 +18,11 @@ requirements:
     - openssl
     - setuptools
   run:
-    - pyqt
-    - vtk
-    - matplotlib
-    - pandas
+    - {{ moose_pyqt }}
+    - {{ moose_qt }}
+    - {{ moose_matplotlib }}
+    - {{ moose_pandas }}
+    - {{ moose_pandas }}
     - python
     - openssl
     - setuptools

--- a/python/peacock/PostprocessorViewer/plugins/LineSettingsWidget.py
+++ b/python/peacock/PostprocessorViewer/plugins/LineSettingsWidget.py
@@ -186,7 +186,7 @@ class LineSettingsWidget(peacock.base.MooseWidget, QtWidgets.QWidget):
         qobject.setMaximumWidth(qobject.height())
         qobject.setAutoFillBackground(False)
         color = self._settings['color']
-        c = QtGui.QColor(color[0]*255, color[1]*255, color[2]*255)
+        c = QtGui.QColor(int(color[0]*255), int(color[1]*255), int(color[2]*255))
         qobject.setStyleSheet('border:none; background:rgb' + str(c.getRgb()))
         qobject.clicked.connect(self._callbackColorButton)
 


### PR DESCRIPTION
Convert the color value to desired type: int

Temporary fix for ghost/stuck frame issue.

PyQt/VTK/Qt has divereged enough where Peacock no longer functions. The changes to moose-peacock Conda package is a bandaid until we allow Peacock to function properly using latest available PyQt/VTK/Qt Conda packages.

Closes #22286
