### PR TITLE
Check for non-existing variable

### DIFF
--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -786,7 +786,7 @@ SubProblem::getVariableHelper(THREAD_ID tid,
     else
       mooseError("Unknown variable " + var_name);
   }
-  else if (expected_var_type == Moose::VarKindType::VAR_NONLINEAR &&
+  else if (expected_var_type == Moose::VarKindType::VAR_NONLINEAR && var_in_nl &&
            nls[nl_sys_num]->hasVariable(var_name))
     var = &(nls[nl_sys_num]->getVariable(tid, var_name));
   else if (expected_var_type == Moose::VarKindType::VAR_AUXILIARY && aux.hasVariable(var_name))


### PR DESCRIPTION
## Reason
Under certain circumstances requesting a non-existing variable would lead to a segfault. I encountered this when converting a Largrange Multiplier contact problem to a Penalty contact problem and forgot to remove postprocessors accessing the (now missing) lagrange multiplier variables.

## Design
Check if the requested variable really exists in the nonlinear system.

## Impact
Better error message.