### PR TITLE
Ensure that coupling matrix gets set for all nonlinear systems

### DIFF
--- a/framework/include/preconditioners/MoosePreconditioner.h
+++ b/framework/include/preconditioners/MoosePreconditioner.h
@@ -17,6 +17,7 @@
 // Libmesh include
 #include "libmesh/preconditioner.h"
 #include "libmesh/linear_solver.h"
+#include "libmesh/coupling_matrix.h"
 
 // Forward declarations
 class FEProblemBase;
@@ -51,6 +52,9 @@ public:
                             NumericVector<Number> & to_vector);
 
 protected:
+  /// Setup the coupling matrix on the finite element problem
+  void setCouplingMatrix(std::unique_ptr<CouplingMatrix> cm);
+
   /// Subproblem this preconditioner is part of
   FEProblemBase & _fe_problem;
 };

--- a/framework/src/preconditioners/FieldSplitPreconditioner.C
+++ b/framework/src/preconditioners/FieldSplitPreconditioner.C
@@ -78,7 +78,7 @@ FieldSplitPreconditioner::FieldSplitPreconditioner(const InputParameters & param
       for (unsigned int j = 0; j < n_vars; j++)
         (*cm)(i, j) = 1; // full coupling
   }
-  _fe_problem.setCouplingMatrix(std::move(cm));
+  setCouplingMatrix(std::move(cm));
 
   // turn on a flag
   _nl.useFieldSplitPreconditioner(true);

--- a/framework/src/preconditioners/FiniteDifferencePreconditioner.C
+++ b/framework/src/preconditioners/FiniteDifferencePreconditioner.C
@@ -88,7 +88,7 @@ FiniteDifferencePreconditioner::FiniteDifferencePreconditioner(const InputParame
         (*cm)(i, j) = 1;
   }
 
-  _fe_problem.setCouplingMatrix(std::move(cm));
+  setCouplingMatrix(std::move(cm));
 
   bool implicit_geometric_coupling = getParam<bool>("implicit_geometric_coupling");
 

--- a/framework/src/preconditioners/MoosePreconditioner.C
+++ b/framework/src/preconditioners/MoosePreconditioner.C
@@ -13,6 +13,7 @@
 #include "PetscSupport.h"
 #include "NonlinearSystem.h"
 
+#include "libmesh/coupling_matrix.h"
 #include "libmesh/numeric_vector.h"
 
 InputParameters
@@ -123,5 +124,18 @@ MoosePreconditioner::copyVarValues(MeshBase & mesh,
 
       to_vector.set(to_dof, from_vector(from_dof));
     }
+  }
+}
+
+void
+MoosePreconditioner::setCouplingMatrix(std::unique_ptr<CouplingMatrix> cm)
+{
+  for (const auto i : make_range(_fe_problem.numNonlinearSystems()))
+  {
+    if (i == libMesh::cast_int<unsigned int>(_fe_problem.numNonlinearSystems() - 1))
+      // This is the last nonlinear system, so it's safe now to move the object
+      _fe_problem.setCouplingMatrix(std::move(cm), i);
+    else
+      _fe_problem.setCouplingMatrix(std::make_unique<CouplingMatrix>(*cm), i);
   }
 }

--- a/framework/src/preconditioners/PhysicsBasedPreconditioner.C
+++ b/framework/src/preconditioners/PhysicsBasedPreconditioner.C
@@ -95,7 +95,7 @@ PhysicsBasedPreconditioner::PhysicsBasedPreconditioner(const InputParameters & p
           (*cm)(i, j) = 1;
     }
 
-    _fe_problem.setCouplingMatrix(std::move(cm));
+    setCouplingMatrix(std::move(cm));
   }
 
   // PC types

--- a/framework/src/preconditioners/SingleMatrixPreconditioner.C
+++ b/framework/src/preconditioners/SingleMatrixPreconditioner.C
@@ -96,13 +96,7 @@ SingleMatrixPreconditioner::SingleMatrixPreconditioner(const InputParameters & p
         (*cm)(i, j) = 1;
   }
 
-  for (const auto i : make_range(_fe_problem.numNonlinearSystems()))
-  {
-    if (i == libMesh::cast_int<unsigned int>(_fe_problem.numNonlinearSystems() - 1))
-      _fe_problem.setCouplingMatrix(std::move(cm), i);
-    else
-      _fe_problem.setCouplingMatrix(std::make_unique<CouplingMatrix>(*cm), i);
-  }
+  setCouplingMatrix(std::move(cm));
   if (getParam<bool>("trust_my_coupling"))
     _fe_problem.trustUserCouplingMatrix();
 }

--- a/framework/src/preconditioners/VariableCondensationPreconditioner.C
+++ b/framework/src/preconditioners/VariableCondensationPreconditioner.C
@@ -181,7 +181,7 @@ VariableCondensationPreconditioner::VariableCondensationPreconditioner(
         (*cm)(i, j) = 1;
   }
 
-  _fe_problem.setCouplingMatrix(std::move(cm));
+  setCouplingMatrix(std::move(cm));
 
   _nl.attachPreconditioner(this);
 }


### PR DESCRIPTION
When using our "monolithic" preconditioning block. This should be controlled on a per-nonlinear system level if using custom executors/executioners

Refs idaholab/moose#22226