### PR TITLE
Minor improvements on eigenvalue executioner

### DIFF
--- a/framework/include/problems/EigenProblem.h
+++ b/framework/include/problems/EigenProblem.h
@@ -234,6 +234,11 @@ public:
    */
   bool bxNormProvided() const { return _bx_norm_name.has_value(); }
 
+  /**
+   * Set the Bx norm postprocessor programatically
+   */
+  void setBxNorm(const PostprocessorName & bx_norm) { _bx_norm_name = bx_norm; }
+
 protected:
   unsigned int _n_eigen_pairs_required;
   bool _generalized_eigenvalue_problem;
@@ -284,7 +289,7 @@ private:
 
   /// The name of the Postprocessor providing the Bx norm. This may be empty in which case the
   /// default L2 norm of Bx will be used as the Bx norm
-  const std::optional<PostprocessorName> _bx_norm_name;
+  std::optional<PostprocessorName> _bx_norm_name;
 
 #endif
 

--- a/framework/src/utils/SlepcSupport.C
+++ b/framework/src/utils/SlepcSupport.C
@@ -501,6 +501,9 @@ slepcSetOptions(EigenProblem & eigen_problem, const InputParameters & params)
   // can be overriden
   setSlepcEigenSolverTolerances(eigen_problem, params);
   setEigenSolverOptions(eigen_problem.solverParams(), params);
+  // when Bx norm postprocessor is provided, we switch off the sign normalization
+  if (eigen_problem.bxNormProvided())
+    Moose::PetscSupport::setSinglePetscOption("-eps_power_sign_normalization", "0");
   setEigenProblemOptions(eigen_problem.solverParams());
   setWhichEigenPairsOptions(eigen_problem.solverParams());
   Moose::PetscSupport::addPetscOptionsFromCommandline();

--- a/test/tests/executioners/eigen_convergence/tests
+++ b/test/tests/executioners/eigen_convergence/tests
@@ -25,7 +25,7 @@
     input = 'a.i'
     expect_out = '7 Nonlinear'
     absent_out = '8 Nonlinear'
-    cli_args = 'Problem/bx_norm=fluxintegral'
+    cli_args = 'Problem/bx_norm=fluxintegral -eps_power_sign_normalization 1'
     petsc_version = '>=3.20.0'
     requirement = 'The system shall be able to solve an eigenvalue problem using the sign of the first nonzero entry of Bx combined with something other than the L2 norm of Bx for normalization with a SLEPc eigenvalue solver.'
   []
@@ -36,7 +36,7 @@
     input = 'a.i'
     expect_out = '4 Nonlinear'
     absent_out = '5 Nonlinear'
-    cli_args = 'Problem/bx_norm=fluxintegral -eps_power_sign_normalization 0'
+    cli_args = 'Problem/bx_norm=fluxintegral'
     petsc_version = '>=3.20.0'
     requirement = 'The system shall be able to solve an eigenvalue problem using something other than the L2 norm of Bx for normalization and a SLEPc eigenvalue solver.'
   []


### PR DESCRIPTION
Refer to #20095.

This allow applications to programmatically set bx postprocessor and switch the sign off when bx postprocessor is used. I also tested this in Griffin for calling `setBxNorm` and it works as expected. I will push that up as well in Griffin. Tag @lindsayad 
