### PR TITLE
Removed `_block_id` from `SideSetsFromBoundingBoxGenerator`

### DIFF
--- a/framework/include/meshgenerators/SideSetsFromBoundingBoxGenerator.h
+++ b/framework/include/meshgenerators/SideSetsFromBoundingBoxGenerator.h
@@ -31,9 +31,6 @@ protected:
   /// ID location (inside of outside of box)
   MooseEnum _location;
 
-  /// Block ID to assign to the region
-  subdomain_id_type _block_id;
-
   /// List of boundary names to select
   std::vector<BoundaryName> _boundaries_old;
 

--- a/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
@@ -36,8 +36,6 @@ SideSetsFromBoundingBoxGenerator::validParams()
       "bottom_left", "The bottom left point (in x,y,z with spaces in-between).");
   params.addRequiredParam<RealVectorValue>(
       "top_right", "The bottom left point (in x,y,z with spaces in-between).");
-  params.addRequiredParam<subdomain_id_type>(
-      "block_id", "Subdomain id to set for inside/outside the bounding box");
   params.addDeprecatedParam<std::vector<BoundaryName>>(
       "boundary_id_old",
       "Boundary id on specified block within the bounding box to select",
@@ -65,7 +63,6 @@ SideSetsFromBoundingBoxGenerator::SideSetsFromBoundingBoxGenerator(
   : MeshGenerator(parameters),
     _input(getMesh("input")),
     _location(parameters.get<MooseEnum>("location")),
-    _block_id(parameters.get<SubdomainID>("block_id")),
     _bounding_box(MooseUtils::buildBoundingBox(parameters.get<RealVectorValue>("bottom_left"),
                                                parameters.get<RealVectorValue>("top_right"))),
     _boundary_id_overlap(parameters.get<bool>("boundary_id_overlap"))

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids.i
@@ -13,7 +13,6 @@
     boundary_new = 10
     bottom_left = '-0.1 -0.1 0'
     top_right = '0.2 0.9 0'
-    block_id = 0
   [../]
   [./createNewSidesetTwo]
     type = SideSetsFromBoundingBoxGenerator
@@ -22,7 +21,6 @@
     boundary_new = 11
     bottom_left = '0.5 0.5 0'
     top_right = '1.1 1.1 0'
-    block_id = 0
   [../]
 []
 

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids_3d.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids_3d.i
@@ -15,7 +15,6 @@
     boundary_new = 10
     bottom_left = '-0.1 -0.1 -0.1'
     top_right = '0.1 0.2 0.3'
-    block_id = 0
   []
   [./createNewSidesetTwo]
     type = SideSetsFromBoundingBoxGenerator
@@ -24,7 +23,6 @@
     boundary_new = 11
     bottom_left = '0.6 0.7 0.8'
     top_right = '1.1 1.1 1.1'
-    block_id = 0
   []
   [./createNewSidesetThree]
     type = SideSetsFromBoundingBoxGenerator
@@ -33,7 +31,6 @@
     boundary_new = 12
     bottom_left = '-0.1 0.9 0.9'
     top_right = '0.1 1.1 1.1'
-    block_id = 0
   []
   [./createNewSidesetFour]
     type = SideSetsFromBoundingBoxGenerator
@@ -42,7 +39,6 @@
     boundary_new = 13
     bottom_left = '0.4 0.4 0.9'
     top_right = '0.6 0.6 1.1'
-    block_id = 0
   [../]
 []
 

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/overlapping_sidesets.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/overlapping_sidesets.i
@@ -15,7 +15,6 @@
     boundary_new = 10
     bottom_left = '-1.1 -1.1 -1.1'
     top_right = '1.1 1.1 1.1'
-    block_id = 0
     boundary_id_overlap = true
   []
   [./createNewSidesetTwo]
@@ -25,7 +24,6 @@
     boundary_new = 11
     bottom_left = '-1.1 -1.1 -1.1'
     top_right = '1.1 1.1 1.1'
-    block_id = 0
     boundary_id_overlap = true
   []
   [./createNewSidesetThree]
@@ -35,7 +33,6 @@
     boundary_new = 12
     bottom_left = '-1.1 -1.1 -1.1'
     top_right = '1.1 1.1 1.1'
-    block_id = 0
     boundary_id_overlap = true
   [../]
 []

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/overlapping_sidesets_not_found.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/overlapping_sidesets_not_found.i
@@ -14,7 +14,6 @@
     boundary_new = 11
     bottom_left = '-1.1 -1.1 -1.1'
     top_right = '1.1 1.1 1.1'
-    block_id = 0
     boundary_id_overlap = true
   [../]
 []


### PR DESCRIPTION
## Reason
The required parameter `block_id` is very counter-intuitive for `SideSetsFromBoundingBoxGenerator` and yet it is not used at all. It would be better to just remove this parameter.

## Design
The parameter has been removed.

## Impact
Since this was a required parameter I am expecting the app tests to fail.

