### PR TITLE
Remove Duplicated test output in console log

### DIFF
--- a/python/TestHarness/testers/CSVDiff.py
+++ b/python/TestHarness/testers/CSVDiff.py
@@ -90,7 +90,7 @@ class CSVDiff(FileTester):
         return commands
 
     def processResults(self, moose_dir, options, output):
-        output += FileTester.processResults(self, moose_dir, options, output)
+        FileTester.processResults(self, moose_dir, options, output)
 
         if self.isFail() or self.specs['skip_checks']:
             return output

--- a/python/TestHarness/testers/CheckFiles.py
+++ b/python/TestHarness/testers/CheckFiles.py
@@ -32,7 +32,7 @@ class CheckFiles(FileTester):
         return self.specs['check_files'] + self.specs['check_not_exists']
 
     def processResults(self, moose_dir, options, output):
-        output += FileTester.processResults(self, moose_dir, options, output)
+        FileTester.processResults(self, moose_dir, options, output)
 
         specs = self.specs
 

--- a/python/TestHarness/testers/Exodiff.py
+++ b/python/TestHarness/testers/Exodiff.py
@@ -73,7 +73,7 @@ class Exodiff(FileTester):
         return commands
 
     def processResults(self, moose_dir, options, output):
-        output += FileTester.processResults(self, moose_dir, options, output)
+        FileTester.processResults(self, moose_dir, options, output)
 
         if self.isFail() or self.specs['skip_checks']:
             return output

--- a/python/TestHarness/testers/ImageDiff.py
+++ b/python/TestHarness/testers/ImageDiff.py
@@ -42,7 +42,7 @@ class ImageDiff(FileTester):
         """
 
         # Call base class processResults
-        output += FileTester.processResults(self, moose_dir, options, output)
+        FileTester.processResults(self, moose_dir, options, output)
         if self.isFail():
             return output
 

--- a/python/TestHarness/testers/RunException.py
+++ b/python/TestHarness/testers/RunException.py
@@ -52,6 +52,6 @@ class RunException(RunApp):
             output += redirected_output
 
         output += self.testFileOutput(moose_dir, options, output)
-        self.testExitCodes(moose_dir, options, output)
+        output += self.testExitCodes(moose_dir, options, output)
 
         return output

--- a/python/TestHarness/testers/SchemaDiff.py
+++ b/python/TestHarness/testers/SchemaDiff.py
@@ -40,7 +40,7 @@ class SchemaDiff(RunApp):
 
     def processResults(self, moose_dir, options, output):
         output += self.testFileOutput(moose_dir, options, output)
-        self.testExitCodes(moose_dir, options, output)
+        output += self.testExitCodes(moose_dir, options, output)
         specs = self.specs
 
         if self.isFail() or specs['skip_checks']:
@@ -169,5 +169,3 @@ class SchemaDiff(RunApp):
             return self.load_file(path1)
         except Exception as e:
             return e
-
-


### PR DESCRIPTION
## Reason
When running the test suite, the console log is duplicated when the test fails. This makes it a tad slower to debug thelast but one test failing, as there's twice the scrolling

## Design
Just dont output the test log twice, only once

## Impact
Less characters to console during testing
Less often will the output be too big to view on civet
Less characters means less electricity use, means a greener moose (marginally)