### PR TITLE
Address bug fix with dummy assembly in first position of CoreMeshGene…

### DIFF
--- a/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
+++ b/modules/reactor/doc/content/source/meshgenerators/CoreMeshGenerator.md
@@ -30,8 +30,8 @@ Users may be interested in defining metadata to represent the reactor geometry a
 
 At the core level, the following metadata is defined on the output mesh:
 
-- `assembly_names`: Mesh generator names of constituent assemblies in lattice
-- `lattice`: 2-D lattice of assemblies in core, where each location represents the 0-based index of the assembly in the list of names under the `assembly_names` metadata entry.
+- `assembly_names`: Mesh generator names of input assemblies in lattice, similar to input parameter (/Mesh/CoreMeshGenerator/inputs) but with the dummy assembly name excluded
+- `lattice`: 2-D lattice of assemblies in core, where each location represents the 0-based index of the assembly in the list of names under the `assembly_names` metadata entry. A -1 entry represents a dummy assembly.
 
 For each of the assemblies listed in `assembly_names`, the assembly-level metadata is also displayed. In addition, if any of these assemblies are comprised of pins in a lattice, the pin-level metadata of these constituent pins is also displayed. A list of assembly-level and pin-level metadata defined on the core mesh can be found in [AssemblyMeshGenerator](AssemblyMeshGenerator.md) and [PinMeshGenerator](PinMeshGenerator.md) respectively.
 

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex_extra_assemblies.i
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/core_hex_extra_assemblies.i
@@ -1,0 +1,133 @@
+[Mesh]
+  [rmp]
+    type = ReactorMeshParams
+    dim = 3
+    geom = "Hex"
+    assembly_pitch = 7.10315
+    radial_boundary_id = 200
+    top_boundary_id = 201
+    bottom_boundary_id = 202
+    axial_regions = '1.0 1.0'
+    axial_mesh_intervals = '1 1'
+  []
+
+  [pin1]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 1
+    pitch = 1.42063
+    num_sectors = 2
+    ring_radii = 0.2
+    duct_halfpitch = 0.68
+    mesh_intervals = '1 1 1'
+    quad_center_elements = false
+    region_ids = '11 12 13; 111 112 113'
+    block_names = 'P1_R11 P1_R12 P1_R13; P1_R111 P1_R112 P1_R113'
+  []
+
+  [pin2]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 2
+    pitch = 1.42063
+    num_sectors = 2
+    quad_center_elements = false
+    mesh_intervals = 1
+    region_ids = '21; 121'
+    block_names = 'P2_R21; P2_R121'
+  []
+
+  [pin3]
+    type = PinMeshGenerator
+    reactor_params = rmp
+    pin_type = 3
+    pitch = 1.42063
+    num_sectors = 2
+    ring_radii = '0.3818'
+    mesh_intervals = '1 1'
+    quad_center_elements = false
+    region_ids = '31 32; 131 132'
+    block_names = 'P3_R31 P3_R32; P3_R131 P3_R132'
+  []
+
+  [amg1]
+    type = AssemblyMeshGenerator
+    assembly_type = 1
+    inputs = 'pin2'
+    pattern='  0   0;
+             0   0   0;
+               0   0'
+    background_intervals = 1
+    background_region_id = '41 141'
+    background_block_name = 'A1_R41 A1_R141'
+  []
+
+  [amg2]
+    type = AssemblyMeshGenerator
+    assembly_type = 2
+    inputs = 'pin1 pin3'
+    pattern = '0 0;
+              0 1 0;
+               0 0'
+    background_region_id = '51 151'
+    background_block_name = 'A2_R51 A2_R151'
+    background_intervals = 1
+    duct_region_ids = '52; 152'
+    duct_block_names = 'A2_R52; A2_R152'
+    duct_halfpitch = '3.5'
+    duct_intervals = '1'
+  []
+
+  [amg3]
+    type = AssemblyMeshGenerator
+    assembly_type = 3
+    inputs = 'pin1 pin3'
+    pattern = '0 0;
+              0 1 0;
+               0 0'
+    background_region_id = '51 151'
+    background_block_name = 'A2_R51 A2_R151'
+    background_intervals = 1
+    duct_region_ids = '52; 152'
+    duct_block_names = 'A2_R52; A2_R152'
+    duct_halfpitch = '3.5'
+    duct_intervals = '1'
+  []
+
+
+  [cmg]
+    type = CoreMeshGenerator
+    inputs = 'amg1 amg2 empty amg3'
+    dummy_assembly_name = empty
+    pattern = '2 1;
+              1 0 2;
+               2 1'
+    show_rgmb_metadata = true
+    extrude = true
+  []
+
+  [rotate90]
+    type = TransformGenerator
+    input = cmg
+    transform = ROTATE
+    vector_value = '0 0 90'
+  []
+[]
+
+[Problem]
+  solve = false
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  [out]
+    type = Exodus
+    execute_on = timestep_end
+    output_extra_element_ids = true
+    extra_element_ids_to_output = 'assembly_id assembly_type_id plane_id pin_id pin_type_id region_id'
+  []
+  file_base = core_in
+[]

--- a/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
+++ b/modules/reactor/test/tests/meshgenerators/core_mesh_generator/tests
@@ -14,7 +14,7 @@
     type = 'RunApp'
     input = 'core_square.i'
     cli_args = "Mesh/cmg/show_rgmb_metadata=true"
-    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Square.+axial_mesh_sizes: 1.+axial_mesh_intervals: 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2.+assembly_lattice:.+0, 1.+1, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin3, pin1, pin2.+pin_lattice:.+0, 1.+1, 2.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 2.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 4.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
+    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Square.+axial_mesh_sizes: 1.+axial_mesh_intervals: 1.+Core-level metadata.+cmg.+assembly_names: amg2, amg1.+assembly_lattice:.+1, 0.+0, 1.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin3, pin1, pin2.+pin_lattice:.+0, 1.+1, 2.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 4.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 2'
   []
   [core_shared_assembly_ids]
     requirement = 'The system shall throw an error if a core is composed of different assemblies with a shared assembly type id'
@@ -60,6 +60,25 @@
     exodiff = 'core_empty_in.e'
     recover = false
   []
+  [empty_first_pos]
+    requirement = 'The system shall generate a 3D square core mesh with empty lattice positions defined as the first input name'
+    type = 'Exodiff'
+    input = 'core_square.i'
+    cli_args = "Mesh/cmg/inputs='empty amg1 amg2'
+                Mesh/cmg/pattern='0 1; 1 2'
+                Outputs/file_base=core_empty_in"
+    exodiff = 'core_empty_in.e'
+    recover = false
+  []
+  [err_all_empty]
+    requirement = 'The system shall throw an error if all input assembly names are defined as dummy assemblies'
+    type = 'RunException'
+    input = 'core_square.i'
+    cli_args = "Mesh/cmg/inputs='empty'
+                Mesh/cmg/pattern='0 0; 0 0'"
+    expect_err = 'At least one non-dummy assembly must be defined'
+    recover = false
+  []
   [hex]
     requirement = 'The system shall generate a 3D hexagonal core mesh with empty lattice positions and explicit block name specification'
     type = 'Exodiff'
@@ -74,7 +93,7 @@
     input = 'core_hex.i'
     cli_args = "Mesh/cmg/show_rgmb_metadata=true
                 Outputs/file_base=core_hex_in"
-    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Hex.+axial_mesh_sizes: 1, 1.+axial_mesh_intervals: 1, 1.+Core-level metadata.+cmg.+assembly_names: amg2, amg1.+assembly_lattice:.+-1, 0.+0, 1, -1.+-1, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 12, 112.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 32, 132.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 21, 121'
+    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Hex.+axial_mesh_sizes: 1, 1.+axial_mesh_intervals: 1, 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2.+assembly_lattice:.+-1, 1.+1, 0, -1.+-1, 1.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 21, 121.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 12, 112.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 32, 132'
   []
   [single_assembly_square_core]
     requirement = 'The system shall generate a full 3D square core mesh with 2 single assembly types'
@@ -149,6 +168,12 @@
     input = 'core_hex_2d.i'
     cli_args = "Mesh/cmg/show_rgmb_metadata=true"
     expect_out = 'Global metadata.+mesh_dimensions: 2.+mesh_geometry: Hex.+Core-level metadata.+cmg.+peripheral_ring_radius: 7.+peripheral_ring_region_id: 5.+assembly_names: amg1.+assembly_lattice:.+0, 0.+0, 0, 0.+0, 0.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin1.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 2'
+  []
+  [hex_metadata_extra_assemblies]
+    requirement = 'The system shall print out reactor-related metadata to console output for a 3D hexagonal core mesh with extra assemblies not part of core lattice'
+    type = 'RunApp'
+    input = 'core_hex_extra_assemblies.i'
+    expect_out = 'Global metadata.+mesh_dimensions: 3.+mesh_geometry: Hex.+axial_mesh_sizes: 1, 1.+axial_mesh_intervals: 1, 1.+Core-level metadata.+cmg.+assembly_names: amg1, amg2, amg3.+assembly_lattice:.+-1, 1.+1, 0, -1.+-1, 1.+Assembly-level metadata.+amg1.+assembly_type: 1.+pin_names: pin2.+pin_lattice:.+0, 0.+0, 0, 0.+0, 0.+Assembly-level metadata.+amg2.+assembly_type: 2.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Assembly-level metadata.+amg3.+assembly_type: 3.+pin_names: pin1, pin3.+pin_lattice:.+0, 0.+0, 1, 0.+0, 0.+Pin-level metadata.+pin2.+pin_type: 2.+background_region_id: 21, 121.+Pin-level metadata.+pin1.+pin_type: 1.+background_region_id: 12, 112.+Pin-level metadata.+pin3.+pin_type: 3.+background_region_id: 32, 132'
   []
   [ptmg_periphery]
     requirement = 'The system shall generate a 2D hex core mesh with a reactor periphery meshed using a triangular mesh.'


### PR DESCRIPTION
refs ##25197

This PR also addresses a bug fix reported by @NamjaeChoi where metadata information needed by CoreMeshGenerator is assumed to come from the first input assembly, which will not work if the first assembly is a dummy assembly