### PR TITLE
Minor fixes to deprecated parameter messages 

### DIFF
--- a/framework/src/functions/MooseParsedFunction.C
+++ b/framework/src/functions/MooseParsedFunction.C
@@ -25,10 +25,7 @@ MooseParsedFunctionTempl<T>::validParams()
   InputParameters params = T::validParams();
   params += MooseParsedFunctionBase::validParams();
   params.addDeprecatedCustomTypeParam<std::string>(
-      "value",
-      "FunctionExpression",
-      "The user defined function.",
-      "function is deprecated, use expression instead");
+      "value", "FunctionExpression", "The user defined function.", "Use 'expression' instead.");
   // TODO Make required once deprecation is handled, see #19119
   params.addCustomTypeParam<std::string>(
       "expression", "FunctionExpression", "The user defined function.");

--- a/framework/src/functions/MooseParsedFunctionBase.C
+++ b/framework/src/functions/MooseParsedFunctionBase.C
@@ -22,12 +22,12 @@ MooseParsedFunctionBase::validParams()
       "vars",
       "Variables (excluding t,x,y,z) that are bound to the values provided by the corresponding "
       "items in the vals vector.",
-      "vars is deprecated, use symbol_names instead");
+      "Use 'symbol_names' instead.");
   params.addDeprecatedParam<std::vector<std::string>>(
       "vals",
       "Constant numeric values, postprocessor names, "
       "function names, and scalar variables for vars.",
-      "vals is deprecated, use symbol_values instead");
+      "Use 'symbol_values' instead.");
   params.addParam<std::vector<std::string>>(
       "symbol_names",
       "Symbols (excluding t,x,y,z) that are bound to the values provided by the corresponding "

--- a/framework/src/functions/MooseParsedGradFunction.C
+++ b/framework/src/functions/MooseParsedGradFunction.C
@@ -19,7 +19,7 @@ MooseParsedGradFunction::validParams()
   params.addClassDescription("Defines a function and its gradient using input file parameters.");
   params += MooseParsedFunctionBase::validParams();
   params.addDeprecatedParam<std::string>(
-      "value", "User defined function.", "value is deprecated, use expression instead");
+      "value", "User defined function.", "Use 'expression' instead.");
   // TODO Make required once deprecation is handled + add 0 default, see #19119
   params.addParam<std::string>("expression", "User defined function.");
   params.addParam<std::string>("grad_x", "0", "Partial derivative with respect to x.");


### PR DESCRIPTION
ref #19119

Old message was incorrect:
```
Deprecated code:
The parameter 'value' is deprecated.
function is deprecated, use expression instead
```
New message:
```
Deprecated code:
The parameter 'value' is deprecated.
Use 'expression' instead
```
Also edited a few other related deprecation messages to make them consistent.