### PR TITLE
Shield MMS testing from MPI issues, point users to their mpirun 

### DIFF
--- a/test/tests/fvkernels/mms/harmonic_interpolation/test.py
+++ b/test/tests/fvkernels/mms/harmonic_interpolation/test.py
@@ -4,7 +4,7 @@ from mooseutils import fuzzyEqual
 
 class TestHarmonicTriangles(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=harmonic', mpi=1)
+        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=harmonic')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
 
@@ -21,7 +21,7 @@ class TestHarmonicTriangles(unittest.TestCase):
 
 class TestAverageTriangles(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=average', mpi=1)
+        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=average')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,
@@ -37,7 +37,7 @@ class TestAverageTriangles(unittest.TestCase):
 
 class TestHarmonicQuads(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('diffusion.i', 4, 'FVKernels/diff/coeff_interp_method=harmonic Mesh/gen_mesh/elem_type=QUAD', mpi=1)
+        df1 = mms.run_spatial('diffusion.i', 4, 'FVKernels/diff/coeff_interp_method=harmonic Mesh/gen_mesh/elem_type=QUAD')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,
@@ -53,7 +53,7 @@ class TestHarmonicQuads(unittest.TestCase):
 
 class TestAverageQuads(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=average Mesh/gen_mesh/elem_type=QUAD', mpi=1)
+        df1 = mms.run_spatial('diffusion.i', 5, 'FVKernels/diff/coeff_interp_method=average Mesh/gen_mesh/elem_type=QUAD')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,

--- a/test/tests/fvkernels/mms/skewness-correction/adv-diff-react/test.py
+++ b/test/tests/fvkernels/mms/skewness-correction/adv-diff-react/test.py
@@ -4,7 +4,7 @@ from mooseutils import fuzzyEqual
 
 class TestAverageStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=average', mpi=1)
+        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=average')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,
@@ -20,7 +20,7 @@ class TestAverageStencil(unittest.TestCase):
 
 class TestSkewnessCorrectedStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected', mpi=1)
+        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,
@@ -36,7 +36,7 @@ class TestSkewnessCorrectedStencil(unittest.TestCase):
 
 class TestSkewnessCorrectedDiffAdvStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected FVKernels/advection/advected_interp_method=skewness-corrected', mpi=1)
+        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected FVKernels/advection/advected_interp_method=skewness-corrected')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,

--- a/test/tests/fvkernels/mms/skewness-correction/diffusion/test.py
+++ b/test/tests/fvkernels/mms/skewness-correction/diffusion/test.py
@@ -4,7 +4,7 @@ from mooseutils import fuzzyEqual
 
 class TestAverageStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=average', mpi=1)
+        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=average')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,
@@ -20,7 +20,7 @@ class TestAverageStencil(unittest.TestCase):
 
 class TestSkewnessCorrectedStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected', mpi=1)
+        df1 = mms.run_spatial('skewed.i', 5, 'Variables/v/face_interp_method=skewness-corrected')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,

--- a/test/tests/fvkernels/mms/skewness-correction/two_term_extrapol/test.py
+++ b/test/tests/fvkernels/mms/skewness-correction/two_term_extrapol/test.py
@@ -4,7 +4,7 @@ from mooseutils import fuzzyEqual
 
 class TestSkewnessCorrectedStencil(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('advection-outflow.i', 5, 'Variables/v/face_interp_method=skewness-corrected', mpi=1)
+        df1 = mms.run_spatial('advection-outflow.i', 5, 'Variables/v/face_interp_method=skewness-corrected')
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,

--- a/test/tests/misc/mpi_setup/tests
+++ b/test/tests/misc/mpi_setup/tests
@@ -1,0 +1,9 @@
+[Tests]
+  [basic_mpirun_works]
+    type = RunCommand
+    command = 'mpirun -n 2 hostname'
+    requirement = "The system's test suite shall verify that the parallel environment is at least minimally working."
+    issues = '#22635'
+    design = 'MooseUtils.md'
+  []
+[]


### PR DESCRIPTION
This has come up at least twice on discussions now. 

Users have a broken mpi (often the gethostbythename macos failure) and find out about it running the finite volume MMS testing

EDIT: I initially modified the mooseUtils to not call mpi if it was called with mpi=1
I changed that because it s a little unexpected, especially in the context of scaling studies
