### PR TITLE
Adding metadata to RGMB to represent reactor geometry and region ID assignment

### DIFF
--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -188,7 +188,7 @@ protected:
   ///@}
 
   /**
-   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store
+   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store. This may often be avoided as getMeshProperty calls can traverse the tree of mesh generators to find a metadata instance
    */
   template <typename T>
   T & copyMeshProperty(const std::string & target_data_name,
@@ -200,7 +200,7 @@ protected:
 
   /**
    * Method for copying attribute from input mesh meta-data store to current mesh meta-data store,
-   * keeping source and target data names the same
+   * keeping source and target data names the same. This may often be avoided as getMeshProperty calls can traverse the tree of mesh generators to find a metadata instance
    */
   template <typename T>
   T & copyMeshProperty(const std::string & source_data_name, const std::string & source_mesh)

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -188,6 +188,17 @@ protected:
   ///@}
 
   /**
+   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store
+   */
+  template <typename T>
+  T & copyMeshProperty(const std::string & source_data_name,
+                       const std::string & source_mesh,
+                       const std::string & target_data_name)
+  {
+    return declareMeshProperty(target_data_name, getMeshProperty<T>(source_data_name, source_mesh));
+  }
+
+  /**
    * Takes the name of a MeshGeneratorName parameter and then gets a pointer to the
    * Mesh that MeshGenerator is going to create.
    *

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -191,11 +191,21 @@ protected:
    * Method for copying attribute from input mesh meta-data store to current mesh meta-data store
    */
   template <typename T>
-  T & copyMeshProperty(const std::string & source_data_name,
-                       const std::string & source_mesh,
-                       const std::string & target_data_name)
+  T & copyMeshProperty(const std::string & target_data_name,
+                       const std::string & source_data_name,
+                       const std::string & source_mesh)
   {
     return declareMeshProperty(target_data_name, getMeshProperty<T>(source_data_name, source_mesh));
+  }
+
+  /**
+   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store,
+   * keeping source and target data names the same
+   */
+  template <typename T>
+  T & copyMeshProperty(const std::string & source_data_name, const std::string & source_mesh)
+  {
+    return copyMeshProperty<T>(source_data_name, source_data_name, source_mesh);
   }
 
   /**

--- a/framework/include/meshgenerators/MeshGenerator.h
+++ b/framework/include/meshgenerators/MeshGenerator.h
@@ -188,7 +188,9 @@ protected:
   ///@}
 
   /**
-   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store. This may often be avoided as getMeshProperty calls can traverse the tree of mesh generators to find a metadata instance
+   * Method for copying attribute from input mesh meta-data store to current mesh meta-data store.
+   * This may often be avoided as getMeshProperty calls can traverse the tree of mesh generators to
+   * find a metadata instance
    */
   template <typename T>
   T & copyMeshProperty(const std::string & target_data_name,
@@ -200,7 +202,8 @@ protected:
 
   /**
    * Method for copying attribute from input mesh meta-data store to current mesh meta-data store,
-   * keeping source and target data names the same. This may often be avoided as getMeshProperty calls can traverse the tree of mesh generators to find a metadata instance
+   * keeping source and target data names the same. This may often be avoided as getMeshProperty
+   * calls can traverse the tree of mesh generators to find a metadata instance
    */
   template <typename T>
   T & copyMeshProperty(const std::string & source_data_name, const std::string & source_mesh)

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -67,6 +67,11 @@ stringify(const T & t)
 
 // overloads for integer types where std::to_string gives the same result and is faster
 inline std::string
+stringify(bool v)
+{
+  return v ? "true" : "false";
+}
+inline std::string
 stringify(int v)
 {
   return std::to_string(v);

--- a/framework/include/utils/Conversion.h
+++ b/framework/include/utils/Conversion.h
@@ -65,12 +65,14 @@ stringify(const T & t)
   return os.str();
 }
 
-// overloads for integer types where std::to_string gives the same result and is faster
+// overload for boolean type instead of simply printing 0 or 1
 inline std::string
 stringify(bool v)
 {
   return v ? "true" : "false";
 }
+
+// overloads for integer types where std::to_string gives the same result and is faster
 inline std::string
 stringify(int v)
 {

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -34,14 +34,9 @@ If the assembly is extruded to three dimensions the top-most boundary ID must be
 
 ## Metadata Information
 
-Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output. The following metadata is defined on the assembly mesh:
 
-At the assembly level, each metadata entry is prepended with the prefix `"assembly_<assembly_type_id>_"`, where `<assembly_type_id>` is the assembly_type id assigned with [!param](/Mesh/AssemblyMeshGenerator/assembly_type), and the following metadata is defined on the assembly mesh:
-
-- `mesh_dimensions`: Number of dimensions in assembly mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
-- `mesh_geometry`: Whether assembly geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
-- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
-- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
+- `assembly_type`: Value of type_id associated with assembly, equivalent to [!param](/Mesh/AssemblyMeshGenerator/assembly_type)
 - `pitch`: Assembly pitch, equivalent to [!param](/Mesh/ReactorMeshParams/assembly_pitch)
 - `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
 - `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to [!param](/Mesh/PinMeshGenerator/use_as_assembly).
@@ -56,10 +51,12 @@ If the assembly is represented as a single pin, the following metadata is also d
 
 If instead the assembly is represented as a lattice of pins, the following metadata is defined:
 
-- `pin_types`: pin_type ids of pins comprising of pin lattice.
-- `lattice`: 2-D lattice of pins in assembly, where each location represents the pin_type id of the pin in that lattice position.
+- `pin_names`: Mesh generator names of constituent pins in lattice.
+- `pin_lattice`: 2-D lattice of pins in assembly, where each location represents the index of the pin in the list of names under the `pin_names` metadata entry
 
-For each of the pins listed in `pin_types`, the pin-level metadata is also displayed. A list of pin-level metadata that is defined on the assembly mesh can be found in [PinMeshGenerator](PinMeshGenerator.md).
+For each of the pins listed in `pin_names`, the pin-level metadata is also displayed when [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) is set to true. A list of pin-level metadata that is defined on the assembly mesh can be found in [PinMeshGenerator](PinMeshGenerator.md).
+
+In addition, the value of the `reactor_params_name` metadata can be used to retrieve global metadata defined by [ReactorMeshParams](ReactorMeshParams.md). Please refer to [ReactorMeshParams](ReactorMeshParams.md) to see a list of metadata defined by this mesh generator.
 
 ## Example Syntax
 

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -45,13 +45,13 @@ At the assembly level, each metadata entry is prepended with the prefix `"assemb
 - `pitch`: Assembly pitch, equivalent to [!param](/Mesh/ReactorMeshParams/assembly_pitch)
 - `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
 - `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to [!param](/Mesh/PinMeshGenerator/use_as_assembly).
-- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
+- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [`AssemblyMeshGenerator`](AssemblyMeshGenerator.md)/[!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
 - `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of assembly mesh.
 - `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
 
 If the assembly is represented as a single pin, the following metadata is also defined:
 
-- `ring_radii`: Location of rings comprising of assembly region, equivalent to [!param](/Mesh/PinMeshGenerator/ring_radii).
+- `ring_radii`: Location of rings comprising of assembly region, equivalent to [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/ring_radii).
 - `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
 
 If instead the assembly is represented as a lattice of pins, the following metadata is defined:

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -32,6 +32,35 @@ The `AssemblyMeshGenerator` objects automatically assigns boundary information d
 
 If the assembly is extruded to three dimensions the top-most boundary ID must be assigned using [!param](/Mesh/ReactorMeshParams/top_boundary_id) and will have the name "top", while the bottom-most boundary must be assigned using [!param](/Mesh/ReactorMeshParams/bottom_boundary_id) and will have the name "bottom".
 
+## Metadata Information
+
+Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+
+At the assembly level, each metadata entry is prepended with the prefix `"assembly_<assembly_type_id>_"`, where `<assembly_type_id>` is the assembly_type id assigned with [!param](/Mesh/AssemblyMeshGenerator/assembly_type), and the following metadata is defined on the assembly mesh:
+
+- `mesh_dimensions`: Number of dimensions in assembly mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
+- `mesh_geometry`: Whether assembly geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
+- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
+- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
+- `pitch`: Assembly pitch, equivalent to [!param](/Mesh/ReactorMeshParams/assembly_pitch)
+- `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
+- `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to [!param](/Mesh/PinMeshGenerator/use_as_assembly).
+- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
+- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of assembly mesh.
+- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
+
+If the assembly is represented as a single pin, the following metadata is also defined:
+
+- `ring_radii`: Location of rings comprising of assembly region, equivalent to [!param](/Mesh/PinMeshGenerator/ring_radii).
+- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
+
+If instead the assembly is represented as a lattice of pins, the following metadata is defined:
+
+- `pin_types`: pin_type ids of pins comprising of pin lattice.
+- `lattice`: 2-D lattice of pins in assembly, where each location represents the pin_type id of the pin in that lattice position.
+
+For each of the pins listed in `pin_types`, the pin-level metadata is also displayed. A list of pin-level metadata that is defined on the assembly mesh can be found in [PinMeshGenerator](PinMeshGenerator.md).
+
 ## Example Syntax
 
 !listing modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_only.i block=Mesh

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -38,7 +38,6 @@ Users may be interested in defining additional metadata to represent the reactor
 
 - `assembly_type`: Value of type_id associated with assembly, equivalent to the input parameter [!param](/Mesh/AssemblyMeshGenerator/assembly_type)
 - `pitch`: Assembly pitch, equivalent to the input parameter [!param](/Mesh/ReactorMeshParams/assembly_pitch)
-- `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/homogenized)
 - `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/use_as_assembly).
 - `duct_halfpitches`: Length of apothems defining the duct locations, equivalent to the input parameter [`AssemblyMeshGenerator`](AssemblyMeshGenerator.md)/[!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
 - `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of assembly mesh, equivalent to the input parameter [!param](/Mesh/AssemblyMeshGenerator/background_region_id).
@@ -48,11 +47,12 @@ If the assembly is represented as a single pin, the following metadata is also d
 
 - `ring_radii`: Length of ring radii comprising of assembly region, equivalent to [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/ring_radii).
 - `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of assembly mesh, corresponding to the ring-related region ids of the input parameter [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/region_ids). Inner indexing is radial zones, while outer index is axial zones.
+- `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to the input parameter [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/homogenized)
 
 If instead the assembly is represented as a lattice of pins, the following metadata is defined:
 
 - `pin_names`: List of mesh generator names of constituent pins in lattice.
-- `pin_lattice`: 2-D lattice of pins in assembly, where each location represents the index of the pin in the list of names under the `pin_names` metadata entry.
+- `pin_lattice`: 2-D lattice of pins in assembly, where each location represents the 0-based index of the pin in the list of names under the `pin_names` metadata entry.
 
 For each of the pins listed in `pin_names`, the pin-level metadata is also displayed when [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) is set to true. A list of pin-level metadata that is defined on the assembly mesh can be found in [PinMeshGenerator](PinMeshGenerator.md).
 

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -60,7 +60,7 @@ In addition, the value of the `reactor_params_name` metadata can be used to retr
 
 ## Example Syntax
 
-!listing modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_only.i block=Mesh
+!listing modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_square.i block=Mesh
 
 This is the resulting mesh block layout, where by default a single block is assigned to the triangular elements and another block is assigned to the quadrilateral elements:
 

--- a/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/AssemblyMeshGenerator.md
@@ -36,23 +36,23 @@ If the assembly is extruded to three dimensions the top-most boundary ID must be
 
 Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output. The following metadata is defined on the assembly mesh:
 
-- `assembly_type`: Value of type_id associated with assembly, equivalent to [!param](/Mesh/AssemblyMeshGenerator/assembly_type)
-- `pitch`: Assembly pitch, equivalent to [!param](/Mesh/ReactorMeshParams/assembly_pitch)
-- `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
-- `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to [!param](/Mesh/PinMeshGenerator/use_as_assembly).
-- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [`AssemblyMeshGenerator`](AssemblyMeshGenerator.md)/[!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
-- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of assembly mesh.
-- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
+- `assembly_type`: Value of type_id associated with assembly, equivalent to the input parameter [!param](/Mesh/AssemblyMeshGenerator/assembly_type)
+- `pitch`: Assembly pitch, equivalent to the input parameter [!param](/Mesh/ReactorMeshParams/assembly_pitch)
+- `is_homogenized`: Whether or not assembly mesh is homogenized, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/homogenized)
+- `is_single_pin`: Whether or not assembly mesh is represented by a single pin region or a lattice of pins, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/use_as_assembly).
+- `duct_halfpitches`: Length of apothems defining the duct locations, equivalent to the input parameter [`AssemblyMeshGenerator`](AssemblyMeshGenerator.md)/[!param](/Mesh/AssemblyMeshGenerator/duct_halfpitch)
+- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of assembly mesh, equivalent to the input parameter [!param](/Mesh/AssemblyMeshGenerator/background_region_id).
+- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of assembly mesh, equivalent to the input parameter [!param](/Mesh/AssemblyMeshGenerator/duct_region_ids). Inner indexing is radial zones, while outer index is axial zones.
 
 If the assembly is represented as a single pin, the following metadata is also defined:
 
-- `ring_radii`: Location of rings comprising of assembly region, equivalent to [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/ring_radii).
-- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of assembly mesh. Inner indexing is radial zones, while outer index is axial zones.
+- `ring_radii`: Length of ring radii comprising of assembly region, equivalent to [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/ring_radii).
+- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of assembly mesh, corresponding to the ring-related region ids of the input parameter [`PinMeshGenerator`](PinMeshGenerator.md)/[!param](/Mesh/PinMeshGenerator/region_ids). Inner indexing is radial zones, while outer index is axial zones.
 
 If instead the assembly is represented as a lattice of pins, the following metadata is defined:
 
-- `pin_names`: Mesh generator names of constituent pins in lattice.
-- `pin_lattice`: 2-D lattice of pins in assembly, where each location represents the index of the pin in the list of names under the `pin_names` metadata entry
+- `pin_names`: List of mesh generator names of constituent pins in lattice.
+- `pin_lattice`: 2-D lattice of pins in assembly, where each location represents the index of the pin in the list of names under the `pin_names` metadata entry.
 
 For each of the pins listed in `pin_names`, the pin-level metadata is also displayed when [!param](/Mesh/AssemblyMeshGenerator/show_rgmb_metadata) is set to true. A list of pin-level metadata that is defined on the assembly mesh can be found in [PinMeshGenerator](PinMeshGenerator.md).
 

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -44,7 +44,7 @@ In addition, the value of the metadata `reactor_params_name` can be used to retr
 
 ## Example Syntax
 
-!listing modules/reactor/test/tests/meshgenerators/core_mesh_generator/core.i block=Mesh
+!listing modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_square.i block=Mesh
 
 This is the resulting mesh block layout, where by default a single block is assigned to all of the quadrilateral elements in the mesh:
 

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -31,7 +31,7 @@ Users may be interested in defining metadata to represent the reactor geometry a
 At the core level, the following metadata is defined on the output mesh:
 
 - `assembly_names`: Mesh generator names of constituent assemblies in lattice
-- `lattice`: 2-D lattice of assemblies in core, where each location represents the index of the assembly in the list of names under the `assembly_names` metadata entry.
+- `lattice`: 2-D lattice of assemblies in core, where each location represents the 0-based index of the assembly in the list of names under the `assembly_names` metadata entry.
 
 For each of the assemblies listed in `assembly_names`, the assembly-level metadata is also displayed. In addition, if any of these assemblies are comprised of pins in a lattice, the pin-level metadata of these constituent pins is also displayed. A list of assembly-level and pin-level metadata defined on the core mesh can be found in [AssemblyMeshGenerator](AssemblyMeshGenerator.md) and [PinMeshGenerator](PinMeshGenerator.md) respectively.
 

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -37,8 +37,8 @@ For each of the assemblies listed in `assembly_names`, the assembly-level metada
 
 For meshes where a core periphery is defined, the following metadata is also defined:
 
-- `peripheral_ring_radius`: Outer radius of core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
-- `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/periphery_region_id).
+- `peripheral_ring_radius`: Outer radius of core periphery, equivalent to the input parameter [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
+- `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to the input parameter [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/periphery_region_id).
 
 In addition, the value of the metadata `reactor_params_name` can be used to retrieve global metadata defined by [ReactorMeshParams](ReactorMeshParams.md). Please refer to [ReactorMeshParams](ReactorMeshParams.md) to see a list of metadata defined by this mesh generator.
 

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -24,6 +24,27 @@ The `CoreMeshGenerator` objects automatically assigns boundary information. The 
 
 If the core is extruded to three dimensions the top-most boundary ID must be assigned using [!param](/Mesh/ReactorMeshParams/top_boundary_id) and will have the name "top", while the bottom-most boundary must be assigned using [!param](/Mesh/ReactorMeshParams/bottom_boundary_id) and will have the name "bottom".
 
+## Metadata Information
+
+Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/CoreMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+
+At the core level, each metadata entry is prepended with the prefix `"core_"`, and the following metadata is defined on the assembly mesh:
+
+- `mesh_dimensions`: Number of dimensions in core mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
+- `mesh_geometry`: Whether core geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
+- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
+- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
+- `assembly_types`: assembly_type ids of assembly comprising of assembly lattice in the core.
+- `lattice`: 2-D lattice of assemblies in core, where each location represents the assembly_type id of the assembly in that lattice position. A value of -1 represents a dummy assembly location
+
+For each of the assemblies listed in `assembly_types`, the assembly-level metadata is also displayed. In addition, if any of these assemblies are comprised of pins in a lattice, the pin-level metadata of these constituent pins is also displayed. A list of assembly-level and pin-level metadata defined on the core mesh can be found in [AssemblyMeshGenerator](AssemblyMeshGenerator.md) and [PinMeshGenerator](PinMeshGenerator.md) respectively.
+
+For meshes where a core periphery is defined, the following metadata is also defined:
+
+- `peripheral_ring_radius`: Outer radius of core periphery, equivalent to [!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
+- `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to [!param](/Mesh/CoreMeshGenerator/periphery_region_id).
+
+
 ## Example Syntax
 
 !listing modules/reactor/test/tests/meshgenerators/core_mesh_generator/core.i block=Mesh

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -26,24 +26,21 @@ If the core is extruded to three dimensions the top-most boundary ID must be ass
 
 ## Metadata Information
 
-Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/CoreMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+Users may be interested in defining metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. [!param](/Mesh/CoreMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
 
-At the core level, each metadata entry is prepended with the prefix `"core_"`, and the following metadata is defined on the assembly mesh:
+At the core level, the following metadata is defined on the output mesh:
 
-- `mesh_dimensions`: Number of dimensions in core mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
-- `mesh_geometry`: Whether core geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
-- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
-- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
-- `assembly_types`: assembly_type ids of assembly comprising of assembly lattice in the core.
-- `lattice`: 2-D lattice of assemblies in core, where each location represents the assembly_type id of the assembly in that lattice position. A value of -1 represents a dummy assembly location
+- `assembly_names`: Mesh generator names of constituent assemblies in lattice
+- `lattice`: 2-D lattice of assemblies in core, where each location represents the index of the assembly in the list of names under the `assembly_names` metadata entry.
 
-For each of the assemblies listed in `assembly_types`, the assembly-level metadata is also displayed. In addition, if any of these assemblies are comprised of pins in a lattice, the pin-level metadata of these constituent pins is also displayed. A list of assembly-level and pin-level metadata defined on the core mesh can be found in [AssemblyMeshGenerator](AssemblyMeshGenerator.md) and [PinMeshGenerator](PinMeshGenerator.md) respectively.
+For each of the assemblies listed in `assembly_names`, the assembly-level metadata is also displayed. In addition, if any of these assemblies are comprised of pins in a lattice, the pin-level metadata of these constituent pins is also displayed. A list of assembly-level and pin-level metadata defined on the core mesh can be found in [AssemblyMeshGenerator](AssemblyMeshGenerator.md) and [PinMeshGenerator](PinMeshGenerator.md) respectively.
 
 For meshes where a core periphery is defined, the following metadata is also defined:
 
 - `peripheral_ring_radius`: Outer radius of core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
 - `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/periphery_region_id).
 
+In addition, the value of the metadata `reactor_params_name` can be used to retrieve global metadata defined by [ReactorMeshParams](ReactorMeshParams.md). Please refer to [ReactorMeshParams](ReactorMeshParams.md) to see a list of metadata defined by this mesh generator.
 
 ## Example Syntax
 

--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -41,8 +41,8 @@ For each of the assemblies listed in `assembly_types`, the assembly-level metada
 
 For meshes where a core periphery is defined, the following metadata is also defined:
 
-- `peripheral_ring_radius`: Outer radius of core periphery, equivalent to [!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
-- `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to [!param](/Mesh/CoreMeshGenerator/periphery_region_id).
+- `peripheral_ring_radius`: Outer radius of core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/outer_circle_radius).
+- `peripheral_ring_region_id`: Region ID associated with core periphery, equivalent to [`CoreMeshGenerator`](CoreMeshGenerator.md)/[!param](/Mesh/CoreMeshGenerator/periphery_region_id).
 
 
 ## Example Syntax

--- a/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
@@ -54,7 +54,7 @@ In addition, the value of the metadata `reactor_params_name` can be used to retr
 
 ## Example Syntax
 
-!listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i block=Mesh
+!listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_square.i block=Mesh
 
 This is the resulting mesh block layout, where by default a single block is assigned to the triangular elements and another block is assigned to the quadrilateral elements:
 

--- a/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
@@ -37,14 +37,11 @@ If the pin is extruded to three dimensions the top-most boundary ID must be assi
 
 ## Metadata Information
 
-Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/PinMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+Users may be interested in defining metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to see the values of these metadata entries as console output, [!param](/Mesh/PinMeshGenerator/show_rgmb_metadata) can be set to true.
 
-At the pin level, each metadata entry is prepended with the prefix `"pin_<pin_type_id>_"`, where `<pin_type_id>` is the pin_type id assigned with [!param](/Mesh/PinMeshGenerator/pin_type), and the following metadata is defined on the pin mesh:
+At the pin level, the following metadata is defined on the pin mesh:
 
-- `mesh_dimensions`: Number of dimensions in pin mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
-- `mesh_geometry`: Whether pin geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
-- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
-- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
+- `pin_type`: pin_type id associated with pin mesh, equivalent to [!param](/Mesh/PinMeshGenerator/pin_type)
 - `pitch`: Pitch of outermost boundary polygon, equivalent to [!param](/Mesh/PinMeshGenerator/pitch)
 - `is_homogenized`: Whether or not pin mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
 - `ring_radii`: Location of rings comprising of pin region, equivalent to [!param](/Mesh/PinMeshGenerator/ring_radii).
@@ -52,6 +49,8 @@ At the pin level, each metadata entry is prepended with the prefix `"pin_<pin_ty
 - `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of pin mesh. Inner indexing is radial zones, while outer index is axial zones.
 - `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of pin mesh.
 - `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of pin mehs. Inner indexing is radial zones, while outer index is axial zones.
+
+In addition, the value of the metadata `reactor_params_name` can be used to retrieve global metadata defined by [ReactorMeshParams](ReactorMeshParams.md). Please refer to [ReactorMeshParams](ReactorMeshParams.md) to see a list of metadata defined by this mesh generator.
 
 ## Example Syntax
 

--- a/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
@@ -35,6 +35,24 @@ The `PinMeshGenerator` object automatically assigns boundary information derived
 
 If the pin is extruded to three dimensions the top-most boundary ID must be assigned using [!param](/Mesh/ReactorMeshParams/top_boundary_id) and will have the name "top", while the bottom-most boundary must be assigned using [!param](/Mesh/ReactorMeshParams/bottom_boundary_id) and will have the name "bottom".
 
+## Metadata Information
+
+Users may be interested in defining additional metadata to represent the reactor geometry and region IDs assigned to each geometry zone, which may be useful to users who want mesh geometry and composition information without having to inspect the generated mesh itself. In order to do so,  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) must be set to true. [!param](/Mesh/PinMeshGenerator/show_rgmb_metadata) can be set to true in order to see the values of these metadata entries as console output.
+
+At the pin level, each metadata entry is prepended with the prefix `"pin_<pin_type_id>_"`, where `<pin_type_id>` is the pin_type id assigned with [!param](/Mesh/PinMeshGenerator/pin_type), and the following metadata is defined on the pin mesh:
+
+- `mesh_dimensions`: Number of dimensions in pin mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
+- `mesh_geometry`: Whether pin geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
+- `axial_boundaries`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
+- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
+- `pitch`: Pitch of outermost boundary polygon, equivalent to [!param](/Mesh/PinMeshGenerator/pitch)
+- `is_homogenized`: Whether or not pin mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
+- `ring_radii`: Location of rings comprising of pin region, equivalent to [!param](/Mesh/PinMeshGenerator/ring_radii).
+- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [!param](/Mesh/PinMeshGenerator/duct_halfpitch)
+- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of pin mesh. Inner indexing is radial zones, while outer index is axial zones.
+- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of pin mesh.
+- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of pin mehs. Inner indexing is radial zones, while outer index is axial zones.
+
 ## Example Syntax
 
 !listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i block=Mesh

--- a/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/PinMeshGenerator.md
@@ -41,14 +41,14 @@ Users may be interested in defining metadata to represent the reactor geometry a
 
 At the pin level, the following metadata is defined on the pin mesh:
 
-- `pin_type`: pin_type id associated with pin mesh, equivalent to [!param](/Mesh/PinMeshGenerator/pin_type)
-- `pitch`: Pitch of outermost boundary polygon, equivalent to [!param](/Mesh/PinMeshGenerator/pitch)
-- `is_homogenized`: Whether or not pin mesh is homogenized, equivalent to [!param](/Mesh/PinMeshGenerator/homogenized)
-- `ring_radii`: Location of rings comprising of pin region, equivalent to [!param](/Mesh/PinMeshGenerator/ring_radii).
-- `duct_halfpitches`: Location of apothems defining the duct locations, equivalent to [!param](/Mesh/PinMeshGenerator/duct_halfpitch)
-- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of pin mesh. Inner indexing is radial zones, while outer index is axial zones.
-- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of pin mesh.
-- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of pin mehs. Inner indexing is radial zones, while outer index is axial zones.
+- `pin_type`: pin_type id associated with pin mesh, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/pin_type)
+- `pitch`: Pitch of outermost boundary polygon, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/pitch)
+- `is_homogenized`: Whether or not pin mesh is homogenized, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/homogenized)
+- `ring_radii`: Length of ring radii comprising of pin region, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/ring_radii).
+- `duct_halfpitches`: Length of apothems defining the duct locations, equivalent to the input parameter [!param](/Mesh/PinMeshGenerator/duct_halfpitch)
+- `ring_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within ring regions of pin mesh, based on the ring-related region ids of the input parameter [!param](/Mesh/PinMeshGenerator/region_ids). Inner indexing is radial zones, while outer index is axial zones.
+- `background_region_id`: 1-D vector of region_ids corresponding to axial zones of background regions of pin mesh, based on the background-related region ids of the input parameter [!param](/Mesh/PinMeshGenerator/region_ids).
+- `duct_region_ids`: 2-D vector of region ids corresponding to radial and axial zones within duct regions of pin mesh, based on the duct-related region ids of the input parameter [!param](/Mesh/PinMeshGenerator/region_ids). Inner indexing is radial zones, while outer index is axial zones.
 
 In addition, the value of the metadata `reactor_params_name` can be used to retrieve global metadata defined by [ReactorMeshParams](ReactorMeshParams.md). Please refer to [ReactorMeshParams](ReactorMeshParams.md) to see a list of metadata defined by this mesh generator.
 

--- a/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
+++ b/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
@@ -6,7 +6,14 @@
 
 The `ReactorMeshParams` object stores persistent mesh information about a reactor's geometry for use with [PinMeshGenerator](/PinMeshGenerator.md), [AssemblyMeshGenerator](/AssemblyMeshGenerator.md), and [CoreMeshGenerator](/CoreMeshGenerator.md). This is where the geometry type ([!param](/Mesh/ReactorMeshParams/geom) as 'Square' or 'Hex' for cartesian and hexagonal definitions respectively) and the number of dimensions of the mesh ([!param](/Mesh/ReactorMeshParams/dim) 2 or 3D) is declared and persistently enforced for the rest of the mesh definition. If the mesh is to be 3-dimensional, this is also where the axial information is declared ([!param](/Mesh/ReactorMeshParams/axial_regions) and [!param](/Mesh/ReactorMeshParams/axial_mesh_intervals)).
 
-For users that require reactor-related metadata be defined onto the subsequent RGMB-based mesh generators that are called in their mesh input, the parameter [!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) can be set to 'true'. A list of metadata that is generated at the pin, assembly, and core levels can be found at [PinMeshGenerator](/PinMeshGenerator.md), [AssemblyMeshGenerator](/AssemblyMeshGenerator.md), and [CoreMeshGenerator](/CoreMeshGenerator.md), respectively.
+## Metadata Information
+
+The `ReactorMeshParams` object stores certain global mesh information as metadata, which can be queried from subsequent RGMB-based mesh generators. A list of metadata that is generated at the pin, assembly, and core levels can be found at [PinMeshGenerator](/PinMeshGenerator.md), [AssemblyMeshGenerator](/AssemblyMeshGenerator.md), and [CoreMeshGenerator](/CoreMeshGenerator.md), respectively, while the following metadata can be queried by passing in the name of the `ReactorMeshParams` mesh generator, which is stored at each RGMB mesh generation level with the metadata name `reactor_params_name`:
+
+- `mesh_dimensions`: Number of dimensions in pin mesh, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/dim)
+- `mesh_geometry`: Whether pin geometry is hexagonal ("Hex") or Cartesian ("Square"), equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/geom)
+- `axial_mesh_sizes`: Length of each axial region, equivalent to  [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_regions). Only relevant for 3-D meshes.
+- `axial_mesh_intervals`: Number of elements in the axial dimension for each axial region, equivalent to [ReactorMeshParams](ReactorMeshParams.md)/[!param](/Mesh/ReactorMeshParams/axial_mesh_intervals). Only relevant for 3-D meshes.
 
 ## Example Syntax
 

--- a/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
+++ b/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
@@ -17,7 +17,7 @@ The `ReactorMeshParams` object stores certain global mesh information as metadat
 
 ## Example Syntax
 
-!listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i block=Mesh/rmp
+!listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_square.i block=Mesh/rmp
 
 !syntax parameters /Mesh/ReactorMeshParams
 

--- a/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
+++ b/modules/reactor/doc/content/source/meshgenerators/ReactorMeshParams.md
@@ -6,6 +6,8 @@
 
 The `ReactorMeshParams` object stores persistent mesh information about a reactor's geometry for use with [PinMeshGenerator](/PinMeshGenerator.md), [AssemblyMeshGenerator](/AssemblyMeshGenerator.md), and [CoreMeshGenerator](/CoreMeshGenerator.md). This is where the geometry type ([!param](/Mesh/ReactorMeshParams/geom) as 'Square' or 'Hex' for cartesian and hexagonal definitions respectively) and the number of dimensions of the mesh ([!param](/Mesh/ReactorMeshParams/dim) 2 or 3D) is declared and persistently enforced for the rest of the mesh definition. If the mesh is to be 3-dimensional, this is also where the axial information is declared ([!param](/Mesh/ReactorMeshParams/axial_regions) and [!param](/Mesh/ReactorMeshParams/axial_mesh_intervals)).
 
+For users that require reactor-related metadata be defined onto the subsequent RGMB-based mesh generators that are called in their mesh input, the parameter [!param](/Mesh/ReactorMeshParams/generate_rgmb_metadata) can be set to 'true'. A list of metadata that is generated at the pin, assembly, and core levels can be found at [PinMeshGenerator](/PinMeshGenerator.md), [AssemblyMeshGenerator](/AssemblyMeshGenerator.md), and [CoreMeshGenerator](/CoreMeshGenerator.md), respectively.
+
 ## Example Syntax
 
 !listing modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i block=Mesh/rmp

--- a/modules/reactor/include/meshgenerators/AssemblyMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/AssemblyMeshGenerator.h
@@ -25,6 +25,8 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  void generateMetadata();
+
   ///The names of the pins that compose the Assembly
   const std::vector<MeshGeneratorName> _inputs;
 

--- a/modules/reactor/include/meshgenerators/AssemblyMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/AssemblyMeshGenerator.h
@@ -25,6 +25,7 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  // Define metadata associated with AssemblyMeshGenerator
   void generateMetadata();
 
   ///The names of the pins that compose the Assembly

--- a/modules/reactor/include/meshgenerators/CoreMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/CoreMeshGenerator.h
@@ -26,6 +26,8 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  void generateMetadata();
+
   ///The names of the assemblies that compose the core
   const std::vector<MeshGeneratorName> _inputs;
 

--- a/modules/reactor/include/meshgenerators/CoreMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/CoreMeshGenerator.h
@@ -26,6 +26,7 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  // Define metadata associated with CoreMeshGenerator
   void generateMetadata();
 
   ///The names of the assemblies that compose the core

--- a/modules/reactor/include/meshgenerators/PinMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PinMeshGenerator.h
@@ -25,6 +25,7 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  // Define metadata associated with PinMeshGenerator
   void generateMetadata();
 
   ///The id number for this pin type

--- a/modules/reactor/include/meshgenerators/PinMeshGenerator.h
+++ b/modules/reactor/include/meshgenerators/PinMeshGenerator.h
@@ -25,6 +25,8 @@ public:
   std::unique_ptr<MeshBase> generate() override;
 
 protected:
+  void generateMetadata();
+
   ///The id number for this pin type
   const subdomain_id_type _pin_type;
 

--- a/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
+++ b/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
@@ -27,12 +27,10 @@ static const std::string reactor_params_name = "reactor_params_name";
 static const std::string is_single_pin = "is_single_pin";
 static const std::string is_homogenized = "is_homogenized";
 static const std::string extruded = "extruded";
-static const std::string generate_metadata = "generate_rgmb_metadata";
 static const std::string pin_region_ids = "pin_region_ids";
 static const std::string pin_block_names = "pin_block_names";
 static const std::string pin_region_id_map = "pin_region_id_map";
 static const std::string pin_block_name_map = "pin_block_name_map";
-static const std::string pin_map_type_to_name = "pin_map_type_to_name";
 
 // Geometrical quantities
 static const std::string pitch = "pitch";
@@ -40,13 +38,14 @@ static const std::string assembly_pitch = "assembly_pitch";
 static const std::string ring_radii = "ring_radii";
 static const std::string duct_halfpitches = "duct_halfpitches";
 static const std::string peripheral_ring_radius = "peripheral_ring_radius";
-static const std::string lattice = "lattice";
+static const std::string pin_lattice = "pin_lattice";
+static const std::string assembly_lattice = "assembly_lattice";
 
 // Quantities related to region ids, type ids, and block names
 static const std::string pin_type = "pin_type";
-static const std::string pin_types = "pin_types";
+static const std::string pin_names = "pin_names";
 static const std::string assembly_type = "assembly_type";
-static const std::string assembly_types = "assembly_types";
+static const std::string assembly_names = "assembly_names";
 static const std::string ring_region_ids = "ring_region_ids";
 static const std::string background_region_id = "background_region_id";
 static const std::string background_block_name = "background_block_name";
@@ -86,91 +85,61 @@ protected:
   void initializeReactorMeshParams(const std::string reactor_param_name);
 
   /**
-   * Declares global reactor-level metadata onto current ReactorGeometryMeshBuilder object
-   * @param prefix prefix to preprend to add metadata names
-   */
-  void generateGlobalReactorMetadata(const std::string prefix);
-
-  /**
-   * Copies pin-level metadata to current ReactorGeometryMeshBuilder object
-   * @param input_name name of input mesh generator object to copy metadata from
-   * @param pin_type_id pin_type_id of pin to query metadata of
-   */
-  void copyPinMetadata(const std::string input_name, const unsigned int pin_type_id);
-
-  /**
-   * Copies assembly-level metadata to current ReactorGeometryMeshBuilder object
-   * @param input_name name of input mesh generator object to copy metadata from
-   * @param assembly_type_id assembly_type_id of pin to query metadata of
-   */
-  void copyAssemblyMetadata(const std::string input_name, const unsigned int assembly_type_id);
-
-  /**
    * Print metadata associated with ReactorGeometryMeshBuilder object
-   * @param metadata_prefix Prefix associated with metadata
-   * @param whether this is the original function call, which will trigger additional output
-   * messages
+   * @param geometry_type       type of geometry (pin / assembly / core) under consideration
+   * @param mg_name             name of mesh generator associated with this object
+   * @param first_function_call whether this is the original function call, which will trigger
+   * additional output messages
    */
-  void printReactorMetadata(const std::string metadata_prefix,
+  void printReactorMetadata(const std::string geometry_type,
+                            const std::string mg_name,
                             const bool first_function_call = true);
 
   /**
    * Print core-level metadata associated with ReactorGeometryMeshBuilder object
-   * @param prefix Prefix associated with metadata
-   * @param whether this is the original function call, which will trigger additional output
-   * messages
+   * @param mg_name name of mesh generator associated with core
+   * @param first_function_call whether this is the original function call, which will trigger
+   * additional output messages
    */
-  void printCoreMetadata(const std::string prefix, const bool first_function_call);
+  void printCoreMetadata(const std::string mg_name, const bool first_function_call);
 
   /**
    * Print assembly-level metadata associated with ReactorGeometryMeshBuilder object
-   * @param prefix Prefix associated with metadata
+   * @param mg_name name of mesh generator associated with assembly
    * @param whether this is the original function call, which will trigger additional output
    * messages
    */
-  void printAssemblyMetadata(const std::string prefix, const bool first_function_call);
+  void printAssemblyMetadata(const std::string mg_name, const bool first_function_call);
 
   /**
    * Print pin-level metadata associated with ReactorGeometryMeshBuilder object
-   * @param prefix Prefix associated with metadata
+   * @param mg_name name of mesh generator associated with assembly
    */
-  void printPinMetadata(const std::string prefix);
+  void printPinMetadata(const std::string mg_name);
 
   /**
    * Print global ReactorMeshParams metadata associated with ReactorGeometryMeshBuilder object
-   * @param prefix Prefix associated with metadata
    */
-  void printGlobalReactorMetadata(const std::string prefix);
+  void printGlobalReactorMetadata();
 
   /**
-   * Print metadata in the form "<prefix>_<name> to console output
+   * Print metadata with provided name that can be found with given mesh generator name
    * @tparam T datatype of metadata value to output
-   * @param prefix Prefix associated with metadata name
-   * @param name Base name of metadata to output
+   * @param metadata_name Name of metadata to output
+   * @param mg_name Name of mesh generator that stores metadata
    */
   template <typename T>
-  void printMetadataToConsole(const std::string prefix, const std::string name);
+  void printMetadataToConsole(const std::string metadata_name, const std::string mg_name);
 
   /**
-   * Print metadata in the form "<prefix>_<name> with data stype std::vector<std::vector<T>> to
-   * console output
+   * Print metadata with data type std::vector<std::vector<T>> and provided name that can be found
+   * with given mesh generator name
    * @tparam T datatype of elements in 2-D vector to output
-   * @param prefix Prefix associated with metadata name
-   * @param name Base name of metadata to output
+   * @param metadata_name Name of metadata to output
+   * @param mg_name Name of mesh generator that stores metadata
    */
   template <typename T>
-  void print2dMetadataToConsole(const std::string prefix, const std::string name);
-
-  /**
-   * Copy reactor metadata from source mesh to current mesh
-   * @tparam T datatype of metadata value to copy
-   * @param prefix Prefix associated with metadata name
-   * @param name Base name of metadata to copy
-   * @param source_mesh Name of mesh containing metadata to copy from
-   */
-  template <typename T>
-  T &
-  copyReactorMetadata(const std::string prefix, const std::string name, std::string source_mesh);
+  void print2dMetadataToConsole(const std::string metadata_name, const std::string mg_name);
 
   /**
    * Releases the mesh obtained in _reactor_params_mesh.

--- a/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
+++ b/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
@@ -64,21 +64,25 @@ protected:
   /**
    * Print metadata associated with ReactorGeometryMeshBuilder object
    * @param metadata_prefix Prefix associated with metadata
-   * @param whether this is the original function call, which will trigger additional output messages
+   * @param whether this is the original function call, which will trigger additional output
+   * messages
    */
-  void printReactorMetadata(const std::string metadata_prefix, const bool first_function_call = true);
+  void printReactorMetadata(const std::string metadata_prefix,
+                            const bool first_function_call = true);
 
   /**
    * Print core-level metadata associated with ReactorGeometryMeshBuilder object
    * @param prefix Prefix associated with metadata
-   * @param whether this is the original function call, which will trigger additional output messages
+   * @param whether this is the original function call, which will trigger additional output
+   * messages
    */
   void printCoreMetadata(const std::string prefix, const bool first_function_call);
 
   /**
    * Print assembly-level metadata associated with ReactorGeometryMeshBuilder object
    * @param prefix Prefix associated with metadata
-   * @param whether this is the original function call, which will trigger additional output messages
+   * @param whether this is the original function call, which will trigger additional output
+   * messages
    */
   void printAssemblyMetadata(const std::string prefix, const bool first_function_call);
 
@@ -98,13 +102,15 @@ protected:
    * Print metadata to console output
    * @param metadata_name Name of metadata to output
    */
-  template <typename T> void printMetadataToConsole(const std::string metadata_name);
+  template <typename T>
+  void printMetadataToConsole(const std::string metadata_name);
 
   /**
    * Print metadata with datatype std::vector<std::vector<T>> to console output
    * @param metadata_name Name of metadata to output
    */
-  template <typename T> void print2dMetadataToConsole(const std::string metadata_name);
+  template <typename T>
+  void print2dMetadataToConsole(const std::string metadata_name);
 
   /**
    * Releases the mesh obtained in _reactor_params_mesh.

--- a/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
+++ b/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
@@ -42,6 +42,71 @@ protected:
   void initializeReactorMeshParams(const std::string reactor_param_name);
 
   /**
+   * Declares global reactor-level metadata onto current ReactorGeometryMeshBuilder object
+   * @param prefix prefix to preprend to add metadata names
+   */
+  void generateGlobalReactorMetadata(const std::string prefix);
+
+  /**
+   * Copies pin-level metadata to current ReactorGeometryMeshBuilder object
+   * @param input_name name of input mesh generator object to copy metadata from
+   * @param pin_type_id pin_type_id of pin to query metadata of
+   */
+  void copyPinMetadata(const std::string input_name, const unsigned int pin_type_id);
+
+  /**
+   * Copies assembly-level metadata to current ReactorGeometryMeshBuilder object
+   * @param input_name name of input mesh generator object to copy metadata from
+   * @param assembly_type_id assembly_type_id of pin to query metadata of
+   */
+  void copyAssemblyMetadata(const std::string input_name, const unsigned int assembly_type_id);
+
+  /**
+   * Print metadata associated with ReactorGeometryMeshBuilder object
+   * @param metadata_prefix Prefix associated with metadata
+   * @param whether this is the original function call, which will trigger additional output messages
+   */
+  void printReactorMetadata(const std::string metadata_prefix, const bool first_function_call = true);
+
+  /**
+   * Print core-level metadata associated with ReactorGeometryMeshBuilder object
+   * @param prefix Prefix associated with metadata
+   * @param whether this is the original function call, which will trigger additional output messages
+   */
+  void printCoreMetadata(const std::string prefix, const bool first_function_call);
+
+  /**
+   * Print assembly-level metadata associated with ReactorGeometryMeshBuilder object
+   * @param prefix Prefix associated with metadata
+   * @param whether this is the original function call, which will trigger additional output messages
+   */
+  void printAssemblyMetadata(const std::string prefix, const bool first_function_call);
+
+  /**
+   * Print pin-level metadata associated with ReactorGeometryMeshBuilder object
+   * @param prefix Prefix associated with metadata
+   */
+  void printPinMetadata(const std::string prefix);
+
+  /**
+   * Print global ReactorMeshParams metadata associated with ReactorGeometryMeshBuilder object
+   * @param prefix Prefix associated with metadata
+   */
+  void printGlobalReactorMetadata(const std::string prefix);
+
+  /**
+   * Print metadata to console output
+   * @param metadata_name Name of metadata to output
+   */
+  template <typename T> void printMetadataToConsole(const std::string metadata_name);
+
+  /**
+   * Print metadata with datatype std::vector<std::vector<T>> to console output
+   * @param metadata_name Name of metadata to output
+   */
+  template <typename T> void print2dMetadataToConsole(const std::string metadata_name);
+
+  /**
    * Releases the mesh obtained in _reactor_params_mesh.
    *
    * This _must_ be called in any object that derives from this one, because

--- a/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
+++ b/modules/reactor/include/meshgenerators/ReactorGeometryMeshBuilderBase.h
@@ -12,6 +12,50 @@
 #include "MeshGenerator.h"
 #include "libmesh/elem.h"
 
+namespace RGMB
+{
+
+// General global quantities for mesh building
+static const std::string mesh_dimensions = "mesh_dimensions";
+static const std::string mesh_geometry = "mesh_geometry";
+static const std::string top_boundary_id = "top_boundary_id";
+static const std::string bottom_boundary_id = "bottom_boundary_id";
+static const std::string radial_boundary_id = "radial_boundary_id";
+static const std::string axial_mesh_intervals = "axial_mesh_intervals";
+static const std::string axial_mesh_sizes = "axial_mesh_sizes";
+static const std::string reactor_params_name = "reactor_params_name";
+static const std::string is_single_pin = "is_single_pin";
+static const std::string is_homogenized = "is_homogenized";
+static const std::string extruded = "extruded";
+static const std::string generate_metadata = "generate_rgmb_metadata";
+static const std::string pin_region_ids = "pin_region_ids";
+static const std::string pin_block_names = "pin_block_names";
+static const std::string pin_region_id_map = "pin_region_id_map";
+static const std::string pin_block_name_map = "pin_block_name_map";
+static const std::string pin_map_type_to_name = "pin_map_type_to_name";
+
+// Geometrical quantities
+static const std::string pitch = "pitch";
+static const std::string assembly_pitch = "assembly_pitch";
+static const std::string ring_radii = "ring_radii";
+static const std::string duct_halfpitches = "duct_halfpitches";
+static const std::string peripheral_ring_radius = "peripheral_ring_radius";
+static const std::string lattice = "lattice";
+
+// Quantities related to region ids, type ids, and block names
+static const std::string pin_type = "pin_type";
+static const std::string pin_types = "pin_types";
+static const std::string assembly_type = "assembly_type";
+static const std::string assembly_types = "assembly_types";
+static const std::string ring_region_ids = "ring_region_ids";
+static const std::string background_region_id = "background_region_id";
+static const std::string background_block_name = "background_block_name";
+static const std::string duct_region_ids = "duct_region_ids";
+static const std::string duct_block_names = "duct_block_names";
+static const std::string peripheral_ring_region_id = "peripheral_ring_region_id";
+
+}
+
 /**
  * A base class that contains common members for Reactor Geometry Mesh Builder mesh generators.
  */
@@ -99,18 +143,34 @@ protected:
   void printGlobalReactorMetadata(const std::string prefix);
 
   /**
-   * Print metadata to console output
-   * @param metadata_name Name of metadata to output
+   * Print metadata in the form "<prefix>_<name> to console output
+   * @tparam T datatype of metadata value to output
+   * @param prefix Prefix associated with metadata name
+   * @param name Base name of metadata to output
    */
   template <typename T>
-  void printMetadataToConsole(const std::string metadata_name);
+  void printMetadataToConsole(const std::string prefix, const std::string name);
 
   /**
-   * Print metadata with datatype std::vector<std::vector<T>> to console output
-   * @param metadata_name Name of metadata to output
+   * Print metadata in the form "<prefix>_<name> with data stype std::vector<std::vector<T>> to
+   * console output
+   * @tparam T datatype of elements in 2-D vector to output
+   * @param prefix Prefix associated with metadata name
+   * @param name Base name of metadata to output
    */
   template <typename T>
-  void print2dMetadataToConsole(const std::string metadata_name);
+  void print2dMetadataToConsole(const std::string prefix, const std::string name);
+
+  /**
+   * Copy reactor metadata from source mesh to current mesh
+   * @tparam T datatype of metadata value to copy
+   * @param prefix Prefix associated with metadata name
+   * @param name Base name of metadata to copy
+   * @param source_mesh Name of mesh containing metadata to copy from
+   */
+  template <typename T>
+  T &
+  copyReactorMetadata(const std::string prefix, const std::string name, std::string source_mesh);
 
   /**
    * Releases the mesh obtained in _reactor_params_mesh.
@@ -125,6 +185,7 @@ protected:
 
   /**
    * Checks whether parameter is defined in ReactorMeshParams metadata
+   * @tparam T datatype of metadata value associated with metadata name
    * @param param_name name of ReactorMeshParams parameter
    * @return whether parameter is defined in ReactorMeshParams metadata
    */
@@ -133,6 +194,7 @@ protected:
 
   /**
    * Returns reference of parameter in ReactorMeshParams object
+   * @tparam T datatype of metadata value associated with metadata name
    * @param param_name name of ReactorMeshParams parameter
    * @return reference to parameter defined in ReactorMeshParams metadata
    */

--- a/modules/reactor/include/meshgenerators/ReactorMeshParams.h
+++ b/modules/reactor/include/meshgenerators/ReactorMeshParams.h
@@ -35,10 +35,10 @@ protected:
   const Real _assembly_pitch;
 
   ///The heights of the axial regions.
-  const std::vector<Real> _axial_regions;
+  std::vector<Real> _axial_regions;
 
   ///The number of mesh divisions in each axial region.
-  const std::vector<unsigned int> _axial_mesh_intervals;
+  std::vector<unsigned int> _axial_mesh_intervals;
 
   ///Boundary id assigned to top boundary of extruded mesh.
   boundary_id_type _top_boundary;

--- a/modules/reactor/include/meshgenerators/ReactorMeshParams.h
+++ b/modules/reactor/include/meshgenerators/ReactorMeshParams.h
@@ -51,4 +51,7 @@ protected:
 
   // Map between RGMB element block names, block ids, and region ids
   std::map<std::string, std::pair<subdomain_id_type, dof_id_type>> _name_id_map;
+
+  // Whether to define additional metadata to represent RGMB geometry and region IDs
+  const bool _define_metadata;
 };

--- a/modules/reactor/include/meshgenerators/ReactorMeshParams.h
+++ b/modules/reactor/include/meshgenerators/ReactorMeshParams.h
@@ -51,7 +51,4 @@ protected:
 
   // Map between RGMB element block names, block ids, and region ids
   std::map<std::string, std::pair<subdomain_id_type, dof_id_type>> _name_id_map;
-
-  // Whether to define additional metadata to represent RGMB geometry and region IDs
-  const bool _define_metadata;
 };

--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -356,8 +356,7 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
             region_id_map.begin()->first, region_id_map.begin()->second));
     subdomain_id_type pin_type_id = getMeshProperty<subdomain_id_type>(RGMB::pin_type, pinMG);
     std::vector<std::vector<std::string>> pin_block_names =
-        getMeshProperty<std::vector<std::vector<std::string>>>(
-            RGMB::pin_block_names, pinMG);
+        getMeshProperty<std::vector<std::vector<std::string>>>(RGMB::pin_block_names, pinMG);
     _pin_block_name_map.insert(std::pair<subdomain_id_type, std::vector<std::vector<std::string>>>(
         pin_type_id, pin_block_names));
   }

--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -291,7 +291,7 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
     {
       std::vector<subdomain_id_type> duct_block_ids;
       std::vector<SubdomainName> duct_block_names;
-      for (std::size_t duct_it = 0; duct_it < _duct_region_ids[0].size(); ++duct_it)
+      for (const auto duct_it : index_range(_duct_region_ids[0]))
       {
         const auto duct_block_name =
             "RGMB_ASSEMBLY" + std::to_string(_assembly_type) + "_R" + std::to_string(duct_it + 1);
@@ -354,11 +354,12 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
     _pin_region_id_map.insert(
         std::pair<subdomain_id_type, std::vector<std::vector<subdomain_id_type>>>(
             region_id_map.begin()->first, region_id_map.begin()->second));
-    std::map<subdomain_id_type, std::vector<std::vector<std::string>>> block_name_map =
-        getMeshProperty<std::map<subdomain_id_type, std::vector<std::vector<std::string>>>>(
+    subdomain_id_type pin_type_id = getMeshProperty<subdomain_id_type>(RGMB::pin_type, pinMG);
+    std::vector<std::vector<std::string>> pin_block_names =
+        getMeshProperty<std::vector<std::vector<std::string>>>(
             RGMB::pin_block_names, pinMG);
     _pin_block_name_map.insert(std::pair<subdomain_id_type, std::vector<std::vector<std::string>>>(
-        block_name_map.begin()->first, block_name_map.begin()->second));
+        pin_type_id, pin_block_names));
   }
 
   if (_extrude && _mesh_dimensions == 3)
@@ -435,10 +436,10 @@ AssemblyMeshGenerator::generateMetadata()
   // Determine constituent pin names and define lattice as metadata
   std::vector<std::vector<int>> pin_name_lattice;
   std::vector<std::string> input_pin_names;
-  for (unsigned int i = 0; i < _pattern.size(); ++i)
+  for (const auto i : index_range(_pattern))
   {
     std::vector<int> pin_name_idx(_pattern[i].size());
-    for (unsigned int j = 0; j < _pattern[i].size(); ++j)
+    for (const auto j : index_range(_pattern[i]))
     {
       const auto input_pin_name = _inputs[_pattern[i][j]];
       const auto it = std::find(input_pin_names.begin(), input_pin_names.end(), input_pin_name);

--- a/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/AssemblyMeshGenerator.C
@@ -152,7 +152,8 @@ AssemblyMeshGenerator::AssemblyMeshGenerator(const InputParameters & parameters)
                  "definition.\n");
     const auto pin_type = getMeshProperty<subdomain_id_type>("pin_type", pin);
     if (input_id_map.find(pin_type) != input_id_map.end() && input_id_map[pin_type] != pin)
-      mooseError("Constituent pins have shared pin_type ids but different names. Each uniquely defined pin in PinMeshGenerator must have its own pin_type id.");
+      mooseError("Constituent pins have shared pin_type ids but different names. Each uniquely "
+                 "defined pin in PinMeshGenerator must have its own pin_type id.");
     input_id_map[pin_type] = pin;
   }
   declareMeshProperty("input_id_map", input_id_map);

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -188,20 +188,28 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
 
     // Check assembly_types across constituent assemblies are uniquely defined
     const auto assembly_type = getMeshProperty<subdomain_id_type>("assembly_type", _inputs[i]);
-    if (assembly_input_id_map.find(assembly_type) != assembly_input_id_map.end() && assembly_input_id_map[assembly_type] != _inputs[i])
-      mooseError("Constituent assemblies have shared assembly_type ids but different names. Each uniquely defined assembly in AssemblyMeshGenerator must have its own assembly_type id.");
+    if (assembly_input_id_map.find(assembly_type) != assembly_input_id_map.end() &&
+        assembly_input_id_map[assembly_type] != _inputs[i])
+      mooseError(
+          "Constituent assemblies have shared assembly_type ids but different names. Each uniquely "
+          "defined assembly in AssemblyMeshGenerator must have its own assembly_type id.");
     assembly_input_id_map[assembly_type] = _inputs[i];
 
-    // If assembly is composed of pins, check pin_types across all constituent assemblies are uniquely defined
+    // If assembly is composed of pins, check pin_types across all constituent assemblies are
+    // uniquely defined
     if (hasMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]))
     {
-      const auto pin_input_id_map = getMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]);
+      const auto pin_input_id_map =
+          getMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]);
       for (auto it = pin_input_id_map.begin(); it != pin_input_id_map.end(); ++it)
       {
         const auto pin_type = it->first;
         const auto input_pin_name = it->second;
-        if (global_pin_input_id_map.find(pin_type) != global_pin_input_id_map.end() && global_pin_input_id_map[pin_type] != input_pin_name)
-          mooseError("Constituent pins within assemblies have shared pin_type ids but different names. Each uniquely defined pin in AssemblyMeshGenerator must have its own pin_type id.");
+        if (global_pin_input_id_map.find(pin_type) != global_pin_input_id_map.end() &&
+            global_pin_input_id_map[pin_type] != input_pin_name)
+          mooseError(
+              "Constituent pins within assemblies have shared pin_type ids but different names. "
+              "Each uniquely defined pin in AssemblyMeshGenerator must have its own pin_type id.");
         global_pin_input_id_map[pin_type] = input_pin_name;
       }
     }
@@ -548,7 +556,8 @@ CoreMeshGenerator::generateMetadata()
         assembly_type_ids[j] = -1;
       else
       {
-        assembly_type_ids[j] = getMeshProperty<subdomain_id_type>("assembly_type", input_assembly_name);
+        assembly_type_ids[j] =
+            getMeshProperty<subdomain_id_type>("assembly_type", input_assembly_name);
         // Copy assembly metadata to core
         if (core_assembly_types.find(assembly_type_ids[j]) == core_assembly_types.end())
         {
@@ -559,7 +568,8 @@ CoreMeshGenerator::generateMetadata()
           // Copy pin metadata to core if assembly is defined as lattice of pins
           if (!getMeshProperty<bool>(assembly_prefix + "_is_single_pin"))
           {
-            const auto pin_type_ids = getMeshProperty<std::set<unsigned int>>(assembly_prefix + "_pin_types");
+            const auto pin_type_ids =
+                getMeshProperty<std::set<unsigned int>>(assembly_prefix + "_pin_types");
             for (const auto & pin_type_id : pin_type_ids)
               if (core_pin_types.find(pin_type_id) == core_pin_types.end())
               {

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -171,7 +171,7 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
   std::map<subdomain_id_type, std::string> assembly_map_type_to_name;
   // Check that MG name for reactor params and assembly homogenization schemes are
   // consistent across all assemblies, and there is no overlap in pin_type / assembly_type ids
-  for (unsigned int i = 0; i < _inputs.size(); i++)
+  for (const auto i : index_range(_inputs))
   {
     // Skip if assembly name is equal to dummy assembly name
     if (_inputs[i] == _empty_key)
@@ -536,10 +536,10 @@ CoreMeshGenerator::generateMetadata()
   std::vector<std::vector<int>> assembly_name_lattice;
   std::vector<std::string> input_assembly_names;
   std::vector<std::string> input_pin_names;
-  for (unsigned int i = 0; i < _pattern.size(); ++i)
+  for (const auto i : index_range(_pattern))
   {
     std::vector<int> assembly_name_idx(_pattern[i].size());
-    for (unsigned int j = 0; j < _pattern[i].size(); ++j)
+    for (const auto j : index_range(_pattern[i]))
     {
       const auto input_assembly_name = _inputs[_pattern[i][j]];
       // Use an assembly type of -1 to represent a dummy assembly

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -192,15 +192,18 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
       mooseError("Constituent assemblies have shared assembly_type ids but different names. Each uniquely defined assembly in AssemblyMeshGenerator must have its own assembly_type id.");
     assembly_input_id_map[assembly_type] = _inputs[i];
 
-    // Check pin_types across all constituent assemblies are uniquely defined
-    const auto pin_input_id_map = getMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]);
-    for (auto it = pin_input_id_map.begin(); it != pin_input_id_map.end(); ++it)
+    // If assembly is composed of pins, check pin_types across all constituent assemblies are uniquely defined
+    if (hasMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]))
     {
-      const auto pin_type = it->first;
-      const auto input_pin_name = it->second;
-      if (global_pin_input_id_map.find(pin_type) != global_pin_input_id_map.end() && global_pin_input_id_map[pin_type] != input_pin_name)
-        mooseError("Constituent pins within assemblies have shared pin_type ids but different names. Each uniquely defined pin in AssemblyMeshGenerator must have its own pin_type id.");
-      global_pin_input_id_map[pin_type] = input_pin_name;
+      const auto pin_input_id_map = getMeshProperty<std::map<subdomain_id_type, std::string>>("input_id_map", _inputs[i]);
+      for (auto it = pin_input_id_map.begin(); it != pin_input_id_map.end(); ++it)
+      {
+        const auto pin_type = it->first;
+        const auto input_pin_name = it->second;
+        if (global_pin_input_id_map.find(pin_type) != global_pin_input_id_map.end() && global_pin_input_id_map[pin_type] != input_pin_name)
+          mooseError("Constituent pins within assemblies have shared pin_type ids but different names. Each uniquely defined pin in AssemblyMeshGenerator must have its own pin_type id.");
+        global_pin_input_id_map[pin_type] = input_pin_name;
+      }
     }
   }
 

--- a/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/CoreMeshGenerator.C
@@ -181,8 +181,8 @@ CoreMeshGenerator::CoreMeshGenerator(const InputParameters & parameters)
       mooseError(
           "All assemblies in the core must be homogenized if assembly homogenization is used\n");
     if (getMeshProperty<bool>("pin_as_assembly", _inputs[i]) != pin_as_assembly)
-      mooseError("All assemblies in the core must be defined as a single pin if "
-                 "`PinMeshGenerator/use_as_assembly` is set to true\n");
+      mooseWarning("Not all assemblies in the core are defined as a single pin by setting "
+                   "`PinMeshGenerator/use_as_assembly` to true\n");
   }
 
   // Initialize ReactorMeshParams object stored in pin input

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -391,10 +391,9 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
                         getMeshProperty<dof_id_type>("node_id_background_meta", name() + "_2D"));
   if (_is_assembly)
     declareMeshProperty("pattern_pitch_meta", getReactorParam<Real>("assembly_pitch"));
-  else
-    if (hasMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"))
-      declareMeshProperty("pattern_pitch_meta",
-                          getMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"));
+  else if (hasMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"))
+    declareMeshProperty("pattern_pitch_meta",
+                        getMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"));
   declareMeshProperty("is_control_drum_meta", false);
 
   // Store pin region ids and block names for id swap after extrusion if needed
@@ -504,8 +503,10 @@ PinMeshGenerator::generateMetadata()
       (_mesh_dimensions == 3)
           ? getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals").size()
           : 1;
-  std::vector<std::vector<subdomain_id_type>> ring_region_ids(n_axial_levels, std::vector<subdomain_id_type>(_ring_radii.size()));
-  std::vector<std::vector<subdomain_id_type>> duct_region_ids(n_axial_levels, std::vector<subdomain_id_type>(_duct_halfpitch.size()));
+  std::vector<std::vector<subdomain_id_type>> ring_region_ids(
+      n_axial_levels, std::vector<subdomain_id_type>(_ring_radii.size()));
+  std::vector<std::vector<subdomain_id_type>> duct_region_ids(
+      n_axial_levels, std::vector<subdomain_id_type>(_duct_halfpitch.size()));
   std::vector<subdomain_id_type> background_region_ids(n_axial_levels);
 
   for (unsigned int axial_idx = 0; axial_idx < n_axial_levels; ++axial_idx)
@@ -515,8 +516,10 @@ PinMeshGenerator::generateMetadata()
 
     background_region_ids[axial_idx] = _region_ids[axial_idx][_ring_radii.size()];
 
-    for (unsigned int duct_idx = _ring_radii.size() + 1; duct_idx < _duct_halfpitch.size(); ++duct_idx)
-      duct_region_ids[axial_idx][duct_idx - _ring_radii.size() - 1] = _region_ids[axial_idx][duct_idx];
+    for (unsigned int duct_idx = _ring_radii.size() + 1; duct_idx < _duct_halfpitch.size();
+         ++duct_idx)
+      duct_region_ids[axial_idx][duct_idx - _ring_radii.size() - 1] =
+          _region_ids[axial_idx][duct_idx];
   }
 
   declareMeshProperty(metadata_prefix + "_ring_region_ids", ring_region_ids);

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -1,4 +1,4 @@
-//* This file is part of the MOOSE framework
+ //* This file is part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
@@ -360,7 +360,7 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
 
       auto num_sides = (_mesh_geometry == "Square") ? 4 : 6;
       std::vector<BoundaryName> boundaries_to_delete = {};
-      for (int i = 0; i < num_sides; i++)
+      for (const auto i : make_range(num_sides))
         boundaries_to_delete.insert(boundaries_to_delete.end(),
                                     {std::to_string(10001 + i), std::to_string(15001 + i)});
       params.set<std::vector<BoundaryName>>("boundary_names") = boundaries_to_delete;
@@ -443,8 +443,6 @@ PinMeshGenerator::generateMetadata()
   // by future mesh generators
   std::map<subdomain_id_type, std::vector<std::vector<subdomain_id_type>>> region_id_map{
       {_pin_type, _region_ids}};
-  std::map<subdomain_id_type, std::vector<std::vector<std::string>>> block_name_map;
-  block_name_map[_pin_type] = _block_names;
 
   // Declare mesh properties that need to be moved up to the assembly level
   if (_is_assembly)
@@ -457,7 +455,7 @@ PinMeshGenerator::generateMetadata()
     declareMeshProperty(RGMB::pin_region_id_map, pin_region_id_map);
     std::map<subdomain_id_type, std::vector<std::vector<std::string>>> pin_block_name_map;
     pin_block_name_map.insert(std::pair<subdomain_id_type, std::vector<std::vector<std::string>>>(
-        block_name_map.begin()->first, block_name_map.begin()->second));
+        _pin_type, _block_names));
     declareMeshProperty(RGMB::pin_block_name_map, pin_block_name_map);
     declareMeshProperty(RGMB::background_block_name, std::vector<std::string>());
     declareMeshProperty(RGMB::duct_block_names, std::vector<std::vector<std::string>>());
@@ -467,7 +465,7 @@ PinMeshGenerator::generateMetadata()
   {
     declareMeshProperty(RGMB::pin_type, _pin_type);
     declareMeshProperty(RGMB::pin_region_ids, region_id_map);
-    declareMeshProperty(RGMB::pin_block_names, block_name_map);
+    declareMeshProperty(RGMB::pin_block_names, _block_names);
   }
 
   // Set metadata to describe pin attributes
@@ -488,9 +486,9 @@ PinMeshGenerator::generateMetadata()
       n_axial_levels, std::vector<subdomain_id_type>(_duct_halfpitch.size()));
   std::vector<subdomain_id_type> background_region_ids(n_axial_levels);
 
-  for (unsigned int axial_idx = 0; axial_idx < n_axial_levels; ++axial_idx)
+  for (const auto axial_idx : make_range(n_axial_levels))
   {
-    for (unsigned int ring_idx = 0; ring_idx < _ring_radii.size(); ++ring_idx)
+    for (const auto ring_idx : index_range(_ring_radii))
       ring_region_ids[axial_idx][ring_idx] = _region_ids[axial_idx][ring_idx];
 
     background_region_ids[axial_idx] = _region_ids[axial_idx][_ring_radii.size()];

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -389,9 +389,13 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
   if (hasMeshProperty<dof_id_type>("node_id_background_meta", name() + "_2D"))
     declareMeshProperty("node_id_background_meta",
                         getMeshProperty<dof_id_type>("node_id_background_meta", name() + "_2D"));
-  if (hasMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"))
-    declareMeshProperty("pattern_pitch_meta",
-                        getMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"));
+  if (_is_assembly)
+    declareMeshProperty("pattern_pitch_meta", getReactorParam<Real>("assembly_pitch"));
+  else
+    if (hasMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"))
+      declareMeshProperty("pattern_pitch_meta",
+                          getMeshProperty<Real>("pattern_pitch_meta", name() + "_2D"));
+  declareMeshProperty("is_control_drum_meta", false);
 
   // Store pin region ids and block names for id swap after extrusion if needed
   // by future mesh generators
@@ -419,12 +423,11 @@ PinMeshGenerator::PinMeshGenerator(const InputParameters & parameters)
     declareMeshProperty("background_block_names", std::vector<std::string>());
     declareMeshProperty("duct_region_ids", std::vector<std::vector<subdomain_id_type>>());
     declareMeshProperty("duct_block_names", std::vector<std::vector<std::string>>());
-
-    // Set metadata to indicate homogenized assemblies to inform CoreMeshGenerator
-    // dummy assembly deletion
-    declareMeshProperty("homogenized_assembly", _homogenized);
-    declareMeshProperty("pin_as_assembly", _is_assembly);
   }
+  // Set metadata to indicate homogenized assemblies to inform CoreMeshGenerator
+  // dummy assembly deletion
+  declareMeshProperty("homogenized_assembly", _homogenized);
+  declareMeshProperty("pin_as_assembly", _is_assembly);
 
   if (_extrude && _mesh_dimensions == 3)
   {

--- a/modules/reactor/src/meshgenerators/PinMeshGenerator.C
+++ b/modules/reactor/src/meshgenerators/PinMeshGenerator.C
@@ -1,4 +1,4 @@
- //* This file is part of the MOOSE framework
+//* This file is part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -13,6 +13,9 @@ InputParameters
 ReactorGeometryMeshBuilderBase::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
+
+  params.addParam<bool>("show_rgmb_metadata", false,
+                        "Print out RGMB-related metadata to console output");
   params.addClassDescription("A base class that contains common members and methods for Reactor "
                              "Geometry Mesh Builder mesh generators.");
 
@@ -41,6 +44,10 @@ ReactorGeometryMeshBuilderBase::initializeReactorMeshParams(const std::string re
 
   // Set reactor_params_name metadata for use by future mesh generators
   declareMeshProperty("reactor_params_name", std::string(_reactor_params));
+
+  // Check value of show_rgmb_metadata is valid
+  if (getParam<bool>("show_rgmb_metadata") && !getReactorParam<bool>("generate_rgmb_metadata"))
+    paramError("show_rgmb_metadata", "`ReactorMeshParams/generate_rgmb_metadata` must be set to true in order for show_rgmb_metadata to be true");
 }
 
 void
@@ -88,4 +95,207 @@ ReactorGeometryMeshBuilderBase::updateElementBlockNameId(
     elem_block_id = name_id_map[elem_block_name];
     elem->subdomain_id() = elem_block_id;
   }
+}
+
+void
+ReactorGeometryMeshBuilderBase::generateGlobalReactorMetadata(const std::string prefix)
+{
+  declareMeshProperty(prefix + "_mesh_dimensions", getReactorParam<int>("mesh_dimensions"));
+  declareMeshProperty(prefix + "_mesh_geometry", getReactorParam<std::string>("mesh_geometry"));
+  declareMeshProperty(prefix + "_axial_boundaries", getReactorParam<std::vector<Real>>("axial_boundaries"));
+  declareMeshProperty(prefix + "_axial_mesh_intervals", getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
+}
+
+void
+ReactorGeometryMeshBuilderBase::copyPinMetadata(const std::string input_name, const unsigned int pin_type_id)
+{
+  std::string metadata_prefix = "pin_" + std::to_string(pin_type_id);
+
+  declareMeshProperty(metadata_prefix + "_pitch", getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
+  declareMeshProperty(metadata_prefix + "_ring_radii", getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
+  declareMeshProperty(metadata_prefix + "_ring_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_ring_region_ids", input_name));
+  declareMeshProperty(metadata_prefix + "_background_region_id", getMeshProperty<std::vector<subdomain_id_type>>(metadata_prefix + "_background_region_id", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_halfpitches", getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_duct_region_ids", input_name));
+}
+
+void
+ReactorGeometryMeshBuilderBase::copyAssemblyMetadata(const std::string input_name, const unsigned int assembly_type_id)
+{
+  std::string metadata_prefix = "assembly_" + std::to_string(assembly_type_id);
+
+  declareMeshProperty(metadata_prefix + "_pitch", getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
+  declareMeshProperty(metadata_prefix + "_background_region_id", getMeshProperty<std::vector<subdomain_id_type>>(metadata_prefix + "_background_region_id", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_halfpitches", getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_duct_region_ids", input_name));
+  const auto is_homogenized = getMeshProperty<bool>(metadata_prefix + "_is_homogenized", input_name);
+  const auto is_single_pin = getMeshProperty<bool>(metadata_prefix + "_is_single_pin", input_name);
+  declareMeshProperty(metadata_prefix + "_is_homogenized", is_homogenized);
+  declareMeshProperty(metadata_prefix + "_is_single_pin", is_single_pin);
+
+  // Define metadata specific to assemblies defined as a lattice of pins
+  if (!is_single_pin)
+  {
+    declareMeshProperty(metadata_prefix + "_pin_types", getMeshProperty<std::set<unsigned int>>(metadata_prefix + "_pin_types", input_name));
+    declareMeshProperty(metadata_prefix + "_lattice", getMeshProperty<std::vector<std::vector<int>>>(metadata_prefix + "_lattice", input_name));
+  }
+  // Defined metadata specific to assemblies defined as a single heterogeneous pin
+  else if (!is_homogenized)
+  {
+    declareMeshProperty(metadata_prefix + "_ring_radii", getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
+  declareMeshProperty(metadata_prefix + "_ring_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_ring_region_ids", input_name));
+  }
+}
+
+void
+ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_prefix, bool first_function_call)
+{
+  if (metadata_prefix == "core")
+  {
+    if (first_function_call)
+    {
+      Moose::out << "Core-level metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+      printGlobalReactorMetadata(metadata_prefix);
+    }
+    printCoreMetadata(metadata_prefix, first_function_call);
+  }
+  else
+  {
+    std::string prefix_substring = metadata_prefix.substr(0, metadata_prefix.find("_"));
+    if (prefix_substring == "assembly")
+    {
+      if (first_function_call)
+      {
+        Moose::out << "Assembly-level metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+        printGlobalReactorMetadata(metadata_prefix);
+      }
+      printAssemblyMetadata(metadata_prefix, first_function_call);
+    }
+    else if (prefix_substring == "pin")
+    {
+      if (first_function_call)
+      {
+        Moose::out << "Pin-level metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+        printGlobalReactorMetadata(metadata_prefix);
+      }
+      printPinMetadata(metadata_prefix);
+    }
+  }
+  if (first_function_call)
+    Moose::out << std::endl;
+}
+
+void
+ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix, bool first_function_call)
+{
+  bool has_mesh_periphery = hasMeshProperty<Real>(prefix + "_peripheral_ring_radius");
+  if (has_mesh_periphery)
+  {
+    printMetadataToConsole<Real>(prefix + "_peripheral_ring_radius");
+    printMetadataToConsole<subdomain_id_type>(prefix + "_peripheral_ring_region_id");
+  }
+
+  printMetadataToConsole<std::set<unsigned int>>(prefix + "_assembly_types");
+  print2dMetadataToConsole<int>(prefix + "_lattice");
+
+  if (first_function_call)
+  {
+    const auto core_assembly_types = getMeshProperty<std::set<unsigned int>>(prefix + "_assembly_types");
+    for (const auto & assembly_type_id : core_assembly_types)
+      printReactorMetadata("assembly_" + Moose::stringify(assembly_type_id), false);
+
+    const auto core_pin_types = getMeshProperty<std::set<unsigned int>>(prefix + "_pin_types");
+    for (const auto & assembly_type_id : core_pin_types)
+      printReactorMetadata("pin_" + Moose::stringify(assembly_type_id), false);
+  }
+}
+
+void
+ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix, bool first_function_call)
+{
+  printMetadataToConsole<Real>(prefix + "_pitch");
+  printMetadataToConsole<bool>(prefix + "_is_homogenized");
+  printMetadataToConsole<bool>(prefix + "_is_single_pin");
+  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix + "_background_region_id");
+
+  const auto duct_halfpitch = getMeshProperty<std::vector<Real>>(prefix + "_duct_halfpitches");
+  if (duct_halfpitch.size() > 0)
+  {
+    printMetadataToConsole<std::vector<Real>>(prefix + "_duct_halfpitches");
+    print2dMetadataToConsole<subdomain_id_type>(prefix + "_duct_region_ids");
+  }
+
+  const auto is_single_pin = getMeshProperty<bool>(prefix + "_is_single_pin");
+  const auto is_homogenized = getMeshProperty<bool>(prefix + "_is_homogenized");
+
+  // Print metadata specific to assemblies defined as a lattice of pins
+  if (!is_single_pin)
+  {
+    printMetadataToConsole<std::set<unsigned int>>(prefix + "_pin_types");
+    print2dMetadataToConsole<int>(prefix + "_lattice");
+
+    // Print information about constituent pins if this is the first function call
+    if (first_function_call)
+    {
+      const auto assembly_pin_types = getMeshProperty<std::set<unsigned int>>(prefix + "_pin_types");
+      for (const auto & pin_type_id : assembly_pin_types)
+        printReactorMetadata("pin_" + Moose::stringify(pin_type_id), false);
+    }
+  }
+  // Print metadata specific to assemblies defined as a single pin
+  else if (!is_homogenized)
+  {
+    const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_ring_radii");
+    if (ring_radii.size() > 0)
+    {
+      printMetadataToConsole<std::vector<Real>>(prefix + "_ring_radii");
+      print2dMetadataToConsole<subdomain_id_type>(prefix + "_ring_region_ids");
+    }
+  }
+}
+
+void
+ReactorGeometryMeshBuilderBase::printPinMetadata(const std::string prefix)
+{
+  printMetadataToConsole<Real>(prefix + "_pitch");
+
+  const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_ring_radii");
+  if (ring_radii.size() > 0)
+  {
+    printMetadataToConsole<std::vector<Real>>(prefix + "_ring_radii");
+    print2dMetadataToConsole<subdomain_id_type>(prefix + "_ring_region_ids");
+  }
+
+  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix + "_background_region_id");
+
+  const auto duct_halfpitch = getMeshProperty<std::vector<Real>>(prefix + "_duct_halfpitches");
+  if (duct_halfpitch.size() > 0)
+  {
+    printMetadataToConsole<std::vector<Real>>(prefix + "_duct_halfpitches");
+    print2dMetadataToConsole<subdomain_id_type>(prefix + "_duct_region_ids");
+  }
+}
+
+void
+ReactorGeometryMeshBuilderBase::printGlobalReactorMetadata(const std::string prefix)
+{
+  printMetadataToConsole<int>(prefix + "_mesh_dimensions");
+  printMetadataToConsole<std::string>(prefix + "_mesh_geometry");
+  printMetadataToConsole<std::vector<Real>>(prefix + "_axial_boundaries");
+  printMetadataToConsole<std::vector<unsigned int>>(prefix + "_axial_mesh_intervals");
+}
+
+template <typename T> void
+ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string metadata_name)
+{
+  Moose::out << "  " << metadata_name << ": " << Moose::stringify(getMeshProperty<T>(metadata_name)) << std::endl;
+}
+
+template <typename T> void
+ReactorGeometryMeshBuilderBase::print2dMetadataToConsole(const std::string metadata_name)
+{
+  const auto metadata_value = getMeshProperty<std::vector<std::vector<T>>>(metadata_name);
+  Moose::out << "  " << metadata_name << ":" << std::endl;
+  for (const auto & row : metadata_value)
+    Moose::out << "    " << Moose::stringify(row) << std::endl;
 }

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -100,29 +100,29 @@ ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string geometry_
 {
   if (first_function_call)
   {
-    Moose::out << "Global metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+    _console << "Global metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
     printGlobalReactorMetadata();
   }
   if (geometry_type == "core")
   {
-    Moose::out << "Core-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
+    _console << "Core-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
                << ":" << std::endl;
     printCoreMetadata(mg_name, first_function_call);
   }
   else if (geometry_type == "assembly")
   {
-    Moose::out << "Assembly-level metadata defined using Reactor Geometry Mesh Builder for "
+    _console << "Assembly-level metadata defined using Reactor Geometry Mesh Builder for "
                << mg_name << ":" << std::endl;
     printAssemblyMetadata(mg_name, first_function_call);
   }
   else if (geometry_type == "pin")
   {
-    Moose::out << "Pin-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
+    _console << "Pin-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
                << ":" << std::endl;
     printPinMetadata(mg_name);
   }
   if (first_function_call)
-    Moose::out << std::endl;
+    _console << std::endl;
 }
 
 void
@@ -236,8 +236,8 @@ void
 ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string metadata_name,
                                                        const std::string mg_name)
 {
-  Moose::out << "  " << metadata_name << ": "
-             << Moose::stringify(getMeshProperty<T>(metadata_name, mg_name)) << std::endl;
+  _console << "  " << metadata_name << ": "
+            << Moose::stringify(getMeshProperty<T>(metadata_name, mg_name)) << std::endl;
 }
 
 template <typename T>
@@ -246,7 +246,7 @@ ReactorGeometryMeshBuilderBase::print2dMetadataToConsole(const std::string metad
                                                          const std::string mg_name)
 {
   const auto metadata_value = getMeshProperty<std::vector<std::vector<T>>>(metadata_name, mg_name);
-  Moose::out << "  " << metadata_name << ":" << std::endl;
+  _console << "  " << metadata_name << ":" << std::endl;
   for (const auto & row : metadata_value)
-    Moose::out << "    " << Moose::stringify(row) << std::endl;
+    _console << "    " << Moose::stringify(row) << std::endl;
 }

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -100,10 +100,14 @@ ReactorGeometryMeshBuilderBase::updateElementBlockNameId(
 void
 ReactorGeometryMeshBuilderBase::generateGlobalReactorMetadata(const std::string prefix)
 {
-  declareMeshProperty(prefix + "_mesh_dimensions", getReactorParam<int>("mesh_dimensions"));
+  const auto mesh_dimension = getReactorParam<int>("mesh_dimensions");
+  declareMeshProperty(prefix + "_mesh_dimensions", mesh_dimension);
   declareMeshProperty(prefix + "_mesh_geometry", getReactorParam<std::string>("mesh_geometry"));
-  declareMeshProperty(prefix + "_axial_boundaries", getReactorParam<std::vector<Real>>("axial_boundaries"));
-  declareMeshProperty(prefix + "_axial_mesh_intervals", getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
+  if (mesh_dimension == 3)
+  {
+    declareMeshProperty(prefix + "_axial_boundaries", getReactorParam<std::vector<Real>>("axial_boundaries"));
+    declareMeshProperty(prefix + "_axial_mesh_intervals", getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
+  }
 }
 
 void

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -102,15 +102,14 @@ ReactorGeometryMeshBuilderBase::updateElementBlockNameId(
 void
 ReactorGeometryMeshBuilderBase::generateGlobalReactorMetadata(const std::string prefix)
 {
-  const auto mesh_dimension = getReactorParam<int>("mesh_dimensions");
-  declareMeshProperty(prefix + "_mesh_dimensions", mesh_dimension);
-  declareMeshProperty(prefix + "_mesh_geometry", getReactorParam<std::string>("mesh_geometry"));
+  copyReactorMetadata<std::string>(prefix, RGMB::mesh_geometry, _reactor_params);
+  const auto mesh_dimension =
+      copyReactorMetadata<int>(prefix, RGMB::mesh_dimensions, _reactor_params);
   if (mesh_dimension == 3)
   {
-    declareMeshProperty(prefix + "_axial_boundaries",
-                        getReactorParam<std::vector<Real>>("axial_boundaries"));
-    declareMeshProperty(prefix + "_axial_mesh_intervals",
-                        getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
+    copyReactorMetadata<std::vector<Real>>(prefix, RGMB::axial_mesh_sizes, _reactor_params);
+    copyReactorMetadata<std::vector<unsigned int>>(
+        prefix, RGMB::axial_mesh_intervals, _reactor_params);
   }
 }
 
@@ -120,23 +119,15 @@ ReactorGeometryMeshBuilderBase::copyPinMetadata(const std::string input_name,
 {
   std::string metadata_prefix = "pin_" + std::to_string(pin_type_id);
 
-  declareMeshProperty(metadata_prefix + "_pitch",
-                      getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
-  declareMeshProperty(
-      metadata_prefix + "_ring_radii",
-      getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
-  declareMeshProperty(metadata_prefix + "_ring_region_ids",
-                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
-                          metadata_prefix + "_ring_region_ids", input_name));
-  declareMeshProperty(metadata_prefix + "_background_region_id",
-                      getMeshProperty<std::vector<subdomain_id_type>>(
-                          metadata_prefix + "_background_region_id", input_name));
-  declareMeshProperty(
-      metadata_prefix + "_duct_halfpitches",
-      getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_region_ids",
-                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
-                          metadata_prefix + "_duct_region_ids", input_name));
+  copyReactorMetadata<Real>(metadata_prefix, RGMB::pitch, input_name);
+  copyReactorMetadata<std::vector<Real>>(metadata_prefix, RGMB::ring_radii, input_name);
+  copyReactorMetadata<std::vector<std::vector<subdomain_id_type>>>(
+      metadata_prefix, RGMB::ring_region_ids, input_name);
+  copyReactorMetadata<std::vector<subdomain_id_type>>(
+      metadata_prefix, RGMB::background_region_id, input_name);
+  copyReactorMetadata<std::vector<Real>>(metadata_prefix, RGMB::duct_halfpitches, input_name);
+  copyReactorMetadata<std::vector<std::vector<subdomain_id_type>>>(
+      metadata_prefix, RGMB::duct_region_ids, input_name);
 }
 
 void
@@ -145,42 +136,29 @@ ReactorGeometryMeshBuilderBase::copyAssemblyMetadata(const std::string input_nam
 {
   std::string metadata_prefix = "assembly_" + std::to_string(assembly_type_id);
 
-  declareMeshProperty(metadata_prefix + "_pitch",
-                      getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
-  declareMeshProperty(metadata_prefix + "_background_region_id",
-                      getMeshProperty<std::vector<subdomain_id_type>>(
-                          metadata_prefix + "_background_region_id", input_name));
-  declareMeshProperty(
-      metadata_prefix + "_duct_halfpitches",
-      getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_region_ids",
-                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
-                          metadata_prefix + "_duct_region_ids", input_name));
+  copyReactorMetadata<Real>(metadata_prefix, RGMB::pitch, input_name);
+  copyReactorMetadata<std::vector<subdomain_id_type>>(
+      metadata_prefix, RGMB::background_region_id, input_name);
+  copyReactorMetadata<std::vector<Real>>(metadata_prefix, RGMB::duct_halfpitches, input_name);
+  copyReactorMetadata<std::vector<std::vector<subdomain_id_type>>>(
+      metadata_prefix, RGMB::duct_region_ids, input_name);
   const auto is_homogenized =
-      getMeshProperty<bool>(metadata_prefix + "_is_homogenized", input_name);
-  const auto is_single_pin = getMeshProperty<bool>(metadata_prefix + "_is_single_pin", input_name);
-  declareMeshProperty(metadata_prefix + "_is_homogenized", is_homogenized);
-  declareMeshProperty(metadata_prefix + "_is_single_pin", is_single_pin);
+      copyReactorMetadata<bool>(metadata_prefix, RGMB::is_homogenized, input_name);
+  const auto is_single_pin =
+      copyReactorMetadata<bool>(metadata_prefix, RGMB::is_single_pin, input_name);
 
   // Define metadata specific to assemblies defined as a lattice of pins
   if (!is_single_pin)
   {
-    declareMeshProperty(
-        metadata_prefix + "_pin_types",
-        getMeshProperty<std::set<unsigned int>>(metadata_prefix + "_pin_types", input_name));
-    declareMeshProperty(
-        metadata_prefix + "_lattice",
-        getMeshProperty<std::vector<std::vector<int>>>(metadata_prefix + "_lattice", input_name));
+    copyReactorMetadata<std::set<unsigned int>>(metadata_prefix, "pin_types", input_name);
+    copyReactorMetadata<std::vector<std::vector<int>>>(metadata_prefix, RGMB::lattice, input_name);
   }
   // Defined metadata specific to assemblies defined as a single heterogeneous pin
   else if (!is_homogenized)
   {
-    declareMeshProperty(
-        metadata_prefix + "_ring_radii",
-        getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
-    declareMeshProperty(metadata_prefix + "_ring_region_ids",
-                        getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
-                            metadata_prefix + "_ring_region_ids", input_name));
+    copyReactorMetadata<std::vector<Real>>(metadata_prefix, RGMB::ring_radii, input_name);
+    copyReactorMetadata<std::vector<std::vector<subdomain_id_type>>>(
+        metadata_prefix, RGMB::ring_region_ids, input_name);
   }
 }
 
@@ -229,15 +207,15 @@ void
 ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix,
                                                   bool first_function_call)
 {
-  bool has_mesh_periphery = hasMeshProperty<Real>(prefix + "_peripheral_ring_radius");
+  bool has_mesh_periphery = hasMeshProperty<Real>(prefix + "_" + RGMB::peripheral_ring_radius);
   if (has_mesh_periphery)
   {
-    printMetadataToConsole<Real>(prefix + "_peripheral_ring_radius");
-    printMetadataToConsole<subdomain_id_type>(prefix + "_peripheral_ring_region_id");
+    printMetadataToConsole<Real>(prefix, RGMB::peripheral_ring_radius);
+    printMetadataToConsole<subdomain_id_type>(prefix, RGMB::peripheral_ring_region_id);
   }
 
-  printMetadataToConsole<std::set<unsigned int>>(prefix + "_assembly_types");
-  print2dMetadataToConsole<int>(prefix + "_lattice");
+  printMetadataToConsole<std::set<unsigned int>>(prefix, "assembly_types");
+  print2dMetadataToConsole<int>(prefix, RGMB::lattice);
 
   if (first_function_call)
   {
@@ -247,8 +225,8 @@ ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix,
       printReactorMetadata("assembly_" + Moose::stringify(assembly_type_id), false);
 
     const auto core_pin_types = getMeshProperty<std::set<unsigned int>>(prefix + "_pin_types");
-    for (const auto & assembly_type_id : core_pin_types)
-      printReactorMetadata("pin_" + Moose::stringify(assembly_type_id), false);
+    for (const auto & pin_type_id : core_pin_types)
+      printReactorMetadata("pin_" + Moose::stringify(pin_type_id), false);
   }
 }
 
@@ -256,26 +234,27 @@ void
 ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix,
                                                       bool first_function_call)
 {
-  printMetadataToConsole<Real>(prefix + "_pitch");
-  printMetadataToConsole<bool>(prefix + "_is_homogenized");
-  printMetadataToConsole<bool>(prefix + "_is_single_pin");
-  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix + "_background_region_id");
+  printMetadataToConsole<Real>(prefix, RGMB::pitch);
+  printMetadataToConsole<bool>(prefix, RGMB::is_homogenized);
+  printMetadataToConsole<bool>(prefix, RGMB::is_single_pin);
+  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix, RGMB::background_region_id);
 
-  const auto duct_halfpitch = getMeshProperty<std::vector<Real>>(prefix + "_duct_halfpitches");
+  const auto duct_halfpitch =
+      getMeshProperty<std::vector<Real>>(prefix + "_" + RGMB::duct_halfpitches);
   if (duct_halfpitch.size() > 0)
   {
-    printMetadataToConsole<std::vector<Real>>(prefix + "_duct_halfpitches");
-    print2dMetadataToConsole<subdomain_id_type>(prefix + "_duct_region_ids");
+    printMetadataToConsole<std::vector<Real>>(prefix, RGMB::duct_halfpitches);
+    print2dMetadataToConsole<subdomain_id_type>(prefix, RGMB::duct_region_ids);
   }
 
-  const auto is_single_pin = getMeshProperty<bool>(prefix + "_is_single_pin");
-  const auto is_homogenized = getMeshProperty<bool>(prefix + "_is_homogenized");
+  const auto is_single_pin = getMeshProperty<bool>(prefix + "_" + RGMB::is_single_pin);
+  const auto is_homogenized = getMeshProperty<bool>(prefix + "_" + RGMB::is_homogenized);
 
   // Print metadata specific to assemblies defined as a lattice of pins
   if (!is_single_pin)
   {
-    printMetadataToConsole<std::set<unsigned int>>(prefix + "_pin_types");
-    print2dMetadataToConsole<int>(prefix + "_lattice");
+    printMetadataToConsole<std::set<unsigned int>>(prefix, "pin_types");
+    print2dMetadataToConsole<int>(prefix, RGMB::lattice);
 
     // Print information about constituent pins if this is the first function call
     if (first_function_call)
@@ -289,11 +268,11 @@ ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix,
   // Print metadata specific to assemblies defined as a single pin
   else if (!is_homogenized)
   {
-    const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_ring_radii");
+    const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_" + RGMB::ring_radii);
     if (ring_radii.size() > 0)
     {
-      printMetadataToConsole<std::vector<Real>>(prefix + "_ring_radii");
-      print2dMetadataToConsole<subdomain_id_type>(prefix + "_ring_region_ids");
+      printMetadataToConsole<std::vector<Real>>(prefix, RGMB::ring_radii);
+      print2dMetadataToConsole<subdomain_id_type>(prefix, RGMB::ring_region_ids);
     }
   }
 }
@@ -301,48 +280,66 @@ ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix,
 void
 ReactorGeometryMeshBuilderBase::printPinMetadata(const std::string prefix)
 {
-  printMetadataToConsole<Real>(prefix + "_pitch");
+  printMetadataToConsole<Real>(prefix, RGMB::pitch);
 
-  const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_ring_radii");
+  const auto ring_radii = getMeshProperty<std::vector<Real>>(prefix + "_" + RGMB::ring_radii);
   if (ring_radii.size() > 0)
   {
-    printMetadataToConsole<std::vector<Real>>(prefix + "_ring_radii");
-    print2dMetadataToConsole<subdomain_id_type>(prefix + "_ring_region_ids");
+    printMetadataToConsole<std::vector<Real>>(prefix, RGMB::ring_radii);
+    print2dMetadataToConsole<subdomain_id_type>(prefix, RGMB::ring_region_ids);
   }
 
-  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix + "_background_region_id");
+  printMetadataToConsole<std::vector<subdomain_id_type>>(prefix, RGMB::background_region_id);
 
-  const auto duct_halfpitch = getMeshProperty<std::vector<Real>>(prefix + "_duct_halfpitches");
+  const auto duct_halfpitch =
+      getMeshProperty<std::vector<Real>>(prefix + "_" + RGMB::duct_halfpitches);
   if (duct_halfpitch.size() > 0)
   {
-    printMetadataToConsole<std::vector<Real>>(prefix + "_duct_halfpitches");
-    print2dMetadataToConsole<subdomain_id_type>(prefix + "_duct_region_ids");
+    printMetadataToConsole<std::vector<Real>>(prefix, RGMB::duct_halfpitches);
+    print2dMetadataToConsole<subdomain_id_type>(prefix, RGMB::duct_region_ids);
   }
 }
 
 void
 ReactorGeometryMeshBuilderBase::printGlobalReactorMetadata(const std::string prefix)
 {
-  printMetadataToConsole<int>(prefix + "_mesh_dimensions");
-  printMetadataToConsole<std::string>(prefix + "_mesh_geometry");
-  printMetadataToConsole<std::vector<Real>>(prefix + "_axial_boundaries");
-  printMetadataToConsole<std::vector<unsigned int>>(prefix + "_axial_mesh_intervals");
+  printMetadataToConsole<int>(prefix, RGMB::mesh_dimensions);
+  printMetadataToConsole<std::string>(prefix, RGMB::mesh_geometry);
+  printMetadataToConsole<std::vector<Real>>(prefix, RGMB::axial_mesh_sizes);
+  printMetadataToConsole<std::vector<unsigned int>>(prefix, RGMB::axial_mesh_intervals);
 }
 
 template <typename T>
 void
-ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string metadata_name)
+ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string prefix,
+                                                       const std::string name)
 {
-  Moose::out << "  " << metadata_name << ": " << Moose::stringify(getMeshProperty<T>(metadata_name))
-             << std::endl;
+  const std::string full_metadata_name = prefix + "_" + name;
+  Moose::out << "  " << full_metadata_name << ": "
+             << Moose::stringify(getMeshProperty<T>(full_metadata_name)) << std::endl;
 }
 
 template <typename T>
 void
-ReactorGeometryMeshBuilderBase::print2dMetadataToConsole(const std::string metadata_name)
+ReactorGeometryMeshBuilderBase::print2dMetadataToConsole(const std::string prefix,
+                                                         const std::string name)
 {
-  const auto metadata_value = getMeshProperty<std::vector<std::vector<T>>>(metadata_name);
-  Moose::out << "  " << metadata_name << ":" << std::endl;
+  const std::string full_metadata_name = prefix + "_" + name;
+  const auto metadata_value = getMeshProperty<std::vector<std::vector<T>>>(full_metadata_name);
+  Moose::out << "  " << full_metadata_name << ":" << std::endl;
   for (const auto & row : metadata_value)
     Moose::out << "    " << Moose::stringify(row) << std::endl;
+}
+
+template <typename T>
+T &
+ReactorGeometryMeshBuilderBase::copyReactorMetadata(const std::string prefix,
+                                                    const std::string name,
+                                                    std::string source_mesh)
+{
+  std::string full_name = prefix + "_" + name;
+  if (source_mesh == _reactor_params)
+    return copyMeshProperty<T>(name, _reactor_params, full_name);
+  else
+    return copyMeshProperty<T>(full_name, source_mesh, full_name);
 }

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -14,8 +14,8 @@ ReactorGeometryMeshBuilderBase::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
 
-  params.addParam<bool>("show_rgmb_metadata", false,
-                        "Print out RGMB-related metadata to console output");
+  params.addParam<bool>(
+      "show_rgmb_metadata", false, "Print out RGMB-related metadata to console output");
   params.addClassDescription("A base class that contains common members and methods for Reactor "
                              "Geometry Mesh Builder mesh generators.");
 
@@ -47,7 +47,9 @@ ReactorGeometryMeshBuilderBase::initializeReactorMeshParams(const std::string re
 
   // Check value of show_rgmb_metadata is valid
   if (getParam<bool>("show_rgmb_metadata") && !getReactorParam<bool>("generate_rgmb_metadata"))
-    paramError("show_rgmb_metadata", "`ReactorMeshParams/generate_rgmb_metadata` must be set to true in order for show_rgmb_metadata to be true");
+    paramError("show_rgmb_metadata",
+               "`ReactorMeshParams/generate_rgmb_metadata` must be set to true in order for "
+               "show_rgmb_metadata to be true");
 }
 
 void
@@ -105,34 +107,57 @@ ReactorGeometryMeshBuilderBase::generateGlobalReactorMetadata(const std::string 
   declareMeshProperty(prefix + "_mesh_geometry", getReactorParam<std::string>("mesh_geometry"));
   if (mesh_dimension == 3)
   {
-    declareMeshProperty(prefix + "_axial_boundaries", getReactorParam<std::vector<Real>>("axial_boundaries"));
-    declareMeshProperty(prefix + "_axial_mesh_intervals", getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
+    declareMeshProperty(prefix + "_axial_boundaries",
+                        getReactorParam<std::vector<Real>>("axial_boundaries"));
+    declareMeshProperty(prefix + "_axial_mesh_intervals",
+                        getReactorParam<std::vector<unsigned int>>("axial_mesh_intervals"));
   }
 }
 
 void
-ReactorGeometryMeshBuilderBase::copyPinMetadata(const std::string input_name, const unsigned int pin_type_id)
+ReactorGeometryMeshBuilderBase::copyPinMetadata(const std::string input_name,
+                                                const unsigned int pin_type_id)
 {
   std::string metadata_prefix = "pin_" + std::to_string(pin_type_id);
 
-  declareMeshProperty(metadata_prefix + "_pitch", getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
-  declareMeshProperty(metadata_prefix + "_ring_radii", getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
-  declareMeshProperty(metadata_prefix + "_ring_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_ring_region_ids", input_name));
-  declareMeshProperty(metadata_prefix + "_background_region_id", getMeshProperty<std::vector<subdomain_id_type>>(metadata_prefix + "_background_region_id", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_halfpitches", getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_duct_region_ids", input_name));
+  declareMeshProperty(metadata_prefix + "_pitch",
+                      getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
+  declareMeshProperty(
+      metadata_prefix + "_ring_radii",
+      getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
+  declareMeshProperty(metadata_prefix + "_ring_region_ids",
+                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
+                          metadata_prefix + "_ring_region_ids", input_name));
+  declareMeshProperty(metadata_prefix + "_background_region_id",
+                      getMeshProperty<std::vector<subdomain_id_type>>(
+                          metadata_prefix + "_background_region_id", input_name));
+  declareMeshProperty(
+      metadata_prefix + "_duct_halfpitches",
+      getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_region_ids",
+                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
+                          metadata_prefix + "_duct_region_ids", input_name));
 }
 
 void
-ReactorGeometryMeshBuilderBase::copyAssemblyMetadata(const std::string input_name, const unsigned int assembly_type_id)
+ReactorGeometryMeshBuilderBase::copyAssemblyMetadata(const std::string input_name,
+                                                     const unsigned int assembly_type_id)
 {
   std::string metadata_prefix = "assembly_" + std::to_string(assembly_type_id);
 
-  declareMeshProperty(metadata_prefix + "_pitch", getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
-  declareMeshProperty(metadata_prefix + "_background_region_id", getMeshProperty<std::vector<subdomain_id_type>>(metadata_prefix + "_background_region_id", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_halfpitches", getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
-  declareMeshProperty(metadata_prefix + "_duct_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_duct_region_ids", input_name));
-  const auto is_homogenized = getMeshProperty<bool>(metadata_prefix + "_is_homogenized", input_name);
+  declareMeshProperty(metadata_prefix + "_pitch",
+                      getMeshProperty<Real>(metadata_prefix + "_pitch", input_name));
+  declareMeshProperty(metadata_prefix + "_background_region_id",
+                      getMeshProperty<std::vector<subdomain_id_type>>(
+                          metadata_prefix + "_background_region_id", input_name));
+  declareMeshProperty(
+      metadata_prefix + "_duct_halfpitches",
+      getMeshProperty<std::vector<Real>>(metadata_prefix + "_duct_halfpitches", input_name));
+  declareMeshProperty(metadata_prefix + "_duct_region_ids",
+                      getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
+                          metadata_prefix + "_duct_region_ids", input_name));
+  const auto is_homogenized =
+      getMeshProperty<bool>(metadata_prefix + "_is_homogenized", input_name);
   const auto is_single_pin = getMeshProperty<bool>(metadata_prefix + "_is_single_pin", input_name);
   declareMeshProperty(metadata_prefix + "_is_homogenized", is_homogenized);
   declareMeshProperty(metadata_prefix + "_is_single_pin", is_single_pin);
@@ -140,19 +165,28 @@ ReactorGeometryMeshBuilderBase::copyAssemblyMetadata(const std::string input_nam
   // Define metadata specific to assemblies defined as a lattice of pins
   if (!is_single_pin)
   {
-    declareMeshProperty(metadata_prefix + "_pin_types", getMeshProperty<std::set<unsigned int>>(metadata_prefix + "_pin_types", input_name));
-    declareMeshProperty(metadata_prefix + "_lattice", getMeshProperty<std::vector<std::vector<int>>>(metadata_prefix + "_lattice", input_name));
+    declareMeshProperty(
+        metadata_prefix + "_pin_types",
+        getMeshProperty<std::set<unsigned int>>(metadata_prefix + "_pin_types", input_name));
+    declareMeshProperty(
+        metadata_prefix + "_lattice",
+        getMeshProperty<std::vector<std::vector<int>>>(metadata_prefix + "_lattice", input_name));
   }
   // Defined metadata specific to assemblies defined as a single heterogeneous pin
   else if (!is_homogenized)
   {
-    declareMeshProperty(metadata_prefix + "_ring_radii", getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
-  declareMeshProperty(metadata_prefix + "_ring_region_ids", getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(metadata_prefix + "_ring_region_ids", input_name));
+    declareMeshProperty(
+        metadata_prefix + "_ring_radii",
+        getMeshProperty<std::vector<Real>>(metadata_prefix + "_ring_radii", input_name));
+    declareMeshProperty(metadata_prefix + "_ring_region_ids",
+                        getMeshProperty<std::vector<std::vector<subdomain_id_type>>>(
+                            metadata_prefix + "_ring_region_ids", input_name));
   }
 }
 
 void
-ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_prefix, bool first_function_call)
+ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_prefix,
+                                                     bool first_function_call)
 {
   if (metadata_prefix == "core")
   {
@@ -170,7 +204,8 @@ ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_
     {
       if (first_function_call)
       {
-        Moose::out << "Assembly-level metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+        Moose::out << "Assembly-level metadata defined using Reactor Geometry Mesh Builder:"
+                   << std::endl;
         printGlobalReactorMetadata(metadata_prefix);
       }
       printAssemblyMetadata(metadata_prefix, first_function_call);
@@ -179,7 +214,8 @@ ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_
     {
       if (first_function_call)
       {
-        Moose::out << "Pin-level metadata defined using Reactor Geometry Mesh Builder:" << std::endl;
+        Moose::out << "Pin-level metadata defined using Reactor Geometry Mesh Builder:"
+                   << std::endl;
         printGlobalReactorMetadata(metadata_prefix);
       }
       printPinMetadata(metadata_prefix);
@@ -190,7 +226,8 @@ ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string metadata_
 }
 
 void
-ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix, bool first_function_call)
+ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix,
+                                                  bool first_function_call)
 {
   bool has_mesh_periphery = hasMeshProperty<Real>(prefix + "_peripheral_ring_radius");
   if (has_mesh_periphery)
@@ -204,7 +241,8 @@ ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix, bool
 
   if (first_function_call)
   {
-    const auto core_assembly_types = getMeshProperty<std::set<unsigned int>>(prefix + "_assembly_types");
+    const auto core_assembly_types =
+        getMeshProperty<std::set<unsigned int>>(prefix + "_assembly_types");
     for (const auto & assembly_type_id : core_assembly_types)
       printReactorMetadata("assembly_" + Moose::stringify(assembly_type_id), false);
 
@@ -215,7 +253,8 @@ ReactorGeometryMeshBuilderBase::printCoreMetadata(const std::string prefix, bool
 }
 
 void
-ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix, bool first_function_call)
+ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix,
+                                                      bool first_function_call)
 {
   printMetadataToConsole<Real>(prefix + "_pitch");
   printMetadataToConsole<bool>(prefix + "_is_homogenized");
@@ -241,7 +280,8 @@ ReactorGeometryMeshBuilderBase::printAssemblyMetadata(const std::string prefix, 
     // Print information about constituent pins if this is the first function call
     if (first_function_call)
     {
-      const auto assembly_pin_types = getMeshProperty<std::set<unsigned int>>(prefix + "_pin_types");
+      const auto assembly_pin_types =
+          getMeshProperty<std::set<unsigned int>>(prefix + "_pin_types");
       for (const auto & pin_type_id : assembly_pin_types)
         printReactorMetadata("pin_" + Moose::stringify(pin_type_id), false);
     }
@@ -289,13 +329,16 @@ ReactorGeometryMeshBuilderBase::printGlobalReactorMetadata(const std::string pre
   printMetadataToConsole<std::vector<unsigned int>>(prefix + "_axial_mesh_intervals");
 }
 
-template <typename T> void
+template <typename T>
+void
 ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string metadata_name)
 {
-  Moose::out << "  " << metadata_name << ": " << Moose::stringify(getMeshProperty<T>(metadata_name)) << std::endl;
+  Moose::out << "  " << metadata_name << ": " << Moose::stringify(getMeshProperty<T>(metadata_name))
+             << std::endl;
 }
 
-template <typename T> void
+template <typename T>
+void
 ReactorGeometryMeshBuilderBase::print2dMetadataToConsole(const std::string metadata_name)
 {
   const auto metadata_value = getMeshProperty<std::vector<std::vector<T>>>(metadata_name);

--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -106,19 +106,19 @@ ReactorGeometryMeshBuilderBase::printReactorMetadata(const std::string geometry_
   if (geometry_type == "core")
   {
     _console << "Core-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
-               << ":" << std::endl;
+             << ":" << std::endl;
     printCoreMetadata(mg_name, first_function_call);
   }
   else if (geometry_type == "assembly")
   {
     _console << "Assembly-level metadata defined using Reactor Geometry Mesh Builder for "
-               << mg_name << ":" << std::endl;
+             << mg_name << ":" << std::endl;
     printAssemblyMetadata(mg_name, first_function_call);
   }
   else if (geometry_type == "pin")
   {
     _console << "Pin-level metadata defined using Reactor Geometry Mesh Builder for " << mg_name
-               << ":" << std::endl;
+             << ":" << std::endl;
     printPinMetadata(mg_name);
   }
   if (first_function_call)
@@ -237,7 +237,7 @@ ReactorGeometryMeshBuilderBase::printMetadataToConsole(const std::string metadat
                                                        const std::string mg_name)
 {
   _console << "  " << metadata_name << ": "
-            << Moose::stringify(getMeshProperty<T>(metadata_name, mg_name)) << std::endl;
+           << Moose::stringify(getMeshProperty<T>(metadata_name, mg_name)) << std::endl;
 }
 
 template <typename T>

--- a/modules/reactor/src/meshgenerators/ReactorMeshParams.C
+++ b/modules/reactor/src/meshgenerators/ReactorMeshParams.C
@@ -43,9 +43,6 @@ ReactorMeshParams::validParams()
   params.addParam<std::vector<unsigned int>>(
       "axial_mesh_intervals",
       "Number of elements in the Z direction for each axial region");
-  params.addParam<bool>("generate_rgmb_metadata",
-                        "Whether to define additional metadata to represent geometry and region "
-                        "IDs of RGMB mesh generators");
   params.addClassDescription("This ReactorMeshParams object acts as storage for persistent "
                              "information about the reactor geometry.");
   return params;
@@ -55,9 +52,7 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
   : MeshGenerator(parameters),
     _dim(getParam<MooseEnum>("dim")),
     _geom(getParam<MooseEnum>("geom")),
-    _assembly_pitch(getParam<Real>("assembly_pitch")),
-    _define_metadata(
-        isParamValid("generate_rgmb_metadata") ? getParam<bool>("generate_rgmb_metadata") : false)
+    _assembly_pitch(getParam<Real>("assembly_pitch"))
 {
   if (int(_dim) == 2)
   {
@@ -106,8 +101,6 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
   if (isParamValid("top_boundary_id") && isParamValid("bottom_boundary_id") &&
       (_bottom_boundary == _top_boundary))
     mooseError("top_boundary_id and bottom_boundary_id must be unique values");
-
-  this->declareMeshProperty(RGMB::generate_metadata, _define_metadata);
 }
 
 std::unique_ptr<MeshBase>

--- a/modules/reactor/src/meshgenerators/ReactorMeshParams.C
+++ b/modules/reactor/src/meshgenerators/ReactorMeshParams.C
@@ -9,6 +9,7 @@
 
 #include "ReactorMeshParams.h"
 #include "CastUniquePointer.h"
+#include "ReactorGeometryMeshBuilderBase.h"
 
 // libMesh includes
 #include "libmesh/mesh_generation.h"
@@ -74,29 +75,29 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
     if (_axial_regions.size() != _axial_mesh_intervals.size())
       mooseError(
           "The number of axial regions is not consistent with the number of axial intervals.");
-    this->declareMeshProperty("axial_boundaries", _axial_regions);
-    this->declareMeshProperty("axial_mesh_intervals", _axial_mesh_intervals);
+    this->declareMeshProperty(RGMB::axial_mesh_sizes, _axial_regions);
+    this->declareMeshProperty(RGMB::axial_mesh_intervals, _axial_mesh_intervals);
   }
 
-  this->declareMeshProperty("mesh_dimensions", int(_dim));
-  this->declareMeshProperty("mesh_geometry", std::string(_geom));
-  this->declareMeshProperty("assembly_pitch", _assembly_pitch);
+  this->declareMeshProperty(RGMB::mesh_dimensions, int(_dim));
+  this->declareMeshProperty(RGMB::mesh_geometry, std::string(_geom));
+  this->declareMeshProperty(RGMB::assembly_pitch, _assembly_pitch);
   this->declareMeshProperty("name_id_map", _name_id_map);
 
   if (isParamValid("top_boundary_id"))
   {
     _top_boundary = getParam<boundary_id_type>("top_boundary_id");
-    this->declareMeshProperty("top_boundary_id", _top_boundary);
+    this->declareMeshProperty(RGMB::top_boundary_id, _top_boundary);
   }
   if (isParamValid("bottom_boundary_id"))
   {
     _bottom_boundary = getParam<boundary_id_type>("bottom_boundary_id");
-    this->declareMeshProperty("bottom_boundary_id", _bottom_boundary);
+    this->declareMeshProperty(RGMB::bottom_boundary_id, _bottom_boundary);
   }
   if (isParamValid("radial_boundary_id"))
   {
     _radial_boundary = getParam<boundary_id_type>("radial_boundary_id");
-    this->declareMeshProperty("radial_boundary_id", _radial_boundary);
+    this->declareMeshProperty(RGMB::radial_boundary_id, _radial_boundary);
     if (isParamValid("top_boundary_id") && _radial_boundary == _top_boundary)
       mooseError("top_boundary_id and radial_boundary_id must be unique values");
     if (isParamValid("bottom_boundary_id") && _radial_boundary == _bottom_boundary)
@@ -106,7 +107,7 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
       (_bottom_boundary == _top_boundary))
     mooseError("top_boundary_id and bottom_boundary_id must be unique values");
 
-  this->declareMeshProperty("generate_rgmb_metadata", _define_metadata);
+  this->declareMeshProperty(RGMB::generate_metadata, _define_metadata);
 }
 
 std::unique_ptr<MeshBase>

--- a/modules/reactor/src/meshgenerators/ReactorMeshParams.C
+++ b/modules/reactor/src/meshgenerators/ReactorMeshParams.C
@@ -44,6 +44,7 @@ ReactorMeshParams::validParams()
       "axial_mesh_intervals",
       std::vector<unsigned int>(1),
       "Number of elements in the Z direction for each axial region");
+  params.addParam<bool>("generate_rgmb_metadata", "Whether to define additional metadata to represent geometry and region IDs of RGMB mesh generators");
   params.addClassDescription("This ReactorMeshParams object acts as storage for persistent "
                              "information about the reactor geometry.");
   return params;
@@ -55,7 +56,8 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
     _geom(getParam<MooseEnum>("geom")),
     _assembly_pitch(getParam<Real>("assembly_pitch")),
     _axial_regions(getParam<std::vector<Real>>("axial_regions")),
-    _axial_mesh_intervals(getParam<std::vector<unsigned int>>("axial_mesh_intervals"))
+    _axial_mesh_intervals(getParam<std::vector<unsigned int>>("axial_mesh_intervals")),
+    _define_metadata(isParamValid("generate_rgmb_metadata") ? getParam<bool>("generate_rgmb_metadata") : false)
 {
   if (_axial_regions.size() != _axial_mesh_intervals.size())
     mooseError("The number of axial regions is not consistent with the number of axial intervals.");
@@ -90,6 +92,8 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
   if (isParamValid("top_boundary_id") && isParamValid("bottom_boundary_id") &&
       (_bottom_boundary == _top_boundary))
     mooseError("top_boundary_id and bottom_boundary_id must be unique values");
+
+  this->declareMeshProperty("generate_rgmb_metadata", _define_metadata);
 }
 
 std::unique_ptr<MeshBase>

--- a/modules/reactor/src/meshgenerators/ReactorMeshParams.C
+++ b/modules/reactor/src/meshgenerators/ReactorMeshParams.C
@@ -38,12 +38,13 @@ ReactorMeshParams::validParams()
   params.addParam<boundary_id_type>(
       "radial_boundary_id",
       "The boundary ID to set on the outer radial boundary of a CoreMeshGenerator object");
-  params.addParam<std::vector<Real>>(
-      "axial_regions", "Length of each axial region");
+  params.addParam<std::vector<Real>>("axial_regions", "Length of each axial region");
   params.addParam<std::vector<unsigned int>>(
       "axial_mesh_intervals",
       "Number of elements in the Z direction for each axial region");
-  params.addParam<bool>("generate_rgmb_metadata", "Whether to define additional metadata to represent geometry and region IDs of RGMB mesh generators");
+  params.addParam<bool>("generate_rgmb_metadata",
+                        "Whether to define additional metadata to represent geometry and region "
+                        "IDs of RGMB mesh generators");
   params.addClassDescription("This ReactorMeshParams object acts as storage for persistent "
                              "information about the reactor geometry.");
   return params;
@@ -54,11 +55,13 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
     _dim(getParam<MooseEnum>("dim")),
     _geom(getParam<MooseEnum>("geom")),
     _assembly_pitch(getParam<Real>("assembly_pitch")),
-    _define_metadata(isParamValid("generate_rgmb_metadata") ? getParam<bool>("generate_rgmb_metadata") : false)
+    _define_metadata(
+        isParamValid("generate_rgmb_metadata") ? getParam<bool>("generate_rgmb_metadata") : false)
 {
   if (int(_dim) == 2)
   {
-    std::vector<std::string> invalid_params = {"axial_regions", "axial_mesh_intervals", "top_boundary_id", "bottom_boundary_id"};
+    std::vector<std::string> invalid_params = {
+        "axial_regions", "axial_mesh_intervals", "top_boundary_id", "bottom_boundary_id"};
     for (const auto & param : invalid_params)
       if (isParamValid(param))
         paramError(param, param + " should not be defined for 2-D meshes");
@@ -69,7 +72,8 @@ ReactorMeshParams::ReactorMeshParams(const InputParameters & parameters)
     _axial_mesh_intervals = getParam<std::vector<unsigned int>>("axial_mesh_intervals");
 
     if (_axial_regions.size() != _axial_mesh_intervals.size())
-      mooseError("The number of axial regions is not consistent with the number of axial intervals.");
+      mooseError(
+          "The number of axial regions is not consistent with the number of axial intervals.");
     this->declareMeshProperty("axial_boundaries", _axial_regions);
     this->declareMeshProperty("axial_mesh_intervals", _axial_mesh_intervals);
   }

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_hex.i
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_hex.i
@@ -2,8 +2,12 @@
   [rmp]
     type = ReactorMeshParams
     dim = 3
-    geom = "Square"
-    assembly_pitch = 2.84126
+    geom = "Hex"
+    assembly_pitch = 7.10315
+    axial_regions = '1.0 1.0'
+    axial_mesh_intervals = '1 1'
+    top_boundary_id = 201
+    bottom_boundary_id = 202
   []
 
   [pin1]
@@ -15,7 +19,7 @@
     ring_radii = '0.2'
     duct_halfpitch = '0.68'
     mesh_intervals = '1 1 1'
-    quad_center_elements = false
+    quad_center_elements = true
     region_ids='1 2 5; 11 12 15'
   []
 
@@ -27,22 +31,22 @@
     num_sectors = 2
     mesh_intervals = '2'
     region_ids='3; 13'
+    quad_center_elements = true
   []
 
   [amg]
     type = AssemblyMeshGenerator
     assembly_type = 1
     inputs = 'pin1 pin2'
-    pattern = '0 0;
-               0 1;'
+    pattern = '1 1;
+              1 0 1;
+               1 1;'
+    background_intervals = 1
+    background_region_id = '6 16'
+    duct_halfpitch = '3.5'
+    duct_region_ids = '7; 17'
+    duct_intervals = '1'
     extrude = true
-  []
-
-  [translate]
-    type = TransformGenerator
-    input = amg
-    transform = TRANSLATE
-    vector_value = '0.710315 -0.710315 0'
   []
 []
 

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_hex_2d.i
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_hex_2d.i
@@ -1,0 +1,54 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 2
+    geom = "Hex"
+    assembly_pitch = 3.7884
+    radial_boundary_id = 200
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.3425
+    num_sectors = 2
+    ring_radii = '0.4404'
+    duct_halfpitch = '0.5404'
+    mesh_intervals = '1 1 1'
+    quad_center_elements = false
+    region_ids='1 2 3'
+  []
+
+  [amg]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin1'
+    pattern = '0 0;
+              0 0 0;
+               0 0;'
+    background_intervals = 1
+    background_region_id = 4
+    duct_halfpitch = 1.7703
+    duct_intervals = 1
+    duct_region_ids = 5
+    extrude = false
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'region_id'
+  []
+[]

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_only.i
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_only.i
@@ -4,10 +4,6 @@
     dim = 3
     geom = "Square"
     assembly_pitch = 2.84126
-    axial_regions = '1.0 1.0'
-    axial_mesh_intervals = '1 1'
-    top_boundary_id = 201
-    bottom_boundary_id = 202
   []
 
   [pin1]

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_square.i
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/assembly_square.i
@@ -1,0 +1,68 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 3
+    geom = "Square"
+    assembly_pitch = 2.84126
+    axial_regions = '1.0 1.0'
+    axial_mesh_intervals = '1 1'
+    top_boundary_id = 201
+    bottom_boundary_id = 202
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.42063
+    num_sectors = 2
+    ring_radii = '0.2'
+    duct_halfpitch = '0.68'
+    mesh_intervals = '1 1 1'
+    quad_center_elements = false
+    region_ids='1 2 5; 11 12 15'
+  []
+
+  [pin2]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    num_sectors = 2
+    mesh_intervals = '2'
+    region_ids='3; 13'
+  []
+
+  [amg]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin1 pin2'
+    pattern = '0 0;
+               0 1;'
+    extrude = true
+  []
+
+  [translate]
+    type = TransformGenerator
+    input = amg
+    transform = TRANSLATE
+    vector_value = '0.710315 -0.710315 0'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'region_id'
+  []
+[]

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
@@ -5,7 +5,11 @@
     requirement = 'The system shall generate a 3D square assembly mesh from 2 pin types'
     type = 'Exodiff'
     input = 'assembly_only.i'
-    cli_args = "Outputs/file_base=assembly_only_in"
+    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Outputs/file_base=assembly_only_in"
     exodiff = 'assembly_only_in.e'
     recover = false
   []
@@ -13,7 +17,11 @@
     requirement = 'The system shall generate a 3D square assembly mesh from 2 pin types and a background region'
     type = 'Exodiff'
     input = 'assembly_only.i'
-    cli_args = "Mesh/pin1/pitch=1.25
+    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/pitch=1.25
                 Mesh/pin1/duct_halfpitch=0.58
                 Mesh/pin2/pitch=1.25
                 Mesh/amg/background_region_id='6 16'
@@ -27,7 +35,11 @@
     requirement = 'The system shall allow for multiple region IDs to be mapped to a specific block name'
     type = 'Exodiff'
     input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/geom='Hex'
+    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/rmp/geom='Hex'
                 Mesh/rmp/assembly_pitch=7.10315
                 Mesh/pin1/region_ids='1 2 5; 11 12 15'
                 Mesh/pin1/quad_center_elements=true
@@ -50,7 +62,11 @@
     requirement = 'The system shall generate a 3D hexagonal assembly mesh with duct regions with assigned IDs'
     type = 'Exodiff'
     input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/geom='Hex'
+    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/rmp/geom='Hex'
                 Mesh/rmp/assembly_pitch=7.10315
                 Mesh/pin1/region_ids='1 2 5; 11 12 15'
                 Mesh/pin1/quad_center_elements=true

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
@@ -4,35 +4,23 @@
   [square]
     requirement = 'The system shall generate a 3D square assembly mesh from 2 pin types'
     type = 'Exodiff'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Outputs/file_base=assembly_only_in"
+    input = 'assembly_square.i'
+    cli_args = "Outputs/file_base=assembly_only_in"
     exodiff = 'assembly_only_in.e'
     recover = false
   []
   [assembly_shared_pin_ids]
     requirement = 'The system shall throw an error if an assembly mesh is composed of pins with identical pin_type ids'
     type = 'RunException'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin2/pin_type=1"
+    input = 'assembly_square.i'
+    cli_args = "Mesh/pin2/pin_type=1"
     expect_err = 'Constituent pins have shared pin_type ids but different names.'
   []
   [square_background]
     requirement = 'The system shall generate a 3D square assembly mesh from 2 pin types and a background region'
     type = 'Exodiff'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/pitch=1.25
+    input = 'assembly_square.i'
+    cli_args = "Mesh/pin1/pitch=1.25
                 Mesh/pin1/duct_halfpitch=0.58
                 Mesh/pin2/pitch=1.25
                 Mesh/amg/background_region_id='6 16'
@@ -45,26 +33,9 @@
   [hex_ID_conflict]
     requirement = 'The system shall allow for multiple region IDs to be mapped to a specific block name'
     type = 'Exodiff'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=7.10315
-                Mesh/pin1/region_ids='1 2 5; 11 12 15'
-                Mesh/pin1/quad_center_elements=true
-                Mesh/pin2/region_ids='3; 13'
-                Mesh/pin2/block_names='BLK3; BLK13'
-                Mesh/pin2/quad_center_elements=true
-                Mesh/amg/pattern='  1   1; 1   0   1; 1   1'
-                Mesh/amg/background_intervals=1
-                Mesh/amg/background_region_id='6 16'
+    input = 'assembly_hex.i'
+    cli_args = "Mesh/pin2/block_names='BLK3; BLK13'
                 Mesh/amg/background_block_name='BLK3 BLK16'
-                Mesh/amg/duct_halfpitch='3.5'
-                Mesh/amg/duct_region_ids='7; 17'
-                Mesh/amg/duct_intervals='1'
-                Mesh/inactive='translate'
                 Outputs/file_base=assembly_ductIDs_conflict"
     exodiff = assembly_ductIDs_conflict.e
     recover = false
@@ -72,50 +43,16 @@
   [hex_ductIDs]
     requirement = 'The system shall generate a 3D hexagonal assembly mesh with duct regions with assigned IDs'
     type = 'Exodiff'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=7.10315
-                Mesh/pin1/region_ids='1 2 5; 11 12 15'
-                Mesh/pin1/quad_center_elements=true
-                Mesh/pin2/region_ids='3; 13'
-                Mesh/pin2/quad_center_elements=true
-                Mesh/amg/pattern='  1   1; 1   0   1; 1   1'
-                Mesh/amg/background_intervals=1
-                Mesh/amg/background_region_id='6 16'
-                Mesh/amg/duct_halfpitch='3.5'
-                Mesh/amg/duct_region_ids='7; 17'
-                Mesh/amg/duct_intervals='1'
-                Mesh/inactive='translate'
-                Outputs/file_base=assembly_ductIDs_in"
+    input = 'assembly_hex.i'
+    cli_args = "Outputs/file_base=assembly_ductIDs_in"
     exodiff = 'assembly_ductIDs_in.e'
     recover = false
   []
   [hex_metadata_transfer]
     requirement = 'The system shall generate a 2D hexagonal assembly mesh that transfers metadata correctly across RGMB mesh generators'
     type = 'Exodiff'
-    input = 'assembly_only.i'
-    cli_args = "Mesh/inactive='pin2 translate'
-                Mesh/rmp/dim=2
-                Mesh/rmp/geom=Hex
-                Mesh/rmp/assembly_pitch=3.7884
-                Mesh/rmp/radial_boundary_id=200
-                Mesh/pin1/pitch=1.3425
-                Mesh/pin1/ring_radii=0.4404
-                Mesh/pin1/duct_halfpitch=0.5404
-                Mesh/pin1/region_ids='1 2 3'
-                Mesh/amg/inputs=pin1
-                Mesh/amg/pattern='0 0; 0 0 0; 0 0'
-                Mesh/amg/background_intervals=1
-                Mesh/amg/background_region_id=4
-                Mesh/amg/duct_halfpitch=1.7703
-                Mesh/amg/duct_intervals=1
-                Mesh/amg/duct_region_ids=5
-                Mesh/amg/extrude=false
-                Outputs/file_base=assembly_metadata_transfer"
+    input = 'assembly_hex_2d.i'
+    cli_args = "Outputs/file_base=assembly_metadata_transfer"
     exodiff = 'assembly_metadata_transfer.e'
     recover = false
   []

--- a/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/assembly_mesh_generator/tests
@@ -13,6 +13,17 @@
     exodiff = 'assembly_only_in.e'
     recover = false
   []
+  [assembly_shared_pin_ids]
+    requirement = 'The system shall throw an error if an assembly mesh is composed of pins with identical pin_type ids'
+    type = 'RunException'
+    input = 'assembly_only.i'
+    cli_args = "Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin2/pin_type=1"
+    expect_err = 'Constituent pins have shared pin_type ids but different names.'
+  []
   [square_background]
     requirement = 'The system shall generate a 3D square assembly mesh from 2 pin types and a background region'
     type = 'Exodiff'

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core.i
@@ -4,10 +4,6 @@
     dim = 3
     geom = "Square"
     assembly_pitch = 2.84126
-    axial_regions = '1.0'
-    axial_mesh_intervals = '1'
-    top_boundary_id = 201
-    bottom_boundary_id = 202
     radial_boundary_id = 200
   []
 

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex.i
@@ -1,0 +1,115 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 3
+    geom = "Hex"
+    assembly_pitch = 7.10315
+    radial_boundary_id = 200
+    top_boundary_id = 201
+    bottom_boundary_id = 202
+    axial_regions = '1.0 1.0'
+    axial_mesh_intervals = '1 1'
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.42063
+    num_sectors = 2
+    ring_radii = 0.2
+    duct_halfpitch = 0.68
+    mesh_intervals = '1 1 1'
+    quad_center_elements = false
+    region_ids = '11 12 13; 111 112 113'
+    block_names = 'P1_R11 P1_R12 P1_R13; P1_R111 P1_R112 P1_R113'
+  []
+
+  [pin2]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    num_sectors = 2
+    quad_center_elements = false
+    mesh_intervals = 1
+    region_ids = '21; 121'
+    block_names = 'P2_R21; P2_R121'
+  []
+
+  [pin3]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 3
+    pitch = 1.42063
+    num_sectors = 2
+    ring_radii = '0.3818'
+    mesh_intervals = '1 1'
+    quad_center_elements = false
+    region_ids = '31 32; 131 132'
+    block_names = 'P3_R31 P3_R32; P3_R131 P3_R132'
+  []
+
+  [amg1]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin2'
+    pattern='  0   0;
+             0   0   0;
+               0   0'
+    background_intervals = 1
+    background_region_id = '41 141'
+    background_block_name = 'A1_R41 A1_R141'
+  []
+
+  [amg2]
+    type = AssemblyMeshGenerator
+    assembly_type = 2
+    inputs = 'pin1 pin3'
+    pattern = '0 0;
+              0 1 0;
+               0 0'
+    background_region_id = '51 151'
+    background_block_name = 'A2_R51 A2_R151'
+    background_intervals = 1
+    duct_region_ids = '52; 152'
+    duct_block_names = 'A2_R52; A2_R152'
+    duct_halfpitch = '3.5'
+    duct_intervals = '1'
+  []
+
+  [cmg]
+    type = CoreMeshGenerator
+    inputs = 'amg1 amg2 empty'
+    dummy_assembly_name = empty
+    pattern = '2 1;
+              1 0 2;
+               2 1'
+    extrude = true
+  []
+
+  [rotate90]
+    type = TransformGenerator
+    input = cmg
+    transform = ROTATE
+    vector_value = '0 0 90'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'assembly_id assembly_type_id plane_id pin_id pin_type_id region_id'
+  []
+  file_base = core_in
+[]

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex_2d.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex_2d.i
@@ -1,0 +1,75 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 2
+    geom = "Hex"
+    assembly_pitch = 3.7884
+    radial_boundary_id = 200
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.3425
+    region_ids = '1 2'
+    quad_center_elements = false
+    num_sectors = 2
+    ring_radii = 0.5404
+    mesh_intervals = '1 1'
+  []
+
+  [amg1]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin1'
+    pattern = '0 0;
+              0 0 0;
+               0 0'
+    background_intervals = 1
+    background_region_id = 3
+    duct_halfpitch = 1.7703
+    duct_intervals = 1
+    duct_region_ids = 4
+  []
+
+  [cmg]
+    type = CoreMeshGenerator
+    inputs = 'amg1'
+    dummy_assembly_name = empty
+    pattern = '0 0;
+              0 0 0;
+               0 0'
+    extrude = false
+    mesh_periphery = true
+    periphery_generator = quad_ring
+    periphery_region_id = 5
+    outer_circle_radius = 7
+    periphery_num_layers = 1
+    desired_area = 5.0
+  []
+
+  [rotate90]
+    type = TransformGenerator
+    input = cmg
+    transform = ROTATE
+    vector_value = '0 0 90'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'assembly_id assembly_type_id pin_id pin_type_id region_id'
+  []
+[]

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_single_assembly.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_single_assembly.i
@@ -2,9 +2,13 @@
   [rmp]
     type = ReactorMeshParams
     dim = 3
-    geom = "Square"
-    assembly_pitch = 2.84126
+    geom = "Hex"
+    assembly_pitch = 1.42063
     radial_boundary_id = 200
+    top_boundary_id = 201
+    bottom_boundary_id = 202
+    axial_regions = '1.0'
+    axial_mesh_intervals = '1'
   []
 
   [pin1]
@@ -12,8 +16,10 @@
     reactor_params = rmp
     pin_type = 1
     pitch = 1.42063
-    region_ids='1 2 5'
+    region_ids='2'
     quad_center_elements = true
+    use_as_assembly = true
+    homogenized = true
   []
 
   [pin2]
@@ -21,41 +27,19 @@
     reactor_params = rmp
     pin_type = 2
     pitch = 1.42063
-    region_ids='2'
-    quad_center_elements = true
-  []
-
-  [pin3]
-    type = PinMeshGenerator
-    reactor_params = rmp
-    pin_type = 3
-    pitch = 1.42063
-    region_ids='3 4'
-    quad_center_elements = true
-  []
-
-  [amg1]
-    type = AssemblyMeshGenerator
-    assembly_type = 1
-    inputs = 'pin2'
-    pattern = '0 0;
-               0 0'
-  []
-
-  [amg2]
-    type = AssemblyMeshGenerator
-    assembly_type = 2
-    inputs = 'pin3 pin1 pin2'
-    pattern = '0 1;
-               1 2'
+    region_ids = '2'
+    quad_center_elements = false
+    use_as_assembly = true
+    homogenized = true
   []
 
   [cmg]
     type = CoreMeshGenerator
-    inputs = 'amg2 amg1 empty'
+    inputs = 'pin1 pin2 empty'
     dummy_assembly_name = empty
-    pattern = '1 0;
-               0 1'
+    pattern = '2 1;
+              1 0 2;
+               2 1'
     extrude = true
   []
 
@@ -68,9 +52,9 @@
 
   [translate]
     type = TransformGenerator
-    input = cmg
+    input = rotate90
     transform = TRANSLATE
-    vector_value = '2.130945 -2.130945 0'
+    vector_value = '0.710315 -0.710315 0'
   []
 []
 
@@ -87,7 +71,7 @@
     type = Exodus
     execute_on = timestep_end
     output_extra_element_ids = true
-    extra_element_ids_to_output = 'assembly_id assembly_type_id plane_id pin_id pin_type_id region_id'
+    extra_element_ids_to_output = 'assembly_id assembly_type_id plane_id pin_type_id region_id'
   []
   file_base = core_in
 []

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_square.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_square.i
@@ -1,0 +1,99 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 3
+    geom = "Square"
+    assembly_pitch = 2.84126
+    radial_boundary_id = 200
+    axial_regions = '1.0'
+    axial_mesh_intervals = '1'
+    top_boundary_id = 201
+    bottom_boundary_id = 202
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.42063
+    region_ids='1 2 5'
+    quad_center_elements = true
+    num_sectors = 2
+    ring_radii = 0.2
+    duct_halfpitch = 0.68
+    mesh_intervals = '1 1 1'
+  []
+
+  [pin2]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    region_ids='2'
+    quad_center_elements = true
+    num_sectors = 2
+    mesh_intervals = '2'
+  []
+
+  [pin3]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 3
+    pitch = 1.42063
+    region_ids='3 4'
+    quad_center_elements = true
+    num_sectors = 2
+    ring_radii = 0.3818
+    mesh_intervals = '1 1'
+  []
+
+  [amg1]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin2'
+    pattern = '0 0;
+               0 0'
+  []
+
+  [amg2]
+    type = AssemblyMeshGenerator
+    assembly_type = 2
+    inputs = 'pin3 pin1 pin2'
+    pattern = '0 1;
+               1 2'
+  []
+
+  [cmg]
+    type = CoreMeshGenerator
+    inputs = 'amg2 amg1 empty'
+    dummy_assembly_name = empty
+    pattern = '1 0;
+               0 1'
+    extrude = true
+  []
+
+  [translate]
+    type = TransformGenerator
+    input = cmg
+    transform = TRANSLATE
+    vector_value = '2.130945 -2.130945 0'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'assembly_id assembly_type_id plane_id pin_id pin_type_id region_id'
+  []
+  file_base = core_in
+[]

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -30,7 +30,6 @@
                 Mesh/rmp/axial_mesh_intervals='1'
                 Mesh/rmp/top_boundary_id=201
                 Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/generate_rgmb_metadata=true
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.68'
@@ -42,7 +41,7 @@
                 Mesh/pin3/mesh_intervals='1 1'
                 Mesh/cmg/show_rgmb_metadata=true
                 Mesh/inactive='rotate90'"
-    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Square.+core_axial_mesh_sizes: 1.+core_axial_mesh_intervals: 1.+core_assembly_types: 1, 2.+core_lattice:.+1, 2.+2, 1.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2.+assembly_2_pin_types: 1, 2, 3.+assembly_2_lattice:.+3, 1.+1, 2.+pin_1_background_region_id: 2.+pin_2_background_region_id: 2.+pin_3_background_region_id: 4'
+    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Square.+axial_mesh_sizes: 1.+axial_mesh_intervals: 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2.+assembly_lattice:.+0, 1.+1, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin3, pin1, pin2.+pin_lattice:.+0, 1.+1, 2.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 2.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 4.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
   []
   [core_shared_assembly_ids]
     requirement = 'The system shall throw an error if a core is composed of assemblies with shared assembly_type ids'
@@ -201,7 +200,6 @@
                 Mesh/rmp/assembly_pitch=7.10315
                 Mesh/rmp/axial_regions='1.0 1.0'
                 Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/rmp/generate_rgmb_metadata=true
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.68'
@@ -239,7 +237,7 @@
                 Mesh/cmg/show_rgmb_metadata=true
                 Mesh/inactive='translate'
                 Outputs/file_base=core_hex_in"
-    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Hex.+core_axial_mesh_sizes: 1, 1.+core_axial_mesh_intervals: 1, 1.+core_assembly_types: 1, 2.+core_lattice:.+-1, 2.+2, 1, -1.+-1, 2.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2, 2.+2, 2.+assembly_2_pin_types: 1, 3.+assembly_2_lattice:.+1, 1.+1, 3, 1.+1, 1.+pin_1_background_region_id: 12, 112.+pin_2_background_region_id: 21, 121.+pin_3_background_region_id: 32, 132'
+    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Hex.+axial_mesh_sizes: 1, 1.+axial_mesh_intervals: 1, 1.+Core-level metadata.+cmg.+assembly_names: amg2, amg1.+assembly_lattice:.+-1, 0.+0, 1, -1.+-1, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 12, 112.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 32, 132.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 21, 121'
   []
   [single_assembly_square_core]
     requirement = 'The system shall generate a full 3D square core mesh with 2 single assembly types'

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -44,7 +44,7 @@
     expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Square.+axial_mesh_sizes: 1.+axial_mesh_intervals: 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2.+assembly_lattice:.+0, 1.+1, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin3, pin1, pin2.+pin_lattice:.+0, 1.+1, 2.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 2.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 4.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
   []
   [core_shared_assembly_ids]
-    requirement = 'The system shall throw an error if a core is composed of assemblies with shared assembly_type ids'
+    requirement = 'The system shall throw an error if a core is composed of different assemblies with a shared assembly type id'
     type = 'RunException'
     input = 'core.i'
     cli_args = "Mesh/rmp/axial_regions='1.0'
@@ -65,7 +65,7 @@
     expect_err = 'Constituent assemblies have shared assembly_type ids but different names.'
   []
   [core_shared_pin_ids]
-    requirement = 'The system shall throw an error if a core is composed of pins with shared pin_type ids'
+    requirement = 'The system shall throw an error if a core is composed of different pins with a shared pin type id'
     type = 'RunException'
     input = 'core.i'
     cli_args = "Mesh/rmp/axial_regions='1.0'

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -42,7 +42,7 @@
                 Mesh/pin3/mesh_intervals='1 1'
                 Mesh/cmg/show_rgmb_metadata=true
                 Mesh/inactive='rotate90'"
-    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Square.+core_axial_boundaries: 1.+core_axial_mesh_intervals: 1.+core_assembly_types: 1, 2.+core_lattice:.+1, 2.+2, 1.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2.+assembly_2_pin_types: 1, 2, 3.+assembly_2_lattice:.+3, 1.+1, 2.+pin_1_background_region_id: 2.+pin_2_background_region_id: 2.+pin_3_background_region_id: 4'
+    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Square.+core_axial_mesh_sizes: 1.+core_axial_mesh_intervals: 1.+core_assembly_types: 1, 2.+core_lattice:.+1, 2.+2, 1.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2.+assembly_2_pin_types: 1, 2, 3.+assembly_2_lattice:.+3, 1.+1, 2.+pin_1_background_region_id: 2.+pin_2_background_region_id: 2.+pin_3_background_region_id: 4'
   []
   [core_shared_assembly_ids]
     requirement = 'The system shall throw an error if a core is composed of assemblies with shared assembly_type ids'
@@ -239,7 +239,7 @@
                 Mesh/cmg/show_rgmb_metadata=true
                 Mesh/inactive='translate'
                 Outputs/file_base=core_hex_in"
-    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Hex.+core_axial_boundaries: 1, 1.+core_axial_mesh_intervals: 1, 1.+core_assembly_types: 1, 2.+core_lattice:.+-1, 2.+2, 1, -1.+-1, 2.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2, 2.+2, 2.+assembly_2_pin_types: 1, 3.+assembly_2_lattice:.+1, 1.+1, 3, 1.+1, 1.+pin_1_background_region_id: 12, 112.+pin_2_background_region_id: 21, 121.+pin_3_background_region_id: 32, 132'
+    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Hex.+core_axial_mesh_sizes: 1, 1.+core_axial_mesh_intervals: 1, 1.+core_assembly_types: 1, 2.+core_lattice:.+-1, 2.+2, 1, -1.+-1, 2.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2, 2.+2, 2.+assembly_2_pin_types: 1, 3.+assembly_2_lattice:.+1, 1.+1, 3, 1.+1, 1.+pin_1_background_region_id: 12, 112.+pin_2_background_region_id: 21, 121.+pin_3_background_region_id: 32, 132'
   []
   [single_assembly_square_core]
     requirement = 'The system shall generate a full 3D square core mesh with 2 single assembly types'

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -5,7 +5,11 @@
     requirement = 'The system shall generate a full 3D square core mesh with 3 pin types and 2 assembly types'
     type = 'Exodiff'
     input = 'core.i'
-    cli_args = "Mesh/pin1/num_sectors=2
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.68'
                 Mesh/pin1/mesh_intervals='1 1 1'
@@ -18,11 +22,59 @@
     exodiff = 'core_in.e'
     recover = false
   []
+  [core_shared_assembly_ids]
+    requirement = 'The system shall throw an error if a core is composed of assemblies with shared assembly_type ids'
+    type = 'RunException'
+    input = 'core.i'
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/num_sectors=2
+                Mesh/pin1/ring_radii='0.2'
+                Mesh/pin1/duct_halfpitch='0.68'
+                Mesh/pin1/mesh_intervals='1 1 1'
+                Mesh/pin2/num_sectors=2
+                Mesh/pin2/mesh_intervals='2'
+                Mesh/pin3/num_sectors=2
+                Mesh/pin3/ring_radii='0.3818'
+                Mesh/pin3/mesh_intervals='1 1'
+                Mesh/amg2/assembly_type=1
+                Mesh/inactive='rotate90'"
+    expect_err = 'Constituent assemblies have shared assembly_type ids but different names.'
+  []
+  [core_shared_pin_ids]
+    requirement = 'The system shall throw an error if a core is composed of pins with shared pin_type ids'
+    type = 'RunException'
+    input = 'core.i'
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/num_sectors=2
+                Mesh/pin1/ring_radii='0.2'
+                Mesh/pin1/duct_halfpitch='0.68'
+                Mesh/pin1/mesh_intervals='1 1 1'
+                Mesh/pin2/pin_type=1
+                Mesh/pin2/num_sectors=2
+                Mesh/pin2/mesh_intervals='2'
+                Mesh/pin3/num_sectors=2
+                Mesh/pin3/ring_radii='0.3818'
+                Mesh/pin3/mesh_intervals='1 1'
+                Mesh/amg2/inputs='pin3 pin1'
+                Mesh/amg2/pattern='0 1; 1 0'
+                Mesh/inactive='rotate90'"
+    expect_err = 'Constituent pins within assemblies have shared pin_type ids but different names.'
+  []
   [square_mixed_background_duct]
     requirement = 'The system shall generate a full 3D square core mesh with an assembly that has a background and duct region and another with no duct/background region'
     type = 'Exodiff'
     input = 'core.i'
-    cli_args = "Mesh/pin1/pitch=1.0
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/pitch=1.0
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.38'
@@ -49,7 +101,11 @@
     requirement = 'The system shall generate a 3D square core mesh with empty lattice positions'
     type = 'Exodiff'
     input = 'core.i'
-    cli_args = "Mesh/pin1/num_sectors=2
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.68'
                 Mesh/pin1/mesh_intervals='1 1 1'
@@ -68,7 +124,9 @@
     requirement = 'The system shall generate a 3D hexagonal core mesh with empty lattice positions and explicit block name specification'
     type = 'Exodiff'
     input = 'core.i'
-    cli_args = "Mesh/rmp/geom='Hex'
+    cli_args = "Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/rmp/geom='Hex'
                 Mesh/rmp/assembly_pitch=7.10315
                 Mesh/rmp/axial_regions='1.0 1.0'
                 Mesh/rmp/axial_mesh_intervals='1 1'
@@ -116,6 +174,10 @@
     type = 'Exodiff'
     input = 'core.i'
     cli_args = "Mesh/inactive='pin3 amg1 amg2 rotate90'
+                Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
                 Mesh/rmp/assembly_pitch=1.42063
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/ring_radii='0.2'
@@ -137,6 +199,10 @@
     type = 'Exodiff'
     input = 'core.i'
     cli_args = "Mesh/inactive='pin3 amg1 amg2 translate'
+                Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
                 Mesh/rmp/geom='Hex'
                 Mesh/rmp/assembly_pitch=1.42063
                 Mesh/pin1/homogenized=true
@@ -157,6 +223,10 @@
     type = 'Exodiff'
     input = 'core.i'
     cli_args = "Mesh/inactive='pin3 amg1 amg2 translate'
+                Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
                 Mesh/rmp/geom='Hex'
                 Mesh/rmp/assembly_pitch=1.42063
                 Mesh/pin1/use_as_assembly=true

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -22,6 +22,28 @@
     exodiff = 'core_in.e'
     recover = false
   []
+  [square_metadata]
+    requirement = 'The system shall print out reactor-related metadata to console output for a full 3D square core mesh with 3 pin types and 2 assembly types'
+    type = 'RunApp'
+    input = 'core.i'
+    cli_args = "Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/axial_mesh_intervals='1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/rmp/generate_rgmb_metadata=true
+                Mesh/pin1/num_sectors=2
+                Mesh/pin1/ring_radii='0.2'
+                Mesh/pin1/duct_halfpitch='0.68'
+                Mesh/pin1/mesh_intervals='1 1 1'
+                Mesh/pin2/num_sectors=2
+                Mesh/pin2/mesh_intervals='2'
+                Mesh/pin3/num_sectors=2
+                Mesh/pin3/ring_radii='0.3818'
+                Mesh/pin3/mesh_intervals='1 1'
+                Mesh/cmg/show_rgmb_metadata=true
+                Mesh/inactive='rotate90'"
+    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Square.+core_axial_boundaries: 1.+core_axial_mesh_intervals: 1.+core_assembly_types: 1, 2.+core_lattice:.+1, 2.+2, 1.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2.+assembly_2_pin_types: 1, 2, 3.+assembly_2_lattice:.+3, 1.+1, 2.+pin_1_background_region_id: 2.+pin_2_background_region_id: 2.+pin_3_background_region_id: 4'
+  []
   [core_shared_assembly_ids]
     requirement = 'The system shall throw an error if a core is composed of assemblies with shared assembly_type ids'
     type = 'RunException'
@@ -168,6 +190,56 @@
                 Outputs/file_base=core_hex_in"
     exodiff = 'core_hex_in.e'
     recover = false
+  []
+  [hex_metadata]
+    requirement = 'The system shall print out reactor-related metadata to console output for a 3D hexagonal core mesh with empty lattice positions and explicit block name specification'
+    type = 'RunApp'
+    input = 'core.i'
+    cli_args = "Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
+                Mesh/rmp/geom='Hex'
+                Mesh/rmp/assembly_pitch=7.10315
+                Mesh/rmp/axial_regions='1.0 1.0'
+                Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/generate_rgmb_metadata=true
+                Mesh/pin1/num_sectors=2
+                Mesh/pin1/ring_radii='0.2'
+                Mesh/pin1/duct_halfpitch='0.68'
+                Mesh/pin1/mesh_intervals='1 1 1'
+                Mesh/pin1/quad_center_elements=false
+                Mesh/pin1/region_ids='11 12 13; 111 112 113'
+                Mesh/pin1/block_names='P1_R11 P1_R12 P1_R13; P1_R111 P1_R112 P1_R113'
+                Mesh/pin2/num_sectors=2
+                Mesh/pin2/mesh_intervals='2'
+                Mesh/pin2/quad_center_elements=false
+                Mesh/pin2/mesh_intervals=1
+                Mesh/pin2/region_ids='21; 121'
+                Mesh/pin2/block_names='P2_R21; P2_R121'
+                Mesh/pin3/num_sectors=2
+                Mesh/pin3/ring_radii='0.3818'
+                Mesh/pin3/mesh_intervals='1 1'
+                Mesh/pin3/quad_center_elements=false
+                Mesh/pin3/region_ids='31 32; 131 132'
+                Mesh/pin3/block_names='P3_R31 P3_R32; P3_R131 P3_R132'
+                Mesh/amg1/pattern='  0   0; 0   0   0; 0   0'
+                Mesh/amg1/background_intervals=1
+                Mesh/amg1/background_region_id='41 141'
+                Mesh/amg1/background_block_name='A1_R41 A1_R141'
+                Mesh/amg2/inputs='pin1 pin3'
+                Mesh/amg2/pattern='  0   0; 0   1   0; 0   0'
+                Mesh/amg2/background_region_id='51 151'
+                Mesh/amg2/background_block_name='A2_R51 A2_R151'
+                Mesh/amg2/background_intervals=1
+                Mesh/amg2/duct_region_ids='52; 152'
+                Mesh/amg2/duct_block_names='A2_R52; A2_R152'
+                Mesh/amg2/duct_halfpitch='3.5'
+                Mesh/amg2/duct_intervals='1'
+                Mesh/cmg/inputs='amg1 amg2 empty'
+                Mesh/cmg/pattern='  2 1; 1 0 2 ; 2 1'
+                Mesh/cmg/show_rgmb_metadata=true
+                Mesh/inactive='translate'
+                Outputs/file_base=core_hex_in"
+    expect_out = 'core_mesh_dimensions: 3.+core_mesh_geometry: Hex.+core_axial_boundaries: 1, 1.+core_axial_mesh_intervals: 1, 1.+core_assembly_types: 1, 2.+core_lattice:.+-1, 2.+2, 1, -1.+-1, 2.+assembly_1_pin_types: 2.+assembly_1_lattice:.+2, 2.+2, 2, 2.+2, 2.+assembly_2_pin_types: 1, 3.+assembly_2_lattice:.+1, 1.+1, 3, 1.+1, 1.+pin_1_background_region_id: 12, 112.+pin_2_background_region_id: 21, 121.+pin_3_background_region_id: 32, 132'
   []
   [single_assembly_square_core]
     requirement = 'The system shall generate a full 3D square core mesh with 2 single assembly types'

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -4,108 +4,41 @@
   [square]
     requirement = 'The system shall generate a full 3D square core mesh with 3 pin types and 2 assembly types'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/inactive='rotate90'"
+    input = 'core_square.i'
+    cli_args = "Outputs/file_base=core_in"
     exodiff = 'core_in.e'
     recover = false
   []
   [square_metadata]
     requirement = 'The system shall print out reactor-related metadata to console output for a full 3D square core mesh with 3 pin types and 2 assembly types'
     type = 'RunApp'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/cmg/show_rgmb_metadata=true
-                Mesh/inactive='rotate90'"
+    input = 'core_square.i'
+    cli_args = "Mesh/cmg/show_rgmb_metadata=true"
     expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Square.+axial_mesh_sizes: 1.+axial_mesh_intervals: 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2.+assembly_lattice:.+0, 1.+1, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin3, pin1, pin2.+pin_lattice:.+0, 1.+1, 2.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 2.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 4.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
   []
   [core_shared_assembly_ids]
     requirement = 'The system shall throw an error if a core is composed of different assemblies with a shared assembly type id'
     type = 'RunException'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/amg2/assembly_type=1
-                Mesh/inactive='rotate90'"
+    input = 'core_square.i'
+    cli_args = "Mesh/amg2/assembly_type=1"
     expect_err = 'Constituent assemblies have shared assembly_type ids but different names.'
   []
   [core_shared_pin_ids]
     requirement = 'The system shall throw an error if a core is composed of different pins with a shared pin type id'
     type = 'RunException'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/pin_type=1
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
+    input = 'core_square.i'
+    cli_args = "Mesh/pin2/pin_type=1
                 Mesh/amg2/inputs='pin3 pin1'
-                Mesh/amg2/pattern='0 1; 1 0'
-                Mesh/inactive='rotate90'"
+                Mesh/amg2/pattern='0 1; 1 0'"
     expect_err = 'Constituent pins within assemblies have shared pin_type ids but different names.'
   []
   [square_mixed_background_duct]
     requirement = 'The system shall generate a full 3D square core mesh with an assembly that has a background and duct region and another with no duct/background region'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/pitch=1.0
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
+    input = 'core_square.i'
+    cli_args = "Mesh/pin1/pitch=1.0
                 Mesh/pin1/duct_halfpitch='0.38'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
                 Mesh/pin3/pitch=1.0
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
                 Mesh/amg2/inputs='pin3 pin1'
                 Mesh/amg2/pattern='0 1; 1 0'
                 Mesh/amg2/background_region_id='6'
@@ -113,7 +46,7 @@
                 Mesh/amg2/duct_region_ids='7'
                 Mesh/amg2/duct_halfpitch='1.2'
                 Mesh/amg2/duct_intervals=1
-                Mesh/inactive='rotate90 translate'
+                Mesh/inactive='translate'
                 Outputs/file_base=core_square_mixed_background_duct"
     exodiff = 'core_square_mixed_background_duct.e'
     recover = false
@@ -121,22 +54,8 @@
   [empty]
     requirement = 'The system shall generate a 3D square core mesh with empty lattice positions'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/cmg/pattern='2 1; 1 0'
-                Mesh/inactive='rotate90'
+    input = 'core_square.i'
+    cli_args = "Mesh/cmg/pattern='2 1; 1 0'
                 Outputs/file_base=core_empty_in"
     exodiff = 'core_empty_in.e'
     recover = false
@@ -144,122 +63,37 @@
   [hex]
     requirement = 'The system shall generate a 3D hexagonal core mesh with empty lattice positions and explicit block name specification'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=7.10315
-                Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin1/quad_center_elements=false
-                Mesh/pin1/region_ids='11 12 13; 111 112 113'
-                Mesh/pin1/block_names='P1_R11 P1_R12 P1_R13; P1_R111 P1_R112 P1_R113'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin2/quad_center_elements=false
-                Mesh/pin2/mesh_intervals=1
-                Mesh/pin2/region_ids='21; 121'
-                Mesh/pin2/block_names='P2_R21; P2_R121'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/pin3/quad_center_elements=false
-                Mesh/pin3/region_ids='31 32; 131 132'
-                Mesh/pin3/block_names='P3_R31 P3_R32; P3_R131 P3_R132'
-                Mesh/amg1/pattern='  0   0; 0   0   0; 0   0'
-                Mesh/amg1/background_intervals=1
-                Mesh/amg1/background_region_id='41 141'
-                Mesh/amg1/background_block_name='A1_R41 A1_R141'
-                Mesh/amg2/inputs='pin1 pin3'
-                Mesh/amg2/pattern='  0   0; 0   1   0; 0   0'
-                Mesh/amg2/background_region_id='51 151'
-                Mesh/amg2/background_block_name='A2_R51 A2_R151'
-                Mesh/amg2/background_intervals=1
-                Mesh/amg2/duct_region_ids='52; 152'
-                Mesh/amg2/duct_block_names='A2_R52; A2_R152'
-                Mesh/amg2/duct_halfpitch='3.5'
-                Mesh/amg2/duct_intervals='1'
-                Mesh/cmg/inputs='amg1 amg2 empty'
-                Mesh/cmg/pattern='  2 1; 1 0 2 ; 2 1'
-                Mesh/inactive='translate'
-                Outputs/file_base=core_hex_in"
+    input = 'core_hex.i'
+    cli_args = "Outputs/file_base=core_hex_in"
     exodiff = 'core_hex_in.e'
     recover = false
   []
   [hex_metadata]
     requirement = 'The system shall print out reactor-related metadata to console output for a 3D hexagonal core mesh with empty lattice positions and explicit block name specification'
     type = 'RunApp'
-    input = 'core.i'
-    cli_args = "Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=7.10315
-                Mesh/rmp/axial_regions='1.0 1.0'
-                Mesh/rmp/axial_mesh_intervals='1 1'
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.2'
-                Mesh/pin1/duct_halfpitch='0.68'
-                Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin1/quad_center_elements=false
-                Mesh/pin1/region_ids='11 12 13; 111 112 113'
-                Mesh/pin1/block_names='P1_R11 P1_R12 P1_R13; P1_R111 P1_R112 P1_R113'
-                Mesh/pin2/num_sectors=2
-                Mesh/pin2/mesh_intervals='2'
-                Mesh/pin2/quad_center_elements=false
-                Mesh/pin2/mesh_intervals=1
-                Mesh/pin2/region_ids='21; 121'
-                Mesh/pin2/block_names='P2_R21; P2_R121'
-                Mesh/pin3/num_sectors=2
-                Mesh/pin3/ring_radii='0.3818'
-                Mesh/pin3/mesh_intervals='1 1'
-                Mesh/pin3/quad_center_elements=false
-                Mesh/pin3/region_ids='31 32; 131 132'
-                Mesh/pin3/block_names='P3_R31 P3_R32; P3_R131 P3_R132'
-                Mesh/amg1/pattern='  0   0; 0   0   0; 0   0'
-                Mesh/amg1/background_intervals=1
-                Mesh/amg1/background_region_id='41 141'
-                Mesh/amg1/background_block_name='A1_R41 A1_R141'
-                Mesh/amg2/inputs='pin1 pin3'
-                Mesh/amg2/pattern='  0   0; 0   1   0; 0   0'
-                Mesh/amg2/background_region_id='51 151'
-                Mesh/amg2/background_block_name='A2_R51 A2_R151'
-                Mesh/amg2/background_intervals=1
-                Mesh/amg2/duct_region_ids='52; 152'
-                Mesh/amg2/duct_block_names='A2_R52; A2_R152'
-                Mesh/amg2/duct_halfpitch='3.5'
-                Mesh/amg2/duct_intervals='1'
-                Mesh/cmg/inputs='amg1 amg2 empty'
-                Mesh/cmg/pattern='  2 1; 1 0 2 ; 2 1'
-                Mesh/cmg/show_rgmb_metadata=true
-                Mesh/inactive='translate'
+    input = 'core_hex.i'
+    cli_args = "Mesh/cmg/show_rgmb_metadata=true
                 Outputs/file_base=core_hex_in"
     expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Hex.+axial_mesh_sizes: 1, 1.+axial_mesh_intervals: 1, 1.+Core-level metadata.+cmg.+assembly_names: amg2, amg1.+assembly_lattice:.+-1, 0.+0, 1, -1.+-1, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 12, 112.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 32, 132.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 21, 121'
   []
   [single_assembly_square_core]
     requirement = 'The system shall generate a full 3D square core mesh with 2 single assembly types'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/inactive='pin3 amg1 amg2 rotate90'
-                Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/assembly_pitch=1.42063
+    input = 'core_single_assembly.i'
+    cli_args = "Mesh/inactive='rotate90'
+                Mesh/rmp/geom='Square'
+                Mesh/pin1/homogenized=false
                 Mesh/pin1/num_sectors=2
+                Mesh/pin1/region_ids='1 2 5'
                 Mesh/pin1/ring_radii='0.2'
                 Mesh/pin1/duct_halfpitch='0.68'
                 Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin1/use_as_assembly=true
+                Mesh/pin2/homogenized=false
                 Mesh/pin2/num_sectors=2
                 Mesh/pin2/mesh_intervals='2'
-                Mesh/pin2/use_as_assembly=true
-                Mesh/translate/vector_value='0.710315 -0.710315 0'
-                Mesh/cmg/inputs='pin1 pin2 empty'
-                Outputs/out/extra_element_ids_to_output='assembly_id assembly_type_id plane_id pin_type_id region_id'
+                Mesh/pin2/quad_center_elements=true
+                Mesh/cmg/pattern='1 0; 0 1'
+                Mesh/translate/input=cmg
                 Outputs/file_base=core_single_assembly_square"
     exodiff = 'core_single_assembly_square.e'
     recover = false
@@ -267,23 +101,8 @@
   [single_assembly_hex_core_empty]
     requirement = 'The system shall generate a full 3D hexagonal core mesh with 2 single assembly types'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/inactive='pin3 amg1 amg2 translate'
-                Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=1.42063
-                Mesh/pin1/homogenized=true
-                Mesh/pin1/use_as_assembly=true
-                Mesh/pin1/region_ids='2'
-                Mesh/pin2/homogenized=true
-                Mesh/pin2/use_as_assembly=true
-                Mesh/pin2/quad_center_elements=false
-                Mesh/cmg/inputs='pin1 pin2 empty'
-                Mesh/cmg/pattern='  2 1; 1 0 2 ; 2 1'
-                Outputs/out/extra_element_ids_to_output='assembly_id assembly_type_id plane_id pin_type_id region_id'
+    input = 'core_single_assembly.i'
+    cli_args = "Mesh/inactive='translate'
                 Outputs/file_base=core_single_assembly_hex_empty"
     exodiff = 'core_single_assembly_hex_empty.e'
     recover = false
@@ -291,28 +110,19 @@
   [duct_het_hex_core_empty]
     requirement = 'The system shall generate a full 3D hexagonal core mesh with 2 duct heterogeneous assembly types'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/inactive='pin3 amg1 amg2 translate'
-                Mesh/rmp/axial_regions='1.0'
-                Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/rmp/top_boundary_id=201
-                Mesh/rmp/bottom_boundary_id=202
-                Mesh/rmp/geom='Hex'
-                Mesh/rmp/assembly_pitch=1.42063
-                Mesh/pin1/use_as_assembly=true
+    input = 'core_single_assembly.i'
+    cli_args = "Mesh/inactive='translate'
+                Mesh/pin1/homogenized=false
                 Mesh/pin1/region_ids='1 2'
                 Mesh/pin1/num_sectors='2'
                 Mesh/pin1/mesh_intervals='1 1'
                 Mesh/pin1/duct_halfpitch='0.5'
-                Mesh/pin2/use_as_assembly=true
+                Mesh/pin2/homogenized=false
                 Mesh/pin2/quad_center_elements=false
                 Mesh/pin2/region_ids='3 4'
                 Mesh/pin2/num_sectors='2'
                 Mesh/pin2/mesh_intervals='1 1'
                 Mesh/pin2/duct_halfpitch='0.6'
-                Mesh/cmg/inputs='pin1 pin2 empty'
-                Mesh/cmg/pattern='  2 1; 1 0 2 ; 2 1'
-                Outputs/out/extra_element_ids_to_output='assembly_id assembly_type_id plane_id pin_type_id region_id'
                 Outputs/file_base=core_duct_het_hex_core_empty"
     exodiff = 'core_duct_het_hex_core_empty.e'
     recover = false
@@ -320,73 +130,16 @@
   [hex_metadata_transfer]
     requirement = 'The system shall generate a 2D hexagonal core mesh that transfers metadata correctly across RGMB mesh generators'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/inactive='pin2 pin3 amg2 translate'
-                Mesh/rmp/dim=2
-                Mesh/rmp/geom=Hex
-                Mesh/rmp/assembly_pitch=3.7884
-                Mesh/rmp/radial_boundary_id=200
-                Mesh/pin1/pitch=1.3425
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii=0.5404
-                Mesh/pin1/mesh_intervals='1 1'
-                Mesh/pin1/region_ids='1 2'
-                Mesh/pin1/quad_center_elements=false
-                Mesh/amg1/inputs=pin1
-                Mesh/amg1/pattern='0 0; 0 0 0; 0 0'
-                Mesh/amg1/background_intervals=1
-                Mesh/amg1/background_region_id=3
-                Mesh/amg1/duct_halfpitch=1.7703
-                Mesh/amg1/duct_intervals=1
-                Mesh/amg1/duct_region_ids=4
-                Mesh/cmg/inputs='amg1'
-                Mesh/cmg/pattern='0 0; 0 0 0; 0 0'
-                Mesh/cmg/mesh_periphery=true
-                Mesh/cmg/periphery_generator=quad_ring
-                Mesh/cmg/periphery_region_id=5
-                Mesh/cmg/outer_circle_radius=7
-                Mesh/cmg/periphery_num_layers=1
-                Mesh/cmg/desired_area=5.0
-                Mesh/cmg/extrude=false
-                Outputs/out/extra_element_ids_to_output='assembly_id assembly_type_id pin_id pin_type_id region_id'
-                Outputs/file_base=core_metadata_transfer"
+    input = 'core_hex_2d.i'
+    cli_args = "Outputs/file_base=core_metadata_transfer"
     exodiff = 'core_metadata_transfer.e'
     recover = false
   []
   [hex_metadata_transfer_mesh_only]
     requirement = 'The system shall generate a 2D hexagonal core mesh that transfers metadata correctly across RGMB mesh generators in mesh only with extra element ids that have been defined with default values for certain id names'
     type = 'Exodiff'
-    input = 'core.i'
-    cli_args = "Mesh/inactive='pin2 pin3 amg2 translate'
-                Mesh/rmp/dim=2
-                Mesh/rmp/geom=Hex
-                Mesh/rmp/assembly_pitch=3.7884
-                Mesh/rmp/radial_boundary_id=200
-                Mesh/pin1/pitch=1.3425
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii=0.5404
-                Mesh/pin1/mesh_intervals='1 1'
-                Mesh/pin1/region_ids='1 2'
-                Mesh/pin1/quad_center_elements=false
-                Mesh/amg1/inputs=pin1
-                Mesh/amg1/pattern='0 0; 0 0 0; 0 0'
-                Mesh/amg1/background_intervals=1
-                Mesh/amg1/background_region_id=3
-                Mesh/amg1/duct_halfpitch=1.7703
-                Mesh/amg1/duct_intervals=1
-                Mesh/amg1/duct_region_ids=4
-                Mesh/cmg/inputs='amg1'
-                Mesh/cmg/pattern='0 0; 0 0 0; 0 0'
-                Mesh/cmg/mesh_periphery=true
-                Mesh/cmg/periphery_generator=quad_ring
-                Mesh/cmg/periphery_region_id=5
-                Mesh/cmg/outer_circle_radius=7
-                Mesh/cmg/periphery_num_layers=1
-                Mesh/cmg/desired_area=5.0
-                Mesh/cmg/extrude=false
-                Outputs/out/extra_element_ids_to_output='assembly_id assembly_type_id pin_id pin_type_id region_id'
-                Outputs/file_base=core_metadata_transfer
-                --mesh-only core_metadata_transfer.e"
+    input = 'core_hex_2d.i'
+    cli_args = "--mesh-only core_metadata_transfer.e"
     exodiff = 'core_metadata_transfer.e'
     recover = false
   []

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_hex.i
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_hex.i
@@ -1,0 +1,37 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 2
+    geom = "Hex"
+    assembly_pitch = 7.10315
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    region_ids='1 2'
+    quad_center_elements = false
+    num_sectors = 2
+    ring_radii = 0.4665
+    mesh_intervals = '1 1'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'region_id'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_homogenized.i
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_homogenized.i
@@ -1,0 +1,35 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 2
+    geom = "Hex"
+    assembly_pitch = 7.10315
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    region_ids='1'
+    quad_center_elements = true
+    homogenized = true
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'region_id pin_type_id'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_only.i
@@ -4,9 +4,6 @@
     dim = 2
     geom = "Square"
     assembly_pitch = 7.10315
-    axial_mesh_intervals = '1'
-    top_boundary_id = 201
-    bottom_boundary_id = 202
   []
 
   [pin1]

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_square.i
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/pin_square.i
@@ -11,8 +11,10 @@
     reactor_params = rmp
     pin_type = 2
     pitch = 1.42063
-    region_ids='1 2 3 4'
+    region_ids='3'
     quad_center_elements = false
+    num_sectors = 2
+    mesh_intervals = '2'
   []
 []
 

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/single_pin_assembly.i
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/single_pin_assembly.i
@@ -1,0 +1,36 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 2
+    geom = "Hex"
+    assembly_pitch = 7.10315
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 7.10315
+    region_ids='1'
+    quad_center_elements = true
+    homogenized = true
+    use_as_assembly = true
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'region_id pin_type_id assembly_type_id'
+  []
+[]
+
+[Executioner]
+  type = Steady
+[]

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
@@ -84,6 +84,8 @@
                 Mesh/rmp/dim=3
                 Mesh/rmp/axial_regions='1.0 1.0'
                 Mesh/rmp/axial_mesh_intervals='1 1'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
                 Mesh/pin1/region_ids='11 12 13; 11 12 13'
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/pin_type=1
@@ -131,6 +133,8 @@
                 Mesh/pin1/homogenized=true
                 Mesh/rmp/dim=3
                 Mesh/rmp/axial_regions='1.0'
+                Mesh/rmp/top_boundary_id=201
+                Mesh/rmp/bottom_boundary_id=202
                 Mesh/rmp/axial_mesh_intervals='1'
                 Mesh/pin1/quad_center_elements=true
                 Mesh/pin1/extrude=true

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
@@ -4,10 +4,11 @@
   [square]
     requirement = 'The system shall generate a 2D square pin mesh with fuel, gap, clad, background regions'
     type = 'Exodiff'
-    input = 'pin_only.i'
+    input = 'pin_square.i'
     cli_args = "Mesh/pin1/ring_radii='0.3385 0.3705 0.4665'
-                Mesh/pin1/num_sectors=4
                 Mesh/pin1/mesh_intervals='1 1 1 1'
+                Mesh/pin1/region_ids='1 2 3 4'
+                Mesh/pin1/num_sectors='4'
                 Outputs/file_base=pin_only_in"
     exodiff = 'pin_only_in.e'
     recover = false
@@ -15,21 +16,15 @@
   [2d_square_w_3d_info]
     requirement = 'The system shall throw an error if 3d info is provided to a 2d mesh'
     type = 'RunException'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/axial_mesh_intervals='5'
-                Mesh/pin1/ring_radii='0.3385 0.3705 0.4665'
-                Mesh/pin1/num_sectors=4
-                Mesh/pin1/mesh_intervals='1 1 1 1'
-                Outputs/file_base=pin_only_in"
+    input = 'pin_square.i'
+    cli_args = "Mesh/rmp/axial_mesh_intervals='5'"
     expect_err = "should not be defined for 2-D meshes"
   []
   [tri]
     requirement = 'The system shall generate a 3D square pin mesh with ring and background region and tri center elements'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/pin1/quad_center_elements=false
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/mesh_intervals='1 1'
+    input = 'pin_square.i'
+    cli_args = "Mesh/pin1/mesh_intervals='1 1'
                 Mesh/pin1/region_ids='1 2'
                 Mesh/pin1/ring_radii='0.4665'
                 Outputs/file_base=pin_only_tri_in"
@@ -39,10 +34,8 @@
   [tri_intervals]
     requirement = 'The system shall generate a pin mesh with more than 1 radial region and tri center elements'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/pin1/quad_center_elements=false
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/mesh_intervals='2 1'
+    input = 'pin_square.i'
+    cli_args = "Mesh/pin1/mesh_intervals='2 1'
                 Mesh/pin1/region_ids='1 2'
                 Mesh/pin1/ring_radii='0.4665'
                 Outputs/file_base=pin_only_tri_intervals_in"
@@ -52,9 +45,8 @@
   [quad_intervals]
     requirement = 'The system shall generate a pin mesh with more than 1 radial region and quad center elements'
     type = 'Exodiff'
-    input = 'pin_only.i'
+    input = 'pin_square.i'
     cli_args = "Mesh/pin1/quad_center_elements=true
-                Mesh/pin1/num_sectors=2
                 Mesh/pin1/mesh_intervals='2 1'
                 Mesh/pin1/region_ids='1 2'
                 Mesh/pin1/ring_radii='0.4665'
@@ -65,40 +57,29 @@
   [background_tri_intervals]
     requirement = 'The system shall generate a pin mesh with no radial region and more than 1 background intervals with tri center elements'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/pin1/quad_center_elements=false
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/mesh_intervals='2'
-                Mesh/pin1/region_ids='3'
-                Outputs/file_base=pin_only_background_tri_intervals_in"
+    input = 'pin_square.i'
+    cli_args = "Outputs/file_base=pin_only_background_tri_intervals_in"
     exodiff = 'pin_only_background_tri_intervals_in.e'
     recover = false
   []
   [hex]
     requirement = 'The system shall generate a 2D hexagonal pin mesh with 2 radial regions'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom='Hex'
-                Mesh/pin1/num_sectors=2
-                Mesh/pin1/ring_radii='0.4665'
-                Mesh/pin1/region_ids='1 2'
-                Mesh/pin1/mesh_intervals='1 1'
-                Outputs/file_base=pin_only_hex_in"
+    input = 'pin_hex.i'
+    cli_args = "Outputs/file_base=pin_only_hex_in"
     exodiff = 'pin_only_hex_in.e'
     recover = false
   []
   [complex]
     requirement = 'The system shall generate a 3D hexagonal pin mesh with radial, background, and duct regions'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom='Hex'
-                Mesh/rmp/dim=3
+    input = 'pin_hex.i'
+    cli_args = "Mesh/rmp/dim=3
                 Mesh/rmp/axial_regions='1.0 1.0'
                 Mesh/rmp/axial_mesh_intervals='1 1'
                 Mesh/rmp/top_boundary_id=201
                 Mesh/rmp/bottom_boundary_id=202
                 Mesh/pin1/region_ids='11 12 13; 11 12 13'
-                Mesh/pin1/num_sectors=2
                 Mesh/pin1/pin_type=1
                 Mesh/pin1/ring_radii='0.4665'
                 Mesh/pin1/duct_halfpitch='0.68'
@@ -113,96 +94,68 @@
   [hex_pin_homogenized_quad]
     requirement = 'The system shall generate a 2D hexagonal homogenized pin mesh with quad discretization'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom=Hex
-                Mesh/pin1/region_ids='1'
-                Mesh/pin1/homogenized=true
-                Mesh/pin1/quad_center_elements=true
-                Outputs/file_base=hex_pin_homogenized_quad
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id'"
+    input = 'pin_homogenized.i'
+    cli_args = "Outputs/file_base=hex_pin_homogenized_quad"
     exodiff = 'hex_pin_homogenized_quad.e'
     recover = false
   []
   [hex_pin_homogenized_tri]
     requirement = 'The system shall generate a 2D hexagonal homogenized pin mesh with tri discretization'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom=Hex
-                Mesh/pin1/region_ids='1'
-                Mesh/pin1/homogenized=true
-                Outputs/file_base=hex_pin_homogenized_tri
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id'"
+    input = 'pin_homogenized.i'
+    cli_args = "Mesh/pin1/quad_center_elements=false
+                Outputs/file_base=hex_pin_homogenized_tri"
     exodiff = 'hex_pin_homogenized_tri.e'
     recover = false
   []
   [hex_pin_homogenized_3d]
     requirement = 'The system shall generate a 3D hexagonal homogenized pin mesh with quad discretization'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom=Hex
-                Mesh/pin1/region_ids='1'
-                Mesh/pin1/homogenized=true
-                Mesh/rmp/dim=3
+    input = 'pin_homogenized.i'
+    cli_args = "Mesh/rmp/dim=3
                 Mesh/rmp/axial_regions='1.0'
                 Mesh/rmp/top_boundary_id=201
                 Mesh/rmp/bottom_boundary_id=202
                 Mesh/rmp/axial_mesh_intervals='1'
-                Mesh/pin1/quad_center_elements=true
                 Mesh/pin1/extrude=true
-                Outputs/file_base=hex_pin_homogenized_3d
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id'"
+                Outputs/file_base=hex_pin_homogenized_3d"
     exodiff = 'hex_pin_homogenized_3d.e'
     recover = false
   []
   [hex_single_assembly_homogenized]
     requirement = 'The system shall generate a 2D hexagonal homogenized pin mesh that is treated as a single assembly'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom=Hex
-                Mesh/pin1/region_ids='1'
-                Mesh/pin1/homogenized=true
-                Mesh/pin1/use_as_assembly=true
-                Mesh/pin1/pitch=7.10315
-                Mesh/pin1/quad_center_elements=true
-                Outputs/file_base=hex_single_assembly_homogenized
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id assembly_type_id'"
+    input = 'single_pin_assembly.i'
+    cli_args = "Outputs/file_base=hex_single_assembly_homogenized"
     exodiff = 'hex_single_assembly_homogenized.e'
     recover = false
   []
   [hex_single_assembly_ducted]
     requirement = 'The system shall generate a 2D hexagonal ducted pin mesh that is treated as a single assembly'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/rmp/geom=Hex
-                Mesh/pin1/use_as_assembly=true
-                Mesh/pin1/pitch=7.10315
-                Mesh/pin1/homogenized=false
+    input = 'single_pin_assembly.i'
+    cli_args = "Mesh/pin1/homogenized=false
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/region_ids='1 2 3'
                 Mesh/pin1/ring_radii='2.0'
                 Mesh/pin1/duct_halfpitch='3.0'
                 Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin1/quad_center_elements=true
-                Outputs/file_base=hex_single_assembly_ducted
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id assembly_type_id'"
+                Outputs/file_base=hex_single_assembly_ducted"
     exodiff = 'hex_single_assembly_ducted.e'
     recover = false
   []
   [cart_single_assembly_ducted]
     requirement = 'The system shall generate a 2D Cartesian ducted pin mesh that is treated as a single assembly'
     type = 'Exodiff'
-    input = 'pin_only.i'
-    cli_args = "Mesh/pin1/use_as_assembly=true
-                Mesh/pin1/pitch=7.10315
+    input = 'single_pin_assembly.i'
+    cli_args = "Mesh/rmp/geom='Square'
                 Mesh/pin1/homogenized=false
                 Mesh/pin1/num_sectors=2
                 Mesh/pin1/region_ids='1 2 3'
                 Mesh/pin1/ring_radii='2.0'
                 Mesh/pin1/duct_halfpitch='3.0'
                 Mesh/pin1/mesh_intervals='1 1 1'
-                Mesh/pin1/quad_center_elements=true
-                Outputs/file_base=cart_single_assembly_ducted
-                Outputs/out/extra_element_ids_to_output='region_id pin_type_id assembly_type_id'"
+                Outputs/file_base=cart_single_assembly_ducted"
     exodiff = 'cart_single_assembly_ducted.e'
     recover = false
   []

--- a/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/pin_mesh_generator/tests
@@ -12,6 +12,17 @@
     exodiff = 'pin_only_in.e'
     recover = false
   []
+  [2d_square_w_3d_info]
+    requirement = 'The system shall throw an error if 3d info is provided to a 2d mesh'
+    type = 'RunException'
+    input = 'pin_only.i'
+    cli_args = "Mesh/rmp/axial_mesh_intervals='5'
+                Mesh/pin1/ring_radii='0.3385 0.3705 0.4665'
+                Mesh/pin1/num_sectors=4
+                Mesh/pin1/mesh_intervals='1 1 1 1'
+                Outputs/file_base=pin_only_in"
+    expect_err = "should not be defined for 2-D meshes"
+  []
   [tri]
     requirement = 'The system shall generate a 3D square pin mesh with ring and background region and tri center elements'
     type = 'Exodiff'


### PR DESCRIPTION
refs #24198 

In addition, I add the following checks to the RGMB mesh generators

- Axial parameters should not be provided for 2-D meshes
- pin_type and assembly_type ids should not overlap among multiple pin and assembly definitions