### PR TITLE
Adding AD version of the grand potential phase-field model

### DIFF
--- a/modules/phase_field/doc/content/bib/phase_field.bib
+++ b/modules/phase_field/doc/content/bib/phase_field.bib
@@ -210,7 +210,18 @@ abstract = {The phase-field method has been established as a de facto standard f
   volume={60},
   pages={16--28},
   year={2018},
-  publisher={Elsevier}
+  publisher={Elsevier},
+  }
+
+@article{Moelans2011,
+  journal = {Acta Materialia},
+  pages = {1077--1086},
+  volume = {59},
+  publisher = {Pergamon},
+  year = {2011},
+  title = {A quantitative and thermodynamically consistent phase-field interpolation function for multi-phase systems},
+  language = {eng},
+  author = {Nele Moelans},
 }
 
 @article{schonfelder1997molecular,

--- a/modules/phase_field/doc/content/source/kernels/ACBarrierFunction.md
+++ b/modules/phase_field/doc/content/source/kernels/ACBarrierFunction.md
@@ -1,6 +1,6 @@
-# ACBarrierFunction
+# ACBarrierFunction / ADACBarrierFunction
 
-The ACBarrierFunction kernel implements the term $\frac{\partial m}{\partial \eta}f(\eta)$
+The `ACBarrierFunction` (and its automatic differentiation version, `ADACBarrierFunction`) kernel implements the term $\frac{\partial m}{\partial \eta}f(\eta)$
 term for the free energy given in [!cite](moelans_quantitative_2008).
 $m$ is the barrier energy coefficient.
 In many phase field models, $m$ is constant, but in the case where it is a function

--- a/modules/phase_field/doc/content/source/kernels/ACGrGrMulti.md
+++ b/modules/phase_field/doc/content/source/kernels/ACGrGrMulti.md
@@ -2,7 +2,7 @@
 
 !syntax description /Kernels/ACGrGrMulti
 
-Implements the term
+`ACGrGrMulti` (and its automatic differentiation version, `ADACGrGrMulti`) implements the term
 
 \begin{equation}
 L \mu \left( \eta_{\alpha i}^3 - \eta_{\alpha i} + 2\eta_{\alpha i} \sum_{\beta=1}^N

--- a/modules/phase_field/doc/content/source/kernels/ACInterface.md
+++ b/modules/phase_field/doc/content/source/kernels/ACInterface.md
@@ -1,8 +1,8 @@
-# ACInterface
+# ACInterface / ADACInterface
 
 !syntax description /Kernels/ACInterface
 
-Implements the Allen-Cahn term for the $\frac{\kappa_i}2|\nabla \eta_i|^2$
+`ACInterface` (and its automatic differentiation version, `ADACInterface`) implements the Allen-Cahn term for the $\frac{\kappa_i}2|\nabla \eta_i|^2$
 gradient energy contribution for the isotropic mobility case. Its weak form is
 
 \begin{equation}

--- a/modules/phase_field/doc/content/source/kernels/ACKappaFunction.md
+++ b/modules/phase_field/doc/content/source/kernels/ACKappaFunction.md
@@ -1,6 +1,6 @@
-# ACKappaFunction
+# ACKappaFunction / ADACKappaFunction
 
-The ACKAppaFunction Kernel calculates the term
+The `ACKAppaFunction` (and its automatic differentiation version, `ADACKappaFunction`) Kernel calculates the term
 $\frac12 L \frac{\partial \kappa}{\partial \eta} f_g(\nabla \eta)$
 for the case where $\kappa$ is a function of $\eta$ and $f_g$ is the gradient
 energy function used in the phase field method.

--- a/modules/phase_field/doc/content/source/kernels/ACSwitching.md
+++ b/modules/phase_field/doc/content/source/kernels/ACSwitching.md
@@ -1,8 +1,8 @@
-# ACSwitching
+# ACSwitching / ADACSwitching
 
 !syntax description /Kernels/ACSwitching
 
-Implements the terms of the form
+`ACSwitching` (and its automatic differentiation version, `ADACSwitching`) implements the terms of the form
 \begin{equation}
 \frac{\partial h_a}{\partial\eta_{ai}} F_a + \frac{\partial h_b}{\partial\eta_{ai}} F_b + \dots,
 \end{equation}

--- a/modules/phase_field/doc/content/source/kernels/CoupledSwitchingTimeDerivative.md
+++ b/modules/phase_field/doc/content/source/kernels/CoupledSwitchingTimeDerivative.md
@@ -1,1 +1,19 @@
-!template load file=stubs/moose_object.md.template name=CoupledSwitchingTimeDerivative syntax=/Kernels/CoupledSwitchingTimeDerivative
+# CoupledSwitchingTimeDerivative / ADCoupledSwitchingTimeDerivative
+
+!syntax description /Kernels/CoupledSwitchingTimeDerivative
+
+`CoupledSwitchingTimeDerivative` (and its automatic differentiation version, `ADCoupledSwitchingTimeDerivative`) is a coupled time derivative Kernel that multiplies the time derivative term by the following
+\begin{equation}
+\frac{\partial h_a}{\partial\eta_{ai}} F_a + \frac{\partial h_b}{\partial\eta_{ai}} F_b + \dots,
+\end{equation}
+where $a,b,\dots$ are the phases, $h_a, h_b,\dots$ are the switching functions,
+$\eta_{ai}$ is the order parameter for the phase/grain that is the nonlinear variable,
+and $F_a, F_b,\dots$ are the free energies or grand potentials.
+
+See also [CoupledTimeDerivative](/CoupledTimeDerivative.md).
+
+!syntax parameters /Kernels/CoupledSwitchingTimeDerivative
+
+!syntax inputs /Kernels/CoupledSwitchingTimeDerivative
+
+!syntax children /Kernels/CoupledSwitchingTimeDerivative

--- a/modules/phase_field/doc/content/source/kernels/SusceptibilityTimeDerivative.md
+++ b/modules/phase_field/doc/content/source/kernels/SusceptibilityTimeDerivative.md
@@ -1,8 +1,8 @@
-# SusceptibilityTimeDerivative
+# SusceptibilityTimeDerivative / ADSusceptibilityTimeDerivative
 
 !syntax description /Kernels/SusceptibilityTimeDerivative
 
-Implements
+`SusceptibilityTimeDerivative` (and its automatic differentiation version, `ADSusceptibilityTimeDerivative`) implements
 
 \begin{equation}
 F(u,a,b,\dots)\cdot\frac{\partial u}{\partial t},

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase.i
@@ -1,6 +1,6 @@
 # This is an example of implementation of the multi-phase, multi-order parameter
 # grand potential based phase-field model described in Phys. Rev. E, 98, 023309
-# (2019). It includes 3 phases with 1 grain of each phase. This example was used
+# (2018). It includes 3 phases with 1 grain of each phase. This example was used
 # to generate the results shown in Fig. 3 of the paper.
 
 [Mesh]

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
@@ -1,0 +1,329 @@
+# This is an example of implementation of the multi-phase, multi-order parameter
+# grand potential based phase-field model described in Phys. Rev. E, 98, 023309
+# (2019). It includes 3 phases with 1 grain of each phase. This example was used
+# to generate the results shown in Fig. 3 of the paper.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 60
+  xmin = -15
+  xmax = 15
+[]
+
+[Variables]
+  [./w]
+  [../]
+  [./etaa0]
+  [../]
+  [./etab0]
+  [../]
+  [./etad0]
+  [../]
+[]
+
+[ICs]
+  [./IC_etaa0]
+    type = FunctionIC
+    variable = etaa0
+    function = ic_func_etaa0
+  [../]
+  [./IC_etab0]
+    type = FunctionIC
+    variable = etab0
+    function = ic_func_etab0
+  [../]
+  [./IC_etad0]
+    type = ConstantIC
+    variable = etad0
+    value = 0.1
+  [../]
+  [./IC_w]
+    type = FunctionIC
+    variable = w
+    function = ic_func_w
+  [../]
+[]
+
+[Functions]
+  [./ic_func_etaa0]
+    type = ParsedFunction
+    value = '0.9*0.5*(1.0-tanh((x)/sqrt(2.0)))'
+  [../]
+  [./ic_func_etab0]
+    type = ParsedFunction
+    value = '0.9*0.5*(1.0+tanh((x)/sqrt(2.0)))'
+  [../]
+  [./ic_func_w]
+    type = ParsedFunction
+    value = 0
+  [../]
+[]
+
+[Kernels]
+# Order parameter eta_alpha0
+  [./ACa0_bulk]
+    type = ADACGrGrMulti
+    variable = etaa0
+    v =           'etab0 etad0'
+    gamma_names = 'gab   gad'
+  [../]
+  [./ACa0_sw]
+    type = ADACSwitching
+    variable = etaa0
+    Fj_names  = 'omegaa omegab omegad'
+    hj_names  = 'ha     hb     hd'
+  [../]
+  [./ACa0_int]
+    type = ADACInterface
+    variable = etaa0
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./ea0_dot]
+    type = ADTimeDerivative
+    variable = etaa0
+  [../]
+# Order parameter eta_beta0
+  [./ACb0_bulk]
+    type = ADACGrGrMulti
+    variable = etab0
+    v =           'etaa0 etad0'
+    gamma_names = 'gab   gbd'
+  [../]
+  [./ACb0_sw]
+    type = ADACSwitching
+    variable = etab0
+    Fj_names  = 'omegaa omegab omegad'
+    hj_names  = 'ha     hb     hd'
+  [../]
+  [./ACb0_int]
+    type = ADACInterface
+    variable = etab0
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./eb0_dot]
+    type = ADTimeDerivative
+    variable = etab0
+  [../]
+# Order parameter eta_delta0
+  [./ACd0_bulk]
+    type = ADACGrGrMulti
+    variable = etad0
+    v =           'etaa0 etab0'
+    gamma_names = 'gad   gbd'
+  [../]
+  [./ACd0_sw]
+    type = ADACSwitching
+    variable = etad0
+    Fj_names  = 'omegaa omegab omegad'
+    hj_names  = 'ha     hb     hd'
+  [../]
+  [./ACd0_int]
+    type = ADACInterface
+    variable = etad0
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./ed0_dot]
+    type = ADTimeDerivative
+    variable = etad0
+  [../]
+#Chemical potential
+  [./w_dot]
+    type = ADSusceptibilityTimeDerivative
+    variable = w
+    f_name = chi
+  [../]
+  [./Diffusion]
+    type = ADMatDiffusion
+    variable = w
+    diffusivity = Dchi
+  [../]
+  [./coupled_etaa0dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etaa0
+    Fj_names = 'rhoa rhob rhod'
+    hj_names = 'ha   hb   hd'
+    args = 'etaa0 etab0 etad0'
+  [../]
+  [./coupled_etab0dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etab0
+    Fj_names = 'rhoa rhob rhod'
+    hj_names = 'ha   hb   hd'
+    args = 'etaa0 etab0 etad0'
+  [../]
+  [./coupled_etad0dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etad0
+    Fj_names = 'rhoa rhob rhod'
+    hj_names = 'ha   hb   hd'
+    args = 'etaa0 etab0 etad0'
+  [../]
+[]
+
+[Materials]
+  [./ha_test]
+    type = ADSwitchingFunctionMultiPhaseMaterial
+    h_name = ha
+    all_etas = 'etaa0 etab0 etad0'
+    phase_etas = 'etaa0'
+  [../]
+  [./hb_test]
+    type = ADSwitchingFunctionMultiPhaseMaterial
+    h_name = hb
+    all_etas = 'etaa0 etab0 etad0'
+    phase_etas = 'etab0'
+  [../]
+  [./hd_test]
+    type = ADSwitchingFunctionMultiPhaseMaterial
+    h_name = hd
+    all_etas = 'etaa0 etab0 etad0'
+    phase_etas = 'etad0'
+  [../]
+  [./omegaa]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = omegaa
+    material_property_names = 'Vm ka caeq'
+    function = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
+    derivative_order = 2
+  [../]
+  [./omegab]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = omegab
+    material_property_names = 'Vm kb cbeq'
+    function = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
+    derivative_order = 2
+  [../]
+  [./omegad]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = omegad
+    material_property_names = 'Vm kd cdeq'
+    function = '-0.5*w^2/Vm^2/kd-w/Vm*cdeq'
+    derivative_order = 2
+  [../]
+  [./rhoa]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = rhoa
+    material_property_names = 'Vm ka caeq'
+    function = 'w/Vm^2/ka + caeq/Vm'
+    derivative_order = 2
+  [../]
+  [./rhob]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = rhob
+    material_property_names = 'Vm kb cbeq'
+    function = 'w/Vm^2/kb + cbeq/Vm'
+    derivative_order = 2
+  [../]
+  [./rhod]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = rhod
+    material_property_names = 'Vm kd cdeq'
+    function = 'w/Vm^2/kd + cdeq/Vm'
+    derivative_order = 2
+  [../]
+  [./c]
+    type = ADParsedMaterial
+    material_property_names = 'Vm rhoa rhob rhod ha hb hd'
+    function = 'Vm * (ha * rhoa + hb * rhob + hd * rhod)'
+    f_name = c
+  [../]
+  [./const]
+    type = ADGenericConstantMaterial
+    prop_names =  'kappa_c  kappa   L   D    Vm   ka    caeq kb    cbeq  kd    cdeq  gab gad gbd  mu  tgrad_corr_mult'
+    prop_values = '0        1       1.0 1.0  1.0  10.0  0.1  10.0  0.9   10.0  0.5   1.5 1.5 1.5  1.0 0.0'
+  [../]
+  [./Mobility]
+    type = ADDerivativeParsedMaterial
+    f_name = Dchi
+    material_property_names = 'D chi'
+    function = 'D*chi'
+    derivative_order = 2
+  [../]
+  [./chi]
+    type = ADDerivativeParsedMaterial
+    f_name = chi
+    material_property_names = 'Vm ha(etaa0,etab0,etad0) ka hb(etaa0,etab0,etad0) kb hd(etaa0,etab0,etad0) kd'
+    function = '(ha/ka + hb/kb + hd/kd) / Vm^2'
+    args = 'etaa0 etab0 etad0'
+    derivative_order = 2
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./etaa0]
+    type = LineValueSampler
+    variable = etaa0
+    start_point = '-15 0 0'
+    end_point = '15 0 0'
+    num_points = 61
+    sort_by = x
+    execute_on = 'initial timestep_end final'
+  [../]
+  [./etab0]
+    type = LineValueSampler
+    variable = etab0
+    start_point = '-15 0 0'
+    end_point = '15 0 0'
+    num_points = 61
+    sort_by = x
+    execute_on = 'initial timestep_end final'
+  [../]
+  [./etad0]
+    type = LineValueSampler
+    variable = etad0
+    start_point = '-15 0 0'
+    end_point = '15 0 0'
+    num_points = 61
+    sort_by = x
+    execute_on = 'initial timestep_end final'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  nl_max_its = 15
+  scheme = bdf2
+  solve_type = NEWTON
+  petsc_options_iname = -pc_type
+  petsc_options_value = lu
+  l_max_its = 15
+  l_tol = 1.0e-3
+  nl_rel_tol = 1.0e-8
+  start_time = 0.0
+  num_steps = 20
+  nl_abs_tol = 1e-10
+  dt = 1.0
+[]
+
+[Outputs]
+  [./exodus]
+    type = Exodus
+    execute_on = 'initial timestep_end final'
+    interval = 1
+  [../]
+  [./csv]
+    type = CSV
+    execute_on = 'initial timestep_end final'
+    interval = 1
+  [../]
+[]

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
@@ -12,265 +12,265 @@
 []
 
 [Variables]
-  [./w]
-  [../]
-  [./etaa0]
-  [../]
-  [./etab0]
-  [../]
-  [./etad0]
-  [../]
+  [w]
+  []
+  [etaa0]
+  []
+  [etab0]
+  []
+  [etad0]
+  []
 []
 
 [ICs]
-  [./IC_etaa0]
+  [IC_etaa0]
     type = FunctionIC
     variable = etaa0
     function = ic_func_etaa0
-  [../]
-  [./IC_etab0]
+  []
+  [IC_etab0]
     type = FunctionIC
     variable = etab0
     function = ic_func_etab0
-  [../]
-  [./IC_etad0]
+  []
+  [IC_etad0]
     type = ConstantIC
     variable = etad0
     value = 0.1
-  [../]
-  [./IC_w]
+  []
+  [IC_w]
     type = FunctionIC
     variable = w
     function = ic_func_w
-  [../]
+  []
 []
 
 [Functions]
-  [./ic_func_etaa0]
-    type = ParsedFunction
+  [ic_func_etaa0]
+    type = ADParsedFunction
     value = '0.9*0.5*(1.0-tanh((x)/sqrt(2.0)))'
-  [../]
-  [./ic_func_etab0]
-    type = ParsedFunction
+  []
+  [ic_func_etab0]
+    type = ADParsedFunction
     value = '0.9*0.5*(1.0+tanh((x)/sqrt(2.0)))'
-  [../]
-  [./ic_func_w]
-    type = ParsedFunction
+  []
+  [ic_func_w]
+    type = ADParsedFunction
     value = 0
-  [../]
+  []
 []
 
 [Kernels]
 # Order parameter eta_alpha0
-  [./ACa0_bulk]
+  [ACa0_bulk]
     type = ADACGrGrMulti
     variable = etaa0
     v =           'etab0 etad0'
     gamma_names = 'gab   gad'
-  [../]
-  [./ACa0_sw]
+  []
+  [ACa0_sw]
     type = ADACSwitching
     variable = etaa0
     Fj_names  = 'omegaa omegab omegad'
     hj_names  = 'ha     hb     hd'
-  [../]
-  [./ACa0_int]
+  []
+  [ACa0_int]
     type = ADACInterface
     variable = etaa0
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./ea0_dot]
+  []
+  [ea0_dot]
     type = ADTimeDerivative
     variable = etaa0
-  [../]
+  []
 # Order parameter eta_beta0
-  [./ACb0_bulk]
+  [ACb0_bulk]
     type = ADACGrGrMulti
     variable = etab0
     v =           'etaa0 etad0'
     gamma_names = 'gab   gbd'
-  [../]
-  [./ACb0_sw]
+  []
+  [ACb0_sw]
     type = ADACSwitching
     variable = etab0
     Fj_names  = 'omegaa omegab omegad'
     hj_names  = 'ha     hb     hd'
-  [../]
-  [./ACb0_int]
+  []
+  [ACb0_int]
     type = ADACInterface
     variable = etab0
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./eb0_dot]
+  []
+  [eb0_dot]
     type = ADTimeDerivative
     variable = etab0
-  [../]
+  []
 # Order parameter eta_delta0
-  [./ACd0_bulk]
+  [ACd0_bulk]
     type = ADACGrGrMulti
     variable = etad0
     v =           'etaa0 etab0'
     gamma_names = 'gad   gbd'
-  [../]
-  [./ACd0_sw]
+  []
+  [ACd0_sw]
     type = ADACSwitching
     variable = etad0
     Fj_names  = 'omegaa omegab omegad'
     hj_names  = 'ha     hb     hd'
-  [../]
-  [./ACd0_int]
+  []
+  [ACd0_int]
     type = ADACInterface
     variable = etad0
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./ed0_dot]
+  []
+  [ed0_dot]
     type = ADTimeDerivative
     variable = etad0
-  [../]
+  []
 #Chemical potential
-  [./w_dot]
+  [w_dot]
     type = ADSusceptibilityTimeDerivative
     variable = w
     f_name = chi
-  [../]
-  [./Diffusion]
+  []
+  [Diffusion]
     type = ADMatDiffusion
     variable = w
     diffusivity = Dchi
-  [../]
-  [./coupled_etaa0dot]
+  []
+  [coupled_etaa0dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etaa0
     Fj_names = 'rhoa rhob rhod'
     hj_names = 'ha   hb   hd'
     args = 'etaa0 etab0 etad0'
-  [../]
-  [./coupled_etab0dot]
+  []
+  [coupled_etab0dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etab0
     Fj_names = 'rhoa rhob rhod'
     hj_names = 'ha   hb   hd'
     args = 'etaa0 etab0 etad0'
-  [../]
-  [./coupled_etad0dot]
+  []
+  [coupled_etad0dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etad0
     Fj_names = 'rhoa rhob rhod'
     hj_names = 'ha   hb   hd'
     args = 'etaa0 etab0 etad0'
-  [../]
+  []
 []
 
 [Materials]
-  [./ha_test]
+  [ha_test]
     type = ADSwitchingFunctionMultiPhaseMaterial
     h_name = ha
     all_etas = 'etaa0 etab0 etad0'
     phase_etas = 'etaa0'
-  [../]
-  [./hb_test]
+  []
+  [hb_test]
     type = ADSwitchingFunctionMultiPhaseMaterial
     h_name = hb
     all_etas = 'etaa0 etab0 etad0'
     phase_etas = 'etab0'
-  [../]
-  [./hd_test]
+  []
+  [hd_test]
     type = ADSwitchingFunctionMultiPhaseMaterial
     h_name = hd
     all_etas = 'etaa0 etab0 etad0'
     phase_etas = 'etad0'
-  [../]
-  [./omegaa]
+  []
+  [omegaa]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = omegaa
     material_property_names = 'Vm ka caeq'
     function = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
     derivative_order = 2
-  [../]
-  [./omegab]
+  []
+  [omegab]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = omegab
     material_property_names = 'Vm kb cbeq'
     function = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
     derivative_order = 2
-  [../]
-  [./omegad]
+  []
+  [omegad]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = omegad
     material_property_names = 'Vm kd cdeq'
     function = '-0.5*w^2/Vm^2/kd-w/Vm*cdeq'
     derivative_order = 2
-  [../]
-  [./rhoa]
+  []
+  [rhoa]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = rhoa
     material_property_names = 'Vm ka caeq'
     function = 'w/Vm^2/ka + caeq/Vm'
     derivative_order = 2
-  [../]
-  [./rhob]
+  []
+  [rhob]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = rhob
     material_property_names = 'Vm kb cbeq'
     function = 'w/Vm^2/kb + cbeq/Vm'
     derivative_order = 2
-  [../]
-  [./rhod]
+  []
+  [rhod]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = rhod
     material_property_names = 'Vm kd cdeq'
     function = 'w/Vm^2/kd + cdeq/Vm'
     derivative_order = 2
-  [../]
-  [./c]
+  []
+  [c]
     type = ADParsedMaterial
     material_property_names = 'Vm rhoa rhob rhod ha hb hd'
     function = 'Vm * (ha * rhoa + hb * rhob + hd * rhod)'
     f_name = c
-  [../]
-  [./const]
+  []
+  [const]
     type = ADGenericConstantMaterial
     prop_names =  'kappa_c  kappa   L   D    Vm   ka    caeq kb    cbeq  kd    cdeq  gab gad gbd  mu  tgrad_corr_mult'
     prop_values = '0        1       1.0 1.0  1.0  10.0  0.1  10.0  0.9   10.0  0.5   1.5 1.5 1.5  1.0 0.0'
-  [../]
-  [./Mobility]
+  []
+  [Mobility]
     type = ADDerivativeParsedMaterial
     f_name = Dchi
     material_property_names = 'D chi'
     function = 'D*chi'
     derivative_order = 2
-  [../]
-  [./chi]
+  []
+  [chi]
     type = ADDerivativeParsedMaterial
     f_name = chi
     material_property_names = 'Vm ha(etaa0,etab0,etad0) ka hb(etaa0,etab0,etad0) kb hd(etaa0,etab0,etad0) kd'
     function = '(ha/ka + hb/kb + hd/kd) / Vm^2'
     args = 'etaa0 etab0 etad0'
     derivative_order = 2
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./SMP]
+  [SMP]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [VectorPostprocessors]
-  [./etaa0]
+  [etaa0]
     type = LineValueSampler
     variable = etaa0
     start_point = '-15 0 0'
@@ -278,8 +278,8 @@
     num_points = 61
     sort_by = x
     execute_on = 'initial timestep_end final'
-  [../]
-  [./etab0]
+  []
+  [etab0]
     type = LineValueSampler
     variable = etab0
     start_point = '-15 0 0'
@@ -287,8 +287,8 @@
     num_points = 61
     sort_by = x
     execute_on = 'initial timestep_end final'
-  [../]
-  [./etad0]
+  []
+  [etad0]
     type = LineValueSampler
     variable = etad0
     start_point = '-15 0 0'
@@ -296,7 +296,7 @@
     num_points = 61
     sort_by = x
     execute_on = 'initial timestep_end final'
-  [../]
+  []
 []
 
 [Executioner]
@@ -316,14 +316,14 @@
 []
 
 [Outputs]
-  [./exodus]
+  [exodus]
     type = Exodus
     execute_on = 'initial timestep_end final'
     interval = 1
-  [../]
-  [./csv]
+  []
+  [csv]
     type = CSV
     execute_on = 'initial timestep_end final'
     interval = 1
-  [../]
+  []
 []

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase_AD.i
@@ -1,6 +1,6 @@
 # This is an example of implementation of the multi-phase, multi-order parameter
 # grand potential based phase-field model described in Phys. Rev. E, 98, 023309
-# (2019). It includes 3 phases with 1 grain of each phase. This example was used
+# (2018). It includes 3 phases with 1 grain of each phase. This example was used
 # to generate the results shown in Fig. 3 of the paper.
 
 [Mesh]

--- a/modules/phase_field/examples/multiphase/GrandPotential3Phase_masscons.i
+++ b/modules/phase_field/examples/multiphase/GrandPotential3Phase_masscons.i
@@ -1,6 +1,6 @@
 # This is an example of implementation of the multi-phase, multi-order parameter
 # grand potential based phase-field model described in Phys. Rev. E, 98, 023309
-# (2019). It includes 3 phases with 1 grain of each phase.
+# (2018). It includes 3 phases with 1 grain of each phase.
 # This is a revised version of the model that eliminates small variations in mass
 # that have been observed with the original formulation. In this version, rather
 # than evolving the chemical potential as a field variable, we evolve the composition

--- a/modules/phase_field/examples/multiphase/tests
+++ b/modules/phase_field/examples/multiphase/tests
@@ -29,7 +29,7 @@
     input = 'GrandPotential3Phase_AD.i'
     check_input = True
     requirement = "The multi-phase grand potential phase-field model shall have an AD example with 3 phases"
-    design = 'kernels/ADACSwitching.md'
+    design = 'kernels/ACSwitching.md'
     issues = '#15573'
   [../]
 []

--- a/modules/phase_field/examples/multiphase/tests
+++ b/modules/phase_field/examples/multiphase/tests
@@ -24,4 +24,12 @@
     issues = '#22159'
     method = '!DBG'
   [../]
+  [./GrandPotential3Phase_AD]
+    type = RunApp
+    input = 'GrandPotential3Phase_AD.i'
+    check_input = True
+    requirement = "The multi-phase grand potential phase-field model shall have an AD example with 3 phases"
+    design = 'kernels/ADACSwitching.md'
+    issues = '#15573'
+  [../]
 []

--- a/modules/phase_field/include/kernels/ACBarrierFunction.h
+++ b/modules/phase_field/include/kernels/ACBarrierFunction.h
@@ -38,8 +38,6 @@ protected:
   using ACBarrierFunctionBase<is_ad>::_qp;
   using ACBarrierFunctionBase<is_ad>::_vals;
   using ACBarrierFunctionBase<is_ad>::_u;
-  // using ACBarrierFunctionBase<is_ad>::_vals;
-  // using ACGrGrMultiBase<is_ad>::_test;
 };
 
 class ACBarrierFunction : public ACBarrierFunctionTempl<false>

--- a/modules/phase_field/include/kernels/ACBarrierFunction.h
+++ b/modules/phase_field/include/kernels/ACBarrierFunction.h
@@ -10,17 +10,41 @@
 #pragma once
 
 #include "ACGrGrBase.h"
+#include "ADGrainGrowthBase.h"
 
 /**
  * Several kernels use a material property called mu. If mu is not a constant,
  * then this kernel will calculate the bulk AC term where mu is the derivative term.
  * It currently only takes a single value for gamma.
  **/
-class ACBarrierFunction : public ACGrGrBase
+template <bool is_ad>
+using ACBarrierFunctionBase = typename std::conditional<is_ad, ADGrainGrowthBase, ACGrGrBase>::type;
+
+template <bool is_ad>
+class ACBarrierFunctionTempl : public ACBarrierFunctionBase<is_ad>
 {
 public:
   static InputParameters validParams();
 
+  ACBarrierFunctionTempl(const InputParameters & parameters);
+
+protected:
+  const NonlinearVariableName _uname;
+  const MaterialPropertyName _gamma_name;
+  const GenericMaterialProperty<Real, is_ad> & _gamma;
+  const GenericMaterialProperty<Real, is_ad> & _dmudvar;
+
+  using ACBarrierFunctionBase<is_ad>::_op_num;
+  using ACBarrierFunctionBase<is_ad>::_qp;
+  using ACBarrierFunctionBase<is_ad>::_vals;
+  using ACBarrierFunctionBase<is_ad>::_u;
+  // using ACBarrierFunctionBase<is_ad>::_vals;
+  // using ACGrGrMultiBase<is_ad>::_test;
+};
+
+class ACBarrierFunction : public ACBarrierFunctionTempl<false>
+{
+public:
   ACBarrierFunction(const InputParameters & parameters);
 
 protected:
@@ -28,10 +52,6 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
   unsigned int _n_eta;
-  const NonlinearVariableName _uname;
-  const MaterialPropertyName _gamma_name;
-  const MaterialProperty<Real> & _gamma;
-  const MaterialProperty<Real> & _dmudvar;
   const MaterialProperty<Real> & _d2mudvar2;
 
   const std::vector<VariableName> _vname;
@@ -40,4 +60,13 @@ protected:
 
 private:
   Real calculateF0(); /// calculates the free energy function
+};
+
+class ADACBarrierFunction : public ACBarrierFunctionTempl<true>
+{
+public:
+  using ACBarrierFunctionTempl<true>::ACBarrierFunctionTempl;
+
+protected:
+  virtual ADReal computeDFDOP();
 };

--- a/modules/phase_field/include/kernels/ACGrGrMulti.h
+++ b/modules/phase_field/include/kernels/ACGrGrMulti.h
@@ -10,37 +10,63 @@
 #pragma once
 
 #include "ACGrGrBase.h"
-
-// Forward Declarations
+#include "ADGrainGrowthBase.h"
 
 /**
  * This kernel calculates the residual for grain growth for a multi-phase,
  * poly-crystal system. A list of material properties needs to be supplied for the gammas
  * (prefactors of the cross-terms between order parameters).
  */
-class ACGrGrMulti : public ACGrGrBase
+
+template <bool is_ad>
+using ACGrGrMultiBase = typename std::conditional<is_ad, ADGrainGrowthBase, ACGrGrBase>::type;
+
+template <bool is_ad>
+class ACGrGrMultiTempl : public ACGrGrMultiBase<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  ACGrGrMulti(const InputParameters & parameters);
+  ACGrGrMultiTempl(const InputParameters & parameters);
 
 protected:
-  virtual Real computeDFDOP(PFFunctionType type);
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-
   /// Names of gammas for each order parameter
   std::vector<MaterialPropertyName> _gamma_names;
   unsigned int _num_j;
 
   /// Values of gammas for each order parameter
-  std::vector<const MaterialProperty<Real> *> _prop_gammas;
+  std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_gammas;
+
+  using ACGrGrMultiBase<is_ad>::_op_num;
+  using ACGrGrMultiBase<is_ad>::_qp;
+  using ACGrGrMultiBase<is_ad>::_vals;
+  using ACGrGrMultiBase<is_ad>::_u;
+  using ACGrGrMultiBase<is_ad>::_mu;
+  using ACGrGrMultiBase<is_ad>::_test;
+
+  GenericReal<is_ad> computedF0du();
+};
+
+class ACGrGrMulti : public ACGrGrMultiTempl<false>
+{
+public:
+  ACGrGrMulti(const InputParameters & parameters);
+
+protected:
+  virtual Real computeDFDOP(PFFunctionType type);
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const NonlinearVariableName _uname;
   const MaterialProperty<Real> & _dmudu;
   const std::vector<VariableName> _vname;
   std::vector<const MaterialProperty<Real> *> _dmudEtaj;
+};
 
-private:
-  Real computedF0du();
+class ADACGrGrMulti : public ACGrGrMultiTempl<true>
+{
+public:
+  using ACGrGrMultiTempl<true>::ACGrGrMultiTempl;
+
+protected:
+  virtual ADReal computeDFDOP();
 };

--- a/modules/phase_field/include/kernels/ACGrGrMulti.h
+++ b/modules/phase_field/include/kernels/ACGrGrMulti.h
@@ -42,7 +42,6 @@ protected:
   using ACGrGrMultiBase<is_ad>::_vals;
   using ACGrGrMultiBase<is_ad>::_u;
   using ACGrGrMultiBase<is_ad>::_mu;
-  using ACGrGrMultiBase<is_ad>::_test;
 
   GenericReal<is_ad> computedF0du();
 };
@@ -53,7 +52,7 @@ public:
   ACGrGrMulti(const InputParameters & parameters);
 
 protected:
-  virtual Real computeDFDOP(PFFunctionType type);
+  virtual Real computeDFDOP(PFFunctionType type) override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const NonlinearVariableName _uname;
@@ -68,5 +67,5 @@ public:
   using ACGrGrMultiTempl<true>::ACGrGrMultiTempl;
 
 protected:
-  virtual ADReal computeDFDOP();
+  virtual ADReal computeDFDOP() override;
 };

--- a/modules/phase_field/include/kernels/ACKappaFunction.h
+++ b/modules/phase_field/include/kernels/ACKappaFunction.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "Kernel.h"
+#include "GenericKernel.h"
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
@@ -18,32 +18,51 @@
  * to calculate the term which includes the derivatives of kappa.
  **/
 
-class ACKappaFunction : public DerivativeMaterialInterface<JvarMapKernelInterface<Kernel>>
+template <bool is_ad>
+class ACKappaFunctionTempl
+  : public DerivativeMaterialInterface<JvarMapKernelInterface<GenericKernel<is_ad>>>
 {
 public:
   static InputParameters validParams();
 
+  ACKappaFunctionTempl(const InputParameters & parameters);
+
+protected:
+  virtual GenericReal<is_ad> computeQpResidual() override;
+
+  const GenericMaterialProperty<Real, is_ad> & _L;
+
+  const MaterialPropertyName _kappa_name;
+  const GenericMaterialProperty<Real, is_ad> & _dkappadvar;
+
+  const unsigned int _v_num;
+  std::vector<const GenericVariableGradient<is_ad> *> _grad_v;
+
+  GenericReal<is_ad> computeFg(); /// gradient energy term
+
+  // using GenericKernel<is_ad>::_op_num;
+  using GenericKernel<is_ad>::_qp;
+  using GenericKernel<is_ad>::_i;
+  using GenericKernel<is_ad>::_grad_u;
+  using GenericKernel<is_ad>::_var;
+  using GenericKernel<is_ad>::_test;
+};
+
+class ACKappaFunction : public ACKappaFunctionTempl<false>
+{
+public:
   ACKappaFunction(const InputParameters & parameters);
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
-  const MaterialProperty<Real> & _L;
   const MaterialProperty<Real> & _dLdvar;
-
-  const MaterialPropertyName _kappa_name;
-  const MaterialProperty<Real> & _dkappadvar;
   const MaterialProperty<Real> & _d2kappadvar2;
 
-  const unsigned int _v_num;
   JvarMap _v_map;
-
-  std::vector<const VariableGradient *> _grad_v;
   std::vector<const MaterialProperty<Real> *> _dLdv;
   std::vector<const MaterialProperty<Real> *> _d2kappadvardv;
-
-private:
-  Real computeFg(); /// gradient energy term
 };
+
+typedef ACKappaFunctionTempl<true> ADACKappaFunction;

--- a/modules/phase_field/include/kernels/ACKappaFunction.h
+++ b/modules/phase_field/include/kernels/ACKappaFunction.h
@@ -40,7 +40,6 @@ protected:
 
   GenericReal<is_ad> computeFg(); /// gradient energy term
 
-  // using GenericKernel<is_ad>::_op_num;
   using GenericKernel<is_ad>::_qp;
   using GenericKernel<is_ad>::_i;
   using GenericKernel<is_ad>::_grad_u;

--- a/modules/phase_field/include/kernels/ACSwitching.h
+++ b/modules/phase_field/include/kernels/ACSwitching.h
@@ -10,8 +10,7 @@
 #pragma once
 
 #include "ACBulk.h"
-
-// Forward Declarations
+#include "ADAllenCahnBase.h"
 
 /**
  * ACSwitching adds terms of the form
@@ -20,19 +19,20 @@
  * \f$ \eta_{ai} is the order parameter for the phase/grain that is the nonlinear variable,
  * and \f$ F_a, F_b,.. \f$ are the free energies or grand potentials.
  */
-class ACSwitching : public ACBulk<Real>
+
+template <bool is_ad>
+using ACSwitchingBase = typename std::conditional<is_ad, ADAllenCahnBase<Real>, ACBulk<Real>>::type;
+
+template <bool is_ad>
+class ACSwitchingTempl : public ACSwitchingBase<is_ad>
 {
 public:
   static InputParameters validParams();
 
-  ACSwitching(const InputParameters & parameters);
-
-  virtual void initialSetup();
+  ACSwitchingTempl(const InputParameters & parameters);
+  // virtual void initialSetup() override;
 
 protected:
-  virtual Real computeDFDOP(PFFunctionType type);
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-
   /// name of order parameter that derivatives are taken wrt (needed to retrieve the derivative material properties)
   VariableName _etai_name;
 
@@ -41,20 +41,45 @@ protected:
   unsigned int _num_j;
 
   /// Values of the free energy functions for each phase \f$ F_j \f$
-  std::vector<const MaterialProperty<Real> *> _prop_Fj;
-
-  /// Derivatives of the free energy functions (needed for off-diagonal Jacobians)
-  std::vector<std::vector<const MaterialProperty<Real> *>> _prop_dFjdarg;
+  std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_Fj;
 
   /// switching function names
   std::vector<MaterialPropertyName> _hj_names;
 
   /// Derivatives of the switching functions wrt the order parameter for this kernel
-  std::vector<const MaterialProperty<Real> *> _prop_dhjdetai;
+  std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_dhjdetai;
+
+  using ACSwitchingBase<is_ad>::_qp;
+  using ACSwitchingBase<is_ad>::_var;
+  using ACSwitchingBase<is_ad>::_test;
+};
+
+class ACSwitching : public ACSwitchingTempl<false>
+{
+public:
+  ACSwitching(const InputParameters & parameters);
+
+  virtual void initialSetup() override;
+
+protected:
+  virtual Real computeDFDOP(PFFunctionType type) override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
+
+  /// Derivatives of the free energy functions (needed for off-diagonal Jacobians)
+  std::vector<std::vector<const MaterialProperty<Real> *>> _prop_dFjdarg;
 
   /// Second derivatives of the switching functions wrt the order parameter for this kernel
   std::vector<const MaterialProperty<Real> *> _prop_d2hjdetai2;
 
   /// Second derivatives of the switching functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_d2hjdetaidarg;
+};
+
+class ADACSwitching : public ACSwitchingTempl<true>
+{
+public:
+  using ACSwitchingTempl<true>::ACSwitchingTempl;
+
+protected:
+  virtual ADReal computeDFDOP() override;
 };

--- a/modules/phase_field/include/kernels/ACSwitching.h
+++ b/modules/phase_field/include/kernels/ACSwitching.h
@@ -11,6 +11,8 @@
 
 #include "ACBulk.h"
 #include "ADAllenCahnBase.h"
+// #include "JvarMapInterface.h"
+// #include "DerivativeMaterialInterface.h"
 
 /**
  * ACSwitching adds terms of the form
@@ -30,7 +32,7 @@ public:
   static InputParameters validParams();
 
   ACSwitchingTempl(const InputParameters & parameters);
-  // virtual void initialSetup() override;
+  virtual void initialSetup() override;
 
 protected:
   /// name of order parameter that derivatives are taken wrt (needed to retrieve the derivative material properties)

--- a/modules/phase_field/include/kernels/ACSwitching.h
+++ b/modules/phase_field/include/kernels/ACSwitching.h
@@ -11,8 +11,6 @@
 
 #include "ACBulk.h"
 #include "ADAllenCahnBase.h"
-// #include "JvarMapInterface.h"
-// #include "DerivativeMaterialInterface.h"
 
 /**
  * ACSwitching adds terms of the form

--- a/modules/phase_field/include/kernels/ADAllenCahnBase.h
+++ b/modules/phase_field/include/kernels/ADAllenCahnBase.h
@@ -10,7 +10,8 @@
 #pragma once
 
 #include "ADKernelValue.h"
-#include "DerivativeMaterialPropertyNameInterface.h"
+#include "JvarMapInterface.h"
+#include "DerivativeMaterialInterface.h"
 
 /**
  * This is the Allen-Cahn equation base class that implements the bulk or
@@ -20,7 +21,7 @@
  * ADAllenCahnBase. This is the AD equivalent of ACBulk<>.
  */
 template <typename T>
-class ADAllenCahnBase : public ADKernelValue, public DerivativeMaterialPropertyNameInterface
+class ADAllenCahnBase : public DerivativeMaterialInterface<JvarMapKernelInterface<ADKernelValue>>
 {
 public:
   ADAllenCahnBase(const InputParameters & parameters);
@@ -50,8 +51,7 @@ ADAllenCahnBase<T>::validParams()
 
 template <typename T>
 ADAllenCahnBase<T>::ADAllenCahnBase(const InputParameters & parameters)
-  : ADKernelValue(parameters),
-    DerivativeMaterialPropertyNameInterface(),
+  : DerivativeMaterialInterface<JvarMapKernelInterface<ADKernelValue>>(parameters),
     _prop_L(getADMaterialProperty<T>("mob_name"))
 {
 }

--- a/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
+++ b/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
@@ -63,8 +63,6 @@ protected:
   std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_dhjdetai;
 
   using CoupledSwitchingTimeDerivativeBase<is_ad>::_qp;
-  // using ACSwitchingBase<is_ad>::_var;
-  // using CoupledSwitchingTimeDerivativeBase<is_ad>::_test;
 };
 
 class CoupledSwitchingTimeDerivative : public CoupledSwitchingTimeDerivativeTempl<false>

--- a/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
+++ b/modules/phase_field/include/kernels/CoupledSwitchingTimeDerivative.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "CoupledTimeDerivative.h"
+#include "ADCoupledTimeDerivative.h"
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
@@ -25,20 +26,23 @@
  * and \f$ F_a, F_b,.. \f$ are functions for each phase. For the grand-potential
  * model susceptibility equation, \f$ F_a \f$ etc. are the phase densities.
  */
-class CoupledSwitchingTimeDerivative
-  : public DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>
+
+template <bool is_ad>
+using CoupledSwitchingTimeDerivativeBase =
+    typename std::conditional<is_ad, ADCoupledTimeDerivative, CoupledTimeDerivative>::type;
+
+template <bool is_ad>
+class CoupledSwitchingTimeDerivativeTempl
+  : public DerivativeMaterialInterface<
+        JvarMapKernelInterface<CoupledSwitchingTimeDerivativeBase<is_ad>>>
 {
 public:
   static InputParameters validParams();
 
-  CoupledSwitchingTimeDerivative(const InputParameters & parameters);
-  virtual void initialSetup();
+  CoupledSwitchingTimeDerivativeTempl(const InputParameters & parameters);
+  virtual void initialSetup() override;
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
-
   /// name of order parameter that derivatives are taken wrt (needed to retrieve
   /// the derivative material properties)
   const VariableName _v_name;
@@ -50,23 +54,47 @@ protected:
   const unsigned int _num_j;
 
   /// Values of the functions for each phase \f$ F_j \f$
-  std::vector<const MaterialProperty<Real> *> _prop_Fj;
+  std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_Fj;
 
+  /// switching function names
+  std::vector<MaterialPropertyName> _hj_names;
+
+  /// Derivatives of the switching functions wrt the order parameter for this kernel
+  std::vector<const GenericMaterialProperty<Real, is_ad> *> _prop_dhjdetai;
+
+  using CoupledSwitchingTimeDerivativeBase<is_ad>::_qp;
+  // using ACSwitchingBase<is_ad>::_var;
+  // using CoupledSwitchingTimeDerivativeBase<is_ad>::_test;
+};
+
+class CoupledSwitchingTimeDerivative : public CoupledSwitchingTimeDerivativeTempl<false>
+{
+public:
+  CoupledSwitchingTimeDerivative(const InputParameters & parameters);
+  virtual void initialSetup() override;
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   /// Derivatives of the functions wrt the nonlinear variable for this kernel
   std::vector<const MaterialProperty<Real> *> _prop_dFjdv;
 
   /// Derivatives of the functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_dFjdarg;
 
-  /// switching function names
-  std::vector<MaterialPropertyName> _hj_names;
-
-  /// Derivatives of the switching functions wrt the order parameter for this kernel
-  std::vector<const MaterialProperty<Real> *> _prop_dhjdetai;
-
   /// Second derivatives of the switching functions wrt the order parameter for this kernel
   std::vector<const MaterialProperty<Real> *> _prop_d2hjdetai2;
 
   /// Second derivatives of the switching functions (needed for off-diagonal Jacobians)
   std::vector<std::vector<const MaterialProperty<Real> *>> _prop_d2hjdetaidarg;
+};
+
+class ADCoupledSwitchingTimeDerivative : public CoupledSwitchingTimeDerivativeTempl<true>
+{
+public:
+  using CoupledSwitchingTimeDerivativeTempl<true>::CoupledSwitchingTimeDerivativeTempl;
+
+protected:
+  virtual ADReal precomputeQpResidual() override;
 };

--- a/modules/phase_field/include/materials/SwitchingFunctionMultiPhaseMaterial.h
+++ b/modules/phase_field/include/materials/SwitchingFunctionMultiPhaseMaterial.h
@@ -37,12 +37,12 @@ protected:
 
   /// Order parameters for phase alpha
   const unsigned int _num_eta_p;
-  const std::vector<const VariableValue *> _eta_p;
+  const std::vector<const GenericVariableValue<is_ad> *> _eta_p;
   const std::vector<VariableName> _eta_p_names;
 
   /// Order parameters for all phases (including alpha)
   const unsigned int _num_eta;
-  const std::vector<const VariableValue *> _eta;
+  const std::vector<const GenericVariableValue<is_ad> *> _eta;
   const std::vector<VariableName> _eta_names;
 
   /// List of which order parameters in the full list of all etas belong to phase p

--- a/modules/phase_field/include/materials/SwitchingFunctionMultiPhaseMaterial.h
+++ b/modules/phase_field/include/materials/SwitchingFunctionMultiPhaseMaterial.h
@@ -21,12 +21,13 @@
  * \f$ h_\alpha = (sum_i \eta_{\alpha i}^2) / (sum_\rho sum_i \eta_{\rho i}^2) \f$
  * for phase alpha, where \f$ i \f$  indexes grains of a phase and \f$ rho \f$  indexes phases
  */
-class SwitchingFunctionMultiPhaseMaterial : public DerivativeMaterialInterface<Material>
+template <bool is_ad>
+class SwitchingFunctionMultiPhaseMaterialTempl : public DerivativeMaterialInterface<Material>
 {
 public:
   static InputParameters validParams();
 
-  SwitchingFunctionMultiPhaseMaterial(const InputParameters & parameters);
+  SwitchingFunctionMultiPhaseMaterialTempl(const InputParameters & parameters);
 
 protected:
   virtual void computeQpProperties();
@@ -48,7 +49,10 @@ protected:
   std::vector<bool> _is_p;
 
   /// Switching function and derivatives
-  MaterialProperty<Real> & _prop_h;
-  std::vector<MaterialProperty<Real> *> _prop_dh;
-  std::vector<std::vector<MaterialProperty<Real> *>> _prop_d2h;
+  GenericMaterialProperty<Real, is_ad> & _prop_h;
+  std::vector<GenericMaterialProperty<Real, is_ad> *> _prop_dh;
+  std::vector<std::vector<GenericMaterialProperty<Real, is_ad> *>> _prop_d2h;
 };
+
+typedef SwitchingFunctionMultiPhaseMaterialTempl<false> SwitchingFunctionMultiPhaseMaterial;
+typedef SwitchingFunctionMultiPhaseMaterialTempl<true> ADSwitchingFunctionMultiPhaseMaterial;

--- a/modules/phase_field/src/kernels/ACGrGrMulti.C
+++ b/modules/phase_field/src/kernels/ACGrGrMulti.C
@@ -10,11 +10,13 @@
 #include "ACGrGrMulti.h"
 
 registerMooseObject("PhaseFieldApp", ACGrGrMulti);
+registerMooseObject("PhaseFieldApp", ADACGrGrMulti);
 
+template <bool is_ad>
 InputParameters
-ACGrGrMulti::validParams()
+ACGrGrMultiTempl<is_ad>::validParams()
 {
-  InputParameters params = ACGrGrBase::validParams();
+  InputParameters params = ACGrGrMultiBase<is_ad>::validParams();
   params.addClassDescription("Multi-phase poly-crystalline Allen-Cahn Kernel");
   params.addRequiredParam<std::vector<MaterialPropertyName>>(
       "gamma_names",
@@ -23,26 +25,32 @@ ACGrGrMulti::validParams()
   return params;
 }
 
-ACGrGrMulti::ACGrGrMulti(const InputParameters & parameters)
-  : ACGrGrBase(parameters),
-    _gamma_names(getParam<std::vector<MaterialPropertyName>>("gamma_names")),
+template <bool is_ad>
+ACGrGrMultiTempl<is_ad>::ACGrGrMultiTempl(const InputParameters & parameters)
+  : ACGrGrMultiBase<is_ad>(parameters),
+    _gamma_names(this->template getParam<std::vector<MaterialPropertyName>>("gamma_names")),
     _num_j(_gamma_names.size()),
-    _prop_gammas(_num_j),
-    _uname(getParam<NonlinearVariableName>("variable")),
-    _dmudu(getMaterialPropertyDerivative<Real>("mu", _uname)),
-    _vname(getParam<std::vector<VariableName>>("v")),
-    _dmudEtaj(_num_j)
+    _prop_gammas(_num_j)
 {
   // check passed in parameter vectors
-  if (_num_j != coupledComponents("v"))
-    paramError("gamma_names",
-               "Need to pass in as many gamma_names as coupled variables in v in ACGrGrMulti");
+  if (_num_j != this->coupledComponents("v"))
+    this->paramError(
+        "gamma_names",
+        "Need to pass in as many gamma_names as coupled variables in v in ACGrGrMulti");
 
   for (unsigned int n = 0; n < _num_j; ++n)
-  {
-    _prop_gammas[n] = &getMaterialPropertyByName<Real>(_gamma_names[n]);
-    _dmudEtaj[n] = &getMaterialPropertyDerivative<Real>("mu", _vname[n]);
-  }
+    _prop_gammas[n] = &this->template getGenericMaterialProperty<Real, is_ad>(_gamma_names[n]);
+}
+
+ACGrGrMulti::ACGrGrMulti(const InputParameters & parameters)
+  : ACGrGrMultiTempl<false>(parameters),
+    _uname(this->template getParam<NonlinearVariableName>("variable")),
+    _dmudu(this->template getMaterialPropertyDerivative<Real>("mu", _uname)),
+    _vname(this->template getParam<std::vector<VariableName>>("v")),
+    _dmudEtaj(_num_j)
+{
+  for (unsigned int n = 0; n < _num_j; ++n)
+    _dmudEtaj[n] = &this->template getMaterialPropertyDerivative<Real>("mu", _vname[n]);
 }
 
 Real
@@ -50,7 +58,7 @@ ACGrGrMulti::computeDFDOP(PFFunctionType type)
 {
   // Sum all other order parameters
   Real SumGammaEtaj = 0.0;
-  for (unsigned int i = 0; i < _op_num; ++i)
+  for (const auto i : make_range(_op_num))
     SumGammaEtaj += (*_prop_gammas[i])[_qp] * (*_vals[i])[_qp] * (*_vals[i])[_qp];
 
   // Calculate either the residual or Jacobian of the grain growth free energy
@@ -64,12 +72,23 @@ ACGrGrMulti::computeDFDOP(PFFunctionType type)
     case Jacobian:
     {
       Real d2f0du2 = 3.0 * _u[_qp] * _u[_qp] - 1.0 + 2.0 * SumGammaEtaj;
-      return _phi[_j][_qp] * (_mu[_qp] * d2f0du2 + _dmudu[_qp] * computedF0du());
+      return this->_phi[_j][_qp] * (_mu[_qp] * d2f0du2 + _dmudu[_qp] * computedF0du());
     }
 
     default:
       mooseError("Invalid type passed in");
   }
+}
+
+ADReal
+ADACGrGrMulti::computeDFDOP()
+{
+  // Sum all other order parameters
+  ADReal SumGammaEtaj = 0.0;
+  for (const auto i : make_range(_op_num))
+    SumGammaEtaj += (*_prop_gammas[i])[_qp] * (*_vals[i])[_qp] * (*_vals[i])[_qp];
+
+  return _mu[_qp] * computedF0du();
 }
 
 Real
@@ -89,12 +108,16 @@ ACGrGrMulti::computeQpOffDiagJacobian(unsigned int jvar)
   return 0.0;
 }
 
-Real
-ACGrGrMulti::computedF0du()
+template <bool is_ad>
+GenericReal<is_ad>
+ACGrGrMultiTempl<is_ad>::computedF0du()
 {
-  Real SumGammaEtaj = 0.0;
-  for (unsigned int i = 0; i < _op_num; ++i)
+  GenericReal<is_ad> SumGammaEtaj = 0.0;
+  for (const auto i : make_range(_op_num))
     SumGammaEtaj += (*_prop_gammas[i])[_qp] * (*_vals[i])[_qp] * (*_vals[i])[_qp];
 
   return _u[_qp] * _u[_qp] * _u[_qp] - _u[_qp] + 2.0 * _u[_qp] * SumGammaEtaj;
 }
+
+template class ACGrGrMultiTempl<false>;
+template class ACGrGrMultiTempl<true>;

--- a/modules/phase_field/src/kernels/ACGrGrMulti.C
+++ b/modules/phase_field/src/kernels/ACGrGrMulti.C
@@ -72,7 +72,7 @@ ACGrGrMulti::computeDFDOP(PFFunctionType type)
     case Jacobian:
     {
       Real d2f0du2 = 3.0 * _u[_qp] * _u[_qp] - 1.0 + 2.0 * SumGammaEtaj;
-      return this->_phi[_j][_qp] * (_mu[_qp] * d2f0du2 + _dmudu[_qp] * computedF0du());
+      return _phi[_j][_qp] * (_mu[_qp] * d2f0du2 + _dmudu[_qp] * computedF0du());
     }
 
     default:

--- a/modules/phase_field/src/kernels/ACSwitching.C
+++ b/modules/phase_field/src/kernels/ACSwitching.C
@@ -46,11 +46,9 @@ ACSwitchingTempl<is_ad>::ACSwitchingTempl(const InputParameters & parameters)
     // get phase free energy
     _prop_Fj[n] = &this->template getGenericMaterialProperty<Real, is_ad>(_Fj_names[n]);
 
-    // mooseWarning("Derivative property name = ",
-    //              this->derivativePropertyNameFirst(_hj_names[n], _etai_name));
-    // get switching derivatives wrt eta_i, the nonlinear variable
-    _prop_dhjdetai[n] = &this->template getGenericMaterialProperty<Real, is_ad>(
-        this->derivativePropertyNameFirst(_hj_names[n], _etai_name));
+    // get first derivative of the switching functions
+    _prop_dhjdetai[n] =
+        &this->template getMaterialPropertyDerivative<Real, is_ad>(_hj_names[n], _etai_name);
   }
 }
 
@@ -80,16 +78,21 @@ ACSwitching::ACSwitching(const InputParameters & parameters)
   }
 }
 
+template <bool is_ad>
+void
+ACSwitchingTempl<is_ad>::initialSetup()
+{
+  ACSwitchingBase<is_ad>::initialSetup();
+  for (unsigned int n = 0; n < _num_j; ++n)
+    this->template validateNonlinearCoupling<GenericReal<is_ad>>(_hj_names[n]);
+}
+
 void
 ACSwitching::initialSetup()
 {
-  ACBulk<Real>::initialSetup();
-
+  ACSwitchingTempl<false>::initialSetup();
   for (unsigned int n = 0; n < _num_j; ++n)
-  {
     validateNonlinearCoupling<Real>(_Fj_names[n]);
-    validateNonlinearCoupling<Real>(_hj_names[n]);
-  }
 }
 
 Real

--- a/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
@@ -47,14 +47,12 @@ CoupledSwitchingTimeDerivativeTempl<is_ad>::CoupledSwitchingTimeDerivativeTempl(
   // reserve space and set phase material properties
   for (unsigned int n = 0; n < _num_j; ++n)
   {
-    // get phase free energy and derivatives
-    // _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
+    // get phase free energy
     _prop_Fj[n] = &this->template getGenericMaterialProperty<Real, is_ad>(_Fj_names[n]);
 
-    // get switching function and derivatives wrt eta_i, the nonlinear variable
-    // _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name);
-    _prop_dhjdetai[n] = &this->template getGenericMaterialProperty<Real, is_ad>(
-        this->derivativePropertyNameFirst(_hj_names[n], _v_name));
+    // get switching function derivatives wrt eta_i, the nonlinear variable
+    _prop_dhjdetai[n] =
+        &this->template getMaterialPropertyDerivative<Real, is_ad>(_hj_names[n], _v_name);
   }
 }
 

--- a/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
+++ b/modules/phase_field/src/kernels/CoupledSwitchingTimeDerivative.C
@@ -10,11 +10,13 @@
 #include "CoupledSwitchingTimeDerivative.h"
 
 registerMooseObject("PhaseFieldApp", CoupledSwitchingTimeDerivative);
+registerMooseObject("PhaseFieldApp", ADCoupledSwitchingTimeDerivative);
 
+template <bool is_ad>
 InputParameters
-CoupledSwitchingTimeDerivative::validParams()
+CoupledSwitchingTimeDerivativeTempl<is_ad>::validParams()
 {
-  InputParameters params = CoupledTimeDerivative::validParams();
+  InputParameters params = CoupledSwitchingTimeDerivativeBase<is_ad>::validParams();
   params.addClassDescription(
       "Coupled time derivative Kernel that multiplies the time derivative by "
       "$\\frac{dh_\\alpha}{d\\eta_i} F_\\alpha + \\frac{dh_\\beta}{d\\eta_i} F_\\beta + \\dots$");
@@ -26,34 +28,51 @@ CoupledSwitchingTimeDerivative::validParams()
   params.deprecateCoupledVar("args", "coupled_variables", "02/27/2024");
   return params;
 }
-
-CoupledSwitchingTimeDerivative::CoupledSwitchingTimeDerivative(const InputParameters & parameters)
-  : DerivativeMaterialInterface<JvarMapKernelInterface<CoupledTimeDerivative>>(parameters),
-    _v_name(coupledName("v", 0)),
-    _Fj_names(getParam<std::vector<MaterialPropertyName>>("Fj_names")),
+template <bool is_ad>
+CoupledSwitchingTimeDerivativeTempl<is_ad>::CoupledSwitchingTimeDerivativeTempl(
+    const InputParameters & parameters)
+  : DerivativeMaterialInterface<JvarMapKernelInterface<CoupledSwitchingTimeDerivativeBase<is_ad>>>(
+        parameters),
+    _v_name(this->coupledName("v", 0)),
+    _Fj_names(this->template getParam<std::vector<MaterialPropertyName>>("Fj_names")),
     _num_j(_Fj_names.size()),
     _prop_Fj(_num_j),
-    _prop_dFjdv(_num_j),
-    _prop_dFjdarg(_num_j),
-    _hj_names(getParam<std::vector<MaterialPropertyName>>("hj_names")),
-    _prop_dhjdetai(_num_j),
-    _prop_d2hjdetai2(_num_j),
-    _prop_d2hjdetaidarg(_num_j)
+    _hj_names(this->template getParam<std::vector<MaterialPropertyName>>("hj_names")),
+    _prop_dhjdetai(_num_j)
 {
   // check passed in parameter vectors
   if (_num_j != _hj_names.size())
-    paramError("hj_names", "Need to pass in as many hj_names as Fj_names");
+    this->paramError("hj_names", "Need to pass in as many hj_names as Fj_names");
 
   // reserve space and set phase material properties
   for (unsigned int n = 0; n < _num_j; ++n)
   {
     // get phase free energy and derivatives
-    _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
+    // _prop_Fj[n] = &getMaterialPropertyByName<Real>(_Fj_names[n]);
+    _prop_Fj[n] = &this->template getGenericMaterialProperty<Real, is_ad>(_Fj_names[n]);
+
+    // get switching function and derivatives wrt eta_i, the nonlinear variable
+    // _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name);
+    _prop_dhjdetai[n] = &this->template getGenericMaterialProperty<Real, is_ad>(
+        this->derivativePropertyNameFirst(_hj_names[n], _v_name));
+  }
+}
+
+CoupledSwitchingTimeDerivative::CoupledSwitchingTimeDerivative(const InputParameters & parameters)
+  : CoupledSwitchingTimeDerivativeTempl<false>(parameters),
+    _prop_dFjdv(_num_j),
+    _prop_dFjdarg(_num_j),
+    _prop_d2hjdetai2(_num_j),
+    _prop_d2hjdetaidarg(_num_j)
+{
+  // reserve space and set phase material properties
+  for (unsigned int n = 0; n < _num_j; ++n)
+  {
+    // get phase free energy and derivatives
     _prop_dFjdv[n] = &getMaterialPropertyDerivative<Real>(_Fj_names[n], _var.name());
     _prop_dFjdarg[n].resize(_n_args);
 
     // get switching function and derivatives wrt eta_i, the nonlinear variable
-    _prop_dhjdetai[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name);
     _prop_d2hjdetai2[n] = &getMaterialPropertyDerivative<Real>(_hj_names[n], _v_name, _v_name);
     _prop_d2hjdetaidarg[n].resize(_n_args);
 
@@ -68,14 +87,20 @@ CoupledSwitchingTimeDerivative::CoupledSwitchingTimeDerivative(const InputParame
   }
 }
 
+template <bool is_ad>
+void
+CoupledSwitchingTimeDerivativeTempl<is_ad>::initialSetup()
+{
+  for (unsigned int n = 0; n < _num_j; ++n)
+    this->template validateNonlinearCoupling<GenericReal<is_ad>>(_hj_names[n]);
+}
+
 void
 CoupledSwitchingTimeDerivative::initialSetup()
 {
+  CoupledSwitchingTimeDerivativeTempl<false>::initialSetup();
   for (unsigned int n = 0; n < _num_j; ++n)
-  {
     validateNonlinearCoupling<Real>(_Fj_names[n]);
-    validateNonlinearCoupling<Real>(_hj_names[n]);
-  }
 }
 
 Real
@@ -86,6 +111,16 @@ CoupledSwitchingTimeDerivative::computeQpResidual()
     sum += (*_prop_dhjdetai[n])[_qp] * (*_prop_Fj[n])[_qp];
 
   return CoupledTimeDerivative::computeQpResidual() * sum;
+}
+
+ADReal
+ADCoupledSwitchingTimeDerivative::precomputeQpResidual()
+{
+  ADReal sum = 0.0;
+  for (unsigned int n = 0; n < _num_j; ++n)
+    sum += (*_prop_dhjdetai[n])[_qp] * (*_prop_Fj[n])[_qp];
+
+  return _v_dot[_qp] * sum;
 }
 
 Real
@@ -123,3 +158,6 @@ CoupledSwitchingTimeDerivative::computeQpOffDiagJacobian(unsigned int jvar)
 
   return CoupledTimeDerivative::computeQpResidual() * sum * _phi[_j][_qp];
 }
+
+template class CoupledSwitchingTimeDerivativeTempl<false>;
+template class CoupledSwitchingTimeDerivativeTempl<true>;

--- a/modules/phase_field/src/materials/SwitchingFunctionMultiPhaseMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunctionMultiPhaseMaterial.C
@@ -8,11 +8,14 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "SwitchingFunctionMultiPhaseMaterial.h"
+#include "MooseException.h"
 
 registerMooseObject("PhaseFieldApp", SwitchingFunctionMultiPhaseMaterial);
+registerMooseObject("PhaseFieldApp", ADSwitchingFunctionMultiPhaseMaterial);
 
+template <bool is_ad>
 InputParameters
-SwitchingFunctionMultiPhaseMaterial::validParams()
+SwitchingFunctionMultiPhaseMaterialTempl<is_ad>::validParams()
 {
   InputParameters params = Material::validParams();
   params.addRequiredParam<MaterialPropertyName>(
@@ -24,10 +27,11 @@ SwitchingFunctionMultiPhaseMaterial::validParams()
   return params;
 }
 
-SwitchingFunctionMultiPhaseMaterial::SwitchingFunctionMultiPhaseMaterial(
+template <bool is_ad>
+SwitchingFunctionMultiPhaseMaterialTempl<is_ad>::SwitchingFunctionMultiPhaseMaterialTempl(
     const InputParameters & parameters)
   : DerivativeMaterialInterface<Material>(parameters),
-    _h_name(getParam<MaterialPropertyName>("h_name")),
+    _h_name(this->getParam<MaterialPropertyName>("h_name")),
     _num_eta_p(coupledComponents("phase_etas")),
     _eta_p(coupledValues("phase_etas")),
     _eta_p_names(coupledNames("phase_etas")),
@@ -35,21 +39,22 @@ SwitchingFunctionMultiPhaseMaterial::SwitchingFunctionMultiPhaseMaterial(
     _eta(coupledValues("all_etas")),
     _eta_names(coupledNames("all_etas")),
     _is_p(_num_eta),
-    _prop_h(declareProperty<Real>(_h_name)),
+    _prop_h(declareGenericProperty<Real, is_ad>(_h_name)),
     _prop_dh(_num_eta),
     _prop_d2h(_num_eta)
 {
   // Declare h derivative properties
   for (unsigned int i = 0; i < _num_eta; ++i)
-    _prop_d2h[i].resize(_num_eta);
+    _prop_d2h[i].resize(_num_eta, NULL);
 
   for (unsigned int i = 0; i < _num_eta; ++i)
   {
-    _prop_dh[i] = &declarePropertyDerivative<Real>(_h_name, _eta_names[i]);
+    _prop_dh[i] = &this->template declarePropertyDerivative<Real, is_ad>(_h_name, _eta_names[i]);
+    // mooseWarning("Property name = ", _h_name, " and variable names are = ", _eta_names[i]);
     for (unsigned int j = i; j < _num_eta; ++j)
     {
-      _prop_d2h[i][j] = _prop_d2h[j][i] =
-          &declarePropertyDerivative<Real>(_h_name, _eta_names[i], _eta_names[j]);
+      _prop_d2h[i][j] = _prop_d2h[j][i] = &this->template declarePropertyDerivative<Real, is_ad>(
+          _h_name, _eta_names[i], _eta_names[j]);
     }
   }
 
@@ -65,11 +70,12 @@ SwitchingFunctionMultiPhaseMaterial::SwitchingFunctionMultiPhaseMaterial(
   }
 }
 
+template <bool is_ad>
 void
-SwitchingFunctionMultiPhaseMaterial::computeQpProperties()
+SwitchingFunctionMultiPhaseMaterialTempl<is_ad>::computeQpProperties()
 {
-  Real sum_p = 0.0;
-  Real sum_all = 0.0;
+  GenericReal<is_ad> sum_p = 0.0;
+  GenericReal<is_ad> sum_all = 0.0;
 
   for (unsigned int i = 0; i < _num_eta_p; ++i)
     sum_p += (*_eta_p[i])[_qp] * (*_eta_p[i])[_qp];
@@ -77,7 +83,7 @@ SwitchingFunctionMultiPhaseMaterial::computeQpProperties()
   for (unsigned int i = 0; i < _num_eta; ++i)
     sum_all += (*_eta[i])[_qp] * (*_eta[i])[_qp];
 
-  Real sum_notp = sum_all - sum_p;
+  GenericReal<is_ad> sum_notp = sum_all - sum_p;
 
   _prop_h[_qp] = sum_p / sum_all;
 
@@ -115,3 +121,7 @@ SwitchingFunctionMultiPhaseMaterial::computeQpProperties()
     }
   }
 }
+
+// explicit instantiation
+template class SwitchingFunctionMultiPhaseMaterialTempl<true>;
+template class SwitchingFunctionMultiPhaseMaterialTempl<false>;

--- a/modules/phase_field/src/materials/SwitchingFunctionMultiPhaseMaterial.C
+++ b/modules/phase_field/src/materials/SwitchingFunctionMultiPhaseMaterial.C
@@ -33,10 +33,10 @@ SwitchingFunctionMultiPhaseMaterialTempl<is_ad>::SwitchingFunctionMultiPhaseMate
   : DerivativeMaterialInterface<Material>(parameters),
     _h_name(this->getParam<MaterialPropertyName>("h_name")),
     _num_eta_p(coupledComponents("phase_etas")),
-    _eta_p(coupledValues("phase_etas")),
+    _eta_p(coupledGenericValues<is_ad>("phase_etas")),
     _eta_p_names(coupledNames("phase_etas")),
     _num_eta(coupledComponents("all_etas")),
-    _eta(coupledValues("all_etas")),
+    _eta(coupledGenericValues<is_ad>("all_etas")),
     _eta_names(coupledNames("all_etas")),
     _is_p(_num_eta),
     _prop_h(declareGenericProperty<Real, is_ad>(_h_name)),
@@ -50,7 +50,6 @@ SwitchingFunctionMultiPhaseMaterialTempl<is_ad>::SwitchingFunctionMultiPhaseMate
   for (unsigned int i = 0; i < _num_eta; ++i)
   {
     _prop_dh[i] = &this->template declarePropertyDerivative<Real, is_ad>(_h_name, _eta_names[i]);
-    // mooseWarning("Property name = ", _h_name, " and variable names are = ", _eta_names[i]);
     for (unsigned int j = i; j < _num_eta; ++j)
     {
       _prop_d2h[i][j] = _prop_d2h[j][i] = &this->template declarePropertyDerivative<Real, is_ad>(

--- a/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
@@ -211,7 +211,7 @@
     args = 'w'
     f_name = omegaa
     material_property_names = 'Vm ka caeq'
-    function = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
+    expression = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
     derivative_order = 2
   []
   [omegab]
@@ -219,7 +219,7 @@
     args = 'w'
     f_name = omegab
     material_property_names = 'Vm kb cbeq'
-    function = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
+    expression = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
     derivative_order = 2
   []
   [rhoa]
@@ -227,7 +227,7 @@
     args = 'w'
     f_name = rhoa
     material_property_names = 'Vm ka caeq'
-    function = 'w/Vm^2/ka + caeq/Vm'
+    expression = 'w/Vm^2/ka + caeq/Vm'
     derivative_order = 2
   []
   [rhob]
@@ -235,7 +235,7 @@
     args = 'w'
     f_name = rhob
     material_property_names = 'Vm kb cbeq'
-    function = 'w/Vm^2/kb + cbeq/Vm'
+    expression = 'w/Vm^2/kb + cbeq/Vm'
     derivative_order = 2
   []
   [const]
@@ -247,7 +247,7 @@
     type = ADDerivativeParsedMaterial
     f_name = Dchi
     material_property_names = 'D chi'
-    function = 'D*chi'
+    expression = 'D*chi'
     derivative_order = 2
   []
 []

--- a/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
@@ -1,0 +1,282 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 20
+  ny = 20
+  xmin = -20
+  xmax = 20
+  ymin = -20
+  ymax = 20
+[]
+
+[GlobalParams]
+  op_num = 2
+  var_name_base = etab
+[]
+
+[Variables]
+  [./w]
+  [../]
+  [./etaa0]
+  [../]
+  [./etab0]
+  [../]
+  [./etab1]
+  [../]
+[]
+
+[AuxVariables]
+  [./bnds]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[ICs]
+
+  [./IC_etaa0]
+    type = FunctionIC
+    variable = etaa0
+    function = ic_func_etaa0
+  [../]
+  [./IC_etab0]
+    type = FunctionIC
+    variable = etab0
+    function = ic_func_etab0
+  [../]
+  [./IC_etab1]
+    type = FunctionIC
+    variable = etab1
+    function = ic_func_etab1
+  [../]
+  [./IC_w]
+    type = ConstantIC
+    value = -0.05
+    variable = w
+  [../]
+[]
+
+[Functions]
+  [./ic_func_etaa0]
+    type = ParsedFunction
+    value = 'r:=sqrt(x^2+y^2);0.5*(1.0-tanh((r-10.0)/sqrt(2.0)))'
+  [../]
+  [./ic_func_etab0]
+    type = ParsedFunction
+    value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0+tanh((y)/sqrt(2.0)))'
+  [../]
+  [./ic_func_etab1]
+    type = ParsedFunction
+    value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0-tanh((y)/sqrt(2.0)))'
+  [../]
+[]
+
+
+[BCs]
+[]
+
+[Kernels]
+# Order parameter eta_alpha0
+  [./ACa0_bulk]
+    type = ADACGrGrMulti
+    variable = etaa0
+    v =           'etab0 etab1'
+    gamma_names = 'gab   gab'
+  [../]
+  [./ACa0_sw]
+    type = ADACSwitching
+    variable = etaa0
+    Fj_names  = 'omegaa omegab'
+    hj_names  = 'ha     hb'
+  [../]
+  [./ACa0_int]
+    type = ADACInterface
+    variable = etaa0
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./ea0_dot]
+    type = ADTimeDerivative
+    variable = etaa0
+  [../]
+# Order parameter eta_beta0
+  [./ACb0_bulk]
+    type = ADACGrGrMulti
+    variable = etab0
+    v =           'etaa0 etab1'
+    gamma_names = 'gab   gbb'
+  [../]
+  [./ACb0_sw]
+    type = ADACSwitching
+    variable = etab0
+    Fj_names  = 'omegaa omegab'
+    hj_names  = 'ha     hb'
+  [../]
+  [./ACb0_int]
+    type = ADACInterface
+    variable = etab0
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./eb0_dot]
+    type = ADTimeDerivative
+    variable = etab0
+  [../]
+# Order parameter eta_beta1
+  [./ACb1_bulk]
+    type = ADACGrGrMulti
+    variable = etab1
+    v =           'etaa0 etab0'
+    gamma_names = 'gab   gbb'
+  [../]
+  [./ACb1_sw]
+    type = ADACSwitching
+    variable = etab1
+    Fj_names  = 'omegaa omegab'
+    hj_names  = 'ha     hb'
+  [../]
+  [./ACb1_int]
+    type = ADACInterface
+    variable = etab1
+    kappa_name = kappa
+    variable_L = false
+  [../]
+  [./eb1_dot]
+    type = ADTimeDerivative
+    variable = etab1
+  [../]
+#Chemical potential
+  [./w_dot]
+    type = ADSusceptibilityTimeDerivative
+    variable = w
+    f_name = chi
+  [../]
+  [./Diffusion]
+    type = ADMatDiffusion
+    variable = w
+    diffusivity = Dchi
+  [../]
+  [./coupled_etaa0dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etaa0
+    Fj_names = 'rhoa rhob'
+    hj_names = 'ha   hb'
+    args = 'etaa0 etab0 etab1'
+  [../]
+  [./coupled_etab0dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etab0
+    Fj_names = 'rhoa rhob'
+    hj_names = 'ha   hb'
+    args = 'etaa0 etab0 etab1'
+  [../]
+  [./coupled_etab1dot]
+    type = ADCoupledSwitchingTimeDerivative
+    variable = w
+    v = etab1
+    Fj_names = 'rhoa rhob'
+    hj_names = 'ha   hb'
+    args = 'etaa0 etab0 etab1'
+  [../]
+[]
+
+[AuxKernels]
+  [./BndsCalc]
+    type = BndsCalcAux
+    variable = bnds
+    execute_on = timestep_end
+  [../]
+[]
+
+# enable_jit set to false in many materials to make this test start up faster.
+# It is recommended to set enable_jit = true or just remove these lines for
+# production runs with this model
+[Materials]
+  [./ha]
+    type = ADSwitchingFunctionMultiPhaseMaterial
+    h_name = ha
+    all_etas = 'etaa0 etab0 etab1'
+    phase_etas = 'etaa0'
+  [../]
+  [./hb]
+    type = ADSwitchingFunctionMultiPhaseMaterial
+    h_name = hb
+    all_etas = 'etaa0 etab0 etab1'
+    phase_etas = 'etab0 etab1'
+  [../]
+  [./omegaa]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = omegaa
+    material_property_names = 'Vm ka caeq'
+    function = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
+    derivative_order = 2
+  [../]
+  [./omegab]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = omegab
+    material_property_names = 'Vm kb cbeq'
+    function = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
+    derivative_order = 2
+  [../]
+  [./rhoa]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = rhoa
+    material_property_names = 'Vm ka caeq'
+    function = 'w/Vm^2/ka + caeq/Vm'
+    derivative_order = 2
+  [../]
+  [./rhob]
+    type = ADDerivativeParsedMaterial
+    args = 'w'
+    f_name = rhob
+    material_property_names = 'Vm kb cbeq'
+    function = 'w/Vm^2/kb + cbeq/Vm'
+    derivative_order = 2
+  [../]
+  [./const]
+    type = ADGenericConstantMaterial
+    prop_names =  'kappa_c  kappa   L   D    chi  Vm   ka    caeq kb    cbeq  gab gbb mu'
+    prop_values = '0        1       1.0 1.0  1.0  1.0  10.0  0.1  10.0  0.9   4.5 1.5 1.0'
+  [../]
+  [./Mobility]
+    type = ADDerivativeParsedMaterial
+    f_name = Dchi
+    material_property_names = 'D chi'
+    function = 'D*chi'
+    derivative_order = 2
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = bdf2
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type '
+  petsc_options_value = 'lu     '
+  l_tol = 1.0e-3
+  nl_rel_tol = 1.0e-8
+  nl_abs_tol = 1e-8
+  num_steps = 2
+  [./TimeStepper]
+    type = SolutionTimeAdaptiveDT
+    dt = 0.1
+  [../]
+
+[]
+
+[Outputs]
+  exodus = true
+  file_base = GrandPotentialMultiphase_out
+[]

--- a/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
@@ -15,60 +15,60 @@
 []
 
 [Variables]
-  [./w]
-  [../]
-  [./etaa0]
-  [../]
-  [./etab0]
-  [../]
-  [./etab1]
-  [../]
+  [w]
+  []
+  [etaa0]
+  []
+  [etab0]
+  []
+  [etab1]
+  []
 []
 
 [AuxVariables]
-  [./bnds]
+  [bnds]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [ICs]
 
-  [./IC_etaa0]
+  [IC_etaa0]
     type = FunctionIC
     variable = etaa0
     function = ic_func_etaa0
-  [../]
-  [./IC_etab0]
+  []
+  [IC_etab0]
     type = FunctionIC
     variable = etab0
     function = ic_func_etab0
-  [../]
-  [./IC_etab1]
+  []
+  [IC_etab1]
     type = FunctionIC
     variable = etab1
     function = ic_func_etab1
-  [../]
-  [./IC_w]
+  []
+  [IC_w]
     type = ConstantIC
     value = -0.05
     variable = w
-  [../]
+  []
 []
 
 [Functions]
-  [./ic_func_etaa0]
+  [ic_func_etaa0]
     type = ParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0-tanh((r-10.0)/sqrt(2.0)))'
-  [../]
-  [./ic_func_etab0]
+  []
+  [ic_func_etab0]
     type = ParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0+tanh((y)/sqrt(2.0)))'
-  [../]
-  [./ic_func_etab1]
+  []
+  [ic_func_etab1]
     type = ParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0-tanh((y)/sqrt(2.0)))'
-  [../]
+  []
 []
 
 
@@ -77,186 +77,186 @@
 
 [Kernels]
 # Order parameter eta_alpha0
-  [./ACa0_bulk]
+  [ACa0_bulk]
     type = ADACGrGrMulti
     variable = etaa0
     v =           'etab0 etab1'
     gamma_names = 'gab   gab'
-  [../]
-  [./ACa0_sw]
+  []
+  [ACa0_sw]
     type = ADACSwitching
     variable = etaa0
     Fj_names  = 'omegaa omegab'
     hj_names  = 'ha     hb'
-  [../]
-  [./ACa0_int]
+  []
+  [ACa0_int]
     type = ADACInterface
     variable = etaa0
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./ea0_dot]
+  []
+  [ea0_dot]
     type = ADTimeDerivative
     variable = etaa0
-  [../]
+  []
 # Order parameter eta_beta0
-  [./ACb0_bulk]
+  [ACb0_bulk]
     type = ADACGrGrMulti
     variable = etab0
     v =           'etaa0 etab1'
     gamma_names = 'gab   gbb'
-  [../]
-  [./ACb0_sw]
+  []
+  [ACb0_sw]
     type = ADACSwitching
     variable = etab0
     Fj_names  = 'omegaa omegab'
     hj_names  = 'ha     hb'
-  [../]
-  [./ACb0_int]
+  []
+  [ACb0_int]
     type = ADACInterface
     variable = etab0
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./eb0_dot]
+  []
+  [eb0_dot]
     type = ADTimeDerivative
     variable = etab0
-  [../]
+  []
 # Order parameter eta_beta1
-  [./ACb1_bulk]
+  [ACb1_bulk]
     type = ADACGrGrMulti
     variable = etab1
     v =           'etaa0 etab0'
     gamma_names = 'gab   gbb'
-  [../]
-  [./ACb1_sw]
+  []
+  [ACb1_sw]
     type = ADACSwitching
     variable = etab1
     Fj_names  = 'omegaa omegab'
     hj_names  = 'ha     hb'
-  [../]
-  [./ACb1_int]
+  []
+  [ACb1_int]
     type = ADACInterface
     variable = etab1
     kappa_name = kappa
     variable_L = false
-  [../]
-  [./eb1_dot]
+  []
+  [eb1_dot]
     type = ADTimeDerivative
     variable = etab1
-  [../]
+  []
 #Chemical potential
-  [./w_dot]
+  [w_dot]
     type = ADSusceptibilityTimeDerivative
     variable = w
     f_name = chi
-  [../]
-  [./Diffusion]
+  []
+  [Diffusion]
     type = ADMatDiffusion
     variable = w
     diffusivity = Dchi
-  [../]
-  [./coupled_etaa0dot]
+  []
+  [coupled_etaa0dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etaa0
     Fj_names = 'rhoa rhob'
     hj_names = 'ha   hb'
     args = 'etaa0 etab0 etab1'
-  [../]
-  [./coupled_etab0dot]
+  []
+  [coupled_etab0dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etab0
     Fj_names = 'rhoa rhob'
     hj_names = 'ha   hb'
     args = 'etaa0 etab0 etab1'
-  [../]
-  [./coupled_etab1dot]
+  []
+  [coupled_etab1dot]
     type = ADCoupledSwitchingTimeDerivative
     variable = w
     v = etab1
     Fj_names = 'rhoa rhob'
     hj_names = 'ha   hb'
     args = 'etaa0 etab0 etab1'
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./BndsCalc]
+  [BndsCalc]
     type = BndsCalcAux
     variable = bnds
     execute_on = timestep_end
-  [../]
+  []
 []
 
 # enable_jit set to false in many materials to make this test start up faster.
 # It is recommended to set enable_jit = true or just remove these lines for
 # production runs with this model
 [Materials]
-  [./ha]
+  [ha]
     type = ADSwitchingFunctionMultiPhaseMaterial
     h_name = ha
     all_etas = 'etaa0 etab0 etab1'
     phase_etas = 'etaa0'
-  [../]
-  [./hb]
+  []
+  [hb]
     type = ADSwitchingFunctionMultiPhaseMaterial
     h_name = hb
     all_etas = 'etaa0 etab0 etab1'
     phase_etas = 'etab0 etab1'
-  [../]
-  [./omegaa]
+  []
+  [omegaa]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = omegaa
     material_property_names = 'Vm ka caeq'
     function = '-0.5*w^2/Vm^2/ka-w/Vm*caeq'
     derivative_order = 2
-  [../]
-  [./omegab]
+  []
+  [omegab]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = omegab
     material_property_names = 'Vm kb cbeq'
     function = '-0.5*w^2/Vm^2/kb-w/Vm*cbeq'
     derivative_order = 2
-  [../]
-  [./rhoa]
+  []
+  [rhoa]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = rhoa
     material_property_names = 'Vm ka caeq'
     function = 'w/Vm^2/ka + caeq/Vm'
     derivative_order = 2
-  [../]
-  [./rhob]
+  []
+  [rhob]
     type = ADDerivativeParsedMaterial
     args = 'w'
     f_name = rhob
     material_property_names = 'Vm kb cbeq'
     function = 'w/Vm^2/kb + cbeq/Vm'
     derivative_order = 2
-  [../]
-  [./const]
+  []
+  [const]
     type = ADGenericConstantMaterial
     prop_names =  'kappa_c  kappa   L   D    chi  Vm   ka    caeq kb    cbeq  gab gbb mu'
     prop_values = '0        1       1.0 1.0  1.0  1.0  10.0  0.1  10.0  0.9   4.5 1.5 1.0'
-  [../]
-  [./Mobility]
+  []
+  [Mobility]
     type = ADDerivativeParsedMaterial
     f_name = Dchi
     material_property_names = 'D chi'
     function = 'D*chi'
     derivative_order = 2
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./SMP]
+  [SMP]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -269,10 +269,10 @@
   nl_rel_tol = 1.0e-8
   nl_abs_tol = 1e-8
   num_steps = 2
-  [./TimeStepper]
+  [TimeStepper]
     type = SolutionTimeAdaptiveDT
     dt = 0.1
-  [../]
+  []
 
 []
 

--- a/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/GrandPotentialMultiphase_AD.i
@@ -58,15 +58,15 @@
 
 [Functions]
   [ic_func_etaa0]
-    type = ParsedFunction
+    type = ADParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0-tanh((r-10.0)/sqrt(2.0)))'
   []
   [ic_func_etab0]
-    type = ParsedFunction
+    type = ADParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0+tanh((y)/sqrt(2.0)))'
   []
   [ic_func_etab1]
-    type = ParsedFunction
+    type = ADParsedFunction
     value = 'r:=sqrt(x^2+y^2);0.5*(1.0+tanh((r-10)/sqrt(2.0)))*0.5*(1.0-tanh((y)/sqrt(2.0)))'
   []
 []

--- a/modules/phase_field/test/tests/GrandPotentialPFM/tests
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/tests
@@ -91,4 +91,26 @@
     requirement = 'The system shall provide a Grand Potential based sintering model with ideal '
                   'solution defect free energies'
   []
+
+  [GrandPotentialMultiphase_ad]
+    type = 'Exodiff'
+    input = 'GrandPotentialMultiphase_AD.i'
+    exodiff = 'GrandPotentialMultiphase_out.e'
+    issues = '#15573'
+    design = '/ADACSwitching.md'
+    requirement = 'MOOSE shall provide a Grand Potential based multiphase model with AD option'
+  []
+
+  [ADGrandPotentialMultiphase_jac]
+    type = 'PetscJacobianTester'
+    input = 'GrandPotentialMultiphase_AD.i'
+    allow_test_objects = true
+    run_sim = 'True'
+    cli_args = 'Outputs/exodus=false Executioner/num_steps=1'
+    ratio_tol = 1e-7
+    difference_tol = 1e-4
+    issues = '#15573'
+    design = '/ADAllenCahn.md'
+    requirement = 'The Jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
+  []
 []

--- a/modules/phase_field/test/tests/GrandPotentialPFM/tests
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/tests
@@ -104,13 +104,12 @@
   [ADGrandPotentialMultiphase_jac]
     type = 'PetscJacobianTester'
     input = 'GrandPotentialMultiphase_AD.i'
-    allow_test_objects = true
     run_sim = 'True'
     cli_args = 'Outputs/exodus=false Executioner/num_steps=1'
     ratio_tol = 1e-7
     difference_tol = 1e-4
     issues = '#15573'
     design = '/ADAllenCahn.md'
-    requirement = 'The Jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
+    requirement = 'The jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
   []
 []

--- a/modules/phase_field/test/tests/GrandPotentialPFM/tests
+++ b/modules/phase_field/test/tests/GrandPotentialPFM/tests
@@ -97,7 +97,7 @@
     input = 'GrandPotentialMultiphase_AD.i'
     exodiff = 'GrandPotentialMultiphase_out.e'
     issues = '#15573'
-    design = '/ADACSwitching.md'
+    design = '/ACSwitching.md /CoupledSwitchingTimeDerivative.md'
     requirement = 'MOOSE shall provide a Grand Potential based multiphase model with AD option'
   []
 
@@ -109,7 +109,7 @@
     ratio_tol = 1e-7
     difference_tol = 1e-4
     issues = '#15573'
-    design = '/ADAllenCahn.md'
+    design = '/ACSwitching.md /CoupledSwitchingTimeDerivative.md'
     requirement = 'The jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
   []
 []

--- a/modules/phase_field/test/tests/phase_field_kernels/ADnonuniform_barrier_coefficient.i
+++ b/modules/phase_field/test/tests/phase_field_kernels/ADnonuniform_barrier_coefficient.i
@@ -1,0 +1,197 @@
+# This material tests the kernels ACBarrierFunction and ACKappaFunction for a
+# multiphase system.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  nx = 20
+  ny = 20
+  xmin = -200
+  xmax = 200
+  ymin = -200
+  ymax = 200
+  uniform_refine = 0
+[]
+
+[Variables]
+  [./gr0]
+  [../]
+  [./gr1]
+  [../]
+[]
+
+[ICs]
+  [./gr0_IC]
+    type = BoundingBoxIC
+    variable = gr0
+    x1 = -80
+    y1 = -80
+    x2 = 80
+    y2 = 80
+    inside = 0
+    outside = 1
+  [../]
+  [./gr1_IC]
+    type = BoundingBoxIC
+    variable = gr1
+    x1 = -80
+    y1 = -80
+    x2 = 80
+    y2 = 80
+    inside = 1
+    outside = 0
+  [../]
+[]
+
+[Materials]
+  [./constants]
+    type = ADGenericConstantMaterial
+    prop_names =  'L   gamma E0 E1'
+    prop_values = '0.1 1.5   3  1'
+  [../]
+  [./h0]
+    type = ADDerivativeParsedMaterial
+    f_name = h0
+    args = 'gr0 gr1'
+    function = 'gr0^2 / (gr0^2 + gr1^2)'
+    derivative_order = 2
+  [../]
+  [./h1]
+    type = ADDerivativeParsedMaterial
+    f_name = h1
+    args = 'gr0 gr1'
+    function = 'gr1^2 / (gr0^2 + gr1^2)'
+    derivative_order = 2
+  [../]
+  [./mu]
+    type = ADDerivativeParsedMaterial
+    f_name = mu
+    args = 'gr0 gr1'
+    constant_names = 'mag'
+    constant_expressions = '16'
+    function = 'mag * (gr0^2 * gr1^2 + 0.1)'
+    derivative_order = 2
+  [../]
+  [./kappa]
+    type = ADDerivativeParsedMaterial
+    f_name = kappa
+    args = 'gr0 gr1'
+    material_property_names = 'h0(gr0,gr1) h1(gr0,gr1)'
+    constant_names = 'mag0 mag1'
+    constant_expressions = '200 100'
+    function = 'h0*mag0 + h1*mag1'
+    derivative_order = 2
+  [../]
+[]
+
+[Kernels]
+  [./gr0_time]
+    type = ADTimeDerivative
+    variable = gr0
+  [../]
+  [./gr0_interface]
+    type = ADACInterface
+    variable = gr0
+    args = 'gr1'
+    mob_name = L
+    kappa_name = 'kappa'
+    variable_L = false
+  [../]
+  [./gr0_switching]
+    type = ADACSwitching
+    variable = gr0
+    hj_names = 'h0 h1'
+    Fj_names = 'E0 E1'
+    mob_name = L
+  [../]
+  [./gr0_multi]
+    type = ADACGrGrMulti
+    variable = gr0
+    v = 'gr1'
+    mob_name = L
+    gamma_names = 'gamma'
+  [../]
+  [./gr0_barrier]
+    type = ADACBarrierFunction
+    variable = gr0
+    mob_name = L
+    gamma = gamma
+    v = 'gr1'
+  [../]
+  [./gr0_kappa]
+    type = ADACKappaFunction
+    variable = gr0
+    mob_name = L
+    kappa_name = kappa
+    v = 'gr1'
+  [../]
+
+  [./gr1_time]
+    type = ADTimeDerivative
+    variable = gr1
+  [../]
+  [./gr1_interface]
+    type = ADACInterface
+    variable = gr1
+    args = 'gr0'
+    mob_name = L
+    kappa_name = 'kappa'
+    variable_L = false
+  [../]
+  [./gr1_switching]
+    type = ADACSwitching
+    variable = gr1
+    hj_names = 'h0 h1'
+    Fj_names = 'E0 E1'
+    mob_name = L
+  [../]
+  [./gr1_multi]
+    type = ADACGrGrMulti
+    variable = gr1
+    v = 'gr0'
+    mob_name = L
+    gamma_names = 'gamma'
+  [../]
+  [./gr1_barrier]
+    type = ADACBarrierFunction
+    variable = gr1
+    mob_name = L
+    gamma = gamma
+    v = 'gr0'
+  [../]
+  [./gr1_kappa]
+    type = ADACKappaFunction
+    variable = gr1
+    mob_name = L
+    kappa_name = kappa
+    v = 'gr0'
+  [../]
+[]
+
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = bdf2
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type '
+  petsc_options_value = ' lu     '
+  nl_max_its = 20
+  l_max_its = 30
+  l_tol = 1e-4
+  nl_rel_tol = 1e-12
+  nl_abs_tol = 1e-12
+  start_time = 0
+  num_steps = 3
+  dt = 1
+[]
+
+[Outputs]
+  exodus = true
+  file_base = nonuniform_barrier_coefficient_out
+[]

--- a/modules/phase_field/test/tests/phase_field_kernels/tests
+++ b/modules/phase_field/test/tests/phase_field_kernels/tests
@@ -200,4 +200,27 @@
     design = '/ACBarrierFunction.md'
     requirement = 'The system shall verify that the barrier height and gradient energy parameter must be permitted to depend on non-linear variables.'
   [../]
+
+  [./nonuniform_barrier_coefficient_AD]
+    type = 'Exodiff'
+    #prereq = 'nonuniform_barrier_coefficient'
+    input = 'ADnonuniform_barrier_coefficient.i'
+    exodiff = 'nonuniform_barrier_coefficient_out.e'
+    issues = '#15573'
+    design = '/ADACBarrierFunction.md /ADACKappaFunction.md'
+    requirement = 'MOOSE shall have AD examples where the barrier height and gradient energy parameter depend on non-linear variables'
+  [../]
+
+  [./ADnonuniform_barrier_coefficient-jac]
+    type = 'PetscJacobianTester'
+    input = 'ADnonuniform_barrier_coefficient.i'
+    allow_test_objects = true
+    run_sim = 'True'
+    cli_args = 'Outputs/exodus=false Executioner/num_steps=1'
+    ratio_tol = 1e-7
+    difference_tol = 2e-4
+    issues = '#15573'
+    design = '/ADACBarrierFunction.md /ADACKappaFunction.md'
+    requirement = 'The Jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
+  [../]
 []

--- a/modules/phase_field/test/tests/phase_field_kernels/tests
+++ b/modules/phase_field/test/tests/phase_field_kernels/tests
@@ -203,24 +203,22 @@
 
   [./nonuniform_barrier_coefficient_AD]
     type = 'Exodiff'
-    #prereq = 'nonuniform_barrier_coefficient'
     input = 'ADnonuniform_barrier_coefficient.i'
     exodiff = 'nonuniform_barrier_coefficient_out.e'
     issues = '#15573'
-    design = '/ADACBarrierFunction.md /ADACKappaFunction.md'
+    design = '/ACBarrierFunction.md /ACKappaFunction.md'
     requirement = 'MOOSE shall have AD examples where the barrier height and gradient energy parameter depend on non-linear variables'
   [../]
 
   [./ADnonuniform_barrier_coefficient-jac]
     type = 'PetscJacobianTester'
     input = 'ADnonuniform_barrier_coefficient.i'
-    allow_test_objects = true
     run_sim = 'True'
     cli_args = 'Outputs/exodus=false Executioner/num_steps=1'
     ratio_tol = 1e-7
     difference_tol = 2e-4
     issues = '#15573'
-    design = '/ADACBarrierFunction.md /ADACKappaFunction.md'
+    design = '/ACBarrierFunction.md /ACKappaFunction.md'
     requirement = 'The Jacobian for the AD Allen-Cahn problem with a variable dependent coeffecients shall be perfect'
   [../]
 []


### PR DESCRIPTION
- Converting the kernels and materials associated with the grand potential phase field model to AD
- Using the `<is_ad>` templating 

Addresses #15573 