### PR TITLE
No dlopen fix

### DIFF
--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -2126,7 +2126,7 @@ MooseApp::loadLibraryAndDependencies(const std::string & library_filename,
     else
     {
 
-#ifdef DEBUG
+#if defined(DEBUG) && defined(LIBMESH_HAVE_DLOPEN)
       // We found a dynamic library that doesn't have a dynamic
       // registration method in it. This shouldn't be an error, so
       // we'll just move on.

--- a/framework/src/base/MooseApp.C
+++ b/framework/src/base/MooseApp.C
@@ -1948,6 +1948,7 @@ MooseApp::dynamicAppRegistration(const std::string & app_name,
   }
 
 #else
+  libmesh_ignore(app_name, library_path, library_name, lib_load_deps);
   mooseError("Dynamic Loading is either not supported or was not detected by libMesh configure.");
 #endif
 }
@@ -1976,6 +1977,7 @@ MooseApp::dynamicAllRegistration(const std::string & app_name,
 
   dynamicRegistration(params);
 #else
+  libmesh_ignore(app_name, factory, action_factory, syntax, library_path, library_name);
   mooseError("Dynamic Loading is either not supported or was not detected by libMesh configure.");
 #endif
 }


### PR DESCRIPTION
This gets builds with `!LIBMESH_HAVE_DLOPEN` working for me.  I have yet to figure out what changed in https://civet.inl.gov/job/1853109/ to cause such builds to *need* to be working, though.

Fixes #25911