### PR TITLE
Remove possible evaluation of norm of zero vector

### DIFF
--- a/modules/navier_stokes/include/materials/INSADTauMaterial.h
+++ b/modules/navier_stokes/include/materials/INSADTauMaterial.h
@@ -139,9 +139,12 @@ INSADTauMaterialTempl<T>::computeQpProperties()
 
   auto && nu = _mu[_qp] / _rho[_qp];
   auto && transient_part = _has_transient ? 4. / (_dt * _dt) : 0.;
+  // avoid norm of a zero vector which has a NaN/Inf derivative. Checking is_zero() is not good
+  // enough because floating point comparison to zero will yield false at times that the norm
+  // derivative will still yield a NaN/Inf derivative
+  const ADReal velocity_norm = (_velocity[_qp] + RealVectorValue(1e-50, 0, 0)).norm();
   _tau[_qp] = _alpha / std::sqrt(transient_part +
-                                 (2. * _velocity[_qp].norm() / _hmax) *
-                                     (2. * _velocity[_qp].norm() / _hmax) +
+                                 (2. * velocity_norm / _hmax) * (2. * velocity_norm / _hmax) +
                                  9. * (4. * nu / (_hmax * _hmax)) * (4. * nu / (_hmax * _hmax)));
 
   _momentum_strong_residual[_qp] = _advective_strong_residual[_qp] + _grad_p[_qp];


### PR DESCRIPTION
This should also remove the need for users to set non-zero initial conditions for their velocities

Closes #22413

Thanks for pushing on this issue @suqingji. I've known about this but have never been significantly motivated to resolve it. I think it's a great improvement to no longer have to avoid zero velocities