### PR TITLE
Qualify use of _dof_indices in MooseVariableFV.C

### DIFF
--- a/framework/src/variables/MooseVariableFV.C
+++ b/framework/src/variables/MooseVariableFV.C
@@ -374,8 +374,8 @@ OutputType
 MooseVariableFV<OutputType>::getValue(const Elem * elem) const
 {
   Moose::initDofIndices(const_cast<MooseVariableFV<OutputType> &>(*this), *elem);
-  mooseAssert(_dof_indices.size() == 1, "Wrong size for dof indices");
-  OutputType value = (*this->_sys.currentSolution())(_dof_indices[0]);
+  mooseAssert(this->_dof_indices.size() == 1, "Wrong size for dof indices");
+  OutputType value = (*this->_sys.currentSolution())(this->_dof_indices[0]);
   return value;
 }
 
@@ -478,10 +478,10 @@ MooseVariableFV<OutputType>::getElemValue(const Elem * const elem) const
   Moose::initDofIndices(const_cast<MooseVariableFV<OutputType> &>(*this), *elem);
 
   mooseAssert(
-      _dof_indices.size() == 1,
+      this->_dof_indices.size() == 1,
       "There should only be one dof-index for a constant monomial variable on any given element");
 
-  const dof_id_type index = _dof_indices[0];
+  const dof_id_type index = this->_dof_indices[0];
 
   ADReal value = (*_solution)(index);
 
@@ -798,10 +798,10 @@ MooseVariableFV<Real>::evaluateDot(const ElemArg & elem_arg,
   Moose::initDofIndices(const_cast<MooseVariableFV<Real> &>(*this), *elem);
 
   mooseAssert(
-      _dof_indices.size() == 1,
+      this->_dof_indices.size() == 1,
       "There should only be one dof-index for a constant monomial variable on any given element");
 
-  const dof_id_type dof_index = _dof_indices[0];
+  const dof_id_type dof_index = this->_dof_indices[0];
 
   if (_var_kind == Moose::VAR_NONLINEAR)
   {


### PR DESCRIPTION
This code has been around for a while but somehow a user on Sawtooth with gcc 8.4 is seeing compile errors due to not recognizing that `_dof_indices` comes from a type dependent base, even though we are pulling it in with `using`