### PR TITLE
Xfem speed-up

### DIFF
--- a/modules/xfem/include/base/XFEM.h
+++ b/modules/xfem/include/base/XFEM.h
@@ -174,7 +174,7 @@ public:
   Point getEFANodeCoords(EFANode * CEMnode,
                          EFAElement * CEMElem,
                          const Elem * elem,
-                         MeshBase * displaced_mesh = NULL) const;
+                         MeshBase * displaced_mesh = nullptr) const;
 
   /**
    * Get the volume fraction of an element that is physical

--- a/modules/xfem/include/base/XFEMCutElem.h
+++ b/modules/xfem/include/base/XFEMCutElem.h
@@ -55,7 +55,7 @@ protected:
   std::vector<Real> _new_weights;
   /// face quadrature weights from surface area fraction
   std::vector<std::vector<Real>> _new_face_weights;
-  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = NULL) const = 0;
+  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = nullptr) const = 0;
 
 public:
   void setQuadraturePointsAndWeights(const std::vector<Point> & qp_points,
@@ -85,13 +85,13 @@ public:
   virtual void computeMomentFittingWeights() = 0;
   Real getMomentFittingWeight(unsigned int i_qp) const;
   virtual Point getCutPlaneOrigin(unsigned int plane_id,
-                                  MeshBase * displaced_mesh = NULL) const = 0;
+                                  MeshBase * displaced_mesh = nullptr) const = 0;
   virtual Point getCutPlaneNormal(unsigned int plane_id,
-                                  MeshBase * displaced_mesh = NULL) const = 0;
+                                  MeshBase * displaced_mesh = nullptr) const = 0;
   virtual void
   getCrackTipOriginAndDirection(unsigned tip_id, Point & origin, Point & direction) const = 0;
   virtual void getFragmentFaces(std::vector<std::vector<Point>> & frag_faces,
-                                MeshBase * displaced_mesh = NULL) const = 0;
+                                MeshBase * displaced_mesh = nullptr) const = 0;
   virtual const EFAElement * getEFAElement() const = 0;
   virtual unsigned int numCutPlanes() const = 0;
   void getWeightMultipliers(MooseArray<Real> & weights,
@@ -130,5 +130,5 @@ public:
   virtual void getIntersectionInfo(unsigned int plane_id,
                                    Point & normal,
                                    std::vector<Point> & intersectionPoints,
-                                   MeshBase * displaced_mesh = NULL) const = 0;
+                                   MeshBase * displaced_mesh = nullptr) const = 0;
 };

--- a/modules/xfem/include/base/XFEMCutElem2D.h
+++ b/modules/xfem/include/base/XFEMCutElem2D.h
@@ -39,24 +39,24 @@ public:
 
 private:
   EFAElement2D _efa_elem2d; // 2D EFAelement
-  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = NULL) const;
+  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = nullptr) const;
 
 public:
   virtual void computePhysicalVolumeFraction();
   virtual void computePhysicalFaceAreaFraction(unsigned int side);
   virtual void computeMomentFittingWeights();
-  virtual Point getCutPlaneOrigin(unsigned int plane_id, MeshBase * displaced_mesh = NULL) const;
-  virtual Point getCutPlaneNormal(unsigned int plane_id, MeshBase * displaced_mesh = NULL) const;
+  virtual Point getCutPlaneOrigin(unsigned int plane_id, MeshBase * displaced_mesh = nullptr) const;
+  virtual Point getCutPlaneNormal(unsigned int plane_id, MeshBase * displaced_mesh = nullptr) const;
   virtual void
   getCrackTipOriginAndDirection(unsigned tip_id, Point & origin, Point & direction) const;
   virtual void getFragmentFaces(std::vector<std::vector<Point>> & frag_faces,
-                                MeshBase * displaced_mesh = NULL) const;
+                                MeshBase * displaced_mesh = nullptr) const;
   virtual const EFAElement * getEFAElement() const;
   virtual unsigned int numCutPlanes() const;
   virtual void getIntersectionInfo(unsigned int plane_id,
                                    Point & normal,
                                    std::vector<Point> & intersectionPoints,
-                                   MeshBase * displaced_mesh = NULL) const;
+                                   MeshBase * displaced_mesh = nullptr) const;
 
 private:
   void getPhysicalQuadraturePoints(std::vector<std::vector<Real>> & tsg);

--- a/modules/xfem/include/base/XFEMCutElem3D.h
+++ b/modules/xfem/include/base/XFEMCutElem3D.h
@@ -39,22 +39,22 @@ public:
 
 private:
   EFAElement3D _efa_elem3d; // 3D EFAelement
-  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = NULL) const;
+  virtual Point getNodeCoordinates(EFANode * node, MeshBase * displaced_mesh = nullptr) const;
 
 public:
   virtual void computePhysicalVolumeFraction();
   virtual void computePhysicalFaceAreaFraction(unsigned int side);
   virtual void computeMomentFittingWeights();
-  virtual Point getCutPlaneOrigin(unsigned int plane_id, MeshBase * displaced_mesh = NULL) const;
-  virtual Point getCutPlaneNormal(unsigned int plane_id, MeshBase * displaced_mesh = NULL) const;
+  virtual Point getCutPlaneOrigin(unsigned int plane_id, MeshBase * displaced_mesh = nullptr) const;
+  virtual Point getCutPlaneNormal(unsigned int plane_id, MeshBase * displaced_mesh = nullptr) const;
   virtual void
   getCrackTipOriginAndDirection(unsigned tip_id, Point & origin, Point & direction) const;
   virtual void getFragmentFaces(std::vector<std::vector<Point>> & frag_faces,
-                                MeshBase * displaced_mesh = NULL) const;
+                                MeshBase * displaced_mesh = nullptr) const;
   virtual const EFAElement * getEFAElement() const;
   virtual unsigned int numCutPlanes() const;
   virtual void getIntersectionInfo(unsigned int plane_id,
                                    Point & normal,
                                    std::vector<Point> & intersectionPoints,
-                                   MeshBase * displaced_mesh = NULL) const;
+                                   MeshBase * displaced_mesh = nullptr) const;
 };

--- a/modules/xfem/include/efa/EFAEdge.h
+++ b/modules/xfem/include/efa/EFAEdge.h
@@ -29,7 +29,14 @@ private:
   std::vector<double> _intersection_x;
 
 public:
+  std::pair<EFANode *, EFANode *> getSortedNodes() const
+  {
+    return {std::min(_edge_node1, _edge_node2), std::max(_edge_node1, _edge_node2)};
+  }
+
   bool equivalent(const EFAEdge & other) const;
+  bool isEmbeddedPermanent() const;
+
   bool isPartialOverlap(const EFAEdge & other) const;
   bool containsEdge(const EFAEdge & other) const;
   bool getNodeMasters(EFANode * node,

--- a/modules/xfem/include/efa/EFAElement.h
+++ b/modules/xfem/include/efa/EFAElement.h
@@ -59,7 +59,8 @@ public:
   unsigned int numChildren() const;
   void addChild(EFAElement * child);
   void clearParentAndChildren();
-  void findGeneralNeighbors(std::map<EFANode *, std::set<EFAElement *>> & InverseConnectivity);
+  void
+  findGeneralNeighbors(const std::map<EFANode *, std::set<EFAElement *>> & InverseConnectivity);
   EFAElement * getGeneralNeighbor(unsigned int index) const;
   unsigned int numGeneralNeighbors() const;
 

--- a/modules/xfem/include/efa/EFAElement.h
+++ b/modules/xfem/include/efa/EFAElement.h
@@ -41,6 +41,7 @@ public:
   unsigned int numNodes() const;
   void setNode(unsigned int node_id, EFANode * node);
   EFANode * getNode(unsigned int node_id) const;
+  const std::vector<EFANode *> & getNodes() const { return _nodes; }
   bool containsNode(EFANode * node) const;
   void printNodes(std::ostream & ostream) const;
   EFANode * createLocalNodeFromGlobalNode(const EFANode * global_node) const;

--- a/modules/xfem/include/efa/EFAElement3D.h
+++ b/modules/xfem/include/efa/EFAElement3D.h
@@ -105,8 +105,7 @@ public:
   unsigned int getFaceID(EFAFace * face) const;
   std::vector<unsigned int> getCommonFaceID(const EFAElement3D * other_elem) const;
   bool getCommonEdgeID(const EFAElement3D * other_elem,
-                       std::vector<unsigned int> & face_id,
-                       std::vector<unsigned int> & edge_id) const;
+                       std::vector<std::pair<unsigned int, unsigned int>> & common_ids) const;
   unsigned int getNeighborFaceNodeID(unsigned int face_id,
                                      unsigned int node_id,
                                      EFAElement3D * neighbor_elem) const;

--- a/modules/xfem/include/efa/EFAFace.h
+++ b/modules/xfem/include/efa/EFAFace.h
@@ -46,8 +46,8 @@ public:
   unsigned int numInteriorNodes() const;
   void createNodes();
 
-  unsigned int numEdges() const;
-  EFAEdge * getEdge(unsigned int edge_id) const;
+  unsigned int numEdges() const { return _edges.size(); }
+  EFAEdge * getEdge(unsigned int edge_id) const { return _edges[edge_id]; }
   void setEdge(unsigned int edge_id, EFAEdge * new_edge);
   void createEdges();
   void combineTwoEdges(unsigned int edge_id1, unsigned int edge_id2);

--- a/modules/xfem/include/efa/EFANode.h
+++ b/modules/xfem/include/efa/EFANode.h
@@ -23,7 +23,7 @@ public:
     N_CATEGORY_LOCAL_INDEX
   };
 
-  EFANode(unsigned int nid, N_CATEGORY ncat, EFANode * nparent = NULL);
+  EFANode(unsigned int nid, N_CATEGORY ncat, EFANode * nparent = nullptr);
 
 private:
   N_CATEGORY _category;

--- a/modules/xfem/include/efa/ElementFragmentAlgorithm.h
+++ b/modules/xfem/include/efa/ElementFragmentAlgorithm.h
@@ -34,7 +34,6 @@ private:
   std::map<unsigned int, EFANode *> _temp_nodes;
   std::map<unsigned int, EFANode *> _embedded_permanent_nodes;
   std::map<unsigned int, EFAElement *> _elements;
-  //  std::map< std::set< EFAnode* >, std::set< EFAelement* > > _merged_edge_map;
   std::set<EFAElement *> _crack_tip_elements;
   std::vector<EFANode *> _new_nodes;
   std::vector<EFANode *> _deleted_nodes;

--- a/modules/xfem/include/efa/ElementFragmentAlgorithm.h
+++ b/modules/xfem/include/efa/ElementFragmentAlgorithm.h
@@ -43,8 +43,8 @@ private:
 
 public:
   unsigned int add2DElements(std::vector<std::vector<unsigned int>> & quads);
-  EFAElement * add2DElement(std::vector<unsigned int> quad, unsigned int id);
-  EFAElement * add3DElement(std::vector<unsigned int> quad, unsigned int id);
+  EFAElement * add2DElement(const std::vector<unsigned int> & quad, unsigned int id);
+  EFAElement * add3DElement(const std::vector<unsigned int> & quad, unsigned int id);
 
   void updateEdgeNeighbors();
   void initCrackTipTopology();
@@ -53,12 +53,12 @@ public:
   bool addFragEdgeIntersection(unsigned int elemid, unsigned int frag_edge_id, double position);
   void addElemFaceIntersection(unsigned int elemid,
                                unsigned int faceid,
-                               std::vector<unsigned int> edgeid,
-                               std::vector<double> position);
+                               const std::vector<unsigned int> & edgeid,
+                               const std::vector<double> & position);
   void addFragFaceIntersection(unsigned int ElemID,
                                unsigned int FragFaceID,
-                               std::vector<unsigned int> FragFaceEdgeID,
-                               std::vector<double> position);
+                               const std::vector<unsigned int> & FragFaceEdgeID,
+                               const std::vector<double> & position);
 
   void updatePhysicalLinksAndFragments();
 

--- a/modules/xfem/src/actions/XFEMAction.C
+++ b/modules/xfem/src/actions/XFEMAction.C
@@ -135,7 +135,7 @@ XFEMAction::act()
 {
 
   std::shared_ptr<XFEMInterface> xfem_interface = _problem->getXFEM();
-  if (xfem_interface == NULL)
+  if (xfem_interface == nullptr)
   {
     const auto & params = _app.getInputParameterWarehouse().getInputParameters();
     InputParameters & pars(*(params.find(uniqueActionName())->second.get()));
@@ -146,7 +146,7 @@ XFEMAction::act()
   }
 
   std::shared_ptr<XFEM> xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(xfem_interface);
-  if (xfem == NULL)
+  if (xfem == nullptr)
     mooseError("dynamic cast of xfem object failed");
 
   if (_current_task == "setup_xfem")

--- a/modules/xfem/src/auxkernels/XFEMCutPlaneAux.C
+++ b/modules/xfem/src/auxkernels/XFEMCutPlaneAux.C
@@ -32,7 +32,7 @@ XFEMCutPlaneAux::XFEMCutPlaneAux(const InputParameters & parameters)
     _plane_id(getParam<unsigned int>("plane_id"))
 {
   FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
-  if (fe_problem == NULL)
+  if (fe_problem == nullptr)
     mooseError("Problem casting _subproblem to FEProblemBase in XFEMCutPlaneAux");
   _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());
   if (_xfem == nullptr)

--- a/modules/xfem/src/auxkernels/XFEMMarkerAux.C
+++ b/modules/xfem/src/auxkernels/XFEMMarkerAux.C
@@ -24,7 +24,7 @@ XFEMMarkerAux::validParams()
 XFEMMarkerAux::XFEMMarkerAux(const InputParameters & parameters) : AuxKernel(parameters)
 {
   FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
-  if (fe_problem == NULL)
+  if (fe_problem == nullptr)
     mooseError("Problem casting _subproblem to FEProblemBase in XFEMMarkerAux");
   _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());
   if (_xfem == nullptr)

--- a/modules/xfem/src/auxkernels/XFEMVolFracAux.C
+++ b/modules/xfem/src/auxkernels/XFEMVolFracAux.C
@@ -27,7 +27,7 @@ XFEMVolFracAux::XFEMVolFracAux(const InputParameters & parameters) : AuxKernel(p
   if (isNodal())
     mooseError("XFEMVolFracAux must be run on an element variable");
   FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
-  if (fe_problem == NULL)
+  if (fe_problem == nullptr)
     mooseError("Problem casting _subproblem to FEProblemBase in XFEMVolFracAux");
   _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());
   if (_xfem == nullptr)

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -343,6 +343,7 @@ XFEM::buildEFAMesh()
     std::vector<unsigned int> quad;
     for (unsigned int i = 0; i < elem->n_nodes(); ++i)
       quad.push_back(elem->node_id(i));
+
     if (_mesh->mesh_dimension() == 2)
       _efa_mesh.add2DElement(quad, elem->id());
     else if (_mesh->mesh_dimension() == 3)

--- a/modules/xfem/src/base/XFEM.C
+++ b/modules/xfem/src/base/XFEM.C
@@ -604,8 +604,8 @@ XFEM::markCutEdgesByState(Real time)
     unsigned int nsides = CEMElem->numEdges();
     unsigned int orig_cut_side_id = std::numeric_limits<unsigned int>::max();
     Real orig_cut_distance = -1.0;
-    EFANode * orig_node = NULL;
-    EFAEdge * orig_edge = NULL;
+    EFANode * orig_node = nullptr;
+    EFAEdge * orig_edge = nullptr;
 
     // crack tip origin coordinates and direction
     Point crack_tip_origin(0, 0, 0);
@@ -1111,7 +1111,7 @@ XFEM::cutMeshWithEFA(const std::vector<std::shared_ptr<NonlinearSystemBase>> & n
 
   // Copy the current geometric cut element info (from last time) into the
   // _old_geom_cut_elems.
-  _old_geom_cut_elems = _geom_cut_elems;
+  _old_geom_cut_elems.swap(_geom_cut_elems);
   _geom_cut_elems.clear();
 
   _efa_mesh.updatePhysicalLinksAndFragments();
@@ -1210,8 +1210,8 @@ XFEM::cutMeshWithEFA(const std::vector<std::shared_ptr<NonlinearSystemBase>> & n
     if (new_elements[i]->getParent()->numChildren() > 1)
       temporary_parent_children_map[parent_elem->id()].push_back(libmesh_elem);
 
-    Elem * parent_elem2 = NULL;
-    Elem * libmesh_elem2 = NULL;
+    Elem * parent_elem2 = nullptr;
+    Elem * libmesh_elem2 = nullptr;
     if (_displaced_mesh)
     {
       parent_elem2 = _displaced_mesh->elem_ptr(parent_id);
@@ -1316,7 +1316,7 @@ XFEM::cutMeshWithEFA(const std::vector<std::shared_ptr<NonlinearSystemBase>> & n
     if (_debug_output_level > 1)
       _console << "XFEM added new element: " << libmesh_elem->id() << std::endl;
 
-    XFEMCutElem * xfce = NULL;
+    XFEMCutElem * xfce = nullptr;
     if (_mesh->mesh_dimension() == 2)
     {
       EFAElement2D * new_efa_elem2d = dynamic_cast<EFAElement2D *>(new_elements[i]);
@@ -1704,24 +1704,23 @@ XFEM::isElemAtCrackTip(const Elem * elem) const
 bool
 XFEM::isElemCut(const Elem * elem, XFEMCutElem *& xfce) const
 {
-  xfce = NULL;
-  bool is_cut = false;
-  std::map<unique_id_type, XFEMCutElem *>::const_iterator it;
-  it = _cut_elem_map.find(elem->unique_id());
+  const auto it = _cut_elem_map.find(elem->unique_id());
   if (it != _cut_elem_map.end())
   {
     xfce = it->second;
     const EFAElement * EFAelem = xfce->getEFAElement();
     if (EFAelem->isPartial()) // exclude the full crack tip elements
-      is_cut = true;
+      return true;
   }
-  return is_cut;
+
+  xfce = nullptr;
+  return false;
 }
 
 bool
 XFEM::isElemCut(const Elem * elem) const
 {
-  XFEMCutElem * xfce = NULL;
+  XFEMCutElem * xfce;
   return isElemCut(elem, xfce);
 }
 
@@ -1846,10 +1845,10 @@ XFEM::getXFEMWeights(MooseArray<Real> & weights,
                      const MooseArray<Point> & q_points)
 {
   bool have_weights = false;
-  XFEMCutElem * xfce = NULL;
+  XFEMCutElem * xfce = nullptr;
   if (isElemCut(elem, xfce))
   {
-    mooseAssert(xfce != NULL, "Must have valid XFEMCutElem object here");
+    mooseAssert(xfce != nullptr, "Must have valid XFEMCutElem object here");
     xfce->getWeightMultipliers(weights, qrule, getXFEMQRule(), q_points);
     have_weights = true;
   }
@@ -1864,10 +1863,10 @@ XFEM::getXFEMFaceWeights(MooseArray<Real> & weights,
                          unsigned int side)
 {
   bool have_weights = false;
-  XFEMCutElem * xfce = NULL;
+  XFEMCutElem * xfce = nullptr;
   if (isElemCut(elem, xfce))
   {
-    mooseAssert(xfce != NULL, "Must have valid XFEMCutElem object here");
+    mooseAssert(xfce != nullptr, "Must have valid XFEMCutElem object here");
     xfce->getFaceWeightMultipliers(weights, qrule, getXFEMQRule(), q_points, side);
     have_weights = true;
   }

--- a/modules/xfem/src/base/XFEMCutElem.C
+++ b/modules/xfem/src/base/XFEMCutElem.C
@@ -23,7 +23,7 @@ XFEMCutElem::XFEMCutElem(Elem * elem, unsigned int n_qpoints, unsigned int n_sid
   : _n_nodes(elem->n_nodes()),
     _n_qpoints(n_qpoints),
     _n_sides(n_sides),
-    _nodes(_n_nodes, NULL),
+    _nodes(_n_nodes, nullptr),
     _elem_side_area(n_sides),
     _physical_areafrac(n_sides),
     _have_weights(false),

--- a/modules/xfem/src/base/XFEMCutElem2D.C
+++ b/modules/xfem/src/base/XFEMCutElem2D.C
@@ -134,7 +134,7 @@ XFEMCutElem2D::getCutPlaneOrigin(unsigned int plane_id, MeshBase * displaced_mes
   {
     if (_efa_elem2d.getFragment(0)->isEdgeInterior(i))
     {
-      std::vector<EFANode *> node_line(2, NULL);
+      std::vector<EFANode *> node_line(2, nullptr);
       node_line[0] = _efa_elem2d.getFragmentEdge(0, i)->getNode(0);
       node_line[1] = _efa_elem2d.getFragmentEdge(0, i)->getNode(1);
       cut_line_nodes.push_back(node_line);
@@ -156,7 +156,7 @@ XFEMCutElem2D::getCutPlaneNormal(unsigned int plane_id, MeshBase * displaced_mes
   {
     if (_efa_elem2d.getFragment(0)->isEdgeInterior(i))
     {
-      std::vector<EFANode *> node_line(2, NULL);
+      std::vector<EFANode *> node_line(2, nullptr);
       node_line[0] = _efa_elem2d.getFragmentEdge(0, i)->getNode(0);
       node_line[1] = _efa_elem2d.getFragmentEdge(0, i)->getNode(1);
       cut_line_nodes.push_back(node_line);
@@ -187,7 +187,7 @@ XFEMCutElem2D::getCrackTipOriginAndDirection(unsigned tip_id,
   {
     if (_efa_elem2d.getFragment(0)->isEdgeInterior(i))
     {
-      std::vector<EFANode *> node_line(2, NULL);
+      std::vector<EFANode *> node_line(2, nullptr);
       node_line[0] = _efa_elem2d.getFragmentEdge(0, i)->getNode(0);
       node_line[1] = _efa_elem2d.getFragmentEdge(0, i)->getNode(1);
       if (node_line[1]->id() == tip_id)
@@ -451,7 +451,7 @@ XFEMCutElem2D::getIntersectionInfo(unsigned int plane_id,
   {
     if (_efa_elem2d.getFragment(0)->isEdgeInterior(i))
     {
-      std::vector<EFANode *> node_line(2, NULL);
+      std::vector<EFANode *> node_line(2, nullptr);
       node_line[0] = _efa_elem2d.getFragmentEdge(0, i)->getNode(0);
       node_line[1] = _efa_elem2d.getFragmentEdge(0, i)->getNode(1);
       cut_line_nodes.push_back(node_line);

--- a/modules/xfem/src/efa/EFAEdge.C
+++ b/modules/xfem/src/efa/EFAEdge.C
@@ -17,7 +17,7 @@ EFAEdge::EFAEdge(EFANode * node1, EFANode * node2) : _edge_node1(node1), _edge_n
 {
   _embedded_nodes.clear();
   _intersection_x.clear();
-  _edge_interior_node = NULL;
+  _edge_interior_node = nullptr;
   consistencyCheck();
 }
 
@@ -198,10 +198,10 @@ bool
 EFAEdge::hasIntersection() const
 {
   bool has = false;
-  if (_edge_node1->parent() != NULL)
+  if (_edge_node1->parent() != nullptr)
     has = has || _edge_node1->parent()->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT;
 
-  if (_edge_node2->parent() != NULL)
+  if (_edge_node2->parent() != nullptr)
     has = has || _edge_node2->parent()->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT;
 
   return has || _embedded_nodes.size() > 0;

--- a/modules/xfem/src/efa/EFAEdge.C
+++ b/modules/xfem/src/efa/EFAEdge.C
@@ -37,20 +37,22 @@ EFAEdge::~EFAEdge() // do not delete edge node - they will be deleted
 bool
 EFAEdge::equivalent(const EFAEdge & other) const
 {
-  bool isEqual = false;
-  if (other._edge_node1 == _edge_node1 && other._edge_node2 == _edge_node2)
-    isEqual = true;
-  else if (other._edge_node2 == _edge_node1 && other._edge_node1 == _edge_node2)
-    isEqual = true;
-
-  // For cut along the edge case
-  if (isEqual)
+  if (getSortedNodes() == other.getSortedNodes())
   {
-    if (_edge_node1->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT &&
-        _edge_node2->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT)
-      isEqual = false;
+    // For cut along the edge case
+    if (isEmbeddedPermanent())
+      return false;
+    return true;
   }
-  return isEqual;
+
+  return false;
+}
+
+bool
+EFAEdge::isEmbeddedPermanent() const
+{
+  return _edge_node1->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT &&
+         _edge_node2->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT;
 }
 
 bool

--- a/modules/xfem/src/efa/EFAElement.C
+++ b/modules/xfem/src/efa/EFAElement.C
@@ -16,8 +16,8 @@
 EFAElement::EFAElement(unsigned int eid, unsigned int n_nodes)
   : _id(eid),
     _num_nodes(n_nodes),
-    _nodes(_num_nodes, NULL),
-    _parent(NULL),
+    _nodes(_num_nodes, nullptr),
+    _parent(nullptr),
     _crack_tip_split_element(false)
 {
 }
@@ -75,7 +75,7 @@ EFAElement::createLocalNodeFromGlobalNode(const EFANode * global_node) const
       global_node->category() != EFANode::N_CATEGORY_EMBEDDED_PERMANENT)
     EFAError("In createLocalNodeFromGlobalNode node is not global");
 
-  EFANode * new_local_node = NULL;
+  EFANode * new_local_node = nullptr;
   unsigned int inode = 0;
   for (; inode < _nodes.size(); ++inode)
   {
@@ -200,19 +200,21 @@ EFAElement::addChild(EFAElement * child)
 void
 EFAElement::clearParentAndChildren()
 {
-  _parent = NULL;
+  _parent = nullptr;
   _children.clear();
 }
 
 void
-EFAElement::findGeneralNeighbors(std::map<EFANode *, std::set<EFAElement *>> & InverseConnectivity)
+EFAElement::findGeneralNeighbors(
+    const std::map<EFANode *, std::set<EFAElement *>> & inverse_connectivity)
 {
   _general_neighbors.clear();
   std::set<EFAElement *> patch_elements;
   for (unsigned int inode = 0; inode < _num_nodes; ++inode)
   {
-    std::set<EFAElement *> this_node_connected_elems = InverseConnectivity[_nodes[inode]];
-    patch_elements.insert(this_node_connected_elems.begin(), this_node_connected_elems.end());
+    auto it = inverse_connectivity.find(_nodes[inode]);
+    if (it != inverse_connectivity.end())
+      patch_elements.insert(it->second.begin(), it->second.end());
   }
 
   std::set<EFAElement *>::iterator eit2;
@@ -276,7 +278,7 @@ EFAElement::mergeNodes(EFANode *& childNode,
           }
           childNode = childOfNeighborNode;
         }
-        else if (childNode->parent() != NULL &&
+        else if (childNode->parent() != nullptr &&
                  childNode->parent() == childOfNeighborNode->parent())
         {
           // merge into childNode if both nodes are child permanent

--- a/modules/xfem/src/efa/EFAElement.C
+++ b/modules/xfem/src/efa/EFAElement.C
@@ -51,8 +51,8 @@ EFAElement::getNode(unsigned int node_id) const
 bool
 EFAElement::containsNode(EFANode * node) const
 {
-  for (unsigned int i = 0; i < _nodes.size(); ++i)
-    if (_nodes[i] == node)
+  for (const auto element_node : _nodes)
+    if (element_node == node)
       return true;
   return false;
 }

--- a/modules/xfem/src/efa/EFAElement2D.C
+++ b/modules/xfem/src/efa/EFAElement2D.C
@@ -29,16 +29,15 @@ EFAElement2D::EFAElement2D(unsigned int eid, unsigned int n_nodes) : EFAElement(
   else
     EFAError("In EFAelement2D the supported element types are QUAD4, QUAD8, QUAD9, TRI3 and TRI6");
   setLocalCoordinates();
-  _edges = std::vector<EFAEdge *>(_num_edges, NULL);
-  _edge_neighbors =
-      std::vector<std::vector<EFAElement2D *>>(_num_edges, std::vector<EFAElement2D *>(1, NULL));
+  _edges = std::vector<EFAEdge *>(_num_edges, nullptr);
+  _edge_neighbors = std::vector<std::vector<EFAElement2D *>>(_num_edges, {nullptr});
 }
 
 EFAElement2D::EFAElement2D(const EFAElement2D * from_elem, bool convert_to_local)
   : EFAElement(from_elem->_id, from_elem->_num_nodes),
     _num_edges(from_elem->_num_edges),
-    _edges(_num_edges, NULL),
-    _edge_neighbors(_num_edges, std::vector<EFAElement2D *>(1, NULL))
+    _edges(_num_edges, nullptr),
+    _edge_neighbors(_num_edges, {nullptr})
 {
   if (convert_to_local)
   {
@@ -90,8 +89,8 @@ EFAElement2D::EFAElement2D(const EFAElement2D * from_elem, bool convert_to_local
 EFAElement2D::EFAElement2D(const EFAFace * from_face)
   : EFAElement(0, from_face->numNodes()),
     _num_edges(from_face->numEdges()),
-    _edges(_num_edges, NULL),
-    _edge_neighbors(_num_edges, std::vector<EFAElement2D *>(1, NULL))
+    _edges(_num_edges, nullptr),
+    _edge_neighbors(_num_edges, {nullptr})
 {
   for (unsigned int i = 0; i < _num_nodes; ++i)
     _nodes[i] = from_face->getNode(i);
@@ -108,7 +107,7 @@ EFAElement2D::~EFAElement2D()
     if (_fragments[i])
     {
       delete _fragments[i];
-      _fragments[i] = NULL;
+      _fragments[i] = nullptr;
     }
   }
   for (unsigned int i = 0; i < _edges.size(); ++i)
@@ -116,7 +115,7 @@ EFAElement2D::~EFAElement2D()
     if (_edges[i])
     {
       delete _edges[i];
-      _edges[i] = NULL;
+      _edges[i] = nullptr;
     }
   }
   for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
@@ -124,7 +123,7 @@ EFAElement2D::~EFAElement2D()
     if (_interior_nodes[i])
     {
       delete _interior_nodes[i];
-      _interior_nodes[i] = NULL;
+      _interior_nodes[i] = nullptr;
     }
   }
   for (unsigned int i = 0; i < _local_nodes.size(); ++i)
@@ -132,7 +131,7 @@ EFAElement2D::~EFAElement2D()
     if (_local_nodes[i])
     {
       delete _local_nodes[i];
-      _local_nodes[i] = NULL;
+      _local_nodes[i] = nullptr;
     }
   }
 }
@@ -460,13 +459,13 @@ EFAElement2D::clearNeighbors()
 {
   _general_neighbors.clear();
   for (unsigned int edge_iter = 0; edge_iter < _num_edges; ++edge_iter)
-    _edge_neighbors[edge_iter] = std::vector<EFAElement2D *>(1, NULL);
+    _edge_neighbors[edge_iter] = {nullptr};
 }
 
 void
-EFAElement2D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & InverseConnectivityMap)
+EFAElement2D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & inverse_connectivity_map)
 {
-  findGeneralNeighbors(InverseConnectivityMap);
+  findGeneralNeighbors(inverse_connectivity_map);
   for (unsigned int eit2 = 0; eit2 < _general_neighbors.size(); ++eit2)
   {
     EFAElement2D * neigh_elem = dynamic_cast<EFAElement2D *>(_general_neighbors[eit2]);
@@ -527,7 +526,7 @@ EFAElement2D::neighborSanityCheck() const
     for (unsigned int en_iter = 0; en_iter < _edge_neighbors[edge_iter].size(); ++en_iter)
     {
       EFAElement2D * neigh_elem = _edge_neighbors[edge_iter][en_iter];
-      if (neigh_elem != NULL)
+      if (neigh_elem != nullptr)
       {
         bool found_neighbor = false;
         for (unsigned int edge_iter2 = 0; edge_iter2 < neigh_elem->numEdges(); ++edge_iter2)
@@ -599,7 +598,7 @@ EFAElement2D::getCrackTipSplitElementID() const
     {
       if ((_edge_neighbors[edge_iter].size() == 2) && (_edges[edge_iter]->hasIntersection()))
       {
-        if (_edge_neighbors[edge_iter][0] != NULL &&
+        if (_edge_neighbors[edge_iter][0] != nullptr &&
             _edge_neighbors[edge_iter][0]->isCrackTipSplit())
         {
           return _edge_neighbors[edge_iter][0]->id();
@@ -1252,7 +1251,7 @@ EFAElement2D::connectNeighbors(std::map<unsigned int, EFANode *> & PermanentNode
                 EFANode * childNode = _edges[j]->getNode(childNodeIndex);
                 EFANode * childOfNeighborNode = neighborChildEdge->getNode(neighborChildNodeIndex);
 
-                if (childNode->parent() != NULL &&
+                if (childNode->parent() != nullptr &&
                     childNode->parent() ==
                         childOfNeighborNode
                             ->parent()) // non-material node and both come from same parent
@@ -1302,7 +1301,7 @@ EFAElement2D::updateFragmentNode()
 {
   for (unsigned int j = 0; j < _num_nodes; ++j)
   {
-    if (_nodes[j]->parent() != NULL &&
+    if (_nodes[j]->parent() != nullptr &&
         _nodes[j]->parent()->category() == EFANode::N_CATEGORY_EMBEDDED_PERMANENT)
       switchNode(_nodes[j], _nodes[j]->parent(), false);
   }
@@ -1571,7 +1570,7 @@ EFAElement2D::numEdgeNeighbors(unsigned int edge_id) const
 EFAElement2D *
 EFAElement2D::getEdgeNeighbor(unsigned int edge_id, unsigned int neighbor_id) const
 {
-  if (_edge_neighbors[edge_id][0] != NULL && neighbor_id < _edge_neighbors[edge_id].size())
+  if (_edge_neighbors[edge_id][0] != nullptr && neighbor_id < _edge_neighbors[edge_id].size())
     return _edge_neighbors[edge_id][neighbor_id];
   else
     EFAError("edge neighbor does not exist");
@@ -1636,7 +1635,7 @@ EFANode *
 EFAElement2D::getTipEmbeddedNode() const
 {
   // if this element is a crack tip element, returns the crack tip edge's ID
-  EFANode * tip_emb = NULL;
+  EFANode * tip_emb = nullptr;
   if (_fragments.size() == 1) // crack tip element with a partial fragment saved
   {
     for (unsigned int i = 0; i < _num_edges; ++i)
@@ -1713,7 +1712,7 @@ EFAElement2D::addEdgeCut(unsigned int edge_id,
                          std::map<unsigned int, EFANode *> & EmbeddedNodes,
                          bool add_to_neighbor)
 {
-  EFANode * local_embedded = NULL;
+  EFANode * local_embedded = nullptr;
   EFANode * edge_node1 = _edges[edge_id]->getNode(0);
   if (embedded_node) // use the existing embedded node if it was passed in
     local_embedded = embedded_node;
@@ -1742,8 +1741,8 @@ EFAElement2D::addEdgeCut(unsigned int edge_id,
     // check if it is necessary to add cuts to fragment
     // id of partially overlapping fragment edge
     unsigned int frag_edge_id = std::numeric_limits<unsigned int>::max();
-    EFAEdge * frag_edge = NULL;
-    EFANode * frag_edge_node1 = NULL;
+    EFAEdge * frag_edge = nullptr;
+    EFANode * frag_edge_node1 = nullptr;
     double frag_pos = -1.0;
     bool add2frag = false;
 
@@ -1817,7 +1816,7 @@ EFAElement2D::addNodeCut(unsigned int node_id,
                          std::map<unsigned int, EFANode *> & PermanentNodes,
                          std::map<unsigned int, EFANode *> & EmbeddedPermanentNodes)
 {
-  EFANode * local_embedded_permanent = NULL;
+  EFANode * local_embedded_permanent = nullptr;
   EFANode * node = _nodes[node_id];
   if (embedded_permanent_node) // use the existing embedded node if it was passed in
     local_embedded_permanent = embedded_permanent_node;
@@ -1841,7 +1840,7 @@ EFAElement2D::addFragmentEdgeCut(unsigned int frag_edge_id,
 {
   if (_fragments.size() != 1)
     EFAError("Element: ", _id, " should have only 1 fragment in addFragEdgeIntersection");
-  EFANode * local_embedded = NULL;
+  EFANode * local_embedded = nullptr;
 
   // check if this intersection coincide with any embedded node on this edge
   bool isValidIntersection = true;
@@ -1961,7 +1960,7 @@ EFAElement2D::branchingSplit(std::map<unsigned int, EFANode *> & EmbeddedNodes)
   std::vector<EFAFragment2D *> new_fragments;
   for (unsigned int i = 0; i < 3; ++i) // loop over 3 sectors
   {
-    EFAFragment2D * new_frag = new EFAFragment2D(this, false, NULL);
+    EFAFragment2D * new_frag = new EFAFragment2D(this, false, nullptr);
     unsigned int iplus1(i < 2 ? i + 1 : 0);
     new_frag->addEdge(new EFAEdge(three_nodes[iplus1], new_emb));
     new_frag->addEdge(new EFAEdge(new_emb, three_nodes[i]));

--- a/modules/xfem/src/efa/EFAElement3D.C
+++ b/modules/xfem/src/efa/EFAElement3D.C
@@ -400,7 +400,7 @@ EFAElement3D::getMasterInfo(EFANode * node,
   }
 
   if (!masters_found)
-    EFAError("In EFAelement3D::getMaterInfo, cannot find the given EFAnode");
+    EFAError("In EFAelement3D::getMasterInfo, cannot find the given EFANode");
 }
 
 unsigned int

--- a/modules/xfem/src/efa/EFAElement3D.C
+++ b/modules/xfem/src/efa/EFAElement3D.C
@@ -24,7 +24,7 @@
 EFAElement3D::EFAElement3D(unsigned int eid, unsigned int n_nodes, unsigned int n_faces)
   : EFAElement(eid, n_nodes),
     _num_faces(n_faces),
-    _faces(_num_faces, NULL),
+    _faces(_num_faces, nullptr),
     _face_neighbors(_num_faces),
     _face_edge_neighbors(_num_faces)
 {
@@ -58,7 +58,7 @@ EFAElement3D::EFAElement3D(unsigned int eid, unsigned int n_nodes, unsigned int 
 EFAElement3D::EFAElement3D(const EFAElement3D * from_elem, bool convert_to_local)
   : EFAElement(from_elem->_id, from_elem->_num_nodes),
     _num_faces(from_elem->_num_faces),
-    _faces(_num_faces, NULL),
+    _faces(_num_faces, nullptr),
     _face_neighbors(_num_faces),
     _face_edge_neighbors(_num_faces)
 {
@@ -116,37 +116,20 @@ EFAElement3D::EFAElement3D(const EFAElement3D * from_elem, bool convert_to_local
 EFAElement3D::~EFAElement3D()
 {
   for (unsigned int i = 0; i < _fragments.size(); ++i)
-  {
     if (_fragments[i])
-    {
       delete _fragments[i];
-      _fragments[i] = NULL;
-    }
-  }
+
   for (unsigned int i = 0; i < _faces.size(); ++i)
-  {
     if (_faces[i])
-    {
       delete _faces[i];
-      _faces[i] = NULL;
-    }
-  }
+
   for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
-  {
     if (_interior_nodes[i])
-    {
       delete _interior_nodes[i];
-      _interior_nodes[i] = NULL;
-    }
-  }
+
   for (unsigned int i = 0; i < _local_nodes.size(); ++i)
-  {
     if (_local_nodes[i])
-    {
       delete _local_nodes[i];
-      _local_nodes[i] = NULL;
-    }
-  }
 }
 
 void
@@ -274,7 +257,6 @@ EFAElement3D::numFragments() const
 bool
 EFAElement3D::isPartial() const
 {
-  bool partial = false;
   if (_fragments.size() > 0)
   {
     for (unsigned int i = 0; i < _num_vertices; ++i)
@@ -288,14 +270,12 @@ EFAElement3D::isPartial() const
           break;
         }
       } // j
+
       if (!node_in_frag)
-      {
-        partial = true;
-        break;
-      }
+        return true;
     } // i
   }
-  return partial;
+  return false;
 }
 
 void
@@ -436,7 +416,7 @@ EFAElement3D::overlaysElement(const EFAElement3D * other_elem) const
     EFAError("failed to dynamic cast to other3d");
 
   // Find indices of common nodes
-  std::vector<unsigned int> common_face_curr = getCommonFaceID(other3d);
+  const auto & common_face_curr = getCommonFaceID(other3d);
   if (common_face_curr.size() == 1)
   {
     unsigned int curr_face_id = common_face_curr[0];
@@ -504,28 +484,27 @@ EFAElement3D::clearNeighbors()
 }
 
 void
-EFAElement3D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & InverseConnectivityMap)
+EFAElement3D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & inverse_connectivity_map)
 {
-  findGeneralNeighbors(InverseConnectivityMap);
+  findGeneralNeighbors(inverse_connectivity_map);
   for (unsigned int eit2 = 0; eit2 < _general_neighbors.size(); ++eit2)
   {
     EFAElement3D * neigh_elem = dynamic_cast<EFAElement3D *>(_general_neighbors[eit2]);
     if (!neigh_elem)
       EFAError("neighbor_elem is not of EFAelement3D type");
 
-    std::vector<unsigned int> common_face_id = getCommonFaceID(neigh_elem);
+    const auto & common_face_id = getCommonFaceID(neigh_elem);
     std::vector<unsigned int> face_ids, edge_ids;
-    if (common_face_id.size() == 0 && getCommonEdgeID(neigh_elem, face_ids, edge_ids) &&
+    if (common_face_id.empty() && getCommonEdgeID(neigh_elem, face_ids, edge_ids) &&
         !overlaysElement(neigh_elem))
     {
       bool is_edge_neighbor = false;
 
       // Fragments must match up.
       if ((_fragments.size() > 1) || (neigh_elem->numFragments() > 1))
-      {
         EFAError("in updateFaceNeighbors: Cannot have more than 1 fragment");
-      }
-      else if ((_fragments.size() == 1) && (neigh_elem->numFragments() == 1))
+
+      if ((_fragments.size() == 1) && (neigh_elem->numFragments() == 1))
       {
         if (_fragments[0]->isEdgeConnected(neigh_elem->getFragment(0)))
           is_edge_neighbor = true;
@@ -534,14 +513,12 @@ EFAElement3D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & Inver
         is_edge_neighbor = true;
 
       if (is_edge_neighbor)
-      {
         for (unsigned int i = 0; i < face_ids.size(); ++i)
         {
           unsigned int face_id = face_ids[i];
           unsigned int edge_id = edge_ids[i];
           _face_edge_neighbors[face_id][edge_id].push_back(neigh_elem);
         }
-      }
     }
 
     if (common_face_id.size() == 1 && !overlaysElement(neigh_elem))
@@ -551,10 +528,9 @@ EFAElement3D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & Inver
 
       // Fragments must match up.
       if ((_fragments.size() > 1) || (neigh_elem->numFragments() > 1))
-      {
         EFAError("in updateFaceNeighbors: Cannot have more than 1 fragment");
-      }
-      else if ((_fragments.size() == 1) && (neigh_elem->numFragments() == 1))
+
+      if ((_fragments.size() == 1) && (neigh_elem->numFragments() == 1))
       {
         if (_fragments[0]->isConnected(neigh_elem->getFragment(0)))
           is_face_neighbor = true;
@@ -565,14 +541,12 @@ EFAElement3D::setupNeighbors(std::map<EFANode *, std::set<EFAElement *>> & Inver
       if (is_face_neighbor)
       {
         if (_face_neighbors[face_id].size() > 1)
-        {
           EFAError("Element ",
                    _id,
                    " already has 2 face neighbors: ",
                    _face_neighbors[face_id][0]->id(),
                    " ",
                    _face_neighbors[face_id][1]->id());
-        }
         _face_neighbors[face_id].push_back(neigh_elem);
       }
     }
@@ -587,7 +561,7 @@ EFAElement3D::neighborSanityCheck() const
     for (unsigned int en_iter = 0; en_iter < _face_neighbors[face_iter].size(); ++en_iter)
     {
       EFAElement3D * neigh_elem = _face_neighbors[face_iter][en_iter];
-      if (neigh_elem != NULL)
+      if (neigh_elem != nullptr)
       {
         bool found_neighbor = false;
         for (unsigned int face_iter2 = 0; face_iter2 < neigh_elem->numFaces(); ++face_iter2)
@@ -598,10 +572,8 @@ EFAElement3D::neighborSanityCheck() const
             if (neigh_elem->getFaceNeighbor(face_iter2, en_iter2) == this)
             {
               if ((en_iter2 > 1) && (en_iter > 1))
-              {
                 EFAError(
                     "Element and neighbor element cannot both have >1 neighbors on a common face");
-              }
               found_neighbor = true;
               break;
             }
@@ -1230,7 +1202,7 @@ EFAElement3D::connectNeighbors(std::map<unsigned int, EFANode *> & PermanentNode
                 EFANode * childNode = _faces[j]->getNode(childNodeIndex);
                 EFANode * childOfNeighborNode = neighborChildFace->getNode(neighborChildNodeIndex);
 
-                if (childNode->parent() != NULL &&
+                if (childNode->parent() != nullptr &&
                     childNode->parent() ==
                         childOfNeighborNode
                             ->parent()) // non-material node and both come from same parent
@@ -1465,7 +1437,7 @@ EFAElement3D::createFaces()
                                               {16, 17, 18, 19, 25}};
   int tet_interior_face_node_indices[4][3] = {{4, 5, 6}, {4, 7, 8}, {5, 8, 9}, {6, 7, 9}};
 
-  _faces = std::vector<EFAFace *>(_num_faces, NULL);
+  _faces = std::vector<EFAFace *>(_num_faces, nullptr);
   if (_num_nodes == 8 || _num_nodes == 20 || _num_nodes == 27)
   {
     if (_num_faces != 6)
@@ -1538,16 +1510,13 @@ EFAElement3D::getCommonFaceID(const EFAElement3D * other_elem) const
 {
   std::vector<unsigned int> face_id;
   for (unsigned int i = 0; i < _num_faces; ++i)
-  {
     for (unsigned int j = 0; j < other_elem->_num_faces; ++j)
-    {
       if (_faces[i]->equivalent(other_elem->_faces[j]))
       {
         face_id.push_back(i);
         break;
       }
-    }
-  }
+
   return face_id;
 }
 
@@ -1682,7 +1651,7 @@ EFAElement3D::findFacesAdjacentToFaces()
   _faces_adjacent_to_faces.clear();
   for (unsigned int i = 0; i < _faces.size(); ++i)
   {
-    std::vector<EFAFace *> face_adjacents(_faces[i]->numEdges(), NULL);
+    std::vector<EFAFace *> face_adjacents(_faces[i]->numEdges(), nullptr);
     for (unsigned int j = 0; j < _faces.size(); ++j)
     {
       if (_faces[j] != _faces[i] && _faces[i]->isAdjacent(_faces[j]))
@@ -1849,7 +1818,7 @@ EFAElement3D::numEdgeNeighbors(unsigned int face_id, unsigned int edge_id) const
 EFAElement3D *
 EFAElement3D::getFaceNeighbor(unsigned int face_id, unsigned int neighbor_id) const
 {
-  if (_face_neighbors[face_id][0] != NULL && neighbor_id < _face_neighbors[face_id].size())
+  if (_face_neighbors[face_id][0] != nullptr && neighbor_id < _face_neighbors[face_id].size())
     return _face_neighbors[face_id][neighbor_id];
   else
     EFAError("edge neighbor does not exist");
@@ -1998,7 +1967,7 @@ EFAElement3D::addFaceEdgeCut(unsigned int face_id,
                              bool add_to_adjacent)
 {
   // Purpose: add intersection on Edge edge_id of Face face_id
-  EFANode * local_embedded = NULL;
+  EFANode * local_embedded = nullptr;
   EFAEdge * cut_edge = _faces[face_id]->getEdge(edge_id);
   EFANode * edge_node1 = cut_edge->getNode(0);
   if (embedded_node) // use the existing embedded node if it was passed in

--- a/modules/xfem/src/efa/EFAFace.C
+++ b/modules/xfem/src/efa/EFAFace.C
@@ -18,18 +18,18 @@
 
 EFAFace::EFAFace(unsigned int n_nodes, unsigned int num_interior_face_nodes)
   : _num_nodes(n_nodes),
-    _nodes(_num_nodes, NULL),
+    _nodes(_num_nodes, nullptr),
     _num_edges(_num_nodes),
-    _edges(_num_edges, NULL),
-    _face_interior_nodes(num_interior_face_nodes, NULL)
+    _edges(_num_edges, nullptr),
+    _face_interior_nodes(num_interior_face_nodes, nullptr)
 {
 }
 
 EFAFace::EFAFace(const EFAFace & other_face)
   : _num_nodes(other_face._num_nodes),
-    _nodes(_num_nodes, NULL),
+    _nodes(_num_nodes, nullptr),
     _num_edges(_num_nodes),
-    _edges(_num_edges, NULL)
+    _edges(_num_edges, nullptr)
 {
   for (unsigned int k = 0; k < other_face._num_nodes; ++k)
   {
@@ -42,9 +42,9 @@ EFAFace::EFAFace(const EFAFace & other_face)
 
 EFAFace::EFAFace(const EFAFragment2D * frag)
   : _num_nodes(frag->numEdges()),
-    _nodes(_num_nodes, NULL),
+    _nodes(_num_nodes, nullptr),
     _num_edges(_num_nodes),
-    _edges(_num_edges, NULL)
+    _edges(_num_edges, nullptr)
 {
   for (unsigned int k = 0; k < frag->numEdges(); ++k)
   {
@@ -64,7 +64,7 @@ EFAFace::~EFAFace()
     if (_edges[i])
     {
       delete _edges[i];
-      _edges[i] = NULL;
+      _edges[i] = nullptr;
     }
   }
   for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
@@ -72,7 +72,7 @@ EFAFace::~EFAFace()
     if (_interior_nodes[i])
     {
       delete _interior_nodes[i];
-      _interior_nodes[i] = NULL;
+      _interior_nodes[i] = nullptr;
     }
   }
 }
@@ -243,7 +243,7 @@ EFAFace::createNodes()
 {
   for (unsigned int i = 0; i < _edges.size(); ++i)
   {
-    if (_edges[i] != NULL)
+    if (_edges[i] != nullptr)
       _nodes[i] = _edges[i]->getNode(0);
     else
       EFAError("in EFAface::createNodes() _edges[i] does not exist");
@@ -274,7 +274,7 @@ EFAFace::createEdges()
   for (unsigned int i = 0; i < _num_nodes; ++i)
   {
     unsigned int i_plus1(i < (_num_nodes - 1) ? i + 1 : 0);
-    if (_nodes[i] != NULL && _nodes[i_plus1] != NULL)
+    if (_nodes[i] != nullptr && _nodes[i_plus1] != nullptr)
     {
       EFAEdge * new_edge = new EFAEdge(_nodes[i], _nodes[i_plus1]);
       _edges[i] = new_edge;
@@ -317,7 +317,7 @@ EFAFace::combineTwoEdges(unsigned int edge_id1, unsigned int edge_id2)
     // update face memeber variables
     _num_edges -= 1;
     _num_nodes -= 1;
-    _nodes.resize(_num_nodes, NULL);
+    _nodes.resize(_num_nodes, nullptr);
     for (unsigned int k = 0; k < _num_edges; ++k)
       _nodes[k] = _edges[k]->getNode(0);
   }
@@ -328,7 +328,7 @@ EFAFace::combineTwoEdges(unsigned int edge_id1, unsigned int edge_id2)
 void
 EFAFace::sortEdges()
 {
-  std::vector<EFAEdge *> ordered_edges(_num_edges, NULL);
+  std::vector<EFAEdge *> ordered_edges(_num_edges, nullptr);
   ordered_edges[0] = _edges[0];
   for (unsigned int i = 1; i < _num_edges; ++i)
   {
@@ -366,51 +366,39 @@ EFAFace::isTriOrQuad() const
 bool
 EFAFace::equivalent(const EFAFace * other_face) const
 {
-  unsigned int counter = 0; // counter number of equal nodes
-  bool overlap = false;
-  if (_num_nodes == other_face->_num_nodes)
-  {
-    for (unsigned int i = 0; i < _num_nodes; ++i)
-    {
-      for (unsigned int j = 0; j < other_face->_num_nodes; ++j)
+  // bail out early if the number of face nodes is not equal
+  if (_num_nodes != other_face->_num_nodes)
+    return false;
+
+  // counter number of equal nodes
+  unsigned int counter = 0;
+
+  for (unsigned int i = 0; i < _num_nodes; ++i)
+    for (unsigned int j = 0; j < other_face->_num_nodes; ++j)
+      if (_nodes[i] == other_face->_nodes[j])
       {
-        if (_nodes[i] == other_face->_nodes[j])
-        {
-          counter += 1;
-          break;
-        }
-      } // j
-    }   // i
-    if (counter == _num_nodes)
-      overlap = true;
-  }
-  return overlap;
+        counter += 1;
+        break;
+      }
+
+  if (counter == _num_nodes)
+    return true;
+
+  return false;
 }
 
 bool
 EFAFace::containsNode(const EFANode * node) const
 {
-  bool contains = false;
   for (unsigned int i = 0; i < _num_edges; ++i)
-  {
     if (_edges[i]->containsNode(node))
-    {
-      contains = true;
-      break;
-    }
-  }
-  if (!contains)
-  {
-    for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
-    {
-      if (_interior_nodes[i]->getNode() == node)
-      {
-        contains = true;
-        break;
-      }
-    }
-  }
-  return contains;
+      return true;
+
+  for (unsigned int i = 0; i < _interior_nodes.size(); ++i)
+    if (_interior_nodes[i]->getNode() == node)
+      return true;
+
+  return false;
 }
 
 bool
@@ -468,7 +456,7 @@ EFAFace::split() const
   if (getNumCuts() > 0)
   {
     // construct a fragment from this face
-    EFAFragment2D * frag_tmp = new EFAFragment2D(NULL, this);
+    EFAFragment2D * frag_tmp = new EFAFragment2D(nullptr, this);
     std::vector<EFAFragment2D *> new_frags_tmp = frag_tmp->split();
 
     // copy new_frags to new_faces
@@ -490,7 +478,7 @@ EFAFace *
 EFAFace::combineWithFace(const EFAFace * other_face) const
 {
   // combine this face with another adjacent face
-  EFAFace * new_face = NULL;
+  EFAFace * new_face = nullptr;
   if (isAdjacent(other_face))
   {
     unsigned int this_common_edge_id = adjacentCommonEdge(other_face);
@@ -500,7 +488,7 @@ EFAFace::combineWithFace(const EFAFace * other_face) const
 
     unsigned int other_common_edge_id = other_face->adjacentCommonEdge(this);
     unsigned int new_n_nodes = _num_edges + other_face->_num_edges - 4;
-    EFAFragment2D * new_frag = new EFAFragment2D(NULL, false, NULL); // temp fragment
+    EFAFragment2D * new_frag = new EFAFragment2D(nullptr, false, nullptr); // temp fragment
 
     unsigned int this_edge_id0(this_common_edge_id > 0 ? this_common_edge_id - 1
                                                        : _num_edges - 1); // common_nodes[0]

--- a/modules/xfem/src/efa/EFAFace.C
+++ b/modules/xfem/src/efa/EFAFace.C
@@ -250,18 +250,6 @@ EFAFace::createNodes()
   }
 }
 
-unsigned int
-EFAFace::numEdges() const
-{
-  return _edges.size();
-}
-
-EFAEdge *
-EFAFace::getEdge(unsigned int edge_id) const
-{
-  return _edges[edge_id];
-}
-
 void
 EFAFace::setEdge(unsigned int edge_id, EFAEdge * new_edge)
 {
@@ -366,25 +354,8 @@ EFAFace::isTriOrQuad() const
 bool
 EFAFace::equivalent(const EFAFace * other_face) const
 {
-  // bail out early if the number of face nodes is not equal
-  if (_num_nodes != other_face->_num_nodes)
-    return false;
-
-  // counter number of equal nodes
-  unsigned int counter = 0;
-
-  for (unsigned int i = 0; i < _num_nodes; ++i)
-    for (unsigned int j = 0; j < other_face->_num_nodes; ++j)
-      if (_nodes[i] == other_face->_nodes[j])
-      {
-        counter += 1;
-        break;
-      }
-
-  if (counter == _num_nodes)
-    return true;
-
-  return false;
+  return std::is_permutation(
+      _nodes.begin(), _nodes.end(), other_face->_nodes.begin(), other_face->_nodes.end());
 }
 
 bool

--- a/modules/xfem/src/efa/EFAFragment2D.C
+++ b/modules/xfem/src/efa/EFAFragment2D.C
@@ -57,7 +57,7 @@ EFAFragment2D::~EFAFragment2D()
     if (_boundary_edges[i])
     {
       delete _boundary_edges[i];
-      _boundary_edges[i] = NULL;
+      _boundary_edges[i] = nullptr;
     }
   }
 }
@@ -371,7 +371,7 @@ EFAFragment2D::split()
       // check to make sure an edge wasn't cut
       if (this_frag_nodes.size() >= 3)
       {
-        EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, NULL);
+        EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, nullptr);
         for (unsigned int inode = 0; inode < this_frag_nodes.size() - 1; inode++)
           new_frag->addEdge(new EFAEdge(this_frag_nodes[inode], this_frag_nodes[inode + 1]));
 
@@ -384,7 +384,7 @@ EFAFragment2D::split()
   }
   else if (edge_cut_count == 1) // single edge cut case
   {
-    EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, NULL);
+    EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, nullptr);
     for (unsigned int inode = 0; inode < fragment_nodes[0].size() - 1;
          inode++) // assemble fragment part 1
       new_frag->addEdge(new EFAEdge(fragment_nodes[0][inode], fragment_nodes[0][inode + 1]));
@@ -400,7 +400,7 @@ EFAFragment2D::split()
   }
   else if (node_cut_count == 1) // single node cut case
   {
-    EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, NULL);
+    EFAFragment2D * new_frag = new EFAFragment2D(_host_elem, false, nullptr);
     for (unsigned int iedge = 0; iedge < _boundary_edges.size(); ++iedge)
     {
       EFANode * first_node_on_edge = _boundary_edges[iedge]->getNode(0);

--- a/modules/xfem/src/efa/EFANode.C
+++ b/modules/xfem/src/efa/EFANode.C
@@ -53,7 +53,7 @@ EFANode::parent() const
 void
 EFANode::removeParent()
 {
-  _parent = NULL;
+  _parent = nullptr;
 }
 
 void

--- a/modules/xfem/src/efa/ElementFragmentAlgorithm.C
+++ b/modules/xfem/src/efa/ElementFragmentAlgorithm.C
@@ -35,28 +35,28 @@ ElementFragmentAlgorithm::~ElementFragmentAlgorithm()
   for (mit = _permanent_nodes.begin(); mit != _permanent_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   for (mit = _embedded_nodes.begin(); mit != _embedded_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   for (mit = _embedded_permanent_nodes.begin(); mit != _embedded_permanent_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   for (mit = _temp_nodes.begin(); mit != _temp_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   std::map<unsigned int, EFAElement *>::iterator eit;
   for (eit = _elements.begin(); eit != _elements.end(); ++eit)
   {
     delete eit->second;
-    eit->second = NULL;
+    eit->second = nullptr;
   }
 }
 
@@ -80,7 +80,7 @@ ElementFragmentAlgorithm::add2DElements(std::vector<std::vector<unsigned int>> &
 
     for (unsigned int j = 0; j < num_nodes; ++j)
     {
-      EFANode * currNode = NULL;
+      EFANode * currNode = nullptr;
       std::map<unsigned int, EFANode *>::iterator mit = _permanent_nodes.find(quads[i][j]);
       if (mit == _permanent_nodes.end())
       {
@@ -112,7 +112,7 @@ ElementFragmentAlgorithm::add2DElement(std::vector<unsigned int> quad, unsigned 
 
   for (unsigned int j = 0; j < num_nodes; ++j)
   {
-    EFANode * currNode = NULL;
+    EFANode * currNode = nullptr;
     std::map<unsigned int, EFANode *>::iterator mit = _permanent_nodes.find(quad[j]);
     if (mit == _permanent_nodes.end())
     {
@@ -156,7 +156,7 @@ ElementFragmentAlgorithm::add3DElement(std::vector<unsigned int> quad, unsigned 
 
   for (unsigned int j = 0; j < num_nodes; ++j)
   {
-    EFANode * currNode = NULL;
+    EFANode * currNode = nullptr;
     std::map<unsigned int, EFANode *>::iterator mit = _permanent_nodes.find(quad[j]);
     if (mit == _permanent_nodes.end())
     {
@@ -221,7 +221,7 @@ ElementFragmentAlgorithm::addElemEdgeIntersection(unsigned int elemid,
   EFAElement2D * curr_elem = dynamic_cast<EFAElement2D *>(eit->second);
   if (!curr_elem)
     EFAError("addElemEdgeIntersection: elem ", elemid, " is not of type EFAelement2D");
-  curr_elem->addEdgeCut(edgeid, position, NULL, _embedded_nodes, true);
+  curr_elem->addEdgeCut(edgeid, position, nullptr, _embedded_nodes, true);
 }
 
 void
@@ -238,7 +238,7 @@ ElementFragmentAlgorithm::addElemNodeIntersection(unsigned int elemid, unsigned 
 
   // Only add cut node when the curr_elem does not have any fragment
   if (curr_elem->numFragments() == 0)
-    curr_elem->addNodeCut(nodeid, NULL, _permanent_nodes, _embedded_permanent_nodes);
+    curr_elem->addNodeCut(nodeid, nullptr, _permanent_nodes, _embedded_permanent_nodes);
 }
 
 bool
@@ -273,8 +273,8 @@ ElementFragmentAlgorithm::addElemFaceIntersection(unsigned int elemid,
     EFAError("addElemEdgeIntersection: elem ", elemid, " is not of type EFAelement2D");
 
   // add cuts to two face edges at the same time
-  curr_elem->addFaceEdgeCut(faceid, edgeid[0], position[0], NULL, _embedded_nodes, true, true);
-  curr_elem->addFaceEdgeCut(faceid, edgeid[1], position[1], NULL, _embedded_nodes, true, true);
+  curr_elem->addFaceEdgeCut(faceid, edgeid[0], position[0], nullptr, _embedded_nodes, true, true);
+  curr_elem->addFaceEdgeCut(faceid, edgeid[1], position[1], nullptr, _embedded_nodes, true, true);
 }
 
 void
@@ -308,7 +308,6 @@ ElementFragmentAlgorithm::updateTopology(bool mergeUncutVirtualEdges)
   _new_nodes.clear();
   _child_elements.clear();
   _parent_elements.clear();
-  //  _merged_edge_map.clear();
 
   unsigned int first_new_node_id = Efa::getNewID(_permanent_nodes);
 
@@ -317,12 +316,10 @@ ElementFragmentAlgorithm::updateTopology(bool mergeUncutVirtualEdges)
   sanityCheck();
   updateCrackTipElements();
 
-  std::map<unsigned int, EFANode *>::iterator mit;
-  for (mit = _permanent_nodes.begin(); mit != _permanent_nodes.end(); ++mit)
-  {
-    if (mit->first >= first_new_node_id)
-      _new_nodes.push_back(mit->second);
-  }
+  for (const auto & [id, node] : _permanent_nodes)
+    if (id >= first_new_node_id)
+      _new_nodes.push_back(node);
+
   clearPotentialIsolatedNodes(); // _new_nodes and _permanent_nodes may change here
 }
 
@@ -339,21 +336,21 @@ ElementFragmentAlgorithm::reset()
   for (mit = _permanent_nodes.begin(); mit != _permanent_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   _permanent_nodes.clear();
 
   for (mit = _temp_nodes.begin(); mit != _temp_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   _temp_nodes.clear();
   std::map<unsigned int, EFAElement *>::iterator eit;
   for (eit = _elements.begin(); eit != _elements.end(); ++eit)
   {
     delete eit->second;
-    eit->second = NULL;
+    eit->second = nullptr;
   }
   _elements.clear();
 }
@@ -390,7 +387,7 @@ ElementFragmentAlgorithm::clearAncestry()
   for (mit = _temp_nodes.begin(); mit != _temp_nodes.end(); ++mit)
   {
     delete mit->second;
-    mit->second = NULL;
+    mit->second = nullptr;
   }
   _temp_nodes.clear();
 
@@ -446,7 +443,7 @@ ElementFragmentAlgorithm::connectFragments(bool mergeUncutVirtualEdges)
   std::vector<EFAElement *>::iterator vit;
   for (vit = _child_elements.begin(); vit != _child_elements.end();)
   {
-    if (*vit == NULL)
+    if (*vit == nullptr)
       vit = _child_elements.erase(vit);
     else
       ++vit;

--- a/modules/xfem/src/materials/LevelSetBiMaterialBase.C
+++ b/modules/xfem/src/materials/LevelSetBiMaterialBase.C
@@ -50,7 +50,7 @@ LevelSetBiMaterialBaseTempl<is_ad>::LevelSetBiMaterialBaseTempl(const InputParam
 {
   FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
 
-  if (fe_problem == NULL)
+  if (fe_problem == nullptr)
     mooseError("Problem casting _subproblem to FEProblemBase in XFEMMaterialStateMarkerBase");
 
   _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());

--- a/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
+++ b/modules/xfem/src/userobjects/CrackMeshCut3DUserObject.C
@@ -62,12 +62,12 @@ CrackMeshCut3DUserObject::CrackMeshCut3DUserObject(const InputParameters & param
     _n_step_growth(getParam<unsigned int>("n_step_growth")),
     _is_mesh_modified(false),
     _func_x(parameters.isParamValid("growth_direction_x") ? &getFunction("growth_direction_x")
-                                                          : NULL),
+                                                          : nullptr),
     _func_y(parameters.isParamValid("growth_direction_y") ? &getFunction("growth_direction_y")
-                                                          : NULL),
+                                                          : nullptr),
     _func_z(parameters.isParamValid("growth_direction_z") ? &getFunction("growth_direction_z")
-                                                          : NULL),
-    _func_v(parameters.isParamValid("growth_rate") ? &getFunction("growth_rate") : NULL)
+                                                          : nullptr),
+    _func_v(parameters.isParamValid("growth_rate") ? &getFunction("growth_rate") : nullptr)
 {
   _grow = (_n_step_growth == 0 ? 0 : 1);
 
@@ -79,13 +79,13 @@ CrackMeshCut3DUserObject::CrackMeshCut3DUserObject(const InputParameters & param
     _size_control = getParam<Real>("size_control");
 
     if (_growth_dir_method == GrowthDirectionEnum::FUNCTION &&
-        (_func_x == NULL || _func_y == NULL || _func_z == NULL))
+        (_func_x == nullptr || _func_y == nullptr || _func_z == nullptr))
       mooseError("function is not specified for the function method that defines growth direction");
 
-    if (_growth_dir_method == GrowthDirectionEnum::FUNCTION && _func_v == NULL)
+    if (_growth_dir_method == GrowthDirectionEnum::FUNCTION && _func_v == nullptr)
       mooseError("function is not specified for the function method that defines growth rate");
 
-    if (_growth_dir_method == GrowthDirectionEnum::FUNCTION && _func_v == NULL)
+    if (_growth_dir_method == GrowthDirectionEnum::FUNCTION && _func_v == nullptr)
       mooseError("function with a variable is not specified for the fatigue method that defines "
                  "growth rate");
 
@@ -664,7 +664,7 @@ CrackMeshCut3DUserObject::findActiveBoundaryNodes()
     Point & this_point = *this_node;
 
     const Elem * elem = (*pl)(this_point);
-    if (elem == NULL)
+    if (elem == nullptr)
       _inactive_boundary_pos.push_back(j);
   }
 
@@ -937,10 +937,10 @@ CrackMeshCut3DUserObject::findFrontIntersection()
       std::unique_ptr<PointLocatorBase> pl = _mesh.getPointLocator();
       pl->enable_out_of_mesh_mode();
       const Elem * elem = (*pl)(p1);
-      if (elem == NULL)
+      if (elem == nullptr)
         do_inter1 = 0;
       elem = (*pl)(p4);
-      if (elem == NULL)
+      if (elem == nullptr)
         do_inter2 = 0;
 
       for (const auto & belem : range)

--- a/modules/xfem/src/userobjects/GeometricCutUserObject.C
+++ b/modules/xfem/src/userobjects/GeometricCutUserObject.C
@@ -45,7 +45,7 @@ GeometricCutUserObject::GeometricCutUserObject(const InputParameters & parameter
   auto new_xfem_epl = std::make_shared<XFEMElementPairLocator>(_xfem, _interface_id);
   _fe_problem.geomSearchData().addElementPairLocator(_interface_id, new_xfem_epl);
 
-  if (_fe_problem.getDisplacedProblem() != NULL)
+  if (_fe_problem.getDisplacedProblem() != nullptr)
   {
     auto new_xfem_epl2 = std::make_shared<XFEMElementPairLocator>(_xfem, _interface_id, true);
     _fe_problem.getDisplacedProblem()->geomSearchData().addElementPairLocator(_interface_id,

--- a/modules/xfem/src/userobjects/XFEMMaterialStateMarkerBase.C
+++ b/modules/xfem/src/userobjects/XFEMMaterialStateMarkerBase.C
@@ -32,7 +32,7 @@ XFEMMaterialStateMarkerBase::XFEMMaterialStateMarkerBase(const InputParameters &
     _secondary_cracks(getParam<bool>("secondary_cracks"))
 {
   FEProblemBase * fe_problem = dynamic_cast<FEProblemBase *>(&_subproblem);
-  if (fe_problem == NULL)
+  if (fe_problem == nullptr)
     mooseError("Problem casting _subproblem to FEProblemBase in XFEMMaterialStateMarkerBase");
   _xfem = MooseSharedNamespace::dynamic_pointer_cast<XFEM>(fe_problem->getXFEM());
   if (_xfem == nullptr)


### PR DESCRIPTION
Refs #24942 

This improves the performance of `getCommonEdgeID` and dramatically speeds up `clearPotentialIsolatedNodes`. Additionally some code cleanup is done to use more range based loops, destructuring assignments, `nullptr` instead of `NULL`, and avoiding passing `std::vector`s by copy.

Attached are two profiles of an XFEM levelset cut

### Pre-PR (~7h runtime)
![profile001](https://github.com/idaholab/moose/assets/202302/e4b3c9cd-df14-4323-bc39-26f510000585)

### Post-PR (13mins runtime)
![profile001](https://github.com/idaholab/moose/assets/202302/ad59867c-b665-4c3e-8f71-846e84db9366)
