### PR TITLE
Fixup deprecated and legacy items in darcy tutorial

### DIFF
--- a/tutorials/darcy_thermo_mech/step01_diffusion/problems/step1.i
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/problems/step1.i
@@ -7,6 +7,8 @@
     xmax = 0.304                  # Length of test chamber
     ymax = 0.0257                 # Test chamber radius
   []
+  coord_type = RZ                 # Axisymmetric RZ
+  rz_coord_axis = X               # Which axis the symmetry is around
 []
 
 [Variables]
@@ -39,8 +41,6 @@
 
 [Problem]
   type = FEProblem  # This is the "normal" type of Finite Element Problem in MOOSE
-  coord_type = RZ   # Axisymmetric RZ
-  rz_coord_axis = X # Which axis the symmetry is around
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/src/base/DarcyThermoMechApp.C
@@ -21,6 +21,7 @@ DarcyThermoMechApp::validParams()
   InputParameters params = MooseApp::validParams();
 
   params.set<bool>("automatic_automatic_scaling") = false;
+  params.set<bool>("use_legacy_material_output") = false;
 
   return params;
 }

--- a/tutorials/darcy_thermo_mech/step01_diffusion/tests/kernels/simple_diffusion/simple_diffusion.i
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/tests/kernels/simple_diffusion/simple_diffusion.i
@@ -5,6 +5,8 @@
     nx = 10
     ny = 10
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -36,8 +38,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/problems/step2.i
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/problems/step2.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables/pressure]
@@ -37,8 +39,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step02_darcy_pressure/tests/kernels/darcy_pressure/darcy_pressure.i
+++ b/tutorials/darcy_thermo_mech/step02_darcy_pressure/tests/kernels/darcy_pressure/darcy_pressure.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -39,8 +41,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/problems/step3.i
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/problems/step3.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables/pressure]
@@ -42,8 +44,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/problems/step3b.i
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/problems/step3b.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables/pressure]
@@ -44,8 +46,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/tests/kernels/darcy_pressure/darcy_pressure.i
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/tests/kernels/darcy_pressure/darcy_pressure.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -46,8 +48,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/tests/materials/packed_column/packed_column.i
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/tests/materials/packed_column/packed_column.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -45,8 +47,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/problems/step4.i
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/problems/step4.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables/pressure]
@@ -59,8 +61,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.i
+++ b/tutorials/darcy_thermo_mech/step04_velocity_aux/tests/auxkernels/velocity_aux/velocity_aux.i
@@ -5,6 +5,8 @@
     nx = 2
     ny = 2
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -45,8 +47,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
   solve = false
 []
 

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5a_steady.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5a_steady.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -46,8 +48,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5b_transient.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -51,8 +53,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5c_outflow.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/problems/step5c_outflow.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -50,8 +52,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step05_heat_conduction/tests/bcs/outflow/outflow.i
+++ b/tutorials/darcy_thermo_mech/step05_heat_conduction/tests/bcs/outflow/outflow.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -50,8 +52,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6a_coupled.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6a_coupled.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -89,8 +91,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6b_transient_inflow.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -105,8 +107,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6c_decoupled.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/problems/step6c_decoupled.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -69,8 +71,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/kernels/darcy_advection/darcy_advection.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/kernels/darcy_advection/darcy_advection.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -61,8 +63,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/materials/packed_column/packed_column.i
+++ b/tutorials/darcy_thermo_mech/step06_coupled_darcy_heat_conduction/tests/materials/packed_column/packed_column.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -45,8 +47,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7a_coarse.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7a_coarse.i
@@ -7,6 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -89,8 +91,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7b_fine.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7b_fine.i
@@ -7,7 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
-
+  coord_type = RZ
+  rz_coord_axis = X
   uniform_refine = 3
 []
 
@@ -91,8 +92,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7c_adapt.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7c_adapt.i
@@ -7,7 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
-
+  coord_type = RZ
+  rz_coord_axis = X
   uniform_refine = 3
 []
 
@@ -92,8 +93,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7d_adapt_blocks.i
+++ b/tutorials/darcy_thermo_mech/step07_adaptivity/problems/step7d_adapt_blocks.i
@@ -16,6 +16,8 @@
     top_right = '0.304 0.01285 0'
     block_id = 1
   []
+  coord_type = RZ
+  rz_coord_axis = X
 []
 
 [Variables]
@@ -119,8 +121,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step08_postprocessors/problems/step8.i
+++ b/tutorials/darcy_thermo_mech/step08_postprocessors/problems/step8.i
@@ -7,7 +7,8 @@
     xmax = 0.304 # Length of test chamber
     ymax = 0.0257 # Test chamber radius
   []
-
+  coord_type = RZ
+  rz_coord_axis = X
   uniform_refine = 2
 []
 
@@ -116,8 +117,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
-  rz_coord_axis = X
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
+++ b/tutorials/darcy_thermo_mech/step09_mechanics/problems/step9.i
@@ -19,6 +19,7 @@
     top_right = '0.01285 0.304 0'
     block_id = 1
   []
+  coord_type = RZ
 []
 
 [Variables]
@@ -178,7 +179,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step11_action/problems/step11.i
+++ b/tutorials/darcy_thermo_mech/step11_action/problems/step11.i
@@ -11,6 +11,7 @@
     ymax = 0.304 # Length of test chamber
     xmax = 0.0257 # Test chamber radius
   []
+  coord_type = RZ
 []
 
 [Variables]
@@ -126,7 +127,6 @@
 
 [Problem]
   type = FEProblem
-  coord_type = RZ
 []
 
 [Executioner]

--- a/tutorials/darcy_thermo_mech/step11_action/src/base/DarcyThermoMechApp.C
+++ b/tutorials/darcy_thermo_mech/step11_action/src/base/DarcyThermoMechApp.C
@@ -21,6 +21,7 @@ DarcyThermoMechApp::validParams()
   InputParameters params = MooseApp::validParams();
 
   params.set<bool>("automatic_automatic_scaling") = false;
+  params.set<bool>("use_legacy_material_output") = false;
 
   return params;
 }


### PR DESCRIPTION
Noticed some deprecated items in the tutorial earlier this week. 

- Problem/coord_type --> Mesh/coord_type
- Problem/rz_coord_axis --> Mesh/rz_coord_axis
- Sets `use_legacy_material_output` to false in DarcyThermoMechApp

Refs #15426
