### PR TITLE
Revert "Fixed periods breaking path in testharness"

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -927,7 +927,7 @@ class TestHarness:
         exec_suffix = 'Windows' if platform.system() == 'Windows' else ''
         self.executable = app_name + '-' + self.options.method + exec_suffix
         # if the executable has a slash - assume it is a file path
-        if '/' or './' in app_name:
+        if '/' in app_name:
             self.executable = os.path.abspath(self.executable)
         # look for executable in PATH - if not there, check other places.
         elif shutil.which(self.executable) is None:


### PR DESCRIPTION
Reverts idaholab/moose#23131

This logic is bad. I think it meant to be:

```
if '/' in app_name or './' in app_name
```

because the condition `if '/'` means nothing... but the new code doesn't make any sense because the second condition will always be satisfied by the first.

@socratesgorilla any comment? This breaks https://civet.inl.gov/job/1311959/, so I'm going to revert it unless you have a quick solution.