### PR TITLE
Don't use AD grad test neighbor in ADInterfaceKernel

### DIFF
--- a/framework/include/interfacekernels/ADInterfaceKernel.h
+++ b/framework/include/interfacekernels/ADInterfaceKernel.h
@@ -95,10 +95,10 @@ protected:
   const MooseArray<ADPoint> & _ad_q_point;
 
   /// shape function
-  const ADTemplateVariablePhiValue<T> & _phi;
+  const typename OutputTools<T>::VariablePhiValue & _phi;
 
   /// Side shape function.
-  const ADTemplateVariableTestValue<T> & _test;
+  const typename OutputTools<T>::VariableTestValue & _test;
 
   /// Gradient of side shape function
   const ADTemplateVariableTestGradient<T> & _grad_test;
@@ -113,13 +113,14 @@ protected:
   const ADTemplateVariableGradient<T> & _grad_neighbor_value;
 
   /// Side neighbor shape function.
-  const ADTemplateVariablePhiValue<T> & _phi_neighbor;
+  const typename OutputTools<T>::VariablePhiValue & _phi_neighbor;
 
   /// Side neighbor test function
-  const ADTemplateVariableTestValue<T> & _test_neighbor;
+  const typename OutputTools<T>::VariableTestValue & _test_neighbor;
 
-  /// Gradient of side neighbor shape function
-  const ADTemplateVariableTestGradient<T> & _grad_test_neighbor;
+  /// Gradient of side neighbor shape function. No AD because we have not implemented support for
+  /// neighbor AD FE data in Assembly
+  const typename OutputTools<T>::VariableTestGradient & _grad_test_neighbor;
 
   /// Holds residual entries as they are accumulated by this InterfaceKernel
   /// This variable is temporarily reserved for RattleSnake

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -115,6 +115,9 @@ std::string stringify(FEFamily f);
 /// Convert SolutionIterationType into string
 std::string stringify(SolutionIterationType t);
 
+/// Convert ElementType into string
+std::string stringify(ElementType t);
+
 /// Add pair stringify to support maps
 template <typename T, typename U>
 std::string

--- a/framework/include/variables/MooseVariableData.h
+++ b/framework/include/variables/MooseVariableData.h
@@ -12,6 +12,7 @@
 #include "MooseArray.h"
 #include "MooseTypes.h"
 #include "MooseVariableDataBase.h"
+#include "Conversion.h"
 
 #include "libmesh/tensor_tools.h"
 #include "libmesh/vector_value.h"
@@ -192,15 +193,12 @@ public:
   /**
    * ad_grad_phi getter
    */
-  const ADTemplateVariablePhiGradient<OutputShape> & adGradPhi() const { return *_ad_grad_phi; }
+  const ADTemplateVariablePhiGradient<OutputShape> & adGradPhi() const;
 
   /**
    * ad_grad_phi_face getter
    */
-  const ADTemplateVariablePhiGradient<OutputShape> & adGradPhiFace() const
-  {
-    return *_ad_grad_phi_face;
-  }
+  const ADTemplateVariablePhiGradient<OutputShape> & adGradPhiFace() const;
 
   /**
    * Return phi size
@@ -724,4 +722,24 @@ MooseVariableData<OutputType>::adUDotDot() const
     _need_u_dotdot = true;
 
   return _ad_u_dotdot;
+}
+
+template <typename OutputType>
+const ADTemplateVariablePhiGradient<typename MooseVariableData<OutputType>::OutputShape> &
+MooseVariableData<OutputType>::adGradPhi() const
+{
+  if (_element_type == Moose::ElementType::Neighbor || _element_type == Moose::ElementType::Lower)
+    mooseError("Unsupported element type: ", Moose::stringify(_element_type));
+  mooseAssert(_ad_grad_phi, "this should be non-null");
+  return *_ad_grad_phi;
+}
+
+template <typename OutputType>
+const ADTemplateVariablePhiGradient<typename MooseVariableData<OutputType>::OutputShape> &
+MooseVariableData<OutputType>::adGradPhiFace() const
+{
+  if (_element_type == Moose::ElementType::Neighbor || _element_type == Moose::ElementType::Lower)
+    mooseError("Unsupported element type: ", Moose::stringify(_element_type));
+  mooseAssert(_ad_grad_phi_face, "this should be non-null");
+  return *_ad_grad_phi_face;
 }

--- a/framework/src/interfacekernels/ADInterfaceKernel.C
+++ b/framework/src/interfacekernels/ADInterfaceKernel.C
@@ -56,7 +56,7 @@ ADInterfaceKernelTempl<T>::ADInterfaceKernelTempl(const InputParameters & parame
     _grad_neighbor_value(_neighbor_var.adGradSlnNeighbor()),
     _phi_neighbor(_assembly.phiFaceNeighbor(_neighbor_var)),
     _test_neighbor(_neighbor_var.phiFaceNeighbor()),
-    _grad_test_neighbor(_neighbor_var.adGradPhiFaceNeighbor())
+    _grad_test_neighbor(_neighbor_var.gradPhiFaceNeighbor())
 
 {
   _subproblem.haveADObjects(true);

--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -502,6 +502,22 @@ stringify(SolutionIterationType t)
 }
 
 std::string
+stringify(ElementType t)
+{
+  switch (t)
+  {
+    case ElementType::Element:
+      return "ELEMENT";
+    case ElementType::Neighbor:
+      return "NEIGHBOR";
+    case ElementType::Lower:
+      return "LOWER";
+    default:
+      mooseError("unrecognized type");
+  }
+}
+
+std::string
 stringify(const std::string & s)
 {
   return s;


### PR DESCRIPTION
Neighbor AD data is not implemented in Assembly at this time. Add some error checking to help guard against this in the future

Closes #24473