### PR TITLE
Support old Nanoflann API *and* new Nanoflann API

### DIFF
--- a/framework/include/utils/KDTree.h
+++ b/framework/include/utils/KDTree.h
@@ -16,6 +16,15 @@
 #include "libmesh/nanoflann.hpp"
 #include "libmesh/utility.h"
 
+// Make newer nanoflann API compatible with older nanoflann versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 class KDTree
 {
 public:
@@ -34,7 +43,7 @@ public:
 
   void radiusSearch(const Point & query_point,
                     Real radius,
-                    std::vector<std::pair<std::size_t, Real>> & indices_dist);
+                    std::vector<nanoflann::ResultItem<std::size_t, Real>> & indices_dist);
 
   std::size_t numberCandidatePoints();
 

--- a/framework/src/constraints/AutomaticMortarGeneration.C
+++ b/framework/src/constraints/AutomaticMortarGeneration.C
@@ -49,6 +49,15 @@
 using namespace libMesh;
 using MetaPhysicL::DualNumber;
 
+// Make newer nanoflann API spelling compatible with older nanoflann
+// versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+}
+#endif
+
 class MortarNodalGeometryOutput : public Output
 {
 public:
@@ -1109,7 +1118,7 @@ AutomaticMortarGeneration::buildMortarSegmentMesh3d()
       std::vector<Real> out_dist_sqr(num_results);
       nanoflann::KNNResultSet<Real> result_set(num_results);
       result_set.init(&ret_index[0], &out_dist_sqr[0]);
-      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParams(10));
+      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParameters(10));
 
       // Initialize list of processed primary elements, we don't want to revisit processed elements
       std::set<const Elem *, CompareDofObjectsByID> processed_primary_elems;
@@ -1918,7 +1927,7 @@ AutomaticMortarGeneration::projectSecondaryNodesSinglePair(
       std::vector<Real> out_dist_sqr(num_results);
       nanoflann::KNNResultSet<Real> result_set(num_results);
       result_set.init(&ret_index[0], &out_dist_sqr[0]);
-      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParams(10));
+      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParameters(10));
 
       // If this flag gets set in the loop below, we can break out of the outer r-loop as well.
       bool projection_succeeded = false;
@@ -2217,7 +2226,7 @@ AutomaticMortarGeneration::projectPrimaryNodesSinglePair(
       std::vector<Real> out_dist_sqr(num_results);
       nanoflann::KNNResultSet<Real> result_set(num_results);
       result_set.init(&ret_index[0], &out_dist_sqr[0]);
-      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParams(10));
+      kd_tree.findNeighbors(result_set, &query_pt[0], nanoflann::SearchParameters(10));
 
       // If this flag gets set in the loop below, we can break out of the outer r-loop as well.
       bool projection_succeeded = false;

--- a/framework/src/mesh/MooseMesh.C
+++ b/framework/src/mesh/MooseMesh.C
@@ -62,6 +62,17 @@
 static const int GRAIN_SIZE =
     1; // the grain_size does not have much influence on our execution speed
 
+// Make newer nanoflann API compatible with older nanoflann versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 InputParameters
 MooseMesh::validParams()
 {
@@ -1586,8 +1597,8 @@ MooseMesh::buildPeriodicNodeMap(std::multimap<dof_id_type, dof_id_type> & period
   kd_tree->buildIndex();
 
   // data structures for kd-tree search
-  nanoflann::SearchParams search_params;
-  std::vector<std::pair<std::size_t, Real>> ret_matches;
+  nanoflann::SearchParameters search_params;
+  std::vector<nanoflann::ResultItem<std::size_t, Real>> ret_matches;
 
   // iterate over periodic nodes (boundary ids are in contiguous blocks)
   PeriodicBoundaryBase * periodic = nullptr;

--- a/framework/src/userobjects/RadialAverage.C
+++ b/framework/src/userobjects/RadialAverage.C
@@ -20,6 +20,17 @@
 #include <iterator>
 #include <algorithm>
 
+// Make newer nanoflann API compatible with older nanoflann versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 registerMooseObject("MooseApp", RadialAverage);
 
 // specialization for PointListAdaptor<RadialAverage::QPData>
@@ -250,8 +261,8 @@ RadialAverage::updateCommunicationLists()
   mooseAssert(kd_tree != nullptr, "KDTree was not properly initialized.");
   kd_tree->buildIndex();
 
-  std::vector<std::pair<std::size_t, Real>> ret_matches;
-  nanoflann::SearchParams search_params;
+  std::vector<nanoflann::ResultItem<std::size_t, Real>> ret_matches;
+  nanoflann::SearchParameters search_params;
 
   // iterate over all boundary nodes and collect all boundary-near data points
   _boundary_data_indices.clear();

--- a/framework/src/userobjects/ThreadedRadialAverageLoop.C
+++ b/framework/src/userobjects/ThreadedRadialAverageLoop.C
@@ -10,6 +10,18 @@
 #include "ThreadedRadialAverageLoop.h"
 #include "Function.h"
 
+// Make newer nanoflann API spelling compatible with older nanoflann
+// versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 ThreadedRadialAverageLoop::ThreadedRadialAverageLoop(RadialAverage & green) : _radavg(green) {}
 
 // Splitting Constructor
@@ -29,8 +41,8 @@ ThreadedRadialAverageLoop::operator()(const QPDataRange & qpdata_range)
   const auto & weights_type = _radavg._weights_type;
 
   // tree search data structures
-  std::vector<std::pair<std::size_t, Real>> ret_matches;
-  nanoflann::SearchParams search_params;
+  std::vector<nanoflann::ResultItem<std::size_t, Real>> ret_matches;
+  nanoflann::SearchParameters search_params;
 
   // result map entry
   const auto end_it = _radavg._average.end();

--- a/framework/src/utils/KDTree.C
+++ b/framework/src/utils/KDTree.C
@@ -13,6 +13,17 @@
 #include "libmesh/nanoflann.hpp"
 #include "libmesh/point.h"
 
+// Make newer nanoflann API compatible with older nanoflann versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 KDTree::KDTree(std::vector<Point> & master_points, unsigned int max_leaf_size)
   : _point_list_adaptor(master_points.begin(), master_points.end()),
     _kd_tree(std::make_unique<KdTreeT>(
@@ -53,9 +64,9 @@ KDTree::neighborSearch(const Point & query_point,
 void
 KDTree::radiusSearch(const Point & query_point,
                      Real radius,
-                     std::vector<std::pair<std::size_t, Real>> & indices_dist)
+                     std::vector<nanoflann::ResultItem<std::size_t, Real>> & indices_dist)
 {
-  nanoflann::SearchParams sp;
+  nanoflann::SearchParameters sp;
   _kd_tree->radiusSearch(&query_point(0), radius * radius, indices_dist, sp);
 }
 

--- a/modules/contact/src/actions/ContactAction.C
+++ b/modules/contact/src/actions/ContactAction.C
@@ -29,6 +29,17 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/string_to_enum.h"
 
+// Make newer nanoflann API compatible with older nanoflann versions
+#if NANOFLANN_VERSION < 0x150
+namespace nanoflann
+{
+typedef SearchParams SearchParameters;
+
+template <typename T, typename U>
+using ResultItem = std::pair<T, U>;
+}
+#endif
+
 using NodeBoundaryIDInfo = std::pair<const Node *, BoundaryID>;
 
 // Counter for naming mortar auxiliary kernels
@@ -1291,8 +1302,8 @@ ContactAction::createSidesetsFromNodeProximity()
   kd_tree->buildIndex();
 
   // data structures for kd-tree search
-  nanoflann::SearchParams search_params;
-  std::vector<std::pair<std::size_t, Real>> ret_matches;
+  nanoflann::SearchParameters search_params;
+  std::vector<nanoflann::ResultItem<std::size_t, Real>> ret_matches;
 
   const auto radius_for_search = getParam<Real>("automatic_pairing_distance");
 


### PR DESCRIPTION
## Reason
This gets us around the chicken-and-egg problem of not being able to get the Nanoflann update in libMesh to pass MOOSE tests.

Remember to build backwards compatibility into your library API updates, kids!

## Design
Switch MOOSE usage of Nanoflann to the new API, but also add version-dependent shims in the `nanoflann` namespace which, if we're on an old version, implement the new API via the old API.

We can remove the `namespace nanoflann` shims after the update makes it into the libMesh submodule.

## Impact
The nanoflann update itself might break downstream code that's still using the old APIs.  We'll find out when we kick the libMesh update PR testing after this goes through, if so.

Refs #25904, but we can wait until the shims are gone before we close that ticket.
