### PR TITLE
Actually register scalar transport module to ModulesApp

### DIFF
--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -67,6 +67,9 @@
 #ifdef RICHARDS_ENABLED
 #include "RichardsApp.h"
 #endif
+#ifdef SCALAR_TRANSPORT_ENABLED
+#include "ScalarTransportApp.h"
+#endif
 #ifdef SOLID_PROPERTIES_ENABLED
 #include "SolidPropertiesApp.h"
 #endif
@@ -458,6 +461,10 @@ ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 
 #ifdef RICHARDS_ENABLED
   RichardsApp::registerAll(f, af, s);
+#endif
+
+#ifdef SCALAR_TRANSPORT_ENABLED
+  ScalarTransportApp::registerAll(f, af, s);
 #endif
 
 #ifdef SOLID_PROPERTIES_ENABLED


### PR DESCRIPTION
@lindsayad We need this change to fixup your TMAP8 PR. Scalar transport module objects were not being properly registered. 

Refs #22392
Refs idaholab/TMAP8#38
