### PR TITLE
Added some accessor functions in `Component`

### DIFF
--- a/modules/thermal_hydraulics/include/base/Simulation.h
+++ b/modules/thermal_hydraulics/include/base/Simulation.h
@@ -292,7 +292,7 @@ public:
    *
    * @return true if initial conditions are specified from a file
    */
-  bool hasInitialConditionsFromFile();
+  bool hasInitialConditionsFromFile() const;
 
   Logger & log() { return _log; }
 

--- a/modules/thermal_hydraulics/include/components/Component.h
+++ b/modules/thermal_hydraulics/include/components/Component.h
@@ -47,7 +47,18 @@ public:
 
   Component * parent() { return _parent; }
 
-  THMMesh & mesh() const { return _mesh; }
+  /**
+   * Const reference to mesh, which can be called at any point
+   *
+   * Note that overloading mesh() was not possible due to the need to call this
+   * const version, even when the component is not const.
+   */
+  const THMMesh & constMesh() const { return _mesh; }
+
+  /**
+   * Non-const reference to THM mesh, which can only be called before the end of mesh setup
+   */
+  THMMesh & mesh();
 
   /**
    * Test if a parameter exists in the object's input parameters
@@ -371,10 +382,11 @@ protected:
   /// The Factory associated with the MooseApp
   Factory & _factory;
 
-  /// Global mesh this component works on
-  THMMesh & _mesh;
-
   const Real & _zero;
+
+  /// The THM mesh
+  /// TODO: make _mesh private (applications need to switch to getters to avoid breaking)
+  THMMesh & _mesh;
 
 private:
   /// Component setup status

--- a/modules/thermal_hydraulics/include/components/Component.h
+++ b/modules/thermal_hydraulics/include/components/Component.h
@@ -224,6 +224,11 @@ public:
 
 protected:
   /**
+   * Gets the THM problem
+   */
+  THMProblem & getTHMProblem() const;
+
+  /**
    * Performs any post-constructor, pre-mesh-setup setup
    */
   virtual void preSetupMesh() {}
@@ -377,6 +382,8 @@ protected:
   Component * _parent;
 
   /// THM problem this component is part of
+  /// TODO: make _sim private (applications need to switch to getters to avoid breaking).
+  /// Also, rename to "_thm_problem" at that point.
   THMProblem & _sim;
 
   /// The Factory associated with the MooseApp

--- a/modules/thermal_hydraulics/include/components/FlowChannel1Phase.h
+++ b/modules/thermal_hydraulics/include/components/FlowChannel1Phase.h
@@ -50,7 +50,7 @@ protected:
   /**
    * Adds a material for the hydraulic diameter
    */
-  virtual void addHydraulicDiameterMaterial() const;
+  virtual void addHydraulicDiameterMaterial();
 
   /**
    * Populates heat connection variable names lists

--- a/modules/thermal_hydraulics/include/utils/FlowChannel3DAlignment.h
+++ b/modules/thermal_hydraulics/include/utils/FlowChannel3DAlignment.h
@@ -22,7 +22,7 @@ public:
   /**
    * @param mesh[in] The mesh
    */
-  FlowChannel3DAlignment(THMMesh & mesh);
+  FlowChannel3DAlignment(const THMMesh & mesh);
 
   /**
    * Build the neighborhood information between the heat structure boundary and the flow channel
@@ -59,7 +59,7 @@ public:
 
 protected:
   /// Mesh
-  THMMesh & _mesh;
+  const THMMesh & _mesh;
   /// List of hs boundary infos
   std::vector<std::tuple<dof_id_type, unsigned short int>> _hs_boundary_info;
   /// List of hs element IDs

--- a/modules/thermal_hydraulics/include/utils/FlowChannelAlignment.h
+++ b/modules/thermal_hydraulics/include/utils/FlowChannelAlignment.h
@@ -25,7 +25,7 @@ public:
   /**
    * @param mesh[in] The mesh
    */
-  FlowChannelAlignment(THMMesh & mesh);
+  FlowChannelAlignment(const THMMesh & mesh);
 
   /**
    * Build the neighborhood information between master and slave side
@@ -66,7 +66,7 @@ public:
 
 protected:
   /// Mesh
-  THMMesh & _mesh;
+  const THMMesh & _mesh;
   /// List of master element boundary infos
   std::vector<std::tuple<dof_id_type, unsigned short int>> _master_boundary_info;
   /// List of slave element IDs

--- a/modules/thermal_hydraulics/src/base/Simulation.C
+++ b/modules/thermal_hydraulics/src/base/Simulation.C
@@ -907,7 +907,7 @@ Simulation::getOutputsVector(const std::string & key) const
 }
 
 bool
-Simulation::hasInitialConditionsFromFile()
+Simulation::hasInitialConditionsFromFile() const
 {
   return _pars.isParamValid("initial_from_file");
 }

--- a/modules/thermal_hydraulics/src/components/Component.C
+++ b/modules/thermal_hydraulics/src/components/Component.C
@@ -135,6 +135,12 @@ Component::addDependency(const std::string & dependency)
   _dependencies.push_back(dependency);
 }
 
+THMProblem &
+Component::getTHMProblem() const
+{
+  return _sim;
+}
+
 void
 Component::makeFunctionControllableIfConstant(const FunctionName & fn_name,
                                               const std::string & control_name,

--- a/modules/thermal_hydraulics/src/components/Component.C
+++ b/modules/thermal_hydraulics/src/components/Component.C
@@ -38,8 +38,8 @@ Component::Component(const InputParameters & parameters)
     _parent(getParam<Component *>("_parent")),
     _sim(*getCheckedPointerParam<THMProblem *>("_thm_problem")),
     _factory(_app.getFactory()),
-    _mesh(static_cast<THMMesh &>(_sim.mesh())),
     _zero(_sim._real_zero[0]),
+    _mesh(static_cast<THMMesh &>(_sim.mesh())),
     _component_setup_status(CREATED)
 {
 }
@@ -51,6 +51,16 @@ Component::cname() const
     return _parent->cname();
   else
     return name();
+}
+
+THMMesh &
+Component::mesh()
+{
+  if (_component_setup_status >= MESH_PREPARED)
+    mooseError(
+        "A non-const reference to the THM mesh cannot be obtained after mesh setup is complete.");
+  else
+    return _mesh;
 }
 
 void

--- a/modules/thermal_hydraulics/src/components/Component1D.C
+++ b/modules/thermal_hydraulics/src/components/Component1D.C
@@ -35,11 +35,11 @@ Component1D::buildMesh()
 {
   buildMeshNodes();
 
-  MeshBase & the_mesh = _mesh.getMesh();
+  MeshBase & the_mesh = mesh().getMesh();
   BoundaryInfo & boundary_info = the_mesh.get_boundary_info();
 
   // create nodeset for all nodes for this component
-  _nodeset_id = _mesh.getNextBoundaryId();
+  _nodeset_id = mesh().getNextBoundaryId();
   _nodeset_name = name();
   boundary_info.nodeset_name(_nodeset_id) = _nodeset_name;
 
@@ -73,9 +73,9 @@ Component1D::buildMesh()
   }
 
   // elems
-  BoundaryID bc_id_inlet = _mesh.getNextBoundaryId();
-  BoundaryID bc_id_outlet = _mesh.getNextBoundaryId();
-  auto & binfo = _mesh.getMesh().get_boundary_info();
+  BoundaryID bc_id_inlet = mesh().getNextBoundaryId();
+  BoundaryID bc_id_outlet = mesh().getNextBoundaryId();
+  auto & binfo = mesh().getMesh().get_boundary_info();
   for (unsigned int i = 0; i < _n_elem; i++)
   {
     Elem * elem = nullptr;
@@ -109,27 +109,27 @@ Component1D::buildMesh()
     for (unsigned int i = 0; i < _axial_region_names.size(); i++)
     {
       const std::string & region_name = _axial_region_names[i];
-      SubdomainID subdomain_id = _mesh.getNextSubdomainId();
+      SubdomainID subdomain_id = mesh().getNextSubdomainId();
       setSubdomainInfo(subdomain_id, genName(name(), region_name));
 
       for (unsigned int j = 0; j < _n_elems[i]; j++, k++)
       {
         dof_id_type elem_id = _elem_ids[k];
-        _mesh.elemPtr(elem_id)->subdomain_id() = subdomain_id;
+        mesh().elemPtr(elem_id)->subdomain_id() = subdomain_id;
       }
     }
   }
   else
   {
-    SubdomainID subdomain_id = _mesh.getNextSubdomainId();
+    SubdomainID subdomain_id = mesh().getNextSubdomainId();
     setSubdomainInfo(subdomain_id, name());
 
     for (auto && id : _elem_ids)
-      _mesh.elemPtr(id)->subdomain_id() = subdomain_id;
+      mesh().elemPtr(id)->subdomain_id() = subdomain_id;
   }
 
   // Update the mesh
-  _mesh.update();
+  mesh().update();
 }
 
 bool

--- a/modules/thermal_hydraulics/src/components/Component1DBoundary.C
+++ b/modules/thermal_hydraulics/src/components/Component1DBoundary.C
@@ -41,8 +41,8 @@ Component1DBoundary::setupMesh()
     _normal = _normals[0];
 
     // create a nodeset/sideset corresponding to the node of the connected component end
-    const BoundaryID boundary_id = _mesh.getNextBoundaryId();
-    auto & binfo = _mesh.getMesh().get_boundary_info();
+    const BoundaryID boundary_id = mesh().getNextBoundaryId();
+    auto & binfo = mesh().getMesh().get_boundary_info();
     binfo.add_node(_node, boundary_id);
     binfo.nodeset_name(boundary_id) = name();
   }

--- a/modules/thermal_hydraulics/src/components/Component1DConnection.C
+++ b/modules/thermal_hydraulics/src/components/Component1DConnection.C
@@ -72,7 +72,7 @@ Component1DConnection::init()
       const std::string comp_name = connection._component_name;
       if (hasComponentByName<Component1D>(comp_name))
       {
-        const Component1D & comp = _sim.getComponentByName<Component1D>(comp_name);
+        const Component1D & comp = getTHMProblem().getComponentByName<Component1D>(comp_name);
 
         // add to list of subdomain names
         const std::vector<SubdomainName> & subdomain_names = comp.getSubdomainNames();

--- a/modules/thermal_hydraulics/src/components/Component1DJunction.C
+++ b/modules/thermal_hydraulics/src/components/Component1DJunction.C
@@ -34,9 +34,9 @@ Component1DJunction::setupMesh()
 {
   Component1DConnection::setupMesh();
 
-  const BoundaryID boundary_id = _mesh.getNextBoundaryId();
+  const BoundaryID boundary_id = mesh().getNextBoundaryId();
 
-  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+  auto & boundary_info = mesh().getMesh().get_boundary_info();
 
   for (const auto & connection : getConnections())
   {
@@ -54,7 +54,7 @@ Component1DJunction::setupMesh()
   // name the nodeset/sideset corresponding to the nodes of all connected component ends
   boundary_info.nodeset_name(boundary_id) = name();
 
-  const std::map<dof_id_type, std::vector<dof_id_type>> & node_to_elem = _mesh.nodeToElemMap();
+  const std::map<dof_id_type, std::vector<dof_id_type>> & node_to_elem = mesh().nodeToElemMap();
   for (auto & nid : _nodes)
   {
     const auto & it = node_to_elem.find(nid);
@@ -74,7 +74,7 @@ Component1DJunction::initSecondary()
 
   for (auto & eid : _connected_elems)
   {
-    const Elem * elem = _mesh.queryElemPtr(eid);
+    const Elem * elem = constMesh().queryElemPtr(eid);
     if (elem != nullptr && elem->processor_id() == processor_id())
       _proc_ids.push_back(elem->processor_id());
     else

--- a/modules/thermal_hydraulics/src/components/Component2D.C
+++ b/modules/thermal_hydraulics/src/components/Component2D.C
@@ -72,7 +72,7 @@ Component2D::build2DMesh()
     _outer_heat_node_ids.push_back(node_ids[i][_total_elem_number]);
   }
 
-  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+  auto & boundary_info = mesh().getMesh().get_boundary_info();
 
   // create elements from nodes
   unsigned int i = 0;
@@ -222,7 +222,7 @@ Component2D::build2DMesh2ndOrder()
     _outer_heat_node_ids.push_back(node_ids[i][_total_elem_number * 2]);
   }
 
-  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+  auto & boundary_info = mesh().getMesh().get_boundary_info();
 
   // create elements from nodes
   unsigned int i = 0;
@@ -335,38 +335,38 @@ Component2D::buildMesh()
     // The coordinate system for MOOSE is always XYZ, even for axisymmetric
     // components, since we do the RZ integration ourselves until we can set
     // arbitrary number of axis symmetries in MOOSE.
-    setSubdomainInfo(_mesh.getNextSubdomainId(), genName(_name, _names[i]), Moose::COORD_XYZ);
+    setSubdomainInfo(mesh().getNextSubdomainId(), genName(_name, _names[i]), Moose::COORD_XYZ);
   }
 
   // Create boundary IDs and associated boundary names
-  _inner_bc_id.push_back(_mesh.getNextBoundaryId());
-  _outer_bc_id.push_back(_mesh.getNextBoundaryId());
+  _inner_bc_id.push_back(mesh().getNextBoundaryId());
+  _outer_bc_id.push_back(mesh().getNextBoundaryId());
   _boundary_names_inner.push_back(genName(name(), "inner"));
   _boundary_names_outer.push_back(genName(name(), "outer"));
   if (_n_sections > 1 && _axial_region_names.size() == _n_sections)
     for (unsigned int i = 0; i < _n_sections; i++)
     {
-      _axial_inner_bc_id.push_back(_mesh.getNextBoundaryId());
-      _axial_outer_bc_id.push_back(_mesh.getNextBoundaryId());
+      _axial_inner_bc_id.push_back(mesh().getNextBoundaryId());
+      _axial_outer_bc_id.push_back(mesh().getNextBoundaryId());
       _boundary_names_axial_inner.push_back(genName(name(), _axial_region_names[i], "inner"));
       _boundary_names_axial_outer.push_back(genName(name(), _axial_region_names[i], "outer"));
     }
 
   // exterior axial boundaries
-  _start_bc_id.push_back(_mesh.getNextBoundaryId());
-  _end_bc_id.push_back(_mesh.getNextBoundaryId());
+  _start_bc_id.push_back(mesh().getNextBoundaryId());
+  _end_bc_id.push_back(mesh().getNextBoundaryId());
   _boundary_names_start.push_back(genName(name(), "start"));
   _boundary_names_end.push_back(genName(name(), "end"));
   if (_names.size() > 1)
     for (unsigned int i = 0; i < _names.size(); i++)
     {
-      _radial_start_bc_id.push_back(_mesh.getNextBoundaryId());
-      _radial_end_bc_id.push_back(_mesh.getNextBoundaryId());
+      _radial_start_bc_id.push_back(mesh().getNextBoundaryId());
+      _radial_end_bc_id.push_back(mesh().getNextBoundaryId());
       _boundary_names_radial_start.push_back(genName(name(), _names[i], "start"));
       _boundary_names_radial_end.push_back(genName(name(), _names[i], "end"));
       if (i != _names.size() - 1)
       {
-        _inner_radial_bc_id.push_back(_mesh.getNextBoundaryId());
+        _inner_radial_bc_id.push_back(mesh().getNextBoundaryId());
         _boundary_names_inner_radial.push_back(genName(name(), _names[i], _names[i + 1]));
       }
     }
@@ -376,7 +376,7 @@ Component2D::buildMesh()
     for (unsigned int i = 0; i < _n_sections - 1; i++)
       for (unsigned int j = 0; j < _names.size(); j++)
       {
-        _interior_axial_per_radial_section_bc_id.push_back(_mesh.getNextBoundaryId());
+        _interior_axial_per_radial_section_bc_id.push_back(mesh().getNextBoundaryId());
         _boundary_names_interior_axial_per_radial_section.push_back(
             genName(name(), _names[j], _axial_region_names[i] + ":" + _axial_region_names[i + 1]));
       }
@@ -388,7 +388,7 @@ Component2D::buildMesh()
     build2DMesh();
 
   // Set boundary names
-  auto & binfo = _mesh.getMesh().get_boundary_info();
+  auto & binfo = mesh().getMesh().get_boundary_info();
   binfo.sideset_name(_inner_bc_id[0]) = _boundary_names_inner[0];
   binfo.sideset_name(_outer_bc_id[0]) = _boundary_names_outer[0];
   if (_n_sections > 1 && _axial_region_names.size() == _n_sections)

--- a/modules/thermal_hydraulics/src/components/FlowBoundary.C
+++ b/modules/thermal_hydraulics/src/components/FlowBoundary.C
@@ -31,7 +31,7 @@ FlowBoundary::init()
     if (hasComponentByName<FlowChannelBase>(_connected_component_name))
     {
       const FlowChannelBase & comp =
-          _sim.getComponentByName<FlowChannelBase>(_connected_component_name);
+          getTHMProblem().getComponentByName<FlowChannelBase>(_connected_component_name);
 
       _fp_name = comp.getFluidPropertiesName();
       _flow_model_id = comp.getFlowModelID();

--- a/modules/thermal_hydraulics/src/components/FlowBoundary1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FlowBoundary1Phase.C
@@ -31,7 +31,7 @@ FlowBoundary1Phase::init()
   if (hasComponentByName<FlowChannel1Phase>(_connected_component_name))
   {
     const FlowChannel1Phase & comp =
-        _sim.getComponentByName<FlowChannel1Phase>(_connected_component_name);
+        getTHMProblem().getComponentByName<FlowChannel1Phase>(_connected_component_name);
 
     _numerical_flux_name = comp.getNumericalFluxUserObjectName();
   }
@@ -57,7 +57,7 @@ FlowBoundary1Phase::addWeakBC3Eqn()
   params.set<std::vector<VariableName>>("rhoA") = {FlowModelSinglePhase::RHOA};
   params.set<std::vector<VariableName>>("rhouA") = {FlowModelSinglePhase::RHOUA};
   params.set<std::vector<VariableName>>("rhoEA") = {FlowModelSinglePhase::RHOEA};
-  params.set<bool>("implicit") = _sim.getImplicitTimeIntegrationFlag();
+  params.set<bool>("implicit") = getTHMProblem().getImplicitTimeIntegrationFlag();
 
   const std::vector<NonlinearVariableName> variables{
       FlowModelSinglePhase::RHOA, FlowModelSinglePhase::RHOUA, FlowModelSinglePhase::RHOEA};
@@ -65,6 +65,7 @@ FlowBoundary1Phase::addWeakBC3Eqn()
   for (const auto & var : variables)
   {
     params.set<NonlinearVariableName>("variable") = var;
-    _sim.addBoundaryCondition(class_name, genName(name(), var, "bnd_flux_3eqn_bc"), params);
+    getTHMProblem().addBoundaryCondition(
+        class_name, genName(name(), var, "bnd_flux_3eqn_bc"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/FlowChannel1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannel1Phase.C
@@ -56,7 +56,7 @@ FlowChannel1Phase::init()
 {
   FlowChannelBase::init();
 
-  const UserObject & fp = _sim.getUserObject<UserObject>(_fp_name);
+  const UserObject & fp = getTHMProblem().getUserObject<UserObject>(_fp_name);
   if (dynamic_cast<const SinglePhaseFluidProperties *>(&fp) == nullptr)
     logError("Supplied fluid properties must be for 1-phase fluids.");
 }
@@ -66,10 +66,10 @@ FlowChannel1Phase::buildFlowModel()
 {
   const std::string class_name = "FlowModelSinglePhase";
   InputParameters pars = _factory.getValidParams(class_name);
-  pars.set<THMProblem *>("_thm_problem") = &_sim;
+  pars.set<THMProblem *>("_thm_problem") = &getTHMProblem();
   pars.set<FlowChannelBase *>("_flow_channel") = this;
   pars.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
-  pars.set<bool>("output_vector_velocity") = _sim.getVectorValuedVelocity();
+  pars.set<bool>("output_vector_velocity") = getTHMProblem().getVectorValuedVelocity();
   pars.applyParameters(parameters());
   return _factory.create<FlowModel>(class_name, name(), pars, 0);
 }
@@ -90,7 +90,7 @@ FlowChannel1Phase::check() const
   }
 
   bool ics_set =
-      _sim.hasInitialConditionsFromFile() ||
+      getTHMProblem().hasInitialConditionsFromFile() ||
       (isParamValid("initial_p") && isParamValid("initial_T") && isParamValid("initial_vel"));
 
   if (!ics_set && !_app.isRestarting())
@@ -116,7 +116,7 @@ FlowChannel1Phase::addMooseObjects()
 }
 
 void
-FlowChannel1Phase::addHydraulicDiameterMaterial() const
+FlowChannel1Phase::addHydraulicDiameterMaterial()
 {
   const std::string mat_name = genName(name(), "D_h_material");
 
@@ -129,7 +129,7 @@ FlowChannel1Phase::addHydraulicDiameterMaterial() const
     params.set<std::vector<SubdomainName>>("block") = getSubdomainNames();
     params.set<std::vector<std::string>>("prop_names") = {FlowModelSinglePhase::HYDRAULIC_DIAMETER};
     params.set<std::vector<FunctionName>>("prop_values") = {D_h_fn_name};
-    _sim.addMaterial(class_name, mat_name, params);
+    getTHMProblem().addMaterial(class_name, mat_name, params);
 
     makeFunctionControllableIfConstant(D_h_fn_name, "D_h");
   }
@@ -140,7 +140,7 @@ FlowChannel1Phase::addHydraulicDiameterMaterial() const
     params.set<std::vector<SubdomainName>>("block") = getSubdomainNames();
     params.set<MaterialPropertyName>("D_h_name") = FlowModelSinglePhase::HYDRAULIC_DIAMETER;
     params.set<std::vector<VariableName>>("A") = {FlowModel::AREA};
-    _sim.addMaterial(class_name, mat_name, params);
+    getTHMProblem().addMaterial(class_name, mat_name, params);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/FlowJunction.C
+++ b/modules/thermal_hydraulics/src/components/FlowJunction.C
@@ -39,7 +39,8 @@ FlowJunction::init()
       const std::string comp_name = connection._component_name;
       if (hasComponentByName<FlowChannelBase>(comp_name))
       {
-        const FlowChannelBase & comp = _sim.getComponentByName<FlowChannelBase>(comp_name);
+        const FlowChannelBase & comp =
+            getTHMProblem().getComponentByName<FlowChannelBase>(comp_name);
 
         fp_names.push_back(comp.getFluidPropertiesName());
         flow_model_ids.push_back(comp.getFlowModelID());

--- a/modules/thermal_hydraulics/src/components/FlowJunction1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FlowJunction1Phase.C
@@ -29,7 +29,8 @@ FlowJunction1Phase::init()
     const std::string comp_name = connection._component_name;
     if (hasComponentByName<FlowChannel1Phase>(comp_name))
     {
-      const FlowChannel1Phase & comp = _sim.getComponentByName<FlowChannel1Phase>(comp_name);
+      const FlowChannel1Phase & comp =
+          getTHMProblem().getComponentByName<FlowChannel1Phase>(comp_name);
 
       _numerical_flux_names.push_back(comp.getNumericalFluxUserObjectName());
     }

--- a/modules/thermal_hydraulics/src/components/FormLoss1PhaseBase.C
+++ b/modules/thermal_hydraulics/src/components/FormLoss1PhaseBase.C
@@ -56,6 +56,7 @@ FormLoss1PhaseBase::addMooseObjects()
     params.set<std::vector<VariableName>>("A") = {FlowModel::AREA};
     params.set<MaterialPropertyName>("rho") = FlowModelSinglePhase::DENSITY;
     params.set<MaterialPropertyName>("vel") = FlowModelSinglePhase::VELOCITY;
-    _sim.addKernel(class_name, genName(name(), FlowModelSinglePhase::RHOUA, "form_loss"), params);
+    getTHMProblem().addKernel(
+        class_name, genName(name(), FlowModelSinglePhase::RHOUA, "form_loss"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/FormLossFromExternalApp1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FormLossFromExternalApp1Phase.C
@@ -30,7 +30,8 @@ FormLossFromExternalApp1Phase::FormLossFromExternalApp1Phase(const InputParamete
 void
 FormLossFromExternalApp1Phase::addVariables()
 {
-  _sim.addSimVariable(false, _K_prime_var_name, FEType(FIRST, LAGRANGE), _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _K_prime_var_name, FEType(FIRST, LAGRANGE), _flow_channel_subdomains);
 }
 
 void
@@ -44,6 +45,6 @@ FormLossFromExternalApp1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<MaterialPropertyName>("prop_name") = "K_prime";
     params.set<std::vector<VariableName>>("coupled_variable") = {_K_prime_var_name};
-    _sim.addMaterial(class_name, genName(name(), "k_prime_material"), params);
+    getTHMProblem().addMaterial(class_name, genName(name(), "k_prime_material"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/FormLossFromFunction1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FormLossFromFunction1Phase.C
@@ -40,6 +40,6 @@ FormLossFromFunction1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<std::vector<std::string>>("prop_names") = {"K_prime"};
     params.set<std::vector<FunctionName>>("prop_values") = {getParam<FunctionName>("K_prime")};
-    _sim.addMaterial(class_name, genName(name(), "k_prime_material"), params);
+    getTHMProblem().addMaterial(class_name, genName(name(), "k_prime_material"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/FreeBoundary1Phase.C
+++ b/modules/thermal_hydraulics/src/components/FreeBoundary1Phase.C
@@ -36,7 +36,7 @@ FreeBoundary1Phase::addMooseObjects()
     InputParameters params = _factory.getValidParams(class_name);
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
   }
 
   // BCs

--- a/modules/thermal_hydraulics/src/components/GateValve1Phase.C
+++ b/modules/thermal_hydraulics/src/components/GateValve1Phase.C
@@ -35,7 +35,7 @@ GateValve1Phase::setupMesh()
   FlowJunction1Phase::setupMesh();
 
   if (_connected_elems.size() == 2)
-    _sim.augmentSparsity(_connected_elems[0], _connected_elems[1]);
+    getTHMProblem().augmentSparsity(_connected_elems[0], _connected_elems[1]);
 }
 
 void
@@ -86,7 +86,7 @@ GateValve1Phase::addMooseObjects()
     params.set<std::vector<VariableName>>("rhoEA") = {FlowModelSinglePhase::RHOEA};
     params.set<std::string>("component_name") = name();
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
 
     connectObject(params, _junction_uo_name, "open_area_fraction");
   }
@@ -110,8 +110,8 @@ GateValve1Phase::addMooseObjects()
       params.set<std::vector<VariableName>>("rhoA") = {FlowModelSinglePhase::RHOA};
       params.set<std::vector<VariableName>>("rhouA") = {FlowModelSinglePhase::RHOUA};
       params.set<std::vector<VariableName>>("rhoEA") = {FlowModelSinglePhase::RHOEA};
-      params.set<bool>("implicit") = _sim.getImplicitTimeIntegrationFlag();
-      _sim.addBoundaryCondition(
+      params.set<bool>("implicit") = getTHMProblem().getImplicitTimeIntegrationFlag();
+      getTHMProblem().addBoundaryCondition(
           class_name, genName(name(), i, var_names[j] + ":" + class_name), params);
     }
 }

--- a/modules/thermal_hydraulics/src/components/GeometricalComponent.C
+++ b/modules/thermal_hydraulics/src/components/GeometricalComponent.C
@@ -45,7 +45,7 @@ GeometricalComponent::computeNumberOfNodes(unsigned int n_elems)
 Node *
 GeometricalComponent::addNode(const Point & pt)
 {
-  auto node = _mesh.addNode(pt);
+  auto node = mesh().addNode(pt);
   _node_ids.push_back(node->id());
   return node;
 }
@@ -54,7 +54,7 @@ Elem *
 GeometricalComponent::addElement(libMesh::ElemType elem_type,
                                  const std::vector<dof_id_type> & node_ids)
 {
-  auto elem = _mesh.addElement(elem_type, node_ids);
+  auto elem = mesh().addElement(elem_type, node_ids);
   _elem_ids.push_back(elem->id());
   return elem;
 }
@@ -62,7 +62,7 @@ GeometricalComponent::addElement(libMesh::ElemType elem_type,
 Elem *
 GeometricalComponent::addElementEdge2(dof_id_type node0, dof_id_type node1)
 {
-  auto elem = _mesh.addElementEdge2(node0, node1);
+  auto elem = mesh().addElementEdge2(node0, node1);
   _elem_ids.push_back(elem->id());
   return elem;
 }
@@ -70,7 +70,7 @@ GeometricalComponent::addElementEdge2(dof_id_type node0, dof_id_type node1)
 Elem *
 GeometricalComponent::addElementEdge3(dof_id_type node0, dof_id_type node1, dof_id_type node2)
 {
-  auto elem = _mesh.addElementEdge3(node0, node1, node2);
+  auto elem = mesh().addElementEdge3(node0, node1, node2);
   _elem_ids.push_back(elem->id());
   return elem;
 }
@@ -81,7 +81,7 @@ GeometricalComponent::addElementQuad4(dof_id_type node0,
                                       dof_id_type node2,
                                       dof_id_type node3)
 {
-  auto elem = _mesh.addElementQuad4(node0, node1, node2, node3);
+  auto elem = mesh().addElementQuad4(node0, node1, node2, node3);
   _elem_ids.push_back(elem->id());
   return elem;
 }
@@ -97,7 +97,7 @@ GeometricalComponent::addElementQuad9(dof_id_type node0,
                                       dof_id_type node7,
                                       dof_id_type node8)
 {
-  auto elem = _mesh.addElementQuad9(node0, node1, node2, node3, node4, node5, node6, node7, node8);
+  auto elem = mesh().addElementQuad9(node0, node1, node2, node3, node4, node5, node6, node7, node8);
   _elem_ids.push_back(elem->id());
   return elem;
 }
@@ -111,7 +111,7 @@ GeometricalComponent::setupMesh()
   // displace nodes
   for (auto && node_id : _node_ids)
   {
-    Node & curr_node = _mesh.nodeRef(node_id);
+    Node & curr_node = mesh().nodeRef(node_id);
     RealVectorValue p(curr_node(0), curr_node(1), curr_node(2));
     curr_node = computeRealPointFromReferencePoint(p);
   }
@@ -231,7 +231,7 @@ GeometricalComponent::setSubdomainInfo(SubdomainID subdomain_id,
     gc->_subdomain_names.push_back(subdomain_name);
     gc->_coord_sys.push_back(coord_system);
   }
-  _mesh.setSubdomainName(subdomain_id, subdomain_name);
+  mesh().setSubdomainName(subdomain_id, subdomain_name);
 }
 
 const std::vector<dof_id_type> &

--- a/modules/thermal_hydraulics/src/components/GeometricalComponent.C
+++ b/modules/thermal_hydraulics/src/components/GeometricalComponent.C
@@ -206,7 +206,7 @@ const FunctionName &
 GeometricalComponent::getVariableFn(const FunctionName & fn_param_name)
 {
   const FunctionName & fn_name = getParam<FunctionName>(fn_param_name);
-  const Function & fn = _sim.getFunction(fn_name);
+  const Function & fn = getTHMProblem().getFunction(fn_name);
 
   if (dynamic_cast<const ConstantFunction *>(&fn) != nullptr)
   {

--- a/modules/thermal_hydraulics/src/components/HSBoundaryAmbientConvection.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundaryAmbientConvection.C
@@ -45,7 +45,7 @@ HSBoundaryAmbientConvection::check() const
   if (isParamValid("scale_pp"))
   {
     const PostprocessorName & pp_name = getParam<PostprocessorName>("scale_pp");
-    if (!_sim.hasPostprocessor(pp_name))
+    if (!getTHMProblem().hasPostprocessor(pp_name))
       logError("The post-processor name provided for the parameter 'scale_pp' is '" + pp_name +
                "', but no post-processor of this name exists.");
   }
@@ -76,7 +76,7 @@ HSBoundaryAmbientConvection::addMooseObjects()
     if (isParamValid("scale_pp"))
       pars.set<PostprocessorName>("scale_pp") = getParam<PostprocessorName>("scale_pp");
 
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
   }
 
   // Create integral PP for cylindrical heat structures
@@ -92,6 +92,6 @@ HSBoundaryAmbientConvection::addMooseObjects()
     pars.set<RealVectorValue>("axis_dir") = hs.getDirection();
     pars.set<Real>("offset") = hs_cyl->getInnerRadius() - hs_cyl->getAxialOffset();
     pars.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_TIMESTEP_END};
-    _sim.addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
+    getTHMProblem().addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HSBoundaryExternalAppConvection.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundaryExternalAppConvection.C
@@ -45,7 +45,7 @@ HSBoundaryExternalAppConvection::check() const
   if (isParamValid("scale_pp"))
   {
     const PostprocessorName & pp_name = getParam<PostprocessorName>("scale_pp");
-    if (!_sim.hasPostprocessor(pp_name))
+    if (!getTHMProblem().hasPostprocessor(pp_name))
       logError("The post-processor name provided for the parameter 'scale_pp' is '" + pp_name +
                "', but no post-processor of this name exists.");
   }
@@ -57,8 +57,10 @@ HSBoundaryExternalAppConvection::addVariables()
   const HeatStructureBase & hs = getComponent<HeatStructureBase>("hs");
   const std::vector<SubdomainName> & subdomain_names = hs.getSubdomainNames();
 
-  _sim.addSimVariable(false, _T_ext_var_name, HeatConductionModel::feType(), subdomain_names);
-  _sim.addSimVariable(false, _htc_ext_var_name, HeatConductionModel::feType(), subdomain_names);
+  getTHMProblem().addSimVariable(
+      false, _T_ext_var_name, HeatConductionModel::feType(), subdomain_names);
+  getTHMProblem().addSimVariable(
+      false, _htc_ext_var_name, HeatConductionModel::feType(), subdomain_names);
 }
 
 void
@@ -86,7 +88,7 @@ HSBoundaryExternalAppConvection::addMooseObjects()
     if (isParamValid("scale_pp"))
       pars.set<PostprocessorName>("scale_pp") = getParam<PostprocessorName>("scale_pp");
 
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
   }
 
   // Create integral PP for cylindrical heat structures
@@ -102,6 +104,6 @@ HSBoundaryExternalAppConvection::addMooseObjects()
     pars.set<RealVectorValue>("axis_dir") = hs.getDirection();
     pars.set<Real>("offset") = hs_cyl->getInnerRadius() - hs_cyl->getAxialOffset();
     pars.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_TIMESTEP_END};
-    _sim.addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
+    getTHMProblem().addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HSBoundaryExternalAppTemperature.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundaryExternalAppTemperature.C
@@ -36,7 +36,8 @@ HSBoundaryExternalAppTemperature::addVariables()
   const HeatStructureBase & hs = getComponent<HeatStructureBase>("hs");
   const std::vector<SubdomainName> & subdomain_names = hs.getSubdomainNames();
 
-  _sim.addSimVariable(false, _T_ext_var_name, HeatConductionModel::feType(), subdomain_names);
+  getTHMProblem().addSimVariable(
+      false, _T_ext_var_name, HeatConductionModel::feType(), subdomain_names);
 }
 
 void
@@ -48,6 +49,6 @@ HSBoundaryExternalAppTemperature::addMooseObjects()
     pars.set<NonlinearVariableName>("variable") = HeatConductionModel::TEMPERATURE;
     pars.set<std::vector<BoundaryName>>("boundary") = _boundary;
     pars.set<std::vector<VariableName>>("v") = {_T_ext_var_name};
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HSBoundaryHeatFlux.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundaryHeatFlux.C
@@ -42,7 +42,7 @@ HSBoundaryHeatFlux::check() const
   if (isParamValid("scale_pp"))
   {
     const PostprocessorName & pp_name = getParam<PostprocessorName>("scale_pp");
-    if (!_sim.hasPostprocessor(pp_name))
+    if (!getTHMProblem().hasPostprocessor(pp_name))
       logError("The post-processor name provided for the parameter 'scale_pp' is '" + pp_name +
                "', but no post-processor of this name exists.");
   }
@@ -71,7 +71,7 @@ HSBoundaryHeatFlux::addMooseObjects()
     if (isParamValid("scale_pp"))
       pars.set<PostprocessorName>("scale_pp") = getParam<PostprocessorName>("scale_pp");
 
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
   }
 
   // Create integral PP for cylindrical heat structures
@@ -85,6 +85,6 @@ HSBoundaryHeatFlux::addMooseObjects()
     pars.set<RealVectorValue>("axis_dir") = hs.getDirection();
     pars.set<Real>("offset") = hs_cyl->getInnerRadius() - hs_cyl->getAxialOffset();
     pars.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_TIMESTEP_END};
-    _sim.addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
+    getTHMProblem().addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HSBoundaryRadiation.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundaryRadiation.C
@@ -39,7 +39,7 @@ HSBoundaryRadiation::check() const
   if (isParamValid("scale_pp"))
   {
     const PostprocessorName & pp_name = getParam<PostprocessorName>("scale_pp");
-    if (!_sim.hasPostprocessor(pp_name))
+    if (!getTHMProblem().hasPostprocessor(pp_name))
       logError("The post-processor name provided for the parameter 'scale_pp' is '" + pp_name +
                "', but no post-processor of this name exists.");
   }
@@ -71,7 +71,7 @@ HSBoundaryRadiation::addMooseObjects()
     if (isParamValid("scale_pp"))
       pars.set<PostprocessorName>("scale_pp") = getParam<PostprocessorName>("scale_pp");
 
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
   }
 
   // Create integral PP for cylindrical heat structures
@@ -88,6 +88,6 @@ HSBoundaryRadiation::addMooseObjects()
     pars.set<RealVectorValue>("axis_dir") = hs.getDirection();
     pars.set<Real>("offset") = hs_cyl->getInnerRadius() - hs_cyl->getAxialOffset();
     pars.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_TIMESTEP_END};
-    _sim.addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
+    getTHMProblem().addPostprocessor(class_name, genSafeName(name(), "integral"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HSBoundarySpecifiedTemperature.C
+++ b/modules/thermal_hydraulics/src/components/HSBoundarySpecifiedTemperature.C
@@ -42,7 +42,7 @@ HSBoundarySpecifiedTemperature::addMooseObjects()
     pars.set<NonlinearVariableName>("variable") = HeatConductionModel::TEMPERATURE;
     pars.set<std::vector<BoundaryName>>("boundary") = _boundary;
     pars.set<FunctionName>("function") = _T_func;
-    _sim.addBoundaryCondition(class_name, genName(name(), "bc"), pars);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "bc"), pars);
     makeFunctionControllableIfConstant(_T_func, "T");
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatSourceFromPowerDensity.C
+++ b/modules/thermal_hydraulics/src/components/HeatSourceFromPowerDensity.C
@@ -57,6 +57,6 @@ HeatSourceFromPowerDensity::addMooseObjects()
       pars.set<Real>("offset") = hs_cyl->getInnerRadius() - hs_cyl->getAxialOffset();
     }
     std::string mon = genName(name(), "heat_src");
-    _sim.addKernel(class_name, mon, pars);
+    getTHMProblem().addKernel(class_name, mon, pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatSourceFromTotalPower.C
+++ b/modules/thermal_hydraulics/src/components/HeatSourceFromTotalPower.C
@@ -80,7 +80,7 @@ HeatSourceFromTotalPower::addMooseObjects()
     std::string class_name = "ConstantFunction";
     InputParameters pars = _factory.getValidParams(class_name);
     pars.set<Real>("value") = 1. / hs.getLength();
-    _sim.addFunction(class_name, _power_shape_func, pars);
+    getTHMProblem().addFunction(class_name, _power_shape_func, pars);
   }
 
   const std::string power_shape_integral_name = _has_psf
@@ -104,8 +104,8 @@ HeatSourceFromTotalPower::addMooseObjects()
     // that should be here, becuase we don't want this PPS to be in any output. The effect
     // of this line is correct, but for some reason, MOOSE will start output scalar variables
     // even though we did not ask it to do so. Refs idaholab/thm#
-    // pars.set<std::vector<OutputName>>("outputs") = _sim.getOutputsVector("none");
-    _sim.addPostprocessor(class_name, power_shape_integral_name, pars);
+    // pars.set<std::vector<OutputName>>("outputs") = getTHMProblem().getOutputsVector("none");
+    getTHMProblem().addPostprocessor(class_name, power_shape_integral_name, pars);
   }
 
   {
@@ -134,7 +134,7 @@ HeatSourceFromTotalPower::addMooseObjects()
     }
     pars.set<PostprocessorName>("power_shape_integral_pp") = power_shape_integral_name;
     std::string mon = genName(name(), "heat_src");
-    _sim.addKernel(class_name, mon, pars);
+    getTHMProblem().addKernel(class_name, mon, pars);
     connectObject(pars, mon, "power_fraction");
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatSourceVolumetric1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatSourceVolumetric1Phase.C
@@ -49,6 +49,6 @@ HeatSourceVolumetric1Phase::addMooseObjects()
     pars.set<std::vector<SubdomainName>>("block") = fch.getSubdomainNames();
     pars.set<FunctionName>("q") = getParam<FunctionName>("q");
     pars.set<std::vector<VariableName>>("A") = {FlowModel::AREA};
-    _sim.addKernel(class_name, genName(name(), "rhoE_heat_source"), pars);
+    getTHMProblem().addKernel(class_name, genName(name(), "rhoE_heat_source"), pars);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatStructure2DCoupler.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructure2DCoupler.C
@@ -68,6 +68,6 @@ HeatStructure2DCoupler::addMooseObjects()
       params.set<Real>("offset") =
           hs_cylindrical.getInnerRadius() - hs_cylindrical.getAxialOffset();
     }
-    _sim.addBoundaryCondition(class_name, genName(name(), class_name, i), params);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), class_name, i), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatStructure2DCouplerBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructure2DCouplerBase.C
@@ -73,7 +73,7 @@ HeatStructure2DCouplerBase::init()
         {
           const auto neighbor_elem_id = _mesh_alignment.getNeighborElemID(elem_id);
           if (neighbor_elem_id != DofObject::invalid_id)
-            _sim.augmentSparsity(elem_id, neighbor_elem_id);
+            getTHMProblem().augmentSparsity(elem_id, neighbor_elem_id);
         }
     }
   }

--- a/modules/thermal_hydraulics/src/components/HeatStructure2DCouplerBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructure2DCouplerBase.C
@@ -37,7 +37,7 @@ HeatStructure2DCouplerBase::HeatStructure2DCouplerBase(const InputParameters & p
     _hs_boundaries(
         {getParam<BoundaryName>("primary_boundary"), getParam<BoundaryName>("secondary_boundary")}),
 
-    _mesh_alignment(_mesh),
+    _mesh_alignment(constMesh()),
     _is_plate({false, false}),
     _is_cylindrical({false, false})
 {
@@ -51,7 +51,7 @@ HeatStructure2DCouplerBase::init()
   BoundaryBase::init();
 
   if (hasComponentByName<HeatStructureBase>(_hs_names[0]) &&
-      hasComponentByName<HeatStructureBase>(_hs_names[1]) && !_mesh.isDistributedMesh())
+      hasComponentByName<HeatStructureBase>(_hs_names[1]) && !constMesh().isDistributedMesh())
   {
     const HeatStructureBase & primary_hs = getComponentByName<HeatStructureBase>(_hs_names[0]);
     const HeatStructureBase & secondary_hs = getComponentByName<HeatStructureBase>(_hs_names[1]);
@@ -116,7 +116,7 @@ HeatStructure2DCouplerBase::check() const
   if ((_is_plate[0] && _is_cylindrical[1]) || (_is_cylindrical[0] && _is_plate[1]))
     logError("The coupled heat structures must have the same type.");
 
-  if (_mesh.isDistributedMesh())
+  if (constMesh().isDistributedMesh())
     logError("HeatStructure2DCouplerBase does not work with a distributed mesh.");
 
 #ifndef MOOSE_GLOBAL_AD_INDEXING

--- a/modules/thermal_hydraulics/src/components/HeatStructure2DRadiationCouplerRZ.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructure2DRadiationCouplerRZ.C
@@ -102,6 +102,6 @@ HeatStructure2DRadiationCouplerRZ::addMooseObjects()
     params.set<Real>("perimeter") = _perimeters[i];
     params.set<Real>("coupled_perimeter") = _perimeters[j];
     params.set<Real>("stefan_boltzmann_constant") = getParam<Real>("stefan_boltzmann_constant");
-    _sim.addBoundaryCondition(class_name, genName(name(), class_name, i), params);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), class_name, i), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatStructureBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureBase.C
@@ -53,7 +53,7 @@ HeatStructureBase::buildModel()
 {
   const std::string class_name = "HeatConductionModel";
   InputParameters pars = _factory.getValidParams(class_name);
-  pars.set<THMProblem *>("_thm_problem") = &_sim;
+  pars.set<THMProblem *>("_thm_problem") = &getTHMProblem();
   pars.set<HeatStructureBase *>("_hs") = this;
   pars.applyParameters(parameters());
   return _factory.create<HeatConductionModel>(class_name, name(), pars, 0);
@@ -70,7 +70,7 @@ HeatStructureBase::check() const
 {
   Component2D::check();
 
-  bool ics_set = _sim.hasInitialConditionsFromFile() || isParamValid("initial_T");
+  bool ics_set = getTHMProblem().hasInitialConditionsFromFile() || isParamValid("initial_T");
 
   if (!ics_set && !_app.isRestarting())
     logError("Missing initial condition for temperature.");
@@ -106,7 +106,7 @@ HeatStructureBase::addMooseObjects()
     for (unsigned int i = 0; i < _number_of_hs; i++)
     {
       const SolidMaterialProperties & smp =
-          _sim.getUserObject<SolidMaterialProperties>(_material_names[i]);
+          getTHMProblem().getUserObject<SolidMaterialProperties>(_material_names[i]);
 
       Component * comp = (_parent != nullptr) ? _parent : this;
       // if the values were given as constant, allow them to be controlled

--- a/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
@@ -61,7 +61,7 @@ HeatStructureFromFile3D::buildModel()
 {
   const std::string class_name = "HeatConductionModel";
   InputParameters pars = _factory.getValidParams(class_name);
-  pars.set<THMProblem *>("_thm_problem") = &_sim;
+  pars.set<THMProblem *>("_thm_problem") = &getTHMProblem();
   pars.set<HeatStructureBase *>("_hs") = this;
   pars.applyParameters(parameters());
   return _factory.create<HeatConductionModel>(class_name, name(), pars, 0);
@@ -78,7 +78,7 @@ HeatStructureFromFile3D::check() const
 {
   GeometricalComponent::check();
 
-  bool ics_set = _sim.hasInitialConditionsFromFile() || isParamValid("initial_T");
+  bool ics_set = getTHMProblem().hasInitialConditionsFromFile() || isParamValid("initial_T");
   if (!ics_set && !_app.isRestarting())
     logError("Missing initial condition for temperature.");
 }

--- a/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
+++ b/modules/thermal_hydraulics/src/components/HeatStructureFromFile3D.C
@@ -137,7 +137,7 @@ HeatStructureFromFile3D::buildMesh()
     _name_index[subdomain_name] = i;
 
     const std::string solid_block_name = genName(_name, subdomain_name);
-    SubdomainID sid = _mesh.getNextSubdomainId();
+    SubdomainID sid = mesh().getNextSubdomainId();
     setSubdomainInfo(sid, solid_block_name, Moose::COORD_XYZ);
 
     const std::string type_str(exio_helper.get_elem_type());
@@ -177,18 +177,18 @@ HeatStructureFromFile3D::buildMesh()
     if (sideset_name.empty())
       sideset_name = Moose::stringify(ex_sideset_id);
 
-    unsigned int bc_id = _mesh.getNextBoundaryId();
+    unsigned int bc_id = mesh().getNextBoundaryId();
     thm_bc_id_map[ex_sideset_id] = bc_id;
     new_ids_to_names.emplace(bc_id, sideset_name);
   }
 
-  auto & boundary_info = _mesh.getMesh().get_boundary_info();
+  auto & boundary_info = mesh().getMesh().get_boundary_info();
 
   for (auto e : index_range(exio_helper.elem_list))
   {
     int ex_elem_id = exio_helper.elem_num_map[exio_helper.elem_list[e] - 1];
     dof_id_type elem_id = thm_elem_map[ex_elem_id];
-    Elem * elem = _mesh.elemPtr(elem_id);
+    Elem * elem = mesh().elemPtr(elem_id);
     const auto & conv = exio_helper.get_conversion(elem->type());
     // Map the zero-based Exodus side numbering to the libmesh side numbering
     unsigned int raw_side_index = exio_helper.side_list[e] - 1;
@@ -199,7 +199,7 @@ HeatStructureFromFile3D::buildMesh()
     boundary_info.add_side(elem, mapped_side, bc_id);
   }
   for (const auto & pr : new_ids_to_names)
-    _mesh.getMesh().get_boundary_info().sideset_name(pr.first) = genName(_name, pr.second);
+    mesh().getMesh().get_boundary_info().sideset_name(pr.first) = genName(_name, pr.second);
 
   _number_of_hs = _names.size();
 }

--- a/modules/thermal_hydraulics/src/components/HeatTransferBase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferBase.C
@@ -109,14 +109,15 @@ HeatTransferBase::addMooseObjects()
     execute_on = {EXEC_TIMESTEP_BEGIN, EXEC_INITIAL};
     params.set<ExecFlagEnum>("execute_on") = execute_on;
 
-    _sim.addAuxKernel(class_name, genName(name(), "P_hf_auxkernel"), params);
+    getTHMProblem().addAuxKernel(class_name, genName(name(), "P_hf_auxkernel"), params);
   }
 }
 
 void
 HeatTransferBase::addHeatedPerimeter()
 {
-  _sim.addSimVariable(false, _P_hf_name, _sim.getFlowFEType(), _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _P_hf_name, getTHMProblem().getFlowFEType(), _flow_channel_subdomains);
 
   // create heat flux perimeter variable if not transferred from external app
   if (!_P_hf_transferred)
@@ -133,12 +134,12 @@ HeatTransferBase::addHeatedPerimeter()
       const std::string class_name = "GeneralizedCircumference";
       InputParameters params = _factory.getValidParams(class_name);
       params.set<FunctionName>("area_function") = _A_fn_name;
-      _sim.addFunction(class_name, _P_hf_fn_name, params);
+      getTHMProblem().addFunction(class_name, _P_hf_fn_name, params);
 
       makeFunctionControllableIfConstant(_P_hf_fn_name, "P_hf");
     }
 
-    _sim.addFunctionIC(_P_hf_name, _P_hf_fn_name, _flow_channel_subdomains);
+    getTHMProblem().addFunctionIC(_P_hf_name, _P_hf_fn_name, _flow_channel_subdomains);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromExternalAppHeatFlux1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromExternalAppHeatFlux1Phase.C
@@ -32,8 +32,9 @@ HeatTransferFromExternalAppHeatFlux1Phase::addVariables()
 {
   HeatTransfer1PhaseBase::addVariables();
 
-  _sim.addSimVariable(false, _q_wall_name, FEType(CONSTANT, MONOMIAL), _flow_channel_subdomains);
-  _sim.addConstantIC(_q_wall_name, 0, _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _q_wall_name, FEType(CONSTANT, MONOMIAL), _flow_channel_subdomains);
+  getTHMProblem().addConstantIC(_q_wall_name, 0, _flow_channel_subdomains);
 }
 
 void
@@ -47,7 +48,7 @@ HeatTransferFromExternalAppHeatFlux1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<MaterialPropertyName>("prop_name") = _q_wall_name;
     params.set<std::vector<VariableName>>("coupled_variable") = {_q_wall_name};
-    _sim.addMaterial(class_name, genName(name(), "q_wall_material"), params);
+    getTHMProblem().addMaterial(class_name, genName(name(), "q_wall_material"), params);
   }
 
   // wall heat transfer kernel
@@ -58,7 +59,7 @@ HeatTransferFromExternalAppHeatFlux1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<MaterialPropertyName>("q_wall") = _q_wall_name;
     params.set<std::vector<VariableName>>("P_hf") = {_P_hf_name};
-    _sim.addKernel(class_name, genName(name(), "wall_heat"), params);
+    getTHMProblem().addKernel(class_name, genName(name(), "wall_heat"), params);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromExternalAppTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromExternalAppTemperature1Phase.C
@@ -54,7 +54,7 @@ HeatTransferFromExternalAppTemperature1Phase::addVariables()
 
   if (!isParamValid("T_ext"))
     if (isParamValid("initial_T_wall"))
-      _sim.addFunctionIC(
+      getTHMProblem().addFunctionIC(
           _T_wall_name, getParam<FunctionName>("initial_T_wall"), _flow_channel_subdomains);
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromHeatFlux1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromHeatFlux1Phase.C
@@ -38,7 +38,7 @@ HeatTransferFromHeatFlux1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<std::vector<std::string>>("prop_names") = {_q_wall_name};
     params.set<std::vector<FunctionName>>("prop_values") = {_q_wall_fn_name};
-    _sim.addMaterial(class_name, genName(name(), "q_wall_material"), params);
+    getTHMProblem().addMaterial(class_name, genName(name(), "q_wall_material"), params);
   }
 
   // wall heat transfer kernel
@@ -49,7 +49,7 @@ HeatTransferFromHeatFlux1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = _flow_channel_subdomains;
     params.set<MaterialPropertyName>("q_wall") = _q_wall_name;
     params.set<std::vector<VariableName>>("P_hf") = {_P_hf_name};
-    _sim.addKernel(class_name, genName(name(), "wall_heat"), params);
+    getTHMProblem().addKernel(class_name, genName(name(), "wall_heat"), params);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure1Phase.C
@@ -68,7 +68,7 @@ HeatTransferFromHeatStructure1Phase::setupMesh()
     {
       dof_id_type nearest_elem_id = _fch_alignment.getNearestElemID(elem_id);
       if (nearest_elem_id != DofObject::invalid_id)
-        _sim.augmentSparsity(elem_id, nearest_elem_id);
+        getTHMProblem().augmentSparsity(elem_id, nearest_elem_id);
     }
   }
 }
@@ -124,10 +124,10 @@ HeatTransferFromHeatStructure1Phase::addVariables()
   HeatTransferFromTemperature1Phase::addVariables();
 
   // wall temperature initial condition
-  if (!_sim.hasInitialConditionsFromFile() && !_app.isRestarting())
+  if (!getTHMProblem().hasInitialConditionsFromFile() && !_app.isRestarting())
   {
     const HeatStructureBase & hs = getComponentByName<HeatStructureBase>(_hs_name);
-    _sim.addFunctionIC(_T_wall_name, hs.getInitialT(), _flow_channel_subdomains);
+    getTHMProblem().addFunctionIC(_T_wall_name, hs.getInitialT(), _flow_channel_subdomains);
   }
 }
 
@@ -155,7 +155,7 @@ HeatTransferFromHeatStructure1Phase::addMooseObjects()
     params.set<MaterialPropertyName>("Hw") = _Hw_1phase_name;
     params.set<MaterialPropertyName>("T") = FlowModelSinglePhase::TEMPERATURE;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, heat_flux_uo_name, params);
+    getTHMProblem().addUserObject(class_name, heat_flux_uo_name, params);
   }
 
   {
@@ -164,7 +164,7 @@ HeatTransferFromHeatStructure1Phase::addMooseObjects()
     params.set<std::vector<SubdomainName>>("block") = flow_channel.getSubdomainNames();
     params.set<NonlinearVariableName>("variable") = FlowModelSinglePhase::RHOEA;
     params.set<UserObjectName>("q_uo") = heat_flux_uo_name;
-    _sim.addKernel(class_name, genName(name(), "heat_flux_kernel"), params);
+    getTHMProblem().addKernel(class_name, genName(name(), "heat_flux_kernel"), params);
   }
 
   {
@@ -176,7 +176,7 @@ HeatTransferFromHeatStructure1Phase::addMooseObjects()
     params.set<Real>("P_hs_unit") = hs.getUnitPerimeter(_hs_side);
     params.set<unsigned int>("n_unit") = hs.getNumberOfUnits();
     params.set<bool>("hs_coord_system_is_cylindrical") = is_cylindrical;
-    _sim.addBoundaryCondition(class_name, genName(name(), "heat_flux_bc"), params);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "heat_flux_bc"), params);
   }
 
   // Transfer the temperature of the solid onto the flow channel
@@ -188,7 +188,7 @@ HeatTransferFromHeatStructure1Phase::addMooseObjects()
     params.set<BoundaryName>("secondary_boundary") = {getSlaveSideName()};
     params.set<BoundaryName>("primary_boundary") = getMasterSideName();
     params.set<std::string>("paired_variable") = HeatConductionModel::TEMPERATURE;
-    _sim.addMaterial(class_name, genName(name(), "T_wall_transfer_mat"), params);
+    getTHMProblem().addMaterial(class_name, genName(name(), "T_wall_transfer_mat"), params);
   }
 
   // Transfer the temperature of the solid onto the flow channel as aux varaible for visualization
@@ -200,7 +200,7 @@ HeatTransferFromHeatStructure1Phase::addMooseObjects()
     params.set<BoundaryName>("paired_boundary") = getMasterSideName();
     params.set<std::vector<VariableName>>("paired_variable") =
         std::vector<VariableName>(1, HeatConductionModel::TEMPERATURE);
-    _sim.addAuxKernel(class_name, genName(name(), "T_wall_transfer"), params);
+    getTHMProblem().addAuxKernel(class_name, genName(name(), "T_wall_transfer"), params);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure1Phase.C
@@ -30,7 +30,9 @@ HeatTransferFromHeatStructure1Phase::validParams()
 
 HeatTransferFromHeatStructure1Phase::HeatTransferFromHeatStructure1Phase(
     const InputParameters & parameters)
-  : HeatTransferFromTemperature1Phase(parameters), HSBoundaryInterface(this), _fch_alignment(_mesh)
+  : HeatTransferFromTemperature1Phase(parameters),
+    HSBoundaryInterface(this),
+    _fch_alignment(constMesh())
 {
 }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure3D1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure3D1Phase.C
@@ -98,7 +98,7 @@ HeatTransferFromHeatStructure3D1Phase::setupMesh()
       {
         dof_id_type nearest_elem_id = _fch_alignment.getNearestElemID(elem_id);
         if (nearest_elem_id != DofObject::invalid_id)
-          _sim.augmentSparsity(elem_id, nearest_elem_id);
+          getTHMProblem().augmentSparsity(elem_id, nearest_elem_id);
       }
     }
   }
@@ -238,20 +238,22 @@ HeatTransferFromHeatStructure3D1Phase::check() const
 void
 HeatTransferFromHeatStructure3D1Phase::addVariables()
 {
-  _sim.addSimVariable(false, _P_hf_name, _sim.getFlowFEType(), _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _P_hf_name, getTHMProblem().getFlowFEType(), _flow_channel_subdomains);
 
   _P_hf_fn_name = getParam<FunctionName>("P_hf");
-  _sim.addFunctionIC(_P_hf_name, _P_hf_fn_name, _flow_channel_subdomains);
+  getTHMProblem().addFunctionIC(_P_hf_name, _P_hf_fn_name, _flow_channel_subdomains);
 
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       false, FlowModel::TEMPERATURE_WALL, FEType(CONSTANT, MONOMIAL), _flow_channel_subdomains);
-  _sim.addSimVariable(false, _T_wall_name, FEType(CONSTANT, MONOMIAL), _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _T_wall_name, FEType(CONSTANT, MONOMIAL), _flow_channel_subdomains);
 
   // wall temperature initial condition
-  if (!_sim.hasInitialConditionsFromFile() && !_app.isRestarting())
+  if (!getTHMProblem().hasInitialConditionsFromFile() && !_app.isRestarting())
   {
     const HeatStructureBase & hs = getComponentByName<HeatStructureBase>(_hs_name);
-    _sim.addFunctionIC(_T_wall_name, hs.getInitialT(), _flow_channel_subdomains);
+    getTHMProblem().addFunctionIC(_T_wall_name, hs.getInitialT(), _flow_channel_subdomains);
   }
 }
 
@@ -286,7 +288,7 @@ HeatTransferFromHeatStructure3D1Phase::addMooseObjects()
     params.set<MooseEnum>("direction") = _layered_average_uo_direction;
     params.set<unsigned int>("num_layers") = _num_layers;
     params.set<std::vector<Point>>("points") = fch_positions;
-    _sim.addUserObject(class_name, T_wall_avg_uo_name, params);
+    getTHMProblem().addUserObject(class_name, T_wall_avg_uo_name, params);
   }
   {
     std::string class_name = "SpatialUserObjectAux";
@@ -295,7 +297,7 @@ HeatTransferFromHeatStructure3D1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _T_wall_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
     params.set<UserObjectName>("user_object") = T_wall_avg_uo_name;
-    _sim.addAuxKernel(class_name, genName(name(), "T_wall_transfer"), params);
+    getTHMProblem().addAuxKernel(class_name, genName(name(), "T_wall_transfer"), params);
   }
   {
     const std::string class_name = "ADOneD3EqnEnergyHeatFluxFromHeatStructure3D";
@@ -306,7 +308,7 @@ HeatTransferFromHeatStructure3D1Phase::addMooseObjects()
     params.set<UserObjectName>("user_object") = T_wall_avg_uo_name;
     params.set<MaterialPropertyName>("T") = FlowModelSinglePhase::TEMPERATURE;
     params.set<NonlinearVariableName>("variable") = FlowModelSinglePhase::RHOEA;
-    _sim.addKernel(class_name, genName(name(), "heat_flux_kernel"), params);
+    getTHMProblem().addKernel(class_name, genName(name(), "heat_flux_kernel"), params);
   }
 
   const UserObjectName heat_transfer_uo_name = genName(name(), "heat_flux_uo");
@@ -319,7 +321,7 @@ HeatTransferFromHeatStructure3D1Phase::addMooseObjects()
     params.set<MaterialPropertyName>("Hw") = _Hw_1phase_name;
     params.set<MaterialPropertyName>("T") = FlowModelSinglePhase::TEMPERATURE;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, heat_transfer_uo_name, params);
+    getTHMProblem().addUserObject(class_name, heat_transfer_uo_name, params);
   }
   {
     const std::string class_name = "ADConvectionHeatTransfer3DBC";
@@ -327,6 +329,6 @@ HeatTransferFromHeatStructure3D1Phase::addMooseObjects()
     params.set<std::vector<BoundaryName>>("boundary") = {_boundary};
     params.set<NonlinearVariableName>("variable") = HeatConductionModel::TEMPERATURE;
     params.set<UserObjectName>("ht_uo") = heat_transfer_uo_name;
-    _sim.addBoundaryCondition(class_name, genName(name(), "heat_flux_bc"), params);
+    getTHMProblem().addBoundaryCondition(class_name, genName(name(), "heat_flux_bc"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure3D1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromHeatStructure3D1Phase.C
@@ -43,7 +43,7 @@ HeatTransferFromHeatStructure3D1Phase::HeatTransferFromHeatStructure3D1Phase(
     _flow_channel_names(getParam<std::vector<std::string>>("flow_channels")),
     _boundary(getParam<BoundaryName>("boundary")),
     _hs_name(getParam<std::string>("hs")),
-    _fch_alignment(_mesh),
+    _fch_alignment(constMesh()),
     _layered_average_uo_direction(MooseEnum("x y z"))
 {
   for (const auto & fch_name : _flow_channel_names)
@@ -76,9 +76,9 @@ HeatTransferFromHeatStructure3D1Phase::setupMesh()
     }
     // Boundary info (element ID, local side number) for the heat structure side
     std::vector<std::tuple<dof_id_type, unsigned short int>> bnd_info;
-    BoundaryID bd_id = _mesh.getBoundaryID(_boundary);
-    _mesh.buildBndElemList();
-    const auto & bnd_to_elem_map = _mesh.getBoundariesToActiveSemiLocalElemIds();
+    BoundaryID bd_id = mesh().getBoundaryID(_boundary);
+    mesh().buildBndElemList();
+    const auto & bnd_to_elem_map = mesh().getBoundariesToActiveSemiLocalElemIds();
     auto search = bnd_to_elem_map.find(bd_id);
     if (search == bnd_to_elem_map.end())
       mooseDoOnce(logError("The boundary '", _boundary, "' (", bd_id, ") was not found."));
@@ -87,8 +87,8 @@ HeatTransferFromHeatStructure3D1Phase::setupMesh()
       const std::unordered_set<dof_id_type> & bnd_elems = search->second;
       for (auto elem_id : bnd_elems)
       {
-        const Elem * elem = _mesh.elemPtr(elem_id);
-        unsigned int side = _mesh.sideWithBoundaryID(elem, bd_id);
+        const Elem * elem = mesh().elemPtr(elem_id);
+        unsigned int side = mesh().sideWithBoundaryID(elem, bd_id);
         bnd_info.push_back(std::tuple<dof_id_type, unsigned short int>(elem_id, side));
       }
 

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromSpecifiedTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromSpecifiedTemperature1Phase.C
@@ -33,7 +33,7 @@ HeatTransferFromSpecifiedTemperature1Phase::addVariables()
 {
   HeatTransferFromTemperature1Phase::addVariables();
 
-  _sim.addFunctionIC(_T_wall_name, _T_wall_fn_name, _flow_channel_subdomains);
+  getTHMProblem().addFunctionIC(_T_wall_name, _T_wall_fn_name, _flow_channel_subdomains);
   makeFunctionControllableIfConstant(_T_wall_fn_name, "T_wall");
 }
 
@@ -53,7 +53,7 @@ HeatTransferFromSpecifiedTemperature1Phase::addMooseObjects()
     execute_on = {EXEC_INITIAL, EXEC_LINEAR};
     params.set<ExecFlagEnum>("execute_on") = execute_on;
 
-    _sim.addAuxKernel(class_name, genName(name(), "T_wall_auxkernel"), params);
+    getTHMProblem().addAuxKernel(class_name, genName(name(), "T_wall_auxkernel"), params);
   }
 
   addHeatTransferKernels();

--- a/modules/thermal_hydraulics/src/components/HeatTransferFromTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/HeatTransferFromTemperature1Phase.C
@@ -39,7 +39,7 @@ HeatTransferFromTemperature1Phase::addVariables()
 {
   HeatTransfer1PhaseBase::addVariables();
 
-  _sim.addSimVariable(false, _T_wall_name, getFEType(), _flow_channel_subdomains);
+  getTHMProblem().addSimVariable(false, _T_wall_name, getFEType(), _flow_channel_subdomains);
 }
 
 void
@@ -60,7 +60,7 @@ HeatTransferFromTemperature1Phase::addHeatTransferKernels()
     params.set<MaterialPropertyName>("Hw") = _Hw_1phase_name;
     params.set<std::vector<VariableName>>("P_hf") = {_P_hf_name};
     params.set<MaterialPropertyName>("T") = FlowModelSinglePhase::TEMPERATURE;
-    _sim.addKernel(class_name, genName(name(), "wall_heat_transfer"), params);
+    getTHMProblem().addKernel(class_name, genName(name(), "wall_heat_transfer"), params);
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/InletDensityVelocity1Phase.C
+++ b/modules/thermal_hydraulics/src/components/InletDensityVelocity1Phase.C
@@ -58,7 +58,7 @@ InletDensityVelocity1Phase::addMooseObjects()
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
 
     connectObject(params, _boundary_uo_name, "rho");
     connectObject(params, _boundary_uo_name, "vel");

--- a/modules/thermal_hydraulics/src/components/InletMassFlowRateTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/InletMassFlowRateTemperature1Phase.C
@@ -59,7 +59,7 @@ InletMassFlowRateTemperature1Phase::addMooseObjects()
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
     connectObject(params, _boundary_uo_name, "m_dot", "mass_flow_rate");
     connectObject(params, _boundary_uo_name, "T");
   }

--- a/modules/thermal_hydraulics/src/components/InletStagnationPressureTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/InletStagnationPressureTemperature1Phase.C
@@ -59,7 +59,7 @@ InletStagnationPressureTemperature1Phase::addMooseObjects()
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
     connectObject(params, _boundary_uo_name, "p0");
     connectObject(params, _boundary_uo_name, "T0");
   }

--- a/modules/thermal_hydraulics/src/components/InletVelocityTemperature1Phase.C
+++ b/modules/thermal_hydraulics/src/components/InletVelocityTemperature1Phase.C
@@ -59,7 +59,7 @@ InletVelocityTemperature1Phase::addMooseObjects()
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
     connectObject(params, _boundary_uo_name, "vel");
     connectObject(params, _boundary_uo_name, "T");
   }

--- a/modules/thermal_hydraulics/src/components/JunctionOneToOne1Phase.C
+++ b/modules/thermal_hydraulics/src/components/JunctionOneToOne1Phase.C
@@ -39,7 +39,7 @@ JunctionOneToOne1Phase::setupMesh()
   FlowJunction1Phase::setupMesh();
 
   if (_connected_elems.size() == 2)
-    _sim.augmentSparsity(_connected_elems[0], _connected_elems[1]);
+    getTHMProblem().augmentSparsity(_connected_elems[0], _connected_elems[1]);
 }
 
 void
@@ -93,7 +93,7 @@ JunctionOneToOne1Phase::addMooseObjects()
     params.set<std::string>("junction_name") = name();
     params.set<MooseEnum>("scheme") = _slope_reconstruction;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
   }
 
   const std::vector<NonlinearVariableName> var_names = {
@@ -113,8 +113,8 @@ JunctionOneToOne1Phase::addMooseObjects()
       params.set<std::vector<VariableName>>("rhoA") = {FlowModelSinglePhase::RHOA};
       params.set<std::vector<VariableName>>("rhouA") = {FlowModelSinglePhase::RHOUA};
       params.set<std::vector<VariableName>>("rhoEA") = {FlowModelSinglePhase::RHOEA};
-      params.set<bool>("implicit") = _sim.getImplicitTimeIntegrationFlag();
-      _sim.addBoundaryCondition(
+      params.set<bool>("implicit") = getTHMProblem().getImplicitTimeIntegrationFlag();
+      getTHMProblem().addBoundaryCondition(
           class_name, genName(name(), i, var_names[j] + ":" + class_name), params);
     }
 }

--- a/modules/thermal_hydraulics/src/components/JunctionParallelChannels1Phase.C
+++ b/modules/thermal_hydraulics/src/components/JunctionParallelChannels1Phase.C
@@ -34,25 +34,28 @@ JunctionParallelChannels1Phase::addVariables()
 {
   auto connected_subdomains = getConnectedSubdomainNames();
 
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhoV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhoV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhouV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhouV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhovV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhovV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhowV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhowV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhoEV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhoEV);
 
   if (isParamValid("initial_p") && isParamValid("initial_T") && isParamValid("initial_vel_x") &&
       isParamValid("initial_vel_y") && isParamValid("initial_vel_z"))
   {
-    Function & initial_p_fn = _sim.getFunction(getParam<FunctionName>("initial_p"));
-    Function & initial_T_fn = _sim.getFunction(getParam<FunctionName>("initial_T"));
-    Function & initial_vel_x_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_x"));
-    Function & initial_vel_y_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_y"));
-    Function & initial_vel_z_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_z"));
+    Function & initial_p_fn = getTHMProblem().getFunction(getParam<FunctionName>("initial_p"));
+    Function & initial_T_fn = getTHMProblem().getFunction(getParam<FunctionName>("initial_T"));
+    Function & initial_vel_x_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_x"));
+    Function & initial_vel_y_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_y"));
+    Function & initial_vel_z_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_z"));
 
     initial_p_fn.initialSetup();
     initial_T_fn.initialSetup();
@@ -66,17 +69,18 @@ JunctionParallelChannels1Phase::addVariables()
     const Real initial_vel_y = initial_vel_y_fn.value(0, _position);
     const Real initial_vel_z = initial_vel_z_fn.value(0, _position);
 
-    SinglePhaseFluidProperties & fp = _sim.getUserObject<SinglePhaseFluidProperties>(_fp_name);
+    SinglePhaseFluidProperties & fp =
+        getTHMProblem().getUserObject<SinglePhaseFluidProperties>(_fp_name);
     fp.initialSetup();
     const Real initial_rho = fp.rho_from_p_T(initial_p, initial_T);
     const RealVectorValue vel(initial_vel_x, initial_vel_y, initial_vel_z);
     const Real initial_E = fp.e_from_p_rho(initial_p, initial_rho) + 0.5 * vel * vel;
 
-    _sim.addConstantScalarIC(_rhoV_var_name, initial_rho * _volume);
-    _sim.addConstantScalarIC(_rhouV_var_name, initial_rho * initial_vel_x * _volume);
-    _sim.addConstantScalarIC(_rhovV_var_name, initial_rho * initial_vel_y * _volume);
-    _sim.addConstantScalarIC(_rhowV_var_name, initial_rho * initial_vel_z * _volume);
-    _sim.addConstantScalarIC(_rhoEV_var_name, initial_rho * initial_E * _volume);
+    getTHMProblem().addConstantScalarIC(_rhoV_var_name, initial_rho * _volume);
+    getTHMProblem().addConstantScalarIC(_rhouV_var_name, initial_rho * initial_vel_x * _volume);
+    getTHMProblem().addConstantScalarIC(_rhovV_var_name, initial_rho * initial_vel_y * _volume);
+    getTHMProblem().addConstantScalarIC(_rhowV_var_name, initial_rho * initial_vel_z * _volume);
+    getTHMProblem().addConstantScalarIC(_rhoEV_var_name, initial_rho * initial_E * _volume);
   }
 }
 
@@ -109,7 +113,7 @@ JunctionParallelChannels1Phase::buildVolumeJunctionUserObject()
     params.set<Real>("A_ref") = _A_ref;
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
   }
 }
 
@@ -142,8 +146,8 @@ JunctionParallelChannels1Phase::addMooseObjects()
       params.set<std::vector<VariableName>>("rhovV") = {_rhovV_var_name};
       params.set<std::vector<VariableName>>("rhowV") = {_rhowV_var_name};
       params.set<std::vector<VariableName>>("rhoEV") = {_rhoEV_var_name};
-      params.set<bool>("implicit") = _sim.getImplicitTimeIntegrationFlag();
-      _sim.addBoundaryCondition(
+      params.set<bool>("implicit") = getTHMProblem().getImplicitTimeIntegrationFlag();
+      getTHMProblem().addBoundaryCondition(
           class_name, genName(name(), i, var_names[j] + ":" + class_name), params);
     }
   }
@@ -161,7 +165,7 @@ JunctionParallelChannels1Phase::addMooseObjects()
       const std::string class_name = "ODETimeDerivative";
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = var_names[i];
-      _sim.addScalarKernel(class_name, genName(name(), var_names[i], "td"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), var_names[i], "td"), params);
     }
     {
       const std::string class_name = "ADVolumeJunctionAdvectionScalarKernel";
@@ -169,7 +173,7 @@ JunctionParallelChannels1Phase::addMooseObjects()
       params.set<NonlinearVariableName>("variable") = var_names[i];
       params.set<UserObjectName>("volume_junction_uo") = _junction_uo_name;
       params.set<unsigned int>("equation_index") = i;
-      _sim.addScalarKernel(class_name, genName(name(), var_names[i], "vja_sk"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), var_names[i], "vja_sk"), params);
     }
   }
 }

--- a/modules/thermal_hydraulics/src/components/Outlet1Phase.C
+++ b/modules/thermal_hydraulics/src/components/Outlet1Phase.C
@@ -51,7 +51,7 @@ Outlet1Phase::addMooseObjects()
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
     connectObject(params, _boundary_uo_name, "p");
   }
 

--- a/modules/thermal_hydraulics/src/components/Pump1Phase.C
+++ b/modules/thermal_hydraulics/src/components/Pump1Phase.C
@@ -64,7 +64,7 @@ Pump1Phase::buildVolumeJunctionUserObject()
     params.set<Real>("K") = getParam<Real>("K");
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
     connectObject(params, _junction_uo_name, "head");
   }
 }

--- a/modules/thermal_hydraulics/src/components/Shaft.C
+++ b/modules/thermal_hydraulics/src/components/Shaft.C
@@ -58,7 +58,7 @@ Shaft::check() const
   if (_connected_components.size() == 0)
     logError("No components are connected to the shaft.");
 
-  bool ics_set = _sim.hasInitialConditionsFromFile() || isParamValid("initial_speed");
+  bool ics_set = getTHMProblem().hasInitialConditionsFromFile() || isParamValid("initial_speed");
   if (!ics_set && !_app.isRestarting())
     logError("The `initial_speed` parameter is missing.");
 }
@@ -79,13 +79,14 @@ Shaft::addVariables()
   }
 
   if (connected_subdomains.size() > 0)
-    _sim.addSimVariable(
+    getTHMProblem().addSimVariable(
         true, _omega_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_omega);
   else
-    _sim.addSimVariable(true, _omega_var_name, FEType(FIRST, SCALAR), _scaling_factor_omega);
+    getTHMProblem().addSimVariable(
+        true, _omega_var_name, FEType(FIRST, SCALAR), _scaling_factor_omega);
 
   if (isParamValid("initial_speed"))
-    _sim.addConstantScalarIC(_omega_var_name, getParam<Real>("initial_speed"));
+    getTHMProblem().addConstantScalarIC(_omega_var_name, getParam<Real>("initial_speed"));
 }
 
 void
@@ -107,7 +108,7 @@ Shaft::addMooseObjects()
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = _omega_var_name;
       params.set<std::vector<UserObjectName>>("uo_names") = {uo_names};
-      _sim.addScalarKernel(class_name, genName(name(), "td"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), "td"), params);
     }
 
     for (std::size_t i = 0; i < uo_names.size(); i++)
@@ -116,7 +117,7 @@ Shaft::addMooseObjects()
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = _omega_var_name;
       params.set<UserObjectName>("shaft_connected_component_uo") = uo_names[i];
-      _sim.addScalarKernel(class_name, genName(name(), i, "shaft_speed"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), i, "shaft_speed"), params);
     }
   }
   else
@@ -126,7 +127,7 @@ Shaft::addMooseObjects()
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = _omega_var_name;
       params.set<std::vector<UserObjectName>>("uo_names") = {uo_names};
-      _sim.addScalarKernel(class_name, genName(name(), "td"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), "td"), params);
     }
 
     for (std::size_t i = 0; i < uo_names.size(); i++)
@@ -135,7 +136,7 @@ Shaft::addMooseObjects()
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = _omega_var_name;
       params.set<UserObjectName>("shaft_connected_component_uo") = uo_names[i];
-      _sim.addScalarKernel(class_name, genName(name(), i, "shaft_speed"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), i, "shaft_speed"), params);
     }
   }
 }

--- a/modules/thermal_hydraulics/src/components/ShaftConnectedCompressor1Phase.C
+++ b/modules/thermal_hydraulics/src/components/ShaftConnectedCompressor1Phase.C
@@ -156,7 +156,7 @@ ShaftConnectedCompressor1Phase::buildVolumeJunctionUserObject()
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<std::string>("compressor_name") = cname();
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, getShaftConnectedUserObjectName(), params);
+    getTHMProblem().addUserObject(class_name, getShaftConnectedUserObjectName(), params);
   }
 }
 
@@ -165,20 +165,20 @@ ShaftConnectedCompressor1Phase::addVariables()
 {
   VolumeJunction1Phase::addVariables();
 
-  _sim.addSimVariable(false, _delta_p_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_delta_p_var_name, 0);
+  getTHMProblem().addSimVariable(false, _delta_p_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_delta_p_var_name, 0);
 
-  _sim.addSimVariable(false, _isentropic_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_isentropic_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _isentropic_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_isentropic_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _dissipation_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_dissipation_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _dissipation_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_dissipation_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_friction_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_friction_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
+  getTHMProblem().addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
 }
 
 void
@@ -192,7 +192,8 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _delta_p_var_name;
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "delta_p_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "delta_p_aux"), params);
   }
   {
     std::string class_name = "Compressor1PhaseIsentropicTorqueAux";
@@ -200,7 +201,7 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _isentropic_torque_var_name;
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(
+    getTHMProblem().addAuxScalarKernel(
         class_name, Component::genName(name(), "isentropic_torque_aux"), params);
   }
   {
@@ -209,7 +210,7 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _dissipation_torque_var_name;
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(
+    getTHMProblem().addAuxScalarKernel(
         class_name, Component::genName(name(), "dissipation_torque_aux"), params);
   }
   {
@@ -218,7 +219,8 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _friction_torque_var_name;
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "friction_torque_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "friction_torque_aux"), params);
   }
   {
     std::string class_name = "Compressor1PhaseInertiaAux";
@@ -226,7 +228,8 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _moment_of_inertia_var_name;
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "inertia_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "inertia_aux"), params);
   }
   {
     const std::string class_name = "ShaftConnectedCompressor1PhasePostprocessor";
@@ -234,6 +237,7 @@ ShaftConnectedCompressor1Phase::addMooseObjects()
     params.set<MooseEnum>("quantity") = "pressure_ratio";
     params.set<UserObjectName>("compressor_uo") = getShaftConnectedUserObjectName();
     params.set<ExecFlagEnum>("execute_on") = {EXEC_INITIAL, EXEC_TIMESTEP_END};
-    _sim.addPostprocessor(class_name, Component::genName(name(), "pressure_ratio"), params);
+    getTHMProblem().addPostprocessor(
+        class_name, Component::genName(name(), "pressure_ratio"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/ShaftConnectedMotor.C
+++ b/modules/thermal_hydraulics/src/components/ShaftConnectedMotor.C
@@ -61,7 +61,7 @@ ShaftConnectedMotor::addMooseObjects()
     params.set<FunctionName>("torque") = _torque_fn_name;
     params.set<FunctionName>("inertia") = _inertia_fn_name;
     params.set<std::vector<VariableName>>("shaft_speed") = {shaft_speed_var_name};
-    _sim.addUserObject(class_name, uo_name, params);
+    getTHMProblem().addUserObject(class_name, uo_name, params);
   }
   else
   {
@@ -70,6 +70,6 @@ ShaftConnectedMotor::addMooseObjects()
     params.set<FunctionName>("torque") = _torque_fn_name;
     params.set<FunctionName>("inertia") = _inertia_fn_name;
     params.set<std::vector<VariableName>>("shaft_speed") = {shaft_speed_var_name};
-    _sim.addUserObject(class_name, uo_name, params);
+    getTHMProblem().addUserObject(class_name, uo_name, params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/ShaftConnectedPump1Phase.C
+++ b/modules/thermal_hydraulics/src/components/ShaftConnectedPump1Phase.C
@@ -141,7 +141,7 @@ ShaftConnectedPump1Phase::buildVolumeJunctionUserObject()
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<std::string>("pump_name") = cname();
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, getShaftConnectedUserObjectName(), params);
+    getTHMProblem().addUserObject(class_name, getShaftConnectedUserObjectName(), params);
   }
 }
 
@@ -150,17 +150,17 @@ ShaftConnectedPump1Phase::addVariables()
 {
   VolumeJunction1Phase::addVariables();
 
-  _sim.addSimVariable(false, _head_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_head_var_name, 0);
+  getTHMProblem().addSimVariable(false, _head_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_head_var_name, 0);
 
-  _sim.addSimVariable(false, _hydraulic_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_hydraulic_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _hydraulic_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_hydraulic_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_friction_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_friction_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
+  getTHMProblem().addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
 }
 
 void
@@ -174,7 +174,7 @@ ShaftConnectedPump1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _head_var_name;
     params.set<UserObjectName>("pump_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "head_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, Component::genName(name(), "head_aux"), params);
   }
   {
     std::string class_name = "HydraulicTorqueAux";
@@ -182,7 +182,8 @@ ShaftConnectedPump1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _hydraulic_torque_var_name;
     params.set<UserObjectName>("pump_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "hydraulic_torque_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "hydraulic_torque_aux"), params);
   }
   {
     std::string class_name = "PumpFrictionAux";
@@ -190,7 +191,8 @@ ShaftConnectedPump1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _friction_torque_var_name;
     params.set<UserObjectName>("pump_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "friction_torque_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "friction_torque_aux"), params);
   }
   {
     std::string class_name = "PumpInertiaAux";
@@ -198,6 +200,7 @@ ShaftConnectedPump1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _moment_of_inertia_var_name;
     params.set<UserObjectName>("pump_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, Component::genName(name(), "inertia_aux"), params);
+    getTHMProblem().addAuxScalarKernel(
+        class_name, Component::genName(name(), "inertia_aux"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/ShaftConnectedTurbine1Phase.C
+++ b/modules/thermal_hydraulics/src/components/ShaftConnectedTurbine1Phase.C
@@ -133,7 +133,7 @@ ShaftConnectedTurbine1Phase::buildVolumeJunctionUserObject()
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<std::string>("turbine_name") = cname();
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, getShaftConnectedUserObjectName(), params);
+    getTHMProblem().addUserObject(class_name, getShaftConnectedUserObjectName(), params);
   }
 }
 
@@ -142,23 +142,23 @@ ShaftConnectedTurbine1Phase::addVariables()
 {
   VolumeJunction1Phase::addVariables();
 
-  _sim.addSimVariable(false, _delta_p_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_delta_p_var_name, 0);
+  getTHMProblem().addSimVariable(false, _delta_p_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_delta_p_var_name, 0);
 
-  _sim.addSimVariable(false, _power_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_power_var_name, 0);
+  getTHMProblem().addSimVariable(false, _power_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_power_var_name, 0);
 
-  _sim.addSimVariable(false, _driving_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_driving_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _driving_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_driving_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _flow_coeff_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_flow_coeff_var_name, 0);
+  getTHMProblem().addSimVariable(false, _flow_coeff_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_flow_coeff_var_name, 0);
 
-  _sim.addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_friction_torque_var_name, 0);
+  getTHMProblem().addSimVariable(false, _friction_torque_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_friction_torque_var_name, 0);
 
-  _sim.addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
+  getTHMProblem().addSimVariable(false, _moment_of_inertia_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_moment_of_inertia_var_name, _inertia_const);
 }
 
 void
@@ -172,7 +172,7 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _delta_p_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "delta_p_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "delta_p_aux"), params);
   }
   {
     std::string class_name = "Turbine1PhasePowerAux";
@@ -180,7 +180,7 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _power_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "power"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "power"), params);
   }
   {
     std::string class_name = "Turbine1PhaseDrivingTorqueAux";
@@ -188,7 +188,7 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _driving_torque_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "driving_torque_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "driving_torque_aux"), params);
   }
   {
     std::string class_name = "Turbine1PhaseFlowCoefficientAux";
@@ -196,7 +196,7 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _flow_coeff_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "flow_coeff_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "flow_coeff_aux"), params);
   }
   {
     std::string class_name = "Turbine1PhaseFrictionTorqueAux";
@@ -204,7 +204,7 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _friction_torque_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "friction_torque_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "friction_torque_aux"), params);
   }
   {
     std::string class_name = "Turbine1PhaseMomentOfInertiaAux";
@@ -212,6 +212,6 @@ ShaftConnectedTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _moment_of_inertia_var_name;
     params.set<UserObjectName>("turbine_uo") = getShaftConnectedUserObjectName();
 
-    _sim.addAuxScalarKernel(class_name, genName(name(), "inertia_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "inertia_aux"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/components/SimpleTurbine1Phase.C
+++ b/modules/thermal_hydraulics/src/components/SimpleTurbine1Phase.C
@@ -41,7 +41,7 @@ SimpleTurbine1Phase::addVariables()
 {
   JunctionParallelChannels1Phase::addVariables();
 
-  _sim.addSimVariable(false, _W_dot_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addSimVariable(false, _W_dot_var_name, FEType(FIRST, SCALAR));
 }
 
 void
@@ -75,7 +75,7 @@ SimpleTurbine1Phase::buildVolumeJunctionUserObject()
     params.set<Real>("W_dot") = _power;
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
     connectObject(params, _junction_uo_name, "power", "W_dot");
     connectObject(params, _junction_uo_name, "on");
   }
@@ -93,7 +93,7 @@ SimpleTurbine1Phase::addMooseObjects()
     params.set<AuxVariableName>("variable") = _W_dot_var_name;
     params.set<Real>("value") = _power;
     params.set<bool>("on") = _on;
-    _sim.addAuxScalarKernel(class_name, nm, params);
+    getTHMProblem().addAuxScalarKernel(class_name, nm, params);
     connectObject(params, nm, "power", "value");
     connectObject(params, nm, "on");
   }

--- a/modules/thermal_hydraulics/src/components/SolidWall1Phase.C
+++ b/modules/thermal_hydraulics/src/components/SolidWall1Phase.C
@@ -34,7 +34,7 @@ SolidWall1Phase::addMooseObjects()
     params.set<UserObjectName>("numerical_flux") = _numerical_flux_name;
     params.set<Real>("normal") = _normal;
     params.set<ExecFlagEnum>("execute_on") = userobject_execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
   }
 
   // BCs

--- a/modules/thermal_hydraulics/src/components/TotalPower.C
+++ b/modules/thermal_hydraulics/src/components/TotalPower.C
@@ -31,7 +31,7 @@ TotalPower::addVariables()
 {
   TotalPowerBase::addVariables();
 
-  _sim.addConstantScalarIC(_power_var_name, _power);
+  getTHMProblem().addConstantScalarIC(_power_var_name, _power);
 }
 
 void
@@ -43,7 +43,7 @@ TotalPower::addMooseObjects()
     pars.set<AuxVariableName>("variable") = _power_var_name;
     pars.set<Real>("value") = _power;
     std::string nm = genName(name(), "power_aux");
-    _sim.addAuxScalarKernel(class_name, nm, pars);
+    getTHMProblem().addAuxScalarKernel(class_name, nm, pars);
     connectObject(pars, nm, "power", "value");
   }
 }

--- a/modules/thermal_hydraulics/src/components/TotalPowerBase.C
+++ b/modules/thermal_hydraulics/src/components/TotalPowerBase.C
@@ -24,5 +24,5 @@ TotalPowerBase::TotalPowerBase(const InputParameters & parameters)
 void
 TotalPowerBase::addVariables()
 {
-  _sim.addSimVariable(false, _power_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addSimVariable(false, _power_var_name, FEType(FIRST, SCALAR));
 }

--- a/modules/thermal_hydraulics/src/components/VolumeJunction1Phase.C
+++ b/modules/thermal_hydraulics/src/components/VolumeJunction1Phase.C
@@ -82,7 +82,7 @@ VolumeJunction1Phase::check() const
   FlowJunction1Phase::check();
 
   bool ics_set =
-      _sim.hasInitialConditionsFromFile() ||
+      getTHMProblem().hasInitialConditionsFromFile() ||
       (isParamValid("initial_p") && isParamValid("initial_T") && isParamValid("initial_vel_x") &&
        isParamValid("initial_vel_y") && isParamValid("initial_vel_z"));
 
@@ -105,28 +105,34 @@ VolumeJunction1Phase::addVariables()
 {
   auto connected_subdomains = getConnectedSubdomainNames();
 
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhoV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhoV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhouV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhouV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhovV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhovV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhowV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhowV);
-  _sim.addSimVariable(
+  getTHMProblem().addSimVariable(
       true, _rhoEV_var_name, FEType(FIRST, SCALAR), connected_subdomains, _scaling_factor_rhoEV);
-  _sim.addSimVariable(false, _pressure_var_name, FEType(FIRST, SCALAR), connected_subdomains);
-  _sim.addSimVariable(false, _temperature_var_name, FEType(FIRST, SCALAR), connected_subdomains);
-  _sim.addSimVariable(false, _velocity_var_name, FEType(FIRST, SCALAR), connected_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _pressure_var_name, FEType(FIRST, SCALAR), connected_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _temperature_var_name, FEType(FIRST, SCALAR), connected_subdomains);
+  getTHMProblem().addSimVariable(
+      false, _velocity_var_name, FEType(FIRST, SCALAR), connected_subdomains);
 
   if (isParamValid("initial_p") && isParamValid("initial_T") && isParamValid("initial_vel_x") &&
       isParamValid("initial_vel_y") && isParamValid("initial_vel_z"))
   {
-    Function & initial_p_fn = _sim.getFunction(getParam<FunctionName>("initial_p"));
-    Function & initial_T_fn = _sim.getFunction(getParam<FunctionName>("initial_T"));
-    Function & initial_vel_x_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_x"));
-    Function & initial_vel_y_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_y"));
-    Function & initial_vel_z_fn = _sim.getFunction(getParam<FunctionName>("initial_vel_z"));
+    Function & initial_p_fn = getTHMProblem().getFunction(getParam<FunctionName>("initial_p"));
+    Function & initial_T_fn = getTHMProblem().getFunction(getParam<FunctionName>("initial_T"));
+    Function & initial_vel_x_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_x"));
+    Function & initial_vel_y_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_y"));
+    Function & initial_vel_z_fn =
+        getTHMProblem().getFunction(getParam<FunctionName>("initial_vel_z"));
 
     initial_p_fn.initialSetup();
     initial_T_fn.initialSetup();
@@ -140,21 +146,22 @@ VolumeJunction1Phase::addVariables()
     const Real initial_vel_y = initial_vel_y_fn.value(0, _position);
     const Real initial_vel_z = initial_vel_z_fn.value(0, _position);
 
-    SinglePhaseFluidProperties & fp = _sim.getUserObject<SinglePhaseFluidProperties>(_fp_name);
+    SinglePhaseFluidProperties & fp =
+        getTHMProblem().getUserObject<SinglePhaseFluidProperties>(_fp_name);
     fp.initialSetup();
     const Real initial_rho = fp.rho_from_p_T(initial_p, initial_T);
     const RealVectorValue vel(initial_vel_x, initial_vel_y, initial_vel_z);
     const Real initial_E = fp.e_from_p_rho(initial_p, initial_rho) + 0.5 * vel * vel;
 
-    _sim.addConstantScalarIC(_rhoV_var_name, initial_rho * _volume);
-    _sim.addConstantScalarIC(_rhouV_var_name, initial_rho * initial_vel_x * _volume);
-    _sim.addConstantScalarIC(_rhovV_var_name, initial_rho * initial_vel_y * _volume);
-    _sim.addConstantScalarIC(_rhowV_var_name, initial_rho * initial_vel_z * _volume);
-    _sim.addConstantScalarIC(_rhoEV_var_name, initial_rho * initial_E * _volume);
+    getTHMProblem().addConstantScalarIC(_rhoV_var_name, initial_rho * _volume);
+    getTHMProblem().addConstantScalarIC(_rhouV_var_name, initial_rho * initial_vel_x * _volume);
+    getTHMProblem().addConstantScalarIC(_rhovV_var_name, initial_rho * initial_vel_y * _volume);
+    getTHMProblem().addConstantScalarIC(_rhowV_var_name, initial_rho * initial_vel_z * _volume);
+    getTHMProblem().addConstantScalarIC(_rhoEV_var_name, initial_rho * initial_E * _volume);
 
-    _sim.addConstantScalarIC(_pressure_var_name, initial_p);
-    _sim.addConstantScalarIC(_temperature_var_name, initial_T);
-    _sim.addConstantScalarIC(_velocity_var_name, vel.norm());
+    getTHMProblem().addConstantScalarIC(_pressure_var_name, initial_p);
+    getTHMProblem().addConstantScalarIC(_temperature_var_name, initial_T);
+    getTHMProblem().addConstantScalarIC(_velocity_var_name, vel.norm());
   }
 }
 
@@ -185,7 +192,7 @@ VolumeJunction1Phase::buildVolumeJunctionUserObject()
     params.set<Real>("A_ref") = _A_ref;
     params.set<UserObjectName>("fp") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _junction_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _junction_uo_name, params);
   }
 }
 
@@ -218,8 +225,8 @@ VolumeJunction1Phase::addMooseObjects()
       params.set<std::vector<VariableName>>("rhovV") = {_rhovV_var_name};
       params.set<std::vector<VariableName>>("rhowV") = {_rhowV_var_name};
       params.set<std::vector<VariableName>>("rhoEV") = {_rhoEV_var_name};
-      params.set<bool>("implicit") = _sim.getImplicitTimeIntegrationFlag();
-      _sim.addBoundaryCondition(
+      params.set<bool>("implicit") = getTHMProblem().getImplicitTimeIntegrationFlag();
+      getTHMProblem().addBoundaryCondition(
           class_name, genName(name(), i, var_names[j] + ":" + class_name), params);
     }
   }
@@ -237,7 +244,7 @@ VolumeJunction1Phase::addMooseObjects()
       const std::string class_name = "ADScalarTimeDerivative";
       InputParameters params = _factory.getValidParams(class_name);
       params.set<NonlinearVariableName>("variable") = var_names[i];
-      _sim.addScalarKernel(class_name, genName(name(), var_names[i], "td"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), var_names[i], "td"), params);
     }
     {
       const std::string class_name = "ADVolumeJunctionAdvectionScalarKernel";
@@ -245,7 +252,7 @@ VolumeJunction1Phase::addMooseObjects()
       params.set<NonlinearVariableName>("variable") = var_names[i];
       params.set<UserObjectName>("volume_junction_uo") = _junction_uo_name;
       params.set<unsigned int>("equation_index") = i;
-      _sim.addScalarKernel(class_name, genName(name(), var_names[i], "vja_sk"), params);
+      getTHMProblem().addScalarKernel(class_name, genName(name(), var_names[i], "vja_sk"), params);
     }
   }
 
@@ -260,7 +267,7 @@ VolumeJunction1Phase::addMooseObjects()
     params.set<std::vector<VariableName>>("rhowV") = {_rhowV_var_name};
     params.set<std::vector<VariableName>>("rhoEV") = {_rhoEV_var_name};
     params.set<UserObjectName>("fp") = _fp_name;
-    _sim.addAuxScalarKernel(class_name, genName(name(), "pressure_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "pressure_aux"), params);
   }
   {
     const std::string class_name = "VolumeJunction1PhaseTemperatureAux";
@@ -273,7 +280,7 @@ VolumeJunction1Phase::addMooseObjects()
     params.set<std::vector<VariableName>>("rhowV") = {_rhowV_var_name};
     params.set<std::vector<VariableName>>("rhoEV") = {_rhoEV_var_name};
     params.set<UserObjectName>("fp") = _fp_name;
-    _sim.addAuxScalarKernel(class_name, genName(name(), "temperature_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "temperature_aux"), params);
   }
   {
     const std::string class_name = "VolumeJunction1PhaseVelocityMagnitudeAux";
@@ -283,6 +290,6 @@ VolumeJunction1Phase::addMooseObjects()
     params.set<std::vector<VariableName>>("rhouV") = {_rhouV_var_name};
     params.set<std::vector<VariableName>>("rhovV") = {_rhovV_var_name};
     params.set<std::vector<VariableName>>("rhowV") = {_rhowV_var_name};
-    _sim.addAuxScalarKernel(class_name, genName(name(), "velmag_aux"), params);
+    getTHMProblem().addAuxScalarKernel(class_name, genName(name(), "velmag_aux"), params);
   }
 }

--- a/modules/thermal_hydraulics/src/utils/FlowChannel3DAlignment.C
+++ b/modules/thermal_hydraulics/src/utils/FlowChannel3DAlignment.C
@@ -13,7 +13,7 @@
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
 
-FlowChannel3DAlignment::FlowChannel3DAlignment(THMMesh & mesh) : _mesh(mesh) {}
+FlowChannel3DAlignment::FlowChannel3DAlignment(const THMMesh & mesh) : _mesh(mesh) {}
 
 void
 FlowChannel3DAlignment::build(

--- a/modules/thermal_hydraulics/src/utils/FlowChannelAlignment.C
+++ b/modules/thermal_hydraulics/src/utils/FlowChannelAlignment.C
@@ -13,7 +13,7 @@
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
 
-FlowChannelAlignment::FlowChannelAlignment(THMMesh & mesh) : _mesh(mesh) {}
+FlowChannelAlignment::FlowChannelAlignment(const THMMesh & mesh) : _mesh(mesh) {}
 
 void
 FlowChannelAlignment::build(

--- a/modules/thermal_hydraulics/test/src/components/InletFunction1Phase.C
+++ b/modules/thermal_hydraulics/test/src/components/InletFunction1Phase.C
@@ -45,7 +45,7 @@ InletFunction1Phase::addMooseObjects()
     params.set<FunctionName>("p") = getParam<FunctionName>("p");
     params.set<UserObjectName>("fluid_properties") = _fp_name;
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, _boundary_uo_name, params);
+    getTHMProblem().addUserObject(class_name, _boundary_uo_name, params);
   }
 
   // BCs

--- a/modules/thermal_hydraulics/test/src/components/ShaftConnectedTestComponent.C
+++ b/modules/thermal_hydraulics/test/src/components/ShaftConnectedTestComponent.C
@@ -33,8 +33,8 @@ ShaftConnectedTestComponent::ShaftConnectedTestComponent(const InputParameters &
 void
 ShaftConnectedTestComponent::addVariables()
 {
-  _sim.addSimVariable(true, _jct_var_name, FEType(FIRST, SCALAR));
-  _sim.addConstantScalarIC(_jct_var_name, 2.3);
+  getTHMProblem().addSimVariable(true, _jct_var_name, FEType(FIRST, SCALAR));
+  getTHMProblem().addConstantScalarIC(_jct_var_name, 2.3);
 }
 
 void
@@ -60,14 +60,14 @@ ShaftConnectedTestComponent::addMooseObjects()
     params.set<std::vector<VariableName>>("omega") = {omega_var_name};
     params.set<std::vector<VariableName>>("jct_var") = {_jct_var_name};
     params.set<ExecFlagEnum>("execute_on") = execute_on;
-    _sim.addUserObject(class_name, getShaftConnectedUserObjectName(), params);
+    getTHMProblem().addUserObject(class_name, getShaftConnectedUserObjectName(), params);
   }
 
   {
     const std::string class_name = "ADScalarTimeDerivative";
     InputParameters params = _factory.getValidParams(class_name);
     params.set<NonlinearVariableName>("variable") = _jct_var_name;
-    _sim.addScalarKernel(class_name, genName(name(), _jct_var_name, "td"), params);
+    getTHMProblem().addScalarKernel(class_name, genName(name(), _jct_var_name, "td"), params);
   }
   {
     const std::string class_name = "ADVolumeJunctionAdvectionScalarKernel";
@@ -75,6 +75,6 @@ ShaftConnectedTestComponent::addMooseObjects()
     params.set<NonlinearVariableName>("variable") = _jct_var_name;
     params.set<UserObjectName>("volume_junction_uo") = getShaftConnectedUserObjectName();
     params.set<unsigned int>("equation_index") = 0;
-    _sim.addScalarKernel(class_name, genName(name(), _jct_var_name, "vja_sk"), params);
+    getTHMProblem().addScalarKernel(class_name, genName(name(), _jct_var_name, "vja_sk"), params);
   }
 }


### PR DESCRIPTION
These changes are a step toward completion of #22354.

The changes are as follows:

- Created `Component::constMesh()`. This API is used to get a constant reference to THMMesh in places where the THMMesh should not be modified. This is to be extra careful not to modify THMMesh after mesh setup, since in the future, the ultimate mesh (combining THMMesh with mesh generators) will not be able to get these changes, since there will be a copy of THMMesh made at the point that it enters the MeshGenerator system.
- Modified `Component::mesh()` (the non-const version) to check that it is not being called after mesh setup is complete.
- Made `Component::getTHMProblem()` accessor function. The THMProblem reference member variable in `Component` (named `_sim`) will need to be deleted because THMProblem will no longer be available at the time of component construction. Thus the reference will be encapsulated to allow some other implementation.
- Used new accessor functions in all components.

After this is merged, THM-based applications will need to be similarly updated. Then `_mesh` can be made a private member variable in `Component`, and `_sim` can be removed. 
