### PR TITLE
Improved naming for multiple heat transfers on a flow channel

### DIFF
--- a/modules/thermal_hydraulics/src/closures/Closures1PhaseNone.C
+++ b/modules/thermal_hydraulics/src/closures/Closures1PhaseNone.C
@@ -17,6 +17,10 @@ InputParameters
 Closures1PhaseNone::validParams()
 {
   InputParameters params = Closures1PhaseBase::validParams();
+  params.addParam<bool>("add_wall_temperature_property",
+                        true,
+                        "If true, create a material property for the wall temperature (average if "
+                        "multiple heat transfers)");
   params.addClassDescription("No 1-phase closures. Useful for testing with one-time correlations.");
   return params;
 }
@@ -39,16 +43,19 @@ Closures1PhaseNone::checkHeatTransfer(const HeatTransferBase & /*heat_transfer*/
 void
 Closures1PhaseNone::addMooseObjectsFlowChannel(const FlowChannelBase & flow_channel)
 {
-  const FlowChannel1Phase & flow_channel_1phase =
-      dynamic_cast<const FlowChannel1Phase &>(flow_channel);
-
-  const unsigned int n_ht_connections = flow_channel_1phase.getNumberOfHeatTransferConnections();
-  if ((n_ht_connections > 0) && (flow_channel.getTemperatureMode()))
+  if (getParam<bool>("add_wall_temperature_property"))
   {
-    if (flow_channel.getNumberOfHeatTransferConnections() > 1)
-      addAverageWallTemperatureMaterial(flow_channel_1phase);
-    else
-      addWallTemperatureFromAuxMaterial(flow_channel_1phase);
+    const FlowChannel1Phase & flow_channel_1phase =
+        dynamic_cast<const FlowChannel1Phase &>(flow_channel);
+
+    const unsigned int n_ht_connections = flow_channel_1phase.getNumberOfHeatTransferConnections();
+    if ((n_ht_connections > 0) && (flow_channel.getTemperatureMode()))
+    {
+      if (flow_channel.getNumberOfHeatTransferConnections() > 1)
+        addAverageWallTemperatureMaterial(flow_channel_1phase);
+      else
+        addWallTemperatureFromAuxMaterial(flow_channel_1phase);
+    }
   }
 }
 

--- a/modules/thermal_hydraulics/src/components/FlowChannelBase.C
+++ b/modules/thermal_hydraulics/src/components/FlowChannelBase.C
@@ -90,6 +90,11 @@ FlowChannelBase::validParams()
       "Set to true if Dh, P_hf and A are going to be transferred in from an external source");
   params.addParam<bool>("lump_mass_matrix", false, "Lump the mass matrix");
   params.addRequiredParam<std::string>("closures", "Closures type");
+  params.addParam<bool>("name_multiple_ht_by_index",
+                        true,
+                        "If true, when there are multiple heat transfer components connected to "
+                        "this flow channel, use their index for naming related quantities; "
+                        "otherwise, use the name of the heat transfer component.");
 
   params.setDocString(
       "orientation",
@@ -367,7 +372,13 @@ FlowChannelBase::getHeatTransferNamesSuffix(const std::string & ht_name) const
     if (it != _heat_transfer_names.end())
     {
       const unsigned int index = std::distance(_heat_transfer_names.begin(), it);
-      const std::string suffix = ":" + std::to_string(index + 1);
+
+      std::string suffix = ":";
+      if (getParam<bool>("name_multiple_ht_by_index"))
+        suffix += std::to_string(index + 1);
+      else
+        suffix += _heat_transfer_names[index];
+
       return suffix;
     }
     else

--- a/modules/thermal_hydraulics/test/tests/components/heat_transfer_from_heat_flux_1phase/phy.q_wall_multiple_3eqn.i
+++ b/modules/thermal_hydraulics/test/tests/components/heat_transfer_from_heat_flux_1phase/phy.q_wall_multiple_3eqn.i
@@ -125,6 +125,15 @@
     variable = rhoEA
     block = pipe
   []
+  # This is included to test the naming of heat transfer quantities in the case
+  # of multiple heat transfers connected to a flow channel. This PP is not used
+  # in output but just included to ensure that an error does not occur (which is
+  # the case if the expected material property name does not exist).
+  # See https://github.com/idaholab/moose/issues/26286.
+  [q_wall_name_check]
+    type = ADElementAverageMaterialProperty
+    mat_prop = 'q_wall:2'
+  []
 []
 
 [Outputs]

--- a/modules/thermal_hydraulics/test/tests/components/heat_transfer_from_heat_flux_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/heat_transfer_from_heat_flux_1phase/tests
@@ -1,8 +1,12 @@
 [Tests]
+  design = 'HeatTransferFromHeatFlux1Phase.md'
+  issues = '#26286'
+
   [phy:q_wall_multiple_3eqn]
     type = 'CSVDiff'
     input = 'phy.q_wall_multiple_3eqn.i'
     csvdiff = 'phy.q_wall_multiple_3eqn_out.csv'
+    requirement = "The system shall allow application of multiple heat fluxes to a single-phase flow channel."
   []
 
   [phy.energy_heatflux_ss_1phase]
@@ -10,5 +14,15 @@
     input = 'phy.energy_heatflux_ss_1phase.i'
     csvdiff = 'phy.energy_heatflux_ss_1phase_out.csv'
     abs_zero = 1e-8
+    requirement = "The system shall conserve energy when applying a heat flux function to a single-phase flow channel."
+  []
+
+  [naming_for_multiple_ht]
+    type = RunApp
+    input = 'phy.q_wall_multiple_3eqn.i'
+    cli_args = "
+      Components/pipe/name_multiple_ht_by_index=false
+      Postprocessors/q_wall_name_check/mat_prop=q_wall:ht2"
+    requirement = "The system shall allow heat transfer names to be named with the heat transfer object as a suffix when there are multiple heat fluxes applied to a single-phase flow channel."
   []
 []


### PR DESCRIPTION
Closes #26286

Also, I've added an option to `Closures1PhaseNone` because it was always trying to add an a wall temperature material property, even if not needed, which increases the burden on the user because they need to add irrelevant materials to their input files.
