### PR TITLE
Fix recovery test for mortar periodic-segmental-constraint

### DIFF
--- a/test/tests/mortar/periodic_segmental_constraint/periodic_aux2d.i
+++ b/test/tests/mortar/periodic_segmental_constraint/periodic_aux2d.i
@@ -181,8 +181,8 @@
 
 [Executioner]
   type = Steady
-  petsc_options_iname = '-pc_type -pc_factor_shift_type'
-  petsc_options_value = 'lu       NONZERO'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount'
+  petsc_options_value = 'lu       NONZERO               1e-15'
   solve_type = NEWTON
 []
 

--- a/test/tests/mortar/periodic_segmental_constraint/periodic_checker2d.i
+++ b/test/tests/mortar/periodic_segmental_constraint/periodic_checker2d.i
@@ -242,8 +242,8 @@
 
 [Executioner]
   type = Steady
-  petsc_options_iname = '-pc_type -pc_factor_shift_type'
-  petsc_options_value = 'lu       NONZERO'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount'
+  petsc_options_value = 'lu       NONZERO               1e-15'
   solve_type = NEWTON
 []
 

--- a/test/tests/mortar/periodic_segmental_constraint/periodic_simple2d.i
+++ b/test/tests/mortar/periodic_segmental_constraint/periodic_simple2d.i
@@ -173,8 +173,8 @@
 
 [Executioner]
   type = Steady
-  petsc_options_iname = '-pc_type -pc_factor_shift_type'
-  petsc_options_value = 'lu       NONZERO'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount'
+  petsc_options_value = 'lu       NONZERO               1e-15'
   solve_type = NEWTON
 []
 

--- a/test/tests/mortar/periodic_segmental_constraint/periodic_simple3d.i
+++ b/test/tests/mortar/periodic_segmental_constraint/periodic_simple3d.i
@@ -217,8 +217,8 @@
 
 [Executioner]
   type = Steady
-  petsc_options_iname = '-pc_type -pc_factor_shift_type'
-  petsc_options_value = 'lu       NONZERO'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount'
+  petsc_options_value = 'lu       NONZERO               1e-15'
   solve_type = NEWTON
 []
 


### PR DESCRIPTION
Add a specific diagonal offset to PETSC solver for Lagrange-multiplier test cases to pass recovery tests.
closes [#<25541>](https://github.com/idaholab/moose/issues/25541)