### PR TITLE
Speed up getBoundaryIDs when distributed

### DIFF
--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -90,10 +90,11 @@ getBoundaryIDs(const MeshBase & mesh,
    */
   if (generate_unknown)
   {
-    const std::set<BoundaryID> & local_bids = mesh.get_boundary_info().get_boundary_ids();
-    max_boundary_local_id = local_bids.empty() ? 0 : *(local_bids.rbegin());
+    const auto & bids = mesh.is_prepared() ? mesh.get_boundary_info().get_global_boundary_ids()
+                                           : mesh.get_boundary_info().get_boundary_ids();
+    max_boundary_local_id = bids.empty() ? 0 : *(bids.rbegin());
     /* We should not hit this often */
-    if (!mesh.is_serial())
+    if (!mesh.is_prepared() && !mesh.is_serial())
       mesh.comm().max(max_boundary_local_id);
   }
 

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -61,6 +61,9 @@ changeBoundaryId(MeshBase & mesh,
   // from showing up when printing information, etc.
   if (delete_prev)
     boundary_info.remove_id(old_id);
+
+  // global information may now be out of sync
+  mesh.set_isnt_prepared();
 }
 
 std::vector<boundary_id_type>

--- a/framework/src/utils/MooseMeshUtils.C
+++ b/framework/src/utils/MooseMeshUtils.C
@@ -242,6 +242,9 @@ changeSubdomainId(MeshBase & mesh, const subdomain_id_type old_id, const subdoma
   for (const auto & elem : mesh.element_ptr_range())
     if (elem->subdomain_id() == old_id)
       elem->subdomain_id() = new_id;
+
+  // global cached information may now be out of sync
+  mesh.set_isnt_prepared();
 }
 
 Point


### PR DESCRIPTION
If we are prepared, then we can use the cached data in `BoundaryInfo::get_global_boundary_ids`. This allows us to avoid a communication call that we would otherwise have to do if the mesh is distributed