### PR TITLE
fix incorrectly titled docs for InternalSideIntegralVariablePostprocessor

### DIFF
--- a/framework/doc/content/source/postprocessors/InternalSideIntegralVariablePostprocessor.md
+++ b/framework/doc/content/source/postprocessors/InternalSideIntegralVariablePostprocessor.md
@@ -1,4 +1,4 @@
-# SideIntegralVariablePostprocessor
+# InternalSideIntegralVariablePostprocessor
 
 !syntax description /Postprocessors/InternalSideIntegralVariablePostprocessor
 


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Currently the title for the `InternalSideIntegralVariablePostprocessor` docs is mislabeled as `SideIntegralVariablePostprocessor`
## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
