### PR TITLE
Make sure FMGs error on LFS pointer files

### DIFF
--- a/framework/src/meshgenerators/FileMeshGenerator.C
+++ b/framework/src/meshgenerators/FileMeshGenerator.C
@@ -71,6 +71,7 @@ FileMeshGenerator::generate()
   if (exodus)
   {
     auto exreader = std::make_shared<ExodusII_IO>(*mesh);
+    MooseUtils::checkFileReadable(_file_name);
 
     if (has_exodus_integers)
       exreader->set_extra_integer_vars(
@@ -108,6 +109,7 @@ FileMeshGenerator::generate()
 
     // Supports old suffix (xxxx_mesh.cpr -> xxxx-mesh.cpr) and LATEST
     const auto file_name = deduceCheckpointPath(*this, _file_name);
+    MooseUtils::checkFileReadable(file_name);
 
     mesh->skip_partitioning(_skip_partitioning);
     mesh->allow_renumbering(_allow_renumbering);

--- a/test/tests/misc/check_error/mesh_pointer_error_check.i
+++ b/test/tests/misc/check_error/mesh_pointer_error_check.i
@@ -1,5 +1,4 @@
 [Mesh]
-  file = mesh_pointer.e
 []
 
 [Variables]

--- a/test/tests/misc/check_error/tests
+++ b/test/tests/misc/check_error/tests
@@ -1155,8 +1155,19 @@
     type = 'RunException'
     input = 'mesh_pointer_error_check.i'
     expect_err = 'appears to be a Git-LFS pointer'
+    cli_args = 'Mesh/file=mesh_pointer.e'
 
-    requirement = 'The system shall report an error when a git-lfs file pointer is encountered.'
+    requirement = 'The system shall report an error when a git-lfs file pointer is encountered for the mesh file.'
+    design = 'MooseUtils.md'
+    issues = '#17407'
+  []
+  [check_git_lfs_pointer_fmg]
+    type = 'RunException'
+    input = 'mesh_pointer_error_check.i'
+    expect_err = 'appears to be a Git-LFS pointer'
+    cli_args = 'Mesh/fmg/type=FileMeshGenerator Mesh/fmg/file=mesh_pointer.e'
+
+    requirement = 'The system shall report an error when a git-lfs file pointer is encountered for the mesh for a mesh generator.'
     design = 'MooseUtils.md'
     issues = '#17407'
   []


### PR DESCRIPTION
refs #17407

I was thinking the other day that we had to make Griffin error on missing cross sections XML due to LFS.
But we should have been erroring on missing mesh too, except the input in question was probably using a reactor-generated mesh. 

Turned out if we use the FileMesh we already have that check, but not for the FMG. 