### PR TITLE
Use just short name for naming objects in mortar heat transfer action…

### DIFF
--- a/modules/heat_conduction/src/actions/MortarGapHeatTransferAction.C
+++ b/modules/heat_conduction/src/actions/MortarGapHeatTransferAction.C
@@ -18,13 +18,6 @@
 #include "GapFluxModelRadiation.h"
 #include "GapFluxModelConduction.h"
 
-// Counter for modular user objects
-static unsigned int thermal_action_userobject_radiation_counter_uo = 0;
-static unsigned int thermal_action_userobject_conduction_counter_uo = 0;
-
-static unsigned int thermal_action_userobject_radiation_counter_constraint = 0;
-static unsigned int thermal_action_userobject_conduction_counter_constraint = 0;
-
 registerMooseAction("HeatConductionApp", MortarGapHeatTransferAction, "append_mesh_generator");
 registerMooseAction("HeatConductionApp", MortarGapHeatTransferAction, "add_mortar_variable");
 registerMooseAction("HeatConductionApp", MortarGapHeatTransferAction, "add_constraint");
@@ -264,13 +257,11 @@ MortarGapHeatTransferAction::addConstraints()
     for (const auto & uo_name : _gap_flux_models)
     {
       if (uo_name == MortarGapHeatTransfer::UserObjectToBuild::CONDUCTION)
-        uoname_strings.push_back(
-            "gap_flux_model_conduction_object_" + MooseUtils::shortName(name()) + "_" +
-            Moose::stringify(thermal_action_userobject_conduction_counter_constraint++));
+        uoname_strings.push_back("gap_flux_model_conduction_object_" +
+                                 MooseUtils::shortName(name()));
       else if (uo_name == MortarGapHeatTransfer::UserObjectToBuild::RADIATION)
-        uoname_strings.push_back(
-            "gap_flux_model_radiation_object_" + MooseUtils::shortName(name()) + "_" +
-            Moose::stringify(thermal_action_userobject_radiation_counter_constraint++));
+        uoname_strings.push_back("gap_flux_model_radiation_object_" +
+                                 MooseUtils::shortName(name()));
     }
 
     params.set<std::vector<UserObjectName>>("gap_flux_models") = uoname_strings;
@@ -334,11 +325,9 @@ MortarGapHeatTransferAction::addUserObjects()
 
       var_params.set<bool>("use_displaced_mesh") = true;
 
-      _problem->addUserObject(
-          "GapFluxModelConduction",
-          "gap_flux_model_conduction_object_" + MooseUtils::shortName(name()) + "_" +
-              Moose::stringify(thermal_action_userobject_conduction_counter_uo++),
-          var_params);
+      _problem->addUserObject("GapFluxModelConduction",
+                              "gap_flux_model_conduction_object_" + MooseUtils::shortName(name()),
+                              var_params);
     }
     else if (uo_name == MortarGapHeatTransfer::UserObjectToBuild::RADIATION)
 
@@ -357,11 +346,9 @@ MortarGapHeatTransferAction::addUserObjects()
 
       var_params.set<bool>("use_displaced_mesh") = true;
 
-      _problem->addUserObject(
-          "GapFluxModelRadiation",
-          "gap_flux_model_radiation_object_" + MooseUtils::shortName(name()) + "_" +
-              Moose::stringify(thermal_action_userobject_radiation_counter_uo++),
-          var_params);
+      _problem->addUserObject("GapFluxModelRadiation",
+                              "gap_flux_model_radiation_object_" + MooseUtils::shortName(name()),
+                              var_params);
     }
   }
 }

--- a/modules/heat_conduction/src/actions/MortarGapHeatTransferAction.C
+++ b/modules/heat_conduction/src/actions/MortarGapHeatTransferAction.C
@@ -85,13 +85,13 @@ MortarGapHeatTransferAction::MortarGapHeatTransferAction(const InputParameters &
   // We do not currently support building more than one condution or more than one radiation user
   // object from this action.
   const unsigned int conduction_build_uos =
-      std::count(_gap_flux_models.cbegin(),
-                 _gap_flux_models.cend(),
-                 MortarGapHeatTransfer::UserObjectToBuild::CONDUCTION);
+      cast_int<unsigned int>(std::count(_gap_flux_models.cbegin(),
+                                        _gap_flux_models.cend(),
+                                        MortarGapHeatTransfer::UserObjectToBuild::CONDUCTION));
   const unsigned int radiation_build_uos =
-      std::count(_gap_flux_models.cbegin(),
-                 _gap_flux_models.cend(),
-                 MortarGapHeatTransfer::UserObjectToBuild::RADIATION);
+      cast_int<unsigned int>(std::count(_gap_flux_models.cbegin(),
+                                        _gap_flux_models.cend(),
+                                        MortarGapHeatTransfer::UserObjectToBuild::RADIATION));
 
   if (conduction_build_uos > 1 || radiation_build_uos > 1)
     paramError("gap_flux_options",

--- a/modules/heat_conduction/test/tests/gap_heat_transfer_mortar_action/tests
+++ b/modules/heat_conduction/test/tests/gap_heat_transfer_mortar_action/tests
@@ -54,4 +54,13 @@
                   'for two ways of building gap heat transfer options and error out, to avoid having '
                   'misleading input files.'
   []
+  [modular_gap_heat_transfer_mortar_displaced_radiation_conduction_action_too_many_uos]
+    type = RunException
+    input = 'modular_gap_heat_transfer_mortar_displaced_radiation_conduction_action.i'
+    cli_args = "MortarGapHeatTransfer/mortar_heat_transfer/gap_flux_options='CONDUCTION RADIATION CONDUCTION'"
+    expect_err = 'You cannot choose to have more than one conduction or more than one radiation user'
+    requirement = 'We shall be able to inform the user that the mortar gap heat transfer action '
+                  'cannot internally build more than one conduction or more than one radiation user '
+                  'object.'
+  []
 []


### PR DESCRIPTION
 Refs #23869



