### PR TITLE
Update WSL instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/conda.md
+++ b/modules/doc/content/getting_started/installation/conda.md
@@ -5,7 +5,7 @@ application development is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
 an option to install MOOSE directly on a Windows system is not yet supported.
 On-going efforts are being made to add a conda installation option for Windows,
-and an experimental [WSL](installation/windows10.md) option is available.
+and an experimental [WSL](installation/windows.md) option is available.
 
 !include installation/install_miniconda.md
 

--- a/modules/doc/content/getting_started/installation/index.md
+++ b/modules/doc/content/getting_started/installation/index.md
@@ -3,7 +3,7 @@
 To install the MOOSE Framework, click the link below that corresponds to your operating system/platform and follow the instructions:
 
 - [Linux and MacOS](installation/conda.md)
-- [installation/windows10.md]
+- [installation/windows.md]
 - [installation/docker.md]
 - Advanced Instructions:
 

--- a/modules/doc/content/getting_started/installation/windows.md
+++ b/modules/doc/content/getting_started/installation/windows.md
@@ -1,14 +1,14 @@
-# Windows 10
+# Windows
 
 !alert! warning
-Using MOOSE on Windows 10 is experimental and not fully supported.
+Using MOOSE on Windows 10 and 11 is experimental and not fully supported.
 
 Caveats:
 
 - Peacock does not work correctly (artifacts during rendering: surface normals are flipped).
-- Different flavors of Linux are available.
-
-    - Be sure to choose an OS in which we support. While MOOSE will ultimately work on just about every flavor of Linux, this document assumes you have chosen Ubuntu 20.04.
+- Different flavors of Linux are available, but *be sure to choose a distribution which we support*.
+  While MOOSE will ultimately work on just about every flavor of Linux, this document assumes you
+  have chosen Ubuntu 20.04, which is the Windows Subsystem for Linux (WSL) default as of December 2022.
 !alert-end!
 
 !include installation/wsl.md
@@ -17,6 +17,6 @@ Caveats:
 
 With the above complete, close the WSL terminal, and re-open it. Then proceed to our [Conda Install Instructions](getting_started/installation/conda.md).
 
-!alert! note
+!alert! tip
 Your Download's folder, while using WSL, is located at: `/mnt/c/Users/<Your User Name>/Downloads`
 !alert-end!

--- a/modules/doc/content/getting_started/installation/windows.md
+++ b/modules/doc/content/getting_started/installation/windows.md
@@ -20,3 +20,43 @@ With the above complete, close the WSL terminal, and re-open it. Then proceed to
 !alert! tip
 Your Download's folder, while using WSL, is located at: `/mnt/c/Users/<Your User Name>/Downloads`
 !alert-end!
+
+## Miscellaneous Tips for WSL
+
+Like WSL installation, the following sections require performing all commands in a PowerShell
+or Command Prompt in *administrator* mode!
+
+### Updating the WSL Linux Kernel
+
+The WSL linux kernel receives periodic updates. To perform these updates, one can run:
+
+```bash
+wsl --update
+```
+
+### Change WSL Version
+
+In this instruction set, WSL version 2 is used (and is the default, recommended release). If WSL version
+1 is desired, this can be changed by performing the command:
+
+```bash
+wsl --set-version 1
+```
+
+The default for new Linux kernel instances can be set by performing the following:
+
+```bash
+wsl --set-default-version n
+```
+
+where `n` can be replaced by either 1 or 2, depending on the version desired.
+
+### Shutdown All WSL Instances
+
+To shutdown all instances of WSL on the machine, perform the following:
+
+```bash
+wsl --shutdown
+```
+
+WSL can then be restarted from the Start menu.

--- a/modules/doc/content/getting_started/installation/wsl.md
+++ b/modules/doc/content/getting_started/installation/wsl.md
@@ -29,7 +29,7 @@ used (10 version 2004+ and build 19041+, or 11). For more information see
 
 Open PowerShell or Windows Command Prompt in *administrator* mode by right-clicking the application
 and selecting "Run as administrator". In the prompt that appears, one command can be used to install
-WSL dependencies and a default Linux distribution of Ubuntu 20.04 LTS.
+WSL version 2 dependencies and a default Linux distribution of Ubuntu 20.04 LTS.
 
 ```bash
 wsl --install

--- a/modules/doc/content/getting_started/installation/wsl.md
+++ b/modules/doc/content/getting_started/installation/wsl.md
@@ -1,45 +1,84 @@
 Begin by performing the following external instructions:
 
-- Install [Ubuntu 20.04](https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71) from the Microsoft store
 - Install [VcXsrv](https://sourceforge.net/projects/vcxsrv/reviews/) (Only needed for Peacock)
 
 ## Launch VcXsrv
 
-Each time you reboot, or basically each time VcXsrv is *not* running, and you wish to use the graphical capabilities of MOOSE (Peacock), you should start VcXsrv before launching your WSL terminal.
+Each time you reboot, or basically each time VcXsrv is *not* running, and you wish to use the graphical
+capabilities of MOOSE (Peacock), you should start VcXsrv before launching your WSL terminal.
 
-We have found better performance instructing VcXsrv to use software rendering over native OpenGL. When launching VcXsrv, search for the option: "Native opengl", and un-check it. All other options can remain the default.
+When starting VcXsrv, options for the server can be adjusted. In general, the default options are
+adequate, except for the following:
 
-## Edit Hostname within WSL
+- Un-check "Native opengl". We have found better performance instructing VcXsrv to use software
+  rendering over native OpenGL.
+- Check "Disable access control". This allows the WSL instance to open windows via VcXsrv without
+  requiring an authorization protocol.
 
-Launch the Windows 10 Command Prompt as an Administrator (right-click the Windows Start button, and select Command Prompt(Admin) in the resulting menu that appears), and modify the Windows 10 hosts file (located in `C:\Windows\System32\Drivers\etc\hosts`) to include the results of `hostname` to resolve to 127.0.0.1. This is necessary due to the way
-MPICH (a message passing interface) passes information among itself when running applications (like MOOSE) in parallel.
+Again, all other options for VcXsrv can remain the default.
 
-```
-C:\Users\[your_user_name]> hostname
-DESKTOP-L7BGA7L
+!alert tip title=VcXsrv network connections
+In some cases, the system firewall may block connections to the X window server. If errors or window
+rendering stalls are experienced after adopting the VcXsrv settings above, check to make sure that all
+network connections to VcXsrv are allowed.
 
-C:\Users\[your_user_name]> Notepad "C:\Windows\System32\Drivers\etc\hosts"
-# localhost name resolution is handled within DNS itself.
-#       127.0.0.1       localhost
-#       ::1             localhost
+## Install WSL
 
-127.0.0.1   DESKTOP-L7BGA7L    <---- ADD THAT
-```
+!alert note
+To use the simplified installation instructions outlined below, a recent build of Windows should be
+used (10 version 2004+ and build 19041+, or 11). For more information see
+[Microsoft's information page on WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
-## Update Ubuntu, install additional libraries
-
-Launch WSL, perform an update, and install necessary OpenGL libraries:
+Open PowerShell or Windows Command Prompt in *administrator* mode by right-clicking the application
+and selecting "Run as administrator". In the prompt that appears, one command can be used to install
+WSL dependencies and a default Linux distribution of Ubuntu 20.04 LTS.
 
 ```bash
-sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install x11-apps libglu1-mesa
+wsl --install
+```
+
+Program output will appear showing installation and setup of dependencies before prompting the user
+for a restart to finish initial setup. See below for an example of the summary output.
+
+```bash
+C:\Users\USER>wsl --install
+Installing: Virtual Machine Platform
+Virtual Machine Platform has been installed.
+Installing: Windows Subsystem for Linux
+Windows Subsystem for Linux has been installed.
+Downloading: WSL Kernel
+Installing: WSL Kernel
+WSL Kernel has been installed.
+Downloading: Ubuntu
+The requested operation is successful. Changes will not be effective until the system is rebooted.
+```
+
+## Setup Linux and Enable GUI Dependencies
+
+Once the restart is complete, a prompt will appear on next boot continuing the Ubuntu Linux
+installation and requesting a username for the new UNIX user account.
+
+```
+Installing, this may take a few minutes....
+Please create a default UNIX user account. The username does not need to match your Windows username.
+For more information visit: https://aka.ms/wslusers
+Enter new UNIX username:
+```
+
+After entering a username and a new password, a standard Linux bash prompt will appear. An update
+should be performed to check for any out-of-date packages. To enable usage of Peacock, OpenGL libraries
+must also be installed.
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install x11-apps libglu1-mesa
 ```
 
 ## Configure WSL to use VcXsrv
 
-Modify your bash profile to allow WSL to connect to VcXsrv.
+Modify the bash profile to allow WSL to connect to VcXsrv.
 
 ```bash
-echo "export DISPLAY=localhost:0" >> ~/.bashrc
+echo "export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0.0" >> ~/.bashrc
 ```

--- a/modules/doc/content/getting_started/installation/wsl.md
+++ b/modules/doc/content/getting_started/installation/wsl.md
@@ -10,8 +10,6 @@ capabilities of MOOSE (Peacock), you should start VcXsrv before launching your W
 When starting VcXsrv, options for the server can be adjusted. In general, the default options are
 adequate, except for the following:
 
-- Un-check "Native opengl". We have found better performance instructing VcXsrv to use software
-  rendering over native OpenGL.
 - Check "Disable access control". This allows the WSL instance to open windows via VcXsrv without
   requiring an authorization protocol.
 


### PR DESCRIPTION
As WSL is easier to install and has a few differences compared to 3 years ago, the Windows installation instructions needed to be tweaked a bit. Ubuntu 20.04 LTS is still the default WSL2 installation, and so the instructions are based on that distribution.

Further, WSL2 is now the Microsoft default with this documented installation method, so this PR also closes #16468. 

@milljm If you get a chance, could you take a look and confirm these instructions work on your Windows box at home? 
