### PR TITLE
Disallow by default ICs on restart for restarted variables

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -175,7 +175,7 @@ FEProblemBase::validParams()
                         "True to skip the NonlinearSystem check for work to do (e.g. Make sure "
                         "that there are variables to solve for).");
   params.addParam<bool>("allow_initial_conditions_with_restart",
-                        true,
+                        false,
                         "True to allow the user to specify initial conditions when restarting. "
                         "Initial conditions can override any restarted field");
 


### PR DESCRIPTION
closes #21423

Status of app patches:
- [x] BISON https://github.inl.gov/ncrc/bison/pull/5593
- [x] Griffin https://github.inl.gov/ncrc/griffin/pull/1496
- [x] Pronghorn https://github.inl.gov/ncrc/pronghorn/pull/1223
- [x] RELAP7 https://github.inl.gov/ncrc/relap-7/pull/2547
- [x] SAM https://git-nse.egs.anl.gov/ac.giudicelli/SAM/-/commits/PR_ics
- [x] Sockeye https://github.inl.gov/ncrc/sockeye/pull/725
- [x] Subchannel https://github.inl.gov/ncrc/subchannel/pull/292
- [x] BlueCrab https://github.inl.gov/ncrc/blue_crab/pull/221