### PR TITLE
Added error checking to mesh stitching

### DIFF
--- a/framework/src/mesh/ConcentricCircleMesh.C
+++ b/framework/src/mesh/ConcentricCircleMesh.C
@@ -440,7 +440,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true, true, true, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
       mesh.get_boundary_info().sideset_name(3) = "right";
@@ -453,7 +453,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
@@ -479,7 +479,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 2, 4, TOLERANCE, true, true, true, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
       mesh.get_boundary_info().sideset_name(3) = "right";
@@ -492,7 +492,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 2, 2, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
       mesh.get_boundary_info().sideset_name(1) = "left";
@@ -527,7 +527,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 7, 1);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 4, 2, TOLERANCE, true, true, true, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
       mesh.get_boundary_info().sideset_name(3) = "right";
@@ -540,7 +540,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
@@ -575,7 +575,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 7, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 1, 3, TOLERANCE, true, true, true, true);
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
       mesh.get_boundary_info().sideset_name(3) = "right";
@@ -588,7 +588,7 @@ ConcentricCircleMesh::buildMesh()
       MeshTools::Modification::change_boundary_id(mesh, 5, 2);
       mesh.prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh.stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(mesh, 3, 2);
@@ -617,7 +617,7 @@ ConcentricCircleMesh::buildMesh()
       mesh.prepare_for_use();
       portion_two.prepare_for_use();
       // 'top_half'
-      mesh.stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
+      mesh.stitch_meshes(portion_two, 1, 3, TOLERANCE, true, true, true, true);
 
       // 'bottom_half'
       ReplicatedMesh portion_bottom(mesh);
@@ -632,7 +632,7 @@ ConcentricCircleMesh::buildMesh()
       mesh.prepare_for_use();
       portion_bottom.prepare_for_use();
       // 'full'
-      mesh.stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
+      mesh.stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true, true, true, true);
 
       mesh.get_boundary_info().sideset_name(1) = "left";
       mesh.get_boundary_info().sideset_name(2) = "bottom";
@@ -648,14 +648,14 @@ ConcentricCircleMesh::buildMesh()
       // 'top half'
       mesh.prepare_for_use();
       portion_two.prepare_for_use();
-      mesh.stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
+      mesh.stitch_meshes(portion_two, 1, 1, TOLERANCE, true, true, true, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
       mesh.prepare_for_use();
       portion_bottom.prepare_for_use();
-      mesh.stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
+      mesh.stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true, true, true, true);
       MeshTools::Modification::change_boundary_id(mesh, 3, 1);
       mesh.get_boundary_info().sideset_name(1) = "outer";
       portion_bottom.clear();

--- a/framework/src/mesh/PatternedMesh.C
+++ b/framework/src/mesh/PatternedMesh.C
@@ -138,7 +138,10 @@ PatternedMesh::buildMesh()
                                    right,
                                    left,
                                    TOLERANCE,
-                                   /*clear_stitched_boundary_ids=*/true);
+                                   /*clear_stitched_boundary_ids=*/true,
+                                   true,
+                                   true,
+                                   true);
 
       // Undo the translation
       MeshTools::Modification::translate(cell_mesh, -deltax, deltay, 0);
@@ -147,6 +150,12 @@ PatternedMesh::buildMesh()
   // Now stitch together the rows
   // We're going to stitch them all to row 0 (which is the real mesh)
   for (MooseIndex(_pattern) i = 1; i < _pattern.size(); i++)
-    row_meshes[0]->stitch_meshes(
-        *row_meshes[i], bottom, top, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+    row_meshes[0]->stitch_meshes(*row_meshes[i],
+                                 bottom,
+                                 top,
+                                 TOLERANCE,
+                                 /*clear_stitched_boundary_ids=*/true,
+                                 true,
+                                 true,
+                                 true);
 }

--- a/framework/src/mesh/StitchedMesh.C
+++ b/framework/src/mesh/StitchedMesh.C
@@ -106,6 +106,6 @@ StitchedMesh::buildMesh()
     BoundaryID second = getBoundaryID(boundary_pair.second);
 
     _original_mesh->stitch_meshes(
-        *_meshes[i], first, second, TOLERANCE, _clear_stitched_boundary_ids);
+        *_meshes[i], first, second, TOLERANCE, _clear_stitched_boundary_ids, true, true, true);
   }
 }

--- a/framework/src/mesh/TiledMesh.C
+++ b/framework/src/mesh/TiledMesh.C
@@ -128,7 +128,10 @@ TiledMesh::buildMesh()
                                    right,
                                    left,
                                    TOLERANCE,
-                                   /*clear_stitched_boundary_ids=*/true);
+                                   /*clear_stitched_boundary_ids=*/true,
+                                   true,
+                                   true,
+                                   true);
       }
     }
     {
@@ -142,7 +145,10 @@ TiledMesh::buildMesh()
                                    top,
                                    bottom,
                                    TOLERANCE,
-                                   /*clear_stitched_boundary_ids=*/true);
+                                   /*clear_stitched_boundary_ids=*/true,
+                                   true,
+                                   true,
+                                   true);
       }
     }
     {
@@ -156,7 +162,10 @@ TiledMesh::buildMesh()
                                    front,
                                    back,
                                    TOLERANCE,
-                                   /*clear_stitched_boundary_ids=*/true);
+                                   /*clear_stitched_boundary_ids=*/true,
+                                   true,
+                                   true,
+                                   true);
       }
     }
   }

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -752,7 +752,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 4);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true, true, true, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
       mesh->get_boundary_info().sideset_name(3) = "right";
@@ -765,7 +765,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
@@ -791,7 +791,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 7, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 2, 4, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 2, 4, TOLERANCE, true, true, true, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
       mesh->get_boundary_info().sideset_name(3) = "right";
@@ -804,7 +804,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(other_mesh, 5, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 2, 2, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 2, 2, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
       mesh->get_boundary_info().sideset_name(1) = "left";
@@ -839,7 +839,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 7, 1);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 4, 2, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 4, 2, TOLERANCE, true, true, true, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
       mesh->get_boundary_info().sideset_name(3) = "right";
@@ -852,7 +852,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
@@ -887,7 +887,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 7, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 1, 3, TOLERANCE, true, true, true, true);
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
       mesh->get_boundary_info().sideset_name(3) = "right";
@@ -900,7 +900,7 @@ ConcentricCircleMeshGenerator::generate()
       MeshTools::Modification::change_boundary_id(*mesh, 5, 2);
       mesh->prepare_for_use();
       other_mesh.prepare_for_use();
-      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true);
+      mesh->stitch_meshes(other_mesh, 1, 1, TOLERANCE, true, true, true, true);
 
       MeshTools::Modification::change_boundary_id(*mesh, 2, 1);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 2);
@@ -929,7 +929,7 @@ ConcentricCircleMeshGenerator::generate()
       mesh->prepare_for_use();
       portion_two.prepare_for_use();
       // 'top_half'
-      mesh->stitch_meshes(portion_two, 1, 3, TOLERANCE, true);
+      mesh->stitch_meshes(portion_two, 1, 3, TOLERANCE, true, true, true, true);
 
       // 'bottom_half'
       ReplicatedMesh portion_bottom(*mesh);
@@ -944,7 +944,7 @@ ConcentricCircleMeshGenerator::generate()
       mesh->prepare_for_use();
       portion_bottom.prepare_for_use();
       // 'full'
-      mesh->stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true);
+      mesh->stitch_meshes(portion_bottom, 2, 4, TOLERANCE, true, true, true, true);
 
       mesh->get_boundary_info().sideset_name(1) = "left";
       mesh->get_boundary_info().sideset_name(2) = "bottom";
@@ -960,14 +960,14 @@ ConcentricCircleMeshGenerator::generate()
       // 'top half'
       mesh->prepare_for_use();
       portion_two.prepare_for_use();
-      mesh->stitch_meshes(portion_two, 1, 1, TOLERANCE, true);
+      mesh->stitch_meshes(portion_two, 1, 1, TOLERANCE, true, true, true, true);
       // 'bottom half'
       ReplicatedMesh portion_bottom(*mesh);
       MeshTools::Modification::rotate(portion_bottom, 180, 0, 0);
       // 'full'
       mesh->prepare_for_use();
       portion_bottom.prepare_for_use();
-      mesh->stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true);
+      mesh->stitch_meshes(portion_bottom, 2, 2, TOLERANCE, true, true, true, true);
       MeshTools::Modification::change_boundary_id(*mesh, 3, 1);
       mesh->get_boundary_info().sideset_name(1) = "outer";
       portion_bottom.clear();

--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -161,7 +161,10 @@ PatternedMeshGenerator::generate()
                                     right,
                                     left,
                                     TOLERANCE,
-                                    /*clear_stitched_boundary_ids=*/true);
+                                    /*clear_stitched_boundary_ids=*/true,
+                                    true,
+                                    true,
+                                    true);
 
       // Undo the translation
       MeshTools::Modification::translate(cell_mesh, -deltax, deltay, 0);
@@ -179,8 +182,14 @@ PatternedMeshGenerator::generate()
     const auto & increment_subdomain_map = _row_meshes[i]->get_subdomain_name_map();
     mergeSubdomainNameMaps(main_subdomain_map, increment_subdomain_map);
 
-    _row_meshes[0]->stitch_meshes(
-        *_row_meshes[i], bottom, top, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+    _row_meshes[0]->stitch_meshes(*_row_meshes[i],
+                                  bottom,
+                                  top,
+                                  TOLERANCE,
+                                  /*clear_stitched_boundary_ids=*/true,
+                                  true,
+                                  true,
+                                  true);
   }
 
   return dynamic_pointer_cast<MeshBase>(_row_meshes[0]);

--- a/framework/src/meshgenerators/StackGenerator.C
+++ b/framework/src/meshgenerators/StackGenerator.C
@@ -138,8 +138,14 @@ StackGenerator::generate()
         MeshTools::Modification::translate(*_meshes[i], 0, 0, heights[i]);
         break;
     }
-    mesh->stitch_meshes(
-        *_meshes[i], first, second, TOLERANCE, /*clear_stitched_boundary_ids=*/true);
+    mesh->stitch_meshes(*_meshes[i],
+                        first,
+                        second,
+                        TOLERANCE,
+                        /*clear_stitched_boundary_ids=*/true,
+                        true,
+                        true,
+                        true);
   }
 
   return dynamic_pointer_cast<MeshBase>(mesh);

--- a/framework/src/meshgenerators/StitchedMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchedMeshGenerator.C
@@ -135,7 +135,8 @@ StitchedMeshGenerator::generate()
                         TOLERANCE,
                         _clear_stitched_boundary_ids,
                         /*verbose = */ true,
-                        use_binary_search);
+                        use_binary_search,
+                        true);
   }
 
   return dynamic_pointer_cast<MeshBase>(mesh);

--- a/framework/src/meshgenerators/TiledMeshGenerator.C
+++ b/framework/src/meshgenerators/TiledMeshGenerator.C
@@ -108,7 +108,10 @@ TiledMeshGenerator::generate()
                           right,
                           left,
                           TOLERANCE,
-                          /*clear_stitched_boundary_ids=*/true);
+                          /*clear_stitched_boundary_ids=*/true,
+                          true,
+                          true,
+                          true);
     }
   }
 
@@ -123,7 +126,10 @@ TiledMeshGenerator::generate()
                           top,
                           bottom,
                           TOLERANCE,
-                          /*clear_stitched_boundary_ids=*/true);
+                          /*clear_stitched_boundary_ids=*/true,
+                          true,
+                          true,
+                          true);
     }
   }
 
@@ -138,7 +144,10 @@ TiledMeshGenerator::generate()
                           front,
                           back,
                           TOLERANCE,
-                          /*clear_stitched_boundary_ids=*/true);
+                          /*clear_stitched_boundary_ids=*/true,
+                          true,
+                          true,
+                          true);
     }
   }
 

--- a/framework/src/meshgenerators/XYDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYDelaunayGenerator.C
@@ -403,7 +403,8 @@ XYDelaunayGenerator::generate()
                           TOLERANCE,
                           /*clear_stitched_bcids*/ true,
                           _verbose_stitching,
-                          use_binary_search);
+                          use_binary_search,
+                          true);
     }
   }
   return mesh;

--- a/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
+++ b/modules/fluid_properties/include/userobjects/SimpleFluidProperties.h
@@ -111,6 +111,10 @@ public:
                           DualReal & dT_dv,
                           DualReal & dT_de) const override;
 
+  virtual Real T_from_v_h(Real v, Real h) const;
+
+  virtual void T_from_v_h(Real v, Real h, Real & T, Real & dT_dv, Real & dT_dh) const;
+
   virtual Real T_from_p_rho(Real p, Real rho) const;
 
   virtual void T_from_p_rho(Real p, Real rho, Real & T, Real & dT_dp, Real & dT_drho) const;
@@ -127,6 +131,10 @@ public:
                           DualReal & dp_dv,
                           DualReal & dp_de) const override;
 
+  virtual Real p_from_v_h(Real v, Real h) const;
+
+  virtual void p_from_v_h(Real v, Real h, Real & p, Real & dp_dv, Real & dp_dh) const;
+
   virtual Real c_from_v_e(Real v, Real e) const override;
 
   virtual void c_from_v_e(Real v, Real e, Real & c, Real & dc_dv, Real & dc_de) const override;
@@ -140,6 +148,10 @@ public:
 
   virtual void
   e_from_p_rho(Real p, Real rho, Real & e, Real & de_dp, Real & de_drho) const override;
+
+  virtual Real e_from_v_h(Real v, Real h) const override;
+
+  virtual void e_from_v_h(Real p, Real v, Real & h, Real & de_dv, Real & de_dh) const override;
 
   virtual Real mu_from_p_T(Real pressure, Real temperature) const override;
 

--- a/modules/fluid_properties/unit/src/SimpleFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/SimpleFluidPropertiesTest.C
@@ -45,6 +45,7 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   Real T = 200.0;
   Real e = 8.372E5;
   Real v = 0.001;
+  Real h = cv * T + p / _fp->rho_from_p_T(p, T);
 
   ABS_TEST(_fp->beta_from_p_T(p, T), thermal_exp, tol);
   ABS_TEST(_fp->cp_from_p_T(p, T), cp, tol);
@@ -56,9 +57,10 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   ABS_TEST(_fp->rho_from_p_T(p, T), density0 * std::exp(p / bulk_modulus - thermal_exp * T), tol);
   ABS_TEST(_fp->e_from_p_T(p, T), cv * T, tol);
   ABS_TEST(_fp->e_from_p_rho(p, 1. / v), cv * T, tol);
+  ABS_TEST(_fp->e_from_v_h(v, h), cv * T, large_tol);
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
-  ABS_TEST(_fp->h_from_p_T(p, T), cv * T + p / _fp->rho_from_p_T(p, T), tol);
+  ABS_TEST(_fp->h_from_p_T(p, T), h, tol);
   ABS_TEST(_fp2->h_from_p_T(p, T), cv * T + p * pp_coef / _fp2->rho_from_p_T(p, T), tol);
   ABS_TEST(_fp->cp_from_v_e(v, e), cp, tol);
   ABS_TEST(_fp->cv_from_v_e(v, e), cv, tol);
@@ -81,6 +83,7 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   T = 300.0;
   e = 1.2558E6;
   v = 6.249991432791718E-4;
+  h = cv * T + p / _fp->rho_from_p_T(p, T);
 
   ABS_TEST(_fp->beta_from_p_T(p, T), thermal_exp, tol);
   ABS_TEST(_fp->cp_from_p_T(p, T), cp, tol);
@@ -92,9 +95,10 @@ TEST_F(SimpleFluidPropertiesTest, properties)
   ABS_TEST(_fp->rho_from_p_T(p, T), density0 * std::exp(p / bulk_modulus - thermal_exp * T), tol);
   ABS_TEST(_fp->e_from_p_T(p, T), cv * T, tol);
   ABS_TEST(_fp->e_from_p_rho(p, 1. / v), cv * T, large_tol);
+  ABS_TEST(_fp->e_from_v_h(v, h), cv * T, large_tol);
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
   ABS_TEST(_fp->mu_from_p_T(p, T), visc, tol);
-  ABS_TEST(_fp->h_from_p_T(p, T), cv * T + p / _fp->rho_from_p_T(p, T), tol);
+  ABS_TEST(_fp->h_from_p_T(p, T), h, tol);
   ABS_TEST(_fp2->h_from_p_T(p, T), cv * T + p * pp_coef / _fp2->rho_from_p_T(p, T), tol);
   ABS_TEST(_fp->cp_from_v_e(v, e), cp, tol);
   ABS_TEST(_fp->cv_from_v_e(v, e), cv, tol);
@@ -131,6 +135,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->mu_from_p_T, p, T, tol);
   DERIV_TEST(_fp->e_from_p_T, p, T, tol);
   DERIV_TEST(_fp->e_from_p_rho, p, 1. / v, tol);
+  DERIV_TEST(_fp->e_from_v_h, v, e + p * v, tol);
   DERIV_TEST(_fp->h_from_p_T, p, T, tol);
   DERIV_TEST(_fp->k_from_p_T, p, T, tol);
   DERIV_TEST(_fp->cp_from_p_T, p, T, tol);
@@ -156,6 +161,7 @@ TEST_F(SimpleFluidPropertiesTest, derivatives)
   DERIV_TEST(_fp->mu_from_p_T, p, T, tol);
   DERIV_TEST(_fp->e_from_p_T, p, T, tol);
   DERIV_TEST(_fp->e_from_p_rho, p, 1. / v, tol);
+  DERIV_TEST(_fp->e_from_v_h, v, e + p * v, tol);
   DERIV_TEST(_fp->h_from_p_T, p, T, tol);
   DERIV_TEST(_fp->k_from_p_T, p, T, tol);
   DERIV_TEST(_fp->cp_from_p_T, p, T, tol);

--- a/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedCartesianMeshGenerator.C
@@ -529,7 +529,10 @@ PatternedCartesianMeshGenerator::generate()
                                     OUTER_SIDESET_ID,
                                     OUTER_SIDESET_ID,
                                     TOLERANCE,
-                                    /*clear_stitched_boundary_ids=*/true);
+                                    /*clear_stitched_boundary_ids=*/true,
+                                    true,
+                                    true,
+                                    true);
           }
 
           continue;
@@ -562,7 +565,10 @@ PatternedCartesianMeshGenerator::generate()
                               OUTER_SIDESET_ID,
                               OUTER_SIDESET_ID,
                               TOLERANCE,
-                              /*clear_stitched_boundary_ids=*/false);
+                              /*clear_stitched_boundary_ids=*/false,
+                              true,
+                              true,
+                              true);
 
       // Translate back now that we've stitched so that anyone else that uses this mesh has it at
       // the origin
@@ -810,7 +816,8 @@ PatternedCartesianMeshGenerator::addPeripheralMesh(
 
       // rotate the peripheral mesh to the desired side of the hexagon.
       MeshTools::Modification::rotate(*meshp0, rotation_angle, 0, 0);
-      mesh.stitch_meshes(*meshp0, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true);
+      mesh.stitch_meshes(
+          *meshp0, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true, true, true, true);
       sub_positions_inner.resize(0);
       sub_d_positions_outer.resize(0);
     }

--- a/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PatternedHexMeshGenerator.C
@@ -571,7 +571,10 @@ PatternedHexMeshGenerator::generate()
                                     OUTER_SIDESET_ID,
                                     OUTER_SIDESET_ID,
                                     TOLERANCE,
-                                    /*clear_stitched_boundary_ids=*/true);
+                                    /*clear_stitched_boundary_ids=*/true,
+                                    true,
+                                    true,
+                                    true);
           }
 
           continue;
@@ -604,7 +607,10 @@ PatternedHexMeshGenerator::generate()
                               OUTER_SIDESET_ID,
                               OUTER_SIDESET_ID,
                               TOLERANCE,
-                              /*clear_stitched_boundary_ids=*/false);
+                              /*clear_stitched_boundary_ids=*/false,
+                              true,
+                              true,
+                              true);
 
       // Translate back now that we've stitched so that anyone else that uses this mesh has it at
       // the origin
@@ -852,7 +858,8 @@ PatternedHexMeshGenerator::addPeripheralMesh(
 
       // rotate the peripheral mesh to the desired side of the hexagon.
       MeshTools::Modification::rotate(*meshp0, rotation_angle, 0, 0);
-      mesh.stitch_meshes(*meshp0, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true);
+      mesh.stitch_meshes(
+          *meshp0, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true, true, true, true);
       sub_positions_inner.resize(0);
       sub_d_positions_outer.resize(0);
     }

--- a/modules/reactor/src/meshgenerators/PatternedPolygonPeripheralModifierBase.C
+++ b/modules/reactor/src/meshgenerators/PatternedPolygonPeripheralModifierBase.C
@@ -240,7 +240,8 @@ PatternedPolygonPeripheralModifierBase::generate()
     mesh->add_elem_integers(extra_integer_names, true);
     transferExtraElemIntegers(*mesh, del_elem_extra_ids);
     mesh->prepare_for_use();
-    input_mesh->stitch_meshes(*mesh, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true);
+    input_mesh->stitch_meshes(
+        *mesh, OUTER_SIDESET_ID, OUTER_SIDESET_ID, TOLERANCE, true, true, true, true);
     mesh->clear();
   }
   input_mesh->subdomain_name(_transition_layer_id) = _transition_layer_name;

--- a/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PeripheralRingMeshGenerator.C
@@ -378,7 +378,8 @@ PeripheralRingMeshGenerator::generate()
     MooseMesh::changeBoundaryId(*input_mesh, _input_mesh_external_bid, OUTER_SIDESET_ID, false);
   mesh->prepare_for_use();
   // Use input_mesh here to retain the subdomain name map
-  input_mesh->stitch_meshes(*mesh, OUTER_SIDESET_ID, OUTER_SIDESET_ID_ALT, TOLERANCE, true);
+  input_mesh->stitch_meshes(
+      *mesh, OUTER_SIDESET_ID, OUTER_SIDESET_ID_ALT, TOLERANCE, true, true, true, true);
 
   // Assign subdomain name to the new block if applicable
   if (isParamValid("peripheral_ring_block_name"))

--- a/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
+++ b/modules/reactor/src/meshgenerators/PolygonConcentricCircleMeshGeneratorBase.C
@@ -723,12 +723,12 @@ PolygonConcentricCircleMeshGeneratorBase::generate()
     MeshTools::Modification::rotate(other_mesh, 360.0 / _num_sides * mesh_index, 0, 0);
     mesh0->prepare_for_use();
     other_mesh.prepare_for_use();
-    mesh0->stitch_meshes(other_mesh, SLICE_BEGIN, SLICE_END, TOLERANCE, true);
+    mesh0->stitch_meshes(other_mesh, SLICE_BEGIN, SLICE_END, TOLERANCE, true, true, true, true);
     other_mesh.clear();
   }
 
   // An extra step to stich the first and last slices together
-  mesh0->stitch_surfaces(SLICE_BEGIN, SLICE_END, TOLERANCE, true);
+  mesh0->stitch_surfaces(SLICE_BEGIN, SLICE_END, TOLERANCE, true, true, true, true);
 
   if (!_has_rings && !_has_ducts && _background_intervals == 1)
     MooseMesh::changeBoundaryId(*mesh0, 1 + _interface_boundary_id_shift, OUTER_SIDESET_ID, false);

--- a/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
+++ b/modules/reactor/src/meshgenerators/TriPinHexAssemblyGenerator.C
@@ -328,7 +328,10 @@ TriPinHexAssemblyGenerator::generate()
                                OUTER_SIDESET_ID,
                                OUTER_SIDESET_ID,
                                TOLERANCE,
-                               /*clear_stitched_boundary_ids=*/true);
+                               /*clear_stitched_boundary_ids=*/true,
+                               true,
+                               true,
+                               true);
     }
   }
 
@@ -514,7 +517,10 @@ TriPinHexAssemblyGenerator::buildSinglePinSection(
                        SLICE_BEGIN,
                        SLICE_END,
                        TOLERANCE,
-                       /*clear_stitched_boundary_ids=*/true);
+                       /*clear_stitched_boundary_ids=*/true,
+                       true,
+                       true,
+                       true);
   MooseMesh::changeBoundaryId(*mesh0, SLICE_BEGIN, SLICE_END, true);
 
   auto mesh2 = dynamic_pointer_cast<ReplicatedMesh>(mesh0->clone());
@@ -523,7 +529,10 @@ TriPinHexAssemblyGenerator::buildSinglePinSection(
                        SLICE_END,
                        SLICE_END,
                        TOLERANCE,
-                       /*clear_stitched_boundary_ids=*/true);
+                       /*clear_stitched_boundary_ids=*/true,
+                       true,
+                       true,
+                       true);
   MeshTools::Modification::translate(*mesh0, side_length / 2.0 + ring_offset, 0, 0);
 
   for (const auto & elem : mesh0->element_ptr_range())


### PR DESCRIPTION
Libmesh's stitch_meshes and stitch_surfaces functions have an optional parameter 'enforce_all_nodes_match_on_boundaries' that, if true, throws an error if the number of nodes on the specified boundaries don't match the number of nodes that were merged.
This parameter is false by default.
This commit changes this parameter to true for all instances of stitch_meshes and stitch_surfaces used in the framework.

Closes #23366