### PR TITLE
Track `conda/moose-dev` in versioner

### DIFF
--- a/conda/moose-dev/meta.yaml
+++ b/conda/moose-dev/meta.yaml
@@ -6,7 +6,7 @@
 #   framework/doc/packages_config.yml
 #
 # As well as any directions pertaining to modifying those files.
-{% set version = "2023.12.13" %}
+{% set version = "2023.12.19" %}
 
 package:
   name: moose-dev

--- a/conda/moose/conda_build_config.yaml
+++ b/conda/moose/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_dev:
-  - moose-dev 2023.12.13
+  - moose-dev 2023.12.19
 
 #### Darwin SDK SYSROOT
 CONDA_BUILD_SYSROOT:                                        # [osx]

--- a/framework/doc/packages_config.yml
+++ b/framework/doc/packages_config.yml
@@ -6,4 +6,4 @@ minimum_python: 3.7
 mpich: 4.0.2
 petsc_alt: 3.11.4
 petsc: 3.20.1
-moose_dev: 2023.12.13
+moose_dev: 2023.12.19

--- a/scripts/tests/versioner_hashes.yaml
+++ b/scripts/tests/versioner_hashes.yaml
@@ -177,3 +177,9 @@ a2e8814e28b97171ff4a06e5343063fed6763dd0: #26102
   libmesh: bad5b94
   moose-dev: 6b7bb74
   wasp: 91987a3
+85f27a758ebb558b09df27385cecadf76b375058: #26374
+  mpich: 702900f
+  petsc: 684d2af
+  libmesh: bad5b94
+  moose-dev: 2cdf24d
+  wasp: 91987a3

--- a/scripts/versioner.yaml
+++ b/scripts/versioner.yaml
@@ -60,6 +60,8 @@ packages:
       - conda/peacock/conda_build_config.yaml
       - conda/tools/meta.yaml
       - conda/tools/conda_build_config.yaml
+      - conda/moose-dev/meta.yaml
+      - conda/moose-dev/conda_build_config.yaml
   app:
     dependencies:
       - moose-dev


### PR DESCRIPTION
Add meta.yaml and conda_build_config.yaml to versioner.yaml. Bump versions.

Closes #26374