### PR TITLE
Remove greedy search-like behavior in a transfer to  get more consistent results in testing

### DIFF
--- a/test/tests/transfers/general_field/nearest_node/regular/main_array.i
+++ b/test/tests/transfers/general_field/nearest_node/regular/main_array.i
@@ -97,6 +97,8 @@
     variable = 'from_sub from_sub'
     target_variable_components = '0 1'
     source_type = 'nodes nodes'
+    # to stabilize nearest-node results in parallel
+    search_value_conflicts = false
   []
 
   [from_sub_elem]


### PR DESCRIPTION
for any partitioning
follow up on #17417