### PR TITLE
Guard against sizing non-existant old material properties

### DIFF
--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -144,7 +144,8 @@ PorousFlowMaterial::sizeNodalProperties()
     props[prop_id]->resize(new_size);
 
   for (const auto prop_id : _supplied_old_prop_ids)
-    props_old[prop_id]->resize(new_size);
+    if (auto * const old_prop = props_old[prop_id])
+      old_prop->resize(new_size);
 
   if (storage.hasOlderProperties())
     for (const auto prop_id : _supplied_old_prop_ids)


### PR DESCRIPTION
@lindsayad - I'm sorry to bug you again but you had previously fixed this where we were just resizing everything in the past.

I'm not exactly sure why an id from the array `_supplied_old_prop_ids` wasn't a valid element of `props_old` in this particular scenario, but this defensive if statement does guard against it. 

This does fix the seg fault in #23650.

Fixes #23650


