### PR TITLE
Fixup regression in empty collection indicator message

### DIFF
--- a/python/MooseDocs/extensions/sqa.py
+++ b/python/MooseDocs/extensions/sqa.py
@@ -318,12 +318,15 @@ class SQARequirementsCommand(command.CommandComponent):
 
     def createToken(self, parent, info, page, settings):
         category = settings['category']
+        collections = settings['collections']
         if category == '_empty_':
             return parent
 
         group_map = self.extension.get('requirement-groups', dict())
-        if len(self.extension.requirements(category)) == 0:
-            tokens.String(parent, content="No requirements of this type exist for this application.")
+
+        # Used in check for number of requirements in a given collection (functional, usability, etc.)
+        # while working through a given category (kernels, etc.)
+        num_collection_reqs = 0
 
         for group, requirements in self.extension.requirements(category).items():
             group = group_map.get(group, group.replace('_', ' ').title())
@@ -331,6 +334,12 @@ class SQARequirementsCommand(command.CommandComponent):
             SQARequirementMatrixHeading(matrix, category=category, string=str(group))
             for req in requirements:
                 self._addRequirement(matrix, info, page, req, requirements, category, settings)
+                if (collections is not None) and (req.collections is not None) and any(c in collections for c in req.collections):
+                    num_collection_reqs += 1
+
+        if num_collection_reqs == 0:
+            tokens.String(parent, content="No requirements of this type exist for this application, beyond those of its dependencies.")
+
         return parent
 
     def _addRequirement(self, parent, info, page, req, requirements, category, settings):

--- a/python/MooseDocs/test/extensions/test_sqa.py
+++ b/python/MooseDocs/test/extensions/test_sqa.py
@@ -604,7 +604,7 @@ class TestSQARequiremetnsWithCollectionsAndTypesAST(MooseDocsTestCase):
     def testTypes(self):
         text = "!sqa requirements types=TestType link=False category=Demo"
         ast = self.tokenize(text)
-        self.assertSize(ast, 1)
+        self.assertSize(ast, 2)
         self.assertToken(ast(0), 'SQARequirementMatrix')
         self.assertSize(ast(0), 3)
         self.assertToken(ast(0,0), 'SQARequirementMatrixHeading', string='Tree')


### PR DESCRIPTION
This addresses S-02 from 2021 Blackbear/Grizzly audit, which had regressed to the prior unsatisfactory state. The test fixups required here should keep us from regressing again. 

Tagging @bwspenc for awareness (as he discovered the regression) and a review if available. 

Refs #18816
