### PR TITLE
libMesh submodule update

### DIFF
--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,10 +3,10 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 17 %}
-{% set vtk_version = "9.1.0" %}
-{% set vtk_friendly_version = "9.1" %}
-{% set sha256 = "8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96" %}
+{% set build = 0 %}
+{% set vtk_version = "9.2.6" %}
+{% set vtk_friendly_version = "9.2" %}
+{% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}
 
 package:
   name: moose-libmesh-vtk

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -5,7 +5,7 @@ moose_petsc:
   - moose-petsc 3.16.6
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.1.0
+  - moose-libmesh-vtk 9.2.6
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,10 +2,10 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.03.02" %}
-{% set vtk_friendly_version = "9.1" %}
+{% set vtk_friendly_version = "9.2" %}
 
 package:
   name: moose-libmesh

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #   moose/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.03.02" %}
+{% set version = "2023.03.29" %}
 {% set vtk_friendly_version = "9.1" %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.29 build_0
 
 moose_python:
  - python 3.9

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.02 build_1
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.29 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.02 build_0
+ - moose-libmesh 2023.03.02 build_1
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=14633497ea867c56053d1ea7a1fbe0442727eb24
+ARG LIBMESH_REV=80494219d2293e467392189814d30330c4f87a25
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/include/reporters/ReporterContext.h
+++ b/framework/include/reporters/ReporterContext.h
@@ -257,17 +257,12 @@ public:
                                 unsigned int time_index = 0) const override;
 
 protected:
-  /// For broadcasting values if it is of fundamental type
-  template <typename Q = T>
-  typename std::enable_if<MooseUtils::canBroadcast<Q>::value, void>::type broadcast()
+  void broadcast()
   {
-    this->comm().broadcast(this->_state.value());
-  }
-  /// Error if trying to broadcast not fundamental type
-  template <typename Q = T>
-  typename std::enable_if<!MooseUtils::canBroadcast<Q>::value, void>::type broadcast()
-  {
-    mooseError("Can only broadcast fundamental types.");
+    if constexpr (MooseUtils::canBroadcast<T>::value)
+      this->comm().broadcast(this->_state.value());
+    else
+      mooseError("Cannot broadcast Reporter type '", MooseUtils::prettyCppType<T>(), "'");
   }
 
   /// Output meta data to JSON, see JSONOutput

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -1006,13 +1006,7 @@ template <typename T>
 struct canBroadcast
 {
   static constexpr bool value = std::is_base_of<TIMPI::DataType, TIMPI::StandardType<T>>::value ||
-                                std::is_same<T, std::string>::value;
-};
-template <typename T>
-struct canBroadcast<std::vector<T>>
-{
-  static constexpr bool value = std::is_base_of<TIMPI::DataType, TIMPI::StandardType<T>>::value ||
-                                std::is_same<T, std::string>::value;
+                                TIMPI::Has_buffer_type<TIMPI::Packing<T>>::value;
 };
 
 ///@{ Comparison helpers that support the MooseUtils::Any wildcard which will match any value

--- a/modules/doc/content/newsletter/2023/2023_03.md
+++ b/modules/doc/content/newsletter/2023/2023_03.md
@@ -88,6 +88,15 @@ to create execution groups that run *after* the default group. Execution order g
 
 ## PETSc-level Changes
 
+## VTK 9.2.6 (moose-libmesh-vtk)
+
+- Bump VTK version 9.1.0 to 9.2.6. Fix issue involving relink on modern
+  systems with latest libm.so:
+
+  ```pre
+  libmesh-vtk/lib/././libvtkkissfft-9.1.so.1' with `/lib64/libm.so.6' for IFUNC symbol `sincos'
+  ```
+
 ## Bug Fixes and Minor Enhancements
 
 - A [VectorPostprocessor parallel bug identified by ANL researchers](https://github.com/idaholab/moose/issues/23514), was fixed by [defaulting to asking for parallel synchronized VPP values](https://github.com/idaholab/moose/pull/23588).

--- a/modules/doc/content/newsletter/2023/2023_03.md
+++ b/modules/doc/content/newsletter/2023/2023_03.md
@@ -58,7 +58,7 @@ to create execution groups that run *after* the default group. Execution order g
 
 - PetscVector local array behavior fixes
 - Bezier extraction from ExodusII IsoGeometric Analysis meshes can now
-  be done to a discontinuous mesh, if specified by user code; this is
+  be done for a discontinuous mesh, if specified by user code; this is
   less efficient but much more flexible.
 - ExodusII I/O support for lower-order edge blocks referring to
   higher-order edges
@@ -79,7 +79,7 @@ to create execution groups that run *after* the default group. Execution order g
 - MetaPhysicL updates:
   - Fixes for builds with `TIMPI` but without `MPI`
   - Fixes for many compiler warnings.  Warnings triggered by
-    --enable-paranoid-warnings configurations are now all fixed, that
+    the `--enable-paranoid-warnings` configuration are now all fixed, that
     configuration is now enabled in MetaPhysicL whenever it is enabled
     in libMesh itself, and it is now tested for regressions in CI.
 

--- a/modules/doc/content/newsletter/2023/2023_03.md
+++ b/modules/doc/content/newsletter/2023/2023_03.md
@@ -54,6 +54,38 @@ to create execution groups that run *after* the default group. Execution order g
   inconsistent values assigned to the same key, packed-range
   communication of pairs with fixed-size data and padding bytes.
 
+### `2023.03.29` Update
+
+- PetscVector local array behavior fixes
+- Bezier extraction from ExodusII IsoGeometric Analysis meshes can now
+  be done to a discontinuous mesh, if specified by user code; this is
+  less efficient but much more flexible.
+- ExodusII I/O support for lower-order edge blocks referring to
+  higher-order edges
+- HDF5 underlying Nemesis output is now a user-controllable option
+- More assertions of parallel synchronization in
+  `PetscNonlinearSolver`
+- TIMPI updates:
+
+  - Better error messages in cases where TIMPI assertions of users'
+    parallel synchronization fail
+  - `parallel_sync.h` algorithms now fully support rvalue data, and
+    their behavior with local data is commented slightly better.
+  - `Packing` specializations for container types now only exist if
+    the container contents are entirely packable
+  - Bug fixes for certain `Packing<tuple>` cases
+  - Better test coverage
+
+- MetaPhysicL updates:
+  - Fixes for builds with `TIMPI` but without `MPI`
+  - Fixes for many compiler warnings.  Warnings triggered by
+    --enable-paranoid-warnings configurations are now all fixed, that
+    configuration is now enabled in MetaPhysicL whenever it is enabled
+    in libMesh itself, and it is now tested for regressions in CI.
+
+- Compiler warning fixes for libMesh builds with newer clang++
+
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -72,3 +72,8 @@ db176aaa92d1fd79b2d92ad8979633f9b7ce65b7: # 23581
   petsc: 64a9a7e
   libmesh: 016f5c8
   moose: f58bca8
+12cc7aa0fb2e129eaecb35a8aaefedd2175ad12b: # 23884
+  mpich: b896b5d
+  petsc: 64a9a7e
+  libmesh: 5070cbf
+  moose: a555101


### PR DESCRIPTION
- PetscVector local array behavior fixes
- Bezier extraction from ExodusII IsoGeometric Analysis meshes can now
  be done to a discontinuous mesh, if specified by user code; this is
  less efficient but much more flexible.
- ExodusII I/O support for lower-order edge blocks referring to
  higher-order edges
- HDF5 underlying Nemesis output is now a user-controllable option
- More assertions of parallel synchronization in
  `PetscNonlinearSolver`
- TIMPI updates:

  - Better error messages in cases where TIMPI assertions of users'
    parallel synchronization fail
  - `parallel_sync.h` algorithms now fully support rvalue data, and
    their behavior with local data is commented slightly better.
  - `Packing` specializations for container types now only exist if
    the container contents are entirely packable
  - Bug fixes for certain `Packing<tuple>` cases
  - Better test coverage

- MetaPhysicL updates:
  - Fixes for builds with `TIMPI` but without `MPI`
  - Fixes for many compiler warnings.  Warnings triggered by
    `--enable-paranoid-warnings` configurations are now all fixed, that
    configuration is now enabled in MetaPhysicL whenever it is enabled
    in libMesh itself, and it is now tested for regressions in CI.

- Compiler warning fixes for libMesh builds with newer clang++


The Bezier extraction enhancements here is necessary for the next stage of #18768; and we have users waiting on the fix for https://github.com/libMesh/libmesh/issues/3493 ; not sure if any of the other MOOSE-relevant changes made it into a tracked issue.

Closes https://github.com/idaholab/moose/issues/23885