### PR TITLE
Suppress nonlinear parameters for `ExternalProblem`

### DIFF
--- a/framework/src/problems/ExternalProblem.C
+++ b/framework/src/problems/ExternalProblem.C
@@ -18,6 +18,14 @@ ExternalProblem::validParams()
   InputParameters params = FEProblemBase::validParams();
   params.set<bool>("skip_nl_system_check") = true;
 
+  // there is no nonlinear system (we set it as empty in the constructor)
+  params.suppressParameter<bool>("ignore_zeros_in_jacobian");
+  params.suppressParameter<bool>("kernel_coverage_check");
+  params.suppressParameter<std::vector<NonlinearSystemName>>("nl_sys_names");
+  params.suppressParameter<bool>("previous_nl_solution_required");
+  params.suppressParameter<bool>("skip_nl_system_check");
+  params.suppressParameter<bool>("use_nonlinear");
+
   params.addClassDescription("Problem extension point for wrapping external applications");
   return params;
 }


### PR DESCRIPTION
Suppress input parameters related to the nonlinear system for `ExternalProblem`. I tested this first with Cardinal, and all of our tests pass (so at least how we use `ExternalProblem` is fine).


Closes #23690
