### PR TITLE
Fix a few documentation typos

### DIFF
--- a/framework/doc/content/framework/documenting.md
+++ b/framework/doc/content/framework/documenting.md
@@ -159,7 +159,7 @@ values are overridden.
     type = CSVDiff
     input = one.i
     csvdiff = one_out.csv
-    requirement = "The system shall must compute a value."
+    requirement = "The system shall compute a value."
   []
   [two]
     type = RunException
@@ -182,27 +182,27 @@ and each of the details are a complete sentence when combined, as shown in the f
   [group] # this is an arbitrary name that is not used
     issues = "#1235"
     design = "MyObject.md"
-    requirement = "The system shall solve the Laplace equation in:"
+    requirement = "The system shall solve the Laplace equation in: "
     [1D]
       type = Exodiff
       input = input_1D.i
       exodiff = input_1D_out.e
 
-      detail = "in 1D,"
+      detail = "1D, "
     []
     [2D]
       type = Exodiff
       input = input_2D.i
       exodiff = input_2D_out.e
 
-      detail = "in 2D, and"
+      detail = "2D, and "
     []
     [3D]
       type = Exodiff
       input = input_3D.i
       exodiff = input_3D_out.e
 
-      detail = "in 3D."
+      detail = "3D."
     []
   []
 []

--- a/framework/doc/content/source/bcs/VectorDivPenaltyDirichletBC.md
+++ b/framework/doc/content/source/bcs/VectorDivPenaltyDirichletBC.md
@@ -8,7 +8,7 @@
 condition on the divergence of a nonlinear vector variable $\vec{u}$ by setting
 
 \begin{equation}
-  R_i(\vec{u}) = p($\vec{\psi_i}$ \cdot \hat{n}, (\vec{u} - \vec{u}_0) \cdot \hat{n})
+  R_i(\vec{u}) = p(\vec{\psi_i} \cdot \hat{n}, (\vec{u} - \vec{u}_0) \cdot \hat{n})
 \end{equation}
 
 where $p$ is a scalar defining the penalty value, $\vec{\psi_i}$ the test

--- a/framework/src/kernels/DivField.C
+++ b/framework/src/kernels/DivField.C
@@ -16,7 +16,7 @@ InputParameters
 DivField::validParams()
 {
   InputParameters params = Kernel::validParams();
-  params.addClassDescription("Takes the divergence of a vector field, optionally"
+  params.addClassDescription("Takes the divergence of a vector field, optionally "
                              "scaled by a constant scalar coefficient.");
   params.addRequiredCoupledVar("coupled_vector_variable", "The vector field");
   params.addParam<Real>("coeff", 1.0, "The constant coefficient");

--- a/framework/src/kernels/GradField.C
+++ b/framework/src/kernels/GradField.C
@@ -16,7 +16,7 @@ InputParameters
 GradField::validParams()
 {
   InputParameters params = VectorKernel::validParams();
-  params.addClassDescription("Takes the gradient of a scalar field, optionally"
+  params.addClassDescription("Takes the gradient of a scalar field, optionally "
                              "scaled by a constant scalar coefficient.");
   params.addRequiredCoupledVar("coupled_scalar_variable", "The scalar field");
   params.addParam<Real>("coeff", 1.0, "The constant coefficient");


### PR DESCRIPTION
## Motivation
The documentation has a bunch of typos that look unsightly

## How to reproduce
Look at the documentation, see the typos

## Impact
None, sentence meanings do not change

Hi @GiudGiud,

Just fixes for a few typos, some of them mine.

Cheers,
-N