### PR TITLE
Simple change for future multi-system to Navier Stokes advected quantities

### DIFF
--- a/framework/doc/content/source/functormaterials/GenericVectorFunctorMaterial.md
+++ b/framework/doc/content/source/functormaterials/GenericVectorFunctorMaterial.md
@@ -3,10 +3,10 @@
 !syntax description /FunctorMaterials/GenericVectorFunctorMaterial
 
 The functor system allows for using different functor types, functions, variables and
-material properties for example, for each component X, Y and Z of the vector functor
+functor material properties for example, for each component X, Y and Z of the vector functor
 material property.
 
-This can be used to quickly create simple constant anisotropic material properties,
+This can be used to quickly create simple constant anisotropic functor material properties,
 for testing, for initial survey of a problem or simply because the material
 properties do not vary much over the domain explored by the simulation.
 
@@ -18,9 +18,9 @@ and clears the cache at the beginning of every time step. Cache clearing behavio
 controlled by setting the `execute_on` parameter.
 
 !alert note
-All AD-types of the components must match. Variables are automatically considered as AD functors, even
-auxiliary variables. The AD version of this material is `ADGenericVectorFunctorMaterial`. Its inputs are a
-vector of AD functors and it creates AD vector functor material properties.
+Variables are automatically considered as AD functors, even
+auxiliary variables. The AD version of this material is `ADGenericVectorFunctorMaterial`.
+It creates AD vector functor material properties.
 
 ## Example Input File Syntax
 

--- a/modules/navier_stokes/src/fvkernels/INSFVMixingLengthScalarDiffusion.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMixingLengthScalarDiffusion.C
@@ -43,7 +43,7 @@ INSFVMixingLengthScalarDiffusion::INSFVMixingLengthScalarDiffusion(const InputPa
     mooseError(
         "In two or more dimensions, the v velocity must be supplied using the 'v' parameter");
   if (_dim >= 3 && !_w)
-    mooseError("In threedimensions, the w velocity must be supplied using the 'w' parameter");
+    mooseError("In three dimensions, the w velocity must be supplied using the 'w' parameter");
 }
 
 ADReal


### PR DESCRIPTION
I gutted this PR to just leave the cleaning up of derivatives from RC UO. 
Is this something we want to handle there?

Or should it be done elsewhere?
- functors could check the current system being solved before returning AD numbers with derivatives
- another idea






OUTDATED:

A few things to discuss:
- should we allow to separate all momentum components in different systems? It seems a common thing to do, but we dont have the Picard fixed point executioner to make it work rn @grmnptr 
- should we separate scalars by default? For reactor physics it make sense. But maybe species react in other physics?

Some preliminary results show this is a lot faster than fully coupled (no shocker here) and possibly 20% faster than multiapps with maybe 60% of the memory cost (no duplication of mesh, a_xy, P, velocities). 

This is still missing some work to enable:
- [ ] transients
- [ ] scaling (see https://github.com/idaholab/moose/issues/25646)
- [ ] cleaner RC code (and maybe faster, ditching AD on the non-velocity system)
- [ ] passing tests

END OUTDATED