### PR TITLE
Add clang-format to moose-mpich base package

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_2
+  - moose-mpich 4.0.2 build_3
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 12 %}
+{% set build = 13 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_2
+  - moose-mpich 4.0.2 build_3
 
 moose_petsc:
   - moose-petsc 3.16.6

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.10.05" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.10.05 build_0
+ - moose-libmesh 2022.10.05 build_1
 
 moose_python:
  - python 3.9

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -5,7 +5,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 
@@ -67,11 +67,12 @@ requirements:
     - {{ moose_mesalib }}       # [linux]
     - openssl <3
     - mpi 1.0 mpich
-    - clang-format-12
+    - clang-tools
 
 test:
   commands:
     - test -f $PREFIX/etc/conda/activate.d/activate_moose-mpich.sh
+    - git clang-format -h
 
 about:
   home: https://mooseframework.org/

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_2
+  - moose-mpich 4.0.2 build_3
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.10.05 build_0
+ - moose-libmesh 2022.10.05 build_1
 
 moose_python:
  - python 3.9


### PR DESCRIPTION
Well... by `mamba install clang-format` you don't actualy get clang-format. You need to ask Conda for clang-tools in order to actually get the `git` clang-format utility.

Closes #22419
