### PR TITLE
Bump moose-dev=version instructions

### DIFF
--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -6,4 +6,4 @@ minimum_python: 3.7
 mpich: 4.0.2
 petsc_alt: 3.11.4
 petsc: 3.20.1
-moose_dev: 2023.11.30
+moose_dev: 2023.12.13


### PR DESCRIPTION
Bump all mentions of `conda install moose-dev=`. There is always something we (well I) forget to include when bumping Conda packages. We really need an automated way to keep it all together.

Closes #26335

