### PR TITLE
outputMeshInformation: print skip_partitioning

### DIFF
--- a/framework/src/outputs/ConsoleUtils.C
+++ b/framework/src/outputs/ConsoleUtils.C
@@ -120,10 +120,16 @@ outputMeshInformation(FEProblemBase & problem, bool verbose)
     oss << std::setw(console_field_width)
         << "  Num Subdomains: " << static_cast<std::size_t>(mesh.n_subdomains()) << '\n';
     if (mesh.n_processors() > 1)
+    {
       oss << std::setw(console_field_width)
           << "  Num Partitions: " << static_cast<std::size_t>(mesh.n_partitions()) << '\n'
           << std::setw(console_field_width) << "  Partitioner: " << moose_mesh.partitionerName()
           << (moose_mesh.isPartitionerForced() ? " (forced) " : "") << '\n';
+      if (mesh.skip_partitioning())
+        oss << std::setw(console_field_width) << "  Skipping all partitioning!" << '\n';
+      else if (mesh.skip_noncritical_partitioning())
+        oss << std::setw(console_field_width) << "  Skipping noncritical partitioning!" << '\n';
+    }
   }
 
   oss << std::endl;


### PR DESCRIPTION
## Reason
There are a number of places in the code and in input files where partitioning can be disabled, and just reporting "Partitioner: metis" is misleading if we're not actually using the partitioner.

Refs #4532, for which I'm currently stripping the third layer of partitioning-disabling workaround off a test case...

## Design
Test `skip_partitioning()` and `skip_noncritical_partitioning()` and print results when mesh information is being printed to console.

## Impact
No API changes.