### PR TITLE
Emissivities in net radiation transfer eps(temperature)

### DIFF
--- a/modules/heat_transfer/include/userobjects/GrayLambertSurfaceRadiationBase.h
+++ b/modules/heat_transfer/include/userobjects/GrayLambertSurfaceRadiationBase.h
@@ -63,9 +63,6 @@ protected:
   /// the coupled temperature variable
   const VariableValue & _temperature;
 
-  /// constant emissivity for each boundary
-  const std::vector<Real> _emissivity;
-
   /// side id to index map, side ids can have holes or be out of order
   std::vector<const Function *> _fixed_side_temperature;
 
@@ -92,6 +89,9 @@ protected:
 
   /// the irradiation into each surface
   std::vector<Real> _surface_irradiation;
+
+  /// constant emissivity for each boundary
+  std::vector<const Function *> _emissivity;
 
   /// side id to index map for isothermal boundaries, side ids can have holes or be out of order
   std::map<unsigned int, unsigned int> _fixed_side_id_index;

--- a/modules/heat_transfer/src/actions/RadiationTransferAction.C
+++ b/modules/heat_transfer/src/actions/RadiationTransferAction.C
@@ -59,7 +59,8 @@ RadiationTransferAction::validParams()
                                   "Available options: x, y, z, radial");
 
   params.addRequiredParam<VariableName>("temperature", "The coupled temperature variable.");
-  params.addRequiredParam<std::vector<Real>>("emissivity", "Emissivities for each boundary.");
+  params.addRequiredParam<std::vector<FunctionName>>("emissivity",
+                                                     "Emissivities for each boundary.");
 
   MooseEnum view_factor_calculator("analytical ray_tracing", "ray_tracing");
   params.addParam<MooseEnum>(
@@ -317,7 +318,7 @@ RadiationTransferAction::addRadiationObject() const
   std::vector<std::vector<std::string>> radiation_patch_names = radiationPatchNames();
 
   // input parameter check
-  std::vector<Real> emissivity = getParam<std::vector<Real>>("emissivity");
+  std::vector<FunctionName> emissivity = getParam<std::vector<FunctionName>>("emissivity");
   if (emissivity.size() != _boundary_names.size())
     mooseError("emissivity parameter needs to be the same size as the boundary parameter.");
 
@@ -326,11 +327,11 @@ RadiationTransferAction::addRadiationObject() const
   InputParameters params = _factory.getValidParams("ViewFactorObjectSurfaceRadiation");
   params.set<std::vector<VariableName>>("temperature") = {getParam<VariableName>("temperature")};
 
-  std::vector<Real> extended_emissivity;
+  std::vector<FunctionName> extended_emissivity;
   for (unsigned int j = 0; j < _boundary_names.size(); ++j)
     for (unsigned int i = 0; i < nPatch(j); ++i)
       extended_emissivity.push_back(emissivity[j]);
-  params.set<std::vector<Real>>("emissivity") = extended_emissivity;
+  params.set<std::vector<FunctionName>>("emissivity") = extended_emissivity;
 
   // add boundary parameter
   std::vector<BoundaryName> boundary_names;

--- a/modules/heat_transfer/src/userobjects/GrayLambertSurfaceRadiationBase.C
+++ b/modules/heat_transfer/src/userobjects/GrayLambertSurfaceRadiationBase.C
@@ -23,7 +23,8 @@ GrayLambertSurfaceRadiationBase::validParams()
       5.670367e-8,
       "The Stefan-Boltzmann constant. Default value is in units of [W / m^2 K^4].");
   params.addRequiredCoupledVar("temperature", "The coupled temperature variable.");
-  params.addRequiredParam<std::vector<Real>>("emissivity", "Emissivities for each boundary.");
+  params.addRequiredParam<std::vector<FunctionName>>("emissivity",
+                                                     "Emissivities for each boundary.");
   params.addParam<std::vector<BoundaryName>>(
       "fixed_temperature_boundary",
       "The list of boundary IDs from the mesh with fixed temperatures.");
@@ -42,7 +43,6 @@ GrayLambertSurfaceRadiationBase::GrayLambertSurfaceRadiationBase(const InputPara
     _sigma_stefan_boltzmann(getParam<Real>("stefan_boltzmann_constant")),
     _n_sides(boundaryIDs().size()),
     _temperature(coupledValue("temperature")),
-    _emissivity(getParam<std::vector<Real>>("emissivity")),
     _radiosity(_n_sides),
     _heat_flux_density(_n_sides),
     _side_temperature(_n_sides),
@@ -51,6 +51,12 @@ GrayLambertSurfaceRadiationBase::GrayLambertSurfaceRadiationBase(const InputPara
     _beta(_n_sides),
     _surface_irradiation(_n_sides)
 {
+  // get emissivity functions
+  auto & eps_names = getParam<std::vector<FunctionName>>("emissivity");
+  _emissivity.resize(eps_names.size());
+  for (unsigned int j = 0; j < _emissivity.size(); ++j)
+    _emissivity[j] = &getFunctionByName(eps_names[j]);
+
   // set up the map from the side id to the local index & check
   // note that boundaryIDs is not in the right order anymore!
   {
@@ -158,8 +164,8 @@ GrayLambertSurfaceRadiationBase::execute()
       temp = _fixed_side_temperature[iso_index]->value(_t, _q_point[qp]);
     }
 
-    _beta[index] += _JxW[qp] * _coord[qp] * _sigma_stefan_boltzmann * _emissivity[index] *
-                    MathUtils::pow(temp, 4);
+    _beta[index] += _JxW[qp] * _coord[qp] * _sigma_stefan_boltzmann *
+                    _emissivity[index]->value(temp, Point()) * MathUtils::pow(temp, 4);
     _side_temperature[index] += _JxW[qp] * _coord[qp] * temp;
   }
 }
@@ -208,7 +214,8 @@ GrayLambertSurfaceRadiationBase::finalize()
       if (_side_type[i] == ADIABATIC)
         matrix(i, j) -= _view_factors[i][j];
       else
-        matrix(i, j) -= (1 - _emissivity[i]) * _view_factors[i][j];
+        matrix(i, j) -=
+            (1 - _emissivity[i]->value(_side_temperature[i], Point())) * _view_factors[i][j];
     }
   }
 
@@ -228,10 +235,11 @@ GrayLambertSurfaceRadiationBase::finalize()
       _heat_flux_density[i] -= _view_factors[i][j] * radiosity(j);
 
     if (_side_type[i] == ADIABATIC)
-      _side_temperature[i] =
-          std::pow((radiosity(i) + (1 - _emissivity[i]) / _emissivity[i] * _heat_flux_density[i]) /
-                       _sigma_stefan_boltzmann,
-                   0.25);
+    {
+      Real e = _emissivity[i]->value(_side_temperature[i], Point());
+      _side_temperature[i] = std::pow(
+          (radiosity(i) + (1 - e) / e * _heat_flux_density[i]) / _sigma_stefan_boltzmann, 0.25);
+    }
 
     // compute the surface irradiation into i from the radiosities
     _surface_irradiation[i] = 0;
@@ -298,9 +306,10 @@ GrayLambertSurfaceRadiationBase::getSurfaceRadiosity(BoundaryID id) const
 Real
 GrayLambertSurfaceRadiationBase::getSurfaceEmissivity(BoundaryID id) const
 {
-  if (_side_id_index.find(id) == _side_id_index.end())
+  auto p = _side_id_index.find(id);
+  if (p == _side_id_index.end())
     return 1;
-  return _emissivity[_side_id_index.find(id)->second];
+  return _emissivity[p->second]->value(_side_temperature[p->second], Point());
 }
 
 Real

--- a/modules/heat_transfer/test/tests/radiation_transfer_action/cavity_with_pillar_vf.i
+++ b/modules/heat_transfer/test/tests/radiation_transfer_action/cavity_with_pillar_vf.i
@@ -132,11 +132,18 @@
 [GrayDiffuseRadiation]
   [cavity]
     sidesets = '6 7 8 9 10 11 12 13 14 15 16'
-    emissivity = '0.8 0.8 0.8 0.8 0.8 0.8 0.8 0.8 0.8 0.8 0.8'
+    emissivity = '0.8 0.8 0.8 0.8 0.8 eps_fn 0.8 0.8 0.8 0.8 0.8'
     n_patches = '5 5 5 5 5 5 5 5 5 5 5'
     partitioners = 'metis metis metis metis metis metis metis metis metis metis metis'
     temperature = temperature
     ray_tracing_face_order = SECOND
+  []
+[]
+
+[Functions]
+  [eps_fn]
+    type = ConstantFunction
+    value = 0.8
   []
 []
 

--- a/modules/heat_transfer/test/tests/radiation_transfer_action/radiative_transfer_action_external_boundary.i
+++ b/modules/heat_transfer/test/tests/radiation_transfer_action/radiative_transfer_action_external_boundary.i
@@ -73,7 +73,7 @@
 [GrayDiffuseRadiation]
   [./cavity]
     boundary = '4 5 6 7'
-    emissivity = '0.9 0.8 0.4 1'
+    emissivity = '0.9 0.8 eps_fn 1'
     n_patches = '2 2 2 3'
     partitioners = 'centroid centroid centroid centroid'
     centroid_partitioner_directions = 'x y y x'
@@ -83,6 +83,13 @@
     fixed_boundary_temperatures = '800'
     view_factor_calculator = analytical
   [../]
+[]
+
+[Functions]
+  [eps_fn]
+    type = ConstantFunction
+    value = 0.4
+  []
 []
 
 [BCs]


### PR DESCRIPTION
closes #25941

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason

Make emissivities a function of temperature.

## Design

This is accomplished by reading Moose function object names and then evaluating
them by providing temperature as the time argument.

## Impact

None expected.


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
