### PR TITLE
Deleting --spec-file argument from TestHarness.

### DIFF
--- a/python/TestHarness/JobDAG.py
+++ b/python/TestHarness/JobDAG.py
@@ -30,7 +30,7 @@ class JobDAG(object):
             # We only need a single tester so we know what spec file to load.
             # TODO: would be nice to have access to this without needing tester.specs
             tester = job[0].getTester()
-            root = pyhit.load(os.path.join(tester.specs['test_dir'], tester.specs['spec_file']))
+            root = pyhit.load(os.path.join(tester.specs['test_dir'], tester.specs['run_dir']))
             self.__parallel_scheduling = root.children[0].get('parallel_scheduling', False)
 
         return self.__parallel_scheduling

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -357,16 +357,32 @@ class TestHarness:
         self.preRun()
         self.start_time = clock()
         launched_tests = []
+
+        #used for -i
         if self.options.input_file_name != '':
+
             self._infiles = self.options.input_file_name.split(',')
 
+            if(os.path.dirname(self._infiles[0]) !=''):
+                print('ERROR entered a path, -i can only accept a file name or directory name.')
+                sys.exit(1)
+
+        #used for --run-dir
         if self.options.run_dir and os.path.isdir(self.options.run_dir):
             search_dir = self.options.run_dir
+
+        #used only when --run-dir <path> is used
         elif self.options.run_dir and os.path.isfile(self.options.run_dir):
-            search_dir = os.path.dirname(self.options.run_dir)
-            self._infiles = [os.path.basename(self.options.run_dir)]
+
+            if(os.path.basename(self.options.run_dir[0]) !=''):
+                print('ERROR entered a filename at end of path, please specify the filename separately with the argument -i file_name.')
+                sys.exit(1)
+            else:
+                search_dir = os.path.dirname(self.options.run_dir)
+                self._infiles = [os.path.basename(self.options.run_dir)]
+
         else:
-            search_dir = os.getcwd()
+            search_dir = os.getcwd()#returns a string of the current working directory
 
         try:
             testroot_params = {}
@@ -1025,7 +1041,7 @@ class TestHarness:
         parser.add_argument('--failed-tests', action='store_true', dest='failed_tests', help='Run tests that previously failed')
         parser.add_argument('--check-input', action='store_true', dest='check_input', help='Run check_input (syntax) tests only')
         parser.add_argument('--no-check-input', action='store_true', dest='no_check_input', help='Do not run check_input (syntax) tests')
-        parser.add_argument('--run-dir', action='store', type=str, dest='run_dir', help='Supply a full or relative path to the tests spec file to run the tests found therein.')
+        parser.add_argument('-C', '--run-dir', action='store', type=str, dest='run_dir', help='Supply a full or relative directory to the tests spec file to run the tests found therein.')
         parser.add_argument('-d', '--pedantic-checks', action='store_true', dest='pedantic_checks', help="Run pedantic checks of the Testers' file writes looking for race conditions.")
 
         # Options that pass straight through to the executable
@@ -1104,7 +1120,7 @@ class TestHarness:
             print('ERROR: --check-input and --recover cannot be used simultaneously')
             sys.exit(1)
         if opts.run_dir and not os.path.exists(opts.run_dir):
-            print('ERROR: --run-dir supplied but path does not exist')
+            print('ERROR: --run-dir does not accept a file name, please enter a directory instead')
             sys.exit(1)
         if opts.queue_cleanup and not opts.pbs:
             print('ERROR: --queue-cleanup cannot be used without additional queue options')

--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -360,11 +360,11 @@ class TestHarness:
         if self.options.input_file_name != '':
             self._infiles = self.options.input_file_name.split(',')
 
-        if self.options.spec_file and os.path.isdir(self.options.spec_file):
-            search_dir = self.options.spec_file
-        elif self.options.spec_file and os.path.isfile(self.options.spec_file):
-            search_dir = os.path.dirname(self.options.spec_file)
-            self._infiles = [os.path.basename(self.options.spec_file)]
+        if self.options.run_dir and os.path.isdir(self.options.run_dir):
+            search_dir = self.options.run_dir
+        elif self.options.run_dir and os.path.isfile(self.options.run_dir):
+            search_dir = os.path.dirname(self.options.run_dir)
+            self._infiles = [os.path.basename(self.options.run_dir)]
         else:
             search_dir = os.getcwd()
 
@@ -409,7 +409,7 @@ class TestHarness:
                         if file in self._infiles \
                                and os.path.abspath(os.path.join(dirpath, file)) not in launched_tests:
 
-                            if self.notMySpecFile(dirpath, file):
+                            if self.notMyRunDir(dirpath, file):
                                 continue
 
                             saved_cwd = os.getcwd()
@@ -487,11 +487,11 @@ class TestHarness:
 
         return testers
 
-    def notMySpecFile(self, dirpath, filename):
-        """ true if dirpath/filename does not match supplied --spec-file """
-        if (self.options.spec_file
-            and os.path.isfile(self.options.spec_file)
-            and os.path.join(dirpath, filename) != self.options.spec_file):
+    def notMyRunDir(self, dirpath, filename):
+        """ true if dirpath/filename does not match supplied --run-dir """
+        if (self.options.run_dir
+            and os.path.isfile(self.options.run_dir)
+            and os.path.join(dirpath, filename) != self.options.run_dir):
             return True
 
     def augmentParameters(self, filename, tester, testroot_params={}):
@@ -513,7 +513,7 @@ class TestHarness:
         relative_hitpath = os.path.join(*params['hit_path'].split(os.sep)[2:])  # Trim root node "[Tests]"
         formatted_name = relative_path + '.' + relative_hitpath
 
-        params['spec_file'] = filename
+        params['run_dir'] = filename
         params['test_name'] = formatted_name
         params['test_dir'] = test_dir
         params['relative_path'] = relative_path
@@ -1025,8 +1025,7 @@ class TestHarness:
         parser.add_argument('--failed-tests', action='store_true', dest='failed_tests', help='Run tests that previously failed')
         parser.add_argument('--check-input', action='store_true', dest='check_input', help='Run check_input (syntax) tests only')
         parser.add_argument('--no-check-input', action='store_true', dest='no_check_input', help='Do not run check_input (syntax) tests')
-        parser.add_argument('--spec-file', action='store', type=str, dest='spec_file', help='Supply a path to the tests spec file to run the tests found therein. Or supply a path to a directory in which the TestHarness will search for tests. You can further alter which tests spec files are found through the use of -i and --re')
-        parser.add_argument('-C', '--test-root', nargs=1, metavar='dir', type=str, dest='spec_file', help='Tell the TestHarness to search for test spec files at this location.')
+        parser.add_argument('--run-dir', action='store', type=str, dest='run_dir', help='Supply a full or relative path to the tests spec file to run the tests found therein.')
         parser.add_argument('-d', '--pedantic-checks', action='store_true', dest='pedantic_checks', help="Run pedantic checks of the Testers' file writes looking for race conditions.")
 
         # Options that pass straight through to the executable
@@ -1104,8 +1103,8 @@ class TestHarness:
         if opts.check_input and opts.enable_recover:
             print('ERROR: --check-input and --recover cannot be used simultaneously')
             sys.exit(1)
-        if opts.spec_file and not os.path.exists(opts.spec_file):
-            print('ERROR: --spec-file supplied but path does not exist')
+        if opts.run_dir and not os.path.exists(opts.run_dir):
+            print('ERROR: --run-dir supplied but path does not exist')
             sys.exit(1)
         if opts.queue_cleanup and not opts.pbs:
             print('ERROR: --queue-cleanup cannot be used without additional queue options')

--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -22,10 +22,10 @@ class QueueManager(Scheduler):
     pool once per group (see augmentJobs).
 
     Using this one unmodified job, the spec file involved is noted, and instructs the derived
-    scheduler how to launch this one single spec file (using --spec-file), along with any
+    scheduler how to launch this one single spec file (using --run-dir), along with any
     supplied/allowable command line arguments (--re, --cli-args, --ignore, etc).
 
-    The third-party queueing manager then executes `run_tests --spec-file /path/to/spec_file`.
+    The third-party queueing manager then executes `run_tests --run-dir /path/to/--run-dir`.
 
     It is the results of this additional ./run_tests run, that is captured and presented to the user as
     the finished result of the test.
@@ -162,7 +162,7 @@ class QueueManager(Scheduler):
                 current_args.extend(arg.split('='))
 
             # Note: we are removing cli-args/ignore because we need to re-encapsulate them below
-            bad_keyword_args.extend(['--spec-file', '-i', '--cli-args', '-j', '-l', '-o', '--output-dir', '--ignore', '--re'])
+            bad_keyword_args.extend(['--run-dir', '-i', '--cli-args', '-j', '-l', '-o', '--output-dir', '--ignore', '--re'])
 
             # remove the key=value pair argument
             for arg in bad_keyword_args:
@@ -197,8 +197,8 @@ class QueueManager(Scheduler):
         # get current sys.args we are allowed to include when we launch run_tests
         args = list(self.cleanAndModifyArgs())
 
-        # Build [<args>, '--spec-file' ,/path/to/tests', '-o', '/path/to', '--sep-files']
-        args.extend(['--spec-file',
+        # Build [<args>, '--run-dir' ,/path/to/tests', '-o', '/path/to', '--sep-files']
+        args.extend(['--run-dir',
                      os.path.join(job.getTestDir(),
                      self.options.input_file_name),
                      '-o', job.getTestDir(),
@@ -215,7 +215,7 @@ class QueueManager(Scheduler):
 
     def _isProcessReady(self, job_data):
         """
-        Return bool on `run_tests --spec_file` submission results being available. Due to the
+        Return bool on `run_tests --run-dir` submission results being available. Due to the
         way the TestHarness writes to this results file (when the TestHarness exits), this file,
         when available, means every test contained therein is finished in some form or another.
 
@@ -416,7 +416,7 @@ class QueueManager(Scheduler):
         plugin = self.harness.scheduler.__class__.__name__
 
         # Top Job (entire TestDir group) not originally part of what was launched
-        # (not launched due to: --re, -i --spec-file)
+        # (not launched due to: --re, -i --run-dir)
         if top_job_key not in self.options.results_storage.keys():
             return
         # All jobs ended up being skipped in this group

--- a/python/TestHarness/tests/test_ArbitrarySpecFile.py
+++ b/python/TestHarness/tests/test_ArbitrarySpecFile.py
@@ -14,10 +14,6 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         Verify an arbitrary test will run when we use the '--run-dir' argument
         """
-        # Test that we do not recursively find additional tests
-        output = self.runTests('--run-dir', 'tests/test_harness/arbitrary_test').decode('utf-8')
-        self.assertIn('tests/test_harness.always_ok', output)
-        self.assertNotIn('tests/test_harness/arbitrary_directory.always_ok', output)
 
         # Test that we do find additional tests with recursion
         output = self.runTests('--run-dir', 'tests/test_harness', '-i', 'arbitrary_test').decode('utf-8')

--- a/python/TestHarness/tests/test_ArbitrarySpecFile.py
+++ b/python/TestHarness/tests/test_ArbitrarySpecFile.py
@@ -12,19 +12,19 @@ from TestHarnessTestCase import TestHarnessTestCase
 class TestHarnessTester(TestHarnessTestCase):
     def testArbitrarySpecFile(self):
         """
-        Verify an arbitrary test will run when we use the --spec-file argument
+        Verify an arbitrary test will run when we use the '--run-dir' argument
         """
         # Test that we do not recursively find additional tests
-        output = self.runTests('--spec-file', 'tests/test_harness/arbitrary_test').decode('utf-8')
+        output = self.runTests('--run-dir', 'tests/test_harness/arbitrary_test').decode('utf-8')
         self.assertIn('tests/test_harness.always_ok', output)
         self.assertNotIn('tests/test_harness/arbitrary_directory.always_ok', output)
 
         # Test that we do find additional tests with recursion
-        output = self.runTests('--spec-file', 'tests/test_harness', '-i', 'arbitrary_test').decode('utf-8')
+        output = self.runTests('--run-dir', 'tests/test_harness', '-i', 'arbitrary_test').decode('utf-8')
         self.assertIn('tests/test_harness.always_ok', output)
         self.assertIn('tests/test_harness/arbitrary_directory.always_ok', output)
 
         # Test that we are not recursively finding our way backwards
-        output = self.runTests('--spec-file', 'tests/test_harness/arbitrary_directory', '-i', 'arbitrary_test').decode('utf-8')
+        output = self.runTests('--run-dir', 'tests/test_harness/arbitrary_directory', '-i', 'arbitrary_test').decode('utf-8')
         self.assertIn('tests/test_harness/arbitrary_directory.always_ok', output)
         self.assertNotIn('tests/test_harness.always_ok', output)


### PR DESCRIPTION
Refs Issue-#19107. --spec-file has overlapping functionality with --test-root. Removed --spec-file and function notMySpecFile that used it from TestHarness.py. 