### PR TITLE
Make the coefficient material property for array time derivative kernel optional

### DIFF
--- a/framework/include/kernels/ArrayTimeDerivative.h
+++ b/framework/include/kernels/ArrayTimeDerivative.h
@@ -23,6 +23,8 @@ protected:
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
+  /// whether or not the coefficient property is provided
+  const bool _has_coefficient;
   /// scalar time derivative coefficient
   const MaterialProperty<Real> * const _coeff;
   /// array time derivative coefficient

--- a/framework/src/kernels/ArrayDiffusion.C
+++ b/framework/src/kernels/ArrayDiffusion.C
@@ -15,9 +15,9 @@ InputParameters
 ArrayDiffusion::validParams()
 {
   InputParameters params = ArrayKernel::validParams();
-  params.addRequiredParam<MaterialPropertyName>("diffusion_coefficient",
-                                                "The name of the diffusivity, "
-                                                "can be scalar, vector, or matrix.");
+  params.addRequiredParam<MaterialPropertyName>(
+      "diffusion_coefficient",
+      "The name of the diffusivity, can be scalar, vector, or matrix material property.");
   params.addClassDescription(
       "The array Laplacian operator ($-\\nabla \\cdot \\nabla u$), with the weak "
       "form of $(\\nabla \\phi_i, \\nabla u_h)$.");

--- a/framework/src/kernels/ArrayReaction.C
+++ b/framework/src/kernels/ArrayReaction.C
@@ -15,9 +15,9 @@ InputParameters
 ArrayReaction::validParams()
 {
   InputParameters params = ArrayKernel::validParams();
-  params.addParam<MaterialPropertyName>("reaction_coefficient",
-                                        "The name of the reactivity, "
-                                        "can be scalar, vector, or matrix.");
+  params.addRequiredParam<MaterialPropertyName>(
+      "reaction_coefficient",
+      "The name of the reactivity, can be scalar, vector, or matrix material property.");
   params.addClassDescription("The array reaction operator with the weak "
                              "form of $(\\psi_i, u_h)$.");
   return params;

--- a/test/tests/tag/tag-array-var.i
+++ b/test/tests/tag/tag-array-var.i
@@ -30,7 +30,6 @@
   [time]
     type = ArrayTimeDerivative
     variable = u
-    time_derivative_coefficient = tc
   []
   [diff]
     type = ArrayDiffusion
@@ -59,11 +58,6 @@
   [dc]
     type = GenericConstantArray
     prop_name = dc
-    prop_value = '1 1'
-  []
-  [tc]
-    type = GenericConstantArray
-    prop_name = tc
     prop_value = '1 1'
   []
 []


### PR DESCRIPTION
Close #22830.

This small enhancement is needed for MSR transient calculations.
