### PR TITLE
Modify SolutionTimeAdaptiveDT to make dt consistent accross all processors.

### DIFF
--- a/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
+++ b/framework/src/timesteppers/SolutionTimeAdaptiveDT.C
@@ -65,6 +65,9 @@ SolutionTimeAdaptiveDT::step()
     auto elapsed_time =
         std::chrono::duration_cast<std::chrono::milliseconds>(solve_end - solve_start).count();
 
+    // Take the maximum time over all processors so all processors compute and use the same dt
+    TimeStepper::_communicator.max(elapsed_time);
+
     _older_sol_time_vs_dt = _old_sol_time_vs_dt;
     _old_sol_time_vs_dt = _sol_time_vs_dt;
     _sol_time_vs_dt = elapsed_time / _dt;


### PR DESCRIPTION

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->
This update is to prevent the possibility of processors becoming out of sync while computing the size of the next time step with the SolutionTimeAdaptiveDT TimeStepper. Previously, the ratio of solution time to time step size was based on local solution time for each processor. These ratios are used to determine whether to increase or decrease dt for the next timestep. Because the ratios differ across processors, it is possible for one processor to recommend increasing dt while another processor recommends decreasing dt.

## Design
<!--A concise description (design) of the enhancement.-->
To prevent the above behavior, this PR introduces the use of the maximum solution time over all processors to compute the (solution time / dt) ratio, resulting in all processors using the same ratio to compute the next dt. This results in each processors recommending the same dt for the next time step.

## Impact
<!--Will the enhancement change existing APIs or add something new?-->
This PR solves the occasionally observed behavior of SolutionTimeAdaptive causing hangs in parallel.

<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
Closes #13426.
