### PR TITLE
Start using apptainer builds for civet testing

### DIFF
--- a/.coverage
+++ b/.coverage
@@ -66,7 +66,7 @@ require_total = 78
 require_total = 85
 
 [porous_flow]
-require_total = 96
+require_total = 95
 
 [ray_tracing]
 require_total = 93

--- a/.coverage
+++ b/.coverage
@@ -30,7 +30,7 @@ require_total = 37
 require_total = 95
 
 [external_petsc_solver]
-require_total = 86
+require_total = 85
 
 [fluid_properties]
 require_total = 84
@@ -39,7 +39,7 @@ require_total = 84
 require_total = 90
 
 [functional_expansion_tools]
-require_total = 83
+require_total = 82
 
 [geochemistry]
 require_total = 96
@@ -63,28 +63,28 @@ require_total = 86
 require_total = 78
 
 [phase_field]
-require_total = 86
+require_total = 85
 
 [porous_flow]
 require_total = 96
 
 [ray_tracing]
-require_total = 94
+require_total = 93
 
 [rdg]
-require_total = 65
+require_total = 64
 
 [richards]
 require_total = 94
 
 [solid_properties]
-require_total = 84
+require_total = 83
 
 [stochastic_tools]
 require_total = 88
 
 [tensor_mechanics]
-require_total = 85
+require_total = 84
 
 [thm]
 require_total = 90

--- a/modules/tensor_mechanics/examples/cframe_iga/tests
+++ b/modules/tensor_mechanics/examples/cframe_iga/tests
@@ -7,5 +7,8 @@
     vtk_version = '>=9.1'
     max_parallel = 1 # number of VTK output files changes with num processes, so we are sticking w/ one for now
     xmldiff = 'cframe_iga_out_001.pvtu cframe_iga_out_001_0.vtu'
+    # Too large for debug and valgrind
+    method = '!DBG'
+    valgrind = none
   []
 []


### PR DESCRIPTION
Reduces coverage as required for the change from gcc 9 -> 8