### PR TITLE
Finite Shell Strain - Total Global Strain Fix

### DIFF
--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteShellStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteShellStrain.C
@@ -108,6 +108,9 @@ ADComputeFiniteShellStrain::computeProperties()
       (*_strain_increment[j])[i](2, 0) = (*_strain_increment[j])[i](0, 2);
       (*_strain_increment[j])[i](2, 1) = (*_strain_increment[j])[i](1, 2);
       (*_total_strain[j])[i] = (*_total_strain_old[j])[i] + (*_strain_increment[j])[i];
+      (*_total_global_strain[j])[i] = (*_contravariant_transformation_matrix[j])[i] *
+                                      _unrotated_total_strain *
+                                      (*_contravariant_transformation_matrix[j])[i].transpose();
     }
   }
 }

--- a/modules/tensor_mechanics/src/materials/ADComputeFiniteShellStrain.C
+++ b/modules/tensor_mechanics/src/materials/ADComputeFiniteShellStrain.C
@@ -108,6 +108,9 @@ ADComputeFiniteShellStrain::computeProperties()
       (*_strain_increment[j])[i](2, 0) = (*_strain_increment[j])[i](0, 2);
       (*_strain_increment[j])[i](2, 1) = (*_strain_increment[j])[i](1, 2);
       (*_total_strain[j])[i] = (*_total_strain_old[j])[i] + (*_strain_increment[j])[i];
+      for (unsigned int ii = 0; ii < 3; ++ii)
+        for (unsigned int jj = 0; jj < 3; ++jj)
+          _unrotated_total_strain(ii, jj) = MetaPhysicL::raw_value((*_total_strain[j])[i](ii, jj));
       (*_total_global_strain[j])[i] = (*_contravariant_transformation_matrix[j])[i] *
                                       _unrotated_total_strain *
                                       (*_contravariant_transformation_matrix[j])[i].transpose();


### PR DESCRIPTION
Very small fix in Tensor Mechanics: all I've done is added the total global strain conversion to ADComputeFiniteShellStrain.C.

This was thankfully pointed out by @neuphris [here](https://github.com/idaholab/moose/discussions/22460#discussioncomment-3963151), but doesn't appear to have been added to master yet.

Without the total global strain conversion, the global strains remain at zero, which messes a lot of our work up. The code for the conversion is identical to that in [ADComputeIncrementalShellStrain](https://github.com/idaholab/moose/blob/983b61fc7768602c010e223b8b1fa0c8cc128070/modules/tensor_mechanics/src/materials/ADComputeIncrementalShellStrain.C#L259).