### PR TITLE
Make VScode associate .C files to cpp so we can use the plugin snippets

### DIFF
--- a/modules/doc/content/help/development/VSCode.md
+++ b/modules/doc/content/help/development/VSCode.md
@@ -70,7 +70,7 @@ The following settings are recommended to pass the MOOSE GitHub CI pre-checks:
         "${env.CONDA_PREFIX}/**",
         "/usr/include/**"
     ],
-    "workbench.editorAssociations": {
+    "files.associations": {
         "*.C": "cpp",
         "*.h": "cpp"
     },


### PR DESCRIPTION
refs #21485
