### PR TITLE
Removed unnecessary warning for 'outputs' parameter

### DIFF
--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -380,9 +380,6 @@ AdvancedOutput::initPostprocessorOrVectorPostprocessorLists(const std::string & 
   oss << "execute_" << execute_data_name << "_on";
   std::string execute_on_name = oss.str();
 
-  // True if the postprocessors has been limited using 'outputs' parameter
-  bool has_limited_pps = false;
-
   std::vector<UserObject *> objs;
   _problem_ptr->theWarehouse()
       .query()
@@ -412,35 +409,19 @@ AdvancedOutput::initPostprocessorOrVectorPostprocessorLists(const std::string & 
       if (!_advanced_execute_on.contains(execute_data_name) ||
           (_advanced_execute_on[execute_data_name].isValid() &&
            _advanced_execute_on[execute_data_name].contains("none")))
-        mooseWarning(
-            "Postprocessor '",
-            pps->PPName(),
-            "' has requested to be output by the '",
-            name(),
-            "' output, but postprocessor output is not support by this type of output object.");
-    }
-
-    // Set the flag state for postprocessors that utilize 'outputs' parameter
-    if (!pps_outputs.empty() && pps_outputs.find("all") == pps_outputs.end())
-      has_limited_pps = true;
-  }
-
-  // Produce the warning when 'outputs' is used, but postprocessor output is disabled
-  if (has_limited_pps && isParamValid(execute_on_name))
-  {
-    const ExecFlagEnum & pp_on = getParam<ExecFlagEnum>(execute_on_name);
-    if (pp_on.contains(EXEC_NONE))
-    {
-      if (execute_on_name == "execute_postprocessors_on")
-        mooseWarning("A Postprocessor utilizes the 'outputs' parameter; however, postprocessor "
-                     "output is disabled for the '",
+      {
+        const bool is_pp_type = (execute_data_name == "postprocessors") ? true : false;
+        const std::string pp_type_str = is_pp_type ? "post-processor" : "vector post-processor";
+        mooseWarning("The ",
+                     pp_type_str,
+                     " '",
+                     pps->PPName(),
+                     "' has requested to be output by the '",
                      name(),
-                     "' output object.");
-      else if (execute_on_name == "execute_vectorpostprocessors_on")
-        mooseWarning("A VectorPostprocessor utilizes the 'outputs' parameter; however, vector "
-                     "postprocessor output is disabled for the '",
-                     name(),
-                     "' output object.");
+                     "' output, but ",
+                     pp_type_str,
+                     " output is disabled for this output object.");
+      }
     }
   }
 }

--- a/framework/include/outputs/AdvancedOutput.h
+++ b/framework/include/outputs/AdvancedOutput.h
@@ -410,7 +410,7 @@ AdvancedOutput::initPostprocessorOrVectorPostprocessorLists(const std::string & 
           (_advanced_execute_on[execute_data_name].isValid() &&
            _advanced_execute_on[execute_data_name].contains("none")))
       {
-        const bool is_pp_type = (execute_data_name == "postprocessors") ? true : false;
+        const bool is_pp_type = (execute_data_name == "postprocessors");
         const std::string pp_type_str = is_pp_type ? "post-processor" : "vector post-processor";
         mooseWarning("The ",
                      pp_type_str,
@@ -420,7 +420,7 @@ AdvancedOutput::initPostprocessorOrVectorPostprocessorLists(const std::string & 
                      name(),
                      "' output, but ",
                      pp_type_str,
-                     " output is disabled for this output object.");
+                     " output is disabled for that output object.");
       }
     }
   }

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -151,8 +151,8 @@ void
 AdvancedOutput::init()
 {
   // Initialize the execution flags
-  for (auto & it : _advanced_execute_on)
-    initExecutionTypes(it.first, it.second);
+  for (auto & [name, input] : _advanced_execute_on)
+    initExecutionTypes(name, input);
 
   // Clear existing execute information lists
   _execute_data.reset();

--- a/framework/src/outputs/AdvancedOutput.C
+++ b/framework/src/outputs/AdvancedOutput.C
@@ -150,6 +150,10 @@ AdvancedOutput::initialSetup()
 void
 AdvancedOutput::init()
 {
+  // Initialize the execution flags
+  for (auto & it : _advanced_execute_on)
+    initExecutionTypes(it.first, it.second);
+
   // Clear existing execute information lists
   _execute_data.reset();
 
@@ -185,10 +189,6 @@ AdvancedOutput::init()
   // Initialize the show/hide/output lists for each of the types of output
   for (auto & it : _execute_data)
     initOutputList(it.second);
-
-  // Initialize the execution flags
-  for (auto & it : _advanced_execute_on)
-    initExecutionTypes(it.first, it.second);
 }
 
 AdvancedOutput::~AdvancedOutput() {}

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -109,8 +109,7 @@
   [pps_screen_out_warn_test]
     type = 'RunApp'
     input = 'pps_screen_out_warn.i'
-    expect_out = "A Postprocessor utilizes the 'outputs' parameter; however, postprocessor output is "
-                 "disabled for the 'console' output object."
+    expect_out = "The post-processor 'avg_block' has requested to be output by the 'console' output, but post-processor output is disabled for this output object"
     allow_warnings = true
     max_parallel = 1 # warning can mix on multiple processes
     issues = '#1426'

--- a/test/tests/outputs/format/tests
+++ b/test/tests/outputs/format/tests
@@ -109,7 +109,7 @@
   [pps_screen_out_warn_test]
     type = 'RunApp'
     input = 'pps_screen_out_warn.i'
-    expect_out = "The post-processor 'avg_block' has requested to be output by the 'console' output, but post-processor output is disabled for this output object"
+    expect_out = "The post-processor 'avg_block' has requested to be output by the 'console' output, but post-processor output is disabled for that output object"
     allow_warnings = true
     max_parallel = 1 # warning can mix on multiple processes
     issues = '#1426'


### PR DESCRIPTION
Closes #25909

Also, cleaned up some grammar in the other warning in this method.
