### PR TITLE
Memory management cleanup

### DIFF
--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1009,8 +1009,9 @@ protected:
   /// Syntax of the input file
   Syntax _syntax;
 
-  /// Input parameter storage structure (this is a raw pointer so the destruction time can be explicitly controlled)
-  InputParameterWarehouse * _input_parameter_warehouse;
+  /// Input parameter storage structure; unique_ptr so we can control
+  /// its destruction order
+  std::unique_ptr<InputParameterWarehouse> _input_parameter_warehouse;
 
   /// The Factory responsible for building Actions
   ActionFactory _action_factory;

--- a/framework/include/geomsearch/NearestNodeLocator.h
+++ b/framework/include/geomsearch/NearestNodeLocator.h
@@ -92,7 +92,7 @@ protected:
 
   MooseMesh & _mesh;
 
-  NodeIdRange * _secondary_node_range;
+  std::unique_ptr<NodeIdRange> _secondary_node_range;
 
 public:
   std::map<dof_id_type, NearestNodeInfo> _nearest_node_info;

--- a/framework/include/meshgenerators/AdvancedExtruderGenerator.h
+++ b/framework/include/meshgenerators/AdvancedExtruderGenerator.h
@@ -87,5 +87,5 @@ protected:
    * @param nd1 index of the first node to be swapped
    * @param nd2 index of the second node to be swapped
    */
-  void swapNodesInElem(Elem * elem, const unsigned int nd1, const unsigned int nd2);
+  void swapNodesInElem(Elem & elem, const unsigned int nd1, const unsigned int nd2);
 };

--- a/framework/include/systems/AuxiliarySystem.h
+++ b/framework/include/systems/AuxiliarySystem.h
@@ -186,8 +186,9 @@ protected:
 
   /// solution vector from nonlinear solver
   const NumericVector<Number> * _current_solution;
-  /// Serialized version of the solution vector
-  NumericVector<Number> & _serialized_solution;
+  /// Serialized version of the solution vector, or nullptr if a
+  /// serialized solution is not needed
+  std::unique_ptr<NumericVector<Number>> _serialized_solution;
   /// solution vector for u^dot
   NumericVector<Number> * _u_dot;
   /// solution vector for u^dotdot
@@ -200,9 +201,6 @@ protected:
 
   /// The current states of the solution (0 = current, 1 = old, etc)
   std::vector<NumericVector<Number> *> _solution_state;
-
-  /// Whether or not a copy of the residual needs to be made
-  bool _need_serialized_solution;
 
   // Variables
   std::vector<std::vector<MooseVariableFEBase *>> _nodal_vars;

--- a/framework/include/systems/NonlinearSystemBase.h
+++ b/framework/include/systems/NonlinearSystemBase.h
@@ -779,11 +779,12 @@ protected:
   /// ghosted form of the residual
   NumericVector<Number> * _residual_ghosted;
 
-  /// Serialized version of the solution vector
-  NumericVector<Number> & _serialized_solution;
+  /// Serialized version of the solution vector, or nullptr if a
+  /// serialized solution is not needed
+  std::unique_ptr<NumericVector<Number>> _serialized_solution;
 
-  /// Copy of the residual vector
-  NumericVector<Number> & _residual_copy;
+  /// Copy of the residual vector, or nullptr if a copy is not needed
+  std::unique_ptr<NumericVector<Number>> _residual_copy;
 
   /// solution vector for u^dot
   NumericVector<Number> * _u_dot;
@@ -891,11 +892,6 @@ protected:
   /// Whether or not to assemble the residual and Jacobian after the application of each constraint.
   bool _assemble_constraints_separately;
 
-  /// Whether or not a copy of the residual needs to be made
-  bool _need_serialized_solution;
-
-  /// Whether or not a copy of the residual needs to be made
-  bool _need_residual_copy;
   /// Whether or not a ghosted copy of the residual needs to be made
   bool _need_residual_ghosted;
   /// true if debugging residuals

--- a/framework/include/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.h
+++ b/framework/include/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.h
@@ -35,8 +35,7 @@ private:
    * @param[in] var_name the variable to build the mesh functions for
    * @param[out] the mesh functions
    */
-  void buildMeshFunctions(const unsigned int var_index,
-                          std::vector<std::shared_ptr<MeshFunction>> & local_meshfuns);
+  void buildMeshFunctions(const unsigned int var_index, std::vector<MeshFunction> & local_meshfuns);
 
   /*
    * Evaluate interpolation values for incoming points
@@ -45,11 +44,10 @@ private:
    * @param[in] the points to evaluate the variable shape functions at
    * @param[out] the values of the variables
    */
-  void evaluateInterpValuesWithMeshFunctions(
-      const std::vector<BoundingBox> & local_bboxes,
-      const std::vector<std::shared_ptr<MeshFunction>> & local_meshfuns,
-      const std::vector<Point> & incoming_points,
-      std::vector<std::pair<Real, Real>> & outgoing_vals);
+  void evaluateInterpValuesWithMeshFunctions(const std::vector<BoundingBox> & local_bboxes,
+                                             std::vector<MeshFunction> & local_meshfuns,
+                                             const std::vector<Point> & incoming_points,
+                                             std::vector<std::pair<Real, Real>> & outgoing_vals);
 
   /*
    * Bounding boxes
@@ -58,5 +56,5 @@ private:
   /*
    * Local mesh functions
    */
-  std::vector<std::shared_ptr<MeshFunction>> _local_meshfuns;
+  std::vector<MeshFunction> _local_meshfuns;
 };

--- a/framework/include/utils/MooseArray.h
+++ b/framework/include/utils/MooseArray.h
@@ -234,14 +234,14 @@ MooseArray<T>::resize(unsigned int size, const T & default_value)
 {
   if (size > _allocated_size)
   {
-    T * new_pointer = new T[size];
+    auto new_pointer = std::make_unique<T[]>(size);
     mooseAssert(new_pointer, "Failed to allocate MooseArray memory!");
 
     if (_data)
       for (unsigned int i = 0; i < _size; i++)
         new_pointer[i] = _data[i];
 
-    _data_ptr.reset(new_pointer);
+    _data_ptr = std::move(new_pointer);
     _data = _data_ptr.get();
     _allocated_size = size;
   }

--- a/framework/include/utils/PerfNode.h
+++ b/framework/include/utils/PerfNode.h
@@ -95,7 +95,7 @@ public:
     auto & child_node = _children[id];
 
     if (!child_node)
-      child_node.reset(new PerfNode(id));
+      child_node = std::make_unique<PerfNode>(id);
 
     return child_node.get();
   }

--- a/framework/include/utils/SyntaxTree.h
+++ b/framework/include/utils/SyntaxTree.h
@@ -11,9 +11,10 @@
 
 #include "SyntaxFormatterInterface.h"
 
-#include <string>
 #include <map>
+#include <memory>
 #include <set>
+#include <string>
 
 // Forward declarations
 class InputParameters;
@@ -72,7 +73,7 @@ protected:
 
   bool isLongNames() const;
 
-  TreeNode * _root;
+  std::unique_ptr<TreeNode> _root;
   bool _use_long_names;
 
 private:

--- a/framework/include/utils/SyntaxTree.h
+++ b/framework/include/utils/SyntaxTree.h
@@ -63,9 +63,9 @@ protected:
                       bool is_action_params,
                       InputParameters * params = NULL);
 
-    std::map<std::string, TreeNode *> _children;
-    std::multimap<std::string, InputParameters *> _action_params;
-    std::multimap<std::string, InputParameters *> _moose_object_params;
+    std::map<std::string, std::unique_ptr<TreeNode>> _children;
+    std::multimap<std::string, std::unique_ptr<InputParameters>> _action_params;
+    std::multimap<std::string, std::unique_ptr<InputParameters>> _moose_object_params;
     std::string _name;
     TreeNode * _parent;
     SyntaxTree & _syntax_tree;

--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -218,42 +218,6 @@ Assembly::~Assembly()
     for (auto & it : _vector_fe_face_neighbor[dim])
       delete it.second;
 
-  for (auto & it : _fe_shape_data)
-    delete it.second;
-
-  for (auto & it : _fe_shape_data_face)
-    delete it.second;
-
-  for (auto & it : _fe_shape_data_neighbor)
-    delete it.second;
-
-  for (auto & it : _fe_shape_data_face_neighbor)
-    delete it.second;
-
-  for (auto & it : _fe_shape_data_lower)
-    delete it.second;
-
-  for (auto & it : _fe_shape_data_dual_lower)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data_face)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data_neighbor)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data_face_neighbor)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data_lower)
-    delete it.second;
-
-  for (auto & it : _vector_fe_shape_data_dual_lower)
-    delete it.second;
-
   for (auto & it : _ad_grad_phi_data)
     it.second.release();
 
@@ -295,13 +259,13 @@ void
 Assembly::buildFE(FEType type) const
 {
   if (!_fe_shape_data[type])
-    _fe_shape_data[type] = new FEShapeData;
+    _fe_shape_data[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
   for (unsigned int dim = 0; dim <= _mesh_dimension; dim++)
   {
     if (!_fe[dim][type])
-      _const_fe[dim][type] = _fe[dim][type] = FEGenericBase<Real>::build(dim, type).release();
+      _fe[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe[dim][type]->get_phi();
     _fe[dim][type]->get_dphi();
@@ -318,14 +282,13 @@ void
 Assembly::buildFaceFE(FEType type) const
 {
   if (!_fe_shape_data_face[type])
-    _fe_shape_data_face[type] = new FEShapeData;
+    _fe_shape_data_face[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
   for (unsigned int dim = 0; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_face[dim][type])
-      _const_fe_face[dim][type] = _fe_face[dim][type] =
-          FEGenericBase<Real>::build(dim, type).release();
+      _fe_face[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe_face[dim][type]->get_phi();
     _fe_face[dim][type]->get_dphi();
@@ -338,14 +301,13 @@ void
 Assembly::buildNeighborFE(FEType type) const
 {
   if (!_fe_shape_data_neighbor[type])
-    _fe_shape_data_neighbor[type] = new FEShapeData;
+    _fe_shape_data_neighbor[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
   for (unsigned int dim = 0; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_neighbor[dim][type])
-      _const_fe_neighbor[dim][type] = _fe_neighbor[dim][type] =
-          FEGenericBase<Real>::build(dim, type).release();
+      _fe_neighbor[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe_neighbor[dim][type]->get_phi();
     _fe_neighbor[dim][type]->get_dphi();
@@ -358,14 +320,13 @@ void
 Assembly::buildFaceNeighborFE(FEType type) const
 {
   if (!_fe_shape_data_face_neighbor[type])
-    _fe_shape_data_face_neighbor[type] = new FEShapeData;
+    _fe_shape_data_face_neighbor[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of the current mesh
   for (unsigned int dim = 0; dim <= _mesh_dimension; dim++)
   {
     if (!_fe_face_neighbor[dim][type])
-      _const_fe_face_neighbor[dim][type] = _fe_face_neighbor[dim][type] =
-          FEGenericBase<Real>::build(dim, type).release();
+      _fe_face_neighbor[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe_face_neighbor[dim][type]->get_phi();
     _fe_face_neighbor[dim][type]->get_dphi();
@@ -378,7 +339,7 @@ void
 Assembly::buildLowerDFE(FEType type) const
 {
   if (!_fe_shape_data_lower[type])
-    _fe_shape_data_lower[type] = new FEShapeData;
+    _fe_shape_data_lower[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of
   // the current mesh minus one (because this is for lower-dimensional
@@ -386,8 +347,7 @@ Assembly::buildLowerDFE(FEType type) const
   for (unsigned int dim = 0; dim <= _mesh_dimension - 1; dim++)
   {
     if (!_fe_lower[dim][type])
-      _const_fe_lower[dim][type] = _fe_lower[dim][type] =
-          FEGenericBase<Real>::build(dim, type).release();
+      _fe_lower[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe_lower[dim][type]->get_phi();
     _fe_lower[dim][type]->get_dphi();
@@ -400,7 +360,7 @@ void
 Assembly::buildLowerDDualFE(FEType type) const
 {
   if (!_fe_shape_data_dual_lower[type])
-    _fe_shape_data_dual_lower[type] = new FEShapeData;
+    _fe_shape_data_dual_lower[type] = std::make_unique<FEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of
   // the current mesh minus one (because this is for lower-dimensional
@@ -408,8 +368,7 @@ Assembly::buildLowerDDualFE(FEType type) const
   for (unsigned int dim = 0; dim <= _mesh_dimension - 1; dim++)
   {
     if (!_fe_lower[dim][type])
-      _const_fe_lower[dim][type] = _fe_lower[dim][type] =
-          FEGenericBase<Real>::build(dim, type).release();
+      _fe_lower[dim][type] = FEGenericBase<Real>::build(dim, type).release();
 
     _fe_lower[dim][type]->get_dual_phi();
     _fe_lower[dim][type]->get_dual_dphi();
@@ -422,7 +381,7 @@ void
 Assembly::buildVectorLowerDFE(FEType type) const
 {
   if (!_vector_fe_shape_data_lower[type])
-    _vector_fe_shape_data_lower[type] = new VectorFEShapeData;
+    _vector_fe_shape_data_lower[type] = std::make_unique<VectorFEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of
   // the current mesh minus one (because this is for lower-dimensional
@@ -430,8 +389,7 @@ Assembly::buildVectorLowerDFE(FEType type) const
   for (unsigned int dim = 0; dim <= _mesh_dimension - 1; dim++)
   {
     if (!_vector_fe_lower[dim][type])
-      _const_vector_fe_lower[dim][type] = _vector_fe_lower[dim][type] =
-          FEVectorBase::build(dim, type).release();
+      _vector_fe_lower[dim][type] = FEVectorBase::build(dim, type).release();
 
     _vector_fe_lower[dim][type]->get_phi();
     _vector_fe_lower[dim][type]->get_dphi();
@@ -444,7 +402,7 @@ void
 Assembly::buildVectorDualLowerDFE(FEType type) const
 {
   if (!_vector_fe_shape_data_dual_lower[type])
-    _vector_fe_shape_data_dual_lower[type] = new VectorFEShapeData;
+    _vector_fe_shape_data_dual_lower[type] = std::make_unique<VectorFEShapeData>();
 
   // Build an FE object for this type for each dimension up to the dimension of
   // the current mesh minus one (because this is for lower-dimensional
@@ -452,8 +410,7 @@ Assembly::buildVectorDualLowerDFE(FEType type) const
   for (unsigned int dim = 0; dim <= _mesh_dimension - 1; dim++)
   {
     if (!_vector_fe_lower[dim][type])
-      _const_vector_fe_lower[dim][type] = _vector_fe_lower[dim][type] =
-          FEVectorBase::build(dim, type).release();
+      _vector_fe_lower[dim][type] = FEVectorBase::build(dim, type).release();
 
     _vector_fe_lower[dim][type]->get_dual_phi();
     _vector_fe_lower[dim][type]->get_dual_dphi();
@@ -466,7 +423,7 @@ void
 Assembly::buildVectorFE(FEType type) const
 {
   if (!_vector_fe_shape_data[type])
-    _vector_fe_shape_data[type] = new VectorFEShapeData;
+    _vector_fe_shape_data[type] = std::make_unique<VectorFEShapeData>();
 
   // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
@@ -480,8 +437,7 @@ Assembly::buildVectorFE(FEType type) const
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe[dim][type])
-      _const_vector_fe[dim][type] = _vector_fe[dim][type] =
-          FEGenericBase<VectorValue<Real>>::build(dim, type).release();
+      _vector_fe[dim][type] = FEGenericBase<VectorValue<Real>>::build(dim, type).release();
 
     _vector_fe[dim][type]->get_phi();
     _vector_fe[dim][type]->get_dphi();
@@ -498,7 +454,7 @@ void
 Assembly::buildVectorFaceFE(FEType type) const
 {
   if (!_vector_fe_shape_data_face[type])
-    _vector_fe_shape_data_face[type] = new VectorFEShapeData;
+    _vector_fe_shape_data_face[type] = std::make_unique<VectorFEShapeData>();
 
   // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
@@ -512,8 +468,7 @@ Assembly::buildVectorFaceFE(FEType type) const
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_face[dim][type])
-      _const_vector_fe_face[dim][type] = _vector_fe_face[dim][type] =
-          FEGenericBase<VectorValue<Real>>::build(dim, type).release();
+      _vector_fe_face[dim][type] = FEGenericBase<VectorValue<Real>>::build(dim, type).release();
 
     _vector_fe_face[dim][type]->get_phi();
     _vector_fe_face[dim][type]->get_dphi();
@@ -526,7 +481,7 @@ void
 Assembly::buildVectorNeighborFE(FEType type) const
 {
   if (!_vector_fe_shape_data_neighbor[type])
-    _vector_fe_shape_data_neighbor[type] = new VectorFEShapeData;
+    _vector_fe_shape_data_neighbor[type] = std::make_unique<VectorFEShapeData>();
 
   // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
@@ -540,8 +495,7 @@ Assembly::buildVectorNeighborFE(FEType type) const
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_neighbor[dim][type])
-      _const_vector_fe_neighbor[dim][type] = _vector_fe_neighbor[dim][type] =
-          FEGenericBase<VectorValue<Real>>::build(dim, type).release();
+      _vector_fe_neighbor[dim][type] = FEGenericBase<VectorValue<Real>>::build(dim, type).release();
 
     _vector_fe_neighbor[dim][type]->get_phi();
     _vector_fe_neighbor[dim][type]->get_dphi();
@@ -554,7 +508,7 @@ void
 Assembly::buildVectorFaceNeighborFE(FEType type) const
 {
   if (!_vector_fe_shape_data_face_neighbor[type])
-    _vector_fe_shape_data_face_neighbor[type] = new VectorFEShapeData;
+    _vector_fe_shape_data_face_neighbor[type] = std::make_unique<VectorFEShapeData>();
 
   // Note that NEDELEC_ONE elements can only be built for dimension > 2
   unsigned int min_dim;
@@ -568,7 +522,7 @@ Assembly::buildVectorFaceNeighborFE(FEType type) const
   for (unsigned int dim = min_dim; dim <= _mesh_dimension; dim++)
   {
     if (!_vector_fe_face_neighbor[dim][type])
-      _const_vector_fe_face_neighbor[dim][type] = _vector_fe_face_neighbor[dim][type] =
+      _vector_fe_face_neighbor[dim][type] =
           FEGenericBase<VectorValue<Real>>::build(dim, type).release();
 
     _vector_fe_face_neighbor[dim][type]->get_phi();
@@ -653,7 +607,7 @@ Assembly::createQRules(QuadratureType type,
 
   delete _qrule_msm;
   _custom_mortar_qrule = false;
-  _const_qrule_msm = _qrule_msm = QBase::build(type, _mesh_dimension - 1, face_order).release();
+  _qrule_msm = QBase::build(type, _mesh_dimension - 1, face_order).release();
   _qrule_msm->allow_rules_with_negative_weights = allow_negative_qweights;
   _fe_msm->attach_quadrature_rule(_qrule_msm);
 }
@@ -661,7 +615,7 @@ Assembly::createQRules(QuadratureType type,
 void
 Assembly::setVolumeQRule(QBase * qrule, unsigned int dim)
 {
-  _const_current_qrule = _current_qrule = qrule;
+  _current_qrule = qrule;
 
   if (qrule) // Don't set a NULL qrule
   {
@@ -675,7 +629,7 @@ Assembly::setVolumeQRule(QBase * qrule, unsigned int dim)
 void
 Assembly::setFaceQRule(QBase * qrule, unsigned int dim)
 {
-  _const_current_qrule_face = _current_qrule_face = qrule;
+  _current_qrule_face = qrule;
 
   for (auto & it : _fe_face[dim])
     it.second->attach_quadrature_rule(qrule);
@@ -689,7 +643,7 @@ Assembly::setLowerQRule(QBase * qrule, unsigned int dim)
   // The lower-dimensional quadrature rule matches the face quadrature rule
   setFaceQRule(qrule, dim);
 
-  _const_current_qrule_lower = _current_qrule_lower = qrule;
+  _current_qrule_lower = qrule;
 
   for (auto & it : _fe_lower[dim])
     it.second->attach_quadrature_rule(qrule);
@@ -700,7 +654,7 @@ Assembly::setLowerQRule(QBase * qrule, unsigned int dim)
 void
 Assembly::setNeighborQRule(QBase * qrule, unsigned int dim)
 {
-  _const_current_qrule_neighbor = _current_qrule_neighbor = qrule;
+  _current_qrule_neighbor = qrule;
 
   for (auto & it : _fe_face_neighbor[dim])
     it.second->attach_quadrature_rule(qrule);
@@ -721,7 +675,7 @@ Assembly::setMortarQRule(Order order)
       const QuadratureType type = _qrule_msm->type();
       delete _qrule_msm;
 
-      _const_qrule_msm = _qrule_msm = QBase::build(type, dim, order).release();
+      _qrule_msm = QBase::build(type, dim, order).release();
       _fe_msm->attach_quadrature_rule(_qrule_msm);
     }
     else
@@ -740,43 +694,42 @@ Assembly::reinitFE(const Elem * elem)
 
   for (const auto & it : _fe[dim])
   {
-    FEBase * fe = it.second;
+    FEBase & fe = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_fe[fe_type] = fe;
+    _current_fe[fe_type] = &fe;
 
-    FEShapeData * fesd = _fe_shape_data[fe_type];
+    FEShapeData & fesd = *_fe_shape_data[fe_type];
 
-    fe->reinit(elem);
+    fe.reinit(elem);
 
-    fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe.get_d2phi()));
   }
   for (const auto & it : _vector_fe[dim])
   {
-    FEVectorBase * fe = it.second;
+    FEVectorBase & fe = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe[fe_type] = fe;
+    _current_vector_fe[fe_type] = &fe;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data[fe_type];
 
-    fe->reinit(elem);
+    fe.reinit(elem);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(
-          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(
+          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe.get_curl_phi()));
   }
 
   // During that last loop the helper objects will have been reinitialized as well
@@ -805,9 +758,9 @@ Assembly::reinitFE(const Elem * elem)
 
     for (const auto & it : _fe[dim])
     {
-      FEBase * fe = it.second;
+      FEBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe->n_shape_functions();
+      auto num_shapes = fe.n_shape_functions();
       auto & grad_phi = _ad_grad_phi_data[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -815,7 +768,7 @@ Assembly::reinitFE(const Elem * elem)
         grad_phi[i].resize(n_qp);
 
       if (_displaced)
-        computeGradPhiAD(elem, n_qp, grad_phi, fe);
+        computeGradPhiAD(elem, n_qp, grad_phi, &fe);
       else
       {
         const auto & regular_grad_phi = _fe_shape_data[fe_type]->_grad_phi;
@@ -826,9 +779,9 @@ Assembly::reinitFE(const Elem * elem)
     }
     for (const auto & it : _vector_fe[dim])
     {
-      FEVectorBase * fe = it.second;
+      FEVectorBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe->n_shape_functions();
+      auto num_shapes = fe.n_shape_functions();
       auto & grad_phi = _ad_vector_grad_phi_data[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -836,7 +789,7 @@ Assembly::reinitFE(const Elem * elem)
         grad_phi[i].resize(n_qp);
 
       if (_displaced)
-        computeGradPhiAD(elem, n_qp, grad_phi, fe);
+        computeGradPhiAD(elem, n_qp, grad_phi, &fe);
       else
       {
         const auto & regular_grad_phi = _vector_fe_shape_data[fe_type]->_grad_phi;
@@ -1256,40 +1209,40 @@ Assembly::reinitFEFace(const Elem * elem, unsigned int side)
 
   for (const auto & it : _fe_face[dim])
   {
-    FEBase * fe_face = it.second;
+    FEBase & fe_face = *it.second;
     const FEType & fe_type = it.first;
-    FEShapeData * fesd = _fe_shape_data_face[fe_type];
-    fe_face->reinit(elem, side);
-    _current_fe_face[fe_type] = fe_face;
+    FEShapeData & fesd = *_fe_shape_data_face[fe_type];
+    fe_face.reinit(elem, side);
+    _current_fe_face[fe_type] = &fe_face;
 
-    fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_d2phi()));
   }
   for (const auto & it : _vector_fe_face[dim])
   {
-    FEVectorBase * fe_face = it.second;
+    FEVectorBase & fe_face = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe_face[fe_type] = fe_face;
+    _current_vector_fe_face[fe_type] = &fe_face;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data_face[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data_face[fe_type];
 
-    fe_face->reinit(elem, side);
+    fe_face.reinit(elem, side);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face->get_dphi()));
+    fesd._phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(
-          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(
+          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_curl_phi()));
   }
 
   // During that last loop the helper objects will have been reinitialized as well
@@ -1576,43 +1529,42 @@ Assembly::reinitFEFaceNeighbor(const Elem * neighbor, const std::vector<Point> &
   // reinit neighbor face
   for (const auto & it : _fe_face_neighbor[neighbor_dim])
   {
-    FEBase * fe_face_neighbor = it.second;
+    FEBase & fe_face_neighbor = *it.second;
     FEType fe_type = it.first;
-    FEShapeData * fesd = _fe_shape_data_face_neighbor[fe_type];
+    FEShapeData & fesd = *_fe_shape_data_face_neighbor[fe_type];
 
-    fe_face_neighbor->reinit(neighbor, &reference_points);
+    fe_face_neighbor.reinit(neighbor, &reference_points);
 
-    _current_fe_face_neighbor[fe_type] = fe_face_neighbor;
+    _current_fe_face_neighbor[fe_type] = &fe_face_neighbor;
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor.get_dphi()));
     if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_d2phi()));
   }
   for (const auto & it : _vector_fe_face_neighbor[neighbor_dim])
   {
-    FEVectorBase * fe_face_neighbor = it.second;
+    FEVectorBase & fe_face_neighbor = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe_face_neighbor[fe_type] = fe_face_neighbor;
+    _current_vector_fe_face_neighbor[fe_type] = &fe_face_neighbor;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data_face_neighbor[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data_face_neighbor[fe_type];
 
-    fe_face_neighbor->reinit(neighbor, &reference_points);
+    fe_face_neighbor.reinit(neighbor, &reference_points);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
-          fe_face_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
+          fe_face_neighbor.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
-          fe_face_neighbor->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
+          fe_face_neighbor.get_curl_phi()));
   }
 }
 
@@ -1624,42 +1576,42 @@ Assembly::reinitFENeighbor(const Elem * neighbor, const std::vector<Point> & ref
   // reinit neighbor face
   for (const auto & it : _fe_neighbor[neighbor_dim])
   {
-    FEBase * fe_neighbor = it.second;
+    FEBase & fe_neighbor = *it.second;
     FEType fe_type = it.first;
-    FEShapeData * fesd = _fe_shape_data_neighbor[fe_type];
+    FEShapeData & fesd = *_fe_shape_data_neighbor[fe_type];
 
-    fe_neighbor->reinit(neighbor, &reference_points);
+    fe_neighbor.reinit(neighbor, &reference_points);
 
-    _current_fe_neighbor[fe_type] = fe_neighbor;
+    _current_fe_neighbor[fe_type] = &fe_neighbor;
 
-    fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<RealGradient>> &>(fe_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<RealGradient>> &>(fe_neighbor.get_dphi()));
     if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor.get_d2phi()));
   }
   for (const auto & it : _vector_fe_neighbor[neighbor_dim])
   {
-    FEVectorBase * fe_neighbor = it.second;
+    FEVectorBase & fe_neighbor = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe_neighbor[fe_type] = fe_neighbor;
+    _current_vector_fe_neighbor[fe_type] = &fe_neighbor;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data_neighbor[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data_neighbor[fe_type];
 
-    fe_neighbor->reinit(neighbor, &reference_points);
+    fe_neighbor.reinit(neighbor, &reference_points);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_neighbor.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_neighbor.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(
-          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(
+          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_neighbor.get_curl_phi()));
   }
 }
 
@@ -1680,15 +1632,15 @@ Assembly::reinitNeighbor(const Elem * neighbor, const std::vector<Point> & refer
   if (_need_neighbor_elem_volume)
   {
     unsigned int dim = neighbor->dim();
-    FEBase * fe = *_holder_fe_neighbor_helper[dim];
+    FEBase & fe = **_holder_fe_neighbor_helper[dim];
     QBase * qrule = qrules(dim).vol.get();
 
-    fe->attach_quadrature_rule(qrule);
-    fe->reinit(neighbor);
+    fe.attach_quadrature_rule(qrule);
+    fe.reinit(neighbor);
 
-    const std::vector<Real> & JxW = fe->get_JxW();
+    const std::vector<Real> & JxW = fe.get_JxW();
     MooseArray<Point> q_points;
-    q_points.shallowCopy(const_cast<std::vector<Point> &>(fe->get_xyz()));
+    q_points.shallowCopy(const_cast<std::vector<Point> &>(fe.get_xyz()));
 
     setCoordinateTransformation(qrule, q_points, _coord_neighbor, _current_neighbor_subdomain_id);
 
@@ -2018,42 +1970,42 @@ Assembly::reinitElemFaceRef(const Elem * elem,
   // reinit face
   for (const auto & it : _fe_face[elem_dim])
   {
-    FEBase * fe_face = it.second;
+    FEBase & fe_face = *it.second;
     FEType fe_type = it.first;
-    FEShapeData * fesd = _fe_shape_data_face[fe_type];
+    FEShapeData & fesd = *_fe_shape_data_face[fe_type];
 
-    fe_face->reinit(elem, elem_side, tolerance, pts, weights);
+    fe_face.reinit(elem, elem_side, tolerance, pts, weights);
 
-    _current_fe_face[fe_type] = fe_face;
+    _current_fe_face[fe_type] = &fe_face;
 
-    fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face.get_dphi()));
     if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_d2phi()));
   }
   for (const auto & it : _vector_fe_face[elem_dim])
   {
-    FEVectorBase * fe_face = it.second;
+    FEVectorBase & fe_face = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe_face[fe_type] = fe_face;
+    _current_vector_fe_face[fe_type] = &fe_face;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data_face[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data_face[fe_type];
 
-    fe_face->reinit(elem, elem_side, tolerance, pts, weights);
+    fe_face.reinit(elem, elem_side, tolerance, pts, weights);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face->get_dphi()));
+    fesd._phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(fe_face.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(
-          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(
+          const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face.get_curl_phi()));
   }
   // During that last loop the helper objects will have been reinitialized
   _current_q_points_face.shallowCopy(
@@ -2111,9 +2063,9 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
 
     for (const auto & it : _fe_face[dim])
     {
-      FEBase * fe = it.second;
+      FEBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe->n_shape_functions();
+      auto num_shapes = fe.n_shape_functions();
       auto & grad_phi = _ad_grad_phi_data_face[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -2123,7 +2075,7 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
       const auto & regular_grad_phi = _fe_shape_data_face[fe_type]->_grad_phi;
 
       if (_displaced)
-        computeGradPhiAD(&elem, n_qp, grad_phi, fe);
+        computeGradPhiAD(&elem, n_qp, grad_phi, &fe);
       else
         for (unsigned qp = 0; qp < n_qp; ++qp)
           for (decltype(num_shapes) i = 0; i < num_shapes; ++i)
@@ -2131,9 +2083,9 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
     }
     for (const auto & it : _vector_fe_face[dim])
     {
-      FEVectorBase * fe = it.second;
+      FEVectorBase & fe = *it.second;
       auto fe_type = it.first;
-      auto num_shapes = fe->n_shape_functions();
+      auto num_shapes = fe.n_shape_functions();
       auto & grad_phi = _ad_vector_grad_phi_data_face[fe_type];
 
       grad_phi.resize(num_shapes);
@@ -2143,7 +2095,7 @@ Assembly::computeADFace(const Elem & elem, const unsigned int side)
       const auto & regular_grad_phi = _vector_fe_shape_data_face[fe_type]->_grad_phi;
 
       if (_displaced)
-        computeGradPhiAD(&elem, n_qp, grad_phi, fe);
+        computeGradPhiAD(&elem, n_qp, grad_phi, &fe);
       else
         for (unsigned qp = 0; qp < n_qp; ++qp)
           for (decltype(num_shapes) i = 0; i < num_shapes; ++i)
@@ -2176,43 +2128,42 @@ Assembly::reinitNeighborFaceRef(const Elem * neighbor,
   // reinit neighbor face
   for (const auto & it : _fe_face_neighbor[neighbor_dim])
   {
-    FEBase * fe_face_neighbor = it.second;
+    FEBase & fe_face_neighbor = *it.second;
     FEType fe_type = it.first;
-    FEShapeData * fesd = _fe_shape_data_face_neighbor[fe_type];
+    FEShapeData & fesd = *_fe_shape_data_face_neighbor[fe_type];
 
-    fe_face_neighbor->reinit(neighbor, neighbor_side, tolerance, pts, weights);
+    fe_face_neighbor.reinit(neighbor, neighbor_side, tolerance, pts, weights);
 
-    _current_fe_face_neighbor[fe_type] = fe_face_neighbor;
+    _current_fe_face_neighbor[fe_type] = &fe_face_neighbor;
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_face_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<RealGradient>> &>(fe_face_neighbor.get_dphi()));
     if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
-      fesd->_second_phi.shallowCopy(
-          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(
+          const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_d2phi()));
   }
   for (const auto & it : _vector_fe_face_neighbor[neighbor_dim])
   {
-    FEVectorBase * fe_face_neighbor = it.second;
+    FEVectorBase & fe_face_neighbor = *it.second;
     const FEType & fe_type = it.first;
 
-    _current_vector_fe_face_neighbor[fe_type] = fe_face_neighbor;
+    _current_vector_fe_face_neighbor[fe_type] = &fe_face_neighbor;
 
-    VectorFEShapeData * fesd = _vector_fe_shape_data_face_neighbor[fe_type];
+    VectorFEShapeData & fesd = *_vector_fe_shape_data_face_neighbor[fe_type];
 
-    fe_face_neighbor->reinit(neighbor, neighbor_side, tolerance, pts, weights);
+    fe_face_neighbor.reinit(neighbor, neighbor_side, tolerance, pts, weights);
 
-    fesd->_phi.shallowCopy(
-        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor->get_phi()));
-    fesd->_grad_phi.shallowCopy(
-        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor->get_dphi()));
+    fesd._phi.shallowCopy(
+        const_cast<std::vector<std::vector<VectorValue<Real>>> &>(fe_face_neighbor.get_phi()));
+    fesd._grad_phi.shallowCopy(
+        const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_face_neighbor.get_dphi()));
     if (_need_second_derivative.find(fe_type) != _need_second_derivative.end())
-      fesd->_second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
-          fe_face_neighbor->get_d2phi()));
+      fesd._second_phi.shallowCopy(const_cast<std::vector<std::vector<TypeNTensor<3, Real>>> &>(
+          fe_face_neighbor.get_d2phi()));
     if (_need_curl.find(fe_type) != _need_curl.end())
-      fesd->_curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
-          fe_face_neighbor->get_curl_phi()));
+      fesd._curl_phi.shallowCopy(const_cast<std::vector<std::vector<VectorValue<Real>>> &>(
+          fe_face_neighbor.get_curl_phi()));
   }
   // During that last loop the helper objects will have been reinitialized as well
   // We need to dig out the q_points from it
@@ -2233,10 +2184,10 @@ Assembly::reinitDual(const Elem * elem,
 
   for (const auto & it : _fe_lower[elem_dim])
   {
-    FEBase * const fe_lower = it.second;
+    FEBase & fe_lower = *it.second;
     // We use customized quadrature rule for integration along the mortar segment elements
-    fe_lower->set_calculate_default_dual_coeff(false);
-    fe_lower->reinit_dual_shape_coeffs(elem, pts, JxW);
+    fe_lower.set_calculate_default_dual_coeff(false);
+    fe_lower.reinit_dual_shape_coeffs(elem, pts, JxW);
   }
 }
 
@@ -2269,31 +2220,30 @@ Assembly::reinitLowerDElem(const Elem * elem,
 
   for (const auto & it : _fe_lower[elem_dim])
   {
-    FEBase * fe_lower = it.second;
+    FEBase & fe_lower = *it.second;
     FEType fe_type = it.first;
 
-    fe_lower->reinit(elem);
+    fe_lower.reinit(elem);
 
-    if (FEShapeData * fesd = _fe_shape_data_lower[fe_type])
+    if (FEShapeData * fesd = _fe_shape_data_lower[fe_type].get())
     {
-      fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_lower->get_phi()));
+      fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_lower.get_phi()));
       fesd->_grad_phi.shallowCopy(
-          const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower->get_dphi()));
+          const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower.get_dphi()));
       if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
         fesd->_second_phi.shallowCopy(
-            const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower->get_d2phi()));
+            const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower.get_d2phi()));
     }
 
     // Dual shape functions need to be computed after primal basis being initialized
-    if (FEShapeData * fesd = _fe_shape_data_dual_lower[fe_type])
+    if (FEShapeData * fesd = _fe_shape_data_dual_lower[fe_type].get())
     {
-      fesd->_phi.shallowCopy(
-          const_cast<std::vector<std::vector<Real>> &>(fe_lower->get_dual_phi()));
+      fesd->_phi.shallowCopy(const_cast<std::vector<std::vector<Real>> &>(fe_lower.get_dual_phi()));
       fesd->_grad_phi.shallowCopy(
-          const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower->get_dual_dphi()));
+          const_cast<std::vector<std::vector<RealGradient>> &>(fe_lower.get_dual_dphi()));
       if (_need_second_derivative_neighbor.find(fe_type) != _need_second_derivative_neighbor.end())
         fesd->_second_phi.shallowCopy(
-            const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower->get_dual_d2phi()));
+            const_cast<std::vector<std::vector<TensorValue<Real>>> &>(fe_lower.get_dual_d2phi()));
     }
   }
 
@@ -2317,9 +2267,9 @@ Assembly::reinitLowerDElem(const Elem * elem,
   else
   {
     // During that last loop the helper objects will have been reinitialized as well
-    auto * helper_fe = *_holder_fe_lower_helper[elem_dim];
-    const auto & physical_q_points = helper_fe->get_xyz();
-    const auto & JxW = helper_fe->get_JxW();
+    FEBase & helper_fe = **_holder_fe_lower_helper[elem_dim];
+    const auto & physical_q_points = helper_fe.get_xyz();
+    const auto & JxW = helper_fe.get_JxW();
     MooseArray<Real> coord;
     setCoordinateTransformation(
         _current_qrule_lower, physical_q_points, coord, elem->subdomain_id());

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -345,7 +345,7 @@ MooseApp::MooseApp(InputParameters parameters)
     _start_time_set(false),
     _start_time(0.0),
     _global_time_offset(0.0),
-    _input_parameter_warehouse(new InputParameterWarehouse()),
+    _input_parameter_warehouse(std::make_unique<InputParameterWarehouse>()),
     _action_factory(*this),
     _action_warehouse(*this, _syntax, _action_factory),
     _output_warehouse(*this),
@@ -603,7 +603,8 @@ MooseApp::~MooseApp()
   _executioner.reset();
   _the_warehouse.reset();
 
-  delete _input_parameter_warehouse;
+  // Don't wait for implicit destruction of input parameter storage
+  _input_parameter_warehouse.reset();
 
 #ifdef LIBMESH_HAVE_DLOPEN
   // Close any open dynamic libraries

--- a/framework/src/base/TheWarehouse.C
+++ b/framework/src/base/TheWarehouse.C
@@ -103,7 +103,7 @@ private:
   std::vector<std::vector<std::unique_ptr<Attribute>>> _data;
 };
 
-TheWarehouse::TheWarehouse() : _store(new VecStore()) {}
+TheWarehouse::TheWarehouse() : _store(std::make_unique<VecStore>()) {}
 TheWarehouse::~TheWarehouse() {}
 
 void isValid(MooseObject * obj);

--- a/framework/src/geomsearch/NearestNodeLocator.C
+++ b/framework/src/geomsearch/NearestNodeLocator.C
@@ -36,7 +36,6 @@ NearestNodeLocator::NearestNodeLocator(SubProblem & subproblem,
                            Moose::stringify(boundary2)),
     _subproblem(subproblem),
     _mesh(mesh),
-    _secondary_node_range(nullptr),
     _boundary1(boundary1),
     _boundary2(boundary2),
     _first(true),
@@ -57,7 +56,7 @@ NearestNodeLocator::NearestNodeLocator(SubProblem & subproblem,
   */
 }
 
-NearestNodeLocator::~NearestNodeLocator() { delete _secondary_node_range; }
+NearestNodeLocator::~NearestNodeLocator() = default;
 
 void
 NearestNodeLocator::findNodes()
@@ -162,7 +161,8 @@ NearestNodeLocator::findNodes()
     }
 
     // Cache the secondary_node_range so we don't have to build it each time
-    _secondary_node_range = new NodeIdRange(_secondary_nodes.begin(), _secondary_nodes.end(), 1);
+    _secondary_node_range =
+        std::make_unique<NodeIdRange>(_secondary_nodes.begin(), _secondary_nodes.end(), 1);
   }
 
   _nearest_node_info.clear();
@@ -208,8 +208,7 @@ NearestNodeLocator::reinit()
   TIME_SECTION("reinit", 3, "Reinitializing Nearest Node Search");
 
   // Reset all data
-  delete _secondary_node_range;
-  _secondary_node_range = nullptr;
+  _secondary_node_range.reset();
   _nearest_node_info.clear();
 
   _first = true;

--- a/framework/src/meshgenerators/AdvancedExtruderGenerator.C
+++ b/framework/src/meshgenerators/AdvancedExtruderGenerator.C
@@ -465,13 +465,13 @@ AdvancedExtruderGenerator::generate()
 
       for (unsigned int k = 0; k != num_layers; ++k)
       {
-        Elem * new_elem;
+        std::unique_ptr<Elem> new_elem;
         bool isFlipped(false);
         switch (etype)
         {
           case EDGE2:
           {
-            new_elem = new Quad4;
+            new_elem = std::make_unique<Quad4>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -490,7 +490,7 @@ AdvancedExtruderGenerator::generate()
           }
           case EDGE3:
           {
-            new_elem = new Quad9;
+            new_elem = std::make_unique<Quad9>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (2 * current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -519,7 +519,7 @@ AdvancedExtruderGenerator::generate()
           }
           case TRI3:
           {
-            new_elem = new Prism6;
+            new_elem = std::make_unique<Prism6>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -542,9 +542,9 @@ AdvancedExtruderGenerator::generate()
 
             if (new_elem->volume() < 0.0)
             {
-              swapNodesInElem(new_elem, 0, 3);
-              swapNodesInElem(new_elem, 1, 4);
-              swapNodesInElem(new_elem, 2, 5);
+              swapNodesInElem(*new_elem, 0, 3);
+              swapNodesInElem(*new_elem, 1, 4);
+              swapNodesInElem(*new_elem, 2, 5);
               isFlipped = true;
             }
 
@@ -552,7 +552,7 @@ AdvancedExtruderGenerator::generate()
           }
           case TRI6:
           {
-            new_elem = new Prism18;
+            new_elem = std::make_unique<Prism18>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (2 * current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -599,12 +599,12 @@ AdvancedExtruderGenerator::generate()
 
             if (new_elem->volume() < 0.0)
             {
-              swapNodesInElem(new_elem, 0, 3);
-              swapNodesInElem(new_elem, 1, 4);
-              swapNodesInElem(new_elem, 2, 5);
-              swapNodesInElem(new_elem, 6, 12);
-              swapNodesInElem(new_elem, 7, 13);
-              swapNodesInElem(new_elem, 8, 14);
+              swapNodesInElem(*new_elem, 0, 3);
+              swapNodesInElem(*new_elem, 1, 4);
+              swapNodesInElem(*new_elem, 2, 5);
+              swapNodesInElem(*new_elem, 6, 12);
+              swapNodesInElem(*new_elem, 7, 13);
+              swapNodesInElem(*new_elem, 8, 14);
               isFlipped = true;
             }
 
@@ -612,7 +612,7 @@ AdvancedExtruderGenerator::generate()
           }
           case QUAD4:
           {
-            new_elem = new Hex8;
+            new_elem = std::make_unique<Hex8>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -641,10 +641,10 @@ AdvancedExtruderGenerator::generate()
 
             if (new_elem->volume() < 0.0)
             {
-              swapNodesInElem(new_elem, 0, 4);
-              swapNodesInElem(new_elem, 1, 5);
-              swapNodesInElem(new_elem, 2, 6);
-              swapNodesInElem(new_elem, 3, 7);
+              swapNodesInElem(*new_elem, 0, 4);
+              swapNodesInElem(*new_elem, 1, 5);
+              swapNodesInElem(*new_elem, 2, 6);
+              swapNodesInElem(*new_elem, 3, 7);
               isFlipped = true;
             }
 
@@ -652,7 +652,7 @@ AdvancedExtruderGenerator::generate()
           }
           case QUAD9:
           {
-            new_elem = new Hex27;
+            new_elem = std::make_unique<Hex27>();
             new_elem->set_node(0) =
                 mesh->node_ptr(elem->node_ptr(0)->id() + (2 * current_layer * orig_nodes));
             new_elem->set_node(1) =
@@ -719,15 +719,15 @@ AdvancedExtruderGenerator::generate()
 
             if (new_elem->volume() < 0.0)
             {
-              swapNodesInElem(new_elem, 0, 4);
-              swapNodesInElem(new_elem, 1, 5);
-              swapNodesInElem(new_elem, 2, 6);
-              swapNodesInElem(new_elem, 3, 7);
-              swapNodesInElem(new_elem, 8, 16);
-              swapNodesInElem(new_elem, 9, 17);
-              swapNodesInElem(new_elem, 10, 18);
-              swapNodesInElem(new_elem, 11, 19);
-              swapNodesInElem(new_elem, 20, 25);
+              swapNodesInElem(*new_elem, 0, 4);
+              swapNodesInElem(*new_elem, 1, 5);
+              swapNodesInElem(*new_elem, 2, 6);
+              swapNodesInElem(*new_elem, 3, 7);
+              swapNodesInElem(*new_elem, 8, 16);
+              swapNodesInElem(*new_elem, 9, 17);
+              swapNodesInElem(*new_elem, 10, 18);
+              swapNodesInElem(*new_elem, 11, 19);
+              swapNodesInElem(*new_elem, 20, 25);
               isFlipped = true;
             }
 
@@ -766,7 +766,8 @@ AdvancedExtruderGenerator::generate()
           // upward_boundary_source_blocks
           for (unsigned int i = 0; i < _upward_boundary_source_blocks[e].size(); i++)
             if (new_elem->subdomain_id() == _upward_boundary_source_blocks[e][i])
-              boundary_info.add_side(new_elem, isFlipped ? 0 : top_id, _upward_boundary_ids[e][i]);
+              boundary_info.add_side(
+                  new_elem.get(), isFlipped ? 0 : top_id, _upward_boundary_ids[e][i]);
         }
         // define downward boundaries
         if (k == 0)
@@ -776,7 +777,7 @@ AdvancedExtruderGenerator::generate()
           for (unsigned int i = 0; i < _downward_boundary_source_blocks[e].size(); i++)
             if (new_elem->subdomain_id() == _downward_boundary_source_blocks[e][i])
               boundary_info.add_side(
-                  new_elem, isFlipped ? top_id : 0, _downward_boundary_ids[e][i]);
+                  new_elem.get(), isFlipped ? top_id : 0, _downward_boundary_ids[e][i]);
         }
 
         if (_subdomain_swap_pairs.size())
@@ -789,11 +790,11 @@ AdvancedExtruderGenerator::generate()
             new_elem->subdomain_id() = new_id_it->second;
         }
 
-        new_elem = mesh->add_elem(new_elem);
+        Elem * added_elem = mesh->add_elem(std::move(new_elem));
 
         // maintain extra integers
         for (unsigned int i = 0; i < num_extra_elem_integers; i++)
-          new_elem->set_extra_integer(i, elem->get_extra_integer(i));
+          added_elem->set_extra_integer(i, elem->get_extra_integer(i));
 
         if (_elem_integers_swap_pairs.size())
         {
@@ -805,8 +806,8 @@ AdvancedExtruderGenerator::generate()
                 elem->get_extra_integer(_elem_integer_indices_to_swap[i]));
 
             if (new_extra_id_it != elevation_extra_swap_pairs.end())
-              new_elem->set_extra_integer(_elem_integer_indices_to_swap[i],
-                                          new_extra_id_it->second);
+              added_elem->set_extra_integer(_elem_integer_indices_to_swap[i],
+                                            new_extra_id_it->second);
           }
         }
 
@@ -815,17 +816,17 @@ AdvancedExtruderGenerator::generate()
         {
           input_boundary_info.boundary_ids(elem, s, ids_to_copy);
 
-          if (new_elem->dim() == 3)
+          if (added_elem->dim() == 3)
           {
             // For 2D->3D extrusion, we give the boundary IDs
             // for side s on the old element to side s+1 on the
             // new element.  This is just a happy coincidence as
             // far as I can tell...
             if (_boundary_swap_pairs.empty())
-              boundary_info.add_side(new_elem, cast_int<unsigned short>(s + 1), ids_to_copy);
+              boundary_info.add_side(added_elem, cast_int<unsigned short>(s + 1), ids_to_copy);
             else
               for (const auto & id_to_copy : ids_to_copy)
-                boundary_info.add_side(new_elem,
+                boundary_info.add_side(added_elem,
                                        cast_int<unsigned short>(s + 1),
                                        _boundary_swap_pairs[e].count(id_to_copy)
                                            ? _boundary_swap_pairs[e][id_to_copy]
@@ -840,10 +841,10 @@ AdvancedExtruderGenerator::generate()
             libmesh_assert_less(s, 2);
             const unsigned short sidemap[2] = {3, 1};
             if (_boundary_swap_pairs.empty())
-              boundary_info.add_side(new_elem, sidemap[s], ids_to_copy);
+              boundary_info.add_side(added_elem, sidemap[s], ids_to_copy);
             else
               for (const auto & id_to_copy : ids_to_copy)
-                boundary_info.add_side(new_elem,
+                boundary_info.add_side(added_elem,
                                        sidemap[s],
                                        _boundary_swap_pairs[e].count(id_to_copy)
                                            ? _boundary_swap_pairs[e][id_to_copy]
@@ -855,11 +856,11 @@ AdvancedExtruderGenerator::generate()
         if (current_layer == 0)
         {
           const unsigned short top_id =
-              new_elem->dim() == 3 ? cast_int<unsigned short>(elem->n_sides() + 1) : 2;
+              added_elem->dim() == 3 ? cast_int<unsigned short>(elem->n_sides() + 1) : 2;
           if (_has_bottom_boundary)
-            boundary_info.add_side(new_elem, isFlipped ? top_id : 0, _bottom_boundary);
+            boundary_info.add_side(added_elem, isFlipped ? top_id : 0, _bottom_boundary);
           else
-            boundary_info.add_side(new_elem, isFlipped ? top_id : 0, next_side_id);
+            boundary_info.add_side(added_elem, isFlipped ? top_id : 0, next_side_id);
         }
 
         if (current_layer == total_num_layers - 1)
@@ -868,13 +869,13 @@ AdvancedExtruderGenerator::generate()
           // element's number of sides.  For 1D->2D extrusion, the
           // "top" ID is side 2.
           const unsigned short top_id =
-              new_elem->dim() == 3 ? cast_int<unsigned short>(elem->n_sides() + 1) : 2;
+              added_elem->dim() == 3 ? cast_int<unsigned short>(elem->n_sides() + 1) : 2;
 
           if (_has_top_boundary)
-            boundary_info.add_side(new_elem, isFlipped ? 0 : top_id, _top_boundary);
+            boundary_info.add_side(added_elem, isFlipped ? 0 : top_id, _top_boundary);
           else
             boundary_info.add_side(
-                new_elem, isFlipped ? 0 : top_id, cast_int<boundary_id_type>(next_side_id + 1));
+                added_elem, isFlipped ? 0 : top_id, cast_int<boundary_id_type>(next_side_id + 1));
         }
 
         current_layer++;
@@ -905,11 +906,11 @@ AdvancedExtruderGenerator::generate()
 }
 
 void
-AdvancedExtruderGenerator::swapNodesInElem(Elem * elem,
+AdvancedExtruderGenerator::swapNodesInElem(Elem & elem,
                                            const unsigned int nd1,
                                            const unsigned int nd2)
 {
-  Node * n_temp = elem->node_ptr(nd1);
-  elem->set_node(nd1) = elem->node_ptr(nd2);
-  elem->set_node(nd2) = n_temp;
+  Node * n_temp = elem.node_ptr(nd1);
+  elem.set_node(nd1) = elem.node_ptr(nd2);
+  elem.set_node(nd2) = n_temp;
 }

--- a/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
+++ b/framework/src/meshgenerators/ConcentricCircleMeshGenerator.C
@@ -315,7 +315,7 @@ ConcentricCircleMeshGenerator::generate()
   while (index <= limit)
   {
     // inner circle area (polygonal core)
-    Elem * elem = mesh->add_elem(new Quad4);
+    Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
     elem->set_node(0) = nodes[index];
     elem->set_node(1) = nodes[index + _num_sectors / 2 + 1];
     elem->set_node(2) = nodes[index + _num_sectors / 2 + 2];
@@ -341,7 +341,7 @@ ConcentricCircleMeshGenerator::generate()
   while (index < limit)
   {
     // inner circle elements touching B
-    Elem * elem = mesh->add_elem(new Quad4);
+    Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
     elem->set_node(0) = nodes[index];
     elem->set_node(1) = nodes[index + _num_sectors / 2 + 1];
     elem->set_node(2) = nodes[index + _num_sectors / 2 + 2];
@@ -359,7 +359,7 @@ ConcentricCircleMeshGenerator::generate()
   while (index != standard / 2)
   {
     // inner circle elements touching C
-    Elem * elem = mesh->add_elem(new Quad4);
+    Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
     elem->set_node(0) = nodes[index];
     elem->set_node(1) = nodes[index + (_num_sectors / 2 + 1) + counter * (_num_sectors / 2 + 2)];
     elem->set_node(2) =
@@ -384,7 +384,7 @@ ConcentricCircleMeshGenerator::generate()
 
   while (index < limit)
   {
-    Elem * elem = mesh->add_elem(new Quad4);
+    Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
     elem->set_node(0) = nodes[index];
     elem->set_node(1) = nodes[index + standard + 1];
     elem->set_node(2) = nodes[index + standard + 2];
@@ -441,7 +441,7 @@ ConcentricCircleMeshGenerator::generate()
       while (index <= limit)
       {
         // outer square sector C
-        Elem * elem = mesh->add_elem(new Quad4);
+        Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
         elem->set_node(0) = nodes[index];
         elem->set_node(1) = nodes[index + 1];
         elem->set_node(2) = nodes[index + 1 + _rings.back() + 1];
@@ -477,7 +477,7 @@ ConcentricCircleMeshGenerator::generate()
       while (index <= limit)
       {
         // outer square sector A
-        Elem * elem = mesh->add_elem(new Quad4);
+        Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
         elem->set_node(3) = nodes[index];
         elem->set_node(2) = nodes[index + _rings.back() + 2];
         elem->set_node(1) = nodes[index + _rings.back() + 3];
@@ -509,7 +509,7 @@ ConcentricCircleMeshGenerator::generate()
                    _rings.back() * (_rings.back() + 2) - (_rings.back() + 1);
 
       // pointy tips of the A sectors, touching the inner circle
-      Elem * elem = mesh->add_elem(new Quad4);
+      Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
       elem->set_node(3) = nodes[index1];
       elem->set_node(2) = nodes[index2];
       elem->set_node(1) = nodes[index2 + _rings.back() + 1];
@@ -524,7 +524,7 @@ ConcentricCircleMeshGenerator::generate()
       while (index <= limit)
       {
         // outer square elements in sector C touching the inner circle
-        Elem * elem = mesh->add_elem(new Quad4);
+        Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
         elem->set_node(3) = nodes[index];
         elem->set_node(2) = nodes[index + 1];
         elem->set_node(1) = nodes[index2 - _rings.back() - 1];
@@ -552,7 +552,7 @@ ConcentricCircleMeshGenerator::generate()
           (_rings.back() + 1) * (standard / 2) - 1 + (_rings.back() + 1) + (_rings.back() + 2);
 
       // elements clockwise from the A sector tips
-      elem = mesh->add_elem(new Quad4);
+      elem = mesh->add_elem(std::make_unique<Quad4>());
       elem->set_node(0) = nodes[index1];
       elem->set_node(1) = nodes[index1 - 1];
       elem->set_node(2) = nodes[index2];
@@ -579,7 +579,7 @@ ConcentricCircleMeshGenerator::generate()
         while (index >= limit)
         {
           // outer square elements in sector B touching the inner circle
-          Elem * elem = mesh->add_elem(new Quad4);
+          Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
           elem->set_node(0) = nodes[index];
           elem->set_node(1) = nodes[index1];
           elem->set_node(2) = nodes[index1 - (_rings.back() + 1)];
@@ -602,7 +602,7 @@ ConcentricCircleMeshGenerator::generate()
       if (standard >= 2)
       {
         // single elements between A and B on the outside of the square
-        Elem * elem = mesh->add_elem(new Quad4);
+        Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
         elem->set_node(3) = nodes[index];
         elem->set_node(2) = nodes[index + 1];
         elem->set_node(1) = nodes[index + 2];
@@ -625,7 +625,7 @@ ConcentricCircleMeshGenerator::generate()
       int k = 1;
       while (index > limit)
       {
-        Elem * elem = mesh->add_elem(new Quad4);
+        Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
         elem->set_node(3) = nodes[index];
         elem->set_node(2) = nodes[index + (_rings.back() + 2) * k + k + 1];
         elem->set_node(1) = nodes[index + (_rings.back() + 2) * k + k + 2];
@@ -656,7 +656,7 @@ ConcentricCircleMeshGenerator::generate()
       {
         while (index < limit)
         {
-          Elem * elem = mesh->add_elem(new Quad4);
+          Elem * elem = mesh->add_elem(std::make_unique<Quad4>());
           elem->set_node(0) = nodes[index];
           elem->set_node(1) = nodes[index + 1];
           elem->set_node(2) = nodes[index + 1 + _rings.back() + 1];

--- a/framework/src/partitioner/HierarchicalGridPartitioner.C
+++ b/framework/src/partitioner/HierarchicalGridPartitioner.C
@@ -110,7 +110,7 @@ HierarchicalGridPartitioner::_do_partition(MeshBase & mesh, const unsigned int /
 
   // Bound the coarse mesh (n_nodes * n_nodes)
   auto nodes_mesh = std::make_unique<ReplicatedMesh>(this->_communicator);
-  nodes_mesh->partitioner().reset(new LinearPartitioner);
+  nodes_mesh->partitioner() = std::make_unique<LinearPartitioner>();
 
   if (mesh.spatial_dimension() == 2)
     MeshTools::Generation::build_cube(*nodes_mesh,
@@ -163,7 +163,7 @@ HierarchicalGridPartitioner::_do_partition(MeshBase & mesh, const unsigned int /
     }
 
     auto procs_mesh = std::make_unique<ReplicatedMesh>(this->_communicator);
-    procs_mesh->partitioner().reset(new LinearPartitioner);
+    procs_mesh->partitioner() = std::make_unique<LinearPartitioner>();
 
     if (mesh.spatial_dimension() == 2)
       MeshTools::Generation::build_cube(*procs_mesh,

--- a/framework/src/partitioner/PetscExternalPartitioner.C
+++ b/framework/src/partitioner/PetscExternalPartitioner.C
@@ -74,7 +74,7 @@ PetscExternalPartitioner::preLinearPartition(MeshBase & mesh)
   // Temporarily cache the old partition method
   auto old_partitioner = std::move(mesh.partitioner());
   // Create a linear partitioner
-  mesh.partitioner().reset(new LinearPartitioner);
+  mesh.partitioner() = std::make_unique<LinearPartitioner>();
   // Partition mesh
   mesh.partition(n_processors());
   // Restore the old partition

--- a/framework/src/restart/DataIO.C
+++ b/framework/src/restart/DataIO.C
@@ -465,7 +465,7 @@ dataLoad(std::istream & stream, std::stringstream & s, void * /* context */)
   size_t s_size = 0;
   stream.read((char *)&s_size, sizeof(s_size));
 
-  std::unique_ptr<char[]> s_s(new char[s_size]);
+  std::unique_ptr<char[]> s_s = std::make_unique<char[]>(s_size);
   stream.read(s_s.get(), s_size);
 
   // Clear the stringstream before loading new data into it.

--- a/framework/src/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.C
@@ -72,11 +72,11 @@ MultiAppGeneralFieldShapeEvaluationTransfer::buildMeshFunctions(
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(getFromVarName(var_index));
 
-    std::shared_ptr<MeshFunction> from_func;
-    from_func.reset(new MeshFunction(getEquationSystem(from_problem, _displaced_source_mesh),
-                                     *from_sys.current_local_solution,
-                                     from_sys.get_dof_map(),
-                                     from_var_num));
+    std::shared_ptr<MeshFunction> from_func =
+        std::make_shared<MeshFunction>(getEquationSystem(from_problem, _displaced_source_mesh),
+                                       *from_sys.current_local_solution,
+                                       from_sys.get_dof_map(),
+                                       from_var_num);
     from_func->init();
     from_func->enable_out_of_mesh_mode(GeneralFieldTransfer::BetterOutOfMeshValue);
     local_meshfuns.push_back(from_func);

--- a/framework/src/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.C
+++ b/framework/src/transfers/MultiAppGeneralFieldShapeEvaluationTransfer.C
@@ -57,8 +57,10 @@ MultiAppGeneralFieldShapeEvaluationTransfer::prepareEvaluationOfInterpValues(
 
 void
 MultiAppGeneralFieldShapeEvaluationTransfer::buildMeshFunctions(
-    const unsigned int var_index, std::vector<std::shared_ptr<MeshFunction>> & local_meshfuns)
+    const unsigned int var_index, std::vector<MeshFunction> & local_meshfuns)
 {
+  local_meshfuns.reserve(_from_problems.size());
+
   // Construct a local mesh function for each origin problem
   for (unsigned int i_from = 0; i_from < _from_problems.size(); ++i_from)
   {
@@ -72,14 +74,12 @@ MultiAppGeneralFieldShapeEvaluationTransfer::buildMeshFunctions(
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(getFromVarName(var_index));
 
-    std::shared_ptr<MeshFunction> from_func =
-        std::make_shared<MeshFunction>(getEquationSystem(from_problem, _displaced_source_mesh),
-                                       *from_sys.current_local_solution,
-                                       from_sys.get_dof_map(),
-                                       from_var_num);
-    from_func->init();
-    from_func->enable_out_of_mesh_mode(GeneralFieldTransfer::BetterOutOfMeshValue);
-    local_meshfuns.push_back(from_func);
+    local_meshfuns.emplace_back(getEquationSystem(from_problem, _displaced_source_mesh),
+                                *from_sys.current_local_solution,
+                                from_sys.get_dof_map(),
+                                from_var_num);
+    local_meshfuns.back().init();
+    local_meshfuns.back().enable_out_of_mesh_mode(GeneralFieldTransfer::BetterOutOfMeshValue);
   }
 }
 
@@ -94,7 +94,7 @@ MultiAppGeneralFieldShapeEvaluationTransfer::evaluateInterpValues(
 void
 MultiAppGeneralFieldShapeEvaluationTransfer::evaluateInterpValuesWithMeshFunctions(
     const std::vector<BoundingBox> & local_bboxes,
-    const std::vector<std::shared_ptr<MeshFunction>> & local_meshfuns,
+    std::vector<MeshFunction> & local_meshfuns,
     const std::vector<Point> & incoming_points,
     std::vector<std::pair<Real, Real>> & outgoing_vals)
 {
@@ -120,7 +120,7 @@ MultiAppGeneralFieldShapeEvaluationTransfer::evaluateInterpValuesWithMeshFunctio
       else
       {
         // Use mesh function to compute interpolation values
-        auto val = (*local_meshfuns[i_from])(pt - _from_positions[i_from]);
+        auto val = (local_meshfuns[i_from])(pt - _from_positions[i_from]);
 
         // Look for overlaps. The check is not active outside of overlap search because in that
         // case we accept the first value from the lowest ranked process

--- a/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
+++ b/framework/src/transfers/MultiAppPostprocessorInterpolationTransfer.C
@@ -89,15 +89,16 @@ MultiAppPostprocessorInterpolationTransfer::execute()
     }
     case FROM_MULTIAPP:
     {
-      InverseDistanceInterpolation<LIBMESH_DIM> * idi;
+      std::unique_ptr<InverseDistanceInterpolation<LIBMESH_DIM>> idi;
 
       switch (_interp_type)
       {
         case 0:
-          idi = new InverseDistanceInterpolation<LIBMESH_DIM>(_communicator, _num_points, _power);
+          idi = std::make_unique<InverseDistanceInterpolation<LIBMESH_DIM>>(
+              _communicator, _num_points, _power);
           break;
         case 1:
-          idi = new RadialBasisInterpolation<LIBMESH_DIM>(_communicator, _radius);
+          idi = std::make_unique<RadialBasisInterpolation<LIBMESH_DIM>>(_communicator, _radius);
           break;
         default:
           mooseError("Unknown interpolation type!");
@@ -196,8 +197,6 @@ MultiAppPostprocessorInterpolationTransfer::execute()
       }
 
       getFromMultiApp()->problemBase().es().update();
-
-      delete idi;
 
       break;
     }

--- a/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
+++ b/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
@@ -245,11 +245,11 @@ MultiAppShapeEvaluationTransfer::transferVariable(unsigned int i)
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
-    std::shared_ptr<MeshFunction> from_func;
-    from_func.reset(new MeshFunction(getEquationSystem(from_problem, _displaced_source_mesh),
-                                     *from_sys.current_local_solution,
-                                     from_sys.get_dof_map(),
-                                     from_var_num));
+    std::shared_ptr<MeshFunction> from_func =
+        std::make_shared<MeshFunction>(getEquationSystem(from_problem, _displaced_source_mesh),
+                                       *from_sys.current_local_solution,
+                                       from_sys.get_dof_map(),
+                                       from_var_num);
     from_func->init();
     from_func->enable_out_of_mesh_mode(OutOfMeshValue);
     local_meshfuns.push_back(from_func);

--- a/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
+++ b/framework/src/transfers/MultiAppShapeEvaluationTransfer.C
@@ -233,7 +233,8 @@ MultiAppShapeEvaluationTransfer::transferVariable(unsigned int i)
   }
 
   // Setup the local mesh functions.
-  std::vector<std::shared_ptr<MeshFunction>> local_meshfuns;
+  std::vector<MeshFunction> local_meshfuns;
+  local_meshfuns.reserve(_from_problems.size());
   for (unsigned int i_from = 0; i_from < _from_problems.size(); ++i_from)
   {
     FEProblemBase & from_problem = *_from_problems[i_from];
@@ -245,14 +246,12 @@ MultiAppShapeEvaluationTransfer::transferVariable(unsigned int i)
     System & from_sys = from_var.sys().system();
     unsigned int from_var_num = from_sys.variable_number(from_var.name());
 
-    std::shared_ptr<MeshFunction> from_func =
-        std::make_shared<MeshFunction>(getEquationSystem(from_problem, _displaced_source_mesh),
-                                       *from_sys.current_local_solution,
-                                       from_sys.get_dof_map(),
-                                       from_var_num);
-    from_func->init();
-    from_func->enable_out_of_mesh_mode(OutOfMeshValue);
-    local_meshfuns.push_back(from_func);
+    local_meshfuns.emplace_back(getEquationSystem(from_problem, _displaced_source_mesh),
+                                *from_sys.current_local_solution,
+                                from_sys.get_dof_map(),
+                                from_var_num);
+    local_meshfuns.back().init();
+    local_meshfuns.back().enable_out_of_mesh_mode(OutOfMeshValue);
   }
 
   /**
@@ -288,7 +287,7 @@ MultiAppShapeEvaluationTransfer::transferVariable(unsigned int i)
               _current_direction == TO_MULTIAPP ? 0 : _from_local2global_map[i_from];
           // Use mesh funciton to compute interpolation values
           vals_ids_for_incoming_points[i_pt].first =
-              (*local_meshfuns[i_from])(_from_transforms[from_global_num]->mapBack(pt));
+              (local_meshfuns[i_from])(_from_transforms[from_global_num]->mapBack(pt));
           // Record problem ID as well
           switch (_current_direction)
           {

--- a/framework/src/utils/SyntaxTree.C
+++ b/framework/src/utils/SyntaxTree.C
@@ -17,11 +17,11 @@
 #include <cctype>
 
 SyntaxTree::SyntaxTree(bool use_long_names)
-  : SyntaxFormatterInterface(), _root(NULL), _use_long_names(use_long_names)
+  : SyntaxFormatterInterface(), _use_long_names(use_long_names)
 {
 }
 
-SyntaxTree::~SyntaxTree() { delete (_root); }
+SyntaxTree::~SyntaxTree() = default;
 
 void
 SyntaxTree::insertNode(std::string syntax,
@@ -29,8 +29,8 @@ SyntaxTree::insertNode(std::string syntax,
                        bool is_action_params,
                        InputParameters * params)
 {
-  if (_root == NULL)
-    _root = new TreeNode("", *this);
+  if (!_root)
+    _root = std::make_unique<TreeNode>("", *this);
 
   _root->insertNode(syntax, action, is_action_params, params);
 }


### PR DESCRIPTION
Refs #7714

## Reason
There's still quite a lot of manual memory allocation/deallocation in MOOSE, a lot of it unnecessary.  This PR doesn't actually cover the allocation issues that sent me down this rabbit hole, but it should fix up most of the raw pointers and raw allocation that are easy to change.

## Design
* Replace raw (manually allocated/deallocated) pointers with `unique_ptr` where appropriate
* Replace raw `new` with `make_unique` or `make_shared` as appropriate
* Use the "cast reference via a pointer" trick that we use for libMesh mesh iterators, to get rid of the need for (and then get rid of) identical-but-with-more-const copies of pointers in `Assembly`

## Impact
I've tried to limit changes to places where encapsulation allowed me to avoid any public API changes.  There are changes to *protected* member types, though, so it's not impossible that subclasses using those might fail to compile.