### PR TITLE
Avoid redundancy and use libMesh::Elem::build() for shorter code

### DIFF
--- a/framework/include/mesh/MooseMesh.h
+++ b/framework/include/mesh/MooseMesh.h
@@ -54,6 +54,15 @@ class BoundingBox;
 // Useful typedefs
 typedef StoredRange<std::set<Node *>::iterator, Node *> SemiLocalNodeRange;
 
+// List of supported geometrical elements
+const std::string LIST_GEOM_ELEM = "EDGE EDGE2 EDGE3 EDGE4 "
+                                   "QUAD QUAD4 QUAD8 QUAD9 "
+                                   "TRI TRI3 TRI6 "
+                                   "HEX HEX8 HEX20 HEX27 "
+                                   "TET TET4 TET10 "
+                                   "PRISM PRISM6 PRISM15 PRISM18 "
+                                   "PYRAMID PYRAMID5 PYRAMID13 PYRAMID14";
+
 /**
  * Helper object for holding qp mapping info.
  */

--- a/framework/src/mesh/GeneratedMesh.C
+++ b/framework/src/mesh/GeneratedMesh.C
@@ -27,9 +27,7 @@ GeneratedMesh::validParams()
 {
   InputParameters params = MooseMesh::validParams();
 
-  MooseEnum elem_types(
-      "EDGE EDGE2 EDGE3 EDGE4 QUAD QUAD4 QUAD8 QUAD9 TRI3 TRI6 HEX HEX8 HEX20 HEX27 TET4 TET10 "
-      "PRISM6 PRISM15 PRISM18 PYRAMID5 PYRAMID13 PYRAMID14"); // no default
+  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
 
   MooseEnum dims("1=1 2 3");
   params.addRequiredParam<MooseEnum>(

--- a/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
+++ b/framework/src/meshgenerators/DistributedRectilinearMeshGenerator.C
@@ -82,9 +82,7 @@ DistributedRectilinearMeshGenerator::validParams()
   params.addParam<MooseEnum>(
       "partition", partition, "Which method (graph linear square) use to partition mesh");
 
-  MooseEnum elem_types(
-      "EDGE EDGE2 EDGE3 EDGE4 QUAD QUAD4 QUAD8 QUAD9 TRI3 TRI6 HEX HEX8 HEX20 HEX27 TET4 TET10 "
-      "PRISM6 PRISM15 PRISM18 PYRAMID5 PYRAMID13 PYRAMID14"); // no default
+  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
   params.addParam<MooseEnum>("elem_type",
                              elem_types,
                              "The type of element from libMesh to "

--- a/framework/src/meshgenerators/ElementGenerator.C
+++ b/framework/src/meshgenerators/ElementGenerator.C
@@ -11,6 +11,7 @@
 #include "CastUniquePointer.h"
 
 #include "libmesh/replicated_mesh.h"
+#include "libmesh/string_to_enum.h"
 
 #include "MooseEnum.h"
 
@@ -41,8 +42,7 @@ ElementGenerator::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
 
-  MooseEnum elem_types("EDGE2 EDGE3 EDGE4 QUAD4 QUAD8 QUAD9 TRI3 TRI6 HEX8 HEX20 HEX27 TET4 TET10 "
-                       "PRISM6 PRISM15 PRISM18 PYRAMID5 PYRAMID13 PYRAMID14");
+  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
 
   params.addParam<MeshGeneratorName>("input", "Optional input mesh to add the elements to");
 
@@ -72,103 +72,7 @@ ElementGenerator::ElementGenerator(const InputParameters & parameters)
 Elem *
 ElementGenerator::getElemType(const std::string & type)
 {
-  if (type == "EDGE2")
-  {
-    Elem * elem = new Edge2;
-    return elem;
-  }
-  if (type == "EDGE3")
-  {
-    Elem * elem = new Edge3;
-    return elem;
-  }
-  if (type == "EDGE4")
-  {
-    Elem * elem = new Edge4;
-    return elem;
-  }
-  if (type == "QUAD4")
-  {
-    Elem * elem = new Quad4;
-    return elem;
-  }
-  if (type == "QUAD8")
-  {
-    Elem * elem = new Quad8;
-    return elem;
-  }
-  if (type == "QUAD9")
-  {
-    Elem * elem = new Quad9;
-    return elem;
-  }
-  if (type == "TRI3")
-  {
-    Elem * elem = new Tri3;
-    return elem;
-  }
-  if (type == "TRI6")
-  {
-    Elem * elem = new Tri6;
-    return elem;
-  }
-  if (type == "HEX8")
-  {
-    Elem * elem = new Hex8;
-    return elem;
-  }
-  if (type == "HEX20")
-  {
-    Elem * elem = new Hex20;
-    return elem;
-  }
-  if (type == "HEX27")
-  {
-    Elem * elem = new Hex27;
-    return elem;
-  }
-  if (type == "TET4")
-  {
-    Elem * elem = new Tet4;
-    return elem;
-  }
-  if (type == "TET10")
-  {
-    Elem * elem = new Tet10;
-    return elem;
-  }
-  if (type == "PRISM6")
-  {
-    Elem * elem = new Prism6;
-    return elem;
-  }
-  if (type == "PRISM15")
-  {
-    Elem * elem = new Prism15;
-    return elem;
-  }
-  if (type == "PRISM18")
-  {
-    Elem * elem = new Prism18;
-    return elem;
-  }
-  if (type == "PYRAMID5")
-  {
-    Elem * elem = new Pyramid5;
-    return elem;
-  }
-  if (type == "PYRAMID13")
-  {
-    Elem * elem = new Pyramid13;
-    return elem;
-  }
-  if (type == "PYRAMID14")
-  {
-    Elem * elem = new Pyramid14;
-    return elem;
-  }
-
-  mooseError("This element type is not available.");
+  return Elem::build(Utility::string_to_enum<ElemType>(type)).release();
 }
 
 std::unique_ptr<MeshBase>

--- a/framework/src/meshgenerators/GeneratedMeshGenerator.C
+++ b/framework/src/meshgenerators/GeneratedMeshGenerator.C
@@ -29,9 +29,7 @@ GeneratedMeshGenerator::validParams()
 {
   InputParameters params = MeshGenerator::validParams();
 
-  MooseEnum elem_types(
-      "EDGE EDGE2 EDGE3 EDGE4 QUAD QUAD4 QUAD8 QUAD9 TRI3 TRI6 HEX HEX8 HEX20 HEX27 TET4 TET10 "
-      "PRISM6 PRISM15 PRISM18 PYRAMID5 PYRAMID13 PYRAMID14"); // no default
+  MooseEnum elem_types(LIST_GEOM_ELEM); // no default
 
   MooseEnum dims("1=1 2 3");
   params.addRequiredParam<MooseEnum>("dim", dims, "The dimension of the mesh to be generated");

--- a/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
+++ b/modules/heat_conduction/src/meshgenerators/PatchSidesetGenerator.C
@@ -381,25 +381,9 @@ PatchSidesetGenerator::sidesetNameHelper(const std::string & base_name) const
 Elem *
 PatchSidesetGenerator::boundaryElementHelper(MeshBase & mesh, libMesh::ElemType type) const
 {
-  switch (type)
-  {
-    case 0:
-      return mesh.add_elem(new libMesh::Edge2);
-    case 1:
-      return mesh.add_elem(new libMesh::Edge3);
-    case 2:
-      return mesh.add_elem(new libMesh::Edge4);
-    case 3:
-      return mesh.add_elem(new libMesh::Tri3);
-    case 4:
-      return mesh.add_elem(new libMesh::Tri6);
-    case 5:
-      return mesh.add_elem(new libMesh::Quad4);
-    case 6:
-      return mesh.add_elem(new libMesh::Quad8);
-    case 7:
-      return mesh.add_elem(new libMesh::Quad9);
-    default:
-      mooseError("Unsupported element type (libMesh elem_type enum): ", type);
-  }
+  std::unique_ptr<Elem> elem = libMesh::Elem::build(type);
+  if (elem->dim() < 3)
+    return mesh.add_elem(std::move(elem));
+
+  mooseError("Unsupported element type (libMesh elem_type enum): ", type);
 }


### PR DESCRIPTION
## Motivation
The list of element types is duplicated in every file where it is an option for users to chose. This can become obsolete as not every instance may be modified when a new element type is added

## Design
A single enum for all elem types, used in the relevant source files, especially the validParams elem_type parameter

## Impact
Code cleanup


Hi @roystgnr, @GiudGiud,

I believe this addresses the issues raised in #25685 that don't really belong there.
I couldn't decide where to place `LIST_GEOM_ELEM` so please just let me know where you'd like it to be (and what you'd like it to be named).

Cheers,
-N
