### PR TITLE
Use this-> qualification for _mesh in CZM

### DIFF
--- a/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
+++ b/modules/tensor_mechanics/src/materials/cohesive_zone_model/CZMComputeDisplacementJumpTotalLagrangian.C
@@ -83,7 +83,7 @@ void
 CZMComputeDisplacementJumpTotalLagrangianTempl<is_ad>::computeRotationMatrices()
 {
   _czm_reference_rotation[_qp] =
-      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], _mesh.dimension());
+      CohesiveZoneModelTools::computeReferenceRotation(_normals[_qp], this->_mesh.dimension());
   computeFandR();
   _czm_total_rotation[_qp] = _R[_qp] * _czm_reference_rotation[_qp];
 }


### PR DESCRIPTION
Some compilers are too dumb to recognize `using` declarations as being sufficient

Refs #23855