### PR TITLE
Constrain Jacobians at the element level only.

### DIFF
--- a/framework/src/base/Assembly.C
+++ b/framework/src/base/Assembly.C
@@ -3497,7 +3497,7 @@ Assembly::addJacobianBlock(SparseMatrix<Number> & jacobian,
       // to constrain the element matrix because it introduces 1s on the diagonal for the
       // constrained dofs
       if (!_sys.computingScalingJacobian())
-        _dof_map.constrain_element_matrix(sub, di, dj, false);
+        _dof_map.constrain_element_matrix(sub, di, dj);
 
       jacobian.add_matrix(sub, di, dj);
     }
@@ -3549,7 +3549,7 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
       // to constrain the element matrix because it introduces 1s on the diagonal for the
       // constrained dofs
       if (!_sys.computingScalingJacobian())
-        _dof_map.constrain_element_matrix(sub, di, dj, false);
+        _dof_map.constrain_element_matrix(sub, di, dj);
 
       for (MooseIndex(di) i = 0; i < di.size(); i++)
         for (MooseIndex(dj) j = 0; j < dj.size(); j++)
@@ -3605,7 +3605,7 @@ Assembly::cacheJacobianBlockNonzero(DenseMatrix<Number> & jac_block,
       if (scaling_factor[i] != 1.0)
         sub *= scaling_factor[i];
 
-      _dof_map.constrain_element_matrix(sub, di, dj, false);
+      _dof_map.constrain_element_matrix(sub, di, dj);
 
       for (MooseIndex(di) i = 0; i < di.size(); i++)
         for (MooseIndex(dj) j = 0; j < dj.size(); j++)
@@ -3640,7 +3640,7 @@ Assembly::cacheJacobianBlock(DenseMatrix<Number> & jac_block,
     // constrain the element matrix because it introduces 1s on the diagonal for the constrained
     // dofs
     if (!_sys.computingScalingJacobian())
-      _dof_map.constrain_element_matrix(jac_block, di, dj, false);
+      _dof_map.constrain_element_matrix(jac_block, di, dj);
 
     if (scaling_factor != 1.0)
       jac_block *= scaling_factor;
@@ -4161,7 +4161,7 @@ Assembly::addJacobianBlock(SparseMatrix<Number> & jacobian,
   // constrain the element matrix because it introduces 1s on the diagonal for the constrained
   // dofs
   if (!_sys.computingScalingJacobian())
-    dof_map.constrain_element_matrix(sub, di, dj, false);
+    dof_map.constrain_element_matrix(sub, di, dj);
 
   if (scaling_factor[i] != 1.0)
     sub *= scaling_factor[i];
@@ -4217,7 +4217,7 @@ Assembly::addJacobianBlockNonlocal(SparseMatrix<Number> & jacobian,
   // constrain the element matrix because it introduces 1s on the diagonal for the constrained
   // dofs
   if (!_sys.computingScalingJacobian())
-    dof_map.constrain_element_matrix(sub, di, dj, false);
+    dof_map.constrain_element_matrix(sub, di, dj);
 
   if (scaling_factor[i] != 1.0)
     sub *= scaling_factor[i];
@@ -4275,9 +4275,9 @@ Assembly::addJacobianNeighbor(SparseMatrix<Number> & jacobian,
   // dofs
   if (!_sys.computingScalingJacobian())
   {
-    dof_map.constrain_element_matrix(suben, dc, dn, false);
-    dof_map.constrain_element_matrix(subne, dn, dc, false);
-    dof_map.constrain_element_matrix(subnn, dn, dn, false);
+    dof_map.constrain_element_matrix(suben, dc, dn);
+    dof_map.constrain_element_matrix(subne, dn, dc);
+    dof_map.constrain_element_matrix(subnn, dn, dn);
   }
 
   if (scaling_factor[i] != 1.0)


### PR DESCRIPTION
## Reason
This should fix https://github.com/libMesh/libmesh/issues/3504 for MOOSE.

## Design
Apply Jacobian constraints consistently at the element level, then don't apply them redundantly at the global level.

## Impact
No API changes.  This also removes the post-facto constraint enforcement sweep we previously did in between residual and Jacobian evaluations, so slight changes in convergence behavior might be possible for problems with strongly-enforced constraints (AMR, PBCs, IGA), which should also run much, much, much faster.