### PR TITLE
Fix boundary id offset code with distributed meshes

### DIFF
--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -208,7 +208,7 @@ GeneratedMeshGenerator::generate()
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
 
   // Copy, since we're modifying the container mid-iteration
-  const auto mesh_boundary_ids = boundary_info.get_boundary_ids();
+  const auto mesh_boundary_ids = boundary_info.get_global_boundary_ids();
   for (auto rit = mesh_boundary_ids.rbegin(); rit != mesh_boundary_ids.rend(); ++rit)
   {
     const std::string old_sideset_name = boundary_info.sideset_name(*rit);

--- a/test/tests/meshgenerators/generated_mesh_generator/tests
+++ b/test/tests/meshgenerators/generated_mesh_generator/tests
@@ -8,7 +8,6 @@
     requirement = 'The system shall be able to use libmesh mesh generation tools.'
     design = 'meshgenerators/GeneratedMeshGenerator.md'
     issues = '#11640'
-    mesh_mode = 'REPLICATED'
     recover = false
   []
 
@@ -22,7 +21,6 @@
                   'ids by a constant offset.'
     design = 'meshgenerators/GeneratedMeshGenerator.md'
     issues = '#11640'
-    mesh_mode = 'REPLICATED'
     recover = false
   []
 
@@ -38,7 +36,6 @@
       cli_args = '--mesh-only'
       exodiff = 'prefix_in.e'
       exodiff_opts = '-pedantic'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = "id and"
@@ -50,7 +47,6 @@
       cli_args = '--mesh-only'
       exodiff = 'prefix_in.e'
       exodiff_opts = '-pedantic -match_by_name'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = "include the added name."
@@ -69,7 +65,6 @@
       cli_args = '--mesh-only'
       exodiff = 'both_in.e'
       exodiff_opts = '-pedantic'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = "the shifted id and"
@@ -82,7 +77,6 @@
       cli_args = '--mesh-only'
       exodiff = 'both_in.e'
       exodiff_opts = '-pedantic -match_by_name'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = "include the added name."
@@ -100,7 +94,6 @@
                   'does not accept them'
     design = 'meshgenerators/GeneratedMeshGenerator.md'
     issues = '#13959'
-    mesh_mode = 'REPLICATED'
   []
 
   [with_subdomain_ids_test]


### PR DESCRIPTION
## Reason
This fixes renaming on distributed mesh cases where some processors
don't have any semilocal elements on some boundary.

This closes #24068 for me.

## Design
Get global boundary ids when we need them instead of just the local set.

## Impact
I have to have seen all those `mesh_mode = 'REPLICATED'` test annotations at some point, and still never bothered finding the one-line fix preemptively, so I can't say the shame here doesn't hurt.

To other developers and users, no negative impact.