### PR TITLE
Mark the following tests as skipped

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/pins/mms/porosity_change/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/mms/porosity_change/tests
@@ -20,6 +20,8 @@
     method = '!dbg'
     min_parallel = 16
     required_python_packages = 'pandas matplotlib'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [pressure-corrected]
     type = PythonUnitTest

--- a/modules/navier_stokes/test/tests/finite_volume/pins/mms/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/pins/mms/tests
@@ -39,5 +39,7 @@
     method = '!dbg'
     min_parallel = 16
     required_python_packages = 'pandas matplotlib'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []


### PR DESCRIPTION
Skip these tests. They cannot run while the binary exists in its relocatble form.

Refs #25279
Closes #25469
