### PR TITLE
Don't ghost higher-D elems in GhostLowerDElems

### DIFF
--- a/framework/src/relationshipmanagers/GhostLowerDElems.C
+++ b/framework/src/relationshipmanagers/GhostLowerDElems.C
@@ -58,8 +58,6 @@ GhostLowerDElems::operator()(const MeshBase::const_element_iterator & range_begi
     {
       const Elem * const neighbor = elem->neighbor_ptr(s);
       const bool elem_owns_lowerd = !neighbor || elem->id() < neighbor->id();
-      if (!elem_owns_lowerd && neighbor->processor_id() != p)
-        coupled_elements.emplace(neighbor, null_mat);
 
       const Elem * const lower_d_elem =
           elem_owns_lowerd


### PR DESCRIPTION
Even if we needed this and didn't have a better place to put it, we'd want to be more careful about how it works on meshes with hanging nodes.

Refs #23389

## Reason
libMesh doesn't currently work with GhostingFunctor subclasses that return non-active elements, which GhostLowerDElems can easily do on an adaptively refined mesh.

## Design
Remove the bad lines.

## Impact
If everything else is working correctly, this will be a fix for #23389 and have no side effects.  If we have more non-active elements returned elsewhere we'll want to fix those too before closing that ticket.  In the worst case, if someone has removed the default functors that ghost side neighbors and somehow *this* was taking up the slack, then removing the last straw here would cause all sorts of things to break, but even in that case the right fix would be to do proper ghosting elsewhere, not here.