### PR TITLE
Removed deprecated code from StorkApp.

### DIFF
--- a/modules/module_loader/src/ModulesApp.C
+++ b/modules/module_loader/src/ModulesApp.C
@@ -385,8 +385,8 @@ void
 ModulesApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {
   mooseDeprecated(
-      "\"registerAll\" in Modules is deprecated. Please update your *App.C file to call the new "
-      "templated \"registerAllObjects\" method (e.g. ModulesApp::registerAllobject<MyApp>(...))");
+      "\"registerAll\" in Modules is deprecated. Please update your *App.C file(s) to call the new "
+      "templated \"registerAllObjects\" method (e.g. ModulesApp::registerAllObjects<MyApp>(...))");
 
 #ifdef CHEMICAL_REACTIONS_ENABLED
   ChemicalReactionsApp::registerAll(f, af, s);

--- a/stork/include/base/StorkApp.h
+++ b/stork/include/base/StorkApp.h
@@ -20,5 +20,4 @@ public:
   virtual ~StorkApp();
 
   static void registerApps();
-  static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
 };

--- a/stork/src/base/StorkApp.C.app
+++ b/stork/src/base/StorkApp.C.app
@@ -14,20 +14,10 @@ StorkApp::validParams()
 
 StorkApp::StorkApp(InputParameters parameters) : MooseApp(parameters)
 {
-  StorkApp::registerAll(_factory, _action_factory, _syntax);
+  ModulesApp::registerAllObjects<StorkApp>(_factory, _action_factory, _syntax);
 }
 
 StorkApp::~StorkApp() {}
-
-void
-StorkApp::registerAll(Factory & f, ActionFactory & af, Syntax & syntax)
-{
-  ModulesApp::registerAll(f, af, syntax);
-  Registry::registerObjectsTo(f, {"StorkApp"});
-  Registry::registerActionsTo(af, {"StorkApp"});
-
-  /* register custom execute flags, action syntax, etc. here */
-}
 
 void
 StorkApp::registerApps()
@@ -41,7 +31,7 @@ StorkApp::registerApps()
 extern "C" void
 StorkApp__registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {
-  StorkApp::registerAll(f, af, s);
+  ModulesApp::registerAllObjects<StorkApp>(f, af, s);
 }
 extern "C" void
 StorkApp__registerApps()

--- a/stork/test/src/base/StorkTestApp.C.app
+++ b/stork/test/src/base/StorkTestApp.C.app
@@ -31,7 +31,7 @@ StorkTestApp::~StorkTestApp() {}
 void
 StorkTestApp::registerAll(Factory & f, ActionFactory & af, Syntax & s, bool use_test_objs)
 {
-  StorkApp::registerAll(f, af, s);
+  ModulesApp::registerAllObjects<StorkApp>(f, af, s);
   if (use_test_objs)
   {
     Registry::registerObjectsTo(f, {"StorkTestApp"});


### PR DESCRIPTION
Replaced the deprecated StorkApp::registerAll with ModuleApp::registerAllObjects<StorkApp>.

Closes #24279.
