### PR TITLE
Don't erase PETSc pc description from Executioner petsc options

### DIFF
--- a/framework/src/utils/PetscSupport.C
+++ b/framework/src/utils/PetscSupport.C
@@ -815,7 +815,7 @@ processPetscPairs(const std::vector<std::pair<MooseEnumItem, std::string>> & pet
   }
 #endif
   // Set Preconditioner description
-  po.pc_description = pc_description;
+  po.pc_description += pc_description;
 
   // Turn off default options_left warnings added in 3.19.3 pre-release for all PETSc builds
   // (PETSc commit: 59f199a7), unless the user has set a preference.

--- a/test/tests/preconditioners/auto_smp/tests
+++ b/test/tests/preconditioners/auto_smp/tests
@@ -17,4 +17,13 @@
     requirement = "The system shall automatically create the correct preconditioning object when performing a Newton solve."
     prereq = manual
   []
+  [petsc_pre_description]
+    type = 'Exodiff'
+    input = 'ad_coupled_convection.i'
+    exodiff = 'ad_coupled_convection_out.e'
+    prereq = auto
+    requirement = 'The system shall output the PETSc preconditioner type requested in the executioner options.'
+    cli_args = "Executioner/petsc_options_iname='-pc_type' Executioner/petsc_options_value='lu'"
+    expect_out = 'PETSc Preconditioner:\s+lu'
+  []
 []


### PR DESCRIPTION
Discovered that this was getting erased when processing the empty petsc options coming from preconditioner setup while investigating discussion #26419