### PR TITLE
Removed non-const Postprocessor::getValue() method

### DIFF
--- a/framework/include/libtorch/postprocessors/LibtorchControlValuePostprocessor.h
+++ b/framework/include/libtorch/postprocessors/LibtorchControlValuePostprocessor.h
@@ -46,7 +46,6 @@ public:
    * Returns the value of the latest response of a neural-network-based controller.
    * This means that we grab current response value stored wihtin the controller.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/AverageElementSize.h
+++ b/framework/include/postprocessors/AverageElementSize.h
@@ -25,7 +25,6 @@ public:
   virtual void execute() override;
 
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/AverageNodalVariableValue.h
+++ b/framework/include/postprocessors/AverageNodalVariableValue.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/ChangeOverFixedPointPostprocessor.h
+++ b/framework/include/postprocessors/ChangeOverFixedPointPostprocessor.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/ChangeOverTimePostprocessor.h
+++ b/framework/include/postprocessors/ChangeOverTimePostprocessor.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ConstantPostprocessor.h
+++ b/framework/include/postprocessors/ConstantPostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/CumulativeValuePostprocessor.h
+++ b/framework/include/postprocessors/CumulativeValuePostprocessor.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/DifferencePostprocessor.h
+++ b/framework/include/postprocessors/DifferencePostprocessor.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementArrayL2Norm.h
+++ b/framework/include/postprocessors/ElementArrayL2Norm.h
@@ -18,7 +18,6 @@ public:
 
   ElementArrayL2Norm(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementAverageMaterialProperty.h
+++ b/framework/include/postprocessors/ElementAverageMaterialProperty.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/ElementAverageValue.h
+++ b/framework/include/postprocessors/ElementAverageValue.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/ElementExtremeMaterialProperty.h
+++ b/framework/include/postprocessors/ElementExtremeMaterialProperty.h
@@ -29,7 +29,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/ElementH1SemiError.h
+++ b/framework/include/postprocessors/ElementH1SemiError.h
@@ -25,7 +25,6 @@ public:
 
   ElementH1SemiError(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementIntegralPostprocessor.h
+++ b/framework/include/postprocessors/ElementIntegralPostprocessor.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void threadJoin(const UserObject & y) override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/framework/include/postprocessors/ElementL2Difference.h
+++ b/framework/include/postprocessors/ElementL2Difference.h
@@ -21,7 +21,6 @@ public:
 
   ElementL2Difference(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementL2Error.h
+++ b/framework/include/postprocessors/ElementL2Error.h
@@ -20,7 +20,6 @@ public:
 
   ElementL2Error(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementL2FunctorError.h
+++ b/framework/include/postprocessors/ElementL2FunctorError.h
@@ -22,7 +22,6 @@ public:
 
   ElementL2FunctorErrorTempl(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementL2Norm.h
+++ b/framework/include/postprocessors/ElementL2Norm.h
@@ -18,7 +18,6 @@ public:
 
   ElementL2Norm(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementSidesL2Norm.h
+++ b/framework/include/postprocessors/ElementSidesL2Norm.h
@@ -22,7 +22,6 @@ public:
 
   ElementSidesL2Norm(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementVectorL2Error.h
+++ b/framework/include/postprocessors/ElementVectorL2Error.h
@@ -20,7 +20,6 @@ public:
 
   ElementVectorL2Error(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementW1pError.h
+++ b/framework/include/postprocessors/ElementW1pError.h
@@ -35,7 +35,6 @@ public:
 
   ElementW1pError(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ElementalVariableValue.h
+++ b/framework/include/postprocessors/ElementalVariableValue.h
@@ -28,7 +28,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/framework/include/postprocessors/EmptyPostprocessor.h
+++ b/framework/include/postprocessors/EmptyPostprocessor.h
@@ -20,6 +20,5 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override { return 0; }
 };

--- a/framework/include/postprocessors/ExtremeValueBase.h
+++ b/framework/include/postprocessors/ExtremeValueBase.h
@@ -20,7 +20,6 @@ public:
   ExtremeValueBase(const InputParameters & parameters);
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/FindValueOnLine.h
+++ b/framework/include/postprocessors/FindValueOnLine.h
@@ -29,7 +29,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/FunctionElementAverage.h
+++ b/framework/include/postprocessors/FunctionElementAverage.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/FunctionSideAverage.h
+++ b/framework/include/postprocessors/FunctionSideAverage.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void finalize() override;

--- a/framework/include/postprocessors/FunctionValuePostprocessor.h
+++ b/framework/include/postprocessors/FunctionValuePostprocessor.h
@@ -27,7 +27,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/GreaterThanLessThanPostprocessor.h
+++ b/framework/include/postprocessors/GreaterThanLessThanPostprocessor.h
@@ -28,7 +28,6 @@ public:
   virtual void execute() override;
 
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:

--- a/framework/include/postprocessors/InterfaceAverageVariableValuePostprocessor.h
+++ b/framework/include/postprocessors/InterfaceAverageVariableValuePostprocessor.h
@@ -23,6 +23,5 @@ public:
   static InputParameters validParams();
 
   InterfaceAverageVariableValuePostprocessor(const InputParameters & parameters);
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 };

--- a/framework/include/postprocessors/InterfaceDiffusiveFluxAverage.h
+++ b/framework/include/postprocessors/InterfaceDiffusiveFluxAverage.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/InterfaceIntegralPostprocessor.h
+++ b/framework/include/postprocessors/InterfaceIntegralPostprocessor.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/InternalSideIntegralPostprocessor.h
+++ b/framework/include/postprocessors/InternalSideIntegralPostprocessor.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/LinearCombinationPostprocessor.h
+++ b/framework/include/postprocessors/LinearCombinationPostprocessor.h
@@ -30,7 +30,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/MemoryUsage.h
+++ b/framework/include/postprocessors/MemoryUsage.h
@@ -28,7 +28,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/NearestNodeNumber.h
+++ b/framework/include/postprocessors/NearestNodeNumber.h
@@ -24,7 +24,6 @@ public:
 
   virtual void execute() override{};
   virtual void initialize() override{};
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:

--- a/framework/include/postprocessors/NodalL2Error.h
+++ b/framework/include/postprocessors/NodalL2Error.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/NodalL2Norm.h
+++ b/framework/include/postprocessors/NodalL2Norm.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/NodalMaxValue.h
+++ b/framework/include/postprocessors/NodalMaxValue.h
@@ -24,7 +24,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/NodalMaxValueId.h
+++ b/framework/include/postprocessors/NodalMaxValueId.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/framework/include/postprocessors/NodalSum.h
+++ b/framework/include/postprocessors/NodalSum.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   void threadJoin(const UserObject & y) override;

--- a/framework/include/postprocessors/NodalVariableValue.h
+++ b/framework/include/postprocessors/NodalVariableValue.h
@@ -31,7 +31,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   void initialSetup() override;

--- a/framework/include/postprocessors/NumDOFs.h
+++ b/framework/include/postprocessors/NumDOFs.h
@@ -27,7 +27,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/NumElems.h
+++ b/framework/include/postprocessors/NumElems.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/NumFailedTimeSteps.h
+++ b/framework/include/postprocessors/NumFailedTimeSteps.h
@@ -24,7 +24,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/NumFixedPointIterations.h
+++ b/framework/include/postprocessors/NumFixedPointIterations.h
@@ -25,6 +25,5 @@ public:
   virtual void execute() override {}
   virtual void initialize() override{};
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 };

--- a/framework/include/postprocessors/NumLinearIterations.h
+++ b/framework/include/postprocessors/NumLinearIterations.h
@@ -21,6 +21,5 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 };

--- a/framework/include/postprocessors/NumNodes.h
+++ b/framework/include/postprocessors/NumNodes.h
@@ -24,7 +24,6 @@ public:
   /**
    * This will return the number of nodes in the system
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/NumNonlinearIterations.h
+++ b/framework/include/postprocessors/NumNonlinearIterations.h
@@ -34,7 +34,6 @@ public:
   /**
    * Get the number of nonlinear iterations
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/NumPositions.h
+++ b/framework/include/postprocessors/NumPositions.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/NumRelationshipManagers.h
+++ b/framework/include/postprocessors/NumRelationshipManagers.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/NumResidualEvaluations.h
+++ b/framework/include/postprocessors/NumResidualEvaluations.h
@@ -24,6 +24,5 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 };

--- a/framework/include/postprocessors/NumVars.h
+++ b/framework/include/postprocessors/NumVars.h
@@ -22,7 +22,6 @@ public:
 
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ParsedPostprocessor.h
+++ b/framework/include/postprocessors/ParsedPostprocessor.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override final;
   virtual void execute() override final;
   virtual void finalize() override final;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override final;
 
 private:

--- a/framework/include/postprocessors/PercentChangePostprocessor.h
+++ b/framework/include/postprocessors/PercentChangePostprocessor.h
@@ -24,7 +24,6 @@ public:
   PercentChangePostprocessor(const InputParameters & parameters);
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/PerfGraphData.h
+++ b/framework/include/postprocessors/PerfGraphData.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/PointValue.h
+++ b/framework/include/postprocessors/PointValue.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override;
   virtual void finalize() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/Postprocessor.h
+++ b/framework/include/postprocessors/Postprocessor.h
@@ -30,24 +30,13 @@ public:
   Postprocessor(const MooseObject * moose_object);
 
   /**
-   * This will get called to actually grab the final value the postprocessor has calculated
-   *
-   * Note that this should only be called by internal methods, namely the problem that
-   * actually sets the value globally for other things to use. If you want the value
-   * outside of one of these external methods, you should use getCurrentValue().
-   *
-   * This method will be removed in favor of the const version.
-   */
-  virtual PostprocessorValue getValue();
-
-  /**
    * This will get called to actually grab the final value the postprocessor has calculated.
    *
    * Note that this should only be called by internal methods, namely the problem that
    * actually sets the value globally for other things to use. If you want the value
    * outside of one of these external methods, you should use getCurrentValue().
    */
-  virtual PostprocessorValue getValue() const;
+  virtual PostprocessorValue getValue() const = 0;
 
   /**
    * @return The "current" value of this Postprocessor.

--- a/framework/include/postprocessors/PostprocessorComparison.h
+++ b/framework/include/postprocessors/PostprocessorComparison.h
@@ -36,7 +36,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/Receiver.h
+++ b/framework/include/postprocessors/Receiver.h
@@ -38,7 +38,6 @@ public:
    * Returns the value stored in _my_value
    * @return A const reference to the value of the postprocessor
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/framework/include/postprocessors/RelativeDifferencePostprocessor.h
+++ b/framework/include/postprocessors/RelativeDifferencePostprocessor.h
@@ -37,7 +37,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/RelativeSolutionDifferenceNorm.h
+++ b/framework/include/postprocessors/RelativeSolutionDifferenceNorm.h
@@ -39,7 +39,6 @@ public:
    * Returns the relative solution norm taken from the transient executioner
    * @return A const reference to the value of the postprocessor
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/Residual.h
+++ b/framework/include/postprocessors/Residual.h
@@ -24,7 +24,6 @@ public:
   /**
    * This will return the final nonlinear residual.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ScalarL2Error.h
+++ b/framework/include/postprocessors/ScalarL2Error.h
@@ -33,7 +33,6 @@ public:
   /**
    * Get the L2 Error.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/ScalarVariable.h
+++ b/framework/include/postprocessors/ScalarVariable.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/framework/include/postprocessors/ScalePostprocessor.h
+++ b/framework/include/postprocessors/ScalePostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/SideAverageMaterialProperty.h
+++ b/framework/include/postprocessors/SideAverageMaterialProperty.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/SideAverageValue.h
+++ b/framework/include/postprocessors/SideAverageValue.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void finalize() override;

--- a/framework/include/postprocessors/SideDiffusiveFluxAverage.h
+++ b/framework/include/postprocessors/SideDiffusiveFluxAverage.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/SideIntegralPostprocessor.h
+++ b/framework/include/postprocessors/SideIntegralPostprocessor.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/framework/include/postprocessors/TimeExtremeValue.h
+++ b/framework/include/postprocessors/TimeExtremeValue.h
@@ -41,7 +41,6 @@ public:
   TimeExtremeValue(const InputParameters & parameters);
   virtual void initialize() override {}
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/TimeIntegratedPostprocessor.h
+++ b/framework/include/postprocessors/TimeIntegratedPostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/TimePostprocessor.h
+++ b/framework/include/postprocessors/TimePostprocessor.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/TimestepSize.h
+++ b/framework/include/postprocessors/TimestepSize.h
@@ -24,7 +24,6 @@ public:
   /**
    * This will return the current time step size.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/VariableResidual.h
+++ b/framework/include/postprocessors/VariableResidual.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/VectorPostprocessorComparison.h
+++ b/framework/include/postprocessors/VectorPostprocessorComparison.h
@@ -37,7 +37,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/VectorPostprocessorComponent.h
+++ b/framework/include/postprocessors/VectorPostprocessorComponent.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/include/postprocessors/VectorPostprocessorReductionValue.h
+++ b/framework/include/postprocessors/VectorPostprocessorReductionValue.h
@@ -21,7 +21,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/framework/src/postprocessors/Postprocessor.C
+++ b/framework/src/postprocessors/Postprocessor.C
@@ -61,22 +61,6 @@ Postprocessor::declareValue(const MooseObject & moose_object)
   return fe_problem.getReporterData().getReporterValue<PostprocessorValue>(r_name);
 }
 
-PostprocessorValue
-Postprocessor::getValue()
-{
-  mooseError(
-      "The non-const 'Postprocessor::getValue()' method is deprecated and should not be called.");
-}
-
-PostprocessorValue
-Postprocessor::getValue() const
-{
-  mooseDeprecated("The non-const 'Postprocessor::getValue()' method is deprecated. Please override "
-                  "the 'Postprocessor::getValue() const' method instead.");
-
-  return const_cast<Postprocessor *>(this)->getValue();
-}
-
 typename Postprocessor::ValueType
 Postprocessor::evaluate(const ElemArg & /*elem_arg*/, const Moose::StateArg & /*state*/) const
 {

--- a/modules/contact/include/postprocessors/ContactDOFSetSize.h
+++ b/modules/contact/include/postprocessors/ContactDOFSetSize.h
@@ -28,7 +28,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:

--- a/modules/contact/include/postprocessors/NumAugmentedLagrangeIterations.h
+++ b/modules/contact/include/postprocessors/NumAugmentedLagrangeIterations.h
@@ -29,7 +29,6 @@ public:
   virtual void execute() override {}
   virtual void finalize() override {}
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
   // only needed for ElementPostprocessors and NodalPostprocessors

--- a/modules/electromagnetics/include/postprocessors/ReflectionCoefficient.h
+++ b/modules/electromagnetics/include/postprocessors/ReflectionCoefficient.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void finalize() override;

--- a/modules/heat_transfer/include/postprocessors/GrayLambertSurfaceRadiationPP.h
+++ b/modules/heat_transfer/include/postprocessors/GrayLambertSurfaceRadiationPP.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/heat_transfer/include/postprocessors/HomogenizedThermalConductivity.h
+++ b/modules/heat_transfer/include/postprocessors/HomogenizedThermalConductivity.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void finalize() override;

--- a/modules/heat_transfer/include/postprocessors/ThermalConductivity.h
+++ b/modules/heat_transfer/include/postprocessors/ThermalConductivity.h
@@ -24,7 +24,6 @@ public:
   ThermalConductivity(const InputParameters & parameters);
 
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/heat_transfer/include/postprocessors/ViewFactorPP.h
+++ b/modules/heat_transfer/include/postprocessors/ViewFactorPP.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/level_set/include/postprocessors/LevelSetCFLCondition.h
+++ b/modules/level_set/include/postprocessors/LevelSetCFLCondition.h
@@ -24,7 +24,6 @@ public:
   void execute() override;
   void finalize() override;
   void threadJoin(const UserObject & user_object) override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:

--- a/modules/level_set/include/postprocessors/LevelSetVolume.h
+++ b/modules/level_set/include/postprocessors/LevelSetVolume.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void computeQpValue() override{};

--- a/modules/misc/include/postprocessors/InternalVolume.h
+++ b/modules/misc/include/postprocessors/InternalVolume.h
@@ -33,7 +33,6 @@ public:
 
 protected:
   virtual Real computeQpIntegral() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   const unsigned int _component;

--- a/modules/navier_stokes/include/postprocessors/CFLTimeStepSize.h
+++ b/modules/navier_stokes/include/postprocessors/CFLTimeStepSize.h
@@ -24,7 +24,6 @@ public:
   virtual void execute() override;
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
+++ b/modules/navier_stokes/include/postprocessors/INSExplicitTimestepSelector.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & uo) override;

--- a/modules/navier_stokes/include/postprocessors/MassFluxWeightedFlowRate.h
+++ b/modules/navier_stokes/include/postprocessors/MassFluxWeightedFlowRate.h
@@ -29,7 +29,6 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/navier_stokes/include/postprocessors/NSEntropyError.h
+++ b/modules/navier_stokes/include/postprocessors/NSEntropyError.h
@@ -20,7 +20,6 @@ public:
   static InputParameters validParams();
 
   NSEntropyError(const InputParameters & parameters);
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/navier_stokes/include/postprocessors/PressureDrop.h
+++ b/modules/navier_stokes/include/postprocessors/PressureDrop.h
@@ -30,7 +30,6 @@ public:
   virtual void execute() override;
   virtual void threadJoin(const UserObject & y) override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/navier_stokes/include/postprocessors/RayleighNumber.h
+++ b/modules/navier_stokes/include/postprocessors/RayleighNumber.h
@@ -25,7 +25,6 @@ public:
 protected:
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   /// Minimum density

--- a/modules/navier_stokes/test/include/postprocessors/TestFaceToCellReconstruction.h
+++ b/modules/navier_stokes/test/include/postprocessors/TestFaceToCellReconstruction.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override final;
 
 protected:

--- a/modules/peridynamics/include/postprocessors/BondStatusConvergedPostprocessorPD.h
+++ b/modules/peridynamics/include/postprocessors/BondStatusConvergedPostprocessorPD.h
@@ -28,7 +28,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void threadJoin(const UserObject & uo) override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/modules/peridynamics/include/postprocessors/NodalDisplacementDifferenceL2NormPD.h
+++ b/modules/peridynamics/include/postprocessors/NodalDisplacementDifferenceL2NormPD.h
@@ -22,7 +22,6 @@ public:
 
   NodalDisplacementDifferenceL2NormPD(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/peridynamics/include/postprocessors/NodalFunctionsL2NormPD.h
+++ b/modules/peridynamics/include/postprocessors/NodalFunctionsL2NormPD.h
@@ -23,7 +23,6 @@ public:
 
   NodalFunctionsL2NormPD(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/peridynamics/include/postprocessors/NodalIntegralPostprocessorBasePD.h
+++ b/modules/peridynamics/include/postprocessors/NodalIntegralPostprocessorBasePD.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void threadJoin(const UserObject & uo) override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
 

--- a/modules/phase_field/include/postprocessors/AverageGrainVolume.h
+++ b/modules/phase_field/include/postprocessors/AverageGrainVolume.h
@@ -31,7 +31,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/phase_field/include/postprocessors/DiscreteNucleationData.h
+++ b/modules/phase_field/include/postprocessors/DiscreteNucleationData.h
@@ -25,7 +25,6 @@ public:
   virtual void execute() override{};
   virtual void initialize() override{};
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/phase_field/include/postprocessors/DiscreteNucleationTimeStep.h
+++ b/modules/phase_field/include/postprocessors/DiscreteNucleationTimeStep.h
@@ -27,7 +27,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
   virtual void finalize() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/phase_field/include/postprocessors/FauxGrainTracker.h
+++ b/modules/phase_field/include/postprocessors/FauxGrainTracker.h
@@ -28,7 +28,6 @@ public:
 
   virtual void initialize() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void execute() override;
 

--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -52,7 +52,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   /// Return the number of active features

--- a/modules/phase_field/include/postprocessors/FeatureVolumeFraction.h
+++ b/modules/phase_field/include/postprocessors/FeatureVolumeFraction.h
@@ -22,7 +22,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/phase_field/include/postprocessors/GrainBoundaryArea.h
+++ b/modules/phase_field/include/postprocessors/GrainBoundaryArea.h
@@ -21,7 +21,6 @@ public:
 
   GrainBoundaryArea(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/phase_field/include/postprocessors/WeightedVariableAverage.h
+++ b/modules/phase_field/include/postprocessors/WeightedVariableAverage.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/modules/porous_flow/include/postprocessors/PorousFlowPlotQuantity.h
+++ b/modules/porous_flow/include/postprocessors/PorousFlowPlotQuantity.h
@@ -28,7 +28,6 @@ public:
   virtual void execute() override;
 
   /// Returns the value of the PorousFlowSumQuantity
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/ray_tracing/include/postprocessors/RayDataValue.h
+++ b/modules/ray_tracing/include/postprocessors/RayDataValue.h
@@ -29,7 +29,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/ray_tracing/include/postprocessors/RayIntegralValue.h
+++ b/modules/ray_tracing/include/postprocessors/RayIntegralValue.h
@@ -30,7 +30,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/modules/ray_tracing/include/postprocessors/RayTracingStudyResult.h
+++ b/modules/ray_tracing/include/postprocessors/RayTracingStudyResult.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/ray_tracing/test/include/postprocessors/LotsOfRaysExpectedDistance.h
+++ b/modules/ray_tracing/test/include/postprocessors/LotsOfRaysExpectedDistance.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/richards/include/postprocessors/RichardsPlotQuantity.h
+++ b/modules/richards/include/postprocessors/RichardsPlotQuantity.h
@@ -28,7 +28,6 @@ public:
   virtual void execute() override;
 
   /// returns the value of the RichardsSumQuantity
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/solid_properties/include/postprocessors/ThermalSolidPropertiesPostprocessor.h
+++ b/modules/solid_properties/include/postprocessors/ThermalSolidPropertiesPostprocessor.h
@@ -33,7 +33,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/stochastic_tools/include/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.h
+++ b/modules/stochastic_tools/include/libtorch/postprocessors/LibtorchDRLLogProbabilityPostprocessor.h
@@ -48,7 +48,6 @@ public:
    * Returns the value of the latest response of a neural-network-based controller.
    * This means that we grab current response value stored wihtin the controller.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/modules/stochastic_tools/include/postprocessors/AdaptiveSamplingCompletedPostprocessor.h
+++ b/modules/stochastic_tools/include/postprocessors/AdaptiveSamplingCompletedPostprocessor.h
@@ -22,7 +22,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void initialSetup() override{};
   virtual void finalize() override;

--- a/modules/stochastic_tools/test/include/utils/TestDistributionDirectPostprocessor.h
+++ b/modules/stochastic_tools/test/include/utils/TestDistributionDirectPostprocessor.h
@@ -26,7 +26,6 @@ public:
   TestDistributionDirectPostprocessor(const InputParameters & parameters);
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/stochastic_tools/test/include/utils/TestDistributionPostprocessor.h
+++ b/modules/stochastic_tools/test/include/utils/TestDistributionPostprocessor.h
@@ -26,7 +26,6 @@ public:
   TestDistributionPostprocessor(const InputParameters & parameters);
   virtual void initialize() override {}
   virtual void execute() override {}
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/tensor_mechanics/include/postprocessors/AsymptoticExpansionHomogenizationElasticConstants.h
+++ b/modules/tensor_mechanics/include/postprocessors/AsymptoticExpansionHomogenizationElasticConstants.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/modules/tensor_mechanics/include/postprocessors/CavityPressurePostprocessor.h
+++ b/modules/tensor_mechanics/include/postprocessors/CavityPressurePostprocessor.h
@@ -24,7 +24,6 @@ public:
 
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/tensor_mechanics/include/postprocessors/CrackFrontData.h
+++ b/modules/tensor_mechanics/include/postprocessors/CrackFrontData.h
@@ -32,7 +32,6 @@ public:
   /**
    * This will return the degrees of freedom in the system.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/tensor_mechanics/include/postprocessors/CriticalTimeStep.h
+++ b/modules/tensor_mechanics/include/postprocessors/CriticalTimeStep.h
@@ -32,7 +32,6 @@ public:
   virtual void initialSetup() override;
 
   virtual void finalize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/modules/tensor_mechanics/include/postprocessors/MaterialTensorAverage.h
+++ b/modules/tensor_mechanics/include/postprocessors/MaterialTensorAverage.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/modules/tensor_mechanics/include/postprocessors/MaterialTimeStepPostprocessor.h
+++ b/modules/tensor_mechanics/include/postprocessors/MaterialTimeStepPostprocessor.h
@@ -23,7 +23,6 @@ public:
   MaterialTimeStepPostprocessor(const InputParameters & parameters);
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & y) override;

--- a/modules/tensor_mechanics/include/postprocessors/NormalBoundaryDisplacement.h
+++ b/modules/tensor_mechanics/include/postprocessors/NormalBoundaryDisplacement.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override;
   virtual void finalize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void threadJoin(const UserObject & y) override;
 

--- a/modules/tensor_mechanics/include/postprocessors/TorqueReaction.h
+++ b/modules/tensor_mechanics/include/postprocessors/TorqueReaction.h
@@ -38,7 +38,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void finalize() override;
   void threadJoin(const UserObject & y) override;

--- a/modules/thermal_hydraulics/include/postprocessors/ADSpecificImpulse1Phase.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ADSpecificImpulse1Phase.h
@@ -29,7 +29,6 @@ public:
   virtual void finalize() override;
 
 protected:
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   /// Number of components in the solution vector used to compute the flux

--- a/modules/thermal_hydraulics/include/postprocessors/BoolComponentParameterValuePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/BoolComponentParameterValuePostprocessor.h
@@ -21,7 +21,6 @@ public:
   BoolComponentParameterValuePostprocessor(const InputParameters & parameters);
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void execute() override;
 

--- a/modules/thermal_hydraulics/include/postprocessors/BoolControlDataValuePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/BoolControlDataValuePostprocessor.h
@@ -23,7 +23,6 @@ public:
   BoolControlDataValuePostprocessor(const InputParameters & parameters);
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void execute() override;
 

--- a/modules/thermal_hydraulics/include/postprocessors/NodalEnergyFluxPostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/NodalEnergyFluxPostprocessor.h
@@ -21,7 +21,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
   virtual void finalize() override;
   virtual void threadJoin(const UserObject & uo) override;

--- a/modules/thermal_hydraulics/include/postprocessors/RealComponentParameterValuePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/RealComponentParameterValuePostprocessor.h
@@ -18,7 +18,6 @@ public:
   RealComponentParameterValuePostprocessor(const InputParameters & parameters);
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void execute() override;
 

--- a/modules/thermal_hydraulics/include/postprocessors/RealControlDataValuePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/RealControlDataValuePostprocessor.h
@@ -23,7 +23,6 @@ public:
   RealControlDataValuePostprocessor(const InputParameters & parameters);
 
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void execute() override;
 

--- a/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedComponentPostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedComponentPostprocessor.h
@@ -14,7 +14,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.h
@@ -14,7 +14,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/thermal_hydraulics/include/postprocessors/SpecificImpulse1Phase.h
+++ b/modules/thermal_hydraulics/include/postprocessors/SpecificImpulse1Phase.h
@@ -29,7 +29,6 @@ public:
   virtual void finalize() override;
 
 protected:
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   /// Number of components in the solution vector used to compute the flux

--- a/modules/thermal_hydraulics/include/postprocessors/SumPostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/SumPostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/thermal_hydraulics/test/include/postprocessors/FunctionElementLoopIntegralGetValueTestPostprocessor.h
+++ b/modules/thermal_hydraulics/test/include/postprocessors/FunctionElementLoopIntegralGetValueTestPostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/modules/xfem/include/postprocessors/ParisLaw.h
+++ b/modules/xfem/include/postprocessors/ParisLaw.h
@@ -22,7 +22,6 @@ public:
   virtual void initialize() override;
   virtual void execute() override;
   virtual void finalize() override {}
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/modules/xfem/test/include/postprocessors/TestCrackCounter.h
+++ b/modules/xfem/test/include/postprocessors/TestCrackCounter.h
@@ -28,7 +28,6 @@ public:
   virtual void execute() override;
 
   /// Get number of Cracks
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/BlocksMaxDimensionPostprocessor.h
+++ b/test/include/postprocessors/BlocksMaxDimensionPostprocessor.h
@@ -24,7 +24,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/ElementL2Diff.h
+++ b/test/include/postprocessors/ElementL2Diff.h
@@ -22,7 +22,6 @@ protected:
   /**
    * Get the L2 Error.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   virtual Real computeQpIntegral() override;

--- a/test/include/postprocessors/ElementSidePP.h
+++ b/test/include/postprocessors/ElementSidePP.h
@@ -19,7 +19,6 @@ public:
   ElementSidePP(const InputParameters & parameters);
 
 protected:
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
   virtual Real computeQpIntegral() override;

--- a/test/include/postprocessors/InsideValuePPS.h
+++ b/test/include/postprocessors/InsideValuePPS.h
@@ -26,7 +26,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/InternalSideJump.h
+++ b/test/include/postprocessors/InternalSideJump.h
@@ -18,7 +18,6 @@ public:
 
   InternalSideJump(const InputParameters & parameters);
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
   virtual void execute() override;
   virtual void initialize() override;

--- a/test/include/postprocessors/MaxVarNDofsPerElemPP.h
+++ b/test/include/postprocessors/MaxVarNDofsPerElemPP.h
@@ -25,6 +25,5 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 };

--- a/test/include/postprocessors/NumAdaptivityCycles.h
+++ b/test/include/postprocessors/NumAdaptivityCycles.h
@@ -24,6 +24,5 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 };

--- a/test/include/postprocessors/NumInternalSides.h
+++ b/test/include/postprocessors/NumInternalSides.h
@@ -27,7 +27,6 @@ public:
   virtual void threadJoin(const UserObject & uo) override;
   virtual void finalize() override;
   virtual void initialize() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
   const unsigned int & count() const { return _count; }
 

--- a/test/include/postprocessors/PrimeProductPostprocessor.h
+++ b/test/include/postprocessors/PrimeProductPostprocessor.h
@@ -26,7 +26,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/RandomPostprocessor.h
+++ b/test/include/postprocessors/RandomPostprocessor.h
@@ -25,7 +25,6 @@ public:
   virtual void initialize() override {}
   virtual void execute() override {}
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/test/include/postprocessors/RealControlParameterReporter.h
+++ b/test/include/postprocessors/RealControlParameterReporter.h
@@ -35,7 +35,6 @@ public:
   /**
    * Return the parameter value
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/test/include/postprocessors/SamplerTester.h
+++ b/test/include/postprocessors/SamplerTester.h
@@ -31,7 +31,6 @@ protected:
   virtual void execute() final;
   virtual void initialize() final;
   virtual void finalize() final;
-  using Postprocessor::getValue;
   virtual Real getValue() const final;
   virtual void threadJoin(const UserObject & uo) final;
   Sampler & _sampler;

--- a/test/include/postprocessors/SetupInterfaceCount.h
+++ b/test/include/postprocessors/SetupInterfaceCount.h
@@ -58,7 +58,7 @@ public:
    * Return the count base on the count type supplied in the input file.
    */
   using Postprocessor::getValue;
-  virtual PostprocessorValue getValue() override;
+  virtual PostprocessorValue getValue() const override;
 
 private:
   /// The type of count to report
@@ -102,7 +102,7 @@ SetupInterfaceCount<T>::SetupInterfaceCount(const InputParameters & parameters)
 
 template <class T>
 PostprocessorValue
-SetupInterfaceCount<T>::getValue()
+SetupInterfaceCount<T>::getValue() const
 {
   return _counts.at(_count_type);
 }

--- a/test/include/postprocessors/SetupInterfaceCount.h
+++ b/test/include/postprocessors/SetupInterfaceCount.h
@@ -57,7 +57,6 @@ public:
   /**
    * Return the count base on the count type supplied in the input file.
    */
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:

--- a/test/include/postprocessors/StatVector.h
+++ b/test/include/postprocessors/StatVector.h
@@ -21,7 +21,6 @@ public:
   static InputParameters validParams();
   StatVector(const InputParameters & parameters);
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
   virtual void initialize() final{};
   virtual void finalize() final{};

--- a/test/include/postprocessors/TestControlPointPP.h
+++ b/test/include/postprocessors/TestControlPointPP.h
@@ -25,7 +25,6 @@ public:
 
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 protected:

--- a/test/include/postprocessors/TestCopyInitialSolution.h
+++ b/test/include/postprocessors/TestCopyInitialSolution.h
@@ -23,7 +23,6 @@ public:
   virtual ~TestCopyInitialSolution();
   virtual void initialize() override;
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/TestDiscontinuousValuePP.h
+++ b/test/include/postprocessors/TestDiscontinuousValuePP.h
@@ -36,7 +36,6 @@ public:
   /// initialSetup gets the pointer to the solution UO
   virtual void initialSetup() override;
 
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/TestPostprocessor.h
+++ b/test/include/postprocessors/TestPostprocessor.h
@@ -42,7 +42,6 @@ public:
    * Returns the postprocessor depending on the 'test_type' parameter
    * @return The postprocessor value
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 private:

--- a/test/include/postprocessors/TestSerializedSolution.h
+++ b/test/include/postprocessors/TestSerializedSolution.h
@@ -34,7 +34,6 @@ public:
   /**
    * Return the summed value.
    */
-  using Postprocessor::getValue;
   virtual Real getValue() const override;
 
 protected:

--- a/test/include/postprocessors/UseOldVectorPostprocessor.h
+++ b/test/include/postprocessors/UseOldVectorPostprocessor.h
@@ -23,7 +23,6 @@ public:
 
   virtual void initialize() override {}
   virtual void execute() override;
-  using Postprocessor::getValue;
   virtual PostprocessorValue getValue() const override;
 
 private:


### PR DESCRIPTION
This is the last step in #7770. It'll be a while before all apps remove the deprecated method.
