### PR TITLE
Loosen perf graph live formatting testing

### DIFF
--- a/test/tests/utils/perf_graph_live_print/tests
+++ b/test/tests/utils/perf_graph_live_print/tests
@@ -25,7 +25,7 @@
     type = RunApp
     input = perf_graph_live_print.i
     cli_args = 'Problem/print_during_section=true'
-    expect_out = "Timed section just started, printing something though\n(Currently|Still)"
+    expect_out = "Timed section just started, printing something though\n(Currently|Still|  Still)"
 
     issues = '#23746'
     design = 'utils/PerfGraphLivePrint.md'


### PR DESCRIPTION
- focus on the presence of the timed section printout even when external print interrupted This printout may be: the Still Executing, the Currently Executing or the space-space Still Testing Slowness as all 3 can happen depending on the timing refs #23746


I believe we have them all now
This is still meeting the issue that was raised