### PR TITLE
Initialize variable causing valgrind failure

### DIFF
--- a/modules/stochastic_tools/include/samplers/ActiveLearningMonteCarloSampler.h
+++ b/modules/stochastic_tools/include/samplers/ActiveLearningMonteCarloSampler.h
@@ -39,7 +39,7 @@ protected:
   const std::vector<bool> & _flag_sample;
 
   /// True if the sampling is completed
-  bool _is_sampling_completed;
+  bool _is_sampling_completed = false;
 
 private:
   /// Track the current step of the main App


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

PR #23435 introduced a valgrind failure due to a member variable being uninitialized.

## Reason
<!--Why do you need this feature or what is the enhancement?-->

Fix valgrind failure.

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
