### PR TITLE
Fixing up missing or incorrect headers

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -15,7 +15,7 @@ https://github.com/idaholab/moose
 
 The following are the complete copyright notices for select institutions
 
-© 2010-2022 Battelle Energy Alliance, LLC
+© 2010-2024 Battelle Energy Alliance, LLC
 ALL RIGHTS RESERVED
 
 Prepared by Battelle Energy Alliance, LLC

--- a/framework/include/userobjects/PostprocessorSpatialUserObject.h
+++ b/framework/include/userobjects/PostprocessorSpatialUserObject.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/framework/include/utils/TimedPrint.h
+++ b/framework/include/utils/TimedPrint.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "MooseError.h"

--- a/framework/src/actions/AutoCheckpointAction.C
+++ b/framework/src/actions/AutoCheckpointAction.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "AutoCheckpointAction.h"
 #include "FEProblem.h"
 #include "Checkpoint.h"

--- a/framework/src/auxkernels/MaterialRealAux.C
+++ b/framework/src/auxkernels/MaterialRealAux.C
@@ -1,4 +1,4 @@
-//*This file is part of the MOOSE framework
+//* This file is part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/framework/src/multiapps/QuadraturePointMultiApp.C
+++ b/framework/src/multiapps/QuadraturePointMultiApp.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/main/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/framework/src/userobjects/PostprocessorSpatialUserObject.C
+++ b/framework/src/userobjects/PostprocessorSpatialUserObject.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "PostprocessorSpatialUserObject.h"
 
 registerMooseObject("MooseApp", PostprocessorSpatialUserObject);

--- a/modules/electromagnetics/test/include/functions/JinSlabCoeffFunc.h
+++ b/modules/electromagnetics/test/include/functions/JinSlabCoeffFunc.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Function.h"

--- a/modules/fluid_properties/include/fluidproperties/StiffenedGasTwoPhaseFluidProperties.h
+++ b/modules/fluid_properties/include/fluidproperties/StiffenedGasTwoPhaseFluidProperties.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "TwoPhaseFluidProperties.h"

--- a/modules/fluid_properties/include/ics/SpecificEnthalpyFromPressureTemperatureIC.h
+++ b/modules/fluid_properties/include/ics/SpecificEnthalpyFromPressureTemperatureIC.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "InitialCondition.h"

--- a/modules/fluid_properties/include/utils/NewtonInversion.h
+++ b/modules/fluid_properties/include/utils/NewtonInversion.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 // * This file is part of the MOOSE framework
 // * https://www.mooseframework.org
 // *

--- a/modules/fluid_properties/src/fluidproperties/StiffenedGasTwoPhaseFluidProperties.C
+++ b/modules/fluid_properties/src/fluidproperties/StiffenedGasTwoPhaseFluidProperties.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "StiffenedGasTwoPhaseFluidProperties.h"
 #include "StiffenedGasFluidProperties.h"
 

--- a/modules/fluid_properties/src/ics/SpecificEnthalpyFromPressureTemperatureIC.C
+++ b/modules/fluid_properties/src/ics/SpecificEnthalpyFromPressureTemperatureIC.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "SpecificEnthalpyFromPressureTemperatureIC.h"
 #include "SinglePhaseFluidProperties.h"
 

--- a/modules/fluid_properties/unit/include/StiffenedGasTwoPhaseFluidPropertiesTest.h
+++ b/modules/fluid_properties/unit/include/StiffenedGasTwoPhaseFluidPropertiesTest.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "MooseObjectUnitTest.h"

--- a/modules/fluid_properties/unit/src/StiffenedGasTwoPhaseFluidPropertiesTest.C
+++ b/modules/fluid_properties/unit/src/StiffenedGasTwoPhaseFluidPropertiesTest.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "StiffenedGasTwoPhaseFluidPropertiesTest.h"
 #include "SinglePhaseFluidPropertiesTestUtils.h"
 

--- a/modules/fsi/src/base/FsiApp.C
+++ b/modules/fsi/src/base/FsiApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "FsiApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/modules/heat_transfer/include/postprocessors/ConvectiveHeatTransferSideIntegral.h
+++ b/modules/heat_transfer/include/postprocessors/ConvectiveHeatTransferSideIntegral.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "SideIntegralPostprocessor.h"

--- a/modules/heat_transfer/src/postprocessors/ConvectiveHeatTransferSideIntegral.C
+++ b/modules/heat_transfer/src/postprocessors/ConvectiveHeatTransferSideIntegral.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ConvectiveHeatTransferSideIntegral.h"
 
 #include "metaphysicl/raw_type.h"

--- a/modules/navier_stokes/include/base/NSEnums.h
+++ b/modules/navier_stokes/include/base/NSEnums.h
@@ -1,16 +1,11 @@
-/********************************************************************/
-/*                   DO NOT MODIFY THIS HEADER                      */
-/*   Pronghorn: Coarse-Mesh, Multi-Dimensional, Thermal-Hydraulics  */
-/*                                                                  */
-/*              (c) 2020 Battelle Energy Alliance, LLC              */
-/*                      ALL RIGHTS RESERVED                         */
-/*                                                                  */
-/*             Prepared by Battelle Energy Alliance, LLC            */
-/*               Under Contract No. DE-AC07-05ID14517               */
-/*               With the U. S. Department of Energy                */
-/*                                                                  */
-/*               See COPYRIGHT for full restrictions                */
-/********************************************************************/
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #pragma once
 

--- a/modules/navier_stokes/unit/src/TestReconstruction.C
+++ b/modules/navier_stokes/unit/src/TestReconstruction.C
@@ -1,3 +1,4 @@
+//* This file is part of the MOOSE framework
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions

--- a/modules/optimization/include/actions/AddOptimizationReporterAction.h
+++ b/modules/optimization/include/actions/AddOptimizationReporterAction.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "MooseObjectAction.h"

--- a/modules/phase_field/include/kernels/ACInterfaceChangedVariable.h
+++ b/modules/phase_field/include/kernels/ACInterfaceChangedVariable.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /// Considers cleavage plane anisotropy in the crack propagation
 
 #pragma once

--- a/modules/phase_field/include/kernels/ACInterfaceCleavageFracture.h
+++ b/modules/phase_field/include/kernels/ACInterfaceCleavageFracture.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /// Considers cleavage plane anisotropy in the crack propagation
 
 #pragma once

--- a/modules/phase_field/src/kernels/ACInterfaceChangedVariable.C
+++ b/modules/phase_field/src/kernels/ACInterfaceChangedVariable.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /// Considers cleavage plane anisotropy in the crack propagation
 
 #include "ACInterfaceChangedVariable.h"

--- a/modules/phase_field/src/kernels/ACInterfaceCleavageFracture.C
+++ b/modules/phase_field/src/kernels/ACInterfaceCleavageFracture.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /// Considers cleavage plane anisotropy in the crack propagation
 
 #include "ACInterfaceCleavageFracture.h"

--- a/modules/ray_tracing/include/raytracing/ParallelRayStudy.h
+++ b/modules/ray_tracing/include/raytracing/ParallelRayStudy.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "ParallelStudy.h"

--- a/modules/ray_tracing/include/raytracing/TraceData.h
+++ b/modules/ray_tracing/include/raytracing/TraceData.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Local includes

--- a/modules/ray_tracing/src/raytracing/ParallelRayStudy.C
+++ b/modules/ray_tracing/src/raytracing/ParallelRayStudy.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ParallelRayStudy.h"
 
 // Local includes

--- a/modules/ray_tracing/test/src/raykernels/CoupledLineSourceRayKernelTestTempl.C
+++ b/modules/ray_tracing/test/src/raykernels/CoupledLineSourceRayKernelTestTempl.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 // * This file is part of the MOOSE framework
 // * https://www.mooseframework.org
 // *

--- a/modules/reactor/src/base/ReactorApp.C
+++ b/modules/reactor/src/base/ReactorApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ReactorApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/modules/solid_properties/test/include/kernels/HeatDiffusion.h
+++ b/modules/solid_properties/test/include/kernels/HeatDiffusion.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Kernel.h"

--- a/modules/stochastic_tools/include/libtorch/controls/LibtorchDRLControl.h
+++ b/modules/stochastic_tools/include/libtorch/controls/LibtorchDRLControl.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #ifdef LIBTORCH_ENABLED
 
 #pragma once

--- a/modules/stochastic_tools/src/reporters/CrossValidationScores.h
+++ b/modules/stochastic_tools/src/reporters/CrossValidationScores.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // MOOSE includes

--- a/modules/tensor_mechanics/src/kernels/ADStressDivergenceShell.C
+++ b/modules/tensor_mechanics/src/kernels/ADStressDivergenceShell.C
@@ -1,9 +1,11 @@
-/****************************************************************/
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
-/*                                                              */
-/*          All contents are licensed under LGPL V2.1           */
-/*             See LICENSE for full restrictions                */
-/****************************************************************/
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
 
 #include "ADStressDivergenceShell.h"
 

--- a/modules/tensor_mechanics/test/plugins/elastic2.C
+++ b/modules/tensor_mechanics/test/plugins/elastic2.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /***************************************************************************************
 **  UMAT, FOR ABAQUS/STANDARD INCORPORATING ISOTROPIC ELASTICITY                      **
 ***************************************************************************************/

--- a/modules/tensor_mechanics/test/plugins/elastic_print_c.C
+++ b/modules/tensor_mechanics/test/plugins/elastic_print_c.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 

--- a/modules/tensor_mechanics/test/plugins/elastic_print_eigen.C
+++ b/modules/tensor_mechanics/test/plugins/elastic_print_eigen.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 

--- a/modules/tensor_mechanics/test/plugins/mutex_test.C
+++ b/modules/tensor_mechanics/test/plugins/mutex_test.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /***************************************************************************************
 **  UMAT, FOR ABAQUS/STANDARD INCORPORATING ISOTROPIC ELASTICITY                      **
 ***************************************************************************************/

--- a/modules/tensor_mechanics/test/plugins/sma_memory.C
+++ b/modules/tensor_mechanics/test/plugins/sma_memory.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /***************************************************************************************
 **  UMAT, FOR ABAQUS/STANDARD INCORPORATING ISOTROPIC ELASTICITY                      **
 ***************************************************************************************/

--- a/modules/tensor_mechanics/test/plugins/small_elastic_tri.C
+++ b/modules/tensor_mechanics/test/plugins/small_elastic_tri.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 

--- a/modules/tensor_mechanics/test/plugins/small_elastic_tri_states.C
+++ b/modules/tensor_mechanics/test/plugins/small_elastic_tri_states.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 

--- a/modules/tensor_mechanics/test/plugins/small_strain_tri_uel.C
+++ b/modules/tensor_mechanics/test/plugins/small_strain_tri_uel.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 /***************************************************************************************
  **  UEL, FOR ABAQUS/STANDARD INCORPORATING ISOTROPIC ELASTICITY                      **
  ***************************************************************************************/

--- a/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedComponentPostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedComponentPostprocessor.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralPostprocessor.h"

--- a/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.h
+++ b/modules/thermal_hydraulics/include/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "GeneralPostprocessor.h"

--- a/modules/thermal_hydraulics/include/utils/MeshAlignment.h
+++ b/modules/thermal_hydraulics/include/utils/MeshAlignment.h
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/include/utils/MeshAlignment1D3D.h
+++ b/modules/thermal_hydraulics/include/utils/MeshAlignment1D3D.h
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/include/utils/MeshAlignment2D3D.h
+++ b/modules/thermal_hydraulics/include/utils/MeshAlignment2D3D.h
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/include/utils/MeshAlignmentBase.h
+++ b/modules/thermal_hydraulics/include/utils/MeshAlignmentBase.h
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/include/utils/MeshAlignmentOneToMany.h
+++ b/modules/thermal_hydraulics/include/utils/MeshAlignmentOneToMany.h
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/src/postprocessors/ShaftConnectedComponentPostprocessor.C
+++ b/modules/thermal_hydraulics/src/postprocessors/ShaftConnectedComponentPostprocessor.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ShaftConnectedComponentPostprocessor.h"
 #include "ADShaftConnectableUserObjectInterface.h"
 

--- a/modules/thermal_hydraulics/src/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.C
+++ b/modules/thermal_hydraulics/src/postprocessors/ShaftConnectedCompressor1PhasePostprocessor.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "ShaftConnectedCompressor1PhasePostprocessor.h"
 #include "ADShaftConnectedCompressor1PhaseUserObject.h"
 

--- a/modules/thermal_hydraulics/src/utils/MeshAlignment.C
+++ b/modules/thermal_hydraulics/src/utils/MeshAlignment.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/src/utils/MeshAlignment1D3D.C
+++ b/modules/thermal_hydraulics/src/utils/MeshAlignment1D3D.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/src/utils/MeshAlignment2D3D.C
+++ b/modules/thermal_hydraulics/src/utils/MeshAlignment2D3D.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/src/utils/MeshAlignmentBase.C
+++ b/modules/thermal_hydraulics/src/utils/MeshAlignmentBase.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/modules/thermal_hydraulics/src/utils/MeshAlignmentOneToMany.C
+++ b/modules/thermal_hydraulics/src/utils/MeshAlignmentOneToMany.C
@@ -2,7 +2,7 @@
 //* https://www.mooseframework.org
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/primary/COPYRIGHT
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
 //*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html

--- a/test/src/auxkernels/RadialAverageAux.C
+++ b/test/src/auxkernels/RadialAverageAux.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "RadialAverageAux.h"
 
 registerMooseObject("MooseTestApp", RadialAverageAux);

--- a/test/src/userobjects/CallTaggedResidualsTest.C
+++ b/test/src/userobjects/CallTaggedResidualsTest.C
@@ -3,7 +3,7 @@
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*repl
+//*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 

--- a/test/src/userobjects/TestShuffle.C
+++ b/test/src/userobjects/TestShuffle.C
@@ -3,7 +3,7 @@
 //*
 //* All rights reserved, see COPYRIGHT for full restrictions
 //* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*repl
+//*
 //* Licensed under LGPL 2.1, please see LICENSE for details
 //* https://www.gnu.org/licenses/lgpl-2.1.html
 

--- a/tutorials/tutorial01_app_development/step01_moose_app/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step01_moose_app/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step02_input_file/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step02_input_file/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step05_kernel_object/include/kernels/DarcyPressure.h
+++ b/tutorials/tutorial01_app_development/step05_kernel_object/include/kernels/DarcyPressure.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Including the "ADKernel" base class here so we can extend it

--- a/tutorials/tutorial01_app_development/step05_kernel_object/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step05_kernel_object/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step05_kernel_object/src/kernels/DarcyPressure.C
+++ b/tutorials/tutorial01_app_development/step05_kernel_object/src/kernels/DarcyPressure.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyPressure.h"
 
 registerMooseObject("BabblerApp", DarcyPressure);

--- a/tutorials/tutorial01_app_development/step06_input_params/include/kernels/DarcyPressure.h
+++ b/tutorials/tutorial01_app_development/step06_input_params/include/kernels/DarcyPressure.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Including the "ADKernel" base class here so we can extend it

--- a/tutorials/tutorial01_app_development/step06_input_params/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step06_input_params/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step06_input_params/src/kernels/DarcyPressure.C
+++ b/tutorials/tutorial01_app_development/step06_input_params/src/kernels/DarcyPressure.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyPressure.h"
 
 registerMooseObject("BabblerApp", DarcyPressure);

--- a/tutorials/tutorial01_app_development/step08_test_harness/include/kernels/DarcyPressure.h
+++ b/tutorials/tutorial01_app_development/step08_test_harness/include/kernels/DarcyPressure.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Including the "ADKernel" base class here so we can extend it

--- a/tutorials/tutorial01_app_development/step08_test_harness/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step08_test_harness/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step08_test_harness/src/kernels/DarcyPressure.C
+++ b/tutorials/tutorial01_app_development/step08_test_harness/src/kernels/DarcyPressure.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyPressure.h"
 
 registerMooseObject("BabblerApp", DarcyPressure);

--- a/tutorials/tutorial01_app_development/step09_mat_props/include/kernels/DarcyPressure.h
+++ b/tutorials/tutorial01_app_development/step09_mat_props/include/kernels/DarcyPressure.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Including the "ADKernel" base class here so we can extend it

--- a/tutorials/tutorial01_app_development/step09_mat_props/include/materials/PackedColumn.h
+++ b/tutorials/tutorial01_app_development/step09_mat_props/include/materials/PackedColumn.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/tutorials/tutorial01_app_development/step09_mat_props/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step09_mat_props/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step09_mat_props/src/kernels/DarcyPressure.C
+++ b/tutorials/tutorial01_app_development/step09_mat_props/src/kernels/DarcyPressure.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyPressure.h"
 
 registerMooseObject("BabblerApp", DarcyPressure);

--- a/tutorials/tutorial01_app_development/step09_mat_props/src/materials/PackedColumn.C
+++ b/tutorials/tutorial01_app_development/step09_mat_props/src/materials/PackedColumn.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "PackedColumn.h"
 
 registerMooseObject("BabblerApp", PackedColumn);

--- a/tutorials/tutorial01_app_development/step10_auxkernels/include/auxkernels/DarcyVelocity.h
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/include/auxkernels/DarcyVelocity.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "AuxKernel.h"

--- a/tutorials/tutorial01_app_development/step10_auxkernels/include/kernels/DarcyPressure.h
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/include/kernels/DarcyPressure.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 // Including the "ADKernel" base class here so we can extend it

--- a/tutorials/tutorial01_app_development/step10_auxkernels/include/materials/PackedColumn.h
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/include/materials/PackedColumn.h
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #pragma once
 
 #include "Material.h"

--- a/tutorials/tutorial01_app_development/step10_auxkernels/src/auxkernels/DarcyVelocity.C
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/src/auxkernels/DarcyVelocity.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyVelocity.h"
 
 #include "metaphysicl/raw_type.h"

--- a/tutorials/tutorial01_app_development/step10_auxkernels/src/base/BabblerApp.C
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/src/base/BabblerApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "BabblerApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial01_app_development/step10_auxkernels/src/kernels/DarcyPressure.C
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/src/kernels/DarcyPressure.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "DarcyPressure.h"
 
 registerMooseObject("BabblerApp", DarcyPressure);

--- a/tutorials/tutorial01_app_development/step10_auxkernels/src/materials/PackedColumn.C
+++ b/tutorials/tutorial01_app_development/step10_auxkernels/src/materials/PackedColumn.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "PackedColumn.h"
 
 registerMooseObject("BabblerApp", PackedColumn);

--- a/tutorials/tutorial02_multiapps/app/src/base/MultiAppTutApp.C
+++ b/tutorials/tutorial02_multiapps/app/src/base/MultiAppTutApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "MultiAppTutApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial03_verification/app/src/base/VerificationTutorialApp.C
+++ b/tutorials/tutorial03_verification/app/src/base/VerificationTutorialApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "VerificationTutorialApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/tutorials/tutorial04_meshing/app/src/base/MeshingTutorialApp.C
+++ b/tutorials/tutorial04_meshing/app/src/base/MeshingTutorialApp.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "MeshingTutorialApp.h"
 #include "Moose.h"
 #include "AppFactory.h"

--- a/unit/src/BuildMeshTest.C
+++ b/unit/src/BuildMeshTest.C
@@ -1,3 +1,12 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
 #include "gtest/gtest.h"
 
 #include "BuildMeshTest.h"


### PR DESCRIPTION
refs #10468

I'm noticing that we have inconsistencies on the branch reference in many of our headers in addition to missing headers. Right now the MOOSE repository still uses "master" for better or worse. Let's leave the reference pointing to "master" until that branch is renamed.