### PR TITLE
Refrain from using mamba update --all

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -56,7 +56,7 @@ static_assert(__cplusplus >= 201703L,
               "MOOSE requires a C++17 compatible compiler (GCC >= 7.5.0, Clang >= 5.0.2). Please "
               "update your compiler or, if compatible, add '-std=c++17' to your compiler flags "
               "and try again. If using the MOOSE conda package, please attempt a MOOSE environment "
-              "update (using `mamba update --all`). If this update is not successful, please "
+              "update (using `mamba update moose-dev`). If this update is not successful, please "
               "create a new MOOSE environment (see "
               "https://mooseframework.inl.gov/getting_started/installation/"
               "conda.html#uninstall-conda-moose-environment).");

--- a/modules/doc/content/getting_started/installation/true_update_conda.md
+++ b/modules/doc/content/getting_started/installation/true_update_conda.md
@@ -2,7 +2,7 @@ Update Conda:
 
 ```bash
 mamba activate moose
-mamba update --all
+mamba update moose-dev
 ```
 
 !alert note title=Always Update MOOSE and the Conda/Mamba packages together

--- a/modules/doc/content/help/faq/build_issues.md
+++ b/modules/doc/content/help/faq/build_issues.md
@@ -9,7 +9,7 @@ date.
 
   ```bash
   mamba activate moose
-  mamba update --all
+  mamba update moose-dev
   ```
 
   if `mamba activate moose` failed, see [Conda Issues](help/troubleshooting.md#condaissues) above.

--- a/modules/doc/content/ncrc/applications/ncrc_develop.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_develop.md.template
@@ -119,7 +119,7 @@ either a Conda update, or rebuild PETSc/libMesh:
 
   ```bash
   mamba activate moose
-  mamba update --all
+  mamba update moose-dev
   ```
 
 - If +[!ac](INL) [!ac](HPC) Sawtooth or Lemhi+:


### PR DESCRIPTION
As we continue to diverge from the latest available packages on conda-forge, `--all` becomes less and less effective. It is time to instruct folks to update the package which matters most in the (moose) Conda environment.

Closes #25854


