### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #   moose/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.01.09" %}
+{% set version = "2023.01.24" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.01.09 build_0
+ - moose-libmesh 2023.01.24 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.01.09 build_0
+ - moose-libmesh 2023.01.24 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=a476dcb36d78923b9d2ed13b937b388f00da77f4
+ARG LIBMESH_REV=482ca36f0ba05dbb5d87d02688d43eaa4bf983eb
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2023/2023_01.md
+++ b/modules/doc/content/newsletter/2023/2023_01.md
@@ -55,6 +55,23 @@ center values.
 - Bug fixes for Abaqus I/O, Tri7 refinement, `L2_HIERARCHIC` shapes on
   Tri3, and an unnecessary header inclusion
 
+### `2023.01.24` Update
+
+- Fixes and workarounds for NVidia HPC SDK compiler warnings.  These
+  compilers are not yet recommended for use, since at least one
+  optimizer bug is keeping their builds from passing our full test
+  suite, but we do hope to have them in CI testing this year.
+- Any `libmesh_*FLAGS` settings given to libMesh configure are now
+  passed downstream to software like MOOSE via `libmesh-config`
+- Compilation fixes for MetaPhysicL under some configurations
+- TIMPI `Packing<std::string>` now uses the same `buffer_type` as all
+  the other built-in `Packing` specializations, allowing automatic
+  packed-range operations of composite datatypes including string data
+  without requiring workarounds like `vector<char>`.
+- Major bugfix for TIMPI `Packing<std::tuple<...>>`
+- More test coverage for parallel operations on MetaPhysicL
+  datatypes using TIMPI methods.
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
* Fixes and workarounds for NVidia HPC SDK compiler warnings.  These
  compilers are not yet recommended for use, since at least one
  optimizer bug is keeping their builds from passing our full test
  suite, but we do hope to have them in CI testing this year.
* Any `libmesh_*FLAGS` settings given to libMesh configure are now
  passed downstream to software like MOOSE via `libmesh-config`
* Compilation fixes for MetaPhysicL under some configurations
* TIMPI `Packing<std::string>` now uses the same `buffer_type` as all
  the other built-in `Packing` specializations, allowing automatic
  packed-range operations of composite datatypes including string data
  without requiring workarounds like `vector<char>`.
* Major bugfix for TIMPI `Packing<std::tuple<...>>`
* More test coverage for parallel operations on MetaPhysicL
  datatypes using TIMPI methods.
