### PR TITLE
Use the translator to find relative paths for tagged pages

### DIFF
--- a/modules/fluid_properties/doc/content/source/fluidproperties/FlinakFluidProperties.md
+++ b/modules/fluid_properties/doc/content/source/fluidproperties/FlinakFluidProperties.md
@@ -15,7 +15,7 @@ assumed to be 1.7324e-7 kg/m$^3$/Pa [!cite](richard), but this may be set to
 a user-defined value. Slightly increasing the partial derivative of density
 with respect to pressure may improve convergence of compressible flow equations
 without significantly affecting the physical accuracy of the density estimation
-[!cite](scarlat). In the absense of the pressure dependence, the uncertainty
+[!cite](scarlat). In the absence of the pressure dependence, the uncertainty
 on density is $\pm$2% [!cite](richard).
 
 Viscosity, isobaric specific heat, and thermal conductivity are calculated

--- a/python/MooseDocs/extensions/tagging.py
+++ b/python/MooseDocs/extensions/tagging.py
@@ -114,13 +114,13 @@ class TaggingExtension(command.CommandExtension):
                         target_page = self.translator.findPages(path_value_cut)
                         filter_page = self.translator.findPages("filter/index.html")
                         if len(target_page) != 1:
-                            LOG.warning(str(len(target_page)) + " pages found after truncating address when "
-                                        "tagging for page initially at address: " + path_value)
+                            LOG.error(str(len(target_page)) + " pages found after truncating address when "
+                                      "tagging for page initially at address: " + path_value)
                         if len(filter_page) != 1:
                             LOG.warning(str(len(filter_page)) + " pages have been found for the filter page "
-                                        "when building tagged pages relative links")
-                        # we did not find the pages, cannot search for their relative path
-                        # do the next best thing
+                                        "when building relative links for tagged pages!")
+                        # We did not find the pages, thus cannot search for their relative path
+                        # So we simply take the full path value and use it to create the link
                         if (len(target_page) == 0 or len(filter_page) == 0):
                             link_value = '/' + path_value_cut.replace('.md', '.html')
                         else:


### PR DESCRIPTION
refs #25387

@cticenhour that was the right solution all along

see https://mooseframework.inl.gov/docs/PRs/25636/site/modules/electromagnetics/filter/index.html