### PR TITLE
Remove valgrind testing of flow-over-circle

### DIFF
--- a/modules/navier_stokes/examples/flow-over-circle/tests
+++ b/modules/navier_stokes/examples/flow-over-circle/tests
@@ -9,6 +9,7 @@
     cli_args = 'refinement=2 Executioner/end_time=2e-3 Outputs/file_base=flow_over_circle_out'
     ad_indexing_type = global
     mesh_mode = replicated
+    valgrind = 'none'
   []
   [vortex_shedding-action]
     type = 'CSVDiff'
@@ -18,5 +19,6 @@
     cli_args = 'refinement=2 Executioner/end_time=2e-3 Outputs/file_base=flow_over_circle-action_out'
     ad_indexing_type = global
     mesh_mode = replicated
+    valgrind = 'none'
   []
 []


### PR DESCRIPTION
PR #22130 may have slowed these down slightly, and so we should profile these examples before and after to see what might have changed. Anyway, these examples don't hit lines of code that our regular regression tests do not so valgrind testing is extraneous