### PR TITLE
HOTFIX Perform the conflict search outside of the value acceptance condition

### DIFF
--- a/test/tests/transfers/general_field/nearest_node/regular/main.i
+++ b/test/tests/transfers/general_field/nearest_node/regular/main.i
@@ -84,8 +84,6 @@
     from_multi_app = sub
     source_variable = to_main
     variable = from_sub
-    # Some equidistant nodes
-    search_value_conflicts = false
   []
 
   [from_sub_elem]

--- a/test/tests/transfers/general_field/nearest_node/regular/main_array.i
+++ b/test/tests/transfers/general_field/nearest_node/regular/main_array.i
@@ -97,8 +97,6 @@
     variable = 'from_sub from_sub'
     target_variable_components = '0 1'
     source_type = 'nodes nodes'
-    # to stabilize nearest-node results in parallel
-    search_value_conflicts = false
   []
 
   [from_sub_elem]

--- a/test/tests/transfers/general_field/nearest_node/subdomain/main.i
+++ b/test/tests/transfers/general_field/nearest_node/subdomain/main.i
@@ -110,7 +110,5 @@
     variable = from_sub_elem
     from_blocks = 1
     to_blocks = 1
-    # Value conflicts search triggers a greedy search which creates a diff
-    search_value_conflicts = false
   []
 []


### PR DESCRIPTION
for general field transfers
This simplifies the logic and avoids accidentally accepting a value refs #24226
