### PR TITLE
Fix Dynamic Loading Random Segfaults

### DIFF
--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -115,9 +115,12 @@ public:
     return _name_to_params_pointer;
   }
 
-  ///@{ Don't allow creation through copy construction or assignment
+  ///@{ Don't allow creation through copy/move construction or assignment
   AppFactory(AppFactory const &) = delete;
-  void operator=(AppFactory const &) = delete;
+  Registry & operator=(AppFactory const &) = delete;
+
+  AppFactory(AppFactory &&) = delete;
+  Registry & operator=(AppFactory &&) = delete;
   ///@}
 
 protected:

--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -115,7 +115,7 @@ public:
     return _name_to_params_pointer;
   }
 
-  ///@{ Don't allow creation through copy consturction or assignment
+  ///@{ Don't allow creation through copy construction or assignment
   AppFactory(AppFactory const &) = delete;
   void operator=(AppFactory const &) = delete;
   ///@}

--- a/framework/include/base/AppFactory.h
+++ b/framework/include/base/AppFactory.h
@@ -115,12 +115,15 @@ public:
     return _name_to_params_pointer;
   }
 
+  ///@{ Don't allow creation through copy consturction or assignment
+  AppFactory(AppFactory const &) = delete;
+  void operator=(AppFactory const &) = delete;
+  ///@}
+
 protected:
   std::map<std::string, appBuildPtr> _name_to_build_pointer;
 
   std::map<std::string, paramsPtr> _name_to_params_pointer;
-
-  static AppFactory _instance;
 
 private:
   // Private constructor for singleton pattern

--- a/framework/include/base/ExecFlagRegistry.h
+++ b/framework/include/base/ExecFlagRegistry.h
@@ -43,9 +43,12 @@ public:
   /// Return Singleton instance
   static ExecFlagRegistry & getExecFlagRegistry();
 
-  ///@{ Don't allow creation through copy consturction or assignment
+  ///@{ Don't allow creation through copy/move consturction or assignment
   ExecFlagRegistry(ExecFlagRegistry const &) = delete;
-  void operator=(ExecFlagRegistry const &) = delete;
+  ExecFlagRegistry & operator=(ExecFlagRegistry const &) = delete;
+
+  ExecFlagRegistry(ExecFlagRegistry &&) = delete;
+  ExecFlagRegistry & operator=(ExecFlagRegistry &&) = delete;
   ///@}
 
 private:

--- a/framework/include/base/ExecFlagRegistry.h
+++ b/framework/include/base/ExecFlagRegistry.h
@@ -11,7 +11,10 @@
 
 #include "ExecFlagEnum.h"
 
-class ExecFlagRegistry;
+namespace moose
+{
+namespace internal
+{
 
 /**
  * Registry for statically defining execute flags with consistent numbering.
@@ -56,6 +59,10 @@ private:
   ExecFlagEnum _default_flags;
 };
 
-#define registerExecFlag(flag) ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, false)
+} // internal
+} // moose
+
+#define registerExecFlag(flag)                                                                     \
+  moose::internal::ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, false)
 #define registerDefaultExecFlag(flag)                                                              \
-  ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, true)
+  moose::internal::ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, true)

--- a/framework/include/base/ExecFlagRegistry.h
+++ b/framework/include/base/ExecFlagRegistry.h
@@ -9,21 +9,9 @@
 
 #pragma once
 
-#include <shared_mutex>
-
 #include "ExecFlagEnum.h"
 
-namespace moose
-{
-namespace internal
-{
-
 class ExecFlagRegistry;
-
-/**
- * Get the global ExecFlagRegistry singleton.
- */
-ExecFlagRegistry & getExecFlagRegistry();
 
 /**
  * Registry for statically defining execute flags with consistent numbering.
@@ -49,17 +37,17 @@ public:
    */
   const ExecFlagEnum & getDefaultFlags() const { return _default_flags; };
 
+  /// Return Singleton instance
+  static ExecFlagRegistry & getExecFlagRegistry();
+
+  ///@{ Don't allow creation through copy consturction or assignment
+  ExecFlagRegistry(ExecFlagRegistry const &) = delete;
+  void operator=(ExecFlagRegistry const &) = delete;
+  ///@}
+
 private:
-  ExecFlagRegistry();
-
-  /// So it can be constructed
-  friend ExecFlagRegistry & getExecFlagRegistry();
-
-  /// Mutex for guarding access to _flags
-  std::shared_mutex _flags_mutex;
-
-  /// Mutex for guarding access to _default_flags;
-  std::shared_mutex _default_flags_mutex;
+  // Private constructor for singleton pattern
+  ExecFlagRegistry() {}
 
   /// The registered flags
   ExecFlagEnum _flags;
@@ -68,9 +56,6 @@ private:
   ExecFlagEnum _default_flags;
 };
 
-}
-}
-
-#define registerExecFlag(flag) moose::internal::getExecFlagRegistry().registerFlag(flag, false)
+#define registerExecFlag(flag) ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, false)
 #define registerDefaultExecFlag(flag)                                                              \
-  moose::internal::getExecFlagRegistry().registerFlag(flag, true)
+  ExecFlagRegistry::getExecFlagRegistry().registerFlag(flag, true)

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1321,8 +1321,14 @@ private:
   /// Cache for a Backup to use for restart / recovery
   std::shared_ptr<Backup> _cached_backup;
 
-  /// Execution flags for this App
-  const ExecFlagEnum & _execute_flags;
+  /**
+   * Execution flags for this App. Note: These are copied on purpose instead of maintaining a
+   * reference to the ExecFlagRegistry registry. In the Multiapp case, the registry may be
+   * augmented, changing the flags "known" to the application in the middle of executing the setup.
+   * This causes issues with the application having to process flags that aren't specifically
+   * registered.
+   */
+  const ExecFlagEnum _execute_flags;
 
   /// Whether to turn on automatic scaling by default
   const bool _automatic_automatic_scaling;

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1168,8 +1168,14 @@ protected:
   /// this map when removing relationship managers/ghosting functors
   std::unordered_map<RelationshipManager *, std::shared_ptr<GhostingFunctor>> _undisp_to_disp_rms;
 
+  struct DynamicLibraryInfo
+  {
+    void * _library_handle;
+    std::unordered_set<std::string> _entry_symbols;
+  };
+
   /// The library, registration method and the handle to the method
-  std::map<std::pair<std::string, std::string>, void *> _lib_handles;
+  std::unordered_map<std::string, DynamicLibraryInfo> _lib_handles;
 
 private:
   ///@{

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1170,8 +1170,8 @@ protected:
 
   struct DynamicLibraryInfo
   {
-    void * _library_handle;
-    std::unordered_set<std::string> _entry_symbols;
+    void * library_handle;
+    std::unordered_set<std::string> entry_symbols;
   };
 
   /// The library, registration method and the handle to the method

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -222,9 +222,12 @@ public:
     return getRegistry()._data_file_paths;
   }
 
-  ///@{ Don't allow creation through copy construction or assignment
+  ///@{ Don't allow creation through copy/move construction or assignment
   Registry(Registry const &) = delete;
-  void operator=(Registry const &) = delete;
+  Registry & operator=(Registry const &) = delete;
+
+  Registry(Registry &&) = delete;
+  Registry & operator=(Registry &&) = delete;
   ///@}
 
 private:

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -222,7 +222,7 @@ public:
     return getRegistry()._data_file_paths;
   }
 
-  ///@{ Don't allow creation through copy consturction or assignment
+  ///@{ Don't allow creation through copy construction or assignment
   Registry(Registry const &) = delete;
   void operator=(Registry const &) = delete;
   ///@}

--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -222,6 +222,11 @@ public:
     return getRegistry()._data_file_paths;
   }
 
+  ///@{ Don't allow creation through copy consturction or assignment
+  Registry(Registry const &) = delete;
+  void operator=(Registry const &) = delete;
+  ///@}
+
 private:
   Registry(){};
 

--- a/framework/src/base/AppFactory.C
+++ b/framework/src/base/AppFactory.C
@@ -12,12 +12,11 @@
 #include "InputParameters.h"
 #include "MooseApp.h"
 
-AppFactory AppFactory::_instance = AppFactory();
-
 AppFactory &
 AppFactory::instance()
 {
-  return _instance;
+  static AppFactory instance;
+  return instance;
 }
 
 AppFactory::~AppFactory() {}

--- a/framework/src/base/ExecFlagRegistry.C
+++ b/framework/src/base/ExecFlagRegistry.C
@@ -8,31 +8,19 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ExecFlagRegistry.h"
-
-#include <mutex>
-
 #include "MooseUtils.h"
 
-namespace moose
-{
-namespace internal
-{
-
 ExecFlagRegistry &
-getExecFlagRegistry()
+ExecFlagRegistry::getExecFlagRegistry()
 {
   static ExecFlagRegistry exec_flag_registry;
   return exec_flag_registry;
 }
 
-ExecFlagRegistry::ExecFlagRegistry() {}
-
 const ExecFlagType &
 ExecFlagRegistry::registerFlag(const std::string & name, const bool is_default)
 {
   const auto name_upper = MooseUtils::toUpper(name);
-  std::unique_lock lock(_flags_mutex);
-
   const auto flag_iter = _flags.find(name_upper);
   if (flag_iter != _flags.items().end())
   {
@@ -44,13 +32,7 @@ ExecFlagRegistry::registerFlag(const std::string & name, const bool is_default)
   const auto & flag = _flags.addAvailableFlags(ExecFlagType(name_upper, _flags.getNextValidID()));
 
   if (is_default)
-  {
-    std::unique_lock default_lock(_default_flags_mutex);
     _default_flags.addAvailableFlags(flag);
-  }
 
   return flag;
-}
-
-}
 }

--- a/framework/src/base/ExecFlagRegistry.C
+++ b/framework/src/base/ExecFlagRegistry.C
@@ -10,6 +10,11 @@
 #include "ExecFlagRegistry.h"
 #include "MooseUtils.h"
 
+namespace moose
+{
+namespace internal
+{
+
 ExecFlagRegistry &
 ExecFlagRegistry::getExecFlagRegistry()
 {
@@ -36,3 +41,6 @@ ExecFlagRegistry::registerFlag(const std::string & name, const bool is_default)
 
   return flag;
 }
+
+} // internal
+} // moose

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -386,7 +386,7 @@ MooseApp::MooseApp(InputParameters parameters)
                                ? parameters.get<const MooseMesh *>("_master_displaced_mesh")
                                : nullptr),
     _mesh_generator_system(*this),
-    _execute_flags(ExecFlagRegistry::getExecFlagRegistry().getFlags()),
+    _execute_flags(moose::internal::ExecFlagRegistry::getExecFlagRegistry().getFlags()),
     _automatic_automatic_scaling(getParam<bool>("automatic_automatic_scaling"))
 {
 #ifdef HAVE_GPERFTOOLS
@@ -610,7 +610,7 @@ MooseApp::~MooseApp()
 #ifdef LIBMESH_HAVE_DLOPEN
   // Close any open dynamic libraries
   for (const auto & lib_pair : _lib_handles)
-    dlclose(lib_pair.second._library_handle);
+    dlclose(lib_pair.second.library_handle);
 #endif
 }
 
@@ -1910,7 +1910,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
                  "dependencies listed in the supplied library (see otool or ldd).\n");
 
     DynamicLibraryInfo lib_info;
-    lib_info._library_handle = lib_handle;
+    lib_info.library_handle = lib_handle;
 
     auto insert_ret = _lib_handles.insert(std::make_pair(library_filename, lib_info));
     mooseAssert(insert_ret.second == true, "Error inserting into lib_handles map");
@@ -1920,7 +1920,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
 
   // Library has been loaded, check to see if we've called the requested registration method
   const auto registration_method = params.get<std::string>("registration_method");
-  auto & entry_sym_from_curr_lib = dyn_lib_it->second._entry_symbols;
+  auto & entry_sym_from_curr_lib = dyn_lib_it->second.entry_symbols;
 
   if (entry_sym_from_curr_lib.find(registration_method) == entry_sym_from_curr_lib.end())
   {
@@ -1929,10 +1929,10 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
     // we also explicitly set the pointer to NULL if dlsym is not
     // available.
 #ifdef LIBMESH_HAVE_DLOPEN
-    void * const registration_handle =
-        dlsym(dyn_lib_it->second._library_handle, registration_method.c_str());
+    void * registration_handle =
+        dlsym(dyn_lib_it->second.library_handle, registration_method.c_str());
 #else
-    void * const registration_handle = nullptr;
+    void * registration_handle = nullptr;
 #endif
 
     if (registration_handle)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1879,7 +1879,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
   }
 
   // This should only occur if we have static linkage.
-  if (dl_lib_filename == "")
+  if (dl_lib_filename.empty())
     return;
 
   // Time to load the library, First see if we've already loaded this particular dynamic library
@@ -1897,9 +1897,9 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
     MooseUtils::checkFileReadable(dl_lib_full_path, false, /*throw_on_unreadable=*/true);
 
 #ifdef LIBMESH_HAVE_DLOPEN
-    void * lib_handle = dlopen(dl_lib_full_path.c_str(), RTLD_LAZY);
+    void * const lib_handle = dlopen(dl_lib_full_path.c_str(), RTLD_LAZY);
 #else
-    void * lib_handle = nullptr;
+    void * const lib_handle = nullptr;
 #endif
 
     if (!lib_handle)
@@ -1919,7 +1919,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
   }
 
   // Library has been loaded, check to see if we've called the requested registration method
-  std::string registration_method = params.get<std::string>("registration_method");
+  const auto registration_method = params.get<std::string>("registration_method");
   auto & entry_sym_from_curr_lib = dyn_lib_it->second._entry_symbols;
 
   if (entry_sym_from_curr_lib.find(registration_method) == entry_sym_from_curr_lib.end())
@@ -1929,10 +1929,10 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
     // we also explicitly set the pointer to NULL if dlsym is not
     // available.
 #ifdef LIBMESH_HAVE_DLOPEN
-    void * registration_handle =
+    void * const registration_handle =
         dlsym(dyn_lib_it->second._library_handle, registration_method.c_str());
 #else
-    void * registration_handle = nullptr;
+    void * const registration_handle = nullptr;
 #endif
 
     if (registration_handle)
@@ -1942,14 +1942,14 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
         case APPLICATION:
         {
           using register_app_t = void (*)();
-          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
+          register_app_t * const reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
           (*reg_ptr)();
           break;
         }
         case REGALL:
         {
           using register_app_t = void (*)(Factory *, ActionFactory *, Syntax *);
-          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
+          register_app_t * const reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
           (*reg_ptr)(params.get<Factory *>("factory"),
                      params.get<ActionFactory *>("action_factory"),
                      params.get<Syntax *>("syntax"));
@@ -1968,7 +1968,6 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
       // We found a dynamic library that doesn't have a dynamic
       // registration method in it. This shouldn't be an error, so
       // we'll just move on.
-
       if (!registration_handle)
         mooseWarning("Unable to find extern \"C\" method \"",
                      registration_method,

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -386,7 +386,7 @@ MooseApp::MooseApp(InputParameters parameters)
                                ? parameters.get<const MooseMesh *>("_master_displaced_mesh")
                                : nullptr),
     _mesh_generator_system(*this),
-    _execute_flags(moose::internal::getExecFlagRegistry().getFlags()),
+    _execute_flags(ExecFlagRegistry::getExecFlagRegistry().getFlags()),
     _automatic_automatic_scaling(getParam<bool>("automatic_automatic_scaling"))
 {
 #ifdef HAVE_GPERFTOOLS

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -609,8 +609,8 @@ MooseApp::~MooseApp()
 
 #ifdef LIBMESH_HAVE_DLOPEN
   // Close any open dynamic libraries
-  for (const auto & it : _lib_handles)
-    dlclose(it.second);
+  for (const auto & lib_pair : _lib_handles)
+    dlclose(lib_pair.second._library_handle);
 #endif
 }
 
@@ -1851,10 +1851,10 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
   // .la)
   pcrecpp::RE re_deps("(/\\S*\\.la)");
 
-  std::ifstream handle(library_filename.c_str());
-  if (handle.is_open())
+  std::ifstream la_handle(library_filename.c_str());
+  if (la_handle.is_open())
   {
-    while (std::getline(handle, line))
+    while (std::getline(la_handle, line))
     {
       // Look for the system dependent dynamic library filename to open
       if (line.find("dlname=") != std::string::npos)
@@ -1875,14 +1875,18 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
         break;
       }
     }
-    handle.close();
+    la_handle.close();
   }
 
-  std::string registration_method_name = params.get<std::string>("registration_method");
+  // This should only occur if we have static linkage.
+  if (dl_lib_filename == "")
+    return;
+
   // Time to load the library, First see if we've already loaded this particular dynamic library
-  if (_lib_handles.find(std::make_pair(library_filename, registration_method_name)) ==
-          _lib_handles.end() && // make sure we haven't already loaded this library
-      dl_lib_filename != "") // AND make sure we have a library name (we won't for static linkage)
+  //     1) make sure we haven't already loaded this library
+  // AND 2) make sure we have a library name (we won't for static linkage)
+  auto dyn_lib_it = _lib_handles.find(library_filename);
+  if (dyn_lib_it == _lib_handles.end())
   {
     std::pair<std::string, std::string> lib_name_parts =
         MooseUtils::splitFileName(library_filename);
@@ -1893,63 +1897,59 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
     MooseUtils::checkFileReadable(dl_lib_full_path, false, /*throw_on_unreadable=*/true);
 
 #ifdef LIBMESH_HAVE_DLOPEN
-    void * handle = dlopen(dl_lib_full_path.c_str(), RTLD_LAZY);
+    void * lib_handle = dlopen(dl_lib_full_path.c_str(), RTLD_LAZY);
 #else
-    void * handle = nullptr;
+    void * lib_handle = nullptr;
 #endif
 
-    if (!handle)
+    if (!lib_handle)
       mooseError("The library file \"",
                  dl_lib_full_path,
                  "\" exists and has proper permissions, but cannot by dynamically loaded.\nThis "
                  "generally means that the loader was unable to load one or more of the "
                  "dependencies listed in the supplied library (see otool or ldd).\n");
 
-// get the pointer to the method in the library.  The dlsym()
-// function returns a null pointer if the symbol cannot be found,
-// we also explicitly set the pointer to NULL if dlsym is not
-// available.
+    DynamicLibraryInfo lib_info;
+    lib_info._library_handle = lib_handle;
+
+    auto insert_ret = _lib_handles.insert(std::make_pair(library_filename, lib_info));
+    mooseAssert(insert_ret.second == true, "Error inserting into lib_handles map");
+
+    dyn_lib_it = insert_ret.first;
+  }
+
+  // Library has been loaded, check to see if we've called the requested registration method
+  std::string registration_method = params.get<std::string>("registration_method");
+  auto & entry_sym_from_curr_lib = dyn_lib_it->second._entry_symbols;
+
+  if (entry_sym_from_curr_lib.find(registration_method) == entry_sym_from_curr_lib.end())
+  {
+    // get the pointer to the method in the library.  The dlsym()
+    // function returns a null pointer if the symbol cannot be found,
+    // we also explicitly set the pointer to NULL if dlsym is not
+    // available.
 #ifdef LIBMESH_HAVE_DLOPEN
-    void * registration_method = dlsym(handle, registration_method_name.c_str());
+    void * registration_handle =
+        dlsym(dyn_lib_it->second._library_handle, registration_method.c_str());
 #else
-    void * registration_method = nullptr;
+    void * registration_handle = nullptr;
 #endif
 
-    if (!registration_method)
+    if (registration_handle)
     {
-// We found a dynamic library that doesn't have a dynamic
-// registration method in it. This shouldn't be an error, so
-// we'll just move on.
-#ifdef DEBUG
-      mooseWarning("Unable to find extern \"C\" method \"",
-                   registration_method_name,
-                   "\" in library: ",
-                   dl_lib_full_path,
-                   ".\n",
-                   "This doesn't necessarily indicate an error condition unless you believe that "
-                   "the method should exist in that library.\n");
-#endif
-
-#ifdef LIBMESH_HAVE_DLOPEN
-      dlclose(handle);
-#endif
-    }
-    else // registration_method is valid!
-    {
-      // TODO: Look into cleaning this up
       switch (params.get<RegistrationType>("reg_type"))
       {
         case APPLICATION:
         {
-          typedef void (*register_app_t)();
-          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_method);
+          using register_app_t = void (*)();
+          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
           (*reg_ptr)();
           break;
         }
         case REGALL:
         {
-          typedef void (*register_app_t)(Factory *, ActionFactory *, Syntax *);
-          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_method);
+          using register_app_t = void (*)(Factory *, ActionFactory *, Syntax *);
+          register_app_t * reg_ptr = reinterpret_cast<register_app_t *>(&registration_handle);
           (*reg_ptr)(params.get<Factory *>("factory"),
                      params.get<ActionFactory *>("action_factory"),
                      params.get<Syntax *>("syntax"));
@@ -1959,9 +1959,25 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
           mooseError("Unhandled RegistrationType");
       }
 
-      // Store the handle so we can close it later
-      _lib_handles.insert(
-          std::make_pair(std::make_pair(library_filename, registration_method_name), handle));
+      entry_sym_from_curr_lib.insert(registration_method);
+    }
+    else
+    {
+
+#ifdef DEBUG
+      // We found a dynamic library that doesn't have a dynamic
+      // registration method in it. This shouldn't be an error, so
+      // we'll just move on.
+
+      if (!registration_handle)
+        mooseWarning("Unable to find extern \"C\" method \"",
+                     registration_method,
+                     "\" in library: ",
+                     dyn_lib_it->first,
+                     ".\n",
+                     "This doesn't necessarily indicate an error condition unless you believe that "
+                     "the method should exist in that library.\n");
+#endif
     }
   }
 }
@@ -1972,7 +1988,7 @@ MooseApp::getLoadedLibraryPaths() const
   // Return the paths but not the open file handles
   std::set<std::string> paths;
   for (const auto & it : _lib_handles)
-    paths.insert(it.first.first);
+    paths.insert(it.first);
 
   return paths;
 }
@@ -2374,14 +2390,15 @@ MooseApp::attachRelationshipManagers(Moose::RelationshipManagerType rm_type,
         if (rm_type == Moose::RelationshipManagerType::COUPLING)
           // We actually need to add this to the FEProblemBase NonlinearSystemBase's DofMap
           // because the DisplacedProblem "nonlinear" DisplacedSystem doesn't have any matrices
-          // for which to do coupling. It's actually horrifying to me that we are adding a coupling
-          // functor, that is going to determine its couplings based on a displaced MeshBase object,
-          // to a System associated with the undisplaced MeshBase object (there is only ever one
-          // EquationSystems object per MeshBase object and visa versa). So here I'm left with the
-          // choice of whether to pass in a MeshBase object that is *not* the MeshBase object that
-          // will actually determine the couplings or to pass in the MeshBase object that is
-          // inconsistent with the System DofMap that we are adding the coupling functor for! Let's
-          // err on the side of *libMesh* consistency and pass properly paired MeshBase-DofMap
+          // for which to do coupling. It's actually horrifying to me that we are adding a
+          // coupling functor, that is going to determine its couplings based on a displaced
+          // MeshBase object, to a System associated with the undisplaced MeshBase object (there
+          // is only ever one EquationSystems object per MeshBase object and visa versa). So here
+          // I'm left with the choice of whether to pass in a MeshBase object that is *not* the
+          // MeshBase object that will actually determine the couplings or to pass in the MeshBase
+          // object that is inconsistent with the System DofMap that we are adding the coupling
+          // functor for! Let's err on the side of *libMesh* consistency and pass properly paired
+          // MeshBase-DofMap
           problem.addCouplingGhostingFunctor(
               createRMFromTemplateAndInit(*rm, undisp_mesh, &undisp_nl_dof_map),
               /*to_mesh = */ false);

--- a/framework/src/utils/JsonSyntaxTree.C
+++ b/framework/src/utils/JsonSyntaxTree.C
@@ -177,7 +177,7 @@ JsonSyntaxTree::addGlobal()
 
     // Just create a list of registered app names
     nlohmann::json apps;
-    auto factory = AppFactory::instance();
+    auto & factory = AppFactory::instance();
     for (auto app = factory.registeredObjectsBegin(); app != factory.registeredObjectsEnd(); ++app)
       apps.push_back(app->first);
 

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -977,7 +977,7 @@ toLower(const std::string & name)
 ExecFlagEnum
 getDefaultExecFlagEnum()
 {
-  return ExecFlagRegistry::getExecFlagRegistry().getDefaultFlags();
+  return moose::internal::ExecFlagRegistry::getExecFlagRegistry().getDefaultFlags();
 }
 
 int

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -977,7 +977,7 @@ toLower(const std::string & name)
 ExecFlagEnum
 getDefaultExecFlagEnum()
 {
-  return moose::internal::getExecFlagRegistry().getDefaultFlags();
+  return ExecFlagRegistry::getExecFlagRegistry().getDefaultFlags();
 }
 
 int


### PR DESCRIPTION
This PR fixes the dynamic loading issue that we see with applications by removing the over aggressive use of "dlclose". There are also issues with the ExecFlag registration. Specifically, since we are using a Singleton, each application can see the flags of other applications, but this is problematic in the Multiapp case, since the setup of the simulation is split around the setup of Multiapps. The flags "known" to an Application can change due to the Multiapp creating issues during finalizing setup. The "easy" workaround to this is to copy construct the available flags known to an app during the early phase of setting up the App.

Testing: There is no real way to test this since the modules seem to dynamically load reliably already even with the current bug. If this passes module testing, at least we'll know these changes don't disrupt the basic dynamic loading cases in the "misc" module. After this PR is in, we can setup additional application based dynamic loading test cases hopefully in the VTB to make sure this is robust. I have a test case that fails before this patch (Pronghorn loading Bison with both running "simple transient diffusion"). That test case now works on Linux, Intel Macs, and Apple Silicon Macs.

Refs #12266.
