### PR TITLE
Secant method for LAROMANCE model

### DIFF
--- a/modules/tensor_mechanics/include/materials/LAROMANCEStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/LAROMANCEStressUpdateBase.h
@@ -60,12 +60,18 @@ protected:
                                              const GenericReal<is_ad> & scalar);
 
   virtual GenericReal<is_ad>
+  initialGuess(const GenericReal<is_ad> & effective_trial_stress) override
+  {
+    return _compute_derivative ? 0.0 : 0.1 * effective_trial_stress / this->_three_shear_modulus;
+  }
+
+  virtual GenericReal<is_ad>
   computeDerivative(const GenericReal<is_ad> & /*effective_trial_stress*/,
                     const GenericReal<is_ad> & /*scalar*/) override
   {
     if (_compute_derivative)
       return _derivative;
-    mooseError("No derivative will be computed use the SECANT solve type");
+    mooseError("No derivative will be computed, use the SECANT solve type");
   }
 
   virtual void

--- a/modules/tensor_mechanics/include/materials/LAROMANCEStressUpdateBase.h
+++ b/modules/tensor_mechanics/include/materials/LAROMANCEStressUpdateBase.h
@@ -55,11 +55,17 @@ protected:
   virtual GenericReal<is_ad> computeResidual(const GenericReal<is_ad> & effective_trial_stress,
                                              const GenericReal<is_ad> & scalar) override;
 
+  template <bool with_derivative>
+  GenericReal<is_ad> computeResidualInternal(const GenericReal<is_ad> & effective_trial_stress,
+                                             const GenericReal<is_ad> & scalar);
+
   virtual GenericReal<is_ad>
   computeDerivative(const GenericReal<is_ad> & /*effective_trial_stress*/,
                     const GenericReal<is_ad> & /*scalar*/) override
   {
-    return _derivative;
+    if (_compute_derivative)
+      return _derivative;
+    mooseError("No derivative will be computed use the SECANT solve type");
   }
 
   virtual void
@@ -644,6 +650,9 @@ protected:
 
   /// JSON object constructed from the datafile
   nlohmann::json _json;
+
+  /// compute serivative (for Newton solve type_)
+  const bool _compute_derivative;
 
   using Material::_dt;
   using Material::_name;

--- a/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
@@ -197,6 +197,9 @@ private:
   /// Whether to output iteration information all the time (regardless of whether iterations converge)
   const bool _internal_solve_full_iteration_history;
 
+  /// Solution update threshold below which the iterations are terminated
+  Real _deltax_tolerance;
+
   /// Relative convergence tolerance
   Real _relative_tolerance;
 

--- a/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
+++ b/modules/tensor_mechanics/include/materials/SingleVariableReturnMappingSolution.h
@@ -31,6 +31,12 @@ public:
   virtual ~SingleVariableReturnMappingSolutionTempl() {}
 
 protected:
+  enum class SolveType
+  {
+    NEWTON,
+    SECANT
+  } _solve_type;
+
   /**
    * Perform the return mapping iterations
    * @param effective_trial_stress Effective trial stress
@@ -235,6 +241,9 @@ private:
   SolveState internalSolve(const GenericReal<is_ad> effective_trial_stress,
                            GenericReal<is_ad> & scalar,
                            std::stringstream * iter_output = nullptr);
+  SolveState internalSecantSolve(const GenericReal<is_ad> effective_trial_stress,
+                                 GenericReal<is_ad> & scalar,
+                                 std::stringstream * iter_output = nullptr);
 
   /**
    * Check to see whether the residual is within acceptable convergence limits.

--- a/modules/tensor_mechanics/src/materials/LAROMANCEStressUpdateBase.C
+++ b/modules/tensor_mechanics/src/materials/LAROMANCEStressUpdateBase.C
@@ -801,6 +801,8 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::computeResidualInternal(
                                             ? _stress_function->value(_t, _q_point[_qp])
                                             : effective_trial_stress * _stress_ucf;
   GenericReal<is_ad> dtrial_stress_dscalar = 0.0;
+  if constexpr (!with_derivative)
+    libmesh_ignore(dtrial_stress_dscalar);
 
   // Update stress if strain is being applied, i.e. non-testing simulation
   if (this->_apply_strain)
@@ -831,6 +833,8 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::computeResidualInternal(
 
   GenericReal<is_ad> total_rom_effective_strain_inc = 0.0;
   GenericReal<is_ad> dtotal_rom_effective_strain_inc_dstress = 0.0;
+  if constexpr (!with_derivative)
+    libmesh_ignore(dtotal_rom_effective_strain_inc_dstress);
 
   // Run ROM if all values are within windows.
   for (unsigned int p = 0; p < _num_partitions; p++)
@@ -933,8 +937,6 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::computeResidualInternal(
   }
 
   _creep_rate[_qp] = total_rom_effective_strain_inc / _dt;
-  if constexpr (with_derivative)
-    _derivative = dtotal_rom_effective_strain_inc_dstress * dtrial_stress_dscalar - 1.0;
 
   if (!this->_apply_strain)
   {
@@ -944,6 +946,12 @@ LAROMANCEStressUpdateBaseTempl<is_ad>::computeResidualInternal(
       _derivative = 1.0;
     return 0.0;
   }
+  else
+  {
+    if constexpr (with_derivative)
+      _derivative = dtotal_rom_effective_strain_inc_dstress * dtrial_stress_dscalar - 1.0;
+  }
+
   return total_rom_effective_strain_inc - scalar;
 }
 

--- a/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
+++ b/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
@@ -353,11 +353,12 @@ SingleVariableReturnMappingSolutionTempl<is_ad>::internalSecantSolve(
   GenericReal<is_ad> fbk = fbk0;
 
   // iterate
-  unsigned int k = 0;
+  _iteration = 0; // (k)
   while (true)
   {
     if (iter_output)
-      *iter_output << "a_k,b_k = " << ak << ',' << bk << '\n';
+      *iter_output << "a_k,b_k = " << ak << ',' << bk << " f(a_k),f(b_k) = " << fak << ' ' << fbk
+                   << '\n';
 
     mooseAssert(fbk != fak, "Division by zero in secant update");
     const auto ck = (ak * fbk - bk * fak) / (fbk - fak);
@@ -372,24 +373,30 @@ SingleVariableReturnMappingSolutionTempl<is_ad>::internalSecantSolve(
     if (std::abs(ak - bk) < _absolute_tolerance)
     {
       scalar = ak;
+      _residual = fak;
+      _initial_residual = fak0;
       return SolveState::SUCCESS;
     }
 
     if (std::abs(fak0 * _relative_tolerance) > std::abs(fak) || std::abs(fak) < _absolute_tolerance)
     {
       scalar = ak;
+      _residual = fak;
+      _initial_residual = fak0;
       return SolveState::SUCCESS;
     }
     if (std::abs(fbk0 * _relative_tolerance) > std::abs(fbk) || std::abs(fbk) < _absolute_tolerance)
     {
       scalar = bk;
+      _residual = fbk;
+      _initial_residual = fbk0;
       return SolveState::SUCCESS;
     }
 
-    if (k == _max_its)
+    if (_iteration == _max_its)
       return SolveState::EXCEEDED_ITERATIONS;
 
-    k++;
+    _iteration++;
     fak = computeResidual(effective_trial_stress, ak);
     fbk = computeResidual(effective_trial_stress, bk);
   }

--- a/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
+++ b/modules/tensor_mechanics/src/materials/SingleVariableReturnMappingSolution.C
@@ -344,8 +344,7 @@ SingleVariableReturnMappingSolutionTempl<is_ad>::internalSecantSolve(
   auto ak = initialGuess(effective_trial_stress);
   auto bk = initialGuess(0.0);
   if (ak == bk)
-    // mooseError("The update model must return a non-zero initialGuess!");
-    bk = ak + 1.0;
+    mooseError("The update model must return a non-zero initialGuess!");
 
   const auto fak0 = computeResidual(effective_trial_stress, ak);
   const auto fbk0 = computeResidual(effective_trial_stress, bk);


### PR DESCRIPTION
Closes #25208

This also adds an option to the LAROMANCE model to _not_ compute the return mapping gradient. Preliminary tests show that the SECANT solve without derivatives is ~20% faster for the SS model in TM tests. Not a huge improvement, but something to investigate further with other LAROMANCE models.