### PR TITLE
Restrict further test with false positive on equidistance detection

### DIFF
--- a/test/tests/transfers/general_field/nearest_node/mesh_division/tests
+++ b/test/tests/transfers/general_field/nearest_node/mesh_division/tests
@@ -19,7 +19,7 @@
                  "Transfers/from_sub_elem/from_mesh_division=middle_sub"
       detail = 'to restrict the source domain for the transfered field,'
       # See #26289. Issue with the search value conflict
-      max_parallel = 8
+      max_parallel = 7
     []
     [restriction_target]
       type = Exodiff


### PR DESCRIPTION
refs #26289
There's definitely something going on with a false positive on the equidistance detection check. It will be best investigated when I m reunited with an INL computer