### PR TITLE
Remove unneeded quadrature string/enum map

### DIFF
--- a/framework/src/utils/Conversion.C
+++ b/framework/src/utils/Conversion.C
@@ -21,7 +21,6 @@
 
 namespace Moose
 {
-std::map<std::string, QuadratureType> quadrature_type_to_enum;
 std::map<std::string, CoordinateSystemType> coordinate_system_type_to_enum;
 std::map<std::string, SolveType> solve_type_to_enum;
 std::map<std::string, EigenSolveType> eigen_solve_type_to_enum;
@@ -31,22 +30,6 @@ std::map<std::string, LineSearchType> line_search_type_to_enum;
 std::map<std::string, TimeIntegratorType> time_integrator_to_enum;
 std::map<std::string, MffdType> mffd_type_to_enum;
 std::map<std::string, RelationshipManagerType> rm_type_to_enum;
-
-void
-initQuadratureType()
-{
-  if (quadrature_type_to_enum.empty())
-  {
-    quadrature_type_to_enum["CLOUGH"] = QCLOUGH;
-    quadrature_type_to_enum["CONICAL"] = QCONICAL;
-    quadrature_type_to_enum["GAUSS"] = QGAUSS;
-    quadrature_type_to_enum["GRID"] = QGRID;
-    quadrature_type_to_enum["MONOMIAL"] = QMONOMIAL;
-    quadrature_type_to_enum["SIMPSON"] = QSIMPSON;
-    quadrature_type_to_enum["TRAP"] = QTRAP;
-    quadrature_type_to_enum["GAUSS_LOBATTO"] = QGAUSS_LOBATTO;
-  }
-}
 
 void
 initCoordinateSystemType()
@@ -182,15 +165,7 @@ template <>
 QuadratureType
 stringToEnum<QuadratureType>(const std::string & s)
 {
-  initQuadratureType();
-
-  std::string upper(s);
-  std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
-
-  if (!quadrature_type_to_enum.count(upper))
-    mooseError("Unknown quadrature type: ", upper);
-
-  return quadrature_type_to_enum[upper];
+  return Utility::string_to_enum<QuadratureType>("Q" + s);
 }
 
 template <>


### PR DESCRIPTION
## Motivation
The same quadrature list is used in a few places, and as such is duplcated from the libmesh one which holds the complete list

## Design 
Use the libmesh quadratrue string/enum map instead of a copy in moose of the list of quadratures

## Impact
Reduce code length
Remove need to update moose when adding new quadratures in libmesh which are moose-compatible

**Do not merge until libMesh is updated. Depends on libMesh/libmesh#3733.**

Note this doesn't change the applicable quadrature rules, which remain limited by:

https://github.com/idaholab/moose/blob/37692f52f0738e005683d1745eac37b3f127e505/framework/src/actions/SetupQuadratureAction.C#L20

Cheers,
-N

