### PR TITLE
Libmesh submodule update

### DIFF
--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,9 +4,9 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 2 %}
+{% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.07.26" %}
+{% set version = "2023.09.06" %}
 {% set vtk_friendly_version = "9.2" %}
 
 package:

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2023.07.26 build_2
+  - moose-libmesh 2023.09.06 build_0
 
 moose_wasp:
   - moose-wasp 2023.08.17

--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -5,7 +5,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 {% set build = 0 %}
-{% set version = "2023.08.29" %}
+{% set version = "2023.09.06" %}
 {% set strbuild = "build_" + build|string %}
 
 package:

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.08.29
+  - moose-dev 2023.09.06
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.08.29
+  - moose-dev 2023.09.06
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/docker_ci/Dockerfile
+++ b/docker_ci/Dockerfile
@@ -114,7 +114,7 @@ if [ ! -d $PETSC_DIR/lib/petsc ]; then exit 1; fi
 #-----------------------------------------------------------------------------#
 # Install Libmesh to system path
 #-----------------------------------------------------------------------------#
-ARG LIBMESH_REV=fd900b54a02b9d1b99f0a4371d4acb4761e57b0f
+ARG LIBMESH_REV=ceff84386bdc83d87e9eb98ac3a9b745711e415a
 ARG LIBMESH_OPTIONS
 ARG LIBMESH_METHODS="opt dbg"
 ENV LIBMESH_DIR=/usr/local \

--- a/modules/doc/content/newsletter/2023/2023_09.md
+++ b/modules/doc/content/newsletter/2023/2023_09.md
@@ -12,3 +12,44 @@ for a complete description of all MOOSE changes.
 ## PETSc-level Changes
 
 ## Bug Fixes and Minor Enhancements
+
+### `2023.09.06` Update
+
+- NetCDF upgrade to 4.9.2, now incorporating NetCDF via a git submodule
+- p-refinement can now be selectively disabled and reenabled on a
+  per-variable-group basis
+- New error indicator for Empirical Interpolation Method (EIM)
+  reduced-basis approximations
+- `Elem::quality(ASPECT_RATIO)` is now defined for all element types
+- Added option to use absolute instead of relative tolerances in
+  linear solvers
+- Added the capability to "upgrade" a vector's ghosting and/or
+  projection settings in subsequent `System::add_vector()` calls
+- Added `MeshRefinement::allow_unrefined_patches()` option
+- Refactored iterator declarations and added more range methods in
+  `MeshBase`: every filtered iterator that could be previously
+  accessed with a `...begin()` and `...end()` method now also has a
+  `...range()` method suitable for range-based for loops
+- Better PETSc versioning macros for use with pre-release PETSc
+  commits
+- Build system now sets `CFLAGS_OPT`, etc. environment variables, not
+  just `CXXFLAGS` and `CPPFLAGS` versions
+- Many more unit tests for ExodusII I/O and for element refinement
+  APIs
+- Assorted fixes 
+  - Fixed Exodus I/O of side sets on 2D triangles embedded in 3D
+    space
+  - Fixed Nemesis dimension variable output
+  - Fixed Nedelec one `FE` compatibility with `Tri7` and `Tet14`
+    geometric elements
+  - Fixed multiple issues with mesh refinement on meshes with certain
+    types of infinite elements
+  - Fixed no-parameters case and improved print statements in EIM code
+  - Fixed typos in code comments
+  - Minor fixes in vector FE example programs
+- Assorted optimizations
+  - an unnecessary pointer-indirection layer has been removed from
+    `DiffContext`
+  - local matrix allocation in `DiffContext` objects is now optional
+  - minor optimizations have been made to Hilbert-curve global
+    indexing calculations


### PR DESCRIPTION
Updates summary:

- NetCDF upgrade to 4.9.2, now incorporating NetCDF via a git submodule
- p-refinement can now be selectively disabled and reenabled on a per-variable-group basis
- New error indicator for Empirical Interpolation Method (EIM) reduced-basis approximations
- `Elem::quality(ASPECT_RATIO)` is now defined for all element types
- Added option to use absolute instead of relative tolerances in linear solvers
- Added the capability to "upgrade" a vector's ghosting and/or projection settings in subsequent `System::add_vector()` calls
- Added `MeshRefinement::allow_unrefined_patches()` option
- Refactored iterator declarations and added more range methods in `MeshBase`: every filtered iterator that could be previously accessed with a `...begin()` and `...end()` method now also has a `...range()` method suitable for range-based for loops
- Better PETSc versioning macros for use with pre-release PETSc commits
- Build system now sets `CFLAGS_OPT`, etc. environment variables, not just `CXXFLAGS` and `CPPFLAGS` versions
- Many more unit tests for ExodusII I/O and for element refinement APIs
- Assorted fixes
  - Fixed Exodus I/O of side sets on 2D triangles embedded in 3D space
  - Fixed Nemesis dimension variable output
  - Fixed Nedelec one `FE` compatibility with `Tri7` and `Tet14` geometric elements
  - Fixed multiple issues with mesh refinement on meshes with certain types of infinite elements
  - Fixed no-parameters case and improved print statements in EIM code
  - Fixed typos in code comments
  - Minor fixes in vector FE example programs
- Assorted optimizations
  - an unnecessary pointer-indirection layer has been removed from `DiffContext`
  - local matrix allocation in `DiffContext` objects is now optional
  - minor optimizations have been made to Hilbert-curve global indexing calculations

Refs #0

Refs https://github.com/idaholab/moose/pull/25290 - we'll want to reenable those tests with new golds after this is safely in.

This fixes https://github.com/idaholab/moose/issues/24631

This fixes https://github.com/idaholab/moose/issues/25007 in my tests

As far as my part goes this is ready to merge, but if we want to just cherry-pick from it to combine with the PETSc update or other conda/docker work then I'm happy with that too.