### PR TITLE
Add submodule init at tail end of Dockerfile

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -145,7 +145,8 @@ ARG BUILD_MODULES
 ARG MOOSE_METHODS=opt
 RUN ./docker_ci/build_moose.sh ; \
 # Ensure a MOOSE test binary was built
-if [ ! -f $MOOSE_DIR/test/moose_test* ]; then exit 1; fi
+if [ ! -f $MOOSE_DIR/test/moose_test* ]; then exit 1; fi ; \
+git submodule init
 
 #-----------------------------------------------------------------------------#
 # Add needed env vars to /etc/environment


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
We need the submodules initialized in the Docker images for MOTD and to build docs.
## Design
<!--A concise description (design) of the enhancement.-->
Added a `git submodule init` at the tail end of `docker_ci/Dockerfile`
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No impact to the framework.  Fixes #22559.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
