### PR TITLE
Update seacas to v2022-10-14

### DIFF
--- a/conda/seacas/conda_build_config.yaml
+++ b/conda/seacas/conda_build_config.yaml
@@ -3,6 +3,19 @@ CONDA_BUILD_SYSROOT:                                        # [osx]
   - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
+c_compiler_version:                                         # [unix]
+  - 10.4.0                                                  # [linux]
+  - 12.0.1                                                  # [osx]
+
+cxx_compiler_version:                                       # [unix]
+  - 10.4.0                                                  # [linux]
+  - 12.0.1                                                  # [osx]
+
+fortran_compiler_version:                                   # [unix]
+  - 10.4.0                                                  # [linux]
+  - 9.3.0                                                   # [not arm64 and osx]
+  - 11.0.1                                                  # [arm64]
+
 macos_min_version:                                          # [osx]
   - 10.12                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/seacas/meta.yaml
+++ b/conda/seacas/meta.yaml
@@ -1,7 +1,7 @@
 # MAKE SURE THAT seacas_version and seacas_git_rev match if performing a version update!
 {% set build = "0" %}
-{% set seacas_version = "2022.05.16" %}
-{% set seacas_git_rev = "v2022-05-16" %}
+{% set seacas_version = "2022.10.14" %}
+{% set seacas_git_rev = "v2022-10-14" %}
 {% set strbuild = "build_" + build|string %}
 
 package:
@@ -30,9 +30,6 @@ requirements:
     - make
     - automake
   run:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - {{ compiler('fortran') }}
     - xorg-libx11
     - python 3
 

--- a/conda/seacas/use-curl-instead-of-wget.patch
+++ b/conda/seacas/use-curl-instead-of-wget.patch
@@ -1,5 +1,5 @@
 diff --git a/install-tpl.sh b/install-tpl.sh
-index d4601be6a..8fbc554e5 100755
+index 5a23107a04..a592c3b3c5 100755
 --- a/install-tpl.sh
 +++ b/install-tpl.sh
 @@ -215,7 +215,6 @@ fi
@@ -10,12 +10,12 @@ index d4601be6a..8fbc554e5 100755
 
  if [ "$NEEDS_SZIP" == "YES" ]
  then
-@@ -418,7 +417,7 @@ then
-         elif [ "${H5VERSION}" == "V110" ]; then
-             wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
-         elif [ "${H5VERSION}" == "V112" ]; then
--            wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
-+            curl --insecure -L -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
-         elif [ "${H5VERSION}" == "V113" ]; then
-             wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
-         elif [ "${H5VERSION}" == "develop" ]; then
+@@ -423,7 +422,7 @@ then
+         if [ "${H5VERSION}" == "develop" ]; then
+             git clone https://github.com/HDFGroup/hdf5.git hdf5-develop
+         else
+-            wget --no-check-certificate https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf_base}/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
++            curl --insecure -L -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf_base}/hdf5-${hdf_version}/src/hdf5-${hdf_version}.tar.bz2
+         fi
+         if [ "${H5VERSION}" != "develop" ]
+         then


### PR DESCRIPTION
This also:
- Updates the wget --> curl patch for the new version.
- Adjusts the C, C++, and Fortran compilers used to build the dependencies to known good versions. Failures on ARM64 were encountered while using "cutting edge" conda compiler versions/builds.
- Removes the compiler runtime dependency. Shouldn't be required, as this package should be able to be used alongside things like the moose-XXX packages.

Refs #21665
