### PR TITLE
Remove setting report_skipped = False if Heavy

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -1152,10 +1152,6 @@ class TestHarness:
         if opts.libmesh_dir:
             self.libmesh_dir = opts.libmesh_dir
 
-        # When running heavy tests, we'll make sure we use --no-report
-        if opts.heavy_tests:
-            self.options.report_skipped = False
-
         # User wants to write all output, so unify the options involved
         if opts.sep_files:
             opts.ok_files = True

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -703,14 +703,20 @@ class Tester(MooseObject):
                     tmp_reason.append(value)
 
             flat_reason = ', '.join(tmp_reason)
-
-            # If the test is deleted we still need to treat this differently
             self.addCaveats(flat_reason)
+
+            # Reasons we wish to silence tests
             if 'deleted' in reasons.keys():
                 if options.extra_info:
                     self.setStatus(self.deleted)
                 else:
                     self.setStatus(self.silent)
+            elif ('heavy' in reasons.keys()
+                  and options.heavy_tests
+                  and not self.specs['heavy']):
+                self.setStatus(self.silent)
+
+            # Failed already (cannot run)
             elif self.getStatus() == self.fail:
                 return False
             else:


### PR DESCRIPTION
This seems to be a value being set before we had a StatusSystem which specifically handles "SILENT" type statuses correctly.

Unittests passed, but lets throw this at Civet, and see what happens.

Closes #24727