### PR TITLE
Add myself as test directory codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -78,3 +78,5 @@
 /scripts/update_and_rebuild_petsc_alt.sh @cticenhour @milljm @loganharbour
 /scripts/configure_libmesh.sh @cticenhour @milljm @loganharbour @roystgnr
 /scripts/update_and_rebuild_libmesh.sh @cticenhour @milljm @loganharbour @roystgnr
+
+/test @lindsayad


### PR DESCRIPTION
I noticed when someone created a test-only modifying PR that no one got pinged for review. Don't want that to happen. And test corresponds logically to the framework so it makes sense to pair the ownership