### PR TITLE
Update libmesh

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,9 +2,9 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.03.29" %}
+{% set version = "2023.04.17" %}
 {% set vtk_friendly_version = "9.2" %}
 
 package:

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #   moose/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.04.17" %}
+{% set version = "2023.04.19" %}
 {% set vtk_friendly_version = "9.2" %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.17 build_0
+ - moose-libmesh 2023.04.19 build_0
 
 moose_python:
  - python 3.9

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.29 build_1
+ - moose-libmesh 2023.04.17 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.17 build_0
+ - moose-libmesh 2023.04.19 build_0
 
 moose_python:
  - python 3.9

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.03.29 build_1
+ - moose-libmesh 2023.04.17 build_0
 
 moose_python:
  - python 3.9

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=f080ab57d79a349699868cd4fd2f28fa32de4ca1
+ARG LIBMESH_REV=5e720a226ba3740dbe92c135936612461f489ada
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=80494219d2293e467392189814d30330c4f87a25
+ARG LIBMESH_REV=f080ab57d79a349699868cd4fd2f28fa32de4ca1
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -277,6 +277,13 @@ MooseApp::validParams()
       false,
       "Keep standard output from all processors when running in parallel");
 
+  params.addCommandLineParam<std::string>(
+      "timpi_sync",
+      "--timpi-sync <sync type>",
+      "nbx",
+      "Changes the sync type used in spare parallel communitations within the TIMPI library "
+      "(advanced option).");
+
   // Options for debugging
   params.addCommandLineParam<std::string>("start_in_debugger",
                                           "--start-in-debugger <debugger>",
@@ -389,6 +396,10 @@ MooseApp::MooseApp(InputParameters parameters)
     _execute_flags(moose::internal::ExecFlagRegistry::getExecFlagRegistry().getFlags()),
     _automatic_automatic_scaling(getParam<bool>("automatic_automatic_scaling"))
 {
+  // Set the TIMPI sync type via --timpi-sync
+  const auto & timpi_sync = parameters.get<std::string>("timpi_sync");
+  const_cast<Parallel::Communicator &>(comm()).sync_type(timpi_sync);
+
 #ifdef HAVE_GPERFTOOLS
   if (isUltimateMaster())
   {

--- a/modules/doc/content/newsletter/2023/2023_04.md
+++ b/modules/doc/content/newsletter/2023/2023_04.md
@@ -9,6 +9,47 @@ for a complete description of all MOOSE changes.
 
 ## libMesh-level Changes
 
+### `2023.04.19` Update
+
+- `MeshBase` subclasses now support `operator==` tests, to check geometric
+  and subclass type and indexing equality.
+- `MeshTools::valid_is_prepared()` test, to help debugging code
+  determine whether a mesh modification has left a mesh in an
+  unprepared state without either using `prepare_for_use()` or
+  `set_isnt_prepared()` to change or indicate that.
+- APIs for applying constraints to a nonlinear system assembly in a
+  Jacobian-consistent way (as the current `PetscNonlinearSolver`
+  does), but at an element-by-element level rather than as a
+  post-facto edit of the global residual and Jacobian.  This will
+  enable MOOSE to fix a *major* performance bug affecting solves with
+  adaptive mesh refinement, strongly-enforced periodic boundary
+  conditions, and/or IsoGeometric Analysis meshes.
+
+- TIMPI updates:
+
+  - TIMPI can now be instructed via a C++ API to use older
+    synchronization algorithms in `parallel_sync.h` push and pull
+    routines, for easier debugging.  libMesh adds a `--timpi-sync=`
+    command line option for this.
+  - Attempts to send empty vectors in sync routines are now assertion
+    failures, since excessive empty sends would be a potential
+    performance issue.
+  - Code cleanup, extra assertion in the default NBX sync routine.  We
+    think we understand what the MPI standard requires of
+    synchronous-send operations, but this should help catch the
+    problem if any MPI implementations disagree.
+
+- Assorted fixes:
+
+  - `NumericVector::compare()` now handles empty local ranges
+  - `ExodusII` edge block reading now handles orientation mismatch
+  - `isspace()` is more robust to polluted global namespaces in libMesh
+    forks
+  - Overzealous assertion about mesh state removed from
+    `copy_nodes_and_elements`
+  - `LinearPartitioner` is now idempotent on distributed meshes
+  - PETSc 3.19 compatibility
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -77,3 +77,8 @@ db176aaa92d1fd79b2d92ad8979633f9b7ce65b7: # 23581
   petsc: 64a9a7e
   libmesh: 5070cbf
   moose: a555101
+d8b61c7117f9eb62d2ffed085d132ca38da30f77: # 24092
+  mpich: b896b5d
+  petsc: 64a9a7e
+  libmesh: af654a2
+  moose: 6e7dd42


### PR DESCRIPTION
 Summary of changes:

 - Adds PETSc 3.19 compatability fixes
 - Makes linear partitioner idempotent for distributed meshes
 - Updates TIMPI to add sync command line switch
 - Allows edges with different orientations to match in ExodusII_IO
 - Removes overzealous assertion in copy_nodes_and_elements
 - Makes use of isspace more robust
 - Fixes NumericVector::compare
 - Fixes make check with MetaPhysical without MPI