### PR TITLE
Remove deprecated call to getBoundariesToElems

### DIFF
--- a/framework/src/markers/BoundaryMarker.C
+++ b/framework/src/markers/BoundaryMarker.C
@@ -29,7 +29,7 @@ BoundaryMarker::validParams()
 BoundaryMarker::BoundaryMarker(const InputParameters & parameters)
   : Marker(parameters),
     _distance(getParam<Real>("distance")),
-    _bnd_elem_ids(_mesh.getBoundariesToElems()),
+    _bnd_elem_ids(_mesh.getBoundariesToActiveSemiLocalElemIds()),
     _mark(parameters.get<MooseEnum>("mark").getEnum<MarkerValue>()),
     _boundary(_mesh.getBoundaryID(getParam<BoundaryName>("next_to")))
 {

--- a/modules/navier_stokes/src/auxkernels/WallDistanceMixingLengthAux.C
+++ b/modules/navier_stokes/src/auxkernels/WallDistanceMixingLengthAux.C
@@ -60,7 +60,7 @@ WallDistanceMixingLengthAux::computeValue()
 
   // Loop over all boundaries
   Real min_dist2 = 1e9;
-  const auto & bnd_to_elem_map = _mesh.getBoundariesToElems();
+  const auto & bnd_to_elem_map = _mesh.getBoundariesToActiveSemiLocalElemIds();
   for (BoundaryID bid : vec_ids)
   {
     // Get the set of elements on this boundary


### PR DESCRIPTION
 refs #22051

A user reported seeing it and was concerned. Let s just fix it
