### PR TITLE
Skip natural_convection.natural_circulation_pipe test for out-of-tree builds

### DIFF
--- a/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/tests
+++ b/modules/navier_stokes/test/tests/finite_volume/wcns/natural_convection/tests
@@ -7,5 +7,7 @@
     exodiff = 'natural_circulation_pipe_out.e'
     requirement = 'The system shall be able to use pressure inlet and outlet boundary conditions to compute open, chimney-type natural circulation problems using weakly compressible navier-stokes equations.'
     abs_zero = 1e-9
+    # skip test if test is being run out-of-tree. Issue Ref: #26129
+    installation_type = in_tree
   []
 []


### PR DESCRIPTION
Skipping for now to allow next to merge freely while this is being explored and fixed up.

Refs #26129
