### PR TITLE
Add moose-opt (combined-opt) INL HPC instructions

### DIFF
--- a/modules/doc/content/getting_started/installation/clone_moose.md
+++ b/modules/doc/content/getting_started/installation/clone_moose.md
@@ -1,8 +1,10 @@
 ## Cloning MOOSE
 
-MOOSE is hosted on [GitHub](https://github.com/idaholab/moose) and should be cloned directly from there using [git](https://git-scm.com/). We recommend creating a directory named projects to put all of your MOOSE related work.
+MOOSE is hosted on [GitHub](https://github.com/idaholab/moose) and should be cloned directly from
+there using [git](https://git-scm.com/). We recommend creating a directory named projects to put all
+of your MOOSE related work.
 
-To install MOOSE run the following commands in a terminal.
+To clone MOOSE, run the following commands in a terminal:
 
 ```bash
 mkdir ~/projects

--- a/modules/doc/content/getting_started/installation/clone_moose.md
+++ b/modules/doc/content/getting_started/installation/clone_moose.md
@@ -1,8 +1,8 @@
 ## Cloning MOOSE
 
 MOOSE is hosted on [GitHub](https://github.com/idaholab/moose) and should be cloned directly from
-there using [git](https://git-scm.com/). We recommend creating a directory named projects to put all
-of your MOOSE related work.
+there using [git](https://git-scm.com/). We recommend creating a directory named "projects" to put
+all of your MOOSE related work.
 
 To clone MOOSE, run the following commands in a terminal:
 

--- a/modules/doc/content/getting_started/installation/index.md
+++ b/modules/doc/content/getting_started/installation/index.md
@@ -1,7 +1,7 @@
 # Install MOOSE
 
 To install the MOOSE Framework, click the link below that corresponds to your operating
-system/platform or your desired method and follow the instructions:
+system, platform, or your desired method and follow the instructions:
 
 - [Linux and MacOS](installation/conda.md)
 - [installation/windows.md]

--- a/modules/doc/content/getting_started/installation/index.md
+++ b/modules/doc/content/getting_started/installation/index.md
@@ -1,6 +1,7 @@
 # Install MOOSE
 
-To install the MOOSE Framework, click the link below that corresponds to your operating system/platform and follow the instructions:
+To install the MOOSE Framework, click the link below that corresponds to your operating
+system/platform or your desired method and follow the instructions:
 
 - [Linux and MacOS](installation/conda.md)
 - [installation/windows.md]
@@ -19,7 +20,8 @@ To install the MOOSE Framework, click the link below that corresponds to your op
 
   - [installation/install_libtorch.md]
 
-Once installation is complete, please proceed to the [getting_started/new_users.md] page to continue.
+With one of the installation methods above complete, please proceed to the
+[getting_started/new_users.md] page to continue.
 
 !include installation/update_moose.md
 

--- a/modules/doc/content/getting_started/installation/index.md
+++ b/modules/doc/content/getting_started/installation/index.md
@@ -5,6 +5,7 @@ To install the MOOSE Framework, click the link below that corresponds to your op
 - [Linux and MacOS](installation/conda.md)
 - [installation/windows.md]
 - [installation/docker.md]
+- [installation/inl_hpc_prebuilt_moose.md]
 - Advanced Instructions:
 
   - [installation/hpc_install_moose.md]

--- a/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
@@ -1,0 +1,90 @@
+# INL HPC Pre-Built MOOSE
+
+While operating on one of our [!ac](INL) [!ac](HPC) clusters, there exists the option of using pre
+built versions of MOOSE. To request access to these clusters, please follow the instructions on
+[INL's Nuclear Computational Resource Center](https://inl.gov/ncrc/) website.
+
+Once access has been granted, log into Sawtooth or Lemhi using either [inl/hpc_ondemand.md]
+Interactive Shell services, or directly by following our [SSH Primer](inl/hpc_remote.md).
+
+!include installation/clone_moose.md
+
+## Load Modules
+
+Load the following modules:
+
+```bash
+module load use.moose moose-apps moose
+```
+
+!alert note
+If you receive an error about modules not known, please make sure you are logged into either
+Sawtooth or Lemhi. We only make a pre-built copies available on these two clusters.
+
+Once loaded, `moose-opt` becomes available. You need now only provide input files to run
+simulations. Example input files are available within the MOOSE repository (next section).
+
+## Run Example
+
+To run `moose-opt` using an example input file from within the MOOSE repository, perform the
+following:
+
+```bash
+cd ~/projects/moose/examples/ex01_inputfile
+moose-opt -i ex01.i
+```
+
+`moose-opt` should run to completion without error. A resulting exodus file is generated in the same
+directory:
+
+```pre
+ex01_out.e
+```
+
+## View Results
+
+You can use HPC OnDemand to view the results file remotely. Head on over to
+[HPC OnDemand Dashboard](https://hpcondemand.inl.gov/pun/sys/dashboard), and select:
+`Interactive Apps` and then `Linux Desktop with Visualization`. Next, select your cluster (such as
+Sawtooth), the amount of time you believe you need, and then click Launch.
+
+It may take some time before your 'Visualization Job' becomes available. When it does, simply click
+on it, and you will be presented within your web browser, your GUI Desktop. From here, you can open
+visualization applications (such as Paraview), and open your results file.
+
+To use Paraview, open a terminal by: Clicking `Applications` at the top left, then click
+`Terminal Emulator`. A terminal window will open. Enter the following commands:
+
+```bash
+module load paraview
+paraview
+```
+
+Paraview should open. From here, you can select `File`, `Open`, and navigate to
+
+```pre
+~/projects/moose/examples/ex01_inputfile
+```
+
+You should see your results file listed (`ex01_out.e`). Double click this file and enjoy the
+results!
+
+In many cases it is more desirable to view results using your local machine. This is done by copying
+result files from the remote machine to your local machine using `scp` or `rsnyc`.
+
+!alert note title=Copying files from remote HPC machine to your machine
+Copying files from an HPC cluster to your machine first requires that you follow the instructions:
+[inl/hpc_remote.md]. This workflow is for advanced users, comfortable with modifying their SSH
+settings, and familiar with their terminal in general.
+
+Example commands you would use with a terminal to copy files from HPC to your local machine's
+Downloads folder:
+
+```bash
+cd ~/Downloads
+scp <your hpc user id>@hpclogin:~/projects/moose/examples/ex01_inputfile/ex01_out.e .
+```
+
+!alert tip
+The `.` at the end is special. Which means "the current directory you are in". The above `.` can be
+replaced with `~/Downloads`, to achieve the same goal.

--- a/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
@@ -1,7 +1,7 @@
 # INL HPC Pre-Built MOOSE
 
-While operating on one of our [!ac](INL) [!ac](HPC) clusters, there exists the option of using pre
-built versions of MOOSE. To request access to these clusters, please follow the instructions on
+While operating on one of the [!ac](INL) [!ac](HPC) clusters, there exists the option of using
+pre-built versions of MOOSE. To request access to these clusters, please follow the instructions on
 [INL's Nuclear Computational Resource Center](https://inl.gov/ncrc/) website.
 
 Once access has been granted, log into Sawtooth or Lemhi using either [inl/hpc_ondemand.md]
@@ -18,7 +18,7 @@ module load use.moose moose-apps moose
 ```
 
 !alert warning
-If you receive an error about modules not known, please make sure you are logged into either
+If you receive an error about modules not being known, please make sure you are logged into either
 Sawtooth or Lemhi.
 
 Once loaded, `moose-opt` becomes available. You need now only provide input files to run
@@ -49,10 +49,10 @@ You can use HPC OnDemand to view the results file remotely. Head on over to
 Sawtooth), the amount of time you believe you need, and then click `Launch`.
 
 It may take some time before your 'Visualization Job' becomes available. When it does, simply click
-on it, and you will be presented within your web browser, your GUI Desktop. From here, you can open
-visualization applications (such as Paraview), and open your results file.
+on it, and you will be presented a [!ac](GUI) desktop within your web browser. From here, you can
+open visualization applications (such as Paraview), and open your results file.
 
-To use Paraview, open a terminal by: Clicking `Applications` at the top left, then click
+To use Paraview, open a terminal by clicking `Applications` at the top left, then click
 `Terminal Emulator`. A terminal window will open. Enter the following commands:
 
 ```bash

--- a/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
+++ b/modules/doc/content/getting_started/installation/inl_hpc_prebuilt_moose.md
@@ -17,9 +17,9 @@ Load the following modules:
 module load use.moose moose-apps moose
 ```
 
-!alert note
+!alert warning
 If you receive an error about modules not known, please make sure you are logged into either
-Sawtooth or Lemhi. We only make a pre-built copies available on these two clusters.
+Sawtooth or Lemhi.
 
 Once loaded, `moose-opt` becomes available. You need now only provide input files to run
 simulations. Example input files are available within the MOOSE repository (next section).
@@ -46,7 +46,7 @@ ex01_out.e
 You can use HPC OnDemand to view the results file remotely. Head on over to
 [HPC OnDemand Dashboard](https://hpcondemand.inl.gov/pun/sys/dashboard), and select:
 `Interactive Apps` and then `Linux Desktop with Visualization`. Next, select your cluster (such as
-Sawtooth), the amount of time you believe you need, and then click Launch.
+Sawtooth), the amount of time you believe you need, and then click `Launch`.
 
 It may take some time before your 'Visualization Job' becomes available. When it does, simply click
 on it, and you will be presented within your web browser, your GUI Desktop. From here, you can open
@@ -84,7 +84,3 @@ Downloads folder:
 cd ~/Downloads
 scp <your hpc user id>@hpclogin:~/projects/moose/examples/ex01_inputfile/ex01_out.e .
 ```
-
-!alert tip
-The `.` at the end is special. Which means "the current directory you are in". The above `.` can be
-replaced with `~/Downloads`, to achieve the same goal.

--- a/modules/doc/content/getting_started/installation/install_conda_moose.md
+++ b/modules/doc/content/getting_started/installation/install_conda_moose.md
@@ -1,13 +1,6 @@
 ## Install MOOSE Conda Packages id=moosepackages
 
-Before we create our virtual conda environment, we first need to initialize mamba.
-For this, execute the following command and +restart your terminal session+.
-
-```bash
-mamba init
-```
-
-Next, create a unique conda environment for moose, named `moose`, and install the moose dependency
+Create a unique conda environment for moose, named `moose`, and install the moose dependency
 packages:
 
 ```bash

--- a/modules/doc/content/getting_started/installation/install_conda_moose.md
+++ b/modules/doc/content/getting_started/installation/install_conda_moose.md
@@ -1,6 +1,6 @@
 ## Install MOOSE Conda Packages id=moosepackages
 
-Create a unique conda environment for moose, named `moose`, and install the moose dependency
+Create a unique conda environment for [!ac](MOOSE), named `moose`, and install the MOOSE dependency
 packages:
 
 ```bash

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -31,7 +31,7 @@ With Mambaforge installed in your home directory, export PATH so that it may be 
 export PATH=$HOME/mambaforge3/bin:$PATH
 ```
 
-Now that we can execute `mamba`, initailize it and then exit the terminal:
+Now that we can execute `mamba`, initialize it and then exit the terminal:
 
 ```bash
 mamba init

--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -1,7 +1,8 @@
-## Install Mambaforge3 id=installconda
 
-Follow the steps below depending on your platform to install mambaforge. If you run into issues during these steps, please visit our [Conda Troubleshooting](help/faq/conda_issues.md optional=True) guide. This installation
-guide relies on the utilization of `mamba`, an optimized package manager for Conda.
+Follow the steps below depending on your platform to install mambaforge. If you run into issues
+during these steps, please visit our [Conda Troubleshooting](help/faq/conda_issues.md optional=True)
+guide. This installation guide relies on the utilization of `mamba`, an optimized package manager
+for Conda.
 
 - +Linux Users:+
 
@@ -24,17 +25,33 @@ guide relies on the utilization of `mamba`, an optimized package manager for Con
   bash Mambaforge-MacOSX-arm64.sh -b -p ~/mambaforge3
   ```
 
-With Mambaforge installed to your home directory, export PATH, so that it may be used:
+With Mambaforge installed in your home directory, export PATH so that it may be used:
 
 ```bash
 export PATH=$HOME/mambaforge3/bin:$PATH
 ```
 
-Configure Conda to work with our INL public channel:
+Now that we can execute `mamba`, initailize it and then exit the terminal:
+
+```bash
+mamba init
+exit
+```
+
+Upon restarting your terminal, you should see your prompt prefixed with (base). This indicates you
+are in the base environment, and Conda is ready for operation:
+
+```bash
+$ (base) ~>
+```
+
+Add [!ac](INL)'s public channel to gain access to [!ac](INL)'s Conda package library:
 
 ```bash
 conda config --add channels https://conda.software.inl.gov/public
 ```
 
-!alert warning title=sudo conda
-If you find yourself using `sudo conda`/`sudo mamba`... something is not right. The most common reason for needing sudo is due to an improper Conda installation. Conda *should* be installed to your home directory, without any use of `sudo`.
+!alert warning title=Do not use sudo
+If you find yourself using `sudo` commands while engaging Conda commands... something is not right.
+The most common reason for needing sudo is due to an improper Conda installation. Conda *should* be
+installed to your home directory, without any use of `sudo`.

--- a/modules/doc/content/getting_started/installation/install_peacock.md
+++ b/modules/doc/content/getting_started/installation/install_peacock.md
@@ -1,0 +1,25 @@
+
+Peacock requires many third party libraries. The easiest way to get these libraries installed is to
+use our `moose-peacock` package available from INL's public Conda channel.
+
+```bash
+conda config --add channels https://conda.software.inl.gov/public
+mamba create -n peacock moose-peacock
+```
+
+!alert note title
+It is safe to ignore a warning about our public channel already among your channel list.
+
+!alert warning title=Separate Environments
+It is important to create a new environment to contain the libraries necessary to run Peacock. Do
+not install `moose-peacock` while inside the `moose` environment (or any environment with
+`moose-libmesh` installed).
+
+Activate the newly created `peacock` environment:
+
+```bash
+mamba activate peacock
+```
+
+!alert note
+When ever you wish to run Peacock, it will be necessary to activate this environment.

--- a/modules/doc/content/getting_started/installation/installation_troubleshooting.md
+++ b/modules/doc/content/getting_started/installation/installation_troubleshooting.md
@@ -1,4 +1,4 @@
-## Install Troubleshooting
+### Install Troubleshooting
 
 Please see the MOOSE [FAQ](help/faq/index.md optional=True) page for common issues. If your issue is not listed, this
 would be an excellent time to visit the

--- a/modules/doc/content/getting_started/installation/manual_installation_gcc.md
+++ b/modules/doc/content/getting_started/installation/manual_installation_gcc.md
@@ -14,7 +14,25 @@
 
 !include manual_mpich_gcc.md
 
-!include getting_started/installation/manual_miniconda.md
+## Python (possibly optional)
+
+Building MOOSE requires having Python headers (python-devel) and the Python package: `packaging`
+available. If you know you have this requirement satisfied, and you do not plan on also using
+Peacock (next section) you can skip this section.
+
+These requirements are easily installed via Conda.
+
+!include getting_started/installation/install_miniconda.md
+
+Next, install the necessary `packaging` module:
+
+```bash
+mamba install packaging
+```
+
+## Peacock (optional)
+
+!include installation/install_peacock.md
 
 ## bash_profile
 
@@ -40,6 +58,7 @@ export CC=mpicc
 export CXX=mpicxx
 export FC=mpif90
 export F90=mpif90
+mamba activate peacock  # if you choose to optionally install Peacock
 !package-end!
 
 Thats it! Now you can either source this file manually each time you need to work on a MOOSE based

--- a/modules/doc/content/getting_started/installation/manual_installation_gcc.md
+++ b/modules/doc/content/getting_started/installation/manual_installation_gcc.md
@@ -14,25 +14,7 @@
 
 !include manual_mpich_gcc.md
 
-## Python (possibly optional)
-
-Building MOOSE requires having Python headers (python-devel) and the Python package: `packaging`
-available. If you know you have this requirement satisfied, and you do not plan on also using
-Peacock (next section) you can skip this section.
-
-These requirements are easily installed via Conda.
-
-!include getting_started/installation/install_miniconda.md
-
-Next, install the necessary `packaging` module:
-
-```bash
-mamba install packaging
-```
-
-## Peacock (optional)
-
-!include installation/install_peacock.md
+!include optional_python_and_peacock.md
 
 ## bash_profile
 
@@ -70,7 +52,6 @@ source /path/to/moose-environment.sh
 
 Or you can permanently have it loaded each time you open a terminal by adding the above `source`
 command in your ~/.bash_profile (or ~/.bashrc which ever your system uses).
-
 
 ## Compiler Stack Finished
 

--- a/modules/doc/content/getting_started/installation/manual_installation_llvm.md
+++ b/modules/doc/content/getting_started/installation/manual_installation_llvm.md
@@ -34,25 +34,7 @@ export LD_LIBRARY_PATH=$PACKAGES_DIR/llvm-__LLVM__/lib:$LD_LIBRARY_PATH
 
 !include manual_mpich_llvm.md
 
-## Python (possibly optional)
-
-Building MOOSE requires having Python headers (python-devel) and the Python package: `packaging`
-available. If you know you have this requirement satisfied, and you do not plan on also using
-Peacock (next section) you can skip this section.
-
-These requirements are easily installed via Conda.
-
-!include getting_started/installation/install_miniconda.md
-
-Next, install the necessary `packaging` module:
-
-```bash
-mamba install packaging
-```
-
-## Peacock (optional)
-
-!include installation/install_peacock.md
+!include optional_python_and_peacock.md
 
 ## bash_profile
 
@@ -91,7 +73,6 @@ source /path/to/moose-environment.sh
 
 Or you can permanently have it loaded each time you open a terminal by adding the above `source`
 command in your ~/.bash_profile (or ~/.bashrc which ever your system uses).
-
 
 ## Compiler Stack Finished
 

--- a/modules/doc/content/getting_started/installation/manual_installation_llvm.md
+++ b/modules/doc/content/getting_started/installation/manual_installation_llvm.md
@@ -34,7 +34,25 @@ export LD_LIBRARY_PATH=$PACKAGES_DIR/llvm-__LLVM__/lib:$LD_LIBRARY_PATH
 
 !include manual_mpich_llvm.md
 
-!include getting_started/installation/manual_miniconda.md
+## Python (possibly optional)
+
+Building MOOSE requires having Python headers (python-devel) and the Python package: `packaging`
+available. If you know you have this requirement satisfied, and you do not plan on also using
+Peacock (next section) you can skip this section.
+
+These requirements are easily installed via Conda.
+
+!include getting_started/installation/install_miniconda.md
+
+Next, install the necessary `packaging` module:
+
+```bash
+mamba install packaging
+```
+
+## Peacock (optional)
+
+!include installation/install_peacock.md
 
 ## bash_profile
 
@@ -61,6 +79,7 @@ export CC=mpicc
 export CXX=mpicxx
 export FC=mpif90
 export F90=mpif90
+mamba activate peacock  # if you choose to optionally install Peacock
 !package-end!
 
 Thats it! Now you can either source this file manually each time you need to work on a MOOSE based

--- a/modules/doc/content/getting_started/installation/optional_python_and_peacock.md
+++ b/modules/doc/content/getting_started/installation/optional_python_and_peacock.md
@@ -1,0 +1,20 @@
+
+## Python (possibly optional)
+
+Building MOOSE requires having Python headers (python-devel) and the Python package: `packaging`
+available. If you know you have this requirement satisfied, and you do not plan on also using
+Peacock (next section) you can skip this section.
+
+These requirements are easily installed via Conda.
+
+!include getting_started/installation/install_miniconda.md
+
+Next, install the necessary `packaging` module:
+
+```bash
+mamba install packaging
+```
+
+## Peacock (optional)
+
+!include installation/install_peacock.md

--- a/modules/doc/content/getting_started/installation/uninstall_conda.md
+++ b/modules/doc/content/getting_started/installation/uninstall_conda.md
@@ -3,6 +3,6 @@
 If you wish to remove the moose environment at any time, you may do so using the following commands:
 
 ```bash
-conda deactivate   # if 'moose' was currently activated
-conda env remove -n moose
+mamba activate base
+mamba env remove -n moose
 ```

--- a/modules/doc/content/getting_started/installation/update_moose.md
+++ b/modules/doc/content/getting_started/installation/update_moose.md
@@ -1,4 +1,4 @@
-## Update MOOSE and Conda id=update
+### Update MOOSE and Conda id=update
 
 MOOSE does not use traditional versioning, is under heavy development, and is being updated
 continuously. Therefore, it is important that you continue to update MOOSE as you use it to develop your
@@ -7,8 +7,8 @@ application(s); weekly updates are recommended.
 If you are using our Conda environment, you should always perform an update to both Conda +and+ your MOOSE repository. If you update one, always update the other:
 
 ```bash
-conda activate moose
-conda update --all
+mamba activate moose
+mamba update --all
 ```
 
 To update your MOOSE repository use the following commands.

--- a/modules/doc/content/help/faq/build_issues.md
+++ b/modules/doc/content/help/faq/build_issues.md
@@ -5,11 +5,11 @@ Build issues are normally caused by an invalid environment, or perhaps an update
 - Verify the Conda Environment is active and up to date, with the latest version of our moose packages:
 
   ```bash
-  conda activate moose
-  conda update --all
+  mamba activate moose
+  mamba update --all
   ```
 
-  if `conda activate moose` failed, see [Conda Issues](troubleshooting.md#condaissues) above.
+  if `mamba activate moose` failed, see [Conda Issues](troubleshooting.md#condaissues) above.
 
   !alert note
   When ever an update is performed in Conda, it is a good idea to re-build MOOSE and your application. While specific updates to moose-libmesh and/or moose-petsc may not have occurred, there are several other libraries out of our control which may have been upgraded, requiring you to rebuild.
@@ -85,7 +85,7 @@ Build issues are normally caused by an invalid environment, or perhaps an update
   mpicxx -fopenmp hello.C
   ```
 
-  If the above build fails, and you have the correct Conda environment loaded (`conda activate moose`), then something is failing beyond the scope of this document, and you should now contact us via the [disussion forum](faq/discussion_forum.md).
+  If the above build fails, and you have the correct Conda environment loaded (`mamba activate moose`), then something is failing beyond the scope of this document, and you should now contact us via the [disussion forum](faq/discussion_forum.md).
 
   If the build was successfull, attempt to execute the hello word example:
 

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -1,7 +1,7 @@
 ## Conda Issues id=condaissues
 
 Conda issues can be the root cause for just about any issue on this page. Scroll through this
-section, for what may look familiar, and follow those instructions:
+section for what may look familiar, and follow those instructions:
 
 - #### 404 error, The channel is not accessible or is invalid.
 
@@ -76,7 +76,7 @@ section, for what may look familiar, and follow those instructions:
   installed (perhaps with sudo rights, or as another user). You should look into removing this
   installation of conda, and starting over with our
   [Getting Started](getting_started/installation/conda.md) instructions. Failures of this nature can
-  also mean your conda resource file (~/.condarc) is in bad shape. We have no way of diagnosing this
+  also mean your conda resource file (`~/.condarc`) is in bad shape. We have no way of diagnosing this
   in a troubleshooting fashion, as this file can contain more than just moose-related configs. For
   reference, the bare minimum should resemble the following:
 
@@ -102,7 +102,7 @@ section, for what may look familiar, and follow those instructions:
 
 - #### Your issue not listed
 
-  The quick fix-attempt, is to delete the faulty environment and re-install it again:
+  The quick fix-attempt, is to delete the faulty environment and re-install it:
 
   ```bash
   mamba activate base

--- a/modules/doc/content/help/faq/conda_issues.md
+++ b/modules/doc/content/help/faq/conda_issues.md
@@ -1,10 +1,12 @@
 ## Conda Issues id=condaissues
 
-Conda issues can be the root cause for just about any issue on this page. Scroll through this section, for what may look familiar, and follow those instructions:
+Conda issues can be the root cause for just about any issue on this page. Scroll through this
+section, for what may look familiar, and follow those instructions:
 
 - #### 404 error, The channel is not accessible or is invalid.
 
-  If you are receiving this, you may be victim of us changing the channel name out from underneath you (Sorry!). Remove the offending channel(s):
+  If you are receiving this, you may be victim of us changing the channel name out from underneath
+  you (Sorry!). Remove the offending channel(s):
 
   ```bash
   conda config --remove channels https://mooseframework.org/conda/moose
@@ -12,7 +14,8 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
   conda config --remove channels https://mooseframework.inl.gov/conda/moose
   ```
 
-  If you receive errors about a channel not present (CondaKeyError), please ignore. You most likely will not have all three 'old' channels. Next, add the correct channel:
+  If you receive errors about a channel not present (CondaKeyError), please ignore. You most likely
+  will not have all three 'old' channels. Next, add the correct channel:
 
   ```bash
   conda config --add channels https://conda.software.inl.gov/public
@@ -28,9 +31,11 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
     - defaults
   ```
 
-- #### command not found: conda
+- #### command not found: mamba
 
-  You have yet to install conda, or your path to it is incorrect or not set. You will need to recall how you installed conda. Our instructions ask to have Mambaforge3 installed to your home directory: `~/mambaforge3`. Which requires you to set your PATH accordingly:
+  You have yet to install conda, or your path to it is incorrect or not set. You will need to recall
+  how you installed conda. Our instructions ask to have Mambaforge3 installed to your home
+  directory: `~/mambaforge3`. Which requires you to set your PATH accordingly:
 
   ```bash
   export PATH=~/mambaforge3/bin:$PATH
@@ -38,46 +43,42 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
 
   With PATH set, try to run again, what ever command you were initially attempting.
 
-- #### conda activate moose
+- #### mamba activate moose
 
-  If `conda activate moose` is failing like so:
+  If `mamba activate moose` is failing like so:
 
   ```bash
-  CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
-  To initialize your shell, run
-
-      $ conda init <SHELL_NAME>
-
-  Currently supported shells are:
-    - bash
-    - fish
-    - tcsh
-    - xonsh
-    - zsh
-    - powershell
-
-  See 'conda init --help' for more information and options.
-
-  IMPORTANT: You may need to close and restart your shell after running 'conda init'.
+  Run 'mamba init' to be able to run mamba activate/deactivate
+  and start a new shell session. Or use conda to activate/deactivate.
   ```
 
-  ...it's possible you have yet to perform a `conda init` *properly*. See conda init below.
+  ...it's possible you have yet to perform a `mamba init`.
 
-  It could also mean you have an older version of Conda, or that the environment you are trying to activate is somewhere other than where conda thinks it should be, or simply missing / not yet created. Unfortunately, much of what can be diagnosed, is going to be beyond the scope of this document, and better left to the support teams at [Conda](https://docs.conda.io/en/latest/help-support.html). What we can attempt, is to create a new environment and go from there:
+  It could also mean you have an older version of Conda, or that the environment you are trying to
+  activate is somewhere other than where conda thinks it should be, or simply missing / not yet
+  created. Unfortunately, much of what can be diagnosed, is going to be beyond the scope of this
+  document, and better left to the support teams at
+  [Conda](https://docs.conda.io/en/latest/help-support.html). What we can attempt, is to create a
+  new environment and go from there:
 
   ```bash
-  conda create -n testing -q -y
+  mamba create -n testing -q -y
   ```
 
   The above should create an empty environment. Try and activate it:
 
   ```bash
-  conda activate testing
+  mamba activate testing
   ```
 
-  If the above is asking you to initialize conda, see `conda init` below.
-
-  If the command failed, or the `conda create` command before it, the error will likely be involved with how Conda was first installed (perhaps with sudo rights, or as another user). You should look into removing this installation of conda, and starting over with our [Getting Started](getting_started/installation/conda.md) instructions. Failures of this nature can also mean your conda resource file (~/.condarc) is in bad shape. We have no way of diagnosing this in a troubleshooting fashion, as this file can contain more than just moose-related configs. For reference, the bare minimum should resemble the following:
+  If the command continues to ask you to perform a `mamba init` or the command failed, or the
+  `conda create` command before it, the error will likely be involved with how Conda was first
+  installed (perhaps with sudo rights, or as another user). You should look into removing this
+  installation of conda, and starting over with our
+  [Getting Started](getting_started/installation/conda.md) instructions. Failures of this nature can
+  also mean your conda resource file (~/.condarc) is in bad shape. We have no way of diagnosing this
+  in a troubleshooting fashion, as this file can contain more than just moose-related configs. For
+  reference, the bare minimum should resemble the following:
 
   ```bash
   channels:
@@ -86,38 +87,29 @@ Conda issues can be the root cause for just about any issue on this page. Scroll
     - defaults
   ```
 
-- #### conda init
+- #### mamba init
 
-  If `conda init` is failing, or similarly doing nothing, it is possible that Conda simply does not know what shell you are operating in, and it created a 'configuration' for the wrong shell, or not at all.
-
-  To figure out what shell you are operating in:
+  If `mamba init` is failing, or similarly doing nothing, it is possible that Conda simply does not
+  support the shell you are operating in. To figure out what shell you are operating in run the
+  following:
 
   ```bash
   echo $0
   ```
 
-  What ever returns here, is the type of shell you are operating in, and is also what you should be instructing Conda to 'initialize'. Example:
-
-  ```bash
-  conda init zsh
-  ```
-
-  +Hint:+ For Linux, this will most likely be `conda init bash`. For Macintosh, this can either be bash or zsh.
-
-  !alert note title=mamba init
-  When using `mambaforge3` you might also need to perform a `mamba init` in order to properly use the
-  `mamba` command to install packages. We recommend this as an alternative to conda, as mamba can take
-  advantage of multiple cores to perform tasks. This means mamba will generally be faster at performing
-  installations than standard conda. Otherwise, they are interchangeable.
+  What ever returns here, is the type of shell you are operating in. Please verify this is a shell
+  that Conda supports.
 
 - #### Your issue not listed
 
-  The quick fix-attempt, is to re-install the moose-packages:
+  The quick fix-attempt, is to delete the faulty environment and re-install it again:
 
   ```bash
-  conda deactivate
-  conda env remove -n moose
-  conda create -n moose moose-libmesh moose-tools
+  mamba activate base
+  mamba env remove -n moose
+  mamba create -n moose moose-tools moose-libmesh
+  mamba activate moose
   ```
 
-  If the above re-install method ultimately failed, it is time to submit your errors to the [discussion forum](faq/discussion_forum.md).
+  If the above re-install method ultimately failed, it is time to submit your errors to the
+  [discussion forum](faq/discussion_forum.md).

--- a/modules/doc/content/ncrc/applications/ncrc_install_conda.md
+++ b/modules/doc/content/ncrc/applications/ncrc_install_conda.md
@@ -1,16 +1,6 @@
+## Install Conda
+
 !include getting_started/installation/install_miniconda.md
-
-Before we continue, we first need to initialize mamba. Execute the following command and +restart your terminal session+.
-
-```bash
-$ ~> mamba init
-```
-
-Upon restarting your terminal, you should see your prompt prefixed with (base). This indicates you are in the base environment, and Conda is ready for operation:
-
-```bash
-$ (base) ~>
-```
 
 ## Install NCRC Client
 

--- a/python/doc/content/python/peacock.md
+++ b/python/doc/content/python/peacock.md
@@ -2,6 +2,10 @@
 
 Peacock is a graphical front end for the MOOSE input file syntax. Peacock allows the user to build or modify an input file, execute the application and view the results all within one package.
 
+## Conda Packages
+
+!include installation/install_peacock.md
+
 ## Environment
 
 Adding Peacock to yout PATH will allow you to launch it from your application or "tests" directory. Peacock will search up through the filesystem directory tree until it finds your application, obviating the need th specify your application as an argument, and simplifying Peacock usage.
@@ -224,4 +228,8 @@ If you get the following error:
 ImportError: No module named vtk
 ```
 
-Then either you don't have VTK installed, or it's not installed correctly. Use the MOOSE redistributable package and its included VTK, or carefully compile your own.
+Then either you don't have VTK installed, or it's not installed correctly. Use the `moose-peacock`
+Conda package, or carefully compile your own. If you are using the `moose-peacock` package, chances
+are that your machine has other libraries being made available causing conflicts in ways Python
+errors can not detect. There are plenty of posts surrounding the subject on our
+[Discussions](https://github.com/idaholab/moose/discussions) site.


### PR DESCRIPTION
Add inl_hpc_prebuilt_moose.md. Detailing instructions on how to use `moose-opt` and how to view the results.

Fix grammar in clone_moose.md

Closes #23351
