### PR TITLE
Displaced mesh must always be an exact clone

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -509,11 +509,21 @@ public:
 
   /**
    * Calls prepare_for_use() if the underlying MeshBase object isn't prepared, then communicates
-   * various boundary information on parallel meshes. Also calls update() internally
-   * @param force_mesh_prepare Whether to force a mesh preparation
-   * @return Whether the libMesh mesh was prepared
+   * various boundary information on parallel meshes. Also calls update() internally. Instead of
+   * calling \p prepare_for_use on the currently held \p MeshBase object, a \p mesh_to_clone can be
+   * provided. If it is provided (e.g. this method is given a non-null argument), then \p _mesh will
+   * be assigned a clone of the \p mesh_to_clone. The provided \p mesh_to_clone must already be
+   * prepared
+   * @param mesh_to_clone If nonnull, we will clone this mesh instead of preparing our current one
+   * @return Whether the libMesh mesh was prepared. This should really only be relevant in MOOSE
+   * framework contexts where we need to make a decision about what to do with the displaced mesh.
+   * If the reference mesh base object has \p prepare_for_use called (e.g. this method returns \p
+   * true when called for the reference mesh), then we must pass the reference mesh base object into
+   * this method when we call this for the displaced mesh. This is because the displaced mesh \emph
+   * must be an exact clone of the reference mesh. We have seen that \p prepare_for_use called on
+   * two previously identical meshes can result in two different meshes even with Metis partitioning
    */
-  bool prepare(bool force_mesh_prepare);
+  bool prepare(const MeshBase * mesh_to_clone);
 
   /**
    * Calls buildNodeListFromSideList(), buildNodeList(), and buildBndElemList().

--- a/framework/src/actions/SetupMeshCompleteAction.C
+++ b/framework/src/actions/SetupMeshCompleteAction.C
@@ -118,14 +118,15 @@ SetupMeshCompleteAction::act()
     bool prepare_for_use_called_on_undisplaced = false;
     {
       TIME_SECTION("completeSetupUndisplaced", 2, "Setting Up Undisplaced Mesh");
-      prepare_for_use_called_on_undisplaced = _mesh->prepare(/*force_mesh_prepare=*/false);
+      prepare_for_use_called_on_undisplaced = _mesh->prepare(/*mesh_to_clone=*/nullptr);
     }
 
     if (_displaced_mesh)
     {
       TIME_SECTION("completeSetupDisplaced", 2, "Setting Up Displaced Mesh");
       // If the reference mesh was prepared, then we must prepare also
-      _displaced_mesh->prepare(/*force_mesh_prepare=*/prepare_for_use_called_on_undisplaced);
+      _displaced_mesh->prepare(
+          /*mesh_to_clone=*/prepare_for_use_called_on_undisplaced ? &_mesh->getMesh() : nullptr);
     }
   }
 }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -343,7 +343,7 @@ MooseMesh::freeBndElems()
 }
 
 bool
-MooseMesh::prepare(const bool force_mesh_prepare)
+MooseMesh::prepare(const MeshBase * const mesh_to_clone)
 {
   TIME_SECTION("prepare", 2, "Preparing Mesh", true);
 
@@ -355,7 +355,14 @@ MooseMesh::prepare(const bool force_mesh_prepare)
     // For whatever reason we do not want to allow renumbering here nor ever in the future?
     getMesh().allow_renumbering(false);
 
-  if (!_mesh->is_prepared() || force_mesh_prepare)
+  if (mesh_to_clone)
+  {
+    mooseAssert(mesh_to_clone->is_prepared(),
+                "The mesh we wish to clone from must already be prepared");
+    _mesh = mesh_to_clone->clone();
+    _moose_mesh_prepared = false;
+  }
+  else if (!_mesh->is_prepared())
   {
     _mesh->prepare_for_use();
     _moose_mesh_prepared = false;

--- a/framework/src/outputs/OversampleOutput.C
+++ b/framework/src/outputs/OversampleOutput.C
@@ -272,7 +272,7 @@ OversampleOutput::cloneMesh()
     _cloned_mesh_ptr = std::make_unique<FileMesh>(mesh_params);
     _cloned_mesh_ptr->allowRecovery(false); // We actually want to reread the initial mesh
     _cloned_mesh_ptr->init();
-    _cloned_mesh_ptr->prepare(/*force_mesh_prepare=*/false);
+    _cloned_mesh_ptr->prepare(/*mesh_to_clone=*/nullptr);
     _cloned_mesh_ptr->meshChanged();
   }
 

--- a/modules/navier_stokes/unit/src/TestFaceCenteredMapFunctor.C
+++ b/modules/navier_stokes/unit/src/TestFaceCenteredMapFunctor.C
@@ -61,7 +61,7 @@ TEST(FaceCenteredMapFunctorTest, testArgs)
     mesh->setMeshBase(std::move(lm_mesh));
   }
 
-  mesh->prepare(false);
+  mesh->prepare(nullptr);
   MultiMooseEnum coord_type_enum("XYZ RZ RSPHERICAL", "XYZ");
   mesh->setCoordSystem({}, coord_type_enum);
   const auto & all_fi = mesh->allFaceInfo();

--- a/modules/navier_stokes/unit/src/TestReconstruction.C
+++ b/modules/navier_stokes/unit/src/TestReconstruction.C
@@ -81,7 +81,7 @@ testReconstruction(const Moose::CoordinateSystemType coord_type)
       mesh->setMeshBase(std::move(lm_mesh));
     }
 
-    mesh->prepare(false);
+    mesh->prepare(nullptr);
     mesh->setCoordSystem({}, coord_type_enum);
     mooseAssert(mesh->getAxisymmetricRadialCoord() == 0,
                 "This should be 0 because we haven't set anything.");

--- a/unit/src/ContainerFunctors.C
+++ b/unit/src/ContainerFunctors.C
@@ -61,7 +61,7 @@ TEST(ContainerFunctors, Test)
     mesh->setMeshBase(std::move(lm_mesh));
   }
 
-  mesh->prepare(false);
+  mesh->prepare(nullptr);
   mesh->setCoordSystem({}, coord_type_enum);
   mooseAssert(mesh->getAxisymmetricRadialCoord() == 0,
               "This should be 0 because we haven't set anything.");

--- a/unit/src/MooseCoordTest.C
+++ b/unit/src/MooseCoordTest.C
@@ -216,7 +216,7 @@ TEST(MooseCoordTest, testLengthUnit)
     mesh->setMeshBase(std::move(lm_mesh));
   }
 
-  mesh->prepare(false);
+  mesh->prepare(nullptr);
 
   EXPECT_TRUE(mesh->lengthUnit() == MooseUnits("1*m"));
 }

--- a/unit/src/MooseFunctorTest.C
+++ b/unit/src/MooseFunctorTest.C
@@ -272,7 +272,7 @@ TEST(MooseFunctorTest, testArgs)
     mesh->setMeshBase(std::move(lm_mesh));
   }
 
-  mesh->prepare(false);
+  mesh->prepare(nullptr);
   mesh->setCoordSystem({}, coord_type_enum);
   // Build the face info
   const auto & all_fi = mesh->allFaceInfo();


### PR DESCRIPTION
In #24018 we checked to see whether the reference mesh base object was prepared in `MooseMesh::prepare`, and if so then we would later also prepare the displaced mesh. The issue with this is that even Metis may yield different partitions for identical meshes and this plays havoc when we want to sync vectors between undisplaced and displaced meshes. Back when we had this problem in the past we proposed issue #12799 as a solution but ended up going with #12889 which has the same spirit as this new fix: *ensure* the displaced mesh is an exact copy of the reference mesh. Now of course I am getting paranoid about what can happen when we have adaptivity...

Thank you to discussion #24499 for illustrating that we had this issue crop up again