### PR TITLE
Remove Thermochimica API string comparisons

### DIFF
--- a/modules/chemical_reactions/include/actions/ChemicalCompositionAction.h
+++ b/modules/chemical_reactions/include/actions/ChemicalCompositionAction.h
@@ -44,9 +44,9 @@ public:
     return _tokenized_phase_elements;
   }
 
-  const std::string & outputSpeciesUnit() const { return _output_mass_unit; }
+  const MooseEnum & outputSpeciesUnit() const { return _output_mass_unit; }
 
-  const std::string & reinitializationType() const { return _reinit; }
+  const MooseEnum & reinitializationType() const { return _reinit; }
 
   virtual void act();
 
@@ -75,7 +75,7 @@ protected:
   std::vector<std::string> _species;
 
   /// Mass unit for output species
-  std::string _output_mass_unit;
+  MooseEnum _output_mass_unit;
 
   /// List of element chemical potentials to be extracted from Thermochimica
   std::vector<std::string> _element_potentials;
@@ -87,7 +87,7 @@ protected:
   std::vector<std::string> _element_phases;
 
   /// Flag for whether Thermochimica should use the reinit feature or not
-  std::string _reinit;
+  MooseEnum _reinit;
 
   /// Name of the ThermochimicaNodalData UO to be set up
   std::string _uo_name;

--- a/modules/chemical_reactions/include/userobjects/ThermochimicaNodalData.h
+++ b/modules/chemical_reactions/include/userobjects/ThermochimicaNodalData.h
@@ -74,7 +74,7 @@ protected:
   std::vector<unsigned int> _el_ids;
 
   // re-initialization data
-  const std::string _reinit;
+  const enum class ReinitializationType { NONE, TIME, NODE } _reinit;
 
   const std::vector<std::string> & _ph_names;
   const std::vector<std::string> & _element_potentials;
@@ -107,5 +107,5 @@ protected:
   std::vector<MooseVariable *> _el_ph;
 
   /// Mass unit for output species
-  std::string _output_mass_unit;
+  const enum class OutputMassUnit { MOLES, FRACTION } _output_mass_unit;
 };

--- a/modules/chemical_reactions/src/actions/ChemicalCompositionAction.C
+++ b/modules/chemical_reactions/src/actions/ChemicalCompositionAction.C
@@ -64,7 +64,7 @@ ChemicalCompositionAction::validParams()
   params.addParam<std::vector<std::string>>("output_phases", "List of phases to be output");
   params.addParam<std::vector<std::string>>(
       "output_species", "List species for which concentration in the phases is needed");
-  MooseEnum mUnit_op("mole_fraction moles", "moles");
+  MooseEnum mUnit_op("moles mole_fraction", "moles");
   params.addParam<MooseEnum>(
       "output_species_unit", mUnit_op, "Mass unit for output species: mole_fractions or moles");
   params.addParam<std::vector<std::string>>(


### PR DESCRIPTION
Refs #25216.

This just switches from string comparisons for `_reinit` and `_output_mass_unit` in `ThermochimicaNodalData` to enum classes.
