### PR TITLE
libMesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #   moose/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.09.09" %}
+{% set version = "2022.10.05" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.09.09 build_0
+ - moose-libmesh 2022.10.05 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.09.09 build_0
+ - moose-libmesh 2022.10.05 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=1eef758792bff86e26258972ab9dc60533161964
+ARG LIBMESH_REV=69dad44d8ef2b871ec1a6a5b5788b00385642c39
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2022_10.md
+++ b/modules/doc/content/newsletter/2022_10.md
@@ -1,0 +1,24 @@
+# MOOSE Newsletter (October 2022)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in November 2022
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+### `2022.10.05` Update
+
+- More code refactoring and deduplication
+- More thorough consistency testing in `add_variable`
+- Fixes for discontinuous ExodusII output with added-sides option
+- Additional unit coverage:
+  - Partition-of-unity tests added to Finite Element basis testing
+  - Discontinuous ExodusII output with added-sides option, on various
+    combinations of Finite Element and geometric Element types
+
+## PETSc-level Changes
+
+## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
* More code refactoring and deduplication
* More thorough consistency testing in `add_variable()`
* Fixes for discontinuous ExodusII output with added-sides option
* Additional unit coverage:
  * Partition-of-unity tests added to Finite Element basis testing
  * Discontinuous ExodusII output with added-sides option, on various combinations of Finite Element and geometric Element types

Not much this month, but one of the fixes is for a bug that's currently blocking my next MOOSE PR.