### PR TITLE
Redistribute stateful material properties

### DIFF
--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -434,7 +434,8 @@ dataLoad(std::istream & stream, MaterialProperties & v, void * context)
   const std::size_t old_size = mat_props.size();
 #endif
   loadHelper(stream, mat_props, context);
-  libmesh_assert_equal_to(old_size, mat_props.size());
+  mooseAssert(old_size == mat_props.size(),
+              "Loading MaterialProperties data into mis-sized target");
 }
 
 // Scalar Init Helper Function

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -428,7 +428,13 @@ dataLoad(std::istream & stream, MaterialProperties & v, void * context)
   // Cast this to a vector so we can just piggy back on the vector store capability
   std::vector<PropertyValue *> & mat_props = static_cast<std::vector<PropertyValue *> &>(v);
 
+  // But the vector store capability should not be changing the vector
+  // size
+#ifndef NDEBUG
+  const std::size_t old_size = mat_props.size();
+#endif
   loadHelper(stream, mat_props, context);
+  libmesh_assert_equal_to(old_size, mat_props.size());
 }
 
 // Scalar Init Helper Function

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -336,7 +336,10 @@ private:
                  unsigned int side,
                  unsigned int n_qpoints);
 
-  libMesh::Threads::spin_mutex spin_mutex;
+  // You'd think a private mutex would work here, so I'll leave this
+  // in the namespace for when that happens, but CI thinks that can
+  // make us crash, so I'll just initialize this to Threads::spin_mtx
+  libMesh::Threads::spin_mutex & _spin_mtx;
 
   // Need to be able to eraseProperty from here
   friend class ProjectMaterialProperties;

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -325,6 +325,8 @@ private:
                  unsigned int side,
                  unsigned int n_qpoints);
 
+  libMesh::Threads::spin_mutex spin_mutex;
+
   // Need to be able to eraseProperty from here
   friend class ProjectMaterialProperties;
 

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -190,35 +190,26 @@ public:
    */
   bool hasOlderProperties() const { return _has_older_prop; }
 
+  /**
+   * Accessible type of the stored material property data.
+   *
+   * This probably should have been returned as a proxy class; only
+   * access it via foo[elem][side] and maybe we'll be able to refactor
+   * it in the future without breaking your code.
+   */
+  typedef HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> PropsType;
+
   ///@{
   /**
    * Access methods to the stored material property data
    *
    */
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & props()
-  {
-    return *_props_elem;
-  }
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & propsOld()
-  {
-    return *_props_elem_old;
-  }
-  HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & propsOlder()
-  {
-    return *_props_elem_older;
-  }
-  const HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & props() const
-  {
-    return *_props_elem;
-  }
-  const HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & propsOld() const
-  {
-    return *_props_elem_old;
-  }
-  const HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>> & propsOlder() const
-  {
-    return *_props_elem_older;
-  }
+  PropsType & props() { return *_props_elem; }
+  PropsType & propsOld() { return *_props_elem_old; }
+  PropsType & propsOlder() { return *_props_elem_older; }
+  const PropsType & props() const { return *_props_elem; }
+  const PropsType & propsOld() const { return *_props_elem_old; }
+  const PropsType & propsOlder() const { return *_props_elem_older; }
   MaterialProperties & props(const Elem * elem, unsigned int side)
   {
     return (*_props_elem)[elem][side];
@@ -273,10 +264,9 @@ protected:
   void releasePropertyMap(HashMap<unsigned int, MaterialProperties> & inner_map);
 
   // indexing: [element][side]->material_properties
-  std::unique_ptr<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>> _props_elem;
-  std::unique_ptr<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>> _props_elem_old;
-  std::unique_ptr<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>>
-      _props_elem_older;
+  std::unique_ptr<PropsType> _props_elem;
+  std::unique_ptr<PropsType> _props_elem_old;
+  std::unique_ptr<PropsType> _props_elem_older;
 
   /// mapping from property name to property ID
   /// NOTE: this is static so the property numbering is global within the simulation (not just FEProblemBase - should be useful when we will use material properties from

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -203,54 +203,17 @@ public:
 
   ///@{
   /**
-   * Const access methods to the stored material property data.
-   *
-   * We used to have non-const accessors too, but the violation of
-   * encapsulation there was too much.
+   * Access methods to the stored material property data.
    */
   const PropsType & props() const { return *_props_elem; }
   const PropsType & propsOld() const { return *_props_elem_old; }
   const PropsType & propsOlder() const { return *_props_elem_older; }
-  const MaterialProperties & props(const Elem * elem, unsigned int side) const
-  {
-    libmesh_assert(props().contains(elem));
-    libmesh_assert(props().find(elem)->second.contains(side));
-    return props().find(elem)->second.find(side)->second;
-  }
-  const MaterialProperties & propsOld(const Elem * elem, unsigned int side) const
-  {
-    libmesh_assert(propsOld().contains(elem));
-    libmesh_assert(propsOld().find(elem)->second.contains(side));
-    return propsOld().find(elem)->second.find(side)->second;
-  }
-  const MaterialProperties & propsOlder(const Elem * elem, unsigned int side) const
-  {
-    libmesh_assert(propsOlder().contains(elem));
-    libmesh_assert(propsOlder().find(elem)->second.contains(side));
-    return propsOlder().find(elem)->second.find(side)->second;
-  }
-  MaterialProperties & setProps(const Elem * elem, unsigned int side)
-  {
-    // Many problems rely on reinitMaterials also being the first
-    // init, and I'm not sure I can clean that up to reallow these
-    // assertions without also hurting performance on subsequent
-    // iterations.
-    // libmesh_assert(_props_elem->contains(elem));
-    // libmesh_assert((*_props_elem)[elem].contains(side));
-    return (*_props_elem)[elem][side];
-  }
-  MaterialProperties & setPropsOld(const Elem * elem, unsigned int side)
-  {
-    // libmesh_assert(_props_elem_old->contains(elem));
-    // libmesh_assert((*_props_elem_old)[elem].contains(side));
-    return (*_props_elem_old)[elem][side];
-  }
-  MaterialProperties & setPropsOlder(const Elem * elem, unsigned int side)
-  {
-    // libmesh_assert(_props_elem_older->contains(elem));
-    // libmesh_assert((*_props_elem_older)[elem].contains(side));
-    return (*_props_elem_older)[elem][side];
-  }
+  const MaterialProperties & props(const Elem * elem, unsigned int side) const;
+  const MaterialProperties & propsOld(const Elem * elem, unsigned int side) const;
+  const MaterialProperties & propsOlder(const Elem * elem, unsigned int side) const;
+  MaterialProperties & setProps(const Elem * elem, unsigned int side);
+  MaterialProperties & setPropsOld(const Elem * elem, unsigned int side);
+  MaterialProperties & setPropsOlder(const Elem * elem, unsigned int side);
   ///@}
 
   bool hasProperty(const std::string & prop_name) const;
@@ -351,6 +314,58 @@ private:
   friend void dataLoad<MaterialPropertyStorage>(std::istream &, MaterialPropertyStorage &, void *);
   friend void dataStore<MaterialPropertyStorage>(std::ostream &, MaterialPropertyStorage &, void *);
 };
+
+inline const MaterialProperties &
+MaterialPropertyStorage::props(const Elem * elem, unsigned int side) const
+{
+  libmesh_assert(props().contains(elem));
+  libmesh_assert(props().find(elem)->second.contains(side));
+  return props().find(elem)->second.find(side)->second;
+}
+
+inline const MaterialProperties &
+MaterialPropertyStorage::propsOld(const Elem * elem, unsigned int side) const
+{
+  libmesh_assert(propsOld().contains(elem));
+  libmesh_assert(propsOld().find(elem)->second.contains(side));
+  return propsOld().find(elem)->second.find(side)->second;
+}
+
+inline const MaterialProperties &
+MaterialPropertyStorage::propsOlder(const Elem * elem, unsigned int side) const
+{
+  libmesh_assert(propsOlder().contains(elem));
+  libmesh_assert(propsOlder().find(elem)->second.contains(side));
+  return propsOlder().find(elem)->second.find(side)->second;
+}
+
+inline MaterialProperties &
+MaterialPropertyStorage::setProps(const Elem * elem, unsigned int side)
+{
+  // Many problems rely on reinitMaterials also being the first
+  // init, and I'm not sure I can clean that up to reallow these
+  // assertions without also hurting performance on subsequent
+  // iterations.
+  // libmesh_assert(_props_elem->contains(elem));
+  // libmesh_assert((*_props_elem)[elem].contains(side));
+  return (*_props_elem)[elem][side];
+}
+
+inline MaterialProperties &
+MaterialPropertyStorage::setPropsOld(const Elem * elem, unsigned int side)
+{
+  // libmesh_assert(_props_elem_old->contains(elem));
+  // libmesh_assert((*_props_elem_old)[elem].contains(side));
+  return (*_props_elem_old)[elem][side];
+}
+
+inline MaterialProperties &
+MaterialPropertyStorage::setPropsOlder(const Elem * elem, unsigned int side)
+{
+  // libmesh_assert(_props_elem_older->contains(elem));
+  // libmesh_assert((*_props_elem_older)[elem].contains(side));
+  return (*_props_elem_older)[elem][side];
+}
 
 template <>
 inline void

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -201,12 +201,11 @@ public:
 
   ///@{
   /**
-   * Access methods to the stored material property data
+   * Const access methods to the stored material property data.
    *
+   * We used to have non-const accessors too, but the violation of
+   * encapsulation there was too much.
    */
-  PropsType & props() { return *_props_elem; }
-  PropsType & propsOld() { return *_props_elem_old; }
-  PropsType & propsOlder() { return *_props_elem_older; }
   const PropsType & props() const { return *_props_elem; }
   const PropsType & propsOld() const { return *_props_elem_old; }
   const PropsType & propsOlder() const { return *_props_elem_older; }
@@ -305,26 +304,30 @@ private:
 
   // Need to be able to initProps from here
   friend class RedistributeProperties;
+
+  // Need non-const props from here
+  friend void dataLoad<MaterialPropertyStorage>(std::istream &, MaterialPropertyStorage &, void *);
+  friend void dataStore<MaterialPropertyStorage>(std::ostream &, MaterialPropertyStorage &, void *);
 };
 
 template <>
 inline void
 dataStore(std::ostream & stream, MaterialPropertyStorage & storage, void * context)
 {
-  dataStore(stream, storage.props(), context);
-  dataStore(stream, storage.propsOld(), context);
+  dataStore(stream, *storage._props_elem, context);
+  dataStore(stream, *storage._props_elem_old, context);
 
   if (storage.hasOlderProperties())
-    dataStore(stream, storage.propsOlder(), context);
+    dataStore(stream, *storage._props_elem_older, context);
 }
 
 template <>
 inline void
 dataLoad(std::istream & stream, MaterialPropertyStorage & storage, void * context)
 {
-  dataLoad(stream, storage.props(), context);
-  dataLoad(stream, storage.propsOld(), context);
+  dataLoad(stream, *storage._props_elem, context);
+  dataLoad(stream, *storage._props_elem_old, context);
 
   if (storage.hasOlderProperties())
-    dataLoad(stream, storage.propsOlder(), context);
+    dataLoad(stream, *storage._props_elem_older, context);
 }

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -231,20 +231,24 @@ public:
   }
   MaterialProperties & setProps(const Elem * elem, unsigned int side)
   {
-    libmesh_assert(_props_elem->contains(elem));
-    libmesh_assert((*_props_elem)[elem].contains(side));
+    // Many problems rely on reinitMaterials also being the first
+    // init, and I'm not sure I can clean that up to reallow these
+    // assertions without also hurting performance on subsequent
+    // iterations.
+    // libmesh_assert(_props_elem->contains(elem));
+    // libmesh_assert((*_props_elem)[elem].contains(side));
     return (*_props_elem)[elem][side];
   }
   MaterialProperties & setPropsOld(const Elem * elem, unsigned int side)
   {
-    libmesh_assert(_props_elem_old->contains(elem));
-    libmesh_assert((*_props_elem_old)[elem].contains(side));
+    // libmesh_assert(_props_elem_old->contains(elem));
+    // libmesh_assert((*_props_elem_old)[elem].contains(side));
     return (*_props_elem_old)[elem][side];
   }
   MaterialProperties & setPropsOlder(const Elem * elem, unsigned int side)
   {
-    libmesh_assert(_props_elem_older->contains(elem));
-    libmesh_assert((*_props_elem_older)[elem].contains(side));
+    // libmesh_assert(_props_elem_older->contains(elem));
+    // libmesh_assert((*_props_elem_older)[elem].contains(side));
     return (*_props_elem_older)[elem][side];
   }
   ///@}

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -318,24 +318,29 @@ private:
 inline const MaterialProperties &
 MaterialPropertyStorage::props(const Elem * elem, unsigned int side) const
 {
-  libmesh_assert(props().contains(elem));
-  libmesh_assert(props().find(elem)->second.contains(side));
+  mooseAssert(props().contains(elem), "Trying to read properties on an element that lacks them");
+  mooseAssert(props().find(elem)->second.contains(side),
+              "Trying to read properties on an element side that lacks them");
   return props().find(elem)->second.find(side)->second;
 }
 
 inline const MaterialProperties &
 MaterialPropertyStorage::propsOld(const Elem * elem, unsigned int side) const
 {
-  libmesh_assert(propsOld().contains(elem));
-  libmesh_assert(propsOld().find(elem)->second.contains(side));
+  mooseAssert(propsOld().contains(elem),
+              "Trying to read old properties on an element that lacks them");
+  mooseAssert(propsOld().find(elem)->second.contains(side),
+              "Trying to read old properties on an element side that lacks them");
   return propsOld().find(elem)->second.find(side)->second;
 }
 
 inline const MaterialProperties &
 MaterialPropertyStorage::propsOlder(const Elem * elem, unsigned int side) const
 {
-  libmesh_assert(propsOlder().contains(elem));
-  libmesh_assert(propsOlder().find(elem)->second.contains(side));
+  mooseAssert(propsOlder().contains(elem),
+              "Trying to read older properties on an element that lacks them");
+  mooseAssert(propsOlder().find(elem)->second.contains(side),
+              "Trying to read older properties on an element side that lacks them");
   return propsOlder().find(elem)->second.find(side)->second;
 }
 

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -302,6 +302,9 @@ private:
 
   // Need to be able to eraseProperty from here
   friend class ProjectMaterialProperties;
+
+  // Need to be able to initProps from here
+  friend class RedistributeProperties;
 };
 
 template <>

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -211,14 +211,20 @@ public:
   const PropsType & propsOlder() const { return *_props_elem_older; }
   MaterialProperties & props(const Elem * elem, unsigned int side)
   {
+    libmesh_assert(_props_elem->contains(elem));
+    libmesh_assert((*_props_elem)[elem].contains(side));
     return (*_props_elem)[elem][side];
   }
   MaterialProperties & propsOld(const Elem * elem, unsigned int side)
   {
+    libmesh_assert(_props_elem_old->contains(elem));
+    libmesh_assert((*_props_elem_old)[elem].contains(side));
     return (*_props_elem_old)[elem][side];
   }
   MaterialProperties & propsOlder(const Elem * elem, unsigned int side)
   {
+    libmesh_assert(_props_elem_older->contains(elem));
+    libmesh_assert((*_props_elem_older)[elem].contains(side));
     return (*_props_elem_older)[elem][side];
   }
   ///@}

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -209,19 +209,37 @@ public:
   const PropsType & props() const { return *_props_elem; }
   const PropsType & propsOld() const { return *_props_elem_old; }
   const PropsType & propsOlder() const { return *_props_elem_older; }
-  MaterialProperties & props(const Elem * elem, unsigned int side)
+  const MaterialProperties & props(const Elem * elem, unsigned int side) const
+  {
+    libmesh_assert(props().contains(elem));
+    libmesh_assert(props().find(elem)->second.contains(side));
+    return props().find(elem)->second.find(side)->second;
+  }
+  const MaterialProperties & propsOld(const Elem * elem, unsigned int side) const
+  {
+    libmesh_assert(propsOld().contains(elem));
+    libmesh_assert(propsOld().find(elem)->second.contains(side));
+    return propsOld().find(elem)->second.find(side)->second;
+  }
+  const MaterialProperties & propsOlder(const Elem * elem, unsigned int side) const
+  {
+    libmesh_assert(propsOlder().contains(elem));
+    libmesh_assert(propsOlder().find(elem)->second.contains(side));
+    return propsOlder().find(elem)->second.find(side)->second;
+  }
+  MaterialProperties & setProps(const Elem * elem, unsigned int side)
   {
     libmesh_assert(_props_elem->contains(elem));
     libmesh_assert((*_props_elem)[elem].contains(side));
     return (*_props_elem)[elem][side];
   }
-  MaterialProperties & propsOld(const Elem * elem, unsigned int side)
+  MaterialProperties & setPropsOld(const Elem * elem, unsigned int side)
   {
     libmesh_assert(_props_elem_old->contains(elem));
     libmesh_assert((*_props_elem_old)[elem].contains(side));
     return (*_props_elem_old)[elem][side];
   }
-  MaterialProperties & propsOlder(const Elem * elem, unsigned int side)
+  MaterialProperties & setPropsOlder(const Elem * elem, unsigned int side)
   {
     libmesh_assert(_props_elem_older->contains(elem));
     libmesh_assert((*_props_elem_older)[elem].contains(side));

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -325,6 +325,13 @@ private:
                  unsigned int side,
                  unsigned int n_qpoints);
 
+  /// Initializes just one hashmap's entries
+  void initProps(MaterialData & material_data,
+                 PropsType & mat_props_map,
+                 const Elem * elem,
+                 unsigned int side,
+                 unsigned int n_qpoints);
+
   libMesh::Threads::spin_mutex spin_mutex;
 
   // Need to be able to eraseProperty from here

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -63,6 +63,7 @@ public:
    *    Call on boundary MaterialPropertyStorage and pass volume MaterialPropertyStorage for
    * parent_material_props
    *
+   * @param pid - processor id of children to prolong to
    * @param refinement_map - 2D array of QpMap objects
    * @param qrule The current quadrature rule
    * @param qrule_face The current face qrule
@@ -73,7 +74,8 @@ public:
    * @param input_child - the number of the child
    * @param input_child_side - the side on the child where material properties will be prolonged
    */
-  void prolongStatefulProps(const std::vector<std::vector<QpMap>> & refinement_map,
+  void prolongStatefulProps(processor_id_type pid,
+                            const std::vector<std::vector<QpMap>> & refinement_map,
                             const QBase & qrule,
                             const QBase & qrule_face,
                             MaterialPropertyStorage & parent_material_props,

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -2421,6 +2421,12 @@ private:
   determineNonlinearSystem(const std::string & var_name,
                            bool error_if_not_found = false) const override;
 
+  /*
+   * Test if stateful property redistribution is expected to be
+   * necessary, and set it up if so.
+   */
+  void addAnyRedistributers();
+
   void updateMaxQps();
 
   void joinAndFinalize(TheWarehouse::Query query, bool isgen = false);

--- a/framework/include/relationshipmanagers/RedistributeProperties.h
+++ b/framework/include/relationshipmanagers/RedistributeProperties.h
@@ -1,0 +1,46 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "RelationshipManager.h"
+
+class MaterialPropertyStorage;
+
+/**
+ * RedistributeProperties is used for its \p redistribute() callback,
+ * which ensures that any stateful properties are restributed to the
+ * same properties to which elements they are associated with are
+ * redistributed.
+ */
+class RedistributeProperties : public RelationshipManager
+{
+public:
+  static InputParameters validParams();
+
+  RedistributeProperties(const InputParameters & parameters);
+
+  RedistributeProperties(const RedistributeProperties & other) = default;
+
+  virtual void operator()(const MeshBase::const_element_iterator & range_begin,
+                          const MeshBase::const_element_iterator & range_end,
+                          processor_id_type p,
+                          map_type & coupled_elements) override;
+
+  virtual std::unique_ptr<GhostingFunctor> clone() const override;
+
+  virtual std::string getInfo() const override;
+
+  virtual bool operator>=(const RelationshipManager & rhs) const override;
+
+  virtual void redistribute() override;
+
+private:
+  MaterialPropertyStorage * _mat_prop_storage;
+};

--- a/framework/include/relationshipmanagers/RedistributeProperties.h
+++ b/framework/include/relationshipmanagers/RedistributeProperties.h
@@ -11,6 +11,8 @@
 
 #include "RelationshipManager.h"
 
+// MOOSE Forward Declares
+class MaterialData;
 class MaterialPropertyStorage;
 
 /**
@@ -41,8 +43,10 @@ public:
 
   virtual void redistribute() override;
 
-  void addMaterialPropertyStorage(MaterialPropertyStorage & mat_props);
+  void addMaterialPropertyStorage(std::vector<std::shared_ptr<MaterialData>> & mat_data,
+                                  MaterialPropertyStorage & mat_props);
 
 private:
-  std::vector<MaterialPropertyStorage *> _mat_prop_storages;
+  std::vector<std::pair<std::vector<std::shared_ptr<MaterialData>> *, MaterialPropertyStorage *>>
+      _materials;
 };

--- a/framework/include/relationshipmanagers/RedistributeProperties.h
+++ b/framework/include/relationshipmanagers/RedistributeProperties.h
@@ -30,11 +30,20 @@ public:
 
   RedistributeProperties(const RedistributeProperties & other) = default;
 
+  /**
+   * This function doesn't actually add anything to \p
+   * coupled_elements - we solely use the \p redistribute()
+   * override to keep internal data structures up to date.
+   */
   virtual void operator()(const MeshBase::const_element_iterator & range_begin,
                           const MeshBase::const_element_iterator & range_end,
                           processor_id_type p,
                           map_type & coupled_elements) override;
 
+  /**
+   * Abstract GhostingFunctor code relies on clone(), which for us is
+   * just a copy construction into a new object.
+   */
   virtual std::unique_ptr<GhostingFunctor> clone() const override;
 
   virtual std::string getInfo() const override;
@@ -43,6 +52,11 @@ public:
 
   virtual void redistribute() override;
 
+  /**
+   * Pushes the given pair ( \p mat_data , \p mat_props ) onto our
+   * list of \p _materials data to redistribute each time our
+   * underlying mesh is redistributed.
+   */
   void addMaterialPropertyStorage(std::vector<std::shared_ptr<MaterialData>> & mat_data,
                                   MaterialPropertyStorage & mat_props);
 

--- a/framework/include/relationshipmanagers/RedistributeProperties.h
+++ b/framework/include/relationshipmanagers/RedistributeProperties.h
@@ -41,6 +41,8 @@ public:
 
   virtual void redistribute() override;
 
+  void addMaterialPropertyStorage(MaterialPropertyStorage & mat_props);
+
 private:
-  MaterialPropertyStorage * _mat_prop_storage;
+  std::vector<MaterialPropertyStorage *> _mat_prop_storages;
 };

--- a/framework/include/utils/HashMap.h
+++ b/framework/include/utils/HashMap.h
@@ -32,8 +32,25 @@ public:
     return std::unordered_map<Key, T>::erase(k);
   }
 
+  using typename std::unordered_map<Key, T>::const_iterator;
+  using typename std::unordered_map<Key, T>::iterator;
+
+  inline iterator find(const Key & k)
+  {
+    libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
+
+    return std::unordered_map<Key, T>::find(k);
+  }
+
+  inline const_iterator find(const Key & k) const
+  {
+    libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
+
+    return std::unordered_map<Key, T>::find(k);
+  }
+
   inline bool contains(const Key & key) const { return this->find(key) != this->end(); }
 
 private:
-  libMesh::Threads::spin_mutex spin_mutex;
+  mutable libMesh::Threads::spin_mutex spin_mutex;
 };

--- a/framework/include/utils/HashMap.h
+++ b/framework/include/utils/HashMap.h
@@ -21,14 +21,12 @@ public:
   inline T & operator[](const Key & k)
   {
     libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
-
     return std::unordered_map<Key, T>::operator[](k);
   }
 
   inline std::size_t erase(const Key & k)
   {
     libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
-
     return std::unordered_map<Key, T>::erase(k);
   }
 
@@ -38,14 +36,12 @@ public:
   inline iterator find(const Key & k)
   {
     libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
-
     return std::unordered_map<Key, T>::find(k);
   }
 
   inline const_iterator find(const Key & k) const
   {
     libMesh::Threads::spin_mutex::scoped_lock lock(spin_mutex);
-
     return std::unordered_map<Key, T>::find(k);
   }
 

--- a/framework/include/utils/HashMap.h
+++ b/framework/include/utils/HashMap.h
@@ -32,7 +32,7 @@ public:
     return std::unordered_map<Key, T>::erase(k);
   }
 
-  inline bool contains(const Key & key) { return this->find(key) != this->end(); }
+  inline bool contains(const Key & key) const { return this->find(key) != this->end(); }
 
 private:
   libMesh::Threads::spin_mutex spin_mutex;

--- a/framework/src/loops/CacheChangedListsThread.C
+++ b/framework/src/loops/CacheChangedListsThread.C
@@ -27,9 +27,25 @@ CacheChangedListsThread::~CacheChangedListsThread() {}
 void
 CacheChangedListsThread::onElement(const Elem * elem)
 {
-  if (elem->refinement_flag() == Elem::INACTIVE && elem->has_children() &&
-      elem->child_ptr(0)->refinement_flag() == Elem::JUST_REFINED)
-    _refined_elements.push_back(elem);
+  // Cache any parents of local elements that have just been refined
+  // away.
+  //
+  // The parent itself might *not* be local, because only some of its
+  // new children are.  Make sure to cache every such case exactly once.
+  if (elem->refinement_flag() == Elem::JUST_REFINED)
+  {
+    const Elem * parent = elem->parent();
+    const unsigned int child_num = parent->which_child_am_i(elem);
+
+    bool im_the_lowest_local_child = true;
+    for (unsigned int c = 0; c != child_num; ++c)
+      if (parent->child_ptr(c) && parent->child_ptr(c) != remote_elem &&
+          parent->child_ptr(c)->processor_id() == elem->processor_id())
+        im_the_lowest_local_child = false;
+
+    if (im_the_lowest_local_child)
+      _refined_elements.push_back(parent);
+  }
 
   if (elem->refinement_flag() == Elem::JUST_COARSENED)
   {

--- a/framework/src/loops/CacheChangedListsThread.C
+++ b/framework/src/loops/CacheChangedListsThread.C
@@ -34,11 +34,11 @@ CacheChangedListsThread::onElement(const Elem * elem)
   // new children are.  Make sure to cache every such case exactly once.
   if (elem->refinement_flag() == Elem::JUST_REFINED)
   {
-    const Elem * parent = elem->parent();
+    const Elem * const parent = elem->parent();
     const unsigned int child_num = parent->which_child_am_i(elem);
 
     bool im_the_lowest_local_child = true;
-    for (unsigned int c = 0; c != child_num; ++c)
+    for (const auto c : make_range(child_num))
       if (parent->child_ptr(c) && parent->child_ptr(c) != remote_elem &&
           parent->child_ptr(c)->processor_id() == elem->processor_id())
         im_the_lowest_local_child = false;

--- a/framework/src/loops/ProjectMaterialProperties.C
+++ b/framework/src/loops/ProjectMaterialProperties.C
@@ -86,6 +86,7 @@ ProjectMaterialProperties::onElement(const Elem * elem)
         _mesh.getRefinementMap(*elem, -1, -1, -1);
 
     _material_props.prolongStatefulProps(
+        _mesh.processor_id(),
         refinement_map,
         *_assembly[_tid][0]->qRule(),
         *_assembly[_tid][0]->qRuleFace(),
@@ -128,6 +129,7 @@ ProjectMaterialProperties::onBoundary(const Elem * elem,
           _mesh.getRefinementMap(*elem, side, -1, side);
 
       _bnd_material_props.prolongStatefulProps(
+          _mesh.processor_id(),
           refinement_map,
           *_assembly[_tid][0]->qRule(),
           *_assembly[_tid][0]->qRuleFace(),
@@ -172,6 +174,7 @@ ProjectMaterialProperties::onInternalSide(const Elem * elem, unsigned int /*side
               _mesh.getRefinementMap(*elem, -1, child, side);
 
           _bnd_material_props.prolongStatefulProps(
+              _mesh.processor_id(),
               refinement_map,
               *_assembly[_tid][0]->qRule(),
               *_assembly[_tid][0]->qRuleFace(),

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -421,37 +421,37 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
                                    unsigned int side,
                                    unsigned int n_qpoints)
 {
+  this->initProps(material_data, *_props_elem, elem, side, n_qpoints);
+  this->initProps(material_data, *_props_elem_old, elem, side, n_qpoints);
+
+  if (this->hasOlderProperties())
+    this->initProps(material_data, *_props_elem_older, elem, side, n_qpoints);
+}
+
+void
+MaterialPropertyStorage::initProps(MaterialData & material_data,
+                                   PropsType & mat_props_map,
+                                   const Elem * elem,
+                                   unsigned int side,
+                                   unsigned int n_qpoints)
+{
   material_data.resize(n_qpoints);
   auto n = _stateful_prop_id_to_prop_id.size();
+
+  MaterialProperties & mat_props = mat_props_map[elem][side];
 
   // In some special cases, material_data might be larger than n_qpoints
   if (material_data.isOnlyResizeIfSmaller())
     n_qpoints = material_data.nQPoints();
 
-  MaterialProperties & mat_props = (*_props_elem)[elem][side];
-  MaterialProperties & mat_props_old = (*_props_elem_old)[elem][side];
-  MaterialProperties * mat_props_older =
-      hasOlderProperties() ? &(*_props_elem_older)[elem][side] : nullptr;
-
   if (mat_props.size() < n)
     mat_props.resize(n, nullptr);
-  if (mat_props_old.size() < n)
-    mat_props_old.resize(n, nullptr);
-  if (hasOlderProperties() && mat_props_older->size() < n)
-    mat_props_older->resize(n, nullptr);
 
   // init properties (allocate memory. etc)
   for (unsigned int i = 0; i < n; i++)
   {
     auto prop_id = _stateful_prop_id_to_prop_id[i];
-    // duplicate the stateful property in property storage (all three states - we will reuse the
-    // allocated memory there)
-    // also allocating the right amount of memory, so we do not have to resize, etc.
     if (mat_props[i] == nullptr)
       mat_props[i] = material_data.props()[prop_id]->init(n_qpoints);
-    if (mat_props_old[i] == nullptr)
-      mat_props_old[i] = material_data.propsOld()[prop_id]->init(n_qpoints);
-    if (hasOlderProperties() && (*mat_props_older)[i] == nullptr)
-      (*mat_props_older)[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
   }
 }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -25,7 +25,7 @@ std::map<std::string, unsigned int> MaterialPropertyStorage::_prop_ids;
  * @param data_from Source data
  */
 void
-shallowCopyData(const std::vector<unsigned int> & stateful_prop_ids,
+shallowSwapData(const std::vector<unsigned int> & stateful_prop_ids,
                 MaterialProperties & data,
                 MaterialProperties & data_from)
 {
@@ -41,7 +41,7 @@ shallowCopyData(const std::vector<unsigned int> & stateful_prop_ids,
 }
 
 void
-shallowCopyDataBack(const std::vector<unsigned int> & stateful_prop_ids,
+shallowSwapDataBack(const std::vector<unsigned int> & stateful_prop_ids,
                     MaterialProperties & data,
                     MaterialProperties & data_from)
 {
@@ -332,10 +332,10 @@ MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, u
 {
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
-  shallowCopyData(_stateful_prop_id_to_prop_id, material_data.props(), props(&elem, side));
-  shallowCopyData(_stateful_prop_id_to_prop_id, material_data.propsOld(), propsOld(&elem, side));
+  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.props(), props(&elem, side));
+  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.propsOld(), propsOld(&elem, side));
   if (hasOlderProperties())
-    shallowCopyData(
+    shallowSwapData(
         _stateful_prop_id_to_prop_id, material_data.propsOlder(), propsOlder(&elem, side));
 }
 
@@ -346,11 +346,11 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
 {
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
-  shallowCopyDataBack(_stateful_prop_id_to_prop_id, props(&elem, side), material_data.props());
-  shallowCopyDataBack(
+  shallowSwapDataBack(_stateful_prop_id_to_prop_id, props(&elem, side), material_data.props());
+  shallowSwapDataBack(
       _stateful_prop_id_to_prop_id, propsOld(&elem, side), material_data.propsOld());
   if (hasOlderProperties())
-    shallowCopyDataBack(
+    shallowSwapDataBack(
         _stateful_prop_id_to_prop_id, propsOlder(&elem, side), material_data.propsOlder());
 }
 

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -423,7 +423,6 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
 {
   this->initProps(material_data, *_props_elem, elem, side, n_qpoints);
   this->initProps(material_data, *_props_elem_old, elem, side, n_qpoints);
-
   if (this->hasOlderProperties())
     this->initProps(material_data, *_props_elem_older, elem, side, n_qpoints);
 }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -59,12 +59,9 @@ shallowCopyDataBack(const std::vector<unsigned int> & stateful_prop_ids,
 MaterialPropertyStorage::MaterialPropertyStorage()
   : _has_stateful_props(false), _has_older_prop(false)
 {
-  _props_elem =
-      std::make_unique<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>>();
-  _props_elem_old =
-      std::make_unique<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>>();
-  _props_elem_older =
-      std::make_unique<HashMap<const Elem *, HashMap<unsigned int, MaterialProperties>>>();
+  _props_elem = std::make_unique<PropsType>();
+  _props_elem_old = std::make_unique<PropsType>();
+  _props_elem_older = std::make_unique<PropsType>();
 }
 
 MaterialPropertyStorage::~MaterialPropertyStorage() { releaseProperties(); }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -104,6 +104,7 @@ MaterialPropertyStorage::eraseProperty(const Elem * elem)
 
 void
 MaterialPropertyStorage::prolongStatefulProps(
+    processor_id_type pid,
     const std::vector<std::vector<QpMap>> & refinement_map,
     const QBase & qrule,
     const QBase & qrule_face,
@@ -150,6 +151,11 @@ MaterialPropertyStorage::prolongStatefulProps(
       continue;
 
     const Elem * child_elem = elem.child_ptr(child);
+
+    // If it's not a local child then it'll be prolonged where it is
+    // local
+    if (child_elem->processor_id() != pid)
+      continue;
 
     mooseAssert(child < refinement_map.size(), "Refinement_map vector not initialized");
     const std::vector<QpMap> & child_map = refinement_map[child];

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -57,7 +57,7 @@ shallowSwapDataBack(const std::vector<unsigned int> & stateful_prop_ids,
 }
 
 MaterialPropertyStorage::MaterialPropertyStorage()
-  : _has_stateful_props(false), _has_older_prop(false)
+  : _has_stateful_props(false), _has_older_prop(false), _spin_mtx(libMesh::Threads::spin_mtx)
 {
   _props_elem = std::make_unique<PropsType>();
   _props_elem_old = std::make_unique<PropsType>();
@@ -336,7 +336,7 @@ MaterialPropertyStorage::copy(MaterialData & material_data,
 void
 MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, unsigned int side)
 {
-  Threads::spin_mutex::scoped_lock lock(this->spin_mutex);
+  Threads::spin_mutex::scoped_lock lock(this->_spin_mtx);
 
   shallowSwapData(_stateful_prop_id_to_prop_id, material_data.props(), setProps(&elem, side));
   shallowSwapData(_stateful_prop_id_to_prop_id, material_data.propsOld(), setPropsOld(&elem, side));
@@ -350,7 +350,7 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
                                   const Elem & elem,
                                   unsigned int side)
 {
-  Threads::spin_mutex::scoped_lock lock(this->spin_mutex);
+  Threads::spin_mutex::scoped_lock lock(this->_spin_mtx);
 
   shallowSwapDataBack(_stateful_prop_id_to_prop_id, setProps(&elem, side), material_data.props());
   shallowSwapDataBack(

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -422,12 +422,16 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
   if (material_data.isOnlyResizeIfSmaller())
     n_qpoints = material_data.nQPoints();
 
-  if (props(elem, side).size() < n)
-    props(elem, side).resize(n, nullptr);
-  if (propsOld(elem, side).size() < n)
-    propsOld(elem, side).resize(n, nullptr);
-  if (propsOlder(elem, side).size() < n)
-    propsOlder(elem, side).resize(n, nullptr);
+  auto & mat_props = (*_props_elem)[elem][side];
+  auto & mat_props_old = (*_props_elem_old)[elem][side];
+  auto & mat_props_older = (*_props_elem_older)[elem][side];
+
+  if (mat_props.size() < n)
+    mat_props.resize(n, nullptr);
+  if (mat_props_old.size() < n)
+    mat_props_old.resize(n, nullptr);
+  if (mat_props_older.size() < n)
+    mat_props_older.resize(n, nullptr);
 
   // init properties (allocate memory. etc)
   for (unsigned int i = 0; i < n; i++)
@@ -436,11 +440,11 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
     // duplicate the stateful property in property storage (all three states - we will reuse the
     // allocated memory there)
     // also allocating the right amount of memory, so we do not have to resize, etc.
-    if (props(elem, side)[i] == nullptr)
-      props(elem, side)[i] = material_data.props()[prop_id]->init(n_qpoints);
-    if (propsOld(elem, side)[i] == nullptr)
-      propsOld(elem, side)[i] = material_data.propsOld()[prop_id]->init(n_qpoints);
+    if (mat_props[i] == nullptr)
+      mat_props[i] = material_data.props()[prop_id]->init(n_qpoints);
+    if (mat_props_old[i] == nullptr)
+      mat_props_old[i] = material_data.propsOld()[prop_id]->init(n_qpoints);
     if (hasOlderProperties() && propsOlder(elem, side)[i] == nullptr)
-      propsOlder(elem, side)[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
+      mat_props_older[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
   }
 }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -332,11 +332,11 @@ MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, u
 {
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
-  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.props(), props(&elem, side));
-  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.propsOld(), propsOld(&elem, side));
+  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.props(), setProps(&elem, side));
+  shallowSwapData(_stateful_prop_id_to_prop_id, material_data.propsOld(), setPropsOld(&elem, side));
   if (hasOlderProperties())
     shallowSwapData(
-        _stateful_prop_id_to_prop_id, material_data.propsOlder(), propsOlder(&elem, side));
+        _stateful_prop_id_to_prop_id, material_data.propsOlder(), setPropsOlder(&elem, side));
 }
 
 void
@@ -346,12 +346,12 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
 {
   Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
 
-  shallowSwapDataBack(_stateful_prop_id_to_prop_id, props(&elem, side), material_data.props());
+  shallowSwapDataBack(_stateful_prop_id_to_prop_id, setProps(&elem, side), material_data.props());
   shallowSwapDataBack(
-      _stateful_prop_id_to_prop_id, propsOld(&elem, side), material_data.propsOld());
+      _stateful_prop_id_to_prop_id, setPropsOld(&elem, side), material_data.propsOld());
   if (hasOlderProperties())
     shallowSwapDataBack(
-        _stateful_prop_id_to_prop_id, propsOlder(&elem, side), material_data.propsOlder());
+        _stateful_prop_id_to_prop_id, setPropsOlder(&elem, side), material_data.propsOlder());
 }
 
 bool
@@ -444,7 +444,7 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
       mat_props[i] = material_data.props()[prop_id]->init(n_qpoints);
     if (mat_props_old[i] == nullptr)
       mat_props_old[i] = material_data.propsOld()[prop_id]->init(n_qpoints);
-    if (hasOlderProperties() && propsOlder(elem, side)[i] == nullptr)
+    if (hasOlderProperties() && mat_props_older[i] == nullptr)
       mat_props_older[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
   }
 }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -275,9 +275,9 @@ MaterialPropertyStorage::initStatefulProps(MaterialData & material_data,
   // Copy the properties to Old and Older as needed
   for (unsigned int i = 0; i < _stateful_prop_id_to_prop_id.size(); ++i)
   {
-    auto curr = props(&elem, side)[i];
-    auto old = propsOld(&elem, side)[i];
-    auto older = propsOlder(&elem, side)[i];
+    auto curr = setProps(&elem, side)[i];
+    auto old = setPropsOld(&elem, side)[i];
+    PropertyValue * older = hasOlderProperties() ? setPropsOlder(&elem, side)[i] : nullptr;
     for (unsigned int qp = 0; qp < n_qpoints; ++qp)
     {
       old->qpCopy(qp, curr, qp);
@@ -428,16 +428,17 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
   if (material_data.isOnlyResizeIfSmaller())
     n_qpoints = material_data.nQPoints();
 
-  auto & mat_props = (*_props_elem)[elem][side];
-  auto & mat_props_old = (*_props_elem_old)[elem][side];
-  auto & mat_props_older = (*_props_elem_older)[elem][side];
+  MaterialProperties & mat_props = (*_props_elem)[elem][side];
+  MaterialProperties & mat_props_old = (*_props_elem_old)[elem][side];
+  MaterialProperties * mat_props_older =
+      hasOlderProperties() ? &(*_props_elem_older)[elem][side] : nullptr;
 
   if (mat_props.size() < n)
     mat_props.resize(n, nullptr);
   if (mat_props_old.size() < n)
     mat_props_old.resize(n, nullptr);
-  if (mat_props_older.size() < n)
-    mat_props_older.resize(n, nullptr);
+  if (hasOlderProperties() && mat_props_older->size() < n)
+    mat_props_older->resize(n, nullptr);
 
   // init properties (allocate memory. etc)
   for (unsigned int i = 0; i < n; i++)
@@ -450,7 +451,7 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
       mat_props[i] = material_data.props()[prop_id]->init(n_qpoints);
     if (mat_props_old[i] == nullptr)
       mat_props_old[i] = material_data.propsOld()[prop_id]->init(n_qpoints);
-    if (hasOlderProperties() && mat_props_older[i] == nullptr)
-      mat_props_older[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
+    if (hasOlderProperties() && (*mat_props_older)[i] == nullptr)
+      (*mat_props_older)[i] = material_data.propsOlder()[prop_id]->init(n_qpoints);
   }
 }

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -336,7 +336,7 @@ MaterialPropertyStorage::copy(MaterialData & material_data,
 void
 MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, unsigned int side)
 {
-  Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+  Threads::spin_mutex::scoped_lock lock(this->spin_mutex);
 
   shallowSwapData(_stateful_prop_id_to_prop_id, material_data.props(), setProps(&elem, side));
   shallowSwapData(_stateful_prop_id_to_prop_id, material_data.propsOld(), setPropsOld(&elem, side));
@@ -350,7 +350,7 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
                                   const Elem & elem,
                                   unsigned int side)
 {
-  Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+  Threads::spin_mutex::scoped_lock lock(this->spin_mutex);
 
   shallowSwapDataBack(_stateful_prop_id_to_prop_id, setProps(&elem, side), material_data.props());
   shallowSwapDataBack(

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -105,6 +105,7 @@
 #include "NodalBCBase.h"
 #include "MortarUserObject.h"
 #include "MortarUserObjectThread.h"
+#include "RedistributeProperties.h"
 
 #include "libmesh/exodusII_io.h"
 #include "libmesh/quadrature.h"
@@ -757,6 +758,53 @@ FEProblemBase::initialSetup()
                                    std::vector<RealTensor>(getMaxQps(), RealTensor(0.)));
     }
   }
+
+  // Set up stateful material property redistribution, if we suspect
+  // it may be necessary later.
+#ifdef LIBMESH_ENABLE_AMR
+  if ((_adaptivity.isOn() || _num_grid_steps) &&
+      (_material_props.hasStatefulProperties() || _bnd_material_props.hasStatefulProperties() ||
+       _neighbor_material_props.hasStatefulProperties()))
+  {
+    // Even on a serialized Mesh, we don't keep our material
+    // properties serialized, so we'll rely on the callback to
+    // redistribute() to redistribute properties at the same time
+    // libMesh is redistributing elements.
+    auto add_redistributer =
+        [this](MooseMesh & mesh, const std::string & redistributer_name, bool use_displaced_mesh)
+    {
+      InputParameters redistribute_params = RedistributeProperties::validParams();
+      redistribute_params.set<MooseApp *>("_moose_app") = &_app;
+      redistribute_params.set<std::string>("for_whom") = this->name();
+      redistribute_params.set<MooseMesh *>("mesh") = &mesh;
+      redistribute_params.set<Moose::RelationshipManagerType>("rm_type") =
+          Moose::RelationshipManagerType::GEOMETRIC;
+      redistribute_params.set<bool>("use_displaced_mesh") = use_displaced_mesh;
+
+      std::shared_ptr<RedistributeProperties> redistributer =
+          _factory.create<RedistributeProperties>(
+              "RedistributeProperties", redistributer_name, redistribute_params);
+
+      if (_material_props.hasStatefulProperties())
+        redistributer->addMaterialPropertyStorage(_material_data, _material_props);
+
+      if (_bnd_material_props.hasStatefulProperties())
+        redistributer->addMaterialPropertyStorage(_bnd_material_data, _bnd_material_props);
+
+      if (_neighbor_material_props.hasStatefulProperties())
+        redistributer->addMaterialPropertyStorage(_neighbor_material_data,
+                                                  _neighbor_material_props);
+
+      mesh.getMesh().add_ghosting_functor(redistributer);
+    };
+
+    add_redistributer(_mesh, "mesh_property_redistributer", false);
+    if (_displaced_problem)
+      add_redistributer(_displaced_problem->mesh(), "displaced_mesh_property_redistributer", true);
+  }
+#endif // LIBMESH_ENABLE_AMR
+
+  // Restart/recovery code
 
   if (_app.isRecovering() && (_app.isUltimateMaster() || _force_restart))
   {
@@ -7015,13 +7063,14 @@ FEProblemBase::meshChangedHelper(bool intermediate_change)
 
   reinitBecauseOfGhostingOrNewGeomObjects(/*mortar_changed=*/true);
 
-  // We need to create new storage for the new elements and copy stateful properties from the old
-  // elements.
+  // We need to create new storage for newly active elements, and copy
+  // stateful properties from the old elements.
   if (_has_initialized_stateful &&
       (_material_props.hasStatefulProperties() || _bnd_material_props.hasStatefulProperties()))
   {
+    // Prolong properties onto newly refined elements' children
     {
-      ProjectMaterialProperties pmp(true,
+      ProjectMaterialProperties pmp(/* refine = */ true,
                                     *this,
                                     _material_data,
                                     _bnd_material_data,
@@ -7038,11 +7087,13 @@ FEProblemBase::meshChangedHelper(bool intermediate_change)
       {
         _material_props.eraseProperty(elem);
         _bnd_material_props.eraseProperty(elem);
+        _neighbor_material_props.eraseProperty(elem);
       }
     }
 
+    // Restrict properties onto newly coarsened elements
     {
-      ProjectMaterialProperties pmp(false,
+      ProjectMaterialProperties pmp(/* refine = */ false,
                                     *this,
                                     _material_data,
                                     _bnd_material_data,
@@ -7058,6 +7109,7 @@ FEProblemBase::meshChangedHelper(bool intermediate_change)
         {
           _material_props.eraseProperty(child);
           _bnd_material_props.eraseProperty(child);
+          _neighbor_material_props.eraseProperty(child);
         }
       }
     }
@@ -7115,27 +7167,8 @@ FEProblemBase::checkProblemIntegrity()
         (_material_props.hasStatefulProperties() || _bnd_material_props.hasStatefulProperties() ||
          _neighbor_material_props.hasStatefulProperties()))
     {
-      _console << "Using EXPERIMENTAL Stateful Material Property projection with Adaptivity!\n";
-
-      if (n_processors() > 1)
-      {
-        if (_mesh.uniformRefineLevel() > 0 && _mesh.getMesh().skip_partitioning() == false)
-          mooseError("This simulation is using uniform refinement on the mesh, with stateful "
-                     "properties and adaptivity. "
-                     "You must skip partitioning to run this case:\nMesh/skip_partitioning=true");
-
-        _console << "\nWarning! Mesh re-partitioning is disabled while using stateful material "
-                    "properties!  This can lead to large load imbalances and degraded "
-                    "performance!!\n\n";
-        _mesh.getMesh().skip_partitioning(true);
-
-        _mesh.errorIfDistributedMesh("StatefulMaterials + Adaptivity");
-
-        if (_displaced_problem)
-          _displaced_problem->mesh().getMesh().skip_partitioning(true);
-      }
-
-      _console << std::flush;
+      _console << "Using EXPERIMENTAL Stateful Material Property projection with Adaptivity!\n"
+               << std::flush;
     }
 #endif
 

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -56,6 +56,17 @@ RedistributeProperties::operator>=(const RelationshipManager & rhs) const
 }
 
 void
+RedistributeProperties::addMaterialPropertyStorage(MaterialPropertyStorage & mat_props)
+{
+  _mat_prop_storages.push_back(&mat_props);
+}
+
+void
 RedistributeProperties::redistribute()
 {
+  for (auto mat_props : _mat_prop_storages)
+    if (mat_props->hasStatefulProperties())
+    {
+      libMesh::out << "redistributing mat_props at " << mat_props << std::endl;
+    }
 }

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -20,7 +20,6 @@ InputParameters
 RedistributeProperties::validParams()
 {
   InputParameters params = RelationshipManager::validParams();
-
   return params;
 }
 

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -89,7 +89,9 @@ RedistributeProperties::redistribute()
       MaterialData & my_mat_data = *((*mat_data)[/*_tid*/ 0]); // Not threaded
 
       std::array<MaterialPropertyStorage::PropsType *, 3> props_maps{
-          &mat_prop_store->props(), &mat_prop_store->propsOld(), &mat_prop_store->propsOlder()};
+          mat_prop_store->_props_elem.get(),
+          mat_prop_store->_props_elem_old.get(),
+          mat_prop_store->_props_elem_older.get()};
 
       for (auto * props_map_ptr : props_maps)
       {

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -92,7 +92,7 @@ RedistributeProperties::redistribute()
           mat_prop_store->_props_elem_old.get(),
           mat_prop_store->_props_elem_older.get()};
 
-      for (auto * props_map_ptr : props_maps)
+      for (auto * const props_map_ptr : props_maps)
       {
         MaterialPropertyStorage::PropsType & props_map = *props_map_ptr;
         typedef std::unordered_map<unsigned int, std::string> stored_props_type;
@@ -150,7 +150,7 @@ RedistributeProperties::redistribute()
               {
                 libmesh_assert(!prop_vals.empty());
 
-                for (PropertyValue * prop : prop_vals)
+                for (const PropertyValue * const prop : prop_vals)
                 {
                   libmesh_assert(prop);
                   n_q_points = std::max(n_q_points, prop->size());

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -153,6 +153,7 @@ RedistributeProperties::redistribute()
 
                 for (PropertyValue * prop : prop_vals)
                 {
+                  libmesh_assert(prop);
                   n_q_points = std::max(n_q_points, prop->size());
                 }
 

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -172,7 +172,8 @@ RedistributeProperties::redistribute()
             elems_being_migrated.insert(elem);
         }
 
-        auto recv_functor = [&](processor_id_type, const std::vector<stored_elem_type> & data)
+        auto recv_functor = [&, mat_prop_store_ptr = mat_prop_store](
+                                processor_id_type, const std::vector<stored_elem_type> & data)
         {
           for (const auto & [elem_hash, elem_id, n_q_points] : data)
           {
@@ -188,7 +189,7 @@ RedistributeProperties::redistribute()
               // on, otherwise we might see an
               // initialized-but-not-filled entry in the next map and
               // foolishly try to send it places.
-              mat_prop_store->initProps(my_mat_data, props_map, elem, prop_id, n_q_points);
+              mat_prop_store_ptr->initProps(my_mat_data, props_map, elem, prop_id, n_q_points);
 
               libmesh_assert(elem_props.contains(prop_id));
               MaterialProperties & mat_props = elem_props[prop_id];

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -72,7 +72,18 @@ RedistributeProperties::redistribute()
 {
   const MeshBase & mesh = _moose_mesh->getMesh();
   const processor_id_type pid = mesh.processor_id();
+
   for (auto & [mat_data, mat_prop_store] : _materials)
+  {
+    // Once we've redistributed data elsewhere we'll delete it here.
+    //
+    // We don't need stored properties on non-local elements, and so
+    // we don't compute them and we don't *bother deleting them when
+    // non-local elements are coarsened away*, so this may be our last
+    // chance to avoid dangling pointers in future redistribute()
+    // calls.
+    std::set<const Elem *> elems_being_migrated;
+
     if (mat_prop_store->hasStatefulProperties())
     {
       MaterialData & my_mat_data = *((*mat_data)[/*_tid*/ 0]); // Not threaded
@@ -87,37 +98,75 @@ RedistributeProperties::redistribute()
         typedef std::tuple<stored_props_type, dof_id_type, int> stored_elem_type;
         std::map<processor_id_type, std::vector<stored_elem_type>> props_to_push;
 
-        // Take non-const references here for compatibility with old
-        // dataStore(T&)
+        // Take non-const references here for compatibility with dataStore(T&)
         for (auto & [elem, elem_props_map] : props_map)
         {
           // There better be an element here
           libmesh_assert(elem);
 
-          // There better be a *real* element here, not a dangling
+          // It had better be a *real* element here, not a dangling
           // pointer
           libmesh_assert(elem->id() < mesh.max_elem_id());
           libmesh_assert(elem->processor_id() < mesh.n_processors());
 
-          if (elem->processor_id() != pid)
+          // If it's not in the particular mesh we're responsible for,
+          // we can skip it.  MOOSE mixes non-displaced with displaced
+          // mesh properties in their storages.
+          if (elem != mesh.query_elem_ptr(elem->id()))
+            continue;
+
+          std::vector<processor_id_type> target_pids;
+
+          if (elem->active())
+            target_pids.push_back(elem->processor_id());
+          else if (elem->subactive())
           {
-            stored_props_type stored_props;
-            unsigned int n_q_points = 0;
-            for (auto & [prop_id, prop_vals] : elem_props_map)
+            libmesh_assert(elem->parent());
+            libmesh_assert(elem->parent()->refinement_flag() == Elem::JUST_COARSENED);
+            target_pids.push_back(elem->parent()->processor_id());
+          }
+          else
+          {
+            libmesh_assert(elem->ancestor());
+            libmesh_assert(elem->has_children());
+            for (const Elem & child : elem->child_ref_range())
+              target_pids.push_back(child.processor_id());
+          }
+
+          // If we're being migrated elsewhere and we're not needed
+          // for AMR/C locally then we should erase the local entry
+          bool remote_pid = false, local_pid = false;
+          for (processor_id_type target_pid : target_pids)
+            if (target_pid == pid)
+              local_pid = true;
+            else
             {
-              for (PropertyValue * prop : prop_vals)
+              remote_pid = true;
+
+              stored_props_type stored_props;
+              unsigned int n_q_points = 0;
+              for (auto & [prop_id, prop_vals] : elem_props_map)
               {
-                n_q_points = std::max(n_q_points, prop->size());
+                libmesh_assert(!prop_vals.empty());
+
+                for (PropertyValue * prop : prop_vals)
+                {
+                  n_q_points = std::max(n_q_points, prop->size());
+                }
+
+                std::ostringstream oss;
+                dataStore(oss, prop_vals, nullptr);
+                stored_props[prop_id] = oss.str();
               }
 
-              std::ostringstream oss;
-              dataStore(oss, prop_vals, nullptr);
-              stored_props[prop_id] = oss.str();
+              // Get the stored data ready to push to the element's new
+              // processor
+              props_to_push[target_pid].emplace_back(
+                  std::move(stored_props), elem->id(), n_q_points);
             }
 
-            props_to_push[elem->processor_id()].emplace_back(
-                std::move(stored_props), elem->id(), n_q_points);
-          }
+          if (remote_pid && !local_pid)
+            elems_being_migrated.insert(elem);
         }
 
         auto recv_functor = [&](processor_id_type, const std::vector<stored_elem_type> & data)
@@ -125,17 +174,18 @@ RedistributeProperties::redistribute()
           for (const auto & [elem_hash, elem_id, n_q_points] : data)
           {
             const Elem * elem = mesh.elem_ptr(elem_id);
-            auto it = props_map.find(elem);
-            if (it == props_map.end())
-              for (const auto & [prop_id, prop_str] : elem_hash)
-                mat_prop_store->initProps(my_mat_data, elem, prop_id, n_q_points);
-
             auto & elem_props = props_map[elem];
 
             for (const auto & [prop_id, prop_str] : elem_hash)
             {
+              // This should be called "initPropsIfNecessary"... which
+              // is confusing but convenient.
+              mat_prop_store->initProps(my_mat_data, elem, prop_id, n_q_points);
+
+              libmesh_assert(elem_props.contains(prop_id));
+              MaterialProperties & mat_props = elem_props[prop_id];
               std::istringstream iss(prop_str);
-              dataLoad(iss, elem_props[prop_id], nullptr);
+              dataLoad(iss, mat_props, nullptr);
             }
           }
         };
@@ -143,4 +193,8 @@ RedistributeProperties::redistribute()
         Parallel::push_parallel_vector_data(mesh.comm(), props_to_push, recv_functor);
       }
     }
+
+    for (const Elem * elem : elems_being_migrated)
+      mat_prop_store->eraseProperty(elem);
+  }
 }

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -9,6 +9,11 @@
 
 #include "RedistributeProperties.h"
 
+#include "MaterialProperty.h"
+#include "MaterialPropertyStorage.h"
+
+#include <timpi/parallel_sync.h>
+
 registerMooseObject("MooseApp", RedistributeProperties);
 
 InputParameters
@@ -56,17 +61,86 @@ RedistributeProperties::operator>=(const RelationshipManager & rhs) const
 }
 
 void
-RedistributeProperties::addMaterialPropertyStorage(MaterialPropertyStorage & mat_props)
+RedistributeProperties::addMaterialPropertyStorage(
+    std::vector<std::shared_ptr<MaterialData>> & mat_data, MaterialPropertyStorage & mat_props)
 {
-  _mat_prop_storages.push_back(&mat_props);
+  _materials.emplace_back(&mat_data, &mat_props);
 }
 
 void
 RedistributeProperties::redistribute()
 {
-  for (auto mat_props : _mat_prop_storages)
-    if (mat_props->hasStatefulProperties())
+  const MeshBase & mesh = _moose_mesh->getMesh();
+  const processor_id_type pid = mesh.processor_id();
+  for (auto & [mat_data, mat_prop_store] : _materials)
+    if (mat_prop_store->hasStatefulProperties())
     {
-      libMesh::out << "redistributing mat_props at " << mat_props << std::endl;
+      MaterialData & my_mat_data = *((*mat_data)[/*_tid*/ 0]); // Not threaded
+
+      std::array<MaterialPropertyStorage::PropsType *, 3> props_maps{
+          &mat_prop_store->props(), &mat_prop_store->propsOld(), &mat_prop_store->propsOlder()};
+
+      for (auto * props_map_ptr : props_maps)
+      {
+        MaterialPropertyStorage::PropsType & props_map = *props_map_ptr;
+        typedef std::unordered_map<unsigned int, std::string> stored_props_type;
+        typedef std::tuple<stored_props_type, dof_id_type, int> stored_elem_type;
+        std::map<processor_id_type, std::vector<stored_elem_type>> props_to_push;
+
+        // Take non-const references here for compatibility with old
+        // dataStore(T&)
+        for (auto & [elem, elem_props_map] : props_map)
+        {
+          // There better be an element here
+          libmesh_assert(elem);
+
+          // There better be a *real* element here, not a dangling
+          // pointer
+          libmesh_assert(elem->id() < mesh.max_elem_id());
+          libmesh_assert(elem->processor_id() < mesh.n_processors());
+
+          if (elem->processor_id() != pid)
+          {
+            stored_props_type stored_props;
+            unsigned int n_q_points = 0;
+            for (auto & [prop_id, prop_vals] : elem_props_map)
+            {
+              for (PropertyValue * prop : prop_vals)
+              {
+                n_q_points = std::max(n_q_points, prop->size());
+              }
+
+              std::ostringstream oss;
+              dataStore(oss, prop_vals, nullptr);
+              stored_props[prop_id] = oss.str();
+            }
+
+            props_to_push[elem->processor_id()].emplace_back(
+                std::move(stored_props), elem->id(), n_q_points);
+          }
+        }
+
+        auto recv_functor = [&](processor_id_type, const std::vector<stored_elem_type> & data)
+        {
+          for (const auto & [elem_hash, elem_id, n_q_points] : data)
+          {
+            const Elem * elem = mesh.elem_ptr(elem_id);
+            auto it = props_map.find(elem);
+            if (it == props_map.end())
+              for (const auto & [prop_id, prop_str] : elem_hash)
+                mat_prop_store->initProps(my_mat_data, elem, prop_id, n_q_points);
+
+            auto & elem_props = props_map[elem];
+
+            for (const auto & [prop_id, prop_str] : elem_hash)
+            {
+              std::istringstream iss(prop_str);
+              dataLoad(iss, elem_props[prop_id], nullptr);
+            }
+          }
+        };
+
+        Parallel::push_parallel_vector_data(mesh.comm(), props_to_push, recv_functor);
+      }
     }
 }

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -85,6 +85,10 @@ RedistributeProperties::redistribute()
 
     if (mat_prop_store->hasStatefulProperties())
     {
+      mooseAssert(
+          !Threads::in_threads,
+          "This routine has not been implemented for threads. Please query this routine before "
+          "a threaded region or contact a MOOSE developer to discuss.");
       MaterialData & my_mat_data = *((*mat_data)[/*_tid*/ 0]); // Not threaded
 
       std::array<MaterialPropertyStorage::PropsType *, 3> props_maps{

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -1,0 +1,61 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "RedistributeProperties.h"
+
+registerMooseObject("MooseApp", RedistributeProperties);
+
+InputParameters
+RedistributeProperties::validParams()
+{
+  InputParameters params = RelationshipManager::validParams();
+
+  return params;
+}
+
+RedistributeProperties::RedistributeProperties(const InputParameters & parameters)
+  : RelationshipManager(parameters)
+{
+}
+
+void
+RedistributeProperties::operator()(const MeshBase::const_element_iterator &,
+                                   const MeshBase::const_element_iterator &,
+                                   processor_id_type,
+                                   map_type &)
+{
+}
+
+std::unique_ptr<GhostingFunctor>
+RedistributeProperties::clone() const
+{
+  return std::make_unique<RedistributeProperties>(*this);
+}
+
+std::string
+RedistributeProperties::getInfo() const
+{
+  return "RedistributeProperties";
+}
+
+// the LHS ("this" object) in MooseApp::addRelationshipManager is the existing RelationshipManager
+// object to which we are comparing the rhs to determine whether it should get added
+bool
+RedistributeProperties::operator>=(const RelationshipManager & rhs) const
+{
+  const auto * rm = dynamic_cast<const RedistributeProperties *>(&rhs);
+
+  // All RedistributeProperties objects are effectively equivalent
+  return rm;
+}
+
+void
+RedistributeProperties::redistribute()
+{
+}

--- a/modules/doc/content/newsletter/2023/2023_04.md
+++ b/modules/doc/content/newsletter/2023/2023_04.md
@@ -7,6 +7,24 @@ for a complete description of all MOOSE changes.
 
 ## MOOSE Improvements
 
+### Support for mesh repartitioning with stateful material properties
+
+We previously could not handle any repartitioning in problems using
+stateful material properties, and so MOOSE disabled repartitioning in
+This made adaptive mesh refinement/coarsening (AMR/C) and other mesh
+modifying simulation types less efficient in parallel.
+
+Now MOOSE will automatically redistribute stateful material property
+data as part of any mesh repartitioning step, using the same
+serialization APIs that are also used for restarts, for what should be
+seamless backwards compatibility.
+
+One note to watch out for: because simulations with stateful material
+properties and AMR/C will now enable repartitioning+redistribution by
+default, any *other* application code used in a such a simulation
+should be either compatible with those operations, or should itself
+disable them.
+
 ## libMesh-level Changes
 
 ## PETSc-level Changes

--- a/modules/porous_flow/test/src/vectorpostprocessors/DiracPointsWriter.C
+++ b/modules/porous_flow/test/src/vectorpostprocessors/DiracPointsWriter.C
@@ -9,6 +9,8 @@
 
 #include "DiracPointsWriter.h"
 
+#include "libmesh/parallel_algebra.h"
+
 registerMooseObject("PorousFlowTestApp", DiracPointsWriter);
 
 InputParameters
@@ -35,6 +37,10 @@ DiracPointsWriter::execute()
   for (auto & entry : _subproblem.diracKernelInfo().getPoints())
     if (entry.first->active())
       points.insert(entry.second.first.begin(), entry.second.first.end());
+
+  // Not every processor might know about every point
+  this->comm().set_union(points);
+
   for (auto & p : points)
   {
     _xs.push_back(p(0));

--- a/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/spatial_adaptivity_test.i
@@ -4,11 +4,6 @@
   nx = 2
   ny = 2
   uniform_refine = 3
-  # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
-  skip_partitioning = true
-  # stateful material properties + adaptivity are not yet compatible
-  # with distributed meshes
-  parallel_type = replicated
 []
 
 [Variables]

--- a/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
+++ b/test/tests/materials/stateful_prop/stateful_prop_adaptivity_test.i
@@ -5,11 +5,6 @@
   ny = 2
   nz = 2
   uniform_refine = 2
-  # This option is necessary if you have uniform refinement + stateful material properties + adaptivity
-  skip_partitioning = true
-  # stateful material properties + adaptivity are not yet compatible
-  # with distributed meshes
-  parallel_type = replicated
 []
 
 [Variables]


### PR DESCRIPTION
This should close #4532

## Reason
We previously could not handle any repartitioning in problems using stateful material properties; in particular this made adaptive mesh refinement less efficient in parallel.

## Design
We now attach a GhostingFunctor subclass, RedistributeProperties, which uses the libMesh redistribute() callback as an opportunity to serialize stored material property data and send it to whichever processor (or processors, when we're repartitioning in conjunction with refinement) will need it next.

## Impact
Two public `MaterialPropertyStorage` APIs have had a new parameter added.  I think these are only being used internally, but any external users would have to modify their code to match.

Three `MaterialPropertyStorage` setter APIs have had a name change; this helped with debugging, and again I think they're only being used internally, but we might revert this if there turn out to be apps trying to do tricky things under the framework hood.

The range returned by `refinedElementRange` now includes *all* parents of local just-refined children, not just local parents.  I think this is more consistent with the API comment, and it's a better fit for our internal use of that method, but if anyone else is using refinement with repartitioning and was assuming the former behavior then they'll have a bit of a surprise.

Hopefully, no further impact other than "problems with stateful material problems will now automatically allow repartitioning if the users don't manually disable it".  Debugging this code was quite horrific, so I do worry about the possibility of corner cases I missed, but if there still are any then I believe "manually disable repartitioning" would be an easy workaround while a further fix was worked on.