### PR TITLE
Skip test which only works in_tree

### DIFF
--- a/conda/moose/build.sh
+++ b/conda/moose/build.sh
@@ -26,8 +26,10 @@ mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
 export PATH=\${PATH}:${PREFIX}/moose/bin
 export MOOSE_BIN=${PREFIX}/moose/bin/moose
+export MOOSE_ADFPARSER_JIT_INCLUDE=\${CONDA_PREFIX}/moose/include/moose/ADRealMonolithic.h
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
 export PATH=\${PATH%":${PREFIX}/moose/bin"}
 unset MOOSE_BIN
+unset MOOSE_ADFPARSER_JIT_INCLUDE
 EOF

--- a/conda/moose/build.sh
+++ b/conda/moose/build.sh
@@ -26,7 +26,7 @@ mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
 export PATH=\${PATH}:${PREFIX}/moose/bin
 export MOOSE_BIN=${PREFIX}/moose/bin/moose
-export MOOSE_ADFPARSER_JIT_INCLUDE=\${CONDA_PREFIX}/moose/include/moose/ADRealMonolithic.h
+export MOOSE_ADFPARSER_JIT_INCLUDE=${PREFIX}/moose/include/moose/ADRealMonolithic.h
 EOF
 cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
 export PATH=\${PATH%":${PREFIX}/moose/bin"}

--- a/conda/moose/run_test.sh
+++ b/conda/moose/run_test.sh
@@ -28,6 +28,10 @@ PLACEHOLDER='tests'
 if [[ $(uname) == Darwin ]]; then
     PLACEHOLDER=''
 fi
+
+# Do not halt on the first failed test. We want a log of all of them
+set +e
+
 for ACTUAL in ${ACTUALS[@]}; do
     printf "Working on ${ACTUAL}...\n"
     combined-opt --copy-inputs ${ACTUAL}

--- a/modules/combined/test/tests/invOpt_nonlinear/tests
+++ b/modules/combined/test/tests/invOpt_nonlinear/tests
@@ -14,6 +14,8 @@
     max_threads = 1
     valgrind = none
     recover = false
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [Newton]
     detail = " matrix free hessian and Newton algorithm"
@@ -25,5 +27,7 @@
     cli_args = "Executioner/tao_solver=taonls"
     max_threads = 1
     recover = false
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/contact/test/tests/mortar_restart/tests
+++ b/modules/contact/test/tests/mortar_restart/tests
@@ -25,5 +25,7 @@
     prereq = 'frictional_bouncing_block_action_restart_1'
     valgrind = 'heavy'
     method = '!dbg'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/electromagnetics/test/tests/bcs/reflectionBC_helmholtz/tests
+++ b/modules/electromagnetics/test/tests/bcs/reflectionBC_helmholtz/tests
@@ -6,5 +6,7 @@
     requirement = 'The system shall be able to simulate the field result of an incoming wave reflected on a biased surface and properly absorb the reflected wave in a boundary condition.'
     design = 'EMRobinBC.md'
     issues = '#21098'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/electromagnetics/test/tests/benchmarks/waveguide2D/tests
+++ b/modules/electromagnetics/test/tests/benchmarks/waveguide2D/tests
@@ -7,6 +7,8 @@
     design = 'ADMatReaction.md EMRobinBC.md benchmarks/WaveguideTransmission.md'
     verification = 'benchmarks/WaveguideTransmission.md'
     issues = '#21098'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [absorbing_error]
     type = 'RunException'

--- a/modules/electromagnetics/test/tests/kernels/scalar_complex_helmholtz/tests
+++ b/modules/electromagnetics/test/tests/kernels/scalar_complex_helmholtz/tests
@@ -7,5 +7,7 @@
     requirement = 'The system shall be capable of modeling the Helmholtz equation for scalar complex field variables, where real/imaginary coupling occurs for both the diffusion and reaction terms and coefficient values vary spatially.'
     design = 'FunctionDiffusion.md ADMatReaction.md ADMatCoupledForce.md'
     issues = '#13744'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/fsi/test/tests/2d-finite-strain-steady/tests
+++ b/modules/fsi/test/tests/2d-finite-strain-steady/tests
@@ -9,5 +9,7 @@
     method = '!dbg'
     valgrind = 'none'
     rel_err = 1e-4
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/optimization/test/tests/executioners/steady_and_adjoint/tests
+++ b/modules/optimization/test/tests/executioners/steady_and_adjoint/tests
@@ -33,6 +33,8 @@
       input = nonlinear_diffusion.i
       exodiff = nonlinear_diffusion_out.e
       detail = 'have non-linear material properties.'
+      # skip test if test is being run out-of-tree. Issue Ref: #25279
+      installation_type = in_tree
     []
   []
 []

--- a/modules/optimization/test/tests/executioners/transient_and_adjoint/tests
+++ b/modules/optimization/test/tests/executioners/transient_and_adjoint/tests
@@ -21,6 +21,8 @@
       input = nonlinear_diffusivity.i
       csvdiff = 'nonlinear_diffusivity_forward.csv nonlinear_diffusivity_adjoint.csv'
       detail = 'have non-linear steady-state material properties, and'
+      # skip test if test is being run out-of-tree. Issue Ref: #25279
+      installation_type = in_tree
     []
     [nonuniform_tstep]
       type = CSVDiff

--- a/modules/optimization/test/tests/optimizationreporter/nonlinear_material/tests
+++ b/modules/optimization/test/tests/optimizationreporter/nonlinear_material/tests
@@ -9,5 +9,7 @@
     max_threads = 1 # Optimize executioner does not support multiple threads
     recover = False
     requirement = 'The system shall be able perform inverse source optimization on a problem with nonlinear material properties using automatically computed adjoint.'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/phase_field/test/tests/ad_coupled_gradient_dot/tests
+++ b/modules/phase_field/test/tests/ad_coupled_gradient_dot/tests
@@ -9,5 +9,7 @@
     requirement = 'The phase field module shall be able to compute the gradient of the rate of the '
                   'variable using automatic differentiation.'
     valgrind = HEAVY
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []

--- a/modules/phase_field/test/tests/anisotropic_interfaces/tests
+++ b/modules/phase_field/test/tests/anisotropic_interfaces/tests
@@ -10,5 +10,7 @@
     exodiff = 'adkobayashi_out.e'
     custom_cmp = 'adkobayashi.exodiff'
     valgrind = HEAVY
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   [../]
 []

--- a/modules/tensor_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
+++ b/modules/tensor_mechanics/test/tests/ad_viscoplasticity_stress_update/tests
@@ -61,6 +61,8 @@
     input = 'lps_single.i'
     csvdiff = 'lps_single_out.csv'
     requirement = 'The ADViscoplasticityStressUpdate class shall compute the viscoplastic response using a single model with LPS spherical formulation that increases the porosity due to an external strain.'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   [../]
   [./lps_single-jac]
     type = 'PetscJacobianTester'
@@ -78,6 +80,8 @@
     input = 'lps_single_split.i'
     csvdiff = 'lps_single_split_out.csv'
     requirement = 'The ADViscoplasticityStressUpdate class shall compute the viscoplastic response using two LPS models with spherical formulations and the same stress exponential that is close to combining the models into a single ADViscoplasticityStressUpdate instance.'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   [../]
   [./lps_single_split-jac]
     type = 'PetscJacobianTester'
@@ -95,6 +99,8 @@
     input = 'lps_dual.i'
     csvdiff = 'lps_dual_out.csv'
     requirement = 'The ADViscoplasticityStressUpdate class shall compute the viscoplastic response using two LPS models with spherical formulations and two different stress exponents that increases the porosity due to an external strain.'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   [../]
   [./lps_dual-jac]
     type = 'PetscJacobianTester'
@@ -112,6 +118,8 @@
     input = 'gtn_single.i'
     csvdiff = 'gtn_single_out.csv'
     requirement = 'The ADViscoplasticityStressUpdate class shall compute the viscoplastic response using a single model with GTN formulation that increases the porosity due to an external strain.'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   [../]
   [./gtn_single-jac]
     type = 'PetscJacobianTester'
@@ -132,6 +140,8 @@
       csvdiff = 'negative_porosity_zero_out.csv'
       cli_args = 'Outputs/file_base=negative_porosity_zero_out Materials/lps/negative_behavior=ZERO'
       detail = 'by setting the porosity to zero.'
+      # skip test if test is being run out-of-tree. Issue Ref: #25279
+      installation_type = in_tree
     []
     [initial]
       type = CSVDiff
@@ -139,6 +149,8 @@
       csvdiff = 'negative_porosity_initial_out.csv'
       cli_args = 'Outputs/file_base=negative_porosity_initial_out Materials/lps/negative_behavior=INITIAL_CONDITION'
       detail = 'by setting the porosity to the initial condition.'
+      # skip test if test is being run out-of-tree. Issue Ref: #25279
+      installation_type = in_tree
     []
     [exception]
       type = RunException
@@ -146,6 +158,8 @@
       expect_err = 'porosity is negative'
       cli_args = 'Materials/lps/negative_behavior=EXCEPTION'
       detail = 'by throwing an exception.'
+      # skip test if test is being run out-of-tree. Issue Ref: #25279
+      installation_type = in_tree
     []
   []
 []


### PR DESCRIPTION
Skip the following test, if being tested out-of-tree. Added reference to the issue where this test should have been included with the rest.

This should fix the Conda MOOSE (ARM Mac) target on next.

Closes #25293

