### PR TITLE
Simply testing for Conda MOOSE, update libmesh

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,13 +1,13 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_9
+  - moose-mpich 4.0.2 build_10
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -15,5 +15,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -7,6 +7,8 @@
 {% set vtk_version = "9.2.6" %}
 {% set vtk_friendly_version = "9.2" %}
 {% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}
+
+# permanent
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 2 %}
+{% set build = 3 %}
 {% set vtk_version = "9.2.6" %}
 {% set vtk_friendly_version = "9.2" %}
 {% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,16 +1,16 @@
 moose_petsc:
-  - moose-petsc 3.16.6 build_9
+  - moose-petsc 3.16.6 build_10
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.2.6 build_2
+  - moose-libmesh-vtk 9.2.6 build_3
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -18,5 +18,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 2 %}
+{% set build = 3 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "2023.07.26" %}
 {% set vtk_friendly_version = "9.2" %}

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -5,9 +5,11 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 3 %}
-{% set strbuild = "build_" + build|string %}
 {% set version = "2023.07.26" %}
 {% set vtk_friendly_version = "9.2" %}
+
+# permanent
+{% set strbuild = "build_" + build|string %}
 
 package:
   name: moose-libmesh

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,8 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 3 %}
-{% set version = "2023.07.26" %}
+{% set build = 0 %}
+{% set version = "2023.09.06" %}
 {% set vtk_friendly_version = "9.2" %}
 
 # permanent

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,11 +1,11 @@
 moose_libmesh:
-  - moose-libmesh 2023.07.26 build_2
+  - moose-libmesh 2023.07.26 build_3
 
 moose_wasp:
-  - moose-wasp 2023.08.17
+  - moose-wasp 2023.08.31
 
 moose_tools:
-  - moose-tools 2023.08.17
+  - moose-tools 2023.08.31
 
 moose_peacock:
-  - moose-peacock 2023.08.17
+  - moose-peacock 2023.08.31

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2023.07.26 build_3
+  - moose-libmesh 2023.09.06 build_0
 
 moose_wasp:
   - moose-wasp 2023.08.31

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -4,8 +4,7 @@
 #   template/conda_build_config.yaml
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
-{% set version = "2023.08.29" %}
+{% set version = "2023.08.31" %}
 {% set strbuild = "build_" + build|string %}
 
 package:
@@ -17,7 +16,6 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ strbuild }}
   skip: true  # [win]
 
 requirements:

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -5,7 +5,6 @@
 #
 # As well as any directions pertaining to modifying those files.
 {% set version = "2023.08.31" %}
-{% set strbuild = "build_" + build|string %}
 
 package:
   name: moose-dev
@@ -15,7 +14,8 @@ source:
   path: ../moose-dev
 
 build:
-  number: {{ build }}
+  number: 0
+  string: build_0
   skip: true  # [win]
 
 requirements:

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -4,7 +4,7 @@
 #   template/conda_build_config.yaml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.08.31" %}
+{% set version = "2023.09.06" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,13 +1,13 @@
 moose_dev:
-  - moose-dev 2023.08.29
+  - moose-dev 2023.08.31
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -15,5 +15,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.08.31
+  - moose-dev 2023.09.06
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -3,8 +3,6 @@
 # conda_build_config.yaml file (moose_libmesh)
 {% set VERSION = "<VERSION>" %}
 {% set SKIP_DOCS = "<SKIP_DOCS>" %}
-{% set build = 0 %}
-{% set strbuild = "build_" + build|string %}
 
 package:
   name: moose
@@ -15,7 +13,6 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ strbuild }}
   skip: true # [win]
   pin_depends: strict
   script_env:

--- a/conda/moose/meta.yaml
+++ b/conda/moose/meta.yaml
@@ -12,7 +12,8 @@ source:
   - path: ../../../moose
 
 build:
-  number: {{ build }}
+  number: 0
+  string: build_0
   skip: true # [win]
   pin_depends: strict
   script_env:

--- a/conda/moose/run_test.sh
+++ b/conda/moose/run_test.sh
@@ -1,51 +1,10 @@
 #!/bin/bash
-
+set -e
 # If Intel Mac, forget about it. The environment doesn't seem fit to run
 if [[ $(uname) == 'Darwin' ]] && [[ $(uname -m) == 'x86_64' ]]; then
     exit 0
 fi
-
-# A list of module(s)/directories that we do not want to include for testing
-NOT_RUNNABLE=(doc module_load framework external_petsc_solver)
-
-# Support older bash (like Darwin Intel) to build a list of possible modules we want to test
-cd ${CONDA_PREFIX}/moose/share/combined
-IFS=$'\n' POSSIBLE=(`find . -mindepth 1 -maxdepth 1 -type d -exec basename {} \;`)
-_my_temp=`mktemp -d`
-cd ${_my_temp}
-
-# For my next bash trick... replace spaces for new lines and use `uniq` to remove any matches we
-# find in POSSIBLE, and then again for any remainder in NOT_RUNNABLE to clean it up. ACTUALS should
-# be what we are actually able to run.
-ACTUALS=(`printf '%s\n' ${NOT_RUNNABLE[*]} ${POSSIBLE[*]} ${NOT_RUNNABLE[*]} | sort | uniq -u`)
-
-CORES=${MOOSE_JOBS:-2}
-# TestHarness (Python threads) does not perform well beyond 12 cores
-if [ $CORES -ge 12 ]; then CORES=12; fi
-EXIT_CODE=0
-# A hack for now, to make Darwin work
-PLACEHOLDER='tests'
-if [[ $(uname) == Darwin ]]; then
-    PLACEHOLDER=''
-fi
-
-# Do not halt on the first failed test. We want a log of all of them
-set +e
-
-for ACTUAL in ${ACTUALS[@]}; do
-    printf "Working on ${ACTUAL}...\n"
-    combined-opt --copy-inputs ${ACTUAL}
-    cd combined/${ACTUAL}/${PLACEHOLDER}
-    combined-opt --run -j ${CORES}
-    _last_run=$?
-    if [ $_last_run -ge 1 ]; then
-        EXIT_CODE=${_last_run}
-    fi
-    cd -
-done
-
-# CLEANUP
-cd /tmp
-rm -rf ${_my_temp}
-
-exit ${EXIT_CODE}
+combined-opt --copy-inputs framework
+cd combined/framework
+combined-opt --run -j 4 --re=kernels/simple_diffusion
+exit 0

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -79,11 +79,11 @@ moose_mesalib:                                              # [linux]
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -91,5 +91,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 9 %}
+{% set build = 10 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
 

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -7,8 +7,10 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 10 %}
-{% set strbuild = "build_" + build|string %}
 {% set version = "4.0.2" %}
+
+# permanent
+{% set strbuild = "build_" + build|string %}
 
 package:
   name: moose-mpich

--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_9
+  - moose-mpich 4.0.2 build_10
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -3,7 +3,6 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
 {% set version = "2023.08.31" %}
 
 package:
@@ -14,7 +13,7 @@ source:
   path: ../peacock
 
 build:
-  number: {{ build }}
+  number: 0
 
 requirements:
   run:

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 {% set build = 0 %}
-{% set version = "2023.08.17" %}
+{% set version = "2023.08.31" %}
 
 package:
   name: moose-peacock

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,13 +1,13 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_9
+  - moose-mpich 4.0.2 build_10
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -15,5 +15,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 9 %}
+{% set build = 10 %}
 {% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
 {% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -5,9 +5,10 @@
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 10 %}
-{% set strbuild = "build_" + build|string %}
 {% set version = "3.16.6" %}
-{% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}
+
+# permanent
+{% set strbuild = "build_" + build|string %}
 
 package:
   name: moose-petsc

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,13 +1,13 @@
 moose_dev:
-  - moose-dev 2023.08.29
+  - moose-dev 2023.08.31
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -15,5 +15,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.08.31
+  - moose-dev 2023.09.06
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -1,7 +1,6 @@
 # Do not alter <BUILD>, <VERSION>. These are template tokens altered
 # on the fly by the generate_recipe.py script. The only modifiable
 # item in template/ is the conda_build_config.yaml file (moose_libmesh)
-{% set build = "<BUILD>" %}
 {% set version = "<VERSION>" %}
 
 package:
@@ -12,7 +11,8 @@ source:
   path: <REPO>
 
 build:
-  number: {{ build }}  # [linux,osx]
+  number: 0
+  string: build_0
   pin_depends: strict
   skip: true # [win]
 

--- a/conda/template/meta.yaml
+++ b/conda/template/meta.yaml
@@ -3,7 +3,6 @@
 # item in template/ is the conda_build_config.yaml file (moose_libmesh)
 {% set build = "<BUILD>" %}
 {% set version = "<VERSION>" %}
-{% set strbuild = "build_" + build|string %}
 
 package:
   name: <PREFIX_PACKAGE_WITH><FORMATTED_APPLICATION>
@@ -14,7 +13,6 @@ source:
 
 build:
   number: {{ build }}  # [linux,osx]
-  string: {{ strbuild }}
   pin_depends: strict
   skip: true # [win]
 

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 {% set build = 0 %}
-{% set version = "2023.08.17" %}
+{% set version = "2023.08.31" %}
 
 package:
   name: moose-test-tools

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -3,7 +3,6 @@
 #   tools/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
 {% set version = "2023.08.31" %}
 
 package:
@@ -14,7 +13,7 @@ source:
   path: ../test-tools
 
 build:
-  number: {{ build }}
+  number: 0
 
 requirements:
   build:

--- a/conda/tools/conda_build_config.yaml
+++ b/conda/tools/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_test_tools:
-  - moose-test-tools 2023.08.17
+  - moose-test-tools 2023.08.31
 
 moose_python:
   - python 3.10

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 {% set build = 0 %}
-{% set version = "2023.08.17" %}
+{% set version = "2023.08.31" %}
 
 package:
   name: moose-tools

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,6 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 0 %}
 {% set version = "2023.08.31" %}
 
 package:
@@ -14,7 +13,7 @@ source:
   path: ../tools
 
 build:
-  number: {{ build }}
+  number: 0
 
 requirements:
   build:

--- a/conda/wasp/conda_build_config.yaml
+++ b/conda/wasp/conda_build_config.yaml
@@ -1,6 +1,6 @@
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]
-  - /opt/MacOSX10.12.sdk                                    # [not arm64 and osx]
+  - /opt/MacOSX10.15.sdk                                    # [not arm64 and osx]
   - /opt/MacOSX11.3.sdk                                     # [arm64]
 
 c_compiler_version:                                         # [unix]
@@ -17,7 +17,7 @@ fortran_compiler_version:                                   # [unix]
   - 11.3                                                    # [arm64]
 
 macos_min_version:                                          # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]
 
 macos_machine:                                              # [osx]
@@ -25,5 +25,5 @@ macos_machine:                                              # [osx]
   - arm64-apple-darwin20.0.0                                # [arm64]
 
 MACOSX_DEPLOYMENT_TARGET:                                   # [osx]
-  - 10.12                                                   # [not arm64 and osx]
+  - 10.15                                                   # [not arm64 and osx]
   - 11.3                                                    # [arm64]

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,6 +4,8 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
+{% set build = 0 %}
+{% set strbuild = "build_" + build|string %}
 {% set version = "2023.08.31" %}
 
 package:
@@ -16,6 +18,7 @@ source:
 
 build:
   number: {{ build }}
+  string: {{ strbuild }}
   skip: true  # [win]
   script_env:
     - MOOSE_JOBS

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -4,9 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 0 %}
-{% set strbuild = "build_" + build|string %}
-{% set version = "2023.08.17" %}
+{% set version = "2023.08.31" %}
 
 package:
   name: moose-wasp
@@ -18,7 +16,6 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ strbuild }}
   skip: true  # [win]
   script_env:
     - MOOSE_JOBS

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=fd900b54a02b9d1b99f0a4371d4acb4761e57b0f
+ARG LIBMESH_REV=ceff84386bdc83d87e9eb98ac3a9b745711e415a
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -111,3 +111,9 @@ fbdfe0b21aa567c79f7f89808720231977987a12: # 24661
   libmesh: d5b4a94
   moose: 3ba4cc1
   wasp: 0052bf7
+fa4c2347f80a3859d2bf68d92f52341331274f34: # 25370
+  mpich: ac902f8
+  petsc: 9fe2e73
+  libmesh: 26585cd
+  moose: fc4e3b7
+  wasp: 76657f9


### PR DESCRIPTION
Remove most testing being done during Conda MOOSE package creation. Testing will be implemented as a separate target. This will allow for quicker package creation when things go awry.

Closes #25369

---

From @roystgnr:
libMesh submodule update added, to minimize the number of mamba updates users will get hit with:

- NetCDF upgrade to 4.9.2, now incorporating NetCDF via a git submodule
- p-refinement can now be selectively disabled and reenabled on a per-variable-group basis
- New error indicator for Empirical Interpolation Method (EIM) reduced-basis approximations
- `Elem::quality(ASPECT_RATIO)` is now defined for all element types
- Added option to use absolute instead of relative tolerances in linear solvers
- Added the capability to "upgrade" a vector's ghosting and/or projection settings in subsequent `System::add_vector()` calls
- Added `MeshRefinement::allow_unrefined_patches()` option
- Refactored iterator declarations and added more range methods in `MeshBase`: every filtered iterator that could be previously accessed with a `...begin()` and `...end()` method now also has a `...range()` method suitable for range-based for loops
- Better PETSc versioning macros for use with pre-release PETSc commits
- Build system now sets `CFLAGS_OPT`, etc. environment variables, not just `CXXFLAGS` and `CPPFLAGS` versions
- Many more unit tests for ExodusII I/O and for element refinement APIs
- Assorted fixes
  - Fixed Exodus I/O of side sets on 2D triangles embedded in 3D space
  - Fixed Nemesis dimension variable output
  - Fixed Nedelec one `FE` compatibility with `Tri7` and `Tet14` geometric elements
  - Fixed multiple issues with mesh refinement on meshes with certain types of infinite elements
  - Fixed no-parameters case and improved print statements in EIM code
  - Fixed typos in code comments
  - Minor fixes in vector FE example programs
- Assorted optimizations
  - An unnecessary pointer-indirection layer has been removed from `DiffContext`
  - Local matrix allocation in `DiffContext` objects is now optional
  - Minor optimizations have been made to Hilbert-curve global indexing calculations

Refs https://github.com/idaholab/moose/pull/25290 - we'll want to reenable those tests with new golds after this is safely in.

This fixes https://github.com/idaholab/moose/issues/24631

This fixes https://github.com/idaholab/moose/issues/25007 in my tests