### PR TITLE
Correct invalid temperature solves for negative temperatures. 

### DIFF
--- a/modules/heat_conduction/include/materials/HeatConductionMaterial.h
+++ b/modules/heat_conduction/include/materials/HeatConductionMaterial.h
@@ -16,7 +16,7 @@
 class Function;
 
 /**
- * Simple material with constant properties.
+ * Simple material with properties set as constants or by functions.
  */
 template <bool is_ad>
 class HeatConductionMaterialTempl : public Material
@@ -41,6 +41,9 @@ protected:
 
   GenericMaterialProperty<Real, is_ad> & _specific_heat;
   const Function * const _specific_heat_temperature_function;
+
+  /// Minimum temperature, below which temperature is "clipped" before evaluating functions
+  const Real * _min_T;
 };
 
 typedef HeatConductionMaterialTempl<false> HeatConductionMaterial;

--- a/modules/heat_conduction/include/materials/HeatConductionMaterial.h
+++ b/modules/heat_conduction/include/materials/HeatConductionMaterial.h
@@ -27,7 +27,7 @@ public:
   HeatConductionMaterialTempl(const InputParameters & parameters);
 
 protected:
-  virtual void computeProperties();
+  virtual void computeQpProperties() override;
 
   const bool _has_temp;
   const GenericVariableValue<is_ad> & _temperature;

--- a/modules/heat_conduction/src/materials/HeatConductionMaterial.C
+++ b/modules/heat_conduction/src/materials/HeatConductionMaterial.C
@@ -80,27 +80,12 @@ HeatConductionMaterialTempl<is_ad>::computeProperties()
 {
   for (unsigned int qp(0); qp < _qrule->n_points(); ++qp)
   {
-    auto qp_temperature = _temperature[qp];
-    if (_has_temp)
-    {
-      if (qp_temperature < 0)
-      {
-        std::stringstream msg;
-        msg << "WARNING:  In HeatConductionMaterial:  negative temperature!\n"
-            << "\tResetting to zero.\n"
-            << "\t_qp: " << qp << "\n"
-            << "\ttemp: " << qp_temperature << "\n"
-            << "\telem: " << _current_elem->id() << "\n"
-            << "\tproc: " << processor_id() << "\n";
-        mooseWarning(msg.str());
-        qp_temperature = 0;
-      }
-    }
     if (_thermal_conductivity_temperature_function)
     {
-      _thermal_conductivity[qp] = _thermal_conductivity_temperature_function->value(qp_temperature);
+      _thermal_conductivity[qp] =
+          _thermal_conductivity_temperature_function->value(_temperature[_qp]);
       _thermal_conductivity_dT[qp] = _thermal_conductivity_temperature_function->timeDerivative(
-          MetaPhysicL::raw_value(qp_temperature));
+          MetaPhysicL::raw_value(_temperature[_qp]));
     }
     else
     {
@@ -109,7 +94,7 @@ HeatConductionMaterialTempl<is_ad>::computeProperties()
     }
 
     if (_specific_heat_temperature_function)
-      _specific_heat[qp] = _specific_heat_temperature_function->value(qp_temperature);
+      _specific_heat[qp] = _specific_heat_temperature_function->value(_temperature[_qp]);
     else
       _specific_heat[qp] = _my_specific_heat;
   }

--- a/modules/heat_conduction/src/materials/HeatConductionMaterial.C
+++ b/modules/heat_conduction/src/materials/HeatConductionMaterial.C
@@ -76,28 +76,25 @@ HeatConductionMaterialTempl<is_ad>::HeatConductionMaterialTempl(const InputParam
 
 template <bool is_ad>
 void
-HeatConductionMaterialTempl<is_ad>::computeProperties()
+HeatConductionMaterialTempl<is_ad>::computeQpProperties()
 {
-  for (unsigned int qp(0); qp < _qrule->n_points(); ++qp)
+  if (_thermal_conductivity_temperature_function)
   {
-    if (_thermal_conductivity_temperature_function)
-    {
-      _thermal_conductivity[qp] =
-          _thermal_conductivity_temperature_function->value(_temperature[_qp]);
-      _thermal_conductivity_dT[qp] = _thermal_conductivity_temperature_function->timeDerivative(
-          MetaPhysicL::raw_value(_temperature[_qp]));
-    }
-    else
-    {
-      _thermal_conductivity[qp] = _my_thermal_conductivity;
-      _thermal_conductivity_dT[qp] = 0;
-    }
-
-    if (_specific_heat_temperature_function)
-      _specific_heat[qp] = _specific_heat_temperature_function->value(_temperature[_qp]);
-    else
-      _specific_heat[qp] = _my_specific_heat;
+    _thermal_conductivity[_qp] =
+        _thermal_conductivity_temperature_function->value(_temperature[_qp]);
+    _thermal_conductivity_dT[_qp] = _thermal_conductivity_temperature_function->timeDerivative(
+        MetaPhysicL::raw_value(_temperature[_qp]));
   }
+  else
+  {
+    _thermal_conductivity[_qp] = _my_thermal_conductivity;
+    _thermal_conductivity_dT[_qp] = 0;
+  }
+
+  if (_specific_heat_temperature_function)
+    _specific_heat[_qp] = _specific_heat_temperature_function->value(_temperature[_qp]);
+  else
+    _specific_heat[_qp] = _my_specific_heat;
 }
 
 template class HeatConductionMaterialTempl<false>;


### PR DESCRIPTION
This warning is invalid if temperature is in units of celsius, fahrenheit, or non-dimensional units. All of these units can be negative.

This isn't just a nuisance - because it's changing the value of a material property by evaluating it at zero-temperature, this is giving WRONG simulations for negative temperatures. For example, below is a hypothetical model for thermal conductivity which is going to be modified by the original code to the wrong correlation.

![Screen Shot 2023-06-08 at 6 03 58 PM](https://github.com/idaholab/moose/assets/17039662/4e52a4be-7d0a-4df5-a49b-4574bb798478)

Closes #24635 