### PR TITLE
Test an update to MPICH 4.0.3

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.3 build_0
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 16 %}
+{% set build = 17 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.3 build_0
 
 moose_petsc:
   - moose-petsc 3.16.6

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.11.07" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_2
+ - moose-libmesh 2022.11.07 build_3
 
 moose_python:
  - python 3.9

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -1,42 +1,34 @@
 #### Compilers
 base_mpich:
-  - mpich 4.0.2                                            # [linux]
-  - mpich 4.0.2                                            # [not arm64 and osx]
-  - mpich 4.0.2                                            # [arm64]
+  - mpich 4.0.3
 
 base_mpicc:
-  - mpich-mpicc 4.0.2                                      # [linux]
-  - mpich-mpicc 4.0.2                                      # [not arm64 and osx]
-  - mpich-mpicc 4.0.2                                      # [arm64]
+  - mpich-mpicc 4.0.3
 
 base_mpicxx:
-  - mpich-mpicxx 4.0.2                                     # [linux]
-  - mpich-mpicxx 4.0.2                                     # [not arm64 and osx]
-  - mpich-mpicxx 4.0.2                                     # [arm64]
+  - mpich-mpicxx 4.0.3
 
 base_mpifort:
-  - mpich-mpifort 4.0.2                                     # [linux]
-  - mpich-mpifort 4.0.2                                     # [not arm64 and osx]
-  - mpich-mpifort 4.0.2                                     # [arm64]
+  - mpich-mpifort 4.0.3
 
 moose_libgfortran:
-  - libgfortran-ng 12.1.0 h69a702a_16                       # [linux]
-  - libgfortran 5.0.0 9_3_0_h6c81a4c_23                     # [not arm64 and osx]
-  - libgfortran 5.0.0.dev0 11_0_1_hf114ba7_23               # [arm64]
+  - libgfortran-ng 12.2.0 h69a702a_19                       # [linux]
+  - libgfortran 5.0.0 9_5_0_h97931a8_26                     # [not arm64 and osx]
+  - libgfortran 5.0.0 11_3_0_hd922786_26                    # [arm64]
 
 moose_libgfortran5:
-  - libgfortran5 12.1.0 hdcd56e2_16                         # [linux]
-  - libgfortran5 9.3.0 h6c81a4c_23                          # [not arm64 and osx]
-  - libgfortran5 11.0.1.dev0 hf114ba7_23                    # [arm64]
+  - libgfortran5 12.2.0 h337968e_19                         # [linux]
+  - libgfortran5 11.3.0 h082f757_26                         # [not arm64 and osx]
+  - libgfortran5 11.3.0 hdaf2cc0_26                         # [arm64]
 
 moose_ld64:                                                 # [osx]
   - ld64 609                                                # [not arm64 and osx]
   - ld64_osx-arm64 609                                      # [arm64]
 
 moose_hdf5:
-  - hdf5 1.12.1 mpi_mpich_hfd824e9_4                        # [not arm64 and osx]
-  - hdf5 1.12.1 mpi_mpich_h08b82f9_4                        # [linux]
-  - hdf5 1.12.1 mpi_mpich_hfc22502_3                        # [arm64]
+  - hdf5 1.12.1 mpi_mpich_h611ac81_4                        # [not arm64 and osx]
+  - hdf5 1.12.1 mpi_mpich_h5d83325_4                        # [linux]
+  - hdf5 1.12.1 mpi_mpich_hc830fdb_4                        # [arm64]
 
 mpi:
   - moose-mpich

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -5,9 +5,9 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 6 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "4.0.2" %}
+{% set version = "4.0.3" %}
 
 package:
   name: moose-mpich

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.3 build_0
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 5 %}
+{% set build = 6 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_2
+ - moose-libmesh 2022.11.07 build_3
 
 moose_python:
  - python 3.9

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -3,7 +3,7 @@
 #   template/ (must contain any python major.minor version this
 #              package is building. Usually the latest version.)
 {% set build = 0 %}
-{% set version = "2022.12.05" %}
+{% set version = "2022.12.15" %}
 
 package:
   name: moose-test-tools

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   template/ (must contain any python major.minor version this
 #              package is building. Usually the latest version.)
 {% set build = 0 %}
-{% set version = "2022.12.05" %}
+{% set version = "2022.12.15" %}
 
 package:
   name: moose-tools
@@ -27,7 +27,7 @@ requirements:
     - mock
     - pylatexenc
     - python
-    - clang-tools 12.0.1
+    - clang-tools 14.0.6
 
 test:
   commands:
@@ -44,7 +44,7 @@ about:
   license: LGPL 2.1
   summary: >
     This superficial module (moose-tools) acts as a top-level module designed to provide all
-    dependencies required in order to run the TestHarness, clang-format, and create MOOSE 
+    dependencies required in order to run the TestHarness, clang-format, and create MOOSE
     Documentation.
 
 extra:


### PR DESCRIPTION
Bumping to 4.0.3 means bumping clang to 14.0.6 with GCC remaining at 10.4.0.

Closes #22993 
