### PR TITLE
set Petsc options before every execute call in optimizeSolve 

### DIFF
--- a/modules/optimization/include/executioners/OptimizeSolve.h
+++ b/modules/optimization/include/executioners/OptimizeSolve.h
@@ -11,6 +11,9 @@
 
 #include "SolveObject.h"
 
+#include "SolverParams.h"
+#include "PetscSupport.h"
+
 #include "ExecFlagEnum.h"
 #include <petsctao.h>
 
@@ -111,6 +114,15 @@ private:
   std::vector<double> _cnorm_vec;
   /// step length per iteration
   std::vector<double> _xdiff_vec;
+
+  ///@{
+  /// These are needed to reset the petsc options for the optimization solve
+  /// using Moose::PetscSupport::petscSetOptions
+  /// This only sets the finite difference options, the other optimizeSolve
+  /// options are set-up in TAO using TaoSetFromOptions()
+  Moose::PetscSupport::PetscOptions _petsc_options;
+  SolverParams _solver_params;
+  ///@}
 
   /// Here is where we call tao and solve
   PetscErrorCode taoSolve();

--- a/modules/optimization/test/tests/optimizationreporter/point_loads/tests
+++ b/modules/optimization/test/tests/optimizationreporter/point_loads/tests
@@ -1,5 +1,5 @@
 [Tests]
-  issues = '#21885 #24101 #25689'
+  issues = '#21885 #24101 #25689 #26262'
   design = 'ReporterPointSource.md OptimizationReporter/index.md'
   [point_loads]
     requirement = "The system shall be able to invert for point loads using"
@@ -78,6 +78,18 @@
       # steady solve
       recover = false
       detail = 'gradient-based optimization with an automatically computed adjoint, with Tikhonov regularization, and initial conditions do not affect the converged regularized solution, or'
+    []
+    [finite_diff_view]
+      type = RunApp
+      input = main_auto_adjoint.i
+      expect_out = 'Hand-coded minus finite-difference gradient'
+      cli_args = " Executioner/petsc_options_iname='-tao_max_it -tao_fd_test -tao_test_gradient -tao_ls_type'"
+                 " Executioner/petsc_options_value='1 true true unit'"
+                 " Executioner/petsc_options='-tao_test_gradient_view'"
+      max_threads = 1 # Optimize executioner does not support multiple threads
+      # steady solve
+      recover = false
+      detail = 'print finite difference gradient information to the screen when using the automatically formed adjoint.'
     []
   []
 []


### PR DESCRIPTION
Make sure Automatic Adjoint Petsc Options do not overwrite this. This allows the finite difference gradient check to be output to the terminal.  closes #26262

<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
