### PR TITLE
Use coordinate transforms to run in position

### DIFF
--- a/framework/include/multiapps/MultiApp.h
+++ b/framework/include/multiapps/MultiApp.h
@@ -548,7 +548,10 @@ protected:
   /// Transfers associated with this multiapp
   std::vector<MultiAppTransfer *> _associated_transfers;
 
-  ///Timers
+  /// Whether to run the child apps with their meshes transformed with the coordinate transforms
+  const bool _run_in_position;
+
+  /// Timers
   const PerfID _solve_step_timer;
   const PerfID _init_timer;
   const PerfID _backup_timer;

--- a/framework/include/utils/MooseAppCoordTransform.h
+++ b/framework/include/utils/MooseAppCoordTransform.h
@@ -42,17 +42,15 @@ public:
    * 1: a value describing the scaling
    * 2: whether a rotation matrix exists
    * 3: the Euler angles describing the rotation
-   * 4: the translation vector
-   * 5: the coordinate system type
-   * 6: the r-axis direction
-   * 7: the z-axis direction
-   * 8: whether there are multiple coordinate system types on the mesh
-   * 9: whether the mesh has been transformed using the transform
+   * 4: the coordinate system type
+   * 5: the r-axis direction
+   * 6: the z-axis direction
+   * 7: whether there are multiple coordinate system types on the mesh
+   * 8: whether the mesh has been transformed using the transform
    */
   typedef std::tuple<short int,
                      Real,
                      short int,
-                     std::array<Real, 3>,
                      std::array<Real, 3>,
                      int,
                      unsigned int,
@@ -179,8 +177,9 @@ public:
    * Transforms the entire mesh with the coordinate transform
    * This can be done to output in position, or to avoid transforming on every data point
    * @param mesh the mesh to modify, usually the child app mesh
+   * @param translation the translation to apply to the mesh, often the app position
    */
-  void transformMesh(MooseMesh & mesh);
+  void transformMesh(MooseMesh & mesh, Point translation);
 
 private:
   /**
@@ -218,9 +217,6 @@ private:
 
   /// How much distance one mesh length unit represents, e.g. 1 cm, 1 nm, 1 ft, 5 inches
   MooseUnits _length_unit;
-
-  /// Describes a forward translation transformation from our domain to the reference frame domain
-  libMesh::Point _translation;
 
   /// The Euler angles describing rotation
   std::array<Real, 3> _euler_angles;
@@ -337,6 +333,4 @@ private:
 
   /// Describes a forward translation transformation from our domain to the reference frame domain
   Point _translation;
-  // TODO: remove the duplicate _translation attribute in MooseAppCoord (used for mesh
-  // transformation) and here (used for transfers).
 };

--- a/framework/include/utils/MooseAppCoordTransform.h
+++ b/framework/include/utils/MooseAppCoordTransform.h
@@ -277,6 +277,15 @@ public:
   void setDestinationCoordTransform(const MooseAppCoordTransform & destination_coord_transform);
 
   /**
+   * Set how much our domain should be translated in order to match a reference frame. In practice
+   * we choose the parent application to be the reference frame with respect to translation, e.g.
+   * the parent application origin is the reference frame origin, and we set the translation vectors
+   * of child applications to the multiapp positions parameter. Similarly to the \p setRotation with
+   * angles API, this represents a forward transformation from our domain to the reference domain
+   */
+  void setTranslationVector(const Point & translation);
+
+  /**
    * @return whether the coordinate transformation object modifies an incoming point, e.g. whether
    * the transformation is anything other than the identity matrix
    */
@@ -318,8 +327,16 @@ private:
   /// A pointer to the \p MooseAppCoordTransform object that describes scaling, rotation, and
   /// coordinate system transformations from the destination domain to the reference domain,
   /// e.g. transformations that occur irrespective of the existence of other applications
+  /// This attribute is currently mostly providing only the coordinate system for conversions
+  /// and sanity checking. The actual transformation of destination app points in transfers is done
+  /// by the MultiAppCoordTransform for the other direction
   const MooseAppCoordTransform * _destination_app_transform;
 
   /// whether coordinate collapsing operations should be skipped
   bool _skip_coordinate_collapsing;
+
+  /// Describes a forward translation transformation from our domain to the reference frame domain
+  Point _translation;
+  // TODO: remove the duplicate _translation attribute in MooseAppCoord (used for mesh
+  // transformation) and here (used for transfers).
 };

--- a/framework/include/utils/MooseAppCoordTransform.h
+++ b/framework/include/utils/MooseAppCoordTransform.h
@@ -179,7 +179,7 @@ public:
    * @param mesh the mesh to modify, usually the child app mesh
    * @param translation the translation to apply to the mesh, often the app position
    */
-  void transformMesh(MooseMesh & mesh, Point translation);
+  void transformMesh(MooseMesh & mesh, const libMesh::Point & translation);
 
 private:
   /**
@@ -262,6 +262,15 @@ public:
   libMesh::Point mapBack(const libMesh::Point & point) const;
 
   /**
+   * Set how much our domain should be translated in order to match a reference frame. In practice
+   * we choose the parent application to be the reference frame with respect to translation, e.g.
+   * the parent application origin is the reference frame origin, and we set the translation vectors
+   * of child applications to the multiapp positions parameter. Similarly to the \p setRotation with
+   * angles API, this represents a forward transformation from our domain to the reference domain
+   */
+  void setTranslationVector(const libMesh::Point & translation);
+
+  /**
    * Set the destination coordinate system and destination radial and symmetry axes as appropriate
    * for RZ or RSPHERICAL simulations. Depending on the coordinate system type of the provided
    * coordinate transform we may perform additional transformations. For instance if the destination
@@ -271,15 +280,6 @@ public:
    * 2pi rotation around the symmetry axis
    */
   void setDestinationCoordTransform(const MooseAppCoordTransform & destination_coord_transform);
-
-  /**
-   * Set how much our domain should be translated in order to match a reference frame. In practice
-   * we choose the parent application to be the reference frame with respect to translation, e.g.
-   * the parent application origin is the reference frame origin, and we set the translation vectors
-   * of child applications to the multiapp positions parameter. Similarly to the \p setRotation with
-   * angles API, this represents a forward transformation from our domain to the reference domain
-   */
-  void setTranslationVector(const Point & translation);
 
   /**
    * @return whether the coordinate transformation object modifies an incoming point, e.g. whether
@@ -328,9 +328,9 @@ private:
   /// by the MultiAppCoordTransform for the other direction
   const MooseAppCoordTransform * _destination_app_transform;
 
+  /// Describes a forward translation transformation from our domain to the reference frame domain
+  libMesh::Point _translation;
+
   /// whether coordinate collapsing operations should be skipped
   bool _skip_coordinate_collapsing;
-
-  /// Describes a forward translation transformation from our domain to the reference frame domain
-  Point _translation;
 };

--- a/framework/include/utils/MooseAppCoordTransform.h
+++ b/framework/include/utils/MooseAppCoordTransform.h
@@ -46,6 +46,7 @@ public:
    * 5: the r-axis direction
    * 6: the z-axis direction
    * 7: whether there are multiple coordinate system types on the mesh
+   * 8: whether the mesh has been transformed using the transform
    */
   typedef std::tuple<short int,
                      Real,
@@ -54,6 +55,7 @@ public:
                      int,
                      unsigned int,
                      unsigned int,
+                     short int,
                      short int>
       MinimalData;
 
@@ -202,6 +204,10 @@ private:
   /// The Euler angles describing rotation
   std::array<Real, 3> _euler_angles;
 
+  /// Whether the mesh has been translated and rotated. In this case, applying the transform every
+  /// time is no longer necessary
+  bool _mesh_transformed;
+
   friend class MultiAppCoordTransform;
 };
 
@@ -237,6 +243,13 @@ public:
    * 3. invert scaling
    */
   libMesh::Point mapBack(const libMesh::Point & point) const;
+
+  /**
+   * Transforms the entire mesh with the coordinate transform
+   * This can be done to output in position, or to avoid transforming on every data point
+   * @param mesh the mesh to modify, usually the child app mesh
+   */
+  void transformMesh(MooseMesh & mesh);
 
   /**
    * Set how much our domain should be translated in order to match a reference frame. In practice

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -554,9 +554,16 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
       // Similarly we need to transform the mesh again
       if (_run_in_position)
       {
-        for (const auto & app_ptr : _apps)
-          app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
-              app_ptr->getExecutioner()->feProblem().mesh());
+        for (const auto & i : make_range(_my_num_apps))
+        {
+          auto app_ptr = _apps[i];
+          if (usingPositions())
+            app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
+                app_ptr->getExecutioner()->feProblem().mesh(), _positions[_first_local_app + i]);
+          else
+            app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
+                app_ptr->getExecutioner()->feProblem().mesh(), Point(0, 0, 0));
+        }
       }
 
       // If the time step covers multiple reset times, set them all as having 'happened'
@@ -1041,10 +1048,11 @@ MultiApp::createApp(unsigned int i, Real start_time)
   if (_run_in_position)
   {
     if (usingPositions())
-      app->getExecutioner()->feProblem().coordTransform().setTranslationVector(
-          _positions[_first_local_app + i]);
-    app->getExecutioner()->feProblem().coordTransform().transformMesh(
-        app->getExecutioner()->feProblem().mesh());
+      app->getExecutioner()->feProblem().coordTransform().transformMesh(
+          app->getExecutioner()->feProblem().mesh(), _positions[_first_local_app + i]);
+    else
+      app->getExecutioner()->feProblem().coordTransform().transformMesh(
+          app->getExecutioner()->feProblem().mesh(), Point(0, 0, 0));
   }
 }
 

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -553,8 +553,7 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
 
       // Similarly we need to transform the mesh again
       if (_run_in_position)
-      {
-        for (const auto & i : make_range(_my_num_apps))
+        for (const auto i : make_range(_my_num_apps))
         {
           auto app_ptr = _apps[i];
           if (usingPositions())
@@ -564,7 +563,6 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
             app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
                 app_ptr->getExecutioner()->feProblem().mesh(), Point(0, 0, 0));
         }
-      }
 
       // If the time step covers multiple reset times, set them all as having 'happened'
       for (unsigned int j = i; j < _reset_times.size(); j++)

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -557,6 +557,7 @@ MultiApp::preTransfer(Real /*dt*/, Real target_time)
         for (const auto & app_ptr : _apps)
           app_ptr->getExecutioner()->feProblem().coordTransform().transformMesh(
               app_ptr->getExecutioner()->feProblem().mesh());
+      }
 
       // If the time step covers multiple reset times, set them all as having 'happened'
       for (unsigned int j = i; j < _reset_times.size(); j++)
@@ -916,7 +917,8 @@ MultiApp::moveApp(unsigned int global_app, Point p)
       if (_output_in_position)
         _apps[local_app]->setOutputPosition(p);
       if (_run_in_position)
-        paramError("run_in_position", "Moving apps is not supported");
+        paramError("run_in_position",
+                   "Sub-apps are already displaced, so they are already output in position");
     }
   }
 }

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -344,6 +344,8 @@ MultiAppTransfer::getAppInfo()
         transforms.push_back(std::make_unique<MultiAppCoordTransform>(moose_app_transform));
         auto & transform = transforms[i];
         transform->skipCoordinateCollapsing(skip_coordinate_collapsing);
+        if (multiapp->usingPositions())
+          transform->setTranslationVector(multiapp->position(i));
       }
     }
   };

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -344,8 +344,6 @@ MultiAppTransfer::getAppInfo()
         transforms.push_back(std::make_unique<MultiAppCoordTransform>(moose_app_transform));
         auto & transform = transforms[i];
         transform->skipCoordinateCollapsing(skip_coordinate_collapsing);
-        if (multiapp->usingPositions())
-          transform->targetAppTransform()->setTranslationVector(multiapp->position(i));
       }
     }
   };

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -345,7 +345,7 @@ MultiAppTransfer::getAppInfo()
         auto & transform = transforms[i];
         transform->skipCoordinateCollapsing(skip_coordinate_collapsing);
         if (multiapp->usingPositions())
-          transform->setTranslationVector(multiapp->position(i));
+          transform->targetAppTransform()->setTranslationVector(multiapp->position(i));
       }
     }
   };

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -395,7 +395,7 @@ MooseAppCoordTransform::computeRS()
 }
 
 void
-MooseAppCoordTransform::transformMesh(MooseMesh & mesh, Point translation)
+MooseAppCoordTransform::transformMesh(MooseMesh & mesh, const Point & translation)
 {
   // Transforming a RZ or R-spherical mesh doesnt always make sense, disallow it
   if (_coord_type != Moose::COORD_XYZ)

--- a/framework/src/utils/MooseAppCoordTransform.C
+++ b/framework/src/utils/MooseAppCoordTransform.C
@@ -425,12 +425,14 @@ MooseAppCoordTransform::transformMesh(MooseMesh & mesh)
   if (_coord_type != Moose::COORD_XYZ)
     mooseError("Running MultiApps 'in position' is only supported for XYZ coordinate systems");
   if (_mesh_transformed)
-    mooseError("Child app mesh is being transformed twice");
+    mooseError("App mesh is being transformed twice");
 
   // Apply all the transformation to the mesh
+  if (_scale)
+    MeshTools::Modification::scale(mesh, (*_scale)(0, 0), (*_scale)(1, 1), (*_scale)(2, 2));
+  if (_rotate)
+    MeshTools::Modification::rotate(mesh, _euler_angles[0], _euler_angles[1], _euler_angles[2]);
   MeshTools::Modification::translate(mesh, _translation(0), _translation(1), _translation(2));
-  MeshTools::Modification::rotate(mesh, _euler_angles[0], _euler_angles[1], _euler_angles[2]);
-  MeshTools::Modification::scale(mesh, (*_scale)(0, 0), (*_scale)(1, 1), (*_scale)(2, 2));
 
   // Translation, scaling and rotation need not be applied anymore when performing coordinate
   // transforms

--- a/test/tests/multiapps/run_in_position/gold/main-app_out.e
+++ b/test/tests/multiapps/run_in_position/gold/main-app_out.e
@@ -1,0 +1,1 @@
+../../../transfers/coord_transform/gold/main-app_out.e

--- a/test/tests/multiapps/run_in_position/gold/single-app_out.e
+++ b/test/tests/multiapps/run_in_position/gold/single-app_out.e
@@ -1,0 +1,1 @@
+../../../transfers/coord_transform/gold/single-app_out.e

--- a/test/tests/multiapps/run_in_position/gold/transform-main-main-app_out.e
+++ b/test/tests/multiapps/run_in_position/gold/transform-main-main-app_out.e
@@ -1,0 +1,1 @@
+../../../transfers/coord_transform/gold/transform-main-main-app_out.e

--- a/test/tests/multiapps/run_in_position/main-app.i
+++ b/test/tests/multiapps/run_in_position/main-app.i
@@ -1,0 +1,1 @@
+../../transfers/coord_transform/main-app.i

--- a/test/tests/multiapps/run_in_position/sub-app.i
+++ b/test/tests/multiapps/run_in_position/sub-app.i
@@ -1,0 +1,1 @@
+../../transfers/coord_transform/sub-app.i

--- a/test/tests/multiapps/run_in_position/tests
+++ b/test/tests/multiapps/run_in_position/tests
@@ -1,0 +1,48 @@
+[Tests]
+  issues = '#19121'
+  design = 'syntax/MultiApps/index.md'
+
+  [group]
+    requirement = "The system shall support executing sub-applications in a specified position and/or with the specified frame of reference transformation"
+
+    [multi-app]
+      type = Exodiff
+      input = main-app.i
+      exodiff = main-app_out.e
+      cli_args = 'MultiApps/sub/run_in_position=true'
+      detail = 'with a scaled, rotated, translated child application'
+    []
+    [transform-main-multi-app]
+      type = Exodiff
+      input = transform-main-main-app.i
+      exodiff = transform-main-main-app_out.e
+      cli_args = 'MultiApps/sub/run_in_position=true'
+      detail = 'with a scaled, rotated, translated parent application exchanging information with a translated child application'
+    []
+  []
+
+  [errors]
+    requirement = "The system shall error if"
+    [output_and_run_in_position]
+      type = RunException
+      input = 'main-app.i'
+      cli_args = 'MultiApps/sub/run_in_position=true MultiApps/sub/output_in_position=true'
+      expect_err = 'Sub-apps are already displaced, so they are already output in position'
+      detail = 'both outputting in position and displacing applications are requested at the same time, as displaced apps are already output in position'
+    []
+    [invalid_frame_for_translation]
+      type = RunException
+      input = 'transform-main-main-app.i'
+      cli_args = 'MultiApps/sub/run_in_position=true MultiApps/sub/cli_args=Mesh/coord_type=RZ'
+      expect_err = 'Running MultiApps \'in position\' is only supported for XYZ coordinate systems'
+      detail = 'a translation is requested on a spherical or cylindrical coordinate mesh, as this is not expected to be a valid transformation'
+    []
+    [move_apps_not_supported]
+      type = RunException
+      input = 'transform-main-main-app.i'
+      cli_args = "MultiApps/sub/run_in_position=true Executioner/type=Transient MultiApps/sub/move_time=0.9 MultiApps/sub/move_apps=0 MultiApps/sub/move_positions='0 1 1'"
+      expect_err = 'Moving apps and running apps in position is not supported'
+      detail = 'displacing applications and moving applications at a certain time are both requested as this combination of features is not implemented'
+    []
+  []
+[]

--- a/test/tests/multiapps/run_in_position/transform-main-main-app.i
+++ b/test/tests/multiapps/run_in_position/transform-main-main-app.i
@@ -1,0 +1,1 @@
+../../transfers/coord_transform/transform-main-main-app.i

--- a/test/tests/multiapps/run_in_position/transform-main-sub-app.i
+++ b/test/tests/multiapps/run_in_position/transform-main-sub-app.i
@@ -1,0 +1,1 @@
+../../transfers/coord_transform/transform-main-sub-app.i


### PR DESCRIPTION
refs #19121

I thought I needed this to debug general field transfers but turns out not really. As a result this is lower priority

Thoughts?

Todo:
- [x] Test this using all the coordinate transforms tests, using custom comparison files that ignore the mesh coordinates and only compare the fields
- [x] Check if output_in_position could be extended to coordinate transforms

EDIT: output in position is done simply by passing a point. To extend it we would need to pass a coordinate transform. It s not that difficult, just not the focus for now. 

EDIT: only did two tests from the coordinate transforms. The bulk of these tests are with every kind of transfer. I think we are covered already with the ones we have