### PR TITLE
NCRC Fix markdown syntax, add wasp

### DIFF
--- a/modules/doc/content/application_development/profiling.md
+++ b/modules/doc/content/application_development/profiling.md
@@ -58,6 +58,12 @@ contains `oprof` (or not if you wish to profile with another method and have spe
 scripts/update_and_rebuild_libmesh.sh
 ```
 
+WASP must also be built:
+
+```
+scripts/update_and_rebuild_wasp.sh
+```
+
 Finally, when building MOOSE, you set the GPERF_DIR environment variable to the location of a
 gperftools installation (i.e. $GPERF_DIR/lib/libprofiler.so should exist).  Then you compile MOOSE
 like normal - it should look something like this:

--- a/modules/doc/content/getting_started/installation/manual_installation_linux_lldb.md
+++ b/modules/doc/content/getting_started/installation/manual_installation_linux_lldb.md
@@ -130,6 +130,16 @@ Now let's build!
 scripts/update_and_rebuild_libmesh.sh --without-gdb-command
 !package-end!
 
+## Build WASP
+
+Building WASP is also necessary. With the compilers already set in the above step, we only need to
+run the following commands:
+
+!package! code
+cd $MOOSE_DIR
+scripts/update_and_rebuild_wasp.sh
+!package-end!
+
 ## Build MOOSE
 
 I always prefer to make sure that all potentially stale object files have been

--- a/modules/doc/content/ncrc/applications/ncrc_develop.md.template
+++ b/modules/doc/content/ncrc/applications/ncrc_develop.md.template
@@ -22,7 +22,7 @@ operating on one of our [!ac](INL) [!ac](HPC) clusters, you need only load a cou
   instructions and then install our MOOSE Conda packages:
 
 !package! code
-  mamba create -n moose moose-dev=__MOOSE_DEV__
+mamba create -n moose moose-dev=__MOOSE_DEV__
 !package-end!
 
 - If +[!ac](INL) [!ac](HPC) Sawtooth or Lemhi+ (required each time you log in):
@@ -135,6 +135,7 @@ either a Conda update, or rebuild PETSc/libMesh:
   cd ~/projects/{{binary}}/moose
   scripts/update_and_rebuild_petsc.sh
   scripts/update_and_rebuild_libmesh.sh
+  scripts/update_and_rebuild_wasp.sh
   ```
 
   For more information on the `METHODS` variable (and other influential environment variables) check out:


### PR DESCRIPTION
Fix a syntax error when displaying package code.
Add `update_and_rebuild_wasp.sh` instructions.

Closes #26209

