### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -2,6 +2,7 @@
 # REMEMBER TO UPDATE the .yaml files for the following packages:
 #   template/
 #   moose/
+#   moose-dev/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.06.23" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #   moose/
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.06.19" %}
+{% set version = "2023.06.23" %}
 {% set vtk_friendly_version = "9.2" %}
 
 package:

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2023.06.19 build_0
+  - moose-libmesh 2023.06.23 build_0
 
 moose_wasp:
   - moose-wasp 2023.05.01

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2023.06.22" %}
+{% set version = "2023.06.23" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.06.19 build_0
+ - moose-libmesh 2023.06.23 build_0
 
 moose_wasp:
   - moose-wasp 2023.05.01

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - moose-libmesh 2023.06.19 build_0
+ - moose-libmesh 2023.06.23 build_0
 
 moose_wasp:
  - moose-wasp 2023.05.01

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=dfaf6b5da757424806547c81d7dcba07c8ced6b8
+ARG LIBMESH_REV=dc964ef4e459ba7ce080f8d6c1f4cac939cfbfed
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2023/2023_06.md
+++ b/modules/doc/content/newsletter/2023/2023_06.md
@@ -82,6 +82,14 @@ TIMPI changes:
   remove deprecated code
 - Cleaner `vector<bool>` unpacking code
 
+### `2023.06.23` Update
+
+- Un-condensed Eigensystem solves of constrained systems now throw
+  *warnings*, not errors, for the sake of downstream apps getting away
+  with it so far.
+- PETSc DM interface error messages now use proper format strings for
+  32-bit builds too
+
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements


### PR DESCRIPTION
This reverts the "error when trying to do eigensolves on an uncondensed constrained system" to "warn that you like to live dangerously when trying to do eigensolves on an uncondensed unconstrained system", since Griffin has some periodic BC cases relying on (and working with) that.