### PR TITLE
Allow heavy tests to depend on non-heavy tests

### DIFF
--- a/python/TestHarness/JobDAG.py
+++ b/python/TestHarness/JobDAG.py
@@ -142,10 +142,24 @@ class JobDAG(object):
                 try:
                     self.__name_to_job[prereq_job]
                     self._addEdge(self.__name_to_job[prereq_job], job)
+                    # Fix heavy test corner cases
+                    self._fix_cornercases(self.__name_to_job[prereq_job])
 
                 # test file has invalid prereq set
                 except KeyError:
                     job.setStatus(job.error, 'unknown dependency')
+
+    def _fix_cornercases(self, prereq_job):
+        """
+        Fix skipped dependency when we have a heavy test depend on a not-heavy test
+        TODO: We discovered several other cases where tests may never run. However,
+              solving those issues is a rabbit hole better left to another PR: #26329
+        """
+        if self.options.heavy_tests:
+            prereq_tester = prereq_job.getTester()
+            if not prereq_tester.specs['heavy']:
+                prereq_tester.specs['heavy'] = True
+                prereq_tester.addCaveats(f'implicit heavy')
 
     def _hasDownStreamsWithFailures(self, job):
         """ Return True if any dependents of job has previous failures """

--- a/python/TestHarness/tests/test_SoftHeavyDependency.py
+++ b/python/TestHarness/tests/test_SoftHeavyDependency.py
@@ -1,0 +1,32 @@
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+from TestHarnessTestCase import TestHarnessTestCase
+
+class TestHarnessTester(TestHarnessTestCase):
+    def testNotHeavy(self):
+        """
+        Heavy test is skipped while non-heavy tests are not
+        """
+        # Run a skipped test
+        output = self.runTests('--no-color', '-i', 'heavy_on_not_heavy')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy.*? \[HEAVY\] SKIP')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.singleton.*?OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy.*?OK')
+
+    def testSoftHeavy(self):
+        """
+        Heavy test runs along with a non-heavy prereq test.
+        Non-heavy non-prereq tests do not run.
+        """
+        # Run a skipped test
+        output = self.runTests('--no-color', '-i', 'heavy_on_not_heavy', '--heavy')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy.*?OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy.*? \[IMPLICIT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.singleton.*?OK')

--- a/python/TestHarness/tests/tests
+++ b/python/TestHarness/tests/tests
@@ -281,4 +281,10 @@
     requirement = "The system shall skip tests not capable of being run depending on micro architecture"
     issues = '#25317'
   []
+  [test_soft_heavy]
+    type = PythonUnitTest
+    input = test_SoftHeavyDependency.py
+    requirement = "The system shall not skip non-heavy tests for which heavy tests depend on"
+    issues = '#26215'
+  []
 []

--- a/test/tests/test_harness/heavy_on_not_heavy
+++ b/test/tests/test_harness/heavy_on_not_heavy
@@ -1,0 +1,16 @@
+[Tests]
+  [./singleton]
+    type = RunApp
+    input = good.i
+  [../]
+  [./not_heavy]
+    type = RunApp
+    input = good.i
+  [../]
+  [./heavy]
+    type = RunApp
+    input = good.i
+    heavy = true
+    prereq = not_heavy
+  [../]
+[]


### PR DESCRIPTION
This change will allow non-heavy tests to run if a heavy test depends on it.

It was discovered that other scenarios exist which prevent tests from ever running. Those will be addressed in a separate PR.

Closes #26215
