### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,9 +2,9 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
-{% set build = 1 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.04.19" %}
+{% set version = "2023.06.19" %}
 {% set vtk_friendly_version = "9.2" %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.19 build_1
+ - moose-libmesh 2023.06.19 build_0
 
 moose_wasp:
   - moose-wasp 2023.05.01

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.04.19 build_1
+ - moose-libmesh 2023.06.19 build_0
 
 moose_wasp:
  - moose-wasp 2023.05.01

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=5e720a226ba3740dbe92c135936612461f489ada
+ARG LIBMESH_REV=dfaf6b5da757424806547c81d7dcba07c8ced6b8
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2023/2023_06.md
+++ b/modules/doc/content/newsletter/2023/2023_06.md
@@ -23,6 +23,52 @@ information.
 
 ## libMesh-level Changes
 
+### `2023.06.19` Update
+
+- Avoid using direct `new` calls or C-style casts in examples and
+  unit tests
+- `RBConstruction`: Re-throw exceptions on all procs in parallel
+- Added `QBase::size()` for more generic algorithm compatibility
+- Optimization of `LAGRANGE` Hex and especially `RATIONAL_BERNSTEIN`
+  shape function and derivative evaluations
+- Updated `reduced_basis` APIs, including vectorization of
+  RBParameters values and optimization work
+- `EquationSystems` I/O can now be done to any `istream`/`ostream`,
+  not just directly to files; this is in support of future
+  serialization improvements in MOOSE
+- `FEAbstract::add_p_level_in_reinit()` API to allow `FE` objects
+  to individually ignore `Elem` p-refinement levels; this is a
+  prerequisite to p-refinement support in MOOSE
+- Better error checking and handling in `ExodusII_IO` input and mesh
+  stitching
+- `EigenSystem` (as opposed to `CondensedEigenSystem` solves of
+  constrained systems now throw errors, rather than risking returning
+  non-physical eigenmodes
+- Major bug fixes for certain triangulation refinement cases with
+  `Poly2TriTriangulator`
+- Assorted bug fixes
+  - `all_second_order()` leaves untouched any elements in the range
+    that are already second-order
+  - build system console output cleaned up;
+  - Fixes, workarounds to pass `-fsanitize=integer` builds
+  - `CouplingMatrix` is now compatible with hundreds of thousands of
+    variable fields
+  - `Elem::key()` is now 64-bit for 64-bit `dof_id_type` builds,
+    improving performance by reducing hash conflicts
+  - `ExodusII_IO` output now handles matching sideset and shellface set ids
+  - `DistributedMesh` can handle nodes being not-quite-orphaned by
+    user code element deletion
+  - Mesh copying and cloning now handles missing entries in boundary
+    id to name maps, as well as better preserving partitioning
+    settings
+
+TIMPI changes:
+- Fixes, workarounds to pass `-fsanitize=integer` builds: correct
+  signed-vs-unsigned use, explicit casts when converting, etc.
+- Test coverage for `vector<bool>` reductions, test updates to
+  remove deprecated code
+- Cleaner `vector<bool>` unpacking code
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
libMesh changes:
* Remove possibly bad "copying" of id to name maps
* Remove setting of skip_noncritical_partitioning in copy_nodes_and_elements
* Avoid using direct `new` calls or C-style casts in examples and unit tests
* RBConstruction: Re-throw exceptions on all procs in parallel
* all_second_order: Skip any elements in the range that are already second-order
* Add size() to QBase
* Fixes, workarounds to pass `-fsanitize=integer` builds
* Fix `CouplingMatrix` compatibility with hundreds of thousands of variable fields
* Optimization of `LAGRANGE` Hex and especially `RATIONAL_BERNSTEIN` shape function and derivative evaluations
* Updated `reduced_basis` APIs, including vectorization of RBParameters values and optimization work
* `EquationSystems` I/O can now be done to any `istream`/`ostream`, not just directly to files
* `FEAbstract::add_p_level_in_reinit()` API to allow `FE` objects to individually ignore `Elem` p refinement levels
* Better error checking and handling in `Exodus` input and mesh stitching
* `EigenSystem` solves of constrained systems now throw errors, rather than risking returning non-physical eigenmodes
* Major bug fixes for certain triangulation refinement cases with `Poly2TriTriangulator`
* Assorted bug fixes: build system console output cleaned up; `Elem::key()` is now 64-bit for 64-bit `dof_id_type` builds, Exodus output can handle matching sideset and shellface set ids, and `DistributedMesh` can handle nodes being not-quite-orphaned by user code element deletion
    
TIMPI changes:
* Fixes, workarounds to pass `-fsanitize=integer` builds: correct signed-vs-unsigned use, explicit casts when converting, etc.
* Test coverage for vector<bool> reductions, test updates to remove deprecated code
* Cleaner vector<bool> unpacking code