### PR TITLE
Factor out common code between mooseObject and Action

### DIFF
--- a/framework/include/actions/Action.h
+++ b/framework/include/actions/Action.h
@@ -153,13 +153,6 @@ protected:
   /// Timers
   PerfID _act_timer;
 
+  // Base classes have the same name for that attribute, pick one
   using MooseBase::_app;
-  using MooseBase::_name;
-  using MooseBase::_type;
-  using MooseBaseErrorInterface::_console;
-  using MooseBaseErrorInterface::mooseDeprecated;
-  using MooseBaseErrorInterface::mooseError;
-  using MooseBaseErrorInterface::mooseWarning;
-  using MooseBaseParameterInterface::_action_factory;
-  using MooseBaseParameterInterface::_factory;
 };

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -9,6 +9,9 @@
 
 #pragma once
 #include <string>
+#include <sstream>
+
+#include "MooseApp.h"
 
 /**
  * Base class for everything in MOOSE with a name and a type.
@@ -19,32 +22,59 @@
 class MooseBase
 {
 public:
-  MooseBase(const std::string & type, const std::string & name) : _type(type), _name(name) {}
+  MooseBase(const std::string & type, const std::string & name, MooseApp * app)
+    : _type(type), _name(name), _app(*app)
+  {
+  }
 
   virtual ~MooseBase() = default;
 
   /**
-   * Get the type of this object.
-   * @return the name of the type of this object
+   * Get the MooseApp this class is associated with.
+   */
+  MooseApp & getMooseApp() const { return _app; }
+
+  /**
+   * Get the type of this class.
+   * @return the name of the type of this class
    */
   const std::string & type() const { return _type; }
 
   /**
-   * Get the name of the object
-   * @return The name of the object
+   * Get the name of the class
+   * @return The name of the class
    */
   virtual const std::string & name() const { return _name; }
 
   /**
-   * Get the object's combined type and name; useful in error handling.
-   * @return The type and name of this object in the form '<type()> "<name()>"'.
+   * Get the class's combined type and name; useful in error handling.
+   * @return The type and name of this class in the form '<type()> "<name()>"'.
    */
   std::string typeAndName() const;
 
+  /**
+   * A descriptive prefix for errors for this class:
+   *
+   * The following <error_type> occurred in the class "<name>", of type "<type>".
+   */
+  std::string errorPrefix(const std::string & error_type) const;
+
 protected:
-  /// The type of this object (the Class name)
+  /// The MOOSE application this is associated with
+  MooseApp & _app;
+
+  /// The type of this class
   const std::string & _type;
 
-  /// The name of this object, reference to value stored in InputParameters
+  /// The name of this class, reference to value stored in InputParameters
   const std::string & _name;
 };
+
+std::string
+MooseBase::errorPrefix(const std::string & error_type) const
+{
+  std::stringstream oss;
+  oss << "The following " << error_type << " occurred in the class \"" << name() << "\", of type \""
+      << type() << "\".\n\n";
+  return oss.str();
+}

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -1,0 +1,50 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+#include <string>
+
+/**
+ * Base class for everything in MOOSE with a name and a type.
+ * You will most likely want to inherit instead
+ * - MooseObject for an object created within a system
+ * - Action for a class performing a setup task, like creating objects
+ */
+class MooseBase
+{
+public:
+  MooseBase(const std::string & type, const std::string & name) : _type(type), _name(name) {}
+
+  virtual ~MooseBase() = default;
+
+  /**
+   * Get the type of this object.
+   * @return the name of the type of this object
+   */
+  const std::string & type() const { return _type; }
+
+  /**
+   * Get the name of the object
+   * @return The name of the object
+   */
+  virtual const std::string & name() const { return _name; }
+
+  /**
+   * Get the object's combined type and name; useful in error handling.
+   * @return The type and name of this object in the form '<type()> "<name()>"'.
+   */
+  std::string typeAndName() const;
+
+protected:
+  /// The type of this object (the Class name)
+  const std::string & _type;
+
+  /// The name of this object, reference to value stored in InputParameters
+  const std::string & _name;
+};

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <sstream>
 
-#include "MooseApp.h"
+class MooseApp;
 
 /**
  * Base class for everything in MOOSE with a name and a type.
@@ -22,8 +22,8 @@
 class MooseBase
 {
 public:
-  MooseBase(const std::string & type, const std::string & name, MooseApp * app)
-    : _type(type), _name(name), _app(*app)
+  MooseBase(const std::string & type, const std::string & name, MooseApp & app)
+    : _app(app), _type(type), _name(name)
   {
   }
 
@@ -52,13 +52,6 @@ public:
    */
   std::string typeAndName() const;
 
-  /**
-   * A descriptive prefix for errors for this class:
-   *
-   * The following <error_type> occurred in the class "<name>", of type "<type>".
-   */
-  std::string errorPrefix(const std::string & error_type) const;
-
 protected:
   /// The MOOSE application this is associated with
   MooseApp & _app;
@@ -69,12 +62,3 @@ protected:
   /// The name of this class, reference to value stored in InputParameters
   const std::string & _name;
 };
-
-std::string
-MooseBase::errorPrefix(const std::string & error_type) const
-{
-  std::stringstream oss;
-  oss << "The following " << error_type << " occurred in the class \"" << name() << "\", of type \""
-      << type() << "\".\n\n";
-  return oss.str();
-}

--- a/framework/include/base/MooseBase.h
+++ b/framework/include/base/MooseBase.h
@@ -8,8 +8,8 @@
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #pragma once
+
 #include <string>
-#include <sstream>
 
 class MooseApp;
 
@@ -50,7 +50,10 @@ public:
    * Get the class's combined type and name; useful in error handling.
    * @return The type and name of this class in the form '<type()> "<name()>"'.
    */
-  std::string typeAndName() const;
+  std::string typeAndName() const
+  {
+    return type() + std::string(" \"") + name() + std::string("\"");
+  }
 
 protected:
   /// The MOOSE application this is associated with

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -9,17 +9,21 @@
 
 #pragma once
 
-#include "MooseApp.h"
 #include "MooseBase.h"
+#include "ConsoleStreamInterface.h"
+
+/// Needed to break include cycle between MooseApp.h and Action.h
+class MooseApp;
+[[noreturn]] void callMooseErrorRaw(std::string & msg, MooseApp * app);
 
 /**
- * Class to handle errors
+ * Interface that provides APIs to output errors/warnings/info messages
  */
 class MooseBaseErrorInterface : public ConsoleStreamInterface
 {
 public:
   MooseBaseErrorInterface(const MooseBase * const base)
-    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()){};
+    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()), _moose_base(base){};
 
   virtual ~MooseBaseErrorInterface() = default;
 
@@ -88,14 +92,7 @@ public:
 protected:
   /// The MOOSE application this is associated with
   MooseApp & _app;
-}
 
-[[noreturn]] void
-callMooseErrorRaw(std::string & msg, MooseApp * app)
-{
-  app->getOutputWarehouse().mooseConsole();
-  std::string prefix;
-  if (!app->isUltimateMaster())
-    prefix = app->name();
-  moose::internal::mooseErrorRaw(msg, prefix);
-}
+  /// The MooseBase class deriving from this interface
+  const MooseBase * const _moose_base;
+};

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -1,0 +1,101 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MooseApp.h"
+#include "MooseBase.h"
+
+/**
+ * Class to handle errors
+ */
+class MooseBaseErrorInterface : public ConsoleStreamInterface
+{
+public:
+  MooseBaseErrorInterface(const MooseBase * const base)
+    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()){};
+
+  virtual ~MooseBaseErrorInterface() = default;
+
+  /**
+   * Emits an error prefixed with object name and type.
+   */
+  template <typename... Args>
+  [[noreturn]] void mooseError(Args &&... args) const
+  {
+    std::ostringstream oss;
+    moose::internal::mooseStreamAll(oss, errorPrefix("error"), std::forward<Args>(args)...);
+    std::string msg = oss.str();
+    callMooseErrorRaw(msg, &_app);
+  }
+
+  /**
+   * Emits an error without the prefixing included in mooseError().
+   */
+  template <typename... Args>
+  [[noreturn]] void mooseErrorNonPrefixed(Args &&... args) const
+  {
+    std::ostringstream oss;
+    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
+    std::string msg = oss.str();
+    callMooseErrorRaw(msg, &_app);
+  }
+
+  /**
+   * Emits a warning prefixed with object name and type.
+   */
+  template <typename... Args>
+  void mooseWarning(Args &&... args) const
+  {
+    moose::internal::mooseWarningStream(
+        _console, errorPrefix("warning"), std::forward<Args>(args)...);
+  }
+
+  /**
+   * Emits a warning without the prefixing included in mooseWarning().
+   */
+  template <typename... Args>
+  void mooseWarningNonPrefixed(Args &&... args) const
+  {
+    moose::internal::mooseWarningStream(_console, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  void mooseDeprecated(Args &&... args) const
+  {
+    moose::internal::mooseDeprecatedStream(_console, false, true, std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  void mooseInfo(Args &&... args) const
+  {
+    moose::internal::mooseInfoStream(_console, std::forward<Args>(args)...);
+  }
+
+  /**
+   * A descriptive prefix for errors for this object:
+   *
+   * The following <error_type> occurred in the object "<name>", of type "<type>".
+   */
+  std::string errorPrefix(const std::string & error_type) const;
+
+protected:
+  /// The MOOSE application this is associated with
+  MooseApp & _app;
+}
+
+[[noreturn]] void
+callMooseErrorRaw(std::string & msg, MooseApp * app)
+{
+  app->getOutputWarehouse().mooseConsole();
+  std::string prefix;
+  if (!app->isUltimateMaster())
+    prefix = app->name();
+  moose::internal::mooseErrorRaw(msg, prefix);
+}

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -9,8 +9,10 @@
 
 #pragma once
 
-#include "MooseBase.h"
+#include <sstream>
 #include "ConsoleStreamInterface.h"
+#include "MooseError.h"
+#include "MooseBase.h"
 
 /// Needed to break include cycle between MooseApp.h and Action.h
 class MooseApp;

--- a/framework/include/base/MooseBaseErrorInterface.h
+++ b/framework/include/base/MooseBaseErrorInterface.h
@@ -25,7 +25,9 @@ class MooseBaseErrorInterface : public ConsoleStreamInterface
 {
 public:
   MooseBaseErrorInterface(const MooseBase * const base)
-    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()), _moose_base(base){};
+    : ConsoleStreamInterface(base->getMooseApp()), _app(base->getMooseApp()), _moose_base(base)
+  {
+  }
 
   virtual ~MooseBaseErrorInterface() = default;
 
@@ -91,7 +93,7 @@ public:
    */
   std::string errorPrefix(const std::string & error_type) const;
 
-protected:
+private:
   /// The MOOSE application this is associated with
   MooseApp & _app;
 

--- a/framework/include/base/MooseBaseParameterInterface.h
+++ b/framework/include/base/MooseBaseParameterInterface.h
@@ -154,9 +154,6 @@ public:
                                  const std::string & object_parameter) const;
 
 protected:
-  /// The MooseBase object that inherits this class
-  const MooseBase * _moose_base;
-
   /// Parameters of this object, references the InputParameters stored in the InputParametersWarehouse
   const InputParameters & _pars;
 
@@ -167,6 +164,9 @@ protected:
   ActionFactory & _action_factory;
 
 private:
+  /// The MooseBase object that inherits this class
+  const MooseBase * const _moose_base;
+
   template <typename... Args>
   std::string paramErrorMsg(const std::string & param, Args... args) const
   {

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -53,23 +53,10 @@ public:
    */
   virtual bool enabled() const { return _enabled; }
 
-  using MooseBaseErrorInterface::_console;
-  using MooseBaseErrorInterface::mooseDeprecated;
-  using MooseBaseErrorInterface::mooseError;
-  using MooseBaseErrorInterface::mooseWarning;
-  using MooseBaseParameterInterface::getCheckedPointerParam;
-  using MooseBaseParameterInterface::getParam;
-  using MooseBaseParameterInterface::paramError;
-  using MooseBaseParameterInterface::paramInfo;
-  using MooseBaseParameterInterface::paramWarning;
-
 protected:
   /// Reference to the "enable" InputParameters, used by Controls for toggling on/off MooseObjects
   const bool & _enabled;
 
+  // Base classes have the same name for that attribute, pick one
   using MooseBase::_app;
-  using MooseBase::_name;
-  using MooseBase::_type;
-  using MooseBaseParameterInterface::_action_factory;
-  using MooseBaseParameterInterface::_factory;
 };

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -11,6 +11,8 @@
 
 // MOOSE includes
 #include "MooseBase.h"
+#include "MooseBaseParameterInterface.h"
+#include "MooseBaseErrorInterface.h"
 #include "InputParameters.h"
 #include "ConsoleStreamInterface.h"
 #include "Registry.h"
@@ -25,16 +27,6 @@
   using MooseObject::isParamSetByUser;                                                             \
   using MooseObject::paramError
 
-class MooseApp;
-
-/**
- * Get canonical paramError prefix for param-related error/warning/info messages.
- *
- * Use this for building custom messages when the default paramError isn't
- * quite what you need.
- */
-std::string paramErrorPrefix(const InputParameters & params, const std::string & param);
-
 // helper macro to explicitly instantiate AD classes
 #define adBaseClass(X)                                                                             \
   template class X<RESIDUAL>;                                                                      \
@@ -44,7 +36,8 @@ std::string paramErrorPrefix(const InputParameters & params, const std::string &
  * Every object that can be built by the factory should be derived from this class.
  */
 class MooseObject : public MooseBase,
-                    public ConsoleStreamInterface,
+                    public MooseBaseParameterInterface,
+                    public MooseBaseErrorInterface,
                     public libMesh::ParallelObject,
                     public DataFileInterface<MooseObject>
 {
@@ -56,267 +49,27 @@ public:
   virtual ~MooseObject() = default;
 
   /**
-   * The unique parameter name of a valid parameter of this object for accessing parameter controls
-   */
-  MooseObjectParameterName uniqueParameterName(const std::string & parameter_name) const
-  {
-    return MooseObjectParameterName(_pars.get<std::string>("_moose_base"), _name, parameter_name);
-  }
-
-  /**
-   * Get the parameters of the object
-   * @return The parameters of the object
-   */
-  const InputParameters & parameters() const { return _pars; }
-
-  /**
-   * Retrieve a parameter for the object
-   * @param name The name of the parameter
-   * @return The value of the parameter
-   */
-  template <typename T>
-  const T & getParam(const std::string & name) const;
-
-  /**
-   * Retrieve a renamed parameter for the object. This helper makes sure we
-   * check both names before erroring, and that only one parameter is passed to avoid
-   * silent errors
-   * @param old_name the old name for the parameter
-   * @param new_name the new name for the parameter
-   */
-  template <typename T>
-  const T & getRenamedParam(const std::string & old_name, const std::string & new_name) const;
-
-  /**
-   * Retrieve two parameters and provide pair of parameters for the object
-   * @param param1 The name of first parameter
-   * @param param2 The name of second parameter
-   * @return Vector of pairs of first and second parameters
-   */
-  template <typename T1, typename T2>
-  std::vector<std::pair<T1, T2>> getParam(const std::string & param1,
-                                          const std::string & param2) const;
-
-  /**
-   * Verifies that the requested parameter exists and is not NULL and returns it to the caller.
-   * The template parameter must be a pointer or an error will be thrown.
-   */
-  template <typename T>
-  T getCheckedPointerParam(const std::string & name, const std::string & error_string = "") const;
-
-  /**
-   * Test if the supplied parameter is valid
-   * @param name The name of the parameter to test
-   */
-  inline bool isParamValid(const std::string & name) const { return _pars.isParamValid(name); }
-
-  /**
-   * Test if the supplied parameter is set by a user, as opposed to not set or set to default
-   * @param nm The name of the parameter to test
-   */
-  inline bool isParamSetByUser(const std::string & nm) const { return _pars.isParamSetByUser(nm); }
-
-  /**
    * Return the enabled status of the object.
    */
   virtual bool enabled() const { return _enabled; }
 
-  /**
-   * Emits an error prefixed with the file and line number of the given param (from the input
-   * file) along with the full parameter path+name followed by the given args as the message.
-   * If this object's parameters were not created directly by the Parser, then this function falls
-   * back to the normal behavior of mooseError - only printing a message using the given args.
-   */
-  template <typename... Args>
-  [[noreturn]] void paramError(const std::string & param, Args... args) const;
-
-  /**
-   * Emits a warning prefixed with the file and line number of the given param (from the input
-   * file) along with the full parameter path+name followed by the given args as the message.
-   * If this object's parameters were not created directly by the Parser, then this function falls
-   * back to the normal behavior of mooseWarning - only printing a message using the given args.
-   */
-  template <typename... Args>
-  void paramWarning(const std::string & param, Args... args) const;
-
-  /**
-   * Emits an informational message prefixed with the file and line number of the given param
-   * (from the input file) along with the full parameter path+name followed by the given args as
-   * the message.  If this object's parameters were not created directly by the Parser, then this
-   * function falls back to the normal behavior of mooseInfo - only printing a message using
-   * the given args.
-   */
-  template <typename... Args>
-  void paramInfo(const std::string & param, Args... args) const;
-
-  /**
-   * Emits an error prefixed with object name and type.
-   */
-  template <typename... Args>
-  [[noreturn]] void mooseError(Args &&... args) const
-  {
-    std::ostringstream oss;
-    moose::internal::mooseStreamAll(oss, errorPrefix("error"), std::forward<Args>(args)...);
-    std::string msg = oss.str();
-    callMooseErrorRaw(msg, &_app);
-  }
-
-  /**
-   * Emits an error without the prefixing included in mooseError().
-   */
-  template <typename... Args>
-  [[noreturn]] void mooseErrorNonPrefixed(Args &&... args) const
-  {
-    std::ostringstream oss;
-    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
-    std::string msg = oss.str();
-    callMooseErrorRaw(msg, &_app);
-  }
-
-  /**
-   * Emits a warning prefixed with object name and type.
-   */
-  template <typename... Args>
-  void mooseWarning(Args &&... args) const
-  {
-    moose::internal::mooseWarningStream(
-        _console, errorPrefix("warning"), std::forward<Args>(args)...);
-  }
-
-  /**
-   * Emits a warning without the prefixing included in mooseWarning().
-   */
-  template <typename... Args>
-  void mooseWarningNonPrefixed(Args &&... args) const
-  {
-    moose::internal::mooseWarningStream(_console, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args>
-  void mooseDeprecated(Args &&... args) const
-  {
-    moose::internal::mooseDeprecatedStream(_console, false, true, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args>
-  void mooseInfo(Args &&... args) const
-  {
-    moose::internal::mooseInfoStream(_console, std::forward<Args>(args)...);
-  }
-
-  /**
-   * A descriptive prefix for errors for this object:
-   *
-   * The following <error_type> occurred in the object "<name>", of type "<type>".
-   */
-  std::string errorPrefix(const std::string & error_type) const;
+  using MooseBaseErrorInterface::_console;
+  using MooseBaseErrorInterface::mooseDeprecated;
+  using MooseBaseErrorInterface::mooseError;
+  using MooseBaseErrorInterface::mooseWarning;
+  using MooseBaseParameterInterface::getCheckedPointerParam;
+  using MooseBaseParameterInterface::getParam;
+  using MooseBaseParameterInterface::paramError;
+  using MooseBaseParameterInterface::paramInfo;
+  using MooseBaseParameterInterface::paramWarning;
 
 protected:
-  /// Parameters of this object, references the InputParameters stored in the InputParametersWarehouse
-  const InputParameters & _pars;
-
-  /// The MooseApp this object is associated with
-  MooseApp & _app;
-
   /// Reference to the "enable" InputParameters, used by Controls for toggling on/off MooseObjects
   const bool & _enabled;
 
-private:
-  template <typename... Args>
-  std::string paramErrorMsg(const std::string & param, Args... args) const
-  {
-    auto param_prefix = paramErrorPrefix(_pars, param);
-
-    // With no input location information, append object info (name + type)
-    const std::string object_prefix =
-        _pars.inputLocation(param).empty() ? errorPrefix("parameter error") : "";
-
-    std::ostringstream oss;
-    moose::internal::mooseStreamAll(oss, std::forward<Args>(args)...);
-    std::string msg = oss.str();
-
-    // Wrap error message to a separate line from param_prefix if it is about to
-    // blow past 100 chars.  But only wrap if the param_prefix is long enough (12
-    // chars) for the wrap to buy us much extra length. We don't check object_prefix
-    // here because it will go before the parameter error
-    if ((param_prefix.size() > 12 && msg.size() + param_prefix.size() > 99) ||
-        msg.find("\n") != std::string::npos)
-    {
-      if (param_prefix.size() > 0 && param_prefix[param_prefix.size() - 1] != ':')
-        param_prefix += ":";
-      return object_prefix + param_prefix + "\n    " + MooseUtils::replaceAll(msg, "\n", "\n    ");
-    }
-    return object_prefix + param_prefix + " " + msg;
-  }
+  using MooseBase::_app;
+  using MooseBase::_name;
+  using MooseBase::_type;
+  using MooseBaseParameterInterface::_action_factory;
+  using MooseBaseParameterInterface::_factory;
 };
-
-template <typename T>
-const T &
-MooseObject::getParam(const std::string & name) const
-{
-  return InputParameters::getParamHelper(name, _pars, static_cast<T *>(0));
-}
-
-template <typename T>
-const T &
-MooseObject::getRenamedParam(const std::string & old_name, const std::string & new_name) const
-{
-  // this enables having a default on the new parameter but bypassing it with the old one
-  // Most important: accept new parameter
-  if (isParamSetByUser(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
-  // Second most: accept old parameter
-  else if (isParamValid(old_name) && !isParamSetByUser(new_name))
-    return InputParameters::getParamHelper(old_name, _pars, static_cast<T *>(0));
-  // Third most: accept default for new parameter
-  else if (isParamValid(new_name) && !isParamValid(old_name))
-    return InputParameters::getParamHelper(new_name, _pars, static_cast<T *>(0));
-  // Refuse: no default, no value passed
-  else if (!isParamValid(old_name) && !isParamValid(new_name))
-    mooseError(_pars.blockFullpath() + ": parameter '" + new_name +
-               "' is being retrieved without being set.\n"
-               "Did you mispell it?");
-  // Refuse: both old and new parameters set by user
-  else
-    mooseError(_pars.blockFullpath() + ": parameter '" + new_name +
-               "' may not be provided alongside former parameter '" + old_name + "'");
-}
-
-template <typename... Args>
-[[noreturn]] void
-MooseObject::paramError(const std::string & param, Args... args) const
-{
-  Moose::show_trace = false;
-  std::string msg = paramErrorMsg(param, std::forward<Args>(args)...);
-  callMooseErrorRaw(msg, &_app);
-  Moose::show_trace = true;
-}
-
-template <typename... Args>
-void
-MooseObject::paramWarning(const std::string & param, Args... args) const
-{
-  mooseWarning(paramErrorMsg(param, std::forward<Args>(args)...));
-}
-
-template <typename... Args>
-void
-MooseObject::paramInfo(const std::string & param, Args... args) const
-{
-  mooseInfo(paramErrorMsg(param, std::forward<Args>(args)...));
-}
-
-template <typename T1, typename T2>
-std::vector<std::pair<T1, T2>>
-MooseObject::getParam(const std::string & param1, const std::string & param2) const
-{
-  return _pars.get<T1, T2>(param1, param2);
-}
-
-template <typename T>
-T
-MooseObject::getCheckedPointerParam(const std::string & name,
-                                    const std::string & error_string) const
-{
-  return parameters().getCheckedPointerParam<T>(name, error_string);
-}

--- a/framework/include/base/MooseObject.h
+++ b/framework/include/base/MooseObject.h
@@ -10,6 +10,7 @@
 #pragma once
 
 // MOOSE includes
+#include "MooseBase.h"
 #include "InputParameters.h"
 #include "ConsoleStreamInterface.h"
 #include "Registry.h"
@@ -44,7 +45,8 @@ std::string paramErrorPrefix(const InputParameters & params, const std::string &
 /**
  * Every object that can be built by the factory should be derived from this class.
  */
-class MooseObject : public ConsoleStreamInterface,
+class MooseObject : public MooseBase,
+                    public ConsoleStreamInterface,
                     public libMesh::ParallelObject,
                     public DataFileInterface<MooseObject>
 {
@@ -56,30 +58,12 @@ public:
   virtual ~MooseObject() = default;
 
   /**
-   * Get the type of this object.
-   * @return the name of the type of this object
-   */
-  const std::string & type() const { return _type; }
-
-  /**
-   * Get the name of the object
-   * @return The name of the object
-   */
-  virtual const std::string & name() const { return _name; }
-
-  /**
    * The unique parameter name of a valid parameter of this object for accessing parameter controls
    */
   MooseObjectParameterName uniqueParameterName(const std::string & parameter_name) const
   {
     return MooseObjectParameterName(_pars.get<std::string>("_moose_base"), _name, parameter_name);
   }
-
-  /**
-   * Get the object's combined type and name; useful in error handling.
-   * @return The type and name of this object in the form '<type()> "<name()>"'.
-   */
-  std::string typeAndName() const;
 
   /**
    * Get the parameters of the object
@@ -241,13 +225,7 @@ protected:
   /// The MooseApp this object is associated with
   MooseApp & _app;
 
-  /// The type of this object (the Class name)
-  const std::string & _type;
-
-  /// The name of this object, reference to value stored in InputParameters
-  const std::string & _name;
-
-  /// Reference to the "enable" InputParaemters, used by Controls for toggling on/off MooseObjects
+  /// Reference to the "enable" InputParameters, used by Controls for toggling on/off MooseObjects
   const bool & _enabled;
 
 private:

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -40,7 +40,12 @@ Action::validParams()
 }
 
 Action::Action(const InputParameters & parameters)
-  : MooseBase(getParam<std::string>("action_type"), getParam<std::string>("_action_name")),
+  : MooseBase(
+        parameters.get<std::string>("action_type"),
+        parameters.get<std::string>("_action_name"),
+        *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
+    MooseBaseParameterInterface(parameters, this),
+    MooseBaseErrorInterface(this),
     MeshMetaDataInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     PerfGraphInterface(
@@ -58,13 +63,9 @@ Action::Action(const InputParameters & parameters)
                  : "")),
     ParallelObject(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     DataFileInterface<Action>(*this),
-    _pars(parameters),
     _registered_identifier(isParamValid("registered_identifier")
                                ? getParam<std::string>("registered_identifier")
                                : ""),
-    _app(*getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
-    _factory(_app.getFactory()),
-    _action_factory(_app.getActionFactory()),
     _specific_task_name(_pars.isParamValid("task") ? getParam<std::string>("task") : ""),
     _awh(*getCheckedPointerParam<ActionWarehouse *>("awh")),
     _current_task(_awh.getCurrentTaskName()),
@@ -150,28 +151,4 @@ Action::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type,
   }
 
   return added;
-}
-
-void
-Action::connectControllableParams(const std::string & parameter,
-                                  const std::string & object_type,
-                                  const std::string & object_name,
-                                  const std::string & object_parameter) const
-{
-  MooseObjectParameterName primary_name(uniqueActionName(), parameter);
-  auto base_type = _factory.getValidParams(object_type).get<std::string>("_moose_base");
-  MooseObjectParameterName secondary_name(base_type, object_name, object_parameter);
-  _app.getInputParameterWarehouse().addControllableParameterConnection(primary_name,
-                                                                       secondary_name);
-
-  const std::vector<std::string> & tags = _pars.get<std::vector<std::string>>("control_tags");
-  for (const auto & tag : tags)
-  {
-    if (!tag.empty())
-    {
-      MooseObjectParameterName tagged_name(tag, _name, parameter);
-      _app.getInputParameterWarehouse().addControllableParameterConnection(tagged_name,
-                                                                           secondary_name);
-    }
-  }
 }

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -41,8 +41,6 @@ Action::validParams()
 
 Action::Action(const InputParameters & parameters)
   : MooseBase(getParam<std::string>("action_type"), getParam<std::string>("_action_name")),
-    ConsoleStreamInterface(
-        *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     MeshMetaDataInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     PerfGraphInterface(

--- a/framework/src/actions/Action.C
+++ b/framework/src/actions/Action.C
@@ -40,7 +40,8 @@ Action::validParams()
 }
 
 Action::Action(const InputParameters & parameters)
-  : ConsoleStreamInterface(
+  : MooseBase(getParam<std::string>("action_type"), getParam<std::string>("_action_name")),
+    ConsoleStreamInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     MeshMetaDataInterface(
         *parameters.getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
@@ -63,8 +64,6 @@ Action::Action(const InputParameters & parameters)
     _registered_identifier(isParamValid("registered_identifier")
                                ? getParam<std::string>("registered_identifier")
                                : ""),
-    _name(getParam<std::string>("_action_name")),
-    _action_type(getParam<std::string>("action_type")),
     _app(*getCheckedPointerParam<MooseApp *>("_moose_app", "In Action constructor")),
     _factory(_app.getFactory()),
     _action_factory(_app.getActionFactory()),
@@ -128,7 +127,10 @@ Action::addRelationshipManager(
   return added;
 }
 
-void Action::addRelationshipManagers(Moose::RelationshipManagerType) {}
+void
+Action::addRelationshipManagers(Moose::RelationshipManagerType)
+{
+}
 
 bool
 Action::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type,
@@ -150,21 +152,6 @@ Action::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type,
   }
 
   return added;
-}
-
-/// DEPRECATED METHODS
-std::string
-Action::getShortName() const
-{
-  mooseDeprecated("getShortName() is deprecated.");
-  return MooseUtils::shortName(_name);
-}
-
-std::string
-Action::getBaseName() const
-{
-  mooseDeprecated("getBaseName() is deprecated.");
-  return MooseUtils::baseName(_name);
 }
 
 void

--- a/framework/src/actions/AddVariableAction.C
+++ b/framework/src/actions/AddVariableAction.C
@@ -235,8 +235,8 @@ AddVariableAction::createInitialConditionAction()
 std::string
 AddVariableAction::determineType(const FEType & fe_type, unsigned int components, bool is_fv)
 {
-  mooseDeprecated("AddVariableAction::determineType() is deprecated. Use "
-                  "AddVariableAction::variableType() instead.");
+  ::mooseDeprecated("AddVariableAction::determineType() is deprecated. Use "
+                    "AddVariableAction::variableType() instead.");
   return variableType(fe_type, is_fv, components > 1);
 }
 
@@ -250,7 +250,7 @@ AddVariableAction::variableType(const FEType & fe_type, const bool is_fv, const 
   {
     if (fe_type.family == LAGRANGE_VEC || fe_type.family == NEDELEC_ONE ||
         fe_type.family == MONOMIAL_VEC)
-      mooseError("Vector finite element families do not currently have ArrayVariable support");
+      ::mooseError("Vector finite element families do not currently have ArrayVariable support");
     else
       return "ArrayMooseVariable";
   }

--- a/framework/src/actions/CouplingFunctorCheckAction.C
+++ b/framework/src/actions/CouplingFunctorCheckAction.C
@@ -23,13 +23,14 @@ registerMooseAction("MooseApp", CouplingFunctorCheckAction, "coupling_functor_ch
 InputParameters
 CouplingFunctorCheckAction::validParams()
 {
+  auto params = Action::validParams();
+  params.set<std::string>("_action_name") = "coupling_functor_check";
   return Action::validParams();
 }
 
 CouplingFunctorCheckAction::CouplingFunctorCheckAction(const InputParameters & parameters)
   : Action(parameters)
 {
-  _name = "coupling_functor_check";
 }
 
 void

--- a/framework/src/base/MooseBaseErrorInterface.C
+++ b/framework/src/base/MooseBaseErrorInterface.C
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "MooseBaseErrorInterface.h"
+#include "MooseBase.h"
+
+std::string
+MooseBaseErrorInterface::errorPrefix(const std::string & error_type) const
+{
+  std::stringstream oss;
+  oss << "The following " << error_type << " occurred in the class \"" << _moose_base->name()
+      << "\", of type \"" << _moose_base->type() << "\".\n\n";
+  return oss.str();
+}
+
+[[noreturn]] void
+callMooseErrorRaw(std::string & msg, MooseApp * app)
+{
+  app->getOutputWarehouse().mooseConsole();
+  std::string prefix;
+  if (!app->isUltimateMaster())
+    prefix = app->name();
+  moose::internal::mooseErrorRaw(msg, prefix);
+}

--- a/framework/src/base/MooseBaseErrorInterface.C
+++ b/framework/src/base/MooseBaseErrorInterface.C
@@ -9,12 +9,13 @@
 
 #include "MooseBaseErrorInterface.h"
 #include "MooseBase.h"
+#include "MooseApp.h"
 
 std::string
 MooseBaseErrorInterface::errorPrefix(const std::string & error_type) const
 {
   std::stringstream oss;
-  oss << "The following " << error_type << " occurred in the class \"" << _moose_base->name()
+  oss << "The following " << error_type << " occurred in the object \"" << _moose_base->name()
       << "\", of type \"" << _moose_base->type() << "\".\n\n";
   return oss.str();
 }

--- a/framework/src/base/MooseBaseParameterInterface.C
+++ b/framework/src/base/MooseBaseParameterInterface.C
@@ -22,11 +22,11 @@ paramErrorPrefix(const InputParameters & params, const std::string & param)
 }
 
 MooseBaseParameterInterface::MooseBaseParameterInterface(const InputParameters & parameters,
-                                                         const MooseBase * base)
-  : _moose_base(base),
-    _pars(parameters),
+                                                         const MooseBase * const base)
+  : _pars(parameters),
     _factory(base->getMooseApp().getFactory()),
-    _action_factory(base->getMooseApp().getActionFactory())
+    _action_factory(base->getMooseApp().getActionFactory()),
+    _moose_base(base)
 {
 }
 
@@ -37,12 +37,12 @@ MooseBaseParameterInterface::connectControllableParams(const std::string & param
                                                        const std::string & object_parameter) const
 {
   MooseObjectParameterName primary_name(uniqueName(), parameter);
-  auto base_type = _factory.getValidParams(object_type).get<std::string>("_moose_base");
+  const auto base_type = _factory.getValidParams(object_type).get<std::string>("_moose_base");
   MooseObjectParameterName secondary_name(base_type, object_name, object_parameter);
   _moose_base->getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
       primary_name, secondary_name);
 
-  const std::vector<std::string> & tags = _pars.get<std::vector<std::string>>("control_tags");
+  const auto & tags = _pars.get<std::vector<std::string>>("control_tags");
   for (const auto & tag : tags)
   {
     if (!tag.empty())

--- a/framework/src/base/MooseBaseParameterInterface.C
+++ b/framework/src/base/MooseBaseParameterInterface.C
@@ -1,0 +1,64 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+// MOOSE includes
+#include "MooseBaseParameterInterface.h"
+#include "MooseObjectParameterName.h"
+#include "MooseApp.h"
+#include "MooseUtils.h"
+#include "MooseBase.h"
+#include "InputParameterWarehouse.h"
+
+std::string
+paramErrorPrefix(const InputParameters & params, const std::string & param)
+{
+  return params.errorPrefix(param);
+}
+
+MooseBaseParameterInterface::MooseBaseParameterInterface(const InputParameters & parameters,
+                                                         const MooseBase * base)
+  : _moose_base(base),
+    _pars(parameters),
+    _factory(base->getMooseApp().getFactory()),
+    _action_factory(base->getMooseApp().getActionFactory())
+{
+}
+
+void
+MooseBaseParameterInterface::connectControllableParams(const std::string & parameter,
+                                                       const std::string & object_type,
+                                                       const std::string & object_name,
+                                                       const std::string & object_parameter) const
+{
+  MooseObjectParameterName primary_name(uniqueName(), parameter);
+  auto base_type = _factory.getValidParams(object_type).get<std::string>("_moose_base");
+  MooseObjectParameterName secondary_name(base_type, object_name, object_parameter);
+  _moose_base->getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
+      primary_name, secondary_name);
+
+  const std::vector<std::string> & tags = _pars.get<std::vector<std::string>>("control_tags");
+  for (const auto & tag : tags)
+  {
+    if (!tag.empty())
+    {
+      MooseObjectParameterName tagged_name(tag, _moose_base->name(), parameter);
+      _moose_base->getMooseApp().getInputParameterWarehouse().addControllableParameterConnection(
+          tagged_name, secondary_name);
+    }
+  }
+}
+
+std::string
+MooseBaseParameterInterface::objectErrorPrefix(const std::string & error_type) const
+{
+  std::stringstream oss;
+  oss << "The following " << error_type << " occurred in the class \"" << _moose_base->name()
+      << "\", of type \"" << _moose_base->type() << "\".\n\n";
+  return oss.str();
+}

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -60,22 +60,3 @@ MooseObject::MooseObject(const InputParameters & parameters)
     _enabled(getParam<bool>("enable"))
 {
 }
-
-[[noreturn]] void
-callMooseErrorRaw(std::string & msg, MooseApp * app)
-{
-  app->getOutputWarehouse().mooseConsole();
-  std::string prefix;
-  if (!app->isUltimateMaster())
-    prefix = app->name();
-  moose::internal::mooseErrorRaw(msg, prefix);
-}
-
-std::string
-MooseObject::errorPrefix(const std::string & error_type) const
-{
-  std::stringstream oss;
-  oss << "The following " << error_type << " occurred in the object \"" << name()
-      << "\", of type \"" << type() << "\".\n\n";
-  return oss.str();
-}

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -51,13 +51,12 @@ MooseObject::validParams()
 }
 
 MooseObject::MooseObject(const InputParameters & parameters)
-  : ConsoleStreamInterface(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
+  : MooseBase(getParam<std::string>("_type"), getParam<std::string>("_object_name")),
+    ConsoleStreamInterface(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     ParallelObject(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     DataFileInterface<MooseObject>(*this),
     _pars(parameters),
     _app(*getCheckedPointerParam<MooseApp *>("_moose_app")),
-    _type(getParam<std::string>("_type")),
-    _name(getParam<std::string>("_object_name")),
     _enabled(getParam<bool>("enable"))
 {
 }
@@ -79,10 +78,4 @@ MooseObject::errorPrefix(const std::string & error_type) const
   oss << "The following " << error_type << " occurred in the object \"" << name()
       << "\", of type \"" << type() << "\".\n\n";
   return oss.str();
-}
-
-std::string
-MooseObject::typeAndName() const
-{
-  return type() + std::string(" \"") + name() + std::string("\"");
 }

--- a/framework/src/base/MooseObject.C
+++ b/framework/src/base/MooseObject.C
@@ -20,12 +20,6 @@ class SystemBase;
 class AuxiliarySystem;
 class Transient;
 
-std::string
-paramErrorPrefix(const InputParameters & params, const std::string & param)
-{
-  return params.errorPrefix(param);
-}
-
 InputParameters
 MooseObject::validParams()
 {
@@ -51,12 +45,13 @@ MooseObject::validParams()
 }
 
 MooseObject::MooseObject(const InputParameters & parameters)
-  : MooseBase(getParam<std::string>("_type"), getParam<std::string>("_object_name")),
-    ConsoleStreamInterface(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
+  : MooseBase(parameters.get<std::string>("_type"),
+              parameters.get<std::string>("_object_name"),
+              *parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
+    MooseBaseParameterInterface(parameters, this),
+    MooseBaseErrorInterface(this),
     ParallelObject(*parameters.getCheckedPointerParam<MooseApp *>("_moose_app")),
     DataFileInterface<MooseObject>(*this),
-    _pars(parameters),
-    _app(*getCheckedPointerParam<MooseApp *>("_moose_app")),
     _enabled(getParam<bool>("enable"))
 {
 }


### PR DESCRIPTION
So much factored from mooseobject we could almost make an Action a MooseObject!

This could be an alternate design but:
- it still keeps the class a little thick if we dont create interfaces
- there's a lot of parameters that dont belong for Action so we would not inherit the validParams

Another one could be to to use templating of the interfaces based on the base class MooseObject / Action.
But we would not gain much, since it already works without, at the cost of added code complexity