### PR TITLE
Make PiecewiseBilinear::parse a static function

### DIFF
--- a/framework/include/functions/PiecewiseBilinear.h
+++ b/framework/include/functions/PiecewiseBilinear.h
@@ -63,6 +63,11 @@ public:
   virtual Real value(Real t, const Point & pt) const override;
   virtual ADReal value(const ADReal & t, const ADPoint & pt) const override;
 
+  static void parse(const std::string & data_file_name,
+                    std::vector<Real> & x,
+                    std::vector<Real> & y,
+                    ColumnMajorMatrix & z);
+
 private:
   std::unique_ptr<BilinearInterpolation> _bilinear_interp;
   const std::string _data_file_name;
@@ -77,6 +82,4 @@ private:
 
   template <typename T, typename P>
   T valueInternal(T t, const P & p) const;
-
-  void parse(std::vector<Real> & x, std::vector<Real> & y, ColumnMajorMatrix & z);
 };

--- a/framework/include/functions/PiecewiseBilinear.h
+++ b/framework/include/functions/PiecewiseBilinear.h
@@ -40,11 +40,10 @@ class BilinearInterpolation;
  *
  *     z has to be x.size() by y.size()
  *
- * PiecewisBilinear also sends samples to BilinearInterpolation.  These samples are the z-coordinate
- * of the current
- * integration point, and the current value of time.  The name of the file that contains this data
- * has to be included
- * in the function block of the inpute file like this...data_file = example.csv.
+ * PiecewiseBilinear also sends samples to BilinearInterpolation.  These samples are the
+ * z-coordinate of the current integration point, and the current value of time.  The name of the
+ * file that contains this data has to be included in the function block of the input file like
+ * this...data_file = example.csv.
  */
 class PiecewiseBilinear : public Function
 {
@@ -63,10 +62,19 @@ public:
   virtual Real value(Real t, const Point & pt) const override;
   virtual ADReal value(const ADReal & t, const ADPoint & pt) const override;
 
+  /**
+   * Parse a text/CSV file to fill two-dimensional data
+   * @param data_file_name the name of the file to read
+   * @param x vector of the first dimension coordinates
+   * @param y vector of the second dimension coordinates
+   * @param z matrix holding the two-dimensional data
+   * @param object_name the name of the object calling this routine
+   */
   static void parse(const std::string & data_file_name,
                     std::vector<Real> & x,
                     std::vector<Real> & y,
-                    ColumnMajorMatrix & z);
+                    ColumnMajorMatrix & z,
+                    const std::string & object_name);
 
 private:
   std::unique_ptr<BilinearInterpolation> _bilinear_interp;

--- a/framework/src/functions/PiecewiseBilinear.C
+++ b/framework/src/functions/PiecewiseBilinear.C
@@ -77,7 +77,7 @@ PiecewiseBilinear::PiecewiseBilinear(const InputParameters & parameters)
         parameters.isParamValid("z"))
       mooseError("In PiecewiseBilinear: Cannot specify 'data_file' and 'x', 'y', or 'z' together.");
     else
-      parse(x, y, z);
+      parse(_data_file_name, x, y, z);
   }
 
   else if (!(parameters.isParamValid("x") && parameters.isParamValid("y") &&
@@ -151,11 +151,14 @@ PiecewiseBilinear::valueInternal(T t, const P & p) const
 }
 
 void
-PiecewiseBilinear::parse(std::vector<Real> & x, std::vector<Real> & y, ColumnMajorMatrix & z)
+PiecewiseBilinear::parse(const std::string & data_file_name,
+                         std::vector<Real> & x,
+                         std::vector<Real> & y,
+                         ColumnMajorMatrix & z)
 {
-  std::ifstream file(_data_file_name.c_str());
+  std::ifstream file(data_file_name.c_str());
   if (!file.good())
-    paramError("data_file", "Error opening file '", _data_file_name, "'.");
+    ::mooseError("Error opening file '", data_file_name, "'.");
 
   std::size_t num_lines = 0;
   std::size_t num_cols = libMesh::invalid_uint;
@@ -167,20 +170,19 @@ PiecewiseBilinear::parse(std::vector<Real> & x, std::vector<Real> & y, ColumnMaj
   {
     num_lines++;
     if (!MooseUtils::tokenizeAndConvert<double>(line, line_data, ", "))
-      paramError("data_file", "Error parsing file '", _data_file_name, "' on line ", num_lines);
+      ::mooseError("Error parsing file '", data_file_name, "' on line ", num_lines);
 
     data.insert(data.end(), line_data.begin(), line_data.end());
 
     if (num_cols == libMesh::invalid_uint)
       num_cols = line_data.size();
     else if (line_data.size() != num_cols + 1)
-      paramError("data_file",
-                 "Read ",
-                 line_data.size(),
-                 " columns of data but expected ",
-                 num_cols + 1,
-                 " columns in line ",
-                 num_lines);
+      ::mooseError("Read ",
+                   line_data.size(),
+                   " columns of data but expected ",
+                   num_cols + 1,
+                   " columns in line ",
+                   num_lines);
   }
 
   x.resize(num_cols);
@@ -203,5 +205,5 @@ PiecewiseBilinear::parse(std::vector<Real> & x, std::vector<Real> & y, ColumnMaj
   }
 
   if (data.size() != offset)
-    paramError("data_file", "Inconsistency in data read from '", _data_file_name, "'.");
+    ::mooseError("Inconsistency in data read from '", data_file_name, "'.");
 }

--- a/framework/src/functions/PiecewiseBilinear.C
+++ b/framework/src/functions/PiecewiseBilinear.C
@@ -77,7 +77,7 @@ PiecewiseBilinear::PiecewiseBilinear(const InputParameters & parameters)
         parameters.isParamValid("z"))
       mooseError("In PiecewiseBilinear: Cannot specify 'data_file' and 'x', 'y', or 'z' together.");
     else
-      parse(_data_file_name, x, y, z);
+      parse(_data_file_name, x, y, z, name());
   }
 
   else if (!(parameters.isParamValid("x") && parameters.isParamValid("y") &&
@@ -154,11 +154,12 @@ void
 PiecewiseBilinear::parse(const std::string & data_file_name,
                          std::vector<Real> & x,
                          std::vector<Real> & y,
-                         ColumnMajorMatrix & z)
+                         ColumnMajorMatrix & z,
+                         const std::string & object_name)
 {
   std::ifstream file(data_file_name.c_str());
   if (!file.good())
-    ::mooseError("Error opening file '", data_file_name, "'.");
+    ::mooseError(object_name, " : Error opening file '", data_file_name, "'.");
 
   std::size_t num_lines = 0;
   std::size_t num_cols = libMesh::invalid_uint;
@@ -170,14 +171,15 @@ PiecewiseBilinear::parse(const std::string & data_file_name,
   {
     num_lines++;
     if (!MooseUtils::tokenizeAndConvert<double>(line, line_data, ", "))
-      ::mooseError("Error parsing file '", data_file_name, "' on line ", num_lines);
+      ::mooseError(object_name, " : Error parsing file '", data_file_name, "' on line ", num_lines);
 
     data.insert(data.end(), line_data.begin(), line_data.end());
 
     if (num_cols == libMesh::invalid_uint)
       num_cols = line_data.size();
     else if (line_data.size() != num_cols + 1)
-      ::mooseError("Read ",
+      ::mooseError(object_name,
+                   " : Read ",
                    line_data.size(),
                    " columns of data but expected ",
                    num_cols + 1,
@@ -205,5 +207,5 @@ PiecewiseBilinear::parse(const std::string & data_file_name,
   }
 
   if (data.size() != offset)
-    ::mooseError("Inconsistency in data read from '", data_file_name, "'.");
+    ::mooseError(object_name, " : Inconsistency in data read from '", data_file_name, "'.");
 }


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

closes #23023 

## Reason

To be able to use the same parse method in other classes. 

## Design

`data_file_name` becomes method parameter and `paramError` become `mooseError`

## Impact

Line numbers of input errors are not emitted in error handling. 


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
