### PR TITLE
FEAT: Exposed the array variable's DotDu value via coupledArrayDotDu

### DIFF
--- a/framework/doc/content/source/kernels/ArrayCoupledTimeDerivative.md
+++ b/framework/doc/content/source/kernels/ArrayCoupledTimeDerivative.md
@@ -1,0 +1,48 @@
+# ArrayCoupledTimeDerivative
+
+## Description
+
+The `ArrayCoupledTimeDerivative` kernel is very similar to the
+[`CoupledTimeDerivative`](/CoupledTimeDerivative.md) kernel with the
+exception that it works for array variables rather than scalars.
+The strong form on the domain $\Omega$ is
+
+\begin{equation}
+\underbrace{\frac{\partial v}{\partial t}}_{\textrm{ArrayCoupledTimeDerivative}} +
+\sum_{i=1}^n \beta_i = 0 \in \Omega
+\label{strong}
+\end{equation}
+where the second term on the left hand side corresponds to the
+strong forms of other kernels. The `ArrayCoupledTimeDerivative` weak form is then
+
+\begin{equation}
+R_i(u_h) = \bigg(\psi_i, \frac{\partial v_h}{\partial t}\bigg) \quad \forall
+\psi_i,
+\label{weak}
+\end{equation}
+where the $\psi_i$ are test functions and $u_h \in \mathcal{S}^h$ is the finite
+element solution of the weak formulation.
+
+The Jacobian contribution is equal to
+\begin{equation}
+\frac{\partial R_i(u_h)}{\partial u_j} = (\psi_i, a_v\phi_j).
+\end{equation}
+where $a_v$ is a constant that depends on the time stepping scheme; $a_v$ is
+denoted by `_dv_dot` in the `ArrayCoupledTimeDerivative` class.
+
+## Example Syntax
+
+The syntax is simple, taking its type (`ArrayCoupledTimeDerivative`), the variable
+to that the residual the `ArrayCoupledTimeDerivative` contributes, and the coupled
+variable `v` that the time derivative operator acts upon. Example syntax can be
+found in the kernel block below:
+
+!listing
+test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
+block=Kernels label=false
+
+!syntax parameters /Kernels/ArrayCoupledTimeDerivative
+
+!syntax inputs /Kernels/ArrayCoupledTimeDerivative
+
+!syntax children /Kernels/ArrayCoupledTimeDerivative

--- a/framework/doc/content/source/kernels/ArrayCoupledTimeDerivative.md
+++ b/framework/doc/content/source/kernels/ArrayCoupledTimeDerivative.md
@@ -37,9 +37,7 @@ to that the residual the `ArrayCoupledTimeDerivative` contributes, and the coupl
 variable `v` that the time derivative operator acts upon. Example syntax can be
 found in the kernel block below:
 
-!listing
-test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
-block=Kernels label=false
+!listing test/tests/kernels/array_coupled_time_derivative/test_jacobian.i block=Kernels
 
 !syntax parameters /Kernels/ArrayCoupledTimeDerivative
 

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1085,6 +1085,17 @@ protected:
                                                 unsigned int comp = 0) const;
 
   /**
+   * Time derivative of a coupled array variable with respect to the coefficients
+   * @param var_name Name of coupled vector variable
+   * @param comp Component number for vector of coupled vector variables
+   * @return Reference to a ArrayVariableValue containing the time derivative of the coupled
+   * variable
+   */
+
+  virtual const VariableValue & coupledArrayDotDu(const std::string & var_name,
+                                                  unsigned int comp = 0) const;
+
+  /**
    * Returns nodal values of a coupled variable
    * @param var_name Name of coupled variable
    * @param comp Component number for vector of coupled variables

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1092,7 +1092,7 @@ protected:
    * variable
    */
   const VariableValue & coupledArrayDotDu(const std::string & var_name,
-                                                  unsigned int comp = 0) const;
+                                          unsigned int comp = 0) const;
 
   /**
    * Returns nodal values of a coupled variable

--- a/framework/include/interfaces/Coupleable.h
+++ b/framework/include/interfaces/Coupleable.h
@@ -1091,8 +1091,7 @@ protected:
    * @return Reference to a ArrayVariableValue containing the time derivative of the coupled
    * variable
    */
-
-  virtual const VariableValue & coupledArrayDotDu(const std::string & var_name,
+  const VariableValue & coupledArrayDotDu(const std::string & var_name,
                                                   unsigned int comp = 0) const;
 
   /**

--- a/framework/include/kernels/ArrayCoupledTimeDerivative.h
+++ b/framework/include/kernels/ArrayCoupledTimeDerivative.h
@@ -22,7 +22,7 @@ public:
   ArrayCoupledTimeDerivative(const InputParameters & parameters);
 
 protected:
-  virtual void computeQpResidual(RealEigenVector &residual) override;
+  virtual void computeQpResidual(RealEigenVector & residual) override;
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 

--- a/framework/include/kernels/ArrayCoupledTimeDerivative.h
+++ b/framework/include/kernels/ArrayCoupledTimeDerivative.h
@@ -1,0 +1,32 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ArrayKernel.h"
+
+/**
+ * This calculates the time derivative for a coupled variable
+ **/
+class ArrayCoupledTimeDerivative : public ArrayKernel
+{
+public:
+  static InputParameters validParams();
+
+  ArrayCoupledTimeDerivative(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpResidual(RealEigenVector &residual) override;
+  virtual RealEigenVector computeQpJacobian() override;
+  virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
+
+  const ArrayVariableValue & _v_dot;
+  const VariableValue & _dv_dot;
+  const unsigned int _v_var;
+};

--- a/framework/include/kernels/ArrayCoupledTimeDerivative.h
+++ b/framework/include/kernels/ArrayCoupledTimeDerivative.h
@@ -26,7 +26,12 @@ protected:
   virtual RealEigenVector computeQpJacobian() override;
   virtual RealEigenMatrix computeQpOffDiagJacobian(const MooseVariableFEBase & jvar) override;
 
+  /// The first temporal derivative of the coupled variable
   const ArrayVariableValue & _v_dot;
+
+  /// The Jacobian of the time derivative of the coupled variable with respect to the coupled variable
   const VariableValue & _dv_dot;
+
+  /// The number of the coupled variable
   const unsigned int _v_var;
 };

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1438,7 +1438,7 @@ Coupleable::coupledArrayDotDu(const std::string & var_name, unsigned int comp) c
   }
   checkFuncType(var_name, VarType::Dot, FuncAge::Curr);
 
-  if(!_coupleable_neighbor)
+  if (!_coupleable_neighbor)
   {
     if (_c_nodal)
       return var->dofValuesDuDotDu();

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1427,6 +1427,31 @@ Coupleable::coupledDotDotDu(const std::string & var_name, unsigned int comp) con
   }
 }
 
+const VariableValue &
+Coupleable::coupledArrayDotDu(const std::string & var_name, unsigned int comp) const
+{
+  const auto * var = getArrayVar(var_name, comp);
+  if (!var)
+  {
+    _default_value_zero.resize(_coupleable_max_qps, 0);
+    return _default_value_zero;
+  }
+  checkFuncType(var_name, VarType::Dot, FuncAge::Curr);
+
+  if(!_coupleable_neighbor)
+  {
+    if (_c_nodal)
+      return var->dofValuesDuDotDu();
+    return var->duDotDu();
+  }
+  else
+  {
+    if (_c_nodal)
+      return var->dofValuesDuDotDuNeighbor();
+    return var->duDotDuNeighbor();
+  }
+}
+
 const VariableGradient &
 Coupleable::coupledGradient(const std::string & var_name, unsigned int comp) const
 {

--- a/framework/src/interfaces/Coupleable.C
+++ b/framework/src/interfaces/Coupleable.C
@@ -1430,7 +1430,7 @@ Coupleable::coupledDotDotDu(const std::string & var_name, unsigned int comp) con
 const VariableValue &
 Coupleable::coupledArrayDotDu(const std::string & var_name, unsigned int comp) const
 {
-  const auto * var = getArrayVar(var_name, comp);
+  const auto * const var = getArrayVar(var_name, comp);
   if (!var)
   {
     _default_value_zero.resize(_coupleable_max_qps, 0);

--- a/framework/src/kernels/ArrayCoupledTimeDerivative.C
+++ b/framework/src/kernels/ArrayCoupledTimeDerivative.C
@@ -15,25 +15,30 @@ InputParameters
 ArrayCoupledTimeDerivative::validParams()
 {
   InputParameters params = ArrayKernel::validParams();
-  params.addClassDescription("Time derivative Array Kernel that acts on a coupled variable. Weak form: "
-                             "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$. The coupled varialbe and"
-                             "the variable must have the same dimensionality");
+  params.addClassDescription(
+      "Time derivative Array Kernel that acts on a coupled variable. Weak form: "
+      "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$. The coupled varialbe and"
+      "the variable must have the same dimensionality");
   params.addRequiredCoupledVar("v", "Coupled variable");
   return params;
 }
 
 ArrayCoupledTimeDerivative::ArrayCoupledTimeDerivative(const InputParameters & parameters)
-  : ArrayKernel(parameters), _v_dot(coupledArrayDot("v")), _dv_dot(coupledArrayDotDu("v")), _v_var(coupled("v"))
+  : ArrayKernel(parameters),
+    _v_dot(coupledArrayDot("v")),
+    _dv_dot(coupledArrayDotDu("v")),
+    _v_var(coupled("v"))
 {
 }
 
 void
-ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector &residual)
+ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector & residual)
 {
 
-  mooseAssert(_var.count()==_v_dot.size(), "The variable and coupled variable have unequal sizes: "
-                                           "  variable size        : " std::to_string(_var.count())
-                                           "  coupled variable size: " _v_dot.size());
+  mooseAssert(_var.count() == _v_dot.size(),
+              "The variable and coupled variable have unequal sizes: "
+              "  variable size        : " std::to_string(
+                  _var.count()) "  coupled variable size: " _v_dot.size());
 
   residual = _test[_i][_qp] * _v_dot[_qp];
 }
@@ -48,7 +53,8 @@ RealEigenMatrix
 ArrayCoupledTimeDerivative::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
 {
   if (jvar.number() == _v_var)
-    return _test[_i][_qp] * _phi[_j][_qp] * _dv_dot[_qp] * RealEigenVector::Ones(jvar.count()).asDiagonal();
+    return _test[_i][_qp] * _phi[_j][_qp] * _dv_dot[_qp] *
+           RealEigenVector::Ones(jvar.count()).asDiagonal();
 
   return RealEigenMatrix::Zero(_var.count(), jvar.count());
 }

--- a/framework/src/kernels/ArrayCoupledTimeDerivative.C
+++ b/framework/src/kernels/ArrayCoupledTimeDerivative.C
@@ -1,0 +1,54 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ArrayCoupledTimeDerivative.h"
+
+registerMooseObject("MooseApp", ArrayCoupledTimeDerivative);
+
+InputParameters
+ArrayCoupledTimeDerivative::validParams()
+{
+  InputParameters params = ArrayKernel::validParams();
+  params.addClassDescription("Time derivative Array Kernel that acts on a coupled variable. Weak form: "
+                             "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$. The coupled varialbe and"
+                             "the variable must have the same dimensionality");
+  params.addRequiredCoupledVar("v", "Coupled variable");
+  return params;
+}
+
+ArrayCoupledTimeDerivative::ArrayCoupledTimeDerivative(const InputParameters & parameters)
+  : ArrayKernel(parameters), _v_dot(coupledArrayDot("v")), _dv_dot(coupledArrayDotDu("v")), _v_var(coupled("v"))
+{
+}
+
+void
+ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector &residual)
+{
+
+  mooseAssert(_var.count()==_v_dot.size(), "The variable and coupled variable have unequal sizes: "
+                                           "  variable size        : " std::to_string(_var.count())
+                                           "  coupled variable size: " _v_dot.size());
+
+  residual = _test[_i][_qp] * _v_dot[_qp];
+}
+
+RealEigenVector
+ArrayCoupledTimeDerivative::computeQpJacobian()
+{
+  return RealEigenVector::Zero(_var.count());
+}
+
+RealEigenMatrix
+ArrayCoupledTimeDerivative::computeQpOffDiagJacobian(const MooseVariableFEBase & jvar)
+{
+  if (jvar.number() == _v_var)
+    return _test[_i][_qp] * _phi[_j][_qp] * _dv_dot[_qp] * RealEigenVector::Ones(jvar.count()).asDiagonal();
+
+  return RealEigenMatrix::Zero(_var.count(), jvar.count());
+}

--- a/framework/src/kernels/ArrayCoupledTimeDerivative.C
+++ b/framework/src/kernels/ArrayCoupledTimeDerivative.C
@@ -36,8 +36,9 @@ ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector & residual)
 {
 
   mooseAssert(_var.count() == _v_dot.size(),
-              "The variable and coupled variable have unequal sizes:\n  variable size        : "+std::to_string(_var.count())+"\n"+
-              "  coupled variable size: "+std::to_string(_v_dot.size()));
+              "The variable and coupled variable have unequal sizes:\n  variable size        : " +
+                  std::to_string(_var.count()) + "\n" +
+                  "  coupled variable size: " + std::to_string(_v_dot.size()));
 
   residual = _test[_i][_qp] * _v_dot[_qp];
 }

--- a/framework/src/kernels/ArrayCoupledTimeDerivative.C
+++ b/framework/src/kernels/ArrayCoupledTimeDerivative.C
@@ -36,9 +36,8 @@ ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector & residual)
 {
 
   mooseAssert(_var.count() == _v_dot.size(),
-              "The variable and coupled variable have unequal sizes: "
-              "  variable size        : " std::to_string(
-                  _var.count()) "  coupled variable size: " _v_dot.size());
+              "The variable and coupled variable have unequal sizes:\n  variable size        : "+std::to_string(_var.count())+"\n"+
+              "  coupled variable size: "+std::to_string(_v_dot.size()));
 
   residual = _test[_i][_qp] * _v_dot[_qp];
 }

--- a/framework/src/kernels/ArrayCoupledTimeDerivative.C
+++ b/framework/src/kernels/ArrayCoupledTimeDerivative.C
@@ -17,7 +17,7 @@ ArrayCoupledTimeDerivative::validParams()
   InputParameters params = ArrayKernel::validParams();
   params.addClassDescription(
       "Time derivative Array Kernel that acts on a coupled variable. Weak form: "
-      "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$. The coupled varialbe and"
+      "$(\\psi_i, \\frac{\\partial v_h}{\\partial t})$. The coupled variable and"
       "the variable must have the same dimensionality");
   params.addRequiredCoupledVar("v", "Coupled variable");
   return params;
@@ -34,7 +34,6 @@ ArrayCoupledTimeDerivative::ArrayCoupledTimeDerivative(const InputParameters & p
 void
 ArrayCoupledTimeDerivative::computeQpResidual(RealEigenVector & residual)
 {
-
   mooseAssert(_var.count() == _v_dot.size(),
               "The variable and coupled variable have unequal sizes:\n  variable size        : " +
                   std::to_string(_var.count()) + "\n" +

--- a/test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
+++ b/test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
@@ -1,0 +1,93 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 3
+[]
+
+[Variables]
+  [u]
+    components = 2
+  []
+  [v]
+    components = 2
+  []
+[]
+
+[Kernels]
+  [u_coupled_time_derivative]
+    type = ArrayCoupledTimeDerivative
+    variable = u
+    v = v
+    use_displaced_mesh = false
+  []
+  [u_time_derivative]
+    type = ArrayTimeDerivative
+    variable = u
+    use_displaced_mesh = false
+  []
+  [u_diffusion]
+    type = ArrayDiffusion
+    variable = u
+    diffusion_coefficient = u_dc
+    use_displaced_mesh = false
+  []
+  [v_time_derivative]
+    type = ArrayTimeDerivative
+    variable = v
+    use_displaced_mesh = false
+  []
+  [v_diffusion]
+    type = ArrayDiffusion
+    variable = v
+    diffusion_coefficient = v_dc
+    use_displaced_mesh = false
+  []
+[]
+
+[ICs]
+  [u]
+    type = ArrayFunctionIC
+    variable = u
+    function = '2*(x+1) 3*(x+1)'
+  []
+  [v]
+    type = ArrayFunctionIC
+    variable = v
+    function = '0.1*(x+1) 0.2*(x+1)'
+  []
+[]
+
+[Materials]
+  [u_dc]
+    type = GenericConstantArray
+    prop_name = u_dc
+    prop_value = '1 1'
+  []
+  [v_dc]
+    type = GenericConstantArray
+    prop_name = v_dc
+    prop_value = '2 2'
+  []
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.1
+  dtmin = 0.1
+  num_steps = 3
+  solve_type = 'NEWTON'
+  petsc_options = '-snes_test_jacobian -snes_test_jacobian_view'
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+[]
+
+[Outputs]
+  exodus = true
+[]

--- a/test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
+++ b/test/tests/kernels/array_coupled_time_derivative/test_jacobian.i
@@ -18,29 +18,24 @@
     type = ArrayCoupledTimeDerivative
     variable = u
     v = v
-    use_displaced_mesh = false
   []
   [u_time_derivative]
     type = ArrayTimeDerivative
     variable = u
-    use_displaced_mesh = false
   []
   [u_diffusion]
     type = ArrayDiffusion
     variable = u
     diffusion_coefficient = u_dc
-    use_displaced_mesh = false
   []
   [v_time_derivative]
     type = ArrayTimeDerivative
     variable = v
-    use_displaced_mesh = false
   []
   [v_diffusion]
     type = ArrayDiffusion
     variable = v
     diffusion_coefficient = v_dc
-    use_displaced_mesh = false
   []
 []
 
@@ -71,10 +66,10 @@
 []
 
 [Preconditioning]
-  [./smp]
+  [smp]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/kernels/array_coupled_time_derivative/tests
+++ b/test/tests/kernels/array_coupled_time_derivative/tests
@@ -1,0 +1,29 @@
+[Tests]
+  [./jac_1d]
+    type = 'PetscJacobianTester'
+    input = 'test_jacobian_1d.i'
+    cli_args = 'Outputs/exodus=false Mesh/dim=1 Mesh/nx=3'
+    run_sim = True
+    ratio_tol = 1e-7
+    difference_tol = 1e-6
+    requirement = 'We shall be able to reproduce the exact Jacobian for a 1d grid'
+  [../]
+  [./jac_2d]
+    type = 'PetscJacobianTester'
+    input = 'test_jacobian_2d.i'
+    cli_args = 'Outputs/exodus=false Mesh/dim=2 Mesh/nx=3 Mesh/ny=3'
+    run_sim = True
+    ratio_tol = 1e-7
+    difference_tol = 1e-6
+    requirement = 'We shall be able to reproduce the exact Jacobian for a 2d grid'
+  [../]
+  [./jac_3d]
+    type = 'PetscJacobianTester'
+    input = 'test_jacobian_3d.i'
+    cli_args = 'Outputs/exodus=false Mesh/dim=3 Mesh/nx=3 Mesh/ny=3 Mesh/nz=3'
+    run_sim = True
+    ratio_tol = 1e-7
+    difference_tol = 1e-6
+    requirement = 'We shall be able to reproduce the exact Jacobian for a 3d grid'
+  [../]
+[]

--- a/test/tests/kernels/array_coupled_time_derivative/tests
+++ b/test/tests/kernels/array_coupled_time_derivative/tests
@@ -1,7 +1,7 @@
 [Tests]
   [./jac_1d]
     type = 'PetscJacobianTester'
-    input = 'test_jacobian_1d.i'
+    input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=1 Mesh/nx=3'
     run_sim = True
     ratio_tol = 1e-7
@@ -10,7 +10,7 @@
   [../]
   [./jac_2d]
     type = 'PetscJacobianTester'
-    input = 'test_jacobian_2d.i'
+    input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=2 Mesh/nx=3 Mesh/ny=3'
     run_sim = True
     ratio_tol = 1e-7
@@ -19,7 +19,7 @@
   [../]
   [./jac_3d]
     type = 'PetscJacobianTester'
-    input = 'test_jacobian_3d.i'
+    input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=3 Mesh/nx=3 Mesh/ny=3 Mesh/nz=3'
     run_sim = True
     ratio_tol = 1e-7

--- a/test/tests/kernels/array_coupled_time_derivative/tests
+++ b/test/tests/kernels/array_coupled_time_derivative/tests
@@ -1,29 +1,35 @@
 [Tests]
-  [./jac_1d]
+  [jac_1d]
     type = 'PetscJacobianTester'
     input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=1 Mesh/nx=3'
     run_sim = True
     ratio_tol = 1e-7
     difference_tol = 1e-6
-    requirement = 'We shall be able to reproduce the exact Jacobian for a 1d grid'
-  [../]
-  [./jac_2d]
+    issues = '#25833'
+    design = 'kernels/ArrayCoupledTimeDerivative.md'
+    requirement = 'The system shall be able to reproduce the exact Jacobian for a 1d grid for a coupled array time derivative kernel.'
+  []
+  [jac_2d]
     type = 'PetscJacobianTester'
     input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=2 Mesh/nx=3 Mesh/ny=3'
     run_sim = True
     ratio_tol = 1e-7
     difference_tol = 1e-6
-    requirement = 'We shall be able to reproduce the exact Jacobian for a 2d grid'
-  [../]
-  [./jac_3d]
+    issues = '#25833'
+    design = 'kernels/ArrayCoupledTimeDerivative.md'
+    requirement = 'The system shall be able to reproduce the exact Jacobian for a 2d grid for a coupled array time derivative kernel.'
+  []
+  [jac_3d]
     type = 'PetscJacobianTester'
     input = 'test_jacobian.i'
     cli_args = 'Outputs/exodus=false Mesh/dim=3 Mesh/nx=3 Mesh/ny=3 Mesh/nz=3'
     run_sim = True
     ratio_tol = 1e-7
     difference_tol = 1e-6
-    requirement = 'We shall be able to reproduce the exact Jacobian for a 3d grid'
-  [../]
+    issues = '#25833'
+    design = 'kernels/ArrayCoupledTimeDerivative.md'
+    requirement = 'The system shall be able to reproduce the exact Jacobian for a 3d grid for a coupled array time derivative kernel.'
+  []
 []


### PR DESCRIPTION
## Discussion

The current implementation of array variable's duDotDu returns a reference to a VariableValue because the derivatives are the same for all of the variables (due to identical time integration scheme). Consequently, the implementation of coupledArrayDotDu also returns a reference to a VariableValue.

closes #25833
