### PR TITLE
Fix error message conditions in XYDelaunayGenerator

### DIFF
--- a/framework/src/meshgenerators/XYDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYDelaunayGenerator.C
@@ -107,7 +107,7 @@ XYDelaunayGenerator::XYDelaunayGenerator(const InputParameters & parameters)
     paramError("stitch_holes", "Need one stitch_holes entry per hole, if specified.");
 
   for (auto hole_i : index_range(_stitch_holes))
-    if (hole_i < _refine_holes.size() && _stitch_holes[hole_i] && _refine_holes[hole_i])
+    if (_stitch_holes[hole_i] && (hole_i >= _refine_holes.size() || _refine_holes[hole_i]))
       paramError("refine_holes", "Disable auto refine of any hole boundary to be stitched.");
 }
 

--- a/framework/src/meshgenerators/XYDelaunayGenerator.C
+++ b/framework/src/meshgenerators/XYDelaunayGenerator.C
@@ -107,7 +107,7 @@ XYDelaunayGenerator::XYDelaunayGenerator(const InputParameters & parameters)
     paramError("stitch_holes", "Need one stitch_holes entry per hole, if specified.");
 
   for (auto hole_i : index_range(_stitch_holes))
-    if (hole_i < _refine_holes.size() && _refine_holes[hole_i])
+    if (hole_i < _refine_holes.size() && _stitch_holes[hole_i] && _refine_holes[hole_i])
       paramError("refine_holes", "Disable auto refine of any hole boundary to be stitched.");
 }
 


### PR DESCRIPTION
## Reason
@shikhar413 reported not seeing the expected error when he had holes marked for stitching but not for refinement.  I ran across an unexpected (and incorrect) error when I was bisecting #24474

## Design
Correct the logic in the if statement preceding paramError()

## Impact
No change to existing APIs, except that input files which could have silently and incorrectly generated non-conforming slit meshes will now exit with an error before trying.

Closes #24538