### PR TITLE
Avoid "unused variable 'id'" with g++ 9.4

### DIFF
--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -900,7 +900,10 @@ MooseMesh::getElemIDMapping(const std::string & from_id_name, const std::string 
     id_map[elem->get_extra_integer(id1)].insert(elem->get_extra_integer(id2));
 
   for (auto & [id, ids] : id_map)
+  {
+    libmesh_ignore(id); // avoid overzealous gcc 9.4 unused var warning
     comm().set_union(ids);
+  }
 
   return id_map;
 }


### PR DESCRIPTION
See https://civet.inl.gov/job/1687661/ for an example.

Refs #25119; this fixes a compatibility issue introduced in #25120
