### PR TITLE
Increase flixibility in setting and storing petsc options.

### DIFF
--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -13,6 +13,7 @@
 
 // MOOSE includes
 #include "MultiMooseEnum.h"
+#include "SolverParams.h"
 
 #include "libmesh/petsc_macro.h"
 #include "libmesh/linear_solver.h"
@@ -52,7 +53,7 @@ public:
 /**
  * A function for setting the PETSc options in PETSc from the options supplied to MOOSE
  */
-void petscSetOptions(FEProblemBase & problem);
+void petscSetOptions(const PetscOptions & po, const SolverParams & solver_params);
 
 /**
  * Set the default options for a KSP

--- a/framework/include/utils/PetscSupport.h
+++ b/framework/include/utils/PetscSupport.h
@@ -96,6 +96,24 @@ PetscErrorCode petscLinearMonitor(KSP /*ksp*/, PetscInt its, PetscReal rnorm, vo
 void storePetscOptions(FEProblemBase & fe_problem, const InputParameters & params);
 
 /**
+ * Populate flags in a given PetscOptions object using a vector of input arguments
+ * @param petsc_flags Container holding the flags of the petsc options
+ * @param petsc_options Data structure which handles petsc options within moose
+ */
+void processPetscFlags(const MultiMooseEnum & petsc_flags, PetscOptions & petsc_options);
+
+/**
+ * Populate name and value pairs in a given PetscOptions object using vectors of input arguments
+ * @param petsc_pair_options Option-value pairs of petsc settings
+ * @param mesh_dimension The mesh dimension, needed for multigrid settings
+ * @param petsc_options Data structure which handles petsc options within moose
+ */
+void
+processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & petsc_pair_options,
+                  const unsigned int mesh_dimension,
+                  PetscOptions & petsc_options);
+
+/**
  * Returns the valid petsc line search options as a set of strings
  */
 std::set<std::string> getPetscValidLineSearches();

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -5594,7 +5594,8 @@ FEProblemBase::solve(const unsigned int nl_sys_num)
     _displaced_problem->clearAllDofIndices();
 
 #if PETSC_RELEASE_LESS_THAN(3, 12, 0)
-  Moose::PetscSupport::petscSetOptions(*this); // Make sure the PETSc options are setup for this app
+  Moose::PetscSupport::petscSetOptions(
+      _petsc_options, _solver_params); // Make sure the PETSc options are setup for this app
 #else
   // Now this database will be the default
   // Each app should have only one database
@@ -5603,7 +5604,7 @@ FEProblemBase::solve(const unsigned int nl_sys_num)
   // We did not add PETSc options to database yet
   if (!_is_petsc_options_inserted)
   {
-    Moose::PetscSupport::petscSetOptions(*this);
+    Moose::PetscSupport::petscSetOptions(_petsc_options, _solver_params);
     _is_petsc_options_inserted = true;
   }
 #endif

--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -135,7 +135,7 @@ stringify(const MffdType & t)
 }
 
 void
-setSolverOptions(SolverParams & solver_params)
+setSolverOptions(const SolverParams & solver_params)
 {
   // set PETSc options implied by a solve type
   switch (solver_params._type)
@@ -235,25 +235,22 @@ addPetscOptionsFromCommandline()
 }
 
 void
-petscSetOptions(FEProblemBase & problem)
+petscSetOptions(const PetscOptions & po, const SolverParams & solver_params)
 {
-  // Reference to the options stored in FEPRoblem
-  PetscOptions & petsc = problem.getPetscOptions();
-
 #if PETSC_VERSION_LESS_THAN(3, 7, 0)
   PetscOptionsClear();
 #else
   PetscOptionsClear(LIBMESH_PETSC_NULLPTR);
 #endif
 
-  setSolverOptions(problem.solverParams());
+  setSolverOptions(solver_params);
 
   // Add any additional options specified in the input file
-  for (const auto & flag : petsc.flags)
+  for (const auto & flag : po.flags)
     setSinglePetscOption(flag.rawName().c_str());
 
   // Add option pairs
-  for (auto & option : petsc.pairs)
+  for (auto & option : po.pairs)
     setSinglePetscOption(option.first, option.second);
 
   addPetscOptionsFromCommandline();

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -491,7 +491,8 @@ setEigenSolverOptions(SolverParams & solver_params, const InputParameters & para
 void
 slepcSetOptions(EigenProblem & eigen_problem, const InputParameters & params)
 {
-  Moose::PetscSupport::petscSetOptions(eigen_problem);
+  Moose::PetscSupport::petscSetOptions(eigen_problem.getPetscOptions(),
+                                       eigen_problem.solverParams());
   // Call "SolverTolerances" first, so some solver specific tolerance such as "eps_max_it"
   // can be overriden
   setSlepcEigenSolverTolerances(eigen_problem, params);


### PR DESCRIPTION
Refs #22356

Attempt to make these routines more flexible to set separate petsc options for different systems in segregated solver executioners.