### PR TITLE
Sync `moose-dev` versions and remove bad dependency

### DIFF
--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -7,7 +7,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.11.30" %}
+{% set version = "2023.12.13" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.11.30
+  - moose-dev 2023.12.13
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/conda/template/conda_build_config.yaml
+++ b/conda/template/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.11.30
+  - moose-dev 2023.12.13
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -171,3 +171,9 @@ a2e8814e28b97171ff4a06e5343063fed6763dd0: #26102
   libmesh: bad5b94
   moose-dev: 9831cd1
   wasp: 91987a3
+0ad6cc9cb950aeb65dbaa97436650e5968d42bfa: 26326
+  mpich: 702900f
+  petsc: 684d2af
+  libmesh: bad5b94
+  moose-dev: 6b7bb74
+  wasp: 91987a3

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -171,7 +171,7 @@ a2e8814e28b97171ff4a06e5343063fed6763dd0: #26102
   libmesh: bad5b94
   moose-dev: 9831cd1
   wasp: 91987a3
-0ad6cc9cb950aeb65dbaa97436650e5968d42bfa: 26326
+0ad6cc9cb950aeb65dbaa97436650e5968d42bfa: #26326
   mpich: 702900f
   petsc: 684d2af
   libmesh: bad5b94

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -171,7 +171,7 @@ a2e8814e28b97171ff4a06e5343063fed6763dd0: #26102
   libmesh: bad5b94
   moose-dev: 9831cd1
   wasp: 91987a3
-0ad6cc9cb950aeb65dbaa97436650e5968d42bfa: #26326
+0ad6cc9cb950aeb65dbaa97436650e5968d42bfa: #26327
   mpich: 702900f
   petsc: 684d2af
   libmesh: bad5b94

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -60,7 +60,6 @@ packages:
       - conda/peacock/conda_build_config.yaml
       - conda/tools/meta.yaml
       - conda/tools/conda_build_config.yaml
-      - conda/moose/build.sh
   app:
     dependencies:
       - moose-dev


### PR DESCRIPTION
Bump moose-dev so as to sync with recent changes needed in versioner.

Closes https://github.com/idaholab/moose/issues/26326