### PR TITLE
Make HFEM lower-D mesh work with distributed mesh

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -466,16 +466,13 @@ MooseMesh::buildLowerDMesh()
       bool build_side = false;
       if (!neig)
         build_side = true;
-      else if (!neig->is_remote())
+      else
       {
-        if (mesh.is_replicated() || elem->processor_id() == comm().rank() ||
-            neig->processor_id() == comm().rank())
-        {
-          if (!neig->active())
-            build_side = true;
-          else if (neig->level() == elem->level() && elem->id() < neig->id())
-            build_side = true;
-        }
+        mooseAssert(!neig->is_remote(), "We error if the mesh is not serial");
+        if (!neig->active())
+          build_side = true;
+        else if (neig->level() == elem->level() && elem->id() < neig->id())
+          build_side = true;
       }
 
       if (build_side)

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -2500,10 +2500,10 @@ MooseMesh::init()
     // Re-enable partitioning so the splitter can partition!
     if (_app.isSplitMesh())
       getMesh().skip_partitioning(false);
-  }
 
-  if (getParam<bool>("build_all_side_lowerd_mesh"))
-    buildLowerDMesh();
+    if (getParam<bool>("build_all_side_lowerd_mesh"))
+      buildLowerDMesh();
+  }
 }
 
 unsigned int

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -215,6 +215,10 @@ MooseMesh::MooseMesh(const InputParameters & parameters)
   else if (isParamValid("block"))
     _provided_coord_blocks = getParam<std::vector<SubdomainName>>("block");
 
+  if (getParam<bool>("build_all_side_lowerd_mesh"))
+    // Do not initially allow removal of remote elements
+    allowRemoteElementRemoval(false);
+
   determineUseDistributedMesh();
 }
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -2141,7 +2141,7 @@ FEProblemBase::reinitElemNeighborAndLowerD(const Elem * elem, unsigned int side,
       std::vector<Point> reference_points;
       FEInterface::inverse_map(
           lower_d_elem_neighbor->dim(), FEType(), lower_d_elem_neighbor, qps, reference_points);
-      reinitLowerDElem(lower_d_elem_neighbor, tid, &qps);
+      reinitLowerDElem(lower_d_elem_neighbor, tid, &reference_points);
     }
   }
 

--- a/test/tests/kernels/hfem/tests
+++ b/test/tests/kernels/hfem/tests
@@ -6,7 +6,6 @@
     input = 'dirichlet.i'
     exodiff = 'dirichlet_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Dirichlet boundary conditions using standard variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [array_dirichlet]
@@ -14,7 +13,6 @@
     input = 'array_dirichlet.i'
     exodiff = 'array_dirichlet_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Dirichlet boundary conditions using array variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [array_dirichlet_pjfnk]
@@ -22,7 +20,6 @@
     input = 'array_dirichlet_pjfnk.i'
     exodiff = 'array_dirichlet_pjfnk_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with preconditioner only using the block diagonal Jacobian.'
-    mesh_mode = replicated
     issues = '#20029'
   []
   [array_dirichlet_transform]
@@ -30,7 +27,6 @@
     input = 'array_dirichlet_transform.i'
     exodiff = 'array_dirichlet_transform_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with coupling of components of array variables on internal sides.'
-    mesh_mode = replicated
     mumps = true
     issues = '#20029'
   []
@@ -39,7 +35,6 @@
     input = 'array_dirichlet_transform_bc.i'
     exodiff = 'array_dirichlet_transform_bc_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with coupling of components of array variables on boundary sides.'
-    mesh_mode = replicated
     mumps = true
     issues = '#20029'
   []
@@ -48,7 +43,6 @@
     input = 'neumann.i'
     exodiff = 'neumann_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Neumann boundary conditions using standard variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [array_neumann]
@@ -56,7 +50,6 @@
     input = 'array_neumann.i'
     exodiff = 'array_neumann_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Neumann boundary conditions using array variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [robin]
@@ -64,7 +57,6 @@
     input = 'robin.i'
     exodiff = 'robin_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Robin boundary conditions using standard variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [array_robin]
@@ -72,7 +64,6 @@
     input = 'array_robin.i'
     exodiff = 'array_robin_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Robin boundary conditions using array variables.'
-    mesh_mode = replicated
     mumps = true
   []
   [high_order]
@@ -81,7 +72,6 @@
     cli_args = 'Variables/u/order=FOURTH Variables/lambda/order=FIRST Outputs/file_base=high_order_out'
     exodiff = 'high_order_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with high order shape functions.'
-    mesh_mode = replicated
     mumps = true
   []
   [variable_robin]
@@ -89,7 +79,6 @@
     input = 'variable_robin.i'
     exodiff = 'variable_robin_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Robin boundary conditions through Lagrange multipliers.'
-    mesh_mode = replicated
     mumps = true
   []
   [robin_displaced]
@@ -97,7 +86,6 @@
     input = 'robin_displaced.i'
     exodiff = 'robin_displaced_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with displaced meshes.'
-    mesh_mode = replicated
     mumps = true
   []
   [robin_adpatation]
@@ -105,7 +93,6 @@
     input = 'robin_adapt.i'
     expect_err = 'HFEM does not support mesh adaptivity currently'
     requirement = 'The system shall issue an error for unsupported mesh adaptation with hybrid finite element method (HFEM) calculations.'
-    mesh_mode = replicated
     mumps = true
   []
   [variable_dirichlet]
@@ -113,14 +100,6 @@
     input = 'variable_dirichlet.i'
     exodiff = 'variable_dirichlet_out.e'
     requirement = 'The system shall support hybrid finite element method (HFEM) calculations with Dirichlet boundary conditions with boundary values specified by variables.'
-    mesh_mode = replicated
-    mumps = true
-  []
-  [robin_distributed_mesh]
-    type = 'RunException'
-    input = 'robin_dist.i'
-    expect_err = 'Hybrid finite element method must use replicated mesh'
-    requirement = 'The system shall issue an error for not fully supported distributed mesh with hybrid finite element method (HFEM) calculations.'
     mumps = true
   []
 
@@ -133,7 +112,6 @@
       exodiff = 'lower-d-volumes_out.e'
       detail = 'two'
       mumps = true
-      mesh_mode = replicated
     []
     [3d]
       type = 'Exodiff'
@@ -141,7 +119,6 @@
       exodiff = '3d-lower-d-volumes_out.e'
       detail = 'three'
       mumps = true
-      mesh_mode = replicated
     []
   []
 []

--- a/test/tests/userobjects/side_uo_with_lowerd_use/tests
+++ b/test/tests/userobjects/side_uo_with_lowerd_use/tests
@@ -4,7 +4,6 @@
     design = 'UserObjects/index.md'
     issues = '#21687'
     input = 'side-uo-with-lower-d-use.i'
-    mesh_mode = 'replicated'
     mumps = true
     type = RunApp
   []


### PR DESCRIPTION
We achieve this by not initially allowing remote element removal
when doing HFEM because the HFEM mesh construction process currently
relies on the mesh being in a serialized state. But then eventually
we can remove all the remote elements.

Closes #17484