### PR TITLE
Remove details page, add 2024 Oct training

### DIFF
--- a/modules/doc/content/training/index.md
+++ b/modules/doc/content/training/index.md
@@ -4,17 +4,10 @@
 Upcoming MOOSE related training:
 !style-end!
 
-- [MOOSE Training (2024 January 16-17, MIT)](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration)
-
-  - [Details](more_detail/MOOSE_2024_01_16-17_MIT.md)
-
-- [BISON Fuels Performance (2024 January 18-19, MIT)](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration)
-
-  - [Details](more_detail/BISON_2024_01_18-19_MIT.md)
-
-- [MOOSE Training (2024 April 2-4, Oregon State University)](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration)
-
-  - [Details](more_detail/2024_04_02-04_OSU.md)
+- [MOOSE Training (2024 January 16-17, MIT)](more_detail/MOOSE_2024_01_16-17_MIT.md)
+- [BISON Fuels Performance (2024 January 18-19, MIT)](more_detail/BISON_2024_01_18-19_MIT.md)
+- [MOOSE Training (2024 April 2-4, Oregon State University)](more_detail/MOOSE_2024_04_02-04_OSU.md)
+- [MOOSE Training (2024 October 15-17, University of Illinois Urbana-Champaign)](more_detail/MOOSE_2024_10_15-17_UIUC.md)
 
 Past Training:
 

--- a/modules/doc/content/training/more_detail/BISON_2024_01_18-19_MIT.md
+++ b/modules/doc/content/training/more_detail/BISON_2024_01_18-19_MIT.md
@@ -1,8 +1,10 @@
 #### BISON Fuels Performance (2024 Jan 18-19, MIT)
 
 !style! halign=left
-The BISON fuel performance team is hosting a two-day, interactive workshop at Massachusetts Institute of Technology to be held on January 18th – 19th, 2023. This workshop is intended to help prospective users get started with the code, provide an overview of the methods to model specific fuel types, and provide practical examples to help users gain experience.
+!include training/more_detail/registration_link.md
 !style-end!
+
+The BISON fuel performance team is hosting a two-day, interactive workshop at Massachusetts Institute of Technology to be held on January 18th – 19th, 2023. This workshop is intended to help prospective users get started with the code, provide an overview of the methods to model specific fuel types, and provide practical examples to help users gain experience.
 
 #### WORKSHOP TOPICS
 

--- a/modules/doc/content/training/more_detail/MOOSE_2024_01_16-17_MIT.md
+++ b/modules/doc/content/training/more_detail/MOOSE_2024_01_16-17_MIT.md
@@ -1,8 +1,10 @@
 #### MOOSE Framework (2024 Jan 16-17, MIT)
 
 !style! halign=left
-!include training/more_detail/generic_moose_training.md
+!include training/more_detail/registration_link.md
 !style-end!
+
+!include training/more_detail/generic_moose_training.md
 
 The room for the training is tentatively 3-370.
 You may download the MIT app for a map of the campus.

--- a/modules/doc/content/training/more_detail/MOOSE_2024_04_02-04_OSU.md
+++ b/modules/doc/content/training/more_detail/MOOSE_2024_04_02-04_OSU.md
@@ -1,8 +1,10 @@
 #### MOOSE Framework (2024 Apr 2-4, Oregon State University)
 
 !style! halign=left
-!include training/more_detail/generic_moose_training.md
+!include training/more_detail/registration_link.md
 !style-end!
+
+!include training/more_detail/generic_moose_training.md
 
 - MOOSE training will be conducted in the Memorial Union
 

--- a/modules/doc/content/training/more_detail/MOOSE_2024_10_15-17_UIUC.md
+++ b/modules/doc/content/training/more_detail/MOOSE_2024_10_15-17_UIUC.md
@@ -1,0 +1,9 @@
+#### MOOSE Framework (2024 Oct 15-17, University of Illinois Urbana-Champaign)
+
+!style! halign=left
+!include training/more_detail/registration_link.md
+!style-end!
+
+!include training/more_detail/generic_moose_training.md
+
+[Back](training/index.md)

--- a/modules/doc/content/training/more_detail/registration_link.md
+++ b/modules/doc/content/training/more_detail/registration_link.md
@@ -1,0 +1,1 @@
+[Register for this training](https://ncrcaims.inl.gov/Identity/Account/TrainingRegistration).


### PR DESCRIPTION
Remove the need to click on a separate link to list details for a giving training. Instead, when clicked, you are brought to the details page, and there is a link to register from that.

Added the upcoming 2024 Oct training I saw on the drop down list at the registration site.

Closes #26249

