### PR TITLE
support VectorVariables for getNodalValue

### DIFF
--- a/framework/include/variables/MooseVariableData.h
+++ b/framework/include/variables/MooseVariableData.h
@@ -358,7 +358,7 @@ public:
    * Write a nodal value to the passed-in solution vector
    */
   void insertNodalValue(NumericVector<Number> & residual, const OutputData & v);
-  OutputData getNodalValue(const Node & node, Moose::SolutionState state) const;
+  OutputType getNodalValue(const Node & node, Moose::SolutionState state) const;
   OutputData
   getElementalValue(const Elem * elem, Moose::SolutionState state, unsigned int idx = 0) const;
 

--- a/framework/include/variables/MooseVariableFE.h
+++ b/framework/include/variables/MooseVariableFE.h
@@ -490,36 +490,36 @@ public:
   /**
    * Get the value of this variable at given node
    */
-  OutputData getNodalValue(const Node & node) const;
+  OutputType getNodalValue(const Node & node) const;
   /**
    * Get the old value of this variable at given node
    */
-  OutputData getNodalValueOld(const Node & node) const;
+  OutputType getNodalValueOld(const Node & node) const;
   /**
    * Get the t-2 value of this variable at given node
    */
-  OutputData getNodalValueOlder(const Node & node) const;
+  OutputType getNodalValueOlder(const Node & node) const;
   /**
    * Get the current value of this variable on an element
    * @param[in] elem   Element at which to get value
    * @param[in] idx    Local index of this variable's element DoFs
    * @return Variable value
    */
-  OutputData getElementalValue(const Elem * elem, unsigned int idx = 0) const;
+  OutputType getElementalValue(const Elem * elem, unsigned int idx = 0) const;
   /**
    * Get the old value of this variable on an element
    * @param[in] elem   Element at which to get value
    * @param[in] idx    Local index of this variable's element DoFs
    * @return Variable value
    */
-  OutputData getElementalValueOld(const Elem * elem, unsigned int idx = 0) const;
+  OutputType getElementalValueOld(const Elem * elem, unsigned int idx = 0) const;
   /**
    * Get the older value of this variable on an element
    * @param[in] elem   Element at which to get value
    * @param[in] idx    Local index of this variable's element DoFs
    * @return Variable value
    */
-  OutputData getElementalValueOlder(const Elem * elem, unsigned int idx = 0) const;
+  OutputType getElementalValueOlder(const Elem * elem, unsigned int idx = 0) const;
   /**
    * Set the current local DOF values to the input vector
    */

--- a/framework/src/variables/MooseVariableFE.C
+++ b/framework/src/variables/MooseVariableFE.C
@@ -171,42 +171,42 @@ MooseVariableFE<OutputType>::getDofIndices(const Elem * elem,
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getNodalValue(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Current);
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getNodalValueOld(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Old);
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getNodalValueOlder(const Node & node) const
 {
   return _element_data->getNodalValue(node, Moose::Older);
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getElementalValue(const Elem * elem, unsigned int idx) const
 {
   return _element_data->getElementalValue(elem, Moose::Current, idx);
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getElementalValueOld(const Elem * elem, unsigned int idx) const
 {
   return _element_data->getElementalValue(elem, Moose::Old, idx);
 }
 
 template <typename OutputType>
-typename MooseVariableFE<OutputType>::OutputData
+OutputType
 MooseVariableFE<OutputType>::getElementalValueOlder(const Elem * elem, unsigned int idx) const
 {
   return _element_data->getElementalValue(elem, Moose::Older, idx);


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->
closes #24060

## Reason
<!--Why do you need this feature or what is the enhancement?-->
`getNodalValue` was only providing the first dof for vector variables.
## Design
<!--A concise description (design) of the enhancement.-->
Replace `typename MooseVariableData<OutputType>::OutputData` with  `OutputType`. Loop through dofs to get all the values. 
## Impact
<!--Will the enhancement change existing APIs or add something new?-->
Fix capability of getNodalValue.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
