### PR TITLE
Less AD for explicit solves

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5902,11 +5902,7 @@ FEProblemBase::computeResidualSys(NonlinearImplicitSystem & sys,
 
   TIME_SECTION("computeResidualSys", 5);
 
-  ADReal::do_derivatives = false;
-
   computeResidual(soln, residual, sys.number());
-
-  ADReal::do_derivatives = true;
 }
 
 void
@@ -6224,6 +6220,8 @@ FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
 
   TIME_SECTION("computeResidualTags", 5, "Computing Residual");
 
+  ADReal::do_derivatives = false;
+
   setCurrentResidualVectorTags(tags);
 
   _aux->zeroVariablesForResidual();
@@ -6317,6 +6315,7 @@ FEProblemBase::computeResidualTags(const std::set<TagID> & tags)
   _current_nl_sys->computeResidualTags(tags);
 
   _safe_access_tagged_vectors = true;
+  ADReal::do_derivatives = true;
 
   // Reset execution flag as after this point we are no longer on LINEAR
   _current_execute_on_flag = EXEC_NONE;


### PR DESCRIPTION
ExplicitSSPRungeKutta for example does not call computeResidualSys so we were unnecessarily doing derivatives

Closes #24616

### sparsity_union before PR

![sparsity-union-filter](https://github.com/idaholab/moose/assets/10248304/c545f3cf-aaba-4a7c-92d1-a78f52928ccd)

### sparsity_union after PR

![with-opts-sparsity-union-filter](https://github.com/idaholab/moose/assets/10248304/827f195b-1a17-4c28-af91-1159db96ca12)
