### PR TITLE
Add UserObjects to Dump Problems

### DIFF
--- a/framework/include/problems/DumpObjectsProblem.h
+++ b/framework/include/problems/DumpObjectsProblem.h
@@ -91,6 +91,7 @@ public:
   captureDump(addFunction,            "Functions")
   captureDump(addFVKernel,            "FVKernels")
   captureDump(addIndicator,           "Adaptivity/Indicators")
+  captureDump(addUserObject,          "UserObject")
   captureDump(addInitialCondition,    "ICs")
   captureDump(addInterfaceKernel,     "InterfaceKernels")
   captureDump(addKernel,              "Kernels")


### PR DESCRIPTION
Refs #22314

## Reason
DumpObjectsProblem did not have access to UserObjects.

## Design
Add UserObjects to DumpObjectsProblem.h

## Impact
DumpProblem should now dump UserObjects


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
