### PR TITLE
Initializer list

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -160,6 +160,17 @@ public:
   void addParam(const std::string & name, const std::string & doc_string);
   ///@}
 
+  /**
+   * Enable support for initializer lists as default arguments for container type.
+   */
+  template <typename T>
+  void addParam(const std::string & name,
+                const std::initializer_list<typename T::value_type> & value,
+                const std::string & doc_string)
+  {
+    addParam<T>(name, T{value}, doc_string);
+  }
+
   ///@{
   // BEGIN RANGE CHECKED PARAMETER METHODS
   /**

--- a/framework/src/actions/AddNodalNormalsAction.C
+++ b/framework/src/actions/AddNodalNormalsAction.C
@@ -28,9 +28,10 @@ AddNodalNormalsAction::validParams()
                              "facing normal from a node.");
 
   // Initialize the 'boundary' input option to default to any boundary
-  std::vector<BoundaryName> everywhere(1, "ANY_BOUNDARY_ID");
   params.addParam<std::vector<BoundaryName>>(
-      "boundary", everywhere, "The boundary ID or name where the normals will be computed");
+      "boundary",
+      {"ANY_BOUNDARY_ID"},
+      "The boundary ID or name where the normals will be computed");
   params.addParam<BoundaryName>("corner_boundary", "boundary ID or name with nodes at 'corners'");
   MooseEnum orders("FIRST SECOND", "FIRST");
   params.addParam<MooseEnum>("order",

--- a/framework/src/actions/SetupMeshAction.C
+++ b/framework/src/actions/SetupMeshAction.C
@@ -50,9 +50,11 @@ SetupMeshAction::validParams()
   params.addParam<std::vector<SubdomainName>>(
       "block_name", "Names of the block id/name pairs (must correspond with \"block_id\"");
 
-  params.addParam<std::vector<BoundaryID>>("boundary_id", "IDs of the boundary id/name pairs");
+  params.addParam<std::vector<BoundaryID>>("boundary_id", {}, "IDs of the boundary id/name pairs");
   params.addParam<std::vector<BoundaryName>>(
-      "boundary_name", "Names of the boundary id/name pairs (must correspond with \"boundary_id\"");
+      "boundary_name",
+      {},
+      "Names of the boundary id/name pairs (must correspond with \"boundary_id\"");
 
   params.addParam<bool>("construct_side_list_from_node_list",
                         false,
@@ -72,8 +74,8 @@ SetupMeshAction::validParams()
       "Create the displaced mesh if the 'displacements' "
       "parameter is set. If this is 'false', a displaced mesh will not be created, "
       "regardless of whether 'displacements' is set.");
-  params.addParam<std::vector<BoundaryName>>("ghosted_boundaries",
-                                             "Boundaries to be ghosted if using Nemesis");
+  params.addParam<std::vector<BoundaryName>>(
+      "ghosted_boundaries", {}, "Boundaries to be ghosted if using Nemesis");
   params.addParam<std::vector<Real>>("ghosted_boundaries_inflation",
                                      "If you are using ghosted boundaries you will want to set "
                                      "this value to a vector of amounts to inflate the bounding "


### PR DESCRIPTION
Refs #24455

This is in preparation for @MengnanLi91 's PR that removes implicitly empty vector defaults for vector input parameters. This will allow users to specify empty vector defaults explicitly as `{}`.