### PR TITLE
Update SQA reports allowances to avoid regression

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,12 +49,14 @@
 /modules/contact @bwspenc @lindsayad @recuero
 /modules/doc/content/getting_started/installation @milljm @loganharbour @cticenhour
 /modules/doc/content/newsletter @cticenhour
+/modules/doc/content/sqa_reports.yml @GiudGiud
 /modules/electromagnetics @cticenhour
 /modules/external_petsc_solver @lindsayad
 /modules/fluid_properties @joshuahansel @GiudGiud
 /modules/fsi @lindsayad
-/modules/functional_expansion_tools @lindsayad
+/modules/functional_expansion_tools @lindsayad @GiudGiud
 /modules/heat_conduction @lindsayad
+/modules/heat_transfer @lindsayad
 /modules/navier_stokes @lindsayad @GiudGiud @grmnptr
 /modules/optimization @zachmprince @dschwen
 /modules/phase_field @dschwen

--- a/modules/doc/sqa_reports.yml
+++ b/modules/doc/sqa_reports.yml
@@ -9,8 +9,6 @@ Applications:
         remove:
             - framework/doc/remove.yml
             - test/doc/remove.yml
-        log_stub_files: WARNING
-        show_warning: false
 
     chemical_reactions:
         exe_directory: modules/combined
@@ -22,7 +20,6 @@ Applications:
         remove:
             - framework/doc/remove.yml
         log_stub_files: WARNING
-        show_warning: false
 
     contact:
         exe_directory: modules/combined
@@ -33,16 +30,13 @@ Applications:
             - framework/doc/unregister.yml
         remove:
             - framework/doc/remove.yml
-        log_missing_description: WARNING
         log_missing_markdown: WARNING
-        show_warning: false
 
     electromagnetics:
         exe_directory: modules/combined
         app_types:
             - ElectromagneticsApp
         content_directory: modules/electromagnetics/doc/content
-        show_warning: false
 
     external_petsc_solver:
         exe_directory: modules/combined
@@ -73,8 +67,6 @@ Applications:
             - framework/doc/unregister.yml
         remove:
             - framework/doc/remove.yml
-        log_stub_files: WARNING
-        show_warning: false
 
     fsi:
         exe_directory: modules/combined
@@ -105,9 +97,6 @@ Applications:
             - framework/doc/unregister.yml
         remove:
             - framework/doc/remove.yml
-        log_stub_files: WARNING
-        log_missing_description: WARNING
-        show_warning: false
 
     level_set:
         exe_directory: modules/combined
@@ -124,9 +113,6 @@ Applications:
         app_types:
             - MiscApp
         content_directory: modules/misc/doc/content
-        log_stub_files: WARNING
-        log_missing_description: WARNING
-        show_warning: false
 
     navier_stokes:
         exe_directory: modules/combined
@@ -138,7 +124,6 @@ Applications:
         unregister:
             - framework/doc/unregister.yml
         log_stub_files: WARNING
-        show_warning: false
 
     optimization:
         exe_directory: modules/combined
@@ -149,8 +134,6 @@ Applications:
             - framework/doc/remove.yml
         unregister:
             - framework/doc/unregister.yml
-        log_stub_files: WARNING
-        show_warning: false
 
     peridynamics:
         exe_directory: modules/combined
@@ -162,7 +145,6 @@ Applications:
         remove:
             - framework/doc/remove.yml
         log_stub_files: WARNING
-        show_warning: false
 
     phase_field:
         exe_directory: modules/combined
@@ -175,7 +157,6 @@ Applications:
             - framework/doc/remove.yml
         log_stub_files: WARNING
         log_missing_description: WARNING
-        show_warning: false
 
     porous_flow:
         exe_directory: modules/combined
@@ -187,7 +168,6 @@ Applications:
         remove:
             - framework/doc/remove.yml
         log_stub_files: WARNING
-        show_warning: false
 
     ray_tracing:
         exe_directory: modules/combined
@@ -249,8 +229,6 @@ Applications:
         remove:
             - framework/doc/remove.yml
             - modules/stochastic_tools/doc/remove.yml
-        log_stub_files: WARNING
-        show_warning: false
 
     tensor_mechanics:
         exe_directory: modules/combined
@@ -263,7 +241,6 @@ Applications:
             - framework/doc/unregister.yml
         log_stub_files: WARNING
         log_missing_description: WARNING
-        show_warning: false
 
     THM:
         exe_directory: modules/combined
@@ -274,10 +251,6 @@ Applications:
             - framework/doc/unregister.yml
         remove:
             - framework/doc/remove.yml
-        log_stub_files: WARNING
-        log_missing_description: WARNING
-        log_missing_markdown: WARNING
-        show_warning: false
 
     XFEM:
         exe_directory: modules/combined
@@ -333,7 +306,6 @@ Requirements:
         directories:
             - python
         log_missing: WARNING
-        show_warning: false
 
     combined:
         directories:
@@ -344,13 +316,11 @@ Requirements:
         log_issue_format: WARNING
         log_design_files: WARNING
         log_duplicate_requirement: WARNING
-        show_warning: false
 
     chemical_reactions:
         directories:
             - modules/chemical_reactions
         log_missing: WARNING
-        show_warning: false
 
     contact:
         directories:
@@ -358,12 +328,10 @@ Requirements:
         log_duplicate_requirement: WARNING
         log_missing: WARNING
         log_missing_requirement: WARNING
-        show_warning: false
 
     electromagnetics:
         directories:
             - modules/electromagnetics
-        show_warning: false
 
     external_petsc_solver:
         directories:
@@ -373,7 +341,6 @@ Requirements:
         directories:
             - modules/fluid_properties
         log_missing: WARNING
-        show_warning: false
 
     fsi:
         directories:
@@ -395,14 +362,12 @@ Requirements:
         directories:
             - modules/level_set
         log_missing: WARNING
-        show_warning: false
 
     misc:
         directories:
             - modules/misc
         log_duplicate_requirement: WARNING
         log_missing: WARNING
-        show_warning: false
 
     navier_stokes:
         directories:
@@ -419,7 +384,6 @@ Requirements:
         log_missing: WARNING
         log_empty_issues: WARNING
         log_design_files: WARNING
-        show_warning: false
 
     porous_flow:
         directories:
@@ -428,14 +392,12 @@ Requirements:
         log_missing: WARNING
         log_issue_format: WARNING
         log_design_files: WARNING
-        show_warning: false
 
     peridynamics:
         directories:
             - modules/peridynamics
         log_duplicate_requirement: WARNING
         log_design_files: WARNING
-        show_warning: false
 
     ray_tracing:
         directories:
@@ -467,7 +429,6 @@ Requirements:
             - modules/stochastic_tools
         log_missing_requirement: WARNING
         log_top_level_detail: WARNING
-        show_warning: false
 
     tensor_mechanics:
         directories:
@@ -475,17 +436,10 @@ Requirements:
         log_duplicate_requirement: WARNING
         log_missing: WARNING
         log_empty_issues: WARNING
-        show_warning: false
 
     thermal_hydraulics:
         directories:
             - modules/thermal_hydraulics
-        log_missing: WARNING
-        log_missing_design: WARNING
-        log_missing_issues: WARNING
-        log_testable: WARNING
-        log_duplicate_requirement: WARNING
-        show_warning: false
 
     xfem:
         directories:

--- a/modules/misc/doc/content/source/kernels/CoefDiffusion.md
+++ b/modules/misc/doc/content/source/kernels/CoefDiffusion.md
@@ -1,1 +1,14 @@
-!template load file=stubs/moose_object.md.template name=CoefDiffusion syntax=/Kernels/CoefDiffusion
+# CoefDiffusion
+
+## Description
+
+`CoefDiffusion` implements a diffusion term using a simple floating point coefficient as the diffusivity.
+It is equivalent to using [FunctionDiffusion.md] or [MatDiffusion.md] with a constant coefficient.
+
+!syntax parameters /Kernels/CoefDiffusion
+
+!syntax inputs /Kernels/CoefDiffusion
+
+!syntax children /Kernels/CoefDiffusion
+
+!bibtex bibliography

--- a/modules/misc/doc/content/source/kernels/ThermoDiffusion.md
+++ b/modules/misc/doc/content/source/kernels/ThermoDiffusion.md
@@ -1,1 +1,24 @@
-!template load file=stubs/moose_object.md.template name=ThermoDiffusion syntax=/Kernels/ThermoDiffusion
+# ThermoDiffusion
+
+## Description
+
+`ThermoDiffusion` implements thermodiffusion (also called thermophoresis, thermomigration, or the Soret effect),
+or the movement of species due a temperature gradient. The mass flux $J$
+is given as
+
+\begin{equation}
+\mathbf{J}=-S\nabla T
+\end{equation}
+
+where $S$ is Soret diffusion coefficient, which is typically a combination of the
+species concentration, temperature, and other material parameters. $S$ is kept
+agnostic in this formulation and ultimately needs to be formulated in a separate
+material property definition.
+
+!syntax parameters /Kernels/ThermoDiffusion
+
+!syntax inputs /Kernels/ThermoDiffusion
+
+!syntax children /Kernels/ThermoDiffusion
+
+!bibtex bibliography

--- a/modules/thermal_hydraulics/test/tests/components/solid_wall_1phase/tests
+++ b/modules/thermal_hydraulics/test/tests/components/solid_wall_1phase/tests
@@ -1,7 +1,7 @@
 [Tests]
   # relap7 #636
   issues = '#26336'
-  requirement = 'SolidWall1Phase.md'
+  design = 'SolidWall1Phase.md'
   # physics
   [phy:3eqn]
     type = 'Exodiff'

--- a/modules/thermal_hydraulics/test/tests/jacobians/userobjects/shaft_connected_motor_uo/tests
+++ b/modules/thermal_hydraulics/test/tests/jacobians/userobjects/shaft_connected_motor_uo/tests
@@ -1,7 +1,7 @@
 [Tests]
   # relap-7#736
   issues = '#26336'
-  requirement = 'ShaftConnectedMotorUserObject.md'
+  design = 'ShaftConnectedMotorUserObject.md'
   [test]
     type = 'PetscJacobianTester'
     input = 'shaft_connected_motor.i'

--- a/modules/thermal_hydraulics/test/tests/jacobians/userobjects/shaft_connected_test_component/tests
+++ b/modules/thermal_hydraulics/test/tests/jacobians/userobjects/shaft_connected_test_component/tests
@@ -1,7 +1,7 @@
 [Tests]
   # relap-7#736
   issues = '#26336'
-  requirement = 'ShaftConnectedTestComponent.md'
+  design = 'ShaftComponentTorqueScalarKernel.md ShaftTimeDerivativeScalarKernel.md'
   [test]
     type = 'PetscJacobianTester'
     input = 'shaft_connected_test_component.i'

--- a/modules/thermal_hydraulics/test/tests/materials/ad_material_function_product/tests
+++ b/modules/thermal_hydraulics/test/tests/materials/ad_material_function_product/tests
@@ -1,7 +1,7 @@
 [Tests]
   # idaholab/sockeye#56
   issues = '#26411'
-  requirement = 'ADMaterialFunctionProductMaterial.md'
+  design = 'ADMaterialFunctionProductMaterial.md'
   [test]
     type = 'CSVDiff'
     input = 'ad_material_function_product.i'

--- a/modules/thermal_hydraulics/test/tests/materials/convective_heat_transfer_coefficient/tests
+++ b/modules/thermal_hydraulics/test/tests/materials/convective_heat_transfer_coefficient/tests
@@ -1,6 +1,6 @@
 [Tests]
   issues = '#19682'
-  requirement = 'ConvectiveHeatTransferCoefficientMaterial.md'
+  design = 'ConvectiveHeatTransferCoefficientMaterial.md'
   [test]
     type = 'CSVDiff'
     input = 'test.i'


### PR DESCRIPTION
refs #12049 

This will prevent regression like in the Navier Stokes module for example, where an old FE NS implementation was merged with insufficient doco. 1 year later, it has not been contributed (actually I think this particular instance would still go through sadly).

I am also turning back on colors in the SQA reports. The modules are pretty close now, that orange can just serve as extra motivation. The worst one (THM) got fixed. 