### PR TITLE
Add an option to not define the time derivative functors

### DIFF
--- a/framework/include/base/MooseFunctor.h
+++ b/framework/include/base/MooseFunctor.h
@@ -649,15 +649,29 @@ FunctorBase<T>::checkFace(const Moose::FaceArg & face) const
   }
 
   if (check_elem_def && !hasFaceSide(*fi, true))
-    mooseError(
-        _functor_name,
-        " is not defined on the element side of the face information, but a face argument producer "
-        "(e.g. residual object, postprocessor, etc.) has requested evaluation there");
+  {
+    std::string additional_message = "It is not defined on the neighbor side either.";
+    if (hasFaceSide(*fi, false))
+      additional_message = "It is however defined on the neighbor side.";
+    additional_message += " Face centroid: " + Moose::stringify(fi->faceCentroid());
+    mooseError(_functor_name,
+               " is not defined on the element side of the face information, but a face argument "
+               "producer "
+               "(e.g. residual object, postprocessor, etc.) has requested evaluation there.\n",
+               additional_message);
+  }
   if (check_neighbor_def && !hasFaceSide(*fi, false))
+  {
+    std::string additional_message = "It is not defined on the element side either.";
+    if (hasFaceSide(*fi, true))
+      additional_message = "It is however defined on the element side.";
+    additional_message += " Face centroid: " + Moose::stringify(fi->faceCentroid());
     mooseError(
         _functor_name,
         " is not defined on the neighbor side of the face information, but a face argument "
-        "producer (e.g. residual object, postprocessor, etc.) has requested evaluation there");
+        "producer (e.g. residual object, postprocessor, etc.) has requested evaluation there.\n",
+        additional_message);
+  }
 
   return ret_face;
 }

--- a/framework/src/functormaterials/GenericFunctorMaterial.C
+++ b/framework/src/functormaterials/GenericFunctorMaterial.C
@@ -46,6 +46,10 @@ GenericFunctorMaterialTempl<is_ad>::validParams()
                                                  "The corresponding names of the "
                                                  "functors that are going to provide "
                                                  "the values for the variables");
+  params.addParam<bool>("define_dot_functors",
+                        true,
+                        "Whether to define additional functors for the time derivative and the "
+                        "time derivative of the gradient");
   return params;
 }
 
@@ -84,16 +88,19 @@ GenericFunctorMaterialTempl<is_ad>::GenericFunctorMaterialTempl(const InputParam
         [this, i](const auto & r, const auto & t) -> GenericReal<is_ad>
         { return (*_functors[i])(r, t); },
         clearance_schedule);
-    addFunctorProperty<GenericReal<is_ad>>(
-        MathUtils::timeDerivName(_prop_names[i]),
-        [this, i](const auto & r, const auto & t) -> GenericReal<is_ad>
-        { return _functors[i]->dot(r, t); },
-        clearance_schedule);
-    addFunctorProperty<GenericRealVectorValue<is_ad>>(
-        MathUtils::gradName(MathUtils::timeDerivName(_prop_names[i])),
-        [this, i](const auto & r, const auto & t) -> GenericRealVectorValue<is_ad>
-        { return _functors[i]->gradDot(r, t); },
-        clearance_schedule);
+    if (getParam<bool>("define_dot_functors"))
+    {
+      addFunctorProperty<GenericReal<is_ad>>(
+          MathUtils::timeDerivName(_prop_names[i]),
+          [this, i](const auto & r, const auto & t) -> GenericReal<is_ad>
+          { return _functors[i]->dot(r, t); },
+          clearance_schedule);
+      addFunctorProperty<GenericRealVectorValue<is_ad>>(
+          MathUtils::gradName(MathUtils::timeDerivName(_prop_names[i])),
+          [this, i](const auto & r, const auto & t) -> GenericRealVectorValue<is_ad>
+          { return _functors[i]->gradDot(r, t); },
+          clearance_schedule);
+    }
   }
 }
 


### PR DESCRIPTION
Hitting a conflict in VTB where the GFunctorFluidProp defines rho_dot but an input is overriding rho with a GenericFM
