### PR TITLE
Remove inheritance of FunctorBase from FunctorEnvelope

### DIFF
--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -239,11 +239,13 @@ INSFVRhieChowInterpolator::fillARead()
     {
       const Moose::FunctorBase<ADReal> *v_comp, *w_comp;
       if (_dim > 1)
-        v_comp = &UserObject::_subproblem.getFunctor<ADReal>(deduceFunctorName("a_v"), tid, name());
+        v_comp = &static_cast<const Moose::FunctorBase<ADReal> &>(
+            UserObject::_subproblem.getFunctor<ADReal>(deduceFunctorName("a_v"), tid, name()));
       else
         v_comp = &_zero_functor;
       if (_dim > 2)
-        w_comp = &UserObject::_subproblem.getFunctor<ADReal>(deduceFunctorName("a_w"), tid, name());
+        w_comp = &static_cast<const Moose::FunctorBase<ADReal> &>(
+            UserObject::_subproblem.getFunctor<ADReal>(deduceFunctorName("a_w"), tid, name()));
       else
         w_comp = &_zero_functor;
 

--- a/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/PINSFVRhieChowInterpolator.C
@@ -111,7 +111,11 @@ PINSFVRhieChowInterpolator::pinsfvSetup()
 
   const auto saved_do_derivatives = ADReal::do_derivatives;
   ADReal::do_derivatives = true;
-  Moose::FV::interpolateReconstruct(_smoothed_eps, _eps, _smoothing_layers, false, _geometric_fi);
+  Moose::FV::interpolateReconstruct(_smoothed_eps,
+                                    static_cast<const Moose::FunctorBase<ADReal> &>(_eps),
+                                    _smoothing_layers,
+                                    false,
+                                    _geometric_fi);
   ADReal::do_derivatives = saved_do_derivatives;
 
   // Assign the new functor to all


### PR DESCRIPTION
Prevents possible developer error if a new virtual API is added to `FunctorBase` and the developer forgets to `override` in `FunctorEnvelope`. With the inheritance removed, the only "danger" occurs when a developer adds a new public API to `FunctorBase` ... and the "danger" is only that the code won't compile if the developer forgets to add the accompanying public API (that calls the equivalent wrapped functor API) to the wrapper. A compile-time error is much better than possible silent bad run-time behavior.

Closes #23154