### PR TITLE
Avoid ambiguous subdomain when stitching in test

### DIFF
--- a/modules/reactor/test/tests/meshgenerators/tri_pin_hex_assemby_generator/dummy_core.i
+++ b/modules/reactor/test/tests/meshgenerators/tri_pin_hex_assemby_generator/dummy_core.i
@@ -38,6 +38,7 @@
     ring_intervals = '1 1;1 1;1 1'
     ring_block_ids = '200 400;200 400;200 400'
     background_block_ids = '40'
+    background_block_names = 'background_1'
     num_sectors_per_side = 14
     background_intervals = 2
     hexagon_size = ${fparse 40.0/sqrt(3.0)}


### PR DESCRIPTION
## Reason

This is all in service of catching bugs like in #25070, via https://github.com/libMesh/libmesh/pull/3613

## Design

libMesh stitch_meshes is going to start handling MOOSE "subdomain names are first-class objects, ids might be just autogenerated" behavior safely, in addition to the old libMesh "subdomain ids are first-class objects, names are just expected to be matching" behavior.  But in between those categories of case is "one submesh may be treating names as first-class objects, another submesh has a matching id without any name", and we can't figure out any safe thing to do there, so by default now we'll scream and die when we see it.

So we definitely don't want to see it in CI.

## Impact

No impact from this PR, except that we'll be able to merge the libMesh PR.

As of the next libMesh submodule update, if any downstream users have similar ambiguous cases, they'll need to apply a similar fix.