### PR TITLE
Missing argument when creating Conda env

### DIFF
--- a/modules/doc/content/getting_started/installation/true_update_conda.md
+++ b/modules/doc/content/getting_started/installation/true_update_conda.md
@@ -3,7 +3,7 @@ Update Conda:
 !package! code
 mamba activate base
 mamba env remove -n moose
-mamba create moose moose-dev=__MOOSE_DEV__
+mamba create -n moose moose-dev=__MOOSE_DEV__
 mamba activate moose
 !package-end!
 


### PR DESCRIPTION
add the missing name argument when instructing users how to create a Conda environment.

Closes #26009
