### PR TITLE
Installs the .la files in the install location

### DIFF
--- a/framework/app.mk
+++ b/framework/app.mk
@@ -487,9 +487,9 @@ install_lib_%: %
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))
-	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
+#@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
+#	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
+#	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
 
 $(binlink): $(copy_input_targets)
 	ln -sf ../../bin/$(notdir $(app_EXEC)) $@
@@ -508,15 +508,9 @@ $(bindst): $(app_EXEC) $(copy_input_targets) install_$(APPLICATION_NAME)_docs $(
 	@mkdir -p $(bin_install_dir)
 	@cp $< $@
 	@$(call patch_rpath,$@,../$(lib_install_suffix)/.)
-	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-	@for lib in $(libpaths); do $(call patch_relink,$@,$$lib,$$(basename $$lib)); done
-
-ifeq ($(want_exec),yes)
-install_bin: $(bindst)
-else
-install_bin:
-endif
+#	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
+#	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
+#	@for lib in $(libpaths); do $(call patch_relink,$@,$$lib,$$(basename $$lib)); done
 ####### end install stuff ##############
 
 # Clang static analyzer

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -470,11 +470,12 @@ $(copy_input_targets):
 
 
 install_lib_%: % all
-	@echo "Installing $<"
 	@mkdir -p $(lib_install_dir)
 	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
-	@$(eval libdst := $(lib_install_dir)/$(libname))
-	@cp $(dir $<)$(libname) $(libdst)
+	@$(eval libdst := $(lib_install_dir)/$(libname))  # full installed path (includes library name)
+	@echo "Installing $(libdst)"
+	@cp $< $(lib_install_dir)           # Copy the library archive file
+	@cp $(dir $<)$(libname) $(libdst)   # Copy the library file
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -431,11 +431,6 @@ else
   install_bin:
 endif
 
-#lib_install_targets = $(foreach lib,$(applibs),$(dir $(lib))install_lib_$(notdir $(lib)))
-#ifneq ($(app_test_LIB),)
-#	lib_install_targets += $(dir $(app_test_LIB))install_lib_$(notdir $(app_test_LIB))
-#endif
-
 install_libs:: $(lib_install_targets)
 
 ifneq ($(wildcard $(APPLICATION_DIR)/data/.),)
@@ -487,9 +482,6 @@ install_lib_%: %
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))
-#@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-#	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-#	@for lib in $(libpaths); do $(call patch_relink,$(libdst),$$lib,$$(basename $$lib)); done
 
 $(binlink): $(copy_input_targets)
 	ln -sf ../../bin/$(notdir $(app_EXEC)) $@
@@ -508,9 +500,6 @@ $(bindst): $(app_EXEC) $(copy_input_targets) install_$(APPLICATION_NAME)_docs $(
 	@mkdir -p $(bin_install_dir)
 	@cp $< $@
 	@$(call patch_rpath,$@,../$(lib_install_suffix)/.)
-#	@$(eval libnames := $(foreach lib,$(applibs),$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-#	@$(eval libpaths := $(foreach lib,$(applibs),$(dir $(lib))$(shell grep "dlname='.*'" $(lib) 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")))
-#	@for lib in $(libpaths); do $(call patch_relink,$@,$$lib,$$(basename $$lib)); done
 ####### end install stuff ##############
 
 # Clang static analyzer

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -431,6 +431,11 @@ else
   install_bin:
 endif
 
+#lib_install_targets = $(foreach lib,$(applibs),$(dir $(lib))install_lib_$(notdir $(lib)))
+#ifneq ($(app_test_LIB),)
+#	lib_install_targets += $(dir $(app_test_LIB))install_lib_$(notdir $(app_test_LIB))
+#endif
+
 install_libs:: $(lib_install_targets)
 
 ifneq ($(wildcard $(APPLICATION_DIR)/data/.),)
@@ -469,13 +474,13 @@ $(copy_input_targets):
 	fi; \
 
 
-install_lib_%: % all
+install_lib_%: %
 	@mkdir -p $(lib_install_dir)
 	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
 	@$(eval libdst := $(lib_install_dir)/$(libname))  # full installed path (includes library name)
 	@$(eval source_dir := $(dir $<))
 	@$(eval la_installed = $(lib_install_dir)/$(notdir $<))
-	@echo "Installing $(libdst)"
+	@echo "Installing library $(libdst)"
 	@cp $< $(la_installed)                   # Copy the library archive file
 	@cp $(source_dir)/$(libname) $(libdst)   # Copy the library file
 	@$(call patch_la,$(la_installed),$(lib_install_dir))

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -481,9 +481,9 @@ install_lib_%: %
 	@$(eval source_dir := $(dir $<))
 	@$(eval la_installed = $(lib_install_dir)/$(notdir $<))
 	@echo "Installing library $(libdst)"
-	@cp $< $(la_installed)                   # Copy the library archive file
+#	@cp $< $(la_installed)                   # Copy the library archive file
 	@cp $(source_dir)/$(libname) $(libdst)   # Copy the library file
-	@$(call patch_la,$(la_installed),$(lib_install_dir))
+#	@$(call patch_la,$(la_installed),$(lib_install_dir))
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -473,9 +473,12 @@ install_lib_%: % all
 	@mkdir -p $(lib_install_dir)
 	@$(eval libname := $(shell grep "dlname='.*'" $< | sed -E "s/dlname='(.*)'/\1/g"))
 	@$(eval libdst := $(lib_install_dir)/$(libname))  # full installed path (includes library name)
+	@$(eval source_dir := $(dir $<))
+	@$(eval la_installed = $(lib_install_dir)/$(notdir $<))
 	@echo "Installing $(libdst)"
-	@cp $< $(lib_install_dir)           # Copy the library archive file
-	@cp $(dir $<)$(libname) $(libdst)   # Copy the library file
+	@cp $< $(la_installed)                   # Copy the library archive file
+	@cp $(source_dir)/$(libname) $(libdst)   # Copy the library file
+	@$(call patch_la,$(la_installed),$(lib_install_dir))
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))

--- a/framework/app.mk
+++ b/framework/app.mk
@@ -481,9 +481,9 @@ install_lib_%: %
 	@$(eval source_dir := $(dir $<))
 	@$(eval la_installed = $(lib_install_dir)/$(notdir $<))
 	@echo "Installing library $(libdst)"
-#	@cp $< $(la_installed)                   # Copy the library archive file
+	@cp $< $(la_installed)                   # Copy the library archive file
 	@cp $(source_dir)/$(libname) $(libdst)   # Copy the library file
-#	@$(call patch_la,$(la_installed),$(lib_install_dir))
+	@$(call patch_la,$(la_installed),$(lib_install_dir))
 	@$(call patch_rpath,$(libdst),../$(lib_install_suffix/.))
 	@$(call patch_relink,$(libdst),$(libpath_pcre),$(libname_pcre))
 	@$(call patch_relink,$(libdst),$(libpath_framework),$(libname_framework))

--- a/framework/build.mk
+++ b/framework/build.mk
@@ -11,6 +11,10 @@ MOOSE_JOBS        ?= 8
 # Include variables defined by MOOSE configure if it's been run
 -include $(MOOSE_DIR)/conf_vars.mk
 
+# PREFIX should be set in conf_vars. If however the user didn't run configure we
+# won't have a prefix. We'll use the automake default then:
+PREFIX ?= '/usr/local'
+
 # If the user has no environment variable
 # called METHOD, they get optimized mode.
 ifeq (x$(METHOD),x)

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -576,7 +576,8 @@ public:
                               const std::string & library_name);
   void dynamicAppRegistration(const std::string & app_name,
                               std::string library_path,
-                              const std::string & library_name);
+                              const std::string & library_name,
+                              bool lib_load_deps);
   ///@}
 
   /**

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -1173,10 +1173,11 @@ protected:
   struct DynamicLibraryInfo
   {
     void * library_handle;
+    std::string full_path;
     std::unordered_set<std::string> entry_symbols;
   };
 
-  /// The library, registration method and the handle to the method
+  /// The library archive (name only), registration method and the handle to the method
   std::unordered_map<std::string, DynamicLibraryInfo> _lib_handles;
 
 private:

--- a/framework/include/base/MooseApp.h
+++ b/framework/include/base/MooseApp.h
@@ -593,9 +593,14 @@ public:
   std::string libNameToAppName(const std::string & library_name) const;
 
   /**
-   * Return the loaded library filenames in a std::set
+   * Return the paths of loaded libraries
    */
   std::set<std::string> getLoadedLibraryPaths() const;
+
+  /**
+   * Return the paths searched by MOOSE when loading libraries
+   */
+  std::set<std::string> getLibrarySearchPaths(const std::string & library_path_from_param) const;
 
   /**
    * Get the InputParameterWarehouse for MooseObjects
@@ -964,7 +969,9 @@ protected:
    * Recursively loads libraries and dependencies in the proper order to fully register a
    * MOOSE application that may have several dependencies. REQUIRES: dynamic linking loader support.
    */
-  void loadLibraryAndDependencies(const std::string & library_filename, const Parameters & params);
+  void loadLibraryAndDependencies(const std::string & library_filename,
+                                  const Parameters & params,
+                                  bool load_dependencies = true);
 
   /// Constructor is protected so that this object is constructed through the AppFactory object
   MooseApp(InputParameters parameters);

--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -469,6 +469,7 @@ else
   patch_relink = :
   patch_rpath = patchelf --set-rpath '$$ORIGIN'/$(2):$$(patchelf --print-rpath $(1)) $(1)
 endif
+patch_la = $(FRAMEWORK_DIR)/scripts/patch_la.py $(1) $(2)
 
 libname_framework = $(shell grep "dlname='.*'" $(MOOSE_DIR)/framework/libmoose-$(METHOD).la 2>/dev/null | sed -E "s/dlname='(.*)'/\1/g")
 libpath_framework = $(MOOSE_DIR)/framework/$(libname_framework)

--- a/framework/scripts/patch_la.py
+++ b/framework/scripts/patch_la.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+# This script finds the current repository revision base on the log file
+# It currently understands both local git-svn and svn repositories
+
+import os, sys, re, shutil
+
+def rewrite_dep_paths(filename, dep_lib_path):
+    f = open(filename)
+    buffer = f.read()
+    f.close()
+
+    depend_lib_pattern = re.compile(r"dependency_libs='\s*(.*)'")
+    lines = buffer.split('\n')
+
+    f = open(filename + '~tmp', 'w')
+    for line in lines:
+        m = depend_lib_pattern.match(line)
+        if m is not None:
+            line_to_process = m.group(1)
+            libs = line_to_process.split()
+            installed_libs = [os.path.join(dep_lib_path, os.path.basename(lib)) for lib in libs]
+            line = "dependency_libs='" + ' '.join(installed_libs) + "'"
+
+        f.write(line + '\n')
+    f.close()
+
+    shutil.copystat(filename, filename + '~tmp')
+    os.rename(filename + '~tmp', filename)
+
+if len(sys.argv) == 3:
+    file_to_process = sys.argv[1]
+    dep_lib_path = sys.argv[2]
+    rewrite_dep_paths(file_to_process, dep_lib_path)

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1830,7 +1830,7 @@ MooseApp::dynamicRegistration(const Parameters & params)
 void
 MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
                                      const Parameters & params,
-                                     bool load_dependencies)
+                                     const bool load_dependencies)
 {
   std::string line;
   std::string dl_lib_filename;
@@ -1878,15 +1878,14 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
   // Time to load the library, First see if we've already loaded this particular dynamic library
   //     1) make sure we haven't already loaded this library
   // AND 2) make sure we have a library name (we won't for static linkage)
-  //
   // Note: Here was are going to assume uniqueness based on the filename alone. This has significant
-  // implications for applications that have have "diamond" inheritance of libraries (usually
-  // modules) We will only load one of those libraries, versions be damned.
+  // implications for applications that have "diamond" inheritance of libraries (usually
+  // modules). We will only load one of those libraries, versions be damned.
   auto dyn_lib_it = _lib_handles.find(file_name);
   if (dyn_lib_it == _lib_handles.end())
   {
     // Assemble the actual filename using the base path of the *.la file and the dl_lib_filename
-    const auto & dl_lib_full_path = dir + '/' + dl_lib_filename;
+    const auto dl_lib_full_path = dir + '/' + dl_lib_filename;
 
     MooseUtils::checkFileReadable(dl_lib_full_path, false, /*throw_on_unreadable=*/true);
 
@@ -1993,7 +1992,7 @@ MooseApp::getLibrarySearchPaths(const std::string & library_path) const
 {
   std::set<std::string> paths;
 
-  if (library_path != "")
+  if (!library_path.empty())
   {
     std::vector<std::string> tmp_paths;
     MooseUtils::tokenize(library_path, tmp_paths, 1, ":");

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1980,7 +1980,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
                      dyn_lib_it->first,
                      ".\n",
                      "This doesn't necessarily indicate an error condition unless you believe that "
-                     "the method should exist in that library.\n");
+                     "the method should exist in that library.\n", lderror());
 #endif
     }
   }

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1820,7 +1820,7 @@ MooseApp::dynamicRegistration(const Parameters & params)
   // Attempt to dynamically load the library
   for (const auto & path : paths)
     if (MooseUtils::checkFileReadable(path + '/' + library_name, false, false))
-      loadLibraryAndDependencies(path + '/' + library_name, params, false);
+      loadLibraryAndDependencies(path + '/' + library_name, params, true);
     else
       mooseWarning("Unable to open library file \"",
                    path + '/' + library_name,

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -82,7 +82,7 @@ MultiApp::validParams()
   params.addParam<bool>("library_load_dependencies",
                         false,
                         "Tells MOOSE to manually load library dependencies. This should not be "
-                        "necessary and is hear for debugging/troubhleshooting.");
+                        "necessary and is hear for debugging/troubleshooting.");
   params.addParam<std::vector<Point>>(
       "positions",
       "The positions of the App locations.  Each set of 3 values will represent a "

--- a/framework/src/multiapps/MultiApp.C
+++ b/framework/src/multiapps/MultiApp.C
@@ -79,6 +79,10 @@ MultiApp::validParams()
       "library_name",
       "",
       "The file name of the library (*.la file) that will be dynamically loaded.");
+  params.addParam<bool>("library_load_dependencies",
+                        false,
+                        "Tells MOOSE to manually load library dependencies. This should not be "
+                        "necessary and is hear for debugging/troubhleshooting.");
   params.addParam<std::vector<Point>>(
       "positions",
       "The positions of the App locations.  Each set of 3 values will represent a "
@@ -218,7 +222,8 @@ MultiApp::validParams()
   params.addParamNamesToGroup("relaxation_factor transformed_variables transformed_postprocessors "
                               "keep_solution_during_restore",
                               "Fixed point acceleration of MultiApp quantities");
-  params.addParamNamesToGroup("library_name library_path", "Dynamic loading");
+  params.addParamNamesToGroup("library_name library_path library_load_dependencies",
+                              "Dynamic loading");
   params.addParamNamesToGroup("cli_args cli_args_files", "Passing command line argument");
   return params;
 }
@@ -347,8 +352,10 @@ MultiApp::createApps()
 
   // If the user provided an unregistered app type, see if we can load it dynamically
   if (!AppFactory::instance().isRegistered(_app_type))
-    _app.dynamicAppRegistration(
-        _app_type, getParam<std::string>("library_path"), getParam<std::string>("library_name"));
+    _app.dynamicAppRegistration(_app_type,
+                                getParam<std::string>("library_path"),
+                                getParam<std::string>("library_name"),
+                                getParam<bool>("library_load_dependencies"));
 
   for (unsigned int i = 0; i < _my_num_apps; i++)
   {

--- a/modules/misc/test/tests/dynamic_loading/dynamic_obj_registration/tests
+++ b/modules/misc/test/tests/dynamic_loading/dynamic_obj_registration/tests
@@ -80,7 +80,7 @@
   [./dynamic_object_loading_wrong_app]
     type = 'RunException'
     input = 'dynamic_wrong_lib.i'
-    expect_err = 'We loaded objects from the following libraries.*\n\t\.\./\.\./\.\./\.\./\.\./tensor_mechanics/lib/libtensor_mechanics'
+    expect_err = 'We loaded objects from the following libraries.*\n\tlibtensor_mechanics'
     library_mode = 'DYNAMIC'
 
     # Test must be run with the misc app to test dynamic loading

--- a/modules/module_loader/include/ModulesApp.h
+++ b/modules/module_loader/include/ModulesApp.h
@@ -21,7 +21,16 @@ public:
 
   static void registerApps();
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
+  template <typename T>
+  static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
   static void registerObjects(Factory & factory);
   static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
   static void registerExecFlags(Factory & factory);
 };
+
+template <typename T>
+void
+ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
+{
+  registerAll(f, af, s);
+}

--- a/modules/module_loader/include/ModulesApp.h
+++ b/modules/module_loader/include/ModulesApp.h
@@ -11,6 +11,85 @@
 
 #include "MooseApp.h"
 
+#ifdef CHEMICAL_REACTIONS_ENABLED
+#include "ChemicalReactionsApp.h"
+#endif
+#ifdef CONTACT_ENABLED
+#include "ContactApp.h"
+#endif
+#ifdef ELECTROMAGNETICS_ENABLED
+#include "ElectromagneticsApp.h"
+#endif
+#ifdef FLUID_PROPERTIES_ENABLED
+#include "FluidPropertiesApp.h"
+#endif
+#ifdef FSI_ENABLED
+#include "FsiApp.h"
+#endif
+#ifdef FUNCTIONAL_EXPANSION_TOOLS_ENABLED
+#include "FunctionalExpansionToolsApp.h"
+#endif
+#ifdef GEOCHEMISTRY_ENABLED
+#include "GeochemistryApp.h"
+#endif
+#ifdef HEAT_CONDUCTION_ENABLED
+#include "HeatConductionApp.h"
+#endif
+#ifdef LEVEL_SET_ENABLED
+#include "LevelSetApp.h"
+#endif
+#ifdef MISC_ENABLED
+#include "MiscApp.h"
+#endif
+#ifdef NAVIER_STOKES_ENABLED
+#include "NavierStokesApp.h"
+#endif
+#ifdef OPTIMIZATION_ENABLED
+#include "OptimizationApp.h"
+#endif
+#ifdef PERIDYNAMICS_ENABLED
+#include "PeridynamicsApp.h"
+#endif
+#ifdef PHASE_FIELD_ENABLED
+#include "PhaseFieldApp.h"
+#endif
+#ifdef POROUS_FLOW_ENABLED
+#include "PorousFlowApp.h"
+#endif
+#ifdef RAY_TRACING_ENABLED
+#include "RayTracingApp.h"
+#endif
+#ifdef RDG_ENABLED
+#include "RdgApp.h"
+#endif
+#ifdef REACTOR_ENABLED
+#include "ReactorApp.h"
+#endif
+#ifdef RICHARDS_ENABLED
+#include "RichardsApp.h"
+#endif
+#ifdef SCALAR_TRANSPORT_ENABLED
+#include "ScalarTransportApp.h"
+#endif
+#ifdef SOLID_PROPERTIES_ENABLED
+#include "SolidPropertiesApp.h"
+#endif
+#ifdef STOCHASTIC_TOOLS_ENABLED
+#include "StochasticToolsApp.h"
+#endif
+#ifdef TENSOR_MECHANICS_ENABLED
+#include "TensorMechanicsApp.h"
+#endif
+#ifdef THERMAL_HYDRAULICS_ENABLED
+#include "ThermalHydraulicsApp.h"
+#endif
+#ifdef XFEM_ENABLED
+#include "XFEMApp.h"
+#endif
+#ifdef EXTERNAL_PETSC_SOLVER_ENABLED
+#include "ExternalPetscSolverApp.h"
+#endif
+
 class ModulesApp : public MooseApp
 {
 public:
@@ -22,15 +101,130 @@ public:
   static void registerApps();
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
   template <typename T>
-  static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
+  static void registerAllObjects(Factory & f, ActionFactory & af, Syntax & s);
   static void registerObjects(Factory & factory);
   static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
   static void registerExecFlags(Factory & factory);
 };
 
+///@{
+/**
+ * Dummy methods to clear unused parameter warnings from compiler
+ */
+void
+clearUnusedWarnings(Factory & /*factory*/)
+{
+}
+void
+clearUnusedWarnings(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
+{
+}
+///@}
+
 template <typename T>
 void
-ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
+ModulesApp::registerAllObjects(Factory & f, ActionFactory & af, Syntax & s)
 {
-  registerAll(f, af, s);
+#ifdef CHEMICAL_REACTIONS_ENABLED
+  ChemicalReactionsApp::registerAll(f, af, s);
+#endif
+
+#ifdef CONTACT_ENABLED
+  ContactApp::registerAll(f, af, s);
+#endif
+
+#ifdef ELECTROMAGNETICS_ENABLED
+  ElectromagneticsApp::registerAll(f, af, s);
+#endif
+
+#ifdef FLUID_PROPERTIES_ENABLED
+  FluidPropertiesApp::registerAll(f, af, s);
+#endif
+
+#ifdef FSI_ENABLED
+  FsiApp::registerAll(f, af, s);
+#endif
+
+#ifdef GEOCHEMISTRY_ENABLED
+  GeochemistryApp::registerAll(f, af, s);
+#endif
+
+#ifdef HEAT_CONDUCTION_ENABLED
+  HeatConductionApp::registerAll(f, af, s);
+#endif
+
+#ifdef LEVEL_SET_ENABLED
+  LevelSetApp::registerAll(f, af, s);
+#endif
+
+#ifdef MISC_ENABLED
+  MiscApp::registerAll(f, af, s);
+#endif
+
+#ifdef NAVIER_STOKES_ENABLED
+  NavierStokesApp::registerAll(f, af, s);
+#endif
+
+#ifdef OPTIMIZATION_ENABLED
+  OptimizationApp::registerAll(f, af, s);
+#endif
+
+#ifdef PERIDYNAMICS_ENABLED
+  PeridynamicsApp::registerAll(f, af, s);
+#endif
+
+#ifdef PHASE_FIELD_ENABLED
+  PhaseFieldApp::registerAll(f, af, s);
+#endif
+
+#ifdef POROUS_FLOW_ENABLED
+  PorousFlowApp::registerAll(f, af, s);
+#endif
+
+#ifdef RAY_TRACING_ENABLED
+  RayTracingApp::registerAll(f, af, s);
+#endif
+
+#ifdef RDG_ENABLED
+  RdgApp::registerAll(f, af, s);
+#endif
+
+#ifdef REACTOR_ENABLED
+  ReactorApp::registerAll(f, af, s);
+#endif
+
+#ifdef RICHARDS_ENABLED
+  RichardsApp::registerAll(f, af, s);
+#endif
+
+#ifdef SCALAR_TRANSPORT_ENABLED
+  ScalarTransportApp::registerAll(f, af, s);
+#endif
+
+#ifdef SOLID_PROPERTIES_ENABLED
+  SolidPropertiesApp::registerAll(f, af, s);
+#endif
+
+#ifdef STOCHASTIC_TOOLS_ENABLED
+  StochasticToolsApp::registerAll(f, af, s);
+#endif
+
+#ifdef TENSOR_MECHANICS_ENABLED
+  TensorMechanicsApp::registerAll(f, af, s);
+#endif
+
+#ifdef THERMAL_HYDRAULICS_ENABLED
+  ThermalHydraulicsApp::registerAll(f, af, s);
+#endif
+
+#ifdef XFEM_ENABLED
+  XFEMApp::registerAll(f, af, s);
+#endif
+
+#ifdef EXTERNAL_PETSC_SOLVER_ENABLED
+  ExternalPetscSolverApp::registerAll(f, af, s);
+#endif
+
+  clearUnusedWarnings(f);
+  clearUnusedWarnings(s, af);
 }

--- a/modules/module_loader/include/ModulesApp.h
+++ b/modules/module_loader/include/ModulesApp.h
@@ -107,20 +107,6 @@ public:
   static void registerExecFlags(Factory & factory);
 };
 
-///@{
-/**
- * Dummy methods to clear unused parameter warnings from compiler
- */
-void
-clearUnusedWarnings(Factory & /*factory*/)
-{
-}
-void
-clearUnusedWarnings(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
-{
-}
-///@}
-
 template <typename T>
 void
 ModulesApp::registerAllObjects(Factory & f, ActionFactory & af, Syntax & s)
@@ -225,6 +211,5 @@ ModulesApp::registerAllObjects(Factory & f, ActionFactory & af, Syntax & s)
   ExternalPetscSolverApp::registerAll(f, af, s);
 #endif
 
-  clearUnusedWarnings(f);
-  clearUnusedWarnings(s, af);
+  libmesh_ignore(f, s, af);
 }

--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -92,20 +92,6 @@
 #include "ExternalPetscSolverApp.h"
 #endif
 
-///@{
-/**
- * Dummy methods to clear unused parameter warnings from compiler
- */
-void
-clearUnusedWarnings(Factory & /*factory*/)
-{
-}
-void
-clearUnusedWarnings(Syntax & /*syntax*/, ActionFactory & /*action_factory*/)
-{
-}
-///@}
-
 InputParameters
 ModulesApp::validParams()
 {
@@ -398,6 +384,10 @@ ModulesApp::registerExecFlags(Factory & factory)
 void
 ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {
+  mooseDeprecated(
+      "\"registerAll\" in Modules is deprecated. Please update your *App.C file to call the new "
+      "templated \"registerAllObjects\" method (e.g. ModulesApp::registerAllobject<MyApp>(...))");
+
 #ifdef CHEMICAL_REACTIONS_ENABLED
   ChemicalReactionsApp::registerAll(f, af, s);
 #endif

--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -199,8 +199,6 @@ ModulesApp::registerObjects(Factory & factory)
 #ifdef XFEM_ENABLED
   XFEMApp::registerObjects(factory);
 #endif
-
-  clearUnusedWarnings(factory);
 }
 
 void
@@ -290,8 +288,6 @@ ModulesApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 #ifdef XFEM_ENABLED
   XFEMApp::associateSyntax(syntax, action_factory);
 #endif
-
-  clearUnusedWarnings(syntax, action_factory);
 }
 
 void
@@ -377,8 +373,6 @@ ModulesApp::registerExecFlags(Factory & factory)
 #ifdef XFEM_ENABLED
   XFEMApp::registerExecFlags(factory);
 #endif
-
-  clearUnusedWarnings(factory);
 }
 
 void
@@ -487,9 +481,6 @@ ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 #ifdef EXTERNAL_PETSC_SOLVER_ENABLED
   ExternalPetscSolverApp::registerAll(f, af, s);
 #endif
-
-  clearUnusedWarnings(f);
-  clearUnusedWarnings(s, af);
 }
 
 extern "C" void

--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -199,6 +199,8 @@ ModulesApp::registerObjects(Factory & factory)
 #ifdef XFEM_ENABLED
   XFEMApp::registerObjects(factory);
 #endif
+
+  libmesh_ignore(factory);
 }
 
 void
@@ -288,6 +290,8 @@ ModulesApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 #ifdef XFEM_ENABLED
   XFEMApp::associateSyntax(syntax, action_factory);
 #endif
+
+  libmesh_ignore(syntax, action_factory);
 }
 
 void
@@ -373,6 +377,8 @@ ModulesApp::registerExecFlags(Factory & factory)
 #ifdef XFEM_ENABLED
   XFEMApp::registerExecFlags(factory);
 #endif
+
+  libmesh_ignore(factory);
 }
 
 void
@@ -481,6 +487,8 @@ ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 #ifdef EXTERNAL_PETSC_SOLVER_ENABLED
   ExternalPetscSolverApp::registerAll(f, af, s);
 #endif
+
+  libmesh_ignore(f, s, af);
 }
 
 extern "C" void


### PR DESCRIPTION
This PR appears to work on Mac for installed MOOSE applications. However, there are as many unanswered questions as there are answered ones with this. First to get this working for our dynamic load case (MacOS only), one most set `DYLD_LIBRARY_PATH` to point to the multiapp's lib location. This is probably not something we want to do in the long run. I have no idea how this behaves yet on Linux. 

What I'm discovering though is that Mac may be automatically loading dependent libraries. I'm making this assumption based on the following error:
```
dlopen(/Users/permcj/projects/installed/lib/bison/libxfem-opt.0.dylib, 0x0001): Library not loaded: @rpath/libtensor_mechanics-opt.0.dylib
  Referenced from: <2DFB3AA0-1CE7-3564-A3FF-96F2369FCAC0> /Users/permcj/projects/installed/lib/bison/libxfem-opt.0.dylib
  Reason: tried: '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/projects/installed/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/projects/installed/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/libmesh/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/libmesh/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/libmesh-vtk/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/libmesh-vtk/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/gcc/arm64-apple-darwin20.0.0/11.0.1/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/gcc/arm64-apple-darwin20.0.0/11.0.1/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/projects/installed/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/libmesh/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/libmesh/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/libmesh-vtk/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/libmesh-vtk/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/mambaforge3/envs/moose/lib/gcc/arm64-apple-darwin20.0.0/11.0.1/libtensor_mechanics-opt.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/permcj/mambaforge3/envs/moose/lib/gcc/arm64-apple-darwin20.0.0/11.0.1/libtensor_mechanics-opt.0.dylib' (no such file), '/Users/permcj/projects/installed/lib/pronghorn/./libtensor_mechanics-opt.0.dylib' (no such file), '/usr/local/lib/libtensor_mechanics-opt.0.dylib' (no such file), '/usr/lib/libtensor_mechanics-opt.0.dylib' (no such file, not in dyld cache)
```

Note all of the paths being search - automatically. This is the second library that's "loaded" by MOOSE. The first being the one being searched for above.

**UPDATE (5/1):** With the latest patch this appears to be working on both Mac and Linux with in-tree and installed binaries. Also the double-free error on tear down is gone!

There were two major confounding factors that lead to what I believe was an implementation problem of this system _since its inception_. Namely, it doesn't appear that manually loading "inter-library dependencies" is necessary despite my long held belief. I believe that the primary issue was the lack of uniqueness in a specific symbol used for loading that was introduced to create our beautiful modules system. Namely the `Modules::registerAll` method is duplicated for each application even though the implementation in the body of that method is dependent based on the specific set of modules enabled. While this design error was successfully covered by compiling applications together (since our library names are unique), it appears to have been a primary cause of some of the longstanding difficulty of missing module registration for our dynamically opened libraries. With the latest patches, I'm successfully opening _just_ the top-level application library dependency and successfully running input files that include objects that are _not_ in the driving application. 

Fixes: With this PR, I'm deprecating `Modules::registerAll` in favor of `Modules::registerAllObjects<AppName>`. This will effectively give us back a unique entry point for each application. I'm also turning off the manually recursive library load logic. 

Intermediate Debugging and Rollout: For right now I'm going to continue to install the .la files, but if everything in this PR works out as planned, we won't need those anymore. The libraries themselves should contain the information needed to properly load the dependent libraries with out library archive files so that will come back out. Also, I'm going to add a Boolean to allow us to toggle the manually recursive loading just in case. Again, I don't expect we'll need this, but it maintains the logic we've had in there for the past ~8 years at least for now in case we need it in a pinch. That can also come out after sufficient testing/usage. Apps (at least the nuclear herd) will need to update to the new module registration method, but the old one can stick around for a while. Several months down the road we should be able to significantlly clean all of this loading logic up. We can probably cut the total lines in those routines by upwards of 70% since we only need to load a single library now. 

Testing: We still don't have a good way of testing all of this. I know some want to create new dummy applications that emulate some of our more complex herd animals, but I don't think that's effective. I've found through all of the implementation that being close (like I was 8 years ago) is not anywhere close to good enough. We need to understand why a specific combination isn't working with all the real-world messy code that each of these applications brings along. At the very least we should be using real applications to test even if we pick specific input files to use in testing. For my testing, I've been using real Pronghorn and BISON input files and using `FullSolveMultiapp` to just run the subapp input file. That's generally enough to give me a warm fuzzy that the subapp is being properly dynamically loaded and fully working. Running `simple_transient_diffusion` is not good enough. We need to know that downstream dependencies are being used and working properly. With the BISON/Pronghorn example, I found many input files that worked because many were using a subset of objects that Pronghorn new about. It wasn't until I stumbled upon files containing XFEM (a module not used by Pronghorn) that I started to unravel this whole mystery. So for testing we do need disjoint subsets of modules enabled and input files that exercise objects from the set difference. 

Should we merge this before we figure out all the testing?
I'm biased, but yes. We know that the halfway baked implementation is already working well for some of our users (notably the microreactor team at ANL), but that's because they are getting lucky with modules. This PR installs the .la files (but those normally won't be used, which also means the python script to patch them also won't be used). Again, we'll pull all that back out later. The main "merge me now" changes here are the two I started this update with (adding a new templated modules registration method - very low impact, and turning off recursive loading). The former is a new method so won't affect existing testing and the second feature can only affect dynamic loading.  
