### PR TITLE
Hotfix for valgrind error arising from PR #24494

### DIFF
--- a/test/tests/materials/functor_conversion/conversion_vec.i
+++ b/test/tests/materials/functor_conversion/conversion_vec.i
@@ -25,7 +25,7 @@
   [u]
     order = FIRST
     family = LAGRANGE_VEC
-    initial_condition = 2
+    initial_condition = '2 2 2'
   []
 []
 
@@ -33,7 +33,7 @@
   [v]
     order = FIRST
     family = MONOMIAL_VEC
-    initial_condition = 3
+    initial_condition = '3 3 3'
   []
 []
 


### PR DESCRIPTION
- vector of shorthand IC syntax is not checked for dimension and it s a tad inconvenient to check as blocks may not be of the same dimension

Refs #24556
