### PR TITLE
Check that generation of MooseRevision.h is successful before continuing compilation.

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -316,9 +316,11 @@ endif
 $(moose_revision_header): $(moose_HEADER_deps)
 	@echo "Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(FRAMEWORK_DIR) \
-	  $(moose_revision_header) MOOSE) \
-        # ensure the header generation step didn't fail
-	@if [ $? ]; then $(error "Failed to generate MooseRevision.h"); fi
+	  $(moose_revision_header) MOOSE)
+        # make sure the header generation step didn't fail
+	@if [ $(.SHELLSTATUS) -ne 0 ]; then \
+	echo "\nFailed to generate MooseRevision.h\n"; exit $(.SHELLSTATUS); \
+	fi
 	@if [ ! -e "$(moose_all_header_dir)/MooseRevision.h" ]; then \
 		ln -sf $(moose_revision_header) $(moose_all_header_dir); \
 	fi

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -317,7 +317,7 @@ $(moose_revision_header): $(moose_HEADER_deps)
 	@echo "Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(FRAMEWORK_DIR) \
 	  $(moose_revision_header) MOOSE)
-        # make sure the header generation step didn't fail
+  # make sure the header generation step didn't fail
 	@if [ $(.SHELLSTATUS) -ne 0 ]; then \
 	echo "\nFailed to generate MooseRevision.h\n"; exit $(.SHELLSTATUS); \
 	fi

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -316,7 +316,9 @@ endif
 $(moose_revision_header): $(moose_HEADER_deps)
 	@echo "Checking if header needs updating: "$@"..."
 	$(shell $(FRAMEWORK_DIR)/scripts/get_repo_revision.py $(FRAMEWORK_DIR) \
-	  $(moose_revision_header) MOOSE)
+	  $(moose_revision_header) MOOSE) \
+        # ensure the header generation step didn't fail
+	@if [ $? ]; then $(error "Failed to generate MooseRevision.h"); fi
 	@if [ ! -e "$(moose_all_header_dir)/MooseRevision.h" ]; then \
 		ln -sf $(moose_revision_header) $(moose_all_header_dir); \
 	fi


### PR DESCRIPTION
This PR is related to https://github.com/idaholab/moose/discussions/22035. The generation of the `MooseRevision.h` header relies on the Python `packaging` module. If this package is missing, an error message appears at the start of compilation:

```shell
 Traceback (most recent call last):
  File "/home/pshriwise/external/cardinal-aurora/build/moose/framework/scripts/get_repo_revision.py", line 19, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

As it stands, compilation will continue until getting to a file that includes that header with a message like:

```shell
In file included from /home/pshriwise/external/cardinal-aurora/build/moose/framework/build/unity_src/outputs_Unity.C:16:
/home/pshriwise/external/cardinal-aurora/build/moose/framework/src/outputs/JsonIO.C:12:10: fatal error: MooseRevision.h: No such file or directory
   12 | #include "MooseRevision.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

The fact that the final error message comes from the compiler but is related to a missing Python package might lead some down the wrong path when they look into fixing this problem.

## Reason
Makes the source of a compilation error related to a missing Python package clearer.

## Design
Added a check on the returned error code from the Python command in the header generation target.

## Impact
Hopefully will make the source of the failure clearer and easier to fix.
