### PR TITLE
Introduce a moose_map_find to get info which object failed the search in a map

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -278,11 +278,13 @@ private:
 #error PETSc has not been detected, please ensure your environment is set up properly then rerun the libmesh build script and try to compile MOOSE again.
 #endif
 
+} // namespace Moose
+
+// TODO namespace this inside MOOSE as Moose::map_find once libmesh namespace is separate
 // This macro is useful to get around the deficiencies of the C++ map 'at' and 'find' operators
 // at errors with an exception which requires catching to output nicely
 // find is a very verbose syntax
 // This should only be used in a class where name() and type() are defined. If not, rely on
 // libmesh_map_find instead
-#define map_find(map, key) MooseUtils::map_find((map), (key), name(), type(), __FILE__, __LINE__)
-
-} // namespace Moose
+#define moose_map_find(map, key)                                                                   \
+  MooseUtils::map_find((map), (key), name(), type(), __FILE__, __LINE__)

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -278,4 +278,11 @@ private:
 #error PETSc has not been detected, please ensure your environment is set up properly then rerun the libmesh build script and try to compile MOOSE again.
 #endif
 
+// This macro is useful to get around the deficiencies of the C++ map 'at' and 'find' operators
+// at errors with an exception which requires catching to output nicely
+// find is a very verbose syntax
+// This should only be used in a class where name() and type() are defined. If not, rely on
+// libmesh_map_find instead
+#define map_find(map, key) MooseUtils::map_find((map), (key), name(), type(), __FILE__, __LINE__)
+
 } // namespace Moose

--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -284,7 +284,6 @@ private:
 // This macro is useful to get around the deficiencies of the C++ map 'at' and 'find' operators
 // at errors with an exception which requires catching to output nicely
 // find is a very verbose syntax
-// This should only be used in a class where name() and type() are defined. If not, rely on
+// This should only be used in a class so that 'this' is defined. If not, rely on
 // libmesh_map_find instead
-#define moose_map_find(map, key)                                                                   \
-  MooseUtils::map_find((map), (key), name(), type(), __FILE__, __LINE__)
+#define moose_map_find(map, key) MooseUtils::map_find((map), (key), (this), __FILE__, __LINE__)

--- a/framework/include/utils/MooseUtils.h
+++ b/framework/include/utils/MooseUtils.h
@@ -1201,7 +1201,7 @@ isDigits(const std::string & str)
 
 /**
  * This function should not be called directly (although it can be),
- * instead see the moose::map_find() macro.
+ * instead see the moose_map_find() macro.
  *
  * Calls find(key), and checks the result against end(). Returns the
  * corresponding value if found, throws an error otherwise. Templated
@@ -1220,13 +1220,15 @@ template <
     typename T,
     typename T::type,
     typename T::name,
-    typename std::enable_if<!libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
+    typename std::enable_if<libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
 inline typename Map::mapped_type &
 map_find(Map & map, const Key & key, const T * object, const char * filename, int line_number)
 {
   auto it = map.find(key);
   if (it == map.end())
-    mooseError("map_find() error: key not found during a search in class ",
+    mooseError("map_find() error: key '",
+               key,
+               "' not found during a search in class ",
                object->name(),
                " of type ",
                object->type(),
@@ -1242,13 +1244,15 @@ template <
     typename T,
     typename T::type,
     typename T::name,
-    typename std::enable_if<!libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
+    typename std::enable_if<libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
 inline const typename Map::mapped_type &
 map_find(const Map & map, const Key & key, const T * object, const char * filename, int line_number)
 {
   auto it = map.find(key);
   if (it == map.end())
-    mooseError("map_find() error: key not found during a search in class ",
+    mooseError("map_find() error: key '",
+               key,
+               "' not found during a search in class ",
                object->name(),
                " of type ",
                object->type(),
@@ -1270,7 +1274,7 @@ template <
     typename Key,
     typename T,
     typename std::enable_if<!std::is_const<Map>::value, Key>::type * = nullptr,
-    typename std::enable_if<libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
+    typename std::enable_if<!libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
 inline typename Map::mapped_type &
 map_find(Map & map, const Key & key, const T * /*obj*/, const char * filename, int line)
 {
@@ -1281,7 +1285,7 @@ template <
     typename Key,
     typename T,
     typename std::enable_if<std::is_const<Map>::value, Key>::type * = nullptr,
-    typename std::enable_if<libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
+    typename std::enable_if<!libMesh::Utility::is_streamable<Key>::value, Key>::type * = nullptr>
 inline const typename Map::mapped_type &
 map_find(Map & map, const Key & key, const T * /*obj*/, const char * filename, int line_number)
 {

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -372,7 +372,7 @@ AutomaticMortarGeneration::getNodalTangents(const Elem & secondary_elem) const
   for (const auto n : make_range(secondary_elem.n_nodes()))
   {
     const auto & tangent_vectors =
-        libmesh_map_find(_secondary_node_to_hh_nodal_tangents, secondary_elem.node_ptr(n));
+        moose_map_find(_secondary_node_to_hh_nodal_tangents, secondary_elem.node_ptr(n));
     nodal_tangents_one.push_back(tangent_vectors[0]);
     nodal_tangents_two.push_back(tangent_vectors[1]);
   }
@@ -845,7 +845,7 @@ AutomaticMortarGeneration::buildMortarSegmentMesh()
    */
   for (auto msm_elem : _mortar_segment_mesh->active_element_ptr_range())
   {
-    MortarSegmentInfo & msinfo = libmesh_map_find(_msm_elem_to_info, msm_elem);
+    MortarSegmentInfo & msinfo = moose_map_find(_msm_elem_to_info, msm_elem);
     Elem * primary_elem = const_cast<Elem *>(msinfo.primary_elem);
     if (primary_elem == nullptr || std::abs(msinfo.xi2_a) > 1.0 + TOLERANCE ||
         std::abs(msinfo.xi2_b) > 1.0 + TOLERANCE)
@@ -894,7 +894,7 @@ AutomaticMortarGeneration::buildMortarSegmentMesh()
   // Verify that all segments without primary contribution have been deleted
   for (auto msm_elem : _mortar_segment_mesh->active_element_ptr_range())
   {
-    const MortarSegmentInfo & msinfo = libmesh_map_find(_msm_elem_to_info, msm_elem);
+    const MortarSegmentInfo & msinfo = moose_map_find(_msm_elem_to_info, msm_elem);
     mooseAssert(msinfo.primary_elem != nullptr,
                 "All mortar segment elements should have valid "
                 "primary element.");

--- a/framework/src/loops/BoundaryNodeIntegrityCheckThread.C
+++ b/framework/src/loops/BoundaryNodeIntegrityCheckThread.C
@@ -64,7 +64,7 @@ BoundaryNodeIntegrityCheckThread::onNode(ConstBndNodeRange::const_iterator & nod
   // Only check vertices. Variables may not be defined on non-vertex nodes (think first order
   // Lagrange on a second order mesh) and user-code can often handle that
   const Elem * const an_elem =
-      mesh.getMesh().elem_ptr(libmesh_map_find(_node_to_elem_map, node->id()).front());
+      mesh.getMesh().elem_ptr(moose_map_find(_node_to_elem_map, node->id()).front());
   if (!an_elem->is_vertex(an_elem->get_node_index(node)))
     return;
 

--- a/framework/src/loops/UpdateDisplacedMeshThread.C
+++ b/framework/src/loops/UpdateDisplacedMeshThread.C
@@ -91,7 +91,7 @@ UpdateDisplacedMeshThread::init()
         this->_fe_problem, _ref_mesh, var_num_and_direction.first, sys);
     Threads::parallel_reduce(node_range, send_list);
     send_list.unique();
-    auto & [soln, ghost_soln] = libmesh_map_find(_sys_to_nonghost_and_ghost_soln, sys_num);
+    auto & [soln, ghost_soln] = moose_map_find(_sys_to_nonghost_and_ghost_soln, sys_num);
     ghost_soln->init(soln->size(), soln->local_size(), send_list.send_list(), true, GHOSTED);
     soln->localize(*ghost_soln, send_list.send_list());
   }
@@ -114,7 +114,7 @@ UpdateDisplacedMeshThread::onNode(NodeRange::const_iterator & nd)
       if (reference_node.n_dofs(sys_num, var_numbers[i]) > 0)
         displaced_node(direction) =
             reference_node(direction) +
-            (*libmesh_map_find(_sys_to_nonghost_and_ghost_soln, sys_num).second)(
+            (*moose_map_find(_sys_to_nonghost_and_ghost_soln, sys_num).second)(
                 reference_node.dof_number(sys_num, var_numbers[i], 0));
     }
   }

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -3466,7 +3466,7 @@ MooseMesh::faceInfo(const Elem * elem, unsigned int side) const
 const ElemInfo &
 MooseMesh::elemInfo(const dof_id_type id) const
 {
-  return libmesh_map_find(_elem_to_elem_info, id);
+  return moose_map_find(_elem_to_elem_info, id);
 }
 
 void

--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -1077,7 +1077,7 @@ FEProblemBase::initialSetup()
       // Only check vertices. Variables may not be defined on non-vertex nodes (think first order
       // Lagrange on a second order mesh) and user-code can often handle that
       const Elem * const an_elem =
-          _mesh.getMesh().elem_ptr(libmesh_map_find(node_to_elem_map, node->id()).front());
+          _mesh.getMesh().elem_ptr(moose_map_find(node_to_elem_map, node->id()).front());
       if (!an_elem->is_vertex(an_elem->get_node_index(node)))
         continue;
 
@@ -2405,7 +2405,7 @@ FEProblemBase::addVariable(const std::string & var_type,
   std::istringstream ss(nl_sys_name);
   unsigned int nl_sys_num;
   if (!(ss >> nl_sys_num) || !ss.eof())
-    nl_sys_num = libmesh_map_find(_nl_sys_name_to_num, nl_sys_name);
+    nl_sys_num = moose_map_find(_nl_sys_name_to_num, nl_sys_name);
 
   _nl[nl_sys_num]->addVariable(var_type, var_name, params);
   if (_displaced_problem)
@@ -5637,7 +5637,7 @@ FEProblemBase::nlSysNum(const NonlinearSystemName & nl_sys_name) const
   std::istringstream ss(nl_sys_name);
   unsigned int nl_sys_num;
   if (!(ss >> nl_sys_num) || !ss.eof())
-    nl_sys_num = libmesh_map_find(_nl_sys_name_to_num, nl_sys_name);
+    nl_sys_num = moose_map_find(_nl_sys_name_to_num, nl_sys_name);
 
   return nl_sys_num;
 }

--- a/framework/src/problems/SubProblem.C
+++ b/framework/src/problems/SubProblem.C
@@ -1132,7 +1132,7 @@ SubProblem::initialSetup()
             "No functor ever provided with name '",
             functor_name,
             "', which was requested by '",
-            MooseUtils::join(libmesh_map_find(_functor_to_requestors, functor_wrapper_name), ","),
+            MooseUtils::join(moose_map_find(_functor_to_requestors, functor_wrapper_name), ","),
             "'.");
       if (true_functor_type == TrueFunctorIs::NONAD ? non_ad_functor->ownsWrappedFunctor()
                                                     : ad_functor->ownsWrappedFunctor())

--- a/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
+++ b/framework/src/relationshipmanagers/GhostHigherDLowerDPointNeighbors.C
@@ -76,7 +76,7 @@ GhostHigherDLowerDPointNeighbors::operator()(const MeshBase::const_element_itera
       if (node.processor_id() != p)
         continue;
 
-      const auto & elem_node_neighbors = libmesh_map_find(node_to_elem_map, node.id());
+      const auto & elem_node_neighbors = moose_map_find(node_to_elem_map, node.id());
       for (const auto elem_id : elem_node_neighbors)
       {
         const Elem * const elem_node_neighbor = _mesh->elem_ptr(elem_id);

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3707,7 +3707,7 @@ NonlinearSystemBase::setupScalingData()
     for (const auto i : index_range(_variable_autoscaled))
       if (std::find(_ignore_variables_for_autoscaling.begin(),
                     _ignore_variables_for_autoscaling.end(),
-                    libmesh_map_find(number_to_var_map, i)->name()) !=
+                    moose_map_find(number_to_var_map, i)->name()) !=
           _ignore_variables_for_autoscaling.end())
         _variable_autoscaled[i] = false;
 }

--- a/framework/src/systems/NonlinearSystemBase.C
+++ b/framework/src/systems/NonlinearSystemBase.C
@@ -3599,8 +3599,9 @@ NonlinearSystemBase::needInterfaceMaterialOnSide(BoundaryID bnd_id, THREAD_ID ti
   return _interface_kernels.hasActiveBoundaryObjects(bnd_id, tid);
 }
 
-bool NonlinearSystemBase::needSubdomainMaterialOnSide(SubdomainID /*subdomain_id*/,
-                                                      THREAD_ID /*tid*/) const
+bool
+NonlinearSystemBase::needSubdomainMaterialOnSide(SubdomainID /*subdomain_id*/,
+                                                 THREAD_ID /*tid*/) const
 {
   return _doing_dg;
 }

--- a/framework/src/userobjects/DomainUserObject.C
+++ b/framework/src/userobjects/DomainUserObject.C
@@ -123,7 +123,7 @@ DomainUserObject::checkVariable(const MooseVariableFieldBase & variable) const
     auto & bnd_ids = it->second;
     for (const auto bnd_id : bnd_ids)
     {
-      const auto & connected_blocks = libmesh_map_find(_interface_connected_blocks, bnd_id);
+      const auto & connected_blocks = moose_map_find(_interface_connected_blocks, bnd_id);
       for (const auto & bid : connected_blocks)
         if (!variable.hasBlocks(bid))
           mooseError("Variable '",

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -116,10 +116,10 @@ InputParameters::attemptPrintDeprecated(const std::string & name_in)
       return true;
     };
 
-    if (_params.count(name) && !libmesh_map_find(_params, name)._deprecation_message.empty())
+    if (_params.count(name) && !moose_map_find(_params, name)._deprecation_message.empty())
       return emit_deprecation_message(name,
                                       "The parameter '" + name + "' is deprecated.\n" +
-                                          libmesh_map_find(_params, name)._deprecation_message);
+                                          moose_map_find(_params, name)._deprecation_message);
     else if (auto it = _old_to_new_name_and_dep.find(name_in);
              it != _old_to_new_name_and_dep.end() && !it->second.second.empty())
       return emit_deprecation_message(name_in, it->second.second);
@@ -940,7 +940,7 @@ InputParameters::applyParameter(const InputParameters & common,
     _values[local_name] = common._values.find(common_name)->second->clone();
     set_attributes(local_name, false);
     _params[local_name]._set_by_add_param =
-        libmesh_map_find(common._params, common_name)._set_by_add_param;
+        moose_map_find(common._params, common_name)._set_by_add_param;
   }
 
   // Enable deprecated message printing

--- a/framework/src/variables/MooseVariableFV.C
+++ b/framework/src/variables/MooseVariableFV.C
@@ -775,7 +775,7 @@ typename MooseVariableFV<OutputType>::ValueType
 MooseVariableFV<OutputType>::evaluate(const NodeArg & node_arg, const StateArg & state) const
 {
   const auto & node_to_elem_map = this->_mesh.nodeToElemMap();
-  const auto & elem_ids = libmesh_map_find(node_to_elem_map, node_arg.node->id());
+  const auto & elem_ids = moose_map_find(node_to_elem_map, node_arg.node->id());
   ValueType sum = 0;
   Real total_weight = 0;
   mooseAssert(elem_ids.size(), "There should always be at least one element connected to a node");

--- a/modules/contact/src/auxkernels/MortarFrictionalPressureVectorAux.C
+++ b/modules/contact/src/auxkernels/MortarFrictionalPressureVectorAux.C
@@ -88,7 +88,7 @@ MortarFrictionalPressureVectorAux::MortarFrictionalPressureVectorAux(const Input
                "frictional pressure vector auxiliary variable definition.");
 
   _mortar_generation_object =
-      &libmesh_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
+      &moose_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
 }
 
 Real
@@ -98,7 +98,7 @@ MortarFrictionalPressureVectorAux::computeValue()
   // A node id may correspond to more than one lower-d elements on the secondary surface.
   // However, we are looping over nodes below, so we will locate the correct geometry
   const Elem * lower_dimensional_element =
-      libmesh_map_find(_mortar_generation_object->nodesToSecondaryElem(), _current_node->id())[0];
+      moose_map_find(_mortar_generation_object->nodesToSecondaryElem(), _current_node->id())[0];
 
   // Get nodal tangents for this element
   const auto & nodal_tangents =

--- a/modules/contact/src/auxkernels/MortarFrictionalPressureVectorAux.C
+++ b/modules/contact/src/auxkernels/MortarFrictionalPressureVectorAux.C
@@ -88,7 +88,7 @@ MortarFrictionalPressureVectorAux::MortarFrictionalPressureVectorAux(const Input
                "frictional pressure vector auxiliary variable definition.");
 
   _mortar_generation_object =
-      &moose_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
+      &libmesh_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
 }
 
 Real

--- a/modules/contact/src/auxkernels/MortarPressureComponentAux.C
+++ b/modules/contact/src/auxkernels/MortarPressureComponentAux.C
@@ -80,7 +80,7 @@ MortarPressureComponentAux::MortarPressureComponentAux(const InputParameters & p
                "frictional pressure vector auxiliary variable definition.");
 
   _mortar_generation_object =
-      &moose_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
+      &libmesh_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
 }
 
 Real

--- a/modules/contact/src/auxkernels/MortarPressureComponentAux.C
+++ b/modules/contact/src/auxkernels/MortarPressureComponentAux.C
@@ -80,7 +80,7 @@ MortarPressureComponentAux::MortarPressureComponentAux(const InputParameters & p
                "frictional pressure vector auxiliary variable definition.");
 
   _mortar_generation_object =
-      &libmesh_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
+      &moose_map_find(displaced_mortar_interfaces, std::make_pair(_primary_id, _secondary_id));
 }
 
 Real
@@ -89,7 +89,7 @@ MortarPressureComponentAux::computeValue()
   // A node id may correspond to more than one lower-d elements on the secondary surface.
   // However, we are looping over nodes below, so we will locate the correct geometry
   const Elem * lower_dimensional_element =
-      libmesh_map_find(_mortar_generation_object->nodesToSecondaryElem(), _current_node->id())[0];
+      moose_map_find(_mortar_generation_object->nodesToSecondaryElem(), _current_node->id())[0];
 
   // Get the nodal normals for this element
   const auto & nodal_normals =

--- a/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
+++ b/modules/contact/src/constraints/ComputeFrictionalForceLMMechanicalContact.C
@@ -129,8 +129,7 @@ ComputeFrictionalForceLMMechanicalContact::post()
     if (dof_object->processor_id() != this->processor_id())
       continue;
 
-    const auto & [weighted_gap_pr, normalization] =
-        libmesh_map_find(dof_to_weighted_gap, dof_object);
+    const auto & [weighted_gap_pr, normalization] = moose_map_find(dof_to_weighted_gap, dof_object);
     _weighted_gap_ptr = &weighted_gap_pr;
     _normalization_ptr = &normalization;
     _tangential_vel_ptr[0] = &(weighted_velocities_pr[0]);

--- a/modules/contact/src/constraints/NormalMortarMechanicalContact.C
+++ b/modules/contact/src/constraints/NormalMortarMechanicalContact.C
@@ -52,7 +52,7 @@ NormalMortarMechanicalContact::computeQpResidual(Moose::MortarType type)
       // normals).
       // Get the _dof_to_weighted_gap map
       {
-        const auto normal_index = libmesh_map_find(_secondary_ip_lowerd_map, _i);
+        const auto normal_index = moose_map_find(_secondary_ip_lowerd_map, _i);
         return _test_secondary[_i][_qp] * _weighted_gap_uo.contactPressure()[_qp] *
                _normals[normal_index](_component);
       }
@@ -61,7 +61,7 @@ NormalMortarMechanicalContact::computeQpResidual(Moose::MortarType type)
       // The normal vector is signed according to the secondary face, so we need to introduce a
       // negative sign here
       {
-        const auto normal_index = libmesh_map_find(_primary_ip_lowerd_map, _i);
+        const auto normal_index = moose_map_find(_primary_ip_lowerd_map, _i);
         return -_test_primary[_i][_qp] * _weighted_gap_uo.contactPressure()[_qp] *
                _normals[normal_index](_component);
       }

--- a/modules/contact/src/constraints/TangentialMortarMechanicalContact.C
+++ b/modules/contact/src/constraints/TangentialMortarMechanicalContact.C
@@ -68,14 +68,14 @@ TangentialMortarMechanicalContact::computeQpResidual(Moose::MortarType type)
       // means we want the residual to be negative in that case. So the sign of this residual should
       // be the same as the sign of lambda
       {
-        const unsigned int tangent_index = libmesh_map_find(_secondary_ip_lowerd_map, _i);
+        const unsigned int tangent_index = moose_map_find(_secondary_ip_lowerd_map, _i);
         return _test_secondary[_i][_qp] * tangential_pressure *
                nodal_tangents[_direction][tangent_index](_component) /
                nodal_tangents[_direction][tangent_index].norm();
       }
     case Moose::MortarType::Primary:
     {
-      const unsigned int tangent_index = libmesh_map_find(_primary_ip_lowerd_map, _i);
+      const unsigned int tangent_index = moose_map_find(_primary_ip_lowerd_map, _i);
       return -_test_primary[_i][_qp] * tangential_pressure *
              nodal_tangents[_direction][tangent_index](_component) /
              nodal_tangents[_direction][tangent_index].norm();

--- a/modules/contact/src/userobjects/PenaltyFrictionUserObject.C
+++ b/modules/contact/src/userobjects/PenaltyFrictionUserObject.C
@@ -244,7 +244,7 @@ PenaltyFrictionUserObject::reinit()
 
     Real normal_lm = -1;
     if (_dof_to_lagrange_multiplier.find(node) != _dof_to_lagrange_multiplier.end())
-      normal_lm = libmesh_map_find(_dof_to_lagrange_multiplier, node);
+      normal_lm = moose_map_find(_dof_to_lagrange_multiplier, node);
 
     // Keep active set fixed from second Uzawa loop
     if (normal_lm < -TOLERANCE && normal_pressure > TOLERANCE)
@@ -252,7 +252,7 @@ PenaltyFrictionUserObject::reinit()
       using namespace std;
 
       const auto & real_tangential_velocity =
-          libmesh_map_find(_dof_to_real_tangential_velocity, node);
+          moose_map_find(_dof_to_real_tangential_velocity, node);
       const ADTwoVector slip_distance = {real_tangential_velocity[0] * _dt,
                                          real_tangential_velocity[1] * _dt};
 
@@ -347,7 +347,7 @@ PenaltyFrictionUserObject::isAugmentedLagrangianConverged()
     if (_dof_to_real_tangential_velocity.find(dof_object) != _dof_to_real_tangential_velocity.end())
     {
       const auto & real_tangential_velocity =
-          libmesh_map_find(_dof_to_real_tangential_velocity, dof_object);
+          moose_map_find(_dof_to_real_tangential_velocity, dof_object);
       slip_velocity = {MetaPhysicL::raw_value(real_tangential_velocity[0]),
                        MetaPhysicL::raw_value(real_tangential_velocity[1])};
     }
@@ -403,11 +403,11 @@ PenaltyFrictionUserObject::updateAugmentedLagrangianMultipliers()
       penalty_friction = _penalty_friction;
 
     // normal quantities
-    const auto & normal_lm = libmesh_map_find(_dof_to_lagrange_multiplier, dof_object);
+    const auto & normal_lm = moose_map_find(_dof_to_lagrange_multiplier, dof_object);
 
     // tangential quantities
     const auto & real_tangential_velocity =
-        libmesh_map_find(_dof_to_real_tangential_velocity, dof_object);
+        moose_map_find(_dof_to_real_tangential_velocity, dof_object);
     const TwoVector slip_velocity = {MetaPhysicL::raw_value(real_tangential_velocity[0]),
                                      MetaPhysicL::raw_value(real_tangential_velocity[1])};
 
@@ -442,7 +442,7 @@ PenaltyFrictionUserObject::updateAugmentedLagrangianMultipliers()
     }
     else if (_adaptivity_friction == AdaptivityFrictionalPenalty::FRICTION_LIMIT)
     {
-      const auto & step_slip = libmesh_map_find(_dof_to_step_slip, dof_object);
+      const auto & step_slip = moose_map_find(_dof_to_step_slip, dof_object);
       // No change of direction: Adjust penalty factor for the frictional problem
       if (step_slip.first.dot(step_slip.second) > 0.0 && std::abs(normal_lm) > TOLERANCE &&
           _slip_tolerance < _dt * slip_velocity.norm())

--- a/modules/contact/src/userobjects/PenaltyWeightedGapUserObject.C
+++ b/modules/contact/src/userobjects/PenaltyWeightedGapUserObject.C
@@ -304,7 +304,7 @@ PenaltyWeightedGapUserObject::updateAugmentedLagrangianMultipliers()
     auto & lagrange_multiplier = _dof_to_lagrange_multiplier[dof_object];
 
     const auto possible_normalization =
-        (_use_physical_gap ? libmesh_map_find(_dof_to_weighted_gap, dof_object).second : 1.0);
+        (_use_physical_gap ? moose_map_find(_dof_to_weighted_gap, dof_object).second : 1.0);
 
     // Update penalty (the factor of 1/4 is suggested in the literature, the limit on AL iteration
     // caps the penalty increase)

--- a/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
+++ b/modules/navier_stokes/src/utils/FaceCenteredMapFunctor.C
@@ -131,7 +131,7 @@ FaceCenteredMapFunctor<T, Map>::evaluate(const FaceInfo * fi) const
 {
   try
   {
-    return libmesh_map_find(*this, fi->id());
+    return moose_map_find(*this, fi->id());
   }
   catch (libMesh::LogicError &)
   {

--- a/modules/navier_stokes/unit/src/TestReconstruction.C
+++ b/modules/navier_stokes/unit/src/TestReconstruction.C
@@ -146,7 +146,7 @@ testReconstruction(const Moose::CoordinateSystemType coord_type)
       auto compute_elem_error =
           [elem_id, current_h, elem, &analytic](auto & container, auto & error)
       {
-        auto & current = moose_map_find(container, elem_id);
+        auto & current = libmesh_map_find(container, elem_id);
         const auto diff = analytic - current;
         error += diff * diff * current_h * current_h;
 
@@ -181,7 +181,7 @@ testReconstruction(const Moose::CoordinateSystemType coord_type)
 
       auto compute_elem_error = [elem_id, current_h, &analytic](auto & container, auto & error)
       {
-        auto & current = moose_map_find(container, elem_id);
+        auto & current = libmesh_map_find(container, elem_id);
         const auto diff = analytic - current;
         error += diff * diff * current_h * current_h;
       };

--- a/modules/navier_stokes/unit/src/TestReconstruction.C
+++ b/modules/navier_stokes/unit/src/TestReconstruction.C
@@ -146,7 +146,7 @@ testReconstruction(const Moose::CoordinateSystemType coord_type)
       auto compute_elem_error =
           [elem_id, current_h, elem, &analytic](auto & container, auto & error)
       {
-        auto & current = libmesh_map_find(container, elem_id);
+        auto & current = moose_map_find(container, elem_id);
         const auto diff = analytic - current;
         error += diff * diff * current_h * current_h;
 
@@ -181,7 +181,7 @@ testReconstruction(const Moose::CoordinateSystemType coord_type)
 
       auto compute_elem_error = [elem_id, current_h, &analytic](auto & container, auto & error)
       {
-        auto & current = libmesh_map_find(container, elem_id);
+        auto & current = moose_map_find(container, elem_id);
         const auto diff = analytic - current;
         error += diff * diff * current_h * current_h;
       };

--- a/modules/stochastic_tools/src/reporters/ParallelSolutionStorage.C
+++ b/modules/stochastic_tools/src/reporters/ParallelSolutionStorage.C
@@ -66,7 +66,7 @@ ParallelSolutionStorage::addEntry(const VariableName & vname,
 unsigned int
 ParallelSolutionStorage::totalNumberOfStoredSolutions(const VariableName & vname) const
 {
-  const auto & samples = libmesh_map_find(_distributed_solutions, vname);
+  const auto & samples = moose_map_find(_distributed_solutions, vname);
 
   return std::accumulate(
       samples.begin(),
@@ -83,7 +83,7 @@ ParallelSolutionStorage::hasGlobalSample(unsigned int global_sample_i,
   if (_distributed_solutions.find(variable) == _distributed_solutions.end())
     return false;
 
-  auto & variable_storage = libmesh_map_find(_distributed_solutions, variable);
+  auto & variable_storage = moose_map_find(_distributed_solutions, variable);
 
   return (variable_storage.find(global_sample_i) != variable_storage.end());
 }
@@ -94,11 +94,11 @@ ParallelSolutionStorage::getGlobalSample(unsigned int global_sample_i,
 {
   mooseAssert(_distributed_solutions.find(variable) != _distributed_solutions.end(),
               "We don't have the requested variable!");
-  const auto & variable_storage = libmesh_map_find(_distributed_solutions, variable);
+  const auto & variable_storage = moose_map_find(_distributed_solutions, variable);
   mooseAssert(variable_storage.find(global_sample_i) != variable_storage.end(),
               "We don't have the requested global sample index! ");
 
-  return libmesh_map_find(variable_storage, global_sample_i);
+  return moose_map_find(variable_storage, global_sample_i);
 }
 
 std::unordered_map<unsigned int, std::vector<DenseVector<Real>>> &
@@ -108,7 +108,7 @@ ParallelSolutionStorage::getStorage(const VariableName & variable)
     mooseError(
         "We are trying to access container for variable '", variable, "' but we don't have it!");
 
-  return libmesh_map_find(_distributed_solutions, variable);
+  return moose_map_find(_distributed_solutions, variable);
 }
 
 const std::unordered_map<unsigned int, std::vector<DenseVector<Real>>> &
@@ -118,7 +118,7 @@ ParallelSolutionStorage::getStorage(const VariableName & variable) const
     mooseError(
         "We are trying to access container for variable '", variable, "' but we don't have it!");
 
-  return libmesh_map_find(_distributed_solutions, variable);
+  return moose_map_find(_distributed_solutions, variable);
 }
 
 void

--- a/modules/tensor_mechanics/src/userobjects/NodalPatchRecoveryBase.C
+++ b/modules/tensor_mechanics/src/userobjects/NodalPatchRecoveryBase.C
@@ -62,8 +62,8 @@ NodalPatchRecoveryBase::nodalPatchRecovery(const Point & x,
   RealEigenVector b = RealEigenVector::Zero(_q);
   for (auto elem_id : elem_ids)
   {
-    A += libmesh_map_find(_Ae, elem_id);
-    b += libmesh_map_find(_be, elem_id);
+    A += moose_map_find(_Ae, elem_id);
+    b += moose_map_find(_be, elem_id);
   }
 
   // Solve the least squares fitting


### PR DESCRIPTION
I would have namespaced it under Moose but right now it conflicts with libmesh's map_find
if we have a better name  I can try again to name space it but map_find is pretty pretty good 