### PR TITLE
Fix broken links to the contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-[Contributing to MOOSE](https://mooseframework.inl.gov/framework_development/contributing.html)
+[Contributing to MOOSE](https://mooseframework.inl.gov/framework/contributing.html)

--- a/modules/porous_flow/README.md
+++ b/modules/porous_flow/README.md
@@ -45,7 +45,7 @@ You may optionally use `./run_tests -j8` if your system has 8 available cores (o
 
 ## Contributing
 
-You are free to contribute to PorousFlow, and the process is described [here](https://mooseframework.inl.gov/framework_development/contributing.html).  MOOSE has strict quality control standards.
+You are free to contribute to PorousFlow, and the process is described [here](https://mooseframework.inl.gov/framework/contributing.html).  MOOSE has strict quality control standards.
 
 ## Contact
 


### PR DESCRIPTION
## Bug description
One link is broken to the contributing guidelines

## Steps to reproduce
click the link

## Impact
limited. Users can always use the search engine to bypass the broken link

Closes #25658.