### PR TITLE
Handle harmonic warning verbosity better

### DIFF
--- a/framework/include/utils/InputParameters.h
+++ b/framework/include/utils/InputParameters.h
@@ -898,6 +898,7 @@ public:
    * @param old_name The old name of the parameter
    * @param new_name The new name of the parameter
    * @param new_docstring The new documentation string for the parameter
+   *                      If left empty, uses the old docstring for the renamed parameter
    */
   void renameParam(const std::string & old_name,
                    const std::string & new_name,

--- a/framework/include/utils/MathFVUtils.h
+++ b/framework/include/utils/MathFVUtils.h
@@ -188,7 +188,9 @@ harmonicInterpolation(const T1 & value1,
     // so we assert that the input values shall be positive.
 #ifndef NDEBUG
     if (value1 * value2 <= 0)
-      mooseWarning("Input values must be of the same sign for harmonic interpolation");
+      mooseWarning("Input values (" + Moose::stringify(MetaPhysicL::raw_value(value1)) + " & " +
+                   Moose::stringify(MetaPhysicL::raw_value(value2)) +
+                   ") must be of the same sign for harmonic interpolation");
 #endif
     return 1.0 / (coeffs.first / value1 + coeffs.second / value2);
   }
@@ -200,8 +202,10 @@ harmonicInterpolation(const T1 & value1,
     {
 #ifndef NDEBUG
       if (value1(i) * value2(i) <= 0)
-        mooseWarning("Component " + std::to_string(i) +
-                     "of input values must be of the same sign for harmonic interpolation");
+        mooseWarning("Component " + std::to_string(i) + "of input values (" +
+                     Moose::stringify(MetaPhysicL::raw_value(value1(i))) + " & " +
+                     Moose::stringify(MetaPhysicL::raw_value(value2(i))) +
+                     ") must be of the same sign for harmonic interpolation");
 #endif
       result(i) = 1.0 / (coeffs.first / value1(i) + coeffs.second / value2(i));
     }
@@ -218,7 +222,10 @@ harmonicInterpolation(const T1 & value1,
 #ifndef NDEBUG
         if (value1(i, j) * value2(i, j) <= 0)
           mooseWarning("Component (" + std::to_string(i) + "," + std::to_string(j) +
-                       ") of input values must be of the same sign for harmonic interpolation");
+                       ") of input values (" +
+                       Moose::stringify(MetaPhysicL::raw_value(value1(i, j))) + " & " +
+                       Moose::stringify(MetaPhysicL::raw_value(value2(i, j))) +
+                       ") must be of the same sign for harmonic interpolation");
 #endif
         result(i, j) = 1.0 / (coeffs.first / value1(i, j) + coeffs.second / value2(i, j));
       }

--- a/framework/src/utils/InputParameters.C
+++ b/framework/src/utils/InputParameters.C
@@ -1316,6 +1316,8 @@ InputParameters::renameParamInternal(const std::string & old_name,
   auto new_metadata = std::move(params_it->second);
   if (!docstring.empty())
     new_metadata._doc_string = docstring;
+  else
+    new_metadata._doc_string = params_it->second._doc_string;
   _params.emplace(new_name, std::move(new_metadata));
   _params.erase(params_it);
 

--- a/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyAnisotropicDiffusion.md
+++ b/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyAnisotropicDiffusion.md
@@ -11,7 +11,7 @@ specified using a [PINSFVEnergyDiffusion.md] kernel.
 \end{equation}
 where $\epsilon$ is the porosity, $k$ is the thermal conductivity, and $T$ the fluid temperature. The
 multiplication by $\epsilon$ may be removed by specifying the
-[!param](/FVKernels/PINSFVEnergyAnisotropicDiffusion/effective_diffusivity) parameter. This effectively
+[!param](/FVKernels/PINSFVEnergyAnisotropicDiffusion/effective_conductivity) parameter. This effectively
 switches from using a $k$ thermal conductivity to a $\kappa$ effective thermal conductivity.
 
 More information may be found on effective thermal conductivity models in the Pronghorn manual. They

--- a/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyDiffusion.md
+++ b/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyDiffusion.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This kernel implements a diffusion term for the fluid energy equation. The thermal diffusivity
+This kernel implements a diffusion term for the fluid energy equation. The thermal conductivity
 is isotropic for this kernel. For anistropic diffusion, use the [PINSFVEnergyAnisotropicDiffusion.md] kernel.
 
 
@@ -15,13 +15,12 @@ The porosity gradient term creates oscillations in the presence of porosity disc
 generally neglected. It is not computed by this kernel.
 
 !alert note
-To switch from using a regular diffusivity to an effective diffusivity, use the
-[!param](/FVKernels/PINSFVEnergyDiffusion/effective_diffusivity) parameter.
+To switch from using a regular conductivity to an effective conductivity, use the
+[!param](/FVKernels/PINSFVEnergyDiffusion/effective_conductivity) parameter.
 
 !alert note
-If specifying a zero thermal diffusivity, the harmonic interpolation method for the face value of the thermal
-conductivity is not well-defined and will
-be automatically changed to an average interpolation.
+If the thermal conductivity is null or negative, the harmonic interpolation method for the face value of the thermal
+conductivity is not well-defined and will be automatically changed to an average interpolation.
 
 !syntax parameters /FVKernels/PINSFVEnergyDiffusion
 

--- a/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyDiffusion.md
+++ b/modules/navier_stokes/doc/content/source/fvkernels/PINSFVEnergyDiffusion.md
@@ -18,6 +18,11 @@ generally neglected. It is not computed by this kernel.
 To switch from using a regular diffusivity to an effective diffusivity, use the
 [!param](/FVKernels/PINSFVEnergyDiffusion/effective_diffusivity) parameter.
 
+!alert note
+If specifying a zero thermal diffusivity, the harmonic interpolation method for the face value of the thermal
+conductivity is not well-defined and will
+be automatically changed to an average interpolation.
+
 !syntax parameters /FVKernels/PINSFVEnergyDiffusion
 
 !syntax inputs /FVKernels/PINSFVEnergyDiffusion

--- a/modules/navier_stokes/include/fvkernels/PINSFVEnergyDiffusion.h
+++ b/modules/navier_stokes/include/fvkernels/PINSFVEnergyDiffusion.h
@@ -11,12 +11,13 @@
 
 #include "FVFluxKernel.h"
 #include "MathFVUtils.h"
+#include "SolutionInvalidInterface.h"
 
 /**
  * A flux kernel for diffusing energy in porous media across cell faces, using a scalar
  * isotropic diffusion coefficient, using functor material properties
  */
-class PINSFVEnergyDiffusion : public FVFluxKernel
+class PINSFVEnergyDiffusion : public FVFluxKernel, protected SolutionInvalidInterface
 {
 public:
   static InputParameters validParams();

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyAnisotropicDiffusion.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyAnisotropicDiffusion.C
@@ -25,8 +25,9 @@ PINSFVEnergyAnisotropicDiffusion::validParams()
   params.addParam<bool>(
       "effective_diffusivity",
       true,
-      "Whether the diffusivity should be multiplied by porosity, or whether the provided "
-      "diffusivity is an effective diffusivity taking porosity effects into account");
+      "Whether the conductivity should be multiplied by porosity, or whether the provided "
+      "conductivity is an effective conductivity taking porosity effects into account");
+  params.renameParam("effective_diffusivity", "effective_conductivity", "");
   MooseEnum coeff_interp_method("average harmonic", "harmonic");
   params.addParam<MooseEnum>(
       "kappa_interp_method",
@@ -41,7 +42,7 @@ PINSFVEnergyAnisotropicDiffusion::PINSFVEnergyAnisotropicDiffusion(const InputPa
   : FVFluxKernel(params),
     _k(getFunctor<ADRealVectorValue>(NS::kappa)),
     _eps(getFunctor<ADReal>(NS::porosity)),
-    _porosity_factored_in(getParam<bool>("effective_diffusivity")),
+    _porosity_factored_in(getParam<bool>("effective_conductivity")),
     _k_interp_method(
         Moose::FV::selectInterpolationMethod(getParam<MooseEnum>("kappa_interp_method")))
 {

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyDiffusion.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyDiffusion.C
@@ -24,8 +24,9 @@ PINSFVEnergyDiffusion::validParams()
   params.addParam<bool>(
       "effective_diffusivity",
       false,
-      "Whether the diffusivity should be multiplied by porosity, or whether the provided "
-      "diffusivity is an effective diffusivity taking porosity effects into account");
+      "Whether the conductivity should be multiplied by porosity, or whether the provided "
+      "conductivity is an effective conductivity taking porosity effects into account");
+  params.renameParam("effective_diffusivity", "effective_conductivity", "");
   MooseEnum coeff_interp_method("average harmonic", "harmonic");
   params.addParam<MooseEnum>(
       "kappa_interp_method",
@@ -41,7 +42,7 @@ PINSFVEnergyDiffusion::PINSFVEnergyDiffusion(const InputParameters & params)
     SolutionInvalidInterface(this),
     _k(getFunctor<ADReal>(NS::k)),
     _eps(getFunctor<ADReal>(NS::porosity)),
-    _porosity_factored_in(getParam<bool>("effective_diffusivity")),
+    _porosity_factored_in(getParam<bool>("effective_conductivity")),
     _k_interp_method(
         Moose::FV::selectInterpolationMethod(getParam<MooseEnum>("kappa_interp_method")))
 {
@@ -72,13 +73,13 @@ PINSFVEnergyDiffusion::computeQpResidual()
     auto value2 = _porosity_factored_in ? _k(face_neighbor, state)
                                         : _k(face_neighbor, state) * _eps(face_neighbor, state);
 
-    // Adapt to users either passing 0 thermal diffusivity, 0 porosity, or k correlations going
+    // Adapt to users either passing 0 thermal conductivity, 0 porosity, or k correlations going
     // negative. The solution is invalid only for the latter case.
     auto k_interp_method = _k_interp_method;
     if (value1 <= 0 || value2 <= 0)
     {
       flagInvalidSolution(
-          "Negative or null thermal diffusivity value. If this is on purpose use arithmetic mean "
+          "Negative or null thermal conductivity value. If this is on purpose use arithmetic mean "
           "interpolation instead of the default harmonic interpolation.");
       if (_k_interp_method == Moose::FV::InterpMethod::HarmonicAverage)
         k_interp_method = Moose::FV::InterpMethod::Average;

--- a/modules/navier_stokes/src/fvkernels/PINSFVEnergyDiffusion.C
+++ b/modules/navier_stokes/src/fvkernels/PINSFVEnergyDiffusion.C
@@ -75,19 +75,17 @@ PINSFVEnergyDiffusion::computeQpResidual()
     // Adapt to users either passing 0 thermal diffusivity, 0 porosity, or k correlations going
     // negative. The solution is invalid only for the latter case.
     auto k_interp_method = _k_interp_method;
-    if (value1 <= 0)
+    if (value1 <= 0 || value2 <= 0)
     {
-      flagInvalidSolution("Negative or null thermal diffusivity value");
+      flagInvalidSolution(
+          "Negative or null thermal diffusivity value. If this is on purpose use arithmetic mean "
+          "interpolation instead of the default harmonic interpolation.");
       if (_k_interp_method == Moose::FV::InterpMethod::HarmonicAverage)
         k_interp_method = Moose::FV::InterpMethod::Average;
-      value1 = 0;
-    }
-    if (value2 <= 0)
-    {
-      flagInvalidSolution("Negative or null thermal diffusivity value");
-      if (_k_interp_method == Moose::FV::InterpMethod::HarmonicAverage)
-        k_interp_method = Moose::FV::InterpMethod::Average;
-      value2 = 0;
+      if (value1 < 0)
+        value1 = 0;
+      if (value2 < 0)
+        value2 = 0;
     }
 
     Moose::FV::interpolate(k_interp_method, k_eps_face, value1, value2, *_face_info, true);


### PR DESCRIPTION
Ultimately I think the following two actions could also be warranted:

- declare the solution invalid directly from MathFVUtil with no-idea what we interpolated. This is not great because we wanted the check on the values to only be in debug mode
- not add the diffusion kernels (energy, momentum, scalar) if the user specifies a 0 diffusivity
