### PR TITLE
Reduce default number of MooseDocs threads to 4 at most

### DIFF
--- a/python/MooseDocs/commands/build.py
+++ b/python/MooseDocs/commands/build.py
@@ -56,7 +56,7 @@ def command_line_options(subparser, parent):
     parser.add_argument('--dump', action='store_true',
                         help="Show page tree to the screen.")
     parser.add_argument('--num-threads', '-j', type=int, choices=range(1,13),
-                        default=int(min(multiprocessing.cpu_count() / 2, 12)),
+                        default=int(min(multiprocessing.cpu_count() / 2, 4)),
                         help="The number of parallel threads to execute with. The max. is twelve.")
     parser.add_argument('--port', default='8000', type=str,
                         help="The host port for live web server (default: %(default)s).")


### PR DESCRIPTION
Closes #23289

