### PR TITLE
Build moose-wasp using default Conda compilers

### DIFF
--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -1,10 +1,20 @@
-moose_mpich:
-  - moose-mpich 4.0.2 build_7
-
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
   - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
+
+c_compiler_version:                                         # [unix]
+  - 10.4.0                                                  # [linux]
+  - 12.0.1                                                  # [osx]
+
+cxx_compiler_version:                                       # [unix]
+  - 10.4.0                                                  # [linux]
+  - 12.0.1                                                  # [osx]
+
+fortran_compiler_version:                                   # [unix]
+  - 10.4.0                                                  # [linux]
+  - 9.3.0                                                   # [not arm64 and osx]
+  - 11.0.1                                                  # [arm64]
 
 macos_min_version:                                          # [osx]
   - 10.12                                                   # [not arm64 and osx]

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -21,12 +21,11 @@ build:
 
 requirements:
   build:
-    - {{ moose_mpich }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - cmake
     - pkg-config
-  host:
-    - {{ moose_mpich }}
-  run:
-    - {{ moose_mpich }}
 
 test:
   commands:


### PR DESCRIPTION
Build WASP using default Conda Compilers. Remove runtime dependencies. This will allow moose-wasp to coexist with any system or HPC MPI compilers presently loaded.

Closes #23996 