### PR TITLE
Ensure PATH gets set in /etc/environment for Docker images

### DIFF
--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -152,6 +152,8 @@ git submodule init
 # Add needed env vars to /etc/environment
 #-----------------------------------------------------------------------------#
 USER root
-RUN for CURR_VAR in $(env | grep 'CC\|CXX\|_DIR'); do \
+
+RUN : > /etc/environment ; \
+for CURR_VAR in $(env | grep '^CC\|^CXX\|_DIR\|^PATH'); do \
     echo "$CURR_VAR" >> /etc/environment ; \
 done


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
The Ubuntu base image has `PATH` in `/etc/environment` by default, but in Rocky Linux, that file is empty.  Downstream, we use `sed` to add the herd code directory to `PATH`, which doesn't work without there being a placeholder.  The Docker env vars don't load over SSH, which is why we have this workaround.

## Design
<!--A concise description (design) of the enhancement.-->
Ensure `/etc/environment` is emptied, then dump the variables we care about.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
No impact to the framework.  Closes #23085.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
