### PR TITLE
Add and emit moose enum docs

### DIFF
--- a/framework/include/outputs/formatters/YAMLFormatter.h
+++ b/framework/include/outputs/formatters/YAMLFormatter.h
@@ -37,6 +37,8 @@ public:
                                   short depth,
                                   const std::string & search_string,
                                   bool & found) override;
+  template <typename T>
+  void addEnumOptionsAndDocs(std::ostringstream & oss, T & param, const std::string & indent);
 
 protected:
   bool _dump_mode;

--- a/framework/include/utils/JsonSyntaxTree.h
+++ b/framework/include/utils/JsonSyntaxTree.h
@@ -81,7 +81,8 @@ public:
 
 protected:
   std::string buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p,
-                           bool & out_of_range_allowed);
+                           bool & out_of_range_allowed,
+                           std::map<MooseEnumItem, std::string> & docs);
 
   size_t setParams(InputParameters * params, bool search_match, nlohmann::json & all_params);
 

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -98,7 +98,7 @@ public:
   void addDocumentation(const std::string & name, const std::string & doc);
 
   /**
-   * Get the item documentation map
+   * Get the map containing each item's documentation string
    */
   const std::map<MooseEnumItem, std::string> & getItemDocumentation() const;
 
@@ -162,6 +162,6 @@ protected:
   /// Flag to enable enumeration items not previously defined
   bool _allow_out_of_range;
 
-  /// The map of deprecated names and optional replacements
+  /// The map of items and their respective documentation strings
   std::map<MooseEnumItem, std::string> _item_documentation;
 };

--- a/framework/include/utils/MooseEnumBase.h
+++ b/framework/include/utils/MooseEnumBase.h
@@ -92,6 +92,16 @@ public:
    */
   const std::set<MooseEnumItem> & items() const { return _items; }
 
+  /**
+   * Add an item documentation string
+   */
+  void addDocumentation(const std::string & name, const std::string & doc);
+
+  /**
+   * Get the item documentation map
+   */
+  const std::map<MooseEnumItem, std::string> & getItemDocumentation() const;
+
   ///@{
   /**
    * Locate an item.
@@ -151,4 +161,7 @@ protected:
 
   /// Flag to enable enumeration items not previously defined
   bool _allow_out_of_range;
+
+  /// The map of deprecated names and optional replacements
+  std::map<MooseEnumItem, std::string> _item_documentation;
 };

--- a/framework/src/outputs/formatters/YAMLFormatter.C
+++ b/framework/src/outputs/formatters/YAMLFormatter.C
@@ -100,19 +100,41 @@ YAMLFormatter::printParams(const std::string & prefix,
     std::string group_name = params.getGroupName(iter.first);
     if (!group_name.empty())
       oss << "'" << group_name << "'";
+    oss << "\n";
 
     if (params.have_parameter<MooseEnum>(name))
-      oss << "\n" << indent << "    options: " << params.get<MooseEnum>(name).getRawNames();
+      addEnumOptionsAndDocs(oss, params.get<MooseEnum>(name), indent);
     if (params.have_parameter<MultiMooseEnum>(name))
-      oss << "\n" << indent << "    options: " << params.get<MultiMooseEnum>(name).getRawNames();
+      addEnumOptionsAndDocs(oss, params.get<MultiMooseEnum>(name), indent);
+    if (params.have_parameter<ExecFlagEnum>(name))
+      addEnumOptionsAndDocs(oss, params.get<ExecFlagEnum>(name), indent);
     if (params.have_parameter<std::vector<MooseEnum>>(name))
-      oss << "\n"
-          << indent << "    options: " << params.get<std::vector<MooseEnum>>(name)[0].getRawNames();
+      addEnumOptionsAndDocs(oss, params.get<std::vector<MooseEnum>>(name)[0], indent);
 
-    oss << "\n" << indent << "    description: |\n      " << indent << doc << std::endl;
+    oss << indent << "    description: |\n      " << indent << doc << std::endl;
   }
 
   return oss.str();
+}
+
+template <typename T>
+void
+YAMLFormatter::addEnumOptionsAndDocs(std::ostringstream & oss,
+                                     T & param,
+                                     const std::string & indent)
+{
+  oss << indent << "    options: " << param.getRawNames() << '\n';
+  const auto & docs = param.getItemDocumentation();
+  if (!docs.empty())
+  {
+    oss << indent << "    option_docs:\n";
+    for (const auto & doc : docs)
+    {
+      oss << indent << "    - name: " << doc.first.name() << "\n";
+      oss << indent << "      description: |\n";
+      oss << indent << "        " << doc.second << "\n";
+    }
+  }
 }
 
 std::string

--- a/framework/src/userobject/Terminator.C
+++ b/framework/src/userobject/Terminator.C
@@ -39,6 +39,11 @@ Terminator::validParams()
                                "when the termination condition is triggered");
 
   MooseEnum errorLevel("INFO WARNING ERROR NONE", "INFO");
+  errorLevel.addDocumentation("INFO", "Output an information message once.");
+  errorLevel.addDocumentation("WARNING", "Output a warning message once.");
+  errorLevel.addDocumentation("ERROR",
+                              "Throw a MOOSE error, resulting in the termination of the run.");
+  errorLevel.addDocumentation("NONE", "No message will be printed.");
   params.addParam<MooseEnum>(
       "error_level",
       errorLevel,

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -131,9 +131,19 @@ JsonSyntaxTree::setParams(InputParameters * params, bool search_match, nlohmann:
       param_json["default"] = params->defaultCoupledValue(iter.first);
 
     bool out_of_range_allowed = false;
-    param_json["options"] = buildOptions(iter, out_of_range_allowed);
+    std::map<MooseEnumItem, std::string> docs;
+    param_json["options"] = buildOptions(iter, out_of_range_allowed, docs);
     if (!nlohmann::to_string(param_json["options"]).empty())
+    {
       param_json["out_of_range_allowed"] = out_of_range_allowed;
+      if (!docs.empty())
+      {
+        nlohmann::json jdocs;
+        for (const auto & doc : docs)
+          jdocs[doc.first.name()] = doc.second;
+        param_json["option_docs"] = jdocs;
+      }
+    }
     auto reserved_values = params->reservedValues(iter.first);
     for (const auto & reserved : reserved_values)
       param_json["reserved_values"].push_back(reserved);
@@ -234,45 +244,46 @@ JsonSyntaxTree::addParameters(const std::string & parent,
 
 std::string
 JsonSyntaxTree::buildOptions(const std::iterator_traits<InputParameters::iterator>::value_type & p,
-                             bool & out_of_range_allowed)
+                             bool & out_of_range_allowed,
+                             std::map<MooseEnumItem, std::string> & docs)
 {
   libMesh::Parameters::Value * val = MooseUtils::get(p.second);
 
   std::string options;
   {
-    InputParameters::Parameter<MooseEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<MooseEnum> *>(val);
+    auto * enum_type = dynamic_cast<InputParameters::Parameter<MooseEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
       options = enum_type->get().getRawNames();
+      docs = enum_type->get().getItemDocumentation();
     }
   }
   {
-    InputParameters::Parameter<MultiMooseEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<MultiMooseEnum> *>(val);
+    auto * enum_type = dynamic_cast<InputParameters::Parameter<MultiMooseEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
       options = enum_type->get().getRawNames();
+      docs = enum_type->get().getItemDocumentation();
     }
   }
   {
-    InputParameters::Parameter<ExecFlagEnum> * enum_type =
-        dynamic_cast<InputParameters::Parameter<ExecFlagEnum> *>(val);
+    auto * enum_type = dynamic_cast<InputParameters::Parameter<ExecFlagEnum> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = enum_type->get().isOutOfRangeAllowed();
       options = enum_type->get().getRawNames();
+      docs = enum_type->get().getItemDocumentation();
     }
   }
   {
-    InputParameters::Parameter<std::vector<MooseEnum>> * enum_type =
-        dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum>> *>(val);
+    auto * enum_type = dynamic_cast<InputParameters::Parameter<std::vector<MooseEnum>> *>(val);
     if (enum_type)
     {
       out_of_range_allowed = (enum_type->get())[0].isOutOfRangeAllowed();
       options = (enum_type->get())[0].getRawNames();
+      docs = enum_type->get()[0].getItemDocumentation();
     }
   }
   return options;

--- a/framework/src/utils/MooseEnumBase.C
+++ b/framework/src/utils/MooseEnumBase.C
@@ -171,6 +171,21 @@ MooseEnumBase::getIDs() const
   return out;
 }
 
+void
+MooseEnumBase::addDocumentation(const std::string & name, const std::string & doc)
+{
+  auto it = find(name);
+  if (it == _items.end())
+    mooseError("Item '", name, "' not found in addDocumentation.");
+  _item_documentation[*it] = doc;
+}
+
+const std::map<MooseEnumItem, std::string> &
+MooseEnumBase::getItemDocumentation() const
+{
+  return _item_documentation;
+}
+
 std::set<MooseEnumItem>::const_iterator
 MooseEnumBase::find(const std::string & name) const
 {


### PR DESCRIPTION
Closes #23004

The  JSON for the `error_level` parameter in `Terminator`  now looks like this:

```
              "error_level": {
                "basic_type": "String",
                "controllable": false,
                "cpp_type": "MooseEnum",
                "default": "INFO",
                "deprecated": false,
                "description": "The error level for the message. A level of ERROR will always lead to a hard termination of the entire simulation.",
                "group_name": "",
                "name": "error_level",
                "option_docs": {
                  "ERROR": "Throw a MOOSE error, resulting in the termination of the run.",
                  "INFO": "Output an information message once.",
                  "NONE": "No message will be printed.",
                  "WARNING": "Output a warning message once."
                },
                "options": "INFO WARNING ERROR NONE",
                "out_of_range_allowed": false,
                "required": false
              },
```