### PR TITLE
Use relationship manager to ghost layers in domain integral action

### DIFF
--- a/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
+++ b/modules/tensor_mechanics/include/actions/DomainIntegralAction.h
@@ -30,6 +30,9 @@ public:
 
   virtual void act() override;
 
+  using Action::addRelationshipManagers;
+  virtual void addRelationshipManagers(Moose::RelationshipManagerType input_rm_type) override;
+
 protected:
   /// Enum used to select the type of integral to be performed
   enum INTEGRAL

--- a/modules/tensor_mechanics/src/actions/DomainIntegralAction.C
+++ b/modules/tensor_mechanics/src/actions/DomainIntegralAction.C
@@ -904,3 +904,13 @@ DomainIntegralAction::calcNumCrackFrontPoints()
     mooseError("Must define either 'boundary' or 'crack_front_points'");
   return num_points;
 }
+
+void
+DomainIntegralAction::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type)
+{
+  if (_integrals.count(INTERACTION_INTEGRAL_T) != 0)
+  {
+    InputParameters params = _factory.getValidParams("CrackFrontDefinition");
+    addRelationshipManagers(input_rm_type, params);
+  }
+}

--- a/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
+++ b/modules/tensor_mechanics/src/userobjects/CrackFrontDefinition.C
@@ -29,6 +29,11 @@ CrackFrontDefinition::validParams()
   params += BoundaryRestrictable::validParams();
   addCrackFrontDefinitionParams(params);
   params.set<bool>("use_displaced_mesh") = false;
+
+  params.addRelationshipManager("ElementSideNeighborLayers",
+                                Moose::RelationshipManagerType::ALGEBRAIC,
+                                [](const InputParameters &, InputParameters & rm_params)
+                                { rm_params.set<unsigned short>("layers") = 2; });
   return params;
 }
 
@@ -783,6 +788,7 @@ CrackFrontDefinition::updateCrackFrontGeometry()
   _tangent_directions.clear();
   _crack_directions.clear();
   _rot_matrix.clear();
+  _strain_along_front.clear();
 
   if (_treat_as_2d)
   {
@@ -1447,6 +1453,8 @@ CrackFrontDefinition::calculateTangentialStrainAlongFront()
   const Node * current_node;
   const Node * previous_node;
   const Node * next_node;
+
+  _strain_along_front.reserve(num_crack_front_nodes);
 
   // In finalize(), gatherMax builds and distributes the complete strain vector on all processors
   // -> reset the vector every time


### PR DESCRIPTION
This is required to compute the T stress in parallel (Closes #22486)

It'd be nice to have module parallel sweeps as an optional recipe to catch some of this type of failures. 