### PR TITLE
Fix readme for new apps

### DIFF
--- a/modules/level_set/README.md
+++ b/modules/level_set/README.md
@@ -1,6 +1,6 @@
 LevelSet
 =====
 
-"Fork LevelSet" to create a new MOOSE-based application.
+Fork "LevelSet" to create a new MOOSE-based application.
 
-For more information see: [http://mooseframework.org/create-an-app/](http://mooseframework.org/create-an-app/)
+For more information see: [https://mooseframework.org/getting_started/new_users.html#create-an-app](https://mooseframework.org/getting_started/new_users.html#create-an-app)

--- a/stork/README.md
+++ b/stork/README.md
@@ -1,6 +1,6 @@
 Stork
 =====
 
-"Fork Stork" to create a new MOOSE-based application.
+Fork "Stork" to create a new MOOSE-based application.
 
-For more information see: [http://mooseframework.org/create-an-app/](http://mooseframework.org/create-an-app/)
+For more information see: [https://mooseframework.org/getting_started/new_users.html#create-an-app](https://mooseframework.org/getting_started/new_users.html#create-an-app)

--- a/tutorials/darcy_thermo_mech/step01_diffusion/README.md
+++ b/tutorials/darcy_thermo_mech/step01_diffusion/README.md
@@ -1,6 +1,6 @@
 DarcyThermoMech
 =====
 
-"Fork DarcyThermoMech" to create a new MOOSE-based application.
+Fork "DarcyThermoMech" to create a new MOOSE-based application.
 
-For more information see: [http://mooseframework.org/create-an-app/](http://mooseframework.org/create-an-app/)
+For more information see: [https://mooseframework.org/getting_started/new_users.html#create-an-app](https://mooseframework.org/getting_started/new_users.html#create-an-app)

--- a/tutorials/tutorial02_multiapps/app/README.md
+++ b/tutorials/tutorial02_multiapps/app/README.md
@@ -1,6 +1,6 @@
 MultiAppTut
 =====
 
-"Fork MultiAppTut" to create a new MOOSE-based application.
+Fork "MultiAppTut" to create a new MOOSE-based application.
 
-For more information see: [http://mooseframework.org/create-an-app/](http://mooseframework.org/create-an-app/)
+For more information see: [https://mooseframework.org/getting_started/new_users.html#create-an-app](https://mooseframework.org/getting_started/new_users.html#create-an-app)


### PR DESCRIPTION
## Bug description
The readme for new apps, in stork, has some mistakes

## How to reproduce
Make a new app, look at the new github repository

## Impact
minor. Any typo can be corrected after the fact in the repo

Hi,

Just fixing a small typo and a broken URL.

Cheers,
-N
