### PR TITLE
Import StatusSystem in RunParallel

### DIFF
--- a/python/TestHarness/schedulers/RunParallel.py
+++ b/python/TestHarness/schedulers/RunParallel.py
@@ -10,6 +10,7 @@
 import traceback
 
 from TestHarness.schedulers.Scheduler import Scheduler
+from TestHarness.StatusSystem import StatusSystem # handle Python Exceptions
 from TestHarness import util
 
 class RunParallel(Scheduler):
@@ -80,7 +81,7 @@ class RunParallel(Scheduler):
                 self.setSuccessfulMessage(tester)
         except Exception as e:
             output += 'Python exception encountered:\n\n' + traceback.format_exc()
-            tester.setStatus(tester.error, 'PYTHON EXCEPTION')
+            tester.setStatus(StatusSystem().error, 'PYTHON EXCEPTION')
 
         if job.getOutputFile():
             job.addMetaData(DIRTY_FILES=[job.getOutputFile()])


### PR DESCRIPTION
RunParallel uses the error status type, when the Tester object itself does not enumerate that specific type.

Reasoning for not simply enumerating the 'error' type in Tester: The Tester was never intended to exhibit 'error' types. That would be too general; A test is supposed to pass or fail for specific reasons.

Closes #23721
