### PR TITLE
Added `ThermalSolidPropertiesPostprocessor` and `ADElementIntegralMaterialPropertyRZ`

### DIFF
--- a/modules/doc/content/newsletter/2023/2023_02.md
+++ b/modules/doc/content/newsletter/2023/2023_02.md
@@ -35,6 +35,13 @@ This will apply the coordinate transformation (rotations and scaling defined in 
 [!param](/MultiApps/FullSolveMultiApp/positions) parameter) to the MultiApps' mesh. Unless a coordinate transformation is also specified in the
 parent app's `[Mesh]` block, this parameter makes the child and parent app execute in the same frame of reference.
 
+### Post-processor added to query solid properties
+
+[ThermalSolidPropertiesPostprocessor.md] was added to the
+[solid properties module](modules/solid_properties/index.md), which allows
+users to query a given property from a [ThermalSolidProperties.md] object
+at a temperature given by a post-processor value.
+
 ## libMesh-level Changes
 
 ## PETSc-level Changes

--- a/modules/solid_properties/doc/content/modules/solid_properties/index.md
+++ b/modules/solid_properties/doc/content/modules/solid_properties/index.md
@@ -39,7 +39,7 @@ the overall type of property. The overall design of this module is as follows:
 
 Thermal properties (density, specific heat, and thermal conductivity) are computed by
 userobjects inheriting from the [ThermalSolidProperties](/userobjects/ThermalSolidProperties.md) base class. This class
-defines functions to compute these material properties as a function of temperature:
+defines functions to compute these properties as a function of temperature:
 
 - compute isobaric specific heat - `Real cp_from_T(const Real & T)`
 - compute thermal conductivity - `Real k_from_T(const Real & T)`
@@ -62,12 +62,18 @@ Userobjects available in the Solid Properties module that provide thermal proper
 
 An example will be provided later on this page for creating a new solid userobject.
 
-Then, in the [ThermalSolidPropertiesMaterial](/materials/ThermalSolidPropertiesMaterial.md) material,
-the `computeQpProperties` method evaluates the thermal conductivity, isobaric specific heat, and density at
-the quadrature points using the values of a coupled variable representing temperature plus the functions provided by
-the selected userobject.
+On their own, these userobjects do not execute; their functions must be called from other
+objects. The most common use case is to compute material properties with these
+userobjects, which can be accomplished with
+[ThermalSolidPropertiesMaterial](/materials/ThermalSolidPropertiesMaterial.md);
+its `computeQpProperties` method evaluates the thermal conductivity, isobaric specific heat, and density at
+the quadrature points using the values of a coupled variable representing temperature
+plus the functions provided by the selected userobject:
 
 !listing modules/solid_properties/src/materials/ThermalSolidPropertiesMaterial.C start=computeQpProperties
+
+Another use case is to get a single property into a post-processor,
+which is accomplished with [ThermalSolidPropertiesPostprocessor.md].
 
 ## Usage
 

--- a/modules/solid_properties/doc/content/source/postprocessors/ThermalSolidPropertiesPostprocessor.md
+++ b/modules/solid_properties/doc/content/source/postprocessors/ThermalSolidPropertiesPostprocessor.md
@@ -1,0 +1,10 @@
+# ThermalSolidPropertiesPostprocessor
+
+This post-processor computes a given property from a [ThermalSolidProperties.md]
+object at a temperature given by another post-processor.
+
+!syntax parameters /Postprocessors/ThermalSolidPropertiesPostprocessor
+
+!syntax inputs /Postprocessors/ThermalSolidPropertiesPostprocessor
+
+!syntax children /Postprocessors/ThermalSolidPropertiesPostprocessor

--- a/modules/solid_properties/include/postprocessors/ThermalSolidPropertiesPostprocessor.h
+++ b/modules/solid_properties/include/postprocessors/ThermalSolidPropertiesPostprocessor.h
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralPostprocessor.h"
+
+class ThermalSolidProperties;
+
+/**
+ * Computes a property from a ThermalSolidProperties object.
+ */
+class ThermalSolidPropertiesPostprocessor : public GeneralPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  ThermalSolidPropertiesPostprocessor(const InputParameters & parameters);
+
+  /// Property to query
+  enum class Property
+  {
+    DENSITY,
+    SPECIFIC_HEAT,
+    THERMAL_CONDUCTIVITY
+  };
+
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual PostprocessorValue getValue() override;
+
+protected:
+  /// Solid properties
+  const ThermalSolidProperties & _solid_properties;
+
+  /// Temperature
+  const PostprocessorValue & _T;
+
+  /// Property to query
+  const Property _property;
+};

--- a/modules/solid_properties/src/postprocessors/ThermalSolidPropertiesPostprocessor.C
+++ b/modules/solid_properties/src/postprocessors/ThermalSolidPropertiesPostprocessor.C
@@ -1,0 +1,67 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ThermalSolidPropertiesPostprocessor.h"
+#include "ThermalSolidProperties.h"
+
+registerMooseObject("SolidPropertiesApp", ThermalSolidPropertiesPostprocessor);
+
+InputParameters
+ThermalSolidPropertiesPostprocessor::validParams()
+{
+  InputParameters params = GeneralPostprocessor::validParams();
+
+  params.addRequiredParam<UserObjectName>("solid_properties", "Solid properties object to query");
+  params.addRequiredParam<PostprocessorName>(
+      "T", "Temperature post-processor at which to evaluate property");
+  MooseEnum property("density=0 specific_heat=1 thermal_conductivity=2");
+  params.addRequiredParam<MooseEnum>("property", property, "Which property to compute.");
+
+  params.addClassDescription("Computes a property from a ThermalSolidProperties object.");
+
+  return params;
+}
+
+ThermalSolidPropertiesPostprocessor::ThermalSolidPropertiesPostprocessor(
+    const InputParameters & parameters)
+  : GeneralPostprocessor(parameters),
+    _solid_properties(getUserObject<ThermalSolidProperties>("solid_properties")),
+    _T(getPostprocessorValue("T")),
+    _property(getParam<MooseEnum>("property").getEnum<Property>())
+{
+}
+
+void
+ThermalSolidPropertiesPostprocessor::initialize()
+{
+}
+
+void
+ThermalSolidPropertiesPostprocessor::execute()
+{
+}
+
+PostprocessorValue
+ThermalSolidPropertiesPostprocessor::getValue()
+{
+  switch (_property)
+  {
+    case Property::DENSITY:
+      return _solid_properties.rho_from_T(_T);
+      break;
+    case Property::SPECIFIC_HEAT:
+      return _solid_properties.cp_from_T(_T);
+      break;
+    case Property::THERMAL_CONDUCTIVITY:
+      return _solid_properties.k_from_T(_T);
+      break;
+    default:
+      mooseError("Invalid property option.");
+  }
+}

--- a/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/gold/thermal_solid_properties_postprocessor.csv
+++ b/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/gold/thermal_solid_properties_postprocessor.csv
@@ -1,0 +1,2 @@
+time,density,specific_heat,thermal_conductivity
+0,7615.16,610.06,26.167

--- a/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/tests
+++ b/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/tests
@@ -1,0 +1,11 @@
+[Tests]
+  [test]
+    type = CSVDiff
+    input = 'thermal_solid_properties_postprocessor.i'
+    csvdiff = 'thermal_solid_properties_postprocessor.csv'
+
+    requirement = "The system shall compute thermal solid properties in a post-processor."
+    design = 'ThermalSolidPropertiesPostprocessor.md'
+    issues = '#23419'
+  []
+[]

--- a/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/thermal_solid_properties_postprocessor.i
+++ b/modules/solid_properties/test/tests/postprocessors/thermal_solid_properties_postprocessor/thermal_solid_properties_postprocessor.i
@@ -1,0 +1,55 @@
+# This input file is used to test ThermalSolidPropertiesPostprocessor.
+
+T_ref = 1000.0
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 1
+[]
+
+[SolidProperties]
+  [solid_props]
+    type = ThermalSS316Properties
+  []
+[]
+
+[Postprocessors]
+  [density]
+    type = ThermalSolidPropertiesPostprocessor
+    solid_properties = solid_props
+    property = density
+    T = ${T_ref}
+    execute_on = 'INITIAL'
+  []
+  [specific_heat]
+    type = ThermalSolidPropertiesPostprocessor
+    solid_properties = solid_props
+    property = specific_heat
+    T = ${T_ref}
+    execute_on = 'INITIAL'
+  []
+  [thermal_conductivity]
+    type = ThermalSolidPropertiesPostprocessor
+    solid_properties = solid_props
+    property = thermal_conductivity
+    T = ${T_ref}
+    execute_on = 'INITIAL'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  file_base = 'thermal_solid_properties_postprocessor'
+  [csv]
+    type = CSV
+    execute_on = 'INITIAL'
+  []
+[]

--- a/modules/thermal_hydraulics/doc/content/source/postprocessors/ADElementIntegralMaterialPropertyRZ.md
+++ b/modules/thermal_hydraulics/doc/content/source/postprocessors/ADElementIntegralMaterialPropertyRZ.md
@@ -1,0 +1,12 @@
+# ADElementIntegralMaterialPropertyRZ
+
+This post-processor integrates a material property over a 2D RZ domain. This
+class derives from [ADElementIntegralMaterialProperty](ElementIntegralMaterialProperty.md)
+and [RZSymmetry.md] and multiplies `ADElementIntegralMaterialProperty::computeQpIntegral()`
+by the local circumference to achieve the desired RZ integral.
+
+!syntax parameters /Postprocessors/ADElementIntegralMaterialPropertyRZ
+
+!syntax inputs /Postprocessors/ADElementIntegralMaterialPropertyRZ
+
+!syntax children /Postprocessors/ADElementIntegralMaterialPropertyRZ

--- a/modules/thermal_hydraulics/include/postprocessors/ADElementIntegralMaterialPropertyRZ.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ADElementIntegralMaterialPropertyRZ.h
@@ -1,0 +1,28 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ElementIntegralMaterialProperty.h"
+#include "RZSymmetry.h"
+
+/**
+ * Computes the volume integral of a material property for an RZ geometry.
+ */
+class ADElementIntegralMaterialPropertyRZ : public ADElementIntegralMaterialProperty,
+                                            public RZSymmetry
+{
+public:
+  static InputParameters validParams();
+
+  ADElementIntegralMaterialPropertyRZ(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpIntegral() override;
+};

--- a/modules/thermal_hydraulics/src/postprocessors/ADElementIntegralMaterialPropertyRZ.C
+++ b/modules/thermal_hydraulics/src/postprocessors/ADElementIntegralMaterialPropertyRZ.C
@@ -1,0 +1,35 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ADElementIntegralMaterialPropertyRZ.h"
+
+registerMooseObject("ThermalHydraulicsApp", ADElementIntegralMaterialPropertyRZ);
+
+InputParameters
+ADElementIntegralMaterialPropertyRZ::validParams()
+{
+  InputParameters params = ADElementIntegralMaterialProperty::validParams();
+  params += RZSymmetry::validParams();
+  params.addClassDescription(
+      "Computes the volume integral of a material property for an RZ geometry.");
+  return params;
+}
+
+ADElementIntegralMaterialPropertyRZ::ADElementIntegralMaterialPropertyRZ(
+    const InputParameters & parameters)
+  : ADElementIntegralMaterialProperty(parameters), RZSymmetry(this, parameters)
+{
+}
+
+Real
+ADElementIntegralMaterialPropertyRZ::computeQpIntegral()
+{
+  const Real circumference = computeCircumference(_q_point[_qp]);
+  return circumference * ADElementIntegralMaterialProperty::computeQpIntegral();
+}

--- a/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/element_integral_material_property_rz.i
+++ b/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/element_integral_material_property_rz.i
@@ -1,0 +1,71 @@
+# Tests the ADElementIntegralMaterialPropertyRZ post-processor.
+
+R_o = 0.2
+thickness = 0.05
+R_i = ${fparse R_o - thickness}
+
+L = 3.0
+V = ${fparse pi * (R_o^2 - R_i^2) * L}
+
+rho_value = 5.0
+mass = ${fparse rho_value * V}
+
+[Materials]
+  [hs_mat]
+    type = ADGenericConstantMaterial
+    prop_names = 'density specific_heat thermal_conductivity'
+    prop_values = '${rho_value} 1.0 1.0'
+  []
+[]
+
+[Components]
+  [heat_structure]
+    type = HeatStructureCylindrical
+
+    position = '1 2 3'
+    orientation = '1 1 1'
+    inner_radius = ${R_i}
+    length = ${L}
+    n_elems = 50
+
+    names = 'region1'
+    widths = '${thickness}'
+    n_part_elems = '5'
+
+    initial_T = 300
+  []
+[]
+
+[Postprocessors]
+  [mass]
+    type = ADElementIntegralMaterialPropertyRZ
+    axis_point = '1 2 3'
+    axis_dir = '1 1 1'
+    mat_prop = density
+    execute_on = 'INITIAL'
+  []
+  [mass_error]
+    type = RelativeDifferencePostprocessor
+    value1 = mass
+    value2 = ${mass}
+    execute_on = 'INITIAL'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Transient
+  num_steps = 1
+[]
+
+[Outputs]
+  file_base = 'element_integral_material_property_rz'
+  [csv]
+    type = CSV
+    show = 'mass_error'
+    execute_on = 'INITIAL'
+  []
+[]

--- a/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/gold/element_integral_material_property_rz.csv
+++ b/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/gold/element_integral_material_property_rz.csv
@@ -1,0 +1,2 @@
+time,mass_error
+0,0

--- a/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/tests
+++ b/modules/thermal_hydraulics/test/tests/postprocessors/element_integral_material_property_rz/tests
@@ -1,0 +1,13 @@
+[Tests]
+  [test]
+    type = CSVDiff
+    input = 'element_integral_material_property_rz.i'
+    csvdiff = 'element_integral_material_property_rz.csv'
+    rel_err = 0
+    abs_zero = 1e-12
+
+    requirement = 'This system shall compute an RZ integral of a material property.'
+    design = 'ADElementIntegralMaterialPropertyRZ.md'
+    issues = '#23420'
+  []
+[]


### PR DESCRIPTION
This merge request adds 2 new post-processors, which will be used by some testing in Sockeye:

- `ThermalSolidPropertiesPostprocessor` (#23419)
- `ADElementIntegralMaterialPropertyRZ` (#23420)
