### PR TITLE
Add subdomain name duplication check

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -1510,6 +1510,12 @@ private:
    */
   void updateCoordTransform();
 
+  /**
+   * Loop through all subdomain IDs and check if there is name duplication used for the subdomains
+   * with same ID. Throw out an error if any name duplication is found.
+   */
+  void checkDuplicateSubdomainNames();
+
   /// Holds mappings for volume to volume and parent side to child side
   std::map<std::pair<int, ElemType>, std::vector<std::vector<QpMap>>> _elem_type_to_refinement_map;
 

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -406,7 +406,7 @@ MooseMesh::prepare(bool)
 
   update();
 
-// Check if there is subdomain name duplication for the same subdomain ID
+  // Check if there is subdomain name duplication for the same subdomain ID
   checkDuplicateSubdomainNames();
 
   _moose_mesh_prepared = true;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3710,7 +3710,7 @@ MooseMesh::checkDuplicateSubdomainNames()
   for (const auto & sbd_id : _mesh_subdomains)
   {
     std::string sub_name = getSubdomainName(sbd_id);
-    if (subdomain.count(sub_name) > 0)
+    if (!sub_name.empty() && subdomain.count(sub_name) > 0)
       mooseError("The subdomain name ",
                  sub_name,
                  " has already been used for the subdomain with ID=",

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3713,10 +3713,11 @@ MooseMesh::checkDuplicateSubdomainNames()
     if (!sub_name.empty() && subdomain.count(sub_name) > 0)
       mooseError("The subdomain name ",
                  sub_name,
-                 " has already been used for the subdomain with ID=",
+                 " is used for both subdomain with ID=",
                  subdomain[sub_name],
-                 ", Please rename the subdomain with ID=",
-                 sbd_id);
+                 " and ID=",
+                 sbd_id,
+                 ", Please rename one of them!");
     else
       subdomain[sub_name] = sbd_id;
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -406,6 +406,9 @@ MooseMesh::prepare(bool)
 
   update();
 
+// Check if there is subdomain name duplication for the same subdomain ID
+  checkDuplicateSubdomainNames();
+
   _moose_mesh_prepared = true;
 }
 
@@ -3698,4 +3701,23 @@ MooseMesh::lengthUnit() const
 {
   mooseAssert(_coord_transform, "This must be non-null");
   return _coord_transform->lengthUnit();
+}
+
+void
+MooseMesh::checkDuplicateSubdomainNames()
+{
+  std::map<SubdomainName, SubdomainID> subdomain;
+  for (const auto & sbd_id : _mesh_subdomains)
+  {
+    std::string sub_name = getSubdomainName(sbd_id);
+    if (subdomain.count(sub_name) > 0)
+      mooseError("The subdomain name ",
+                 sub_name,
+                 " has already been used for the subdomain with ID=",
+                 subdomain[sub_name],
+                 ", Please rename the subdomain with ID=",
+                 sbd_id);
+    else
+      subdomain[sub_name] = sbd_id;
+  }
 }

--- a/test/tests/meshgenerators/check_duplicate_subdomain_names/check_duplicate_subdomain_names.i
+++ b/test/tests/meshgenerators/check_duplicate_subdomain_names/check_duplicate_subdomain_names.i
@@ -1,0 +1,28 @@
+[Mesh]
+    [gmg]
+      type = GeneratedMeshGenerator
+      dim = 2
+      nx = 10
+      ny = 10
+      xmax = 1
+      ymax = 1
+      uniform_refine = 2
+    []
+
+    [subdomains]
+      type = ParsedSubdomainMeshGenerator
+      input = gmg
+      combinatorial_geometry = 'x > 0.1 & x < 0.9 & y > 0.1 & y < 0.9'
+      block_id = 1
+      block_name = 'A'
+    []
+
+    [subdomains2]
+      type = ParsedSubdomainMeshGenerator
+      combinatorial_geometry = 'x < 0.5 & y < 0.5'
+      excluded_subdomain = '0'
+      block_id = 2
+      input = subdomains
+      block_name = 'A'
+    []
+[]

--- a/test/tests/meshgenerators/check_duplicate_subdomain_names/tests
+++ b/test/tests/meshgenerators/check_duplicate_subdomain_names/tests
@@ -6,7 +6,7 @@
 
   type = 'RunException'
   input = 'check_duplicate_subdomain_names.i'
-  expect_err = 'The subdomain name A has already been used for the subdomain with ID=1, Please rename the subdomain with ID=2'
+  expect_err = 'The subdomain name A is used for both subdomain with ID=1 and ID=2, Please rename one of them!'
   cli_args = "--mesh-only"
   recover = false
   []

--- a/test/tests/meshgenerators/check_duplicate_subdomain_names/tests
+++ b/test/tests/meshgenerators/check_duplicate_subdomain_names/tests
@@ -1,0 +1,13 @@
+[Tests]
+  [check_duplicate_subdomain_names]
+  design = 'MooseMesh.md'
+  issues = '#23735'
+  requirement = 'The system shall throw an error if the subdomains with different ID have duplicate names.'
+
+  type = 'RunException'
+  input = 'check_duplicate_subdomain_names.i'
+  expect_err = 'The subdomain name A has already been used for the subdomain with ID=1, Please rename the subdomain with ID=2'
+  cli_args = "--mesh-only"
+  recover = false
+  []
+[]


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
close #23735

## Reason
<!--Why do you need this feature or what is the enhancement?-->
The subdomains with different IDs are allowed to have same subdomain name in current version. This is not intuitive and seems giving trouble to modelers downstream.

## Design
<!--A concise description (design) of the enhancement.-->
A subdomain name duplication check function is added to `MooseMesh`. It will throw out an error message if the name duplication is found for the subdomains with different IDs.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Fix the issue #23735

