### PR TITLE
Skip tests which cannot relocate

### DIFF
--- a/modules/tensor_mechanics/test/tests/uel/tests
+++ b/modules/tensor_mechanics/test/tests/uel/tests
@@ -7,36 +7,48 @@
     command = "cd ../../../examples/uel_tri_tests; make"
     requirement = "The UEL tri tests example shall be built."
     method = 'opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [build_uel_tri_states_tests]
     type = RunCommand
     command = "cd ../../../examples/uel_tri_states_tests; make"
     requirement = "The UEL tri states tests example shall be built."
     method = 'opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [build_uel_build_tests]
     type = RunCommand
     command = "cd ../../../examples/uel_build_tests; make"
     requirement = "The UEL build tests example shall be built."
     method = 'opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [build_uel_tri_tests_dbg]
     type = RunCommand
     command = "cd ../../../examples/uel_tri_tests; METHOD=dbg make"
     requirement = "The UEL tri tests example shall be built."
     method = 'dbg'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [build_uel_tri_states_tests_dbg]
     type = RunCommand
     command = "cd ../../../examples/uel_tri_states_tests; METHOD=dbg make"
     requirement = "The UEL tri states tests example shall be built."
     method = 'dbg'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [build_uel_build_tests_dbg]
     type = RunCommand
     command = "cd ../../../examples/uel_build_tests; METHOD=dbg make"
     requirement = "The UEL build tests example shall be built."
     method = 'dbg'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [reference]
     type = Exodiff
@@ -57,6 +69,8 @@
                   "deformation with a triangular mesh using a UEL plugin."
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test]
     type = Exodiff
@@ -68,6 +82,8 @@
                   "its standard interface."
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [uel_test_print]
     type = RunApp
@@ -125,6 +141,8 @@
                   'non-trivial setup.'
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_uel_umat]
     type = Exodiff
@@ -136,6 +154,8 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_moose_umat]
     type = Exodiff
@@ -148,6 +168,8 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_uel_states_fields]
     type = Exodiff
@@ -160,6 +182,8 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_umat_states_fields]
     type = Exodiff
@@ -172,6 +196,8 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_umat_states_fields_gradient]
     type = Exodiff
@@ -184,6 +210,8 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
   [small_test_uel_states_fields_gradient]
     type = Exodiff
@@ -197,5 +225,7 @@
     abs_zero = 1e-12
     # Only test plugins in dbg and opt.
     method = 'dbg opt'
+    # skip test if test is being run out-of-tree. Issue Ref: #25279
+    installation_type = in_tree
   []
 []


### PR DESCRIPTION
The following represents tests which do not work when run from a relocated location (such as in the case of a `make install`)

Refs #25411
Closes #25524
