### PR TITLE
A couple of FV fixes

### DIFF
--- a/framework/src/fvkernels/FVDiffusion.C
+++ b/framework/src/fvkernels/FVDiffusion.C
@@ -49,12 +49,16 @@ FVDiffusion::computeQpResidual()
 
   // If we are on internal faces, we interpolate the diffusivity as usual
   if (_var.isInternalFace(*_face_info))
-    interpolate(_coeff_interp_method,
-                coeff,
-                _coeff(elemArg(), state),
-                _coeff(neighborArg(), state),
-                *_face_info,
-                true);
+  {
+    const ADReal coeff_elem = _coeff(elemArg(), state);
+    const ADReal coeff_neighbor = _coeff(neighborArg(), state);
+    // If the diffusion coefficients are zero, then we can early return 0 (and avoid warnings if we
+    // have a harmonic interpolation)
+    if (!coeff_elem.value() && !coeff_neighbor.value())
+      return 0;
+
+    interpolate(_coeff_interp_method, coeff, coeff_elem, coeff_neighbor, *_face_info, true);
+  }
   // Else we just use the boundary values (which depend on how the diffusion
   // coefficient is constructed)
   else

--- a/modules/navier_stokes/include/base/NSFVBase.h
+++ b/modules/navier_stokes/include/base/NSFVBase.h
@@ -13,6 +13,7 @@
 #include "FEProblem.h"
 #include "NonlinearSystemBase.h"
 #include "AuxiliarySystem.h"
+#include "NSFVUtils.h"
 
 /**
  * Base class for setting up Navier-Stokes finite volume simulations
@@ -746,7 +747,7 @@ NSFVBase<BaseType>::validParams()
    * Navier-Stokes + energy equations.
    */
 
-  MooseEnum adv_interpol_types("average upwind skewness-corrected min_mod vanLeer", "average");
+  MooseEnum adv_interpol_types(Moose::FV::interpolationMethods());
   params.addParam<MooseEnum>("mass_advection_interpolation",
                              adv_interpol_types,
                              "The numerical scheme to use for interpolating density, "

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-ambient-convection-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-ambient-convection-action.i
@@ -56,6 +56,10 @@ alpha = 1
     # Ambient convection volumetric heat source
     ambient_convection_alpha = 'alpha'
     ambient_temperature = '100'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-friction-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-friction-action.i
@@ -35,6 +35,9 @@ rho = 1.1
 
     friction_types = 'darcy'
     friction_coeffs = '25'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-no-slip-action.i
@@ -32,6 +32,9 @@ rho = 1.1
     outlet_boundaries = 'right'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = '0'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-transient-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-rc-transient-action.i
@@ -54,6 +54,10 @@ h_fs = 0.01
 
     ambient_convection_alpha = 'h_cv'
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-scalar-transport-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/2d-scalar-transport-action.i
@@ -73,6 +73,11 @@ cp = 1
     outlet_boundaries = 'right'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = '0'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
+    passive_scalar_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/no-slip-tris-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/channel-flow/cylindrical/no-slip-tris-action.i
@@ -37,6 +37,9 @@ rho = 1
 
     momentum_two_term_bc_expansion = true
     pressure_two_term_bc_expansion = true
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-action.i
@@ -33,6 +33,9 @@ rho = 1
     pin_pressure = true
     pinned_pressure_type = average
     pinned_pressure_value = 0
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-with-energy-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/lid-driven/lid-driven-with-energy-action.i
@@ -43,6 +43,10 @@ cp = 1
     pin_pressure = true
     pinned_pressure_type = average
     pinned_pressure_value = 0
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/ins/natural_convection/natural_circulation_dogleg.i
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/natural_convection/natural_circulation_dogleg.i
@@ -69,6 +69,7 @@ head = ${fparse height * density * gravity}
     outlet_boundaries = 'top'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = '0'
+    energy_advection_interpolation = 'average'
     momentum_advection_interpolation = 'upwind'
     mass_advection_interpolation = 'upwind'
     friction_blocks = '1'

--- a/modules/navier_stokes/test/tests/finite_volume/materials/flow_diode/friction.i
+++ b/modules/navier_stokes/test/tests/finite_volume/materials/flow_diode/friction.i
@@ -64,6 +64,9 @@ rho = 10
     # friction_coeffs = 'Darcy Forchheimer; Darcy Forchheimer'
     # Combined with diode
     friction_coeffs = 'combined_linear combined_quadratic; combined_linear combined_quadratic'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/materials/flow_diode/transient_operation.i
+++ b/modules/navier_stokes/test/tests/finite_volume/materials/flow_diode/transient_operation.i
@@ -130,6 +130,9 @@ ny = 5
 
     # Option 2: bernouilli jump
     # porosity_interface_pressure_treatment = bernoulli
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/2d-rc-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/2d-rc-action.i
@@ -38,6 +38,9 @@ rho = 1.1
     outlet_boundaries = 'right'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = '0'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/2d-rc-friction-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/2d-rc-friction-action.i
@@ -36,6 +36,9 @@ rho = 1
 
     friction_types = 'darcy forchheimer'
     friction_coeffs = 'Darcy_coefficient Forchheimer_coefficient'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-action.i
@@ -64,6 +64,10 @@ h_cv = 1.0
 
     ambient_convection_alpha = ${h_cv}
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-boussinesq-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-boussinesq-action.i
@@ -66,6 +66,10 @@ T_inlet = 200
 
     ambient_convection_alpha = 1e-3
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-effective-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-rc-heated-effective-action.i
@@ -82,6 +82,10 @@ T_inlet = 200
 
     ambient_convection_alpha = 'h_cv'
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-transient-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/channel-flow/heated/2d-transient-action.i
@@ -76,6 +76,10 @@ top_side_temperature = 150
 
     ambient_convection_alpha = 'h_cv'
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pins/mms/porosity_change/pressure-interpolation-corrected-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/mms/porosity_change/pressure-interpolation-corrected-action.i
@@ -57,6 +57,9 @@ forch=1.1
     outlet_boundaries = 'right'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = 'exact_p'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pwcns/boundary_conditions/flux_bcs_mdot-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pwcns/boundary_conditions/flux_bcs_mdot-action.i
@@ -64,6 +64,10 @@ inlet_velocity = 0.001
     pressure_function = '${outlet_pressure}'
 
     external_heat_source = 'power_density'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/pwcns/channel-flow/2d-transient-action.i
@@ -78,6 +78,10 @@ top_side_temperature = 150
 
     ambient_convection_alpha = 'h_cv'
     ambient_temperature = 'T_solid'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_mdot-action.i
@@ -69,6 +69,10 @@ inlet_velocity = 0.001
 
     external_heat_source = 'power_density'
     passive_scalar_source = 2.1
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/flux_bcs_velocity-action.i
@@ -68,6 +68,10 @@ inlet_velocity = 0.001
 
     external_heat_source = 'power_density'
     passive_scalar_source = 2.1
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/with-direction/flux_bcs-direction-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/boundary_conditions/with-direction/flux_bcs-direction-action.i
@@ -74,6 +74,9 @@ inlet_scalar = 1.2
     pressure_function = '${outlet_pressure}'
 
     external_heat_source = 'power_density'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-action.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/channel-flow/2d-transient-action.i
@@ -55,6 +55,10 @@ inlet_v = 0.001
     pressure_function = '${outlet_pressure}'
 
     external_heat_source = 'power_density'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/natural_circulation_pipe.i
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/natural_circulation_pipe.i
@@ -77,6 +77,7 @@ gamma = 1.4
     friction_coeffs = 'Darcy_coef'
     porous_medium_treatment = true
     porosity = porosity
+    energy_advection_interpolation = 'average'
   []
 []
 

--- a/modules/thermal_hydraulics/test/tests/components/flow_component_ns/flow_component_ns_pinc.i
+++ b/modules/thermal_hydraulics/test/tests/components/flow_component_ns/flow_component_ns_pinc.i
@@ -66,6 +66,9 @@ p_outlet = 0
     outlet_boundaries = 'comp2:right'
     momentum_outlet_types = 'fixed-pressure'
     pressure_function = '${p_outlet}'
+
+    mass_advection_interpolation = 'average'
+    momentum_advection_interpolation = 'average'
   []
 []
 

--- a/test/tests/kernels/simple_diffusion/simple_diffusion.i
+++ b/test/tests/kernels/simple_diffusion/simple_diffusion.i
@@ -35,8 +35,8 @@
 [Executioner]
   type = Steady
   solve_type = 'PJFNK'
-  petsc_options_iname = '-pc_type -pc_hypre_type'
-  petsc_options_value = 'hypre boomeramg'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'hypre'
 []
 
 [Outputs]


### PR DESCRIPTION
- Do early return if both diffusion coefficient values (element and neighbor) are 0 in `FVDiffusion`. This eliminated the warnings in @snschune's input in #24257 which used a thermal conductivity of 0
- Switch advection interpolation default to `upwind` in the action