### PR TITLE
Linker update for ARM64

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_3
+  - moose-mpich 4.0.2 build_4
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 13 %}
+{% set build = 14 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_3
+  - moose-mpich 4.0.2 build_4
 
 moose_petsc:
   - moose-petsc 3.16.6

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 2 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.10.05" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -31,7 +31,7 @@ moose_libgfortran5:
 
 moose_ld64:                                                 # [osx]
   - ld64 609                                                # [not arm64 and osx]
-  - ld64_osx-arm64 530                                      # [arm64]
+  - ld64_osx-arm64 609                                      # [arm64]
 
 moose_hdf5:
   - hdf5 1.12.1 mpi_mpich_hfd824e9_4                        # [not arm64 and osx]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -5,7 +5,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 3 %}
+{% set build = 4 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 
@@ -67,12 +67,10 @@ requirements:
     - {{ moose_mesalib }}       # [linux]
     - openssl <3
     - mpi 1.0 mpich
-    - clang-tools
 
 test:
   commands:
     - test -f $PREFIX/etc/conda/activate.d/activate_moose-mpich.sh
-    - git clang-format -h
 
 about:
   home: https://mooseframework.org/

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_3
+  - moose-mpich 4.0.2 build_4
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.10.05 build_1
+ - moose-libmesh 2022.10.05 build_2
 
 moose_python:
  - python 3.9

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   template/ (must contain any python major.minor version this
 #              package is building. Usually the latest version.)
 {% set build = 0 %}
-{% set version = "2022.07.18" %}
+{% set version = "2022.10.27" %}
 
 package:
   name: moose-tools
@@ -41,10 +41,12 @@ requirements:
     - openssl
     - setuptools
     - graphviz
+    - clang-tools 12.0.1
 
 test:
   commands:
     - dot -V
+    - git clang-format -h
   imports:
     - numpy
     - matplotlib

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -2025,7 +2025,15 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                      DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
+// PETSc changed macro definitions in 3.18; the former correct usage
+// is now a compiler error and the new usage is now a compiler
+// warning.
+#if !PETSC_VERSION_LESS_THAN(3, 18, 0)
   PetscOptionsBegin(((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
+#else
+  ierr = PetscOptionsBegin(
+      ((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
+#endif
   std::string opt, help;
   PetscInt maxvars = dmm->_nl->system().get_dof_map().n_variables();
   char ** vars;


### PR DESCRIPTION
Updates ld64 for ARM64, and tests a new configuration for the `miniarm` test machines (Ventura with CLT 14.1)

This PR also moves clang-tools to moose-tools due to removal of python bin in favor of python3 on MacOS.

Closes #22584

Refs #22562 - a regression occurred in `-Werror` builds that was not caught in CI. 