### PR TITLE
Fix LowerDBlockFromSidesetGenerator functor signatures

### DIFF
--- a/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
+++ b/framework/src/meshgenerators/LowerDBlockFromSidesetGenerator.C
@@ -125,13 +125,13 @@ LowerDBlockFromSidesetGenerator::generate()
         push_node_data[pid] = connected_nodes;
       }
 
-    auto node_action_functor = [](processor_id_type, auto &)
+    auto node_action_functor = [](processor_id_type, const auto &)
     {
       // Node packing specialization already has unpacked node into mesh, so nothing to do
     };
     Parallel::push_parallel_packed_range(
         mesh->comm(), push_node_data, mesh.get(), node_action_functor);
-    auto elem_action_functor = [](processor_id_type, auto &)
+    auto elem_action_functor = [](processor_id_type, const auto &)
     {
       // Elem packing specialization already has unpacked elem into mesh, so nothing to do
     };


### PR DESCRIPTION
The TIMPI docs always said we require action functors to take *const* lvalue references, but we seem to have never actually enforced that until we added the rvalue reference support.

Refs https://github.com/libMesh/TIMPI/pull/113 , where Alex describes making this change but I guess didn't actually push this change?

This fixes https://github.com/libMesh/libmesh/pull/3500 for me, and it'll be needed for the next libMesh submodule update too.

Refs #000