### PR TITLE
SideSetsFromBoundingBoxGenerator: Remove deprecated params, add distributed

### DIFF
--- a/framework/include/meshgenerators/SideSetsFromBoundingBoxGenerator.h
+++ b/framework/include/meshgenerators/SideSetsFromBoundingBoxGenerator.h
@@ -29,16 +29,10 @@ protected:
   std::unique_ptr<MeshBase> & _input;
 
   /// ID location (inside of outside of box)
-  MooseEnum _location;
-
-  /// List of boundary names to select
-  std::vector<BoundaryName> _boundaries_old;
-
-  /// New boundary to assign
-  BoundaryName _boundary_new;
+  const MooseEnum _location;
 
   /// Bounding box for testing element centroids against
-  BoundingBox _bounding_box;
+  const BoundingBox _bounding_box;
 
   /// Flag to determine if the provided boundaries need to overlap
   const bool _boundary_id_overlap;

--- a/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
+++ b/framework/src/meshgenerators/SideSetsFromBoundingBoxGenerator.C
@@ -36,18 +36,6 @@ SideSetsFromBoundingBoxGenerator::validParams()
       "bottom_left", "The bottom left point (in x,y,z with spaces in-between).");
   params.addRequiredParam<RealVectorValue>(
       "top_right", "The bottom left point (in x,y,z with spaces in-between).");
-  params.addDeprecatedParam<subdomain_id_type>(
-      "block_id",
-      "Subdomain id to set for inside/outside the bounding box",
-      "The parameter 'block_id' is not used.");
-  params.addDeprecatedParam<std::vector<BoundaryName>>(
-      "boundary_id_old",
-      "Boundary id on specified block within the bounding box to select",
-      "boundary_id_old is deprecated, use boundaries_old with names or ids");
-  params.addDeprecatedParam<BoundaryName>(
-      "boundary_id_new",
-      "Boundary id on specified block within the bounding box to assign",
-      "boundary_id_new is deprecated, use boundary_new with a name or id");
   params.addParam<std::vector<BoundaryName>>(
       "boundaries_old",
       "The list of boundaries on the specified block within the bounding box to be modified");
@@ -71,47 +59,31 @@ SideSetsFromBoundingBoxGenerator::SideSetsFromBoundingBoxGenerator(
                                                parameters.get<RealVectorValue>("top_right"))),
     _boundary_id_overlap(parameters.get<bool>("boundary_id_overlap"))
 {
-  if (parameters.isParamSetByUser("boundaries_old"))
-    _boundaries_old = parameters.get<std::vector<BoundaryName>>("boundaries_old");
-  else if (parameters.isParamSetByUser("boundary_id_old"))
-    _boundaries_old = parameters.get<std::vector<BoundaryName>>("boundary_id_old");
-  else
-    mooseError("Either boundaries_old or boundary_id_old (deprecated) must be specified.");
-
-  if (parameters.isParamSetByUser("boundary_new"))
-    _boundary_new = parameters.get<BoundaryName>("boundary_new");
-  else if (parameters.isParamSetByUser("boundary_id_new"))
-    _boundary_new = parameters.get<BoundaryName>("boundary_id_new");
-  else
-    mooseError("Either boundary_new or boundary_id_new (deprecated) must be specified.");
 }
 
 std::unique_ptr<MeshBase>
 SideSetsFromBoundingBoxGenerator::generate()
 {
   std::unique_ptr<MeshBase> mesh = std::move(_input);
-  if (!mesh->is_replicated())
-    mooseError("SideSetsFromBoundingBoxGenerator is not implemented for distributed meshes");
 
   // Get a reference to our BoundaryInfo object for later use
   BoundaryInfo & boundary_info = mesh->get_boundary_info();
   boundary_info.build_node_list_from_side_list();
 
-  bool found_element = false;
-  bool found_side_sets = false;
   const bool inside = (_location == "INSIDE");
 
   // Get the list of boundary ids from the boundary names
-  auto boundary_ids = MooseMeshUtils::getBoundaryIDs(*mesh, _boundaries_old, false);
+  const auto & boundaries = getParam<std::vector<BoundaryName>>("boundaries_old");
+  auto boundary_ids = MooseMeshUtils::getBoundaryIDs(*mesh, boundaries, false);
 
   // Check that the old boundary ids/names exist in the mesh
-  for (std::size_t i = 0; i < boundary_ids.size(); ++i)
+  for (const auto i : index_range(boundaries))
     if (boundary_ids[i] == Moose::INVALID_BOUNDARY_ID)
-      paramError(
-          "boundaries", "The boundary '", _boundaries_old[i], "' was not found within the mesh");
+      paramError("boundaries", "The boundary '", boundaries[i], "' was not found within the mesh");
 
   // Attempt to get the new boundary id from the name
-  auto boundary_id_new = MooseMeshUtils::getBoundaryID(_boundary_new, *mesh);
+  const auto boundary_new = getParam<BoundaryName>("boundary_new");
+  auto boundary_id_new = MooseMeshUtils::getBoundaryID(boundary_new, *mesh);
 
   // If the new boundary id is not valid, make it instead
   if (boundary_id_new == Moose::INVALID_BOUNDARY_ID)
@@ -119,12 +91,16 @@ SideSetsFromBoundingBoxGenerator::generate()
     boundary_id_new = MooseMeshUtils::getNextFreeBoundaryID(*mesh);
 
     // Write the name alias of the boundary id to the mesh boundary info
-    boundary_info.sideset_name(boundary_id_new) = _boundary_new;
-    boundary_info.nodeset_name(boundary_id_new) = _boundary_new;
+    boundary_info.sideset_name(boundary_id_new) = boundary_new;
+    boundary_info.nodeset_name(boundary_id_new) = boundary_new;
   }
 
+  // Boundaries do not need to overlap
   if (!_boundary_id_overlap)
   {
+    bool found_element = false;
+    bool found_side_sets = false;
+
     // Loop over the elements
     for (const auto & elem : mesh->active_element_ptr_range())
     {
@@ -136,9 +112,9 @@ SideSetsFromBoundingBoxGenerator::generate()
       {
         found_element = true;
         // loop over sides of elements within bounding box
-        for (unsigned int side = 0; side < elem->n_sides(); side++)
+        for (const auto side : elem->side_index_range())
           // loop over provided boundary vector to check all side sets for all boundary ids
-          for (auto boundary_id : boundary_ids)
+          for (const auto boundary_id : boundary_ids)
             // check if side has same boundary id that you are looking for
             if (boundary_info.has_boundary_id(elem, side, boundary_id))
             {
@@ -148,17 +124,17 @@ SideSetsFromBoundingBoxGenerator::generate()
             }
       }
     }
-    if (!found_element && inside)
-      mooseError("No elements found within the bounding box");
 
-    if (!found_element && !inside)
-      mooseError("No elements found outside the bounding box");
+    comm().max(found_element);
+    if (!found_element)
+      mooseError("No elements found ", inside ? "within" : "outside", " the bounding box");
 
+    comm().max(found_side_sets);
     if (!found_side_sets)
       mooseError("No side sets found on active elements within the bounding box");
   }
-
-  else if (_boundary_id_overlap)
+  // Boundaries need to overlap
+  else
   {
     if (boundary_ids.size() < 2)
       mooseError("boundary_id_old out of bounds: ",
@@ -168,14 +144,14 @@ SideSetsFromBoundingBoxGenerator::generate()
     bool found_node = false;
 
     // Loop over the elements and assign node set id to nodes within the bounding box
-    for (auto node = mesh->active_nodes_begin(); node != mesh->active_nodes_end(); ++node)
+    for (const auto node : mesh->active_node_ptr_range())
     {
       // check if nodes are inside of bounding box
-      if (_bounding_box.contains_point(**node) == inside)
+      if (_bounding_box.contains_point(*node) == inside)
       {
         // read out boundary ids for nodes
         std::vector<boundary_id_type> node_boundary_ids;
-        boundary_info.boundary_ids(*node, node_boundary_ids);
+        boundary_info.boundary_ids(node, node_boundary_ids);
 
         // sort boundary ids on node and sort boundary ids provided in input file
         std::sort(node_boundary_ids.begin(), node_boundary_ids.end());
@@ -188,12 +164,13 @@ SideSetsFromBoundingBoxGenerator::generate()
                           boundary_ids.begin(),
                           boundary_ids.end()))
         {
-          boundary_info.add_node(*node, boundary_id_new);
+          boundary_info.add_node(node, boundary_id_new);
           found_node = true;
         }
       }
     }
 
+    comm().max(found_node);
     if (!found_node)
       mooseError("No nodes found within the bounding box");
   }

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/generate_outside.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/generate_outside.i
@@ -4,7 +4,6 @@
     dim = 2
     nx = 10
     ny = 10
-    parallel_type = replicated
   []
 
   [./createNewSidesetOne]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/generate_sidesets_bounding_box.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/generate_sidesets_bounding_box.i
@@ -4,7 +4,6 @@
     dim = 2
     nx = 10
     ny = 10
-    parallel_type = replicated
   []
 
   [./createNewSidesetOne]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids_3d.i
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/multiple_boundary_ids_3d.i
@@ -5,7 +5,6 @@
     nx = 10
     ny = 10
     nz = 10
-    #parallel_type = replicated
   []
 
   [./createNewSidesetOne]

--- a/test/tests/meshgenerators/sidesets_bounding_box_generator/tests
+++ b/test/tests/meshgenerators/sidesets_bounding_box_generator/tests
@@ -1,6 +1,6 @@
 [Tests]
   design = 'meshgenerators/SideSetsFromBoundingBoxGenerator.md'
-  issues = '#11640 #16813'
+  issues = '#11640 #16813 #25762'
 
   [generate]
     requirement = 'The system shall have the ability to generate side sets based upon bounding '
@@ -10,7 +10,6 @@
       input = 'generate_sidesets_bounding_box.i'
       cli_args = '--mesh-only'
       exodiff = 'generate_sidesets_bounding_box_in.e'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'a bounding box contained within the domain,'
@@ -20,7 +19,6 @@
       type = 'Exodiff'
       input = 'multiple_boundary_ids.i'
       exodiff = 'multiple_boundary_ids_out.e'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'multiple bounding boxes contained within the domain,'
@@ -30,7 +28,6 @@
       type = 'Exodiff'
       input = 'multiple_boundary_ids_3d.i'
       exodiff = 'multiple_boundary_ids_3d_out.e'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'multiple bounding boxes contained within a 3D domain, and'
@@ -39,7 +36,6 @@
       type = 'Exodiff'
       input = 'overlapping_sidesets.i'
       exodiff = 'overlapping_sidesets_out.e'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'where bounding boxes perfectly overlap but create unique ids.'
@@ -49,7 +45,6 @@
       input = 'generate_outside.i'
       cli_args = '--mesh-only'
       exodiff = 'generate_outside_in.e'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'with only elements located outside of the bounding boxes.'
@@ -64,7 +59,6 @@
       type = 'RunException'
       input = 'error_no_elements_in_bounding_box.i'
       expect_err = 'No elements found within the bounding box'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'when no elements are located within the specified bounding box,'
@@ -73,7 +67,6 @@
       type = 'RunException'
       input = 'error_no_side_sets_found.i'
       expect_err = 'No side sets found on active elements within the bounding box'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'when the bounding box is larger than the domain so that no new side set is created, '
@@ -83,7 +76,6 @@
       type = 'RunException'
       input = 'error_no_nodes_found.i'
       expect_err = 'No nodes found within the bounding box'
-      mesh_mode = 'REPLICATED'
       recover = false
 
       detail = 'when the bounding box fails to span over any nodes.'
@@ -92,7 +84,6 @@
       type = 'RunException'
       input = 'error_boundary_number.i'
       expect_err = 'Must be 2 boundary inputs or more.'
-      mesh_mode = REPLICATED
 
       detail = "if the incorrect boundary inputs are supplied."
     []
@@ -106,7 +97,6 @@
       type = 'Exodiff'
       input = 'overlapping_sidesets.i'
       exodiff = 'overlapping_sidesets_out.e'
-      mesh_mode = REPLICATED
 
       detail = "if existing boundaries overlap and"
     []
@@ -114,7 +104,6 @@
       type = 'RunException'
       input = 'overlapping_sidesets_not_found.i'
       expect_err = 'No nodes found within the bounding box'
-      mesh_mode = REPLICATED
 
       detail = "error if no nodes are located in the given bounding box."
     []


### PR DESCRIPTION
Closes #25762

Needs a test. Not sure how to cleanly get a distributed mesh as an input. Would be nice if the test harness did this for us :/
