### PR TITLE
Have an empty default for source variable in conservative transfer

### DIFF
--- a/framework/src/transfers/MultiAppConservativeTransfer.C
+++ b/framework/src/transfers/MultiAppConservativeTransfer.C
@@ -48,7 +48,9 @@ MultiAppConservativeTransfer::validParams()
 
 MultiAppConservativeTransfer::MultiAppConservativeTransfer(const InputParameters & parameters)
   : MultiAppFieldTransfer(parameters),
-    _from_var_names(getParam<std::vector<VariableName>>("source_variable")),
+    _from_var_names(isParamValid("source_variable")
+                        ? getParam<std::vector<VariableName>>("source_variable")
+                        : std::vector<VariableName>()),
     _to_var_names(getParam<std::vector<AuxVariableName>>("variable")),
     _preserve_transfer(isParamValid("from_postprocessors_to_be_preserved")),
     _from_postprocessors_to_be_preserved(


### PR DESCRIPTION
they do not have a source variable for user object transfers , refs #24455
