### PR TITLE
Allow MOOSE_DIR to be treated like an app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,7 @@ modules/reactor/test/tests/meshgenerators/patterned_hex_mesh_generator/positions
 
 # Ignore share directory
 share/
+
+# Ignore vscode local parameters
+.vscode/*
+

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -14,6 +14,9 @@
 {#- TEST_DIRS: Directories to test in the %test section; defaults to just "tests"             -#}
 {#- EXTRA_MAMBA_PACKAGES: Extra mamba packages to install                                     -#}
 
+{#- Civet Specific jinja arguments                                                            -#}
+{#- allowed_to_fail: BOOL, specific to Civet. Only available in %post, %test section          -#}
+
 {#- Optional Application specific jinja arguments                                             -#}
 {#- SECTION_ENVIRONMENT: Adds additional environment variables set upon entering container    -#}
 {#- SECTION_POST: Partially replaces %post (make, make install, section)                      -#}
@@ -116,6 +119,10 @@ From: {{ APPTAINER_FROM }}
     MOOSE_PREFIX=/opt/${BINARY_NAME}
 {%- endif %}
     cd ${MOOSE_DIR}
+{%- if allowed_to_fail is defined %}
+    # CIVET allowed_to_fail is True
+    set +e
+{%- endif %}
 {%- if SECTION_POST_PRE_CONFIGURE is defined %}
     {{ SECTION_POST_PRE_CONFIGURE }}
 {%- endif %}
@@ -143,6 +150,11 @@ From: {{ APPTAINER_FROM }}
 {%- if SECTION_POST_POST_MAKEINSTALL is defined %}
     {{ SECTION_POST_POST_MAKEINSTALL }}
 {%- endif %}
+{%- if allowed_to_fail is defined %}
+    # CIVET allowed_to_fail not allowed for remainder steps
+{%- endif %}
+    # force error shell behavior for remainder steps
+    set -e
     # Fix permissions for installed application
     chmod -R o=u-w,g=u-w ${MOOSE_PREFIX}
 
@@ -166,6 +178,8 @@ From: {{ APPTAINER_FROM }}
     rm -rf $TEMP_LOC
 
 %test
+    # Force error shell behavior
+    set -e
     # Load jinja vars
 {%- if SECTION_TEST_PRE is defined %}
     {{ SECTION_TEST_PRE }}
@@ -191,12 +205,17 @@ From: {{ APPTAINER_FROM }}
         cd $TEMP_LOC
         ${BINARY_NAME}-${METHOD} --copy-inputs $TEST_DIR
         cd ${BINARY_NAME}/${TEST_DIR}
+{%- if allowed_to_fail is defined %}
+        # CIVET allowed_to_fail is True
+        set +e
+{%- endif %}
         ${BINARY_NAME}-${METHOD} --run -j ${MOOSE_JOBS:-1} -t
-        TEST_RETURN_CODE=$?
+{%- if allowed_to_fail is defined %}
+        # CIVET allowed_to_fail not allowed for remainder steps
+{%- endif %}
+        # force error shell behavior for remainder steps
+        set -e
         rm -rf $TEMP_LOC
-        if [ ${TEST_RETURN_CODE} != 0 ]; then
-          exit ${TEST_RETURN_CODE}
-        fi
     done
 {%- if SECTION_TEST_POST is defined %}
     {{ SECTION_TEST_POST }}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -182,11 +182,12 @@ From: {{ APPTAINER_FROM }}
     TEMP_LOC=$(mktemp -u -d /tmp/${BINARY_NAME}test.XXXXXX)
     # Really make sure that we nuke the temp location in all circumstances
     trap "if [ -e $TEMP_LOC ]; then rm -rf $TEMP_LOC; fi" EXIT HUP INT TERM
-
+{%- if SECTION_TEST_PRE_TEST is defined %}
+    {{ SECTION_TEST_PRE_TEST }}
+{%- endif %}
     # Copy and run each subset of tests
-{%- if SECTION_TEST is not defined %}
     for TEST_DIR in ${TEST_DIRS}; do
-        mkdir $TEMP_LOC
+        mkdir -p $TEMP_LOC
         cd $TEMP_LOC
         ${BINARY_NAME}-${METHOD} --copy-inputs $TEST_DIR
         cd ${BINARY_NAME}/${TEST_DIR}
@@ -197,9 +198,6 @@ From: {{ APPTAINER_FROM }}
           exit ${TEST_RETURN_CODE}
         fi
     done
-{%- else %}
-    {{ SECTION_TEST }}
-{%- endif %}
 {%- if SECTION_TEST_POST is defined %}
     {{ SECTION_TEST_POST }}
 {%- endif %}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -71,9 +71,8 @@ From: {{ APPTAINER_FROM }}
     MOOSE_DOCS_FLAGS="{{ MOOSE_DOCS_FLAGS }}"
     export MOOSE_JOBS={{ MOOSE_JOBS or "1" }}
     MOOSE_OPTIONS="{{ MOOSE_OPTIONS }}"
-    MOOSE_SKIP_DOCS={{ MOOSE_SKIP_DOCS }}
+    export MOOSE_SKIP_DOCS={{ MOOSE_SKIP_DOCS }}
     TEMP_LOC={{ ROOT_BUILD_DIR }}
-
     APPLICATION_DIR=${TEMP_LOC}/${APPLICATION_NAME}
     export MOOSE_DIR=${TEMP_LOC}/moose
 
@@ -102,7 +101,7 @@ From: {{ APPTAINER_FROM }}
     ./configure --prefix=$MOOSE_PREFIX ${MOOSE_OPTIONS}
 
     # Build and install
-{%- if BINARY_NAME is 'moose_combined' %}
+{%- if BINARY_NAME == 'moose_combined' %}
     cd ${APPLICATION_DIR}/modules
 {%- else %}
     cd ${APPLICATION_DIR}
@@ -118,9 +117,9 @@ From: {{ APPTAINER_FROM }}
     mamba uninstall -yq ${EXTRA_DOC_PACKAGES}
 {%- endif %}
 
-# Create moose-opt symlink to combined-opt
-{%- if BINARY_NAME is 'moose_combined' %}
-    cd /opt/moose/bin
+{%- if BINARY_NAME == 'moose_combined' %}
+    # Create moose-opt symlink to combined-opt
+    cd /opt/moose_combined/bin
     ln combined-opt moose-opt
 {%- endif %}
 
@@ -132,7 +131,7 @@ From: {{ APPTAINER_FROM }}
 
 %test
     # Load jinja vars
-{%- if BINARY_NAME is 'moose_combined' %}
+{%- if BINARY_NAME == 'moose_combined' %}
     BINARY_NAME=combined
 {%- else %}
     BINARY_NAME={{ BINARY_NAME }}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -14,6 +14,11 @@
 {#- TEST_DIRS: Directories to test in the %test section; defaults to just "tests"             -#}
 {#- EXTRA_MAMBA_PACKAGES: Extra mamba packages to install                                     -#}
 
+{#- Optional Application specific jinja arguments                                             -#}
+{#- SECTION_ENVIRONMENT: Adds additional environment variables set upon entering container    -#}
+{#- SECTION_POST: Partially replaces %post (make, make install, section)                      -#}
+{#- SECTION_TEST: Partially replaces %test (for loop section)                                 -#}
+
 {#- The within-container build directory to use                                               -#}
 {%- set ROOT_BUILD_DIR = '/root/build' -%}
 
@@ -66,6 +71,9 @@ From: {{ APPTAINER_FROM }}
 {%- else %}
     export PATH=/opt/{{ BINARY_NAME }}/bin:$PATH
 {%- endif %}
+{%- if SECTION_ENVIRONMENT is defined %}
+    {{ SECTOIN_ENVIRONMENT }}
+{%- endif %}
 %post
     # Load jinja vars
     APPLICATION_NAME=$(basename {{ APPLICATION_DIR }})
@@ -113,9 +121,12 @@ From: {{ APPTAINER_FROM }}
 {%- else %}
     cd ${APPLICATION_DIR}
 {%- endif %}
+{%- if SECTION_POST is not defined %}
     make -j ${MOOSE_JOBS} METHOD=${METHOD}
     make install -j ${MOOSE_JOBS} MOOSE_SKIP_DOCS=${MOOSE_SKIP_DOCS} MOOSE_DOCS_FLAGS="${MOOSE_DOCS_FLAGS}" METHOD=${METHOD}
-
+{%- else %}
+    {{ SECTION_POST }}
+{%- endif %}
     # Fix permissions for installed application
     chmod -R o=u-w,g=u-w ${MOOSE_PREFIX}
 
@@ -152,6 +163,7 @@ From: {{ APPTAINER_FROM }}
     trap "if [ -e $TEMP_LOC ]; then rm -rf $TEMP_LOC; fi" EXIT HUP INT TERM
 
     # Copy and run each subset of tests
+{%- if SECTION_TEST is not defined %}
     for TEST_DIR in ${TEST_DIRS}; do
         mkdir $TEMP_LOC
         cd $TEMP_LOC
@@ -164,3 +176,6 @@ From: {{ APPTAINER_FROM }}
           exit ${TEST_RETURN_CODE}
         fi
     done
+{%- else %}
+    {{ SECTION_TEST }}
+{%- endif %}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -45,6 +45,10 @@ From: {{ APPTAINER_FROM }}
     if [[ $MOOSE_RELATIVE_PATH = ..* ]]; then
         mkdir ${MOOSE_BUILD_DIR}
         cp -r ${MOOSE_DIR}/. ${MOOSE_BUILD_DIR}
+    # MOOSE_DIR is the application (combined-opt)
+    elif [[ '{{ BINARY_NAME }}' == 'moose_combined' ]]; then
+        # do nothing
+        :
     # MOOSE_DIR is in the application, setup a symlink
     else
         ln -s ./${APPLICATION_NAME}/${MOOSE_RELATIVE_PATH} ${MOOSE_BUILD_DIR}
@@ -98,7 +102,11 @@ From: {{ APPTAINER_FROM }}
     ./configure --prefix=$MOOSE_PREFIX ${MOOSE_OPTIONS}
 
     # Build and install
+{%- if BINARY_NAME is 'moose_combined' %}
+    cd ${APPLICATION_DIR}/modules
+{%- else %}
     cd ${APPLICATION_DIR}
+{%- endif %}
     make -j ${MOOSE_JOBS} METHOD=${METHOD}
     make install -j ${MOOSE_JOBS} MOOSE_SKIP_DOCS=${MOOSE_SKIP_DOCS} MOOSE_DOCS_FLAGS="${MOOSE_DOCS_FLAGS}" METHOD=${METHOD}
 
@@ -110,6 +118,12 @@ From: {{ APPTAINER_FROM }}
     mamba uninstall -yq ${EXTRA_DOC_PACKAGES}
 {%- endif %}
 
+# Create moose-opt symlink to combined-opt
+{%- if BINARY_NAME is 'moose_combined' %}
+    cd /opt/moose/bin
+    ln combined-opt moose-opt
+{%- endif %}
+
     # Install moose-tools from moose-base container
     source /root/install_moose_tools.sh
 
@@ -118,7 +132,11 @@ From: {{ APPTAINER_FROM }}
 
 %test
     # Load jinja vars
+{%- if BINARY_NAME is 'moose_combined' %}
+    BINARY_NAME=combined
+{%- else %}
     BINARY_NAME={{ BINARY_NAME }}
+{%- endif %}
     METHOD={{ METHOD or "opt" }}
     TEST_DIRS={{ TEST_DIRS or "tests" }}
 

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -46,7 +46,7 @@ From: {{ APPTAINER_FROM }}
         mkdir ${MOOSE_BUILD_DIR}
         cp -r ${MOOSE_DIR}/. ${MOOSE_BUILD_DIR}
     # MOOSE_DIR is the application (combined-opt)
-    elif [[ '{{ BINARY_NAME }}' == 'moose_combined' ]]; then
+    elif [[ '{{ BINARY_NAME }}' == 'moose-combined' ]]; then
         # do nothing
         :
     # MOOSE_DIR is in the application, setup a symlink
@@ -61,8 +61,11 @@ From: {{ APPTAINER_FROM }}
 {%- endif %}
 
 %environment
+{%- if BINARY_NAME == 'moose-combined' %}
+    export PATH=/opt/moose/bin:$PATH
+{%- else %}
     export PATH=/opt/{{ BINARY_NAME }}/bin:$PATH
-
+{%- endif %}
 %post
     # Load jinja vars
     APPLICATION_NAME=$(basename {{ APPLICATION_DIR }})
@@ -96,12 +99,16 @@ From: {{ APPTAINER_FROM }}
 {%- endif %}
 
     # Setup install
+{%- if BINARY_NAME == 'moose-combined' %}
+    MOOSE_PREFIX=/opt/moose
+{%- else %}
     MOOSE_PREFIX=/opt/${BINARY_NAME}
+{%- endif %}
     cd ${MOOSE_DIR}
     ./configure --prefix=$MOOSE_PREFIX ${MOOSE_OPTIONS}
 
     # Build and install
-{%- if BINARY_NAME == 'moose_combined' %}
+{%- if BINARY_NAME == 'moose-combined' %}
     cd ${APPLICATION_DIR}/modules
 {%- else %}
     cd ${APPLICATION_DIR}
@@ -117,10 +124,10 @@ From: {{ APPTAINER_FROM }}
     mamba uninstall -yq ${EXTRA_DOC_PACKAGES}
 {%- endif %}
 
-{%- if BINARY_NAME == 'moose_combined' %}
+{%- if BINARY_NAME == 'moose-combined' %}
     # Create moose-opt symlink to combined-opt
-    cd /opt/moose_combined/bin
-    ln combined-opt moose-opt
+    cd /opt/moose/bin
+    ln -s combined-opt moose-opt
 {%- endif %}
 
     # Install moose-tools from moose-base container
@@ -131,7 +138,7 @@ From: {{ APPTAINER_FROM }}
 
 %test
     # Load jinja vars
-{%- if BINARY_NAME == 'moose_combined' %}
+{%- if BINARY_NAME == 'moose-combined' %}
     BINARY_NAME=combined
 {%- else %}
     BINARY_NAME={{ BINARY_NAME }}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -76,6 +76,9 @@ From: {{ APPTAINER_FROM }}
 {%- endif %}
 %post
     # Load jinja vars
+{%- if SECTION_POST_PRE is defined %}
+    {{ SECTION_POST_PRE }}
+{%- endif %}
     APPLICATION_NAME=$(basename {{ APPLICATION_DIR }})
     BINARY_NAME={{ BINARY_NAME }}
     METHOD={{ METHOD or "opt" }}
@@ -113,19 +116,32 @@ From: {{ APPTAINER_FROM }}
     MOOSE_PREFIX=/opt/${BINARY_NAME}
 {%- endif %}
     cd ${MOOSE_DIR}
+{%- if SECTION_POST_PRE_CONFIGURE is defined %}
+    {{ SECTION_POST_PRE_CONFIGURE }}
+{%- endif %}
     ./configure --prefix=$MOOSE_PREFIX ${MOOSE_OPTIONS}
-
+{%- if SECTION_POST_POST_CONFIGURE is defined %}
+    {{ SECTION_POST_POST_CONFIGURE }}
+{%- endif %}
     # Build and install
 {%- if BINARY_NAME == 'moose-combined' %}
     cd ${APPLICATION_DIR}/modules
 {%- else %}
     cd ${APPLICATION_DIR}
 {%- endif %}
-{%- if SECTION_POST is not defined %}
+{%- if SECTION_POST_PRE_MAKE is defined %}
+    {{ SECTION_POST_PRE_MAKE }}
+{%- endif %}
     make -j ${MOOSE_JOBS} METHOD=${METHOD}
+{%- if SECTION_POST_POST_MAKE is defined %}
+    {{ SECTION_POST_POST_MAKE }}
+{%- endif %}
+{%- if SECTION_POST_PRE_MAKEINSTALL is defined %}
+    {{ SECTION_POST_PRE_MAKEINSTALL }}
+{%- endif %}
     make install -j ${MOOSE_JOBS} MOOSE_SKIP_DOCS=${MOOSE_SKIP_DOCS} MOOSE_DOCS_FLAGS="${MOOSE_DOCS_FLAGS}" METHOD=${METHOD}
-{%- else %}
-    {{ SECTION_POST }}
+{%- if SECTION_POST_POST_MAKEINSTALL is defined %}
+    {{ SECTION_POST_POST_MAKEINSTALL }}
 {%- endif %}
     # Fix permissions for installed application
     chmod -R o=u-w,g=u-w ${MOOSE_PREFIX}
@@ -143,12 +159,17 @@ From: {{ APPTAINER_FROM }}
 
     # Install moose-tools from moose-base container
     source /root/install_moose_tools.sh
-
+{%- if SECTION_POST_POST is defined %}
+    {{ SECTION_POST_POST }}
+{%- endif %}
     # Cleanup
     rm -rf $TEMP_LOC
 
 %test
     # Load jinja vars
+{%- if SECTION_TEST_PRE is defined %}
+    {{ SECTION_TEST_PRE }}
+{%- endif %}
 {%- if BINARY_NAME == 'moose-combined' %}
     BINARY_NAME=combined
 {%- else %}
@@ -178,4 +199,7 @@ From: {{ APPTAINER_FROM }}
     done
 {%- else %}
     {{ SECTION_TEST }}
+{%- endif %}
+{%- if SECTION_TEST_POST is defined %}
+    {{ SECTION_TEST_POST }}
 {%- endif %}

--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -72,7 +72,7 @@ From: {{ APPTAINER_FROM }}
     export PATH=/opt/{{ BINARY_NAME }}/bin:$PATH
 {%- endif %}
 {%- if SECTION_ENVIRONMENT is defined %}
-    {{ SECTOIN_ENVIRONMENT }}
+    {{ SECTION_ENVIRONMENT }}
 {%- endif %}
 %post
     # Load jinja vars

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -401,7 +401,7 @@ class ApptainerGenerator:
         # Add your sections here (be sure to modify apptainer/app.def to match)
         section_meta = {'environment': [],
                         'post': ['configure', 'make', 'makeinstall'],
-                        'test': []}
+                        'test': ['test']}
         for section_key, actions in section_meta.items():
             file_list = self.create_filename(app_root, section_key, actions)
             for (a_section, file_path) in file_list:

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -357,13 +357,11 @@ class ApptainerGenerator:
         then the contents therein will be either replaced, or exchanged
         where appropriate
         """
-        app_apptainer = os.path.join(app_root, 'apptainer')
-        if os.path.exists(app_apptainer):
-            sections = ['environment', 'post', 'test']
-            for a_section in sections:
-                if os.path.exists(os.path.join(app_apptainer, f'{a_section}.sh')):
-                    with open(os.path.join(app_apptainer, f'{a_section}.sh'), 'r') as s_file:
-                        jinja_data[f'SECTION_{a_section.upper()}'] = s_file.read()
+        for a_section in ['environment.sh', 'post.sh', 'test.sh']:
+            section_file = os.path.join(app_root, 'apptainer', a_section)
+            if os.path.exists(section_file):
+                with open(section_file, 'r') as s_file:
+                    jinja_data[f'SECTION_{a_section.upper()}'] = s_file.read()
 
     def add_definition_vars(self, jinja_data):
         """

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -357,10 +357,10 @@ class ApptainerGenerator:
         then the contents therein will be either replaced, or exchanged
         where appropriate
         """
-        for a_section in ['environment.sh', 'post.sh', 'test.sh']:
+        for a_section in ['environment', 'post', 'test']:
             section_file = os.path.join(app_root, 'apptainer', a_section)
-            if os.path.exists(section_file):
-                with open(section_file, 'r') as s_file:
+            if os.path.exists(f'{section_file}.sh'):
+                with open(f'{section_file}.sh', 'r') as s_file:
                     jinja_data[f'SECTION_{a_section.upper()}'] = s_file.read()
 
     def add_definition_vars(self, jinja_data):

--- a/scripts/tests/test_versioner.py
+++ b/scripts/tests/test_versioner.py
@@ -103,9 +103,8 @@ class Test(unittest.TestCase):
 
     def testGetApp(self):
         app_name, git_root, git_hash = Versioner.get_app()
-        self.assertEqual(None, app_name)
-        self.assertEqual(None, git_root)
-        self.assertEqual(None, git_hash)
+        self.assertEqual('moose_combined', app_name)
+        self.assertEqual(MOOSE_DIR, git_root)
 
         # still need to test _in_ an app
 

--- a/scripts/tests/test_versioner.py
+++ b/scripts/tests/test_versioner.py
@@ -103,7 +103,7 @@ class Test(unittest.TestCase):
 
     def testGetApp(self):
         app_name, git_root, git_hash = Versioner.get_app()
-        self.assertEqual('moose_combined', app_name)
+        self.assertEqual('moose-combined', app_name)
         self.assertEqual(MOOSE_DIR, git_root)
 
         # still need to test _in_ an app

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -62,7 +62,7 @@ ca1ef9908ae19ffafd84a5d32317b9ad71fd3f17: # 21791
   petsc: 64a9a7e
   libmesh: 7a3c41a
   moose: 244eb80
-4f9901787263e5a9558a89c13aebe656dd7fffe2: # 23247
+7dc8c372a4a3861e7e0050845a6c96c429730258: # 23247
   mpich: b896b5d
   petsc: 64a9a7e
   libmesh: d53146c

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -1,3 +1,17 @@
+# When a change to any Apptainer/Conda influential file is detected, it is necessary
+# to append the `library : hash` so unittests remain valid throughout history. You
+# can ignore entering a hash for the literal 'app' (it will match rev-parse HEAD)
+#
+# Influential files are determined by Civet Precheck (informational):
+# `scripts/versioner.py app --yaml`
+#
+# Know what libraries you need to enter a hash for by running:
+# `scripts/versioner.py -h`
+#
+# Modify versioner_hashes.yaml (this file) using format:
+# `git rev-parse HEAD`: # PR_NUMBER
+#   library: `scripts/versioner.py library`
+
 a5b8705d07eadbb30b983afea4aef74fb6a14266: # 20735
   libmesh: 570a4af
   petsc: 2dbe810
@@ -48,3 +62,8 @@ ca1ef9908ae19ffafd84a5d32317b9ad71fd3f17: # 21791
   petsc: 64a9a7e
   libmesh: 7a3c41a
   moose: 244eb80
+f7f0eeb266eeadbd6d46f53d73dccfe8ad389287: # 23247
+  mpich: b896b5d
+  petsc: 64a9a7e
+  libmesh: d53146c
+  moose: 2f8ef66

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -62,7 +62,7 @@ ca1ef9908ae19ffafd84a5d32317b9ad71fd3f17: # 21791
   petsc: 64a9a7e
   libmesh: 7a3c41a
   moose: 244eb80
-f7f0eeb266eeadbd6d46f53d73dccfe8ad389287: # 23247
+4f9901787263e5a9558a89c13aebe656dd7fffe2: # 23247
   mpich: b896b5d
   petsc: 64a9a7e
   libmesh: d53146c

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -212,10 +212,6 @@ class Versioner:
     @staticmethod
     def get_app():
         """ gets the current application name/dir/commit the cwd is in, if any """
-        # If we're nested within MOOSE_DIR, we're not within an app
-        if (os.getcwd() + os.sep).startswith(MOOSE_DIR + os.sep):
-            return None, None, None
-
         # If we're not within a git rep, we're not within an app
         tree_command = ['git', 'rev-parse', '--is-inside-work-tree']
         process = subprocess.run(tree_command, stdout=subprocess.PIPE,
@@ -226,6 +222,10 @@ class Versioner:
         root_command = ['git', 'rev-parse', '--show-toplevel']
         git_root = subprocess.check_output(root_command, encoding='utf-8').rstrip()
         app_name = os.path.basename(git_root).rstrip().lower()
+
+        # If we're nested within MOOSE_DIR, we're moose_combined app
+        if app_name == 'moose':
+            app_name = 'moose_combined'
 
         hash_command = ['git', 'rev-parse', 'HEAD']
         git_hash = subprocess.check_output(hash_command, encoding='utf-8').rstrip()[0:7]

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -225,7 +225,7 @@ class Versioner:
 
         # If we're nested within MOOSE_DIR, we're moose_combined app
         if app_name == 'moose':
-            app_name = 'moose_combined'
+            app_name = 'moose-combined'
 
         hash_command = ['git', 'rev-parse', 'HEAD']
         git_hash = subprocess.check_output(hash_command, encoding='utf-8').rstrip()[0:7]


### PR DESCRIPTION
When calling versioner.py, no longer short circuit the get_app method if ran while inside MOOSE_DIR. Instead, return with a special identifier designating we want to build the combined-opt application.

`./versioner.py moose` remains valid
`./versioner.py app` while inside MOOSE_DIR will no longer fail

