### PR TITLE
Add output intermediate mesh option to MeshGenerator

### DIFF
--- a/test/tests/meshgenerators/output_intermediate_mesh/output_intermediate_mesh.i
+++ b/test/tests/meshgenerators/output_intermediate_mesh/output_intermediate_mesh.i
@@ -1,0 +1,36 @@
+[Mesh]
+  [./left]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 3
+    ny = 3
+    xmin = -3
+    xmax = 0
+    ymin = -5
+    ymax = 5
+    output = true
+    nemesis = true
+  [../]
+  [./right]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 3
+    ny = 3
+    xmin = 3
+    xmax = 6
+    ymin = -5
+    ymax = 5
+  [../]
+
+  [./left_and_right]
+    type = MeshCollectionGenerator
+    inputs = 'left right'
+  [../]
+
+  parallel_type = distributed
+[]
+
+[Outputs]
+  exodus = true
+[]
+


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

This PR add a new option to MeshGenerator so that the users can output and check any intermediate mesh object in `[Mesh]` block.

## Reason
<!--Why do you need this feature or what is the enhancement?-->

This feature allows the user to output and check the intermediate mesh object besides the final mesh file. It is useful for debugging and complex mesh design.

## Design
<!--A concise description (design) of the enhancement.-->

A new bool option output is introduced to `[Mesh]` block. It can be set _true_ in one mesh object to output the corresponding mesh file.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->

A new option is added to MeshGenerator to allow users output and check any intermediate mesh object

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
