### PR TITLE
Correct coverage reqs due to improper collection

### DIFF
--- a/.coverage
+++ b/.coverage
@@ -51,7 +51,7 @@ require_total = 87
 require_total = 88
 
 [misc]
-require_total = 55
+require_total = 34
 
 [navier_stokes]
 require_total = 77
@@ -63,7 +63,7 @@ require_total = 86
 require_total = 78
 
 [phase_field]
-require_total = 89
+require_total = 86
 
 [porous_flow]
 require_total = 96
@@ -75,7 +75,7 @@ require_total = 94
 require_total = 65
 
 [richards]
-require_total = 97
+require_total = 94
 
 [solid_properties]
 require_total = 84
@@ -84,7 +84,7 @@ require_total = 84
 require_total = 88
 
 [tensor_mechanics]
-require_total = 86
+require_total = 85
 
 [thm]
 require_total = 90


### PR DESCRIPTION
We were not clearing .gcda files from lcov when testing from module to module for coverage; the original requirements were inflated because of this.

