### PR TITLE
Add cp_temp in INSFVEnthalpyMaterial

### DIFF
--- a/modules/navier_stokes/src/materials/INSFVEnthalpyMaterial.C
+++ b/modules/navier_stokes/src/materials/INSFVEnthalpyMaterial.C
@@ -34,4 +34,8 @@ INSFVEnthalpyMaterial::INSFVEnthalpyMaterial(const InputParameters & parameters)
   addFunctorProperty<ADReal>("rho_cp_temp",
                              [this](const auto & r, const auto & t) -> ADReal
                              { return _rho(r, t) * _cp(r, t) * _temperature(r, t); });
+
+  addFunctorProperty<ADReal>("cp_temp",
+                             [this](const auto & r, const auto & t) -> ADReal
+                             { return _cp(r, t) * _temperature(r, t); });
 }


### PR DESCRIPTION
## Reason

Specific enthalpy per unit mass should be computed as well as per unit volume. 
Generally useful, but I need it for overlapping domain coupling of Pronghorn and SAM.

## Design

Adding an addition functor in `INSFVEnthalpyMaterial`

## Impact

None expected. 
