### PR TITLE
mamba init on all console profiles

### DIFF
--- a/modules/doc/content/getting_started/installation/install_miniconda.md
+++ b/modules/doc/content/getting_started/installation/install_miniconda.md
@@ -34,7 +34,7 @@ export PATH=$HOME/mambaforge3/bin:$PATH
 Now that we can execute `mamba`, initialize it and then exit the terminal:
 
 ```bash
-mamba init
+mamba init --all
 exit
 ```
 


### PR DESCRIPTION
closes #26185

This is going to inconvenience some advanced users who actually use two consoles for different purposes and only wanted the MOOSE environment on one of them
These users also know what to delete from their profile to fix the issue. And maybe a good chunk of these people would be using the manual install to get max performance anyway?

On the other hand the mainstream consumers who get forced into this zsh vs bash problem will have one less difficulty to deal with