### PR TITLE
Initial working commit

### DIFF
--- a/apptainer/app.def
+++ b/apptainer/app.def
@@ -146,7 +146,8 @@ From: {{ APPTAINER_FROM }}
 {%- if SECTION_POST_PRE_MAKEINSTALL is defined %}
     {{ SECTION_POST_PRE_MAKEINSTALL }}
 {%- endif %}
-    make install -j ${MOOSE_JOBS} MOOSE_SKIP_DOCS=${MOOSE_SKIP_DOCS} MOOSE_DOCS_FLAGS="${MOOSE_DOCS_FLAGS}" METHOD=${METHOD}
+    make install -j ${MOOSE_JOBS} MOOSE_SKIP_DOCS=${MOOSE_SKIP_DOCS} \
+    MOOSE_DOCS_FLAGS="${MOOSE_DOCS_FLAGS}" METHOD=${METHOD}
 {%- if SECTION_POST_POST_MAKEINSTALL is defined %}
     {{ SECTION_POST_POST_MAKEINSTALL }}
 {%- endif %}
@@ -188,7 +189,7 @@ From: {{ APPTAINER_FROM }}
     BINARY_NAME={{ BINARY_NAME }}
 {%- endif %}
     METHOD={{ METHOD or "opt" }}
-    TEST_DIRS={{ TEST_DIRS or "tests" }}
+    TEST_DIRS='{{ TEST_DIRS or "tests" }}'
 
     # Temp location for copying and running in
     TEMP_LOC=$(mktemp -u -d /tmp/${BINARY_NAME}test.XXXXXX)

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -122,12 +122,20 @@ EOF
     # Add PBS wrapper scripts
     cat << 'EOF' > /usr/local/bin/qsub
 #!/bin/bash
-ssh -q ${PBS_HOST} "source /etc/profile; qsub $*"
+if [[ -n "${PBS_HOST}" ]]; then
+    ssh -q ${PBS_HOST} "source /etc/profile; qsub $*"
+else
+    printf "PBS_HOST not set\n"
+fi
 EOF
     chmod 755 /usr/local/bin/qsub
     cat << 'EOF' > /usr/local/bin/qstat
 #!/bin/bash
-ssh -q ${PBS_HOST} "source /etc/profile; qstat $*"
+if [[ -n "${PBS_HOST}" ]]; then
+    ssh -q ${PBS_HOST} "source /etc/profile; qstat $*"
+else
+    printf "PBS_HOST not set\n"
+fi
 EOF
     chmod 755 /usr/local/bin/qstat
 

--- a/apptainer/mpich.def
+++ b/apptainer/mpich.def
@@ -119,6 +119,18 @@ export MOOSE_MPI_DIR=${MOOSE_OPENMPI_DIR}
 ${USE_MPI_SCRIPT}
 EOF
 
+    # Add PBS wrapper scripts
+    cat << 'EOF' > /usr/local/bin/qsub
+#!/bin/bash
+ssh -q ${PBS_HOST} "source /etc/profile; qsub $*"
+EOF
+    chmod 755 /usr/local/bin/qsub
+    cat << 'EOF' > /usr/local/bin/qstat
+#!/bin/bash
+ssh -q ${PBS_HOST} "source /etc/profile; qstat $*"
+EOF
+    chmod 755 /usr/local/bin/qstat
+
     # Clean Up
     rm -rf ${TEMP_LOC}
     dnf clean all

--- a/python/TestHarness/schedulers/QueueManager.py
+++ b/python/TestHarness/schedulers/QueueManager.py
@@ -190,17 +190,20 @@ class QueueManager(Scheduler):
     def getRunTestsCommand(self, job, cpus):
         """ return the command necessary to launch the TestHarness within the third party scheduler """
 
-        # Build ['/path/to/run_tests', '-j', '#']
-        command = [os.path.join(self.harness.run_tests_dir, 'run_tests'),
-                   '-j', str(cpus)]
+        # Determine if we are running test from a relocatable binary
+        if "RELOCATED" in self.options._checks['installation_type']:
+            # Build ['/path/to/moose_app-method', '--run']
+            command = [job.getSpecs()['executable'], '--run']
+        else:
+            # Build ['/path/to/run_tests']
+            command = [os.path.join(self.harness.run_tests_dir, 'run_tests')]
 
         # get current sys.args we are allowed to include when we launch run_tests
         args = list(self.cleanAndModifyArgs())
 
-        # Build [<args>, '--spec-file' ,/path/to/tests', '-o', '/path/to', '--sep-files']
-        args.extend(['--spec-file',
-                     os.path.join(job.getTestDir(),
-                     self.options.input_file_name),
+        # Extend required args
+        args.extend(['-j', str(cpus),
+                     '--spec-file', os.path.join(job.getTestDir(), self.options.input_file_name),
                      '-o', job.getTestDir(),
                      '--sep-files'])
 

--- a/python/TestHarness/schedulers/RunPBS.py
+++ b/python/TestHarness/schedulers/RunPBS.py
@@ -7,7 +7,7 @@
 #* Licensed under LGPL 2.1, please see LICENSE for details
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
-import os, sys, re, json
+import os, sys, json
 from QueueManager import QueueManager
 from TestHarness import util # to execute qsub
 import math # to compute node requirement
@@ -169,6 +169,10 @@ class RunPBS(QueueManager):
 
         # Command
         template['command'] = ' '.join(self.getRunTestsCommand(job, template['mpi_procs']))
+
+        # Use Apptainer if detected
+        if os.getenv('APPTAINER_NAME'):
+            template['use_apptainer'] = os.getenv('APPTAINER_NAME', '')
 
         return template
 

--- a/python/TestHarness/schedulers/pbs_template
+++ b/python/TestHarness/schedulers/pbs_template
@@ -7,10 +7,33 @@
 #PBS -j oe
 #PBS -o <OUTPUT>
 #PBS -l place=free
-<PRE_COMMAND>
 JOB_NUM=${PBS_JOBID%\.*}
-
 export MV2_ENABLE_AFFINITY=0
 
-cd <WORKING_DIR>
-<COMMAND>
+export MOOSE_COMMAND="cd <WORKING_DIR>; <COMMAND>"
+
+# --pbs-pre-source:
+<PRE_COMMAND>
+
+if [ -n "<USE_APPTAINER>" ]; then
+    if [ -z "${APPTAINER_URI}" ]; then
+      printf "Unknown Apptainer whereabouts. Cannot continue.
+Please use --pbs-pre-source to source some file that will establish
+necessary Apptainer variables.
+
+Missing APPTAINER_URI, where APPTAINER_URI satisfies the following
+funtionality:
+
+    apptainer exec \${APPTAINER_URI}\n\n"
+      exit 1
+    fi
+    if [ -z "${APPTAINER_BINDPATH}" ]; then
+        printf "Warning: No APPTAINER_BINDPATH detected. Perhaps you do not need them?\n"
+    fi
+    # TestHarness influential Apptainer environment variables
+    export APPTAINERENV_MOOSE_STAGE='loopback'
+    export APPTAINERENV_PBS_NODEFILE=${PBS_NODEFILE}
+    export APPTAINERENV_APPTAINER_URI=${APPTAINER_URI}
+    export MOOSE_COMMAND="apptainer exec --containall ${APPTAINER_URI} \"${MOOSE_COMMAND}\""
+fi
+eval ${MOOSE_COMMAND}

--- a/python/TestHarness/schedulers/pbs_template
+++ b/python/TestHarness/schedulers/pbs_template
@@ -17,7 +17,7 @@ export MOOSE_COMMAND="cd <WORKING_DIR>; <COMMAND>"
 
 if [ -n "<USE_APPTAINER>" ]; then
     if [ -z "${APPTAINER_URI}" ]; then
-      printf "Unknown Apptainer whereabouts. Cannot continue.
+        printf "Unknown Apptainer whereabouts. Cannot continue.
 Please use --pbs-pre-source to source some file that will establish
 necessary Apptainer variables.
 
@@ -25,13 +25,13 @@ Missing APPTAINER_URI, where APPTAINER_URI satisfies the following
 funtionality:
 
     apptainer exec \${APPTAINER_URI}\n\n"
-      exit 1
+        exit 1
     fi
     if [ -z "${APPTAINER_BINDPATH}" ]; then
         printf "Warning: No APPTAINER_BINDPATH detected. Perhaps you do not need them?\n"
     fi
     # TestHarness influential Apptainer environment variables
-    export APPTAINERENV_MOOSE_STAGE='loopback'
+    export APPTAINERENV_MOOSE_STAGE='2'
     export APPTAINERENV_PBS_NODEFILE=${PBS_NODEFILE}
     export APPTAINERENV_APPTAINER_URI=${APPTAINER_URI}
     export MOOSE_COMMAND="apptainer exec --containall ${APPTAINER_URI} \"${MOOSE_COMMAND}\""

--- a/python/TestHarness/testers/RunApp.py
+++ b/python/TestHarness/testers/RunApp.py
@@ -74,9 +74,10 @@ class RunApp(Tester):
         being made, and thus this method can be brittle (see pbs_template for influential
         environment variables being set/made use of).
         """
+        # Assume Stage 1
         command = False
         # Stage 2: in container and trying to run an MPI process on a binary
-        if os.getenv('MOOSE_STAGE') == 'loopback':
+        if str(os.getenv('MOOSE_STAGE')) == '2':
             source = ''
             if options.queue_source_command:
                 source = f'source {options.queue_source_command}; '

--- a/python/TestHarness/tests/test_PBS.py
+++ b/python/TestHarness/tests/test_PBS.py
@@ -10,14 +10,10 @@
 import subprocess, unittest, os
 from TestHarnessTestCase import TestHarnessTestCase
 
-def checkQstat():
-    try:
-        if subprocess.call(['qstat']) == 0:
-            return True
-    except:
-        pass
+def checkPBS_HOST():
+    return os.getenv('PBS_HOST', False)
 
-@unittest.skipIf(checkQstat() != True, "PBS not available")
+@unittest.skipIf(checkPBS_HOST() == False, "PBS not available")
 class TestHarnessTester(TestHarnessTestCase):
     """
     Test general PBS functionality. There are some caveats however:


### PR DESCRIPTION
To use/test on Sawtooth:

```bash
module load use.moose
module load moosetainer
```

Create a source file which will function to load the above modules when QSUB launches on nodes:

```pre
$ cat my_apptainer_env.sh
source /etc/profile
export MOOSE_COMMAND=${MOOSE_COMMAND:-"null"}
module load use.moose openmpi
module load moosetainer
```

Then be sure to tell TestHarness to source this file while using pbs options:

```bash
./run_tests --pbs alltests --pbs-pre-source /abs/path/to/my_apptainer_env.sh
```

Closes #25038
