### PR TITLE
Remove assertion of libMesh system number equivalence in block Jacobian computation

### DIFF
--- a/framework/src/problems/FEProblemBase.C
+++ b/framework/src/problems/FEProblemBase.C
@@ -6593,7 +6593,6 @@ FEProblemBase::computeJacobianBlock(SparseMatrix<Number> & jacobian,
   JacobianBlock jac_block(precond_system, jacobian, ivar, jvar);
   std::vector<JacobianBlock *> blocks = {&jac_block};
   mooseAssert(_current_nl_sys, "This should be non-null");
-  mooseAssert(&_current_nl_sys->system() == &precond_system, "libMesh systems should match");
   computeJacobianBlocks(blocks, _current_nl_sys->number());
 }
 


### PR DESCRIPTION
For physics based preconditioning it is expected for the user to create new libMesh systems for preconditioning individual blocks, hence we should expect the system numbers to generally be unequal instead of equal

Refs #24137