### PR TITLE
Updates to Darcy Steps 3 through 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,4 +321,5 @@ share/
 /modules/reactor/unit/reactor-unit.yaml
 /modules/rdg/unit/rdg-unit.yaml
 /modules/fsi/unit/fsi-unit.yaml
-/tutorials/**/*.yaml
+/tutorials/tutorial01_app_development/*/babbler.yaml
+/tutorials/darcy_thermo_mech/*/darcy_thermo_mech.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -321,4 +321,4 @@ share/
 /modules/reactor/unit/reactor-unit.yaml
 /modules/rdg/unit/rdg-unit.yaml
 /modules/fsi/unit/fsi-unit.yaml
-/tutorials/tutorial01_app_development/**/babbler.yaml
+/tutorials/**/*.yaml

--- a/tutorials/darcy_thermo_mech/doc/content/workshop/problem/step03.md
+++ b/tutorials/darcy_thermo_mech/doc/content/workshop/problem/step03.md
@@ -24,8 +24,8 @@ viscosity.
 
 Both shall be computed with a single `Material` object: `PackedColumn`.
 
-As in the reference article, permeability varies with the size of the steel spheres, so linear
-interpolation will be used for defining this property.
+As in the reference article, permeability varies with the size of the steel spheres, so we'll
+perform an interpolation calculation for it over the range of valid values.
 
 !---
 

--- a/tutorials/darcy_thermo_mech/step03_darcy_material/include/materials/PackedColumn.h
+++ b/tutorials/darcy_thermo_mech/step03_darcy_material/include/materials/PackedColumn.h
@@ -11,9 +11,6 @@
 
 #include "Material.h"
 
-// A helper class from MOOSE that linear interpolates x,y data
-#include "LinearInterpolation.h"
-
 /**
  * Material objects inherit from Material and override computeQpProperties.
  *
@@ -37,10 +34,7 @@ protected:
   /// Value of viscosity from the input file
   const Real & _input_viscosity;
 
-  /// Compute permeability based on the radius (mm)
-  LinearInterpolation _permeability_interpolation;
-
-  /// The permeability (K)
+  /// The permeability (K) computed based on the radius (mm)
   ADMaterialProperty<Real> & _permeability;
 
   /// The viscosity of the fluid (mu)


### PR DESCRIPTION
Refs #24549

`LinearInterpolation` is removed from Darcy steps 3 through 5 (where it isn't really used, and isn't introduced). The utility is introduced in Step 6 with new slides, showing the differences and usefulness of the utility. 

This PR also fixes noticed typos. 