### PR TITLE
Remove average plane-poiseuille test

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/test.py
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/test.py
@@ -58,20 +58,6 @@ class TestPlanePoiseuilleRC(unittest.TestCase):
             print("%s, %f" % (key, value))
             self.assertTrue(fuzzyAbsoluteEqual(value, 2., .1))
 
-class TestPlanePoiseuilleAverageFirst(unittest.TestCase):
-    def test(self):
-        labels = ['L2u', 'L2v', 'L2p']
-        df1 = run_spatial('plane-poiseuille-flow.i', 7, "velocity_interp_method='average'", 'two_term_boundary_expansion=false', "--error", "--error-unused", y_pp=labels, mpi=16)
-
-        fig = mms.ConvergencePlot(xlabel='Element Size ($h$)', ylabel='$L_2$ Error')
-        fig.plot(df1, label=labels, marker='o', markersize=8, num_fitted_points=3, slope_precision=1)
-        fig.save('plane-poiseuille-average-first.png')
-        for key,value in fig.label_to_slope.items():
-            if key == 'L2p':
-                self.assertTrue(fuzzyAbsoluteEqual(value, 1., .1))
-            else:
-                self.assertTrue(fuzzyAbsoluteEqual(value, 2., .1))
-
 class TestPlanePoiseuilleRCFirst(unittest.TestCase):
     def test(self):
         labels = ['L2u', 'L2v', 'L2p']

--- a/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/ins/mms/channel-flow/tests
@@ -39,16 +39,6 @@
     min_parallel = 16
     heavy = true
   []
-  [plane-poiseuille-average-first]
-    type = PythonUnitTest
-    input = test.py
-    test_case = TestPlanePoiseuilleAverageFirst
-    method = '!dbg'
-    required_python_packages = 'pandas matplotlib'
-    min_parallel = 16
-    heavy = true
-    requirement = 'The system shall demonstrate global second order convergence for all variables when using an average interpolation for the velocity and a one term Taylor series expansion for face values on non-Dirichlet boundaries.'
-  []
   [plane-poiseuille-rc-first]
     type = PythonUnitTest
     input = test.py


### PR DESCRIPTION
We test average interpolation in many other places and we still have the Plane Poiseuille verification test with Rhie-Chow

Closes #25103

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
