### PR TITLE
Add an interface to mark the solution as invalid / out-of-bounds

### DIFF
--- a/framework/doc/content/source/interfaces/SolutionInvalidInterface.md
+++ b/framework/doc/content/source/interfaces/SolutionInvalidInterface.md
@@ -1,0 +1,7 @@
+# SolutionInvalidInterface
+
+The SolutionInvalidInterface defines the method used to mark a solution as "invalid".  An invalid solution means that the solution somehow does not satisfy requirements such as a value being out of bounds of a correlation.  Solutions are allowed to be invalid _during_ the nonlinear solve - but are not allowed to invalid once it converges.  A "converged" solution that is marked as invalid will cause MOOSE to behave as if the solution did NOT converge - including cutting back timesteps, etc.
+
+This can be overriden by setting `Problem/allow_invalid_solution=true`.
+
+!listing /SolutionInvalidInterface.h start=doco-normal-methods-begin end=doco-normal-methods-end include-start=false

--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -1,0 +1,36 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+// MOOSE includes
+#include "ConsoleStream.h"
+
+// Forward declarations
+class MooseApp;
+class MooseObject;
+class FEProblemBase;
+
+/**
+ * An inteface for the _console for outputting to the Console object
+ */
+class SolutionInvalidInterface
+{
+public:
+  /**
+   * A class for providing a helper stream object for writting message to
+   * all the Output objects.
+   */
+  SolutionInvalidInterface(MooseObject * moose_object);
+  void solutionInvalid();
+
+private:
+  /// An instance of helper class to write streams to the Console objects
+  FEProblemBase * _si_fe_problem;
+};

--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -31,5 +31,5 @@ public:
 
 private:
   /// A reference to the FEProblem
-  FEProblemBase * _si_fe_problem;
+  FEProblemBase & _si_fe_problem;
 };

--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -18,7 +18,7 @@ class MooseObject;
 class FEProblemBase;
 
 /**
- * An interface to communicate a solution invalid state to FEProblemBase
+ * An interface to communicate an invalid solution state to FEProblemBase
  */
 class SolutionInvalidInterface
 {
@@ -30,6 +30,6 @@ public:
   void setSolutionInvalid(bool solution_invalid);
 
 private:
-  /// A pointer to the FEProblem
+  /// A reference to the FEProblem
   FEProblemBase * _si_fe_problem;
 };

--- a/framework/include/interfaces/SolutionInvalidInterface.h
+++ b/framework/include/interfaces/SolutionInvalidInterface.h
@@ -10,7 +10,7 @@
 #pragma once
 
 // MOOSE includes
-#include "ConsoleStream.h"
+#include "Moose.h"
 
 // Forward declarations
 class MooseApp;
@@ -18,19 +18,18 @@ class MooseObject;
 class FEProblemBase;
 
 /**
- * An inteface for the _console for outputting to the Console object
+ * An interface to communicate a solution invalid state to FEProblemBase
  */
 class SolutionInvalidInterface
 {
 public:
   /**
-   * A class for providing a helper stream object for writting message to
-   * all the Output objects.
+   * A class for providing a helper object for communicating to FEProblemBase
    */
   SolutionInvalidInterface(MooseObject * moose_object);
-  void solutionInvalid();
+  void setSolutionInvalid(bool solution_invalid);
 
 private:
-  /// An instance of helper class to write streams to the Console objects
+  /// A pointer to the FEProblem
   FEProblemBase * _si_fe_problem;
 };

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -34,6 +34,7 @@
 #include "Assembly.h"
 #include "GeometricSearchInterface.h"
 #include "FunctorInterface.h"
+#include "SolutionInvalidInterface.h"
 
 #define usingMaterialBaseMembers                                                                   \
   usingTransientInterfaceMembers;                                                                  \
@@ -74,7 +75,8 @@ class MaterialBase : public MooseObject,
                      public RandomInterface,
                      public ElementIDInterface,
                      protected GeometricSearchInterface,
-                     protected FunctorInterface
+                     protected FunctorInterface,
+                     protected SolutionInvalidInterface
 {
 public:
   static InputParameters validParams();

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -1614,6 +1614,11 @@ public:
     _error_on_jacobian_nonzero_reallocation = state;
   }
 
+  /**
+   * Whether or not we are allowing invalid solutions
+   */
+  bool allowInvalidSolution() { return _allow_invalid_solution; }
+
   bool ignoreZerosInJacobian() const { return _ignore_zeros_in_jacobian; }
 
   void setIgnoreZerosInJacobian(bool state) { _ignore_zeros_in_jacobian = state; }
@@ -2332,6 +2337,7 @@ private:
   const bool _skip_additional_restart_data;
   const bool _skip_nl_system_check;
   bool _fail_next_linear_convergence_check;
+  const bool & _allow_invalid_solution;
 
   /// At or beyond initialSteup stage
   bool _started_initial_setup;

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -904,6 +904,14 @@ public:
    */
   Moose::VarKindType varKind() const { return _var_kind; }
 
+  /**
+   * Whether or not the converged solution is valid
+   */
+
+  bool solutionInvalid() const { return _solution_invalid; }
+
+  void solutionInvalid(bool solution_invalid) { _solution_invalid = solution_invalid; }
+
 protected:
   /**
    * Internal getter for solution owned by libMesh.
@@ -972,6 +980,9 @@ protected:
 
   /// Whether or not the solution states have been initialized
   bool _solution_states_initialized;
+
+  /// whether or not the converged solution is valid
+  bool _solution_invalid;
 
 private:
   /**

--- a/framework/include/systems/SystemBase.h
+++ b/framework/include/systems/SystemBase.h
@@ -907,10 +907,9 @@ public:
   /**
    * Whether or not the converged solution is valid
    */
-
   bool solutionInvalid() const { return _solution_invalid; }
 
-  void solutionInvalid(bool solution_invalid) { _solution_invalid = solution_invalid; }
+  void setSolutionInvalid(bool solution_invalid);
 
 protected:
   /**

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -16,12 +16,12 @@
 
 SolutionInvalidInterface::SolutionInvalidInterface(MooseObject * moose_object)
   : _si_fe_problem(
-        moose_object->parameters().getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"))
+        *moose_object->parameters().getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"))
 {
 }
 
 void
 SolutionInvalidInterface::setSolutionInvalid(bool solution_invalid)
 {
-  _si_fe_problem->getNonlinearSystemBase().setSolutionInvalid(solution_invalid);
+  _si_fe_problem.getNonlinearSystemBase().setSolutionInvalid(solution_invalid);
 }

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -21,7 +21,7 @@ SolutionInvalidInterface::SolutionInvalidInterface(MooseObject * moose_object)
 }
 
 void
-SolutionInvalidInterface::solutionInvalid()
+SolutionInvalidInterface::setSolutionInvalid(bool solution_invalid)
 {
-  _si_fe_problem->getNonlinearSystemBase().solutionInvalid(true);
+  _si_fe_problem->getNonlinearSystemBase().setSolutionInvalid(solution_invalid);
 }

--- a/framework/src/interfaces/SolutionInvalidInterface.C
+++ b/framework/src/interfaces/SolutionInvalidInterface.C
@@ -1,0 +1,27 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+// MOOSE includes
+#include "SolutionInvalidInterface.h"
+#include "MooseApp.h"
+#include "NonlinearSystemBase.h"
+#include "FEProblemBase.h"
+#include "MooseObject.h"
+
+SolutionInvalidInterface::SolutionInvalidInterface(MooseObject * moose_object)
+  : _si_fe_problem(
+        moose_object->parameters().getCheckedPointerParam<FEProblemBase *>("_fe_problem_base"))
+{
+}
+
+void
+SolutionInvalidInterface::solutionInvalid()
+{
+  _si_fe_problem->getNonlinearSystemBase().solutionInvalid(true);
+}

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -92,6 +92,7 @@ MaterialBase::MaterialBase(const InputParameters & parameters)
     ElementIDInterface(this),
     GeometricSearchInterface(this),
     FunctorInterface(this),
+    SolutionInvalidInterface(this),
     _subproblem(*getCheckedPointerParam<SubProblem *>("_subproblem")),
     _fe_problem(*getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),
     _tid(parameters.get<THREAD_ID>("_tid")),

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -255,6 +255,11 @@ FEProblemBase::validParams()
 
   params.declareControllable("solve");
 
+  params.addParam<bool>(
+      "allow_invalid_solution",
+      false,
+      "Set to true to allow convergence even though the solution has been marked as 'invalid'");
+
   return params;
 }
 
@@ -343,6 +348,7 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _skip_additional_restart_data(getParam<bool>("skip_additional_restart_data")),
     _skip_nl_system_check(getParam<bool>("skip_nl_system_check")),
     _fail_next_linear_convergence_check(false),
+    _allow_invalid_solution(getParam<bool>("allow_invalid_solution")),
     _started_initial_setup(false),
     _has_internal_edge_residual_objects(false),
     _u_dot_requested(false),

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -341,7 +341,7 @@ NonlinearSystem::converged()
   if (_fe_problem.hasException())
     return false;
 
-  if (_solution_invalid)
+  if (solutionInvalid())
   {
     mooseWarning("The solution is not converged due to the solution being invalid.");
     return false;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -341,7 +341,7 @@ NonlinearSystem::converged()
   if (_fe_problem.hasException())
     return false;
 
-  if (solutionInvalid())
+  if (!_fe_problem.allowInvalidSolution() && solutionInvalid())
   {
     mooseWarning("The solution is not converged due to the solution being invalid.");
     return false;

--- a/framework/src/systems/NonlinearSystem.C
+++ b/framework/src/systems/NonlinearSystem.C
@@ -341,6 +341,12 @@ NonlinearSystem::converged()
   if (_fe_problem.hasException())
     return false;
 
+  if (_solution_invalid)
+  {
+    mooseWarning("The solution is not converged due to the solution being invalid.");
+    return false;
+  }
+
   return _nl_implicit_sys.nonlinear_solver->converged;
 }
 

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -1525,6 +1525,7 @@ NonlinearSystemBase::residualSetup()
   _nodal_bcs.residualSetup();
 
   _fe_problem.residualSetup();
+  setSolutionInvalid(false);
 }
 
 void

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -1184,6 +1184,12 @@ SystemBase::matrixTagActive(TagID tag) const
   return tag < _matrix_tag_active_flags.size() && _matrix_tag_active_flags[tag];
 }
 
+void
+SystemBase::setSolutionInvalid(bool solution_invalid)
+{
+  _solution_invalid = solution_invalid;
+}
+
 unsigned int
 SystemBase::number() const
 {

--- a/framework/src/systems/SystemBase.C
+++ b/framework/src/systems/SystemBase.C
@@ -132,7 +132,8 @@ SystemBase::SystemBase(SubProblem & subproblem,
     _time_integrator(nullptr),
     _automatic_scaling(false),
     _verbose(false),
-    _solution_states_initialized(false)
+    _solution_states_initialized(false),
+    _solution_invalid(false)
 {
 }
 

--- a/modules/doc/content/newsletter/2022_12.md
+++ b/modules/doc/content/newsletter/2022_12.md
@@ -14,6 +14,8 @@ please consider updating to the current supported release (3.16.6) or the altern
 
 ## MOOSE Improvements
 
+Added new ability to [mark a solution as "invalid"](source/interfaces/SolutionInvalidInterface.md).  This gives developers the ability to say that a solution is "out of bounds" for things like material correlations.  A solution is allowed to be invalid _during_ a nonlinear solve - but not once the solve has converged.
+
 ## libMesh-level Changes
 
 ## PETSc-level Changes

--- a/test/include/materials/NonsafeMaterial.h
+++ b/test/include/materials/NonsafeMaterial.h
@@ -13,7 +13,7 @@
 #include "MaterialProperty.h"
 
 /**
- * Simple material to test SolutionInvalid feature.
+ * Simple material to test SolutionInvalidInterface.
  */
 class NonsafeMaterial : public Material
 {

--- a/test/include/materials/NonsafeMaterial.h
+++ b/test/include/materials/NonsafeMaterial.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "Material.h"
+#include "MaterialProperty.h"
+
+/**
+ * Simple material to test vector parameter range checking.
+ */
+class NonsafeMaterial : public Material
+{
+public:
+  static InputParameters validParams();
+
+  NonsafeMaterial(const InputParameters & parameters);
+
+protected:
+  void computeQpProperties() override;
+
+  const Real & _input_diffusivity;
+  const Real & _threshold;
+
+  MaterialProperty<Real> & _diffusivity;
+};

--- a/test/include/materials/NonsafeMaterial.h
+++ b/test/include/materials/NonsafeMaterial.h
@@ -13,7 +13,7 @@
 #include "MaterialProperty.h"
 
 /**
- * Simple material to test vector parameter range checking.
+ * Simple material to test SolutionInvalid feature.
  */
 class NonsafeMaterial : public Material
 {

--- a/test/src/materials/NonsafeMaterial.C
+++ b/test/src/materials/NonsafeMaterial.C
@@ -1,0 +1,40 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "NonsafeMaterial.h"
+
+registerMooseObject("MooseTestApp", NonsafeMaterial);
+
+InputParameters
+NonsafeMaterial::validParams()
+{
+  InputParameters params = Material::validParams();
+
+  params.addRequiredParam<Real>("diffusivity", "The diffusivity value.");
+  params.addParam<Real>(
+      "threshold", 0, "The value sets the upper limit for material property at given condition.");
+
+  return params;
+}
+
+NonsafeMaterial::NonsafeMaterial(const InputParameters & parameters)
+  : Material(parameters),
+    _input_diffusivity(getParam<Real>("diffusivity")),
+    _threshold(getParam<Real>("threshold")),
+    _diffusivity(declareProperty<Real>("diffusivity"))
+{
+}
+
+void
+NonsafeMaterial::computeQpProperties()
+{
+  if (_input_diffusivity > _threshold)
+    solutionInvalid();
+  _diffusivity[_qp] = _input_diffusivity;
+}

--- a/test/src/materials/NonsafeMaterial.C
+++ b/test/src/materials/NonsafeMaterial.C
@@ -18,8 +18,9 @@ NonsafeMaterial::validParams()
 
   params.addRequiredParam<Real>("diffusivity", "The diffusivity value.");
   params.addParam<Real>(
-      "threshold", 0, "The value sets the upper limit for material property at given condition.");
-
+      "threshold",
+      0,
+      "This value sets the upper limit for the validity of the material property value.");
   return params;
 }
 

--- a/test/src/materials/NonsafeMaterial.C
+++ b/test/src/materials/NonsafeMaterial.C
@@ -35,6 +35,6 @@ void
 NonsafeMaterial::computeQpProperties()
 {
   if (_input_diffusivity > _threshold)
-    solutionInvalid();
+    setSolutionInvalid(true);
   _diffusivity[_qp] = _input_diffusivity;
 }

--- a/test/tests/materials/solution_invalid/solution_invalid.i
+++ b/test/tests/materials/solution_invalid/solution_invalid.i
@@ -1,0 +1,59 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 2
+  ny = 2
+  xmax = 1
+  ymax = 1
+[]
+
+[Variables]
+  [u]
+  []
+[]
+
+[Materials]
+  [filter]
+    type = NonsafeMaterial
+    diffusivity = 0.5
+    threshold = 0.0
+  []
+[]
+
+[Kernels]
+  [diffusion]
+    type = MatDiffusion
+    variable = u
+    diffusivity = diffusivity
+  []
+[]
+
+[BCs]
+  [left]
+    type = DirichletBC
+    variable = u
+    boundary = left
+    value = 1
+  []
+  [right]
+    type = DirichletBC
+    variable = u
+    boundary = right
+    value = 0
+  []
+[]
+
+[Problem]
+  type = FEProblem
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'NEWTON'
+  petsc_options_iname = '-pc_type -pc_factor_mat_solver_type'
+  petsc_options_value = 'lu superlu_dist'
+[]
+
+[Outputs]
+  exodus = false
+[]

--- a/test/tests/materials/solution_invalid/solution_invalid.i
+++ b/test/tests/materials/solution_invalid/solution_invalid.i
@@ -12,6 +12,7 @@
   []
 []
 
+# Sets solution invalid using the SolutionInvalidInterface, as diffusivity exceeds the set threshold.
 [Materials]
   [filter]
     type = NonsafeMaterial

--- a/test/tests/materials/solution_invalid/tests
+++ b/test/tests/materials/solution_invalid/tests
@@ -2,9 +2,9 @@
   [./solution_invalid]
     type = 'RunException'
     input = 'solution_invalid.i'
-    expect_err = 'The solution is not converged due to the solution being invalid.'	
+    expect_err = 'The solution is not converged due to the solution being invalid.'
     design = 'syntax/Materials/index.md'
-    issues = '#22814'
-    requirement = 'The system shall not allow a converged solution with an invalid computation.'
+    issues = '#22884'
+    requirement = 'The system shall not accept a converged solution if the solution has been tagged as invalid.'
   [../]
 []

--- a/test/tests/materials/solution_invalid/tests
+++ b/test/tests/materials/solution_invalid/tests
@@ -3,7 +3,7 @@
     type = 'RunException'
     input = 'solution_invalid.i'
     expect_err = 'The solution is not converged due to the solution being invalid.'
-    design = 'syntax/Interfaces/SolutionInvalidInterface.md'
+    design = 'source/interfaces/SolutionInvalidInterface.md'
     issues = '#22884'
     requirement = 'The system shall not accept a converged solution if the solution has been tagged as invalid.'
   []
@@ -12,7 +12,7 @@
     type = 'RunApp'
     input = 'solution_invalid.i'
     cli_args = 'Problem/allow_invalid_solution=true'
-    design = 'syntax/Interfaces/SolutionInvalidInterface.md'
+    design = 'source/interfaces/SolutionInvalidInterface.md'
     issues = '#22884'
     requirement = 'The system shall allow overriding the solution validity checks.'
   []

--- a/test/tests/materials/solution_invalid/tests
+++ b/test/tests/materials/solution_invalid/tests
@@ -1,10 +1,19 @@
 [Tests]
-  [./solution_invalid]
+  [solution_invalid]
     type = 'RunException'
     input = 'solution_invalid.i'
     expect_err = 'The solution is not converged due to the solution being invalid.'
-    design = 'syntax/Materials/index.md'
+    design = 'syntax/Interfaces/SolutionInvalidInterface.md'
     issues = '#22884'
     requirement = 'The system shall not accept a converged solution if the solution has been tagged as invalid.'
-  [../]
+  []
+
+  [allow_solution_invalid]
+    type = 'RunApp'
+    input = 'solution_invalid.i'
+    cli_args = 'Problem/allow_invalid_solution=true'
+    design = 'syntax/Interfaces/SolutionInvalidInterface.md'
+    issues = '#22884'
+    requirement = 'The system shall allow overriding the solution validity checks.'
+  []
 []

--- a/test/tests/materials/solution_invalid/tests
+++ b/test/tests/materials/solution_invalid/tests
@@ -1,0 +1,10 @@
+[Tests]
+  [./solution_invalid]
+    type = 'RunException'
+    input = 'solution_invalid.i'
+    expect_err = 'The solution is not converged due to the solution being invalid.'	
+    design = 'syntax/Materials/index.md'
+    issues = '#22814'
+    requirement = 'The system shall not allow a converged solution with an invalid computation.'
+  [../]
+[]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
ref #22814 Adding new feature to test whether the material property is valid

## Reason
<!--Why do you need this feature or what is the enhancement?-->
The feature is requested to determine whether the solution is valid at the time of convergence.

## Design
<!--A concise description (design) of the enhancement.-->
The function can be called from materials to state the converged solution is invalid. 
A bool function is added with a flag. The default value of the flag is false meaning solution is valid. The flag will flip every time the function is called. The final value will be the state of the converged solution.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
The new feature can state the converged solution is invalid.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
