### PR TITLE
Yell at the user for combining ICs and restart

### DIFF
--- a/framework/include/problems/FEProblemBase.h
+++ b/framework/include/problems/FEProblemBase.h
@@ -2473,6 +2473,7 @@ private:
   bool _ignore_zeros_in_jacobian;
   const bool _force_restart;
   const bool _skip_additional_restart_data;
+  const bool _allow_ics_during_restart;
   const bool _skip_nl_system_check;
   bool _fail_next_nonlinear_convergence_check;
   const bool & _allow_invalid_solution;

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -673,8 +673,8 @@ FEProblemBase::initialSetup()
 
   SubProblem::initialSetup();
 
-  mooseAssert(_app.isRecovering() + _app.isRestarting() + bool(_app.getExReaderForRestart()) <= 1,
-              "Checkpoint recovery and restart and exodus restart are all mutually exclusive.");
+  if (_app.isRecovering() + _app.isRestarting() + bool(_app.getExReaderForRestart()) > 1)
+    mooseError("Checkpoint recovery and restart and exodus restart are all mutually exclusive.");
 
   if (_skip_exception_check)
     mooseWarning("MOOSE may fail to catch an exception when the \"skip_exception_check\" parameter "

--- a/modules/combined/test/tests/restart-transient-from-ss-with-stateful/parent_tr.i
+++ b/modules/combined/test/tests/restart-transient-from-ss-with-stateful/parent_tr.i
@@ -2,6 +2,9 @@
   restart_file_base = parent_ss_checkpoint_cp/LATEST
   force_restart = true
   skip_additional_restart_data = true
+
+  # The auxiliary field has an initial condition
+  allow_initial_conditions_with_restart = true
 []
 
 [Mesh]
@@ -9,68 +12,68 @@
 []
 
 [Variables]
-  [./temp]
+  [temp]
     # no initial condition for restart.
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./power]
+  [power]
     order = FIRST
     family = L2_LAGRANGE
     initial_condition = 350
-  [../]
+  []
 []
 
 [Kernels]
-  [./heat]
+  [heat]
     type = HeatConduction
     variable = temp
-  [../]
-  [./heat_ie]
+  []
+  [heat_ie]
     type = HeatConductionTimeDerivative
     variable = temp
-  [../]
-  [./heat_source_fuel]
+  []
+  [heat_source_fuel]
     type = CoupledForce
     variable = temp
     v = 'power'
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = DirichletBC
     variable = temp
     boundary = 'bottom top left right'
     value = 300
-  [../]
+  []
 []
 
 [Materials]
-  [./heat_material]
+  [heat_material]
     type = HeatConductionMaterial
     temp = temp
     specific_heat = 1000
     thermal_conductivity = 500
-  [../]
-  [./density]
+  []
+  [density]
     type = Density
     density = 2000
-  [../]
+  []
 []
 
 [Postprocessors]
-  [./avg_temp]
+  [avg_temp]
     type = ElementAverageValue
     variable = temp
     execute_on = 'timestep_end'
-  [../]
-  [./avg_power]
+  []
+  [avg_power]
     type = ElementAverageValue
     variable = power
     execute_on = 'timestep_end'
-  [../]
+  []
 []
 
 [Executioner]
@@ -99,20 +102,20 @@
 []
 
 [MultiApps]
-  [./bison]
+  [bison]
     type = TransientMultiApp
     positions = '0 0 0'
     input_files = 'sub_tr.i'
     execute_on = 'timestep_end'
-  [../]
+  []
 []
 
 [Transfers]
-  [./to_bison_mechanics]
+  [to_bison_mechanics]
     type = MultiAppProjectionTransfer
     to_multi_app = bison
     variable = temp
     source_variable = temp
     execute_on = 'timestep_end'
-  [../]
+  []
 []

--- a/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_2.i
+++ b/modules/contact/test/tests/mortar_restart/frictional_bouncing_block_action_restart_2.i
@@ -18,9 +18,11 @@ offset = 1e-2
 
 [Problem]
   #Note that the suffix is left off in the parameter below.
-  restart_file_base = frictional_bouncing_block_action_restart_1_checkpoint_cp/LATEST  # You may also use a specific number here
+  restart_file_base = frictional_bouncing_block_action_restart_1_checkpoint_cp/LATEST # You may also use a specific number here
   kernel_coverage_check = false
   material_coverage_check = false
+  # disp_y has an initial condition despite the checkpoint restart
+  allow_initial_conditions_with_restart = true
 []
 
 [Variables]
@@ -119,8 +121,7 @@ offset = 1e-2
   dtmin = .01
   solve_type = 'PJFNK'
 
-  petsc_options = '-snes_converged_reason -ksp_converged_reason -pc_svd_monitor '
-                  '-snes_linesearch_monitor -snes_ksp_ew'
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -pc_svd_monitor -snes_linesearch_monitor -snes_ksp_ew'
   petsc_options_iname = '-pc_type -pc_factor_mat_solver_type -pc_factor_shift_type -pc_factor_shift_amount -mat_mffd_err'
   petsc_options_value = 'lu       superlu_dist                  NONZERO               1e-13                   1e-5'
   l_max_its = 30

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_thick_fracture_transient.i
@@ -48,6 +48,11 @@
   []
 []
 
+[Problem]
+  # massfrac0 has an initial condition despite the restart
+  allow_initial_conditions_with_restart = true
+[]
+
 [ICs]
   [massfrac0]
     type = ConstantIC
@@ -72,7 +77,7 @@
   [ptop]
     type = DirichletBC
     variable = pp
-    boundary =  top
+    boundary = top
     value = 1e6
   []
   [pbottom]
@@ -158,7 +163,7 @@
   []
   [poro_fracture]
     type = PorousFlowPorosityConst
-    porosity = 1.0    # this is the true porosity of the fracture
+    porosity = 1.0 # this is the true porosity of the fracture
     block = 'fracture'
   []
   [poro_matrix]
@@ -196,9 +201,9 @@
 
 [Functions]
   [dt_controller]
-     type = PiecewiseConstant
-     x = '0    30   40 100 200 83200'
-     y = '0.01 0.1  1  10  100 32'
+    type = PiecewiseConstant
+    x = '0    30   40 100 200 83200'
+    y = '0.01 0.1  1  10  100 32'
   []
 []
 
@@ -229,12 +234,11 @@
     function = dt_controller
   []
 
-# controls for nonlinear iterations
+  # controls for nonlinear iterations
   nl_max_its = 15
   nl_rel_tol = 1e-14
   nl_abs_tol = 1e-9
 []
-
 
 [VectorPostprocessors]
   [xmass]

--- a/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
+++ b/modules/porous_flow/examples/flow_through_fractured_media/fine_transient.i
@@ -50,6 +50,11 @@
   []
 []
 
+[Problem]
+  # massfrac0 has an initial condition despite the restart
+  allow_initial_conditions_with_restart = true
+[]
+
 [ICs]
   [massfrac0]
     type = ConstantIC
@@ -74,7 +79,7 @@
   [ptop]
     type = DirichletBC
     variable = pp
-    boundary =  top
+    boundary = top
     value = 1e6
   []
   [pbottom]
@@ -160,7 +165,7 @@
   []
   [poro_fracture]
     type = PorousFlowPorosityConst
-    porosity = 6e-4   # = a * phif
+    porosity = 6e-4 # = a * phif
     block = 'fracture'
   []
   [poro_matrix]
@@ -198,9 +203,9 @@
 
 [Functions]
   [dt_controller]
-     type = PiecewiseConstant
-     x = '0    30   40 100 200 83200'
-     y = '0.01 0.1  1  10  100 32'
+    type = PiecewiseConstant
+    x = '0    30   40 100 200 83200'
+    y = '0.01 0.1  1  10  100 32'
   []
 []
 
@@ -230,12 +235,11 @@
     function = dt_controller
   []
 
-# controls for nonlinear iterations
+  # controls for nonlinear iterations
   nl_max_its = 15
   nl_rel_tol = 1e-14
   nl_abs_tol = 1e-9
 []
-
 
 [VectorPostprocessors]
   [xmass]

--- a/modules/porous_flow/examples/reservoir_model/field_model.i
+++ b/modules/porous_flow/examples/reservoir_model/field_model.i
@@ -11,6 +11,11 @@
   temperature_unit = Celsius
 []
 
+[Problem]
+  # Variable porepressure has an initial condition despite the restart
+  allow_initial_conditions_with_restart = true
+[]
+
 [Variables]
   [porepressure]
     initial_condition = 20e6
@@ -107,7 +112,7 @@
     type = Water97FluidProperties
   []
   [watertab]
-    type = TabulatedFluidProperties
+    type = TabulatedBicubicFluidProperties
     fp = water
     save_file = false
   []

--- a/modules/porous_flow/examples/reservoir_model/tests
+++ b/modules/porous_flow/examples/reservoir_model/tests
@@ -1,21 +1,23 @@
 [Tests]
-[./regular_grid]
-  type = Exodiff
-  input = regular_grid.i
-  exodiff = regular_grid_out.e
-  threading = '!pthreads'
-  cli_args = 'Mesh/nx=10 Mesh/ny=10'
-  requirement = "PorousFlow shall be able to create a heterogeneous model using supplied heterogeneity data"
-  issues = '#13XXX'
-  design = 'porous_flow/heterogeneous_models.md'
-[../]
-[./field_model]
-  type = Exodiff
-  input = field_model.i
-  exodiff = field_model_out.e
-  threading = '!pthreads'
-  requirement = "PorousFlow shall be able to create a heterogeneous model using data from a supplied mesh"
-  issues = '#13XXX'
-  design = 'porous_flow/heterogeneous_models.md'
-[../]
+  [regular_grid]
+    type = Exodiff
+    input = regular_grid.i
+    exodiff = regular_grid_out.e
+    threading = '!pthreads'
+    cli_args = 'Mesh/nx=10 Mesh/ny=10'
+    requirement = "The system shall be able to create a heterogeneous model using supplied "
+                  "heterogeneity data."
+    issues = '#13751'
+    design = 'porous_flow/heterogeneous_models.md'
+  []
+  [field_model]
+    type = Exodiff
+    input = field_model.i
+    exodiff = field_model_out.e
+    threading = '!pthreads'
+    requirement = "The system shall be able to create a heterogeneous model using data from a "
+                  "supplied mesh."
+    issues = '#13751'
+    design = 'porous_flow/heterogeneous_models.md'
+  []
 []

--- a/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm3.i
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/constant_poroperm3.i
@@ -11,6 +11,10 @@
   gravity = '0 0 -10'
 []
 
+[Problem]
+  allow_initial_conditions_with_restart = true
+[]
+
 [Variables]
   [ppwater]
     initial_condition = 1e6

--- a/modules/porous_flow/test/tests/heterogeneous_materials/tests
+++ b/modules/porous_flow/test/tests/heterogeneous_materials/tests
@@ -1,33 +1,36 @@
 [Tests]
-  [./constant_poroperm]
+  [constant_poroperm]
     type = 'Exodiff'
     input = 'constant_poroperm.i'
     exodiff = 'constant_poroperm_out.e'
     threading = '!pthreads'
-    requirement = "The system shall allow the assignment of porosity and permeability from an AuxVariable field."
+    requirement = "The system shall allow the assignment of porosity and permeability from an "
+                  "AuxVariable field."
     issues = "#8062"
     design = "PorousFlowPorosity.md"
-  [../]
-  [./constant_poroperm2]
+  []
+  [constant_poroperm2]
     type = 'Exodiff'
     input = 'constant_poroperm2.i'
     exodiff = 'constant_poroperm2_out.e'
     threading = '!pthreads'
-    requirement = "The system shall allow the assignment of porosity and permeability from an AuxVariable field with binlinear relationships."
+    requirement = "The system shall allow the assignment of porosity and permeability from an "
+                  "AuxVariable field with binlinear relationships."
     issues = "#8062"
     design = "PorousFlowPorosity.md"
-  [../]
-  [./constant_poroperm3]
+  []
+  [constant_poroperm3]
     type = 'Exodiff'
     input = 'constant_poroperm3.i'
     exodiff = 'constant_poroperm2_out.e'
     prereq = constant_poroperm2
     threading = '!pthreads'
-    requirement = "The system shall allow the assignment of porosity and permeability from an AuxVariable read from a mesh"
+    requirement = "The system shall allow the assignment of porosity and permeability from an "
+                  "AuxVariable read from a mesh."
     issues = "#13478"
     design = "PorousFlowPorosity.md"
-  [../]
-  [./vol_expansion_poroperm]
+  []
+  [vol_expansion_poroperm]
     type = Exodiff
     input = vol_expansion_poroperm.i
     exodiff = vol_expansion_poroperm_out.e
@@ -35,5 +38,5 @@
     requirement = "The system shall calculate permeability from a changing porosity."
     issues = "#8062"
     design = "PorousFlowPorosity.md"
-  [../]
+  []
 []

--- a/modules/tensor_mechanics/test/tests/power_law_creep/ad_restart2.i
+++ b/modules/tensor_mechanics/test/tests/power_law_creep/ad_restart2.i
@@ -131,4 +131,6 @@
 
 [Problem]
   restart_file_base = restart1_out_cp/0006
+  # temp has an initial condition despite the restart
+  allow_initial_conditions_with_restart = true
 []

--- a/modules/tensor_mechanics/test/tests/power_law_creep/restart1.i
+++ b/modules/tensor_mechanics/test/tests/power_law_creep/restart1.i
@@ -20,6 +20,10 @@
   []
 []
 
+[Problem]
+  allow_initial_conditions_with_restart = true
+[]
+
 [Modules/TensorMechanics/Master]
   [all]
     strain = FINITE

--- a/modules/tensor_mechanics/test/tests/power_law_creep/restart2.i
+++ b/modules/tensor_mechanics/test/tests/power_law_creep/restart2.i
@@ -20,6 +20,10 @@
   []
 []
 
+[Problem]
+  allow_initial_conditions_with_restart = true
+[]
+
 [Modules/TensorMechanics/Master]
   [all]
     strain = FINITE

--- a/modules/thermal_hydraulics/test/tests/misc/restart_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/misc/restart_1phase/tests
@@ -25,6 +25,7 @@
     exodiff = 'part2_out.e'
     cli_args = '
       Problem/restart_file_base=part1_out_cp/0005
+      Problem/allow_initial_conditions_with_restart=true
       Executioner/num_steps=10
       Outputs/file_base=part2_out'
     abs_zero = 1e-7
@@ -48,6 +49,7 @@
       Components/inlet/vel=0.1
       Components/temp_outside/T=508
       Problem/restart_file_base=part1_out_cp/0005
+      Problem/allow_initial_conditions_with_restart=true
       Executioner/num_steps=10
       Outputs/file_base=part2_ics_out'
     prereq = 'part1'

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
@@ -6,50 +6,50 @@
 []
 
 [Variables]
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
     initial_condition = 0.0
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./nn]
+  [nn]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./nn]
+  [nn]
     type = SolutionAux
     variable = nn
     solution = soln
-  [../]
+  []
 []
 
 [UserObjects]
-  [./soln]
+  [soln]
     type = SolutionUserObject
     mesh = cubesource.e
     system_variables = source_nodal
-  [../]
+  []
 []
 
 [BCs]
-  [./stuff]
+  [stuff]
     type = DirichletBC
     variable = u
     boundary = '1 2'
     value = 0.0
-  [../]
+  []
 []
 
 [Executioner]
@@ -70,4 +70,7 @@
 
 [Problem]
   restart_file_base = solution_aux_exodus_interp_restart1_out_cp/0005
+  # There are initial conditions overwriting the restart on the nonlinear variables
+  # However this test is targetted at the auxiliary variable initialized from the solution uo so it's ok
+  allow_initial_conditions_with_restart = true
 []

--- a/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
+++ b/test/tests/auxkernels/solution_aux/solution_aux_exodus_interp_restart2.i
@@ -71,6 +71,6 @@
 [Problem]
   restart_file_base = solution_aux_exodus_interp_restart1_out_cp/0005
   # There are initial conditions overwriting the restart on the nonlinear variables
-  # However this test is targetted at the auxiliary variable initialized from the solution uo so it's ok
+  # However this test is targeted at the auxiliary variable initialized from the solution uo so it's ok
   allow_initial_conditions_with_restart = true
 []

--- a/test/tests/ics/from_exodus_solution/elem_part1.i
+++ b/test/tests/ics/from_exodus_solution/elem_part1.i
@@ -13,68 +13,68 @@
 []
 
 [Functions]
-  [./exact_fn]
+  [exact_fn]
     type = ParsedFunction
     expression = t*((x*x)+(y*y))
-  [../]
+  []
 
-  [./forcing_fn]
+  [forcing_fn]
     type = ParsedFunction
     expression = -4+(x*x+y*y)
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./e]
+  [e]
     order = CONSTANT
     family = MONOMIAL
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./ak]
+  [ak]
     type = FunctionAux
     variable = e
     function = exact_fn
-  [../]
+  []
 []
 
 [Variables]
   active = 'u'
 
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [Kernels]
   active = 'ie diff ffn'
 
-  [./ie]
+  [ie]
     type = TimeDerivative
     variable = u
-  [../]
+  []
 
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 
-  [./ffn]
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = '0 1 2 3'
     function = exact_fn
-  [../]
+  []
 []
 
 [Executioner]
@@ -89,4 +89,5 @@
 
 [Outputs]
   exodus = true
+  checkpoint = true
 []

--- a/test/tests/ics/from_exodus_solution/nodal_part2.i
+++ b/test/tests/ics/from_exodus_solution/nodal_part2.i
@@ -8,31 +8,31 @@
 []
 
 [Functions]
-  [./exact_fn]
+  [exact_fn]
     type = ParsedFunction
     expression = ((x*x)+(y*y))
-  [../]
+  []
 
-  [./forcing_fn]
+  [forcing_fn]
     type = ParsedFunction
     expression = -4
-  [../]
+  []
 []
 
 [Variables]
   active = 'u v'
 
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
     initial_from_file_var = u
     initial_from_file_timestep = 6
-  [../]
+  []
 
-  [./v]
+  [v]
     order = FIRST
     family = LAGRANGE
-    [./InitialCondition]
+    [InitialCondition]
       type = BoundingBoxIC
       x1 = 0.0
       x2 = 1.0
@@ -40,49 +40,53 @@
       y2 = 1.0
       inside = 3.0
       outside = 1.0
-    [../]
-  [../]
+    []
+  []
+[]
+
+[Problem]
+  allow_initial_conditions_with_restart = true
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 
-  [./ffn]
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 
-  [./diff_v]
+  [diff_v]
     type = Diffusion
     variable = v
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = '0 1 2 3'
     function = exact_fn
-  [../]
+  []
 
-  [./left_v]
+  [left_v]
     type = DirichletBC
     variable = v
     boundary = '3'
     value = 0
-  [../]
+  []
 
-  [./right_v]
+  [right_v]
     type = DirichletBC
     variable = v
     boundary = '1'
     value = 1
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/kernels/ode/coupled_ode_td_auxvar_ic_from_mesh.i
+++ b/test/tests/kernels/ode/coupled_ode_td_auxvar_ic_from_mesh.i
@@ -70,7 +70,7 @@
 
 [Problem]
   # There are initial conditions overwriting the restart on the nonlinear variables
-  # However this test is targetted at the auxiliary variable restart so it's ok
+  # However this test is targeted at the auxiliary variable restart so it's ok
   allow_initial_conditions_with_restart = true
 []
 

--- a/test/tests/kernels/ode/coupled_ode_td_auxvar_ic_from_mesh.i
+++ b/test/tests/kernels/ode/coupled_ode_td_auxvar_ic_from_mesh.i
@@ -4,68 +4,74 @@
 []
 
 [Variables]
-  [./f]
+  [f]
     family = SCALAR
     order = FIRST
     initial_condition = 1
-  [../]
-  [./f_times_mult]
+  []
+  [f_times_mult]
     family = SCALAR
     order = FIRST
     initial_condition = 1
-  [../]
+  []
 []
 
 [ScalarKernels]
-  [./dT]
+  [dT]
     type = CoupledODETimeDerivative
     variable = f
     v = f_times_mult
-  [../]
+  []
 
-  [./src]
+  [src]
     type = ParsedODEKernel
     variable = f
     expression = '-1'
-  [../]
+  []
 
-  [./f_times_mult_1]
+  [f_times_mult_1]
     type = ParsedODEKernel
     variable = f_times_mult
     expression = 'f_times_mult'
-  [../]
+  []
 
-  [./f_times_mult_2]
+  [f_times_mult_2]
     type = ParsedODEKernel
     variable = f_times_mult
     expression = '-f * g'
     coupled_variables = 'f g'
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./g]
+  [g]
     family = SCALAR
     order = FIRST
     initial_from_file_var = g
     initial_from_file_timestep = 'LATEST'
-  [../]
+  []
 []
 
 [Functions]
-  [./function_g]
+  [function_g]
     type = ParsedFunction
     expression = '(1 + t)'
-  [../]
+  []
 []
 
 [AuxScalarKernels]
-  [./set_g]
+  [set_g]
     type = FunctionScalarAux
     function = function_g
     variable = g
     execute_on = 'timestep_end'
-  [../]
+  []
+[]
+
+[Problem]
+  # There are initial conditions overwriting the restart on the nonlinear variables
+  # However this test is targetted at the auxiliary variable restart so it's ok
+  allow_initial_conditions_with_restart = true
 []
 
 [Executioner]

--- a/test/tests/kernels/ode/coupled_ode_td_var_ic_from_mesh.i
+++ b/test/tests/kernels/ode/coupled_ode_td_var_ic_from_mesh.i
@@ -4,68 +4,68 @@
 []
 
 [Variables]
-  [./f]
+  [f]
     family = SCALAR
     order = FIRST
     initial_from_file_var = f
     initial_from_file_timestep = 'LATEST'
-  [../]
-  [./f_times_mult]
+  []
+  [f_times_mult]
     family = SCALAR
     order = FIRST
     initial_from_file_var = f_times_mult
     initial_from_file_timestep = 'LATEST'
-  [../]
+  []
 []
 
 [ScalarKernels]
-  [./dT]
+  [dT]
     type = CoupledODETimeDerivative
     variable = f
     v = f_times_mult
-  [../]
+  []
 
-  [./src]
+  [src]
     type = ParsedODEKernel
     variable = f
     expression = '-1'
-  [../]
+  []
 
-  [./f_times_mult_1]
+  [f_times_mult_1]
     type = ParsedODEKernel
     variable = f_times_mult
     expression = 'f_times_mult'
-  [../]
+  []
 
-  [./f_times_mult_2]
+  [f_times_mult_2]
     type = ParsedODEKernel
     variable = f_times_mult
     expression = '-f * g'
     coupled_variables = 'f g'
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./g]
+  [g]
     family = SCALAR
     order = FIRST
-  [../]
+  []
 []
 
 [Functions]
-  [./function_g]
+  [function_g]
     type = ParsedFunction
     expression = '(1 + t)'
-  [../]
+  []
 []
 
 [AuxScalarKernels]
-  [./set_g]
+  [set_g]
     type = FunctionScalarAux
     function = function_g
     variable = g
     execute_on = 'linear initial'
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/kernels/ode/tests
+++ b/test/tests/kernels/ode/tests
@@ -1,15 +1,16 @@
 [Tests]
-  [./test_expl]
+  [test_expl]
     type = 'Exodiff'
     input = 'ode_expl_test.i'
     exodiff = 'ode_expl_test_out.e'
 
     design = "ScalarKernels/index.md"
     issues = "#726"
-    requirement = "The system shall support solving Ordinary Differential Equations in explicit form."
-  [../]
+    requirement = "The system shall support solving Ordinary Differential Equations in explicit "
+                  "form."
+  []
 
-  [./test_sys_impl]
+  [test_sys_impl]
     type = 'Exodiff'
     input = 'ode_sys_impl_test.i'
     exodiff = 'ode_sys_impl_test_out.e'
@@ -18,10 +19,11 @@
 
     design = "ScalarKernels/index.md"
     issues = "#726"
-    requirement = "The system shall support solving Ordinary Differential Equations in implicit form."
-  [../]
+    requirement = "The system shall support solving Ordinary Differential Equations in implicit "
+                  "form."
+  []
 
-  [./test_parsed_sys_impl]
+  [test_parsed_sys_impl]
     # uses the same gold file as the previous test
     prereq = 'test_sys_impl'
     type = 'Exodiff'
@@ -32,20 +34,22 @@
 
     design = "ParsedODEKernel.md"
     issues = "#726"
-    requirement = "The system shall support solving ODEs specified within the input file through parsed expression syntax."
-  [../]
+    requirement = "The system shall support solving ODEs specified within the input file through "
+                  "parsed expression syntax."
+  []
 
-  [./test_parsed_pp]
+  [test_parsed_pp]
     type = 'CSVDiff'
     input = 'parsedode_pp_test.i'
     csvdiff = 'ode_pp_test_out.csv'
 
     design = "ParsedODEKernel.md"
     issues = "#14034"
-    requirement = "The system support coupling of postprocessor values in the parsed expression ODE kernel."
-  [../]
+    requirement = "The system support coupling of postprocessor values in the parsed expression ODE "
+                  "kernel."
+  []
 
-  [./test_coupled_ode_td]
+  [test_coupled_ode_td]
     type = 'CSVDiff'
     input = 'coupled_ode_td.i'
     csvdiff = 'coupled_ode_td_out.csv'
@@ -54,9 +58,9 @@
     design = "ScalarKernels/index.md"
     issues = "#726"
     requirement = "The system shall support solving Coupled Ordinary Differential Equations."
-  [../]
+  []
 
-  [./test_coupled_ode_td_var_ic_from_mesh]
+  [test_coupled_ode_td_var_ic_from_mesh]
     type = 'CSVDiff'
     input = 'coupled_ode_td_var_ic_from_mesh.i'
     csvdiff = 'coupled_ode_td_var_ic_from_mesh_out.csv'
@@ -64,10 +68,11 @@
 
     design = "SystemBase.md"
     issues = "#13040"
-    requirement = "The system shall allow scalar variable initial condition to be loaded from a file mesh"
-  [../]
+    requirement = "The system shall allow scalar variable initial condition to be loaded from a file "
+                  "mesh"
+  []
 
-  [./test_coupled_ode_td_auxvar_ic_from_mesh]
+  [test_coupled_ode_td_auxvar_ic_from_mesh]
     type = 'CSVDiff'
     input = 'coupled_ode_td_auxvar_ic_from_mesh.i'
     csvdiff = 'coupled_ode_td_auxvar_ic_from_mesh_out.csv'
@@ -75,6 +80,7 @@
 
     design = "SystemBase.md"
     issues = "#13040"
-    requirement = "The system shall allow auxscalar variable initial condition to be loaded from a file mesh"
-  [../]
+    requirement = "The system shall allow auxscalar variable initial condition to be loaded from a "
+                  "file mesh"
+  []
 []

--- a/test/tests/multiapps/restart_subapp_ic/parent2.i
+++ b/test/tests/multiapps/restart_subapp_ic/parent2.i
@@ -10,49 +10,49 @@
 []
 
 [Functions]
-  [./v_fn]
+  [v_fn]
     type = ParsedFunction
     expression = t*x
-  [../]
-  [./ffn]
+  []
+  [ffn]
     type = ParsedFunction
     expression = x
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./v]
-  [../]
+  [v]
+  []
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
-  [./td]
+  []
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
-  [./ufn]
+  []
+  [ufn]
     type = BodyForce
     variable = u
     function = ffn
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = 'left right top bottom'
     function = v_fn
-  [../]
+  []
 []
 
 [Executioner]
@@ -67,22 +67,22 @@
 []
 
 [MultiApps]
-  [./sub_app]
+  [sub_app]
     app_type = MooseTestApp
     type = TransientMultiApp
     input_files = 'sub2.i'
     execute_on = timestep_end
     positions = '0 -1 0'
-  [../]
+  []
 []
 
 [Transfers]
-  [./from_sub]
+  [from_sub]
     type = MultiAppNearestNodeTransfer
     from_multi_app = sub_app
     source_variable = u
     variable = v
-  [../]
+  []
 []
 
 [Problem]

--- a/test/tests/multiapps/restart_subapp_ic/sub.i
+++ b/test/tests/multiapps/restart_subapp_ic/sub.i
@@ -7,50 +7,50 @@
 []
 
 [Functions]
-  [./u_fn]
+  [u_fn]
     type = ParsedFunction
     expression = t*x
-  [../]
-  [./ffn]
+  []
+  [ffn]
     type = ParsedFunction
     expression = x
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
-  [../]
+  [u]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
-  [./td]
+  []
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
-  [./fn]
+  []
+  [fn]
     type = BodyForce
     variable = u
     function = ffn
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = FunctionDirichletBC
     variable = u
     boundary = right
     function = u_fn
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/multiapps/restart_subapp_ic/sub2.i
+++ b/test/tests/multiapps/restart_subapp_ic/sub2.i
@@ -7,51 +7,57 @@
 []
 
 [Functions]
-  [./u_fn]
+  [u_fn]
     type = ParsedFunction
     expression = t*x
-  [../]
-  [./ffn]
+  []
+  [ffn]
     type = ParsedFunction
     expression = x
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
+  [u]
     initial_condition = 4.2
-  [../]
+  []
 []
 
 [Kernels]
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
-  [./td]
+  []
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
-  [./fn]
+  []
+  [fn]
     type = BodyForce
     variable = u
     function = ffn
-  [../]
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = left
     value = 0
-  [../]
-  [./right]
+  []
+  [right]
     type = FunctionDirichletBC
     variable = u
     boundary = right
     function = u_fn
-  [../]
+  []
+[]
+
+[Problem]
+  # Being restarted by the parent, yet the ICs are overriding the initial solution
+  # See t=0.5s in the gold/parent2_out_sub_app0.e file
+  allow_initial_conditions_with_restart = true
 []
 
 [Executioner]

--- a/test/tests/restart/restart_diffusion/exodus_refined_restart_1_test.i
+++ b/test/tests/restart/restart_diffusion/exodus_refined_restart_1_test.i
@@ -1,47 +1,47 @@
 [Mesh]
-  [./square]
+  [square]
     type = GeneratedMeshGenerator
     nx = 2
     ny = 2
     dim = 2
-  [../]
+  []
   uniform_refine = 2
 []
 
 [Variables]
   active = 'u'
 
-  [./u]
+  [u]
     order = FIRST
     family = LAGRANGE
-  [../]
+  []
 []
 
 [Kernels]
   active = 'diff'
 
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 []
 
 [BCs]
   active = 'left right'
 
-  [./left]
+  [left]
     type = DirichletBC
     variable = u
     boundary = 3
     value = 0
-  [../]
+  []
 
-  [./right]
+  [right]
     type = DirichletBC
     variable = u
     boundary = 1
     value = 1
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/restart/restart_diffusion/tests
+++ b/test/tests/restart/restart_diffusion/tests
@@ -91,8 +91,7 @@
   [restart_use_end_error_check]
     type = 'RunException'
     input = 'restart_diffusion_from_end_part2.i'
-    expect_err = 'Invalid value passed as "initial_from_file_timestep". Expected "LATEST" or a valid '
-                 'integer between \d+ and \d+ inclusive, received \d+'
+    expect_err = 'Invalid value passed as "initial_from_file_timestep". Expected "LATEST" or a valid integer between \d+ and \d+ inclusive, received \d+'
 
     cli_args = 'Variables/u/initial_from_file_timestep=8'
     prereq = 'restart_use_end_part2'
@@ -100,5 +99,15 @@
     issues = "#5748"
     requirement = "The system shall issue a useful error message stating the valid options when a "
                   "user requests an invalid time step number or keyword."
+  []
+
+  [restart_error_with_ics]
+    type = 'RunException'
+    input = 'exodus_refined_restart_2_test.i'
+    expect_err = 'Initial condition has been specified during an Exodus restart'
+    cli_args = 'Variables/u/initial_condition=3'
+    issues = "#21423"
+    requirement = "The system shall issue a useful error message stating that initial conditions "
+                  "should not be used when restarting."
   []
 []

--- a/test/tests/restart/restart_diffusion/tests
+++ b/test/tests/restart/restart_diffusion/tests
@@ -104,8 +104,8 @@
   [restart_error_with_ics]
     type = 'RunException'
     input = 'exodus_refined_restart_2_test.i'
-    expect_err = 'Initial condition has been specified during an Exodus restart'
-    cli_args = 'Variables/u/initial_condition=3'
+    expect_err = 'Initial conditions have been specified during an Exodus restart'
+    cli_args = 'Variables/u/initial_condition=3 Problem/allow_initial_conditions_with_restart=false'
     issues = "#21423"
     requirement = "The system shall issue a useful error message stating that initial conditions "
                   "should not be used when restarting."

--- a/test/tests/time_steppers/timesequence_stepper/timesequence_restart2.i
+++ b/test/tests/time_steppers/timesequence_stepper/timesequence_restart2.i
@@ -4,69 +4,73 @@
 
 [Problem]
   restart_file_base = timesequence_restart1_cp/0002
+  # There is an initial conditions overwriting the restart on the nonlinear variable u
+  # As you can see in the gold file, this makes the initial step output be from the
+  # initial condition
+  allow_initial_conditions_with_restart = true
 []
 
 [Functions]
-  [./exact_fn]
+  [exact_fn]
     type = ParsedFunction
     expression = t*t*(x*x+y*y)
-  [../]
+  []
 
-  [./forcing_fn]
+  [forcing_fn]
     type = ParsedFunction
     expression = 2*t*(x*x+y*y)-4*t*t
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
+  [u]
     family = LAGRANGE
     order = SECOND
-  [../]
+  []
 []
 
 [ICs]
-  [./u_var]
+  [u_var]
     type = FunctionIC
     variable = u
     function = exact_fn
-  [../]
+  []
 []
 
 [Kernels]
-  [./td]
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
+  []
 
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 
-  [./ffn]
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = 'left right top bottom'
     function = exact_fn
-  [../]
+  []
 []
 
 [Executioner]
   type = Transient
   end_time = 4.0
-  [./TimeStepper]
+  [TimeStepper]
     type = TimeSequenceStepper
-    time_sequence  = '0   0.85 1.3 2 4'
-  [../]
+    time_sequence = '0   0.85 1.3 2 4'
+  []
 []
 
 [Outputs]

--- a/test/tests/time_steppers/timesequence_stepper/timesequence_restart3.i
+++ b/test/tests/time_steppers/timesequence_stepper/timesequence_restart3.i
@@ -4,69 +4,73 @@
 
 [Problem]
   restart_file_base = timesequence_restart1_cp/0002
+  # There is an initial conditions overwriting the restart on the nonlinear variable u
+  # As you can see in the gold file, this makes the initial step output be from the
+  # initial condition
+  allow_initial_conditions_with_restart = true
 []
 
 [Functions]
-  [./exact_fn]
+  [exact_fn]
     type = ParsedFunction
     expression = t*t*(x*x+y*y)
-  [../]
+  []
 
-  [./forcing_fn]
+  [forcing_fn]
     type = ParsedFunction
     expression = 2*t*(x*x+y*y)-4*t*t
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
+  [u]
     family = LAGRANGE
     order = SECOND
-  [../]
+  []
 []
 
 [ICs]
-  [./u_var]
+  [u_var]
     type = FunctionIC
     variable = u
     function = exact_fn
-  [../]
+  []
 []
 
 [Kernels]
-  [./td]
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
+  []
 
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 
-  [./ffn]
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = 'left right top bottom'
     function = exact_fn
-  [../]
+  []
 []
 
 [Executioner]
   type = Transient
   end_time = 4.5
-  [./TimeStepper]
+  [TimeStepper]
     type = TimeSequenceStepper
-    time_sequence  = '0   0.85 1.3 1.9 2 4 4.5'
-  [../]
+    time_sequence = '0   0.85 1.3 1.9 2 4 4.5'
+  []
 []
 
 [Outputs]

--- a/test/tests/time_steppers/timesequence_stepper/timesequence_restart_failure.i
+++ b/test/tests/time_steppers/timesequence_stepper/timesequence_restart_failure.i
@@ -4,69 +4,73 @@
 
 [Problem]
   restart_file_base = timesequence_restart_failure1_cp/0002
+  # There is an initial conditions overwriting the restart on the nonlinear variable u
+  # As you can see in the gold file, this makes the initial step output be from the
+  # initial condition
+  allow_initial_conditions_with_restart = true
 []
 
 [Functions]
-  [./exact_fn]
+  [exact_fn]
     type = ParsedFunction
     expression = t*t*(x*x+y*y)
-  [../]
+  []
 
-  [./forcing_fn]
+  [forcing_fn]
     type = ParsedFunction
     expression = 2*t*(x*x+y*y)-4*t*t
-  [../]
+  []
 []
 
 [Variables]
-  [./u]
+  [u]
     family = LAGRANGE
     order = SECOND
-  [../]
+  []
 []
 
 [ICs]
-  [./u_var]
+  [u_var]
     type = FunctionIC
     variable = u
     function = exact_fn
-  [../]
+  []
 []
 
 [Kernels]
-  [./td]
+  [td]
     type = TimeDerivative
     variable = u
-  [../]
+  []
 
-  [./diff]
+  [diff]
     type = Diffusion
     variable = u
-  [../]
+  []
 
-  [./ffn]
+  [ffn]
     type = BodyForce
     variable = u
     function = forcing_fn
-  [../]
+  []
 []
 
 [BCs]
-  [./all]
+  [all]
     type = FunctionDirichletBC
     variable = u
     boundary = 'left right top bottom'
     function = exact_fn
-  [../]
+  []
 []
 
 [Executioner]
   type = Transient
   end_time = 4.0
-  [./TimeStepper]
+  [TimeStepper]
     type = TimeSequenceStepper
-    time_sequence  = '0   0.85 1.2 1.3 2 4'
-  [../]
+    time_sequence = '0   0.85 1.2 1.3 2 4'
+  []
 []
 
 [Outputs]


### PR DESCRIPTION
Right now the system lets you specify both. And the IC takes over. On timestep 0, one can see the initial condition appear, overriding the restart, and the system uses the ICs (which changes the result) 

This is unfortunate because users often have ICs in their input because they copied over the steady input to make a transient that restarts from a steady calculation. There generally is not much of a need for ICs in that restarted case unless:

- new fields are introduced and need to be initialized
- a steady solution is not the one we want to start from for the transient

Hence why I added a boolean to work around the error

refs #21423 
Does not close it since no error with just this PR