### PR TITLE
Optimizations for getExtraIDUniqueCombinationMap

### DIFF
--- a/framework/include/utils/MooseMeshUtils.h
+++ b/framework/include/utils/MooseMeshUtils.h
@@ -200,7 +200,7 @@ computeFaceInfoFaceCoord(FaceInfo & fi,
  * @param extra_ids extra ids
  * @return map of element id to new extra id
  **/
-std::map<dof_id_type, dof_id_type>
+std::unordered_map<dof_id_type, dof_id_type>
 getExtraIDUniqueCombinationMap(const MeshBase & mesh,
                                const std::set<SubdomainID> & block_ids,
                                std::vector<ExtraElementIDName> extra_ids);

--- a/framework/include/vectorpostprocessors/ExtraIDIntegralVectorPostprocessor.h
+++ b/framework/include/vectorpostprocessors/ExtraIDIntegralVectorPostprocessor.h
@@ -41,7 +41,7 @@ protected:
   /// Number of extra IDs in use
   const unsigned int _n_extra_id;
   // Map of element ids to parsed vpp ids
-  std::map<dof_id_type, dof_id_type> _unique_vpp_ids;
+  std::unordered_map<dof_id_type, dof_id_type> _unique_vpp_ids;
   /// Vectors holding extra IDs
   std::vector<VectorPostprocessorValue *> _var_extra_ids;
   /// Coupled MOOSE variables to be integrated

--- a/framework/src/meshgenerators/UniqueExtraIDMeshGenerator.C
+++ b/framework/src/meshgenerators/UniqueExtraIDMeshGenerator.C
@@ -50,8 +50,7 @@ UniqueExtraIDMeshGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
   std::set<SubdomainID> block_ids = {Moose::ANY_BLOCK_ID};
-  std::map<dof_id_type, dof_id_type> parsed_ids =
-      MooseMeshUtils::getExtraIDUniqueCombinationMap(*mesh, block_ids, _extra_ids);
+  auto parsed_ids = MooseMeshUtils::getExtraIDUniqueCombinationMap(*mesh, block_ids, _extra_ids);
 
   // override the extra ID values from MooseMeshUtils::getExtraIDUniqueCombinationMap by using
   // new_id_rule

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -291,12 +291,12 @@ getExtraIDUniqueCombinationMap(const MeshBase & mesh,
     }
     return parsed_ids;
   }
+
   // if extra_ids is not empty, recursively call getExtraIDUniqueCombinationMap
   const auto base_parsed_ids =
       MooseMeshUtils::getExtraIDUniqueCombinationMap(mesh, block_ids, extra_ids);
   // parsing extra ids based on ref_parsed_ids
   std::vector<std::pair<dof_id_type, dof_id_type>> unique_ids;
-  std::map<std::pair<dof_id_type, dof_id_type>, std::set<const Elem *>> map_unique_id_to_elem;
   {
     std::set<std::pair<dof_id_type, dof_id_type>> unique_ids_set;
     for (const auto & elem : mesh.active_element_ptr_range())
@@ -307,7 +307,6 @@ getExtraIDUniqueCombinationMap(const MeshBase & mesh,
       const dof_id_type id2 = elem->get_extra_integer(id_index);
       const std::pair<dof_id_type, dof_id_type> ids = std::make_pair(id1, id2);
       unique_ids_set.insert(ids);
-      map_unique_id_to_elem[ids].insert(elem);
     }
     mesh.comm().set_union(unique_ids_set);
     unique_ids.assign(unique_ids_set.begin(), unique_ids_set.end());
@@ -315,13 +314,18 @@ getExtraIDUniqueCombinationMap(const MeshBase & mesh,
 
   std::unordered_map<dof_id_type, dof_id_type> parsed_ids;
 
-  for (const auto & [ids, elements] : map_unique_id_to_elem)
+  for (const auto & elem : mesh.active_element_ptr_range())
   {
+    if (block_restricted && block_ids.find(elem->subdomain_id()) == block_ids.end())
+      continue;
+    const dof_id_type id1 = libmesh_map_find(base_parsed_ids, elem->id());
+    const dof_id_type id2 = elem->get_extra_integer(id_index);
     const dof_id_type new_id = std::distance(
-        unique_ids.begin(), std::lower_bound(unique_ids.begin(), unique_ids.end(), ids));
-    for (const Elem * elem : elements)
-      parsed_ids[elem->id()] = new_id;
+        unique_ids.begin(),
+        std::lower_bound(unique_ids.begin(), unique_ids.end(), std::make_pair(id1, id2)));
+    parsed_ids[elem->id()] = new_id;
   }
+
   return parsed_ids;
 }
 

--- a/modules/reactor/src/meshgenerators/DepletionIDGenerator.C
+++ b/modules/reactor/src/meshgenerators/DepletionIDGenerator.C
@@ -53,8 +53,7 @@ DepletionIDGenerator::generate()
                "'is not defined in input mesh!");
   id_names.push_back(_material_id_name);
   const std::set<SubdomainID> block_ids = {Moose::ANY_BLOCK_ID};
-  std::map<dof_id_type, dof_id_type> parsed_ids =
-      MooseMeshUtils::getExtraIDUniqueCombinationMap(*mesh, block_ids, id_names);
+  auto parsed_ids = MooseMeshUtils::getExtraIDUniqueCombinationMap(*mesh, block_ids, id_names);
   // re-numbering if exclude_id_name is used
   if (isParamValid("exclude_id_name") && isParamValid("exclude_id_value"))
   {


### PR DESCRIPTION
- Convert to vector before performing std::distance. And then use `std::lower_bound` on the vector find
- Use `std::unordered_map` instead of `std::map`
- Prefer map find over map insertion at end of routine

Refs #25074