### PR TITLE
Bump VTK version

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,10 +3,10 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 17 %}
-{% set vtk_version = "9.1.0" %}
-{% set vtk_friendly_version = "9.1" %}
-{% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}
+{% set build = 0 %}
+{% set vtk_version = "9.2.6" %}
+{% set vtk_friendly_version = "9.2" %}
+{% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}
 
 package:
   name: moose-libmesh-vtk

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -5,7 +5,7 @@ moose_petsc:
   - moose-petsc 3.16.6
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0
+  - moose-libmesh-vtk 9.2.6
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,10 +2,10 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.03.02" %}
-{% set vtk_friendly_version = "9.1" %}
+{% set vtk_friendly_version = "9.2" %}
 
 package:
   name: moose-libmesh

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.02 build_1
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.02 build_1
 
 moose_python:
  - python 3.9


### PR DESCRIPTION
Bumping VTK version to possibly fix a relink issue affecting modern Linux OSs:

```pre
./moose_test-opt: Relink `/data/contribs/conda3/envs/moose/libmesh-vtk/lib/././libvtkkissfft-9.1.so.1' with `/lib64/libm.so.6' for IFUNC symbol `sincos'
```

Closes #23857
