### PR TITLE
Disable XYDelaunay exodiff tests temporarily

### DIFF
--- a/test/tests/meshgenerators/circular_correction_generator/tests
+++ b/test/tests/meshgenerators/circular_correction_generator/tests
@@ -9,14 +9,15 @@
     requirement = 'The system shall correct full circular boundaries radii to preserve areas.'
     recover = false
   []
-  [partial_curve_rad]
-    type = 'Exodiff'
-    input = 'partial_circle_rad.i'
-    exodiff = 'partial_circle_rad_in.e'
-    cli_args = '--mesh-only'
-    requirement = 'The system shall correct partial circular boundaries radii to preserve areas by moving all the nodes in the radial direction.'
-    recover = false
-  []
+# Temporarily disabled for Exodiff-breaking triangulator upgrades
+#  [partial_curve_rad]
+#    type = 'Exodiff'
+#    input = 'partial_circle_rad.i'
+#    exodiff = 'partial_circle_rad_in.e'
+#    cli_args = '--mesh-only'
+#    requirement = 'The system shall correct partial circular boundaries radii to preserve areas by moving all the nodes in the radial direction.'
+#    recover = false
+#  []
   [partial_curve_span]
     type = 'Exodiff'
     input = 'partial_circle_span.i'

--- a/test/tests/meshgenerators/xy_delaunay_generator/tests
+++ b/test/tests/meshgenerators/xy_delaunay_generator/tests
@@ -68,14 +68,15 @@
       recover = false
       detail = "assigning user-provided hole boundary names"
     []
-    [stitching]
-      type = 'Exodiff'
-      input = 'xydelaunay_stitching.i'
-      cli_args = '--mesh-only'
-      exodiff = 'xydelaunay_stitching_in.e'
-      recover = false
-      detail = "selectively stitching 'hole' meshes into the final mesh"
-    []
+# Temporarily disabled for Exodiff-breaking triangulator upgrades
+#    [stitching]
+#      type = 'Exodiff'
+#      input = 'xydelaunay_stitching.i'
+#      cli_args = '--mesh-only'
+#      exodiff = 'xydelaunay_stitching_in.e'
+#      recover = false
+#      detail = "selectively stitching 'hole' meshes into the final mesh"
+#    []
     [nested]
       type = 'Exodiff'
       input = 'xydelaunay_nested.i'
@@ -92,13 +93,14 @@
       recover = false
       detail = "with optional Laplacian mesh smoothing."
     []
-    [area_func]
-      type = 'Exodiff'
-      input = 'xydelaunay_area_func.i'
-      cli_args = '--mesh-only'
-      exodiff = 'xydelaunay_area_func_in.e'
-      recover = false
-      detail = "with optional non-uniform refinement."
-    []
+# Temporarily disabled for Exodiff-breaking triangulator upgrades
+#    [area_func]
+#      type = 'Exodiff'
+#      input = 'xydelaunay_area_func.i'
+#      cli_args = '--mesh-only'
+#      exodiff = 'xydelaunay_area_func_in.e'
+#      recover = false
+#      detail = "with optional non-uniform refinement."
+#    []
   []
 []


### PR DESCRIPTION
These aren't compatible with the fixed + improved exodiff behavior in https://github.com/libMesh/libmesh/pull/3572 - we'll need to regold them this week when we do the next libMesh submodule update.

Refs #20192