### PR TITLE
Fix another inlet parameter check for scalar equations

### DIFF
--- a/modules/navier_stokes/src/actions/NSFVAction.C
+++ b/modules/navier_stokes/src/actions/NSFVAction.C
@@ -2596,11 +2596,11 @@ NSFVAction::checkBoundaryParameterErrors()
   {
     if (_inlet_boundaries.size())
     {
-      checkSizeFriendParams(_inlet_boundaries.size(),
+      checkSizeFriendParams(_inlet_boundaries.size() * _passive_scalar_names.size(),
                             _passive_scalar_inlet_types.size(),
                             "inlet_boundaries",
                             "passive_scalar_inlet_types",
-                            "inlet boundaries");
+                            "inlet boundaries times number of transported scalars");
       checkSizeFriendParams(_passive_scalar_names.size(),
                             _passive_scalar_inlet_function.size(),
                             "passive_scalar_names",

--- a/modules/navier_stokes/src/actions/NSFVAction.C
+++ b/modules/navier_stokes/src/actions/NSFVAction.C
@@ -1821,9 +1821,10 @@ NSFVAction::addScalarInletBC()
   for (unsigned int name_i = 0; name_i < _passive_scalar_names.size(); ++name_i)
   {
     unsigned int flux_bc_counter = 0;
-    for (unsigned int bc_ind = 0; bc_ind < _inlet_boundaries.size(); ++bc_ind)
+    unsigned int num_inlets = _inlet_boundaries.size();
+    for (unsigned int bc_ind = 0; bc_ind < num_inlets; ++bc_ind)
     {
-      if (_passive_scalar_inlet_types[bc_ind] == "fixed-value")
+      if (_passive_scalar_inlet_types[name_i * num_inlets + bc_ind] == "fixed-value")
       {
         const std::string bc_type = "FVFunctionDirichletBC";
         InputParameters params = _factory.getValidParams(bc_type);
@@ -1834,13 +1835,13 @@ NSFVAction::addScalarInletBC()
         _problem->addFVBC(
             bc_type, _passive_scalar_names[name_i] + "_" + _inlet_boundaries[bc_ind], params);
       }
-      else if (_passive_scalar_inlet_types[bc_ind] == "flux-mass" ||
-               _passive_scalar_inlet_types[bc_ind] == "flux-velocity")
+      else if (_passive_scalar_inlet_types[name_i * num_inlets + bc_ind] == "flux-mass" ||
+               _passive_scalar_inlet_types[name_i * num_inlets + bc_ind] == "flux-velocity")
       {
         const std::string bc_type = "WCNSFVScalarFluxBC";
         InputParameters params = _factory.getValidParams(bc_type);
         params.set<NonlinearVariableName>("variable") = _passive_scalar_names[name_i];
-        if (_energy_inlet_types[bc_ind] == "flux-mass")
+        if (_passive_scalar_inlet_types[name_i * num_inlets + bc_ind] == "flux-mass")
         {
           params.set<PostprocessorName>("mdot_pp") = _flux_inlet_pps[flux_bc_counter];
           params.set<PostprocessorName>("area_pp") = "area_pp_" + _inlet_boundaries[bc_ind];

--- a/modules/navier_stokes/test/tests/finite_volume/ins/action/errors/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/action/errors/tests
@@ -69,7 +69,7 @@
     input = 2d-rc-error-action.i
     requirement = 'The system shall throw an error if the number of passive scalar inlet types does not match the number of inlet boundaries.'
     cli_args = "Modules/NavierStokesFV/passive_scalar_inlet_types=''"
-    expect_err = "Size \(0\) is not the same as the number of inlet boundaries in 'inlet_boundaries' "
+    expect_err = "Size \(0\) is not the same as the number of inlet boundaries times number of transported scalars in 'inlet_boundaries' "
                  "\(size 1\)"
     ad_indexing_type = 'global'
   []


### PR DESCRIPTION
refs #22774

what we have checks
N_inlet_types = N_boundaries

but if we have 2 scalars we ll have
2 * N_inlet_types because the inlet types might be different for each scalar