### PR TITLE
Setup Point and LineSegment specializations to enable use with Reporters

### DIFF
--- a/framework/include/dirackernels/ReporterPointSource.h
+++ b/framework/include/dirackernels/ReporterPointSource.h
@@ -37,6 +37,10 @@ private:
   const std::vector<Real> & _y_coord;
   ///z coordinate
   const std::vector<Real> & _z_coord;
+  const std::vector<Point> & _point;
   /// map to associate points with their index into the vpp value
   std::map<Point, size_t> _point_to_index;
+
+  const std::vector<Real> _empty_vec = {};
+  const std::vector<Point> _empty_points = {};
 };

--- a/framework/include/outputs/JsonIO.h
+++ b/framework/include/outputs/JsonIO.h
@@ -12,7 +12,16 @@
 #include "nlohmann/json.h"
 
 class MooseApp;
+namespace libMesh
+{
+class Point;
+}
 
 // Specializations for to_json, which _must_ be specialized in the namespace
 // in which the object is found
 void to_json(nlohmann::json & json, const MooseApp & app); // MooseDocs:to_json
+
+namespace libMesh
+{
+void to_json(nlohmann::json & json, const Point & p);
+}

--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -29,6 +29,7 @@ class Plane;
 class LineSegment
 {
 public:
+  LineSegment() = default;
   LineSegment(const Point & p0, const Point & p1);
 
   virtual ~LineSegment() = default;
@@ -67,6 +68,21 @@ public:
   const Point & end() const { return _p1; }
 
   /**
+   * Sets the beginning of the line segment.
+   */
+  void setStart(const Point & p0) { _p0 = p0; }
+
+  /**
+   * Sets the end of the line segment.
+   */
+  void setEnd(const Point & p1) { _p1 = p1; }
+
+  /**
+   * Sets the points on the line segment.
+   */
+  void set(const Point & p0, const Point & p1);
+
+  /**
    * Length of segment
    */
   Real length() const { return (_p0 - _p1).norm(); }
@@ -80,5 +96,4 @@ private:
 void dataStore(std::ostream & stream, LineSegment & l, void * context);
 void dataLoad(std::istream & stream, LineSegment & l, void * context);
 
-void to_json(nlohmann::json & json, const Point & p);
 void to_json(nlohmann::json & json, const LineSegment & l);

--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -11,7 +11,9 @@
 
 // MOOSE includes
 #include "Moose.h" // using namespace libMesh
+#include "DataIO.h"
 
+#include "json.h"
 #include "libmesh/point.h"
 
 // forward declarations
@@ -74,3 +76,9 @@ private:
 
   Point _p0, _p1;
 };
+
+void dataStore(std::ostream & stream, LineSegment & l, void * context);
+void dataLoad(std::ostream & stream, LineSegment & l, void * context);
+
+void to_json(nlohmann::json & json, const Point * const & p);
+void to_json(nlohmann::json & json, const LineSegment * const & l);

--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -80,5 +80,5 @@ private:
 void dataStore(std::ostream & stream, LineSegment & l, void * context);
 void dataLoad(std::ostream & stream, LineSegment & l, void * context);
 
-void to_json(nlohmann::json & json, const Point * const & p);
-void to_json(nlohmann::json & json, const LineSegment * const & l);
+void to_json(nlohmann::json & json, const Point & p);
+void to_json(nlohmann::json & json, const LineSegment & l);

--- a/framework/include/utils/LineSegment.h
+++ b/framework/include/utils/LineSegment.h
@@ -78,7 +78,7 @@ private:
 };
 
 void dataStore(std::ostream & stream, LineSegment & l, void * context);
-void dataLoad(std::ostream & stream, LineSegment & l, void * context);
+void dataLoad(std::istream & stream, LineSegment & l, void * context);
 
 void to_json(nlohmann::json & json, const Point & p);
 void to_json(nlohmann::json & json, const LineSegment & l);

--- a/framework/src/dirackernels/ReporterPointSource.C
+++ b/framework/src/dirackernels/ReporterPointSource.C
@@ -19,18 +19,20 @@ ReporterPointSource::validParams()
 
   params.addClassDescription("Apply a point load defined by Reporter.");
 
-  params.addRequiredParam<ReporterName>(
+  params.addParam<ReporterName>(
       "x_coord_name",
       "reporter x-coordinate name.  This uses the reporter syntax <reporter>/<name>.");
-  params.addRequiredParam<ReporterName>(
+  params.addParam<ReporterName>(
       "y_coord_name",
       "reporter y-coordinate name.  This uses the reporter syntax <reporter>/<name>.");
-  params.addRequiredParam<ReporterName>(
+  params.addParam<ReporterName>(
       "z_coord_name",
       "reporter z-coordinate name.  This uses the reporter syntax <reporter>/<name>.");
   params.addRequiredParam<ReporterName>(
       "value_name", "reporter value name.  This uses the reporter syntax <reporter>/<name>.");
-
+  params.addParam<ReporterName>("point_name",
+                                "reporter point name.  This uses the reporter syntax "
+                                "<reporter>/<name>.");
   return params;
 }
 
@@ -38,38 +40,76 @@ ReporterPointSource::ReporterPointSource(const InputParameters & parameters)
   : DiracKernel(parameters),
     ReporterInterface(this),
     _values(getReporterValue<std::vector<Real>>("value_name", REPORTER_MODE_REPLICATED)),
-    _x_coord(getReporterValue<std::vector<Real>>("x_coord_name", REPORTER_MODE_REPLICATED)),
-    _y_coord(getReporterValue<std::vector<Real>>("y_coord_name", REPORTER_MODE_REPLICATED)),
-    _z_coord(getReporterValue<std::vector<Real>>("z_coord_name", REPORTER_MODE_REPLICATED))
+    _x_coord(isParamValid("x_coord_name")
+                 ? getReporterValue<std::vector<Real>>("x_coord_name", REPORTER_MODE_REPLICATED)
+                 : _empty_vec),
+    _y_coord(isParamValid("y_coord_name")
+                 ? getReporterValue<std::vector<Real>>("y_coord_name", REPORTER_MODE_REPLICATED)
+                 : _empty_vec),
+    _z_coord(isParamValid("z_coord_name")
+                 ? getReporterValue<std::vector<Real>>("z_coord_name", REPORTER_MODE_REPLICATED)
+                 : _empty_vec),
+    _point(isParamValid("point_name")
+               ? getReporterValue<std::vector<Point>>("point_name", REPORTER_MODE_REPLICATED)
+               : _empty_points)
 {
+  if (isParamValid("point_name") == (isParamValid("x_coord_name") && isParamValid("y_coord_name") &&
+                                     isParamValid("z_coord_name")))
+  {
+    paramError("Either supply x,y, and z reporters or a point reporter.");
+  }
 }
 
 void
 ReporterPointSource::addPoints()
 {
-  if (_values.size() != _x_coord.size() || _values.size() != _y_coord.size() ||
-      _values.size() != _z_coord.size())
+  if (!isParamValid("point_name"))
   {
-    std::string errMsg =
-        "The value and coordinate vectors are a different size.  \n"
-        "There must be one value per coordinate.  If the sizes are \n"
-        "zero, the reporter or reporter may not have been initialized with data \n"
-        "before the Dirac Kernel is called.  \n"
-        "Try setting \"execute_on = timestep_begin\" in the reporter being read. \n"
-        "value size = " +
-        std::to_string(_values.size()) + ";  x_coord size = " + std::to_string(_x_coord.size()) +
-        ";  y_coord size = " + std::to_string(_y_coord.size()) +
-        ";  z_coord size = " + std::to_string(_z_coord.size());
+    if (_values.size() != _x_coord.size() || _values.size() != _y_coord.size() ||
+        _values.size() != _z_coord.size())
+    {
+      std::string errMsg =
+          "The value and coordinate vectors are a different size.  \n"
+          "There must be one value per coordinate.  If the sizes are \n"
+          "zero, the reporter or reporter may not have been initialized with data \n"
+          "before the Dirac Kernel is called.  \n"
+          "Try setting \"execute_on = timestep_begin\" in the reporter being read. \n"
+          "value size = " +
+          std::to_string(_values.size()) + ";  x_coord size = " + std::to_string(_x_coord.size()) +
+          ";  y_coord size = " + std::to_string(_y_coord.size()) +
+          ";  z_coord size = " + std::to_string(_z_coord.size());
 
-    mooseError(errMsg);
+      mooseError(errMsg);
+    }
+
+    _point_to_index.clear();
+    for (std::size_t i = 0; i < _values.size(); ++i)
+    {
+      Point pt(_x_coord[i], _y_coord[i], _z_coord[i]);
+      _point_to_index[pt] = i;
+      addPoint(pt, i);
+    }
   }
-
-  _point_to_index.clear();
-  for (std::size_t i = 0; i < _values.size(); ++i)
+  else
   {
-    Point pt(_x_coord[i], _y_coord[i], _z_coord[i]);
-    _point_to_index[pt] = i;
-    addPoint(pt, i);
+    if (_values.size() != _point.size())
+    {
+      std::string errMsg =
+          "The value and point vectors are a different size.  \n"
+          "There must be one value per point.  If the sizes are \n"
+          "zero, the reporter may not have been initialized with data \n"
+          "before the Dirac Kernel is called.  \n"
+          "Try setting \"execute_on = timestep_begin\" in the reporter being read. \n"
+          "value size = " +
+          std::to_string(_values.size()) + ";  point size = " + std::to_string(_point.size());
+
+      mooseError(errMsg);
+    }
+    for (MooseIndex(_values) i = 0; i < _values.size(); ++i)
+    {
+      _point_to_index[_point[i]] = i;
+      addPoint(_point[i], i);
+    }
   }
 }
 

--- a/framework/src/outputs/JsonIO.C
+++ b/framework/src/outputs/JsonIO.C
@@ -40,3 +40,14 @@ to_json(nlohmann::json & json, const MooseApp & app)
 #endif
 }
 // MooseDocs:to_json_end
+
+namespace libMesh
+{
+void
+to_json(nlohmann::json & json, const Point & p)
+{
+  json["x"] = p(0);
+  json["y"] = p(1);
+  json["z"] = p(2);
+}
+}

--- a/framework/src/reporters/ConstantReporter.C
+++ b/framework/src/reporters/ConstantReporter.C
@@ -22,6 +22,7 @@ ConstantReporter::validParams()
   params += addReporterTypeParams<Real>("real");
   params += addReporterTypeParams<std::string>("string");
   params += addReporterTypeParams<dof_id_type>("dof_id_type");
+  params += addReporterTypeParams<Point>("point");
 
   return params;
 }
@@ -32,6 +33,7 @@ ConstantReporter::ConstantReporter(const InputParameters & parameters) : General
   declareConstantReporterValues<Real>("real");
   declareConstantReporterValues<std::string>("string");
   declareConstantReporterValues<dof_id_type>("dof_id_type");
+  declareConstantReporterValues<Point>("point");
   declareConstantVectorReporterValues<int>("integer");
   declareConstantVectorReporterValues<Real>("real");
   declareConstantVectorReporterValues<std::string>("string");

--- a/framework/src/utils/LineSegment.C
+++ b/framework/src/utils/LineSegment.C
@@ -253,6 +253,6 @@ to_json(nlohmann::json & json, const Point & p)
 void
 to_json(nlohmann::json & json, const LineSegment & l)
 {
-  to_json(json, l.start());
-  to_json(json, l.end());
+  to_json(json["start"], l.start());
+  to_json(json["end"], l.end());
 }

--- a/framework/src/utils/LineSegment.C
+++ b/framework/src/utils/LineSegment.C
@@ -222,3 +222,37 @@ LineSegment::intersect(const LineSegment & l, Point & intersect_p) const
   return true;
      */
 }
+
+template <>
+void
+dataStore(std::ostream & stream, LineSegment & l, void * context)
+{
+  dataStore(stream, l.start(), context);
+  dataStore(stream, l.end(), context);
+}
+
+template <>
+void
+dataLoad(std::istream & stream, LineSegment & l, void * context)
+{
+  Point start;
+  dataLoad(stream, start, context);
+  Point end;
+  dataLoad(stream, end, context);
+  l = LineSegment(start, end);
+}
+
+void
+to_json(nlohmann::json & json, const Point & p)
+{
+  json["x"] = p(0);
+  json["y"] = p(1);
+  json["z"] = p(2);
+}
+
+void
+to_json(nlohmann::json & json, const LineSegment & l)
+{
+  to_json(json, l.start());
+  to_json(json, l.end());
+}

--- a/framework/src/utils/LineSegment.C
+++ b/framework/src/utils/LineSegment.C
@@ -9,6 +9,8 @@
 
 #include "LineSegment.h"
 
+#include "JsonIO.h"
+
 #include "libmesh/plane.h"
 #include "libmesh/vector_value.h"
 
@@ -223,7 +225,13 @@ LineSegment::intersect(const LineSegment & l, Point & intersect_p) const
      */
 }
 
-template <>
+void
+LineSegment::set(const Point & p0, const Point & p1)
+{
+  setStart(p0);
+  setEnd(p1);
+}
+
 void
 dataStore(std::ostream & stream, LineSegment & l, void * context)
 {
@@ -231,23 +239,14 @@ dataStore(std::ostream & stream, LineSegment & l, void * context)
   dataStore(stream, l.end(), context);
 }
 
-template <>
 void
 dataLoad(std::istream & stream, LineSegment & l, void * context)
 {
-  Point start;
-  dataLoad(stream, start, context);
-  Point end;
-  dataLoad(stream, end, context);
-  l = LineSegment(start, end);
-}
-
-void
-to_json(nlohmann::json & json, const Point & p)
-{
-  json["x"] = p(0);
-  json["y"] = p(1);
-  json["z"] = p(2);
+  Point p0;
+  dataLoad(stream, p0, context);
+  Point p1;
+  dataLoad(stream, p1, context);
+  l.set(p0, p1);
 }
 
 void


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
closes #23736 
## Reason
<!--Why do you need this feature or what is the enhancement?-->
Simplifies creating and using reporters that deal with points and line segments. For example, ReporterPointSource requests three reporters for x,y, and z coordinates for creating points.
## Design
<!--A concise description (design) of the enhancement.-->
Create necessary specializations for Point and LineSegment classes.
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Cleaner code and simpler input files.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
