### PR TITLE
Renaming variable names in Simulation to avoid ambiguity

### DIFF
--- a/modules/thermal_hydraulics/include/base/Simulation.h
+++ b/modules/thermal_hydraulics/include/base/Simulation.h
@@ -201,7 +201,7 @@ public:
   /**
    * Get the ThermalHydraulicsApp
    */
-  ThermalHydraulicsApp & getApp() { return _app; }
+  ThermalHydraulicsApp & getApp() { return _thm_app; }
 
   /**
    * Check the integrity of the simulation
@@ -251,7 +251,7 @@ public:
     ControlData<T> * data = nullptr;
     if (_control_data.find(name) == _control_data.end())
     {
-      data = new ControlData<T>(_app, name);
+      data = new ControlData<T>(_thm_app, name);
       _control_data[name] = data;
     }
     else
@@ -335,16 +335,16 @@ protected:
     std::set<SubdomainName> _subdomain;
     Real _scaling_factor;
   };
-  THMMesh & _mesh;
+  THMMesh & _thm_mesh;
 
   /// Pointer to FEProblem representing this simulation
   FEProblemBase & _fe_problem;
 
   /// The application this is associated with
-  ThermalHydraulicsApp & _app;
+  ThermalHydraulicsApp & _thm_app;
 
   /// The Factory associated with the MooseApp
-  Factory & _factory;
+  Factory & _thm_factory;
 
   /// List of components in this simulation
   std::vector<std::shared_ptr<Component>> _components;
@@ -374,7 +374,7 @@ protected:
   std::map<std::string, ICInfo> _ics;
 
   /// "Global" of this simulation
-  const InputParameters & _pars;
+  const InputParameters & _thm_pars;
 
   /// finite element type for the flow in the simulation
   FEType _flow_fe_type;


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
See issue #23037, this pull request fixes the member variable ambiguity in THMProblem.

## Design
<!--A concise description (design) of the enhancement.-->
Use different variable names in `Simulation` to avoid variable ambiguity in `THMProblem`, which inherits from both `FEProblem` and `Simulation`.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Avoid variables ambiguity in `THMProblem` and classes inherited from `THMProblem`.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
Closes #23037