### PR TITLE
Remove moose-test-tools

### DIFF
--- a/apptainer/moose.def
+++ b/apptainer/moose.def
@@ -6,7 +6,6 @@
 {#- Optional jinja arguments                                                                  -#}
 {#- CONDA_ALT_CHANNEL: An alternate channel to add to conda                                   -#}
 {#- MOOSE_TOOLS_VERSION: The version to pin moose-tools to (if any)                           -#}
-{#- MOOSE_TEST_TOOLS_VERSION: The version to pin moose-test-tools to (if any)                 -#}
 {#- DEV_CONTAINER: Set to anything to add development packages                                -#}
 {#- MOOSE_JOBS: Number of jobs to pass to the builds                                          -#}
 
@@ -68,13 +67,9 @@ From: {{ APPTAINER_FROM }}
     if [ -n "$CONDA_ALT_CHANNEL" ]; then
         conda config --env --add channels ${CONDA_ALT_CHANNEL}
     fi
-    {% if DEV_CONTAINER is defined %}
-    # DEV_CONTAINER is set, installing moose-tools
+
+    # Create list of Conda Packages to install
     MAMBA_PACKAGES="moose-tools=${MOOSE_TOOLS_VERSION}"
-    {% else %}
-    # DEV_CONTAINER is not set, installing moose-test-tools
-    MAMBA_PACKAGES="moose-test-tools=${MOOSE_TEST_TOOLS_VERSION}"
-    {% endif -%}
     # Install packages
     mamba create -yq -n ${MOOSE_MAMBA_ENV} python=${PYTHON_VERSION} ${MAMBA_PACKAGES}
 

--- a/conda/moose-dev/conda_build_config.yaml
+++ b/conda/moose-dev/conda_build_config.yaml
@@ -5,7 +5,7 @@ moose_wasp:
   - moose-wasp 2023.10.06
 
 moose_tools:
-  - moose-tools 2023.08.31
+  - moose-tools 2023.10.19
 
 moose_peacock:
   - moose-peacock 2023.09.15

--- a/conda/tools/conda_build_config.yaml
+++ b/conda/tools/conda_build_config.yaml
@@ -1,5 +1,5 @@
-moose_test_tools:
-  - moose-test-tools 2023.08.31
+clang_tools:
+  - clang-tools 14
 
 moose_python:
   - python 3.10

--- a/conda/tools/conda_build_config.yaml
+++ b/conda/tools/conda_build_config.yaml
@@ -1,5 +1,5 @@
-clang_tools:
-  - clang-tools 14
+clang_format:
+  - clang-format 14
 
 moose_python:
   - python 3.10

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - setuptools
   run:
     - beautifulsoup4
-    - {{ clang_tools }}
+    - {{ clang_format }}
+    - clang-tools
     - deepdiff
     - gitpython
     - graphviz

--- a/conda/tools/meta.yaml
+++ b/conda/tools/meta.yaml
@@ -3,7 +3,7 @@
 #   moose-dev/*
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.08.31" %}
+{% set version = "2023.10.19" %}
 
 package:
   name: moose-tools
@@ -20,24 +20,62 @@ requirements:
     - {{ moose_python }}
     - setuptools
   run:
-    - {{ moose_test_tools }}
     - beautifulsoup4
+    - {{ clang_tools }}
+    - deepdiff
+    - gitpython
+    - graphviz
+    - jinja2
     - livereload
-    - pybtex
+    - lxml
+    - mako
+    - matplotlib-base
     - mock
+    - numpy
+    - packaging
+    - pandas
+    - psycopg2
+    - pybtex
+    - pycobertura
+    - pyflakes
     - pylatexenc
+    - pylint
     - python
-    - clang-tools
+    - pyyaml
+    - scikit-image
+    - setuptools
+    - sympy
+    - tabulate
+    - xmltodict
+    - yaml
 
 test:
   commands:
-    - git clang-format -h
+    - clang-format --version
+    - dot -V
+    - pg_config --help
   imports:
     - bs4
+    - deepdiff
+    - git
+    - jinja2
     - livereload
-    - pybtex
+    - lxml
+    - matplotlib
     - mock
+    - numpy
+    - pandas
+    - psycopg2
+    - pybtex
+    - pycobertura
+    - pyflakes
     - pylatexenc
+    - pylint
+    - skimage
+    - sympy
+    - tabulate
+    - xmltodict
+    - yaml
 
 about:
   home: https://mooseframework.org/


### PR DESCRIPTION
Use matplotlib-base, and combined all 'tools' packages into one moose-tools package. This allows for the deprecation of moose-test-tools.

Closes #25777
