### PR TITLE
sets residual and jacobian compute together for NS solvers refs #24352

### DIFF
--- a/framework/src/base/Moose.C
+++ b/framework/src/base/Moose.C
@@ -235,6 +235,7 @@ addActionTypes(Syntax & syntax)
   // Dummy Actions (useful for sync points in the dependencies)
   registerTask("setup_function_complete", false);
   registerTask("setup_variable_complete", false);
+  registerTask("setup_executioner_complete", false);
   registerTask("ready_to_init", true);
 
   // Output related actions
@@ -292,6 +293,7 @@ addActionTypes(Syntax & syntax)
                            "(setup_postprocessor_data)"
                            "(setup_time_integrator)"
                            "(setup_executioner)"
+                           "(setup_executioner_complete)"
                            "(read_executor)"
                            "(add_executor)"
                            "(check_integrity_early)"

--- a/modules/navier_stokes/include/base/NSFVBase.h
+++ b/modules/navier_stokes/include/base/NSFVBase.h
@@ -91,6 +91,9 @@ protected:
   /// Function adding kernels for the incompressible continuity equation
   void addINSMassKernels();
 
+  /// Function for setting joint residual and Jacobian computation in NS solves
+  void setResidualAndJacobianTogether();
+
   /**
    * Functions adding kernels for the incompressible momentum equation
    * If the material properties are not constant, these can be used for
@@ -1302,6 +1305,13 @@ NSFVBase<BaseType>::copyNSNodalVariables()
               parameters().template get<std::string>("initial_from_file_timestep"));
       }
   }
+}
+
+template <class BaseType>
+void
+NSFVBase<BaseType>::setResidualAndJacobianTogether()
+{
+  getProblem().getNonlinearSystemBase().residualAndJacobianTogether();
 }
 
 template <class BaseType>

--- a/modules/navier_stokes/src/actions/NSFVAction.C
+++ b/modules/navier_stokes/src/actions/NSFVAction.C
@@ -8,6 +8,7 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "NSFVAction.h"
+#include "Executioner.h"
 
 registerMooseAction("NavierStokesApp", NSFVAction, "add_navier_stokes_variables");
 registerMooseAction("NavierStokesApp", NSFVAction, "add_navier_stokes_user_objects");
@@ -19,6 +20,7 @@ registerMooseAction("NavierStokesApp", NSFVAction, "add_navier_stokes_pps");
 registerMooseAction("NavierStokesApp", NSFVAction, "add_navier_stokes_materials");
 registerMooseAction("NavierStokesApp", NSFVAction, "navier_stokes_check_copy_nodal_vars");
 registerMooseAction("NavierStokesApp", NSFVAction, "navier_stokes_copy_nodal_vars");
+registerMooseAction("NavierStokesApp", NSFVAction, "setup_executioner_complete");
 
 InputParameters
 NSFVAction::validParams()
@@ -71,6 +73,12 @@ NSFVAction::act()
 
   if (_current_task == "navier_stokes_copy_nodal_vars")
     copyNSNodalVariables();
+
+  if (_current_task == "setup_executioner_complete")
+  {
+    if (!_app.getExecutioner()->parameters().isParamSetByUser("residual_and_jacobian_together"))
+      setResidualAndJacobianTogether();
+  }
 }
 
 void


### PR DESCRIPTION
<!--
Closes #24352. It computes the residual and jacobian together in the NS module if the option "residual_and_jacobian_together" is set to true in the Executioner or in the module block. The simultaneous computation of the residual and Jacobian is set as the default in NS if not otherwise set. 
-->