### PR TITLE
remove non existent methods from ViscoPlasticityStressUpdate

### DIFF
--- a/modules/tensor_mechanics/include/materials/ViscoplasticityStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/ViscoplasticityStressUpdateBase.h
@@ -118,9 +118,7 @@ protected:
   using ViscoplasticityStressUpdateBaseTempl<is_ad>::_porosity_old;                                \
   using ViscoplasticityStressUpdateBaseTempl<is_ad>::updateIntermediatePorosity;                   \
   using ViscoplasticityStressUpdateBaseTempl<is_ad>::computeStressFinalize;                        \
-  using ViscoplasticityStressUpdateBaseTempl<is_ad>::computeStressInitialize;                      \
-  using ViscoplasticityStressUpdateBaseTempl<is_ad>::computeResidual;                              \
-  using ViscoplasticityStressUpdateBaseTempl<is_ad>::computeDerivative
+  using ViscoplasticityStressUpdateBaseTempl<is_ad>::computeStressInitialize
 
 typedef ViscoplasticityStressUpdateBaseTempl<false> ViscoplasticityStressUpdateBase;
 typedef ViscoplasticityStressUpdateBaseTempl<true> ADViscoplasticityStressUpdateBase;


### PR DESCRIPTION
Removes wrong members included in `usingViscoplasticityStressUpdateBaseMembers` introduced by #23219 
Ref #23218 
