### PR TITLE
Add capability to move parameters from one object to another

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -626,6 +626,15 @@ public:
     return _new_to_deprecated_coupled_vars;
   }
 
+  /// Return whether a parameter has a range check
+  bool isRangeChecked(const std::string & param_name) const;
+
+  /// Return the range check function for any parameter (empty string if it is not range checked)
+  std::string rangeCheckedFunction(const std::string & name) const;
+
+  /// Return whether a parameter has a default
+  bool hasDefault(const std::string & param_name) const;
+
   /**
    * Return whether or not the coupled variable exists
    * @param coupling_name The name of the coupled variable to test for
@@ -938,6 +947,18 @@ public:
    */
   template <typename T>
   bool have_parameter(std::string_view name) const;
+
+  /**
+   * A routine to transfer a parameter from one class' validParams to another
+   * @param source_param The parameters list holding the param we would like to transfer
+   * @param name The name of the parameter to transfer
+   * @param new_description A new description of the parameter. If unspecified, uses the
+   * source_params'
+   */
+  template <typename T>
+  void transferParam(const InputParameters & source_param,
+                     std::string name,
+                     std::string new_description = "");
 
   /**
    * Return all the aliased names associated with \p param_name. The returned container will always
@@ -1829,4 +1850,80 @@ InputParameters::have_parameter(std::string_view name_in) const
   const auto name = checkForRename(std::string(name_in));
 
   return Parameters::have_parameter<T>(name);
+}
+
+template <typename T>
+void
+InputParameters::transferParam(const InputParameters & source_params,
+                               std::string name_in,
+                               std::string new_description)
+{
+  const auto name = source_params.checkForRename(std::string(name_in));
+  if (!source_params.have_parameter<T>(name) && !source_params.hasCoupledValue(name))
+    mooseError(
+        "The '",
+        name_in,
+        "' parameter could not be transferred because it does not exist in the source parameters");
+
+  std::string description =
+      new_description.empty() ? source_params.getDescription(name) : new_description;
+
+  if (source_params.isParamRequired(name))
+  {
+    // Use the name_in that was specified in the transfer, not the potentially deprecated name
+    // Check for a variable parameter
+    if (source_params.hasCoupledValue(name))
+      addRequiredCoupledVar(name, description);
+    // Enums parameters have a default list of options
+    else if constexpr (std::is_same_v<MooseEnum, T> || std::is_same_v<MultiMooseEnum, T>)
+      addRequiredParam<T>(name_in, source_params.get<T>(name), description);
+    else if (source_params.isRangeChecked(name))
+      addRequiredRangeCheckedParam<T>(
+          name_in, source_params.rangeCheckedFunction(name), description);
+    else
+      addRequiredParam<T>(name_in, description);
+  }
+  else
+  {
+    // Check for a variable parameter
+    if (source_params.hasCoupledValue(name))
+    {
+      if (!source_params.hasDefaultCoupledValue(name))
+        addCoupledVar(name, description);
+      else if (source_params.numberDefaultCoupledValues(name) == 1)
+        addCoupledVar(name, source_params.defaultCoupledValue(name), description);
+      else
+      {
+        std::vector<Real> coupled_values;
+        for (const auto i : make_range(source_params.numberDefaultCoupledValues(name)))
+          coupled_values.push_back(source_params.defaultCoupledValue(name, i));
+        addCoupledVar(name, coupled_values, description);
+      }
+    }
+    else if (source_params.isRangeChecked(name))
+    {
+      if (source_params.hasDefault(name))
+        addRangeCheckedParam<T>(name_in,
+                                source_params.get<T>(name),
+                                source_params.rangeCheckedFunction(name),
+                                description);
+      else
+        addRangeCheckedParam<T>(name_in, source_params.rangeCheckedFunction(name), description);
+    }
+    else if constexpr (std::is_same_v<MooseEnum, T> || std::is_same_v<MultiMooseEnum, T>)
+      addParam<T>(name_in, source_params.get<T>(name), description);
+    else
+    {
+      if (source_params.hasDefault(name))
+        addParam<T>(name_in, source_params.get<T>(name), description);
+      else
+        addParam<T>(name_in, description);
+    }
+  }
+
+  // Copy other attributes
+  if (source_params.isPrivate(name))
+    _params[name_in]._is_private = true;
+  if (source_params.isControllable(name))
+    _params[name_in]._controllable = true;
 }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -601,6 +601,30 @@ InputParameters::checkParams(const std::string & parsing_syntax)
 }
 
 bool
+InputParameters::isRangeChecked(const std::string & param_name) const
+{
+  const auto name = checkForRename(param_name);
+  return !_params.find(name)->second._range_function.empty();
+}
+
+std::string
+InputParameters::rangeCheckedFunction(const std::string & param_name) const
+{
+  const auto name = checkForRename(param_name);
+  return _params.at(name)._range_function;
+}
+
+bool
+InputParameters::hasDefault(const std::string & param_name) const
+{
+  const auto name = checkForRename(param_name);
+  if (hasDefaultCoupledValue(name))
+    return true;
+  // If it has a default, it's already valid
+  return isParamValid(name);
+}
+
+bool
 InputParameters::hasCoupledValue(const std::string & coupling_name) const
 {
   return _coupled_vars.find(coupling_name) != _coupled_vars.end();

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -621,7 +621,12 @@ InputParameters::hasDefault(const std::string & param_name) const
   if (hasDefaultCoupledValue(name))
     return true;
   // If it has a default, it's already valid
-  return isParamValid(name);
+  else if (isParamSetByAddParam(name))
+    return true;
+  else if (isParamValid(name))
+    mooseError("No way to know if the parameter", param_name, "has a default");
+  else
+    return false;
 }
 
 bool

--- a/unit/src/InputParametersTest.C
+++ b/unit/src/InputParametersTest.C
@@ -411,3 +411,110 @@ TEST(InputParameters, getControllablePairs)
         << "Failed with unexpected error message: " << msg;
   }
 }
+
+TEST(InputParameters, transferParameters)
+{
+  // Add parameters of various types to p1
+  InputParameters p1 = emptyInputParameters();
+  p1.addRequiredParam<Real>("r1", "Required 1");
+  p1.addRequiredRangeCheckedParam<Real>("r2", "r2 > 0", "Required 2");
+  p1.addRequiredCoupledVar("r3", "Required 3");
+  MooseEnum options("option1 option2");
+  MultiMooseEnum several_options("option1 option2");
+  p1.addRequiredParam<MooseEnum>("r4", options, "Required 4");
+  p1.addRequiredParam<MultiMooseEnum>("r5", several_options, "Required 5");
+  p1.addParam<Real>("o1", 3, "Optional 1");
+  p1.addRangeCheckedParam<Real>("o2", "o2 > 0", "Optional 2");
+  p1.addCoupledVar("o3", "Optional 3");
+  p1.addParam<MooseEnum>("o4", options, "Optional 4");
+  p1.addParam<MultiMooseEnum>("o5", several_options, "Optional 5");
+  p1.addParam<Real>("od1", "Optional with default 1");
+  p1.addRangeCheckedParam<Real>("od2", "od2 > 0", "Optional with default 2");
+  p1.addCoupledVar("od3a", 1., "Optional with default 3a");
+  p1.addCoupledVar("od3b", {1., 2.}, "Optional with default 3b");
+
+  // Params with modified attributes
+  p1.declareControllable("r1");
+  p1.addPrivateParam<Real>("private", 2);
+
+  // Transfer them all to p2
+  InputParameters p2 = emptyInputParameters();
+  p2.transferParam<Real>(p1, "r1");
+  p2.transferParam<Real>(p1, "r2");
+  p2.transferParam<std::vector<VariableName>>(p1, "r3");
+  p2.transferParam<MooseEnum>(p1, "r4");
+  p2.transferParam<MultiMooseEnum>(p1, "r5");
+  p2.transferParam<Real>(p1, "o1");
+  p2.transferParam<Real>(p1, "o2");
+  p2.transferParam<std::vector<VariableName>>(p1, "o3");
+  p2.transferParam<MooseEnum>(p1, "o4");
+  p2.transferParam<MultiMooseEnum>(p1, "o5");
+  p2.transferParam<Real>(p1, "od1");
+  p2.transferParam<Real>(p1, "od2");
+  p2.transferParam<std::vector<VariableName>>(p1, "od3a");
+  p2.transferParam<std::vector<VariableName>>(p1, "od3b");
+  p2.transferParam<Real>(p1, "private");
+
+  // Check that all the parameters match
+  // Same parameters
+  EXPECT_EQ(p1.have_parameter<Real>("r1"), p2.have_parameter<Real>("r1"));
+  EXPECT_EQ(p1.have_parameter<Real>("r2"), p2.have_parameter<Real>("r2"));
+  EXPECT_EQ(p1.hasCoupledValue("r3"), p2.hasCoupledValue("r3"));
+  EXPECT_EQ(p1.have_parameter<MooseEnum>("r4"), p2.have_parameter<MooseEnum>("r4"));
+  EXPECT_EQ(p1.have_parameter<MultiMooseEnum>("r5"), p2.have_parameter<MultiMooseEnum>("r5"));
+  EXPECT_EQ(p1.have_parameter<Real>("o1"), p2.have_parameter<Real>("o1"));
+  EXPECT_EQ(p1.have_parameter<Real>("o2"), p2.have_parameter<Real>("o2"));
+  EXPECT_EQ(p1.hasCoupledValue("o3"), p2.hasCoupledValue("o3"));
+  EXPECT_EQ(p1.have_parameter<MooseEnum>("o4"), p2.have_parameter<MooseEnum>("o4"));
+  EXPECT_EQ(p1.have_parameter<MultiMooseEnum>("o5"), p2.have_parameter<MultiMooseEnum>("o5"));
+  EXPECT_EQ(p1.have_parameter<Real>("od1"), p2.have_parameter<Real>("od1"));
+  EXPECT_EQ(p1.have_parameter<Real>("od2"), p2.have_parameter<Real>("od2"));
+  EXPECT_EQ(p1.hasDefaultCoupledValue("od3a"), p2.hasDefaultCoupledValue("od3a"));
+  EXPECT_EQ(p1.hasDefaultCoupledValue("od3b"), p2.hasDefaultCoupledValue("od3b"));
+
+  // Same required status
+  EXPECT_EQ(p1.isParamRequired("r1"), p2.isParamRequired("r1"));
+  EXPECT_EQ(p1.isParamRequired("r2"), p2.isParamRequired("r2"));
+  EXPECT_EQ(p1.isParamRequired("r3"), p2.isParamRequired("r3"));
+  EXPECT_EQ(p1.isParamRequired("r4"), p2.isParamRequired("r4"));
+  EXPECT_EQ(p1.isParamRequired("r5"), p2.isParamRequired("r5"));
+  EXPECT_EQ(p1.isParamRequired("o1"), p2.isParamRequired("o1"));
+  EXPECT_EQ(p1.isParamRequired("o2"), p2.isParamRequired("o2"));
+  EXPECT_EQ(p1.isParamRequired("o3"), p2.isParamRequired("o3"));
+  EXPECT_EQ(p1.isParamRequired("o4"), p2.isParamRequired("o4"));
+  EXPECT_EQ(p1.isParamRequired("o5"), p2.isParamRequired("o5"));
+  EXPECT_EQ(p1.isParamRequired("od1"), p2.isParamRequired("od1"));
+  EXPECT_EQ(p1.isParamRequired("od2"), p2.isParamRequired("od2"));
+  EXPECT_EQ(p1.isParamRequired("od3a"), p2.isParamRequired("od3a"));
+  EXPECT_EQ(p1.isParamRequired("od3b"), p2.isParamRequired("od3b"));
+
+  // Same private status
+  EXPECT_EQ(p1.isPrivate("r1"), p2.isPrivate("r1"));
+  EXPECT_EQ(p1.isPrivate("private"), p2.isPrivate("private"));
+
+  // Same controllable status
+  EXPECT_EQ(p1.isControllable("r1"), p2.isControllable("r1"));
+  EXPECT_EQ(p1.isControllable("r2"), p2.isControllable("r2"));
+
+  // Same defaults
+  EXPECT_EQ(p1.get<Real>("od1"), p2.get<Real>("od1"));
+  EXPECT_EQ(p1.get<Real>("od2"), p2.get<Real>("od2"));
+  EXPECT_EQ(p1.defaultCoupledValue("od3a"), p2.defaultCoupledValue("od3a"));
+  // EXPECT_EQ(p1.defaultCoupledValue("od3b", 1), p2.defaultCoupledValue("od3b", 1));
+
+  // Same docstrings
+  EXPECT_EQ(p1.getDocString("r1"), p2.getDocString("r1"));
+  EXPECT_EQ(p1.getDocString("r2"), p2.getDocString("r2"));
+  EXPECT_EQ(p1.getDocString("r3"), p2.getDocString("r3"));
+  EXPECT_EQ(p1.getDocString("r4"), p2.getDocString("r4"));
+  EXPECT_EQ(p1.getDocString("r5"), p2.getDocString("r5"));
+  EXPECT_EQ(p1.getDocString("o1"), p2.getDocString("o1"));
+  EXPECT_EQ(p1.getDocString("o2"), p2.getDocString("o2"));
+  EXPECT_EQ(p1.getDocString("o3"), p2.getDocString("o3"));
+  EXPECT_EQ(p1.getDocString("o4"), p2.getDocString("o4"));
+  EXPECT_EQ(p1.getDocString("o5"), p2.getDocString("o5"));
+  EXPECT_EQ(p1.getDocString("od1"), p2.getDocString("od1"));
+  EXPECT_EQ(p1.getDocString("od2"), p2.getDocString("od2"));
+  EXPECT_EQ(p1.getDocString("od3a"), p2.getDocString("od3a"));
+  EXPECT_EQ(p1.getDocString("od3b"), p2.getDocString("od3b"));
+}


### PR DESCRIPTION
The way to build these new Physics, see https://github.com/idaholab/moose/issues/25642, is going to pull params from people's existing actions & objects

I think we want to avoid:

- re-writing docstring for every parameters in the coming Physics action(s)
- re-setting the same defaults etc

Ideally we would even move the parameter checking (dependences etc) to the validParam as well so we could transfer that too

For example, in this new ground breaking heat conduction physics:
```
InputParameters
HeatConductionPhysics::validParams()
{
  InputParameters params = PhysicsBase::validParams();
  params.addClassDescription("Add the heat conduction physics");

  params.transferParam<MaterialPropertyName>(ADHeatConduction::validParams(),
                                             "thermal_conductivity");
```
