### PR TITLE
Tighten tolerance on linear solver since central difference is only vailable for linear solves

### DIFF
--- a/test/tests/auxkernels/time_derivative_second_aux/test.i
+++ b/test/tests/auxkernels/time_derivative_second_aux/test.i
@@ -74,7 +74,7 @@
   type = Transient
   dt = 0.1
   num_steps = 2
-  nl_abs_tol = 1e-12
+  l_tol = 1e-10
   [TimeIntegrator]
     type = CentralDifference
   []


### PR DESCRIPTION


refs #23770
