### PR TITLE
Skip tests based on microarchitecture

### DIFF
--- a/python/TestHarness/TestHarness.py
+++ b/python/TestHarness/TestHarness.py
@@ -250,6 +250,7 @@ class TestHarness:
 
         checks = {}
         checks['platform'] = util.getPlatforms()
+        checks['machine'] = util.getMachine()
         checks['submodules'] = util.getInitializedSubmodules(self.run_tests_dir)
         checks['exe_objects'] = None # This gets calculated on demand
         checks['registered_apps'] = None # This gets extracted on demand

--- a/python/TestHarness/testers/Tester.py
+++ b/python/TestHarness/testers/Tester.py
@@ -49,6 +49,7 @@ class Tester(MooseObject):
 
         # Test Filters
         params.addParam('platform',      ['ALL'], "A list of platforms for which this test will run on. ('ALL', 'DARWIN', 'LINUX', 'SL', 'LION', 'ML')")
+        params.addParam('machine',       ['ALL'], "A list of micro architectures for which this test will run on. ('ALL', 'X86_64', 'ARM64')")
         params.addParam('compiler',      ['ALL'], "A list of compilers for which this test is valid on. ('ALL', 'GCC', 'INTEL', 'CLANG')")
         params.addParam('petsc_version', ['ALL'], "A list of petsc versions for which this test will run on, supports normal comparison operators ('<', '>', etc...)")
         params.addParam('petsc_version_release', ['ALL'], "A test that runs against PETSc master if FALSE ('ALL', 'TRUE', 'FALSE')")
@@ -559,7 +560,7 @@ class Tester(MooseObject):
             reasons['libtorch_version'] = 'using libtorch ' + str(checks['libtorch_version']) + ' REQ: ' + libtorch_version
 
         # PETSc and SLEPc is being explicitly checked above
-        local_checks = ['platform', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk',
+        local_checks = ['platform', 'machine', 'compiler', 'mesh_mode', 'method', 'library_mode', 'dtk',
                         'unique_ids', 'vtk', 'tecplot', 'petsc_debug', 'curl', 'superlu', 'mumps',
                         'strumpack', 'cxx11', 'asio', 'unique_id', 'slepc', 'petsc_version_release',
                         'boost', 'fparser_jit', 'parmetis', 'chaco', 'party', 'ptscotch',

--- a/python/TestHarness/tests/test_MachineType.py
+++ b/python/TestHarness/tests/test_MachineType.py
@@ -1,0 +1,44 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import os, sys, io
+import unittest
+import mock
+import TestHarness
+from contextlib import redirect_stdout
+
+class TestHarnessTester(unittest.TestCase):
+    @mock.patch.object(TestHarness.util, 'getMachine')
+    def mocked_output(self, mocked, expect_fail, mocked_return):
+        MOOSE_DIR = os.getenv('MOOSE_DIR')
+        os.chdir(f'{MOOSE_DIR}/test')
+        out = io.StringIO()
+        with redirect_stdout(out):
+            mocked_return.return_value=mocked
+            harness = TestHarness.TestHarness(['', '-i', 'always_ok', '-c'], MOOSE_DIR)
+            if expect_fail:
+                with self.assertRaises(SystemExit):
+                    harness.findAndRunTests()
+            else:
+                harness.findAndRunTests()
+        return out.getvalue()
+
+    def testNotSkipped(self):
+        """
+        Test should not be skipped, as it is set to run on any arch (ALL)
+        """
+        out = self.mocked_output(set(['ALL']), False)
+        self.assertRegex(out, r'.*?OK.*?always_ok')
+
+    def testSkipped(self):
+        """
+        Test that a non existing machine type is skipped (remove default of ALL)
+        """
+        out = self.mocked_output(set(['']), False)
+        self.assertRegex(out, r'.*?SKIP.*?always_ok.*?MACHINE!=ALL')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -281,4 +281,10 @@
     requirement = "The system shall skip tests not capable of being run depending on binary installation type"
     issues = '#24195'
   []
+  [test_machine_type]
+    type = PythonUnitTest
+    input = test_MachineType.py
+    requirement = "The system shall skip tests not capable of being run depending on micro architecture"
+    issues = '#25317'
+  []
 []

--- a/python/TestHarness/util.py
+++ b/python/TestHarness/util.py
@@ -382,6 +382,11 @@ def getPlatforms():
         platforms.add(raw_uname[0].upper())
     return platforms
 
+def getMachine():
+    machine = set(['ALL'])
+    machine.add(platform.machine().upper())
+    return machine
+
 def runExecutable(libmesh_dir, location, bin, args):
     # Installed location of libmesh executable
     libmesh_installed   = libmesh_dir + '/' + location + '/' + bin


### PR DESCRIPTION
Allow the TestHarness to skip tests based on micro architecture.

Ref: #25294, as it was determined ARM64 fails to run certain tests. It may be best to skip these tests based on `machine` rather than `installation_type`. Or perhaps we leave it alone for now.

Either way, this may become a useful feature in the TestHarness.

Closes #25317
