### PR TITLE
Skip Reporter types in `JSONDiff` by default

### DIFF
--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -1202,7 +1202,7 @@ prettyCppType(const std::string & cpp_type)
   std::string s = cpp_type;
   pcrecpp::RE("std::__\\w+::").GlobalReplace("std::", &s);
   // It would be nice if std::string actually looked normal
-  pcrecpp::RE("\\s*std::basic_string<char, std::char_traits<char>, std::allocator<char> >\\s*")
+  pcrecpp::RE("\\s*std::basic_string<char, std::char_traits<char>, std::allocator<char>>\\s*")
       .GlobalReplace("std::string", &s);
   // It would be nice if std::vector looked normal
   pcrecpp::RE r("std::vector<([[:print:]]+),\\s?std::allocator<\\s?\\1\\s?>\\s?>");

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -1200,6 +1200,8 @@ prettyCppType(const std::string & cpp_type)
   // On mac many of the std:: classes are inline namespaced with __1
   // On linux std::string can be inline namespaced with __cxx11
   std::string s = cpp_type;
+  // Remove all spaces surrounding a >
+  pcrecpp::RE("\\s(?=>)").GlobalReplace("", &s);
   pcrecpp::RE("std::__\\w+::").GlobalReplace("std::", &s);
   // It would be nice if std::string actually looked normal
   pcrecpp::RE("\\s*std::basic_string<char, std::char_traits<char>, std::allocator<char>>\\s*")

--- a/python/TestHarness/testers/JSONDiff.py
+++ b/python/TestHarness/testers/JSONDiff.py
@@ -16,6 +16,7 @@ class JSONDiff(SchemaDiff):
         params = SchemaDiff.validParams()
         params.addRequiredParam('jsondiff',   [], "A list of JSON files to compare.")
         params.addParam('skip_keys', [],"Deprecated. Items in the JSON that the differ will ignore. This is functionally identical to ignored_items inside of SchemaDiff.")
+        params.addParam('ignored_regex_items', [], "Items (with regex enabled) to ignore, separated by '/' for each level, i.e., key1/key2/.* will skip all items in ['key1']['key2']['.*']")
         params.addParam('keep_system_information', False, "Whether or not to keep the system information as part of the diff.")
         params.addParam('keep_reporter_types', False, "Whether or not to keep the MOOSE Reporter type information as part of the diff.")
         return params
@@ -23,7 +24,6 @@ class JSONDiff(SchemaDiff):
     def __init__(self, name, params):
         params['schemadiff'] = params['jsondiff']
         params['ignored_items'] += params['skip_keys']
-
 
         SchemaDiff.__init__(self, name, params)
         if not params['keep_system_information']:
@@ -37,6 +37,13 @@ class JSONDiff(SchemaDiff):
                                             'slepc_version'])
         if not params['keep_reporter_types']:
             self.exclude_regex_paths.append("root\['reporters'\]\[.*\]\['values'\]\[.*\]\['type'\]")
+
+        # Form something like root['key1']['key2']... for each entry
+        for entry in self.specs['ignored_regex_items']:
+            re_entry = 'root'
+            for key in entry.split('/'):
+                re_entry += f"\['{key}'\]"
+            self.exclude_regex_paths.append(re_entry)
 
     def prepare(self, options):
         if self.specs['delete_output_before_running'] == True:

--- a/python/TestHarness/testers/JSONDiff.py
+++ b/python/TestHarness/testers/JSONDiff.py
@@ -17,14 +17,16 @@ class JSONDiff(SchemaDiff):
         params.addRequiredParam('jsondiff',   [], "A list of JSON files to compare.")
         params.addParam('skip_keys', [],"Deprecated. Items in the JSON that the differ will ignore. This is functionally identical to ignored_items inside of SchemaDiff.")
         params.addParam('keep_system_information', False, "Whether or not to keep the system information as part of the diff.")
+        params.addParam('keep_reporter_types', False, "Whether or not to keep the MOOSE Reporter type information as part of the diff.")
         return params
 
     def __init__(self, name, params):
         params['schemadiff'] = params['jsondiff']
         params['ignored_items'] += params['skip_keys']
 
+
         SchemaDiff.__init__(self, name, params)
-        if (not params['keep_system_information']):
+        if not params['keep_system_information']:
             self.specs['ignored_items'].extend(['app_name',
                                             'current_time',
                                             'executable',
@@ -33,7 +35,8 @@ class JSONDiff(SchemaDiff):
                                             'libmesh_version',
                                             'petsc_version',
                                             'slepc_version'])
-
+        if not params['keep_reporter_types']:
+            self.exclude_regex_paths.append("root\['reporters'\]\[.*\]\['values'\]\[.*\]\['type'\]")
 
     def prepare(self, options):
         if self.specs['delete_output_before_running'] == True:

--- a/python/TestHarness/testers/JSONDiff.py
+++ b/python/TestHarness/testers/JSONDiff.py
@@ -36,7 +36,7 @@ class JSONDiff(SchemaDiff):
                                             'petsc_version',
                                             'slepc_version'])
         if not params['keep_reporter_types']:
-            self.exclude_regex_paths.append("root\['reporters'\]\[.*\]\['values'\]\[.*\]\['type'\]")
+            self.specs['ignored_regex_items'].append('reporters/.*/values/.*/type')
 
         # Form something like root['key1']['key2']... for each entry
         for entry in self.specs['ignored_regex_items']:

--- a/python/TestHarness/testers/SchemaDiff.py
+++ b/python/TestHarness/testers/SchemaDiff.py
@@ -31,6 +31,9 @@ class SchemaDiff(RunApp):
         elif 'deepdiff' not in self.specs['required_python_packages']:
             self.specs['required_python_packages'] += ' deepdiff'
 
+        # So that derived classes can internally pass skip regex paths
+        self.exclude_regex_paths = []
+
     def prepare(self, options):
         if self.specs['delete_output_before_running'] == True:
             util.deleteFilesAndFolders(self.getTestDir(), self.specs['schemadiff'])
@@ -140,19 +143,24 @@ class SchemaDiff(RunApp):
                         return True #if the values in the pseudo-list are different, but all fall within the accepted rel_err, the list is skipped for diffing.
                     except ValueError:
                         return False
-        to_exclude = []
+        exclude_paths = []
         if exclude_values:
             for value in exclude_values:
                 search = orig | deepdiff.search.grep(value, case_sensitive=True)
                 search2 = comp | deepdiff.search.grep(value, case_sensitive=True)
                 if search:
                     for path in search["matched_paths"]:
-                        to_exclude.append(path)
+                        exclude_paths.append(path)
                 if search2:
                     for path in search2["matched_paths"]:
-                        to_exclude.append(path)
+                        exclude_paths.append(path)
 
-        return deepdiff.DeepDiff(orig,comp,exclude_paths=to_exclude,custom_operators=[testcompare(types=[str,float],rel_err=rel_err,abs_zero=abs_zero)]).pretty()
+        custom_operators = [testcompare(types=[str,float],rel_err=rel_err,abs_zero=abs_zero)]
+        return deepdiff.DeepDiff(orig,
+                                 comp,
+                                 exclude_paths=exclude_paths,
+                                 exclude_regex_paths=self.exclude_regex_paths,
+                                 custom_operators=custom_operators).pretty()
 
     #this is how we call the load_file in the derived classes, and also check for exceptions in the load
     #all python functions are virtual, so there is no templating, but some self shenanigans required

--- a/python/doc/content/python/testers/JSONDiff.md
+++ b/python/doc/content/python/testers/JSONDiff.md
@@ -16,8 +16,14 @@ Test configuration options are added to the `tests` file.
 
 - `rel_err`: Sets a relative error comparison tolerance, defaults to 5.5e-6.
 
-
 Other test commands & restrictions may be found in the [TestHarness documentation](TestHarness.md).
+
+### MOOSE-Specific
+
+The following options are specific to MOOSE JSON output:
+
+- `keep_system_information`: Whether or not to diff the system information reported by MOOSE; this defaults to false because typically diffing on executable name, run time, etc, is not useful for testing
+- `keep_reporter_types` Whether or not to diff the reporter types output by the MOOSE reporter system
 
 ## Example test configuration in the MOOSE test suite
 

--- a/test/tests/reporters/accumulated_reporter/tests
+++ b/test/tests/reporters/accumulated_reporter/tests
@@ -6,7 +6,9 @@
     type = 'JSONDiff'
     input = 'accumulate_reporter.i'
     jsondiff = 'accumulate_reporter_out.json'
-    keep_reporter_types = True
+    keep_reporter_types = true
     requirement = 'The system shall be able to accumulate reporter values over time steps into a vector reporter value.'
+    # dof id type varies based on 32 bit, 64 bit, and machine
+    ignored_regex_items = 'reporters/accumulate/values/rep:dofid.*/type'
   []
 []

--- a/test/tests/reporters/accumulated_reporter/tests
+++ b/test/tests/reporters/accumulated_reporter/tests
@@ -6,7 +6,7 @@
     type = 'JSONDiff'
     input = 'accumulate_reporter.i'
     jsondiff = 'accumulate_reporter_out.json'
-    skip_keys = 'type'
+    keep_reporter_types = True
     requirement = 'The system shall be able to accumulate reporter values over time steps into a vector reporter value.'
   []
 []

--- a/test/tests/reporters/constant_reporter/tests
+++ b/test/tests/reporters/constant_reporter/tests
@@ -6,8 +6,10 @@
     type = 'JSONDiff'
     input = 'constant_reporter.i'
     jsondiff = 'constant_reporter_out.json'
-    keep_reporter_types = true
     requirement = 'The system shall be able to produce arbitrary integer, real number, dof_id_types and string scalar/vector values for use in other calculations.'
+    keep_reporter_types = true
+    # dof id type varies based on 32 bit, 64 bit, and machine
+    ignored_regex_items = 'reporters/constant/values/dofid_.*/type'
   []
   [errors]
     requirement = 'The system shall throw an error when producing constant reporter values if '

--- a/test/tests/reporters/constant_reporter/tests
+++ b/test/tests/reporters/constant_reporter/tests
@@ -6,7 +6,7 @@
     type = 'JSONDiff'
     input = 'constant_reporter.i'
     jsondiff = 'constant_reporter_out.json'
-    skip_keys = 'type'
+    keep_reporter_types = true
     requirement = 'The system shall be able to produce arbitrary integer, real number, dof_id_types and string scalar/vector values for use in other calculations.'
   []
   [errors]

--- a/test/tests/reporters/extra_id_integral/tests
+++ b/test/tests/reporters/extra_id_integral/tests
@@ -10,6 +10,7 @@
       cli_args = "Outputs/file_base='extra_id_integral_default'"
       detail = 'single variable integral with single extra ID'
       recover = false
+      keep_reporter_types = true
     []
     [multi_ids]
       type = 'JSONDiff'
@@ -18,6 +19,7 @@
       cli_args = "Reporters/extra_id_integral/id_name='assembly_id pin_id' Outputs/file_base='extra_id_integral_multi_ids'"
       detail = 'single variable integral with multiple extra IDs'
       recover = false
+      keep_reporter_types = true
     []
     [multi_ids_multi_vars]
       type = 'JSONDiff'
@@ -26,6 +28,7 @@
       cli_args = "Reporters/extra_id_integral/id_name='assembly_id pin_id' Reporters/extra_id_integral/variable='value1 value2' Outputs/file_base='extra_id_integral_multi_vars'"
       detail = 'multiple variable integrals with multiple extra IDs'
       recover = false
+      keep_reporter_types = true
     []
   []
 []

--- a/test/tests/reporters/iteration_info/tests
+++ b/test/tests/reporters/iteration_info/tests
@@ -10,6 +10,7 @@
       jsondiff = iteration_info_out.json
       recover = false # iteration info changes with --recover
       skip_keys = 'part number_of_parts'
+      keep_reporter_types = true
 
       detail = "that outputs all information be default;"
     []
@@ -21,6 +22,7 @@
       cli_args = 'Reporters/iteration_info/items=time timestep Outputs/file_base=limit_out'
       recover = false # iteration info changes with --recover
       skip_keys = 'part number_of_parts'
+      keep_reporter_types = true
 
       detail = "that outputs specific information;"
     []
@@ -31,6 +33,8 @@
       jsondiff = iteration_info_steady_out.json
       recover = false # iteration info changes with --recover
       skip_keys = 'part number_of_parts'
+      keep_reporter_types = true
+
 
       detail = "automatically disables items based on execution;"
     []

--- a/test/tests/reporters/mesh_info/gold/mesh_info_out.json
+++ b/test/tests/reporters/mesh_info/gold/mesh_info_out.json
@@ -6,16 +6,16 @@
             "type": "MeshInfo",
             "values": {
                 "local_sideset_elems": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "local_sidesets": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "local_subdomain_elems": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 },
                 "local_subdomains": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 },
                 "num_dofs": {
                     "type": "unsigned int"
@@ -51,16 +51,16 @@
                     "type": "unsigned int"
                 },
                 "sideset_elems": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "sidesets": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "subdomain_elems": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 },
                 "subdomains": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 }
             }
         }

--- a/test/tests/reporters/mesh_info/gold/mesh_info_out.json.1
+++ b/test/tests/reporters/mesh_info/gold/mesh_info_out.json.1
@@ -6,16 +6,16 @@
             "type": "MeshInfo",
             "values": {
                 "local_sideset_elems": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "local_sidesets": {
-                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo> > >"
+                    "type": "std::map<short, MeshInfo::SidesetInfo, std::less<short>, std::allocator<std::pair<short const, MeshInfo::SidesetInfo>>>"
                 },
                 "local_subdomain_elems": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 },
                 "local_subdomains": {
-                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo> > >"
+                    "type": "std::map<unsigned short, MeshInfo::SubdomainInfo, std::less<unsigned short>, std::allocator<std::pair<unsigned short const, MeshInfo::SubdomainInfo>>>"
                 },
                 "num_dofs": {
                     "type": "unsigned int"

--- a/test/tests/reporters/mesh_info/tests
+++ b/test/tests/reporters/mesh_info/tests
@@ -10,6 +10,7 @@
       jsondiff = 'mesh_info_out.json mesh_info_out.json.1'
       min_parallel = 2
       max_parallel = 2
+      keep_reporter_types = true
 
       detail = "that outputs all information be default and"
     []
@@ -20,6 +21,7 @@
       jsondiff = limit_out.json
       cli_args = 'Reporters/mesh_info/items="num_dofs" Outputs/file_base=limit_out'
       skip_keys = 'part number_of_parts'
+      keep_reporter_types = true
 
       detail = "that outputs specific information."
     []


### PR DESCRIPTION
Closes https://github.com/idaholab/moose/issues/23979

Ping @zachmprince and @grmnptr; with these changes, I would really like for us to in this PR set this parameter (`JSONDiff/keep_reporter_types`) to true for the tests that we can that test _just_ a reporter object. I've only done this for the framework so far