### PR TITLE
Build moose_test-opt in the Conda MOOSE package

### DIFF
--- a/conda/moose/build.sh
+++ b/conda/moose/build.sh
@@ -5,11 +5,18 @@ if [ "$(echo $SKIP_DOCS | tr '[:lower:]' '[:upper:]')" == "TRUE" ]; then
     export MOOSE_SKIP_DOCS=True
 fi
 ./configure --prefix=${PREFIX}/moose ${MOOSE_OPTIONS:-''}
-cd modules/combined
-
 CORES=${MOOSE_JOBS:-2}
+
+# moose_test-opt
+cd test
 make -j $CORES
 make install -j $CORES
+
+# combined-opt
+cd ../modules/combined
+make -j $CORES
+make install -j $CORES
+
 cd ${PREFIX}/moose/bin
 ln -s combined-opt moose-opt
 ln -s combined-opt moose

--- a/test/tests/materials/derivative_material_interface/tests
+++ b/test/tests/materials/derivative_material_interface/tests
@@ -223,7 +223,6 @@
       type = CSVDiff
       input = 'ad_material_chaining.i'
       csvdiff = 'ad_material_chaining_out.csv'
-
       detail = 'involving chain rules of material properties defined by function expressions, and'
     []
   []


### PR DESCRIPTION
Add `moose_test-opt` to the Conda MOOSE package.

Also using this PR to troubleshot the pesky `libwasp` library missing. There are actually many more libraries missing. But libWasp happens to be the first discovered.

Closes #26493