### PR TITLE
Include MetaPhysicL parallelism headers before use

### DIFF
--- a/modules/contact/include/utils/MortarContactUtils.h
+++ b/modules/contact/include/utils/MortarContactUtils.h
@@ -13,6 +13,9 @@
 
 #include "FEProblemBase.h"
 
+#include "metaphysicl/parallel_dualnumber.h"
+#include "metaphysicl/parallel_semidynamicsparsenumberarray.h"
+
 #include "timpi/parallel_sync.h"
 #include "timpi/communicator.h"
 


### PR DESCRIPTION
We must be getting these indirectly somehow, but indirectly doesn't seem to be good enough for the upcoming Packing<tuple> bugfixes.

Fixes #23204 - at least at the MOOSE level