### PR TITLE
Added error message for failed plot script in MooseDocs

### DIFF
--- a/python/MooseDocs/extensions/media.py
+++ b/python/MooseDocs/extensions/media.py
@@ -133,10 +133,10 @@ class ScriptCommand(ImageCommand):
 
         # Generate the plot
         LOG.info("Executing plot script %s", script_path)
-        result = subprocess.run(["python", script_path], capture_output=True)
+        result = subprocess.run(["python", script_path], capture_output=True, text=True)
         if result.returncode != 0:
-            msg = "Failed to execute python script: %s"
-            raise exceptions.MooseDocsException(msg, script_path)
+            msg = "Failed to execute python script '{}':\n{}"
+            raise exceptions.MooseDocsException(msg, script_path, result.stderr)
 
         # Currently the plot is assumed to reside in the same directory as the plot script.
         plot_name = settings['image_name'] or os.path.basename(script_path).replace('.py', '.png')


### PR DESCRIPTION
Right now, the exception message for failed plot script execution in MooseDocs is broken, e.g.,
```
TOKENIZE ERROR: Failed to execute python script: %s
/tmp/civet_builds/civet_lemhi2/griffin/moose/python/doc/content/python/MooseDocs/extensions/media.md:51
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
51│!media example_plot.py                                                                          │
52│       id=example-plot                                                                          │
53│       caption=Example plot.                                                                    │
54│       style=width:50%;padding:20px;                                                            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
Traceback (most recent call last):
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/base/lexers.py", line 230, in tokenize
    obj = self.buildToken(parent, pattern, info, page)
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/base/lexers.py", line 307, in buildToken
    obj = super(RecursiveLexer, self).buildToken(parent, pattern, info, page)
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/base/lexers.py", line 257, in buildToken
    return pattern.function(parent, info, page)
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/base/components.py", line 122, in __call__
    return self.createToken(parent, info, page, settings)
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/extensions/command.py", line 125, in createToken
    token = obj.createToken(parent, info, page, settings)
  File "/tmp/civet_builds/civet_lemhi2/griffin/moose/python/MooseDocs/extensions/media.py", line 139, in createToken
    raise exceptions.MooseDocsException(msg, script_path)
MooseDocs.common.exceptions.MooseDocsException: Failed to execute python script: %s
```

This change fixes the exception message and also adds the actual error message encountered in the plot script.

Refs #23900
