### PR TITLE
Remove non MOOSE related instructions

### DIFF
--- a/modules/doc/content/ncrc/applications/ncrc_hpc_relap5.md
+++ b/modules/doc/content/ncrc/applications/ncrc_hpc_relap5.md
@@ -1,1 +1,20 @@
-!template load file=ncrc/applications/ncrc_hpc.md.template ApplicationName=RELAP5 ApplicationLower=relap5 binary=relap5
+# Relap5-3D Binary Access with INL-HPC
+
+Familiarize yourself with [inl/hpc_ondemand.md], and return here with an interactive shell for the
+machine you wish to run your application on. NCRC Application binaries are only available on
+Sawtooth and Lemhi.
+
+## Load Relap5-3D Environment
+
+Logged into either Sawtooth or Lemhi, load the Relap5-3D environment:
+
+```bash
+module load use.moose moose-apps relap5
+```
+
+At this point you should be able to run `relap5`. For this example, Relap5-3D's
+`--help` can be displayed by running the following command:
+
+```bash
+relap5 --help
+```

--- a/modules/doc/content/ncrc/applications/ncrc_ondemand_relap5.md
+++ b/modules/doc/content/ncrc/applications/ncrc_ondemand_relap5.md
@@ -1,1 +1,0 @@
-!template load file=ncrc/applications/ncrc_ondemand.md.template ApplicationName=RELAP5 ApplicationLower=relap5 binary=relap5 binary_method=relap5

--- a/modules/doc/content/ncrc/applications/ncrc_root_relap5.md
+++ b/modules/doc/content/ncrc/applications/ncrc_root_relap5.md
@@ -2,7 +2,6 @@
 
 - [Documentation](https://relap5-docs.hpcondemand.inl.gov/)
 - [Support Forum (Discourse)](https://relap5-discourse.hpcondemand.inl.gov)
-- [Level 1 - HPC OnDemand Execution](ncrc/applications/ncrc_ondemand_relap5.md)
 - [Level 1 - HPC Binary Execution](ncrc/applications/ncrc_hpc_relap5.md)
 
 !row!


### PR DESCRIPTION
Remove non MOOSE related instructions to Relap5-3D instructions.

Closes #24802


