### PR TITLE
Fix PETSc version requirement for distributed test

### DIFF
--- a/test/tests/partitioners/block_weighted_partitioner/tests
+++ b/test/tests/partitioners/block_weighted_partitioner/tests
@@ -25,7 +25,7 @@
       input = 'block_weighted_partitioner.i'
       exodiff = 'block_weighted_partitioner_out_distributed.e'
       cli_args = 'Outputs/file_base=block_weighted_partitioner_out_distributed'
-      petsc_version = '>=3.10.0'
+      petsc_version = '>=3.18.0' # PTScotch 7.0.1 changes partitioning for this test as of 3.18.0
       min_parallel = 4
       max_parallel = 4
       # different mode generates different partition


### PR DESCRIPTION
We got this updated but only for the replicated version of the test

This fixes regressions we've been seeing in libMesh CI ever since #23502