### PR TITLE
Add Python 3.11 (test), Modify package combination

### DIFF
--- a/conda/libmesh-vtk/conda_build_config.yaml
+++ b/conda/libmesh-vtk/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_10
+  - moose-mpich 4.0.2 build_11
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh-vtk/meta.yaml
+++ b/conda/libmesh-vtk/meta.yaml
@@ -3,7 +3,7 @@
 #   libmesh/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set build = 3 %}
+{% set build = 4 %}
 {% set vtk_version = "9.2.6" %}
 {% set vtk_friendly_version = "9.2" %}
 {% set sha256 = "06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12" %}

--- a/conda/libmesh/conda_build_config.yaml
+++ b/conda/libmesh/conda_build_config.yaml
@@ -1,8 +1,8 @@
 moose_petsc:
-  - moose-petsc 3.16.6 build_10
+  - moose-petsc 3.16.6 build_11
 
 moose_libmesh_vtk:
-  - moose-libmesh-vtk 9.2.6 build_3
+  - moose-libmesh-vtk 9.2.6 build_4
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/libmesh/meta.yaml
+++ b/conda/libmesh/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = "2023.09.06" %}
 {% set vtk_friendly_version = "9.2" %}
 

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -2,10 +2,10 @@ moose_libmesh:
   - moose-libmesh 2023.09.06 build_1
 
 moose_wasp:
-  - moose-wasp 2023.08.31
+  - moose-wasp 2023.09.13
 
 moose_tools:
-  - moose-tools 2023.08.31
+  - moose-tools 2023.09.13
 
 moose_peacock:
-  - moose-peacock 2023.08.31
+  - moose-peacock 2023.09.13

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
-  - moose-libmesh 2023.09.06 build_1
+  - moose-libmesh 2023.09.06 build_2
 
 moose_wasp:
   - moose-wasp 2023.09.13

--- a/conda/mpich/conda_build_config.yaml
+++ b/conda/mpich/conda_build_config.yaml
@@ -1,10 +1,10 @@
 moose_libgfortran:
-  - libgfortran-ng 13.1.0 h69a702a_0                        # [linux]
+  - libgfortran-ng 13.2.0 h69a702a_0                        # [linux]
   - libgfortran 5.0.0 12_3_0_h97931a8_1                     # [not arm64 and osx]
   - libgfortran 5.0.0 12_3_0_hd922786_1                     # [arm64]
 
 moose_libgfortran5:
-  - libgfortran5 13.1.0 h15d22d2_0                          # [linux]
+  - libgfortran5 13.2.0 ha4646dd_0                          # [linux]
   - libgfortran5 12.3.0 hbd3c1fe_1                          # [not arm64 and osx]
   - libgfortran5 12.3.0 ha3a6a3e_1                          # [arm64]
 
@@ -22,7 +22,7 @@ moose_clangxx:                                              # [osx]
   - clangxx 12.0.1 default_h8b1a7b7_0                       # [arm64]
 
 moose_hdf5:
-  - hdf5 1.12.1 mpi_mpich_h08b82f9_4                        # [linux]
+  - hdf5 1.12.2 mpi_mpich_h08b82f9_0                        # [linux]
   - hdf5 1.12.2 mpi_mpich_hc154f39_0                        # [not arm64 and osx]
   - hdf5 1.12.2 mpi_mpich_h16e63df_0                        # [arm64]
 

--- a/conda/mpich/meta.yaml
+++ b/conda/mpich/meta.yaml
@@ -6,7 +6,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 10 %}
+{% set build = 11 %}
 {% set version = "4.0.2" %}
 
 # permanent
@@ -74,7 +74,7 @@ requirements:
     - mpi 1.0 mpich
   # Python min/max constraints
   run_constrained:
-    - python <{{3.11}}
+    - python <{{3.12}}
 
 test:
   commands:

--- a/conda/peacock/conda_build_config.yaml
+++ b/conda/peacock/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_10
+  - moose-mpich 4.0.2 build_11
 
 # Pesky packages that break internal CI
 # Note: Modifying/Updating this will require changes to conda/mpich!

--- a/conda/peacock/meta.yaml
+++ b/conda/peacock/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.08.31" %}
+{% set version = "2023.09.13" %}
 
 package:
   name: moose-peacock
@@ -27,7 +27,7 @@ requirements:
     - pyqt
   # Python min/max constraints
   run_constrained:
-    - python <{{3.11}}
+    - python <{{3.12}}
 
 test:
   imports:

--- a/conda/petsc/conda_build_config.yaml
+++ b/conda/petsc/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_mpich:
-  - moose-mpich 4.0.2 build_10
+  - moose-mpich 4.0.2 build_11
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/petsc/meta.yaml
+++ b/conda/petsc/meta.yaml
@@ -4,7 +4,7 @@
 #
 # As well as any directions pertaining to modifying those files.
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
-{% set build = 10 %}
+{% set build = 11 %}
 {% set version = "3.16.6" %}
 
 # permanent

--- a/conda/test-tools/conda_build_config.yaml
+++ b/conda/test-tools/conda_build_config.yaml
@@ -1,4 +1,5 @@
 moose_python:
+  - python 3.11
   - python 3.10
   - python 3.9
   - python 3.8

--- a/conda/test-tools/meta.yaml
+++ b/conda/test-tools/meta.yaml
@@ -3,7 +3,7 @@
 #   tools/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.08.31" %}
+{% set version = "2023.09.13" %}
 
 package:
   name: moose-test-tools

--- a/conda/tools/conda_build_config.yaml
+++ b/conda/tools/conda_build_config.yaml
@@ -1,7 +1,8 @@
 moose_test_tools:
-  - moose-test-tools 2023.08.31
+  - moose-test-tools 2023.09.13
 
 moose_python:
+  - python 3.11
   - python 3.10
   - python 3.9
   - python 3.8

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.08.31" %}
+{% set version = "2023.09.13" %}
 
 package:
   name: moose-tools

--- a/conda/wasp/meta.yaml
+++ b/conda/wasp/meta.yaml
@@ -6,7 +6,7 @@
 # ALSO: Follow the directions in scripts/tests/versioner_hashes.yaml
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "2023.08.31" %}
+{% set version = "2023.09.13" %}
 
 package:
   name: moose-wasp

--- a/python/mms/ConvergencePlot.py
+++ b/python/mms/ConvergencePlot.py
@@ -41,7 +41,7 @@ class ConvergencePlot(object):
 
         # Adjust tick mark fonts
         for tick in self._axes.xaxis.get_major_ticks() + self._axes.yaxis.get_major_ticks():
-            tick.label.set_fontsize(fontsize)
+            tick.label1.set_fontsize(fontsize)
 
         # Apply grid marks
         plt.grid(True, which='both', color=[0.8]*3)


### PR DESCRIPTION
Allow Ptyhon 3.11 packages to become available. TODO: we have no tests for this version yet. Need to create some.

Attempt to align the Paraview package version which gets installed on Linux (5.10) to match with what is being installed on Mac (5.11)

Closes #25498

