### PR TITLE
Remove unneeded _type parameter 

### DIFF
--- a/framework/include/base/Registry.h
+++ b/framework/include/base/Registry.h
@@ -284,6 +284,5 @@ InputParameters
 RegistryEntry<T>::buildParameters()
 {
   auto params = T::validParams();
-  params.template set<std::string>("_type") = _classname;
   return params;
 }


### PR DESCRIPTION
PR #24225 introduced the `_type` parameter into the JSON syntax dump and thus makes it pop up as a valid autocomplete option. However the parameter must not be set by a user. This should fix that. Tag @brandonlangley 

Refs #24218