### PR TITLE
Petsc 3.18 fixes

### DIFF
--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -406,7 +406,7 @@ DMMooseSetContacts(DM dm,
   if (contacts.size() != displaced.size())
     LIBMESH_SETERRQ2(PETSC_COMM_SELF,
                      PETSC_ERR_ARG_SIZ,
-                     "Nonmatching sizes of the contact and displaced arrays: %D != %D",
+                     "Nonmatching sizes of the contact and displaced arrays: %" MOOSE_PETSCINT_FMT " != %" MOOSE_PETSCINT_FMT,
                      contacts.size(),
                      displaced.size());
   if (dmm->_contacts)
@@ -447,7 +447,7 @@ DMMooseSetUnContacts(DM dm,
   if (uncontacts.size() != displaced.size())
     LIBMESH_SETERRQ2(PETSC_COMM_SELF,
                      PETSC_ERR_ARG_SIZ,
-                     "Nonmatching sizes of the uncontact and displaced arrays: %D != %D",
+                     "Nonmatching sizes of the uncontact and displaced arrays: %" MOOSE_PETSCINT_FMT " != %" MOOSE_PETSCINT_FMT,
                      uncontacts.size(),
                      displaced.size());
   if (dmm->_uncontacts)
@@ -1058,7 +1058,7 @@ DMCreateFieldDecomposition_Moose(
           ierr = ISGetLocalSize(lembedding, &llen);
           CHKERRQ(ierr);
           if (llen != dlen)
-            LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %D", d);
+            LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %u", d);
           ierr = ISDestroy(&dembedding);
           CHKERRQ(ierr);
           // Convert local embedding to global (but still relative) embedding
@@ -1496,7 +1496,7 @@ DMView_Moose(DM dm, PetscViewer viewer)
     CHKERRQ(ierr);
     for (const auto & vit : *(dmm->_var_ids))
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", vit.first.c_str(), vit.second);
+      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%u) ", vit.first.c_str(), vit.second);
       CHKERRQ(ierr);
     }
     ierr = PetscViewerASCIIPrintf(viewer, "\n");
@@ -1505,7 +1505,7 @@ DMView_Moose(DM dm, PetscViewer viewer)
     CHKERRQ(ierr);
     for (const auto & bit : *(dmm->_block_ids))
     {
-      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", bit.first.c_str(), bit.second);
+      ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", bit.first.c_str(), bit.second);
       CHKERRQ(ierr);
     }
     ierr = PetscViewerASCIIPrintf(viewer, "\n");
@@ -1517,7 +1517,7 @@ DMView_Moose(DM dm, PetscViewer viewer)
       CHKERRQ(ierr);
       for (const auto & sit : *(dmm->_side_ids))
       {
-        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit.first.c_str(), sit.second);
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second);
         CHKERRQ(ierr);
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");
@@ -1530,7 +1530,7 @@ DMView_Moose(DM dm, PetscViewer viewer)
       CHKERRQ(ierr);
       for (const auto & sit : *(dmm->_unside_ids))
       {
-        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%D) ", sit.first.c_str(), sit.second);
+        ierr = PetscViewerASCIIPrintf(viewer, "(%s,%d) ", sit.first.c_str(), sit.second);
         CHKERRQ(ierr);
       }
       ierr = PetscViewerASCIIPrintf(viewer, "\n");
@@ -2145,7 +2145,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   if (ncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
-                     "Number of requested contacts %D exceeds the maximum number of contacts %D",
+                     "Number of requested contacts %" MOOSE_PETSCINT_FMT " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
                      ncontacts,
                      maxcontacts);
   for (PetscInt i = 0; i < ncontacts; ++i)
@@ -2166,7 +2166,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
       if (sz != 2)
         LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                          PETSC_ERR_ARG_SIZ,
-                         "Expected 2 sideset IDs (primary & secondary) for contact %D, got %D instead",
+                         "Expected 2 sideset IDs (primary & secondary) for contact %" MOOSE_PETSCINT_FMT ", got %" MOOSE_PETSCINT_FMT " instead",
                          i,
                          sz);
       contacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
@@ -2226,7 +2226,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   if (nuncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
-                     "Number of requested uncontacts %D exceeds the maximum number of contacts %D",
+                     "Number of requested uncontacts %" MOOSE_PETSCINT_FMT " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
                      nuncontacts,
                      maxcontacts);
   for (PetscInt i = 0; i < nuncontacts; ++i)
@@ -2247,7 +2247,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
       if (sz != 2)
         LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                          PETSC_ERR_ARG_SIZ,
-                         "Expected 2 sideset IDs (primary & secondary) for uncontact %D, got %D instead",
+                         "Expected 2 sideset IDs (primary & secondary) for uncontact %" MOOSE_PETSCINT_FMT ", got %" MOOSE_PETSCINT_FMT " instead",
                          i,
                          sz);
       uncontacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
@@ -2313,7 +2313,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
     else if (nsplits != nnsplits)
       LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                        PETSC_ERR_ARG_SIZ,
-                       "Expected %D fieldsplit names, got %D instead",
+                       "Expected %" MOOSE_PETSCINT_FMT " fieldsplit names, got %" MOOSE_PETSCINT_FMT " instead",
                        nsplits,
                        nnsplits);
     else

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -97,11 +97,11 @@ DMMooseGetContacts(DM dm,
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_contact_names))
   {
@@ -126,11 +126,11 @@ DMMooseGetUnContacts(DM dm,
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_uncontact_names))
   {
@@ -153,11 +153,11 @@ DMMooseGetSides(DM dm, std::vector<std::string> & side_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_side_ids))
     side_names.push_back(it.first);
@@ -177,11 +177,11 @@ DMMooseGetUnSides(DM dm, std::vector<std::string> & side_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_unside_ids))
     side_names.push_back(it.first);
@@ -201,11 +201,11 @@ DMMooseGetBlocks(DM dm, std::vector<std::string> & block_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)dm->data;
   for (const auto & it : *(dmm->_block_ids))
     block_names.push_back(it.first);
@@ -225,11 +225,11 @@ DMMooseGetVariables(DM dm, std::vector<std::string> & var_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   for (const auto & it : *(dmm->_var_ids))
     var_names.push_back(it.first);
@@ -249,11 +249,11 @@ DMMooseSetNonlinearSystem(DM dm, NonlinearSystemBase & nl)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(((PetscObject)dm)->comm,
             PETSC_ERR_ARG_WRONGSTATE,
@@ -277,11 +277,11 @@ DMMooseSetVariables(DM dm, const std::set<std::string> & vars)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_vars)
@@ -304,11 +304,11 @@ DMMooseSetBlocks(DM dm, const std::set<std::string> & blocks)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_blocks)
@@ -331,11 +331,11 @@ DMMooseSetSides(DM dm, const std::set<std::string> & sides)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_sides)
@@ -358,11 +358,11 @@ DMMooseSetUnSides(DM dm, const std::set<std::string> & unsides)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (dmm->_sides)
@@ -387,19 +387,19 @@ DMMooseSetContacts(DM dm,
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (contacts.size() != displaced.size())
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_SIZ,
-             "Nonmatching sizes of the contact and displaced arrays: %D != %D",
-             contacts.size(),
-             displaced.size());
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_SIZ,
+                     "Nonmatching sizes of the contact and displaced arrays: %D != %D",
+                     contacts.size(),
+                     displaced.size());
   if (dmm->_contacts)
     delete dmm->_contacts;
   dmm->_contact_displaced->clear();
@@ -428,19 +428,19 @@ DMMooseSetUnContacts(DM dm,
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "Not for an already setup DM");
   if (uncontacts.size() != displaced.size())
-    SETERRQ2(PETSC_COMM_SELF,
-             PETSC_ERR_ARG_SIZ,
-             "Nonmatching sizes of the uncontact and displaced arrays: %D != %D",
-             uncontacts.size(),
-             displaced.size());
+    LIBMESH_SETERRQ2(PETSC_COMM_SELF,
+                     PETSC_ERR_ARG_SIZ,
+                     "Nonmatching sizes of the uncontact and displaced arrays: %D != %D",
+                     uncontacts.size(),
+                     displaced.size());
   if (dmm->_uncontacts)
     delete dmm->_uncontacts;
   dmm->_uncontact_displaced->clear();
@@ -466,11 +466,11 @@ DMMooseGetNonlinearSystem(DM dm, NonlinearSystemBase *& nl)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   nl = dmm->_nl;
   PetscFunctionReturn(0);
@@ -489,11 +489,11 @@ DMMooseSetSplitNames(DM dm, const std::vector<std::string> & split_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)(dm->data);
 
   if (dmm->_splits)
@@ -540,11 +540,11 @@ DMMooseGetSplitNames(DM dm, std::vector<std::string> & split_names)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "Got DM oftype %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "Got DM oftype %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   DM_Moose * dmm = (DM_Moose *)(dm->data);
   if (!dm->setupcalled)
     SETERRQ(PETSC_COMM_SELF, PETSC_ERR_ARG_WRONGSTATE, "DM not set up");
@@ -1049,7 +1049,7 @@ DMCreateFieldDecomposition_Moose(
           ierr = ISGetLocalSize(lembedding, &llen);
           CHKERRQ(ierr);
           if (llen != dlen)
-            SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %D", d);
+            LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %D", d);
           ierr = ISDestroy(&dembedding);
           CHKERRQ(ierr);
           // Convert local embedding to global (but still relative) embedding
@@ -1350,11 +1350,11 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1410,11 +1410,11 @@ DMCreateMatrix_Moose(DM dm, Mat * A)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
   ierr = DMGetMatType(dm, &type);
@@ -1614,11 +1614,11 @@ DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id_type> & blocks)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1646,11 +1646,11 @@ DMSetUp_Moose_Pre(DM dm)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
 
@@ -1916,11 +1916,11 @@ DMSetUp_Moose(DM dm)
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
   if (dmm->_print_embedding)
@@ -2010,11 +2010,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMMOOSE, &ismoose);
   CHKERRQ(ierr);
   if (!ismoose)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_WRONG,
-             "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type_name,
-             DMMOOSE);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_WRONG,
+                     "DM of type %s, not of type %s",
+                     ((PetscObject)dm)->type_name,
+                     DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
   PetscOptionsBegin(
@@ -2134,11 +2134,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
       opt.c_str(), help.c_str(), "DMMooseSetContacts", ncontacts, &ncontacts, PETSC_NULL);
   CHKERRQ(ierr);
   if (ncontacts > maxcontacts)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_SIZ,
-             "Number of requested contacts %D exceeds the maximum number of contacts %D",
-             ncontacts,
-             maxcontacts);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_SIZ,
+                     "Number of requested contacts %D exceeds the maximum number of contacts %D",
+                     ncontacts,
+                     maxcontacts);
   for (PetscInt i = 0; i < ncontacts; ++i)
   {
     {
@@ -2155,11 +2155,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                                      PETSC_NULL);
       CHKERRQ(ierr);
       if (sz != 2)
-        SETERRQ2(((PetscObject)dm)->comm,
-                 PETSC_ERR_ARG_SIZ,
-                 "Expected 2 sideset IDs (primary & secondary) for contact %D, got %D instead",
-                 i,
-                 sz);
+        LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                         PETSC_ERR_ARG_SIZ,
+                         "Expected 2 sideset IDs (primary & secondary) for contact %D, got %D instead",
+                         i,
+                         sz);
       contacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                std::string(primary_secondary[1])));
       ierr = PetscFree(primary_secondary[0]);
@@ -2215,11 +2215,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
       opt.c_str(), help.c_str(), "DMMooseSetUnContacts", nuncontacts, &nuncontacts, PETSC_NULL);
   CHKERRQ(ierr);
   if (nuncontacts > maxcontacts)
-    SETERRQ2(((PetscObject)dm)->comm,
-             PETSC_ERR_ARG_SIZ,
-             "Number of requested uncontacts %D exceeds the maximum number of contacts %D",
-             nuncontacts,
-             maxcontacts);
+    LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                     PETSC_ERR_ARG_SIZ,
+                     "Number of requested uncontacts %D exceeds the maximum number of contacts %D",
+                     nuncontacts,
+                     maxcontacts);
   for (PetscInt i = 0; i < nuncontacts; ++i)
   {
     {
@@ -2236,11 +2236,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                                      PETSC_NULL);
       CHKERRQ(ierr);
       if (sz != 2)
-        SETERRQ2(((PetscObject)dm)->comm,
-                 PETSC_ERR_ARG_SIZ,
-                 "Expected 2 sideset IDs (primary & secondary) for uncontact %D, got %D instead",
-                 i,
-                 sz);
+        LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                         PETSC_ERR_ARG_SIZ,
+                         "Expected 2 sideset IDs (primary & secondary) for uncontact %D, got %D instead",
+                         i,
+                         sz);
       uncontacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                  std::string(primary_secondary[1])));
       ierr = PetscFree(primary_secondary[0]);
@@ -2302,11 +2302,11 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
       }
     }
     else if (nsplits != nnsplits)
-      SETERRQ2(((PetscObject)dm)->comm,
-               PETSC_ERR_ARG_SIZ,
-               "Expected %D fieldsplit names, got %D instead",
-               nsplits,
-               nnsplits);
+      LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
+                       PETSC_ERR_ARG_SIZ,
+                       "Expected %D fieldsplit names, got %D instead",
+                       nsplits,
+                       nnsplits);
     else
     {
       for (PetscInt i = 0; i < nsplits; ++i)

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -37,6 +37,15 @@
 #include "libmesh/preconditioner.h"
 #include "libmesh/elem_side_builder.h"
 
+// As of 3.18, %D is no longer supported in format strings, but the
+// replacement PetscInt_FMT didn't get added until 3.7.2, and the
+// libMesh shim hasn't hit our submodule yet
+#if PETSC_RELEASE_LESS_THAN(3,8,0)
+# define MOOSE_PETSCINT_FMT "D"
+#else
+# define MOOSE_PETSCINT_FMT PetscInt_FMT
+#endif
+
 struct DM_Moose
 {
   NonlinearSystemBase * _nl;     // nonlinear system context

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1492,7 +1492,7 @@ DMView_Moose(DM dm, PetscViewer viewer)
     CHKERRQ(ierr);
     ierr = PetscViewerASCIIPrintf(viewer, "DM Moose with name %s and prefix %s\n", name, prefix);
     CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "variables:", name, prefix);
+    ierr = PetscViewerASCIIPrintf(viewer, "variables:");
     CHKERRQ(ierr);
     for (const auto & vit : *(dmm->_var_ids))
     {
@@ -1549,13 +1549,13 @@ DMView_Moose(DM dm, PetscViewer viewer)
         if ((*dmm->_contact_displaced)[cit.second])
         {
           ierr = PetscViewerASCIIPrintf(
-              viewer, "displaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+              viewer, "displaced) ");
           CHKERRQ(ierr);
         }
         else
         {
           ierr = PetscViewerASCIIPrintf(
-              viewer, "undisplaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+              viewer, "undisplaced) ");
           CHKERRQ(ierr);
         }
       }
@@ -1575,13 +1575,13 @@ DMView_Moose(DM dm, PetscViewer viewer)
         if ((*dmm->_uncontact_displaced)[cit.second])
         {
           ierr = PetscViewerASCIIPrintf(
-              viewer, "displaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+              viewer, "displaced) ");
           CHKERRQ(ierr);
         }
         else
         {
           ierr = PetscViewerASCIIPrintf(
-              viewer, "undisplaced) ", cit.second.first.c_str(), cit.second.second.c_str());
+              viewer, "undisplaced) ");
           CHKERRQ(ierr);
         }
       }

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1353,7 +1353,7 @@ DMCreateGlobalVector_Moose(DM dm, Vec * x)
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
@@ -1413,7 +1413,7 @@ DMCreateMatrix_Moose(DM dm, Mat * A)
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
@@ -1617,7 +1617,7 @@ DMMooseGetMeshBlocks_Private(DM dm, std::set<subdomain_id_type> & blocks)
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
@@ -1649,7 +1649,7 @@ DMSetUp_Moose_Pre(DM dm)
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
@@ -1919,7 +1919,7 @@ DMSetUp_Moose(DM dm)
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
@@ -2010,7 +2010,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
     SETERRQ2(((PetscObject)dm)->comm,
              PETSC_ERR_ARG_WRONG,
              "DM of type %s, not of type %s",
-             ((PetscObject)dm)->type,
+             ((PetscObject)dm)->type_name,
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -2419,8 +2419,11 @@ DMCreate_Moose(DM dm)
 #if PETSC_RELEASE_LESS_THAN(3, 5, 0)
   ierr = PetscNewLog(dm, DM_Moose, &dmm);
   CHKERRQ(ierr);
-#else
+#elif PETSC_RELEASE_LESS_THAN(3, 18, 0)
   ierr = PetscNewLog(dm, &dmm);
+  CHKERRQ(ierr);
+#else // PetscNewLog was deprecated
+  ierr = PetscNew(&dmm);
   CHKERRQ(ierr);
 #endif
   dm->data = dmm;

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1988,7 +1988,10 @@ DMSetUp_Moose(DM dm)
 
 #undef __FUNCT__
 #define __FUNCT__ "DMSetFromOptions_Moose"
-#if !PETSC_VERSION_LESS_THAN(3, 7, 0)
+#if !PETSC_VERSION_LESS_THAN(3, 18, 0)
+PetscErrorCode
+DMSetFromOptions_Moose(DM dm, PetscOptionItems * /*options*/) // >= 3.8.0
+#elif !PETSC_VERSION_LESS_THAN(3, 7, 0)
 PetscErrorCode
 DMSetFromOptions_Moose(PetscOptionItems * /*options*/, DM dm) // >= 3.7.0
 #elif !PETSC_RELEASE_LESS_THAN(3, 6, 0)

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -2017,9 +2017,8 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
              DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
-  ierr = PetscOptionsBegin(
+  PetscOptionsBegin(
       ((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
-  CHKERRQ(ierr);
   std::string opt, help;
   PetscInt maxvars = dmm->_nl->system().get_dof_map().n_variables();
   char ** vars;
@@ -2329,8 +2328,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                           &dmm->_print_embedding,
                           PETSC_NULL);
   CHKERRQ(ierr);
-  ierr = PetscOptionsEnd();
-  CHKERRQ(ierr);
+  PetscOptionsEnd();
   ierr = DMSetUp_Moose_Pre(dm);
   CHKERRQ(ierr); /* Need some preliminary set up because, strangely enough, DMView() is called in
                     DMSetFromOptions(). */

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -1998,7 +1998,7 @@ DMSetUp_Moose(DM dm)
 #define __FUNCT__ "DMSetFromOptions_Moose"
 #if !PETSC_VERSION_LESS_THAN(3, 18, 0)
 PetscErrorCode
-DMSetFromOptions_Moose(DM dm, PetscOptionItems * /*options*/) // >= 3.8.0
+DMSetFromOptions_Moose(DM dm, PetscOptionItems * /*options*/) // >= 3.18.0
 #elif !PETSC_VERSION_LESS_THAN(3, 7, 0)
 PetscErrorCode
 DMSetFromOptions_Moose(PetscOptionItems * /*options*/, DM dm) // >= 3.7.0

--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -40,10 +40,10 @@
 // As of 3.18, %D is no longer supported in format strings, but the
 // replacement PetscInt_FMT didn't get added until 3.7.2, and the
 // libMesh shim hasn't hit our submodule yet
-#if PETSC_RELEASE_LESS_THAN(3,8,0)
-# define MOOSE_PETSCINT_FMT "D"
+#if PETSC_RELEASE_LESS_THAN(3, 8, 0)
+#define MOOSE_PETSCINT_FMT "D"
 #else
-# define MOOSE_PETSCINT_FMT PetscInt_FMT
+#define MOOSE_PETSCINT_FMT PetscInt_FMT
 #endif
 
 struct DM_Moose
@@ -406,7 +406,8 @@ DMMooseSetContacts(DM dm,
   if (contacts.size() != displaced.size())
     LIBMESH_SETERRQ2(PETSC_COMM_SELF,
                      PETSC_ERR_ARG_SIZ,
-                     "Nonmatching sizes of the contact and displaced arrays: %" MOOSE_PETSCINT_FMT " != %" MOOSE_PETSCINT_FMT,
+                     "Nonmatching sizes of the contact and displaced arrays: %" MOOSE_PETSCINT_FMT
+                     " != %" MOOSE_PETSCINT_FMT,
                      contacts.size(),
                      displaced.size());
   if (dmm->_contacts)
@@ -447,7 +448,8 @@ DMMooseSetUnContacts(DM dm,
   if (uncontacts.size() != displaced.size())
     LIBMESH_SETERRQ2(PETSC_COMM_SELF,
                      PETSC_ERR_ARG_SIZ,
-                     "Nonmatching sizes of the uncontact and displaced arrays: %" MOOSE_PETSCINT_FMT " != %" MOOSE_PETSCINT_FMT,
+                     "Nonmatching sizes of the uncontact and displaced arrays: %" MOOSE_PETSCINT_FMT
+                     " != %" MOOSE_PETSCINT_FMT,
                      uncontacts.size(),
                      displaced.size());
   if (dmm->_uncontacts)
@@ -1058,7 +1060,8 @@ DMCreateFieldDecomposition_Moose(
           ierr = ISGetLocalSize(lembedding, &llen);
           CHKERRQ(ierr);
           if (llen != dlen)
-            LIBMESH_SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %u", d);
+            LIBMESH_SETERRQ1(
+                ((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Failed to embed split %u", d);
           ierr = ISDestroy(&dembedding);
           CHKERRQ(ierr);
           // Convert local embedding to global (but still relative) embedding
@@ -1548,14 +1551,12 @@ DMView_Moose(DM dm, PetscViewer viewer)
         CHKERRQ(ierr);
         if ((*dmm->_contact_displaced)[cit.second])
         {
-          ierr = PetscViewerASCIIPrintf(
-              viewer, "displaced) ");
+          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ");
           CHKERRQ(ierr);
         }
         else
         {
-          ierr = PetscViewerASCIIPrintf(
-              viewer, "undisplaced) ");
+          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ");
           CHKERRQ(ierr);
         }
       }
@@ -1574,14 +1575,12 @@ DMView_Moose(DM dm, PetscViewer viewer)
         CHKERRQ(ierr);
         if ((*dmm->_uncontact_displaced)[cit.second])
         {
-          ierr = PetscViewerASCIIPrintf(
-              viewer, "displaced) ");
+          ierr = PetscViewerASCIIPrintf(viewer, "displaced) ");
           CHKERRQ(ierr);
         }
         else
         {
-          ierr = PetscViewerASCIIPrintf(
-              viewer, "undisplaced) ");
+          ierr = PetscViewerASCIIPrintf(viewer, "undisplaced) ");
           CHKERRQ(ierr);
         }
       }
@@ -2026,8 +2025,7 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                      DMMOOSE);
   if (!dmm->_nl)
     SETERRQ(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONGSTATE, "No Moose system set for DM_Moose");
-  PetscOptionsBegin(
-      ((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
+  PetscOptionsBegin(((PetscObject)dm)->comm, ((PetscObject)dm)->prefix, "DMMoose options", "DM");
   std::string opt, help;
   PetscInt maxvars = dmm->_nl->system().get_dof_map().n_variables();
   char ** vars;
@@ -2145,7 +2143,8 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   if (ncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
-                     "Number of requested contacts %" MOOSE_PETSCINT_FMT " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
+                     "Number of requested contacts %" MOOSE_PETSCINT_FMT
+                     " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
                      ncontacts,
                      maxcontacts);
   for (PetscInt i = 0; i < ncontacts; ++i)
@@ -2164,11 +2163,13 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                                      PETSC_NULL);
       CHKERRQ(ierr);
       if (sz != 2)
-        LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
-                         PETSC_ERR_ARG_SIZ,
-                         "Expected 2 sideset IDs (primary & secondary) for contact %" MOOSE_PETSCINT_FMT ", got %" MOOSE_PETSCINT_FMT " instead",
-                         i,
-                         sz);
+        LIBMESH_SETERRQ2(
+            ((PetscObject)dm)->comm,
+            PETSC_ERR_ARG_SIZ,
+            "Expected 2 sideset IDs (primary & secondary) for contact %" MOOSE_PETSCINT_FMT
+            ", got %" MOOSE_PETSCINT_FMT " instead",
+            i,
+            sz);
       contacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                std::string(primary_secondary[1])));
       ierr = PetscFree(primary_secondary[0]);
@@ -2226,7 +2227,8 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
   if (nuncontacts > maxcontacts)
     LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                      PETSC_ERR_ARG_SIZ,
-                     "Number of requested uncontacts %" MOOSE_PETSCINT_FMT " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
+                     "Number of requested uncontacts %" MOOSE_PETSCINT_FMT
+                     " exceeds the maximum number of contacts %" MOOSE_PETSCINT_FMT,
                      nuncontacts,
                      maxcontacts);
   for (PetscInt i = 0; i < nuncontacts; ++i)
@@ -2245,11 +2247,13 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
                                      PETSC_NULL);
       CHKERRQ(ierr);
       if (sz != 2)
-        LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
-                         PETSC_ERR_ARG_SIZ,
-                         "Expected 2 sideset IDs (primary & secondary) for uncontact %" MOOSE_PETSCINT_FMT ", got %" MOOSE_PETSCINT_FMT " instead",
-                         i,
-                         sz);
+        LIBMESH_SETERRQ2(
+            ((PetscObject)dm)->comm,
+            PETSC_ERR_ARG_SIZ,
+            "Expected 2 sideset IDs (primary & secondary) for uncontact %" MOOSE_PETSCINT_FMT
+            ", got %" MOOSE_PETSCINT_FMT " instead",
+            i,
+            sz);
       uncontacts.push_back(DM_Moose::ContactName(std::string(primary_secondary[0]),
                                                  std::string(primary_secondary[1])));
       ierr = PetscFree(primary_secondary[0]);
@@ -2313,7 +2317,8 @@ DMSetFromOptions_Moose(DM dm) // < 3.6.0
     else if (nsplits != nnsplits)
       LIBMESH_SETERRQ2(((PetscObject)dm)->comm,
                        PETSC_ERR_ARG_SIZ,
-                       "Expected %" MOOSE_PETSCINT_FMT " fieldsplit names, got %" MOOSE_PETSCINT_FMT " instead",
+                       "Expected %" MOOSE_PETSCINT_FMT " fieldsplit names, got %" MOOSE_PETSCINT_FMT
+                       " instead",
                        nsplits,
                        nnsplits);
     else


### PR DESCRIPTION
This along with the next libMesh submodule update will take care of #22549.  We might wait until that's ready and merge this branch into the submodule update PR branch, but I'd like to make sure in advance that the changes here don't have any side effects that CI can catch.

## Reason
Compatibility with PETSc 3.18 and later

## Design
Fixes for bad code that PETSc 3.18 now warns about; shims and `#ifdef` clauses for perfectly fine code that PETSc just doesn't support anymore.

## Impact
There should be no external impact, we'll just be able to compile against new PETSc releases again.