### PR TITLE
Move dependency addition to coupledCallback

### DIFF
--- a/framework/src/auxkernels/AuxKernel.C
+++ b/framework/src/auxkernels/AuxKernel.C
@@ -143,11 +143,6 @@ AuxKernelTempl<ComputeValueType>::AuxKernelTempl(const InputParameters & paramet
   addMooseVariableDependency(&_var);
   _supplied_vars.insert(parameters.get<AuxVariableName>("variable"));
 
-  const auto & coupled_vars = getCoupledVars();
-  for (const auto & it : coupled_vars)
-    for (const auto & var : it.second)
-      _depend_vars.insert(var->name());
-
   if (_bnd && !isNodal() && _check_boundary_restricted)
   {
     // when the variable is elemental and this aux kernel operates on boundaries,
@@ -218,11 +213,10 @@ template <typename ComputeValueType>
 void
 AuxKernelTempl<ComputeValueType>::coupledCallback(const std::string & var_name, bool is_old) const
 {
-  if (is_old)
+  if (!is_old)
   {
-    std::vector<VariableName> var_names = getParam<std::vector<VariableName>>(var_name);
-    for (const auto & name : var_names)
-      _depend_vars.erase(name);
+    const auto & var_names = getParam<std::vector<VariableName>>(var_name);
+    _depend_vars.insert(var_names.begin(), var_names.end());
   }
 }
 


### PR DESCRIPTION
We don't want to depend on adding dependencies in the constructor because we later on need to distinguish between old and current values. Once we've gotten to coupledCallback, we could have added a dependency for both a current and an older value... to which the current code would remove that dep even though it is valid

Came across this in https://civet.inl.gov/job/1499780/, in which changing to the WASP parser switched around constructing ordering of aux kernels. With HIT, the the AKs were not defined in dependency order in input. With WASP, they conveniently are. Both should work, but they don't because the dependency on `hoop_stress` within the `cumulative_damage_index` aux kernel is not defined, because it requests both an old and current value, which is deleted due to the bug above.

Closes #24266