### PR TITLE
skip tests if python package versions fail

### DIFF
--- a/python/TestHarness/testers/SchemaDiff.py
+++ b/python/TestHarness/testers/SchemaDiff.py
@@ -27,9 +27,9 @@ class SchemaDiff(RunApp):
     def __init__(self, name, params):
         RunApp.__init__(self, name, params)
         if self.specs['required_python_packages'] is None:
-            self.specs['required_python_packages'] = 'deepdiff'
+            self.specs['required_python_packages'] = 'deepdiff>=6.1.0'
         elif 'deepdiff' not in self.specs['required_python_packages']:
-            self.specs['required_python_packages'] += ' deepdiff'
+            self.specs['required_python_packages'] += ' deepdiff>=6.1.0'
 
         # So that derived classes can internally pass skip regex paths
         self.exclude_regex_paths = []

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -656,7 +656,7 @@ class Tester(MooseObject):
         if py_packages is not None:
             missing = mooseutils.check_configuration(py_packages.split(), message=False)
             if missing:
-                reasons['python_packages_required'] = ', '.join(['no {}'.format(p) for p in missing])
+                reasons['python_packages_required'] = ', '.join(['{}'.format(p) for p in missing])
 
         # Check for programs
         programs = self.specs['requires']

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -216,7 +216,10 @@ def check_configuration(packages, message=True):
                 _op = re_operators.findall(_package)[0]
                 (_package, _operator, _version) = re.findall(f'([.\w_-]+)([{_op}]+)(.*)',
                                                              _package)[0]
+            # Try and capture possible regex issues
             except IndexError:
+                missing.extend([_package, 'version parse error'])
+            except ValueError:
                 missing.extend([_package, 'version parse error'])
 
         # Try to import the package

--- a/python/mooseutils/mooseutils.py
+++ b/python/mooseutils/mooseutils.py
@@ -225,16 +225,16 @@ def check_configuration(packages, message=True):
             # Try and verify version
             if (_operator in ['>=', '>']
                 and version.parse(__import__(_package).__version__) < version.parse(_version)):
-                missing.append(f'{_package}>={_version}')
+                missing.append(f'{_package} is not {_operator} {_version}')
             elif (_operator in ['<=', '<']
                 and version.parse(__import__(_package).__version__) > version.parse(_version)):
-                missing.append(f'{_package}<={_version}')
+                missing.append(f'{_package} is not {_operator} {_version}')
             elif (_operator in ['==', '=']
                 and version.parse(__import__(_package).__version__) != version.parse(_version)):
-                missing.append(f'{_package}!={_version}')
+                missing.append(f'{_package} != {_version}')
 
         except ImportError:
-            missing.append(_package)
+            missing.append(f'no {_package}')
 
         # Python package does not support a __version__ method. Good luck!
         except AttributeError:


### PR DESCRIPTION
Allow the TestHarness to skip tests if required python package versions do not meet specified criteria.

Closes #24736

