### PR TITLE
Avoid preparing for use at the end of every generator

### DIFF
--- a/framework/src/meshgenerators/PatternedMeshGenerator.C
+++ b/framework/src/meshgenerators/PatternedMeshGenerator.C
@@ -256,6 +256,8 @@ PatternedMeshGenerator::generate()
       const auto & increment_subdomain_map = cell_mesh.get_subdomain_name_map();
       mergeSubdomainNameMaps(main_subdomain_map, increment_subdomain_map);
 
+      if (_row_meshes[i]->is_prepared() && !cell_mesh.is_prepared())
+        cell_mesh.prepare_for_use();
       _row_meshes[i]->stitch_meshes(cell_mesh,
                                     right_bid,
                                     left_bid,
@@ -279,6 +281,8 @@ PatternedMeshGenerator::generate()
     const auto & increment_subdomain_map = _row_meshes[i]->get_subdomain_name_map();
     mergeSubdomainNameMaps(main_subdomain_map, increment_subdomain_map);
 
+    if (_row_meshes[0]->is_prepared() && !_row_meshes[i]->is_prepared())
+      _row_meshes[i]->prepare_for_use();
     _row_meshes[0]->stitch_meshes(*_row_meshes[i],
                                   bottom_bid,
                                   top_bid,

--- a/framework/src/meshgenerators/StitchedMeshGenerator.C
+++ b/framework/src/meshgenerators/StitchedMeshGenerator.C
@@ -129,6 +129,10 @@ StitchedMeshGenerator::generate()
 
     const bool use_binary_search = (_algorithm == "BINARY");
 
+    // All meshes must be either prepared or not prepared to be stitched
+    if (mesh->is_prepared() && !meshes[i]->is_prepared())
+      meshes[i]->prepare_for_use();
+
     mesh->stitch_meshes(*meshes[i],
                         first,
                         second,


### PR DESCRIPTION
Let's only do it when it's needed. Instead of preparing, we set set_isnt_prepared.

then in the MGs that take it, or at the end of the MG process, we check is_prepared. 

If not prepared, prepare. 
