### PR TITLE
Set Eigen3_DIR when activating a moose-libmesh env

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.2 build_7
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 16 %}
+{% set build = 17 %}
 {% set vtk_version = "9.1.0" %}
 {% set vtk_friendly_version = "9.1" %}
 {% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}

--- a/conda/libmesh/build.sh
+++ b/conda/libmesh/build.sh
@@ -66,12 +66,14 @@ make -j $CORES
 make install
 sed_replace
 
-# Set LIBMESH_DIR environment variable for those that need it
+# Set LIBMESH_DIR, Eigen3_DIR
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
 export LIBMESH_DIR=${PREFIX}/libmesh
+export Eigen3_DIR=${PREFIX}/libmesh/include/Eigen
 EOF
+# Unset previously set variables
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
 unset LIBMESH_DIR
-unset MOOSE_NO_CODESIGN
+unset Eigen3_DIR
 EOF

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.2 build_7
 
 moose_petsc:
   - moose-petsc 3.16.6

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,9 +2,9 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 3 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2022.11.07" %}
+{% set version = "2023.01.09" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2022.11.07" %}
 {% set vtk_friendly_version = "9.1" %}

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_2
+ - moose-libmesh 2022.11.07 build_3
 
 moose_python:
  - python 3.9

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_3
+ - moose-libmesh 2023.01.09 build_0
 
 moose_python:
  - python 3.9

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -5,7 +5,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 6 %}
+{% set build = 7 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_6
+  - moose-mpich 4.0.2 build_7
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 5 %}
+{% set build = 6 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_2
+ - moose-libmesh 2022.11.07 build_3
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2022.11.07 build_3
+ - moose-libmesh 2023.01.09 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=3f05f40f4a45060c1fd07281f8869a4667086291
+ARG LIBMESH_REV=a476dcb36d78923b9d2ed13b937b388f00da77f4
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2023_01.md
+++ b/modules/doc/content/newsletter/2023_01.md
@@ -1,0 +1,44 @@
+# MOOSE Newsletter (January 2023)
+
+!alert! construction title=In Progress
+This MOOSE Newsletter edition is in progress. Please check back in February 2023
+for a complete description of all MOOSE changes.
+!alert-end!
+
+## MOOSE Improvements
+
+## libMesh-level Changes
+
+### `2023.01.09` Update
+
+- Added `Elem::orient()` method, to automatically reorder "flipped"
+  elements that would otherwise have a negative Jacobian.
+- Added `MeshTools::Modification::orient_elements()` method, to
+  automatically reorder any and all "flipped" elements in an entire
+  mesh.
+- Changed `GhostingFunctor::map_type` definition, to shorten +
+  optimize `SparsityPattern` construction code.  Typical matrix
+  initialization speed is unchanged, common initialization cases are
+  approximately 50% faster, and worst-case initialization benchmarks
+  are 800% faster.
+- libMesh now only prints its own error messages from exceptions which
+  are not caught.  Higher-level code catching error exceptions can
+  choose whether to print their messages or not.
+- Mesh refinement support for Prism21 elements
+- `SIDE_HIERARCHIC` finite element support for prisms, higher shape
+  function orders on hexes
+- Added `Pyramid18` geometry and `Lagrange` basis support
+- Nemesis files now support named blocks, sidesets, and nodesets
+- Added a flag to control whether nodal quadrature is allowed in pyramids
+- Compatibility fixes for MFFD with PETSc 3.18.1
+- Replaced deprecated-by-OSX `sprintf()` calls with proper C++
+- Added `NodeElem` implementations for `contains_point()` and
+  `close_to_point()`
+- Added `PetscVector::pointwise_divide()`
+- `Xdr` now accepts any `std::string_view` compatible comment
+- Bug fixes for Abaqus I/O, Tri7 refinement, `L2_HIERARCHIC` shapes on
+  Tri3, and an unnecessary header inclusion
+
+## PETSc-level Changes
+
+## Bug Fixes and Minor Enhancements

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -311,7 +311,9 @@ class ApptainerGenerator:
             # No luck, we're still screwed
             if not alt_exists:
                 self.error(f'Alternate container dependency {uri} not found')
-        if not prod_exists and self.args.alt_dep_tag is None:
+        if (not prod_exists
+           and self.args.alt_dep_tag is None
+           and self.args.alt_dep_tag_prefix is None):
             self.error(f'Remote container dependency {uri} not found')
 
         self.print(f'Using remote dependency for {name} from {uri}')

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -38,3 +38,8 @@ c722ea3ae20406f0fec795fbf20953d618652f94: # 22945
   petsc: 830572b
   libmesh: a9719c0
   moose: b477fc6
+4771df768ef7c09168f109ccf150643572a0f601: # 23070
+  mpich: b896b5d
+  petsc: 64a9a7e
+  libmesh: 7a3c41a
+  moose: 821a87d

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -1,7 +1,6 @@
 # Add paths relative to repository root that should be taken into account when generating a hash
 packages:
   mpich:
-    - scripts/apptainer_generator.py
     - apptainer/mpich.def
     - conda/mpich/meta.yaml
     - conda/mpich/conda_build_config.yaml


### PR DESCRIPTION
At the request of Cardinal, set a convenient variable so Cardinal users do not have to.

Closes #23069
