### PR TITLE
Constrain python to <3.11, enable rocky9 apptainer, improve versioner, add cuda and clang to apptainer

### DIFF
--- a/apptainer/libmesh.def
+++ b/apptainer/libmesh.def
@@ -81,7 +81,6 @@ From: {{ APPTAINER_FROM }}
 {%- if DEV_CONTAINER is defined %}
     # DEV_CONTAINER set
     METHODS="opt dbg oprof devel"
-    dnf --enablerepo=powertools install -y valgrind cppunit
 {%- else %}
     # DEV_CONTAINER not set
     METHODS="{{ METHODS or "opt" }}"

--- a/apptainer/moose.def
+++ b/apptainer/moose.def
@@ -83,12 +83,8 @@ From: {{ APPTAINER_FROM }}
 
     {% if DEV_CONTAINER is defined -%}
     # Other Development container installs
-    dnf --enablerepo=powertools install -y lcov doxygen
     pip3 --no-cache install lcov-cobertura
     {%- endif %}
-
-    # Few packages needed by apps
-    dnf install -y fftw-devel gsl-devel
 
     # Build and install wasp
     # This is redundant; hopefully we can use the one from conda in the future

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -1,6 +1,15 @@
+{#- Required jinja arguments                                                                  -#}
+{#- ARCH: The machine arch                                                                    -#}
+
+{#- Optional jinja arguments                                                                  -#}
+{#- ALTERNATE_FROM: Set an alternate from (currently supported: rocky9)                       -#}
+
 BootStrap: oras
-# Any Rocky-8 image which supplies a development stack with MPI available
+{%- if ALTERNATE_FROM == "rocky9" %}
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/mpi_03-rocky9-{{ ARCH }}:9.0-0
+{%- else %}
 From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
+{%- endif %}
 
 %environment
     # Set Environment for MPICH

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -109,7 +109,7 @@ ${USE_MPI_SCRIPT}
 EOF
 
     # Add script for loading openmpi environment
-    cat << EOF > /opt/mpi/use-mpich
+    cat << EOF > /opt/mpi/use-openmpi
 #!/bin/bash
 export MOOSE_MPI_DIR=${MOOSE_OPENMPI_DIR}
 ${USE_MPI_SCRIPT}

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -1,6 +1,6 @@
 BootStrap: oras
 # Any Rocky-8 image which supplies a development stack with MPI available
-From: mooseharbor.hpc.inl.gov/hpc-base/rocky8-x86_64-infiniband:10-19-2022
+From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
 
 %environment
     # Set Environment for MPICH

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -14,20 +14,35 @@ From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
     export LC_ALL=C
 
 %post
+    # Get the RHEL version
+    RHEL_VERSION=$(awk -F'=' '/VERSION_ID/{ gsub(/"/,""); print $2}' /etc/os-release)
+
     # Prepare a temp directory
     TEMP_LOC=/root/build
     mkdir ${TEMP_LOC}
 
+    # Enable power tools
+    if [[ $RHEL_VERSION = 9* ]]; then
+        dnf config-manager --enable crb
+    else
+        dnf config-manager --set-enabled powertools
+        dnf install -y redhat-lsb-core.x86_64
+    fi
     # Additional installs
     dnf install -y vim tmux emacs wget rsync hostname python3-pyyaml python3-devel python39 \
-                   cmake diffutils bison flex redhat-lsb-core.x86_64 perl-IO-Compress perl-JSON \
-                   perl-JSON-PP libtirpc libtirpc-devel zlib-devel patch patchutils epel-release \
-                   file libpng libpng-devel unzip jq
+                   cmake diffutils bison flex perl-IO-Compress perl-JSON perl-JSON-PP \
+                   libtirpc libtirpc-devel zlib-devel patch patchutils epel-release file \
+                   libpng libpng-devel unzip jq valgrind cppunit doxygen fftw-devel gsl-devel \
+                   libtool autoconf automake
     # After epel-release
-    dnf install -y glpk-devel patchelf
+    dnf install -y glpk-devel patchelf lcov
 
     # Make python default to python3
-    alternatives --set python /usr/bin/python3
+    if [[ $RHEL_VERSION = 9* ]]; then
+        alternatives --install /usr/bin/python python /usr/bin/python3 0
+    else
+        alternatives --set python /usr/bin/python3
+    fi
 
     # Allow a custom initialization routine if the following files exist at /
     touch ${SINGULARITY_ROOTFS}/none

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -16,18 +16,13 @@ From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
 {%- endif %}
 
 %environment
-    MOOSE_MPI_DIR=${MOOSE_MPI_DIR:-/opt/mpi/mpich-3.4.3}
-
-    # Set Environment for MPI
-    export LD_LIBRARY_PATH=${MOOSE_MPI_DIR}/lib:${LD_LIBRARY_PATH}
-    export MANPATH=${MOOSE_MPI_DIR}/share/man:${MANPATH}
-    export PATH=${MOOSE_MPI_DIR}/bin:${PATH}
-    export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
-
     # Fix locale warnings
     export LC_ALL=C
 
 %post
+    export MOOSE_MPICH_DIR=${MOOSE_MPICH_DIR:-"/opt/mpi/mpich-3.4.3"}
+    export MOOSE_OPENMPI_DIR=${MOOSE_OPENMPI_DIR:-"/opt/mpi/openmpi-4.1.5"}
+
     # Get the RHEL version
     RHEL_VERSION=$(awk -F'=' '/VERSION_ID/{ gsub(/"/,""); print $2}' /etc/os-release)
 
@@ -99,6 +94,26 @@ EOF
     tar -xf git-lfs-linux-amd64-v3.2.0.tar.gz
     cd git-lfs-3.2.0
     ./install.sh
+
+    # Basic script for setting mpich environment
+    USE_MPI_SCRIPT='export LD_LIBRARY_PATH=${MOOSE_MPI_DIR}/lib:${LD_LIBRARY_PATH}
+export MANPATH=${MOOSE_MPI_DIR}/share/man:${MANPATH}
+export PATH=${MOOSE_MPI_DIR}/bin:${PATH}
+export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77'
+
+    # Add script for loading mpich environment
+    cat << EOF > /opt/mpi/use-mpich
+#!/bin/bash
+export MOOSE_MPI_DIR=${MOOSE_MPICH_DIR}
+${USE_MPI_SCRIPT}
+EOF
+
+    # Add script for loading openmpi environment
+    cat << EOF > /opt/mpi/use-mpich
+#!/bin/bash
+export MOOSE_MPI_DIR=${MOOSE_OPENMPI_DIR}
+${USE_MPI_SCRIPT}
+EOF
 
     # Clean Up
     rm -rf ${TEMP_LOC}

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -16,11 +16,12 @@ From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
 {%- endif %}
 
 %environment
-    # Set Environment for MPICH
-    export MPICH_DIR=/opt/mpi/mpich-3.4.3
-    export LD_LIBRARY_PATH=${MPICH_DIR}/lib:${LD_LIBRARY_PATH}
-    export MANPATH=${MPICH_DIR}/share/man:${MANPATH}
-    export PATH=${MPICH_DIR}/bin:${PATH}
+    MOOSE_MPI_DIR=${MOOSE_MPI_DIR:-/opt/mpi/mpich-3.4.3}
+
+    # Set Environment for MPI
+    export LD_LIBRARY_PATH=${MOOSE_MPI_DIR}/lib:${LD_LIBRARY_PATH}
+    export MANPATH=${MOOSE_MPI_DIR}/share/man:${MANPATH}
+    export PATH=${MOOSE_MPI_DIR}/bin:${PATH}
     export CC=mpicc CXX=mpicxx FC=mpif90 F90=mpif90 F77=mpif77
 
     # Fix locale warnings

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -7,6 +7,8 @@
 BootStrap: oras
 {%- if ALTERNATE_FROM == "rocky9" %}
 From: mooseharbor.hpc.inl.gov/moose-hpcbase/mpi_03-rocky9-{{ ARCH }}:9.0-0
+{%- elif ALTERNATE_FROM == "clang" %}
+From: mooseharbor.hpc.inl.gov/moose-base/rocky8-clang:8.7-0
 {%- else %}
 From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
 {%- endif %}
@@ -31,6 +33,7 @@ From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
     mkdir ${TEMP_LOC}
 
     # Enable power tools
+    dnf install -y dnf-plugins-core
     if [[ $RHEL_VERSION = 9* ]]; then
         dnf config-manager --enable crb
     else

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -8,7 +8,7 @@ BootStrap: oras
 {%- if ALTERNATE_FROM == "rocky9" %}
 From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky9-{{ ARCH }}:9.0-0
 {%- elif ALTERNATE_FROM == "clang" %}
-From: mooseharbor.hpc.inl.gov/moose-base/rocky8-clang-{{ ARCH }}:8.7-0
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky8-clang-{{ ARCH }}:8.6-0
 {%- elif ALTERNATE_FROM == "cuda" %}
 From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky8-cuda-{{ ARCH }}:8.6-cuda11.4.0-0
 {%- else %}

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -6,9 +6,11 @@
 
 BootStrap: oras
 {%- if ALTERNATE_FROM == "rocky9" %}
-From: mooseharbor.hpc.inl.gov/moose-hpcbase/mpi_03-rocky9-{{ ARCH }}:9.0-0
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky9-{{ ARCH }}:9.0-0
 {%- elif ALTERNATE_FROM == "clang" %}
-From: mooseharbor.hpc.inl.gov/moose-base/rocky8-clang:8.7-0
+From: mooseharbor.hpc.inl.gov/moose-base/rocky8-clang-{{ ARCH }}:8.7-0
+{%- elif ALTERNATE_FROM == "cuda" %}
+From: mooseharbor.hpc.inl.gov/moose-hpcbase/rocky8-cuda-{{ ARCH }}:8.6-cuda11.4.0-0
 {%- else %}
 From: harbor.hpc.inl.gov/hpcbase/mpi_03:1.1.0
 {%- endif %}

--- a/apptainer/petsc.def
+++ b/apptainer/petsc.def
@@ -7,12 +7,17 @@
 {#- PETSC_ALT: Set to anything to use the alternate version of PETSc                          -#}
 {#- PETSC_OPTIONS: Options to pass to the PETSc build script                                  -#}
 {#- MOOSE_JOBS: Number of jobs to pass to the PETSc build script                              -#}
+{#- MPI_FLAVOUR: The flavour of MPI to use (options: mpich, openmpi; default: mpich)          -#}
 
 {#- The within-container build directory to use                                               -#}
 {%- set ROOT_BUILD_DIR = '/root/build' -%}
 
 {#- The installation location for PETSc                                                       -#}
 {%- set PETSC_DIR = '/opt/petsc' -%}
+
+{%- if MPI_FLAVOUR is not defined %}
+{%- set MPI_FLAVOUR = 'mpich' -%}
+{%- endif %}
 
 BootStrap: {{ APPTAINER_BOOTSTRAP }}
 From: {{ APPTAINER_FROM }}
@@ -27,10 +32,24 @@ From: {{ APPTAINER_FROM }}
     git submodule update --init petsc
 
 %environment
+    # Set the MPI environment
+{%- if MPI_FLAVOUR == "mpich" %}
+    source /opt/mpi/use-mpich
+{%- elif MPI_FLAVOUR == "openmpi" %}
+    source /opt/mpi/use-openmpi
+{%- endif %}
+
     # From moose-petsc
     export PETSC_DIR={{ PETSC_DIR }}
 
 %post
+    # Set the MPI environment
+{%- if MPI_FLAVOUR == "mpich" %}
+    source /opt/mpi/use-mpich
+{%- elif MPI_FLAVOUR == "openmpi" %}
+    source /opt/mpi/use-openmpi
+{%- endif %}
+
     # Load jinja vars
     ROOT_BUILD_DIR={{ ROOT_BUILD_DIR }}
     PETSC_DIR={{ PETSC_DIR }}

--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_7
+  - moose-mpich 4.0.2 build_8
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,9 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 0 %}
+#   moose-dev/
+# ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
+{% set build = 1 %}
 {% set vtk_version = "9.2.6" %}
 {% set vtk_friendly_version = "9.2" %}
 {% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_7
+  - moose-mpich 4.0.2 build_8
 
 moose_petsc:
   - moose-petsc 3.16.6

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,7 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 0 %}
+{% set build = 1 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.04.19" %}
 {% set vtk_friendly_version = "9.2" %}

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2023.04.19 build_0
+  - moose-libmesh 2023.04.19 build_1
 
 moose_wasp:
   - moose-wasp 2023.05.01

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -5,4 +5,4 @@ moose_wasp:
   - moose-wasp 2023.05.01
 
 moose_tools:
-  - moose-tools 2023.05.02
+  - moose-tools 2023.05.12

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2023.05.11" %}
+{% set version = "2023.05.12" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.19 build_0
+ - moose-libmesh 2023.04.19 build_1
 
 moose_wasp:
   - moose-wasp 2023.05.01

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -5,7 +5,10 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 7 %}
+#   moose-dev/
+#
+# ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
+{% set build = 8 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 
@@ -65,6 +68,9 @@ requirements:
     - {{ moose_libglu }}        # [linux]
     - {{ moose_mesalib }}       # [linux]
     - mpi 1.0 mpich
+  # Python min/max constraints
+  run_constrained:
+    - python <{{3.11}}
 
 test:
   commands:

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_7
+  - moose-mpich 4.0.2 build_8
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -3,7 +3,9 @@
 #   libmesh/
 #   template/
 #   moose/
-{% set build = 6 %}
+#   moose-dev/
+# ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
+{% set build = 7 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -5,7 +5,7 @@
 #   moose/
 #   moose-dev/
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 7 %}
+{% set build = 8 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/pyhit/conda_build_config.yaml
+++ b/conda/pyhit/conda_build_config.yaml
@@ -2,7 +2,6 @@ moose_python:
   - python 3.10
   - python 3.9
   - python 3.8
-  - python 3.7                                              # [not arm64]
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2023.04.04" %}
+{% set version = "2023.05.10" %}
 
 package:
   name: moose-pyhit

--- a/conda/pyhit/meta.yaml
+++ b/conda/pyhit/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2022.12.05" %}
+{% set version = "2023.04.04" %}
 
 package:
   name: moose-pyhit

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.19 build_0
+ - moose-libmesh 2023.04.19 build_1
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,6 +1,9 @@
 moose_libmesh:
  - moose-libmesh 2023.04.19 build_1
 
+ moose_wasp:
+  - moose-wasp 2023.05.01
+
 moose_python:
  - python 3.9
 

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,8 +1,8 @@
 moose_libmesh:
  - moose-libmesh 2023.04.19 build_1
 
- moose_wasp:
-  - moose-wasp 2023.05.01
+moose_wasp:
+ - moose-wasp 2023.05.01
 
 moose_python:
  - python 3.9

--- a/conda/test-tools/conda_build_config.yaml
+++ b/conda/test-tools/conda_build_config.yaml
@@ -2,7 +2,6 @@ moose_python:
   - python 3.10
   - python 3.9
   - python 3.8
-  - python 3.7                                             # [not arm64]
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -12,7 +12,7 @@
 #
 # as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
-{% set version = "2023.05.02" %}
+{% set version = "2023.05.10" %}
 
 package:
   name: moose-test-tools

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -12,7 +12,7 @@
 #
 # as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
-{% set version = "2023.05.10" %}
+{% set version = "2023.05.12" %}
 
 package:
   name: moose-test-tools

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -1,7 +1,16 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/ (must contain any python major.minor version this
-#              package is building. Usually the latest version.)
+#              package supports. Usually the latest version.)
+#   tools/
+#
+# If adding a new Python version, you will need to update
+# version in mpich/meta.yaml:
+#
+# run_constrains:
+#     - python <{{version}}
+#
+# as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
 {% set version = "2023.05.02" %}
 

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -1,7 +1,16 @@
 # Making a Change to this package?
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/ (must contain any python major.minor version this
-#              package is building. Usually the latest version.)
+#              package supports. Usually the latest version.)
+#   moose-dev/
+#
+# If adding a new Python version, you will need to update
+# version in mpich/meta.yaml:
+#
+# run_constrains:
+#     - python <{{version}}
+#
+# as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
 {% set version = "2023.05.02" %}
 

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -12,7 +12,7 @@
 #
 # as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
-{% set version = "2023.05.02" %}
+{% set version = "2023.05.10" %}
 
 package:
   name: moose-tools

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -12,7 +12,7 @@
 #
 # as well as follow the directions pertaining to modifying that file.
 {% set build = 0 %}
-{% set version = "2023.05.10" %}
+{% set version = "2023.05.12" %}
 
 package:
   name: moose-tools

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -1,3 +1,9 @@
+# Making a Change to this package?
+# REMEMBER TO UPDATE the .yaml files for the following packages:
+#   template/ (must contain any python major.minor version this
+#              package supports. Usually the latest version.)
+#   moose/
+#   moose-dev/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.05.01" %}

--- a/modules/tensor_mechanics/src/materials/HillElastoPlasticityStressUpdate.C
+++ b/modules/tensor_mechanics/src/materials/HillElastoPlasticityStressUpdate.C
@@ -154,7 +154,7 @@ HillElastoPlasticityStressUpdateTempl<is_ad>::computeElasticityTensorEigenDecomp
 
   const unsigned int dimension = _anisotropic_elastic_tensor.n();
 
-  AnisotropyMatrixReal A;
+  AnisotropyMatrixReal A = AnisotropyMatrixReal::Zero();
   for (unsigned int index_i = 0; index_i < dimension; index_i++)
     for (unsigned int index_j = 0; index_j < dimension; index_j++)
       A(index_i, index_j) = MetaPhysicL::raw_value(_anisotropic_elastic_tensor(index_i, index_j));
@@ -190,7 +190,7 @@ HillElastoPlasticityStressUpdateTempl<is_ad>::computeElasticityTensorEigenDecomp
   b_matrix.left_multiply(eigenvectors_elasticity_transpose);
   b_matrix.left_multiply(sqrt_Delta);
 
-  AnisotropyMatrixReal B_eigen;
+  AnisotropyMatrixReal B_eigen = AnisotropyMatrixReal::Zero();
   for (unsigned int index_i = 0; index_i < dimension; index_i++)
     for (unsigned int index_j = 0; index_j < dimension; index_j++)
       B_eigen(index_i, index_j) = MetaPhysicL::raw_value(b_matrix(index_i, index_j));

--- a/python/MooseDocs/test/tests
+++ b/python/MooseDocs/test/tests
@@ -12,21 +12,21 @@
 
       [serial]
         type = RunCommand
-        command = 'python moosedocs.py verify --form html --executioner MooseDocs.base.Serial'
+        command = 'python3 moosedocs.py verify --form html --executioner MooseDocs.base.Serial'
       []
       [queue]
         type = RunCommand
-        command = 'python moosedocs.py verify --form html --executioner MooseDocs.base.ParallelQueue'
+        command = 'python3 moosedocs.py verify --form html --executioner MooseDocs.base.ParallelQueue'
         prereq = verify/html/serial
       []
       [barrier]
         type = RunCommand
-        command = 'python moosedocs.py verify --form html --executioner MooseDocs.base.ParallelBarrier'
+        command = 'python3 moosedocs.py verify --form html --executioner MooseDocs.base.ParallelBarrier'
         prereq = verify/html/queue
       []
       [pipe]
         type = RunCommand
-        command = 'python moosedocs.py verify --form html --executioner MooseDocs.base.ParallelPipe'
+        command = 'python3 moosedocs.py verify --form html --executioner MooseDocs.base.ParallelPipe'
         prereq = verify/html/barrier
       []
     []
@@ -35,21 +35,21 @@
 
       [serial]
         type = RunCommand
-        command = 'python moosedocs.py verify --form materialize --executioner MooseDocs.base.Serial'
+        command = 'python3 moosedocs.py verify --form materialize --executioner MooseDocs.base.Serial'
       []
       [queue]
         type = RunCommand
-        command = 'python moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelQueue'
+        command = 'python3 moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelQueue'
         prereq = verify/materialize/serial
       []
       [barrier]
         type = RunCommand
-        command = 'python moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelBarrier'
+        command = 'python3 moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelBarrier'
         prereq = verify/materialize/queue
       []
       [pipe]
         type = RunCommand
-        command = 'python moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelPipe'
+        command = 'python3 moosedocs.py verify --form materialize --executioner MooseDocs.base.ParallelPipe'
         prereq = verify/materialize/barrier
       []
     []
@@ -58,21 +58,21 @@
 
       [serial]
         type = RunCommand
-        command = 'python moosedocs.py verify --form latex --executioner MooseDocs.base.Serial'
+        command = 'python3 moosedocs.py verify --form latex --executioner MooseDocs.base.Serial'
       []
       [queue]
         type = RunCommand
-        command = 'python moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelQueue'
+        command = 'python3 moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelQueue'
         prereq = verify/latex/serial
       []
       [barrier]
         type = RunCommand
-        command = 'python moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelBarrier'
+        command = 'python3 moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelBarrier'
         prereq = verify/latex/queue
       []
       [pipe]
         type = RunCommand
-        command = 'python moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelPipe'
+        command = 'python3 moosedocs.py verify --form latex --executioner MooseDocs.base.ParallelPipe'
         prereq = verify/latex/barrier
       []
     []
@@ -85,12 +85,12 @@
 
     [site_subsite]
       type = RunCommand
-      command = 'python moosedocs.py build --config config.yml subsite_config.yml'
+      command = 'python3 moosedocs.py build --config config.yml subsite_config.yml'
       detail = "the build routines for the main test site precede those of the subsite, as well as"
     []
     [subsite_site]
       type = RunCommand
-      command = 'python moosedocs.py build --fast --config subsite_config.yml config.yml'
+      command = 'python3 moosedocs.py build --fast --config subsite_config.yml config.yml'
       prereq = multiconfig_build/site_subsite
       detail = "in the reverse order but with the `--fast` option added for testing efficiency."
     []

--- a/python/TestHarness/testers/PythonUnitTest.py
+++ b/python/TestHarness/testers/PythonUnitTest.py
@@ -44,6 +44,6 @@ class PythonUnitTest(RunApp):
         if self.specs["separate"]:
             cmd = os.path.join(self.specs['moose_dir'], 'scripts', 'separate_unittests.py') + ' -f ' + test_case + use_buffer
         else:
-            cmd = "python -m unittest" + use_buffer + "-v " + test_case
+            cmd = "python3 -m unittest" + use_buffer + "-v " + test_case
 
         return cmd  + ' '.join(self.specs['cli_args'])

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -27,7 +27,14 @@ class ApptainerGenerator:
     """
     def __init__(self):
         self.meta = Versioner().version_meta()
-        self.args = self.parse_args(list(self.meta.keys()))
+
+        # Get the packages that have an 'apptainer' key in versioner.yaml
+        apptainer_packages = []
+        for library, values in self.meta.items():
+            if 'apptainer' in values:
+                apptainer_packages.append(library)
+
+        self.args = self.parse_args(apptainer_packages)
         self.args = self.verify_args(self.args)
 
         library_meta = self.meta[self.args.library]['apptainer'].copy()
@@ -306,12 +313,9 @@ class ApptainerGenerator:
         """
         Find the dependency meta for the given library (if any)
         """
-        if len(self.meta[library].get('dependencies', [])) > 1:
-            raise Exception('apptainer_generator does not yet support multiple dependencies')
-
-        dependency = self.meta[library].get('dependencies', None)
-        if dependency:
-            return self.meta[dependency[0]]['apptainer']
+        apptainer_meta = self.meta[library]['apptainer']
+        if 'from' in apptainer_meta:
+            return self.meta[apptainer_meta['from']]['apptainer']
         return None
 
     def _dependency_from(self, meta):

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -476,6 +476,8 @@ class ApptainerGenerator:
         """
         Adds conditional apptainer definition vars to jinja data
         """
+        jinja_data['ARCH'] = platform.machine()
+
         # Set application-related variables
         if self.args.library == 'app':
             app_name, app_root, _ = Versioner.get_app()

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -296,7 +296,7 @@ class ApptainerGenerator:
         """
         Find the dependency meta for the given library (if any)
         """
-        if len(self.meta[library]['dependencies']) > 1:
+        if len(self.meta[library].get('dependencies', [])) > 1:
             raise Exception('apptainer_generator does not yet support multiple dependencies')
 
         dependency = self.meta[library].get('dependencies', None)

--- a/scripts/apptainer_generator.py
+++ b/scripts/apptainer_generator.py
@@ -8,6 +8,7 @@ import argparse
 import socket
 import subprocess
 import shutil
+import platform
 from datetime import datetime, timezone
 
 import jinja2

--- a/scripts/configure_petsc.sh
+++ b/scripts/configure_petsc.sh
@@ -101,7 +101,7 @@ function configure_petsc()
   fi
 
   cd $PETSC_DIR
-  python ./configure --download-hypre=1 \
+  python3 ./configure --download-hypre=1 \
       --with-shared-libraries=1 \
       "$HDF5_STR" \
       "$HDF5_FORTRAN_STR" \

--- a/scripts/tests/test_versioner.py
+++ b/scripts/tests/test_versioner.py
@@ -114,7 +114,7 @@ class Test(unittest.TestCase):
             is_app = package != 'libmesh'
             def_package = 'app' if is_app else package
             name_prefix = '' if is_app else 'moose-'
-            meta = Versioner.apptainer_meta(package, package_hash, is_app)
+            meta = Versioner.apptainer_meta(package, {'from': 'some_package'}, package_hash, is_app)
             if is_app:
                 package = package.lower()
             self.assertEqual(meta['name'], f'{name_prefix}{package}-{platform.machine()}')
@@ -123,6 +123,7 @@ class Test(unittest.TestCase):
             self.assertEqual(meta['tag'], package_hash)
             self.assertEqual(meta['uri'], f'{name_prefix}{package}-{platform.machine()}:{package_hash}')
             self.assertEqual(meta['def'], os.path.realpath(os.path.join(MOOSE_DIR, f'apptainer/{def_package}.def')))
+            self.assertEqual(meta['from'], 'some_package')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, buffer=True)

--- a/scripts/tests/test_versioner.py
+++ b/scripts/tests/test_versioner.py
@@ -30,18 +30,18 @@ class Test(unittest.TestCase):
     def testOldHashes(self):
         versioner = Versioner()
         for hash, packages in OLD_HASHES.items():
-            meta = versioner.meta(hash)
+            meta = versioner.version_meta(hash)
             for package, package_hash in packages.items():
-                self.assertEqual(package_hash, meta[package]['hash'])
+                self.assertEqual(str(package_hash), str(meta[package]['hash']))
 
     def testBadCommit(self):
         with self.assertRaises(Exception) as e:
-            Versioner().meta('foobar')
+            Versioner().version_meta('foobar')
         self.assertIn('foobar is not a commit', str(e.exception))
 
     def testCLI(self):
         versioner = Versioner()
-        meta = versioner.meta()
+        meta = versioner.version_meta()
 
         for hash in [None, 'HEAD']:
             for package in versioner.entities:

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,25 +87,7 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
-9f5f312ae894252bd8358666a9111b05b31d902d: # 23944 0
-  mpich: b80964e
-  petsc: c2996d5
-  libmesh: e0c71dd
-  moose: 7ed26d4
-  wasp: df5c734
-c830925a44bb3fddd7cded575c53e3f8d29e7c97: # 23944 1
-  mpich: 156fd3f
-  petsc: 2245139
-  libmesh: 98b1946
-  moose: 968f795
-  wasp: df5c734
-328456953d917d1ac4cc70f6d665c7cc5770326b: # 23944 2
-  mpich: a4d40a7
-  petsc: 211095f
-  libmesh: 125b416
-  moose: c6fbb0d
-  wasp: df5c734
-dcff67179e8368f95d2898e9127a26c38b15f861: # 23944 3
+dcff67179e8368f95d2898e9127a26c38b15f861: # 23944
   mpich: c796d60
   petsc: 186119d
   libmesh: 2f0ea15

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -99,3 +99,9 @@ c830925a44bb3fddd7cded575c53e3f8d29e7c97: # 23944 second go
   libmesh: 98b1946
   moose: 968f795
   wasp: df5c734
+328456953d917d1ac4cc70f6d665c7cc5770326b: # 23944 third go
+  mpich: a4d40a7
+  petsc: 211095f
+  libmesh: 125b416
+  moose: c6fbb0d
+  wasp: df5c734

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,21 +87,27 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
-9f5f312ae894252bd8358666a9111b05b31d902d: # 23944 first go
+9f5f312ae894252bd8358666a9111b05b31d902d: # 23944 0
   mpich: b80964e
   petsc: c2996d5
   libmesh: e0c71dd
   moose: 7ed26d4
   wasp: df5c734
-c830925a44bb3fddd7cded575c53e3f8d29e7c97: # 23944 second go
+c830925a44bb3fddd7cded575c53e3f8d29e7c97: # 23944 1
   mpich: 156fd3f
   petsc: 2245139
   libmesh: 98b1946
   moose: 968f795
   wasp: df5c734
-328456953d917d1ac4cc70f6d665c7cc5770326b: # 23944 third go
+328456953d917d1ac4cc70f6d665c7cc5770326b: # 23944 2
   mpich: a4d40a7
   petsc: 211095f
   libmesh: 125b416
   moose: c6fbb0d
+  wasp: df5c734
+dcff67179e8368f95d2898e9127a26c38b15f861: # 23944 3
+  mpich: c796d60
+  petsc: 186119d
+  libmesh: 2f0ea15
+  moose: 010820f
   wasp: df5c734

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,9 +87,15 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
-9f5f312ae894252bd8358666a9111b05b31d902d: # 23944
+9f5f312ae894252bd8358666a9111b05b31d902d: # 23944 first go
   mpich: b80964e
   petsc: c2996d5
   libmesh: e0c71dd
   moose: 7ed26d4
+  wasp: df5c734
+c830925a44bb3fddd7cded575c53e3f8d29e7c97: # 23944 second go
+  mpich: 156fd3f
+  petsc: 2245139
+  libmesh: 98b1946
+  moose: 968f795
   wasp: df5c734

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,9 +87,9 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
-dcff67179e8368f95d2898e9127a26c38b15f861: # 23944
-  mpich: c796d60
-  petsc: 186119d
-  libmesh: 2f0ea15
-  moose: 010820f
+6de86fc66afd7f9ec2b4d86b6f4c79c9c0d23eb6: # 23944
+  mpich: 3f5079a
+  petsc: c87a36a
+  libmesh: 01c4efc
+  moose: 6a2ff2b
   wasp: df5c734

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,3 +87,8 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
+ae9dc6c5e55d5013e5cd8c196beb5e7021b81a9a: # 23944
+  mpich: eb6963d
+  petsc: 9e4720f
+  libmesh: 4a9ff8c
+  moose: 160be0c

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -87,8 +87,9 @@ d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
   petsc: 64a9a7e
   libmesh: e3dc480
   moose: 2ca6f07
-ae9dc6c5e55d5013e5cd8c196beb5e7021b81a9a: # 23944
-  mpich: eb6963d
-  petsc: 9e4720f
-  libmesh: 4a9ff8c
-  moose: 160be0c
+9f5f312ae894252bd8358666a9111b05b31d902d: # 23944
+  mpich: b80964e
+  petsc: c2996d5
+  libmesh: e0c71dd
+  moose: 7ed26d4
+  wasp: df5c734

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -216,7 +216,7 @@ class Versioner:
 
     def influential_list(self, packages_yaml, library=None, recursive_meta=None):
         """ build and return influential dictionary """
-        # key descriptors should to be treated as control identifiers. Anything else will
+        # key descriptors to be treated as control identifiers. Anything else will
         # be treated as trackable libraries.
         key_descriptors = ['dependencies', 'influential']
         # key name for infuential file list value

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -391,7 +391,12 @@ class Versioner:
             name_base = f'moose-{name_base}'
         name_suffix = platform.machine()
         name = f'{name_base}-{name_suffix}'
-        meta = package_apptainer_entry.copy()
+
+        meta = {}
+
+        if package_apptainer_entry is not None:
+            meta.update(package_apptainer_entry)
+
         meta.update({'name': name,
                      'name_base': name_base,
                      'name_suffix': name_suffix,

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -289,7 +289,10 @@ class Versioner:
             influential_meta = OrderedDict()
             file_list = []
             for package, influential in packages.items():
-                file_list.extend(influential)
+                if isinstance(influential, dict):
+                    file_list.extend(influential['influential'])
+                else:
+                    file_list.extend(influential)
                 influential_meta[package] = {'influential' : file_list.copy()}
 
         for package in self.entities:

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -8,6 +8,8 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
+# Dummy change to mark an ancestor
+
 """
 Generate hash based on vetted versions of libraries as listed in
 module_hash.yaml's (zip_keys)

--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -216,9 +216,9 @@ class Versioner:
 
     def influential_list(self, packages_yaml, library=None, recursive_meta=None):
         """ build and return influential dictionary """
-        # Key disctriptors that should be consider control identifiers. Anything else
-        # will be treated as trackable libraries.
-        not_libraries = ['dependencies', 'influential']
+        # key descriptors should to be treated as control identifiers. Anything else will
+        # be treated as trackable libraries.
+        key_descriptors = ['dependencies', 'influential']
         # key name for infuential file list value
         dep_key = 'influential'
         # key name for dependency value
@@ -230,7 +230,7 @@ class Versioner:
             # 'values' is a dictionary with more items to discover (recurse into)
             if isinstance(values, dict):
                 # 'package' is actually a library we wish to track
-                if package not in not_libraries:
+                if package not in key_descriptors:
                     recursive_meta[package] = {}
                 # recursive inspection of packages_yaml[library], preserve history (grow)
                 self.influential_list(packages_yaml[package],

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -9,6 +9,7 @@ packages:
       - apptainer/mpich.def
       - conda/mpich/meta.yaml
       - conda/mpich/conda_build_config.yaml
+    apptainer:
   petsc:
     dependencies:
       - mpich

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -1,31 +1,53 @@
-# Add paths relative to repository root that should be taken into account when generating a hash
+# Add additional libraries and their influential files, along with any dependencies which
+# shall be included when creating a HASH for said library. Order is not important.
+#
+# If adding a new control key, a change to versioner.py:influential_list will be required
+# (add that control key to 'not_libraries').
 packages:
   mpich:
-    - apptainer/mpich.def
-    - conda/mpich/meta.yaml
-    - conda/mpich/conda_build_config.yaml
+    influential:
+      - apptainer/mpich.def
+      - conda/mpich/meta.yaml
+      - conda/mpich/conda_build_config.yaml
   petsc:
-    - petsc
-    - apptainer/petsc.def
-    - conda/petsc/meta.yaml
-    - conda/petsc/conda_build_config.yaml
-    - scripts/configure_petsc.sh
-    - scripts/update_and_rebuild_petsc.sh
+    dependencies:
+      - mpich
+    influential:
+      - petsc
+      - apptainer/petsc.def
+      - conda/petsc/meta.yaml
+      - conda/petsc/conda_build_config.yaml
+      - scripts/configure_petsc.sh
+      - scripts/update_and_rebuild_petsc.sh
   libmesh:
-    - libmesh
-    - apptainer/libmesh.def
-    - conda/libmesh/meta.yaml
-    - conda/libmesh/conda_build_config.yaml
-    - scripts/configure_libmesh.sh
-    - scripts/update_and_rebuild_libmesh.sh
-    - conda/libmesh-vtk/meta.yaml
-    - conda/libmesh-vtk/conda_build_config.yaml
+    dependencies:
+      - petsc
+    influential:
+      - libmesh
+      - apptainer/libmesh.def
+      - conda/libmesh/meta.yaml
+      - conda/libmesh/conda_build_config.yaml
+      - scripts/configure_libmesh.sh
+      - scripts/update_and_rebuild_libmesh.sh
+      - conda/libmesh-vtk/meta.yaml
+      - conda/libmesh-vtk/conda_build_config.yaml
+  wasp:
+    influential:
+      - framework/contrib/wasp
+      - conda/wasp/meta.yaml
+      - conda/wasp/conda_build_config.yaml
   moose:
-    - apptainer/moose.def
-    - apptainer/remove_channels.def
-    - conda/test-tools/meta.yaml
-    - conda/test-tools/conda_build_config.yaml
-    - conda/tools/meta.yaml
-    - conda/tools/conda_build_config.yaml
+    influential:
+      - apptainer/moose.def
+      - apptainer/remove_channels.def
+      - conda/test-tools/meta.yaml
+      - conda/test-tools/conda_build_config.yaml
+      - conda/tools/meta.yaml
+      - conda/tools/conda_build_config.yaml
+    dependencies:
+      - libmesh
   app:
-    - apptainer/app.def
+    influential:
+      - apptainer/app.def
+    dependencies:
+      - moose

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -12,6 +12,8 @@ packages:
   petsc:
     dependencies:
       - mpich
+    apptainer:
+      from: mpich
     influential:
       - petsc
       - apptainer/petsc.def
@@ -22,6 +24,8 @@ packages:
   libmesh:
     dependencies:
       - petsc
+    apptainer:
+      from: petsc
     influential:
       - libmesh
       - apptainer/libmesh.def
@@ -37,6 +41,11 @@ packages:
       - conda/wasp/meta.yaml
       - conda/wasp/conda_build_config.yaml
   moose:
+    dependencies:
+      - libmesh
+      - wasp
+    apptainer:
+      from: libmesh
     influential:
       - apptainer/moose.def
       - apptainer/remove_channels.def
@@ -44,10 +53,10 @@ packages:
       - conda/test-tools/conda_build_config.yaml
       - conda/tools/meta.yaml
       - conda/tools/conda_build_config.yaml
-    dependencies:
-      - libmesh
   app:
-    influential:
-      - apptainer/app.def
     dependencies:
       - moose
+    apptainer:
+      from: moose
+    influential:
+      - apptainer/app.def

--- a/test/tests/reporters/perf_graph_reporter/tests
+++ b/test/tests/reporters/perf_graph_reporter/tests
@@ -12,7 +12,7 @@
     []
     [verify]
       type = RunCommand
-      command = 'python verify_perf_graph_reporter.py'
+      command = 'python3 verify_perf_graph_reporter.py'
       prereq = test/run
       detail = 'and shall provide a tool to post process said information'
     []
@@ -39,7 +39,7 @@
     []
     [verify]
       type = RunCommand
-      command = 'python verify_perf_graph_reporter.py recover'
+      command = 'python3 verify_perf_graph_reporter.py recover'
       prereq = recover/run
       detail = 'and shall provide a tool to post process said information'
     []


### PR DESCRIPTION
When installing moose-mpich and Python, constrain Python to below version 3.11.

Closes #23944
