### PR TITLE
Dont trust the problem for the dimension in NS Rhie Chow User Object

### DIFF
--- a/framework/include/interfaces/BlockRestrictable.h
+++ b/framework/include/interfaces/BlockRestrictable.h
@@ -111,12 +111,7 @@ public:
   /**
    * Return the largest mesh dimension of the elements in the blocks for this object
    */
-  unsigned int blocksMaxDimension() const
-  {
-    mooseAssert(_blk_dim != std::numeric_limits<unsigned int>::max(),
-                "Block restriction not initialized");
-    return _blk_dim;
-  }
+  unsigned int blocksMaxDimension() const;
 
   /**
    * Test if the supplied block name is valid for this object

--- a/framework/include/interfaces/BlockRestrictable.h
+++ b/framework/include/interfaces/BlockRestrictable.h
@@ -104,14 +104,19 @@ public:
   /**
    * Return the block subdomain ids for this object
    * Note, if this is not block restricted, this function returns all mesh subdomain ids.
-   * @return a set of SudomainIDs that are valid for this object
+   * @return a set of SubdomainIDs that are valid for this object
    */
   const virtual std::set<SubdomainID> & blockIDs() const;
 
   /**
    * Return the largest mesh dimension of the elements in the blocks for this object
    */
-  unsigned int blocksMaxDimension() const { return _blk_dim; }
+  unsigned int blocksMaxDimension() const
+  {
+    mooseAssert(_blk_dim != std::numeric_limits<unsigned int>::max(),
+                "Block restriction not initialized");
+    return _blk_dim;
+  }
 
   /**
    * Test if the supplied block name is valid for this object

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -47,7 +47,7 @@ BlockRestrictable::BlockRestrictable(const MooseObject * moose_object, bool init
     _boundary_ids(_empty_boundary_ids),
     _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
     _blk_name(moose_object->getParam<std::string>("_object_name")),
-    _blk_dim(std::numeric_limits<unsigned int>::max())
+    _blk_dim(libMesh::invalid_uint)
 {
   if (initialize)
     initializeBlockRestrictable(moose_object);
@@ -65,7 +65,7 @@ BlockRestrictable::BlockRestrictable(const MooseObject * moose_object,
     _boundary_ids(boundary_ids),
     _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
     _blk_name(moose_object->getParam<std::string>("_object_name")),
-    _blk_dim(std::numeric_limits<unsigned int>::max())
+    _blk_dim(libMesh::invalid_uint)
 {
   initializeBlockRestrictable(moose_object);
 }
@@ -354,4 +354,11 @@ BlockRestrictable::checkVariable(const MooseVariableFieldBase & variable) const
                "': ",
                var_ids);
   }
+}
+
+unsigned int
+BlockRestrictable::blocksMaxDimension() const
+{
+  mooseAssert(_blk_dim != libMesh::invalid_uint, "Block restriction not initialized");
+  return _blk_dim;
 }

--- a/framework/src/interfaces/BlockRestrictable.C
+++ b/framework/src/interfaces/BlockRestrictable.C
@@ -46,7 +46,8 @@ BlockRestrictable::BlockRestrictable(const MooseObject * moose_object, bool init
                                                   : NULL),
     _boundary_ids(_empty_boundary_ids),
     _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
-    _blk_name(moose_object->getParam<std::string>("_object_name"))
+    _blk_name(moose_object->getParam<std::string>("_object_name")),
+    _blk_dim(std::numeric_limits<unsigned int>::max())
 {
   if (initialize)
     initializeBlockRestrictable(moose_object);
@@ -63,7 +64,8 @@ BlockRestrictable::BlockRestrictable(const MooseObject * moose_object,
                                                   : NULL),
     _boundary_ids(boundary_ids),
     _blk_tid(moose_object->isParamValid("_tid") ? moose_object->getParam<THREAD_ID>("_tid") : 0),
-    _blk_name(moose_object->getParam<std::string>("_object_name"))
+    _blk_name(moose_object->getParam<std::string>("_object_name")),
+    _blk_dim(std::numeric_limits<unsigned int>::max())
 {
   initializeBlockRestrictable(moose_object);
 }

--- a/modules/navier_stokes/src/fvkernels/INSFVMixingLengthReynoldsStress.C
+++ b/modules/navier_stokes/src/fvkernels/INSFVMixingLengthReynoldsStress.C
@@ -42,7 +42,7 @@ INSFVMixingLengthReynoldsStress::validParams()
 
 INSFVMixingLengthReynoldsStress::INSFVMixingLengthReynoldsStress(const InputParameters & params)
   : INSFVFluxKernel(params),
-    _dim(_subproblem.mesh().dimension()),
+    _dim(blocksMaxDimension()),
     _axis_index(getParam<MooseEnum>("momentum_component")),
     _u(getFunctor<ADReal>("u")),
     _v(params.isParamValid("v") ? &getFunctor<ADReal>("v") : nullptr),


### PR DESCRIPTION
- on components, problem says 3D even for 2D closes #25936

Be more safe on retrieving the max dimension from the BlockRestrictable interface

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
