### PR TITLE
Parallel sync fix

### DIFF
--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -53,6 +53,8 @@ ComputeMortarFunctor::ComputeMortarFunctor(
 void
 ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type)
 {
+  libmesh_parallel_only(_fe_problem.comm());
+
   unsigned int num_cached = 0;
 
   const auto & secondary_elems_to_mortar_segments = _amg.secondariesToMortarSegments();

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -129,18 +129,29 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type)
     }
   };
 
-  Moose::Mortar::loopOverMortarSegments(iterators,
-                                        _assembly,
-                                        _subproblem,
-                                        _fe_problem,
-                                        _amg,
-                                        _displaced,
-                                        _mortar_constraints,
-                                        0,
-                                        _secondary_ip_sub_to_mats,
-                                        _primary_ip_sub_to_mats,
-                                        _secondary_boundary_mats,
-                                        act_functor);
+  PARALLEL_TRY
+  {
+    try
+    {
+      Moose::Mortar::loopOverMortarSegments(iterators,
+                                            _assembly,
+                                            _subproblem,
+                                            _fe_problem,
+                                            _amg,
+                                            _displaced,
+                                            _mortar_constraints,
+                                            0,
+                                            _secondary_ip_sub_to_mats,
+                                            _primary_ip_sub_to_mats,
+                                            _secondary_boundary_mats,
+                                            act_functor);
+    }
+    catch (MooseException & e)
+    {
+      _fe_problem.setException(e.what());
+    }
+  }
+  PARALLEL_CATCH;
 
   // Call any post operations for our mortar constraints
   for (auto * const mc : _mortar_constraints)

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -148,6 +148,10 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type)
                                             _secondary_boundary_mats,
                                             act_functor);
     }
+    catch (libMesh::LogicError & e)
+    {
+      _fe_problem.setException("We caught a libMesh::LogicError: " + std::string(e.what()));
+    }
     catch (MooseException & e)
     {
       _fe_problem.setException(e.what());

--- a/framework/src/loops/ComputeMortarFunctor.C
+++ b/framework/src/loops/ComputeMortarFunctor.C
@@ -156,6 +156,10 @@ ComputeMortarFunctor::operator()(const Moose::ComputeType compute_type)
     {
       _fe_problem.setException(e.what());
     }
+    catch (MetaPhysicL::LogicError & e)
+    {
+      moose::translateMetaPhysicLError(e);
+    }
   }
   PARALLEL_CATCH;
 

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5804,6 +5804,8 @@ FEProblemBase::computeResidualSys(NonlinearImplicitSystem & sys,
                                   const NumericVector<Number> & soln,
                                   NumericVector<Number> & residual)
 {
+  parallel_object_only();
+
   TIME_SECTION("computeResidualSys", 5);
 
   ADReal::do_derivatives = false;
@@ -6057,6 +6059,8 @@ FEProblemBase::computeResidualInternal(const NumericVector<Number> & soln,
                                        NumericVector<Number> & residual,
                                        const std::set<TagID> & tags)
 {
+  parallel_object_only();
+
   TIME_SECTION("computeResidualInternal", 1);
 
   try
@@ -6117,6 +6121,8 @@ FEProblemBase::computeResidualType(const NumericVector<Number> & soln,
 void
 FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
 {
+  parallel_object_only();
+
   TIME_SECTION("computeResidualTags", 5, "Computing Residual");
 
   _aux->zeroVariablesForResidual();
@@ -7746,6 +7752,8 @@ FEProblemBase::systemBaseAuxiliary()
 void
 FEProblemBase::computingNonlinearResid(bool computing_nonlinear_residual)
 {
+  parallel_object_only();
+
   if (_displaced_problem)
     _displaced_problem->computingNonlinearResid(computing_nonlinear_residual);
   _computing_nonlinear_residual = computing_nonlinear_residual;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6159,7 +6159,7 @@ FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
       }
       catch (libMesh::LogicError & e)
       {
-        throw MooseException("We caught a libMesh error in FEProblemBase");
+        mooseException("We caught a libMesh error in FEProblemBase: ", e.what());
       }
     }
     catch (MooseException & e)

--- a/framework/src/systems/AuxiliarySystem.C
+++ b/framework/src/systems/AuxiliarySystem.C
@@ -768,6 +768,10 @@ AuxiliarySystem::computeMortarNodalVars(const ExecFlagType type)
           {
             _fe_problem.setException("We caught a libMesh::LogicError:" + std::string(e.what()));
           }
+          catch (MetaPhysicL::LogicError & e)
+          {
+            moose::translateMetaPhysicLError(e);
+          }
         }
         PARALLEL_CATCH;
 

--- a/framework/src/systems/ComputeResidualFunctor.C
+++ b/framework/src/systems/ComputeResidualFunctor.C
@@ -19,6 +19,8 @@ ComputeResidualFunctor::residual(const NumericVector<Number> & soln,
                                  NumericVector<Number> & residual,
                                  NonlinearImplicitSystem & sys)
 {
+  libmesh_parallel_only(soln.comm());
+
   if (!_fe_problem.failNextNonlinearConvergenceCheck())
   {
     _fe_problem.computingNonlinearResid(true);

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -750,6 +750,8 @@ NonlinearSystemBase::computeResidual(NumericVector<Number> & residual, TagID tag
 void
 NonlinearSystemBase::computeResidualTags(const std::set<TagID> & tags)
 {
+  parallel_object_only();
+
   TIME_SECTION("nl::computeResidualTags", 5);
 
   _fe_problem.setCurrentNonlinearSystem(number());
@@ -1520,6 +1522,8 @@ NonlinearSystemBase::residualSetup()
 void
 NonlinearSystemBase::computeResidualInternal(const std::set<TagID> & tags)
 {
+  parallel_object_only();
+
   TIME_SECTION("computeResidualInternal", 3);
 
   residualSetup();
@@ -3555,6 +3559,8 @@ NonlinearSystemBase::setPreviousNewtonSolution(const NumericVector<Number> & sol
 void
 NonlinearSystemBase::mortarConstraints(const Moose::ComputeType compute_type)
 {
+  parallel_object_only();
+
   try
   {
     for (auto & map_pr : _undisplaced_mortar_functors)

--- a/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeWeightedGapLMMechanicalContact.C
@@ -206,6 +206,8 @@ ComputeWeightedGapLMMechanicalContact::computeJacobian(const Moose::MortarType m
 void
 ComputeWeightedGapLMMechanicalContact::post()
 {
+  parallel_object_only();
+
   Moose::Mortar::Contact::communicateGaps(
       _dof_to_weighted_gap, this->processor_id(), _mesh, _nodal, _normalize_c, _communicator);
 

--- a/modules/contact/src/utils/MortarContactUtils.C
+++ b/modules/contact/src/utils/MortarContactUtils.C
@@ -26,6 +26,8 @@ communicateGaps(
     const bool normalize_c,
     const Parallel::Communicator & communicator)
 {
+  libmesh_parallel_only(communicator);
+
   // We may have weighted gap information that should go to other processes that own the dofs
   using Datum = std::tuple<dof_id_type, ADReal, Real>;
   std::unordered_map<processor_id_type, std::vector<Datum>> push_data;


### PR DESCRIPTION
## Reason
Fixes #23796.  This fixes the hung parallel runs, and adds assertions to help make those runs a bit easier to debug in the future.

## Design
The first commit wraps `loopOverMortarSegments` in a `PARALLEL_CATCH`, to synchronize handling of any exceptions (like the quadrature point exception thrown in the test case) between ranks.

The second commit adds new assertions.

## Impact
The fix keeps asynchronous exceptions from hanging a whole job, at the cost of adding a `maxloc` that makes exceptionless runs infinitesimally slower.

The new assertions should give fewer hangs and more accurate error messages when any similar bugs are hit in the future, at the cost of adding `max`/`min` calls that make `devel` and `dbg` runs infinitesimally slower.