### PR TITLE
Material storage and interface cleanup

### DIFF
--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -491,10 +491,13 @@ public:
     for (unsigned int i = 0; i < objs.size(); i++)
     {
       auto obj = objs[i];
-      mooseAssert(dynamic_cast<T *>(obj),
-                  "queried object has incompatible c++ type for object named " + obj->name());
+      mooseAssert(obj, "Null object");
+      auto cast_obj = dynamic_cast<T *>(obj);
+      if (obj)
+        mooseAssert(cast_obj,
+                    "Queried object has incompatible c++ type for object named " + obj->name());
       if (show_all || obj->enabled())
-        results.push_back(dynamic_cast<T *>(obj));
+        results.push_back(cast_obj);
     }
     return results;
   }

--- a/framework/include/base/TheWarehouse.h
+++ b/framework/include/base/TheWarehouse.h
@@ -488,9 +488,8 @@ public:
     auto & objs = query(query_id);
     results.clear();
     results.reserve(objs.size());
-    for (unsigned int i = 0; i < objs.size(); i++)
+    for (auto & obj : objs)
     {
-      auto obj = objs[i];
       mooseAssert(obj, "Null object");
       auto cast_obj = dynamic_cast<T *>(obj);
       if (obj)

--- a/framework/include/loops/ComputeFVFluxThread.h
+++ b/framework/include/loops/ComputeFVFluxThread.h
@@ -587,7 +587,7 @@ ComputeFVFluxThread<RangeType, AttributeTagType>::checkPropDeps(
       auto pr = supplied_props.insert(prop_id);
       if (!pr.second)
       {
-        const auto & prop_ids = MaterialPropertyStorage::propIDs();
+        const auto & prop_ids = _fe_problem.getMaterialPropertyRegistry().getNamesToIDs();
         auto same_matprop_name_it =
             std::find_if(prop_ids.begin(),
                          prop_ids.end(),

--- a/framework/include/materials/InterfaceMaterial.h
+++ b/framework/include/materials/InterfaceMaterial.h
@@ -46,35 +46,63 @@ public:
    * to getting it by name
    */
   template <typename T, bool is_ad>
-  const auto & getGenericMaterialProperty(const std::string & name)
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericMaterialProperty(const std::string & name, const unsigned int state = 0);
+  template <typename T>
+  const MaterialProperty<T> & getMaterialProperty(const std::string & name,
+                                                  const unsigned int state = 0)
   {
-    if constexpr (is_ad)
-      return getADMaterialProperty<T>(name);
-    else
-      return getMaterialProperty<T>(name);
+    return getGenericMaterialProperty<T, false>(name, state);
   }
   template <typename T>
-  const MaterialProperty<T> & getMaterialProperty(const std::string & name);
+  const ADMaterialProperty<T> & getADMaterialProperty(const std::string & name)
+  {
+    return getGenericMaterialProperty<T, true>(name, 0);
+  }
   template <typename T>
-  const ADMaterialProperty<T> & getADMaterialProperty(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name)
+  {
+    return getGenericMaterialProperty<T, false>(name, 1);
+  }
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOld(const std::string & name);
-  template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getMaterialPropertyOlder(const std::string & name)
+  {
+    return getGenericMaterialProperty<T, false>(name, 2);
+  }
   ///@}
 
   ///@{
   /**
    * Retrieve the property named "name"
    */
+  template <typename T, bool is_ad>
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericMaterialPropertyByName(const std::string & name, const unsigned int state = 0);
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyByName(const std::string & prop_name,
+                                                        const unsigned int state = 0)
+  {
+
+    return getGenericMaterialPropertyByName<T, false>(prop_name, state);
+  }
   template <typename T>
-  const ADMaterialProperty<T> & getADMaterialPropertyByName(const std::string & prop_name);
+  const ADMaterialProperty<T> & getADMaterialPropertyByName(const std::string & prop_name)
+  {
+
+    return getGenericMaterialPropertyByName<T, true>(prop_name, 0);
+  }
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOldByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyOldByName(const std::string & prop_name)
+  {
+
+    return getGenericMaterialPropertyByName<T, false>(prop_name, 1);
+  }
   template <typename T>
-  const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name);
+  const MaterialProperty<T> & getMaterialPropertyOlderByName(const std::string & prop_name)
+  {
+
+    return getGenericMaterialPropertyByName<T, false>(prop_name, 2);
+  }
   ///@}
 
   ///@{
@@ -82,28 +110,50 @@ public:
    * Retrieve the neighbor property through a given input parameter key with a fallback
    * to getting it by name
    */
+  template <typename T, bool is_ad>
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericNeighborMaterialProperty(const std::string & name, const unsigned int state = 0);
   template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialProperty(const std::string & name);
-
+  const MaterialProperty<T> & getNeighborMaterialProperty(const std::string & name,
+                                                          const unsigned int state = 0)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, state);
+  }
   template <typename T>
-  const ADMaterialProperty<T> & getNeighborADMaterialProperty(const std::string & name);
-
+  const ADMaterialProperty<T> & getNeighborADMaterialProperty(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, true>(name, 0);
+  }
   template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyOld(const std::string & name);
+  const MaterialProperty<T> & getNeighborMaterialPropertyOld(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, 1);
+  }
   template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyOlder(const std::string & name);
+  const MaterialProperty<T> & getNeighborMaterialPropertyOlder(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, 2);
+  }
   ///@}
 
   ///@{
   /**
    * Retrieve the neighbor property named "name"
    */
+  template <typename T, bool is_ad>
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericNeighborMaterialPropertyByName(const std::string & name, const unsigned int state = 0);
   template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyByName(const std::string & prop_name);
-
+  const MaterialProperty<T> & getNeighborMaterialPropertyByName(const std::string & prop_name,
+                                                                const unsigned int state = 0)
+  {
+    return getGenericNeighborMaterialPropertyByName<T, false>(prop_name, state);
+  }
   template <typename T>
-  const ADMaterialProperty<T> & getNeighborADMaterialPropertyByName(const std::string & name);
-
+  const ADMaterialProperty<T> & getNeighborADMaterialPropertyByName(const std::string & prop_name)
+  {
+    return getGenericNeighborMaterialPropertyByName<T, true>(prop_name, 0);
+  }
   ///@}
 
   using MaterialBase::getZeroMaterialProperty;
@@ -136,186 +186,73 @@ protected:
   const unsigned int & _neighbor_side;
 };
 
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialProperty(const std::string & name)
+template <typename T, bool is_ad>
+const GenericMaterialProperty<T, is_ad> &
+InterfaceMaterial::getGenericMaterialProperty(const std::string & name, const unsigned int state)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
 
   // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
+  if (const auto * default_property = defaultGenericMaterialProperty<T, is_ad>(prop_name))
     return *default_property;
 
-  return getMaterialPropertyByName<T>(prop_name);
+  return getGenericMaterialPropertyByName<T, is_ad>(prop_name, state);
 }
 
-template <typename T>
-const ADMaterialProperty<T> &
-InterfaceMaterial::getADMaterialProperty(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
-
-  // Check if it's just a constant.
-  const ADMaterialProperty<T> * default_property = defaultADMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
-
-  return getADMaterialPropertyByName<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialPropertyOld(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
-
-  // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
-
-  return getMaterialPropertyOldByName<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialPropertyOlder(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
-
-  // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
-
-  return getMaterialPropertyOlderByName<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialPropertyByName(const std::string & prop_name)
+template <typename T, bool is_ad>
+const GenericMaterialProperty<T, is_ad> &
+InterfaceMaterial::getGenericMaterialPropertyByName(const std::string & prop_name,
+                                                    const unsigned int state)
 {
   MaterialBase::checkExecutionStage();
+
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the
   // same memory)
-  _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, MaterialPropState::CURRENT);
-  return TwoMaterialPropertyInterface::getMaterialPropertyByName<T>(prop_name);
+  if (state == 0)
+    _requested_props.insert(prop_name);
+
+  // Do this before hand so that the propery id is defined
+  auto & prop =
+      TwoMaterialPropertyInterface::getGenericMaterialPropertyByName<T, is_ad>(prop_name, state);
+
+  registerPropName(prop_name, true, state);
+
+  return prop;
 }
 
-template <typename T>
-const ADMaterialProperty<T> &
-InterfaceMaterial::getADMaterialPropertyByName(const std::string & prop_name)
-{
-  MaterialBase::checkExecutionStage();
-  // The property may not exist yet, so declare it (declare/getADMaterialProperty are referencing
-  // the same memory)
-  _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, MaterialPropState::CURRENT);
-  return TwoMaterialPropertyInterface::getADMaterialPropertyByName<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialPropertyOldByName(const std::string & prop_name)
-{
-  registerPropName(prop_name, true, MaterialPropState::OLD);
-  return TwoMaterialPropertyInterface::getMaterialPropertyOldByName<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getMaterialPropertyOlderByName(const std::string & prop_name)
-{
-  registerPropName(prop_name, true, MaterialPropState::OLDER);
-  return TwoMaterialPropertyInterface::getMaterialPropertyOlderByName<T>(prop_name);
-}
-
-// Neighbor material properties
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getNeighborMaterialProperty(const std::string & name)
+template <typename T, bool is_ad>
+const GenericMaterialProperty<T, is_ad> &
+InterfaceMaterial::getGenericNeighborMaterialProperty(const std::string & name,
+                                                      const unsigned int state)
 {
   // Check if the supplied parameter is a valid input parameter key
   std::string prop_name = deducePropertyName(name);
 
   // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
+  if (const auto * default_property = defaultGenericMaterialProperty<T, is_ad>(prop_name))
     return *default_property;
 
-  return getNeighborMaterialPropertyByName<T>(prop_name);
+  return getGenericNeighborMaterialPropertyByName<T, is_ad>(prop_name, state);
 }
 
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getNeighborMaterialPropertyByName(const std::string & prop_name)
+template <typename T, bool is_ad>
+const GenericMaterialProperty<T, is_ad> &
+InterfaceMaterial::getGenericNeighborMaterialPropertyByName(const std::string & name,
+                                                            const unsigned int state)
 {
   MaterialBase::checkExecutionStage();
+
   // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the
   // same memory)
-  _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, MaterialPropState::CURRENT);
-  return TwoMaterialPropertyInterface::getNeighborMaterialPropertyByName<T>(prop_name);
-}
-template <typename T>
-const ADMaterialProperty<T> &
-InterfaceMaterial::getNeighborADMaterialProperty(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
+  if (state == 0)
+    _requested_props.insert(name);
 
-  // Check if it's just a constant.
-  const ADMaterialProperty<T> * default_property = defaultADMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
+  // Do this before hand so that the propery id is defined
+  auto & prop =
+      TwoMaterialPropertyInterface::getGenericNeighborMaterialPropertyByName<T, is_ad>(name, state);
 
-  return getNeighborADMaterialPropertyByName<T>(prop_name);
-}
+  registerPropName(name, true, state);
 
-template <typename T>
-const ADMaterialProperty<T> &
-InterfaceMaterial::getNeighborADMaterialPropertyByName(const std::string & prop_name)
-{
-  MaterialBase::checkExecutionStage();
-  // The property may not exist yet, so declare it (declare/getMaterialProperty are referencing the
-  // same memory)
-  _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, MaterialPropState::CURRENT);
-  return TwoMaterialPropertyInterface::getNeighborADMaterialPropertyByName<T>(prop_name);
-}
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getNeighborMaterialPropertyOld(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
-
-  // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
-
-  return TwoMaterialPropertyInterface::getNeighborMaterialPropertyOld<T>(prop_name);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-InterfaceMaterial::getNeighborMaterialPropertyOlder(const std::string & name)
-{
-  // Check if the supplied parameter is a valid input parameter key
-  std::string prop_name = deducePropertyName(name);
-
-  // Check if it's just a constant.
-  const MaterialProperty<T> * default_property = defaultMaterialProperty<T>(prop_name);
-  if (default_property)
-    return *default_property;
-
-  return TwoMaterialPropertyInterface::getNeighborMaterialPropertyOlder<T>(prop_name);
+  return prop;
 }

--- a/framework/include/materials/InterfaceMaterial.h
+++ b/framework/include/materials/InterfaceMaterial.h
@@ -44,6 +44,8 @@ public:
   /**
    * Retrieve the property through a given input parameter key with a fallback
    * to getting it by name
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T, bool is_ad>
   const GenericMaterialProperty<T, is_ad> &
@@ -74,6 +76,8 @@ public:
   ///@{
   /**
    * Retrieve the property named "name"
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T, bool is_ad>
   const GenericMaterialProperty<T, is_ad> &
@@ -109,6 +113,8 @@ public:
   /**
    * Retrieve the neighbor property through a given input parameter key with a fallback
    * to getting it by name
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T, bool is_ad>
   const GenericMaterialProperty<T, is_ad> &
@@ -139,6 +145,8 @@ public:
   ///@{
   /**
    * Retrieve the neighbor property named "name"
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T, bool is_ad>
   const GenericMaterialProperty<T, is_ad> &

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -375,7 +375,7 @@ MaterialBase::declarePropertyOld(const std::string & prop_name)
       mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
                       "getMaterialPropertyOld (only) if a reference is required in this class."));
   registerPropName(prop_name, false, MaterialPropState::OLD);
-  return materialData().declarePropertyOld<T>(prop_name);
+  return materialData().getProperty<T>(prop_name, 1);
 }
 
 template <typename T>
@@ -386,7 +386,7 @@ MaterialBase::declarePropertyOlder(const std::string & prop_name)
       mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
                       "getMaterialPropertyOlder (only) if a reference is required in this class."));
   registerPropName(prop_name, false, MaterialPropState::OLDER);
-  return materialData().declarePropertyOlder<T>(prop_name);
+  return materialData().getProperty<T>(prop_name, 2);
 }
 
 template <typename T, bool is_ad>

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -362,7 +362,7 @@ MaterialBase::declareGenericPropertyByName(const std::string & prop_name)
           : MooseUtils::join(std::vector<std::string>({prop_name, _declare_suffix}), "_");
 
   // Call this before so that the ID is valid
-  auto & prop = materialData().getGenericProperty<T, is_ad>(prop_name_modified);
+  auto & prop = materialData().declareProperty<T, is_ad>(prop_name_modified, *this);
 
   registerPropName(prop_name_modified, false, 0);
   return prop;
@@ -385,7 +385,7 @@ const GenericMaterialProperty<T, is_ad> &
 MaterialBase::getGenericZeroMaterialPropertyByName(const std::string & prop_name)
 {
   checkExecutionStage();
-  auto & preload_with_zero = materialData().getGenericProperty<T, is_ad>(prop_name);
+  auto & preload_with_zero = materialData().getProperty<T, is_ad>(prop_name, 0, *this);
 
   _requested_props.insert(prop_name);
   registerPropName(prop_name, true, 0);

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -318,7 +318,8 @@ protected:
     PREV
   };
 
-  std::map<std::string, MaterialPropStateInt> _props_to_flags;
+  /// The minimum states requested (0 = current, 1 = old, 2 = older)
+  std::unordered_map<unsigned int, unsigned int> _props_to_min_states;
 
   /// Small helper function to call store{Subdomain,Boundary}MatPropName
   void registerPropName(const std::string & prop_name, bool is_get, const unsigned int state);

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -120,10 +120,6 @@ public:
   template <typename T>
   MaterialProperty<T> & declareProperty(const std::string & name);
   template <typename T>
-  MaterialProperty<T> & declarePropertyOld(const std::string & prop_name);
-  template <typename T>
-  MaterialProperty<T> & declarePropertyOlder(const std::string & prop_name);
-  template <typename T>
   ADMaterialProperty<T> & declareADPropertyByName(const std::string & prop_name);
   template <typename T>
   ADMaterialProperty<T> & declareADProperty(const std::string & name);
@@ -365,28 +361,6 @@ MaterialBase::declarePropertyByName(const std::string & prop_name_in)
           : MooseUtils::join(std::vector<std::string>({prop_name_in, _declare_suffix}), "_");
   registerPropName(prop_name, false, MaterialPropState::CURRENT);
   return materialData().declareProperty<T>(prop_name);
-}
-
-template <typename T>
-MaterialProperty<T> &
-MaterialBase::declarePropertyOld(const std::string & prop_name)
-{
-  mooseDoOnce(
-      mooseDeprecated("declarePropertyOld is deprecated and not needed anymore.\nUse "
-                      "getMaterialPropertyOld (only) if a reference is required in this class."));
-  registerPropName(prop_name, false, MaterialPropState::OLD);
-  return materialData().getProperty<T>(prop_name, 1);
-}
-
-template <typename T>
-MaterialProperty<T> &
-MaterialBase::declarePropertyOlder(const std::string & prop_name)
-{
-  mooseDoOnce(
-      mooseDeprecated("declarePropertyOlder is deprecated and not needed anymore.  Use "
-                      "getMaterialPropertyOlder (only) if a reference is required in this class."));
-  registerPropName(prop_name, false, MaterialPropState::OLDER);
-  return materialData().getProperty<T>(prop_name, 2);
 }
 
 template <typename T, bool is_ad>

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -321,7 +321,7 @@ protected:
   std::map<std::string, MaterialPropStateInt> _props_to_flags;
 
   /// Small helper function to call store{Subdomain,Boundary}MatPropName
-  void registerPropName(const std::string & prop_name, bool is_get, MaterialPropState state);
+  void registerPropName(const std::string & prop_name, bool is_get, const unsigned int state);
 
   /// Check and throw an error if the execution has progressed past the construction stage
   void checkExecutionStage();
@@ -361,9 +361,9 @@ MaterialBase::declareGenericPropertyByName(const std::string & prop_name)
           : MooseUtils::join(std::vector<std::string>({prop_name, _declare_suffix}), "_");
 
   // Call this before so that the ID is valid
-  auto & prop = materialData().declareGenericProperty<T, is_ad>(prop_name_modified);
+  auto & prop = materialData().getGenericProperty<T, is_ad>(prop_name_modified);
 
-  registerPropName(prop_name_modified, false, MaterialPropState::CURRENT);
+  registerPropName(prop_name_modified, false, 0);
   return prop;
 }
 
@@ -387,7 +387,7 @@ MaterialBase::getGenericZeroMaterialPropertyByName(const std::string & prop_name
   auto & preload_with_zero = materialData().getGenericProperty<T, is_ad>(prop_name);
 
   _requested_props.insert(prop_name);
-  registerPropName(prop_name, true, MaterialPropState::CURRENT);
+  registerPropName(prop_name, true, 0);
   _fe_problem.markMatPropRequested(prop_name);
 
   // Register this material on these blocks and boundaries as a zero property with relaxed

--- a/framework/include/materials/MaterialBase.h
+++ b/framework/include/materials/MaterialBase.h
@@ -319,6 +319,8 @@ protected:
   };
 
   /// The minimum states requested (0 = current, 1 = old, 2 = older)
+  /// This is sparse and is used to keep track of whether or not stateful
+  /// properties are requested without state 0 being requested
   std::unordered_map<unsigned int, unsigned int> _props_to_min_states;
 
   /// Small helper function to call store{Subdomain,Boundary}MatPropName

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -103,14 +103,6 @@ public:
   MaterialProperties & props(const unsigned int state = 0);
   ///@}
 
-  ///@{
-  /**
-   * Deprecated Methods for retrieving older MaterialProperties objects
-   */
-  MaterialProperties & propsOld() { return props(1); }
-  MaterialProperties & propsOlder() { return props(2); }
-  ///@}
-
   template <typename T, bool is_ad>
   bool haveGenericProperty(const std::string & prop_name) const;
 

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -44,29 +44,29 @@ public:
   unsigned int nQPoints() const { return _n_qpoints; }
 
   /**
-   * Declare the Real valued property named "name".
-   * Calling any of the declareProperty
-   * functions multiple times with the same property name is okay and
-   * will result in a single identical reference returned every time.
+   * Declare the normal/AD/generic valued property named \p prop_name.
+   *
+   * Calling any of these functions multiple times with the same property
+   * name is okay and will result in a single identical reference returned
+   * every time.
    */
+  ///@{
+  template <typename T, bool is_ad>
+  GenericMaterialProperty<T, is_ad> & declareGenericProperty(const std::string & prop_name)
+  {
+    return declareHelper<T, is_ad>(prop_name, 0);
+  }
   template <typename T>
   MaterialProperty<T> & declareProperty(const std::string & prop_name)
   {
-    return declareHelper<T, false>(prop_name, 0);
-    ;
+    return declareGenericProperty<T, false>(prop_name);
   }
-
-  /**
-   * Declare the AD property named "name".
-   * Calling any of the declareProperty
-   * functions multiple times with the same property name is okay and
-   * will result in a single identical reference returned every time.
-   */
   template <typename T>
   ADMaterialProperty<T> & declareADProperty(const std::string & prop_name)
   {
-    return declareHelper<T, true>(prop_name, 0);
+    return declareGenericProperty<T, true>(prop_name);
   }
+  //@}
 
   /// copy material properties from one element to another
   void copy(const Elem & elem_to, const Elem & elem_from, unsigned int side);

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -43,31 +43,6 @@ public:
    */
   unsigned int nQPoints() const { return _n_qpoints; }
 
-  /**
-   * Declare the normal/AD/generic valued property named \p prop_name.
-   *
-   * Calling any of these functions multiple times with the same property
-   * name is okay and will result in a single identical reference returned
-   * every time.
-   */
-  ///@{
-  template <typename T, bool is_ad>
-  GenericMaterialProperty<T, is_ad> & declareGenericProperty(const std::string & prop_name)
-  {
-    return declareHelper<T, is_ad>(prop_name, 0);
-  }
-  template <typename T>
-  MaterialProperty<T> & declareProperty(const std::string & prop_name)
-  {
-    return declareGenericProperty<T, false>(prop_name);
-  }
-  template <typename T>
-  ADMaterialProperty<T> & declareADProperty(const std::string & prop_name)
-  {
-    return declareGenericProperty<T, true>(prop_name);
-  }
-  //@}
-
   /// copy material properties from one element to another
   void copy(const Elem & elem_to, const Elem & elem_from, unsigned int side);
 
@@ -129,10 +104,7 @@ public:
    */
   template <typename T, bool is_ad>
   GenericMaterialProperty<T, is_ad> & getGenericProperty(const std::string & prop_name,
-                                                         const unsigned int state = 0)
-  {
-    return declareHelper<T, is_ad>(prop_name, state);
-  }
+                                                         const unsigned int state = 0);
   template <typename T>
   MaterialProperty<T> & getProperty(const std::string & prop_name, const unsigned int state = 0)
   {
@@ -142,16 +114,6 @@ public:
   ADMaterialProperty<T> & getADProperty(const std::string & prop_name)
   {
     return getGenericProperty<T, true>(prop_name, 0);
-  }
-  template <typename T>
-  MaterialProperty<T> & getPropertyOld(const std::string & prop_name)
-  {
-    return declareHelper<T, false>(prop_name, 1);
-  }
-  template <typename T>
-  MaterialProperty<T> & getPropertyOlder(const std::string & prop_name)
-  {
-    return declareHelper<T, false>(prop_name, 2);
   }
   ///@}
 
@@ -239,10 +201,6 @@ private:
   /// Use non-destructive resize of material data (calling resize() will not reduce size).
   /// Default is false (normal resize behaviour)
   bool _resize_only_if_smaller;
-
-  template <typename T, bool is_ad>
-  GenericMaterialProperty<T, is_ad> & declareHelper(const std::string & prop_name,
-                                                    const unsigned int state);
 };
 
 inline const MaterialProperties &
@@ -297,7 +255,7 @@ MaterialData::resizeProps(unsigned int id)
 
 template <typename T, bool is_ad>
 GenericMaterialProperty<T, is_ad> &
-MaterialData::declareHelper(const std::string & prop_name, const unsigned int state)
+MaterialData::getGenericProperty(const std::string & prop_name, const unsigned int state)
 {
   if constexpr (is_ad)
     mooseAssert(state == 0, "Can only request/declare for states other than zero");

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -47,9 +47,6 @@ public:
   /// copy material properties from one element to another
   void copy(const Elem & elem_to, const Elem & elem_from, unsigned int side);
 
-  /// copy material properties from one element to another
-  void copy(const Elem * elem_to, const Elem * elem_from, unsigned int side);
-
   /// material properties for given element (and possible side)
   void swap(const Elem & elem, unsigned int side = 0);
 

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -102,7 +102,7 @@ public:
    * @param requestor The MooseObject requesting the property
    * @return The property for the supplied type and name
    */
-  template <typename T, bool is_ad>
+  template <typename T, bool is_ad = false>
   GenericMaterialProperty<T, is_ad> & getProperty(const std::string & prop_name,
                                                   const unsigned int state,
                                                   const MooseObject & requestor)

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -41,7 +41,7 @@ public:
    * Returns the number of quadrature points the material properties
    * support/hold.
    */
-  unsigned int nQPoints() const;
+  unsigned int nQPoints() const { return _n_qpoints; }
 
   /**
    * Declare the Real valued property named "name".
@@ -158,7 +158,7 @@ public:
   /**
    * Returns true if the stateful material is in a swapped state.
    */
-  bool isSwapped() const;
+  bool isSwapped() const { return _swapped; }
 
   /**
    * Provide read-only access to the underlying MaterialPropertyStorage object.
@@ -300,8 +300,7 @@ GenericMaterialProperty<T, is_ad> &
 MaterialData::declareHelper(const std::string & prop_name, const unsigned int state)
 {
   if constexpr (is_ad)
-    if (state != 0)
-      mooseError("Cannot request/declare AD properties for states other than zero");
+    mooseAssert(state == 0, "Can only request/declare for states other than zero");
 
   const auto prop_id = _storage.addProperty(prop_name, state);
   resizeProps<T, is_ad>(prop_id);

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -258,7 +258,7 @@ GenericMaterialProperty<T, is_ad> &
 MaterialData::getGenericProperty(const std::string & prop_name, const unsigned int state)
 {
   if constexpr (is_ad)
-    mooseAssert(state == 0, "Can only request/declare for states other than zero");
+    mooseAssert(state == 0, "Cannot request/declare AD properties for states other than zero");
 
   const auto prop_id = _storage.addProperty(prop_name, state);
   resizeProps<T, is_ad>(prop_id);

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 class Material;
+class XFEM;
 
 /**
  * Proxy for accessing MaterialPropertyStorage.
@@ -171,6 +172,27 @@ public:
    * Provide read-only access to the underlying MaterialPropertyStorage object.
    */
   const MaterialPropertyStorage & getMaterialPropertyStorage() const { return _storage; }
+
+  /**
+   * Key that provides access to only the XFEM class.
+   */
+  class XFEMKey
+  {
+    friend class XFEM;
+    XFEMKey() {}
+    XFEMKey(const XFEM &) {}
+  };
+
+  /**
+   * Provide write-only access to the underlying MaterialPropertyStorage object JUST FOR XFEM.
+   *
+   * This should be removed. To be clear - you should not ever expect to have write access
+   * to this data. It just turned out that XFEM got away with it when we were storing things
+   * as pointers instead of smart pointers...
+   *
+   * These dirty reasons are why this method is named so egregiously.
+   */
+  MaterialPropertyStorage & getMaterialPropertyStorageForXFEM(const XFEMKey) { return _storage; }
 
   /**
    * Wrapper for MaterialStorage::getPropertyId. Allows classes with a MaterialData object

--- a/framework/include/materials/MaterialData.h
+++ b/framework/include/materials/MaterialData.h
@@ -195,7 +195,7 @@ public:
    */
   unsigned int getPropertyId(const std::string & prop_name) const
   {
-    return _storage.getPropertyId(prop_name);
+    return _storage.getMaterialPropertyRegistry().getID(prop_name);
   }
 
   /**

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -371,7 +371,7 @@ class MaterialPropertiesKey
   MaterialPropertiesKey(const MaterialPropertiesKey &) {}
 };
 
-class MaterialProperties : public UniqueProtectedStorage<PropertyValue>
+class MaterialProperties : public UniqueStorage<PropertyValue>
 {
 public:
   /**
@@ -388,12 +388,12 @@ public:
 
   void resize(const std::size_t size, const MaterialPropertiesKey)
   {
-    UniqueProtectedStorage<PropertyValue>::resize(size);
+    UniqueStorage<PropertyValue>::resize(size);
   }
 
   auto & setValue(const std::size_t i, const MaterialPropertiesKey)
   {
-    return UniqueProtectedStorage<PropertyValue>::setValue(i);
+    return UniqueStorage<PropertyValue>::setValue(i);
   }
 };
 

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -40,7 +40,7 @@ public:
   /**
    * String identifying the type of parameter stored.
    */
-  virtual std::string type() = 0;
+  virtual const std::string & type() const = 0;
 
   /**
    * Clone this value.  Useful in copy-construction.
@@ -107,7 +107,7 @@ public:
   /**
    * String identifying the type of parameter stored.
    */
-  virtual std::string type() override;
+  virtual const std::string & type() const override;
 
   /**
    * Resizes the property to the size n
@@ -223,10 +223,11 @@ rawValueEqualityHelper(std::array<T1, N> & out, const std::array<T2, N> & in)
 }
 
 template <typename T, bool is_ad>
-inline std::string
-MaterialPropertyBase<T, is_ad>::type()
+inline const std::string &
+MaterialPropertyBase<T, is_ad>::type() const
 {
-  return typeid(MooseADWrapper<T, is_ad>).name();
+  static const std::string type_name = typeid(MooseADWrapper<T, is_ad>).name();
+  return type_name;
 }
 
 template <typename T, bool is_ad>
@@ -270,8 +271,6 @@ template <typename T, bool is_ad>
 inline void
 MaterialPropertyBase<T, is_ad>::swap(PropertyValue & rhs)
 {
-  mooseAssert(rhs, "Assigning nullptr?");
-
   // If we're the same
   if (rhs.isAD() == is_ad)
   {

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -18,6 +18,7 @@
 #include "DataIO.h"
 #include "MooseError.h"
 #include "UniqueStorage.h"
+#include "MooseUtils.h"
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/tensor_value.h"
@@ -227,7 +228,7 @@ template <typename T, bool is_ad>
 inline const std::string &
 MaterialPropertyBase<T, is_ad>::type() const
 {
-  static const std::string type_name = typeid(MooseADWrapper<T, is_ad>).name();
+  static const std::string type_name = MooseUtils::prettyCppType<T>();
   return type_name;
 }
 

--- a/framework/include/materials/MaterialProperty.h
+++ b/framework/include/materials/MaterialProperty.h
@@ -62,7 +62,7 @@ public:
 
   virtual void swap(PropertyValue * rhs) = 0;
 
-  virtual bool isAD() = 0;
+  virtual bool isAD() const = 0;
 
   /**
    * Copy the value of a Property from one specific to a specific qp in this Property.
@@ -74,7 +74,7 @@ public:
    * @param from_qp The quadrature point in rhs you want to copy _from_.
    */
   virtual void
-  qpCopy(const unsigned int to_qp, PropertyValue * rhs, const unsigned int from_qp) = 0;
+  qpCopy(const unsigned int to_qp, const PropertyValue * rhs, const unsigned int from_qp) = 0;
 
   // save/restore in a file
   virtual void store(std::ostream & stream) = 0;
@@ -112,7 +112,7 @@ public:
 
   virtual ~MaterialPropertyBase() {}
 
-  bool isAD() override { return is_ad; }
+  bool isAD() const override { return is_ad; }
 
   /**
    * @returns a read-only reference to the parameter value.
@@ -154,7 +154,7 @@ public:
    * @param from_qp The quadrature point in rhs you want to copy _from_.
    */
   virtual void
-  qpCopy(const unsigned int to_qp, PropertyValue * rhs, const unsigned int from_qp) override;
+  qpCopy(const unsigned int to_qp, const PropertyValue * rhs, const unsigned int from_qp) override;
 
   /**
    * Store the property into a binary stream
@@ -259,7 +259,7 @@ MaterialPropertyBase<T, is_ad>::resize(int n)
 template <typename T, bool is_ad>
 inline void
 MaterialPropertyBase<T, is_ad>::qpCopy(const unsigned int to_qp,
-                                       PropertyValue * rhs,
+                                       const PropertyValue * rhs,
                                        const unsigned int from_qp)
 {
   mooseAssert(rhs != NULL, "Assigning NULL?");

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -645,13 +645,16 @@ MaterialPropertyInterface::getBlockMaterialProperty(const MaterialPropertyName &
     return std::pair<const MaterialProperty<T> *, std::set<SubdomainID>>(NULL,
                                                                          std::set<SubdomainID>());
 
+  // Call first so that the ID gets registered
+  auto prop_blocks_pair = std::make_pair<const MaterialProperty<T> *, std::set<SubdomainID>>(
+      &_material_data->getProperty<T>(name), getMaterialPropertyBlocks(name));
+
   _material_property_dependencies.insert(_material_data->getPropertyId(name));
 
   // Update consumed properties in MaterialPropertyDebugOutput
   addConsumedPropertyName(_mi_moose_object_name, name);
 
-  return std::pair<const MaterialProperty<T> *, std::set<SubdomainID>>(
-      &_material_data->getProperty<T>(name), getMaterialPropertyBlocks(name));
+  return prop_blocks_pair;
 }
 
 template <typename T>
@@ -807,13 +810,16 @@ MaterialPropertyInterface::getGenericMaterialPropertyByName(const MaterialProper
   // Update the boolean flag.
   _get_material_property_called = true;
 
+  // Call first so that the ID gets registered
+  auto & prop = material_data.getGenericProperty<T, is_ad>(name);
+
   // Does the material data used here matter?
   _material_property_dependencies.insert(material_data.getPropertyId(name));
 
   // Update consumed properties in MaterialPropertyDebugOutput
   addConsumedPropertyName(_mi_moose_object_name, name);
 
-  return material_data.getGenericProperty<T, is_ad>(name);
+  return prop;
 }
 
 template <typename T>
@@ -882,9 +888,12 @@ MaterialPropertyInterface::getMaterialPropertyOldByName(const MaterialPropertyNa
   // mark property as requested
   markMatPropRequested(name);
 
+  // Call first so that the ID gets registered
+  auto & prop = material_data.getPropertyOld<T>(name);
+
   _material_property_dependencies.insert(material_data.getPropertyId(name));
 
-  return material_data.getPropertyOld<T>(name);
+  return prop;
 }
 
 template <typename T>
@@ -905,7 +914,10 @@ MaterialPropertyInterface::getMaterialPropertyOlderByName(const MaterialProperty
   // mark property as requested
   markMatPropRequested(name);
 
+  // Call first so that the ID gets registered
+  const auto & prop = material_data.getPropertyOlder<T>(name);
+
   _material_property_dependencies.insert(material_data.getPropertyId(name));
 
-  return material_data.getPropertyOlder<T>(name);
+  return prop;
 }

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -142,6 +142,7 @@ public:
   ///@}
 
   ///@{ Optional material property getters
+  /// \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
   template <typename T, bool is_ad>
   const GenericOptionalMaterialProperty<T, is_ad> &
   getGenericOptionalMaterialProperty(const std::string & name, const unsigned int state = 0);
@@ -325,6 +326,8 @@ public:
 
   /**
    * Retrieve the property named "name" for the specified \p material_data
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T>
   const MaterialProperty<T> & getMaterialProperty(const std::string & name,
@@ -336,6 +339,8 @@ public:
 
   /**
    * Retrieve the AD property named "name" for the specified \p material_data
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T>
   const ADMaterialProperty<T> & getADMaterialProperty(const std::string & name,
@@ -354,6 +359,8 @@ public:
 
   /**
    * Retrieve the property named "name" without any deduction for the specified \p material_data
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   template <typename T>
   const MaterialProperty<T> & getMaterialPropertyByName(const MaterialPropertyName & name,
@@ -364,7 +371,7 @@ public:
   }
 
   /**
-   * Retrieve the AD property named "name" without any deduction for the specified \p
+   * Retrieve the AD property named "name" without any deduction for the specified \q
    * material_data
    */
   template <typename T>

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -424,6 +424,10 @@ public:
     return getMaterialPropertyByName<T>(name, material_data, 2);
   }
 
+private:
+  /// The MooseObject creating the MaterialPropertyInterface
+  const MooseObject & _mi_moose_object;
+
 protected:
   /// Parameters of the object with this interface
   const InputParameters & _mi_params;
@@ -780,7 +784,7 @@ MaterialPropertyInterface::getGenericMaterialPropertyByName(const MaterialProper
   _get_material_property_called = true;
 
   // Call first so that the ID gets registered
-  auto & prop = material_data.getGenericProperty<T, is_ad>(name, state);
+  auto & prop = material_data.getProperty<T, is_ad>(name, state, _mi_moose_object);
 
   // Does the material data used here matter?
   _material_property_dependencies.insert(material_data.getPropertyId(name));

--- a/framework/include/materials/MaterialPropertyInterface.h
+++ b/framework/include/materials/MaterialPropertyInterface.h
@@ -622,13 +622,15 @@ MaterialPropertyInterface::getBlockMaterialProperty(const MaterialPropertyName &
   if (_mi_block_ids.empty())
     mooseError("getBlockMaterialProperty must be called by a block restrictable object");
 
+  using pair_type = std::pair<const MaterialProperty<T> *, std::set<SubdomainID>>;
+
   if (!hasMaterialPropertyByName<T>(name))
-    return std::pair<const MaterialProperty<T> *, std::set<SubdomainID>>(NULL,
-                                                                         std::set<SubdomainID>());
+    return pair_type(nullptr, {});
 
   // Call first so that the ID gets registered
-  auto prop_blocks_pair = std::make_pair<const MaterialProperty<T> *, std::set<SubdomainID>>(
-      &_material_data->getProperty<T>(name), getMaterialPropertyBlocks(name));
+  const auto & prop = _material_data->getProperty<T, false>(name, 0, _mi_moose_object);
+  auto blocks = getMaterialPropertyBlocks(name);
+  auto prop_blocks_pair = pair_type(&prop, std::move(blocks));
 
   _material_property_dependencies.insert(_material_data->getPropertyId(name));
 

--- a/framework/include/materials/MaterialPropertyRegistry.h
+++ b/framework/include/materials/MaterialPropertyRegistry.h
@@ -1,0 +1,69 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class MaterialData;
+class MaterialPropertyInterface;
+class MaterialPropertyStorage;
+
+/**
+ * Registry class for material property IDs and names.
+ *
+ * Not thread safe.
+ */
+class MaterialPropertyRegistry
+{
+public:
+  /**
+   * @return True if a material property is registered with the name \p name
+   */
+  bool hasProperty(const std::string & name) const { return _name_to_id.count(name); }
+
+  /**
+   * Key that restricts writing data to the registry.
+   */
+  class WriteKey
+  {
+    friend class MaterialPropertyStorage;
+    WriteKey() {}
+    WriteKey(const WriteKey &) {}
+  };
+
+  /**
+   * @return The property ID for the given name, adding the property and
+   * creating a new ID if it hasn't already been created.
+   *
+   * Protected with the MaterialPropertyRegistry::WriteKey.
+   */
+  unsigned int addOrGetID(const std::string & name, const WriteKey);
+
+  /**
+   * @return The property ID for the property with the name \p name
+   *
+   * Will not create an ID if one does not exist, unlike addOrGetPropertyId
+   */
+  unsigned int getID(const std::string & name) const;
+
+  /**
+   * @return The mapping of material property name to material property ID
+   */
+  const std::unordered_map<std::string, unsigned int> & getNamesToIDs() const
+  {
+    return _name_to_id;
+  }
+
+private:
+  /// Map of material property name -> material property id
+  std::unordered_map<std::string, unsigned int> _name_to_id;
+};

--- a/framework/include/materials/MaterialPropertyRegistry.h
+++ b/framework/include/materials/MaterialPropertyRegistry.h
@@ -31,6 +31,11 @@ public:
   bool hasProperty(const std::string & name) const { return _name_to_id.count(name); }
 
   /**
+   * @return True if a material property is registered with the ID \p id
+   */
+  bool hasProperty(const unsigned int id) const { return id < _id_to_name.size(); }
+
+  /**
    * Key that restricts writing data to the registry.
    */
   class WriteKey
@@ -56,6 +61,11 @@ public:
   unsigned int getID(const std::string & name) const;
 
   /**
+   * @return The property name for the property with the ID \p id
+   */
+  const std::string & getName(const unsigned int id) const;
+
+  /**
    * @return The mapping of material property name to material property ID
    */
   const std::unordered_map<std::string, unsigned int> & getNamesToIDs() const
@@ -66,4 +76,6 @@ public:
 private:
   /// Map of material property name -> material property id
   std::unordered_map<std::string, unsigned int> _name_to_id;
+  /// Map of material property id -> material property name
+  std::vector<std::string> _id_to_name;
 };

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -217,30 +217,6 @@ public:
   MaterialProperties & setProps(const Elem * elem, unsigned int side, const unsigned int state = 0);
   ///@}
 
-  /// @{
-  /**
-   * Deprecated access methods to old/older stored material property data.
-   */
-  const PropsType & propsOld() const { return props(1); }
-  const PropsType & propsOlder() const { return props(2); }
-  const MaterialProperties & propsOld(const Elem * elem, unsigned int side) const
-  {
-    return props(elem, side, 1);
-  }
-  const MaterialProperties & propsOlder(const Elem * elem, unsigned int side) const
-  {
-    return props(elem, side, 2);
-  }
-  MaterialProperties & setPropsOld(const Elem * elem, unsigned int side)
-  {
-    return setProps(elem, side, 1);
-  }
-  MaterialProperties & setPropsOlder(const Elem * elem, unsigned int side)
-  {
-    return setProps(elem, side, 1);
-  }
-  ///@}
-
   bool hasProperty(const std::string & prop_name) const;
 
   /**

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -39,7 +39,6 @@ class MaterialPropertyStorage
 {
 public:
   MaterialPropertyStorage();
-  virtual ~MaterialPropertyStorage();
 
   /// The max time state supported (2 = older)
   static constexpr unsigned int max_state = 2;
@@ -282,12 +281,6 @@ public:
   unsigned int stateIndex() const { return _state_index; }
 
 protected:
-  /// Release all internal data structures
-  void releaseProperties();
-
-  /// Internal property storage release helper
-  void releasePropertyMap(HashMap<unsigned int, MaterialProperties> & inner_map);
-
   using BuildPropertyValuePtr = PropertyValue * (*)();
 
   struct Storage
@@ -325,6 +318,19 @@ private:
                  const Elem * elem,
                  unsigned int side,
                  unsigned int n_qpoints);
+
+  ///@{
+  /**
+   * Shallow copies of material properties
+   *
+   */
+  static void shallowSwapData(const std::vector<unsigned int> & stateful_prop_ids,
+                              MaterialProperties & data,
+                              MaterialProperties & data_from);
+  static void shallowSwapDataBack(const std::vector<unsigned int> & stateful_prop_ids,
+                                  MaterialProperties & data,
+                                  MaterialProperties & data_from);
+  ///@}
 
   PropsType & setProps(const unsigned int state);
 

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -271,8 +271,7 @@ public:
    */
   IntRange<unsigned int> statefulIndexRange() const
   {
-    return hasStatefulProperties() ? IntRange<unsigned int>(1, numStates())
-                                   : IntRange<unsigned int>(0, 0);
+    return IntRange<unsigned int>(1, numStates());
   }
 
 protected:

--- a/framework/include/materials/MaterialPropertyStorage.h
+++ b/framework/include/materials/MaterialPropertyStorage.h
@@ -298,14 +298,8 @@ public:
 protected:
   using BuildPropertyValuePtr = PropertyValue * (*)();
 
-  struct Storage
-  {
-    PropsType props;
-    std::vector<BuildPropertyValuePtr> build_ptr;
-  };
-
   /// The actual storage
-  std::array<MaterialPropertyStorage::Storage, max_state + 1> _storage;
+  std::array<PropsType, max_state + 1> _storage;
 
   /// Mapping from stateful property ID to property name
   std::unordered_map<unsigned int, std::string> _stateful_prop_names;
@@ -383,7 +377,7 @@ inline const MaterialPropertyStorage::PropsType &
 MaterialPropertyStorage::props(const unsigned int state) const
 {
   mooseAssert(state < _storage.size(), "Invalid material property state " + std::to_string(state));
-  return _storage[state].props;
+  return _storage[state];
 }
 
 inline const MaterialProperties &

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -29,86 +29,61 @@ public:
   static InputParameters validParams();
 
   /**
-   * Retrieve the property deduced from the name \p name
+   * Retrieve the neighbor property deduced from the name \p name
    */
-  template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialProperty(const std::string & name);
-
-  /**
-   * Retrieve the property named "name" without any deduction
-   */
-  template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyByName(const std::string & name);
-
-  /**
-   * Retrieve the ADMaterialProperty named "name"
-   */
-  template <typename T>
-  const ADMaterialProperty<T> & getNeighborADMaterialProperty(const std::string & name);
-
-  template <typename T>
-  const ADMaterialProperty<T> & getNeighborADMaterialPropertyByName(const std::string & name);
-
-  template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyOld(const std::string & name);
-
-  template <typename T>
-  const MaterialProperty<T> & getNeighborMaterialPropertyOlder(const std::string & name);
-
-  /**
-   * Retrieve the neighbor material property whether AD or not
-   */
+  ///@{
   template <typename T, bool is_ad>
-  const auto & getGenericNeighborMaterialProperty(const std::string & name)
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericNeighborMaterialProperty(const std::string & name, const unsigned int state = 0)
   {
-    if constexpr (is_ad)
-      return getADMaterialProperty<T>(name, *_neighbor_material_data);
-    else
-      return getMaterialProperty<T>(name, *_neighbor_material_data);
+    return getGenericMaterialProperty<T, is_ad>(name, *_neighbor_material_data, state);
   }
+  template <typename T>
+  const MaterialProperty<T> & getNeighborMaterialProperty(const std::string & name,
+                                                          const unsigned int state = 0)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, state);
+  }
+  template <typename T>
+  const ADMaterialProperty<T> & getNeighborADMaterialProperty(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, true>(name, 0);
+  }
+  template <typename T>
+  const MaterialProperty<T> & getNeighborMaterialPropertyOld(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, 1);
+  }
+  template <typename T>
+  const MaterialProperty<T> & getNeighborMaterialPropertyOlder(const std::string & name)
+  {
+    return getGenericNeighborMaterialProperty<T, false>(name, 2);
+  }
+  ///@}
+
+  /**
+   * Retrieve the neighbor property named "name" without any deduction
+   */
+  ///@{
+  template <typename T, bool is_ad>
+  const GenericMaterialProperty<T, is_ad> &
+  getGenericNeighborMaterialPropertyByName(const std::string & name, const unsigned int state = 0)
+  {
+    return getGenericMaterialPropertyByName<T, is_ad>(name, *_neighbor_material_data, state);
+  }
+  template <typename T>
+  const MaterialProperty<T> & getNeighborMaterialPropertyByName(const std::string & name,
+                                                                const unsigned int state = 0)
+  {
+    return getGenericNeighborMaterialPropertyByName<T, false>(name, state);
+  }
+  template <typename T>
+  const ADMaterialProperty<T> & getNeighborADMaterialPropertyByName(const std::string & name)
+  {
+    return getGenericNeighborMaterialPropertyByName<T, true>(name, 0);
+  }
+  ///@}
 
 protected:
   std::shared_ptr<MaterialData> _neighbor_material_data;
 };
-
-template <typename T>
-const MaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborMaterialProperty(const std::string & name)
-{
-  return getMaterialProperty<T>(name, *_neighbor_material_data);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborMaterialPropertyByName(const std::string & name)
-{
-  return getMaterialPropertyByName<T>(name, *_neighbor_material_data);
-}
-
-template <typename T>
-const ADMaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborADMaterialPropertyByName(const std::string & name)
-{
-  return getADMaterialPropertyByName<T>(name, *_neighbor_material_data);
-}
-
-template <typename T>
-const ADMaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborADMaterialProperty(const std::string & name)
-{
-  return getADMaterialProperty<T>(name, *_neighbor_material_data);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborMaterialPropertyOld(const std::string & name)
-{
-  return getMaterialPropertyOld<T>(name, *_neighbor_material_data);
-}
-
-template <typename T>
-const MaterialProperty<T> &
-TwoMaterialPropertyInterface::getNeighborMaterialPropertyOlder(const std::string & name)
-{
-  return getMaterialPropertyOlder<T>(name, *_neighbor_material_data);
-}

--- a/framework/include/materials/TwoMaterialPropertyInterface.h
+++ b/framework/include/materials/TwoMaterialPropertyInterface.h
@@ -30,6 +30,8 @@ public:
 
   /**
    * Retrieve the neighbor property deduced from the name \p name
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   ///@{
   template <typename T, bool is_ad>
@@ -63,6 +65,8 @@ public:
 
   /**
    * Retrieve the neighbor property named "name" without any deduction
+   *
+   * \p state is the property state; 0 = current, 1 = old, 2 = older, etc.
    */
   ///@{
   template <typename T, bool is_ad>

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -2175,6 +2175,7 @@ protected:
   ///@}
 
   // material properties
+  MaterialPropertyStorage::Registry _material_registry;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
   MaterialPropertyStorage & _neighbor_material_props;

--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -31,6 +31,7 @@
 #include "PerfGraphInterface.h"
 #include "Attributes.h"
 #include "MooseObjectWarehouse.h"
+#include "MaterialPropertyRegistry.h"
 
 #include "libmesh/enum_quadrature_type.h"
 #include "libmesh/equation_systems.h"
@@ -1424,6 +1425,14 @@ public:
   void setRestartFile(const std::string & file_name);
 
   /**
+   * @return A reference to the material property registry
+   */
+  const MaterialPropertyRegistry & getMaterialPropertyRegistry() const
+  {
+    return _material_prop_registry;
+  }
+
+  /**
    * Return a reference to the material property storage
    * @return A const reference to the material property storage
    */
@@ -2175,7 +2184,7 @@ protected:
   ///@}
 
   // material properties
-  MaterialPropertyStorage::Registry _material_registry;
+  MaterialPropertyRegistry _material_prop_registry;
   MaterialPropertyStorage & _material_props;
   MaterialPropertyStorage & _bnd_material_props;
   MaterialPropertyStorage & _neighbor_material_props;

--- a/framework/include/utils/MooseTypes.h
+++ b/framework/include/utils/MooseTypes.h
@@ -127,14 +127,6 @@ template <typename>
 class ADMaterialProperty;
 class InputParameters;
 
-enum class MaterialPropState
-{
-  CURRENT = 0x1,
-  OLD = 0x2,
-  OLDER = 0x4
-};
-using MaterialPropStateInt = std::underlying_type<MaterialPropState>::type;
-
 namespace libMesh
 {
 template <typename>

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -647,7 +647,7 @@ isZero(const T & value, const Real tolerance = TOLERANCE * TOLERANCE * TOLERANCE
 /**
  * Function to dump the contents of MaterialPropertyStorage for debugging purposes
  * @param props The storage item to dump, this should be
- * MaterialPropertyStorage.props()/propsOld()/propsOlder().
+ * MaterialPropertyStorage.props(state)
  *
  * Currently this only words for scalar material properties. Something to do as needed would be to
  * create a method in MaterialProperty

--- a/framework/include/utils/UniqueStorage.h
+++ b/framework/include/utils/UniqueStorage.h
@@ -149,4 +149,3 @@ protected:
   /// The underlying data
   values_type _values;
 };
-

--- a/framework/include/utils/UniqueStorage.h
+++ b/framework/include/utils/UniqueStorage.h
@@ -1,0 +1,164 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <utility>
+
+/**
+ * Storage container that stores a vector of unique pointers of T,
+ * but represents most of the public facing accessors (iterators,
+ * operator[]) as a vector of T.
+ *
+ * That is, these accessors dereference the underlying storage.
+ * More importantly, if data is not properly initialized using
+ * setValue(), this dereferencing will either lead to an assertion
+ * or a nullptr dereference.
+ */
+template <class T>
+class UniqueStorage
+{
+public:
+  UniqueStorage() = default;
+  UniqueStorage(UniqueStorage &&) = default;
+  UniqueStorage(const UniqueStorage & mp) = delete;
+  UniqueStorage & operator=(const UniqueStorage &) = delete;
+
+  /**
+   * Iterator that adds an additional dereference to BaseIterator.
+   */
+  template <class BaseIterator>
+  struct DereferenceIterator : public BaseIterator
+  {
+    DereferenceIterator(const BaseIterator & it) : BaseIterator(it) {}
+
+    using value_type = typename BaseIterator::value_type::element_type;
+    using pointer = value_type *;
+    using reference = value_type &;
+
+    reference operator*() const
+    {
+      auto & val = BaseIterator::operator*();
+      mooseAssert(val, "Null object");
+      return *val;
+    }
+    pointer operator->() const { return BaseIterator::operator*().get(); }
+    reference operator[](size_t n) const
+    {
+      auto & val = BaseIterator::operator[](n);
+      mooseAssert(val, "Null object");
+      return *val;
+    }
+  };
+
+  using values_type = typename std::vector<std::unique_ptr<T>>;
+  using iterator = DereferenceIterator<typename values_type::iterator>;
+  using const_iterator = DereferenceIterator<typename values_type::const_iterator>;
+
+  /**
+   * Begin and end iterators to the underlying data.
+   *
+   * Note that dereferencing these iterators may lead to an assertion
+   * or the dereference of a nullptr whether or not the underlying data
+   * is initialized.
+   */
+  ///@{
+  iterator begin() { return iterator(_values.begin()); }
+  iterator end() { return iterator(_values.end()); }
+  const_iterator begin() const { return const_iterator(_values.begin()); }
+  const_iterator end() const { return const_iterator(_values.end()); }
+  ///@}
+
+  /**
+   * @returns A reference to the underlying data at index \p i.
+   *
+   * Note that the underlying data may not necessarily be initialized,
+   * in which case this will throw an assertion or dereference a nullptr.
+   *
+   * You can check whether or not the underlying data is intialized
+   * with hasValue(i).
+   */
+  ///@{
+  const T & operator[](const std::size_t i) const
+  {
+    mooseAssert(hasValue(i), "Null object");
+    return *value(i);
+  }
+  T & operator[](const std::size_t i) { return const_cast<T &>(std::as_const(*this)[i]); }
+  ///@}
+
+  /**
+   * @returns The size of the underlying storage.
+   *
+   * Note that this is not necessarily the size of _constructed_ objects,
+   * as underlying objects could be uninitialized
+   */
+  std::size_t size() const { return _values.size(); }
+  /**
+   * @returns Whether or not the underlying storage is empty.
+   */
+  bool empty() const { return _values.empty(); }
+
+  /**
+   * @returns whether or not the underlying object at index \p is initialized
+   */
+  bool hasValue(const std::size_t i) const { return value(i) != nullptr; }
+
+  /**
+   * Resizes the underlying vector.
+   *
+   * This is the only method that allows for modification of
+   * the underlying container. Protect it wisely.
+   */
+  void resize(const std::size_t size) { _values.resize(size); }
+
+  /**
+   * Returns a read-only reference to the underlying unique pointer
+   * at index \p i.
+   */
+  const std::unique_ptr<T> & value(const std::size_t i) const
+  {
+    mooseAssert(size() > i, "Invalid size");
+    return _values[i];
+  }
+
+  /**
+   * Returns a writeable reference to the underlying unique pointer
+   * at index \p i.
+   *
+   * This can be used to construct objects in the storage, i.e.,
+   * setValue(0) = std::make_unique<T>(...);
+   *
+   * This is the only method that allows for the modification of
+   * ownership in the underlying vector. Protect it wisely.
+   */
+  std::unique_ptr<T> & setValue(const std::size_t i)
+  {
+    return const_cast<std::unique_ptr<T> &>(std::as_const(*this).value(i));
+  }
+
+protected:
+  /// The underlying data
+  values_type _values;
+};
+
+/**
+ * Same as UniqueStorage, but makes the unique_ptr accessors protected so that
+ * non-const access can be given to this container without granting ownership
+ * to the underlying data.
+ */
+template <class T>
+class UniqueProtectedStorage : public UniqueStorage<T>
+{
+protected:
+  auto & setValue(const std::size_t i) { return UniqueStorage<T>::setValue(i); }
+  void resize(const std::size_t size) { UniqueStorage<T>::resize(size); }
+};

--- a/framework/include/utils/UniqueStorage.h
+++ b/framework/include/utils/UniqueStorage.h
@@ -113,14 +113,6 @@ public:
   bool hasValue(const std::size_t i) const { return value(i) != nullptr; }
 
   /**
-   * Resizes the underlying vector.
-   *
-   * This is the only method that allows for modification of
-   * the underlying container. Protect it wisely.
-   */
-  void resize(const std::size_t size) { _values.resize(size); }
-
-  /**
    * Returns a read-only reference to the underlying unique pointer
    * at index \p i.
    */
@@ -130,6 +122,7 @@ public:
     return _values[i];
   }
 
+protected:
   /**
    * Returns a writeable reference to the underlying unique pointer
    * at index \p i.
@@ -145,20 +138,15 @@ public:
     return const_cast<std::unique_ptr<T> &>(std::as_const(*this).value(i));
   }
 
-protected:
+  /**
+   * Resizes the underlying vector.
+   *
+   * This is the only method that allows for modification of
+   * the underlying container. Protect it wisely.
+   */
+  void resize(const std::size_t size) { _values.resize(size); }
+
   /// The underlying data
   values_type _values;
 };
 
-/**
- * Same as UniqueStorage, but makes the unique_ptr accessors protected so that
- * non-const access can be given to this container without granting ownership
- * to the underlying data.
- */
-template <class T>
-class UniqueProtectedStorage : public UniqueStorage<T>
-{
-protected:
-  auto & setValue(const std::size_t i) { return UniqueStorage<T>::setValue(i); }
-  void resize(const std::size_t size) { UniqueStorage<T>::resize(size); }
-};

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -96,7 +96,7 @@ Material::subdomainSetup()
 
     for (const auto & prop_id : _supplied_prop_ids)
       for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, props[prop_id], 0);
+        props[prop_id]->qpCopy(qp, *props[prop_id], 0);
   }
 }
 
@@ -124,7 +124,7 @@ Material::computeProperties()
     {
       auto nqp = _qrule->n_points();
       for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, props[prop_id], 0);
+        props[prop_id]->qpCopy(qp, *props[prop_id], 0);
     }
   }
   else

--- a/framework/src/materials/Material.C
+++ b/framework/src/materials/Material.C
@@ -89,14 +89,14 @@ Material::subdomainSetup()
 
     MaterialProperties & props = materialData().props();
     for (const auto & prop_id : _supplied_prop_ids)
-      props[prop_id]->resize(nqp);
+      props[prop_id].resize(nqp);
 
     _qp = 0;
     computeQpProperties();
 
     for (const auto & prop_id : _supplied_prop_ids)
       for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, *props[prop_id], 0);
+        props[prop_id].qpCopy(qp, props[prop_id], 0);
   }
 }
 
@@ -124,7 +124,7 @@ Material::computeProperties()
     {
       auto nqp = _qrule->n_points();
       for (decltype(nqp) qp = 1; qp < nqp; ++qp)
-        props[prop_id]->qpCopy(qp, *props[prop_id], 0);
+        props[prop_id].qpCopy(qp, props[prop_id], 0);
     }
   }
   else

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -142,7 +142,7 @@ MaterialBase::checkStatefulSanity() const
 }
 
 void
-MaterialBase::registerPropName(std::string prop_name, bool is_get, MaterialPropState state)
+MaterialBase::registerPropName(const std::string & prop_name, bool is_get, MaterialPropState state)
 {
   if (!is_get)
   {

--- a/framework/src/materials/MaterialBase.C
+++ b/framework/src/materials/MaterialBase.C
@@ -142,15 +142,22 @@ MaterialBase::checkStatefulSanity() const
 }
 
 void
-MaterialBase::registerPropName(const std::string & prop_name, bool is_get, MaterialPropState state)
+MaterialBase::registerPropName(const std::string & prop_name, bool is_get, const unsigned int state)
 {
+  // There may be a better way to do this, but bit ops and enums aren't my thing
+  MaterialPropState state_bit = MaterialPropState::CURRENT;
+  if (state == 1)
+    state_bit = MaterialPropState::CURRENT;
+  else if (state == 2)
+    state_bit = MaterialPropState::CURRENT;
+
   if (!is_get)
   {
     _supplied_props.insert(prop_name);
     const auto & property_id = materialData().getPropertyId(prop_name);
     _supplied_prop_ids.insert(property_id);
 
-    _props_to_flags[prop_name] |= static_cast<MaterialPropStateInt>(state);
+    _props_to_flags[prop_name] |= static_cast<MaterialPropStateInt>(state_bit);
 
     // Store material properties for block ids
     for (const auto & block_id : blockIDs())
@@ -161,7 +168,7 @@ MaterialBase::registerPropName(const std::string & prop_name, bool is_get, Mater
       _fe_problem.storeBoundaryMatPropName(boundary_id, prop_name);
   }
 
-  if (static_cast<MaterialPropStateInt>(state) % 2 == 0)
+  if (state > 0)
     _has_stateful_property = true;
 }
 

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -36,12 +36,6 @@ MaterialData::copy(const Elem & elem_to, const Elem & elem_from, unsigned int si
 }
 
 void
-MaterialData::copy(const Elem * elem_to, const Elem * elem_from, unsigned int side)
-{
-  _storage.copy(*this, elem_to, elem_from, side, nQPoints());
-}
-
-void
 MaterialData::swap(const Elem & elem, unsigned int side /* = 0*/)
 {
   if (!_storage.hasStatefulProperties() || isSwapped())

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -15,15 +15,6 @@ MaterialData::MaterialData(MaterialPropertyStorage & storage)
 {
 }
 
-MaterialData::~MaterialData() { release(); }
-
-void
-MaterialData::release()
-{
-  for (auto & entry : _props)
-    entry.destroy();
-}
-
 void
 MaterialData::resize(unsigned int n_qpoints)
 {

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -67,3 +67,9 @@ MaterialData::swapBack(const Elem & elem, unsigned int side /* = 0*/)
     _swapped = false;
   }
 }
+
+void
+MaterialData::mooseErrorHelper(const MooseObject & object, const std::string_view & error)
+{
+  object.mooseError(error);
+}

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -18,10 +18,10 @@ MaterialData::MaterialData(MaterialPropertyStorage & storage)
 void
 MaterialData::resize(unsigned int n_qpoints)
 {
-  if (n_qpoints == _n_qpoints)
+  if (n_qpoints == nQPoints())
     return;
 
-  if (_resize_only_if_smaller && n_qpoints < _n_qpoints)
+  if (_resize_only_if_smaller && n_qpoints < nQPoints())
     return;
 
   for (const auto state : _storage.stateIndexRange())
@@ -29,28 +29,22 @@ MaterialData::resize(unsigned int n_qpoints)
   _n_qpoints = n_qpoints;
 }
 
-unsigned int
-MaterialData::nQPoints() const
-{
-  return _n_qpoints;
-}
-
 void
 MaterialData::copy(const Elem & elem_to, const Elem & elem_from, unsigned int side)
 {
-  _storage.copy(*this, &elem_to, &elem_from, side, _n_qpoints);
+  _storage.copy(*this, &elem_to, &elem_from, side, nQPoints());
 }
 
 void
 MaterialData::copy(const Elem * elem_to, const Elem * elem_from, unsigned int side)
 {
-  _storage.copy(*this, elem_to, elem_from, side, _n_qpoints);
+  _storage.copy(*this, elem_to, elem_from, side, nQPoints());
 }
 
 void
 MaterialData::swap(const Elem & elem, unsigned int side /* = 0*/)
 {
-  if (!_storage.hasStatefulProperties() || _swapped)
+  if (!_storage.hasStatefulProperties() || isSwapped())
     return;
 
   _storage.swap(*this, elem, side);
@@ -67,15 +61,9 @@ MaterialData::reset(const std::vector<std::shared_ptr<MaterialBase>> & mats)
 void
 MaterialData::swapBack(const Elem & elem, unsigned int side /* = 0*/)
 {
-  if (_swapped && _storage.hasStatefulProperties())
+  if (isSwapped() && _storage.hasStatefulProperties())
   {
     _storage.swapBack(*this, elem, side);
     _swapped = false;
   }
-}
-
-bool
-MaterialData::isSwapped() const
-{
-  return _swapped;
 }

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -25,7 +25,7 @@ MaterialData::resize(unsigned int n_qpoints)
     return;
 
   for (const auto state : make_range(_storage.stateIndex()))
-    props(state).resizeItems(n_qpoints);
+    props(state).resizeItems(n_qpoints, {});
   _n_qpoints = n_qpoints;
 }
 

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -20,9 +20,8 @@ MaterialData::~MaterialData() { release(); }
 void
 MaterialData::release()
 {
-  _props.destroy();
-  _props_old.destroy();
-  _props_older.destroy();
+  for (auto & entry : _props)
+    entry.destroy();
 }
 
 void
@@ -34,18 +33,13 @@ MaterialData::resize(unsigned int n_qpoints)
   if (_resize_only_if_smaller && n_qpoints < _n_qpoints)
     return;
 
-  _props.resizeItems(n_qpoints);
-  // if there are stateful material properties in the system, also resize
-  // storage for old and older material properties
-  if (_storage.hasStatefulProperties())
-    _props_old.resizeItems(n_qpoints);
-  if (_storage.hasOlderProperties())
-    _props_older.resizeItems(n_qpoints);
+  for (const auto state : make_range(_storage.stateIndex()))
+    props(state).resizeItems(n_qpoints);
   _n_qpoints = n_qpoints;
 }
 
 unsigned int
-MaterialData::nQPoints()
+MaterialData::nQPoints() const
 {
   return _n_qpoints;
 }
@@ -90,7 +84,7 @@ MaterialData::swapBack(const Elem & elem, unsigned int side /* = 0*/)
 }
 
 bool
-MaterialData::isSwapped()
+MaterialData::isSwapped() const
 {
   return _swapped;
 }

--- a/framework/src/materials/MaterialData.C
+++ b/framework/src/materials/MaterialData.C
@@ -24,7 +24,7 @@ MaterialData::resize(unsigned int n_qpoints)
   if (_resize_only_if_smaller && n_qpoints < _n_qpoints)
     return;
 
-  for (const auto state : make_range(_storage.stateIndex()))
+  for (const auto state : _storage.stateIndexRange())
     props(state).resizeItems(n_qpoints, {});
   _n_qpoints = n_qpoints;
 }

--- a/framework/src/materials/MaterialProperty.C
+++ b/framework/src/materials/MaterialProperty.C
@@ -1,0 +1,49 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MaterialProperty.h"
+
+void
+dataStore(std::ostream & stream, PropertyValue & p, void *)
+{
+  p.store(stream);
+}
+
+void
+dataLoad(std::istream & stream, PropertyValue & p, void *)
+{
+  p.load(stream);
+}
+
+void
+dataStore(std::ostream & stream, MaterialProperties & v, void * context)
+{
+  std::size_t prop_size = v.size();
+  dataStore(stream, prop_size, context);
+
+  for (const auto i : index_range(v))
+  {
+    mooseAssert(v[i], "Not valid");
+    dataStore(stream, *v[i], context);
+  }
+}
+
+void
+dataLoad(std::istream & stream, MaterialProperties & v, void * context)
+{
+  std::size_t prop_size;
+  dataLoad(stream, prop_size, context);
+  mooseAssert(prop_size == v.size(), "Loading MaterialProperties data into mis-sized target");
+
+  for (const auto i : make_range(prop_size))
+  {
+    mooseAssert(v[i], "Not valid");
+    dataLoad(stream, *v[i], context);
+  }
+}

--- a/framework/src/materials/MaterialProperty.C
+++ b/framework/src/materials/MaterialProperty.C
@@ -28,10 +28,7 @@ dataStore(std::ostream & stream, MaterialProperties & v, void * context)
   dataStore(stream, prop_size, context);
 
   for (const auto i : index_range(v))
-  {
-    mooseAssert(v[i], "Not valid");
-    dataStore(stream, *v[i], context);
-  }
+    dataStore(stream, v[i], context);
 }
 
 void
@@ -42,8 +39,5 @@ dataLoad(std::istream & stream, MaterialProperties & v, void * context)
   mooseAssert(prop_size == v.size(), "Loading MaterialProperties data into mis-sized target");
 
   for (const auto i : make_range(prop_size))
-  {
-    mooseAssert(v[i], "Not valid");
-    dataLoad(stream, *v[i], context);
-  }
+    dataLoad(stream, v[i], context);
 }

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -225,17 +225,20 @@ MaterialPropertyInterface::addConsumedPropertyName(const MooseObjectName & obj_n
 }
 
 void
-MaterialPropertyInterface::checkMaterialProperty(const std::string & name)
+MaterialPropertyInterface::checkMaterialProperty(const std::string & name, const unsigned int state)
 {
-  // If the material property is boundary restrictable, add to the list of materials to check
-  if (_mi_boundary_restricted)
-    for (const auto & bnd_id : _mi_boundary_ids)
-      _mi_feproblem.storeBoundaryDelayedCheckMatProp(_mi_name, bnd_id, name);
+  if (state == 0)
+  {
+    // If the material property is boundary restrictable, add to the list of materials to check
+    if (_mi_boundary_restricted)
+      for (const auto & bnd_id : _mi_boundary_ids)
+        _mi_feproblem.storeBoundaryDelayedCheckMatProp(_mi_name, bnd_id, name);
 
-  // The default is to assume block restrictions
-  else
-    for (const auto & blk_ids : _mi_block_ids)
-      _mi_feproblem.storeSubdomainDelayedCheckMatProp(_mi_name, blk_ids, name);
+    // The default is to assume block restrictions
+    else
+      for (const auto & blk_ids : _mi_block_ids)
+        _mi_feproblem.storeSubdomainDelayedCheckMatProp(_mi_name, blk_ids, name);
+  }
 }
 
 void

--- a/framework/src/materials/MaterialPropertyInterface.C
+++ b/framework/src/materials/MaterialPropertyInterface.C
@@ -29,7 +29,8 @@ MaterialPropertyInterface::validParams()
 MaterialPropertyInterface::MaterialPropertyInterface(const MooseObject * moose_object,
                                                      const std::set<SubdomainID> & block_ids,
                                                      const std::set<BoundaryID> & boundary_ids)
-  : _mi_params(moose_object->parameters()),
+  : _mi_moose_object(*moose_object),
+    _mi_params(_mi_moose_object.parameters()),
     _mi_name(_mi_params.get<std::string>("_object_name")),
     _mi_moose_object_name(_mi_params.get<std::string>("_moose_base"), _mi_name, "::"),
     _mi_feproblem(*_mi_params.getCheckedPointerParam<FEProblemBase *>("_fe_problem_base")),

--- a/framework/src/materials/MaterialPropertyRegistry.C
+++ b/framework/src/materials/MaterialPropertyRegistry.C
@@ -19,8 +19,9 @@ MaterialPropertyRegistry::addOrGetID(const std::string & name,
   if (it != _name_to_id.end())
     return it->second;
 
-  const auto id = _name_to_id.size();
+  const auto id = _id_to_name.size();
   _name_to_id.emplace(name, id);
+  _id_to_name.push_back(name);
   return id;
 }
 
@@ -31,4 +32,12 @@ MaterialPropertyRegistry::getID(const std::string & name) const
   if (it == _name_to_id.end())
     mooseError("MaterialPropertyRegistry: Property '" + name + "' is not declared");
   return it->second;
+}
+
+const std::string &
+MaterialPropertyRegistry::getName(const unsigned int id) const
+{
+  if (!hasProperty(id))
+    mooseError("MaterialPropertyRegistry: Property with ID ", id, " is not declared");
+  return _id_to_name[id];
 }

--- a/framework/src/materials/MaterialPropertyRegistry.C
+++ b/framework/src/materials/MaterialPropertyRegistry.C
@@ -1,0 +1,34 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MaterialPropertyRegistry.h"
+
+#include "MooseError.h"
+
+unsigned int
+MaterialPropertyRegistry::addOrGetID(const std::string & name,
+                                     const MaterialPropertyRegistry::WriteKey)
+{
+  const auto it = _name_to_id.find(name);
+  if (it != _name_to_id.end())
+    return it->second;
+
+  const auto id = _name_to_id.size();
+  _name_to_id.emplace(name, id);
+  return id;
+}
+
+unsigned int
+MaterialPropertyRegistry::getID(const std::string & name) const
+{
+  const auto it = _name_to_id.find(name);
+  if (it == _name_to_id.end())
+    mooseError("MaterialPropertyRegistry: Property '" + name + "' is not declared");
+  return it->second;
+}

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -277,8 +277,10 @@ MaterialPropertyStorage::swap(MaterialData & material_data, const Elem & elem, u
   Threads::spin_mutex::scoped_lock lock(this->_spin_mtx);
 
   for (const auto state : stateIndexRange())
-    shallowSwapData(
-        _stateful_prop_id_to_prop_id, material_data.props(state), setProps(&elem, side, state));
+    shallowSwapData(_stateful_prop_id_to_prop_id,
+                    material_data.props(state),
+                    // Would be nice to make this setProps()
+                    initAndSetProps(&elem, side, state));
 }
 
 void
@@ -372,7 +374,7 @@ MaterialPropertyStorage::initProps(MaterialData & material_data,
 {
   material_data.resize(n_qpoints);
 
-  auto & mat_props = setProps(elem, side, state);
+  auto & mat_props = initAndSetProps(elem, side, state);
 
   // In some special cases, material_data might be larger than n_qpoints
   if (material_data.isOnlyResizeIfSmaller())

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -54,8 +54,8 @@ MaterialPropertyStorage::shallowSwapDataBack(const std::vector<unsigned int> & s
 void
 MaterialPropertyStorage::eraseProperty(const Elem * elem)
 {
-  for (auto & storage_entry : _storage)
-    storage_entry.props.erase(elem);
+  for (const auto state : stateIndexRange())
+    setProps(state).erase(elem);
 }
 
 void

--- a/framework/src/materials/MaterialPropertyStorage.C
+++ b/framework/src/materials/MaterialPropertyStorage.C
@@ -16,7 +16,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/quadrature.h"
 
-MaterialPropertyStorage::MaterialPropertyStorage(MaterialPropertyStorage::Registry & registry)
+MaterialPropertyStorage::MaterialPropertyStorage(MaterialPropertyRegistry & registry)
   : _max_state(0), _spin_mtx(libMesh::Threads::spin_mtx), _registry(registry)
 {
 }
@@ -299,12 +299,6 @@ MaterialPropertyStorage::swapBack(MaterialData & material_data,
       setProps(state)[&elem].erase(side);
 }
 
-bool
-MaterialPropertyStorage::hasProperty(const std::string & prop_name) const
-{
-  return _registry.prop_ids.count(prop_name) > 0;
-}
-
 unsigned int
 MaterialPropertyStorage::addProperty(const std::string & prop_name, const unsigned int state)
 {
@@ -318,7 +312,7 @@ MaterialPropertyStorage::addProperty(const std::string & prop_name, const unsign
   if (maxState() < state)
     _max_state = state;
 
-  const auto prop_id = getPropertyId(prop_name);
+  const auto prop_id = _registry.addOrGetID(prop_name, {});
 
   if (state > 0)
   {
@@ -330,28 +324,6 @@ MaterialPropertyStorage::addProperty(const std::string & prop_name, const unsign
   }
 
   return prop_id;
-}
-
-unsigned int
-MaterialPropertyStorage::getPropertyId(const std::string & prop_name)
-{
-  const auto it = _registry.prop_ids.find(prop_name);
-  if (it != _registry.prop_ids.end())
-    return it->second;
-
-  const auto id = _registry.prop_names.size();
-  _registry.prop_names.push_back(prop_name);
-  _registry.prop_ids.emplace(prop_name, id);
-  return id;
-}
-
-unsigned int
-MaterialPropertyStorage::retrievePropertyId(const std::string & prop_name) const
-{
-  auto it = _registry.prop_ids.find(prop_name);
-  if (it == _registry.prop_ids.end())
-    mooseError("MaterialPropertyStorage: property " + prop_name + " is not yet declared");
-  return it->second;
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -316,11 +316,11 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _aux(nullptr),
     _coupling(Moose::COUPLING_DIAG),
     _material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
-        "material_props", &_mesh, _material_registry)),
+        "material_props", &_mesh, _material_prop_registry)),
     _bnd_material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
-        "bnd_material_props", &_mesh, _material_registry)),
+        "bnd_material_props", &_mesh, _material_prop_registry)),
     _neighbor_material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
-        "neighbor_material_props", &_mesh, _material_registry)),
+        "neighbor_material_props", &_mesh, _material_prop_registry)),
     _reporter_data(_app),
     // TODO: delete the following line after apps have been updated to not call getUserObjects
     _all_user_objects(_app.getExecuteOnEnum()),

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -315,12 +315,12 @@ FEProblemBase::FEProblemBase(const InputParameters & parameters)
     _current_nl_sys(nullptr),
     _aux(nullptr),
     _coupling(Moose::COUPLING_DIAG),
-    _material_props(
-        declareRestartableDataWithContext<MaterialPropertyStorage>("material_props", &_mesh)),
-    _bnd_material_props(
-        declareRestartableDataWithContext<MaterialPropertyStorage>("bnd_material_props", &_mesh)),
+    _material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
+        "material_props", &_mesh, _material_registry)),
+    _bnd_material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
+        "bnd_material_props", &_mesh, _material_registry)),
     _neighbor_material_props(declareRestartableDataWithContext<MaterialPropertyStorage>(
-        "neighbor_material_props", &_mesh)),
+        "neighbor_material_props", &_mesh, _material_registry)),
     _reporter_data(_app),
     // TODO: delete the following line after apps have been updated to not call getUserObjects
     _all_user_objects(_app.getExecuteOnEnum()),

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -91,7 +91,7 @@ RedistributeProperties::redistribute()
           "a threaded region or contact a MOOSE developer to discuss.");
       MaterialData & my_mat_data = *((*mat_data)[/*_tid*/ 0]); // Not threaded
 
-      for (const auto state : make_range(mat_prop_store->stateIndex()))
+      for (const auto state : mat_prop_store->stateIndexRange())
       {
         MaterialPropertyStorage::PropsType & props_map = mat_prop_store->setProps(state);
         typedef std::unordered_map<unsigned int, std::string> stored_props_type;

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -157,7 +157,7 @@ RedistributeProperties::redistribute()
                 mooseAssert(!prop_vals.empty(),
                             "Empty MaterialProperties in stateful properties map?");
 
-                for (const PropertyValue * const prop : prop_vals)
+                for (const auto & prop : prop_vals)
                 {
                   mooseAssert(prop, "Null pointer in MaterialProperties?");
                   n_q_points = std::max(n_q_points, prop->size());

--- a/framework/src/relationshipmanagers/RedistributeProperties.C
+++ b/framework/src/relationshipmanagers/RedistributeProperties.C
@@ -158,10 +158,7 @@ RedistributeProperties::redistribute()
                             "Empty MaterialProperties in stateful properties map?");
 
                 for (const auto & prop : prop_vals)
-                {
-                  mooseAssert(prop, "Null pointer in MaterialProperties?");
-                  n_q_points = std::max(n_q_points, prop->size());
-                }
+                  n_q_points = std::max(n_q_points, prop.size());
 
                 std::ostringstream oss;
                 dataStore(oss, prop_vals, nullptr);

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -670,8 +670,7 @@ MaterialPropertyStorageDump(
       unsigned int cnt = 0;
       for (const auto & mat_prop : side_it.second)
       {
-        mooseAssert(mat_prop, "Not valid");
-        if (auto mp = dynamic_cast<MaterialProperty<Real> *>(mat_prop.get()))
+        if (auto mp = dynamic_cast<const MaterialProperty<Real> *>(&mat_prop))
         {
           Moose::out << "    Property " << cnt << '\n';
           cnt++;

--- a/framework/src/utils/MooseUtils.C
+++ b/framework/src/utils/MooseUtils.C
@@ -670,8 +670,8 @@ MaterialPropertyStorageDump(
       unsigned int cnt = 0;
       for (const auto & mat_prop : side_it.second)
       {
-        MaterialProperty<Real> * mp = dynamic_cast<MaterialProperty<Real> *>(mat_prop);
-        if (mp)
+        mooseAssert(mat_prop, "Not valid");
+        if (auto mp = dynamic_cast<MaterialProperty<Real> *>(mat_prop.get()))
         {
           Moose::out << "    Property " << cnt << '\n';
           cnt++;

--- a/modules/navier_stokes/src/materials/INSADMaterial.C
+++ b/modules/navier_stokes/src/materials/INSADMaterial.C
@@ -84,15 +84,15 @@ INSADMaterial::subdomainSetup()
     // So we have to go through MaterialData here. We already performed the material property
     // requests through the MaterialPropertyInterface APIs in the INSAD kernels, so we should be
     // safe for dependencies
-    _boussinesq_alpha = &_material_data->getADProperty<Real>(
-        _object_tracker->get<MaterialPropertyName>("alpha", _current_subdomain_id));
+    _boussinesq_alpha = &_material_data->getProperty<Real, true>(
+        _object_tracker->get<MaterialPropertyName>("alpha", _current_subdomain_id), 0, *this);
     _temperature =
         &_subproblem
              .getStandardVariable(
                  _tid, _object_tracker->get<std::string>("temperature", _current_subdomain_id))
              .adSln();
-    _ref_temp = &_material_data->getProperty<Real>(
-        _object_tracker->get<MaterialPropertyName>("ref_temp", _current_subdomain_id));
+    _ref_temp = &_material_data->getProperty<Real, false>(
+        _object_tracker->get<MaterialPropertyName>("ref_temp", _current_subdomain_id), 0, *this);
   }
   else
   {

--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -93,7 +93,7 @@ PorousFlowMaterial::computeNodalProperties()
     // Copy from qp = _current_elem->n_nodes() - 1 to qp = _qrule->n_points() -1
     for (const auto & prop_id : _supplied_prop_ids)
       for (unsigned int qp = numnodes; qp < _qrule->n_points(); ++qp)
-        props[prop_id]->qpCopy(qp, props[prop_id], numnodes - 1);
+        props[prop_id]->qpCopy(qp, *props[prop_id], numnodes - 1);
   }
 }
 
@@ -144,12 +144,12 @@ PorousFlowMaterial::sizeNodalProperties()
     props[prop_id]->resize(new_size);
 
   for (const auto prop_id : _supplied_old_prop_ids)
-    if (auto * const old_prop = props_old[prop_id])
+    if (auto & old_prop = props_old[prop_id])
       old_prop->resize(new_size);
 
   if (storage.hasOlderProperties())
     for (const auto prop_id : _supplied_old_prop_ids)
-      if (auto * const older_prop = props_older[prop_id])
+      if (auto & older_prop = props_older[prop_id])
         older_prop->resize(new_size);
 }
 

--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -136,21 +136,15 @@ PorousFlowMaterial::sizeNodalProperties()
 
   const auto new_size = std::max(_current_elem->n_nodes(), _qrule->n_points());
   auto & storage = _material_data->getMaterialPropertyStorage();
-  auto & props = _material_data->props();
-  auto & props_old = _material_data->propsOld();
-  auto & props_older = _material_data->propsOlder();
 
+  auto & props = _material_data->props();
   for (const auto prop_id : _supplied_prop_ids)
     props[prop_id].resize(new_size);
 
-  for (const auto prop_id : _supplied_old_prop_ids)
-    if (props_old.hasValue(prop_id))
-      props_old[prop_id].resize(new_size);
-
-  if (storage.hasOlderProperties())
+  for (const auto state : storage.statefulIndexRange())
     for (const auto prop_id : _supplied_old_prop_ids)
-      if (props_older.hasValue(prop_id))
-        props_older[prop_id].resize(new_size);
+      if (_material_data->props(state).hasValue(prop_id))
+        _material_data->props(state)[prop_id].resize(new_size);
 }
 
 unsigned

--- a/modules/porous_flow/src/materials/PorousFlowMaterial.C
+++ b/modules/porous_flow/src/materials/PorousFlowMaterial.C
@@ -93,7 +93,7 @@ PorousFlowMaterial::computeNodalProperties()
     // Copy from qp = _current_elem->n_nodes() - 1 to qp = _qrule->n_points() -1
     for (const auto & prop_id : _supplied_prop_ids)
       for (unsigned int qp = numnodes; qp < _qrule->n_points(); ++qp)
-        props[prop_id]->qpCopy(qp, *props[prop_id], numnodes - 1);
+        props[prop_id].qpCopy(qp, props[prop_id], numnodes - 1);
   }
 }
 
@@ -141,16 +141,16 @@ PorousFlowMaterial::sizeNodalProperties()
   auto & props_older = _material_data->propsOlder();
 
   for (const auto prop_id : _supplied_prop_ids)
-    props[prop_id]->resize(new_size);
+    props[prop_id].resize(new_size);
 
   for (const auto prop_id : _supplied_old_prop_ids)
-    if (auto & old_prop = props_old[prop_id])
-      old_prop->resize(new_size);
+    if (props_old.hasValue(prop_id))
+      props_old[prop_id].resize(new_size);
 
   if (storage.hasOlderProperties())
     for (const auto prop_id : _supplied_old_prop_ids)
-      if (auto & older_prop = props_older[prop_id])
-        older_prop->resize(new_size);
+      if (props_older.hasValue(prop_id))
+        props_older[prop_id].resize(new_size);
 }
 
 unsigned

--- a/modules/xfem/include/base/XFEM.h
+++ b/modules/xfem/include/base/XFEM.h
@@ -478,16 +478,8 @@ private:
    */
   const GeometricCutUserObject * getGeometricCutForElem(const Elem * elem) const;
 
-  /**
-   * Store the material properties using dataStore
-   * @param props The material properties
-   * @return      Serialized material properties
-   */
-  std::unordered_map<unsigned int, std::string>
-  storeMaterialProperties(HashMap<unsigned int, MaterialProperties> props) const;
-
   void storeMaterialPropertiesForElementHelper(const Elem * elem,
-                                               const MaterialPropertyStorage & storage);
+                                               MaterialPropertyStorage & storage);
 
   /**
    * Helper function to store the material properties of a healed element
@@ -501,19 +493,13 @@ private:
    * Load the material properties
    * @param props_deserialized The material properties
    * @param props_serialized   The serialized material properties
-   */
-  void loadMaterialProperties(
-      HashMap<unsigned int, MaterialProperties> props_deserialized,
-      const std::unordered_map<unsigned int, std::string> & props_serialized) const;
-
-  /**
-   * Load the material properties
-   * @param props_deserialized The material properties
-   * @param props_serialized   The serialized material properties
+   *
+   * This does very dirty things and writes back to MOOSE's stateful properties. It should
+   * not do this in the future.
    */
   void loadMaterialPropertiesForElementHelper(const Elem * elem,
                                               const Xfem::CachedMaterialProperties & cached_props,
-                                              const MaterialPropertyStorage & storage) const;
+                                              MaterialPropertyStorage & storage) const;
 
   /**
    * Helper function to store the material properties of a healed element

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -2165,10 +2165,7 @@ XFEM::getGeometricCutForElem(const Elem * elem) const
 void
 XFEM::storeMaterialPropertiesForElementHelper(const Elem * elem, MaterialPropertyStorage & storage)
 {
-  if (!storage.hasStatefulProperties())
-    return;
-
-  for (const auto state : make_range((unsigned int)1, storage.stateIndex()))
+  for (const auto state : storage.statefulIndexRange())
   {
     const auto & elem_props = storage.props(state).at(elem);
     auto & serialized_props = _geom_cut_elems[elem]._elem_material_properties[state - 1];
@@ -2219,7 +2216,7 @@ XFEM::loadMaterialPropertiesForElementHelper(const Elem * elem,
   if (!storage.hasStatefulProperties())
     return;
 
-  for (const auto state : make_range((unsigned int)1, storage.stateIndex()))
+  for (const auto state : storage.statefulIndexRange())
   {
     const auto & serialized_props = cached_props[state - 1];
     for (const auto & [side, serialized_side_props] : serialized_props)

--- a/test/include/userobjects/MaterialErrorTest.h
+++ b/test/include/userobjects/MaterialErrorTest.h
@@ -1,0 +1,25 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ElementUserObject.h"
+
+class MaterialErrorTest : public ElementUserObject
+{
+public:
+  static InputParameters validParams();
+
+  MaterialErrorTest(const InputParameters & params);
+
+  void initialize() {}
+  void execute() {}
+  void finalize() {}
+  void threadJoin(const UserObject &) {}
+};

--- a/test/src/userobjects/MaterialErrorTest.C
+++ b/test/src/userobjects/MaterialErrorTest.C
@@ -1,0 +1,60 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MaterialErrorTest.h"
+
+registerMooseObject("MooseTestApp", MaterialErrorTest);
+
+InputParameters
+MaterialErrorTest::validParams()
+{
+  InputParameters params = ElementUserObject::validParams();
+  params.addParam<bool>(
+      "get_different_types", false, "Test getting materals with the same name and different types");
+  params.addParam<bool>("use_ad", false, "True to test with AD");
+  params.addParam<bool>("get_different_ad_types",
+                        false,
+                        "Test getting materials with different AD types (one AD, one non-AD)");
+  return params;
+}
+
+MaterialErrorTest::MaterialErrorTest(const InputParameters & params) : ElementUserObject(params)
+{
+  if (getParam<bool>("get_different_types"))
+  {
+    using type1 = Real;
+    using type2 = std::vector<Real>;
+
+    if (getParam<bool>("use_ad"))
+    {
+      getADMaterialPropertyByName<type1>("foo");
+      getADMaterialPropertyByName<type2>("foo");
+    }
+    else
+    {
+      getMaterialPropertyByName<type1>("foo");
+      getMaterialPropertyByName<type2>("foo");
+    }
+  }
+
+  if (getParam<bool>("get_different_ad_types"))
+  {
+    using type = Real;
+    if (getParam<bool>("use_ad"))
+    {
+      getADMaterialPropertyByName<type>("foo");
+      getMaterialPropertyByName<type>("foo");
+    }
+    else
+    {
+      getMaterialPropertyByName<type>("foo");
+      getADMaterialPropertyByName<type>("foo");
+    }
+  }
+}

--- a/test/tests/dirackernels/material_point_source/tests
+++ b/test/tests/dirackernels/material_point_source/tests
@@ -16,8 +16,8 @@
     [old]
       type = 'RunException'
       input = 'material_error_check.i'
-      expect_err = 'Stateful material properties not allowed for this object\. Old property for \S+ '
-                   'was requested.'
+      expect_err = 'Stateful material properties not allowed for this object\. State 1 property for '
+                   '\S+ was requested.'
 
       detail = 'one step back, and'
     []
@@ -25,7 +25,7 @@
       type = 'RunException'
       input = 'material_error_check.i'
       cli_args = 'DiracKernels/material_source/prop_state=older'
-      expect_err = 'Stateful material properties not allowed for this object\. Older property for '
+      expect_err = 'Stateful material properties not allowed for this object\. State 2 property for '
                    '\S+ was requested.'
 
       detail = 'two steps back.'

--- a/test/tests/materials/materialdata/errors.i
+++ b/test/tests/materials/materialdata/errors.i
@@ -1,0 +1,18 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 1
+  []
+[]
+
+[UserObjects/test]
+  type = MaterialErrorTest
+[]
+
+[Problem]
+  solve = False
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/test/tests/materials/materialdata/tests
+++ b/test/tests/materials/materialdata/tests
@@ -1,0 +1,37 @@
+[Tests]
+  design = 'syntax/Materials/index.md'
+  issues = '#8444'
+
+  [errors]
+    requirement = 'The material data system shall report a reasonable error when requesting'
+
+    [get_different_types]
+      type = RunException
+      input = 'errors.i'
+      cli_args = 'UserObjects/test/get_different_types=true'
+      expect_err = 'The requested non-AD material property \'foo\' of type \'std::vector<double>\'\nis already retrieved or declared as a non-AD property of type \'double\''
+      detail = 'a non-AD property and the property has already been requested with a different non-AD type'
+    []
+    [get_different_types_ad]
+      type = RunException
+      input = 'errors.i'
+      cli_args = 'UserObjects/test/get_different_types=true UserObjects/test/use_ad=true'
+      expect_err = 'The requested AD material property \'foo\' of type \'std::vector<double>\'\nis already retrieved or declared as a AD property of type \'double\''
+      detail = 'an AD property and the property has already been requested with a different AD type'
+    []
+    [get_different_ad_types]
+      type = RunException
+      input = 'errors.i'
+      cli_args = 'UserObjects/test/get_different_ad_types=true'
+      expect_err = 'The requested AD material property \'foo\' of type \'double\'\nis already retrieved or declared as a non-AD property of type \'double\'.'
+      detail = 'a non-AD property and the property has already been requested as an AD property'
+    []
+    [get_different_ad_types_ad]
+      type = RunException
+      input = 'errors.i'
+      cli_args = 'UserObjects/test/get_different_ad_types=true UserObjects/test/use_ad=true'
+      expect_err = 'The requested non-AD material property \'foo\' of type \'double\'\nis already retrieved or declared as a AD property of type \'double\'.'
+      detail = 'an AD property and the property has already been requested as a non-AD property'
+    []
+  []
+[]


### PR DESCRIPTION
Closes #24671

This is in support of moving stateful property evaluation in restart/recover load.

- Uses unique_ptr for material data storage
- Uses a wrapper around material data storage that does not grant ownership access to the data
- Adds an integer state for current/old/older in all material properties across interfaces