### PR TITLE
Fix excess material property storage entry creation

### DIFF
--- a/framework/src/loops/ComputeMarkerThread.C
+++ b/framework/src/loops/ComputeMarkerThread.C
@@ -62,7 +62,8 @@ ComputeMarkerThread::onElement(const Elem * elem)
   // Set up Sentinel class so that, even if reinitMaterials() throws, we
   // still remember to swap back during stack unwinding.
   SwapBackSentinel sentinel(_fe_problem,
-                            &FEProblem::swapBackMaterials, _tid,
+                            &FEProblem::swapBackMaterials,
+                            _tid,
                             _fe_problem.hasActiveMaterialProperties(_tid));
 
   _fe_problem.reinitMaterials(_subdomain, _tid);

--- a/framework/src/loops/ComputeMarkerThread.C
+++ b/framework/src/loops/ComputeMarkerThread.C
@@ -61,7 +61,9 @@ ComputeMarkerThread::onElement(const Elem * elem)
 
   // Set up Sentinel class so that, even if reinitMaterials() throws, we
   // still remember to swap back during stack unwinding.
-  SwapBackSentinel sentinel(_fe_problem, &FEProblem::swapBackMaterials, _tid);
+  SwapBackSentinel sentinel(_fe_problem,
+                            &FEProblem::swapBackMaterials, _tid,
+                            _fe_problem.hasActiveMaterialProperties(_tid));
 
   _fe_problem.reinitMaterials(_subdomain, _tid);
 

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -358,6 +358,16 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
   if (hasOlderProperties())
     shallowSwapDataBack(
         _stateful_prop_id_to_prop_id, setPropsOlder(&elem, side), material_data.propsOlder());
+
+  // Workaround for MOOSE difficulties in keeping materialless
+  // elements (e.g. Lower D elements in Mortar code) materialless
+  if (props(&elem, side).empty())
+    (*_props_elem)[&elem].erase(side);
+  if (propsOld(&elem, side).empty())
+    (*_props_elem_old)[&elem].erase(side);
+  if (hasOlderProperties())
+    if (propsOlder(&elem, side).empty())
+      (*_props_elem_older)[&elem].erase(side);
 }
 
 bool

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5190,8 +5190,7 @@ void
 FEProblemBase::setActiveMaterialProperties(const std::set<unsigned int> & mat_prop_ids,
                                            THREAD_ID tid)
 {
-  if (!mat_prop_ids.empty())
-    _active_material_property_ids[tid] = mat_prop_ids;
+  _active_material_property_ids[tid] = mat_prop_ids;
 }
 
 const std::set<unsigned int> &


### PR DESCRIPTION

## Reason
This fixes the failure in mortar/continuity-2d-non-conforming.sequencing-stateful-soln-continuity (in parallel, in debug/devel modes) caused by #23603 - on my system at least.

## Design
Avoid carrying our active material properties over from one subdomain to another.  Remove all active material properties when requested to.  Don't "swap back" when we don't have any active material properties and we didn't swap in the first place.

This was the minimal set of changes needed to fix our CI failure for me; I see similar apparent bugs all over the material property setup, but I'll get a more sweeping update into a separate PR.  I think the best way to fix it everywhere will involve an API change to SwapBackSentinel, and that's not something I want to do while we're trying to fix next ASAP.

## Impact
As well as fixing a correctness bug with redistribution of stateful material properties, this fixes a performance bug ... but it's possible that other codes were inadvertently *relying* on that bug in some sense.  Hopefully not.