### PR TITLE
Adding the post trace and upating the documentation page for RayKernel

### DIFF
--- a/modules/ray_tracing/doc/content/syntax/RayKernels/index.md
+++ b/modules/ray_tracing/doc/content/syntax/RayKernels/index.md
@@ -17,7 +17,7 @@ The remainder of the discussion focuses on the use of the functionality offered 
 
 ## Using a RayKernel
 
-The method that is called on each segment of a [Ray.md] in a RayKernel is `onSegment()`. This method is to be overridden to specialize the on-segment operation. The `preTrace()` method is also available to be overridden and is called before a trace begins on a processor/thread.
+The method that is called on each segment of a [Ray.md] in a RayKernel is `onSegment()`. This method is to be overridden to specialize the on-segment operation. The `preTrace()` method is also available to be overridden and is called before a trace begins on a processor/thread. After the ray has finished its trace the `postTrace()` method is called, this method is also available to be overridden.
 
 The significant information pertaining to the trace that is available within `onSegment()` is as follows:
 

--- a/modules/ray_tracing/include/raykernels/RayKernelBase.h
+++ b/modules/ray_tracing/include/raykernels/RayKernelBase.h
@@ -64,6 +64,11 @@ public:
   virtual void preTrace();
 
   /**
+   * This method is called once a ray has reached the end of its trace.
+   */
+  virtual void postTrace();
+
+  /**
    * Whether or not this RayKernel needs a segment reinit
    */
   bool needSegmentReinit() const { return _need_segment_reinit; }

--- a/modules/ray_tracing/src/raykernels/RayKernelBase.C
+++ b/modules/ray_tracing/src/raykernels/RayKernelBase.C
@@ -121,3 +121,8 @@ void
 RayKernelBase::preTrace()
 {
 }
+
+void
+RayKernelBase::postTrace()
+{
+}

--- a/modules/ray_tracing/src/raytracing/TraceRay.C
+++ b/modules/ray_tracing/src/raytracing/TraceRay.C
@@ -1602,6 +1602,9 @@ TraceRay::trace(const std::shared_ptr<Ray> & ray)
 void
 TraceRay::onCompleteTrace(const std::shared_ptr<Ray> & ray)
 {
+  for (RayKernelBase * rk : _study.currentRayKernels(_tid))
+    rk->postTrace();
+
   debugRay("Called onCompleteTrace()\n", (*_current_ray)->getInfo());
   if (_intersection_distance > 0)
     possiblyAddDebugRayMeshPoint(_incoming_point, _intersection_point);


### PR DESCRIPTION
closes  #26019
## Reason

Will enable PIC capabilities to track which element particles end in. 

## Design
Created a virtual method in RayKernel with a default implementation that does nothing. 
Added a call to postTrace in TraceRay::onCompleteTrace for all kernels 

## Impact

Will enable new capabilities but won't change anything for RayKernels not using it 
