### PR TITLE
Fix bug with printing 3D RGMB metadata

### DIFF
--- a/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
+++ b/modules/reactor/src/meshgenerators/ReactorGeometryMeshBuilderBase.C
@@ -227,8 +227,12 @@ ReactorGeometryMeshBuilderBase::printGlobalReactorMetadata()
 {
   printMetadataToConsole<int>(RGMB::mesh_dimensions, _reactor_params);
   printMetadataToConsole<std::string>(RGMB::mesh_geometry, _reactor_params);
-  printMetadataToConsole<std::vector<Real>>(RGMB::axial_mesh_sizes, _reactor_params);
-  printMetadataToConsole<std::vector<unsigned int>>(RGMB::axial_mesh_intervals, _reactor_params);
+  const auto mesh_dimensions = getReactorParam<int>(RGMB::mesh_dimensions);
+  if (mesh_dimensions == 3)
+  {
+    printMetadataToConsole<std::vector<Real>>(RGMB::axial_mesh_sizes, _reactor_params);
+    printMetadataToConsole<std::vector<unsigned int>>(RGMB::axial_mesh_intervals, _reactor_params);
+  }
 }
 
 template <typename T>

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -143,6 +143,13 @@
     exodiff = 'core_metadata_transfer.e'
     recover = false
   []
+  [hex_metadata_2d]
+    requirement = 'The system shall print out reactor-related metadata to console output for a 2D hexagonal core mesh'
+    type = 'RunApp'
+    input = 'core_hex_2d.i'
+    cli_args = "Mesh/cmg/show_rgmb_metadata=true"
+    expect_out = 'Global metadata.+mesh_dimensions: 2.+mesh_geometry: Hex.+Core-level metadata.+cmg.+peripheral_ring_radius: 7.+peripheral_ring_region_id: 5.+assembly_names: amg1.+assembly_lattice:.+0, 0.+0, 0, 0.+0, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin1.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
+  []
   [ptmg_periphery]
     requirement = 'The system shall generate a 2D hex core mesh with a reactor periphery meshed using a triangular mesh.'
     type = 'CSVDiff'


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
Current print functions will try to print 3D metadata which is not defined for 2D RGMB meshes

## Design
<!--A concise description (design) of the enhancement.-->
Will check dimensionality of RGMB mesh before printing 3D axial information

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
None

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
