### PR TITLE
Fixes for the PETSc 3.17 series

### DIFF
--- a/framework/src/utils/PetscDMMoose.C
+++ b/framework/src/utils/PetscDMMoose.C
@@ -2280,7 +2280,15 @@ DMSetFromOptions_Moose(PetscOptions * /*options*/, DM dm) // >= 3.6.0
                           &dmm->_print_embedding,
                           PETSC_NULL);
   CHKERRQ(ierr);
+  /**
+   * Unused value warning for GCC was introduced for the PetscOptionsEnd() macro in PETSc 3.17.0
+   * via PETSc MR !4889. Fixed up in PETSc 3.18.0 via PETSc MR !5069, so these pragmas can be
+   * removed when we update to that release.
+   */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
   PetscOptionsEnd();
+#pragma GCC diagnostic pop
   ierr = DMSetUp_Moose_Pre(dm);
   CHKERRQ(ierr); /* Need some preliminary set up because, strangely enough, DMView() is called in
                     DMSetFromOptions(). */

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -662,9 +662,15 @@ storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
 
         // MPIAIJ for PETSc 3.12.0: -matptap_via
         // MAIJ for PETSc 3.12.0: -matmaijptap_via
-        // MPIAIJ for PETSc 3.13 or higher: -matptap_via, -matproduct_ptap_via
-        // MAIJ for PETSc 3.13 or higher: -matproduct_ptap_via
-#if !PETSC_VERSION_LESS_THAN(3, 13, 0)
+        // MPIAIJ for PETSc 3.13 to 3.16: -matptap_via, -matproduct_ptap_via
+        // MAIJ for PETSc 3.13 to 3.16: -matproduct_ptap_via
+        // MPIAIJ for PETSc 3.17 and higher: -matptap_via, -mat_product_algorithm
+        // MAIJ for PETSc 3.17 and higher: -mat_product_algorithm
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+      if (hmg_found && (option.first == "-matptap_via" || option.first == "-matmaijptap_via" ||
+                        option.first == "-matproduct_ptap_via"))
+        new_options.emplace_back("-mat_product_algorithm", option.second);
+#elif !PETSC_VERSION_LESS_THAN(3, 13, 0)
       if (hmg_found && (option.first == "-matptap_via" || option.first == "-matmaijptap_via"))
         new_options.emplace_back("-matproduct_ptap_via", option.second);
 #else
@@ -676,7 +682,7 @@ storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
 #endif
 
       if (option.first == "-matptap_via" || option.first == "-matmaijptap_via" ||
-          option.first == "-matproduct_ptap_via")
+          option.first == "-matproduct_ptap_via" || option.first == "-mat_product_algorithm")
         matptap_found = true;
 
       // For 3D problems, we need to set this 0.7
@@ -743,7 +749,9 @@ storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params)
   // Let us switch to use new algorithm
   if (hmg_found && !matptap_found)
   {
-#if !PETSC_VERSION_LESS_THAN(3, 13, 0)
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+    po.pairs.emplace_back("-mat_product_algorithm", "allatonce");
+#elif !PETSC_VERSION_LESS_THAN(3, 13, 0)
     po.pairs.emplace_back("-matproduct_ptap_via", "allatonce");
 #else
     po.pairs.emplace_back("-matptap_via", "allatonce");

--- a/modules/optimization/src/executioners/OptimizeSolve.C
+++ b/modules/optimization/src/executioners/OptimizeSolve.C
@@ -135,20 +135,36 @@ OptimizeSolve::taoSolve()
   CHKERRQ(ierr);
 
   // Set objective and gradient functions
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+  ierr = TaoSetObjective(_tao, objectiveFunctionWrapper, this);
+#else
   ierr = TaoSetObjectiveRoutine(_tao, objectiveFunctionWrapper, this);
+#endif
   CHKERRQ(ierr);
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+  ierr = TaoSetObjectiveAndGradient(_tao, NULL, objectiveAndGradientFunctionWrapper, this);
+#else
   ierr = TaoSetObjectiveAndGradientRoutine(_tao, objectiveAndGradientFunctionWrapper, this);
+#endif
   CHKERRQ(ierr);
 
   // Set matrix-free version of the Hessian function
   ierr = MatCreateShell(_my_comm.get(), _ndof, _ndof, _ndof, _ndof, this, &_hessian);
   CHKERRQ(ierr);
   // Link matrix-free Hessian to Tao
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+  ierr = TaoSetHessian(_tao, _hessian, _hessian, hessianFunctionWrapper, this);
+#else
   ierr = TaoSetHessianRoutine(_tao, _hessian, _hessian, hessianFunctionWrapper, this);
+#endif
   CHKERRQ(ierr);
 
   // Set initial guess
+#if !PETSC_VERSION_LESS_THAN(3, 17, 0)
+  ierr = TaoSetSolution(_tao, _parameters->vec());
+#else
   ierr = TaoSetInitialVector(_tao, _parameters->vec());
+#endif
   CHKERRQ(ierr);
 
   // Set petsc options


### PR DESCRIPTION
## Reason
Updating to newer versions of PETSc enables easier maintenance and new features. But MOOSE requires some fixes to enable updating PETSc. 

## Design
Fixup MOOSE build and operation deficiencies for PETSc 3.17 series.

## Impact
Easier upgrade path for PETSc. 
