### PR TITLE
Makefile improvements

### DIFF
--- a/framework/moose.mk
+++ b/framework/moose.mk
@@ -422,7 +422,7 @@ moose_share_dir = $(share_dir)/moose
 python_install_dir = $(moose_share_dir)/python
 bin_install_dir = $(PREFIX)/bin
 
-install: install_libs install_bin install_harness install_exodiff install_adreal_monolith install_hit install_data
+install: all install_libs install_bin install_harness install_exodiff install_adreal_monolith install_hit install_data
 
 install_data::
 	@mkdir -p $(moose_share_dir)


### PR DESCRIPTION
 - better dependencies
 - don't build test libraries when installing

closes #24079

The primary change here is only setting the "lib_install_targets" variable when we are building an executable. The current implementation sets that variable for each invocation of the "app.mk" file, which is where all the test libraries are being added to the dependency list. The rest is cosmetic and a part of a later pull request to install the library archives needed for dynamic loading in binary installs. 
