### PR TITLE
Fixing timed section name

### DIFF
--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1503,7 +1503,7 @@ NonlinearSystemBase::constraintResiduals(NumericVector<Number> & residual, bool 
 void
 NonlinearSystemBase::residualSetup()
 {
-  TIME_SECTION("computeResidualInternal", 3);
+  TIME_SECTION("residualSetup", 3);
 
   SystemBase::residualSetup();
 


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

Timed section name in `NonlinearSystemBase::residualSetup()` is incorrect.

## Design
<!--A concise description (design) of the enhancement.-->

Changing the name of the time section so it matches the method name.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

Users are no longer confused why there is `computeResidualInternal` in perf log twice.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
