### PR TITLE
Fix convergence test with exact solution. 

### DIFF
--- a/test/tests/fvkernels/fv_adapt/steady-adapt-run-and-plot.py
+++ b/test/tests/fvkernels/fv_adapt/steady-adapt-run-and-plot.py
@@ -4,7 +4,7 @@ from mooseutils import fuzzyEqual
 
 class TestSteadyAdapt(unittest.TestCase):
     def test(self):
-        df1 = mms.run_spatial('steady-adapt.i', 9, "--error", mpi=16)
+        df1 = mms.run_spatial('steady-adapt.i', 9, "FVKernels/inactive='' Postprocessors/error/function='exact-quadratic'", "--error", mpi=16)
 
         fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
         fig.plot(df1,

--- a/test/tests/fvkernels/fv_adapt/steady-adapt.i
+++ b/test/tests/fvkernels/fv_adapt/steady-adapt.i
@@ -18,18 +18,28 @@
 []
 
 [Functions]
-  [exact]
+  [exact-quadratic]
     type = ParsedFunction
-    expression = x
+    expression = '-(x-1)^2+1'
+  []
+  [exact-linear]
+    type = ParsedFunction
+    expression = 'x'
   []
 []
 
 [FVKernels]
+  inactive = 'source'
   [diff]
     type = FVDiffusion
     variable = u
     coeff = coeff
     use_point_neighbors = true
+  []
+  [source]
+    type = FVBodyForce
+    variable = u
+    function = 2
   []
 []
 
@@ -90,7 +100,7 @@
   [error]
     type = ElementL2Error
     variable = u
-    function = exact
+    function = exact-linear
     outputs = 'console csv'
     execute_on = 'timestep_end'
   []


### PR DESCRIPTION
Refs #20953 

Note: The issue was that the reference solution was linear and second-order FVM should get the exact solution. The negative convergence we saw was due to the round-off noise on the error.