### PR TITLE
Catch mispelled parameters for multiapp directions in transfers

### DIFF
--- a/framework/include/transfers/MultiAppTransfer.h
+++ b/framework/include/transfers/MultiAppTransfer.h
@@ -74,7 +74,7 @@ public:
   {
     if (!_to_multi_app)
       mooseError(
-          "A from_multiapp was requested but is unavailable. Check the from_multi_app parameter");
+          "A to_multiapp was requested but is unavailable. Check the to_multi_app parameter");
     else
       return _to_multi_app;
   }

--- a/framework/src/transfers/MultiAppTransfer.C
+++ b/framework/src/transfers/MultiAppTransfer.C
@@ -96,6 +96,9 @@ MultiAppTransfer::MultiAppTransfer(const InputParameters & parameters)
       _to_multi_app = _fe_problem.getMultiApp(getParam<MultiAppName>("to_multi_app"));
       _multi_app = _to_multi_app;
     }
+    if (!isParamValid("direction") && !isParamValid("from_multi_app") &&
+        !isParamValid("to_multi_app"))
+      mooseError("from_multi_app and/or to_multi_app must be specified");
   }
   else
   {

--- a/test/tests/transfers/errors/tests
+++ b/test/tests/transfers/errors/tests
@@ -14,4 +14,14 @@
     cli_args = "Transfers/from_sub/from_multi_app='sub' Transfers/from_sub/multi_app='sub'"
     expect_err = "The deprecated 'direction' parameter is not meant to be used in conjunction with the 'from_multi_app' or 'to_multi_app' parameters"
   []
+  [bad_spelling]
+    requirement = 'The system shall error if the user provides nonsensical direction parameters.'
+    type = RunException
+    input = from_sub.i
+    # from_multi_app is mispelled
+    cli_args = "Transfers/from_sub/multi_app=sub
+                Transfers/from_sub_v2/type=MultiAppCopyTransfer Transfers/from_sub_v2/source_variable=aux Transfers/from_sub_v2/variable=x
+                Transfers/from_sub_v2/from_multiapp='sub'"
+    expect_err = "from_multi_app and/or to_multi_app must be specified"
+  []
 []


### PR DESCRIPTION
closes #22308

