### PR TITLE
Trigger meshChanged on a mesh renumbering for exodus output

### DIFF
--- a/framework/include/outputs/Exodus.h
+++ b/framework/include/outputs/Exodus.h
@@ -160,6 +160,9 @@ protected:
   bool _exodus_initialized;
 
 private:
+  /// Handle the call to mesh renumbering in libmesh's ExodusIO on non-contiguously numbered meshes
+  void handleExodusIOMeshRenumbering();
+
   /**
    * A helper function for 'initializing' the ExodusII output file, see the comments for the
    * _initialized
@@ -194,4 +197,7 @@ private:
 
   /// Flag to output HDF5 format (when available) in Exodus
   bool _write_hdf5;
+
+  /// whether the mesh is contiguously numbered (exodus output will force that)
+  bool _mesh_contiguous_numbering;
 };


### PR DESCRIPTION
refs #22795

This fixes the problem for the MSFR vtb input, because the ghosting of RC elements will be re-done upon the mesh renumbering caused by the exodus output