### PR TITLE
Add SQA link to framework development page

### DIFF
--- a/modules/doc/content/framework_development/index.md
+++ b/modules/doc/content/framework_development/index.md
@@ -42,6 +42,10 @@ For development of MOOSE-based applications see [Application Development](applic
 
 [Test Timing](http://mooseframework.org/docs/timing/)
 
+## Software Quality Assurance Documents
+
+[sqa/index.md exact=True] - Landing page for the MOOSE (and MOOSE Modules) software quality assurance (SQA) pages
+
 ## Utilities
 
 [/PerfGraph.md] - How to time sections of code in MOOSE


### PR DESCRIPTION
This link was dropped from the navigation menu in #22237, and it is now hard to find other than via search.

This PR places the link alongside other MOOSE-related information.
