### PR TITLE
Fix faulty logic

### DIFF
--- a/python/TestHarness/JobDAG.py
+++ b/python/TestHarness/JobDAG.py
@@ -143,19 +143,19 @@ class JobDAG(object):
                     self.__name_to_job[prereq_job]
                     self._addEdge(self.__name_to_job[prereq_job], job)
                     # Fix heavy test corner cases
-                    self._fix_cornercases(self.__name_to_job[prereq_job])
+                    self._fix_cornercases(self.__name_to_job[prereq_job], job)
 
                 # test file has invalid prereq set
                 except KeyError:
                     job.setStatus(job.error, 'unknown dependency')
 
-    def _fix_cornercases(self, prereq_job):
+    def _fix_cornercases(self, prereq_job, job):
         """
         Fix skipped dependency when we have a heavy test depend on a not-heavy test
         TODO: We discovered several other cases where tests may never run. However,
               solving those issues is a rabbit hole better left to another PR: #26329
         """
-        if self.options.heavy_tests:
+        if self.options.heavy_tests and job.specs['heavy']:
             prereq_tester = prereq_job.getTester()
             if not prereq_tester.specs['heavy']:
                 prereq_tester.specs['heavy'] = True

--- a/python/TestHarness/tests/test_SoftHeavyDependency.py
+++ b/python/TestHarness/tests/test_SoftHeavyDependency.py
@@ -14,19 +14,62 @@ class TestHarnessTester(TestHarnessTestCase):
         """
         Heavy test is skipped while non-heavy tests are not
         """
-        # Run a skipped test
         output = self.runTests('--no-color', '-i', 'heavy_on_not_heavy')
-        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy.*? \[HEAVY\] SKIP')
-        self.assertRegex(output.decode('utf-8'), 'test_harness\.singleton.*?OK')
-        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy.*?OK')
+        # The following should be skipped
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_a .*? \[HEAVY\] SKIP')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_b .*? \[HEAVY\] SKIP')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy .*? \[HEAVY\] SKIP')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy_a_and_not_heavy_b .*? \[HEAVY\] SKIP')
+
+        # The following should not be skipped, they should finish with an OK status.
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.singleton_a .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.singleton_b .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy_a .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy_b .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy_on_singleton_a_and_singleton_b .*? OK')
+
+        # The following should run, and should not list [implict heavy] caveat.
+        # (a little redundant, but I don't see a way to check for this and the OK test above, in one go)
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.singleton_a .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.singleton_b .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.not_heavy .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.not_heavy_a .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.not_heavy_b .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.not_heavy_on_singleton_a_and_singleton_b .*? \[IMPLICT HEAVY\] OK')
+
+        # Special: caveat placements are random. Only check that it is skipped.
+        # [skipped dependency,HEAVY] SKIP  versus  [HEAVY,skipped dependency] SKIP
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_heavy_a_and_heavy_b .*?SKIP')
 
     def testSoftHeavy(self):
         """
-        Heavy test runs along with a non-heavy prereq test.
-        Non-heavy non-prereq tests do not run.
+        Heavy tests run along with their non-heavy prereq tests. The non-heavy tests which do run
+        in this manner should have an 'implict heavy' caveat.
+
+        Non-heavy tests with non-heavy prereqs do not run/are not displayed.
         """
-        # Run a skipped test
         output = self.runTests('--no-color', '-i', 'heavy_on_not_heavy', '--heavy')
-        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy.*?OK')
-        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy.*? \[IMPLICIT HEAVY\] OK')
-        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.singleton.*?OK')
+        # The following should run, and mention the additional [implicit heavy] caveat.
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy .*? \[IMPLICIT HEAVY\] OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy_a .*? \[IMPLICIT HEAVY\] OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.not_heavy_b .*? \[IMPLICIT HEAVY\] OK')
+
+        # The following should not be skipped, they should finish with an OK status.
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_a .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_b .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_heavy_a_and_heavy_b .*? OK')
+        self.assertRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy_a_and_not_heavy_b .*? OK')
+
+        # The following should not be skipped, and should not list [implicit heavy] caveat.
+        # (a little redundant, but I don't see a way to check for this and the OK test above, in one go)
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.heavy_a .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.heavy_b .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.heavy_on_heavy_a_and_heavy_b .*? \[IMPLICT HEAVY\] OK')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.heavy_on_not_heavy_a_and_not_heavy_b .*? \[IMPLICT HEAVY\] OK')
+
+        # The following should not run at all (the test is silent, and not displayed in the output)
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.singleton.*?')
+        self.assertNotRegex(output.decode('utf-8'), 'test_harness\.not_heavy_on_singleton_a_and_singleton_b.*?')

--- a/test/tests/test_harness/heavy_on_not_heavy
+++ b/test/tests/test_harness/heavy_on_not_heavy
@@ -1,5 +1,9 @@
 [Tests]
-  [./singleton]
+  [./singleton_a]
+    type = RunApp
+    input = good.i
+  [../]
+  [./singleton_b]
     type = RunApp
     input = good.i
   [../]
@@ -7,10 +11,45 @@
     type = RunApp
     input = good.i
   [../]
-  [./heavy]
+  [./not_heavy_a]
+    type = RunApp
+    input = good.i
+  [../]
+  [./not_heavy_b]
+    type = RunApp
+    input = good.i
+  [../]
+  [./heavy_a]
+    type = RunApp
+    input = good.i
+    heavy = true
+  [../]
+  [./heavy_b]
+    type = RunApp
+    input = good.i
+    heavy = true
+  [../]
+  [./heavy_on_not_heavy]
     type = RunApp
     input = good.i
     heavy = true
     prereq = not_heavy
+  [../]
+  [./heavy_on_heavy_a_and_heavy_b]
+    type = RunApp
+    input = good.i
+    heavy = true
+    prereq = 'heavy_a heavy_b'
+  [../]
+  [./heavy_on_not_heavy_a_and_not_heavy_b]
+    type = RunApp
+    input = good.i
+    heavy = true
+    prereq = 'not_heavy_a not_heavy_b'
+  [../]
+  [./not_heavy_on_singleton_a_and_singleton_b]
+    type = RunApp
+    input = good.i
+    prereq = 'singleton_a singleton_b'
   [../]
 []


### PR DESCRIPTION
Only add heavy spec options if the dependency job is heavy. This was quite the oversight.

Add several more unittests to detect mishaps.

Closes #26391
