### PR TITLE
Add a warning on RC interpolator and avoid crash on unset functor

### DIFF
--- a/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
+++ b/modules/navier_stokes/src/userobjects/INSFVRhieChowInterpolator.C
@@ -583,6 +583,19 @@ INSFVRhieChowInterpolator::getVelocity(const Moose::FV::InterpMethod m,
   if (m == Moose::FV::InterpMethod::Average ||
       std::get<0>(NS::isPorosityJumpFace(epsilon(tid), fi, time)))
     return velocity;
+  // Rhie-Chow coefficients are not available on initial
+  if (_fe_problem.getCurrentExecuteOnFlag() == EXEC_INITIAL)
+  {
+    mooseDoOnce(mooseWarning("Cannot compute Rhie Chow coefficients on initial. Returning linearly "
+                             "interpolated velocities"););
+    return velocity;
+  }
+  if (!_fe_problem.shouldSolve())
+  {
+    mooseDoOnce(mooseWarning("Cannot compute Rhie Chow coefficients if not solving. Returning "
+                             "linearly interpolated velocities"););
+    return velocity;
+  }
 
   mooseAssert(((m == Moose::FV::InterpMethod::RhieChow) &&
                (_velocity_interp_method == Moose::FV::InterpMethod::RhieChow)) ||


### PR DESCRIPTION
- on initial
- on solve = false, refs #24708

This blocked Ramiro for an hour or so. We have to do something about it