### PR TITLE
Fix the logo inconsistencies

### DIFF
--- a/modules/doc/content/index.md
+++ b/modules/doc/content/index.md
@@ -9,7 +9,7 @@ Multiphysics Object-Oriented Simulation Environment
 
 # An open-source, parallel finite element framework class=center style=font-weight:200;font-size:200%
 
-!media gallery/twist_dark.mp4 style=width:100%; controls=False autoplay=True loop=True
+!media gallery/twist_white.webm style=width:100%; controls=False autoplay=True loop=True
 
 !row!
 !col! small=12 medium=4 large=4 icon=computer
@@ -51,7 +51,7 @@ Multiphysics Object-Oriented Simulation Environment
 !row! style=display:inline-flex;
 !col! small=12 medium=4 large=2
 
-!media large_media/organization_logos/INL-Logo_Left-Black.png dark_src=large_media/organization_logos/INL-Logo_Banner-White.png style=width:100%;display:block;
+!media large_media/organization_logos/INL-Logo_Left-Black.png dark_src=large_media/organization_logos/INL-Logo_Left-White.png style=width:100%;display:block;
 
 !col-end!
 


### PR DESCRIPTION
bump large_media to use fixed logo images.
Use the transparent twist mesh animation on home landing page.

Closes #23623
