### PR TITLE
Make GrainDataTracker store restartable information

### DIFF
--- a/modules/phase_field/include/postprocessors/GrainDataTracker.h
+++ b/modules/phase_field/include/postprocessors/GrainDataTracker.h
@@ -31,11 +31,12 @@ protected:
   virtual void newGrainCreated(unsigned int new_grain_id);
 
   /// per grain data
-  std::vector<T> _grain_data;
+  std::vector<T> & _grain_data;
 };
 
 template <typename T>
-GrainDataTracker<T>::GrainDataTracker(const InputParameters & parameters) : GrainTracker(parameters)
+GrainDataTracker<T>::GrainDataTracker(const InputParameters & parameters)
+  : GrainTracker(parameters), _grain_data(declareRestartableData<std::vector<T>>("grain_data"))
 {
 }
 


### PR DESCRIPTION
Makes `GrainDataTracker` restartable. 

Closes #22445  

